### PR TITLE
fix(agents): stop the wake sweep from forking sessions that live SSH panes still own

### DIFF
--- a/src/renderer/src/lib/resume-sleeping-agent-session-live-ssh-dedupe.test.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session-live-ssh-dedupe.test.ts
@@ -1,0 +1,128 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
+import { makePaneKey } from '../../../shared/stable-pane-id'
+import { useAppStore } from '@/store'
+import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+
+const initialAppStoreState = useAppStore.getState()
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const OTHER_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+const SSH_PTY_ID = 'ssh:ssh-target-1@@pty-3'
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+  useAppStore.setState(initialAppStoreState, true)
+})
+
+function makeRecord(
+  overrides: Partial<SleepingAgentSessionRecord> = {}
+): SleepingAgentSessionRecord {
+  return {
+    paneKey: makePaneKey('tab-1', LEAF_ID),
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    agent: 'claude',
+    providerSession: { key: 'session_id', id: 'sess-1' },
+    prompt: 'finish the task',
+    state: 'working',
+    origin: 'quit',
+    capturedAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeTerminalTab(id: string, worktreeId: string): Record<string, unknown> {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'shell',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function makeLayout(leafId: string, ptyId: string | null): Record<string, unknown> {
+  return {
+    root: { type: 'leaf', leafId },
+    activeLeafId: leafId,
+    expandedLeafId: null,
+    ptyIdsByLeafId: ptyId ? { [leafId]: ptyId } : {}
+  }
+}
+
+describe('resumeSleepingAgentSessionsForWorktree — SSH relay panes and stale worktree ids', () => {
+  it('treats a leaf bound to an ssh relay pty as pane-owned while its target is disconnected', () => {
+    const record = makeRecord()
+    useAppStore.setState({
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
+      terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID, SSH_PTY_ID) },
+      ptyIdsByTabId: {},
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('still resumes when the preserved pane has no pty binding and cannot own recovery', () => {
+    const record = makeRecord()
+    useAppStore.setState({
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [makeTerminalTab('tab-1', 'wt-1')] },
+      terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID, null) },
+      ptyIdsByTabId: {},
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(1)
+  })
+
+  it('finds the preserved tab when the record worktreeId is stale', () => {
+    const record = makeRecord()
+    useAppStore.setState({
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [], 'wt-2': [makeTerminalTab('tab-1', 'wt-2')] },
+      terminalLayoutsByTabId: { 'tab-1': makeLayout(LEAF_ID, SSH_PTY_ID) },
+      ptyIdsByTabId: {},
+      sleepingAgentSessionsByPaneKey: { [record.paneKey]: record }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    expect(useAppStore.getState().sleepingAgentSessionsByPaneKey[record.paneKey]).toBe(record)
+  })
+
+  it('clears a record whose provider session is owned by a record in another worktree', () => {
+    const stale = makeRecord({ providerSession: { key: 'session_id', id: 'sess-9' } })
+    const owned = makeRecord({
+      paneKey: makePaneKey('tab-2', OTHER_LEAF_ID),
+      tabId: 'tab-2',
+      worktreeId: 'wt-2',
+      providerSession: { key: 'session_id', id: 'sess-9' }
+    })
+    useAppStore.setState({
+      activeWorktreeId: 'wt-other',
+      tabsByWorktree: { 'wt-1': [], 'wt-2': [makeTerminalTab('tab-2', 'wt-2')] },
+      terminalLayoutsByTabId: { 'tab-2': makeLayout(OTHER_LEAF_ID, SSH_PTY_ID) },
+      ptyIdsByTabId: {},
+      sleepingAgentSessionsByPaneKey: { [stale.paneKey]: stale, [owned.paneKey]: owned }
+    } as never)
+
+    const launched = resumeSleepingAgentSessionsForWorktree('wt-1')
+
+    expect(launched).toBe(0)
+    const records = useAppStore.getState().sleepingAgentSessionsByPaneKey
+    expect(records[stale.paneKey]).toBeUndefined()
+    expect(records[owned.paneKey]).toBe(owned)
+  })
+})

--- a/src/renderer/src/lib/resume-sleeping-agent-session.ts
+++ b/src/renderer/src/lib/resume-sleeping-agent-session.ts
@@ -130,6 +130,23 @@ function activeOrQueuedResumeClaimsProviderSession(
   return false
 }
 
+function providerSessionOwnedElsewhere(
+  record: SleepingAgentSessionRecord,
+  state: ReturnType<typeof useAppStore.getState>
+): boolean {
+  const sessionId = record.providerSession?.id
+  if (!sessionId) {
+    return false
+  }
+  return Object.values(state.sleepingAgentSessionsByPaneKey).some(
+    (other) =>
+      other !== record &&
+      other.agent === record.agent &&
+      agentProviderSessionsEqual(record.agent, other.providerSession, record.providerSession) &&
+      recordPaneIsOwnedByPreservedPane(other, state)
+  )
+}
+
 // Why: an interrupted turn is still resumable — `claude --resume` reopens the transcript at the
 // prompt — so discarding those records only stranded the session across wake and restart.
 function isInvalidWorktreeActivationRecord(record: SleepingAgentSessionRecord): boolean {
@@ -210,6 +227,13 @@ export function resumeSleepingAgentSessionsForWorktree(
       continue
     }
     if (isPaneOwned) {
+      continue
+    }
+    // Why: claim keys are worktree-scoped, but a provider session is global —
+    // a record whose stored worktreeId went stale must not relaunch a session
+    // that a pane tracked by another record still owns.
+    if (providerSessionOwnedElsewhere(record, currentState)) {
+      state.clearSleepingAgentSession(record.paneKey)
       continue
     }
     if (launchSleepingAgentSession(record, options)) {

--- a/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
+++ b/src/renderer/src/lib/sleeping-agent-pane-ownership.ts
@@ -5,6 +5,7 @@ import type {
   TerminalPaneLayoutNode,
   TerminalTab
 } from '../../../shared/terminal-tab-types'
+import { parseAppSshPtyId } from '../../../shared/ssh-pty-id'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { isWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
 
@@ -122,6 +123,31 @@ function paneWillConnectOnActivation(
   return !isWebTerminalSurfaceTabId(tabId)
 }
 
+// Why: sleeping records persist the worktreeId observed at capture time, which
+// goes stale when the session's transcript project differs from the tab's
+// worktree (e.g. an agent-managed checkout). Tab ids are globally unique, so a
+// miss under the recorded worktree must fall back to the tab's real owner —
+// otherwise a live pane is misread as gone and its session forked.
+function findPreservedTabOwner(
+  state: AppStoreState,
+  worktreeIdHint: string,
+  tabId: string
+): { tab: TerminalTab; worktreeId: string } | null {
+  const hinted = (state.tabsByWorktree[worktreeIdHint] ?? []).find(
+    (candidate) => candidate.id === tabId
+  )
+  if (hinted) {
+    return { tab: hinted, worktreeId: worktreeIdHint }
+  }
+  for (const [worktreeId, tabs] of Object.entries(state.tabsByWorktree)) {
+    const tab = tabs.find((candidate) => candidate.id === tabId)
+    if (tab) {
+      return { tab, worktreeId }
+    }
+  }
+  return null
+}
+
 export function recordPaneIsOwnedByPreservedPane(
   record: SleepingAgentSessionRecord,
   state: AppStoreState
@@ -133,10 +159,14 @@ export function recordPaneIsOwnedByPreservedPane(
       return false
     }
     const tabId = record.tabId ?? stable.tabId
-    const tab = worktreeTabs.find((candidate) => candidate.id === tabId) ?? null
-    if (!tab || !hasMatchingStablePaneLayout(tabId, stable.leafId, state.terminalLayoutsByTabId)) {
+    const owner = findPreservedTabOwner(state, record.worktreeId, tabId)
+    if (
+      !owner ||
+      !hasMatchingStablePaneLayout(tabId, stable.leafId, state.terminalLayoutsByTabId)
+    ) {
       return false
     }
+    const tab = owner.tab
     if (isPassiveCompletedHibernationEvidence(record)) {
       return true
     }
@@ -152,6 +182,17 @@ export function recordPaneIsOwnedByPreservedPane(
     ) {
       return true
     }
+    // Why: an SSH relay PTY survives transport loss by design — the disconnect
+    // handler clears ptyIdsByTabId for the whole target while the remote
+    // process keeps running and its lease only flips to 'detached'. A leaf
+    // still bound to a relay pty id therefore owns its session even though no
+    // live PTY is mapped; treating it as dead forks a second `--resume` onto
+    // the same transcript.
+    const leafPtyId =
+      state.terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[stable.leafId] ?? tab.ptyId
+    if (leafPtyId && parseAppSshPtyId(leafPtyId)) {
+      return true
+    }
     // Why: active sessions rely on pane-level cold restore. A preserved leaf
     // without a PTY/session id can repaint scrollback but cannot resume.
     return (
@@ -161,7 +202,7 @@ export function recordPaneIsOwnedByPreservedPane(
         stable.leafId,
         state.ptyIdsByTabId,
         state.terminalLayoutsByTabId
-      ) && paneWillConnectOnActivation(record.worktreeId, tabId, state)
+      ) && paneWillConnectOnActivation(owner.worktreeId, tabId, state)
     )
   }
 


### PR DESCRIPTION
## Summary

Fixes #12699.

The sleeping-agent wake sweep forks live remote sessions into duplicate `claude --resume` tabs through three ownership misjudgments. This PR closes all three in `recordPaneIsOwnedByPreservedPane` and `resumeSleepingAgentSessionsForWorktree`:

- **SSH relay leaf bindings count as pane ownership.** On SSH transport loss the disconnect handler clears `ptyIdsByTabId` for the whole target while the remote process keeps running and its lease only flips to `detached`. A leaf whose persisted layout binding parses as a relay pty id (`parseAppSshPtyId`) therefore owns its session even with no live PTY mapped; treating it as dead forked a second `--resume` onto the same transcript.
- **`findPreservedTabOwner`: global tab lookup when the record's stored `worktreeId` is stale.** Records persist the worktreeId observed at capture time, which goes stale when the session's transcript project differs from the tab's worktree (e.g. an agent-managed checkout). Tab ids are globally unique, so a miss under the recorded worktree falls back to the tab's real owner — the same approach `getTabOwnerWorktreeId` already takes in the AI Vault pane lookup. The activation check uses the owner worktree, not the stale hint.
- **`providerSessionOwnedElsewhere`: cross-worktree provider-session dedupe.** Claim keys are worktree-scoped, so two records for one provider session with different worktree ids never collide. A record is now cleared instead of launched when another record (matched via `agentProviderSessionsEqual`, which keeps the `pi` `transcriptPath` disambiguation) proves the session pane-owned.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/resume-sleeping-agent-session-live-ssh-dedupe.test.ts src/renderer/src/lib/resume-sleeping-agent-session.test.ts` (and the six sibling resume/wake suites)
- `pnpm run typecheck:web`

New tests cover: ssh-bound leaf owns its session while disconnected and inactive; a pane without any binding still resumes (no over-suppression); stale-worktreeId records resolve to the tab's real owner; a record is cleared, not launched, when its session is owned under another worktree.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
