### PR TITLE
fix(browser): wake display on demand for remote screencast

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -100,6 +100,7 @@ docs/**
 !docs/reference/headless-linux-server.md
 !docs/reference/linux-glibc-compatibility.md
 !docs/reference/relay-grace-time-reconfiguration.md
+!docs/reference/remote-browser-display-wake.md
 !docs/reference/remote-wire-compatibility.md
 !docs/reference/windows-setup-shell.md
 

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -10,6 +10,10 @@ startup. Current Orca builds start Xvfb automatically for `orca serve` when no
 not required. When `DISPLAY` is set, Orca uses that display instead of starting
 a competing Xvfb process.
 
+For desktop (non-serve) hosts that stream browser panes to mobile/remote
+clients while the physical display may be off or locked, see
+[Remote browser display wake](./remote-browser-display-wake.md).
+
 The supported deployment matrix covers Ubuntu 20.04, 22.04, and 24.04 and
 current Debian stable — anything with glibc 2.31 or newer (see
 [Linux glibc compatibility](./linux-glibc-compatibility.md)). Package names can

--- a/docs/reference/remote-browser-display-wake.md
+++ b/docs/reference/remote-browser-display-wake.md
@@ -1,0 +1,42 @@
+# Remote browser display wake
+
+Mobile and other remote clients stream host Chromium pages through
+`browser.screencast` (CDP frames). When the host **display** is asleep, the
+compositor often parks and frames stop even though PTYs and RPC still work.
+
+## Behavior
+
+When the first live screencast starts, Orca:
+
+1. **Wake-on-demand** — macOS: `caffeinate -u` (turns the display on if it was
+   already off). Linux: best-effort `xset dpms force on` when `DISPLAY` is set.
+2. **Hold awake** — Electron `prevent-display-sleep` plus the same macOS/Linux
+   sleep assertions used by agent-awake, only while at least one screencast is
+   live.
+3. Temporarily disables main-window background throttling for that window while
+   streaming, then restores the default when idle.
+
+When the last screencast ends, assertions are released so an idle host can sleep
+again.
+
+## Caveats
+
+- **Screen lock:** Remote browsing streams the page's WebContents, not the
+  desktop framebuffer. Unlocking is usually **not** required. Waking the display
+  may still **light the lock screen** on the host (privacy in shared spaces).
+- **Lid closed / clamshell / battery policies:** Some machines refuse to fully
+  wake the panel without local interaction. Prefer an open lid, AC power, or a
+  headless/`orca serve` host with a virtual display when you need this path
+  reliably.
+- **Windows:** Wake-from-display-off is weaker; `prevent-display-sleep` is still
+  applied while streaming.
+- **Full system sleep / hibernation:** If the user session is suspended, wake
+  display alone is not enough — keep the machine from full sleep (or use a
+  server that stays running).
+
+## Related
+
+- Agent keep-awake (settings): same prevent-display-sleep / `caffeinate` family
+  while agents are running.
+- Headless Linux browser panes: [Headless Linux Server](./headless-linux-server.md)
+  (Xvfb / virtual display for `orca serve`).

--- a/src/main/browser-screencast-awake-service-platform-assertions.test.ts
+++ b/src/main/browser-screencast-awake-service-platform-assertions.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { BrowserScreencastAwakeService } from './browser-screencast-awake-service'
+
+vi.mock('electron', () => ({
+  powerMonitor: {
+    on: vi.fn(),
+    off: vi.fn()
+  },
+  powerSaveBlocker: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    isStarted: vi.fn()
+  }
+}))
+
+function createBlocker() {
+  const startedIds = new Set<number>()
+  let nextId = 1
+  return {
+    start: vi.fn(() => {
+      const id = nextId++
+      startedIds.add(id)
+      return id
+    }),
+    stop: vi.fn((id: number) => {
+      startedIds.delete(id)
+    }),
+    isStarted: vi.fn((id: number) => startedIds.has(id))
+  }
+}
+
+describe('BrowserScreencastAwakeService platform assertions', () => {
+  it('still starts the Electron blocker when macOS assertion start throws', () => {
+    const blocker = createBlocker()
+    const macosAssertion = {
+      start: vi.fn(() => {
+        throw new Error('caffeinate failed')
+      }),
+      stop: vi.fn(),
+      dispose: vi.fn()
+    }
+    const service = new BrowserScreencastAwakeService({
+      blocker,
+      linuxAssertion: { start: vi.fn(), stop: vi.fn(), dispose: vi.fn() },
+      macosAssertion,
+      powerMonitor: null,
+      wakeDisplay: vi.fn(),
+      logger: { debug: vi.fn(), warn: vi.fn() }
+    })
+
+    service.acquire('stream-1')
+
+    expect(blocker.start).toHaveBeenCalledWith('prevent-display-sleep')
+  })
+
+  it('still starts platform assertions when the Electron blocker fails', () => {
+    const macosAssertion = { start: vi.fn(), stop: vi.fn(), dispose: vi.fn() }
+    const linuxAssertion = { start: vi.fn(), stop: vi.fn(), dispose: vi.fn() }
+    const service = new BrowserScreencastAwakeService({
+      blocker: {
+        start: vi.fn(() => {
+          throw new Error('blocker failed')
+        }),
+        stop: vi.fn(),
+        isStarted: vi.fn(() => false)
+      },
+      linuxAssertion,
+      macosAssertion,
+      powerMonitor: null,
+      wakeDisplay: vi.fn(),
+      logger: { debug: vi.fn(), warn: vi.fn() }
+    })
+
+    service.acquire('stream-1')
+
+    expect(macosAssertion.start).toHaveBeenCalled()
+    expect(linuxAssertion.start).toHaveBeenCalled()
+  })
+})

--- a/src/main/browser-screencast-awake-service.test.ts
+++ b/src/main/browser-screencast-awake-service.test.ts
@@ -1,0 +1,183 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { BrowserScreencastAwakeService } from './browser-screencast-awake-service'
+
+vi.mock('electron', () => ({
+  powerMonitor: {
+    on: vi.fn(),
+    off: vi.fn()
+  },
+  powerSaveBlocker: {
+    start: vi.fn(),
+    stop: vi.fn(),
+    isStarted: vi.fn()
+  }
+}))
+
+function createBlocker() {
+  const startedIds = new Set<number>()
+  let nextId = 1
+  return {
+    start: vi.fn(() => {
+      const id = nextId++
+      startedIds.add(id)
+      return id
+    }),
+    stop: vi.fn((id: number) => {
+      startedIds.delete(id)
+    }),
+    isStarted: vi.fn((id: number) => startedIds.has(id))
+  }
+}
+
+function createPlatformAssertion() {
+  return {
+    start: vi.fn(),
+    stop: vi.fn(),
+    dispose: vi.fn()
+  }
+}
+
+function createPowerMonitor() {
+  const listeners = new Map<string, Set<() => void>>()
+  return {
+    on: vi.fn((event: string, listener: () => void) => {
+      const set = listeners.get(event) ?? new Set()
+      set.add(listener)
+      listeners.set(event, set)
+    }),
+    off: vi.fn((event: string, listener: () => void) => {
+      listeners.get(event)?.delete(listener)
+    }),
+    emit(event: string) {
+      for (const listener of listeners.get(event) ?? []) {
+        listener()
+      }
+    }
+  }
+}
+
+function createService(
+  blocker = createBlocker(),
+  macosAssertion = createPlatformAssertion(),
+  linuxAssertion = createPlatformAssertion(),
+  powerMonitor: ReturnType<typeof createPowerMonitor> | null = null,
+  wakeDisplay = vi.fn()
+): BrowserScreencastAwakeService {
+  return new BrowserScreencastAwakeService({
+    blocker,
+    linuxAssertion,
+    macosAssertion,
+    powerMonitor,
+    wakeDisplay,
+    logger: {
+      debug: vi.fn(),
+      warn: vi.fn()
+    }
+  })
+}
+
+describe('BrowserScreencastAwakeService', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not start until a screencast token is acquired', () => {
+    const blocker = createBlocker()
+    const wakeDisplay = vi.fn()
+    createService(blocker, createPlatformAssertion(), createPlatformAssertion(), null, wakeDisplay)
+
+    expect(blocker.start).not.toHaveBeenCalled()
+    expect(wakeDisplay).not.toHaveBeenCalled()
+  })
+
+  it('wakes the display once when the first screencast becomes active', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const wakeDisplay = vi.fn()
+    const service = createService(blocker, macosAssertion, linuxAssertion, null, wakeDisplay)
+
+    service.acquire('stream-1')
+    service.acquire('stream-2')
+
+    expect(wakeDisplay).toHaveBeenCalledTimes(1)
+    expect(wakeDisplay).toHaveBeenCalledWith('screencast-start')
+    expect(blocker.start).toHaveBeenCalledWith('prevent-display-sleep')
+    expect(macosAssertion.start).toHaveBeenCalled()
+    expect(linuxAssertion.start).toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(2)
+  })
+
+  it('stops the blocker only after the last token is released', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.acquire('stream-2')
+    service.release('stream-1')
+
+    expect(blocker.stop).not.toHaveBeenCalled()
+
+    service.release('stream-2')
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(macosAssertion.stop).toHaveBeenCalled()
+    expect(linuxAssertion.stop).toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(0)
+  })
+
+  it('ignores duplicate acquire and unknown release', () => {
+    const blocker = createBlocker()
+    const wakeDisplay = vi.fn()
+    const service = createService(
+      blocker,
+      createPlatformAssertion(),
+      createPlatformAssertion(),
+      null,
+      wakeDisplay
+    )
+
+    service.acquire('stream-1')
+    service.acquire('stream-1')
+    service.release('missing')
+
+    expect(wakeDisplay).toHaveBeenCalledTimes(1)
+    expect(blocker.start).toHaveBeenCalledTimes(1)
+    expect(service.getActiveCount()).toBe(1)
+  })
+
+  it('restarts the blocker after power resume while tokens remain', () => {
+    const blocker = createBlocker()
+    const powerMonitor = createPowerMonitor()
+    const service = createService(
+      blocker,
+      createPlatformAssertion(),
+      createPlatformAssertion(),
+      powerMonitor
+    )
+
+    service.acquire('stream-1')
+    blocker.isStarted.mockReturnValueOnce(false)
+    powerMonitor.emit('resume')
+
+    expect(blocker.start).toHaveBeenCalledTimes(2)
+    expect(blocker.start).toHaveBeenLastCalledWith('prevent-display-sleep')
+  })
+
+  it('dispose clears tokens and stops assertions', () => {
+    const blocker = createBlocker()
+    const macosAssertion = createPlatformAssertion()
+    const linuxAssertion = createPlatformAssertion()
+    const service = createService(blocker, macosAssertion, linuxAssertion)
+
+    service.acquire('stream-1')
+    service.dispose()
+
+    expect(blocker.stop).toHaveBeenCalledWith(1)
+    expect(macosAssertion.dispose).toHaveBeenCalled()
+    expect(linuxAssertion.dispose).toHaveBeenCalled()
+    expect(service.getActiveCount()).toBe(0)
+  })
+})

--- a/src/main/browser-screencast-awake-service.ts
+++ b/src/main/browser-screencast-awake-service.ts
@@ -1,0 +1,223 @@
+import { LinuxLidSleepAssertion } from './linux-lid-sleep-assertion'
+import { wakeLinuxDisplay } from './linux-display-wake'
+import { wakeMacosDisplay } from './macos-display-wake'
+import { MacosSystemSleepAssertion } from './macos-system-sleep-assertion'
+
+type PowerSaveBlocker = {
+  start: (type: 'prevent-app-suspension' | 'prevent-display-sleep') => number
+  stop: (id: number) => void
+  isStarted: (id: number) => boolean
+}
+
+type PlatformAwakeAssertion = {
+  start: (reason: string) => void
+  stop: (reason: string) => void
+  dispose: () => void
+}
+
+type PowerMonitorEventSource = {
+  on: (event: 'resume', listener: () => void) => void
+  off: (event: 'resume', listener: () => void) => void
+}
+
+type Logger = Pick<Console, 'debug' | 'warn'>
+
+type BrowserScreencastAwakeServiceOptions = {
+  blocker?: PowerSaveBlocker
+  linuxAssertion?: PlatformAwakeAssertion
+  logger?: Logger
+  macosAssertion?: PlatformAwakeAssertion
+  powerMonitor?: PowerMonitorEventSource | null
+  wakeDisplay?: (reason: string) => void
+}
+
+type ElectronPowerApis = {
+  powerMonitor: PowerMonitorEventSource
+  powerSaveBlocker: PowerSaveBlocker
+}
+
+function loadElectronPowerApis(): ElectronPowerApis {
+  // Why: incomplete vi.mock('electron') fixtures must still load this module.
+  return require('electron') as ElectronPowerApis
+}
+
+/** Wake-on-demand + hold display awake while browser.screencast needs CDP frames. */
+export class BrowserScreencastAwakeService {
+  private readonly activeTokens = new Set<string>()
+  private blockerId: number | null = null
+  private readonly blocker: PowerSaveBlocker
+  private readonly linuxAssertion: PlatformAwakeAssertion
+  private readonly logger: Logger
+  private readonly macosAssertion: PlatformAwakeAssertion
+  private readonly wakeDisplay: (reason: string) => void
+  private readonly unsubscribeResume: (() => void) | null
+
+  constructor(options: BrowserScreencastAwakeServiceOptions = {}) {
+    this.logger = options.logger ?? console
+    this.wakeDisplay =
+      options.wakeDisplay ??
+      ((reason) => {
+        wakeMacosDisplay({ logger: this.logger })
+        wakeLinuxDisplay({ logger: this.logger })
+        this.logger.debug('[browser-screencast-awake] wake-on-demand', { reason })
+      })
+    const electronApis =
+      options.blocker !== undefined && options.powerMonitor !== undefined
+        ? null
+        : loadElectronPowerApis()
+    this.blocker = options.blocker ?? electronApis!.powerSaveBlocker
+    this.linuxAssertion =
+      options.linuxAssertion ??
+      new LinuxLidSleepAssertion({
+        logger: this.logger,
+        onUnexpectedFailure: (reason) => this.refresh(reason)
+      })
+    this.macosAssertion =
+      options.macosAssertion ??
+      new MacosSystemSleepAssertion({
+        logger: this.logger,
+        onUnexpectedFailure: (reason) => this.refresh(reason)
+      })
+    const resumeSource =
+      options.powerMonitor === undefined ? electronApis!.powerMonitor : options.powerMonitor
+    if (resumeSource) {
+      const onResume = () => this.refresh('power-resume')
+      resumeSource.on('resume', onResume)
+      this.unsubscribeResume = () => resumeSource.off('resume', onResume)
+    } else {
+      this.unsubscribeResume = null
+    }
+  }
+
+  acquire(token: string): void {
+    if (!token || this.activeTokens.has(token)) {
+      return
+    }
+    const becomingActive = this.activeTokens.size === 0
+    this.activeTokens.add(token)
+    if (becomingActive) {
+      // Why: prevent-display-sleep alone does not turn an already-sleeping display back on.
+      this.wakeDisplay('screencast-start')
+    }
+    this.refresh('screencast-acquire')
+  }
+
+  release(token: string): void {
+    if (!token || !this.activeTokens.delete(token)) {
+      return
+    }
+    this.refresh('screencast-release')
+  }
+
+  getActiveCount(): number {
+    return this.activeTokens.size
+  }
+
+  dispose(): void {
+    this.unsubscribeResume?.()
+    this.activeTokens.clear()
+    this.stopBlocker('dispose')
+    this.macosAssertion.dispose()
+    this.linuxAssertion.dispose()
+  }
+
+  private refresh(reason: string): void {
+    const activeCount = this.activeTokens.size
+    if (activeCount > 0) {
+      this.startBlocker(reason, activeCount)
+      this.runAssertion('start', this.macosAssertion, reason, 'macOS system sleep assertion')
+      this.runAssertion('start', this.linuxAssertion, reason, 'Linux lid sleep assertion')
+    } else {
+      this.stopBlocker(reason, activeCount)
+      this.runAssertion('stop', this.macosAssertion, reason, 'macOS system sleep assertion')
+      this.runAssertion('stop', this.linuxAssertion, reason, 'Linux lid sleep assertion')
+    }
+  }
+
+  private startBlocker(reason: string, activeCount: number): void {
+    if (this.blockerId !== null) {
+      if (this.reconcileBlocker('start-reconcile')) {
+        return
+      }
+    }
+    try {
+      const id = this.blocker.start('prevent-display-sleep')
+      this.blockerId = id
+      this.reconcileBlocker('post-start')
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to start blocker', {
+        reason,
+        activeCount,
+        error: err
+      })
+    }
+  }
+
+  private runAssertion(
+    action: 'start' | 'stop',
+    assertion: PlatformAwakeAssertion,
+    reason: string,
+    label: string
+  ): void {
+    try {
+      assertion[action](reason)
+    } catch (err) {
+      this.logger.warn(`[browser-screencast-awake] failed to ${action} ${label}`, {
+        reason,
+        error: err
+      })
+    }
+  }
+
+  private stopBlocker(reason: string, activeCount = 0): void {
+    if (this.blockerId === null) {
+      return
+    }
+    const id = this.blockerId
+    // Why: clear before stop so a flaky isStarted() cannot strand a stale id.
+    this.blockerId = null
+    try {
+      this.blocker.stop(id)
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to stop blocker', {
+        reason,
+        activeCount,
+        blockerId: id,
+        error: err
+      })
+    }
+  }
+
+  private reconcileBlocker(reason: string): boolean {
+    if (this.blockerId === null) {
+      return false
+    }
+    const id = this.blockerId
+    try {
+      const isStarted = this.blocker.isStarted(id)
+      if (!isStarted) {
+        this.blockerId = null
+      }
+      return isStarted
+    } catch (err) {
+      this.logger.warn('[browser-screencast-awake] failed to reconcile blocker', {
+        reason,
+        blockerId: id,
+        error: err
+      })
+      return true
+    }
+  }
+}
+
+let sharedBrowserScreencastAwakeService: BrowserScreencastAwakeService | null = null
+
+export function getBrowserScreencastAwakeService(): BrowserScreencastAwakeService {
+  sharedBrowserScreencastAwakeService ??= new BrowserScreencastAwakeService()
+  return sharedBrowserScreencastAwakeService
+}
+
+export function disposeBrowserScreencastAwakeService(): void {
+  sharedBrowserScreencastAwakeService?.dispose()
+  sharedBrowserScreencastAwakeService = null
+}

--- a/src/main/display-wake.test.ts
+++ b/src/main/display-wake.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it, vi } from 'vitest'
+import { wakeMacosDisplay } from './macos-display-wake'
+import { wakeLinuxDisplay } from './linux-display-wake'
+
+describe('display wake helpers', () => {
+  it('spawns caffeinate -u on macOS to turn the display on', () => {
+    const child = { unref: vi.fn() }
+    const spawn = vi.fn(() => child)
+
+    wakeMacosDisplay({ platform: 'darwin', spawn, timeoutSeconds: 5 })
+
+    expect(spawn).toHaveBeenCalledWith('/usr/bin/caffeinate', ['-u', '-t', '5'], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    expect(child.unref).toHaveBeenCalled()
+  })
+
+  it('skips macOS wake on non-darwin platforms', () => {
+    const spawn = vi.fn()
+    wakeMacosDisplay({ platform: 'linux', spawn })
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
+  it('forces DPMS on when Linux has a DISPLAY', () => {
+    const child = { unref: vi.fn() }
+    const spawn = vi.fn(() => child)
+
+    wakeLinuxDisplay({
+      platform: 'linux',
+      env: { DISPLAY: ':0' } as NodeJS.ProcessEnv,
+      spawn
+    })
+
+    expect(spawn).toHaveBeenCalledWith('xset', ['dpms', 'force', 'on'], {
+      stdio: 'ignore',
+      windowsHide: true,
+      env: expect.objectContaining({ DISPLAY: ':0' })
+    })
+    expect(child.unref).toHaveBeenCalled()
+  })
+
+  it('skips Linux wake without DISPLAY', () => {
+    const spawn = vi.fn()
+    wakeLinuxDisplay({
+      platform: 'linux',
+      env: {} as NodeJS.ProcessEnv,
+      spawn
+    })
+    expect(spawn).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -255,6 +255,7 @@ import { AutomationService } from './automations/service'
 import { createHeadlessAutomationOutputSnapshotBuffer } from './automations/headless-dispatch'
 import { buildHeadlessAutomationWorktreeCreateArgs } from './automations/headless-workspace-create'
 import { AgentAwakeService } from './agent-awake-service'
+import { disposeBrowserScreencastAwakeService } from './browser-screencast-awake-service'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
 import { settleTeardownWithinDeadline } from './quit-teardown-deadline'
 import { quitTeardownStartGate } from './quit-teardown-start-gate'
@@ -2988,6 +2989,7 @@ app.on('before-quit', () => {
   unsubscribeAgentAwakeStatusChanges = null
   agentAwakeService?.dispose()
   agentAwakeService = null
+  disposeBrowserScreencastAwakeService()
   // Why: defer PTY cleanup to will-quit so the renderer captures scrollback before PTY-exit events unmount TerminalPane (dropping its capture callbacks).
   rateLimits?.stop()
 })

--- a/src/main/linux-display-wake.ts
+++ b/src/main/linux-display-wake.ts
@@ -1,0 +1,40 @@
+import { spawn as nodeSpawn } from 'node:child_process'
+
+type Logger = Pick<Console, 'debug' | 'warn'>
+
+type WakeSpawn = (
+  command: string,
+  args: string[],
+  options: { stdio: 'ignore'; windowsHide: true; shell?: false; env?: NodeJS.ProcessEnv }
+) => { unref?: () => void }
+
+type LinuxDisplayWakeOptions = {
+  env?: NodeJS.ProcessEnv
+  logger?: Logger
+  platform?: NodeJS.Platform
+  spawn?: WakeSpawn
+}
+
+/** Best-effort DPMS on when a DISPLAY is available; no-op without X. */
+export function wakeLinuxDisplay(options: LinuxDisplayWakeOptions = {}): void {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'linux') {
+    return
+  }
+  const env = options.env ?? process.env
+  if (!env.DISPLAY) {
+    return
+  }
+  const logger = options.logger ?? console
+  const spawn = options.spawn ?? nodeSpawn
+  try {
+    const child = spawn('xset', ['dpms', 'force', 'on'], {
+      stdio: 'ignore',
+      windowsHide: true,
+      env
+    })
+    child.unref?.()
+  } catch (error) {
+    logger.debug('[browser-screencast-awake] failed to wake Linux display', { error })
+  }
+}

--- a/src/main/macos-display-wake.ts
+++ b/src/main/macos-display-wake.ts
@@ -1,0 +1,37 @@
+import { spawn as nodeSpawn } from 'node:child_process'
+
+type Logger = Pick<Console, 'debug' | 'warn'>
+
+type WakeSpawn = (
+  command: string,
+  args: string[],
+  options: { stdio: 'ignore'; windowsHide: true; shell?: false }
+) => { unref?: () => void }
+
+type MacosDisplayWakeOptions = {
+  logger?: Logger
+  platform?: NodeJS.Platform
+  spawn?: WakeSpawn
+  // Why: caffeinate -u default is 5s; keep the pulse short — prevent-display-sleep holds after.
+  timeoutSeconds?: number
+}
+
+/** Turns the display on when already asleep (IOPMAssertionDeclareUserActivity via caffeinate -u). */
+export function wakeMacosDisplay(options: MacosDisplayWakeOptions = {}): void {
+  const platform = options.platform ?? process.platform
+  if (platform !== 'darwin') {
+    return
+  }
+  const logger = options.logger ?? console
+  const spawn = options.spawn ?? nodeSpawn
+  const timeoutSeconds = Math.max(1, options.timeoutSeconds ?? 5)
+  try {
+    const child = spawn('/usr/bin/caffeinate', ['-u', `-t`, String(timeoutSeconds)], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    child.unref?.()
+  } catch (error) {
+    logger.warn('[browser-screencast-awake] failed to wake macOS display', { error })
+  }
+}

--- a/src/main/runtime/orca-runtime-browser.test.ts
+++ b/src/main/runtime/orca-runtime-browser.test.ts
@@ -10,7 +10,9 @@ const {
   startBrowserScreencastMock,
   waitForTabRegistrationMock,
   waitForWorktreeTabRegistrationMock,
-  browserSessionRegistryMock
+  browserSessionRegistryMock,
+  browserScreencastAwakeAcquireMock,
+  browserScreencastAwakeReleaseMock
 } = vi.hoisted(() => ({
   ipcMainOnMock: vi.fn(),
   ipcMainRemoveListenerMock: vi.fn(),
@@ -18,6 +20,8 @@ const {
   startBrowserScreencastMock: vi.fn(),
   waitForTabRegistrationMock: vi.fn(),
   waitForWorktreeTabRegistrationMock: vi.fn(),
+  browserScreencastAwakeAcquireMock: vi.fn(),
+  browserScreencastAwakeReleaseMock: vi.fn(),
   browserSessionRegistryMock: {
     profiles: new Map([
       [
@@ -55,6 +59,16 @@ vi.mock('electron', () => ({
 
 vi.mock('../browser/browser-screencast-stream', () => ({
   startBrowserScreencast: startBrowserScreencastMock
+}))
+
+vi.mock('../browser-screencast-awake-service', () => ({
+  getBrowserScreencastAwakeService: () => ({
+    acquire: browserScreencastAwakeAcquireMock,
+    release: browserScreencastAwakeReleaseMock,
+    dispose: vi.fn(),
+    getActiveCount: vi.fn(() => 0)
+  }),
+  disposeBrowserScreencastAwakeService: vi.fn()
 }))
 
 vi.mock('../ipc/browser', () => ({
@@ -110,6 +124,8 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     ipcMainRemoveListenerMock.mockReset()
     webContentsFromIdMock.mockReset()
     startBrowserScreencastMock.mockReset()
+    browserScreencastAwakeAcquireMock.mockReset()
+    browserScreencastAwakeReleaseMock.mockReset()
     waitForTabRegistrationMock.mockReset()
     waitForTabRegistrationMock.mockResolvedValue(undefined)
     waitForWorktreeTabRegistrationMock.mockReset()
@@ -580,6 +596,38 @@ describe('RuntimeBrowserCommands browser screencast', () => {
     await second.session.done
     expect(secondStop).toHaveBeenCalledTimes(1)
   }, 10_000)
+
+  it('wakes/holds the host and unthrottles the main window only while a screencast is live', async () => {
+    const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')
+    webContentsFromIdMock.mockReturnValue({ isDestroyed: () => false })
+    const done = deferred<void>()
+    const stop = vi.fn(() => done.resolve())
+    startBrowserScreencastMock.mockResolvedValue({ stop, done: done.promise })
+    const setBackgroundThrottling = vi.fn()
+    const getAvailableAuthoritativeWindow = vi.fn(() => ({
+      webContents: { setBackgroundThrottling, isDestroyed: () => false }
+    }))
+
+    const commands = new RuntimeBrowserCommands(
+      createHost({ getAvailableAuthoritativeWindow: getAvailableAuthoritativeWindow as never })
+    )
+    const session = await commands.browserScreencast(
+      { worktree: 'id:wt-1', page: 'page-1', format: 'jpeg' },
+      { sendBinary: vi.fn() }
+    )
+
+    expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledTimes(1)
+    expect(browserScreencastAwakeAcquireMock).toHaveBeenCalledWith('browser-screencast:page-1')
+    expect(setBackgroundThrottling).toHaveBeenCalledWith(false)
+    expect(browserScreencastAwakeReleaseMock).not.toHaveBeenCalled()
+
+    session.session.stop()
+    await session.session.done
+
+    expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledTimes(1)
+    expect(browserScreencastAwakeReleaseMock).toHaveBeenCalledWith('browser-screencast:page-1')
+    expect(setBackgroundThrottling).toHaveBeenLastCalledWith(true)
+  })
 
   it('admits screencast frames through the paired-runtime size guard', async () => {
     const { RuntimeBrowserCommands } = await import('./orca-runtime-browser')

--- a/src/main/runtime/orca-runtime-browser.ts
+++ b/src/main/runtime/orca-runtime-browser.ts
@@ -67,6 +67,7 @@ import {
   importCookiesFromBrowser,
   selectBrowserProfile
 } from '../browser/browser-cookie-import'
+import { getBrowserScreencastAwakeService } from '../browser-screencast-awake-service'
 import { waitForTabRegistration, waitForWorktreeTabRegistration } from '../ipc/browser'
 import { sendRemoteBrowserScreencastFrame } from './remote-browser-screencast-frame-admission'
 
@@ -158,12 +159,46 @@ export type RuntimeBrowserCommandHost = {
   ): void
 }
 
+function syncMainWindowBackgroundThrottlingForScreencast(
+  host: RuntimeBrowserCommandHost,
+  screencastActive: boolean
+): void {
+  const window = host.getAvailableAuthoritativeWindow()
+  const contents = window?.webContents
+  if (!contents || contents.isDestroyed?.() === true) {
+    return
+  }
+  try {
+    // Why: Electron has no throttle getter; restore `true` (createMainWindow default) when idle.
+    contents.setBackgroundThrottling(!screencastActive)
+  } catch {
+    // Why: the window can tear down between the null-check and the call during quit.
+  }
+}
+
 export class RuntimeBrowserCommands {
   private readonly activeScreencastPageIds = new Set<string>()
   private readonly activeScreencastsByPageId = new Map<string, ActiveBrowserScreencastPage>()
   private readonly stoppingScreencastPageIds = new Map<string, Promise<void>>()
 
   constructor(private readonly host: RuntimeBrowserCommandHost) {}
+
+  private screencastAwakeToken(browserPageId: string): string {
+    return `browser-screencast:${browserPageId}`
+  }
+
+  private markScreencastPageActive(browserPageId: string): void {
+    getBrowserScreencastAwakeService().acquire(this.screencastAwakeToken(browserPageId))
+    syncMainWindowBackgroundThrottlingForScreencast(this.host, true)
+  }
+
+  private markScreencastPageInactive(browserPageId: string): void {
+    getBrowserScreencastAwakeService().release(this.screencastAwakeToken(browserPageId))
+    syncMainWindowBackgroundThrottlingForScreencast(
+      this.host,
+      this.activeScreencastsByPageId.size > 0
+    )
+  }
 
   private requireAgentBrowserBridge(): AgentBrowserBridge {
     const bridge = this.host.getAgentBrowserBridge()
@@ -497,6 +532,8 @@ export class RuntimeBrowserCommands {
     }
     this.activeScreencastsByPageId.set(browserPageId, activeRecord)
     try {
+      // Why: wake + hold before CDP start so an already-sleeping display can recover.
+      this.markScreencastPageActive(browserPageId)
       session = await startBrowserScreencast(guest, {
         format,
         quality: clampInteger(params.quality, 10, 100, 70),
@@ -522,11 +559,17 @@ export class RuntimeBrowserCommands {
       if (this.activeScreencastsByPageId.get(browserPageId) === activeRecord) {
         this.activeScreencastsByPageId.delete(browserPageId)
       }
+      this.markScreencastPageInactive(browserPageId)
       resolveActiveDone()
       throw error
     }
     let stoppingPromise: Promise<void> | null = null
+    let pageGateCleared = false
     const clearPageGate = (): void => {
+      if (pageGateCleared) {
+        return
+      }
+      pageGateCleared = true
       this.activeScreencastPageIds.delete(browserPageId)
       if (this.activeScreencastsByPageId.get(browserPageId) === activeRecord) {
         this.activeScreencastsByPageId.delete(browserPageId)
@@ -537,6 +580,7 @@ export class RuntimeBrowserCommands {
       ) {
         this.stoppingScreencastPageIds.delete(browserPageId)
       }
+      this.markScreencastPageInactive(browserPageId)
       resolveActiveDone()
     }
     const markStopping = (): void => {


### PR DESCRIPTION
Fixes #11492

Supersedes the approach in #11491 (closed): that PR only held `prevent-display-sleep` after a screencast was already running. Maintainer feedback asked for an explicit **wake-on-demand** path that recovers when the host display/compositor is **already asleep** before remote browsing starts.

## Summary

- On the first live `browser.screencast`, **wake** the host display (macOS: `caffeinate -u`; Linux: best-effort `xset dpms force on` when `DISPLAY` is set), then hold Electron `prevent-display-sleep` + the same macOS/Linux sleep assertions agent-awake uses until the last stream ends.
- Temporarily disable main-window background throttling while streaming; restore the default when idle.
- Document lock-screen / lid / Windows caveats in `docs/reference/remote-browser-display-wake.md`.

## Why this is different from #11491

| | #11491 | This PR |
|--|--|--|
| Already-asleep display | Not addressed (`prevent-display-sleep` does not turn the panel on) | Explicit wake pulse before hold |
| Complexity | Stale TTL + live-token reconciliation lease model | Simple per-page token set + wake on 0→1 + hold while live |
| Docs | PR notes only | Checked-in reference doc for caveats |

## Screenshots

No visual change.

## Testing

- [x] Targeted vitest: screencast awake, display-wake helpers, platform-assertion isolation, runtime screencast lifecycle
- [x] `pnpm typecheck`
- [x] `pnpm run check:code-quality:changed -- upstream/main`
- [ ] Manual: pair mobile → turn host display off (session still running) → open browser pane → page should update; close pane → host may sleep again
- [ ] Manual: confirm lock screen may light up but unlock is not required for CDP streaming

## AI Review Report

- Cross-platform: macOS wake is the primary path; Linux is best-effort; Windows holds `prevent-display-sleep` only (documented).
- Remote/mobile: triggered from runtime `browser.screencast` start/teardown; no wire protocol change.
- Performance: cost only while a screencast is live (display/compositor + stream); idle releases assertions.

## Security Audit

No new IPC, auth, or secrets. Spawns existing OS tools (`caffeinate` / `xset`) with fixed args. Quit-time dispose releases blockers.

## Notes

- Unlock is usually unnecessary because screencast streams WebContents pixels, not the desktop framebuffer; waking may still illuminate the lock UI (privacy in shared spaces).
- Lid-closed / clamshell / full system sleep limitations are documented rather than papered over.
- Please approve fork workflows so CI can run.

Made with [Cursor](https://cursor.com)