### PR TITLE
fix(agents): focus the live pane when resuming an already-running session from the sidebar

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-original-pane-actions.ts
@@ -7,12 +7,27 @@ import { useAppStore } from '@/store'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import { translate } from '@/i18n/i18n'
-import { findOriginalAiVaultSessionPane } from './ai-vault-original-pane'
+import {
+  findOriginalAiVaultSessionPane,
+  type AiVaultOriginalPaneTarget
+} from './ai-vault-original-pane'
 import {
   createLazyAiVaultOriginalPaneIndex,
   findAiVaultSessionLiveStateInIndex,
   findOriginalAiVaultSessionPaneInIndex
 } from './ai-vault-original-pane-index'
+
+export function focusAiVaultOriginalPaneTarget(target: AiVaultOriginalPaneTarget): boolean {
+  if (!activateAndRevealWorktree(target.worktreeId)) {
+    return false
+  }
+  useAppStore.getState().setActiveTabType('terminal')
+  activateTabAndFocusPane(target.tabId, target.leafId, {
+    flashFocusedPane: true,
+    scrollToBottomIfOutputSinceLastView: true
+  })
+  return true
+}
 
 export function useAiVaultOriginalPaneActions(): {
   getOriginalPaneTarget: (
@@ -62,21 +77,14 @@ export function useAiVaultOriginalPaneActions(): {
       return
     }
 
-    if (!activateAndRevealWorktree(target.worktreeId)) {
+    if (!focusAiVaultOriginalPaneTarget(target)) {
       toast.error(
         translate(
           'auto.components.right.sidebar.AiVaultPanel.worktreeUnavailable',
           'Worktree is no longer available.'
         )
       )
-      return
     }
-    const state = useAppStore.getState()
-    state.setActiveTabType('terminal')
-    activateTabAndFocusPane(target.tabId, target.leafId, {
-      flashFocusedPane: true,
-      scrollToBottomIfOutputSinceLastView: true
-    })
   }, [])
 
   const jumpToWorktree = useCallback((worktreeId: string): void => {

--- a/src/renderer/src/components/right-sidebar/ai-vault-resume-focus-existing-pane.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-resume-focus-existing-pane.test.ts
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import type { OriginalPaneState } from './ai-vault-original-pane'
+import { findLiveAiVaultSessionPane } from './ai-vault-resume-focus-existing-pane'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `tab-1:${LEAF_ID}`
+
+function makeSession(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  return {
+    agent: 'claude',
+    sessionId: 'sess-1',
+    filePath: '/home/user/.claude/projects/proj/sess-1.jsonl',
+    title: 'session',
+    updatedAt: 1,
+    ...overrides
+  } as AiVaultSession
+}
+
+function makeState(overrides: Partial<OriginalPaneState> = {}): OriginalPaneState {
+  return {
+    agentStatusByPaneKey: {},
+    retainedAgentsByPaneKey: {},
+    sleepingAgentSessionsByPaneKey: {},
+    tabsByWorktree: { 'wt-1': [{ id: 'tab-1' }] },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: LEAF_ID },
+        activeLeafId: LEAF_ID,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_ID]: 'ssh:target-a@@pty-3' }
+      }
+    },
+    ...overrides
+  } as never
+}
+
+describe('findLiveAiVaultSessionPane', () => {
+  it('returns the pane of a live agent-status entry with an exact provider session match', () => {
+    const state = makeState({
+      agentStatusByPaneKey: {
+        [PANE_KEY]: {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agentType: 'claude',
+          state: 'working',
+          providerSession: { key: 'session_id', id: 'sess-1' }
+        }
+      }
+    } as never)
+
+    expect(findLiveAiVaultSessionPane(state, makeSession())).toMatchObject({
+      tabId: 'tab-1',
+      leafId: LEAF_ID
+    })
+  })
+
+  it('never matches on prompt heuristics alone', () => {
+    const state = makeState({
+      agentStatusByPaneKey: {
+        [PANE_KEY]: {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agentType: 'claude',
+          state: 'working',
+          providerSession: undefined,
+          firstPrompt: 'session',
+          latestPrompt: 'session'
+        }
+      }
+    } as never)
+
+    expect(findLiveAiVaultSessionPane(state, makeSession())).toBeNull()
+  })
+
+  it('returns the pane of a non-passive sleeping record', () => {
+    const state = makeState({
+      sleepingAgentSessionsByPaneKey: {
+        [PANE_KEY]: {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'claude',
+          providerSession: { key: 'session_id', id: 'sess-1' },
+          state: 'working',
+          origin: 'quit',
+          capturedAt: 1,
+          updatedAt: 1
+        }
+      }
+    } as never)
+
+    expect(findLiveAiVaultSessionPane(state, makeSession())).toMatchObject({ tabId: 'tab-1' })
+  })
+
+  it('skips passive completed-hibernation records — history panes hold no process', () => {
+    const state = makeState({
+      sleepingAgentSessionsByPaneKey: {
+        [PANE_KEY]: {
+          paneKey: PANE_KEY,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          agent: 'claude',
+          providerSession: { key: 'session_id', id: 'sess-1' },
+          state: 'done',
+          origin: 'hibernation',
+          capturedAt: 1,
+          updatedAt: 1
+        }
+      }
+    } as never)
+
+    expect(findLiveAiVaultSessionPane(state, makeSession())).toBeNull()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-resume-focus-existing-pane.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-resume-focus-existing-pane.ts
@@ -1,0 +1,91 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { isPassiveCompletedHibernationEvidence } from '@/lib/sleeping-agent-pane-ownership'
+import { translate } from '@/i18n/i18n'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import {
+  resolveOriginalPaneTarget,
+  type AiVaultOriginalPaneTarget,
+  type OriginalPaneState
+} from './ai-vault-original-pane'
+import { focusAiVaultOriginalPaneTarget } from './ai-vault-original-pane-actions'
+import { agentLabel } from './ai-vault-session-filters'
+
+/**
+ * The pane whose session is genuinely live for this vault row, or null.
+ * Why: unlike the Jump affordance, this lookup gates whether Resume launches at
+ * all, so it must not guess — exact provider-session matches only (no prompt
+ * heuristics), and never a passive completed-hibernation record: that pane
+ * holds display history, not a process, and focusing it would silently swallow
+ * the resume the user asked for.
+ */
+export function findLiveAiVaultSessionPane(
+  state: OriginalPaneState,
+  session: AiVaultSession
+): AiVaultOriginalPaneTarget | null {
+  for (const entry of Object.values(state.agentStatusByPaneKey)) {
+    if (session.agent === entry.agentType && session.sessionId === entry.providerSession?.id) {
+      const target = resolveOriginalPaneTarget({
+        state,
+        paneKey: entry.paneKey,
+        worktreeIdHint: entry.worktreeId,
+        tabIdHint: entry.tabId
+      })
+      if (target) {
+        return target
+      }
+    }
+  }
+  for (const retained of Object.values(state.retainedAgentsByPaneKey)) {
+    if (
+      session.agent === retained.agentType &&
+      session.sessionId === retained.entry.providerSession?.id
+    ) {
+      const target = resolveOriginalPaneTarget({
+        state,
+        paneKey: retained.entry.paneKey,
+        worktreeIdHint: retained.worktreeId,
+        tabIdHint: retained.entry.tabId ?? retained.tab.id
+      })
+      if (target) {
+        return target
+      }
+    }
+  }
+  for (const record of Object.values(state.sleepingAgentSessionsByPaneKey)) {
+    if (
+      session.agent === record.agent &&
+      session.sessionId === record.providerSession.id &&
+      !isPassiveCompletedHibernationEvidence(record)
+    ) {
+      const target = resolveOriginalPaneTarget({
+        state,
+        paneKey: record.paneKey,
+        worktreeIdHint: record.worktreeId,
+        tabIdHint: record.tabId
+      })
+      if (target) {
+        return target
+      }
+    }
+  }
+  return null
+}
+
+// Why: resuming a session that a pane still owns starts a second process
+// writing the same transcript. Focusing the live pane delivers what the user
+// asked for — the session on screen — without the fork.
+export function focusExistingAiVaultSessionPane(session: AiVaultSession): boolean {
+  const existingPane = findLiveAiVaultSessionPane(useAppStore.getState(), session)
+  if (!existingPane || !focusAiVaultOriginalPaneTarget(existingPane)) {
+    return false
+  }
+  toast.success(
+    translate(
+      'auto.components.right.sidebar.AiVaultPanel.agentSessionAlreadyRunning',
+      '{{value0}} session is already running — focused its pane',
+      { value0: agentLabel(session.agent) }
+    )
+  )
+  return true
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.test.ts
@@ -1,0 +1,109 @@
+// @vitest-environment happy-dom
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { renderHook } from '@testing-library/react'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+
+const {
+  activateAndRevealWorktreeMock,
+  activateTabAndFocusPaneMock,
+  focusExistingAiVaultSessionPaneMock,
+  launchAiVaultSessionInNewTabMock,
+  prepareAiVaultSessionForResumeMock
+} = vi.hoisted(() => ({
+  activateAndRevealWorktreeMock: vi.fn(() => true),
+  activateTabAndFocusPaneMock: vi.fn(),
+  focusExistingAiVaultSessionPaneMock: vi.fn(() => false),
+  launchAiVaultSessionInNewTabMock: vi.fn(() => ({
+    tabId: 'new-tab',
+    runtimeLaunch: Promise.resolve({ status: 'ok' })
+  })),
+  prepareAiVaultSessionForResumeMock: vi.fn((session: unknown) => Promise.resolve(session))
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: activateAndRevealWorktreeMock,
+  activateAndRevealFolderWorkspace: vi.fn()
+}))
+vi.mock('@/lib/activate-tab-and-focus-pane', () => ({
+  activateTabAndFocusPane: activateTabAndFocusPaneMock
+}))
+vi.mock('./ai-vault-resume-focus-existing-pane', () => ({
+  focusExistingAiVaultSessionPane: focusExistingAiVaultSessionPaneMock
+}))
+vi.mock('@/lib/launch-ai-vault-session', () => ({
+  launchAiVaultSessionInNewTab: launchAiVaultSessionInNewTabMock
+}))
+vi.mock('@/lib/ai-vault-session-resume-preparation', () => ({
+  prepareAiVaultSessionForResume: prepareAiVaultSessionForResumeMock
+}))
+vi.mock('@/lib/ai-vault-resume-command', () => ({
+  buildAiVaultResumeCopyCommandForWorktree: vi.fn(() => 'claude --resume sess-1'),
+  buildAiVaultResumeStartupForWorktree: vi.fn(() => ({ command: 'claude --resume sess-1' }))
+}))
+vi.mock('@/lib/ai-vault-resume-target', () => ({
+  canResumeAiVaultSessionOnTarget: vi.fn(() => true),
+  getAiVaultResumeWorkspaceExecutionHostId: vi.fn(() => null),
+  getAiVaultResumeWorkspaceTargetStatus: vi.fn(() => 'local')
+}))
+vi.mock('./ai-vault-session-resume', () => ({
+  isKnownAiVaultResumeWorkspaceTarget: vi.fn(() => true)
+}))
+vi.mock('@/lib/sleeping-agent-pane-ownership', () => ({
+  isPassiveCompletedHibernationEvidence: vi.fn(() => false)
+}))
+
+import { useAiVaultSessionLaunchActions } from './ai-vault-session-launch-actions'
+
+function makeSession(overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  return {
+    agent: 'claude',
+    sessionId: 'sess-1',
+    filePath: '/home/user/.claude/projects/proj/sess-1.jsonl',
+    title: 'session',
+    updatedAt: 1,
+    ...overrides
+  } as AiVaultSession
+}
+
+function renderActions(): ReturnType<typeof useAiVaultSessionLaunchActions> {
+  const { result } = renderHook(() =>
+    useAiVaultSessionLaunchActions({
+      activeWorktree: null,
+      activeWorktreeId: 'wt-1',
+      targetState: {} as never
+    })
+  )
+  return result.current
+}
+
+describe('useAiVaultSessionLaunchActions handleResume', () => {
+  beforeEach(() => {
+    focusExistingAiVaultSessionPaneMock.mockReset()
+    launchAiVaultSessionInNewTabMock.mockClear()
+    activateAndRevealWorktreeMock.mockClear()
+    activateTabAndFocusPaneMock.mockClear()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not launch when the pre-flight focused a live pane', () => {
+    focusExistingAiVaultSessionPaneMock.mockReturnValue(true)
+
+    renderActions().handleResume(makeSession())
+
+    expect(focusExistingAiVaultSessionPaneMock).toHaveBeenCalledTimes(1)
+    expect(launchAiVaultSessionInNewTabMock).not.toHaveBeenCalled()
+  })
+
+  it('launches in a new tab when no pane owns the session', async () => {
+    focusExistingAiVaultSessionPaneMock.mockReturnValue(false)
+
+    renderActions().handleResume(makeSession())
+    await vi.waitFor(() => {
+      expect(launchAiVaultSessionInNewTabMock).toHaveBeenCalledTimes(1)
+    })
+    expect(activateTabAndFocusPaneMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.ts
@@ -11,24 +11,20 @@ import {
   activateAndRevealWorktree
 } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
-import {
-  canResumeAiVaultSessionOnTarget,
-  getAiVaultResumeWorkspaceExecutionHostId,
-  getAiVaultResumeWorkspaceTargetStatus
-} from '@/lib/ai-vault-resume-target'
 import type { AiVaultAgent, AiVaultSession } from '../../../../shared/ai-vault-types'
 import { prepareAiVaultSessionForResume } from '@/lib/ai-vault-session-resume-preparation'
 import type { Worktree } from '../../../../shared/worktree/types'
 import { translate } from '@/i18n/i18n'
 import { agentLabel } from './ai-vault-session-filters'
 import { parseWorkspaceKey } from '../../../../shared/workspace-scope'
-import {
-  isKnownAiVaultResumeWorkspaceTarget,
-  type AiVaultSessionResumeTargetState
-} from './ai-vault-session-resume'
+import type { AiVaultSessionResumeTargetState } from './ai-vault-session-resume'
+import { focusExistingAiVaultSessionPane } from './ai-vault-resume-focus-existing-pane'
+import { resolveAiVaultSessionLaunchTargetOrNotify } from './ai-vault-session-launch-target'
 import { prepareAiVaultSessionContinuation } from './ai-vault-session-continuation'
 import type { AgentSessionContinuationRequest } from '@/lib/agent-session-continuation'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
+
+export { resolveAiVaultSessionLaunchTarget } from './ai-vault-session-launch-target'
 
 export function useAiVaultSessionLaunchActions({
   activeWorktree,
@@ -93,6 +89,13 @@ export function useAiVaultSessionLaunchActions({
 
   const handleResume = useCallback(
     (session: AiVaultSession, targetWorktreeId?: string): void => {
+      // Why: a session that is live in some pane needs no launch target — the
+      // pane may sit on a different worktree or host than the one the launch
+      // resolver would pick, and resolving first would reject exactly the
+      // cross-worktree case where focusing the live pane is the right outcome.
+      if (focusExistingAiVaultSessionPane(session)) {
+        return
+      }
       const targetId = resolveAiVaultSessionLaunchTargetOrNotify({
         sessionFilePath: session.filePath,
         sessionExecutionHostId: session.executionHostId,
@@ -103,7 +106,6 @@ export function useAiVaultSessionLaunchActions({
       if (!targetId) {
         return
       }
-
       const showQueuedToast = (): void => {
         toast.success(
           translate(
@@ -227,85 +229,6 @@ function resolveAiVaultTargetWorkspacePath(
   }
   const worktreeId = scope?.type === 'worktree' ? scope.worktreeId : workspaceId
   return findWorktreeById(state.worktreesByRepo, worktreeId)?.path ?? null
-}
-
-export type AiVaultSessionLaunchTarget =
-  | { status: 'missing' }
-  | {
-      status: 'unsupported'
-      targetStatus: ReturnType<typeof getAiVaultResumeWorkspaceTargetStatus>
-    }
-  | { status: 'ready'; worktreeId: string }
-
-export function resolveAiVaultSessionLaunchTarget(args: {
-  sessionFilePath: string | null
-  sessionExecutionHostId?: AiVaultSession['executionHostId'] | null
-  activeWorktreeId: string | null
-  targetWorktreeId?: string
-  targetState: AiVaultSessionResumeTargetState
-}): AiVaultSessionLaunchTarget {
-  const targetWorktreeId = args.targetWorktreeId ?? args.activeWorktreeId
-  if (
-    !targetWorktreeId ||
-    !isKnownAiVaultResumeWorkspaceTarget(args.targetState, targetWorktreeId)
-  ) {
-    return { status: 'missing' }
-  }
-
-  const targetStatus = getAiVaultResumeWorkspaceTargetStatus(args.targetState, targetWorktreeId)
-  const targetExecutionHostId = getAiVaultResumeWorkspaceExecutionHostId(
-    args.targetState,
-    targetWorktreeId
-  )
-  if (
-    !canResumeAiVaultSessionOnTarget({
-      sessionFilePath: args.sessionFilePath,
-      sessionExecutionHostId: args.sessionExecutionHostId,
-      targetStatus,
-      targetExecutionHostId
-    })
-  ) {
-    return { status: 'unsupported', targetStatus }
-  }
-
-  return { status: 'ready', worktreeId: targetWorktreeId }
-}
-
-function resolveAiVaultSessionLaunchTargetOrNotify(
-  args: Parameters<typeof resolveAiVaultSessionLaunchTarget>[0]
-): Extract<AiVaultSessionLaunchTarget, { status: 'ready' }> | null {
-  const target = resolveAiVaultSessionLaunchTarget(args)
-  if (target.status === 'missing') {
-    toast.error(
-      translate(
-        'auto.components.right.sidebar.AiVaultPanel.openWorkspaceBeforeResuming',
-        'Open a workspace before resuming a session.'
-      )
-    )
-    return null
-  }
-  if (target.status === 'unsupported') {
-    toast.error(aiVaultResumeUnsupportedMessage(target.targetStatus))
-    return null
-  }
-  return target
-}
-
-function aiVaultResumeUnsupportedMessage(
-  targetStatus: ReturnType<typeof getAiVaultResumeWorkspaceTargetStatus>
-): string {
-  // Why: local and SSH targets can both be valid generally; this branch means
-  // the session's recorded host does not match the selected workspace.
-  if (targetStatus === 'ssh' || targetStatus === 'local' || targetStatus === 'runtime') {
-    return translate(
-      'auto.components.right.sidebar.AiVaultPanel.sessionHostMismatchUnsupported',
-      'This session belongs to a different host. Open a workspace on the same host to resume it.'
-    )
-  }
-  return translate(
-    'auto.components.right.sidebar.AiVaultPanel.openSupportedWorkspace',
-    'Open a workspace before resuming a session.'
-  )
 }
 
 function activateAiVaultResumeWorkspace(workspaceId: string): void {

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-launch-target.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-launch-target.ts
@@ -1,0 +1,91 @@
+import { toast } from 'sonner'
+import {
+  canResumeAiVaultSessionOnTarget,
+  getAiVaultResumeWorkspaceExecutionHostId,
+  getAiVaultResumeWorkspaceTargetStatus
+} from '@/lib/ai-vault-resume-target'
+import { translate } from '@/i18n/i18n'
+import type { AiVaultSession } from '../../../../shared/ai-vault-types'
+import {
+  isKnownAiVaultResumeWorkspaceTarget,
+  type AiVaultSessionResumeTargetState
+} from './ai-vault-session-resume'
+
+export type AiVaultSessionLaunchTarget =
+  | { status: 'missing' }
+  | {
+      status: 'unsupported'
+      targetStatus: ReturnType<typeof getAiVaultResumeWorkspaceTargetStatus>
+    }
+  | { status: 'ready'; worktreeId: string }
+
+export function resolveAiVaultSessionLaunchTarget(args: {
+  sessionFilePath: string | null
+  sessionExecutionHostId?: AiVaultSession['executionHostId'] | null
+  activeWorktreeId: string | null
+  targetWorktreeId?: string
+  targetState: AiVaultSessionResumeTargetState
+}): AiVaultSessionLaunchTarget {
+  const targetWorktreeId = args.targetWorktreeId ?? args.activeWorktreeId
+  if (
+    !targetWorktreeId ||
+    !isKnownAiVaultResumeWorkspaceTarget(args.targetState, targetWorktreeId)
+  ) {
+    return { status: 'missing' }
+  }
+
+  const targetStatus = getAiVaultResumeWorkspaceTargetStatus(args.targetState, targetWorktreeId)
+  const targetExecutionHostId = getAiVaultResumeWorkspaceExecutionHostId(
+    args.targetState,
+    targetWorktreeId
+  )
+  if (
+    !canResumeAiVaultSessionOnTarget({
+      sessionFilePath: args.sessionFilePath,
+      sessionExecutionHostId: args.sessionExecutionHostId,
+      targetStatus,
+      targetExecutionHostId
+    })
+  ) {
+    return { status: 'unsupported', targetStatus }
+  }
+
+  return { status: 'ready', worktreeId: targetWorktreeId }
+}
+
+export function resolveAiVaultSessionLaunchTargetOrNotify(
+  args: Parameters<typeof resolveAiVaultSessionLaunchTarget>[0]
+): Extract<AiVaultSessionLaunchTarget, { status: 'ready' }> | null {
+  const target = resolveAiVaultSessionLaunchTarget(args)
+  if (target.status === 'missing') {
+    toast.error(
+      translate(
+        'auto.components.right.sidebar.AiVaultPanel.openWorkspaceBeforeResuming',
+        'Open a workspace before resuming a session.'
+      )
+    )
+    return null
+  }
+  if (target.status === 'unsupported') {
+    toast.error(aiVaultResumeUnsupportedMessage(target.targetStatus))
+    return null
+  }
+  return target
+}
+
+function aiVaultResumeUnsupportedMessage(
+  targetStatus: ReturnType<typeof getAiVaultResumeWorkspaceTargetStatus>
+): string {
+  // Why: local and SSH targets can both be valid generally; this branch means
+  // the session's recorded host does not match the selected workspace.
+  if (targetStatus === 'ssh' || targetStatus === 'local' || targetStatus === 'runtime') {
+    return translate(
+      'auto.components.right.sidebar.AiVaultPanel.sessionHostMismatchUnsupported',
+      'This session belongs to a different host. Open a workspace on the same host to resume it.'
+    )
+  }
+  return translate(
+    'auto.components.right.sidebar.AiVaultPanel.openSupportedWorkspace',
+    'Open a workspace before resuming a session.'
+  )
+}


### PR DESCRIPTION
## Summary

Fixes #12700.

The Agents sidebar's Resume action launches a new tab + `claude --resume` unconditionally, starting a second process on a transcript whose session may still be running in an existing pane. This PR makes `handleResume` pre-flight a strict live-pane lookup and focus the pane instead of launching when it hits:

- `ai-vault-resume-focus-existing-pane.ts` — `findLiveAiVaultSessionPane` matches on exact provider-session identity only (no prompt heuristics: a fuzzy match may not be the same session, and here a false positive suppresses a launch, not just a navigation) and skips passive completed-hibernation records (those panes hold display history, not a process). `focusExistingAiVaultSessionPane` focuses the hit and toasts.
- The pre-flight runs before launch-target resolution: a live pane can sit on a different worktree or host than the resolver would pick, and resolving first rejects exactly the cross-worktree case where focusing is the right outcome.
- `focusAiVaultOriginalPaneTarget` (in `ai-vault-original-pane-actions.ts`) is the shared activate-worktree → focus-pane primitive, also used by Jump to Original Pane.
- The launch-target resolvers move to `ai-vault-session-launch-target.ts` (re-exported from the actions module) to keep the actions file inside the lint budget.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ai-vault-session-launch-actions.test.ts src/renderer/src/components/right-sidebar/ai-vault-resume-focus-existing-pane.test.ts src/renderer/src/components/right-sidebar/ai-vault-session-resume.test.ts`
- `pnpm run typecheck:web`

New tests cover: no launch when the pre-flight focuses a live pane; normal launch when nothing owns the session; exact-match-only and skip-passive-records behavior of the lookup.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
