### PR TITLE
fix(agent-hooks): restore Cursor status updates in reused panes

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -2310,6 +2310,95 @@ describe('AgentHookServer listener replay', () => {
     ).toBeNull()
   })
 
+  it('accepts a new local Cursor turn without launch authority in a reusable pane', async () => {
+    const server = new AgentHookServer()
+    await server.start({ env: 'production' })
+    try {
+      const env = server.buildPtyEnv()
+      const postHook = (payload: Record<string, unknown>): Promise<Response> =>
+        fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/cursor`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+          },
+          body: JSON.stringify(buildBody(payload))
+        })
+
+      await postHook({ hook_event_name: 'beforeSubmitPrompt', prompt: 'first Cursor turn' })
+      server.retirePaneAuthority(PANE)
+      await postHook({ hook_event_name: 'stop', status: 'completed' })
+      expect(server.getStatusSnapshot()).toEqual([])
+
+      await postHook({ hook_event_name: 'beforeSubmitPrompt', prompt: 'restored Cursor turn' })
+      await postHook({ hook_event_name: 'stop', status: 'completed' })
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'done',
+          prompt: 'restored Cursor turn',
+          agentType: 'cursor'
+        })
+      ])
+    } finally {
+      server.stop()
+    }
+  })
+
+  it('accepts a live remote Cursor turn but not replay after launch authority retires', () => {
+    const server = new AgentHookServer()
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'retired-cursor-launch-token',
+        payload: { state: 'working', prompt: 'first Cursor turn', agentType: 'cursor' }
+      },
+      'conn-1'
+    )
+    server.retirePaneAuthority(PANE)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'retired-cursor-launch-token',
+        isReplay: true,
+        payload: { state: 'working', prompt: 'stale Cursor replay', agentType: 'cursor' }
+      },
+      'conn-1'
+    )
+    expect(server.getStatusSnapshot()).toEqual([])
+
+    server.ingestRemote(
+      {
+        paneKey: PANE,
+        hookEventName: 'beforeSubmitPrompt',
+        launchToken: 'retired-cursor-launch-token',
+        payload: { state: 'working', prompt: 'live Cursor restart', agentType: 'cursor' }
+      },
+      'conn-1'
+    )
+
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'working',
+        prompt: 'live Cursor restart',
+        connectionId: 'conn-1'
+      })
+    ])
+    expect(
+      server.attestCompatibilityAuthority({
+        paneKey: PANE,
+        launchTokenHash: createHash('sha256').update('retired-cursor-launch-token').digest('hex'),
+        connectionId: 'conn-1',
+        terminalProvenance: 'current_runtime'
+      })
+    ).toBeNull()
+  })
+
   it('hydrates cached statuses as not observed in the current runtime', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-agent-hooks-'))
     const firstServer = new AgentHookServer()

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -995,8 +995,11 @@ export class AgentHookServer {
     if (!paneRetired) {
       return 'accept'
     }
-    // Why: command completion retires launch authority but leaves its shell pane reusable.
-    if (event?.hookEventName === 'UserPromptSubmit' && event.isReplay !== true) {
+    // Why: command completion retires launch authority but leaves its shell pane reusable;
+    // only a live provider prompt boundary may reopen it.
+    const isLivePromptBoundary =
+      event?.hookEventName === 'UserPromptSubmit' || event?.hookEventName === 'beforeSubmitPrompt'
+    if (isLivePromptBoundary && event.isReplay !== true) {
       this.closedAgentStatusPaneKeys.delete(paneKey)
       this.closedAgentStatusPaneKeys.delete(ownerPaneKey)
       return 'restart'


### PR DESCRIPTION
## Summary

- Restore Cursor status updates when a completed command leaves its terminal pane reusable.
- Treat Cursor's live `beforeSubmitPrompt` hook as the new-turn boundary, matching the existing Claude `UserPromptSubmit` behavior.
- Keep replayed hooks, closed tabs, and retired launch tokens unable to restore pane authority.

Fixes #12686

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 46,319 passed; 25 unrelated existing/environment-sensitive tests failed across terminal snapshot/IME, zsh path, Git environment, process timing, and a renderer timeout
- [x] `pnpm build`
- [x] Added local and remote Cursor regression tests covering live restart, replay suppression, completed status, and retired-token rejection
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts` — 269 passed

## AI Review Report

Reviewed the status-authority transition for local and SSH/remote hook ingestion. The main risk was reopening a retired pane from stale traffic, so the change remains limited to non-replayed provider prompt boundaries and preserves the existing closed-tab fence. Regression tests verify both local Cursor hooks without launch authority and remote hooks with replay and retired-token checks.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change does not touch shortcuts, labels, paths, shell behavior, UI, or Electron platform branches; it only recognizes an already-normalized Cursor hook event in shared main-process status handling.

## Security Audit

Reviewed hook authentication and authority handling. The restart path continues to strip the retired launch token before recording authority, does not weaken the HTTP hook token requirement, rejects replayed events, and does not add command execution, path handling, IPC, secrets, or dependency changes.

## Notes

- The production build succeeded. Its existing optional `/usr/local/bin/orca-dev` symlink step reported a permission warning but did not fail the build.
- Manual Windows Cursor session restoration was not run locally; local and remote ingestion paths are covered by unit tests.
- X (Twitter): not provided
