### PR TITLE
fix(agent-hooks): keep interrupted Stops working while background tasks run

### DIFF
--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2546,13 +2546,13 @@ function getOrCreateClaudeSubagentRoster(
   return roster
 }
 
+// Why: the inventory is the only authority here — Claude lists a background task only while it is running/pending, so a present entry is positive evidence of live work. An interrupt ends the assistant turn, not a backgrounded shell or Workflow, so it must not veto that evidence (STA-3344).
 function updateClaudeRunningNonAgentTask(
   state: HookListenerState,
   paneKey: string,
-  hasRunningNonAgentTask: boolean,
-  interrupted: boolean
+  hasRunningNonAgentTask: boolean
 ): void {
-  if (hasRunningNonAgentTask && !interrupted) {
+  if (hasRunningNonAgentTask) {
     state.claudeRunningNonAgentTaskPaneKeys.add(paneKey)
   } else {
     state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
@@ -2568,10 +2568,10 @@ function resolveClaudePaneState(
     return lead.state
   }
   const roster = state.claudeSubagentRosterByPaneKey.get(paneKey)
+  // Why: background tasks and session crons keep the pane alive on the same terms as a working subagent — an interrupt gate here disagreed with the ungated roster check and retired live Workflows that had no child (STA-3344).
   return claudeRosterHasWorkingSubagent(roster) ||
-    (!lead.interrupted &&
-      (state.claudeRunningNonAgentTaskPaneKeys.has(paneKey) ||
-        state.claudeActiveSessionCronPaneKeys.has(paneKey)))
+    state.claudeRunningNonAgentTaskPaneKeys.has(paneKey) ||
+    state.claudeActiveSessionCronPaneKeys.has(paneKey)
     ? 'working'
     : 'done'
 }
@@ -2781,15 +2781,11 @@ function normalizeClaudeEvent(
     return null
   }
   if (backgroundTasks.present && eventAgentId === undefined) {
-    updateClaudeRunningNonAgentTask(
-      state,
-      paneKey,
-      backgroundTasks.hasRunningNonAgentTask,
-      interrupted === true
-    )
+    updateClaudeRunningNonAgentTask(state, paneKey, backgroundTasks.hasRunningNonAgentTask)
   }
   if (sessionCronInventoryPresent && eventAgentId === undefined) {
-    if (hasActiveSessionCron && interrupted !== true) {
+    // Why: a session cron is registered on the session, not the turn — interrupting the turn does not unregister it, and server.ts already refuses to infer done for a pane with one.
+    if (hasActiveSessionCron) {
       state.claudeActiveSessionCronPaneKeys.add(paneKey)
     } else {
       state.claudeActiveSessionCronPaneKeys.delete(paneKey)
@@ -2866,11 +2862,6 @@ function normalizeClaudeEvent(
     ...(isWaitingInducing && eventAgentId ? { waitingAgentId: eventAgentId } : {}),
     ...(stateBeforeWait ? { stateBeforeWait } : {})
   })
-
-  if (interrupted && eventAgentId === undefined) {
-    state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
-    state.claudeActiveSessionCronPaneKeys.delete(paneKey)
-  }
 
   const effectiveState = resolveClaudePaneState(state, paneKey, {
     state: reportedStateName,

--- a/src/shared/claude-background-task-status.test.ts
+++ b/src/shared/claude-background-task-status.test.ts
@@ -158,38 +158,87 @@ describe('Claude background task status', () => {
     ).toBe('working')
   })
 
-  it('keeps an interrupted Stop terminal even when its task inventory is still running', () => {
+  // STA-3344: an interrupt ends the assistant turn, not a backgrounded shell or Workflow.
+  it('keeps an interrupted Stop working while its task inventory is still running', () => {
     const state = createHookListenerState()
-    const interrupted = claudeEvent(state, SOURCE_PANE, {
-      hook_event_name: 'Stop',
-      is_interrupt: true,
-      background_tasks: [RUNNING_SHELL]
-    })
 
-    expect(interrupted).toMatchObject({ state: 'done', interrupted: true })
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        is_interrupt: true,
+        background_tasks: [RUNNING_SHELL]
+      })
+    ).toMatchObject({ state: 'working' })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
     expect(
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'SubagentStop',
         agent_id: 'a70fdf2986e38302b',
         background_tasks: [RUNNING_SHELL]
       })
+    ).toMatchObject({ state: 'working' })
+    // Why: the drained inventory is what retires the pane — not the interrupt. The turn is still
+    // an interrupted one, so the eventual done must carry `interrupted` for downstream consumers.
+    expect(
+      claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', background_tasks: [] })
     ).toMatchObject({ state: 'done', interrupted: true })
+  })
+
+  // STA-3344: the roster path already ignored `interrupted`; the background-task path must agree,
+  // or a Workflow parked between agent() calls (no live child) is reported finished while running.
+  it('keeps an interrupted Stop working with a running workflow and no subagent', () => {
+    const state = createHookListenerState()
+    const withoutChild = claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      is_interrupt: true,
+      background_tasks: [{ id: 'wf_1', type: 'workflow', status: 'running' }]
+    })
+    const withChild = claudeEvent(state, TARGET_PANE, {
+      hook_event_name: 'Stop',
+      is_interrupt: true,
+      background_tasks: [
+        { id: 'sub_1', type: 'subagent', status: 'running' },
+        { id: 'wf_1', type: 'workflow', status: 'running' }
+      ]
+    })
+
+    expect(withoutChild).toMatchObject({ state: 'working' })
+    expect(withChild).toMatchObject({ state: 'working' })
+  })
+
+  it('still retires an interrupted Stop with no background task and no subagent', () => {
+    const state = createHookListenerState()
+
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'Stop',
+        is_interrupt: true,
+        background_tasks: []
+      })
+    ).toMatchObject({ state: 'done', interrupted: true })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
+  })
+
+  // STA-3344: `interrupted` is sticky by design; it must not make the discard sticky too.
+  it('recovers to working when a later Stop still carries running background tasks', () => {
+    const state = createHookListenerState()
+    claudeEvent(state, SOURCE_PANE, {
+      hook_event_name: 'Stop',
+      is_interrupt: true,
+      background_tasks: [RUNNING_SHELL]
+    })
+
     expect(
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'Stop',
         background_tasks: [RUNNING_SHELL]
       })
-    ).toMatchObject({ state: 'done', interrupted: true })
-    expect(
-      claudeEvent(state, SOURCE_PANE, {
-        hook_event_name: 'SubagentStop',
-        agent_id: 'a8ab60ba5d4410c47',
-        background_tasks: [RUNNING_SHELL]
-      })
-    ).toMatchObject({ state: 'done', interrupted: true })
+    ).toMatchObject({ state: 'working' })
   })
 
-  it('keeps an interrupted Stop terminal while a session cron remains', () => {
+  // STA-3344: a session cron is registered on the session, not the turn — server.ts already
+  // refuses to infer done for a pane holding one, so the hook path must not discard it either.
+  it('keeps an interrupted Stop working while a session cron remains', () => {
     const state = createHookListenerState()
 
     expect(
@@ -198,7 +247,11 @@ describe('Claude background task status', () => {
         is_interrupt: true,
         session_crons: [{ id: 'cron-1' }]
       })
-    ).toMatchObject({ state: 'done', interrupted: true })
+    ).toMatchObject({ state: 'working' })
+    expect(state.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
+    expect(
+      claudeEvent(state, SOURCE_PANE, { hook_event_name: 'Stop', session_crons: [] })
+    ).toMatchObject({ state: 'done' })
   })
 
   it('keeps a session cron working through child lifecycle events until a drained inventory', () => {
@@ -273,7 +326,7 @@ describe('Claude background task status', () => {
     expect(legacyStopState.claudeActiveSessionCronPaneKeys.has(SOURCE_PANE)).toBe(true)
   })
 
-  it('treats an interrupted StopFailure as terminal', () => {
+  it('keeps an interrupted StopFailure working while its background shell runs', () => {
     const state = createHookListenerState()
 
     expect(
@@ -282,8 +335,15 @@ describe('Claude background task status', () => {
         is_interrupt: true,
         background_tasks: [RUNNING_SHELL]
       })
+    ).toMatchObject({ state: 'working' })
+    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(true)
+    expect(
+      claudeEvent(state, SOURCE_PANE, {
+        hook_event_name: 'StopFailure',
+        is_interrupt: true,
+        background_tasks: []
+      })
     ).toMatchObject({ state: 'done', interrupted: true })
-    expect(state.claudeRunningNonAgentTaskPaneKeys.has(SOURCE_PANE)).toBe(false)
   })
 
   it('keeps a failed turn working while its background shell runs', () => {
@@ -340,7 +400,7 @@ describe('Claude background task status', () => {
         is_interrupt: true,
         background_tasks: [RUNNING_SHELL]
       })
-    ).toMatchObject({ state: 'done', interrupted: true })
+    ).toMatchObject({ state: 'working' })
     expect(
       claudeEvent(state, SOURCE_PANE, {
         hook_event_name: 'UserPromptSubmit',


### PR DESCRIPTION
## Summary

An interrupted Claude turn no longer discards evidence that background work is still running, so a pane holding a live Workflow or backgrounded shell stays `working` instead of flipping to `done`.

Claude emits a `background_tasks` entry only while that task is `running` or `pending`, so the presence of an entry is positive evidence of live work. `is_interrupt` on a `Stop` payload ends the assistant *turn* — it says nothing about a backgrounded shell or a Workflow sitting between `agent()` calls. The hook listener was treating the turn-level interrupt as a veto over that inventory, so:

- an interrupted `Stop` carrying a running Workflow and **no** live subagent reported `done` while the Workflow was still running;
- the same payload **with** a working subagent in the roster correctly stayed `working` — the two keep-alive paths disagreed with each other;
- the discard was sticky: once a pane saw an interrupted turn, a later non-interrupted `Stop` still carrying running tasks never recovered to `working`.

The fix removes the interrupt gate from the three discard sites in `src/shared/agent-hook-listener.ts` (`updateClaudeRunningNonAgentTask`, `resolveClaudePaneState`, and the session-cron normalizer branch) and drops the `markClaudeLeadTurnInterrupted` deletes that cleared the inventory outright. `interrupted: true` is still emitted on the payload for downstream consumers — only the *liveness* inference changes.

Session crons got the same treatment deliberately: a cron is registered on the session, not the turn, so interrupting the turn does not unregister it — and `src/main/agent-hooks/server.ts:820-827` already refuses to infer `done` for a pane holding a running background task or an active session cron. Before this change the hook path and the main-process path encoded opposite rules for the same state; now they agree.

Retirement is still driven by the inventory draining, not by the interrupt: an interrupted `Stop` with an empty `background_tasks` list still goes `done` (carrying `interrupted: true`), which is covered by a regression test.

Linear STA-3344 · closes #12382

## Screenshots

No visual change. This changes agent-status inference in the hook listener; the sidebar renders the same states it always did. Verified against the persisted `agent-hooks/last-status.json` marker, not pixels.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` (targeted: `npx vitest run --config config/vitest.config.ts` over `claude-background-task-status.test.ts`, `claude-subagent-roster.test.ts`, `src/main/agent-hooks/server.test.ts`, `agent-hook-server.test.ts` — 4 files / 346 tests passed)
- [ ] `pnpm build` — not run; this change touches no build inputs (two files under `src/shared`, one of them a test)
- [x] Added or updated high-quality tests that would catch regressions

**Live reproduction (macOS, isolated profile).** Built a dev Electron instance from this branch's worktree (`REMOTE_DEBUGGING_PORT=9334`, renderer `5174`, `ORCA_DEV_USER_DATA_PATH` = a fresh `mktemp -d`), confirmed identity via `window.api.app.getIdentity()`, recovered that instance's own `ORCA_AGENT_HOOK_PORT`/token from the endpoint file it wrote (port cross-checked against the dev process by PID ancestry so the production app could not be the target), and POSTed `Stop` payloads byte-shaped like `~/.orca/agent-hooks/claude-hook.sh` does. Each row used a fresh pane key; stickiness was probed separately on one pane key.

| row | payload | expected | before | after |
|---|---|---|---|---|
| 1 | running workflow, no `is_interrupt` | working | working | working |
| 2 | same + `is_interrupt: true` | working | **done (bug)** | **working** |
| 3 | running subagent + running workflow, no interrupt | working | working | working |
| 4 | same as 3 + `is_interrupt: true` | working | working | working |
| ctrl | `is_interrupt: true`, `background_tasks: []` | done | done (`interrupted: true`) | done (`interrupted: true`) |
| sticky A | `is_interrupt: true` + running workflow | working | **done** | **working** |
| sticky B | later **non**-interrupted Stop, task still running | working | **done (sticky)** | **working** |

The after-phase re-ran the same rig on the fixed head: row 2 and both sticky rows flip, rows 1/3/4 and the control are unchanged.

**Non-vacuity.** Six of the new/changed assertions fail against a stash of the fix (`expected { state: 'done' } to match object { state: 'working' }`); all 26 in the file pass with it.

The diff renames and inverts five pre-existing assertions that #11838 pinned. That is intentional and is the main thing to scrutinize here — see below.

## AI Review Report

Two fresh-Codex review rounds ran at the same model and reasoning effort as the author loop, each in its own worktree and context.

- **Round 1** — reviewed the diff against the seven risks below. Verdict: clean, zero findings, no commits pushed.
- **Round 2** — dispatched deliberately to *break* round 1, because a single clean round is weak evidence for a diff that inverts assertions a prior merged PR pinned. It wrote its own findings list before reading round 1, then tried to falsify every round-1 verdict and every citation. Verdict: clean, zero findings, zero citation discrepancies, no commits pushed.

Round 2 independently re-derived rather than accepted: the `a20d82294b` history, the single guarded caller of `markClaudeLeadTurnInterrupted`, the persistence/hydration path, the relay/SSH field path, every retirement path, and the test non-vacuity (it reverse-applied only the listener diff itself and reproduced the 6 failures).

Risks raised by the author loop and handed to the reviewer:

- **Does this revert #11838?** The changed assertions were deliberately pinned by `a20d82294b` ("narrow interruption retention", "test(agent-status): pin session cron interrupts"). Adjudicated rather than assumed: `src/main/agent-hooks/server.ts:820-827` already refuses to infer `done` for a pane with a running non-agent task or an active session cron, with the comment *"Escape/Ctrl+C at Claude's idle prompt does not stop provider-owned shells or session crons."* Stronger than that, though: `git show a20d82294b -- src/main/agent-hooks/server.ts` shows that guard arriving as **added lines in #11838 itself**. So #11838 shipped, in one commit, both the server rule that an inferred interrupt must not retire a pane holding running background work *and* shared-listener tests asserting that an explicit interrupted `Stop` with running inventory does retire. Its own title is *"fix(agent-status): preserve Claude background work"*. This PR completes #11838 in the direction #11838 stated, rather than reverting it. Both review rounds re-ran that `git show` and confirmed it.
- **Can a pane get stuck `working` forever?** No — nothing about retirement depends on the interrupt. The pane retires when the inventory drains, and the control row proves an interrupted `Stop` with no background tasks still reports `done`. A pane that never receives another `Stop` was already in that position before this change.
- **Test vacuity** — proven by the stashed-fix failure output above, not asserted.
- **Cross-platform (macOS / Linux / Windows).** No platform-conditional code, no paths, no shell invocation, no keyboard handling, no Electron platform APIs are touched. The change is pure state inference over a JSON payload in `src/shared`, identical on all three platforms. SSH, remote-runtime, folder-workspace, and GitLab-provider paths are untouched. Live verification was macOS-only.
- **Scope** — 2 files, +85/−34, one of them the test file. No refactors, renames, or reformatting.

## Security Audit

No new input handling, command execution, path handling, auth, secrets, dependency, or IPC surface. The change only removes conditions from an existing in-memory state machine that consumes an already-authenticated agent-hook payload (`X-Orca-Agent-Hook-Token`); it adds no new fields, no new parsing, and no new trust in payload contents — `background_tasks` was already read and already trusted on the non-interrupted path. No follow-up needed.

## Notes

- Verified live on macOS only. The change has no platform-conditional behavior, so Linux/Windows parity is by construction rather than by measurement.
- The reproduction used synthetic payloads shaped exactly like `claude-hook.sh` emits, driven against a real dev Electron instance's real hook endpoint. It was not driven by a real Claude CLI session end to end.
- Rendered sidebar pixels **were** verified, on the final head, in an isolated-profile dev Electron instance driving a real terminal pane (screenshots in the comment below): an interrupted `Stop` carrying a running background workflow renders **Working - Claude**, and the drained-inventory control on the same pane renders **Interrupted - Interrupted by user**. That control is the pixel-level proof the change is narrow.

