### PR TITLE
feat(right-sidebar): add a Linear panel for the workspace's linked issue

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -18,6 +18,10 @@ import {
   WORKTREE_CARD_PROPERTIES
 } from '../../../../shared/worktree-card-properties'
 import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
+import {
+  isStaticRightSidebarTab,
+  type StaticRightSidebarTab
+} from '../../../../shared/right-sidebar-tabs'
 import type { TaskProvider } from '../../../../shared/types'
 import { TaskResumeState } from './task-resume-state-schema'
 import { omitUndefinedValues, tolerateUnknownValues } from './ui-update-value-tolerance'
@@ -30,30 +34,17 @@ const TaskProviderParam = z.custom<TaskProvider>(isTaskProvider, {
 const FeatureTipIds = z.array(z.custom(isFeatureTipId, { message: 'Unknown feature tip id' }))
 const UnknownRecord = z.record(z.string(), z.unknown())
 const UnknownRecordArray = z.array(UnknownRecord)
-type StaticRightSidebarTab = (typeof STATIC_RIGHT_SIDEBAR_TABS)[number]
 // Derived from the shared union so a new card property cannot drift out of the
 // client schema — it previously omitted 'cli' and rejected the whole payload.
 const WorktreeCardPropertyParam = z.enum(WORKTREE_CARD_PROPERTIES)
 const WorktreeCardProperties = z
   .array(WorktreeCardPropertyParam)
   .transform((value) => normalizeWorktreeCardProperties(value))
-const STATIC_RIGHT_SIDEBAR_TABS = [
-  'explorer',
-  'search',
-  'vault',
-  'workspaces',
-  'pr-checks',
-  'source-control',
-  'checks',
-  'ports'
-] as const
 // Plugin panels are open-ended `plugin:<publisher>.<id>/<panel>` keys, so the
 // schema validates their shape rather than enumerating them.
 const RightSidebarTabParam = z.custom<StaticRightSidebarTab | `plugin:${string}`>(
   (value) =>
-    typeof value === 'string' &&
-    (STATIC_RIGHT_SIDEBAR_TABS.includes(value as StaticRightSidebarTab) ||
-      isPluginPanelTabKey(value)),
+    isStaticRightSidebarTab(value) || (typeof value === 'string' && isPluginPanelTabKey(value)),
   { message: 'Unknown right sidebar tab' }
 )
 const AgentActivityDisplayMode = z.enum(['compact', 'full'])

--- a/src/renderer/src/components/right-sidebar/LinearPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/LinearPanel.test.tsx
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { LinearIssue, Worktree } from '../../../../shared/types'
+
+type MockStoreState = {
+  settings: Record<string, unknown>
+  linearStatus: { connected: boolean } | null
+  fetchLinearIssue: (id: string, workspaceId?: string | null) => Promise<LinearIssue | null>
+  refreshLinearIssue: (id: string, workspaceId?: string | null) => Promise<LinearIssue | null>
+}
+
+const testState = vi.hoisted(() => ({
+  activeWorktree: null as Worktree | null,
+  store: {} as MockStoreState,
+  fetchCalls: [] as { id: string; workspaceId?: string | null }[],
+  commentCalls: 0
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: <T,>(selector: (state: MockStoreState) => T): T => selector(testState.store)
+}))
+vi.mock('@/store/selectors', () => ({
+  useActiveWorktree: (): Worktree | null => testState.activeWorktree
+}))
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string): string => fallback
+}))
+vi.mock('@/runtime/runtime-linear-client', () => ({
+  linearIssueComments: async (): Promise<unknown[]> => {
+    testState.commentCalls += 1
+    return []
+  }
+}))
+// The edit section and comment composer own their own Linear mutations; this
+// panel test only covers target resolution, gating, and empty states.
+vi.mock('@/components/LinearItemDrawer', () => ({
+  LinearIssueEditSection: (): React.JSX.Element => <div data-testid="edit-section" />,
+  LinearIssueCommentFooter: (): React.JSX.Element => <div data-testid="comment-footer" />,
+  initLinearIssueEditState: (issue: LinearIssue) => ({
+    state: issue.state,
+    priority: issue.priority,
+    estimate: issue.estimate,
+    assignee: issue.assignee,
+    labelIds: issue.labelIds,
+    labels: issue.labels
+  })
+}))
+vi.mock('@/components/sidebar/CommentMarkdown', () => ({
+  default: ({ content }: { content: string }): React.JSX.Element => <div>{content}</div>
+}))
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const { default: LinearPanel } = await import('./LinearPanel')
+
+function issue(overrides: Partial<LinearIssue> = {}): LinearIssue {
+  return {
+    id: 'issue-uuid',
+    identifier: 'ENG-123',
+    title: 'Ship the sidebar panel',
+    labels: [],
+    labelIds: [],
+    priority: 0,
+    ...overrides
+  } as LinearIssue
+}
+
+function worktree(overrides: Partial<Worktree>): Worktree {
+  return { ...(overrides as Worktree) }
+}
+
+const roots: Root[] = []
+
+function render(props: { isVisible?: boolean } = {}): HTMLDivElement {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  roots.push(root)
+  act(() => {
+    root.render(<LinearPanel {...props} />)
+  })
+  return container
+}
+
+beforeEach(() => {
+  testState.activeWorktree = null
+  testState.fetchCalls = []
+  testState.commentCalls = 0
+  testState.store = {
+    settings: {},
+    linearStatus: { connected: true },
+    fetchLinearIssue: async (id, workspaceId) => {
+      testState.fetchCalls.push({ id, workspaceId })
+      return issue()
+    },
+    refreshLinearIssue: async (id, workspaceId) => {
+      testState.fetchCalls.push({ id, workspaceId })
+      return issue()
+    }
+  }
+})
+
+afterEach(() => {
+  for (const root of roots.splice(0)) {
+    act(() => root.unmount())
+  }
+  document.body.innerHTML = ''
+})
+
+describe('LinearPanel', () => {
+  it('explains itself when the workspace has no linked issue, without fetching', () => {
+    testState.activeWorktree = worktree({ linkedLinearIssue: null })
+    const container = render()
+    expect(container.textContent).toContain('no linked Linear issue')
+    expect(testState.fetchCalls).toHaveLength(0)
+  })
+
+  it('asks the user to connect Linear before trying to fetch', () => {
+    testState.activeWorktree = worktree({ linkedLinearIssue: 'ENG-123' })
+    testState.store.linearStatus = { connected: false }
+    const container = render()
+    expect(container.textContent).toContain('Connect Linear')
+  })
+
+  it('does not fetch while the panel is off screen', () => {
+    testState.activeWorktree = worktree({ linkedLinearIssue: 'ENG-123' })
+    render({ isVisible: false })
+    expect(testState.fetchCalls).toHaveLength(0)
+    expect(testState.commentCalls).toBe(0)
+  })
+
+  it('renders the linked issue and its comment composer once visible', async () => {
+    testState.activeWorktree = worktree({
+      linkedLinearIssue: 'ENG-123',
+      linkedLinearIssueWorkspaceId: 'ws-1'
+    })
+    const container = render({ isVisible: true })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(testState.fetchCalls).toEqual([{ id: 'ENG-123', workspaceId: 'ws-1' }])
+    expect(container.textContent).toContain('Ship the sidebar panel')
+    expect(container.querySelector('[data-testid="edit-section"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="comment-footer"]')).not.toBeNull()
+  })
+
+  it('looks across workspaces when the link predates multi-workspace support', async () => {
+    testState.activeWorktree = worktree({ linkedLinearIssue: 'ENG-9' })
+    render({ isVisible: true })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(testState.fetchCalls).toEqual([{ id: 'ENG-9', workspaceId: 'all' }])
+  })
+
+  it('reports an unavailable issue instead of rendering an empty panel', async () => {
+    testState.activeWorktree = worktree({ linkedLinearIssue: 'ENG-123' })
+    testState.store.fetchLinearIssue = async () => null
+    const container = render({ isVisible: true })
+    await act(async () => {
+      await Promise.resolve()
+    })
+    expect(container.textContent).toContain('unavailable')
+  })
+})

--- a/src/renderer/src/components/right-sidebar/LinearPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/LinearPanel.tsx
@@ -1,0 +1,318 @@
+import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { ExternalLink, LoaderCircle, RefreshCw } from 'lucide-react'
+import { useAppStore } from '@/store'
+import { useActiveWorktree } from '@/store/selectors'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { Button } from '@/components/ui/button'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '@/components/ui/tooltip'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import { linearIssueComments } from '@/runtime/runtime-linear-client'
+import { formatUiRelativeTimeFromDate } from '@/i18n/relative-time-format'
+import CommentMarkdown from '@/components/sidebar/CommentMarkdown'
+import {
+  LinearIssueCommentFooter,
+  LinearIssueEditSection,
+  initLinearIssueEditState,
+  type LinearEditState,
+  type LinearLocalComment
+} from '@/components/LinearItemDrawer'
+import type { LinearComment, LinearIssue } from '../../../../shared/types'
+import { getLinearIssueBrowserUrl, getLinearPanelTarget } from './linear-panel-target'
+
+type LinearPanelProps = {
+  isVisible?: boolean
+}
+
+/**
+ * Per-worktree view of the workspace's linked Linear issue. Data comes from the
+ * same store cache the sidebar cards use, so opening the panel on an already
+ * rendered worktree is usually a cache hit.
+ */
+export default function LinearPanel({ isVisible = true }: LinearPanelProps): React.JSX.Element {
+  const activeWorktree = useActiveWorktree()
+  const settings = useAppStore((s) => s.settings)
+  const linearStatus = useAppStore((s) => s.linearStatus)
+  const fetchLinearIssue = useAppStore((s) => s.fetchLinearIssue)
+  const refreshLinearIssue = useAppStore((s) => s.refreshLinearIssue)
+
+  const target = useMemo(() => getLinearPanelTarget(activeWorktree), [activeWorktree])
+  const targetKey = target ? `${target.workspaceId}::${target.identifier}` : null
+
+  const [issue, setIssue] = useState<LinearIssue | null>(null)
+  const [issueLoading, setIssueLoading] = useState(false)
+  const [issueError, setIssueError] = useState<string | null>(null)
+  const [comments, setComments] = useState<LinearComment[]>([])
+  const [commentsLoading, setCommentsLoading] = useState(false)
+  const [editState, setEditState] = useState<LinearEditState | null>(null)
+  const requestIdRef = useRef(0)
+  const hydratedKeyRef = useRef<string | null>(null)
+  // Why: a late fetch must not clobber fields the user just edited optimistically.
+  const hasEditedRef = useRef(false)
+  const optimisticCommentsRef = useRef<LinearComment[]>([])
+  const mountedRef = useMountedRef()
+
+  const handleEditStateChange = useCallback((patch: Partial<LinearEditState>) => {
+    hasEditedRef.current = true
+    setIssue((prev) => (prev ? { ...prev, ...patch } : prev))
+    setEditState((prev) => (prev ? { ...prev, ...patch } : prev))
+  }, [])
+
+  const handleCommentAdded = useCallback((comment: LinearLocalComment) => {
+    const local: LinearComment = {
+      id: comment.id,
+      body: comment.body,
+      createdAt: comment.createdAt
+    }
+    optimisticCommentsRef.current = [...optimisticCommentsRef.current, local]
+    setComments((prev) => [...prev, local])
+  }, [])
+
+  const load = useCallback(
+    async (force: boolean): Promise<void> => {
+      if (!target) {
+        return
+      }
+      requestIdRef.current += 1
+      const requestId = requestIdRef.current
+      hasEditedRef.current = false
+      if (force) {
+        optimisticCommentsRef.current = []
+      }
+      setIssueLoading(true)
+      setIssueError(null)
+
+      const fetched = await (force
+        ? refreshLinearIssue(target.identifier, target.workspaceId)
+        : fetchLinearIssue(target.identifier, target.workspaceId))
+      if (!mountedRef.current || requestId !== requestIdRef.current) {
+        return
+      }
+      if (!fetched) {
+        setIssue(null)
+        setEditState(null)
+        setIssueLoading(false)
+        setIssueError(
+          translate(
+            'auto.components.right.sidebar.LinearPanel.issueUnavailable',
+            'Linear issue details unavailable.'
+          )
+        )
+        return
+      }
+      setIssue(fetched)
+      if (!hasEditedRef.current) {
+        setEditState(initLinearIssueEditState(fetched))
+      }
+      setIssueLoading(false)
+
+      // Why: comments are a separate surface; a comments failure must not blank
+      // the issue detail that already loaded.
+      setCommentsLoading(true)
+      try {
+        const list = (await linearIssueComments(
+          settings,
+          fetched.id,
+          fetched.workspaceId
+        )) as LinearComment[]
+        if (!mountedRef.current || requestId !== requestIdRef.current) {
+          return
+        }
+        const optimistic = optimisticCommentsRef.current
+        const known = new Set(list.map((comment) => comment.id))
+        setComments([...list, ...optimistic.filter((comment) => !known.has(comment.id))])
+      } catch {
+        /* Keep the issue detail; the comment thread simply stays empty. */
+      } finally {
+        if (mountedRef.current && requestId === requestIdRef.current) {
+          setCommentsLoading(false)
+        }
+      }
+    },
+    [fetchLinearIssue, mountedRef, refreshLinearIssue, settings, target]
+  )
+
+  // One effect owns hydration so a switch always clears before it fetches.
+  // Why the hydrated key: `load` changes identity whenever settings do, and
+  // re-running would reset the edit guard and clobber a just-made edit.
+  // Why gate on isVisible: panels stay mounted while the sidebar is closed, so
+  // an ungated fetch would hit Linear for every worktree the user passes through.
+  useEffect(() => {
+    if (hydratedKeyRef.current === targetKey) {
+      return
+    }
+    // Drop the previous worktree's issue immediately: showing the old ticket
+    // under the new workspace is worse than showing nothing.
+    requestIdRef.current += 1
+    setIssue(null)
+    setEditState(null)
+    setComments([])
+    setIssueError(null)
+    optimisticCommentsRef.current = []
+
+    if (!isVisible || !targetKey) {
+      hydratedKeyRef.current = null
+      return
+    }
+    hydratedKeyRef.current = targetKey
+    void load(false)
+  }, [isVisible, targetKey, load])
+
+  const browserUrl = target ? getLinearIssueBrowserUrl(target, issue?.url) : null
+
+  if (!target) {
+    return (
+      <PanelMessage>
+        {translate(
+          'auto.components.right.sidebar.LinearPanel.noLinkedIssue',
+          'This workspace has no linked Linear issue.'
+        )}
+      </PanelMessage>
+    )
+  }
+
+  if (!linearStatus?.connected) {
+    return (
+      <PanelMessage>
+        {translate(
+          'auto.components.right.sidebar.LinearPanel.notConnected',
+          'Connect Linear in Settings to see this issue.'
+        )}
+      </PanelMessage>
+    )
+  }
+
+  return (
+    <div className="flex min-h-0 flex-1 flex-col">
+      <div className="flex h-[36px] shrink-0 items-center gap-2 border-b border-border/60 px-3">
+        <span className="truncate font-mono text-xs text-muted-foreground">
+          {target.identifier}
+        </span>
+        {/* Panel content sits outside the sidebar chrome's provider, so each
+            panel supplies its own (matching PortsPanel). */}
+        <TooltipProvider delayDuration={400}>
+          <div className="ml-auto flex items-center gap-1">
+            {browserUrl ? (
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <Button
+                    variant="ghost"
+                    size="icon"
+                    className="size-6"
+                    onClick={() => void window.api.shell.openUrl(browserUrl)}
+                  >
+                    <ExternalLink size={13} />
+                  </Button>
+                </TooltipTrigger>
+                <TooltipContent>
+                  {translate(
+                    'auto.components.right.sidebar.LinearPanel.openInLinear',
+                    'Open in Linear'
+                  )}
+                </TooltipContent>
+              </Tooltip>
+            ) : null}
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="size-6"
+                  disabled={issueLoading}
+                  onClick={() => void load(true)}
+                >
+                  <RefreshCw size={13} className={cn(issueLoading && 'animate-spin')} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent>
+                {translate('auto.components.right.sidebar.LinearPanel.refresh', 'Refresh')}
+              </TooltipContent>
+            </Tooltip>
+          </div>
+        </TooltipProvider>
+      </div>
+
+      {issueLoading && !issue ? (
+        <PanelMessage>
+          <LoaderCircle size={14} className="animate-spin" />
+        </PanelMessage>
+      ) : null}
+
+      {!issue && issueError ? <PanelMessage>{issueError}</PanelMessage> : null}
+
+      {issue && editState ? (
+        <div className="min-h-0 flex-1 overflow-y-auto scrollbar-sleek">
+          <div className="px-3 py-3">
+            <h2 className="text-sm font-semibold leading-snug text-foreground">{issue.title}</h2>
+          </div>
+
+          <div className="border-t border-border/60 px-3 py-3">
+            <LinearIssueEditSection
+              issue={issue}
+              editState={editState}
+              onEditStateChange={handleEditStateChange}
+              layout="properties"
+            />
+          </div>
+
+          {issue.description ? (
+            <div className="border-t border-border/60 px-3 py-3">
+              <CommentMarkdown content={issue.description} className="text-[13px] leading-6" />
+            </div>
+          ) : null}
+
+          <div className="border-t border-border/60 px-3 py-3">
+            <div className="mb-2 flex items-center gap-2 text-xs font-medium text-muted-foreground">
+              {translate('auto.components.right.sidebar.LinearPanel.comments', 'Comments')}
+              {commentsLoading ? <LoaderCircle size={12} className="animate-spin" /> : null}
+            </div>
+            {comments.length > 0 ? (
+              <div className="flex flex-col gap-3">
+                {comments.map((comment) => (
+                  <article key={comment.id} className="min-w-0">
+                    <div className="mb-1 flex min-w-0 items-center gap-2 text-xs">
+                      <span className="truncate font-medium text-foreground">
+                        {comment.user?.displayName ??
+                          translate(
+                            'auto.components.right.sidebar.LinearPanel.unknownAuthor',
+                            'Unknown'
+                          )}
+                      </span>
+                      <span className="shrink-0 text-muted-foreground">
+                        {formatUiRelativeTimeFromDate(comment.createdAt)}
+                      </span>
+                    </div>
+                    <div className="rounded-lg border border-border/60 bg-card px-3 py-2">
+                      <CommentMarkdown content={comment.body} className="text-[13px] leading-6" />
+                    </div>
+                  </article>
+                ))}
+              </div>
+            ) : !commentsLoading ? (
+              <p className="text-xs text-muted-foreground">
+                {translate('auto.components.right.sidebar.LinearPanel.noComments', 'No comments')}
+              </p>
+            ) : null}
+
+            <div className="mt-3">
+              <LinearIssueCommentFooter
+                issueId={issue.id}
+                workspaceId={issue.workspaceId}
+                onCommentAdded={handleCommentAdded}
+                variant="compact"
+              />
+            </div>
+          </div>
+        </div>
+      ) : null}
+    </div>
+  )
+}
+
+function PanelMessage({ children }: { children: React.ReactNode }): React.JSX.Element {
+  return (
+    <div className="flex flex-1 items-center justify-center gap-2 px-4 text-center text-xs text-muted-foreground">
+      {children}
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
+++ b/src/renderer/src/components/right-sidebar/activity-bar-buttons.tsx
@@ -25,6 +25,8 @@ export type ActivityBarItem = {
   folderOnly?: boolean
   /** When true, shown only for worktrees that belong to an SSH repo. */
   sshOnly?: boolean
+  /** When true, shown only for workspaces that have a linked Linear issue. */
+  linearOnly?: boolean
   /** Host-owned health indicator; plugin content cannot style this chrome. */
   statusIndicator?: CheckStatus
 }

--- a/src/renderer/src/components/right-sidebar/index.tsx
+++ b/src/renderer/src/components/right-sidebar/index.tsx
@@ -47,6 +47,7 @@ import { RightSidebarPanelContent } from './right-sidebar-panel-content'
 import { useMeasuredWidth } from './right-sidebar-measured-width'
 import { normalizeRightSidebarRoute } from '@/store/right-sidebar-route'
 import { AgentSessionHistoryIcon } from './agent-session-history-icon'
+import { LinearIcon } from '@/components/icons/LinearIcon'
 import { resolveRightSidebarEffectiveTab } from './right-sidebar-effective-tab'
 import {
   isPairedWebClientWindow,
@@ -90,6 +91,7 @@ function RightSidebarInner(): React.JSX.Element {
   const isFolderWorkspace = activeWorkspaceScope?.type === 'folder'
   const isFolder = isFolderWorkspace || (activeRepo ? isFolderRepo(activeRepo) : false)
   const isSshRepo = Boolean(activeRepo?.connectionId)
+  const hasLinkedLinearIssue = Boolean(activeWorktree?.linkedLinearIssue)
   const pluginSystemEnabled = useAppStore((s) => s.settings?.pluginSystemEnabled === true)
   const pluginPanels = usePluginPanels()
   const visiblePluginPanels = useMemo(
@@ -156,6 +158,13 @@ function RightSidebarInner(): React.JSX.Element {
         shortcut: portsShortcut === 'Unassigned' ? '' : portsShortcut,
         sshOnly: true
       },
+      {
+        id: 'linear',
+        icon: LinearIcon,
+        title: translate('auto.components.right.sidebar.index.linearIssue', 'Linear issue'),
+        shortcut: '',
+        linearOnly: true
+      },
       // Why: plugin panels append after the built-in tabs so core navigation
       // keeps stable positions regardless of which plugins are installed.
       ...getPluginPanelActivityItems(visiblePluginPanels, pluginPanelErrors)
@@ -175,9 +184,10 @@ function RightSidebarInner(): React.JSX.Element {
       getVisibleRightSidebarActivityItems(activityItems, {
         isFolder,
         isFolderWorkspace,
-        isSshRepo
+        isSshRepo,
+        hasLinkedLinearIssue
       }),
-    [activityItems, isFolder, isFolderWorkspace, isSshRepo]
+    [activityItems, isFolder, isFolderWorkspace, isSshRepo, hasLinkedLinearIssue]
   )
 
   const rememberedFolderTabByWorkspaceKeyRef = useRef<Record<string, ActiveRightSidebarTab>>({})

--- a/src/renderer/src/components/right-sidebar/linear-panel-target.test.ts
+++ b/src/renderer/src/components/right-sidebar/linear-panel-target.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import { getLinearIssueBrowserUrl, getLinearPanelTarget } from './linear-panel-target'
+
+function worktree(overrides: Partial<Worktree>): Worktree {
+  return { ...(overrides as Worktree) }
+}
+
+describe('getLinearPanelTarget', () => {
+  it('returns null when the worktree has no linked Linear issue', () => {
+    expect(getLinearPanelTarget(null)).toBeNull()
+    expect(getLinearPanelTarget(worktree({ linkedLinearIssue: null }))).toBeNull()
+  })
+
+  it('carries the recorded workspace id', () => {
+    expect(
+      getLinearPanelTarget(
+        worktree({ linkedLinearIssue: 'ENG-123', linkedLinearIssueWorkspaceId: 'ws-1' })
+      )
+    ).toEqual({ identifier: 'ENG-123', workspaceId: 'ws-1', organizationUrlKey: null })
+  })
+
+  it('falls back to every workspace when the link predates multi-workspace support', () => {
+    expect(getLinearPanelTarget(worktree({ linkedLinearIssue: 'ENG-9' }))?.workspaceId).toBe('all')
+    expect(
+      getLinearPanelTarget(
+        worktree({ linkedLinearIssue: 'ENG-9', linkedLinearIssueWorkspaceId: '' })
+      )?.workspaceId
+    ).toBe('all')
+  })
+})
+
+describe('getLinearIssueBrowserUrl', () => {
+  const target = { identifier: 'ENG-123', workspaceId: 'ws-1', organizationUrlKey: 'acme' }
+
+  it('prefers the url the fetched issue carries', () => {
+    expect(getLinearIssueBrowserUrl(target, 'https://linear.app/acme/issue/ENG-123/title')).toBe(
+      'https://linear.app/acme/issue/ENG-123/title'
+    )
+  })
+
+  it('builds a url from the recorded org key before the issue hydrates', () => {
+    expect(getLinearIssueBrowserUrl(target)).toBe('https://linear.app/acme/issue/ENG-123')
+  })
+
+  it('returns null when no org key was ever recorded', () => {
+    expect(getLinearIssueBrowserUrl({ ...target, organizationUrlKey: null })).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/linear-panel-target.ts
+++ b/src/renderer/src/components/right-sidebar/linear-panel-target.ts
@@ -1,0 +1,45 @@
+import type { Worktree } from '../../../../shared/types'
+
+/** The linked Linear issue a panel should render, resolved from a worktree. */
+export type LinearPanelTarget = {
+  /** Human identifier (e.g. `ENG-123`); the Linear SDK resolves it like a uuid. */
+  identifier: string
+  /** Concrete Linear workspace, or 'all' when the worktree never recorded one. */
+  workspaceId: string
+  organizationUrlKey: string | null
+}
+
+/**
+ * Why 'all': worktrees linked before multi-workspace support (and those created
+ * from a search across workspaces) carry no workspace id, and a narrowed lookup
+ * would miss the issue entirely. Matches how WorktreeCard resolves the link.
+ */
+export function getLinearPanelTarget(
+  worktree: Worktree | null | undefined
+): LinearPanelTarget | null {
+  const identifier = worktree?.linkedLinearIssue
+  if (!identifier) {
+    return null
+  }
+  return {
+    identifier,
+    workspaceId: worktree?.linkedLinearIssueWorkspaceId || 'all',
+    organizationUrlKey: worktree?.linkedLinearIssueOrganizationUrlKey ?? null
+  }
+}
+
+/**
+ * Offline URL builder: the fetched issue carries its own url, but the panel has
+ * to offer "open in Linear" before hydration and while the fetch is failing.
+ */
+export function getLinearIssueBrowserUrl(
+  target: LinearPanelTarget,
+  fetchedUrl?: string | null
+): string | null {
+  if (fetchedUrl) {
+    return fetchedUrl
+  }
+  return target.organizationUrlKey
+    ? `https://linear.app/${encodeURIComponent(target.organizationUrlKey)}/issue/${encodeURIComponent(target.identifier)}`
+    : null
+}

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.test.ts
@@ -27,6 +27,7 @@ const items: ActivityBarItem[] = [
     gitOnly: true
   },
   { id: 'ports', icon: Files, title: 'Ports', shortcut: '', sshOnly: true },
+  { id: 'linear', icon: Files, title: 'Linear issue', shortcut: '', linearOnly: true },
   // Plugin panels carry no visibility flags, so they show in every context.
   {
     id: 'plugin:orca-samples.my-plugin/dashboard',
@@ -42,7 +43,8 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: false,
         isFolderWorkspace: false,
-        isSshRepo: false
+        isSshRepo: false,
+        hasLinkedLinearIssue: false
       }).map((item) => item.id)
     ).toEqual(['explorer', 'source-control', 'plugin:orca-samples.my-plugin/dashboard'])
 
@@ -50,7 +52,8 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: false,
         isFolderWorkspace: false,
-        isSshRepo: true
+        isSshRepo: true,
+        hasLinkedLinearIssue: false
       }).map((item) => item.id)
     ).toEqual(['explorer', 'source-control', 'ports', 'plugin:orca-samples.my-plugin/dashboard'])
   })
@@ -60,7 +63,8 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: true,
         isFolderWorkspace: true,
-        isSshRepo: true
+        isSshRepo: true,
+        hasLinkedLinearIssue: false
       }).map((item) => item.id)
     ).toEqual([
       'explorer',
@@ -74,8 +78,31 @@ describe('getVisibleRightSidebarActivityItems', () => {
       getVisibleRightSidebarActivityItems(items, {
         isFolder: true,
         isFolderWorkspace: false,
-        isSshRepo: true
+        isSshRepo: true,
+        hasLinkedLinearIssue: false
       }).map((item) => item.id)
     ).toEqual(['explorer', 'ports', 'plugin:orca-samples.my-plugin/dashboard'])
+  })
+
+  it('shows the Linear tab only when the workspace has a linked issue', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, {
+        isFolder: false,
+        isFolderWorkspace: false,
+        isSshRepo: false,
+        hasLinkedLinearIssue: true
+      }).map((item) => item.id)
+    ).toEqual(['explorer', 'source-control', 'linear', 'plugin:orca-samples.my-plugin/dashboard'])
+  })
+
+  it('keeps the Linear tab available for folder workspaces and SSH repos', () => {
+    expect(
+      getVisibleRightSidebarActivityItems(items, {
+        isFolder: true,
+        isFolderWorkspace: true,
+        isSshRepo: true,
+        hasLinkedLinearIssue: true
+      }).map((item) => item.id)
+    ).toContain('linear')
   })
 })

--- a/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-activity-visibility.ts
@@ -4,11 +4,17 @@ type RightSidebarActivityVisibilityState = {
   isFolder: boolean
   isFolderWorkspace: boolean
   isSshRepo: boolean
+  hasLinkedLinearIssue: boolean
 }
 
 export function getVisibleRightSidebarActivityItems(
   items: ActivityBarItem[],
-  { isFolder, isFolderWorkspace, isSshRepo }: RightSidebarActivityVisibilityState
+  {
+    isFolder,
+    isFolderWorkspace,
+    isSshRepo,
+    hasLinkedLinearIssue
+  }: RightSidebarActivityVisibilityState
 ): ActivityBarItem[] {
   return items.filter((item) => {
     if (item.gitOnly && isFolder) {
@@ -18,6 +24,9 @@ export function getVisibleRightSidebarActivityItems(
       return false
     }
     if (item.sshOnly && !isSshRepo) {
+      return false
+    }
+    if (item.linearOnly && !hasLinkedLinearIssue) {
       return false
     }
     return true

--- a/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/right-sidebar-panel-content.tsx
@@ -10,6 +10,7 @@ const PortsPanel = lazy(() => import('./PortsPanel'))
 const AiVaultPanel = lazy(() => import('./AiVaultPanel'))
 const FolderWorkspaceWorktreesPanel = lazy(() => import('./FolderWorkspaceWorktreesPanel'))
 const FolderWorkspacePrChecksPanel = lazy(() => import('./FolderWorkspacePrChecksPanel'))
+const LinearPanel = lazy(() => import('./LinearPanel'))
 const PluginPanel = lazy(() => import('./PluginPanel'))
 
 type RightSidebarPanelContentProps = {
@@ -34,6 +35,11 @@ export function RightSidebarPanelContent({
           <PortsPanel isVisible={rightSidebarOpen && effectiveTab === 'ports'} />
         )}
         {effectiveTab === 'vault' && <AiVaultPanel />}
+        {/* Why isVisible: the panel stays mounted while the sidebar is closed,
+            so issue and comment fetches are gated on it being on screen. */}
+        {effectiveTab === 'linear' && (
+          <LinearPanel isVisible={rightSidebarOpen && effectiveTab === 'linear'} />
+        )}
         {effectiveTab === 'workspaces' && <FolderWorkspaceWorktreesPanel />}
         {effectiveTab === 'pr-checks' && (
           <FolderWorkspacePrChecksPanel

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11151,7 +11151,8 @@
             "fc3095d2ed": "explorer",
             "aiVaultSessionHistory": "Agents",
             "folderWorkspaces": "Attached worktrees",
-            "parentPrChecks": "PR Checks"
+            "parentPrChecks": "PR Checks",
+            "linearIssue": "Linear issue"
           },
           "right": {
             "panel": {
@@ -11607,6 +11608,16 @@
             "mayBeSlower": "May be slower",
             "slowest": "Slowest",
             "unlimited": "Unlimited"
+          },
+          "LinearPanel": {
+            "issueUnavailable": "Linear issue details unavailable.",
+            "noLinkedIssue": "This workspace has no linked Linear issue.",
+            "notConnected": "Connect Linear in Settings to see this issue.",
+            "openInLinear": "Open in Linear",
+            "refresh": "Refresh",
+            "comments": "Comments",
+            "unknownAuthor": "Unknown",
+            "noComments": "No comments"
           }
         }
       },

--- a/src/renderer/src/store/right-sidebar-route.test.ts
+++ b/src/renderer/src/store/right-sidebar-route.test.ts
@@ -9,6 +9,13 @@ describe('normalizeRightSidebarRoute', () => {
     })
   })
 
+  it('preserves the Linear issue route across a restart', () => {
+    expect(normalizeRightSidebarRoute('linear')).toEqual({
+      rightSidebarTab: 'linear',
+      rightSidebarExplorerView: 'files'
+    })
+  })
+
   it('still normalizes invalid tabs to Explorer files', () => {
     expect(normalizeRightSidebarRoute('missing')).toEqual({
       rightSidebarTab: 'explorer',

--- a/src/renderer/src/store/right-sidebar-route.ts
+++ b/src/renderer/src/store/right-sidebar-route.ts
@@ -1,5 +1,6 @@
 import type { ActiveRightSidebarTab, RightSidebarExplorerView } from '../../../shared/types'
 import { isPluginPanelTabKey } from '../../../shared/plugins/plugin-manifest'
+import { isActiveStaticRightSidebarTab } from '../../../shared/right-sidebar-tabs'
 
 export type RightSidebarRoute = {
   rightSidebarTab: ActiveRightSidebarTab
@@ -36,15 +37,8 @@ export function normalizeRightSidebarRoute(
     }
     return { rightSidebarTab: tab, rightSidebarExplorerView: 'files' }
   }
-  if (
-    tab === 'explorer' ||
-    tab === 'vault' ||
-    tab === 'workspaces' ||
-    tab === 'pr-checks' ||
-    tab === 'source-control' ||
-    tab === 'checks' ||
-    tab === 'ports'
-  ) {
+  // 'search' is handled above; every other static tab is a valid route.
+  if (isActiveStaticRightSidebarTab(tab)) {
     return {
       rightSidebarTab: tab,
       rightSidebarExplorerView:

--- a/src/shared/right-sidebar-tabs.ts
+++ b/src/shared/right-sidebar-tabs.ts
@@ -1,0 +1,36 @@
+import type { RightSidebarTab } from './types'
+
+/**
+ * Every non-plugin right-sidebar tab. Lives in shared so the renderer's route
+ * normalizer and the runtime RPC client schema read one list — a tab added in
+ * only one of them is the drift the ui-state parity assertions exist to catch.
+ * Plugin panels are open-ended `plugin:<publisher>.<id>/<panel>` keys and are
+ * validated by shape instead.
+ */
+export const STATIC_RIGHT_SIDEBAR_TABS = [
+  'explorer',
+  'search',
+  'vault',
+  'workspaces',
+  'pr-checks',
+  'source-control',
+  'checks',
+  'ports',
+  'linear'
+] as const satisfies readonly Exclude<RightSidebarTab, `plugin:${string}`>[]
+
+export type StaticRightSidebarTab = (typeof STATIC_RIGHT_SIDEBAR_TABS)[number]
+
+export function isStaticRightSidebarTab(value: unknown): value is StaticRightSidebarTab {
+  return (
+    typeof value === 'string' && (STATIC_RIGHT_SIDEBAR_TABS as readonly string[]).includes(value)
+  )
+}
+
+/** Static tabs a panel can actually be showing. 'search' is a legacy persisted
+ *  value that resolves to Explorer's search view, never to a tab of its own. */
+export function isActiveStaticRightSidebarTab(
+  value: unknown
+): value is Exclude<StaticRightSidebarTab, 'search'> {
+  return isStaticRightSidebarTab(value) && value !== 'search'
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3339,6 +3339,7 @@ export type RightSidebarTab =
   | 'source-control'
   | 'checks'
   | 'ports'
+  | 'linear'
   // Plugin-contributed panels are keyed `plugin:<pluginId>/<panelId>` so the
   // static union stays closed while plugin tabs remain type-representable.
   | `plugin:${string}`


### PR DESCRIPTION
Closes #12693 (filed first to ask where you'd want this — happy to rework or drop it if the answer is "not like that").

## Summary

Adds a **`linear` right-sidebar tab** that shows the active workspace's linked Linear issue: title, properties (state, assignee, priority, estimate, labels), description, and the comment thread with a composer.

Orca already links a worktree to a Linear issue, but once you're working in that workspace the ticket only appears as identifier + title + state on the sidebar card. Reading the description, checking status, or leaving a comment means going to the browser. With several agent workspaces open at once, each ticket lives in a different tab you have to keep paired with the right workspace by hand. This puts the ticket where the work is.

The tab only appears when the workspace has a linked issue, via a `linearOnly` visibility flag alongside the existing `gitOnly` / `folderOnly` / `sshOnly` predicates.

**No new data layer.** It composes the already-exported `LinearIssueEditSection` (`layout="properties"`) and `LinearIssueCommentFooter` (`variant="compact"`) from `LinearItemDrawer` over the store's existing `fetchLinearIssue` / `refreshLinearIssue` and `runtime-linear-client`, so local and SSH/remote workspaces are both covered by routing that already exists. `LinearIssueWorkspace` is already a second consumer of those exports; this is a third, narrower one. Mutations (state, assignee, comment) therefore go through the same optimistic-update and revert paths as the drawer.

One refactor came along for the ride: the static tab list moved to `src/shared/right-sidebar-tabs.ts` so the renderer route normalizer and the runtime RPC client schema read **one** source. Adding a tab to only one of them is exactly the drift the `ui-state-schema-parity-checks` assertions were added to catch — that guard caught me during this change, which is what prompted the move. It also kept `client-ui-schemas.ts` under the `max-lines` cap without a suppression.

## Screenshots

**None, and I want to be upfront about why rather than quietly skip the section.** This surface only renders against a connected Linear workspace with a linked issue, and I couldn't produce a screenshot that wasn't either a mock or full of a real workspace's ticket data. So this PR is **verified by types, lint, tests and a clean build, not by a visual pass on my side** — please treat the visual review as outstanding. If you want it, tell me which of these you'd prefer and I'll follow up: a recording against a throwaway Linear workspace, or a fixture-driven story if you have a preferred harness for that.

The layout deliberately borrows structure rather than inventing any: a 36px header row matching the other panels, `scrollbar-sleek` on the scroll container per the lint rule, and all spacing/colour from existing tokens. No new colour values, font sizes, or shadow tiers.

## Testing

- [x] `pnpm lint` — clean (including the localization catalog, extraction, coverage, and max-lines ratchet gates; the 9 new keys were added via `pnpm run sync:localization-catalog`)
- [x] `pnpm typecheck` — clean across all three projects
- [x] `pnpm test` — ran the affected areas rather than the whole suite: `src/renderer/src/components/right-sidebar/`, `src/renderer/src/store/`, `src/main/runtime/rpc/`, `src/shared/` → **9214 passed, 17 skipped, 2 failed**. Both failures are timing/perf assertions (`terminal-output-frame-chunks-equivalence`, `ai-vault-session-worktree-map`) that pass in isolation both with and without this change — they're load flakes on my machine under a parallel run, not regressions. Called out rather than hidden in case they're known to you.
- [x] `pnpm build` (`build:desktop`) — exit 0
- [x] Added tests

New tests: `linear-panel-target.test.ts` (target resolution, the `'all'` workspace fallback for links that predate multi-workspace support, offline URL building) and `LinearPanel.test.tsx` (no-linked-issue and not-connected empty states, no fetching while off screen, the fetch/render path, and the unavailable-issue path). Extended `right-sidebar-activity-visibility.test.ts` and `right-sidebar-route.test.ts` for the new tab and flag.

## AI Review Report

Reviewed with an AI agent against this repo's `AGENTS.md` and `CONTRIBUTING.md`. What it checked and what actually changed as a result:

- **Cross-platform (macOS / Linux / Windows).** No `e.metaKey`, no keyboard shortcut, no accelerator, no shortcut label, no path handling, no shell invocation, no platform-conditional code anywhere in this diff. The one platform-touching call is `window.api.shell.openUrl` for "open in Linear", which is the existing Electron-mediated helper used elsewhere in the renderer. **Flagged and fixed:** I first wrote `window.api.openExternal`, which does not exist — typecheck caught it and it now matches the `shell.openUrl` helper other components use.
- **SSH / remote / local.** All reads and writes go through `runtime-linear-client`, which routes to the runtime RPC surface for remote environments and to local IPC otherwise, so SSH-backed workspaces are covered without special-casing. No assumption of local processes, files, or credentials.
- **Folder workspaces.** The panel keys off `linkedLinearIssue`, which `folderWorkspaceToWorktree` populates from `linkedTask.linearIdentifier`, so folder workspaces work; the visibility flag is orthogonal to `gitOnly`/`folderOnly`, and there's a test asserting the tab survives for folder and SSH scopes.
- **Remote wire compatibility.** This was the main risk it raised. `linear` is a new *value* on the existing `UiUpdate.rightSidebarTab` field, not a new field or opcode. Traced the decode path: `UiUpdate` wraps its shape in `tolerateUnknownValues`, so an older host drops the unrecognized value and still applies the rest of the batch. A newer client paired to an older host degrades to the stored tab rather than losing the whole UI-state write. Rule 1 by that doc's framing, no negotiation needed.
- **Performance.** Panels stay mounted while the sidebar is closed, so fetches are gated on `isVisible` (the `ChecksPanel` pattern) — otherwise passing through worktrees would hit Linear for each one. Reads go through the store's cache with its existing TTL and in-flight dedup, so opening the panel on an already-rendered worktree is usually a cache hit.
- **Correctness.** Two real bugs found in self-review and fixed before this PR: (1) the fetch effect depended on `load`, whose identity changes with `settings`, so it could re-run and reset the optimistic-edit guard, clobbering a just-made edit — now keyed on a hydration ref, and clearing and fetching live in one effect so a workspace switch can't race them; (2) the panel used `Tooltip` without a `TooltipProvider` — panel content sits outside the sidebar chrome's provider, so it would have thrown at runtime. `PortsPanel` supplies its own for the same reason; this now does too. A component test covers the render path that would have caught it.
- **Repo conventions.** Comments kept to one-line "why not how"; no `max-lines` suppression added (fixed by extraction instead, per the explicit rule); no vague module names; `.ts` not `.d.ts`; all user-facing strings routed through `translate` with catalog entries.

## Security Audit

Low surface: renderer-only UI over an integration that already exists.

- **Secrets / auth.** No token is read, stored, logged, or passed through this code. Linear credentials stay in the main process behind the existing IPC and runtime RPC boundaries; the panel only ever sees mapped issue data.
- **IPC.** No new IPC channel, handler, or preload surface. The one schema change widens an existing enum on an existing channel; it does not add a route or loosen validation, and `.strict()` on unknown keys is untouched.
- **Input handling / injection.** Issue description and comment bodies render through the existing `CommentMarkdown` component rather than any raw HTML path — no `dangerouslySetInnerHTML` introduced. The externally-opened URL is either the URL Linear itself returned or one built from the stored org key and identifier with both segments `encodeURIComponent`-wrapped (matching `WorktreeCard`), so a hostile identifier can't break out of the path.
- **Command execution / paths / dependencies.** None, none, and no new dependency.
- **Follow-up:** none identified.

## Notes

- **Two design calls I'd rather you make than have me assume**, both raised in #12693 and both cheap to change:
  1. **Hidden vs always-visible.** I went with hiding the tab when there's no linked issue, since that matches how `ports` and `pr-checks` behave. The trade-off is discoverability: someone who's never linked an issue will never see the tab exists. If you'd rather it always showed with an empty state that offers to link one, that's a small change to the flag.
  2. **Provider-specific vs generic.** `CONTRIBUTING.md` asks that generic behavior stay provider-neutral, and a `linear` tab is not that. The generic version is an **"Issue"** tab driven by `WorkspaceLinkedItem.provider` (which already carries the discriminator) with Linear as the first implementation and GitHub/GitLab/Jira later. I didn't build that because it's a materially bigger surface and I didn't want to presume the direction — but I think it's the better shape, and I'm happy to rework this into it.
- No visual change to any existing surface; the tab is additive and hidden for workspaces without a linked issue.
- No release/version changes included, per the contributing guide.
- I don't have an X handle to shout out, so nothing needed there.
