### PR TITLE
fix(ssh): snapshot detached SSH leases on quit and bound the teardown

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -258,7 +258,7 @@ import { AgentAwakeService } from './agent-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { settleTeardownWithinDeadline } from './quit-teardown-deadline'
 import { quitTeardownStartGate } from './quit-teardown-start-gate'
-import { detachAllSshSessionsForShutdown } from './ipc/ssh'
+import { beginSshShutdown } from './ipc/ssh'
 import { PluginService } from './plugins/plugin-service'
 import { PluginKillListService } from './plugins/plugin-kill-list-service'
 import { getPluginsDataDir } from './plugins/plugin-discovery'
@@ -3047,7 +3047,9 @@ app.on('will-quit', (e) => {
   runtime?.getOffscreenBrowserBackend()?.destroyAll?.()
   browserManager.setBrowserGuestStateChangedListener(null)
   const emulatorShutdown = runtime?.getEmulatorBridge()?.destroyAllSessions() ?? Promise.resolve()
-  const sshShutdown = detachAllSshSessionsForShutdown()
+  // Why immediately before store.flushAsync() with no await in between: beginSshShutdown() marks every
+  // active SSH lease detached in memory synchronously, and that flush is what persists it.
+  const sshShutdown = beginSshShutdown()
   killAllPty()
   const watcherShutdown = shutdownWatchersOnce()
   const storeFlush = store?.flushAsync() ?? Promise.resolve()

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -264,7 +264,8 @@ import {
   getActiveMultiplexer,
   getSshConnectionManager,
   registerSshHandlers,
-  resetSshHandlerStateForTests
+  resetSshHandlerStateForTests,
+  type SshShutdownResult
 } from './ssh'
 import { RelayVersionMismatchError } from '../ssh/ssh-relay-version-mismatch-error'
 import {
@@ -674,6 +675,50 @@ describe('SSH IPC handlers', () => {
       'ssh-1',
       'detached'
     )
+  })
+
+  it('detaches the remaining sessions and still returns when one session throws mid-transition', async () => {
+    const targets: Record<string, SshTarget> = {
+      'ssh-1': { id: 'ssh-1', label: 'A', host: 'a.example.com', port: 22, username: 'deploy' },
+      'ssh-2': { id: 'ssh-2', label: 'B', host: 'b.example.com', port: 22, username: 'deploy' }
+    }
+    mockSshStore.getTarget.mockImplementation((id: string) => targets[id] ?? null)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockImplementation((targetId: string) => ({
+      targetId,
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    }))
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-2' })
+    mockConnectionManager.disconnectAll.mockClear().mockResolvedValue(undefined)
+    vi.mocked(mockStore.markSshRemotePtyLeasesForShutdown).mockClear()
+    // Why webContents.send: quit destroys the renderer, and that is what makes broadcastEmptyLists
+    // throw out of the pre-pass for whichever session reaches it first.
+    mockWindow.webContents.send.mockImplementation((_channel: string, payload: unknown) => {
+      if ((payload as { targetId?: string } | undefined)?.targetId === 'ssh-1') {
+        throw new Error('Object has been destroyed')
+      }
+    })
+    quitTeardownStartGate.tryStart({ preventDefault() {} })
+
+    // Why not-throw rather than a resolved promise: the caller is a non-async will-quit listener, so
+    // a synchronous throw escapes it and skips killAllPty, the watchers and store.flushAsync() — the
+    // very flush that persists the detached leases this pre-pass just staged.
+    let shutdown!: Promise<SshShutdownResult>
+    expect(() => {
+      shutdown = beginSshShutdown()
+    }).not.toThrow()
+    // Why asserted before the await: the real flush starts on the next synchronous line.
+    expect(mockStore.markSshRemotePtyLeasesForShutdown).toHaveBeenCalledWith('ssh-2', 'detached')
+
+    const result = await shutdown
+    expect(
+      result.errors.some(
+        (error) => error instanceof Error && error.message === 'Object has been destroyed'
+      )
+    ).toBe(true)
   })
 
   it('reports the target and phase left unfinished when the shutdown budget expires', async () => {

--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -259,7 +259,8 @@ vi.mock('../ssh/ssh-port-scanner', () => ({
 }))
 
 import {
-  detachAllSshSessionsForShutdown,
+  beginSshShutdown,
+  SSH_SHUTDOWN_BUDGET_MS,
   getActiveMultiplexer,
   getSshConnectionManager,
   registerSshHandlers,
@@ -306,6 +307,7 @@ describe('SSH IPC handlers', () => {
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),
     markSshRemotePtyLeasesAsync: vi.fn(),
+    markSshRemotePtyLeasesForShutdown: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     removeSshRemotePtyLeases: vi.fn()
   }
@@ -587,13 +589,158 @@ describe('SSH IPC handlers', () => {
     mockMux.dispose.mockClear()
     mockConnectionManager.disconnectAll.mockClear().mockResolvedValue(undefined)
 
-    await detachAllSshSessionsForShutdown()
+    await beginSshShutdown()
 
     expect(mockPortForwardManager.removeAllForwards).toHaveBeenCalledWith('ssh-1')
     expect(mockMux.dispose).toHaveBeenCalledWith('connection_lost')
     expect(mockStore.markSshRemotePtyLeasesAsync).toHaveBeenCalledWith('ssh-1', 'detached')
     expect(mockStore.removeSshPtyConsumerRecovery).not.toHaveBeenCalled()
     expect(mockConnectionManager.disconnectAll).toHaveBeenCalled()
+  })
+
+  it('detaches every lease in memory before a slow forward removal can cross the final flush', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+    mockConnectionManager.disconnectAll.mockClear().mockResolvedValue(undefined)
+    let releaseForwards!: () => void
+    vi.mocked(mockPortForwardManager.removeAllForwards).mockImplementationOnce(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseForwards = resolve
+        })
+    )
+    vi.mocked(mockStore.markSshRemotePtyLeasesForShutdown).mockClear()
+    quitTeardownStartGate.tryStart({ preventDefault() {} })
+
+    const shutdown = beginSshShutdown()
+
+    // Why asserted with no await: the committed quit path calls store.flushAsync() on the very next
+    // line, so anything not already in memory at this instant can never reach the final snapshot.
+    expect(mockStore.markSshRemotePtyLeasesForShutdown).toHaveBeenCalledWith('ssh-1', 'detached')
+    // Why 'detached' and never 'terminated': the app is letting go of the lease, not proving the
+    // remote shell died. Those PTYs keep running for the next attach.
+    expect(mockStore.markSshRemotePtyLeasesForShutdown).not.toHaveBeenCalledWith(
+      'ssh-1',
+      'terminated'
+    )
+    expect(mockStore.removeSshPtyConsumerRecovery).not.toHaveBeenCalled()
+    expect(mockPortForwardManager.removeAllForwards).toHaveBeenCalledWith('ssh-1')
+
+    releaseForwards()
+    await shutdown
+  })
+
+  it('repeats no state transition when shutdown is begun twice', async () => {
+    const target: SshTarget = {
+      id: 'ssh-1',
+      label: 'Server',
+      host: 'example.com',
+      port: 22,
+      username: 'deploy'
+    }
+    mockSshStore.getTarget.mockReturnValue(target)
+    mockConnectionManager.connect.mockResolvedValue({})
+    mockConnectionManager.getState.mockReturnValue({
+      targetId: 'ssh-1',
+      status: 'connected',
+      error: null,
+      reconnectAttempt: 0
+    })
+    await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+    mockConnectionManager.disconnectAll.mockClear().mockResolvedValue(undefined)
+    vi.mocked(mockStore.markSshRemotePtyLeasesForShutdown).mockClear()
+    quitTeardownStartGate.tryStart({ preventDefault() {} })
+
+    const first = beginSshShutdown()
+    const second = beginSshShutdown()
+
+    expect(second).toBe(first)
+    await Promise.all([first, second])
+    expect(mockStore.markSshRemotePtyLeasesForShutdown).toHaveBeenCalledExactlyOnceWith(
+      'ssh-1',
+      'detached'
+    )
+  })
+
+  it('reports the target and phase left unfinished when the shutdown budget expires', async () => {
+    vi.useFakeTimers()
+    try {
+      const target: SshTarget = {
+        id: 'ssh-1',
+        label: 'Server',
+        host: 'example.com',
+        port: 22,
+        username: 'deploy'
+      }
+      mockSshStore.getTarget.mockReturnValue(target)
+      mockConnectionManager.connect.mockResolvedValue({})
+      mockConnectionManager.getState.mockReturnValue({
+        targetId: 'ssh-1',
+        status: 'connected',
+        error: null,
+        reconnectAttempt: 0
+      })
+      await handlers.get('ssh:connect')!(null, { targetId: 'ssh-1' })
+      mockConnectionManager.disconnectAll.mockClear().mockResolvedValue(undefined)
+      // Why never resolved, on every call: a forward whose child never reports exit is exactly the
+      // case the shared deadline exists for, and it must not get a fresh budget per phase.
+      vi.mocked(mockPortForwardManager.removeAllForwards).mockImplementation(
+        () => new Promise(() => {})
+      )
+      quitTeardownStartGate.tryStart({ preventDefault() {} })
+
+      let settled = false
+      const shutdown = beginSshShutdown().then((value) => {
+        settled = true
+        return value
+      })
+      // Why the whole budget and not a millisecond more: the entire drain/join/drain sequence has to
+      // fit inside one deadline, so advancing exactly that far must be enough to settle it. Asserting
+      // the flag rather than awaiting keeps a per-phase budget a failure instead of a hang.
+      await vi.advanceTimersByTimeAsync(SSH_SHUTDOWN_BUDGET_MS)
+      expect(settled).toBe(true)
+      const result = await shutdown
+
+      expect(result.unfinished).toContainEqual({ targetId: 'ssh-1', phase: 'drain' })
+      // Why no final-drain entry: the budget was already spent, so no later phase was awaited at all.
+      expect(result.unfinished.some((entry) => entry.phase === 'final-drain')).toBe(false)
+      // Why the lease still stands: the drain timing out says nothing about the remote PTYs, and the
+      // pre-pass already recorded the only thing that was ever provable.
+      expect(mockStore.markSshRemotePtyLeasesForShutdown).toHaveBeenCalledWith('ssh-1', 'detached')
+      expect(mockStore.removeSshPtyConsumerRecovery).not.toHaveBeenCalled()
+    } finally {
+      vi.mocked(mockPortForwardManager.removeAllForwards).mockReset().mockResolvedValue(undefined)
+      vi.useRealTimers()
+    }
+  })
+
+  it('returns as soon as a fast shutdown drains rather than waiting out the budget', async () => {
+    vi.useFakeTimers()
+    try {
+      mockConnectionManager.disconnectAll.mockClear().mockResolvedValue(undefined)
+      quitTeardownStartGate.tryStart({ preventDefault() {} })
+
+      const result = await beginSshShutdown()
+
+      expect(result.unfinished).toEqual([])
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('refuses the replacement session a paused connect would publish after shutdown began', async () => {
@@ -639,7 +786,7 @@ describe('SSH IPC handlers', () => {
     mockConnectionManager.disconnectAll.mockClear()
     // Why latch the gate here: the committed quit path owns it, so the drain alone must not fence.
     quitTeardownStartGate.tryStart({ preventDefault() {} })
-    const shutdown = detachAllSshSessionsForShutdown()
+    const shutdown = beginSshShutdown()
     releaseDetach()
 
     await expect(replacement).rejects.toThrow('closed for app shutdown')
@@ -698,7 +845,7 @@ describe('SSH IPC handlers', () => {
     expect(mockConnectionManager.connect).toHaveBeenCalledWith(target)
 
     quitTeardownStartGate.tryStart({ preventDefault() {} })
-    const shutdown = detachAllSshSessionsForShutdown()
+    const shutdown = beginSshShutdown()
     openProbeTransport()
     await shutdown
 

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -1653,11 +1653,12 @@ function sshShutdownTasks(targetIds: readonly string[]): SshShutdownTask[] {
 
 async function drainSshShutdown(
   targetIds: readonly string[],
-  inFlight: readonly SshShutdownTask[]
+  inFlight: readonly SshShutdownTask[],
+  detachErrors: readonly unknown[] = []
 ): Promise<SshShutdownResult> {
   const deadline = Date.now() + SSH_SHUTDOWN_BUDGET_MS
   const unfinished: SshShutdownUnfinished[] = []
-  const errors: unknown[] = []
+  const errors: unknown[] = [...detachErrors]
   const runPhase = async (
     phase: SshShutdownPhase,
     tasks: readonly SshShutdownTask[]
@@ -1718,10 +1719,19 @@ export function beginSshShutdown(): Promise<SshShutdownResult> {
   const targetIds = [...activeSessions.keys()]
   // Why before any await: this is the whole point of the split. Each session marks its recovery lease
   // detached in memory now, and the final flush persists it — the remote PTYs keep running.
+  const detachErrors: unknown[] = []
   for (const session of activeSessions.values()) {
-    session.beginShutdownDetach()
+    // Why per-session: this runs synchronously inside a non-async will-quit listener, so one throw
+    // (teardownProviders -> webContents.send on a destroyed renderer, routine on quit) would escape
+    // it and skip every later session, the drain assignment, and the store flush that persists all
+    // of this. Collect and keep going; the drain reports them.
+    try {
+      session.beginShutdownDetach()
+    } catch (error) {
+      detachErrors.push(error)
+    }
   }
-  sshShutdownDrain = drainSshShutdown(targetIds, inFlight)
+  sshShutdownDrain = drainSshShutdown(targetIds, inFlight, detachErrors)
   return sshShutdownDrain
 }
 

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -1590,59 +1590,139 @@ export function getSshConnectionManager(): SshConnectionManager | null {
   return connectionManager
 }
 
-// Why: an invalidated connect only observes its cancellation at the next checkpoint, and one blocked
-// in the transport handshake can sit there for the whole SSH timeout. Bound the join so the final
-// drain always runs well inside the quit deadline instead of racing it.
-const SSH_SHUTDOWN_INFLIGHT_JOIN_MS = 2_000
+// Why one budget for the whole sequence rather than one per phase: an invalidated connect only
+// observes its cancellation at the next checkpoint, and one blocked in the transport handshake can
+// sit there for the whole SSH timeout. A per-phase timeout lets any single phase consume the global
+// quit deadline; a shared absolute deadline cannot.
+export const SSH_SHUTDOWN_BUDGET_MS = 6_000
 
-async function settleWithinMs(work: readonly Promise<unknown>[], timeoutMs: number): Promise<void> {
-  if (work.length === 0) {
-    return
-  }
-  await Promise.race([
-    Promise.allSettled(work),
-    new Promise<void>((resolve) => {
-      const timer = setTimeout(resolve, timeoutMs)
-      timer.unref?.()
-    })
-  ])
+export type SshShutdownPhase = 'drain' | 'in-flight-join' | 'final-drain'
+export type SshShutdownUnfinished = { targetId: string; phase: SshShutdownPhase }
+export type SshShutdownResult = {
+  unfinished: readonly SshShutdownUnfinished[]
+  errors: readonly unknown[]
 }
 
+type SshShutdownTask = { targetId: string; promise: Promise<unknown> }
+
+let sshShutdownDrain: Promise<SshShutdownResult> | null = null
+
+async function settleTasksWithinMs(
+  tasks: readonly SshShutdownTask[],
+  timeoutMs: number
+): Promise<{ timedOut: SshShutdownTask[]; errors: unknown[] }> {
+  const pending = new Set(tasks)
+  const errors: unknown[] = []
+  if (tasks.length === 0) {
+    return { timedOut: [], errors }
+  }
+  const tracked = tasks.map(async (task) => {
+    try {
+      await task.promise
+    } catch (error) {
+      errors.push(error)
+    }
+    pending.delete(task)
+  })
+  let timer: ReturnType<typeof setTimeout> | undefined
+  try {
+    await Promise.race([
+      Promise.all(tracked),
+      new Promise<void>((resolve) => {
+        timer = setTimeout(resolve, timeoutMs)
+        timer.unref?.()
+      })
+    ])
+  } finally {
+    clearTimeout(timer)
+  }
+  return { timedOut: [...pending], errors }
+}
+
+function sshShutdownTasks(targetIds: readonly string[]): SshShutdownTask[] {
+  return [
+    ...targetIds
+      .filter((targetId) => activeSessions.has(targetId))
+      .map((targetId) => ({
+        targetId,
+        promise: teardownActiveSshSession(targetId, (session) => session.detachAndPersist())
+      })),
+    { targetId: '*transports', promise: connectionManager?.disconnectAll() ?? Promise.resolve() }
+  ]
+}
+
+async function drainSshShutdown(
+  targetIds: readonly string[],
+  inFlight: readonly SshShutdownTask[]
+): Promise<SshShutdownResult> {
+  const deadline = Date.now() + SSH_SHUTDOWN_BUDGET_MS
+  const unfinished: SshShutdownUnfinished[] = []
+  const errors: unknown[] = []
+  const runPhase = async (
+    phase: SshShutdownPhase,
+    tasks: readonly SshShutdownTask[]
+  ): Promise<boolean> => {
+    const remainingMs = deadline - Date.now()
+    if (remainingMs <= 0) {
+      unfinished.push(...tasks.map((task) => ({ targetId: task.targetId, phase })))
+      return false
+    }
+    const settled = await settleTasksWithinMs(tasks, remainingMs)
+    errors.push(...settled.errors)
+    unfinished.push(...settled.timedOut.map((task) => ({ targetId: task.targetId, phase })))
+    return settled.timedOut.length === 0
+  }
+
+  await runPhase('drain', sshShutdownTasks(targetIds))
+  // Why a second drain after the join: a connect paused in old-session teardown still publishes its
+  // replacement session and opens a transport before it reaches the cancellation checkpoint, so the
+  // first drain can miss both.
+  if (await runPhase('in-flight-join', inFlight)) {
+    await runPhase('final-drain', sshShutdownTasks([...activeSessions.keys()]))
+  }
+
+  if (errors.length > 0 || unfinished.length > 0) {
+    // Why one aggregate line: per-target logging on the quit path competes with the final flush for
+    // the little time that remains.
+    console.warn(
+      `[ssh] Shutdown drain finished with ${errors.length} error(s); unfinished: ${
+        unfinished.map((entry) => `${entry.targetId}/${entry.phase}`).join(', ') || 'none'
+      }`
+    )
+  }
+  return { unfinished, errors }
+}
+
+// Why one entry point that returns rather than awaits: every in-memory transition the final store
+// flush must snapshot happens synchronously here, before this returns, so the caller can start that
+// flush with no await in between. Idempotent — a later call joins the same drain and repeats no
+// state transition.
+//
 // Why no fence latch here: the committed quit path sets it before calling this, so it is already on
 // for the snapshot below. Called without that gate (tests), this degrades to a plain drain.
-export async function detachAllSshSessionsForShutdown(): Promise<void> {
-  const inFlightWork: Promise<unknown>[] = [
-    ...[...connectInFlight.values()].map((attempt) => attempt.promise),
-    ...resetRelayInFlight.values(),
-    ...testConnectionProbes
+export function beginSshShutdown(): Promise<SshShutdownResult> {
+  if (sshShutdownDrain) {
+    return sshShutdownDrain
+  }
+  const inFlight: SshShutdownTask[] = [
+    ...[...connectInFlight.entries()].map(([targetId, attempt]) => ({
+      targetId,
+      promise: attempt.promise
+    })),
+    ...[...resetRelayInFlight.entries()].map(([targetId, promise]) => ({ targetId, promise })),
+    ...[...testConnectionProbes].map((promise) => ({ targetId: '*probe', promise }))
   ]
   for (const targetId of Array.from(connectInFlight.keys())) {
     invalidateConnectAttempt(targetId)
   }
-
-  const errors: unknown[] = []
-  const drain = async (): Promise<void> => {
-    const results = await Promise.allSettled([
-      ...[...activeSessions.keys()].map((targetId) =>
-        teardownActiveSshSession(targetId, (session) => session.detachAndPersist())
-      ),
-      connectionManager?.disconnectAll() ?? Promise.resolve()
-    ])
-    for (const result of results) {
-      if (result.status === 'rejected') {
-        errors.push(result.reason as unknown)
-      }
-    }
+  const targetIds = [...activeSessions.keys()]
+  // Why before any await: this is the whole point of the split. Each session marks its recovery lease
+  // detached in memory now, and the final flush persists it — the remote PTYs keep running.
+  for (const session of activeSessions.values()) {
+    session.beginShutdownDetach()
   }
-
-  await drain()
-  // Why: a connect paused in old-session teardown still publishes its replacement session and opens a
-  // transport before it reaches the cancellation checkpoint, so the first drain can miss both.
-  await settleWithinMs(inFlightWork, SSH_SHUTDOWN_INFLIGHT_JOIN_MS)
-  await drain()
-  if (errors.length > 0) {
-    throw new AggregateError(errors, 'SSH shutdown detach failed')
-  }
+  sshShutdownDrain = drainSshShutdown(targetIds, inFlight)
+  return sshShutdownDrain
 }
 
 export async function resetSshHandlerStateForTests(): Promise<void> {
@@ -1674,6 +1754,7 @@ export async function resetSshHandlerStateForTests(): Promise<void> {
   testConnectionProbes.clear()
   credentialRequestedForTarget.clear()
   quitTeardownStartGate.resetForTests()
+  sshShutdownDrain = null
 
   await connectionManager?.disconnectAll()
   portForwardManager?.dispose()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -7075,6 +7075,13 @@ export class Store {
     }
   }
 
+  // Why no write of its own: the committed quit path calls this immediately before the final store
+  // flush, and that flush is what persists it. A durable write here would race the flush and be
+  // rejected the moment it latches, which is exactly how an attached lease used to survive quit.
+  markSshRemotePtyLeasesForShutdown(targetId: string, state: SshRemotePtyLease['state']): void {
+    this.updateSshRemotePtyLeaseStates(targetId, state)
+  }
+
   async markSshRemotePtyLeasesAsync(
     targetId: string,
     state: SshRemotePtyLease['state']

--- a/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
+++ b/src/main/ssh/ssh-relay-session-recovery-durability.test.ts
@@ -388,6 +388,45 @@ describe('SshRelaySession consumer recovery durability', () => {
     expect(mockStore.upsertSshPtyConsumerRecovery).not.toHaveBeenCalled()
   })
 
+  it('detaches for shutdown in memory without a per-session durable write', async () => {
+    const targetId = 'target-shutdown-detach'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockClear()
+
+    session.beginShutdownDetach()
+    session.beginShutdownDetach()
+
+    // Why in-memory only: the committed quit path runs the final store flush immediately after this,
+    // and a durable write here would race that flush rather than be captured by it.
+    expect(mockStore.markSshRemotePtyLeasesForShutdown).toHaveBeenCalledExactlyOnceWith(
+      targetId,
+      'detached'
+    )
+    expect(mockStore.markSshRemotePtyLeasesAsync).not.toHaveBeenCalled()
+    // Why the recovery record survives: 'detached' means this app let go, not that the remote shell
+    // died — the identity is what lets the next launch reattach those still-running PTYs.
+    expect(mockStore.removeSshPtyConsumerRecovery).not.toHaveBeenCalled()
+    expect(getSshPtyConsumerRecovery(targetId)?.detached).toBe(true)
+    expect(getSshPtyConsumerRecovery(targetId)?.clientInstanceId).toBeTypeOf('string')
+  })
+
+  it('keeps ordinary detach durability reporting unchanged after a shutdown detach exists', async () => {
+    const targetId = 'target-shutdown-vs-ordinary-detach'
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.markSshRemotePtyLeasesAsync).mockRejectedValueOnce(
+      new Error('lease write failed')
+    )
+    const session = new SshRelaySession(targetId, getMainWindow, mockStore, mockPortForward)
+    await session.establish(mockConn)
+
+    // Why still rejecting: only the shutdown path delegates durability; an ordinary detach must keep
+    // surfacing a failed write to its caller.
+    await expect(session.detachAndPersist()).rejects.toThrow('lease write failed')
+    expect(mockStore.markSshRemotePtyLeasesForShutdown).not.toHaveBeenCalled()
+  })
+
   it('upgrades a pending detach to a full disposal', async () => {
     const targetId = 'target-teardown-upgrade'
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -25,6 +25,7 @@ export function createMockDeps(): SshRelaySessionTestDeps {
     markSshRemotePtyLease: vi.fn(),
     markSshRemotePtyLeases: vi.fn(),
     markSshRemotePtyLeasesAsync: vi.fn(),
+    markSshRemotePtyLeasesForShutdown: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     persistPtyBinding: vi.fn()
   } as unknown as Store

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -831,6 +831,28 @@ export class SshRelaySession {
     }
   }
 
+  // Why a separate transition from detachAndPersist: on the committed quit path every in-memory
+  // change has to land before the final store flush snapshots, and that flush — not a per-session
+  // durable write — is what persists it. Idempotent, and it schedules no persistence of its own, so
+  // nothing the async drain finishes later can write recovery state after the snapshot.
+  //
+  // 'detached' says this app let go of the lease, not that the remote shell died. The remote PTYs are
+  // left running for the next attach, exactly as an ordinary detach leaves them.
+  beginShutdownDetach(): void {
+    if (this.detachedInMemory || this._state === 'disposed') {
+      return
+    }
+    detachSshPtyConsumerRecovery(this.targetId, this.ptyConsumerClientInstanceId)
+    this.abortController?.abort()
+    this.stopPortScanning()
+    this.broadcastEmptyLists()
+    this.teardownProviders('connection_lost')
+    this.currentConnection = null
+    this._state = 'disposed'
+    this.detachedInMemory = true
+    this.store.markSshRemotePtyLeasesForShutdown(this.targetId, 'detached')
+  }
+
   private runDetach(): Promise<void> {
     if (!this.detachedInMemory) {
       if (this._state === 'disposed') {

--- a/src/main/ssh/system-ssh-forward-process.test.ts
+++ b/src/main/ssh/system-ssh-forward-process.test.ts
@@ -335,12 +335,15 @@ describe('system SSH forward process', () => {
     expect(resolved).toBe(false)
 
     await vi.advanceTimersByTimeAsync(1)
-    await pending
 
+    // Why asserted before awaiting `pending`: dropping the post-kill bound is the regression this
+    // test exists to catch, and awaiting a promise that then never settles reports it as a 30s suite
+    // timeout instead of a failed assertion.
     // Why this is not a death claim: the promise resolving bounds teardown; nothing here records the
     // child as gone or drops state that assumes it is.
     expect(resolved).toBe(true)
     expect(child.kill).toHaveBeenCalledTimes(2)
+    await pending
   })
 
   it('clears the post-kill timer once the child exits after SIGKILL', async () => {

--- a/src/main/ssh/system-ssh-forward-process.test.ts
+++ b/src/main/ssh/system-ssh-forward-process.test.ts
@@ -27,7 +27,9 @@ vi.mock('net', () => ({
 
 import {
   SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS,
+  SYSTEM_SSH_FORWARD_POST_KILL_TIMEOUT_MS,
   SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS,
+  SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS,
   spawnSystemSshPortForward,
   startSystemSshPortForwardProcess,
   waitForSystemSshForwardStartup,
@@ -316,5 +318,64 @@ describe('system SSH forward process', () => {
     child.emit('exit', null)
     await pending
     expect(resolved).toBe(true)
+  })
+
+  it('resolves stop after the post-kill bound when the child never reports exit', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+
+    let resolved = false
+    const pending = waitForSystemSshForwardStop(child as never).then(() => {
+      resolved = true
+    })
+
+    await vi.advanceTimersByTimeAsync(SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+    expect(child.kill).toHaveBeenNthCalledWith(2, 'SIGKILL')
+    await vi.advanceTimersByTimeAsync(SYSTEM_SSH_FORWARD_POST_KILL_TIMEOUT_MS - 1)
+    expect(resolved).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(1)
+    await pending
+
+    // Why this is not a death claim: the promise resolving bounds teardown; nothing here records the
+    // child as gone or drops state that assumes it is.
+    expect(resolved).toBe(true)
+    expect(child.kill).toHaveBeenCalledTimes(2)
+  })
+
+  it('clears the post-kill timer once the child exits after SIGKILL', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+
+    const pending = waitForSystemSshForwardStop(child as never)
+    await vi.advanceTimersByTimeAsync(SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
+    child.emit('exit', null)
+    await expect(pending).resolves.toBeUndefined()
+
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('sends no signal to a child that already exited', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+    child.exitCode = 0
+
+    await expect(waitForSystemSshForwardStop(child as never)).resolves.toBeUndefined()
+
+    expect(child.kill).not.toHaveBeenCalled()
+    expect(vi.getTimerCount()).toBe(0)
+  })
+
+  it('sends no SIGKILL or post-kill timer when the child exits after SIGTERM', async () => {
+    vi.useFakeTimers()
+    const child = createFakeProcess()
+
+    const pending = waitForSystemSshForwardStop(child as never)
+    await vi.advanceTimersByTimeAsync(SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS - 1)
+    child.emit('exit', null)
+    await expect(pending).resolves.toBeUndefined()
+
+    expect(child.kill).toHaveBeenCalledExactlyOnceWith('SIGTERM')
+    expect(vi.getTimerCount()).toBe(0)
   })
 })

--- a/src/main/ssh/system-ssh-forward-process.ts
+++ b/src/main/ssh/system-ssh-forward-process.ts
@@ -6,6 +6,9 @@ import type { SshTarget } from '../../shared/ssh-types'
 export const SYSTEM_SSH_FORWARD_STARTUP_GRACE_MS = 750
 export const SYSTEM_SSH_FORWARD_LISTENER_PROBE_INTERVAL_MS = 50
 export const SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS = 2_000
+// Why short: SIGKILL is uncatchable, so a child that has not reported exit this long after it is
+// either already reaped or beyond anything teardown can do about it.
+export const SYSTEM_SSH_FORWARD_POST_KILL_TIMEOUT_MS = 500
 
 export type SystemSshPortForwardProcess = {
   process: ChildProcess
@@ -161,8 +164,10 @@ export function waitForSystemSshForwardStartup(
 export function waitForSystemSshForwardStop(process: ChildProcess): Promise<void> {
   return new Promise((resolve) => {
     let settled = false
+    let postKillTimer: ReturnType<typeof setTimeout> | undefined
     const cleanup = (): void => {
       clearTimeout(escalationTimer)
+      clearTimeout(postKillTimer)
       process.off('exit', onExit)
     }
     const finish = (): void => {
@@ -193,8 +198,18 @@ export function waitForSystemSshForwardStop(process: ChildProcess): Promise<void
       // Why: update/reconnect callers must not rebind while a stubborn ssh -L
       // process still owns the local port.
       kill('SIGKILL')
+      // Why a second timer: SIGKILL is never acknowledged, so if the runtime never reports the exit —
+      // a reparented child, a lost handle — nothing else can settle this promise and quit waits on it
+      // forever. Resolving here bounds teardown; it does not claim the child is gone.
+      postKillTimer = setTimeout(finish, SYSTEM_SSH_FORWARD_POST_KILL_TIMEOUT_MS)
     }, SYSTEM_SSH_FORWARD_STOP_TIMEOUT_MS)
 
+    // Why before any signal: a child that already exited needs no SIGTERM, and signalling a reaped pid
+    // can land on whatever the OS reassigned it to.
+    if (hasExited()) {
+      finish()
+      return
+    }
     process.once('exit', onExit)
     kill('SIGTERM')
   })


### PR DESCRIPTION
Implements the design in #12425 (STA-3366). **Stacked on #12673 (STA-3365)** — the base branch is that PR, so review it first; the diff shown here is this ticket only.

## The problem

Quit already started SSH teardown before `store.flushAsync()`, but per-target teardown awaits port-forward removal *before* anything marks the session's recovery lease detached:

```ts
await portForwardManager?.removeAllForwards(targetId)   // slow
await teardown(session)                                 // ← only here does the lease become 'detached'
```

So a slow forward close let the final store flush latch and snapshot while leases still said `attached`. The per-session durable write that arrived afterwards was rejected, because persistence had already been finalized. The next launch then believed it was still attached to PTYs the app had let go of.

Separately, the SSH shutdown bound applied only to the in-flight join *between* the two drains. Either drain could consume the whole global quit deadline. And `waitForSystemSshForwardStop` had no timer after `SIGKILL`, so a child that never reported exit left the promise pending forever and could hold quit open.

## What changed

**One shutdown entry point.** `beginSshShutdown()` performs every in-memory transition synchronously before it returns — invalidating connect and reset authorities, transitioning each active session, and marking its recovery lease detached in memory — then returns the asynchronous transport drain. The quit path calls it immediately before `store.flushAsync()` with no await in between, so the flush that succeeds is the one that persists the detached state. It is idempotent: a second call joins the same drain and repeats no transition.

**Durability split, not weakened.** `detachAndPersist()` keeps its required durable write and still reports a failed one to its caller. Only the shutdown transition delegates durability to the immediately following final flush, via a new in-memory-only `Store.markSshRemotePtyLeasesForShutdown`. Because the in-memory update lands first, the drain's later `markSshRemotePtyLeasesAsync` finds nothing changed and attempts no flush at all — which is also what stops async drain code from mutating recovery state after the snapshot.

The guarantee is conditional and stated as such: *when the final store flush succeeds*, its snapshot contains detached SSH leases. Write failure and the outer process deadline remain visible residual risk.

**One deadline for the whole drain.** The drain/join/drain sequence shares a single absolute budget instead of bounding only the join, so no single phase can consume the global quit deadline. On expiry it stops awaiting later phases and returns unfinished work as `{ targetId, phase }` entries with one aggregate log line.

**A post-`SIGKILL` bound.** `waitForSystemSshForwardStop` arms a short timer when `SIGKILL` is sent, because `SIGKILL` is never acknowledged and a reparented child or lost handle would otherwise leave the promise pending. A child that has already exited is detected before any signal, so teardown never signals a pid the OS may have reassigned.

## Why nothing here destroys a session

This is the part the ticket most needed to get right, given #12642 (STA-3376) established that an abandoned SSH PTY is **not** proven dead.

- `detached` means *this app let go of the lease*, not that the remote shell died. It is the same state an ordinary user-initiated disconnect writes.
- Every PTY those leases name is left running for the next attach. Nothing on this path terminates, tombstones, or reaps anything, and no recovery identity is removed.
- The pre-pass is the opposite of a reaper: it exists so that still-running remote PTYs are correctly recorded as detached-but-alive rather than being lost to a snapshot that says `attached`.
- The shared deadline is used strictly for *reporting* unfinished phases. Expiry changes no lease state, removes no recovery record, and draws no conclusion about liveness — the test asserts exactly that.
- The post-`SIGKILL` timer bounds teardown; it does not claim the child is gone and drops no state that assumed it was alive.

## Acceptance criteria

| Criterion | Status |
| --- | --- |
| A successful final flush contains detached state for every session at the pre-pass | Met |
| No SSH connect/reset continuation publishes after the pre-pass | Met (pre-existing publication fence, covered by the retained connect-fence test) |
| The whole SSH shutdown path returns within its local budget | Met |
| A never-exiting forward child cannot hold quit open | Met |
| Ordinary detach durability behavior is unchanged | Met |
| Platform/topology impact documented | Met, below |

## Verification

Each production behavior was proven covered by breaking it and watching a named test fail, then restoring the edit:

| Mutation | Tests red |
| --- | --- |
| Pre-pass deferred past one await (the original defect) | 1 |
| Shutdown transition does a per-session durable write instead | 4 |
| Shutdown idempotency removed | 1 |
| Each phase gets its own full budget | 1 |
| Post-`SIGKILL` timer removed | 1 |
| Already-exited child is still signalled | 1 |

The headline ordering test asserts, with no `await` between, that every lease is already detached in memory while forward removal is still pending — the exact instant the quit path starts the final flush. Two of these tests were initially not sensitive to their mutation (one polluted by a shared mock, one that hung rather than failed); both were rewritten until the mutation produced a clean, fast failure.

Negative coverage that live sessions survive: leases are marked `detached` and never `terminated`; recovery records are never removed, including when the budget expires with work unfinished; and ordinary non-quit detach still surfaces a failed durable write to its caller.

Suites `src/main/ssh`, `src/relay`, `src/shared`, `src/main/ipc`, `src/main/persistence.test.ts`: 9692 passed, 2 failed. Both failures (`agent-exec-handler`) reproduce identically on `origin/main` in a clean worktree and are unrelated. `pnpm run typecheck`, `oxlint`, and `oxfmt --check` are clean.

## Platform and topology impact

- **SSH:** the changed path. Covered by the tests above.
- **Local, daemon, WSL, folder workspaces, mobile/relay, Git providers:** unaffected. `beginSshShutdown()` replaces `detachAllSshSessionsForShutdown()` one-for-one at the same point in the quit sequence, and the new store method is only called from the SSH shutdown transition.
- **macOS/Linux/Windows:** the forward-stop change is signal handling on a `ChildProcess`, already guarded by an exit check on all platforms; no new platform-conditional behavior.

Refs STA-3366.