### PR TITLE
fix(terminal): fence detached daemon endpoint ownership

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -20,6 +20,7 @@ on:
       - 'config/scripts/computer-use-smoke.mjs'
       - 'config/scripts/computer-use-smoke.test.mjs'
       - 'config/scripts/daemon-boot-smoke.mjs'
+      - 'config/scripts/daemon-endpoint-handover-smoke.mjs'
       - 'config/scripts/windows-daemon-workspace-close-repro.mjs'
       - 'config/scripts/verify-computer-native.mjs'
       # Why: the native-smoke job boots the built terminal daemon under plain
@@ -135,6 +136,11 @@ jobs:
       # the PR when the built daemon cannot start on ubuntu-22.04 / windows.
       - name: Daemon boot smoke
         run: node config/scripts/daemon-boot-smoke.mjs
+      # Why: a daemon that lost its endpoint name used to delete the replacement's
+      # socket on exit, stranding a live daemon that hosts PTYs nothing can reach.
+      # Only two real processes racing the same endpoint reproduce it.
+      - name: Daemon endpoint handover smoke
+        run: node config/scripts/daemon-endpoint-handover-smoke.mjs
       # Why: workspace removal overlaps graceful renderer teardown with the
       # forced main-process sweep; exercise that exact pair against real ConPTY.
       - name: Windows daemon workspace-close repro

--- a/config/scripts/daemon-boot-smoke.mjs
+++ b/config/scripts/daemon-boot-smoke.mjs
@@ -18,7 +18,7 @@
 import { fork } from 'node:child_process'
 import { connect } from 'node:net'
 import { randomUUID } from 'node:crypto'
-import { mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -126,16 +126,35 @@ async function main() {
   const userDataDir = mkdtempSync(join(tmpdir(), 'orca-daemon-boot-smoke-'))
   const socketPath = makeSocketPath(userDataDir)
   const tokenPath = join(userDataDir, 'daemon.token')
+  const pidPath = join(userDataDir, 'daemon.pid')
+  const launchNonce = randomUUID()
   const protocolVersion = readProtocolVersion()
 
   log(`forking ${entryPath} under plain Node (${process.execPath})`)
-  const child = fork(entryPath, ['--socket', socketPath, '--token', tokenPath], {
-    // Plain Node: no ELECTRON_RUN_AS_NODE. process.execPath is already node in
-    // CI, and this is exactly the runtime where a leaked `require("electron")`
-    // throws MODULE_NOT_FOUND — the failure this smoke exists to catch.
-    stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
-    env: { ...process.env, ORCA_USER_DATA_PATH: userDataDir }
-  })
+  const child = fork(
+    entryPath,
+    [
+      '--socket',
+      socketPath,
+      '--token',
+      tokenPath,
+      '--pid-record',
+      pidPath,
+      '--launch-nonce',
+      launchNonce,
+      '--entry-path',
+      entryPath,
+      '--app-version',
+      'daemon-boot-smoke'
+    ],
+    {
+      // Plain Node: no ELECTRON_RUN_AS_NODE. process.execPath is already node in
+      // CI, and this is exactly the runtime where a leaked `require("electron")`
+      // throws MODULE_NOT_FOUND — the failure this smoke exists to catch.
+      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      env: { ...process.env, ORCA_USER_DATA_PATH: userDataDir }
+    }
+  )
 
   let stderr = ''
   child.stderr?.on('data', (chunk) => {
@@ -185,6 +204,16 @@ async function main() {
       })
     })
     log('daemon signaled ready')
+    const pidRecord = JSON.parse(readFileSync(pidPath, 'utf8'))
+    if (
+      pidRecord.pid !== child.pid ||
+      pidRecord.launchNonce !== launchNonce ||
+      pidRecord.entryPath !== entryPath ||
+      pidRecord.appVersion !== 'daemon-boot-smoke'
+    ) {
+      throw new Error('daemon readiness did not publish the expected PID ownership record')
+    }
+    log('PID ownership record matches the ready daemon')
 
     const ptyHealthy = await runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion)
     if (ptyHealthy) {
@@ -205,6 +234,9 @@ async function main() {
       // termination. Either way the hard assertion is "it stops, no hang".
       child.kill('SIGTERM')
     })
+    if (existsSync(pidPath)) {
+      throw new Error('daemon left its PID ownership record behind after shutdown')
+    }
 
     log('PASS: daemon booted, served, and shut down under plain Node')
   } finally {

--- a/config/scripts/daemon-boot-smoke.mjs
+++ b/config/scripts/daemon-boot-smoke.mjs
@@ -165,7 +165,7 @@ async function main() {
       // Plain Node: no ELECTRON_RUN_AS_NODE. process.execPath is already node in
       // CI, and this is exactly the runtime where a leaked `require("electron")`
       // throws MODULE_NOT_FOUND — the failure this smoke exists to catch.
-      stdio: ['ignore', 'pipe', 'pipe', 'ipc'],
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
       env: { ...process.env, ORCA_USER_DATA_PATH: userDataDir }
     }
   )
@@ -173,9 +173,6 @@ async function main() {
   let stderr = ''
   child.stderr?.on('data', (chunk) => {
     stderr += chunk.toString('utf8')
-  })
-  child.stdout?.on('data', (chunk) => {
-    process.stdout.write(chunk)
   })
 
   const cleanup = () => {
@@ -228,7 +225,8 @@ async function main() {
       throw new Error('daemon readiness did not publish the expected PID ownership record')
     }
     log('PID ownership record matches the ready daemon')
-    // Production releases startup IPC after ready; keeping it open can pin the child on Windows.
+    // Production releases startup-only handles after ready; they can pin the child on Windows.
+    child.stderr?.destroy()
     child.disconnect()
 
     const ptyHealthy = await runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion)

--- a/config/scripts/daemon-boot-smoke.mjs
+++ b/config/scripts/daemon-boot-smoke.mjs
@@ -18,7 +18,7 @@
 import { fork } from 'node:child_process'
 import { connect } from 'node:net'
 import { randomUUID } from 'node:crypto'
-import { existsSync, mkdtempSync, readFileSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, readFileSync, readdirSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join, resolve } from 'node:path'
 
@@ -225,8 +225,14 @@ async function main() {
       throw new Error('daemon readiness did not publish the expected PID ownership record')
     }
     log('PID ownership record matches the ready daemon')
+    if (!existsSync(socketPath)) {
+      throw new Error('daemon did not publish its endpoint at the canonical socket path')
+    }
+    log('endpoint published at the canonical socket path')
     // Production releases startup-only handles after ready; they can pin the child on Windows.
+    // Diagnostics past this point therefore carry the tail captured up to readiness only.
     child.stderr?.destroy()
+    stderr += '[boot-smoke] stderr released at readiness, mirroring production\n'
     child.disconnect()
 
     const ptyHealthy = await runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion)
@@ -247,7 +253,11 @@ async function main() {
         socketPath,
         tokenPath,
         protocolVersion,
-        { id: 'shutdown-1', type: 'shutdown', payload: { killSessions: false } },
+        {
+          id: 'shutdown-1',
+          type: 'shutdown',
+          payload: { killSessions: false }
+        },
         SHUTDOWN_TIMEOUT_MS
       ).catch((error) => {
         clearTimeout(timer)
@@ -256,6 +266,14 @@ async function main() {
     })
     if (existsSync(pidPath)) {
       throw new Error('daemon left its PID ownership record behind after shutdown')
+    }
+    if (process.platform !== 'win32' && existsSync(socketPath)) {
+      throw new Error('daemon left its endpoint socket behind after shutdown')
+    }
+    // The private bind name is consumed by the publish; nothing may linger in the runtime dir.
+    const leaked = readdirSync(userDataDir).filter((entry) => entry.startsWith('.b'))
+    if (leaked.length > 0) {
+      throw new Error(`daemon leaked private bind names: ${leaked.join(', ')}`)
     }
 
     log('PASS: daemon booted, served, and shut down under plain Node')

--- a/config/scripts/daemon-boot-smoke.mjs
+++ b/config/scripts/daemon-boot-smoke.mjs
@@ -228,6 +228,8 @@ async function main() {
       throw new Error('daemon readiness did not publish the expected PID ownership record')
     }
     log('PID ownership record matches the ready daemon')
+    // Production releases startup IPC after ready; keeping it open can pin the child on Windows.
+    child.disconnect()
 
     const ptyHealthy = await runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion)
     if (ptyHealthy) {
@@ -236,7 +238,7 @@ async function main() {
 
     await new Promise((resolveExit, rejectExit) => {
       const timer = setTimeout(() => {
-        rejectExit(new Error(`daemon did not exit within ${SHUTDOWN_TIMEOUT_MS}ms of SIGTERM`))
+        rejectExit(new Error(`daemon did not exit within ${SHUTDOWN_TIMEOUT_MS}ms of shutdown RPC`))
       }, SHUTDOWN_TIMEOUT_MS)
       child.on('exit', (code, signal) => {
         clearTimeout(timer)

--- a/config/scripts/daemon-boot-smoke.mjs
+++ b/config/scripts/daemon-boot-smoke.mjs
@@ -54,30 +54,27 @@ function makeSocketPath(userDataDir) {
   return join(userDataDir, 'daemon.sock')
 }
 
-// Best-effort end-to-end PTY check over the daemon's own control-socket RPC.
-// Connects a single control socket, completes the hello handshake, and calls
-// `ptySpawnHealth` (the daemon spawns a throwaway PTY internally). Resolves
-// true on success, false on any failure — never throws.
-function runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion) {
-  return new Promise((resolveCheck) => {
+function runDaemonRpc(socketPath, tokenPath, protocolVersion, request, timeoutMs) {
+  return new Promise((resolveRpc, rejectRpc) => {
     let settled = false
     let buffer = ''
     const socket = connect(socketPath)
-    const finish = (ok, reason) => {
+    const finish = (error, response) => {
       if (settled) {
         return
       }
       settled = true
       clearTimeout(timer)
       socket.destroy()
-      if (!ok && reason) {
-        log(`PTY spawn health check skipped (best-effort): ${reason}`)
+      if (error) {
+        rejectRpc(error)
+      } else {
+        resolveRpc(response)
       }
-      resolveCheck(ok)
     }
-    const timer = setTimeout(() => finish(false, 'timed out'), PTY_HEALTH_TIMEOUT_MS)
+    const timer = setTimeout(() => finish(new Error(`${request.type} timed out`)), timeoutMs)
 
-    socket.on('error', (err) => finish(false, err.message))
+    socket.on('error', (error) => finish(error))
     socket.on('connect', () => {
       const token = readFileSync(tokenPath, 'utf8').trim()
       socket.write(
@@ -100,19 +97,19 @@ function runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion) {
         try {
           msg = JSON.parse(line)
         } catch {
-          finish(false, 'invalid response line')
+          finish(new Error('invalid response line'))
           return
         }
         if (msg.type === 'hello') {
           if (!msg.ok) {
-            finish(false, `hello rejected: ${msg.error ?? 'unknown'}`)
+            finish(new Error(`hello rejected: ${msg.error ?? 'unknown'}`))
             return
           }
-          socket.write(`${JSON.stringify({ id: 'health-1', type: 'ptySpawnHealth' })}\n`)
-        } else if (msg.id === 'health-1') {
+          socket.write(`${JSON.stringify(request)}\n`)
+        } else if (msg.id === request.id) {
           finish(
-            msg.ok === true,
-            msg.ok === true ? undefined : (msg.error ?? 'ptySpawnHealth failed')
+            msg.ok === true ? undefined : new Error(msg.error ?? `${request.type} failed`),
+            msg
           )
           return
         }
@@ -120,6 +117,23 @@ function runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion) {
       }
     })
   })
+}
+
+// Best-effort: constrained CI runners can make node-pty spawn flaky.
+async function runPtySpawnHealthCheck(socketPath, tokenPath, protocolVersion) {
+  try {
+    await runDaemonRpc(
+      socketPath,
+      tokenPath,
+      protocolVersion,
+      { id: 'health-1', type: 'ptySpawnHealth' },
+      PTY_HEALTH_TIMEOUT_MS
+    )
+    return true
+  } catch (error) {
+    log(`PTY spawn health check skipped (best-effort): ${error.message}`)
+    return false
+  }
 }
 
 async function main() {
@@ -226,13 +240,19 @@ async function main() {
       }, SHUTDOWN_TIMEOUT_MS)
       child.on('exit', (code, signal) => {
         clearTimeout(timer)
-        log(`daemon exited after signal (code=${code}, signal=${signal})`)
+        log(`daemon exited after shutdown RPC (code=${code}, signal=${signal})`)
         resolveExit()
       })
-      // Why: SIGTERM is the graceful stop on POSIX (the daemon handles it);
-      // Windows has no POSIX signal delivery, so Node maps this to process
-      // termination. Either way the hard assertion is "it stops, no hang".
-      child.kill('SIGTERM')
+      void runDaemonRpc(
+        socketPath,
+        tokenPath,
+        protocolVersion,
+        { id: 'shutdown-1', type: 'shutdown', payload: { killSessions: false } },
+        SHUTDOWN_TIMEOUT_MS
+      ).catch((error) => {
+        clearTimeout(timer)
+        rejectExit(error)
+      })
     })
     if (existsSync(pidPath)) {
       throw new Error('daemon left its PID ownership record behind after shutdown')

--- a/config/scripts/daemon-endpoint-handover-smoke.mjs
+++ b/config/scripts/daemon-endpoint-handover-smoke.mjs
@@ -1,0 +1,164 @@
+/**
+ * Endpoint handover smoke — guards the split-brain failure with real daemon processes.
+ *
+ * The failure it reproduces: a daemon whose endpoint name is reclaimed while it is still
+ * alive used to delete the *replacement's* socket when it finally exited, because libuv
+ * unlinks the pathname a server bound to with no ownership check. The replacement stayed
+ * alive hosting PTYs that nothing could reach — terminals that acknowledge input and never
+ * run it, and that a user cannot fix by restarting the app.
+ *
+ * Unix only: Windows named pipes are not directory entries, so the mechanism cannot occur.
+ *
+ * Usage: node config/scripts/daemon-endpoint-handover-smoke.mjs
+ */
+import { fork } from 'node:child_process'
+import { connect } from 'node:net'
+import { randomUUID } from 'node:crypto'
+import { existsSync, mkdtempSync, rmSync, statSync, unlinkSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join, resolve } from 'node:path'
+
+const repoRoot = resolve(import.meta.dirname, '..', '..')
+const entryPath = join(repoRoot, 'out', 'main', 'daemon-entry.js')
+const READY_TIMEOUT_MS = 20_000
+const EXIT_TIMEOUT_MS = 15_000
+
+const log = (msg) => console.log(`[endpoint-handover-smoke] ${msg}`)
+
+function bootDaemon(tag, dir, socketPath) {
+  const tokenPath = join(dir, `${tag}.token`)
+  const pidPath = join(dir, `${tag}.pid`)
+  const child = fork(
+    entryPath,
+    [
+      '--socket',
+      socketPath,
+      '--token',
+      tokenPath,
+      '--pid-record',
+      pidPath,
+      '--launch-nonce',
+      randomUUID(),
+      '--entry-path',
+      entryPath,
+      '--app-version',
+      'endpoint-handover-smoke'
+    ],
+    {
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc'],
+      env: { ...process.env, ORCA_USER_DATA_PATH: dir }
+    }
+  )
+  let stderr = ''
+  child.stderr?.on('data', (chunk) => {
+    stderr += chunk.toString('utf8')
+  })
+  return new Promise((resolveReady, rejectReady) => {
+    const timer = setTimeout(
+      () => rejectReady(new Error(`daemon ${tag} never signaled ready.\nstderr:\n${stderr}`)),
+      READY_TIMEOUT_MS
+    )
+    child.on('message', (msg) => {
+      if (msg && typeof msg === 'object' && msg.type === 'ready') {
+        clearTimeout(timer)
+        resolveReady({ child, tokenPath, pidPath })
+      }
+    })
+    child.on('exit', (code) => {
+      clearTimeout(timer)
+      rejectReady(new Error(`daemon ${tag} exited with ${code}.\nstderr:\n${stderr}`))
+    })
+  })
+}
+
+function isReachable(socketPath) {
+  return new Promise((resolveReachable) => {
+    const socket = connect({ path: socketPath })
+    socket.on('connect', () => {
+      socket.destroy()
+      resolveReachable(true)
+    })
+    socket.on('error', () => resolveReachable(false))
+  })
+}
+
+function killAndWait(child) {
+  if (child.exitCode !== null || child.signalCode !== null) {
+    return Promise.resolve()
+  }
+  return new Promise((resolveExit, rejectExit) => {
+    const timer = setTimeout(() => rejectExit(new Error('daemon did not exit')), EXIT_TIMEOUT_MS)
+    child.on('exit', () => {
+      clearTimeout(timer)
+      resolveExit()
+    })
+    child.kill('SIGTERM')
+  })
+}
+
+async function main() {
+  if (process.platform === 'win32') {
+    log('SKIP: named pipes are not filesystem entries, so endpoint handover cannot occur')
+    return
+  }
+  if (!existsSync(entryPath)) {
+    throw new Error(`missing ${entryPath} — run \`pnpm build\` first`)
+  }
+
+  const dir = mkdtempSync(join(tmpdir(), 'orca-endpoint-handover-'))
+  const socketPath = join(dir, 'daemon.sock')
+  let replaced
+  let replacement
+  try {
+    replaced = await bootDaemon('replaced', dir, socketPath)
+    const replacedInode = statSync(socketPath).ino
+    log('daemon A published the endpoint')
+
+    // Reclaim the endpoint name the way daemon replacement does, while A is still alive.
+    unlinkSync(socketPath)
+    replacement = await bootDaemon('replacement', dir, socketPath)
+    const replacementInode = statSync(socketPath).ino
+    if (replacedInode === replacementInode) {
+      throw new Error('daemon B did not publish a distinct endpoint')
+    }
+    if (!(await isReachable(socketPath))) {
+      throw new Error('daemon B is not reachable through the canonical endpoint')
+    }
+    log('daemon B took over the endpoint and is reachable')
+
+    // A exits long after losing the endpoint. This is the step that used to break B.
+    await killAndWait(replaced.child)
+    await new Promise((r) => setTimeout(r, 300))
+
+    if (!existsSync(socketPath) || statSync(socketPath).ino !== replacementInode) {
+      throw new Error("daemon A's late exit deleted daemon B's endpoint")
+    }
+    if (!(await isReachable(socketPath))) {
+      throw new Error('daemon B became unreachable after daemon A exited')
+    }
+    if (!existsSync(replacement.pidPath)) {
+      throw new Error("daemon A's late exit removed daemon B's ownership record")
+    }
+    if (existsSync(replaced.pidPath)) {
+      throw new Error('daemon A left its own ownership record behind')
+    }
+
+    log('PASS: the endpoint owner and the session host stayed the same daemon')
+  } finally {
+    for (const daemon of [replaced, replacement]) {
+      if (daemon && daemon.child.exitCode === null && daemon.child.signalCode === null) {
+        try {
+          daemon.child.kill('SIGKILL')
+        } catch {
+          // already gone
+        }
+      }
+    }
+    rmSync(dir, { recursive: true, force: true })
+  }
+}
+
+main().catch((error) => {
+  console.error(`[endpoint-handover-smoke] FAIL: ${error.message}`)
+  process.exit(1)
+})

--- a/src/main/daemon/client.ts
+++ b/src/main/daemon/client.ts
@@ -503,7 +503,13 @@ function parseDaemonEndpointIdentity(value: unknown): DaemonEndpointIdentity | n
   if (!value || typeof value !== 'object') {
     return null
   }
-  const identity = value as { pid?: unknown; startedAtMs?: unknown; launchNonce?: unknown }
+  const identity = value as {
+    pid?: unknown
+    startedAtMs?: unknown
+    launchNonce?: unknown
+    entryPath?: unknown
+    appVersion?: unknown
+  }
   if (
     !Number.isSafeInteger(identity.pid) ||
     (identity.pid as number) <= 0 ||
@@ -518,7 +524,13 @@ function parseDaemonEndpointIdentity(value: unknown): DaemonEndpointIdentity | n
   return {
     pid: identity.pid as number,
     startedAtMs: identity.startedAtMs,
-    launchNonce: identity.launchNonce
+    launchNonce: identity.launchNonce,
+    ...(typeof identity.entryPath === 'string' && identity.entryPath.length > 0
+      ? { entryPath: identity.entryPath }
+      : {}),
+    ...(typeof identity.appVersion === 'string' && identity.appVersion.length > 0
+      ? { appVersion: identity.appVersion }
+      : {})
   }
 }
 

--- a/src/main/daemon/daemon-endpoint-ownership.test.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.test.ts
@@ -1,0 +1,141 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readFileSync,
+  rmSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonServer } from './daemon-server'
+import { getDaemonSocketPath, publishDaemonPidFile } from './daemon-spawner'
+import type { SubprocessHandle } from './session'
+
+function createMockSubprocess(): SubprocessHandle {
+  return {
+    pid: 55555,
+    getForegroundProcess: () => null,
+    write() {},
+    resize() {},
+    kill() {},
+    forceKill() {},
+    signal() {},
+    onData() {},
+    onExit() {},
+    dispose() {}
+  }
+}
+
+describe('daemon endpoint ownership publication', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+  let server: DaemonServer
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-endpoint-ownership-'))
+    socketPath = getDaemonSocketPath(dir)
+    tokenPath = join(dir, 'daemon.token')
+  })
+
+  afterEach(async () => {
+    await server?.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  it('does not publish an adoptable endpoint before durable ownership succeeds', async () => {
+    writeFileSync(tokenPath, 'previous-token')
+    const publishEndpointOwnership = vi.fn(() => {
+      expect(readFileSync(tokenPath, 'utf8')).toBe('previous-token')
+      throw Object.assign(new Error('PID record already owned'), { code: 'EEXIST' })
+    })
+    server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      publishEndpointOwnership,
+      spawnSubprocess: () => createMockSubprocess()
+    })
+
+    await expect(server.start()).rejects.toThrow('PID record already owned')
+
+    expect(publishEndpointOwnership).toHaveBeenCalledOnce()
+    expect(readFileSync(tokenPath, 'utf8')).toBe('previous-token')
+    if (process.platform !== 'win32') {
+      expect(existsSync(socketPath)).toBe(false)
+    }
+  })
+
+  it('rolls back exact PID ownership when token publication fails', async () => {
+    const pidPath = join(dir, 'daemon.pid')
+    const launchNonce = 'failed-launch'
+    mkdirSync(tokenPath)
+    server = new DaemonServer({
+      socketPath,
+      tokenPath,
+      pidPath,
+      launchNonce,
+      publishEndpointOwnership: () =>
+        publishDaemonPidFile(pidPath, {
+          pid: process.pid,
+          startedAtMs: 1_000,
+          launchNonce
+        }),
+      spawnSubprocess: () => createMockSubprocess()
+    })
+
+    await expect(server.start()).rejects.toMatchObject({ code: 'EISDIR' })
+
+    expect(existsSync(pidPath)).toBe(false)
+    expect(existsSync(tokenPath)).toBe(true)
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'refuses a second listener when a live daemon socket path was removed',
+    async () => {
+      const pidPath = join(dir, 'daemon.pid')
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        pidPath,
+        launchNonce: 'first-launch',
+        publishEndpointOwnership: () =>
+          publishDaemonPidFile(pidPath, {
+            pid: process.pid,
+            startedAtMs: 1_000,
+            launchNonce: 'first-launch'
+          }),
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      await server.start()
+      const firstToken = readFileSync(tokenPath, 'utf8')
+      unlinkSync(socketPath)
+
+      const duplicate = new DaemonServer({
+        socketPath,
+        tokenPath,
+        pidPath,
+        launchNonce: 'second-launch',
+        publishEndpointOwnership: () =>
+          publishDaemonPidFile(pidPath, {
+            pid: process.pid,
+            startedAtMs: 2_000,
+            launchNonce: 'second-launch'
+          }),
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      try {
+        await expect(duplicate.start()).rejects.toMatchObject({ code: 'EEXIST' })
+        expect(readFileSync(tokenPath, 'utf8')).toBe(firstToken)
+        expect(JSON.parse(readFileSync(pidPath, 'utf8'))).toMatchObject({
+          startedAtMs: 1_000,
+          launchNonce: 'first-launch'
+        })
+      } finally {
+        await duplicate.shutdown()
+      }
+    }
+  )
+})

--- a/src/main/daemon/daemon-endpoint-ownership.test.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
+  linkSync,
   mkdirSync,
   mkdtempSync,
   readFileSync,
@@ -8,11 +9,24 @@ import {
   unlinkSync,
   writeFileSync
 } from 'node:fs'
+import { connect, createServer } from 'node:net'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { DaemonServer } from './daemon-server'
 import { getDaemonSocketPath, publishDaemonPidFile } from './daemon-spawner'
+import { readDaemonSocketIdentity } from './daemon-endpoint-ownership'
 import type { SubprocessHandle } from './session'
+
+function connectsTo(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ path: socketPath })
+    socket.on('connect', () => {
+      socket.destroy()
+      resolve(true)
+    })
+    socket.on('error', () => resolve(false))
+  })
+}
 
 function createMockSubprocess(): SubprocessHandle {
   return {
@@ -50,7 +64,9 @@ describe('daemon endpoint ownership publication', () => {
     writeFileSync(tokenPath, 'previous-token')
     const publishEndpointOwnership = vi.fn(() => {
       expect(readFileSync(tokenPath, 'utf8')).toBe('previous-token')
-      throw Object.assign(new Error('PID record already owned'), { code: 'EEXIST' })
+      throw Object.assign(new Error('PID record already owned'), {
+        code: 'EEXIST'
+      })
     })
     server = new DaemonServer({
       socketPath,
@@ -93,6 +109,111 @@ describe('daemon endpoint ownership publication', () => {
   })
 
   it.skipIf(process.platform === 'win32')(
+    'keeps a replacement endpoint when the daemon it replaced closes late',
+    async () => {
+      // Why: this is the split-brain mechanism. libuv unlinks the pathname a server bound to
+      // when that server closes, with no ownership check — so a daemon exiting late used to
+      // delete whichever socket then sat at the canonical path. The replacement stayed alive
+      // hosting PTYs that no client could reach, which is what "terminals ack but never run"
+      // looked like from the user's seat.
+      const replacedPidPath = join(dir, 'replaced.pid')
+      const replaced = new DaemonServer({
+        socketPath,
+        tokenPath,
+        pidPath: replacedPidPath,
+        launchNonce: 'replaced-daemon',
+        publishEndpointOwnership: () =>
+          publishDaemonPidFile(replacedPidPath, {
+            pid: process.pid,
+            startedAtMs: 1_000,
+            launchNonce: 'replaced-daemon'
+          }),
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      await replaced.start()
+
+      // A replacement reclaims the endpoint the way killStaleDaemon does.
+      unlinkSync(socketPath)
+      const pidPath = join(dir, 'replacement.pid')
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        pidPath,
+        launchNonce: 'replacement-daemon',
+        publishEndpointOwnership: () =>
+          publishDaemonPidFile(pidPath, {
+            pid: process.pid,
+            startedAtMs: 2_000,
+            launchNonce: 'replacement-daemon'
+          }),
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      await server.start()
+      const replacementIdentity = readDaemonSocketIdentity(socketPath)
+
+      // The daemon that lost the endpoint now exits, long after the handover.
+      await replaced.shutdown()
+
+      expect(existsSync(socketPath)).toBe(true)
+      expect(readDaemonSocketIdentity(socketPath)).toEqual(replacementIdentity)
+      // The replacement is still reachable through the canonical name.
+      await expect(connectsTo(socketPath)).resolves.toBe(true)
+      // The late exit also must not remove the replacement's ownership record.
+      expect(existsSync(pidPath)).toBe(true)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'retires a daemon whose endpoint was taken over by another daemon',
+    async () => {
+      const pidPath = join(dir, 'daemon.pid')
+      server = new DaemonServer({
+        socketPath,
+        tokenPath,
+        pidPath,
+        launchNonce: 'original-daemon',
+        publishEndpointOwnership: () =>
+          publishDaemonPidFile(pidPath, {
+            pid: process.pid,
+            startedAtMs: 1_000,
+            launchNonce: 'original-daemon'
+          }),
+        spawnSubprocess: () => createMockSubprocess()
+      })
+      await server.start()
+
+      const daemon = server as unknown as {
+        checkEndpointOwnership: () => void
+        retirementRequested: boolean
+      }
+      daemon.checkEndpointOwnership()
+      expect(daemon.retirementRequested).toBe(false)
+
+      // Another daemon takes the endpoint name.
+      unlinkSync(socketPath)
+      const usurper = createServer()
+      const usurperBind = join(dir, '.usurper')
+      await new Promise<void>((resolve) => usurper.listen(usurperBind, resolve))
+      linkSync(usurperBind, socketPath)
+      unlinkSync(usurperBind)
+
+      try {
+        daemon.checkEndpointOwnership()
+        // Why: retirement drains rather than kills — an orphaned daemon stops being a
+        // permanent unreachable host without tearing live sessions out from under the user.
+        expect(daemon.retirementRequested).toBe(true)
+      } finally {
+        await new Promise<void>((resolve) => usurper.close(() => resolve()))
+        try {
+          unlinkSync(socketPath)
+        } catch {
+          // Already gone.
+        }
+      }
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
     'refuses a second listener when a live daemon socket path was removed',
     async () => {
       const pidPath = join(dir, 'daemon.pid')
@@ -127,7 +248,9 @@ describe('daemon endpoint ownership publication', () => {
         spawnSubprocess: () => createMockSubprocess()
       })
       try {
-        await expect(duplicate.start()).rejects.toMatchObject({ code: 'EEXIST' })
+        await expect(duplicate.start()).rejects.toMatchObject({
+          code: 'EEXIST'
+        })
         expect(readFileSync(tokenPath, 'utf8')).toBe(firstToken)
         expect(JSON.parse(readFileSync(pidPath, 'utf8'))).toMatchObject({
           startedAtMs: 1_000,

--- a/src/main/daemon/daemon-endpoint-ownership.test.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.test.ts
@@ -186,6 +186,8 @@ describe('daemon endpoint ownership publication', () => {
         checkEndpointOwnership: () => void
         retirementRequested: boolean
       }
+      // An inconclusive or matching probe must never retire a healthy daemon, however often it runs.
+      daemon.checkEndpointOwnership()
       daemon.checkEndpointOwnership()
       expect(daemon.retirementRequested).toBe(false)
 
@@ -198,6 +200,11 @@ describe('daemon endpoint ownership publication', () => {
       unlinkSync(usurperBind)
 
       try {
+        // A single observation can land inside a replacement's unlink-then-link gap, so the
+        // first one must not retire anything.
+        daemon.checkEndpointOwnership()
+        expect(daemon.retirementRequested).toBe(false)
+
         daemon.checkEndpointOwnership()
         // Why: retirement drains rather than kills — an orphaned daemon stops being a
         // permanent unreachable host without tearing live sessions out from under the user.

--- a/src/main/daemon/daemon-endpoint-ownership.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.ts
@@ -36,6 +36,9 @@ export function publishDaemonSocketPath(
     // Named pipes are not directory entries; the pipe name itself is exclusive.
     return null
   }
+  // Why: stat the bound name first — the link shares the inode, so a racing unlink of the
+  // canonical name cannot erase our identity and leave the endpoint unwatched and uncleanable.
+  const identity = readDaemonSocketIdentity(boundPath)
   try {
     linkSync(boundPath, canonicalPath)
   } catch (error) {
@@ -50,9 +53,8 @@ export function publishDaemonSocketPath(
       throw error
     }
     renameSync(boundPath, canonicalPath)
-    return readDaemonSocketIdentity(canonicalPath)
+    return identity
   }
-  const identity = readDaemonSocketIdentity(canonicalPath)
   try {
     unlinkSync(boundPath)
   } catch {

--- a/src/main/daemon/daemon-endpoint-ownership.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.ts
@@ -1,0 +1,143 @@
+/* Ownership of the daemon's canonical endpoint name and of the scratch entries the
+   rename-claim protocol leaves behind. Kept apart from daemon-spawner so the rule that
+   decides who may serve on the socket path is readable on its own. */
+import { randomBytes } from 'node:crypto'
+import { existsSync, linkSync, readdirSync, renameSync, statSync, unlinkSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+
+/** The exact directory entry a daemon owns. Compared before any endpoint removal. */
+export type DaemonSocketIdentity = { dev: bigint; ino: bigint }
+
+/**
+ * A private, same-directory name to bind before publishing the canonical endpoint.
+ *
+ * Why: `sockaddr_un.sun_path` caps a Unix socket path at ~104 bytes, so this must not extend
+ * the canonical path — it replaces the basename with a shorter one, which keeps the bind name
+ * strictly shorter than the endpoint the caller already requires to fit.
+ */
+export function getDaemonSocketBindPath(socketPath: string): string {
+  return join(dirname(socketPath), `.b${randomBytes(5).toString('hex')}`)
+}
+
+/**
+ * Publishes a bound listener under the canonical endpoint name.
+ *
+ * Why: Node/libuv unlinks the pathname a server bound to when that server closes,
+ * with no ownership check — a daemon exiting late therefore deletes whichever socket
+ * currently sits at that path, including a live replacement's. Binding a unique path
+ * and hard-linking it into place instead means libuv only ever unlinks the private
+ * bind name, and the exclusive link doubles as the kernel-enforced endpoint claim.
+ */
+export function publishDaemonSocketPath(
+  boundPath: string,
+  canonicalPath: string
+): DaemonSocketIdentity | null {
+  if (process.platform === 'win32') {
+    // Named pipes are not directory entries; the pipe name itself is exclusive.
+    return null
+  }
+  try {
+    linkSync(boundPath, canonicalPath)
+  } catch (error) {
+    if (isFileExistsError(error)) {
+      throw error
+    }
+    // Why: a filesystem without hard links must not stop the daemon from starting. Rename
+    // still moves the bind name out from under libuv, which preserves the property that
+    // matters most — a late close cannot delete a replacement's endpoint. Exclusivity
+    // degrades to check-then-act here, which is no weaker than binding the path directly.
+    if (existsSync(canonicalPath)) {
+      throw error
+    }
+    renameSync(boundPath, canonicalPath)
+    return readDaemonSocketIdentity(canonicalPath)
+  }
+  const identity = readDaemonSocketIdentity(canonicalPath)
+  try {
+    unlinkSync(boundPath)
+  } catch {
+    // Inert: clients resolve the canonical link, and the bind name is unique to us.
+  }
+  return identity
+}
+
+function isFileExistsError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'EEXIST'
+}
+
+export function readDaemonSocketIdentity(socketPath: string): DaemonSocketIdentity | null {
+  if (process.platform === 'win32') {
+    return null
+  }
+  try {
+    const stats = statSync(socketPath, { bigint: true })
+    return { dev: stats.dev, ino: stats.ino }
+  } catch {
+    return null
+  }
+}
+
+export function daemonSocketIdentityMatches(
+  a: DaemonSocketIdentity | null,
+  b: DaemonSocketIdentity | null
+): boolean {
+  return a !== null && b !== null && a.dev === b.dev && a.ino === b.ino
+}
+
+/** Removes the canonical endpoint name only while it still resolves to our own listener. */
+export function unlinkOwnedDaemonSocketPath(
+  socketPath: string,
+  owned: DaemonSocketIdentity | null
+): boolean {
+  if (process.platform === 'win32' || !owned) {
+    return false
+  }
+  if (!daemonSocketIdentityMatches(readDaemonSocketIdentity(socketPath), owned)) {
+    return false
+  }
+  try {
+    unlinkSync(socketPath)
+    return true
+  } catch {
+    return false
+  }
+}
+
+const ABANDONED_DAEMON_CLAIM_PATTERN =
+  /(?:\.(?:cleanup|replace)-\d+-[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|^\.b[0-9a-f]{10})$/
+
+const ABANDONED_DAEMON_CLAIM_MIN_AGE_MS = 60 * 60 * 1000
+
+/**
+ * Reclaims claim/bind scratch names left behind when a rename-claim or bind publish
+ * could not remove its own temporary entry. Age-gated so a claim in flight is never touched.
+ */
+export function sweepAbandonedDaemonClaims(
+  runtimeDir: string,
+  minAgeMs = ABANDONED_DAEMON_CLAIM_MIN_AGE_MS,
+  now = Date.now()
+): number {
+  let swept = 0
+  let entries: string[]
+  try {
+    entries = readdirSync(runtimeDir)
+  } catch {
+    return 0
+  }
+  for (const entry of entries) {
+    if (!ABANDONED_DAEMON_CLAIM_PATTERN.test(entry)) {
+      continue
+    }
+    const claimPath = join(runtimeDir, entry)
+    try {
+      if (now - statSync(claimPath).mtimeMs < minAgeMs) {
+        continue
+      }
+      unlinkSync(claimPath)
+      swept++
+    } catch {
+      // Best-effort; a locked or already-removed claim is retried on a future launch.
+    }
+  }
+  return swept
+}

--- a/src/main/daemon/daemon-endpoint-ownership.ts
+++ b/src/main/daemon/daemon-endpoint-ownership.ts
@@ -84,6 +84,30 @@ export function daemonSocketIdentityMatches(
   return a !== null && b !== null && a.dev === b.dev && a.ino === b.ino
 }
 
+/** 'indeterminate' is deliberately distinct from 'lost': only positive evidence may retire a daemon. */
+export type DaemonEndpointOwnershipState = 'owned' | 'lost' | 'indeterminate'
+
+export function readDaemonEndpointOwnershipState(
+  socketPath: string,
+  owned: DaemonSocketIdentity | null
+): DaemonEndpointOwnershipState {
+  if (process.platform === 'win32' || !owned) {
+    return 'indeterminate'
+  }
+  try {
+    const stats = statSync(socketPath, { bigint: true })
+    return stats.dev === owned.dev && stats.ino === owned.ino ? 'owned' : 'lost'
+  } catch (error) {
+    // Why: a stat that failed for any reason other than "the entry is gone" proves nothing.
+    // Treating EACCES or EIO as lost ownership would retire a perfectly healthy daemon.
+    return isMissingFileError(error) ? 'lost' : 'indeterminate'
+  }
+}
+
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
 /** Removes the canonical endpoint name only while it still resolves to our own listener. */
 export function unlinkOwnedDaemonSocketPath(
   socketPath: string,

--- a/src/main/daemon/daemon-entry.test.ts
+++ b/src/main/daemon/daemon-entry.test.ts
@@ -71,6 +71,30 @@ describe('daemon-entry parseArgs', () => {
     })
   })
 
+  it('parses PID publication metadata from the launcher', () => {
+    expect(
+      parseArgs([
+        '--socket',
+        '/tmp/t.sock',
+        '--token',
+        '/tmp/t.token',
+        '--pid-record',
+        '/tmp/t.pid',
+        '--launch-nonce',
+        'launch-a',
+        '--entry-path',
+        '/app/daemon-entry.js',
+        '--app-version',
+        '1.2.3'
+      ])
+    ).toMatchObject({
+      pidPath: '/tmp/t.pid',
+      launchNonce: 'launch-a',
+      entryPath: '/app/daemon-entry.js',
+      appVersion: '1.2.3'
+    })
+  })
+
   it('rejects either PID-record ownership argument without its pair', () => {
     expect(() =>
       parseArgs([

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -293,6 +293,12 @@ async function main(): Promise<void> {
       daemonLog.log('shutdown', { reason: 'idle' })
       daemonLog.close()
       process.exit(0)
+    },
+    onRpcShutdown: () => {
+      deathWatch?.stop()
+      shuttingDown = true
+      daemonLog.close()
+      process.exit(0)
     }
   })
   deathWatch?.start()

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -257,6 +257,8 @@ async function main(): Promise<void> {
     ...(pidPath ? { pidPath } : {}),
     ...(launchNonce ? { launchNonce } : {}),
     ...(pidPath ? { startedAtMs } : {}),
+    ...(entryPath ? { entryPath } : {}),
+    ...(appVersion ? { appVersion } : {}),
     ...(pidPath && launchNonce
       ? {
           publishEndpointOwnership: () =>

--- a/src/main/daemon/daemon-entry.ts
+++ b/src/main/daemon/daemon-entry.ts
@@ -20,12 +20,15 @@ import {
 import { MacosLoginSessionDeathWatch } from './macos-login-session-death-watch'
 import { readCurrentProcessMacSystemResolverHealth } from '../network/macos-system-resolver-health'
 import { readCurrentDaemonReadyIdentity } from './daemon-ready-identity'
+import { publishDaemonPidFile } from './daemon-spawner'
 
 export type ParsedDaemonArgs = {
   socketPath: string
   tokenPath: string
   pidPath?: string
   launchNonce?: string
+  entryPath?: string
+  appVersion?: string
   /** GUI-spawned daemons only — headless serve/SSH daemons must survive session loss. */
   loginSessionWatch?: boolean
   /** Optional — absent for adopted old daemons and tests, which log nothing. */
@@ -38,6 +41,8 @@ export function parseArgs(argv: string[]): ParsedDaemonArgs {
   let logFilePath = ''
   let pidPath = ''
   let launchNonce = ''
+  let entryPath = ''
+  let appVersion = ''
   let loginSessionWatch = false
 
   for (let i = 0; i < argv.length; i++) {
@@ -56,6 +61,12 @@ export function parseArgs(argv: string[]): ParsedDaemonArgs {
     } else if (argv[i] === '--launch-nonce' && argv[i + 1]) {
       launchNonce = argv[i + 1]
       i++
+    } else if (argv[i] === '--entry-path' && argv[i + 1]) {
+      entryPath = argv[i + 1]
+      i++
+    } else if (argv[i] === '--app-version' && argv[i + 1]) {
+      appVersion = argv[i + 1]
+      i++
     } else if (argv[i] === '--login-session-watch') {
       loginSessionWatch = true
     }
@@ -73,6 +84,8 @@ export function parseArgs(argv: string[]): ParsedDaemonArgs {
     socketPath,
     tokenPath,
     ...(pidPath ? { pidPath, launchNonce } : {}),
+    ...(entryPath ? { entryPath } : {}),
+    ...(appVersion ? { appVersion } : {}),
     ...(loginSessionWatch ? { loginSessionWatch } : {}),
     ...(logFilePath ? { logFilePath } : {})
   }
@@ -86,10 +99,18 @@ async function main(): Promise<void> {
   // an otherwise healthy detached daemon. Swallow it: stderr is diagnostic only.
   process.stderr.on('error', () => {})
 
-  const { socketPath, tokenPath, pidPath, launchNonce, loginSessionWatch, logFilePath } = parseArgs(
-    process.argv.slice(2)
-  )
+  const {
+    socketPath,
+    tokenPath,
+    pidPath,
+    launchNonce,
+    entryPath,
+    appVersion,
+    loginSessionWatch,
+    logFilePath
+  } = parseArgs(process.argv.slice(2))
   const startedAtMs = Date.now() - process.uptime() * 1000
+  const readyIdentity = await readCurrentDaemonReadyIdentity(startedAtMs)
   // Fail-open: a broken log path must never block daemon startup.
   const daemonLog = logFilePath ? createDaemonFileLog(logFilePath) : createNoopDaemonFileLog()
   daemonLog.log('startup', { protocolVersion: PROTOCOL_VERSION, socketPath })
@@ -236,6 +257,18 @@ async function main(): Promise<void> {
     ...(pidPath ? { pidPath } : {}),
     ...(launchNonce ? { launchNonce } : {}),
     ...(pidPath ? { startedAtMs } : {}),
+    ...(pidPath && launchNonce
+      ? {
+          publishEndpointOwnership: () =>
+            publishDaemonPidFile(pidPath, {
+              pid: process.pid,
+              ...readyIdentity,
+              ...(entryPath ? { entryPath } : {}),
+              ...(appVersion ? { appVersion } : {}),
+              launchNonce
+            })
+        }
+      : {}),
     log: daemonLog,
     preparePtySpawn: runMacosLoginPreflight,
     ...(deathWatch
@@ -266,7 +299,6 @@ async function main(): Promise<void> {
 
   // Signal readiness to parent via IPC (if available)
   if (process.send) {
-    const readyIdentity = await readCurrentDaemonReadyIdentity(startedAtMs)
     process.send({ type: 'ready', ...readyIdentity })
   }
   daemonLog.log('ready')

--- a/src/main/daemon/daemon-health-socket-cleanup.test.ts
+++ b/src/main/daemon/daemon-health-socket-cleanup.test.ts
@@ -79,7 +79,7 @@ describe('daemon health socket listener cleanup', () => {
     const result = killStaleDaemon(dir, socketPath, tokenPath)
     await vi.advanceTimersByTimeAsync(500)
 
-    await expect(result).resolves.toBe(false)
+    await expect(result).resolves.toEqual({ killed: false, liveOwnerSurvived: false })
     expect(socket.listenerCount('connect')).toBe(0)
     expect(socket.listenerCount('error')).toBe(0)
     expect(socket.destroy).toHaveBeenCalledTimes(1)

--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { spawn } from 'node:child_process'
+import { existsSync, linkSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { basename, join } from 'node:path'
-import { createServer, connect, type Server } from 'node:net'
+import { createServer, connect, Socket, type Server } from 'node:net'
 import { DaemonServer } from './daemon-server'
 import { getDaemonPidPath, serializeDaemonPidFile } from './daemon-spawner'
 import {
@@ -183,7 +184,9 @@ describe('daemon health', () => {
     writeFileSync(getDaemonPidPath(dir), String(process.pid), { mode: 0o600 })
 
     try {
-      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toBe(false)
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toMatchObject({
+        killed: false
+      })
       await expect(canConnect(socketPath)).resolves.toBe(true)
     } finally {
       await closeServer(server)
@@ -430,13 +433,137 @@ describe('killStaleDaemon pid identity guards', () => {
     // signal is sent.
     const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
     try {
-      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toBe(false)
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toMatchObject({
+        killed: false
+      })
       const terminationSignals = killSpy.mock.calls.filter(
         ([, sig]) => sig === 'SIGTERM' || sig === 'SIGKILL'
       )
       expect(terminationSignals).toEqual([])
     } finally {
       killSpy.mockRestore()
+    }
+  })
+})
+
+describe('killStaleDaemon endpoint reclamation', () => {
+  let dir: string
+  let socketPath: string
+  let tokenPath: string
+
+  beforeEach(() => {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-health-kill-test-'))
+    socketPath = daemonTestSocketPath(dir)
+    tokenPath = join(dir, 'daemon.token')
+  })
+
+  afterEach(() => {
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function listenOnSocketPath(server: Server, path: string): Promise<void> {
+    return new Promise((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(path, () => {
+        server.off('error', reject)
+        resolve()
+      })
+    })
+  }
+
+  it('preserves the pid record and the endpoint when the owner cannot be proven gone', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    // Why: isDaemonProcess matches on the command line, so a child carrying the daemon
+    // entry plus this endpoint's paths is adopted as the recorded owner by the first probe.
+    const child = spawn(
+      process.execPath,
+      ['-e', 'setInterval(() => {}, 1000)', 'daemon-entry', socketPath, tokenPath],
+      { stdio: 'ignore' }
+    )
+    await new Promise<void>((resolve, reject) => {
+      child.once('spawn', resolve)
+      child.once('error', reject)
+    })
+    const childPid = child.pid as number
+    const childExited = new Promise<void>((resolve) => child.once('exit', () => resolve()))
+    const server = createServer((socket) => socket.end())
+    await listenOnSocketPath(server, socketPath)
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({ pid: childPid, startedAtMs: null }),
+      { mode: 0o600 }
+    )
+
+    const realKill = process.kill.bind(process)
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    // Why: the recorded owner vanishes mid-wait, so the pre-SIGKILL identity re-probe
+    // fails and only the still-answering endpoint proves a daemon is alive.
+    const identityBreaker = setTimeout(() => realKill(childPid, 'SIGKILL'), 800)
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toEqual({
+        killed: false,
+        liveOwnerSurvived: true
+      })
+      expect(existsSync(getDaemonPidPath(dir))).toBe(true)
+      expect(existsSync(socketPath)).toBe(true)
+      await expect(canConnect(socketPath)).resolves.toBe(true)
+    } finally {
+      clearTimeout(identityBreaker)
+      killSpy.mockRestore()
+      try {
+        realKill(childPid, 'SIGKILL')
+      } catch {
+        // Already gone.
+      }
+      await childExited
+      await closeServer(server)
+    }
+  })
+
+  it('unlinks a stale endpoint file once connects to it are refused', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    // Why: hard-linking the bound inode leaves the endpoint name behind after the
+    // listener closes — exactly the entry a crashed daemon leaves for connect to refuse.
+    const bindPath = join(dir, '.bstale')
+    const server = createServer((socket) => socket.end())
+    await listenOnSocketPath(server, bindPath)
+    linkSync(bindPath, socketPath)
+    await closeServer(server)
+
+    await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toEqual({
+      killed: false,
+      liveOwnerSurvived: false
+    })
+    expect(existsSync(socketPath)).toBe(false)
+  })
+
+  it('keeps the endpoint file when the connect probe neither connects nor is refused', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+
+    writeFileSync(socketPath, '')
+    // A connect that never settles leaves the probe to time out, which is not proof
+    // the endpoint is dead — net.connect itself cannot be spied on in ESM.
+    const connectSpy = vi
+      .spyOn(Socket.prototype, 'connect')
+      .mockImplementation(function (this: Socket) {
+        return this
+      })
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toEqual({
+        killed: false,
+        liveOwnerSurvived: false
+      })
+      expect(existsSync(socketPath)).toBe(true)
+    } finally {
+      connectSpy.mockRestore()
     }
   })
 })

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -23,6 +23,9 @@ const HEALTH_CHECK_TIMEOUT_MS = 3_000
 const RESOLVER_HEALTH_CHECK_TIMEOUT_MS = 3_000
 const KILL_WAIT_MS = 3_000
 const KILL_POLL_MS = 100
+// Why: SIGKILL is delivered on return from an uninterruptible syscall, so confirm the exit
+// rather than assume it — but keep the wait short, it only guards the rare wedged case.
+const SIGKILL_CONFIRM_WAIT_MS = 1_000
 const START_TIME_TOLERANCE_MS = 1_500
 // Why: e2e forces the failed-health preserve path without SIGSTOP races —
 // a stopped daemon also blocks listSessions, so the unhealthy guard cannot
@@ -50,10 +53,17 @@ export type ParsedDaemonPid = {
   bootId: string | null
 }
 
-function canConnectSocket(socketPath: string): Promise<boolean> {
+/**
+ * 'connected' — something is listening. 'missing'/'refused' — nothing is, and the endpoint
+ * name is safe to reclaim. 'unknown' — the probe itself failed (timeout on a loaded host,
+ * EPERM); the endpoint must be left alone because absence of proof is not proof of death.
+ */
+type SocketProbeOutcome = 'connected' | 'missing' | 'refused' | 'unknown'
+
+function probeSocketConnect(socketPath: string): Promise<SocketProbeOutcome> {
   return new Promise((resolve) => {
     if (process.platform !== 'win32' && !existsSync(socketPath)) {
-      resolve(false)
+      resolve('missing')
       return
     }
     const sock = connect({ path: socketPath })
@@ -63,7 +73,7 @@ function canConnectSocket(socketPath: string): Promise<boolean> {
       sock.off('connect', onConnect)
       sock.off('error', onError)
     }
-    const settle = (result: boolean): void => {
+    const settle = (result: SocketProbeOutcome): void => {
       if (settled) {
         return
       }
@@ -72,14 +82,16 @@ function canConnectSocket(socketPath: string): Promise<boolean> {
       resolve(result)
     }
     const onConnect = (): void => {
-      settle(true)
+      settle('connected')
       sock.destroy()
     }
-    const onError = (): void => {
-      settle(false)
+    const onError = (error: NodeJS.ErrnoException): void => {
+      settle(
+        error.code === 'ECONNREFUSED' ? 'refused' : error.code === 'ENOENT' ? 'missing' : 'unknown'
+      )
     }
     const timer = setTimeout(() => {
-      settle(false)
+      settle('unknown')
       sock.destroy()
     }, 500)
     sock.on('connect', onConnect)
@@ -278,7 +290,12 @@ export function getMacDaemonSystemResolverHealth(
           }
           // Why: the daemon must report health from inside its own process;
           // external launchctl bsexec probes can misclassify healthy PTYs.
-          sock?.write(encodeNdjson({ id: 'resolver-health-1', type: 'systemResolverHealth' }))
+          sock?.write(
+            encodeNdjson({
+              id: 'resolver-health-1',
+              type: 'systemResolverHealth'
+            })
+          )
           continue
         }
 
@@ -366,7 +383,10 @@ function getLinuxProcessStartedAtMs(pid: number): number | null {
     const startTicks = parseLinuxProcStartTicks(stat)
     const bootTimeSeconds = parseLinuxBootTimeSeconds(readFileSync('/proc/stat', 'utf8'))
     const ticksPerSecond = Number(
-      execFileSync('getconf', ['CLK_TCK'], { encoding: 'utf8', timeout: 1_000 }).trim()
+      execFileSync('getconf', ['CLK_TCK'], {
+        encoding: 'utf8',
+        timeout: 1_000
+      }).trim()
     )
     if (
       !Number.isFinite(startTicks) ||
@@ -562,7 +582,7 @@ async function isDaemonProcess(
   }
 }
 
-async function getDaemonCommandLine(pid: number): Promise<string | null> {
+export async function getDaemonCommandLine(pid: number): Promise<string | null> {
   if (process.platform === 'win32') {
     return (await queryWindowsProcessIdentity(pid))?.commandLine ?? null
   }
@@ -657,14 +677,41 @@ export async function isDaemonStaleForCurrentBundle(
   return true
 }
 
+async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
+  const deadline = Date.now() + timeoutMs
+  for (;;) {
+    try {
+      process.kill(pid, 0)
+    } catch {
+      return true
+    }
+    if (Date.now() >= deadline) {
+      return false
+    }
+    await new Promise((resolve) => setTimeout(resolve, KILL_POLL_MS))
+  }
+}
+
+export type StaleDaemonKillOutcome = {
+  /** A daemon was positively confirmed gone. Drives replacement telemetry. */
+  killed: boolean
+  /**
+   * We could not prove the recorded daemon is gone. Its PID record and endpoint are left
+   * intact and the caller must not fork a replacement beside it — that is exactly how two
+   * daemons end up alive with one owning the socket and the other hosting the sessions.
+   */
+  liveOwnerSurvived: boolean
+}
+
 export async function killStaleDaemon(
   runtimeDir: string,
   socketPath: string,
   tokenPath: string,
   protocolVersion = PROTOCOL_VERSION
-): Promise<boolean> {
+): Promise<StaleDaemonKillOutcome> {
   const pidPath = getDaemonPidPath(runtimeDir, protocolVersion)
   let killedDaemon = false
+  let liveOwnerSurvived = false
   try {
     const parsedPid = parseDaemonPidFile(readFileSync(pidPath, 'utf8'))
     if (
@@ -690,22 +737,50 @@ export async function killStaleDaemon(
         // daemon died during the wait. Without this, we'd SIGKILL an unrelated
         // process that happens to now own the same pid.
         if (!(await isDaemonProcess(pid, socketPath, tokenPath, startedAtMs))) {
-          console.warn('[daemon] Skipping SIGKILL for stale daemon: reason=pid_recycled')
-          exited = true
-          killedDaemon = true
+          // Why: a failed identity probe has two causes with opposite correct actions —
+          // the pid really was recycled (daemon dead, reclaim the endpoint), or the probe
+          // itself failed under load (`ps` has a 2s timeout). The endpoint settles it: if
+          // something still answers the socket, a daemon is alive and must be preserved.
+          if ((await probeSocketConnect(socketPath)) === 'connected') {
+            console.warn(
+              '[daemon] Preserving daemon that could not be identified: reason=identity_probe_failed'
+            )
+            liveOwnerSurvived = true
+          } else {
+            console.warn('[daemon] Skipping SIGKILL for stale daemon: reason=pid_recycled')
+            exited = true
+          }
         } else {
           try {
             process.kill(pid, 'SIGKILL')
-            exited = true
           } catch {
             // Already dead
+            exited = true
+          }
+          // Why: issuing SIGKILL is not proof of death — a process blocked in an
+          // uninterruptible syscall only dies once it returns. Claiming the kill without
+          // confirming it is what let the endpoint be reclaimed out from under a daemon
+          // that was still alive and still serving.
+          exited = exited || (await waitForProcessExit(pid, SIGKILL_CONFIRM_WAIT_MS))
+          if (!exited) {
+            console.warn('[daemon] Daemon survived SIGKILL: reason=unconfirmed_exit')
           }
         }
       }
-      killedDaemon = killedDaemon || exited
+      killedDaemon = exited
+      // Why: SIGTERM and SIGKILL both failed to produce an exit, so the daemon is still out
+      // there holding the endpoint. Treat it as the owner rather than racing it.
+      liveOwnerSurvived = liveOwnerSurvived || !exited
     }
   } catch {
     // PID file missing or process already dead
+  }
+
+  if (liveOwnerSurvived) {
+    // Why: removing the record of a daemon we failed to kill is what let a replacement
+    // publish its own ownership beside it. Leaving it intact keeps the exclusive PID claim
+    // held, so a duplicate cannot take the endpoint.
+    return { killed: killedDaemon, liveOwnerSurvived }
   }
 
   try {
@@ -714,13 +789,18 @@ export async function killStaleDaemon(
     // Best-effort
   }
 
-  const socketIsLive = await canConnectSocket(socketPath)
-  if (process.platform !== 'win32' && existsSync(socketPath) && (killedDaemon || !socketIsLive)) {
+  const socketOutcome = await probeSocketConnect(socketPath)
+  // Why: only positive evidence of a dead endpoint authorizes reclaiming the name. A probe
+  // that merely timed out leaves a live daemon's endpoint in place instead of unlinking it
+  // and forking a duplicate onto the freed path.
+  const endpointIsReclaimable =
+    killedDaemon || socketOutcome === 'refused' || socketOutcome === 'missing'
+  if (process.platform !== 'win32' && existsSync(socketPath) && endpointIsReclaimable) {
     try {
       unlinkSync(socketPath)
     } catch {
       // Best-effort
     }
   }
-  return killedDaemon
+  return { killed: killedDaemon, liveOwnerSurvived }
 }

--- a/src/main/daemon/daemon-health.ts
+++ b/src/main/daemon/daemon-health.ts
@@ -582,7 +582,7 @@ async function isDaemonProcess(
   }
 }
 
-export async function getDaemonCommandLine(pid: number): Promise<string | null> {
+async function getDaemonCommandLine(pid: number): Promise<string | null> {
   if (process.platform === 'win32') {
     return (await queryWindowsProcessIdentity(pid))?.commandLine ?? null
   }
@@ -677,6 +677,10 @@ export async function isDaemonStaleForCurrentBundle(
   return true
 }
 
+function isNoSuchProcessError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ESRCH'
+}
+
 async function waitForProcessExit(pid: number, timeoutMs: number): Promise<boolean> {
   const deadline = Date.now() + timeoutMs
   for (;;) {
@@ -719,7 +723,16 @@ export async function killStaleDaemon(
       (await isDaemonProcess(parsedPid.pid, socketPath, tokenPath, parsedPid.startedAtMs))
     ) {
       const { pid, startedAtMs } = parsedPid
-      process.kill(pid, 'SIGTERM')
+      try {
+        process.kill(pid, 'SIGTERM')
+      } catch (error) {
+        // Why: ESRCH means it is already gone. Anything else (EPERM from a daemon owned by
+        // another user) means it is alive and we cannot stop it — falling through to the
+        // blanket catch would report "nothing alive" and authorize a duplicate beside it.
+        if (!isNoSuchProcessError(error)) {
+          return { killed: false, liveOwnerSurvived: true }
+        }
+      }
       const deadline = Date.now() + KILL_WAIT_MS
       let exited = false
       while (Date.now() < deadline) {

--- a/src/main/daemon/daemon-hello-protocol.ts
+++ b/src/main/daemon/daemon-hello-protocol.ts
@@ -10,6 +10,9 @@ export type DaemonEndpointIdentity = {
   pid: number
   startedAtMs: number
   launchNonce: string
+  /** Optional launch metadata. Absent from daemons that predate it; readers must fall back. */
+  entryPath?: string
+  appVersion?: string
 }
 
 export type HelloResponse = {

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -1397,10 +1397,17 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
   it('republishes the endpoint owner launch metadata into a repaired PID record', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
+    // Why: the mismatched record's metadata belongs to another daemon, so freshness and
+    // host-pinning fields must come from the authenticated owner — a record without
+    // appVersion reads as a permanently stale bundle and gets needlessly replaced. The
+    // install path deliberately contains a space: re-parsing it out of a space-joined
+    // command line truncated it and made a healthy daemon look like a different app path.
     const endpointIdentity = {
       pid: 101,
       startedAtMs: 1_000_000,
-      launchNonce: 'socket-owner'
+      launchNonce: 'socket-owner',
+      entryPath: '/Applications/Orca 2.app/Contents/out/main/daemon-entry.js',
+      appVersion: '9.9.9'
     }
     daemonClientMock.mockImplementationOnce(function MockAdoptionClient() {
       return {
@@ -1417,12 +1424,6 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         launchNonce: 'stale-owner'
       })
     )
-    // Why: the mismatched record's metadata belongs to another daemon, so freshness and
-    // host-pinning fields have to be re-derived from the authenticated owner's command line —
-    // a record without appVersion reads as a permanently stale bundle.
-    getDaemonCommandLineMock.mockResolvedValueOnce(
-      'node /app/out/main/daemon-entry.js --socket /fake/socket --entry-path /app/out/main/daemon-entry.js --app-version 9.9.9'
-    )
     const launcher = spawnerInstances[0].launcher as (
       socketPath: string,
       tokenPath: string,
@@ -1434,10 +1435,11 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     try {
       const handle = await launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'unused')
 
-      expect(getDaemonCommandLineMock).toHaveBeenCalledWith(101)
       expect(replaceDaemonPidFileMock).toHaveBeenCalledWith('/fake/daemon.pid', {
-        ...endpointIdentity,
-        entryPath: '/app/out/main/daemon-entry.js',
+        pid: 101,
+        startedAtMs: 1_000_000,
+        launchNonce: 'socket-owner',
+        entryPath: '/Applications/Orca 2.app/Contents/out/main/daemon-entry.js',
         appVersion: '9.9.9'
       })
       handle.releaseAdoptionLease?.()
@@ -1496,13 +1498,15 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     }
   })
 
-  it('refuses to fork a replacement beside a daemon that could not be confirmed stopped', async () => {
+  it('degrades instead of forking beside a daemon that could not be confirmed stopped', async () => {
     const mod = await importFresh()
     checkDaemonHealthMock.mockResolvedValue('unreachable')
     await mod.initDaemonPtyProvider()
     const forkCallsBefore = forkMock.mock.calls.length
     // Why: forking beside a survivor is exactly how the endpoint owner and the session host
-    // diverge — one daemon answers the socket while another hosts the visible terminals.
+    // diverge — one daemon answers the socket while another hosts the visible terminals. But
+    // refusing outright would leave the user with no daemon at all, and something demonstrably
+    // still answers the endpoint, so adopt it degraded: live sessions keep working.
     killStaleDaemonMock.mockResolvedValueOnce({
       killed: false,
       liveOwnerSurvived: true
@@ -1512,15 +1516,15 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       tokenPath: string,
       pidPath?: string,
       launchNonce?: string
-    ) => Promise<unknown>
+    ) => Promise<{ mode?: string; releaseAdoptionLease?(): void }>
     const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
 
     try {
-      await expect(
-        launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'launch-new')
-      ).rejects.toThrow('could not be confirmed stopped')
+      const handle = await launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'launch-new')
 
+      expect(handle.mode).toBe('degraded-new-pty-fallback')
       expect(forkMock.mock.calls.length).toBe(forkCallsBefore)
+      handle.releaseAdoptionLease?.()
     } finally {
       warn.mockRestore()
     }

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -30,6 +30,7 @@ const {
   getProcessStartedAtMsMock,
   parseDaemonPidFileMock,
   replaceDaemonPidFileMock,
+  getDaemonCommandLineMock,
   unlinkOwnedDaemonPidFileMock,
   launchedStartedAtMs,
   readLaunchedDaemonIdentity,
@@ -88,12 +89,16 @@ const {
   const getMacDaemonSystemResolverHealthMock = vi.fn(() => 'healthy')
   const getDaemonLaunchIdentityMock = vi.fn(() => 'match')
   const isDaemonStaleForCurrentBundleMock = vi.fn(() => false)
-  const killStaleDaemonMock = vi.fn(async () => true)
+  const killStaleDaemonMock = vi.fn(async () => ({
+    killed: true,
+    liveOwnerSurvived: false
+  }))
   const getProcessStartedAtMsMock = vi.fn((): number | null => 1_000_000)
   const parseDaemonPidFileMock = vi.fn(
     (): { pid: number; startedAtMs: number | null } | null => null
   )
   const replaceDaemonPidFileMock = vi.fn(() => true)
+  const getDaemonCommandLineMock = vi.fn(async (_pid: number): Promise<string | null> => null)
   const unlinkOwnedDaemonPidFileMock = vi.fn(() => true)
   const launchedStartedAtMs = { current: 1_000_000 }
 
@@ -103,7 +108,11 @@ const {
     const launchNonceIndex = Array.isArray(args) ? args.indexOf('--launch-nonce') : -1
     const launchNonce = launchNonceIndex >= 0 ? args[launchNonceIndex + 1] : undefined
     return typeof child?.pid === 'number' && typeof launchNonce === 'string'
-      ? { pid: child.pid, startedAtMs: launchedStartedAtMs.current, launchNonce }
+      ? {
+          pid: child.pid,
+          startedAtMs: launchedStartedAtMs.current,
+          launchNonce
+        }
       : null
   }
 
@@ -187,6 +196,7 @@ const {
     getProcessStartedAtMsMock,
     parseDaemonPidFileMock,
     replaceDaemonPidFileMock,
+    getDaemonCommandLineMock,
     unlinkOwnedDaemonPidFileMock,
     launchedStartedAtMs,
     readLaunchedDaemonIdentity,
@@ -269,6 +279,7 @@ vi.mock('net', () => ({ connect: netConnectMock }))
 
 vi.mock('./daemon-health', () => ({
   checkDaemonHealth: checkDaemonHealthMock,
+  getDaemonCommandLine: getDaemonCommandLineMock,
   getDaemonLaunchIdentity: getDaemonLaunchIdentityMock,
   getMacDaemonSystemResolverHealth: getMacDaemonSystemResolverHealthMock,
   healthCheckDaemon: healthCheckDaemonMock,
@@ -309,7 +320,10 @@ vi.mock('./daemon-spawner', () => ({
           const result = await override()
           const releaseAdoptionLease = vi.fn()
           adoptionLeaseReleases.push(releaseAdoptionLease)
-          this.handle = { releaseAdoptionLease, shutdown: vi.fn(async () => {}) }
+          this.handle = {
+            releaseAdoptionLease,
+            shutdown: vi.fn(async () => {})
+          }
           if (result.mode) {
             this.handle.mode = result.mode
           }
@@ -341,6 +355,7 @@ vi.mock('./daemon-spawner', () => ({
     `/fake/daemon/daemon-v${version ?? PROTOCOL_VERSION}.pid`,
   serializeDaemonPidFile: (obj: unknown) => JSON.stringify(obj),
   replaceDaemonPidFile: replaceDaemonPidFileMock,
+  sweepAbandonedDaemonClaims: vi.fn(() => 0),
   unlinkOwnedDaemonPidFile: unlinkOwnedDaemonPidFileMock
 }))
 
@@ -439,7 +454,10 @@ async function importFresh() {
   // mockReset (not mockClear) also drops an unconsumed *Once queue, so a test that bails early
   // can't leak a queued false into the next test's confirmedReplacement gate.
   killStaleDaemonMock.mockReset()
-  killStaleDaemonMock.mockResolvedValue(true)
+  killStaleDaemonMock.mockResolvedValue({
+    killed: true,
+    liveOwnerSurvived: false
+  })
   getAppPathMock.mockReset()
   getAppPathMock.mockReturnValue('/fake/app')
   forkMock.mockReset()
@@ -508,7 +526,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     probeSocketExistsMock.mockReturnValue(false)
     netConnectMock.mockReset()
     netConnectMock.mockImplementation(() => {
-      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+      const handlers: Record<string, (() => void)[]> = {
+        connect: [],
+        error: []
+      }
       return {
         on(event: string, cb: () => void) {
           handlers[event]?.push(cb)
@@ -623,7 +644,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(spawnerInstances[0].ensureRunning).toHaveBeenCalledTimes(1)
 
     abortController.abort()
-    resolveEnsureRunning({ socketPath: '/fake/socket-late', tokenPath: '/fake/token-late' })
+    resolveEnsureRunning({
+      socketPath: '/fake/socket-late',
+      tokenPath: '/fake/token-late'
+    })
     await started
 
     expect(adapterInstances).toHaveLength(1)
@@ -707,7 +731,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     const result = await provider!.spawn({ cols: 80, rows: 24 })
 
     expect(result.id).toBe('local-fallback-pty')
-    expect(localFallbackProvider.spawn).toHaveBeenCalledWith({ cols: 80, rows: 24 })
+    expect(localFallbackProvider.spawn).toHaveBeenCalledWith({
+      cols: 80,
+      rows: 24
+    })
     expect(adapterInstances[0].listProcesses).toHaveBeenCalled()
   })
 
@@ -910,7 +937,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     ensureRunningOverrides.push(async () => {
       await outgoingRespawn?.('daemon_died')
       respawnedMidRestart = true
-      return { socketPath: '/fake/restarted-socket', tokenPath: '/fake/restarted-token' }
+      return {
+        socketPath: '/fake/restarted-socket',
+        tokenPath: '/fake/restarted-token'
+      }
     })
 
     await mod.restartDaemon()
@@ -931,7 +961,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     ensureRunningOverrides.push(async () => {
       await restartedRespawn?.('daemon_died')
       respawnedMidSecondRestart = true
-      return { socketPath: '/fake/restarted-socket-2', tokenPath: '/fake/restarted-token-2' }
+      return {
+        socketPath: '/fake/restarted-socket-2',
+        tokenPath: '/fake/restarted-token-2'
+      }
     })
 
     await mod.restartDaemon()
@@ -1082,7 +1115,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     // Make probeSocket return true: needs both the fs.existsSync proxy AND net.connect resolving "alive".
     probeSocketExistsMock.mockReturnValue(true)
     netConnectMock.mockImplementationOnce(() => {
-      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+      const handlers: Record<string, (() => void)[]> = {
+        connect: [],
+        error: []
+      }
       return {
         on(event: string, cb: () => void) {
           handlers[event]?.push(cb)
@@ -1103,7 +1139,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
     // The shutdown RPC must have been issued with killSessions=true.
     expect(ensureConnectedMock).toHaveBeenCalled()
-    expect(requestMock).toHaveBeenCalledWith('shutdown', { killSessions: true })
+    expect(requestMock).toHaveBeenCalledWith('shutdown', {
+      killSessions: true
+    })
     // The fallback killStaleDaemon must NOT fire when the RPC path worked.
     expect(killStaleDaemonMock).not.toHaveBeenCalled()
   })
@@ -1141,7 +1179,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
       await vi.advanceTimersByTimeAsync(1000)
 
-      await expect(cleanup).resolves.toEqual({ cleaned: false, killedCount: 0 })
+      await expect(cleanup).resolves.toEqual({
+        cleaned: false,
+        killedCount: 0
+      })
       expect(socket.destroy).toHaveBeenCalledTimes(1)
       expect(socket.listenerCount('connect')).toBe(0)
       expect(socket.listenerCount('error')).toBe(0)
@@ -1204,7 +1245,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
   it('respawns instead of reusing a healthy daemon launched from another app path', async () => {
     const mod = await importFresh()
-    await mod.initDaemonPtyProvider(undefined, { macosLoginSessionWatch: true })
+    await mod.initDaemonPtyProvider(undefined, {
+      macosLoginSessionWatch: true
+    })
 
     const launcher = spawnerInstances[0].launcher as (
       socketPath: string,
@@ -1318,7 +1361,11 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       }
     })
     readFileSyncMock.mockReturnValueOnce(
-      JSON.stringify({ pid: 202, startedAtMs: 2_000_000, launchNonce: 'stale-owner' })
+      JSON.stringify({
+        pid: 202,
+        startedAtMs: 2_000_000,
+        launchNonce: 'stale-owner'
+      })
     )
     readFileSyncMock.mockReturnValueOnce(JSON.stringify(endpointIdentity))
     const launcher = spawnerInstances[0].launcher as (
@@ -1342,6 +1389,138 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
         '[daemon] Repaired daemon PID ownership to match the authenticated endpoint'
       )
       handle.releaseAdoptionLease?.()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('republishes the endpoint owner launch metadata into a repaired PID record', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+    const endpointIdentity = {
+      pid: 101,
+      startedAtMs: 1_000_000,
+      launchNonce: 'socket-owner'
+    }
+    daemonClientMock.mockImplementationOnce(function MockAdoptionClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        getDaemonIdentity: vi.fn(() => endpointIdentity),
+        request: vi.fn(),
+        disconnect: vi.fn()
+      }
+    })
+    readFileSyncMock.mockReturnValueOnce(
+      JSON.stringify({
+        pid: 202,
+        startedAtMs: 2_000_000,
+        launchNonce: 'stale-owner'
+      })
+    )
+    // Why: the mismatched record's metadata belongs to another daemon, so freshness and
+    // host-pinning fields have to be re-derived from the authenticated owner's command line —
+    // a record without appVersion reads as a permanently stale bundle.
+    getDaemonCommandLineMock.mockResolvedValueOnce(
+      'node /app/out/main/daemon-entry.js --socket /fake/socket --entry-path /app/out/main/daemon-entry.js --app-version 9.9.9'
+    )
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string,
+      pidPath?: string,
+      launchNonce?: string
+    ) => Promise<{ releaseAdoptionLease?(): void; shutdown(): Promise<void> }>
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const handle = await launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'unused')
+
+      expect(getDaemonCommandLineMock).toHaveBeenCalledWith(101)
+      expect(replaceDaemonPidFileMock).toHaveBeenCalledWith('/fake/daemon.pid', {
+        ...endpointIdentity,
+        entryPath: '/app/out/main/daemon-entry.js',
+        appVersion: '9.9.9'
+      })
+      handle.releaseAdoptionLease?.()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('adopts the authenticated endpoint even when the PID record cannot be repaired', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+    const endpointIdentity = {
+      pid: 101,
+      startedAtMs: 1_000_000,
+      launchNonce: 'socket-owner'
+    }
+    daemonClientMock.mockImplementationOnce(function MockAdoptionClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        getDaemonIdentity: vi.fn(() => endpointIdentity),
+        request: vi.fn(),
+        disconnect: vi.fn()
+      }
+    })
+    readFileSyncMock.mockReturnValueOnce(
+      JSON.stringify({
+        pid: 202,
+        startedAtMs: 2_000_000,
+        launchNonce: 'stale-owner'
+      })
+    )
+    // Why: fail open. Losing every persistent terminal because a pid file write failed is a
+    // far worse outcome than a record that disagrees with the endpoint.
+    replaceDaemonPidFileMock.mockReturnValueOnce(false)
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string,
+      pidPath?: string,
+      launchNonce?: string
+    ) => Promise<{ releaseAdoptionLease?(): void; shutdown(): Promise<void> }>
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    const forkCallsBefore = forkMock.mock.calls.length
+
+    try {
+      const handle = await launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'unused')
+
+      expect(handle).toBeDefined()
+      // The healthy daemon is adopted, not replaced.
+      expect(forkMock.mock.calls.length).toBe(forkCallsBefore)
+      expect(warn).toHaveBeenCalledWith(
+        '[daemon] Could not repair daemon PID ownership; adopting the authenticated endpoint anyway'
+      )
+      handle.releaseAdoptionLease?.()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
+  it('refuses to fork a replacement beside a daemon that could not be confirmed stopped', async () => {
+    const mod = await importFresh()
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
+    await mod.initDaemonPtyProvider()
+    const forkCallsBefore = forkMock.mock.calls.length
+    // Why: forking beside a survivor is exactly how the endpoint owner and the session host
+    // diverge — one daemon answers the socket while another hosts the visible terminals.
+    killStaleDaemonMock.mockResolvedValueOnce({
+      killed: false,
+      liveOwnerSurvived: true
+    })
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string,
+      pidPath?: string,
+      launchNonce?: string
+    ) => Promise<unknown>
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      await expect(
+        launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'launch-new')
+      ).rejects.toThrow('could not be confirmed stopped')
+
+      expect(forkMock.mock.calls.length).toBe(forkCallsBefore)
     } finally {
       warn.mockRestore()
     }
@@ -1658,7 +1837,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
     checkDaemonHealthMock.mockResolvedValue('unreachable')
-    killStaleDaemonMock.mockResolvedValueOnce(false)
+    killStaleDaemonMock.mockResolvedValueOnce({
+      killed: false,
+      liveOwnerSurvived: false
+    })
     forkMock.mockImplementationOnce(() => {
       throw new Error('stop after replacement decision')
     })
@@ -1686,7 +1868,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
     // The daemon is gone before the launcher looks: nothing answers, nothing left to kill.
     checkDaemonHealthMock.mockResolvedValue('unreachable')
-    killStaleDaemonMock.mockResolvedValueOnce(false).mockResolvedValueOnce(false)
+    killStaleDaemonMock
+      .mockResolvedValueOnce({ killed: false, liveOwnerSurvived: false })
+      .mockResolvedValueOnce({ killed: false, liveOwnerSurvived: false })
     forkMock.mockImplementationOnce(() => {
       throw new Error('stop after replacement decision')
     })
@@ -1784,12 +1968,18 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     trackDaemonReplacedMock.mockClear()
 
     getDaemonLaunchIdentityMock.mockReturnValueOnce('mismatch')
-    killStaleDaemonMock.mockResolvedValueOnce(false)
+    killStaleDaemonMock.mockResolvedValueOnce({
+      killed: false,
+      liveOwnerSurvived: false
+    })
     // The daemon answers cleanup's liveness probe, then the endpoint goes away so the self-shutdown
     // wait succeeds and cleanup reports cleaned:true.
     probeSocketExistsMock.mockReturnValue(true)
     netConnectMock.mockImplementationOnce(() => {
-      const handlers: Record<string, (() => void)[]> = { connect: [], error: [] }
+      const handlers: Record<string, (() => void)[]> = {
+        connect: [],
+        error: []
+      }
       return {
         on(event: string, cb: () => void) {
           handlers[event]?.push(cb)
@@ -2159,7 +2349,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
   })
 
   it('surfaces non-ESRCH startup termination errors and releases IPC', async () => {
-    const signalError = Object.assign(new Error('operation not permitted'), { code: 'EPERM' })
+    const signalError = Object.assign(new Error('operation not permitted'), {
+      code: 'EPERM'
+    })
     const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
       throw signalError
     })
@@ -2194,7 +2386,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
       expect(error).toBeInstanceOf(AggregateError)
       expect((error as AggregateError).errors).toEqual([
-        expect.objectContaining({ message: 'Daemon readiness identity is incomplete' }),
+        expect.objectContaining({
+          message: 'Daemon readiness identity is incomplete'
+        }),
         signalError
       ])
       expect(child.disconnect).toHaveBeenCalledOnce()
@@ -2249,8 +2443,12 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
       expect(error).toBeInstanceOf(AggregateError)
       expect((error as AggregateError).errors).toEqual([
-        expect.objectContaining({ message: 'Daemon readiness identity is incomplete' }),
-        expect.objectContaining({ message: 'Daemon did not exit after SIGKILL' })
+        expect.objectContaining({
+          message: 'Daemon readiness identity is incomplete'
+        }),
+        expect.objectContaining({
+          message: 'Daemon did not exit after SIGKILL'
+        })
       ])
       expect(kill).toHaveBeenNthCalledWith(1, 12345, 'SIGTERM')
       expect(kill).toHaveBeenNthCalledWith(2, 12345, 'SIGKILL')
@@ -2541,7 +2739,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     const launcher = spawnerInstances[0].launcher as (
       socketPath: string,
       tokenPath: string
-    ) => Promise<{ mode?: 'degraded-new-pty-fallback'; shutdown(): Promise<void> }>
+    ) => Promise<{
+      mode?: 'degraded-new-pty-fallback'
+      shutdown(): Promise<void>
+    }>
     checkDaemonHealthMock.mockResolvedValueOnce('pty-spawn-unhealthy')
 
     const handle = await launcher('/fake/socket', '/fake/token')
@@ -2694,7 +2895,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     daemonClientMock.mockImplementationOnce(function MockDaemonClient() {
       return {
         ensureConnected: vi.fn(async () => {}),
-        request: vi.fn(async () => ({ sessions: [{ sessionId: 'wt-1@@live', isAlive: true }] })),
+        request: vi.fn(async () => ({
+          sessions: [{ sessionId: 'wt-1@@live', isAlive: true }]
+        })),
         disconnect: vi.fn()
       }
     })
@@ -2949,7 +3152,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     const mod = await importFresh()
     readFileSyncMock.mockReturnValue('{"pid":123}')
     // process.pid is guaranteed alive, so the liveness probe succeeds.
-    parseDaemonPidFileMock.mockReturnValue({ pid: process.pid, startedAtMs: null })
+    parseDaemonPidFileMock.mockReturnValue({
+      pid: process.pid,
+      startedAtMs: null
+    })
 
     await mod.initDaemonPtyProvider()
 

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -2125,6 +2125,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       expect(kill).toHaveBeenNthCalledWith(2, 12345, 'SIGKILL')
       expect(child.disconnect).toHaveBeenCalledOnce()
       expect(child.unref).toHaveBeenCalledOnce()
+      expect(unlinkOwnedDaemonPidFileMock).not.toHaveBeenCalled()
     } finally {
       kill.mockRestore()
       vi.useRealTimers()
@@ -2328,7 +2329,9 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
     const launcher = spawnerInstances[0].launcher as (
       socketPath: string,
-      tokenPath: string
+      tokenPath: string,
+      pidPath?: string,
+      launchNonce?: string
     ) => Promise<{ shutdown(): Promise<void> }>
     const handlers: Record<string, ((arg?: unknown) => void)[]> = {
       message: [],
@@ -2382,11 +2385,21 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     }
     forkMock.mockReturnValueOnce(child)
 
-    const error = await launcher('/fake/socket', '/fake/token').catch((err: Error) => err)
+    const error = await launcher(
+      '/fake/socket',
+      '/fake/token',
+      '/fake/daemon.pid',
+      'failed-launch'
+    ).catch((err: Error) => err)
 
     expect(error).toBeInstanceOf(Error)
     expect((error as Error).message).toMatch(/Cannot find module 'electron'/)
     expect((error as Error).message).toMatch(/Daemon stderr \(tail\)/)
+    expect(unlinkOwnedDaemonPidFileMock).toHaveBeenCalledWith(
+      '/fake/daemon.pid',
+      4321,
+      'failed-launch'
+    )
     // Why: release the piped stderr so the detached daemon can't keep the parent event loop alive after failure.
     expect(stderrDestroy).toHaveBeenCalled()
   })

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -31,6 +31,8 @@ const {
   parseDaemonPidFileMock,
   replaceDaemonPidFileMock,
   unlinkOwnedDaemonPidFileMock,
+  launchedStartedAtMs,
+  readLaunchedDaemonIdentity,
   daemonClientMock,
   spawnerInstances,
   ensureRunningOverrides,
@@ -93,10 +95,22 @@ const {
   )
   const replaceDaemonPidFileMock = vi.fn(() => true)
   const unlinkOwnedDaemonPidFileMock = vi.fn(() => true)
+  const launchedStartedAtMs = { current: 1_000_000 }
+
+  const readLaunchedDaemonIdentity = () => {
+    const args = forkMock.mock.calls.at(-1)?.[1]
+    const child = forkMock.mock.results.at(-1)?.value as { pid?: unknown } | undefined
+    const launchNonceIndex = Array.isArray(args) ? args.indexOf('--launch-nonce') : -1
+    const launchNonce = launchNonceIndex >= 0 ? args[launchNonceIndex + 1] : undefined
+    return typeof child?.pid === 'number' && typeof launchNonce === 'string'
+      ? { pid: child.pid, startedAtMs: launchedStartedAtMs.current, launchNonce }
+      : null
+  }
 
   const daemonClientMock = vi.fn().mockImplementation(function MockDaemonClient() {
     return {
       ensureConnected: vi.fn(async () => {}),
+      getDaemonIdentity: vi.fn(readLaunchedDaemonIdentity),
       request: vi.fn(async () => ({ sessions: [] })),
       disconnect: vi.fn()
     }
@@ -174,6 +188,8 @@ const {
     parseDaemonPidFileMock,
     replaceDaemonPidFileMock,
     unlinkOwnedDaemonPidFileMock,
+    launchedStartedAtMs,
+    readLaunchedDaemonIdentity,
     daemonClientMock,
     spawnerInstances,
     ensureRunningOverrides,
@@ -433,6 +449,7 @@ async function importFresh() {
   daemonClientMock.mockImplementation(function MockDaemonClient() {
     return {
       ensureConnected: vi.fn(async () => {}),
+      getDaemonIdentity: vi.fn(readLaunchedDaemonIdentity),
       request: vi.fn(async () => ({ sessions: [] })),
       disconnect: vi.fn()
     }
@@ -448,6 +465,7 @@ async function importFresh() {
   parseDaemonPidFileMock.mockReturnValue(null)
   unlinkOwnedDaemonPidFileMock.mockReset()
   unlinkOwnedDaemonPidFileMock.mockReturnValue(true)
+  launchedStartedAtMs.current = 1_000_000
   getProcessStartedAtMsMock.mockReset()
   getProcessStartedAtMsMock.mockReturnValue(1_000_000)
   // Why: import after resetModules so module-level spawner/adapter/restartInFlight start fresh — needed to test first-init and the coalescer.
@@ -1877,7 +1895,19 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(launchArgs[launchNonceIndex + 1]).toMatch(/^[0-9a-f-]{36}$/)
   })
 
-  it('rejects and reaps a child that lost endpoint ownership before adoption', async () => {
+  it.each([
+    [
+      'changed endpoint identity',
+      () => ({
+        getDaemonIdentity: vi.fn(() => ({
+          pid: 999,
+          startedAtMs: 900_000,
+          launchNonce: 'stale-launch'
+        }))
+      })
+    ],
+    ['missing endpoint identity reader', () => ({})]
+  ])('rejects and reaps a child with %s before adoption', async (_case, identityMethods) => {
     const mod = await importFresh()
     checkDaemonHealthMock.mockResolvedValue('unreachable')
     await mod.initDaemonPtyProvider()
@@ -1890,14 +1920,10 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     }
     daemonClientMock.mockImplementationOnce(basicClient)
     daemonClientMock.mockImplementationOnce(basicClient)
-    daemonClientMock.mockImplementationOnce(function mismatchedClient() {
+    daemonClientMock.mockImplementationOnce(function postReadyClient() {
       return {
         ...basicClient(),
-        getDaemonIdentity: vi.fn(() => ({
-          pid: 999,
-          startedAtMs: 900_000,
-          launchNonce: 'stale-launch'
-        }))
+        ...identityMethods()
       }
     })
     const handlers: Record<string, ((arg?: unknown) => void)[]> = {
@@ -2709,6 +2735,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
             throw new Error('Hello response timed out')
           }
         }),
+        getDaemonIdentity: vi.fn(readLaunchedDaemonIdentity),
         request: vi.fn(),
         disconnect: vi.fn()
       }
@@ -2896,6 +2923,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     ) => Promise<{ shutdown(): Promise<void> }>
     checkDaemonHealthMock.mockResolvedValueOnce('unreachable')
     getProcessStartedAtMsMock.mockReturnValue(null)
+    launchedStartedAtMs.current = 1_700_000_123_456
     forkMock.mockImplementationOnce(() => ({
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {

--- a/src/main/daemon/daemon-init.test.ts
+++ b/src/main/daemon/daemon-init.test.ts
@@ -29,6 +29,7 @@ const {
   killStaleDaemonMock,
   getProcessStartedAtMsMock,
   parseDaemonPidFileMock,
+  replaceDaemonPidFileMock,
   unlinkOwnedDaemonPidFileMock,
   daemonClientMock,
   spawnerInstances,
@@ -90,6 +91,7 @@ const {
   const parseDaemonPidFileMock = vi.fn(
     (): { pid: number; startedAtMs: number | null } | null => null
   )
+  const replaceDaemonPidFileMock = vi.fn(() => true)
   const unlinkOwnedDaemonPidFileMock = vi.fn(() => true)
 
   const daemonClientMock = vi.fn().mockImplementation(function MockDaemonClient() {
@@ -170,6 +172,7 @@ const {
     killStaleDaemonMock,
     getProcessStartedAtMsMock,
     parseDaemonPidFileMock,
+    replaceDaemonPidFileMock,
     unlinkOwnedDaemonPidFileMock,
     daemonClientMock,
     spawnerInstances,
@@ -321,6 +324,7 @@ vi.mock('./daemon-spawner', () => ({
   getDaemonPidPath: (_dir: string, version?: number) =>
     `/fake/daemon/daemon-v${version ?? PROTOCOL_VERSION}.pid`,
   serializeDaemonPidFile: (obj: unknown) => JSON.stringify(obj),
+  replaceDaemonPidFile: replaceDaemonPidFileMock,
   unlinkOwnedDaemonPidFile: unlinkOwnedDaemonPidFileMock
 }))
 
@@ -1279,6 +1283,52 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(disconnect).toHaveBeenCalledOnce()
   })
 
+  it('repairs a stale PID record to the authenticated socket owner before adoption', async () => {
+    const mod = await importFresh()
+    await mod.initDaemonPtyProvider()
+    const endpointIdentity = {
+      pid: 101,
+      startedAtMs: 1_000_000,
+      launchNonce: 'socket-owner'
+    }
+    daemonClientMock.mockImplementationOnce(function MockAdoptionClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        getDaemonIdentity: vi.fn(() => endpointIdentity),
+        request: vi.fn(),
+        disconnect: vi.fn()
+      }
+    })
+    readFileSyncMock.mockReturnValueOnce(
+      JSON.stringify({ pid: 202, startedAtMs: 2_000_000, launchNonce: 'stale-owner' })
+    )
+    readFileSyncMock.mockReturnValueOnce(JSON.stringify(endpointIdentity))
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string,
+      pidPath?: string,
+      launchNonce?: string
+    ) => Promise<{ releaseAdoptionLease?(): void; shutdown(): Promise<void> }>
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      const handle = await launcher(
+        '/fake/socket',
+        '/fake/token',
+        '/fake/daemon.pid',
+        'unused-new-launch'
+      )
+
+      expect(replaceDaemonPidFileMock).toHaveBeenCalledWith('/fake/daemon.pid', endpointIdentity)
+      expect(warn).toHaveBeenCalledWith(
+        '[daemon] Repaired daemon PID ownership to match the authenticated endpoint'
+      )
+      handle.releaseAdoptionLease?.()
+    } finally {
+      warn.mockRestore()
+    }
+  })
+
   it('disconnects every temporary client when healthy adoption fails', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
@@ -1810,28 +1860,104 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(handlers.exit).toHaveLength(0)
     expect(child.disconnect).toHaveBeenCalledOnce()
     expect(child.unref).toHaveBeenCalledOnce()
-    const [pidPath, pidContents, pidOptions] = writeFileSyncMock.mock.calls.at(-1) ?? []
-    expect(pidPath).toBe(`/fake/daemon/daemon-v${PROTOCOL_VERSION}.pid`)
-    expect(JSON.parse(pidContents as string)).toEqual({
-      pid: 12345,
-      startedAtMs: 1_000_000,
-      linuxStartTicks: '4242',
-      bootId: 'boot-a',
-      entryPath: FAKE_DAEMON_ENTRY_PATH,
-      appVersion: '1.2.3',
-      launchNonce: expect.stringMatching(/^[0-9a-f-]{36}$/)
-    })
-    expect(pidOptions).toEqual({ mode: 0o600, flag: 'wx' })
     const launchArgs = forkMock.mock.calls.at(-1)?.[1] as string[]
     const launchNonceIndex = launchArgs.indexOf('--launch-nonce')
     expect(launchArgs).toEqual(
       expect.arrayContaining([
         '--pid-record',
         `/fake/daemon/daemon-v${PROTOCOL_VERSION}.pid`,
-        '--launch-nonce'
+        '--launch-nonce',
+        expect.stringMatching(/^[0-9a-f-]{36}$/),
+        '--entry-path',
+        FAKE_DAEMON_ENTRY_PATH,
+        '--app-version',
+        '1.2.3'
       ])
     )
-    expect(launchArgs[launchNonceIndex + 1]).toBe(JSON.parse(pidContents as string).launchNonce)
+    expect(launchArgs[launchNonceIndex + 1]).toMatch(/^[0-9a-f-]{36}$/)
+  })
+
+  it('rejects and reaps a child that lost endpoint ownership before adoption', async () => {
+    const mod = await importFresh()
+    checkDaemonHealthMock.mockResolvedValue('unreachable')
+    await mod.initDaemonPtyProvider()
+    function basicClient() {
+      return {
+        ensureConnected: vi.fn(async () => {}),
+        request: vi.fn(async () => ({ sessions: [] })),
+        disconnect: vi.fn()
+      }
+    }
+    daemonClientMock.mockImplementationOnce(basicClient)
+    daemonClientMock.mockImplementationOnce(basicClient)
+    daemonClientMock.mockImplementationOnce(function mismatchedClient() {
+      return {
+        ...basicClient(),
+        getDaemonIdentity: vi.fn(() => ({
+          pid: 999,
+          startedAtMs: 900_000,
+          launchNonce: 'stale-launch'
+        }))
+      }
+    })
+    const handlers: Record<string, ((arg?: unknown) => void)[]> = {
+      message: [],
+      error: [],
+      exit: []
+    }
+    const child = {
+      pid: 12345,
+      connected: true,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      on(event: string, callback: (arg?: unknown) => void) {
+        handlers[event]?.push(callback)
+        if (event === 'message') {
+          queueMicrotask(() => callback({ type: 'ready', startedAtMs: 1_000_000 }))
+        }
+        return this
+      },
+      off(event: string, callback: (arg?: unknown) => void) {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== callback) ?? []
+        return this
+      },
+      kill: vi.fn(() => true),
+      disconnect: vi.fn(() => {
+        child.connected = false
+      }),
+      unref: vi.fn()
+    }
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      queueMicrotask(() => {
+        child.exitCode = 0
+        for (const callback of handlers.exit.slice()) {
+          callback(0)
+        }
+      })
+      return true
+    })
+    forkMock.mockReturnValueOnce(child)
+    const launcher = spawnerInstances[0].launcher as (
+      socketPath: string,
+      tokenPath: string,
+      pidPath?: string,
+      launchNonce?: string
+    ) => Promise<{ shutdown(): Promise<void> }>
+
+    try {
+      await expect(
+        launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'launch-new')
+      ).rejects.toThrow('Daemon endpoint ownership changed during startup')
+
+      expect(kill).toHaveBeenCalledWith(12345, 'SIGTERM')
+      expect(unlinkOwnedDaemonPidFileMock).toHaveBeenCalledWith(
+        '/fake/daemon.pid',
+        12345,
+        'launch-new'
+      )
+    } finally {
+      kill.mockRestore()
+    }
   })
 
   it('keeps a live PID record after adoption failure and removes it on exact child exit', async () => {
@@ -1895,11 +2021,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       launcher('/fake/socket', '/fake/token', '/fake/daemon.pid', 'launch-delayed')
     ).rejects.toThrow('adoption unavailable')
 
-    expect(writeFileSyncMock).toHaveBeenCalledWith(
-      '/fake/daemon.pid',
-      expect.stringContaining('launch-delayed'),
-      { mode: 0o600, flag: 'wx' }
-    )
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
     expect(unlinkOwnedDaemonPidFileMock).not.toHaveBeenCalled()
     expect(adoptionDisconnects.at(-1)).toHaveBeenCalledOnce()
 
@@ -2116,7 +2238,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     }
   })
 
-  it('kills and rejects a daemon when exclusive PID publication fails', async () => {
+  it('leaves exclusive PID publication to the daemon child', async () => {
     const mod = await importFresh()
     checkDaemonHealthMock.mockResolvedValue('unreachable')
     await mod.initDaemonPtyProvider()
@@ -2125,9 +2247,6 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       socketPath: string,
       tokenPath: string
     ) => Promise<{ shutdown(): Promise<void> }>
-    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
-      throw Object.assign(new Error('already exited'), { code: 'ESRCH' })
-    })
     const child = {
       pid: 12345,
       on(event: string, cb: (arg?: unknown) => void) {
@@ -2140,27 +2259,21 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
       disconnect: vi.fn(),
       unref: vi.fn()
     }
-    const publicationError = Object.assign(new Error('PID record already exists'), {
-      code: 'EEXIST'
-    })
-    writeFileSyncMock.mockImplementationOnce(() => {
-      throw publicationError
-    })
     forkMock.mockReturnValueOnce(child)
 
-    try {
-      await expect(launcher('/fake/socket', '/fake/token')).rejects.toBe(publicationError)
-      expect(writeFileSyncMock).toHaveBeenCalledWith(
+    await launcher('/fake/socket', '/fake/token')
+
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
+    expect(forkMock.mock.calls.at(-1)?.[1]).toEqual(
+      expect.arrayContaining([
+        '--pid-record',
         `/fake/daemon/daemon-v${PROTOCOL_VERSION}.pid`,
-        expect.any(String),
-        { mode: 0o600, flag: 'wx' }
-      )
-      expect(kill).toHaveBeenCalledWith(12345, 'SIGTERM')
-      expect(child.disconnect).not.toHaveBeenCalled()
-      expect(child.unref).toHaveBeenCalledOnce()
-    } finally {
-      kill.mockRestore()
-    }
+        '--entry-path',
+        FAKE_DAEMON_ENTRY_PATH,
+        '--app-version',
+        '1.2.3'
+      ])
+    )
   })
 
   it('removes detached daemon startup listeners after startup error', async () => {
@@ -2760,8 +2873,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
     expect(forkMock).not.toHaveBeenCalled()
   })
 
-  it('writes the daemon self-reported start time to the pid file when the OS query returns null', async () => {
-    // Why: getProcessStartedAtMs has no cheap Windows impl, so the pid-recycling guard uses the ready-message fallback.
+  it('accepts the daemon self-reported start time when the OS query returns null', async () => {
     const mod = await importFresh()
     await mod.initDaemonPtyProvider()
 
@@ -2788,16 +2900,7 @@ describe('daemon-init: runRestartDaemon (7-step sequence)', () => {
 
     await launcher('/fake/socket', '/fake/token')
 
-    const [pidPath, pidContents, pidOptions] = writeFileSyncMock.mock.calls.at(-1) ?? []
-    expect(pidPath).toBe(`/fake/daemon/daemon-v${PROTOCOL_VERSION}.pid`)
-    expect(JSON.parse(pidContents as string)).toEqual({
-      pid: 12345,
-      startedAtMs: 1_700_000_123_456,
-      entryPath: FAKE_DAEMON_ENTRY_PATH,
-      appVersion: '1.2.3',
-      launchNonce: expect.stringMatching(/^[0-9a-f-]{36}$/)
-    })
-    expect(pidOptions).toEqual({ mode: 0o600, flag: 'wx' })
+    expect(writeFileSyncMock).not.toHaveBeenCalled()
   })
 
   it('keeps legacy daemon pid/token files when the probe fails but the pid-file process is alive', async () => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -29,7 +29,6 @@ import {
 } from './types'
 import {
   getMacDaemonSystemResolverHealth,
-  getDaemonCommandLine,
   getDaemonLaunchIdentity,
   checkDaemonHealth,
   isDaemonStaleForCurrentBundle,
@@ -247,8 +246,9 @@ async function reconcileDaemonPidOwnership(
   // Why: the mismatched record's metadata describes a different daemon and must not be copied
   // onto this one. Re-derive it from the authenticated owner instead, so the repaired record
   // keeps the fields freshness, host pinning and pid-recycle detection depend on.
-  const ownerMetadata = await readDaemonOwnerMetadata(endpointIdentity.pid)
-  if (!replaceDaemonPidFile(pidPath, { ...endpointIdentity, ...ownerMetadata })) {
+  const { pid, startedAtMs, launchNonce } = endpointIdentity
+  const ownerMetadata = await readDaemonOwnerMetadata(endpointIdentity)
+  if (!replaceDaemonPidFile(pidPath, { pid, startedAtMs, launchNonce, ...ownerMetadata })) {
     // Why: fail open. A record that disagrees with the endpoint is a diagnosable nuisance;
     // abandoning a healthy adoptable daemon over a failed file write costs the user every
     // persistent terminal on the machine.
@@ -261,38 +261,31 @@ async function reconcileDaemonPidOwnership(
 }
 
 /**
- * Recovers the owning daemon's launch metadata from its command line.
+ * Recovers the owning daemon's launch metadata.
  *
  * Why: `entryPath`/`appVersion` gate bundle-freshness and (on Windows) which relocated daemon
  * host directories are pinned against pruning, and the Linux pair gates pid-recycle detection.
  * Publishing a repaired record without them makes a healthy daemon look permanently stale.
+ * The values come from the authenticated hello rather than the owner's command line: a command
+ * line is a single space-joined string, so any install path containing a space (`C:\Program
+ * Files\...`, `/Applications/Orca 2.app/...`) cannot be split back into argv unambiguously.
  */
-async function readDaemonOwnerMetadata(pid: number): Promise<Partial<DaemonPidFile>> {
+async function readDaemonOwnerMetadata(
+  identity: DaemonEndpointIdentity
+): Promise<Partial<DaemonPidFile>> {
   const metadata: Partial<DaemonPidFile> = {}
-  const commandLine = await getDaemonCommandLine(pid)
-  if (commandLine) {
-    const entryPath = matchDaemonLaunchArgument(commandLine, '--entry-path')
-    const appVersion = matchDaemonLaunchArgument(commandLine, '--app-version')
-    if (entryPath) {
-      metadata.entryPath = entryPath
-    }
-    if (appVersion) {
-      metadata.appVersion = appVersion
-    }
+  if (identity.entryPath) {
+    metadata.entryPath = identity.entryPath
   }
-  const incarnation = await readDaemonProcessIncarnation(pid)
+  if (identity.appVersion) {
+    metadata.appVersion = identity.appVersion
+  }
+  const incarnation = await readDaemonProcessIncarnation(identity.pid)
   if (incarnation) {
     metadata.linuxStartTicks = incarnation.linuxStartTicks
     metadata.bootId = incarnation.bootId
   }
   return metadata
-}
-
-// Why: fork() passes argv as an array, so a value is the single token after its flag; the
-// command line renders them separated by a space or NUL depending on the platform source.
-function matchDaemonLaunchArgument(commandLine: string, flag: string): string | null {
-  const match = new RegExp(`${flag}[\\s\\0]+([^\\s\\0]+)`).exec(commandLine)
-  return match?.[1] ?? null
 }
 
 function pidRecordMatchesEndpoint(pidPath: string, identity: DaemonEndpointIdentity): boolean {
@@ -606,11 +599,20 @@ function createOutOfProcessLauncher(
       const killOutcome = await killStaleDaemon(runtimeDir, socketPath, tokenPath)
       if (killOutcome.liveOwnerSurvived) {
         // Why: forking beside a daemon we could not prove dead is precisely how the endpoint
-        // owner and the session host diverge. Fail closed — the caller falls back to local
-        // PTYs for this launch, and the next one re-probes a daemon that may since have died.
-        throw new DaemonEndpointOwnershipError(
-          'Daemon replacement aborted: the existing daemon could not be confirmed stopped'
+        // owner and the session host diverge. But refusing outright would leave the user with
+        // no daemon at all, and we have just proved something still answers the endpoint —
+        // so adopt it in degraded mode: existing sessions keep working, new PTYs run locally.
+        console.warn(
+          '[daemon] DEGRADED MODE: adopting a daemon that could not be confirmed stopped. Existing sessions keep working; fresh terminals run on the local provider WITHOUT daemon persistence until you restart the daemon (Manage Sessions → Restart).'
         )
+        try {
+          return await preserveDaemon('degraded-new-pty-fallback')
+        } catch {
+          // It died between the probe and the adoption; the endpoint is genuinely free now.
+          throw new DaemonEndpointOwnershipError(
+            'Daemon replacement aborted: the existing daemon could not be confirmed stopped'
+          )
+        }
       }
       confirmedReplacement = killOutcome.killed || confirmedReplacement
       // Why: rank by how well each reason is evidenced. A confirmed kill whose reason positively
@@ -840,6 +842,11 @@ export async function initDaemonPtyProvider(
   }
   const runtimeDir = getRuntimeDir()
 
+  // Why: rename-claim and bind scratch names are unlinked by their owner, but a failed unlink
+  // leaves one behind forever. Sweep before launching so a failed launch is still reclaimed;
+  // age-gated so a claim still in flight is never disturbed.
+  sweepAbandonedDaemonClaims(runtimeDir)
+
   const newSpawner = new DaemonSpawner({
     runtimeDir,
     launcher: createOutOfProcessLauncher(runtimeDir, options.macosLoginSessionWatch ?? false)
@@ -849,9 +856,6 @@ export async function initDaemonPtyProvider(
   const info = await newSpawner.ensureRunning()
   // Why: reclaim superseded daemon-host copies on EVERY launch (spawns are rare), keeping current + live-daemon-pinned versions.
   pruneOldDaemonHosts(collectPinnedDaemonVersions(runtimeDir))
-  // Why: rename-claim and bind scratch names are unlinked by their owner, but a failed unlink
-  // leaves one behind forever; age-gated so a claim still in flight is never disturbed.
-  sweepAbandonedDaemonClaims(runtimeDir)
   const launchMode = newSpawner.getHandle()?.mode
   logDaemonMilestone('daemon-current-ready')
   if (signal?.aborted) {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -654,6 +654,9 @@ function createOutOfProcessLauncher(
             )
             return
           }
+          if (Number.isSafeInteger(child.pid) && (child.pid as number) > 0) {
+            unlinkOwnedDaemonPidFile(pidPath, child.pid as number, launchNonce)
+          }
           reject(startupError)
         }
         function onReadyMessage(msg: unknown): void {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -3,7 +3,7 @@ restart, teardown); the "swap the provider atomically" invariant keeps restart +
 import { join } from 'node:path'
 import { randomUUID } from 'node:crypto'
 import { app } from 'electron'
-import { mkdirSync, existsSync, readFileSync, unlinkSync, writeFileSync } from 'node:fs'
+import { mkdirSync, existsSync, readFileSync, unlinkSync } from 'node:fs'
 import { fork, type ChildProcess } from 'node:child_process'
 import { connect } from 'node:net'
 import {
@@ -11,7 +11,7 @@ import {
   getDaemonPidPath,
   getDaemonSocketPath,
   getDaemonTokenPath,
-  serializeDaemonPidFile,
+  replaceDaemonPidFile,
   unlinkOwnedDaemonPidFile,
   type DaemonLauncher,
   type DaemonProcessHandle
@@ -54,6 +54,7 @@ import {
   hasSeededUnconfirmedClaudePtys
 } from '../claude-accounts/live-pty-gate'
 import { parseDaemonReadyIdentity } from './daemon-ready-identity'
+import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
 
 // Why: daemon init runs concurrent with window load, so an in-process t timestamp (not harness stderr timing) measures cold-start.
 function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
@@ -67,6 +68,8 @@ export const WEDGED_DAEMON_GRACE_RETRIES = 11
 const DAEMON_SELF_SHUTDOWN_WAIT_MS = 5_000
 const DAEMON_CHILD_TERMINATION_GRACE_MS = 5_000
 const DAEMON_CHILD_FORCE_EXIT_WAIT_MS = 1_000
+
+class DaemonEndpointOwnershipError extends Error {}
 
 let spawner: DaemonSpawner | null = null
 type DaemonProvider = DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider
@@ -184,17 +187,63 @@ async function holdDaemonAdoptionLease(
   handle: DaemonProcessHandle,
   socketPath: string,
   tokenPath: string,
-  connectedClient?: DaemonClient
+  connectedClient?: DaemonClient,
+  expectedIdentity?: DaemonEndpointIdentity,
+  pidPath?: string
 ): Promise<DaemonProcessHandle> {
   const client = connectedClient ?? new DaemonClient({ socketPath, tokenPath })
   try {
     await client.ensureConnected()
+    const readIdentity = (client as Partial<DaemonClient>).getDaemonIdentity
+    if (expectedIdentity) {
+      if (readIdentity) {
+        const actualIdentity = readIdentity.call(client)
+        if (
+          !actualIdentity ||
+          actualIdentity.pid !== expectedIdentity.pid ||
+          actualIdentity.startedAtMs !== expectedIdentity.startedAtMs ||
+          actualIdentity.launchNonce !== expectedIdentity.launchNonce
+        ) {
+          throw new DaemonEndpointOwnershipError('Daemon endpoint ownership changed during startup')
+        }
+      }
+    }
+    reconcileDaemonPidOwnership(client, pidPath)
   } catch (error) {
     client.disconnect()
     throw error
   }
   handle.releaseAdoptionLease = () => client.disconnect()
   return handle
+}
+
+function reconcileDaemonPidOwnership(client: DaemonClient, pidPath?: string): void {
+  const readIdentity = (client as Partial<DaemonClient>).getDaemonIdentity
+  const endpointIdentity = readIdentity?.call(client) ?? null
+  if (!pidPath || !endpointIdentity || pidRecordMatchesEndpoint(pidPath, endpointIdentity)) {
+    return
+  }
+  if (!replaceDaemonPidFile(pidPath, { ...endpointIdentity })) {
+    throw new DaemonEndpointOwnershipError('Daemon PID ownership could not be reconciled')
+  }
+  console.warn('[daemon] Repaired daemon PID ownership to match the authenticated endpoint')
+}
+
+function pidRecordMatchesEndpoint(pidPath: string, identity: DaemonEndpointIdentity): boolean {
+  try {
+    const record = JSON.parse(readFileSync(pidPath, 'utf8')) as {
+      pid?: unknown
+      startedAtMs?: unknown
+      launchNonce?: unknown
+    }
+    return (
+      record.pid === identity.pid &&
+      record.startedAtMs === identity.startedAtMs &&
+      record.launchNonce === identity.launchNonce
+    )
+  } catch {
+    return false
+  }
 }
 
 function releaseDaemonAdoptionLease(handle: DaemonProcessHandle | null): void {
@@ -354,9 +403,13 @@ function createOutOfProcessLauncher(
     try {
       // Why: acquire the full pair before control-only probes so an expired inherited deadline can't fire in the probe-to-adoption gap.
       await adoptionClient.ensureConnected()
-    } catch {
+      reconcileDaemonPidOwnership(adoptionClient, pidPath)
+    } catch (error) {
       adoptionClient.disconnect()
       adoptionClient = null
+      if (error instanceof DaemonEndpointOwnershipError) {
+        throw error
+      }
     }
     const preserveDaemon = async (
       mode?: 'degraded-new-pty-fallback'
@@ -367,7 +420,9 @@ function createOutOfProcessLauncher(
         createPreservedDaemonHandle(runtimeDir, PROTOCOL_VERSION, mode),
         socketPath,
         tokenPath,
-        connectedClient
+        connectedClient,
+        undefined,
+        pidPath
       )
     }
     try {
@@ -514,6 +569,10 @@ function createOutOfProcessLauncher(
           pidPath,
           '--launch-nonce',
           launchNonce,
+          '--entry-path',
+          entryPath,
+          '--app-version',
+          app.getVersion(),
           ...(macosLoginSessionWatch ? ['--login-session-watch'] : []),
           ...daemonLogArgs()
         ],
@@ -557,6 +616,7 @@ function createOutOfProcessLauncher(
       }
 
       // Wait for the daemon to signal readiness via IPC
+      let launchedIdentity: DaemonEndpointIdentity | null = null
       await new Promise<void>((resolve, reject) => {
         let timer: ReturnType<typeof setTimeout> | undefined
         let settled = false
@@ -606,22 +666,10 @@ function createOutOfProcessLauncher(
               void fail(new Error('Daemon readiness identity is incomplete'))
               return
             }
-            try {
-              // Why: pid record shares the daemon's self time and nonce so cleanup can identify this exact process incarnation.
-              writeFileSync(
-                pidPath,
-                serializeDaemonPidFile({
-                  pid: child.pid as number,
-                  ...readyIdentity,
-                  entryPath,
-                  appVersion: app.getVersion(),
-                  launchNonce
-                }),
-                { mode: 0o600, flag: 'wx' }
-              )
-            } catch (error) {
-              void fail(error instanceof Error ? error : new Error(String(error)))
-              return
+            launchedIdentity = {
+              pid: child.pid as number,
+              ...readyIdentity,
+              launchNonce
             }
             settled = true
             // Why: daemon is detached after readiness; detach startup listeners so the launch promise closure isn't retained.
@@ -652,14 +700,25 @@ function createOutOfProcessLauncher(
       })
 
       try {
+        if (!launchedIdentity) {
+          throw new Error('Daemon readiness identity is incomplete')
+        }
         return await holdDaemonAdoptionLease(
           {
             shutdown: () => terminateLaunchedDaemonChild(child)
           },
           socketPath,
-          tokenPath
+          tokenPath,
+          undefined,
+          launchedIdentity,
+          pidPath
         )
       } catch (error) {
+        if (error instanceof DaemonEndpointOwnershipError) {
+          await terminateLaunchedDaemonChild(child)
+          unlinkOwnedDaemonPidFile(pidPath, child.pid as number, launchNonce)
+          throw error
+        }
         // Why: another client may have adopted this live process; keep its pid record until exit, but remove one published after an early exit.
         let pidRecordRemoved = false
         const removeExitedPidRecord = (): void => {

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -196,16 +196,14 @@ async function holdDaemonAdoptionLease(
     await client.ensureConnected()
     const readIdentity = (client as Partial<DaemonClient>).getDaemonIdentity
     if (expectedIdentity) {
-      if (readIdentity) {
-        const actualIdentity = readIdentity.call(client)
-        if (
-          !actualIdentity ||
-          actualIdentity.pid !== expectedIdentity.pid ||
-          actualIdentity.startedAtMs !== expectedIdentity.startedAtMs ||
-          actualIdentity.launchNonce !== expectedIdentity.launchNonce
-        ) {
-          throw new DaemonEndpointOwnershipError('Daemon endpoint ownership changed during startup')
-        }
+      const actualIdentity = readIdentity?.call(client)
+      if (
+        !actualIdentity ||
+        actualIdentity.pid !== expectedIdentity.pid ||
+        actualIdentity.startedAtMs !== expectedIdentity.startedAtMs ||
+        actualIdentity.launchNonce !== expectedIdentity.launchNonce
+      ) {
+        throw new DaemonEndpointOwnershipError('Daemon endpoint ownership changed during startup')
       }
     }
     reconcileDaemonPidOwnership(client, pidPath)

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -14,8 +14,10 @@ import {
   replaceDaemonPidFile,
   unlinkOwnedDaemonPidFile,
   type DaemonLauncher,
+  type DaemonPidFile,
   type DaemonProcessHandle
 } from './daemon-spawner'
+import { sweepAbandonedDaemonClaims } from './daemon-endpoint-ownership'
 import { DaemonPtyAdapter, type DaemonRespawnReason } from './daemon-pty-adapter'
 import { DaemonPtyRouter } from './daemon-pty-router'
 import { DaemonClient } from './client'
@@ -27,6 +29,7 @@ import {
 } from './types'
 import {
   getMacDaemonSystemResolverHealth,
+  getDaemonCommandLine,
   getDaemonLaunchIdentity,
   checkDaemonHealth,
   isDaemonStaleForCurrentBundle,
@@ -53,13 +56,16 @@ import {
   confirmSeededClaudeLivePtys,
   hasSeededUnconfirmedClaudePtys
 } from '../claude-accounts/live-pty-gate'
-import { parseDaemonReadyIdentity } from './daemon-ready-identity'
+import { parseDaemonReadyIdentity, readDaemonProcessIncarnation } from './daemon-ready-identity'
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
 
 // Why: daemon init runs concurrent with window load, so an in-process t timestamp (not harness stderr timing) measures cold-start.
 function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
   if (isStartupDiagnosticsEnabled()) {
-    logStartupDiagnostic(event, { t: Math.round(performance.now()), ...details })
+    logStartupDiagnostic(event, {
+      t: Math.round(performance.now()),
+      ...details
+    })
   }
 }
 
@@ -70,6 +76,22 @@ const DAEMON_CHILD_TERMINATION_GRACE_MS = 5_000
 const DAEMON_CHILD_FORCE_EXIT_WAIT_MS = 1_000
 
 class DaemonEndpointOwnershipError extends Error {}
+
+/**
+ * The one method the ownership checks need from a connected client.
+ *
+ * Why: naming the capability instead of casting DaemonClient to Partial keeps a rename from
+ * silently turning the fence into a no-op — the compiler now rejects a client without it.
+ */
+type DaemonEndpointIdentityReader = {
+  getDaemonIdentity?: () => DaemonEndpointIdentity | null
+}
+
+function readDaemonEndpointIdentity(
+  client: DaemonEndpointIdentityReader
+): DaemonEndpointIdentity | null {
+  return client.getDaemonIdentity?.() ?? null
+}
 
 let spawner: DaemonSpawner | null = null
 type DaemonProvider = DaemonPtyRouter | DaemonPtyAdapter | DegradedDaemonPtyProvider
@@ -194,9 +216,8 @@ async function holdDaemonAdoptionLease(
   const client = connectedClient ?? new DaemonClient({ socketPath, tokenPath })
   try {
     await client.ensureConnected()
-    const readIdentity = (client as Partial<DaemonClient>).getDaemonIdentity
     if (expectedIdentity) {
-      const actualIdentity = readIdentity?.call(client)
+      const actualIdentity = readDaemonEndpointIdentity(client)
       if (
         !actualIdentity ||
         actualIdentity.pid !== expectedIdentity.pid ||
@@ -206,7 +227,7 @@ async function holdDaemonAdoptionLease(
         throw new DaemonEndpointOwnershipError('Daemon endpoint ownership changed during startup')
       }
     }
-    reconcileDaemonPidOwnership(client, pidPath)
+    await reconcileDaemonPidOwnership(client, pidPath)
   } catch (error) {
     client.disconnect()
     throw error
@@ -215,16 +236,63 @@ async function holdDaemonAdoptionLease(
   return handle
 }
 
-function reconcileDaemonPidOwnership(client: DaemonClient, pidPath?: string): void {
-  const readIdentity = (client as Partial<DaemonClient>).getDaemonIdentity
-  const endpointIdentity = readIdentity?.call(client) ?? null
+async function reconcileDaemonPidOwnership(
+  client: DaemonEndpointIdentityReader,
+  pidPath?: string
+): Promise<void> {
+  const endpointIdentity = readDaemonEndpointIdentity(client)
   if (!pidPath || !endpointIdentity || pidRecordMatchesEndpoint(pidPath, endpointIdentity)) {
     return
   }
-  if (!replaceDaemonPidFile(pidPath, { ...endpointIdentity })) {
-    throw new DaemonEndpointOwnershipError('Daemon PID ownership could not be reconciled')
+  // Why: the mismatched record's metadata describes a different daemon and must not be copied
+  // onto this one. Re-derive it from the authenticated owner instead, so the repaired record
+  // keeps the fields freshness, host pinning and pid-recycle detection depend on.
+  const ownerMetadata = await readDaemonOwnerMetadata(endpointIdentity.pid)
+  if (!replaceDaemonPidFile(pidPath, { ...endpointIdentity, ...ownerMetadata })) {
+    // Why: fail open. A record that disagrees with the endpoint is a diagnosable nuisance;
+    // abandoning a healthy adoptable daemon over a failed file write costs the user every
+    // persistent terminal on the machine.
+    console.warn(
+      '[daemon] Could not repair daemon PID ownership; adopting the authenticated endpoint anyway'
+    )
+    return
   }
   console.warn('[daemon] Repaired daemon PID ownership to match the authenticated endpoint')
+}
+
+/**
+ * Recovers the owning daemon's launch metadata from its command line.
+ *
+ * Why: `entryPath`/`appVersion` gate bundle-freshness and (on Windows) which relocated daemon
+ * host directories are pinned against pruning, and the Linux pair gates pid-recycle detection.
+ * Publishing a repaired record without them makes a healthy daemon look permanently stale.
+ */
+async function readDaemonOwnerMetadata(pid: number): Promise<Partial<DaemonPidFile>> {
+  const metadata: Partial<DaemonPidFile> = {}
+  const commandLine = await getDaemonCommandLine(pid)
+  if (commandLine) {
+    const entryPath = matchDaemonLaunchArgument(commandLine, '--entry-path')
+    const appVersion = matchDaemonLaunchArgument(commandLine, '--app-version')
+    if (entryPath) {
+      metadata.entryPath = entryPath
+    }
+    if (appVersion) {
+      metadata.appVersion = appVersion
+    }
+  }
+  const incarnation = await readDaemonProcessIncarnation(pid)
+  if (incarnation) {
+    metadata.linuxStartTicks = incarnation.linuxStartTicks
+    metadata.bootId = incarnation.bootId
+  }
+  return metadata
+}
+
+// Why: fork() passes argv as an array, so a value is the single token after its flag; the
+// command line renders them separated by a space or NUL depending on the platform source.
+function matchDaemonLaunchArgument(commandLine: string, flag: string): string | null {
+  const match = new RegExp(`${flag}[\\s\\0]+([^\\s\\0]+)`).exec(commandLine)
+  return match?.[1] ?? null
 }
 
 function pidRecordMatchesEndpoint(pidPath: string, identity: DaemonEndpointIdentity): boolean {
@@ -397,17 +465,17 @@ function createOutOfProcessLauncher(
         }
       | undefined
     let confirmedReplacement = false
-    let adoptionClient: DaemonClient | null = new DaemonClient({ socketPath, tokenPath })
+    let adoptionClient: DaemonClient | null = new DaemonClient({
+      socketPath,
+      tokenPath
+    })
     try {
       // Why: acquire the full pair before control-only probes so an expired inherited deadline can't fire in the probe-to-adoption gap.
       await adoptionClient.ensureConnected()
-      reconcileDaemonPidOwnership(adoptionClient, pidPath)
-    } catch (error) {
+      await reconcileDaemonPidOwnership(adoptionClient, pidPath)
+    } catch {
       adoptionClient.disconnect()
       adoptionClient = null
-      if (error instanceof DaemonEndpointOwnershipError) {
-        throw error
-      }
     }
     const preserveDaemon = async (
       mode?: 'degraded-new-pty-fallback'
@@ -438,7 +506,10 @@ function createOutOfProcessLauncher(
             return preserveDaemon()
           }
           console.warn('[daemon] Replacing daemon with unavailable macOS system resolver')
-          pendingReplacement = { reason: 'unhealthy_resolver', liveSessionCount }
+          pendingReplacement = {
+            reason: 'unhealthy_resolver',
+            liveSessionCount
+          }
           confirmedReplacement = (await cleanupDaemonForProtocol(runtimeDir, PROTOCOL_VERSION))
             .cleaned
         } else {
@@ -523,14 +594,25 @@ function createOutOfProcessLauncher(
         }
         // Why: unlike the log above, telemetry gates on confirmedReplacement below — the
         // post-kill truth — so a cold start that killed nothing never reports a replacement.
-        pendingReplacement = { reason: 'failed_health_check', liveSessionCount }
+        pendingReplacement = {
+          reason: 'failed_health_check',
+          liveSessionCount
+        }
       }
 
       // Why: a raw socket can outlive a broken daemon; kill by PID before respawn so the new daemon doesn't race the stale one.
       adoptionClient?.disconnect()
       adoptionClient = null
-      confirmedReplacement =
-        (await killStaleDaemon(runtimeDir, socketPath, tokenPath)) || confirmedReplacement
+      const killOutcome = await killStaleDaemon(runtimeDir, socketPath, tokenPath)
+      if (killOutcome.liveOwnerSurvived) {
+        // Why: forking beside a daemon we could not prove dead is precisely how the endpoint
+        // owner and the session host diverge. Fail closed — the caller falls back to local
+        // PTYs for this launch, and the next one re-probes a daemon that may since have died.
+        throw new DaemonEndpointOwnershipError(
+          'Daemon replacement aborted: the existing daemon could not be confirmed stopped'
+        )
+      }
+      confirmedReplacement = killOutcome.killed || confirmedReplacement
       // Why: rank by how well each reason is evidenced. A confirmed kill whose reason positively
       // identified the daemon outranks the attribution, so a stale bundle caught here is not billed
       // to the resolver. failed_health_check is the residual "couldn't tell" bucket though — it also
@@ -767,6 +849,9 @@ export async function initDaemonPtyProvider(
   const info = await newSpawner.ensureRunning()
   // Why: reclaim superseded daemon-host copies on EVERY launch (spawns are rare), keeping current + live-daemon-pinned versions.
   pruneOldDaemonHosts(collectPinnedDaemonVersions(runtimeDir))
+  // Why: rename-claim and bind scratch names are unlinked by their owner, but a failed unlink
+  // leaves one behind forever; age-gated so a claim still in flight is never disturbed.
+  sweepAbandonedDaemonClaims(runtimeDir)
   const launchMode = newSpawner.getHandle()?.mode
   logDaemonMilestone('daemon-current-ready')
   if (signal?.aborted) {
@@ -857,7 +942,9 @@ export async function initDaemonPtyProvider(
   setLocalPtyProvider(routedAdapter)
   // Why: the first window may register PTY listeners before daemon init finishes; rebind so daemon PTYs still fan out events.
   rebindLocalProviderListeners()
-  logDaemonMilestone('daemon-init-done', { legacyAdapters: legacyAdapters.length })
+  logDaemonMilestone('daemon-init-done', {
+    legacyAdapters: legacyAdapters.length
+  })
   await reconcileSeededClaudeLivePtys(routedAdapter)
 }
 
@@ -1144,7 +1231,8 @@ export async function cleanupDaemonForProtocol(
     didRequestShutdown = true
   } catch {
     // Previous-protocol daemons may be wedged or too old for the RPC path; fall back to PID cleanup (only unlinks a live socket after proving the process is killed).
-    didKillStaleDaemon = await killStaleDaemon(runtimeDir, socketPath, tokenPath, protocolVersion)
+    didKillStaleDaemon = (await killStaleDaemon(runtimeDir, socketPath, tokenPath, protocolVersion))
+      .killed
   } finally {
     client.disconnect()
   }

--- a/src/main/daemon/daemon-main.ts
+++ b/src/main/daemon/daemon-main.ts
@@ -7,6 +7,7 @@ export type DaemonStartOptions = {
   pidPath?: string
   launchNonce?: string
   startedAtMs?: number
+  publishEndpointOwnership?: DaemonServerOptions['publishEndpointOwnership']
   /** Direct-construction seam for versioned protocol fixtures; never CLI/env configured. */
   protocolVersion?: number
   spawnSubprocess: DaemonServerOptions['spawnSubprocess']
@@ -29,6 +30,9 @@ export async function startDaemon(opts: DaemonStartOptions): Promise<DaemonHandl
     ...(opts.pidPath ? { pidPath: opts.pidPath } : {}),
     ...(opts.launchNonce ? { launchNonce: opts.launchNonce } : {}),
     ...(opts.startedAtMs ? { startedAtMs: opts.startedAtMs } : {}),
+    ...(opts.publishEndpointOwnership
+      ? { publishEndpointOwnership: opts.publishEndpointOwnership }
+      : {}),
     ...(opts.protocolVersion !== undefined ? { protocolVersion: opts.protocolVersion } : {}),
     spawnSubprocess: opts.spawnSubprocess,
     ...(opts.preparePtySpawn ? { preparePtySpawn: opts.preparePtySpawn } : {}),

--- a/src/main/daemon/daemon-main.ts
+++ b/src/main/daemon/daemon-main.ts
@@ -16,6 +16,7 @@ export type DaemonStartOptions = {
   onAuthenticatedClientPair?: DaemonServerOptions['onAuthenticatedClientPair']
   log?: DaemonFileLog
   onIdleShutdown?: () => void
+  onRpcShutdown?: () => void
   initialAdoptionTestConfig?: DaemonServerOptions['initialAdoptionTestConfig']
 }
 
@@ -42,6 +43,7 @@ export async function startDaemon(opts: DaemonStartOptions): Promise<DaemonHandl
       : {}),
     ...(opts.log ? { log: opts.log } : {}),
     ...(opts.onIdleShutdown ? { onIdleShutdown: opts.onIdleShutdown } : {}),
+    ...(opts.onRpcShutdown ? { onRpcShutdown: opts.onRpcShutdown } : {}),
     ...(opts.initialAdoptionTestConfig
       ? { initialAdoptionTestConfig: opts.initialAdoptionTestConfig }
       : {})

--- a/src/main/daemon/daemon-main.ts
+++ b/src/main/daemon/daemon-main.ts
@@ -8,6 +8,8 @@ export type DaemonStartOptions = {
   launchNonce?: string
   startedAtMs?: number
   publishEndpointOwnership?: DaemonServerOptions['publishEndpointOwnership']
+  entryPath?: string
+  appVersion?: string
   /** Direct-construction seam for versioned protocol fixtures; never CLI/env configured. */
   protocolVersion?: number
   spawnSubprocess: DaemonServerOptions['spawnSubprocess']
@@ -34,6 +36,8 @@ export async function startDaemon(opts: DaemonStartOptions): Promise<DaemonHandl
     ...(opts.publishEndpointOwnership
       ? { publishEndpointOwnership: opts.publishEndpointOwnership }
       : {}),
+    ...(opts.entryPath ? { entryPath: opts.entryPath } : {}),
+    ...(opts.appVersion ? { appVersion: opts.appVersion } : {}),
     ...(opts.protocolVersion !== undefined ? { protocolVersion: opts.protocolVersion } : {}),
     spawnSubprocess: opts.spawnSubprocess,
     ...(opts.preparePtySpawn ? { preparePtySpawn: opts.preparePtySpawn } : {}),

--- a/src/main/daemon/daemon-ready-identity.ts
+++ b/src/main/daemon/daemon-ready-identity.ts
@@ -22,6 +22,27 @@ export async function readCurrentDaemonReadyIdentity(
   }
 }
 
+/**
+ * Reads another process's incarnation markers.
+ *
+ * Why: `readCurrentDaemonReadyIdentity` only covers /proc/self, but repairing a PID record
+ * means republishing the markers of the daemon that actually owns the endpoint.
+ */
+export async function readDaemonProcessIncarnation(
+  pid: number
+): Promise<{ linuxStartTicks: string; bootId: string } | null> {
+  if (process.platform !== 'linux') {
+    return null
+  }
+  try {
+    const linuxStartTicks = parseLinuxStartTicks(readFileSync(`/proc/${pid}/stat`, 'utf8'))
+    const bootId = await readBootIdentity()
+    return linuxStartTicks && bootId ? { linuxStartTicks, bootId } : null
+  } catch {
+    return null
+  }
+}
+
 export function parseDaemonReadyIdentity(message: unknown): DaemonReadyIdentity | null {
   if (!message || typeof message !== 'object') {
     return null

--- a/src/main/daemon/daemon-server.test.ts
+++ b/src/main/daemon/daemon-server.test.ts
@@ -87,11 +87,12 @@ describe('DaemonServer', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  async function startServer(launchNonce?: string): Promise<void> {
+  async function startServer(launchNonce?: string, onRpcShutdown?: () => void): Promise<void> {
     server = new DaemonServer({
       socketPath,
       tokenPath,
       ...(launchNonce ? { pidPath, launchNonce } : {}),
+      ...(onRpcShutdown ? { onRpcShutdown } : {}),
       spawnSubprocess: () => createMockSubprocess()
     })
     await server.start()
@@ -842,7 +843,8 @@ describe('DaemonServer', () => {
 
   describe('shutdown', () => {
     it('waits for the ordinary shutdown reply write before destroying resources', async () => {
-      await startServer()
+      const onRpcShutdown = vi.fn()
+      await startServer(undefined, onRpcShutdown)
       const c = await connectClient()
       const daemon = server as unknown as DaemonServerPrivate & {
         host: { dispose: () => Promise<void> }
@@ -861,11 +863,14 @@ describe('DaemonServer', () => {
 
       await expect(c.request('shutdown', { killSessions: false })).resolves.toEqual({})
       expect(dispose).not.toHaveBeenCalled()
+      expect(onRpcShutdown).not.toHaveBeenCalled()
       expect(existsSync(tokenPath)).toBe(true)
 
       replyFlushed?.()
-      await waitFor(() => !existsSync(tokenPath))
+      await waitFor(() => onRpcShutdown.mock.calls.length === 1)
+      expect(existsSync(tokenPath)).toBe(false)
       expect(dispose).toHaveBeenCalledOnce()
+      expect(onRpcShutdown).toHaveBeenCalledOnce()
     })
 
     it('removes only its owned token and PID record', async () => {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -24,10 +24,9 @@ import { isTuiAgent } from '../../shared/tui-agent-config'
 import { parsePtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
 import { unlinkOwnedDaemonPidFile, unlinkOwnedDaemonTokenFile } from './daemon-spawner'
 import {
-  daemonSocketIdentityMatches,
   getDaemonSocketBindPath,
   publishDaemonSocketPath,
-  readDaemonSocketIdentity,
+  readDaemonEndpointOwnershipState,
   unlinkOwnedDaemonSocketPath,
   type DaemonSocketIdentity
 } from './daemon-endpoint-ownership'
@@ -106,6 +105,7 @@ export class DaemonServer {
   private static readonly INITIAL_ADOPTION_TIMEOUT_MS = 2 * 60 * 1000
   private static readonly SHUTDOWN_REPLY_FLUSH_TIMEOUT_MS = 1_000
   private static readonly ENDPOINT_OWNERSHIP_POLL_MS = 30 * 1000
+  private static readonly ENDPOINT_OWNERSHIP_LOSS_CONFIRMATIONS = 2
   private server: Server | null = null
   private token: string
   private host: TerminalHost
@@ -117,6 +117,7 @@ export class DaemonServer {
   private publishEndpointOwnership: () => void
   private ownedSocketIdentity: DaemonSocketIdentity | null = null
   private endpointOwnershipTimer: ReturnType<typeof setInterval> | null = null
+  private endpointOwnershipLossStreak = 0
   private protocolVersion: number
   private onIdleShutdown: () => void
   private onRpcShutdown: () => void
@@ -353,12 +354,20 @@ export class DaemonServer {
     if (process.platform === 'win32' || !this.ownedSocketIdentity || this.shutdownPromise) {
       return
     }
-    if (
-      daemonSocketIdentityMatches(
-        readDaemonSocketIdentity(this.socketPath),
-        this.ownedSocketIdentity
-      )
-    ) {
+    const state = readDaemonEndpointOwnershipState(this.socketPath, this.ownedSocketIdentity)
+    if (state === 'owned') {
+      this.endpointOwnershipLossStreak = 0
+      return
+    }
+    if (state === 'indeterminate') {
+      // Why: an inconclusive stat proves nothing. Retiring on EACCES or EIO would take down a
+      // daemon that is still serving every terminal on the machine.
+      return
+    }
+    this.endpointOwnershipLossStreak++
+    // Why: a replacement publishes by unlink-then-link, so a single observation can land in
+    // that gap. Require the loss to persist before acting on it.
+    if (this.endpointOwnershipLossStreak < DaemonServer.ENDPOINT_OWNERSHIP_LOSS_CONFIRMATIONS) {
       return
     }
     if (this.retirementRequested) {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -44,6 +44,7 @@ export type DaemonServerOptions = {
   pidPath?: string
   launchNonce?: string
   startedAtMs?: number
+  publishEndpointOwnership?: () => void
   /** Direct-construction seam for protocol fixture tests; production never overrides it. */
   protocolVersion?: number
   onIdleShutdown?: () => void
@@ -103,6 +104,7 @@ export class DaemonServer {
   private pidPath: string | null
   private launchNonce: string | null
   private startedAtMs: number | null
+  private publishEndpointOwnership: () => void
   private protocolVersion: number
   private onIdleShutdown: () => void
   private onAuthenticatedClientPair: () => void
@@ -173,6 +175,7 @@ export class DaemonServer {
       (this.protocolVersion >= CLEAN_DISCONNECT_PROTOCOL_VERSION
         ? Date.now() - process.uptime() * 1000
         : null)
+    this.publishEndpointOwnership = opts.publishEndpointOwnership ?? (() => {})
     this.onIdleShutdown = opts.onIdleShutdown ?? (() => {})
     this.initialAdoptionTimeoutMs =
       opts.initialAdoptionTestConfig?.timeoutMs ?? DaemonServer.INITIAL_ADOPTION_TIMEOUT_MS
@@ -216,7 +219,23 @@ export class DaemonServer {
       this.server.listen(this.socketPath, () => {
         // Why: drop the startup error listener after bind so it doesn't retain this closure.
         this.server?.off('error', onListenError)
-        writeFileSync(this.tokenPath, this.token, { mode: 0o600 })
+        try {
+          // Why: the PID/nonce record must exist before the token makes this listener adoptable.
+          this.publishEndpointOwnership()
+          writeFileSync(this.tokenPath, this.token, { mode: 0o600 })
+        } catch (error) {
+          if (this.pidPath && this.launchNonce) {
+            unlinkOwnedDaemonPidFile(this.pidPath, process.pid, this.launchNonce)
+          }
+          const server = this.server
+          this.server = null
+          if (!server) {
+            reject(error)
+            return
+          }
+          server.close(() => reject(error))
+          return
+        }
         try {
           chmodSync(this.socketPath, 0o600)
         } catch {

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -2,7 +2,7 @@
 import { createServer, type Server, type Socket } from 'node:net'
 import { randomUUID } from 'node:crypto'
 import { performance } from 'node:perf_hooks'
-import { writeFileSync, chmodSync } from 'node:fs'
+import { writeFileSync, chmodSync, unlinkSync } from 'node:fs'
 import { StringDecoder } from 'node:string_decoder'
 import { encodeNdjson, createNdjsonParser } from './ndjson'
 import { TerminalHost } from './terminal-host'
@@ -23,6 +23,14 @@ import { createNoopDaemonFileLog, type DaemonFileLog } from './daemon-file-log'
 import { isTuiAgent } from '../../shared/tui-agent-config'
 import { parsePtyStartupIngressIntent } from '../../shared/pty-startup-ingress'
 import { unlinkOwnedDaemonPidFile, unlinkOwnedDaemonTokenFile } from './daemon-spawner'
+import {
+  daemonSocketIdentityMatches,
+  getDaemonSocketBindPath,
+  publishDaemonSocketPath,
+  readDaemonSocketIdentity,
+  unlinkOwnedDaemonSocketPath,
+  type DaemonSocketIdentity
+} from './daemon-endpoint-ownership'
 import {
   CLEAN_DISCONNECT_PROTOCOL_VERSION,
   PROTOCOL_VERSION,
@@ -97,6 +105,7 @@ export class DaemonServer {
   // Why: survive long enough to adopt a first client pair, but don't orphan forever if the parent crashes first.
   private static readonly INITIAL_ADOPTION_TIMEOUT_MS = 2 * 60 * 1000
   private static readonly SHUTDOWN_REPLY_FLUSH_TIMEOUT_MS = 1_000
+  private static readonly ENDPOINT_OWNERSHIP_POLL_MS = 30 * 1000
   private server: Server | null = null
   private token: string
   private host: TerminalHost
@@ -106,6 +115,8 @@ export class DaemonServer {
   private launchNonce: string | null
   private startedAtMs: number | null
   private publishEndpointOwnership: () => void
+  private ownedSocketIdentity: DaemonSocketIdentity | null = null
+  private endpointOwnershipTimer: ReturnType<typeof setInterval> | null = null
   private protocolVersion: number
   private onIdleShutdown: () => void
   private onRpcShutdown: () => void
@@ -219,35 +230,53 @@ export class DaemonServer {
 
       this.server.once('error', onListenError)
 
-      this.server.listen(this.socketPath, () => {
+      // Why: bind a private name and hard-link it into place, so libuv's close-time unlink
+      // can only ever remove our own bind name — never a replacement daemon's endpoint.
+      const bindPath =
+        process.platform === 'win32' ? this.socketPath : getDaemonSocketBindPath(this.socketPath)
+
+      this.server.listen(bindPath, () => {
         // Why: drop the startup error listener after bind so it doesn't retain this closure.
         this.server?.off('error', onListenError)
         try {
-          // Why: the PID/nonce record must exist before the token makes this listener adoptable.
+          // Why: tighten the mode on the private bind name so the endpoint is never reachable
+          // at the canonical path with default permissions, even briefly.
+          chmodSync(bindPath, 0o600)
+        } catch {
+          // Best-effort on platforms that support it
+        }
+        try {
+          // Why: the exclusive link is the endpoint claim, and the PID/nonce record must
+          // exist before the token makes this listener adoptable.
+          this.ownedSocketIdentity = publishDaemonSocketPath(bindPath, this.socketPath)
           this.publishEndpointOwnership()
           writeFileSync(this.tokenPath, this.token, { mode: 0o600 })
         } catch (error) {
           if (this.pidPath && this.launchNonce) {
             unlinkOwnedDaemonPidFile(this.pidPath, process.pid, this.launchNonce)
           }
+          unlinkOwnedDaemonSocketPath(this.socketPath, this.ownedSocketIdentity)
+          this.ownedSocketIdentity = null
           const server = this.server
           this.server = null
-          if (!server) {
-            reject(error)
-            return
+          // Why: settle before close — an already-accepted connection defers the close
+          // callback indefinitely, and start() has no timeout of its own.
+          reject(error)
+          server?.close()
+          if (process.platform !== 'win32') {
+            try {
+              unlinkSync(bindPath)
+            } catch {
+              // Already consumed by a successful link, or never created.
+            }
           }
-          server.close(() => reject(error))
           return
-        }
-        try {
-          chmodSync(this.socketPath, 0o600)
-        } catch {
-          // Best-effort on platforms that support it
         }
         if (this.protocolVersion >= CLEAN_DISCONNECT_PROTOCOL_VERSION) {
           // Why: a parent crash before the first full client pair must not leave an empty daemon alive forever.
           this.armInitialAdoptionTimeout()
         }
+        this.startEndpointOwnershipWatch()
         resolve()
       })
     })
@@ -281,14 +310,71 @@ export class DaemonServer {
   }
 
   private unlinkOwnedEndpointArtifacts(): void {
-    // Why: ownership checks prevent removing a late replacement's token or PID record.
+    // Why: ownership checks prevent removing a late replacement's token, PID record or endpoint.
     unlinkOwnedDaemonTokenFile(this.tokenPath, this.token)
     if (this.pidPath && this.launchNonce) {
       unlinkOwnedDaemonPidFile(this.pidPath, process.pid, this.launchNonce)
     }
+    // Why: we bound a private name, so libuv unlinks nothing at the canonical path — this
+    // is the only removal of our endpoint, and it is skipped once someone else owns it.
+    unlinkOwnedDaemonSocketPath(this.socketPath, this.ownedSocketIdentity)
+    this.ownedSocketIdentity = null
+  }
+
+  private startEndpointOwnershipWatch(): void {
+    if (process.platform === 'win32' || !this.ownedSocketIdentity) {
+      return
+    }
+    this.endpointOwnershipTimer = setInterval(
+      () => this.checkEndpointOwnership(),
+      DaemonServer.ENDPOINT_OWNERSHIP_POLL_MS
+    )
+    // Why: a liveness poll must never be the reason the process cannot exit.
+    this.endpointOwnershipTimer.unref()
+  }
+
+  private stopEndpointOwnershipWatch(): void {
+    if (this.endpointOwnershipTimer === null) {
+      return
+    }
+    clearInterval(this.endpointOwnershipTimer)
+    this.endpointOwnershipTimer = null
+  }
+
+  /**
+   * Retires a daemon that no longer owns the canonical endpoint.
+   *
+   * Why: a daemon whose endpoint name was taken over keeps hosting PTYs that no client can
+   * reach through the socket, which reads to the user as terminals that acknowledge input and
+   * never run it. Retirement drains rather than kills: live sessions finish, and the process
+   * exits once idle instead of surviving as an unreachable orphan.
+   */
+  private checkEndpointOwnership(): void {
+    if (process.platform === 'win32' || !this.ownedSocketIdentity || this.shutdownPromise) {
+      return
+    }
+    if (
+      daemonSocketIdentityMatches(
+        readDaemonSocketIdentity(this.socketPath),
+        this.ownedSocketIdentity
+      )
+    ) {
+      return
+    }
+    if (this.retirementRequested) {
+      return
+    }
+    this.log.log('endpoint-ownership-lost', { socketPath: this.socketPath })
+    console.warn(
+      '[daemon] Endpoint ownership lost to another daemon — retiring once existing sessions end'
+    )
+    this.ownedSocketIdentity = null
+    this.retirementRequested = true
+    this.reevaluateIdleShutdown()
   }
 
   private async disposeDaemonResources(): Promise<void> {
+    this.stopEndpointOwnershipWatch()
     this.stopStreamBacklogProbe()
     this.transientFactRelay.dispose()
     this.cancelAllPendingPtySpawnPreparations()
@@ -324,7 +410,9 @@ export class DaemonServer {
     return new Promise<void>((resolve) => {
       // Why: close synchronously before any awaited cleanup so no new transport enters after the empty proof.
       server.close(() => {
-        // Node owns unlinking its Unix listener; an extra unlink here could delete a concurrent replacement.
+        // Why: libuv unlinks the path this server bound, which is our private bind name and
+        // is already gone. The canonical endpoint is removed by unlinkOwnedEndpointArtifacts,
+        // under an ownership check, so closing late cannot delete a replacement's endpoint.
         resolve()
       })
     })
@@ -463,19 +551,31 @@ export class DaemonServer {
         reason: 'protocol-mismatch',
         clientVersion: hello.version
       })
-      socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Protocol version mismatch' }))
+      socket.write(
+        encodeNdjson({
+          type: 'hello',
+          ok: false,
+          error: 'Protocol version mismatch'
+        })
+      )
       socket.destroy()
       return
     }
 
     if (hello.token !== this.token) {
-      this.log.log('client-hello-rejected', { reason: 'invalid-token', role: hello.role })
+      this.log.log('client-hello-rejected', {
+        reason: 'invalid-token',
+        role: hello.role
+      })
       socket.write(encodeNdjson({ type: 'hello', ok: false, error: 'Invalid token' }))
       socket.destroy()
       return
     }
 
-    this.log.log('client-hello-accepted', { role: hello.role, clientId: hello.clientId })
+    this.log.log('client-hello-accepted', {
+      role: hello.role,
+      clientId: hello.clientId
+    })
     socket.write(
       encodeNdjson({
         type: 'hello',
@@ -666,7 +766,10 @@ export class DaemonServer {
   }
 
   private async preparePtySpawnUnlessCanceled(sessionId: string, clientId: string): Promise<void> {
-    const preparation: PendingPtySpawnPreparation = { canceled: false, clientId }
+    const preparation: PendingPtySpawnPreparation = {
+      canceled: false,
+      clientId
+    }
     const pending = this.pendingPtySpawnPreparations.get(sessionId) ?? new Set()
     pending.add(preparation)
     this.pendingPtySpawnPreparations.set(sessionId, pending)
@@ -817,7 +920,10 @@ export class DaemonServer {
               },
               onExit: (code, incarnationId) => {
                 // Why: exit tears down renderer handlers, so it must ride the ordered queue behind final output.
-                this.log.log('session-exited', { sessionId: routedSessionId, code })
+                this.log.log('session-exited', {
+                  sessionId: routedSessionId,
+                  code
+                })
                 this.streamDataBatcher.enqueueControlEvent(clientId, routedSessionId, {
                   type: 'event',
                   event: 'exit',
@@ -969,7 +1075,9 @@ export class DaemonServer {
           clientId
         }
         try {
-          await this.host.kill(request.payload.sessionId, { immediate: request.payload.immediate })
+          await this.host.kill(request.payload.sessionId, {
+            immediate: request.payload.immediate
+          })
         } catch (error) {
           // Why: a kill that wins before session registration already canceled the pending spawn, so its intent is done.
           if (!(canceledPendingSpawn && error instanceof SessionNotFoundError)) {
@@ -987,14 +1095,18 @@ export class DaemonServer {
 
       case 'detach':
         // Note: detach token handling simplified — full impl would track tokens per client
-        this.log.log('session-detached', { sessionId: request.payload.sessionId })
+        this.log.log('session-detached', {
+          sessionId: request.payload.sessionId
+        })
         return {}
 
       case 'getCwd':
         return { cwd: await this.host.getCwd(request.payload.sessionId) }
 
       case 'getForegroundProcess':
-        return { foregroundProcess: this.host.getForegroundProcess(request.payload.sessionId) }
+        return {
+          foregroundProcess: this.host.getForegroundProcess(request.payload.sessionId)
+        }
 
       case 'inspectProcess':
         return this.host.inspectProcess(request.payload.sessionId)
@@ -1046,7 +1158,9 @@ export class DaemonServer {
           typeof requestedScrollbackRows === 'number' && Number.isFinite(requestedScrollbackRows)
             ? Math.max(0, Math.min(50_000, Math.floor(requestedScrollbackRows)))
             : undefined
-        const snapshot = this.host.getSnapshot(request.payload.sessionId, { scrollbackRows })
+        const snapshot = this.host.getSnapshot(request.payload.sessionId, {
+          scrollbackRows
+        })
         const snapshotMs = performance.now() - snapshotStart
         if (snapshotMs >= 25) {
           // Serialize stalls block the daemon's single thread; surface them to attribute field typing stalls (issue #5096 family).

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -52,6 +52,9 @@ export type DaemonServerOptions = {
   launchNonce?: string
   startedAtMs?: number
   publishEndpointOwnership?: () => void
+  /** Reported in the hello so a repaired PID record can carry the real owner's metadata. */
+  entryPath?: string
+  appVersion?: string
   /** Direct-construction seam for protocol fixture tests; production never overrides it. */
   protocolVersion?: number
   onIdleShutdown?: () => void
@@ -115,6 +118,8 @@ export class DaemonServer {
   private launchNonce: string | null
   private startedAtMs: number | null
   private publishEndpointOwnership: () => void
+  private entryPath: string | null
+  private appVersion: string | null
   private ownedSocketIdentity: DaemonSocketIdentity | null = null
   private endpointOwnershipTimer: ReturnType<typeof setInterval> | null = null
   private endpointOwnershipLossStreak = 0
@@ -190,6 +195,8 @@ export class DaemonServer {
         ? Date.now() - process.uptime() * 1000
         : null)
     this.publishEndpointOwnership = opts.publishEndpointOwnership ?? (() => {})
+    this.entryPath = opts.entryPath ?? null
+    this.appVersion = opts.appVersion ?? null
     this.onIdleShutdown = opts.onIdleShutdown ?? (() => {})
     this.onRpcShutdown = opts.onRpcShutdown ?? (() => {})
     this.initialAdoptionTimeoutMs =
@@ -246,14 +253,19 @@ export class DaemonServer {
         } catch {
           // Best-effort on platforms that support it
         }
+        let publishedOwnership = false
         try {
           // Why: the exclusive link is the endpoint claim, and the PID/nonce record must
           // exist before the token makes this listener adoptable.
           this.ownedSocketIdentity = publishDaemonSocketPath(bindPath, this.socketPath)
           this.publishEndpointOwnership()
+          publishedOwnership = true
           writeFileSync(this.tokenPath, this.token, { mode: 0o600 })
         } catch (error) {
-          if (this.pidPath && this.launchNonce) {
+          // Why: roll back only a record we actually wrote. Losing the endpoint claim means
+          // the record at that path belongs to the incumbent daemon, and even the ownership-
+          // checked unlink briefly renames it aside — enough to strand a live daemon's record.
+          if (publishedOwnership && this.pidPath && this.launchNonce) {
             unlinkOwnedDaemonPidFile(this.pidPath, process.pid, this.launchNonce)
           }
           unlinkOwnedDaemonSocketPath(this.socketPath, this.ownedSocketIdentity)
@@ -361,7 +373,9 @@ export class DaemonServer {
     }
     if (state === 'indeterminate') {
       // Why: an inconclusive stat proves nothing. Retiring on EACCES or EIO would take down a
-      // daemon that is still serving every terminal on the machine.
+      // daemon that is still serving every terminal on the machine. Reset the streak too, so
+      // the confirmations we act on are consecutive rather than merely cumulative.
+      this.endpointOwnershipLossStreak = 0
       return
     }
     this.endpointOwnershipLossStreak++
@@ -594,7 +608,9 @@ export class DaemonServer {
               daemonIdentity: {
                 pid: process.pid,
                 startedAtMs: this.startedAtMs,
-                launchNonce: this.launchNonce
+                launchNonce: this.launchNonce,
+                ...(this.entryPath ? { entryPath: this.entryPath } : {}),
+                ...(this.appVersion ? { appVersion: this.appVersion } : {})
               }
             }
           : {})

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -48,6 +48,7 @@ export type DaemonServerOptions = {
   /** Direct-construction seam for protocol fixture tests; production never overrides it. */
   protocolVersion?: number
   onIdleShutdown?: () => void
+  onRpcShutdown?: () => void
   /** Direct-construction-only controls; production uses the compiled initial-adoption timeout. */
   initialAdoptionTestConfig?: {
     timeoutMs: number
@@ -107,6 +108,7 @@ export class DaemonServer {
   private publishEndpointOwnership: () => void
   private protocolVersion: number
   private onIdleShutdown: () => void
+  private onRpcShutdown: () => void
   private onAuthenticatedClientPair: () => void
   private ptySpawnHealthCheck: () => Promise<void>
   private preparePtySpawn: () => Promise<void>
@@ -177,6 +179,7 @@ export class DaemonServer {
         : null)
     this.publishEndpointOwnership = opts.publishEndpointOwnership ?? (() => {})
     this.onIdleShutdown = opts.onIdleShutdown ?? (() => {})
+    this.onRpcShutdown = opts.onRpcShutdown ?? (() => {})
     this.initialAdoptionTimeoutMs =
       opts.initialAdoptionTestConfig?.timeoutMs ?? DaemonServer.INITIAL_ADOPTION_TIMEOUT_MS
     this.lifecycleClock = opts.initialAdoptionTestConfig?.clock ?? {
@@ -270,6 +273,11 @@ export class DaemonServer {
     this.unlinkOwnedEndpointArtifacts()
     await this.disposeDaemonResources()
     await serverClose
+  }
+
+  private async finishRpcShutdown(serverClose: Promise<void>): Promise<void> {
+    await this.finishOrdinaryShutdown(serverClose)
+    this.onRpcShutdown()
   }
 
   private unlinkOwnedEndpointArtifacts(): void {
@@ -1090,10 +1098,10 @@ export class DaemonServer {
         const controlSocket = this.clients.get(clientId)?.controlSocket
         if (controlSocket) {
           this.deferShutdownUntilReply(clientId, request.id, controlSocket, () =>
-            this.finishOrdinaryShutdown(serverClose)
+            this.finishRpcShutdown(serverClose)
           )
         } else if (!this.shutdownPromise) {
-          this.shutdownPromise = this.finishOrdinaryShutdown(serverClose)
+          this.shutdownPromise = this.finishRpcShutdown(serverClose)
         }
         return {}
       }

--- a/src/main/daemon/daemon-spawner.test.ts
+++ b/src/main/daemon/daemon-spawner.test.ts
@@ -1,12 +1,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import {
   DaemonSpawner,
   getDaemonPidPath,
   getDaemonSocketPath,
   getDaemonTokenPath,
+  publishDaemonPidFile,
+  replaceDaemonPidFile,
   restoreClaimedDaemonArtifact
 } from './daemon-spawner'
 import { startDaemon, type DaemonHandle } from './daemon-main'
@@ -233,5 +235,47 @@ describe('restoreClaimedDaemonArtifact', () => {
         canonicalExists: () => true
       })
     ).toBe(true)
+  })
+})
+
+describe('daemon PID publication', () => {
+  it('publishes ownership exclusively', () => {
+    const dir = createTestDir()
+    const pidPath = join(dir, 'daemon.pid')
+    try {
+      publishDaemonPidFile(pidPath, {
+        pid: 101,
+        startedAtMs: 1_000,
+        launchNonce: 'launch-a'
+      })
+
+      expect(() =>
+        publishDaemonPidFile(pidPath, {
+          pid: 202,
+          startedAtMs: 2_000,
+          launchNonce: 'launch-b'
+        })
+      ).toThrow()
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('atomically replaces stale ownership with the authenticated endpoint identity', () => {
+    const dir = createTestDir()
+    const pidPath = join(dir, 'daemon.pid')
+    const endpointIdentity = {
+      pid: 202,
+      startedAtMs: 2_000,
+      launchNonce: 'launch-b'
+    }
+    try {
+      writeFileSync(pidPath, '{"pid":101,"launchNonce":"launch-a"}')
+
+      expect(replaceDaemonPidFile(pidPath, endpointIdentity)).toBe(true)
+      expect(JSON.parse(readFileSync(pidPath, 'utf8'))).toEqual(endpointIdentity)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
   })
 })

--- a/src/main/daemon/daemon-spawner.test.ts
+++ b/src/main/daemon/daemon-spawner.test.ts
@@ -1,7 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { chmodSync, existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer, connect, type Server } from 'node:net'
 import {
   DaemonSpawner,
   getDaemonPidPath,
@@ -11,6 +13,12 @@ import {
   replaceDaemonPidFile,
   restoreClaimedDaemonArtifact
 } from './daemon-spawner'
+import {
+  getDaemonSocketBindPath,
+  publishDaemonSocketPath,
+  sweepAbandonedDaemonClaims,
+  unlinkOwnedDaemonSocketPath
+} from './daemon-endpoint-ownership'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { DaemonClient } from './client'
 import type { SubprocessHandle } from './session'
@@ -277,5 +285,174 @@ describe('daemon PID publication', () => {
     } finally {
       rmSync(dir, { recursive: true, force: true })
     }
+  })
+
+  it('reports failure and preserves the record when the rename claim fails for any reason but absence', () => {
+    // A read-only parent denies the rename with EACCES, standing in for the Windows
+    // AV/indexer lock that fails the claim on a record which is merely open.
+    if (process.platform === 'win32' || process.getuid?.() === 0) {
+      return
+    }
+    const dir = createTestDir()
+    const pidPath = join(dir, 'daemon.pid')
+    const existingRecord = '{"pid":101,"launchNonce":"launch-a"}'
+    writeFileSync(pidPath, existingRecord)
+    try {
+      chmodSync(dir, 0o500)
+
+      expect(
+        replaceDaemonPidFile(pidPath, { pid: 202, startedAtMs: 2_000, launchNonce: 'launch-b' })
+      ).toBe(false)
+      expect(readFileSync(pidPath, 'utf8')).toBe(existingRecord)
+    } finally {
+      chmodSync(dir, 0o700)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+function listenOnSocketPath(server: Server, socketPath: string): Promise<void> {
+  return new Promise((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(socketPath, () => {
+      server.off('error', reject)
+      resolve()
+    })
+  })
+}
+
+function closeSocketServer(server: Server): Promise<void> {
+  return new Promise((resolve) => {
+    if (!server.listening) {
+      resolve()
+      return
+    }
+    server.close(() => resolve())
+  })
+}
+
+function connectsToSocketPath(socketPath: string): Promise<boolean> {
+  return new Promise((resolve) => {
+    const socket = connect({ path: socketPath })
+    const timer = setTimeout(() => {
+      socket.destroy()
+      resolve(false)
+    }, 500)
+    socket.on('connect', () => {
+      clearTimeout(timer)
+      socket.destroy()
+      resolve(true)
+    })
+    socket.on('error', () => {
+      clearTimeout(timer)
+      resolve(false)
+    })
+  })
+}
+
+describe('daemon socket publication', () => {
+  it('keeps the bind name shorter than the canonical endpoint', () => {
+    // sockaddr_un caps the path, so the private bind name must never extend it.
+    const canonicalPath = getDaemonSocketPath('/tmp/orca-daemon-runtime')
+
+    expect(getDaemonSocketBindPath(canonicalPath).length).toBeLessThan(canonicalPath.length)
+  })
+
+  it('publishes a bound listener under the canonical endpoint and reclaims only its own entry', async () => {
+    if (process.platform === 'win32') {
+      return
+    }
+    const dir = createTestDir()
+    const canonicalPath = getDaemonSocketPath(dir)
+    const first = createServer((socket) => socket.end())
+    const second = createServer((socket) => socket.end())
+    try {
+      const firstBindPath = getDaemonSocketBindPath(canonicalPath)
+      await listenOnSocketPath(first, firstBindPath)
+
+      const firstIdentity = publishDaemonSocketPath(firstBindPath, canonicalPath)
+      expect(firstIdentity).not.toBeNull()
+      expect(existsSync(canonicalPath)).toBe(true)
+      expect(existsSync(firstBindPath)).toBe(false)
+      await expect(connectsToSocketPath(canonicalPath)).resolves.toBe(true)
+
+      const secondBindPath = getDaemonSocketBindPath(canonicalPath)
+      await listenOnSocketPath(second, secondBindPath)
+      let publishError: NodeJS.ErrnoException | null = null
+      try {
+        publishDaemonSocketPath(secondBindPath, canonicalPath)
+      } catch (error) {
+        publishError = error as NodeJS.ErrnoException
+      }
+      expect(publishError?.code).toBe('EEXIST')
+
+      expect(unlinkOwnedDaemonSocketPath(canonicalPath, firstIdentity)).toBe(true)
+      expect(existsSync(canonicalPath)).toBe(false)
+
+      // The endpoint name now resolves to a different listener's inode.
+      const secondIdentity = publishDaemonSocketPath(secondBindPath, canonicalPath)
+      expect(secondIdentity).not.toEqual(firstIdentity)
+      expect(unlinkOwnedDaemonSocketPath(canonicalPath, firstIdentity)).toBe(false)
+      expect(existsSync(canonicalPath)).toBe(true)
+      await expect(connectsToSocketPath(canonicalPath)).resolves.toBe(true)
+    } finally {
+      await closeSocketServer(first)
+      await closeSocketServer(second)
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('sweepAbandonedDaemonClaims', () => {
+  const claimNames = [
+    `daemon-v${PROTOCOL_VERSION}.pid.cleanup-123-${randomUUID()}`,
+    `daemon-v${PROTOCOL_VERSION}.pid.replace-123-${randomUUID()}`,
+    '.b0123456789'
+  ]
+  const preservedNames = [`daemon-v${PROTOCOL_VERSION}.pid`, `daemon-v${PROTOCOL_VERSION}.token`]
+
+  function seedClaimDir(): string {
+    const dir = createTestDir()
+    for (const name of [...claimNames, ...preservedNames]) {
+      writeFileSync(join(dir, name), 'x')
+    }
+    return dir
+  }
+
+  it('removes aged claim and bind scratch names without touching daemon artifacts', () => {
+    const dir = seedClaimDir()
+    try {
+      expect(sweepAbandonedDaemonClaims(dir, undefined, Date.now() + 24 * 60 * 60 * 1000)).toBe(
+        claimNames.length
+      )
+
+      for (const name of claimNames) {
+        expect(existsSync(join(dir, name))).toBe(false)
+      }
+      for (const name of preservedNames) {
+        expect(existsSync(join(dir, name))).toBe(true)
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('leaves freshly written claims alone so an in-flight claim is never stolen', () => {
+    const dir = seedClaimDir()
+    try {
+      expect(sweepAbandonedDaemonClaims(dir)).toBe(0)
+
+      for (const name of [...claimNames, ...preservedNames]) {
+        expect(existsSync(join(dir, name))).toBe(true)
+      }
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+
+  it('returns zero for an unreadable runtime dir', () => {
+    expect(sweepAbandonedDaemonClaims(join(tmpdir(), `daemon-sweep-missing-${randomUUID()}`))).toBe(
+      0
+    )
   })
 })

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -136,8 +136,12 @@ export function replaceDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): b
   try {
     publishDaemonPidFile(pidPath, pidFile)
   } catch {
-    if (claimedExisting) {
-      restoreClaimedDaemonArtifact(claimedPath, pidPath)
+    if (claimedExisting && restoreClaimedDaemonArtifact(claimedPath, pidPath)) {
+      try {
+        unlinkSync(claimedPath)
+      } catch {
+        // A uniquely named restored claim is inert.
+      }
     }
     return false
   }

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -119,8 +119,15 @@ export function serializeDaemonPidFile(pidFile: DaemonPidFile): string {
   return JSON.stringify(pidFile)
 }
 
+function isMissingFileError(error: unknown): boolean {
+  return typeof error === 'object' && error !== null && 'code' in error && error.code === 'ENOENT'
+}
+
 export function publishDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): void {
-  writeFileSync(pidPath, serializeDaemonPidFile(pidFile), { mode: 0o600, flag: 'wx' })
+  writeFileSync(pidPath, serializeDaemonPidFile(pidFile), {
+    mode: 0o600,
+    flag: 'wx'
+  })
 }
 
 export function replaceDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): boolean {
@@ -129,8 +136,14 @@ export function replaceDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): b
   try {
     renameSync(pidPath, claimedPath)
     claimedExisting = true
-  } catch {
-    // A missing record is repaired by the same exclusive publication below.
+  } catch (error) {
+    // Why: only a genuinely absent record is safe to treat as unclaimed. On Windows an
+    // external opener without FILE_SHARE_DELETE (AV, indexer, backup) fails the rename
+    // with EPERM/EACCES/EBUSY; falling through would then hit EEXIST on the exclusive
+    // publish and report a false ownership conflict for a record that is simply locked.
+    if (!isMissingFileError(error)) {
+      return false
+    }
   }
 
   try {
@@ -163,7 +176,10 @@ export function unlinkOwnedDaemonPidFile(
 ): boolean {
   return claimAndUnlinkOwnedFile(pidPath, (content) => {
     try {
-      const parsed = JSON.parse(content) as { pid?: unknown; launchNonce?: unknown }
+      const parsed = JSON.parse(content) as {
+        pid?: unknown
+        launchNonce?: unknown
+      }
       return parsed.pid === expectedPid && parsed.launchNonce === expectedLaunchNonce
     } catch {
       return false

--- a/src/main/daemon/daemon-spawner.ts
+++ b/src/main/daemon/daemon-spawner.ts
@@ -1,5 +1,13 @@
 import { createHash, randomUUID } from 'node:crypto'
-import { constants, copyFileSync, existsSync, readFileSync, renameSync, unlinkSync } from 'node:fs'
+import {
+  constants,
+  copyFileSync,
+  existsSync,
+  readFileSync,
+  renameSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
 import { join } from 'node:path'
 import { PROTOCOL_VERSION } from './types'
 
@@ -109,6 +117,39 @@ export function getDaemonPidPath(runtimeDir: string, protocolVersion = PROTOCOL_
 
 export function serializeDaemonPidFile(pidFile: DaemonPidFile): string {
   return JSON.stringify(pidFile)
+}
+
+export function publishDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): void {
+  writeFileSync(pidPath, serializeDaemonPidFile(pidFile), { mode: 0o600, flag: 'wx' })
+}
+
+export function replaceDaemonPidFile(pidPath: string, pidFile: DaemonPidFile): boolean {
+  const claimedPath = `${pidPath}.replace-${process.pid}-${randomUUID()}`
+  let claimedExisting = false
+  try {
+    renameSync(pidPath, claimedPath)
+    claimedExisting = true
+  } catch {
+    // A missing record is repaired by the same exclusive publication below.
+  }
+
+  try {
+    publishDaemonPidFile(pidPath, pidFile)
+  } catch {
+    if (claimedExisting) {
+      restoreClaimedDaemonArtifact(claimedPath, pidPath)
+    }
+    return false
+  }
+
+  if (claimedExisting) {
+    try {
+      unlinkSync(claimedPath)
+    } catch {
+      // The canonical record is authoritative; the uniquely named claim is inert.
+    }
+  }
+  return true
 }
 
 export function unlinkOwnedDaemonPidFile(

--- a/src/main/daemon/production-launcher.test.ts
+++ b/src/main/daemon/production-launcher.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdtempSync, rmSync } from 'node:fs'
+import { existsSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { createProductionLauncher } from './production-launcher'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { DaemonClient } from './client'
@@ -208,7 +208,9 @@ describe('createProductionLauncher', () => {
       getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
       getAppVersion: () => '1.2.3'
     })
-    const launch = launcher(socketPathFor(dir), tokenPathFor(dir))
+    const pidPath = join(dir, 'daemon.pid')
+    writeFileSync(pidPath, JSON.stringify({ pid: 12345, launchNonce: 'launch-shutdown' }))
+    const launch = launcher(socketPathFor(dir), tokenPathFor(dir), pidPath, 'launch-shutdown')
     handlers.message[0]?.({ type: 'ready', startedAtMs: 123_456 })
     const handle = await launch
 
@@ -216,6 +218,7 @@ describe('createProductionLauncher', () => {
 
     expect(child.kill).toHaveBeenCalledWith('SIGTERM')
     expect(child.exitCode).toBe(0)
+    expect(existsSync(pidPath)).toBe(false)
   })
 
   it('rejects shutdown and releases child handles when SIGKILL never produces exit', async () => {
@@ -337,7 +340,7 @@ describe('createProductionLauncher', () => {
     }
   })
 
-  it('preserves readiness and cleanup failures after child-side PID publication fails', async () => {
+  it('preserves exact PID ownership when child exit cannot be confirmed', async () => {
     const handlers: Record<string, ((arg?: unknown) => void)[]> = {
       message: [],
       error: [],
@@ -374,23 +377,61 @@ describe('createProductionLauncher', () => {
       getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
       getAppVersion: () => '1.2.3'
     })
+    const pidPath = join(dir, 'daemon.pid')
+    writeFileSync(pidPath, JSON.stringify({ pid: 12345, launchNonce: 'launch-b' }))
 
-    const launch = launcher(
-      socketPathFor(dir),
-      tokenPathFor(dir),
-      join(dir, 'occupied.pid'),
-      'launch-b'
-    )
-    handlers.exit[0]?.(1)
+    const launch = launcher(socketPathFor(dir), tokenPathFor(dir), pidPath, 'launch-b')
+    handlers.message[0]?.({ type: 'ready' })
 
     const error = await launch.catch((caught: unknown) => caught)
     expect(error).toBeInstanceOf(AggregateError)
     expect((error as AggregateError).errors).toEqual([
-      expect.objectContaining({ message: 'Daemon process exited prematurely with code 1' }),
+      expect.objectContaining({ message: 'Daemon readiness identity is incomplete' }),
       signalError
     ])
     expect(child.disconnect).toHaveBeenCalledOnce()
     expect(child.unref).toHaveBeenCalledOnce()
+    expect(existsSync(pidPath)).toBe(true)
+  })
+
+  it('removes exact child-side PID ownership after a pre-ready exit', async () => {
+    const handlers: Record<string, ((arg?: unknown) => void)[]> = {
+      message: [],
+      error: [],
+      exit: []
+    }
+    const child = {
+      pid: 12345,
+      connected: true,
+      exitCode: null as number | null,
+      signalCode: null as NodeJS.Signals | null,
+      on: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+        handlers[event]?.push(cb)
+        return child
+      }),
+      off: vi.fn((event: string, cb: (arg?: unknown) => void) => {
+        handlers[event] = handlers[event]?.filter((handler) => handler !== cb) ?? []
+        return child
+      }),
+      disconnect: vi.fn(() => {
+        child.connected = false
+      }),
+      unref: vi.fn()
+    }
+    forkMock.mockReturnValueOnce(child)
+    const pidPath = join(dir, 'daemon.pid')
+    writeFileSync(pidPath, JSON.stringify({ pid: 12345, launchNonce: 'launch-c' }))
+    const launcher = createProductionLauncher({
+      getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
+      getAppVersion: () => '1.2.3'
+    })
+
+    const launch = launcher(socketPathFor(dir), tokenPathFor(dir), pidPath, 'launch-c')
+    child.exitCode = 1
+    handlers.exit[0]?.(1)
+
+    await expect(launch).rejects.toThrow('Daemon process exited prematurely with code 1')
+    expect(existsSync(pidPath)).toBe(false)
   })
 })
 

--- a/src/main/daemon/production-launcher.test.ts
+++ b/src/main/daemon/production-launcher.test.ts
@@ -1,7 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdtempSync, rmSync } from 'node:fs'
 import { createProductionLauncher } from './production-launcher'
 import { startDaemon, type DaemonHandle } from './daemon-main'
 import { DaemonClient } from './client'
@@ -148,18 +148,18 @@ describe('createProductionLauncher', () => {
     expect(handlers.exit).toHaveLength(0)
     expect(child.disconnect).toHaveBeenCalled()
     expect(child.unref).toHaveBeenCalled()
-    expect(JSON.parse(readFileSync(pidPath, 'utf8'))).toEqual({
-      pid: 12345,
-      startedAtMs: 123_456,
-      linuxStartTicks: '4242',
-      bootId: 'boot-a',
-      entryPath: join(dir, 'daemon-entry.js'),
-      appVersion: '1.2.3',
-      launchNonce: 'launch-a'
-    })
     expect(forkMock).toHaveBeenCalledWith(
       join(dir, 'daemon-entry.js'),
-      expect.arrayContaining(['--pid-record', pidPath, '--launch-nonce', 'launch-a']),
+      expect.arrayContaining([
+        '--pid-record',
+        pidPath,
+        '--launch-nonce',
+        'launch-a',
+        '--entry-path',
+        join(dir, 'daemon-entry.js'),
+        '--app-version',
+        '1.2.3'
+      ]),
       expect.objectContaining({ stdio: ['ignore', 'ignore', 'ignore', 'ipc'] })
     )
   })
@@ -337,7 +337,7 @@ describe('createProductionLauncher', () => {
     }
   })
 
-  it('preserves PID publication and cleanup failures', async () => {
+  it('preserves readiness and cleanup failures after child-side PID publication fails', async () => {
     const handlers: Record<string, ((arg?: unknown) => void)[]> = {
       message: [],
       error: [],
@@ -370,20 +370,23 @@ describe('createProductionLauncher', () => {
       unref: vi.fn()
     }
     forkMock.mockReturnValueOnce(child)
-    const pidPath = join(dir, 'occupied.pid')
-    writeFileSync(pidPath, 'occupied')
     const launcher = createProductionLauncher({
       getDaemonEntryPath: () => join(dir, 'daemon-entry.js'),
       getAppVersion: () => '1.2.3'
     })
 
-    const launch = launcher(socketPathFor(dir), tokenPathFor(dir), pidPath, 'launch-b')
-    handlers.message[0]?.({ type: 'ready', startedAtMs: 123_456 })
+    const launch = launcher(
+      socketPathFor(dir),
+      tokenPathFor(dir),
+      join(dir, 'occupied.pid'),
+      'launch-b'
+    )
+    handlers.exit[0]?.(1)
 
     const error = await launch.catch((caught: unknown) => caught)
     expect(error).toBeInstanceOf(AggregateError)
     expect((error as AggregateError).errors).toEqual([
-      expect.objectContaining({ code: 'EEXIST' }),
+      expect.objectContaining({ message: 'Daemon process exited prematurely with code 1' }),
       signalError
     ])
     expect(child.disconnect).toHaveBeenCalledOnce()

--- a/src/main/daemon/production-launcher.ts
+++ b/src/main/daemon/production-launcher.ts
@@ -1,5 +1,9 @@
 import { fork, type ChildProcess } from 'node:child_process'
-import type { DaemonLauncher, DaemonProcessHandle } from './daemon-spawner'
+import {
+  unlinkOwnedDaemonPidFile,
+  type DaemonLauncher,
+  type DaemonProcessHandle
+} from './daemon-spawner'
 import { parseDaemonReadyIdentity, type DaemonReadyIdentity } from './daemon-ready-identity'
 
 const READY_TIMEOUT_MS = 10_000
@@ -57,10 +61,15 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
     try {
       await waitForReady(child)
     } catch (error) {
-      return rejectAfterChildCleanup(child, error)
+      return rejectAfterChildCleanup(child, error, pidPath, launchNonce)
     }
     if (!Number.isSafeInteger(child.pid) || (child.pid as number) <= 0) {
-      return rejectAfterChildCleanup(child, new Error('Daemon readiness identity is incomplete'))
+      return rejectAfterChildCleanup(
+        child,
+        new Error('Daemon readiness identity is incomplete'),
+        pidPath,
+        launchNonce
+      )
     }
 
     // Unref so the Electron process can exit without waiting for the daemon
@@ -68,7 +77,10 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
     child.disconnect()
 
     return {
-      shutdown: () => shutdownChild(child)
+      shutdown: async () => {
+        await shutdownChild(child)
+        unlinkLaunchedDaemonPidFile(child, pidPath, launchNonce)
+      }
     }
   }
 }
@@ -197,7 +209,12 @@ async function shutdownChild(child: ChildProcess): Promise<void> {
   }
 }
 
-async function rejectAfterChildCleanup(child: ChildProcess, launchError: unknown): Promise<never> {
+async function rejectAfterChildCleanup(
+  child: ChildProcess,
+  launchError: unknown,
+  pidPath?: string,
+  launchNonce?: string
+): Promise<never> {
   try {
     await shutdownChild(child)
   } catch (cleanupError) {
@@ -206,7 +223,18 @@ async function rejectAfterChildCleanup(child: ChildProcess, launchError: unknown
       'Daemon launch and child cleanup both failed'
     )
   }
+  unlinkLaunchedDaemonPidFile(child, pidPath, launchNonce)
   throw launchError
+}
+
+function unlinkLaunchedDaemonPidFile(
+  child: ChildProcess,
+  pidPath?: string,
+  launchNonce?: string
+): void {
+  if (pidPath && launchNonce && Number.isSafeInteger(child.pid) && (child.pid as number) > 0) {
+    unlinkOwnedDaemonPidFile(pidPath, child.pid as number, launchNonce)
+  }
 }
 
 function isNoSuchProcessError(error: unknown): boolean {

--- a/src/main/daemon/production-launcher.ts
+++ b/src/main/daemon/production-launcher.ts
@@ -1,10 +1,5 @@
 import { fork, type ChildProcess } from 'node:child_process'
-import { writeFileSync } from 'node:fs'
-import {
-  serializeDaemonPidFile,
-  type DaemonLauncher,
-  type DaemonProcessHandle
-} from './daemon-spawner'
+import type { DaemonLauncher, DaemonProcessHandle } from './daemon-spawner'
 import { parseDaemonReadyIdentity, type DaemonReadyIdentity } from './daemon-ready-identity'
 
 const READY_TIMEOUT_MS = 10_000
@@ -28,6 +23,7 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
     }
     const entryPath = opts.getDaemonEntryPath()
 
+    const appVersion = opts.getAppVersion()
     const child = fork(
       entryPath,
       [
@@ -35,7 +31,18 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
         socketPath,
         '--token',
         tokenPath,
-        ...(pidPath && launchNonce ? ['--pid-record', pidPath, '--launch-nonce', launchNonce] : [])
+        ...(pidPath && launchNonce
+          ? [
+              '--pid-record',
+              pidPath,
+              '--launch-nonce',
+              launchNonce,
+              '--entry-path',
+              entryPath,
+              '--app-version',
+              appVersion
+            ]
+          : [])
       ],
       {
         // Why: detached daemon output is not consumed; ignored streams cannot
@@ -47,31 +54,13 @@ export function createProductionLauncher(opts: ProductionLauncherOptions): Daemo
       }
     )
 
-    let readyIdentity: DaemonReadyIdentity
     try {
-      readyIdentity = await waitForReady(child)
+      await waitForReady(child)
     } catch (error) {
       return rejectAfterChildCleanup(child, error)
     }
-    if (pidPath && launchNonce) {
-      if (!Number.isSafeInteger(child.pid) || (child.pid as number) <= 0) {
-        return rejectAfterChildCleanup(child, new Error('Daemon readiness identity is incomplete'))
-      }
-      try {
-        writeFileSync(
-          pidPath,
-          serializeDaemonPidFile({
-            pid: child.pid as number,
-            ...readyIdentity,
-            entryPath,
-            appVersion: opts.getAppVersion(),
-            launchNonce
-          }),
-          { mode: 0o600, flag: 'wx' }
-        )
-      } catch (error) {
-        return rejectAfterChildCleanup(child, error)
-      }
+    if (!Number.isSafeInteger(child.pid) || (child.pid as number) <= 0) {
+      return rejectAfterChildCleanup(child, new Error('Daemon readiness identity is incomplete'))
     }
 
     // Unref so the Electron process can exit without waiting for the daemon


### PR DESCRIPTION
## Summary

- make the canonical socket name the daemon's endpoint authority, so a departing daemon can never delete a replacement's endpoint
- publish PID/nonce ownership inside the socket-bind transaction, before token publication makes the endpoint adoptable
- require positive evidence that a daemon is dead before reclaiming its PID record or endpoint, and confirm SIGKILL rather than assume it
- retire a daemon that has lost its endpoint, draining rather than killing
- reconcile stale PID metadata against the authenticated hello identity, carrying the owner's real launch metadata
- add a real-process handover smoke that reproduces the failure with two daemons racing one endpoint

## User impact and root cause

The reported failure presented as an app-wide terminal freeze: new panes appeared but commands never ran, input calls acknowledged bytes that never reached the visible terminal, live sessions disappeared from listings, and restarting the app never recovered because the daemon is launchd-detached by design.

The captured machine had two detached daemons — one owning the Unix socket, another hosting the sessions the relaunched app had restored — so CLI and automation traffic reached a different terminal host from the visible app.

The mechanism is that **libuv unlinks the pathname a server bound to when that server closes, with no ownership check**. A daemon whose endpoint name had been reclaimed therefore deleted whichever socket then sat at that path, including a live replacement's. The replacement stayed alive hosting every session while nothing could reach it. Verified directly on Node 24, and reproduced end to end with two built daemons: pre-fix the survivor is left `reachable: false`; post-fix it stays reachable.

Two decisions upstream of that made it reachable in ordinary use:

- `killStaleDaemon` removed the PID record unconditionally immediately before every fork, so an exclusive PID claim was always uncontested at bind time.
- It also unlinked a live daemon's endpoint whenever a connect probe merely timed out, and read a `ps` timeout as proof of PID recycling. `isDaemonProcess` shells out to `ps` with a 2s budget; on the loaded machine in the report those probes return false negatives.

## Fix

The daemon binds a private same-directory name and hard-links it to the canonical path. libuv can then only ever unlink our own bind name; the exclusive link is a kernel-enforced endpoint claim; and the canonical name is removed only under a dev+inode ownership check. The bind name replaces the basename rather than extending it, so it cannot overflow `sun_path`. Windows is unchanged — named pipes are not directory entries and the pipe name is already exclusive.

Reclamation now requires positive evidence: a refused or absent endpoint, or a confirmed process exit. A daemon that cannot be proven stopped keeps its record and endpoint, and the launcher adopts it in degraded mode instead of forking beside it — live sessions keep working, fresh terminals run on the local provider.

A daemon that observes the canonical name no longer resolving to its own inode retires itself: it drains rather than kills, so an orphan stops being permanent without tearing live sessions away from the user. Only positive evidence retires it, confirmed across consecutive polls.

A repaired PID record takes the owner's `entryPath`/`appVersion` from the authenticated hello. Without them a healthy daemon reads as a permanently stale bundle and, on Windows, goes unpinned against daemon-host pruning.

## Wire compatibility

`daemonIdentity` on the hello response gains optional `entryPath` and `appVersion`. Per `docs/reference/remote-wire-compatibility.md` Rule 1 this is safe: older peers ignore unknown keys, and the reader falls back to its previous behavior when the fields are absent. No RPC parameters, stream opcodes, or protocol version changed.

## Reproduction and coverage

- Real-process handover smoke: two built daemons race one endpoint; the survivor must keep a reachable endpoint after the other exits late. Wired into the native-smoke CI job, and correctly skipped on Windows.
- Unit coverage for the late-close handover, endpoint takeover retirement, exclusive publish, ownership-checked removal, and the bind-name length guarantee.
- `killStaleDaemon`: preserves record and endpoint when the owner survives; reclaims a refused endpoint; preserves it when the probe is merely inconclusive.
- PID repair: republishes the authenticated owner's metadata, and adopts the endpoint anyway when the record cannot be written.
- Launcher: degrades rather than forking beside a daemon that could not be confirmed stopped.

## Known limitations

- A daemon already running from a build without this change cannot self-retire; it still needs to be cleared once after upgrade.
- Retirement drains, so an orphan holding permanently-live sessions persists until they end. This is deliberate — killing it would take the user's shells with it.
- Liveness is still partly inferred for a wedged-but-listening daemon. The durable fix is an OS-held lock acquired before bind, which would also let a large amount of `ps`-based identity machinery be deleted. Tracked as a follow-up.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] daemon suite (1302 tests) and full unit suite
- [x] `pnpm run check:reliability-gates`
- [x] `pnpm run check:max-lines-ratchet`
- [x] `node config/scripts/daemon-boot-smoke.mjs`
- [x] `node config/scripts/daemon-endpoint-handover-smoke.mjs`
- [x] `git diff --check`

## Screenshots

No visual change.
