### PR TITLE
fix: preserve project filter when importing or revealing a repo

### DIFF
--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.test.ts
@@ -61,9 +61,48 @@ describe('finalizeImportedRepoAfterSkip', () => {
     finalizeImportedRepoAfterSkip(state, 'repo-new')
 
     expect(state.setActiveRepo).toHaveBeenCalledWith('repo-new')
-    expect(state.setFilterRepoIds).toHaveBeenCalledWith([])
+    expect(state.setFilterRepoIds).toHaveBeenCalledWith(['repo-old', 'repo-new'])
     expect(state.setShowActiveOnly).toHaveBeenCalledWith(false)
     expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
+  })
+
+  it('adds the imported repo to an active filter instead of clearing it', () => {
+    const state = makeState({
+      filterRepoIds: ['repo-a', 'repo-b'],
+      worktreesByRepo: {
+        'repo-new': [makeWorktree({ id: 'repo-new::/repo/feature', repoId: 'repo-new' })]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setFilterRepoIds).toHaveBeenCalledWith(['repo-a', 'repo-b', 'repo-new'])
+  })
+
+  it('leaves the filter untouched when it is empty (all projects already visible)', () => {
+    const state = makeState({
+      filterRepoIds: [],
+      worktreesByRepo: {
+        'repo-new': [makeWorktree({ id: 'repo-new::/repo/feature', repoId: 'repo-new' })]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setFilterRepoIds).not.toHaveBeenCalled()
+  })
+
+  it('leaves the filter untouched when the imported repo is already selected', () => {
+    const state = makeState({
+      filterRepoIds: ['repo-a', 'repo-new'],
+      worktreesByRepo: {
+        'repo-new': [makeWorktree({ id: 'repo-new::/repo/feature', repoId: 'repo-new' })]
+      }
+    })
+
+    finalizeImportedRepoAfterSkip(state, 'repo-new')
+
+    expect(state.setFilterRepoIds).not.toHaveBeenCalled()
   })
 
   it('clears default-branch hiding when it would hide every imported worktree', () => {
@@ -140,7 +179,7 @@ describe('finalizeImportedRepoAfterSkip', () => {
     finalizeImportedRepoAfterSkip(state, 'repo-new')
 
     expect(state.setActiveRepo).toHaveBeenCalledWith('repo-new')
-    expect(state.setFilterRepoIds).toHaveBeenCalledWith([])
+    expect(state.setFilterRepoIds).toHaveBeenCalledWith(['repo-old', 'repo-new'])
     expect(state.setShowActiveOnly).toHaveBeenCalledWith(false)
     expect(state.setHideDefaultBranchWorkspace).not.toHaveBeenCalled()
   })

--- a/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
+++ b/src/renderer/src/components/sidebar/add-repo-skip-finalization.ts
@@ -1,5 +1,6 @@
 import type { Worktree } from '../../../../shared/types'
 import { isDefaultBranchWorkspace } from './visible-worktrees'
+import { revealRepoInProjectFilter } from './reveal-repo-in-project-filter'
 
 export type AddRepoSkipFinalizationState = {
   activeRepoId: string | null
@@ -27,8 +28,11 @@ export function finalizeImportedRepoAfterSkip(
   if (state.activeRepoId !== importedRepoId) {
     state.setActiveRepo(importedRepoId)
   }
-  if (state.filterRepoIds.length > 0 && !state.filterRepoIds.includes(importedRepoId)) {
-    state.setFilterRepoIds([])
+  // Why reveal-not-clear: adding the imported project to an active filter keeps
+  // the user's other filtered projects selected instead of wiping the filter.
+  const revealedFilter = revealRepoInProjectFilter(state.filterRepoIds, importedRepoId)
+  if (revealedFilter) {
+    state.setFilterRepoIds(revealedFilter)
   }
   if (state.showActiveOnly) {
     state.setShowActiveOnly(false)

--- a/src/renderer/src/components/sidebar/reveal-repo-in-project-filter.test.ts
+++ b/src/renderer/src/components/sidebar/reveal-repo-in-project-filter.test.ts
@@ -1,0 +1,26 @@
+import { describe, expect, it } from 'vitest'
+import { revealRepoInProjectFilter } from './reveal-repo-in-project-filter'
+
+describe('revealRepoInProjectFilter', () => {
+  it('appends the repo so previously filtered projects stay selected', () => {
+    expect(revealRepoInProjectFilter(['repo-a', 'repo-b'], 'repo-c')).toEqual([
+      'repo-a',
+      'repo-b',
+      'repo-c'
+    ])
+  })
+
+  it('returns null for an empty filter (all repos already visible)', () => {
+    expect(revealRepoInProjectFilter([], 'repo-c')).toBeNull()
+  })
+
+  it('returns null when the repo is already selected', () => {
+    expect(revealRepoInProjectFilter(['repo-a', 'repo-c'], 'repo-c')).toBeNull()
+  })
+
+  it('does not mutate the input array', () => {
+    const input = ['repo-a']
+    revealRepoInProjectFilter(input, 'repo-b')
+    expect(input).toEqual(['repo-a'])
+  })
+})

--- a/src/renderer/src/components/sidebar/reveal-repo-in-project-filter.ts
+++ b/src/renderer/src/components/sidebar/reveal-repo-in-project-filter.ts
@@ -1,0 +1,20 @@
+/**
+ * The sidebar "Projects" filter (`filterRepoIds`) is a show-only-these
+ * allowlist. When a flow needs to reveal a specific repo's workspaces through
+ * an active filter (importing a project, jumping to a hidden worktree), it must
+ * add that repo to the selection — never wipe the filter, which would drop every
+ * other project the user deliberately filtered to.
+ *
+ * Returns the next `filterRepoIds` to apply, or null when no change is needed:
+ * an empty filter already shows all repos, and a repo already selected is a
+ * no-op. Centralized so no caller reintroduces the "clear the whole filter" bug.
+ */
+export function revealRepoInProjectFilter(
+  filterRepoIds: readonly string[],
+  repoId: string
+): string[] | null {
+  if (filterRepoIds.length === 0 || filterRepoIds.includes(repoId)) {
+    return null
+  }
+  return [...filterRepoIds, repoId]
+}

--- a/src/renderer/src/components/sidebar/reveal-repo-in-project-filter.ts
+++ b/src/renderer/src/components/sidebar/reveal-repo-in-project-filter.ts
@@ -1,14 +1,4 @@
-/**
- * The sidebar "Projects" filter (`filterRepoIds`) is a show-only-these
- * allowlist. When a flow needs to reveal a specific repo's workspaces through
- * an active filter (importing a project, jumping to a hidden worktree), it must
- * add that repo to the selection — never wipe the filter, which would drop every
- * other project the user deliberately filtered to.
- *
- * Returns the next `filterRepoIds` to apply, or null when no change is needed:
- * an empty filter already shows all repos, and a repo already selected is a
- * no-op. Centralized so no caller reintroduces the "clear the whole filter" bug.
- */
+/** Adds a repo to the "show-only-these" project filter without wiping other selections; null = no change (empty filter or already selected). */
 export function revealRepoInProjectFilter(
   filterRepoIds: readonly string[],
   repoId: string

--- a/src/renderer/src/lib/worktree-activation.test.ts
+++ b/src/renderer/src/lib/worktree-activation.test.ts
@@ -1100,4 +1100,65 @@ describe('activateAndRevealWorktree', () => {
     expect(result).toEqual({ primaryTabId: 'tab-1' })
     expect(queueTabInitialCwd).toHaveBeenCalledWith('tab-1', '/repo/packages/web')
   })
+
+  it('adds the target repo to an active filter to reveal it, keeping other filtered projects', () => {
+    const setFilterRepoIds = vi.fn()
+    useAppStore.setState({
+      activeRepoId: null,
+      activeWorktreeId: null,
+      activeView: 'terminal',
+      // Why: a filter that hides the reveal target — appending keeps the others.
+      filterRepoIds: ['repo-a', 'repo-b'],
+      isNavigatingHistory: false,
+      repos: [{ id: 'repo-1', connectionId: null }],
+      worktreesByRepo: {
+        'repo-1': [
+          {
+            id: 'wt-1',
+            repoId: 'repo-1',
+            path: '/repo',
+            displayName: 'main',
+            branch: 'main',
+            head: 'abc',
+            isBare: false,
+            isMainWorktree: true
+          }
+        ]
+      },
+      getKnownWorktreeById: (worktreeId: string) =>
+        worktreeId === 'wt-1'
+          ? ({
+              id: 'wt-1',
+              repoId: 'repo-1',
+              path: '/repo',
+              displayName: 'main',
+              branch: 'main',
+              head: 'abc',
+              isBare: false,
+              isMainWorktree: true
+            } as never)
+          : null,
+      setActiveRepo: vi.fn(),
+      setActiveView: vi.fn(),
+      setActiveWorktree: vi.fn(),
+      setFilterRepoIds,
+      markWorktreeVisited: vi.fn(),
+      recordWorktreeVisit: vi.fn(),
+      reconcileWorktreeTabModel: vi.fn(() => ({ renderableTabCount: 0 })),
+      createTab: vi.fn(() => ({ id: 'tab-1' })),
+      setActiveTab: vi.fn(),
+      setTabCustomTitle: vi.fn(),
+      setTabColor: vi.fn(),
+      markDefaultTerminalTabsApplied: vi.fn(),
+      queueTabStartupCommand: vi.fn(),
+      queueTabInitialCwd: vi.fn(),
+      queueTabSetupSplit: vi.fn(),
+      queueTabIssueCommandSplit: vi.fn(),
+      revealWorktreeInSidebar: vi.fn()
+    } as never)
+
+    activateAndRevealWorktree('wt-1')
+
+    expect(setFilterRepoIds).toHaveBeenCalledWith(['repo-a', 'repo-b', 'repo-1'])
+  })
 })

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -53,6 +53,7 @@ import { toast } from 'sonner'
 import { initialAgentTabViewModeProps } from './native-chat-initial-view-mode'
 import { getConnectionId } from '@/lib/connection-context'
 import { isDetachedHeadWorkspace } from '@/components/sidebar/visible-worktrees'
+import { revealRepoInProjectFilter } from '@/components/sidebar/reveal-repo-in-project-filter'
 import { isNativeChatTranscriptLocalReadable } from '@/lib/native-chat-transcript-readability'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 import type { SessionOptionValue } from '../../../shared/native-chat-session-options'
@@ -338,9 +339,12 @@ export function activateAndRevealWorktree(
     useAppStore.getState().queueTabInitialCwd(primaryTabId, opts.initialCwd)
   }
 
-  // 5. Clear sidebar filters hiding the target — reveal needs the card rendered, else it silently no-ops.
-  if (state.filterRepoIds.length > 0 && !state.filterRepoIds.includes(wt.repoId)) {
-    state.setFilterRepoIds([])
+  // 5. Reveal past sidebar filters hiding the target — reveal needs the card rendered, else it silently no-ops.
+  // Add the target's repo to an active project filter so the card renders while
+  // the user's other filtered projects stay selected (never wipe the filter).
+  const revealedFilter = revealRepoInProjectFilter(state.filterRepoIds, wt.repoId)
+  if (revealedFilter) {
+    state.setFilterRepoIds(revealedFilter)
   }
   if (
     state.hideAutomationGeneratedWorkspaces &&


### PR DESCRIPTION
## Summary

Importing a new project used to reset the sidebar **Projects** filter: after adding a repo, *every* project reappeared instead of the ones the user had filtered to **plus** the newly imported one.

Root cause: two spots in the import/reveal flow wiped the whole filter allowlist with `setFilterRepoIds([])` whenever the target repo wasn't already in the filter.

- `finalizeImportedRepoAfterSkip` (the "skip worktree creation" import handoff)
- `activateAndRevealWorktree` (the general reveal path, which the import flow routes through whenever the imported repo has a default checkout — the common case)

`filterRepoIds` is a *show-only-these* allowlist, so emptying it turns the filter off entirely — hence "all repos show up."

**Fix:** reveal the target by **adding its repo id to the active filter** instead of clearing it, through a small shared pure helper (`revealRepoInProjectFilter`) so no future caller can reintroduce the clear-the-filter bug. An empty filter (already all-visible) and an already-selected repo remain no-ops.

Result: after importing, you see your previously filtered projects **plus** the new one — exactly what you'd expect.

## Screenshots

No visual change (behavior fix to existing sidebar filter state). The **Projects** filter simply retains its chips and gains the newly imported project instead of resetting.

## Testing

- [x] `pnpm lint` (oxlint clean on touched files; reliability-gates, max-lines-ratchet, localization extraction/coverage pass)
- [x] `pnpm typecheck`
- [x] `pnpm test` (touched suites: 55 tests pass — `add-repo-skip-finalization`, `worktree-activation`, new `reveal-repo-in-project-filter`)
- [ ] `pnpm build` (not run locally; no build-surface changes — renderer-only logic)
- [x] Added/updated tests: append-to-existing-filter, empty-filter-untouched, already-selected-untouched, an activation-path reveal test, and a focused unit suite for the new pure helper

## AI Review Report

Reviewed with an AI agent (Fable) before and after implementation. Risks checked:

- **Correctness:** `setFilterRepoIds` performs no id validation, so appending is safe even before the repo is registered; the store separately prunes `filterRepoIds` to valid repo ids on every catalog fetch, so any dangling id self-heals. Both guards keep the `length > 0` check so an empty (all-visible) filter is never narrowed, and the `includes` guard prevents duplicates.
- **Scope of the activation-path change:** `activateAndRevealWorktree` is synchronous (no awaits between reading state and the append) and only mutates the filter when the target repo is genuinely filtered out, so Cmd+J jumps / notifications / card clicks to an already-visible repo stay no-ops. The new behavior (add the target's repo) is strictly less destructive than the old (wipe the filter).
- **DRY / regression-proofing:** extracted the guard+append into one pure helper so a third callsite can't reintroduce the bug.
- **Cross-platform (macOS/Linux/Windows):** no platform-specific code, no keyboard shortcuts, no file paths, no shell/Electron-process behavior touched — pure renderer state logic, identical on all three.
- **SSH/remote/local & git provider:** no host-, transport-, or provider-specific logic; operates only on in-memory sidebar filter ids.
- **Performance:** O(n) over the filter id list (typically a handful of repos), on a user action, not a hot path.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The change only recomputes an in-memory array of repo ids for a UI filter. No new attack surface.

## Notes

- No platform-, remote/SSH-, agent-, integration-, or git-provider-specific behavior.
- The `activateAndRevealWorktree` change is a small, intentional, user-visible improvement beyond the strict import path: revealing a worktree in a filtered-out repo now preserves your other filters instead of clearing them.

X handle: happy to add on request.
