### PR TITLE
feat(native-chat): autofocus composer on new session and tab switch

### DIFF
--- a/src/renderer/src/components/cmd-j/palette-focus-restore-target.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-focus-restore-target.test.ts
@@ -58,21 +58,52 @@ describe('resolvePaletteFocusRestoreTarget', () => {
     expect(resolvePaletteFocusRestoreTarget(null)).toBeNull()
   })
 
-  it('skips a terminal whose pane composer owns focus, falling back to the editor', () => {
+  it('redirects a chat-owned pane to its composer instead of the hidden xterm', () => {
     const pane = document.createElement('div')
     pane.className = 'pane'
     const owner = document.createElement('div')
     owner.setAttribute('data-pane-prevent-terminal-focus', 'true')
+    owner.tabIndex = -1
+    const composer = document.createElement('textarea')
+    composer.setAttribute('data-native-chat-composer-input', 'true')
+    owner.appendChild(composer)
     pane.appendChild(owner)
     const terminal = addTerminal('chat-owned')
     pane.appendChild(terminal)
     document.body.appendChild(pane)
-    const editor = document.createElement('div')
-    editor.className = 'monaco-editor'
-    const editorTextarea = document.createElement('textarea')
-    editor.appendChild(editorTextarea)
-    document.body.appendChild(editor)
 
-    expect(resolvePaletteFocusRestoreTarget(null)).toBe(editorTextarea)
+    expect(resolvePaletteFocusRestoreTarget(null)).toBe(composer)
+  })
+
+  it('redirects a captured xterm helper whose pane switched to chat mode', () => {
+    const pane = document.createElement('div')
+    pane.className = 'pane'
+    const terminal = addTerminal('was-terminal')
+    pane.appendChild(terminal)
+    const owner = document.createElement('div')
+    owner.setAttribute('data-pane-prevent-terminal-focus', 'true')
+    owner.tabIndex = -1
+    const composer = document.createElement('textarea')
+    composer.setAttribute('data-native-chat-composer-input', 'true')
+    owner.appendChild(composer)
+    pane.appendChild(owner)
+    document.body.appendChild(pane)
+
+    expect(resolvePaletteFocusRestoreTarget(terminal)).toBe(composer)
+  })
+
+  it('skips a hidden pane so the visible plain terminal is chosen', () => {
+    const hiddenPane = document.createElement('div')
+    hiddenPane.className = 'pane'
+    hiddenPane.style.display = 'none'
+    hiddenPane.appendChild(addTerminal('hidden'))
+    document.body.appendChild(hiddenPane)
+    const visiblePane = document.createElement('div')
+    visiblePane.className = 'pane'
+    const visibleTerminal = addTerminal('visible')
+    visiblePane.appendChild(visibleTerminal)
+    document.body.appendChild(visiblePane)
+
+    expect(resolvePaletteFocusRestoreTarget(null)).toBe(visibleTerminal)
   })
 })

--- a/src/renderer/src/components/cmd-j/palette-focus-restore-target.test.ts
+++ b/src/renderer/src/components/cmd-j/palette-focus-restore-target.test.ts
@@ -57,4 +57,22 @@ describe('resolvePaletteFocusRestoreTarget', () => {
   it('returns null when nothing is focusable', () => {
     expect(resolvePaletteFocusRestoreTarget(null)).toBeNull()
   })
+
+  it('skips a terminal whose pane composer owns focus, falling back to the editor', () => {
+    const pane = document.createElement('div')
+    pane.className = 'pane'
+    const owner = document.createElement('div')
+    owner.setAttribute('data-pane-prevent-terminal-focus', 'true')
+    pane.appendChild(owner)
+    const terminal = addTerminal('chat-owned')
+    pane.appendChild(terminal)
+    document.body.appendChild(pane)
+    const editor = document.createElement('div')
+    editor.className = 'monaco-editor'
+    const editorTextarea = document.createElement('textarea')
+    editor.appendChild(editorTextarea)
+    document.body.appendChild(editor)
+
+    expect(resolvePaletteFocusRestoreTarget(null)).toBe(editorTextarea)
+  })
 })

--- a/src/renderer/src/components/cmd-j/palette-focus-restore-target.ts
+++ b/src/renderer/src/components/cmd-j/palette-focus-restore-target.ts
@@ -1,8 +1,11 @@
+import { isInsideFocusOwnedPane } from '@/lib/pane-manager/pane-pointer-focus'
+
 // Why: when Cmd+J closes it must hand focus back to whatever the user was
 // doing. Prefer the exact element focused before the palette opened (e.g. the
 // specific terminal textarea they were typing in); the querySelector fallbacks
 // grab the first match in the DOM, which can be a background worktree's
-// mounted-but-hidden terminal rather than the visible one.
+// mounted-but-hidden terminal rather than the visible one — or a pane whose
+// native chat composer owns focus, which this must not steal from either.
 export function resolvePaletteFocusRestoreTarget(
   preferredTarget: HTMLElement | null,
   doc: Document = document
@@ -11,7 +14,7 @@ export function resolvePaletteFocusRestoreTarget(
     return preferredTarget
   }
   const xterm = doc.querySelector('.xterm-helper-textarea')
-  if (xterm instanceof HTMLElement) {
+  if (xterm instanceof HTMLElement && !isInsideFocusOwnedPane(xterm)) {
     return xterm
   }
   const monaco = doc.querySelector('.monaco-editor textarea')

--- a/src/renderer/src/components/cmd-j/palette-focus-restore-target.ts
+++ b/src/renderer/src/components/cmd-j/palette-focus-restore-target.ts
@@ -1,21 +1,31 @@
-import { isInsideFocusOwnedPane } from '@/lib/pane-manager/pane-pointer-focus'
+import {
+  PANE_CONTAINER_SELECTOR,
+  resolvePaneSurfaceFocusTarget,
+  resolveVisibleTerminalSurfaceTarget
+} from '@/lib/pane-manager/pane-surface-focus'
 
 // Why: when Cmd+J closes it must hand focus back to whatever the user was
 // doing. Prefer the exact element focused before the palette opened (e.g. the
-// specific terminal textarea they were typing in); the querySelector fallbacks
-// grab the first match in the DOM, which can be a background worktree's
-// mounted-but-hidden terminal rather than the visible one — or a pane whose
-// native chat composer owns focus, which this must not steal from either.
+// specific terminal textarea they were typing in). Fallbacks route through
+// resolveVisibleTerminalSurfaceTarget so a hidden background pane can't be
+// picked and a chat-owned pane yields its composer, not the hidden xterm.
 export function resolvePaletteFocusRestoreTarget(
   preferredTarget: HTMLElement | null,
   doc: Document = document
 ): HTMLElement | null {
   if (preferredTarget && preferredTarget.isConnected) {
+    // Why: the captured element can be an xterm helper whose pane has since
+    // switched to chat mode; its keyboard surface is now the composer.
+    if (preferredTarget.classList.contains('xterm-helper-textarea')) {
+      const pane = preferredTarget.closest(PANE_CONTAINER_SELECTOR) as HTMLElement | null
+      const owned = pane ? resolvePaneSurfaceFocusTarget(pane) : null
+      return owned ?? preferredTarget
+    }
     return preferredTarget
   }
-  const xterm = doc.querySelector('.xterm-helper-textarea')
-  if (xterm instanceof HTMLElement && !isInsideFocusOwnedPane(xterm)) {
-    return xterm
+  const terminalSurface = resolveVisibleTerminalSurfaceTarget(doc)
+  if (terminalSurface) {
+    return terminalSurface
   }
   const monaco = doc.querySelector('.monaco-editor textarea')
   return monaco instanceof HTMLElement ? monaco : null

--- a/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatComposerField.tsx
@@ -166,6 +166,8 @@ export function NativeChatComposerField({
               ref={textareaRef}
               value={draft}
               disabled={disabled}
+              // Why: stable hook for imperative focus routing (focusPaneSurface).
+              data-native-chat-composer-input="true"
               rows={2}
               onChange={(e) => onDraftChange(e.target.value, e.currentTarget)}
               onKeyDown={onKeyDown}

--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -38,11 +38,9 @@ import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage
 } from '../../../../shared/native-chat-streaming'
-import {
-  shouldFocusNativeChatComposerFromEditingKey,
-  shouldFocusNativeChatPaneFromPointerTarget,
-  shouldRedirectNativeChatTyping
-} from './native-chat-typing-redirect'
+import { shouldFocusNativeChatPaneFromPointerTarget } from './native-chat-typing-redirect'
+import { useNativeChatComposerAutofocus } from './use-native-chat-composer-autofocus'
+import { useNativeChatRootKeyDownCapture } from './use-native-chat-root-keydown-capture'
 import {
   emptyNativeChatContextMenuActions,
   useNativeChatContextMenu
@@ -65,6 +63,7 @@ export default function NativeChatView({
   resolvedAgent,
   onSwitchToTerminal,
   readTerminalScreen,
+  shouldFocusComposer = false,
   contextMenuActions
 }: NativeChatViewProps): React.JSX.Element {
   // Select only this tab's status entry (shallow-compared) so an unrelated
@@ -98,6 +97,7 @@ export default function NativeChatView({
           terminalTabId={terminalTabId}
           onSwitchToTerminal={onSwitchToTerminal}
           readTerminalScreen={readTerminalScreen}
+          shouldFocusComposer={shouldFocusComposer}
           contextMenuActions={contextMenuActions}
         />
       )}
@@ -114,6 +114,7 @@ function NativeChatResolvedView({
   terminalTabId,
   onSwitchToTerminal,
   readTerminalScreen,
+  shouldFocusComposer,
   contextMenuActions
 }: {
   paneKey: string
@@ -124,6 +125,7 @@ function NativeChatResolvedView({
   terminalTabId: string
   onSwitchToTerminal?: () => void
   readTerminalScreen?: () => string | null
+  shouldFocusComposer: boolean
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }): React.JSX.Element {
   // Primitive owner selection (no useShallow): routes the pane's read/subscribe to
@@ -362,6 +364,15 @@ function NativeChatResolvedView({
   }, [interactiveSend, pendingScope])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
+  useNativeChatComposerAutofocus({
+    chatSurfaceActive: shouldFocusComposer,
+    composerEnabled: targetPtyId !== null && canSend,
+    questionActive,
+    rootRef,
+    composerRef
+  })
+  const handleRootKeyDownCapture = useNativeChatRootKeyDownCapture(composerRef)
+
   // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so
   // the chord is inert on the loading/empty/error states and elsewhere.
   const fontScale = useNativeChatFontScale(isConversation)
@@ -370,6 +381,8 @@ function NativeChatResolvedView({
     <div
       ref={rootRef}
       data-native-chat-root="true"
+      // Why: keeps imperative terminal focus off the hidden xterm underneath (paneContainerOwnsFocus).
+      data-pane-prevent-terminal-focus="true"
       tabIndex={-1}
       onPointerDownCapture={(event) => {
         if (event.button === 2) {
@@ -382,22 +395,7 @@ function NativeChatResolvedView({
           rootRef.current?.focus({ preventScroll: true })
         }
       }}
-      onKeyDownCapture={(event) => {
-        // Backspace/Delete outside an input focuses the composer (like typing)
-        // but inserts nothing — let the now-focused field handle the keystroke.
-        if (shouldFocusNativeChatComposerFromEditingKey(event)) {
-          composerRef.current?.focus()
-          return
-        }
-        if (!shouldRedirectNativeChatTyping(event)) {
-          return
-        }
-        if (!composerRef.current?.insertTypedText(event.key)) {
-          return
-        }
-        event.preventDefault()
-        event.stopPropagation()
-      }}
+      onKeyDownCapture={handleRootKeyDownCapture}
       onMouseUpCapture={contextMenu.onSelectionCapture}
       onKeyUpCapture={contextMenu.onSelectionCapture}
       onContextMenuCapture={contextMenu.onContextMenuCapture}

--- a/src/renderer/src/components/native-chat/native-chat-composer-autofocus.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autofocus.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import { shouldAutofocusNativeChatComposer } from './native-chat-composer-autofocus'
+
+describe('shouldAutofocusNativeChatComposer', () => {
+  it('does not focus when the chat surface is not active (background tab/pane)', () => {
+    expect(
+      shouldAutofocusNativeChatComposer({
+        chatSurfaceActive: false,
+        composerEnabled: true,
+        activeElement: null
+      })
+    ).toBe(false)
+  })
+
+  it('does not focus while the composer is disabled (pty not yet bound)', () => {
+    expect(
+      shouldAutofocusNativeChatComposer({
+        chatSurfaceActive: true,
+        composerEnabled: false,
+        activeElement: null
+      })
+    ).toBe(false)
+  })
+
+  it('focuses when the surface is active, the composer is enabled, and focus is neutral', () => {
+    expect(
+      shouldAutofocusNativeChatComposer({
+        chatSurfaceActive: true,
+        composerEnabled: true,
+        activeElement: null
+      })
+    ).toBe(true)
+  })
+
+  it('does not steal focus from a real input elsewhere (e.g. a rename field)', () => {
+    const input = { tagName: 'INPUT', closest: (selector: string) => (selector ? {} : null) }
+
+    expect(
+      shouldAutofocusNativeChatComposer({
+        chatSurfaceActive: true,
+        composerEnabled: true,
+        activeElement: input
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-composer-autofocus.ts
+++ b/src/renderer/src/components/native-chat/native-chat-composer-autofocus.ts
@@ -1,0 +1,23 @@
+import { shouldFocusMobileDriverAction } from '../terminal-pane/mobile-driver-overlay-focus'
+
+/**
+ * Gate for the chat composer's autofocus effect (new session, switching to an
+ * existing chat tab/pane). `chatSurfaceActive` is the tab/pane visibility
+ * trigger (mirrors CodexRestartChip's `shouldFocus`); `composerEnabled`
+ * covers the not-yet-bound-pty case, where focus() would otherwise be a
+ * no-op and must be retried once the composer enables. Politeness (don't
+ * steal focus from a real input elsewhere) reuses the same check as the
+ * mobile-driver recovery overlay.
+ */
+export function shouldAutofocusNativeChatComposer(args: {
+  chatSurfaceActive: boolean
+  composerEnabled: boolean
+  activeElement: unknown
+  body?: unknown
+  focusScope?: unknown
+}): boolean {
+  if (!args.chatSurfaceActive || !args.composerEnabled) {
+    return false
+  }
+  return shouldFocusMobileDriverAction(args.activeElement, args.body, args.focusScope)
+}

--- a/src/renderer/src/components/native-chat/native-chat-view-types.ts
+++ b/src/renderer/src/components/native-chat/native-chat-view-types.ts
@@ -16,5 +16,9 @@ export type NativeChatViewProps = {
   onSwitchToTerminal?: () => void
   /** Current xterm screen reader used to recover agent-reported session state. */
   readTerminalScreen?: () => string | null
+  /** True while this tab/pane is the visible, active chat surface — drives
+   *  composer autofocus on new-session launch and on switching back to this
+   *  chat tab (mirrors CodexRestartChip's `shouldFocus`). */
+  shouldFocusComposer?: boolean
   contextMenuActions?: Omit<NativeChatContextMenuActions, 'onPaste'>
 }

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.test.ts
@@ -5,7 +5,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { useNativeChatComposerAutofocus } from './use-native-chat-composer-autofocus'
 import type { NativeChatComposerHandle } from './NativeChatComposer'
 
-function installAnimationFrameStubs(): { flushOneFrame: () => void } {
+function installAnimationFrameStubs(): { flushOneFrame: () => void; flushAll: () => void } {
   const pending: FrameRequestCallback[] = []
   vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
     pending.push(callback)
@@ -14,37 +14,51 @@ function installAnimationFrameStubs(): { flushOneFrame: () => void } {
   vi.stubGlobal('cancelAnimationFrame', vi.fn())
   return {
     flushOneFrame: () => {
-      const callback = pending.shift()
-      callback?.(0)
+      pending.shift()?.(0)
+    },
+    flushAll: () => {
+      for (let i = 0; i < 10 && pending.length > 0; i += 1) {
+        pending.shift()?.(0)
+      }
     }
   }
 }
 
-function renderAutofocus(args: {
-  chatSurfaceActive: boolean
-  composerEnabled: boolean
-  root: HTMLElement
-}): { composerRef: React.RefObject<NativeChatComposerHandle | null> } {
+type HookProps = { chatSurfaceActive: boolean; composerEnabled: boolean; questionActive: boolean }
+
+function renderAutofocus(initial: Partial<HookProps> & { root: HTMLElement }): {
+  composerRef: React.RefObject<NativeChatComposerHandle | null>
+  rerender: (next: Partial<HookProps>) => void
+} {
   const rootRef = createRef<HTMLElement>()
-  rootRef.current = args.root
+  rootRef.current = initial.root
   const composerRef = createRef<NativeChatComposerHandle>()
-  const composerHandle: NativeChatComposerHandle = {
+  composerRef.current = {
     focus: vi.fn(() => true),
     insertTypedText: vi.fn(() => true),
     handlePasteEvent: vi.fn(),
     pasteFromClipboard: vi.fn()
   }
-  composerRef.current = composerHandle
-  renderHook(() =>
-    useNativeChatComposerAutofocus({
-      chatSurfaceActive: args.chatSurfaceActive,
-      composerEnabled: args.composerEnabled,
-      questionActive: false,
-      rootRef,
-      composerRef
-    })
+  const props: HookProps = {
+    chatSurfaceActive: initial.chatSurfaceActive ?? false,
+    composerEnabled: initial.composerEnabled ?? true,
+    questionActive: initial.questionActive ?? false
+  }
+  const rendered = renderHook(
+    (current: HookProps) =>
+      useNativeChatComposerAutofocus({
+        chatSurfaceActive: current.chatSurfaceActive,
+        composerEnabled: current.composerEnabled,
+        questionActive: current.questionActive,
+        rootRef,
+        composerRef
+      }),
+    { initialProps: props }
   )
-  return { composerRef }
+  return {
+    composerRef,
+    rerender: (next) => rendered.rerender({ ...props, ...Object.assign(props, next) })
+  }
 }
 
 describe('useNativeChatComposerAutofocus', () => {
@@ -126,5 +140,66 @@ describe('useNativeChatComposerAutofocus', () => {
 
     expect(composerRef.current?.focus).not.toHaveBeenCalled()
     expect(document.activeElement).toBe(unrelatedInput)
+  })
+
+  it('waits for the composer to enable, then focuses once (new-session flow)', () => {
+    const { flushAll } = installAnimationFrameStubs()
+    const root = document.createElement('div')
+    document.body.append(root)
+
+    const { composerRef, rerender } = renderAutofocus({
+      chatSurfaceActive: true,
+      composerEnabled: false,
+      root
+    })
+
+    flushAll()
+    expect(composerRef.current?.focus).not.toHaveBeenCalled()
+
+    rerender({ composerEnabled: true })
+    flushAll()
+    expect(composerRef.current?.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('does not re-steal focus on a later enable flip once the activation intent is consumed', () => {
+    // Why: composerEnabled tracks the async mobile presence-lock; a release
+    // minutes after activation must not yank focus (codex review finding).
+    const { flushAll } = installAnimationFrameStubs()
+    const root = document.createElement('div')
+    document.body.append(root)
+
+    const { composerRef, rerender } = renderAutofocus({
+      chatSurfaceActive: true,
+      composerEnabled: true,
+      root
+    })
+
+    flushAll()
+    expect(composerRef.current?.focus).toHaveBeenCalledTimes(1)
+
+    rerender({ composerEnabled: false })
+    rerender({ composerEnabled: true })
+    flushAll()
+
+    expect(composerRef.current?.focus).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-arms the intent on the next activation', () => {
+    const { flushAll } = installAnimationFrameStubs()
+    const root = document.createElement('div')
+    document.body.append(root)
+
+    const { composerRef, rerender } = renderAutofocus({
+      chatSurfaceActive: true,
+      composerEnabled: true,
+      root
+    })
+
+    flushAll()
+    rerender({ chatSurfaceActive: false })
+    rerender({ chatSurfaceActive: true })
+    flushAll()
+
+    expect(composerRef.current?.focus).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.test.ts
@@ -1,0 +1,130 @@
+// @vitest-environment happy-dom
+import { createRef } from 'react'
+import { renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useNativeChatComposerAutofocus } from './use-native-chat-composer-autofocus'
+import type { NativeChatComposerHandle } from './NativeChatComposer'
+
+function installAnimationFrameStubs(): { flushOneFrame: () => void } {
+  const pending: FrameRequestCallback[] = []
+  vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback): number => {
+    pending.push(callback)
+    return pending.length
+  })
+  vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  return {
+    flushOneFrame: () => {
+      const callback = pending.shift()
+      callback?.(0)
+    }
+  }
+}
+
+function renderAutofocus(args: {
+  chatSurfaceActive: boolean
+  composerEnabled: boolean
+  root: HTMLElement
+}): { composerRef: React.RefObject<NativeChatComposerHandle | null> } {
+  const rootRef = createRef<HTMLElement>()
+  rootRef.current = args.root
+  const composerRef = createRef<NativeChatComposerHandle>()
+  const composerHandle: NativeChatComposerHandle = {
+    focus: vi.fn(() => true),
+    insertTypedText: vi.fn(() => true),
+    handlePasteEvent: vi.fn(),
+    pasteFromClipboard: vi.fn()
+  }
+  composerRef.current = composerHandle
+  renderHook(() =>
+    useNativeChatComposerAutofocus({
+      chatSurfaceActive: args.chatSurfaceActive,
+      composerEnabled: args.composerEnabled,
+      questionActive: false,
+      rootRef,
+      composerRef
+    })
+  )
+  return { composerRef }
+}
+
+describe('useNativeChatComposerAutofocus', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.unstubAllGlobals()
+  })
+
+  it('schedules no frames when the chat surface is not active', () => {
+    const requestAnimationFrame = vi.fn()
+    vi.stubGlobal('requestAnimationFrame', requestAnimationFrame)
+    const root = document.createElement('div')
+    document.body.append(root)
+
+    renderAutofocus({ chatSurfaceActive: false, composerEnabled: true, root })
+
+    expect(requestAnimationFrame).not.toHaveBeenCalled()
+  })
+
+  it('focuses the composer once both frames flush and focus is neutral', () => {
+    const { flushOneFrame } = installAnimationFrameStubs()
+    const root = document.createElement('div')
+    document.body.append(root)
+
+    const { composerRef } = renderAutofocus({
+      chatSurfaceActive: true,
+      composerEnabled: true,
+      root
+    })
+
+    expect(composerRef.current?.focus).not.toHaveBeenCalled()
+    flushOneFrame()
+    expect(composerRef.current?.focus).not.toHaveBeenCalled()
+    flushOneFrame()
+    expect(composerRef.current?.focus).toHaveBeenCalled()
+  })
+
+  it('reads activeElement only after both frames — regression for the tab-switch race where a sibling chat tab’s own real composer is still focused at effect-run time and only blurs (to body) between frames', () => {
+    const { flushOneFrame } = installAnimationFrameStubs()
+    const root = document.createElement('div')
+    document.body.append(root)
+    const stalePreviousComposer = document.createElement('textarea')
+    document.body.append(stalePreviousComposer)
+    stalePreviousComposer.focus()
+    expect(document.activeElement).toBe(stalePreviousComposer)
+
+    const { composerRef } = renderAutofocus({
+      chatSurfaceActive: true,
+      composerEnabled: true,
+      root
+    })
+
+    flushOneFrame()
+    // Why: the browser's real display:none-triggered blur is what this
+    // simulates — it can land in the gap between the two scheduled frames.
+    stalePreviousComposer.blur()
+    expect(document.activeElement).toBe(document.body)
+    flushOneFrame()
+
+    expect(composerRef.current?.focus).toHaveBeenCalled()
+  })
+
+  it('does not steal focus from a real input that is still genuinely focused after both frames', () => {
+    const { flushOneFrame } = installAnimationFrameStubs()
+    const root = document.createElement('div')
+    document.body.append(root)
+    const unrelatedInput = document.createElement('input')
+    document.body.append(unrelatedInput)
+    unrelatedInput.focus()
+
+    const { composerRef } = renderAutofocus({
+      chatSurfaceActive: true,
+      composerEnabled: true,
+      root
+    })
+
+    flushOneFrame()
+    flushOneFrame()
+
+    expect(composerRef.current?.focus).not.toHaveBeenCalled()
+    expect(document.activeElement).toBe(unrelatedInput)
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
@@ -1,9 +1,16 @@
-import { useEffect, type RefObject } from 'react'
+import { useEffect, useRef, type RefObject } from 'react'
+import { PANE_CONTAINER_SELECTOR } from '@/lib/pane-manager/pane-surface-focus'
 import { shouldAutofocusNativeChatComposer } from './native-chat-composer-autofocus'
 import type { NativeChatComposerHandle } from './NativeChatComposer'
 
-/** Autofocuses the composer on new-session launch and on switching back to
- *  this chat tab/pane; retries once the pty binds or a question card closes.
+/** Autofocuses the composer when this chat surface becomes active (new
+ *  session, switching back to the tab/pane).
+ *
+ *  One-shot intent: activation arms a pending-focus flag that the first
+ *  attempt consumes. The attempt is deferred until the composer is enabled
+ *  (pty bound, no mobile presence-lock) and no question card owns the input —
+ *  but a later enable flip with the intent already consumed (e.g. a mobile
+ *  lock releasing minutes after activation) must not steal focus again.
  *
  *  Why double-rAF: switching FROM another chat tab hides its composer via
  *  display:none, which blurs it back to the browser — but that blur is not
@@ -11,7 +18,7 @@ import type { NativeChatComposerHandle } from './NativeChatComposer'
  *  passive effects don't wait for an actual paint, especially for updates
  *  originating outside a DOM event, e.g. the Cmd+Shift+[/] IPC tab-cycle).
  *  Checking activeElement too early sees the old tab's real textarea still
- *  focused and its politeness check correctly-but-wrongly declines to steal
+ *  focused and the politeness check correctly-but-wrongly declines to steal
  *  it. Same race focus-terminal-tab-surface.ts already waits out. */
 export function useNativeChatComposerAutofocus(args: {
   chatSurfaceActive: boolean
@@ -21,12 +28,28 @@ export function useNativeChatComposerAutofocus(args: {
   composerRef: RefObject<NativeChatComposerHandle | null>
 }): void {
   const { chatSurfaceActive, composerEnabled, questionActive, rootRef, composerRef } = args
+  const pendingFocusIntentRef = useRef(false)
+  const wasActiveRef = useRef(false)
   useEffect(() => {
-    if (!chatSurfaceActive || !composerEnabled) {
+    if (chatSurfaceActive && !wasActiveRef.current) {
+      pendingFocusIntentRef.current = true
+    }
+    wasActiveRef.current = chatSurfaceActive
+    if (!chatSurfaceActive) {
+      pendingFocusIntentRef.current = false
+      return
+    }
+    if (!pendingFocusIntentRef.current || !composerEnabled || questionActive) {
       return
     }
     let frameId = requestAnimationFrame(() => {
       frameId = requestAnimationFrame(() => {
+        if (!pendingFocusIntentRef.current) {
+          return
+        }
+        // Consumed on attempt either way: a politeness decline (user typing
+        // elsewhere) must not turn into a delayed steal on a later dep flip.
+        pendingFocusIntentRef.current = false
         if (
           !shouldAutofocusNativeChatComposer({
             chatSurfaceActive,
@@ -37,7 +60,7 @@ export function useNativeChatComposerAutofocus(args: {
             // (both children of .pane), not an ancestor of the helper textarea —
             // scope the politeness check to .pane so this same pane's xterm is
             // recognized as stealable, not mistaken for a focus elsewhere.
-            focusScope: rootRef.current?.closest('.pane') ?? rootRef.current
+            focusScope: rootRef.current?.closest(PANE_CONTAINER_SELECTOR) ?? rootRef.current
           })
         ) {
           return

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
@@ -19,7 +19,11 @@ export function useNativeChatComposerAutofocus(args: {
         composerEnabled,
         activeElement: typeof document === 'undefined' ? null : document.activeElement,
         body: typeof document === 'undefined' ? undefined : document.body,
-        focusScope: rootRef.current
+        // Why: the composer overlay is a DOM sibling of the xterm container
+        // (both children of .pane), not an ancestor of the helper textarea —
+        // scope the politeness check to .pane so this same pane's xterm is
+        // recognized as stealable, not mistaken for a focus elsewhere.
+        focusScope: rootRef.current?.closest('.pane') ?? rootRef.current
       })
     ) {
       return

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
@@ -3,7 +3,16 @@ import { shouldAutofocusNativeChatComposer } from './native-chat-composer-autofo
 import type { NativeChatComposerHandle } from './NativeChatComposer'
 
 /** Autofocuses the composer on new-session launch and on switching back to
- *  this chat tab/pane; retries once the pty binds or a question card closes. */
+ *  this chat tab/pane; retries once the pty binds or a question card closes.
+ *
+ *  Why double-rAF: switching FROM another chat tab hides its composer via
+ *  display:none, which blurs it back to the browser — but that blur is not
+ *  guaranteed to have landed by the time this effect's callback runs (React's
+ *  passive effects don't wait for an actual paint, especially for updates
+ *  originating outside a DOM event, e.g. the Cmd+Shift+[/] IPC tab-cycle).
+ *  Checking activeElement too early sees the old tab's real textarea still
+ *  focused and its politeness check correctly-but-wrongly declines to steal
+ *  it. Same race focus-terminal-tab-surface.ts already waits out. */
 export function useNativeChatComposerAutofocus(args: {
   chatSurfaceActive: boolean
   composerEnabled: boolean
@@ -13,22 +22,30 @@ export function useNativeChatComposerAutofocus(args: {
 }): void {
   const { chatSurfaceActive, composerEnabled, questionActive, rootRef, composerRef } = args
   useEffect(() => {
-    if (
-      !shouldAutofocusNativeChatComposer({
-        chatSurfaceActive,
-        composerEnabled,
-        activeElement: typeof document === 'undefined' ? null : document.activeElement,
-        body: typeof document === 'undefined' ? undefined : document.body,
-        // Why: the composer overlay is a DOM sibling of the xterm container
-        // (both children of .pane), not an ancestor of the helper textarea —
-        // scope the politeness check to .pane so this same pane's xterm is
-        // recognized as stealable, not mistaken for a focus elsewhere.
-        focusScope: rootRef.current?.closest('.pane') ?? rootRef.current
-      })
-    ) {
+    if (!chatSurfaceActive || !composerEnabled) {
       return
     }
-    composerRef.current?.focus()
+    let frameId = requestAnimationFrame(() => {
+      frameId = requestAnimationFrame(() => {
+        if (
+          !shouldAutofocusNativeChatComposer({
+            chatSurfaceActive,
+            composerEnabled,
+            activeElement: typeof document === 'undefined' ? null : document.activeElement,
+            body: typeof document === 'undefined' ? undefined : document.body,
+            // Why: the composer overlay is a DOM sibling of the xterm container
+            // (both children of .pane), not an ancestor of the helper textarea —
+            // scope the politeness check to .pane so this same pane's xterm is
+            // recognized as stealable, not mistaken for a focus elsewhere.
+            focusScope: rootRef.current?.closest('.pane') ?? rootRef.current
+          })
+        ) {
+          return
+        }
+        composerRef.current?.focus()
+      })
+    })
+    return () => cancelAnimationFrame(frameId)
     // Why: activeElement/focusScope are read fresh at trigger time, not tracked reactively.
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [chatSurfaceActive, composerEnabled, questionActive])

--- a/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-composer-autofocus.ts
@@ -1,0 +1,31 @@
+import { useEffect, type RefObject } from 'react'
+import { shouldAutofocusNativeChatComposer } from './native-chat-composer-autofocus'
+import type { NativeChatComposerHandle } from './NativeChatComposer'
+
+/** Autofocuses the composer on new-session launch and on switching back to
+ *  this chat tab/pane; retries once the pty binds or a question card closes. */
+export function useNativeChatComposerAutofocus(args: {
+  chatSurfaceActive: boolean
+  composerEnabled: boolean
+  questionActive: boolean
+  rootRef: RefObject<HTMLElement | null>
+  composerRef: RefObject<NativeChatComposerHandle | null>
+}): void {
+  const { chatSurfaceActive, composerEnabled, questionActive, rootRef, composerRef } = args
+  useEffect(() => {
+    if (
+      !shouldAutofocusNativeChatComposer({
+        chatSurfaceActive,
+        composerEnabled,
+        activeElement: typeof document === 'undefined' ? null : document.activeElement,
+        body: typeof document === 'undefined' ? undefined : document.body,
+        focusScope: rootRef.current
+      })
+    ) {
+      return
+    }
+    composerRef.current?.focus()
+    // Why: activeElement/focusScope are read fresh at trigger time, not tracked reactively.
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [chatSurfaceActive, composerEnabled, questionActive])
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-root-keydown-capture.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-root-keydown-capture.ts
@@ -1,0 +1,31 @@
+import { useCallback, type KeyboardEvent, type RefObject } from 'react'
+import {
+  shouldFocusNativeChatComposerFromEditingKey,
+  shouldRedirectNativeChatTyping
+} from './native-chat-typing-redirect'
+import type { NativeChatComposerHandle } from './NativeChatComposer'
+
+/** Backspace/Delete outside an input focuses the composer like typing does
+ *  (see shouldFocusNativeChatComposerFromEditingKey); printable keys redirect
+ *  into the composer via insertTypedText (shouldRedirectNativeChatTyping). */
+export function useNativeChatRootKeyDownCapture(
+  composerRef: RefObject<NativeChatComposerHandle | null>
+): (event: KeyboardEvent<HTMLDivElement>) => void {
+  return useCallback(
+    (event: KeyboardEvent<HTMLDivElement>) => {
+      if (shouldFocusNativeChatComposerFromEditingKey(event)) {
+        composerRef.current?.focus()
+        return
+      }
+      if (!shouldRedirectNativeChatTyping(event)) {
+        return
+      }
+      if (!composerRef.current?.insertTypedText(event.key)) {
+        return
+      }
+      event.preventDefault()
+      event.stopPropagation()
+    },
+    [composerRef]
+  )
+}

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -81,7 +81,7 @@ import { track } from '@/lib/telemetry'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
 import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
-import { isInsideFocusOwnedPane } from '@/lib/pane-manager/pane-pointer-focus'
+import { resolveVisibleTerminalSurfaceTarget } from '@/lib/pane-manager/pane-surface-focus'
 import {
   type Row,
   type ProjectGroupingModel,
@@ -2567,13 +2567,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         navigateWorktree(e.key === 'ArrowUp' ? 'up' : 'down')
         e.preventDefault()
       } else if (e.key === 'Enter') {
-        const helper = document.querySelector(
-          '.xterm-helper-textarea'
-        ) as HTMLTextAreaElement | null
-        // Why: don't steal focus from a pane whose native chat composer owns it.
-        if (helper && !isInsideFocusOwnedPane(helper)) {
-          helper.focus()
-        }
+        // Why: skips hidden panes; a chat-owned pane yields its composer.
+        resolveVisibleTerminalSurfaceTarget(document)?.focus()
         e.preventDefault()
       } else if (['PageUp', 'PageDown', 'Home', 'End', ' '].includes(e.key)) {
         markDirectScrollInput()

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -81,6 +81,7 @@ import { track } from '@/lib/telemetry'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import { deriveRunningAgentSendTargets } from '@/lib/running-agent-targets'
 import { rightSidebarShowsPullRequestData } from '@/lib/right-sidebar-visibility'
+import { isInsideFocusOwnedPane } from '@/lib/pane-manager/pane-pointer-focus'
 import {
   type Row,
   type ProjectGroupingModel,
@@ -2569,7 +2570,8 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
         const helper = document.querySelector(
           '.xterm-helper-textarea'
         ) as HTMLTextAreaElement | null
-        if (helper) {
+        // Why: don't steal focus from a pane whose native chat composer owns it.
+        if (helper && !isInsideFocusOwnedPane(helper)) {
           helper.focus()
         }
         e.preventDefault()

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -2954,6 +2954,7 @@ function TerminalPane(
                 resolvedAgent={chatPaneResolvedAgent}
                 onSwitchToTerminal={() => toggleNativeChatForLeaf(chatPane.leafId)}
                 readTerminalScreen={readNativeChatTerminalScreen}
+                shouldFocusComposer={isActive && isVisible && activePaneIsChatLeaf}
                 contextMenuActions={{
                   onSplitRight: () => contextMenu.runForPane(chatPane.id, contextMenu.onSplitRight),
                   onSplitDown: () => contextMenu.runForPane(chatPane.id, contextMenu.onSplitDown),

--- a/src/renderer/src/components/terminal-pane/expand-collapse.ts
+++ b/src/renderer/src/components/terminal-pane/expand-collapse.ts
@@ -1,5 +1,6 @@
 import { useMemo } from 'react'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { focusPaneSurface } from '@/lib/pane-manager/pane-surface-focus'
 import { safeFit } from '@/lib/pane-manager/pane-tree-ops'
 
 type ExpandCollapseState = {
@@ -142,7 +143,10 @@ export function createExpandCollapseActions(state: ExpandCollapseState) {
       }
       if (focusActive) {
         const active = manager.getActivePane() ?? panes[0]
-        active?.terminal.focus()
+        if (active) {
+          // Why: a chat-owned pane gets its composer, not the hidden xterm.
+          focusPaneSurface(active.container, () => active.terminal.focus())
+        }
       }
     })
   }

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -4,6 +4,7 @@
 import { useEffect } from 'react'
 import type { IDisposable } from '@xterm/xterm'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { focusPaneSurface } from '@/lib/pane-manager/pane-surface-focus'
 import type { PtyTransport } from './pty-transport'
 import { safeFind } from '../terminal-search-safe-find'
 import { resolveTerminalShortcutAction } from './terminal-shortcut-policy'
@@ -545,7 +546,7 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         runTerminalSearchNavigation(pane, direction, searchStateRef.current)
-        pane.terminal.focus()
+        focusPaneSurface(pane.container, () => pane.terminal.focus())
         return
       }
 
@@ -706,7 +707,9 @@ export function useTerminalKeyboardShortcuts({
         }
         manager.equalizePaneSizes()
         const paneToFocus = manager.getActivePane() ?? manager.getPanes()[0]
-        paneToFocus?.terminal.focus()
+        if (paneToFocus) {
+          focusPaneSurface(paneToFocus.container, () => paneToFocus.terminal.focus())
+        }
         return
       }
 

--- a/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
@@ -76,12 +76,18 @@ describe('fitAndFocusPanes', () => {
     vi.unstubAllGlobals()
   })
 
-  function makeManager(): { manager: PaneManager; terminal: { focus: ReturnType<typeof vi.fn> } } {
+  function makeManager(args?: { activeContainerHasFocusOwner?: boolean }): {
+    manager: PaneManager
+    terminal: { focus: ReturnType<typeof vi.fn> }
+  } {
     const terminal = { focus: vi.fn() }
+    const container = {
+      querySelector: vi.fn(() => (args?.activeContainerHasFocusOwner ? {} : null))
+    }
     const manager = {
       fitAllPanes: vi.fn(),
-      getActivePane: () => ({ terminal }),
-      getPanes: () => [{ terminal }]
+      getActivePane: () => ({ terminal, container }),
+      getPanes: () => [{ terminal, container }]
     } as unknown as PaneManager
     return { manager, terminal }
   }
@@ -131,5 +137,15 @@ describe('fitAndFocusPanes', () => {
 
     expect(manager.fitAllPanes).toHaveBeenCalled()
     expect(terminal.focus).toHaveBeenCalled()
+  })
+
+  it('does not steal focus from a pane showing the native chat composer', () => {
+    stubDocument(null)
+    const { manager, terminal } = makeManager({ activeContainerHasFocusOwner: true })
+
+    fitAndFocusPanes(manager)
+
+    expect(manager.fitAllPanes).toHaveBeenCalled()
+    expect(terminal.focus).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.test.ts
@@ -79,17 +79,20 @@ describe('fitAndFocusPanes', () => {
   function makeManager(args?: { activeContainerHasFocusOwner?: boolean }): {
     manager: PaneManager
     terminal: { focus: ReturnType<typeof vi.fn> }
+    focusOwner: { focus: ReturnType<typeof vi.fn> }
   } {
     const terminal = { focus: vi.fn() }
+    // Shaped like the chat root: focusable, no enabled composer input inside.
+    const focusOwner = { focus: vi.fn(), querySelector: vi.fn(() => null) }
     const container = {
-      querySelector: vi.fn(() => (args?.activeContainerHasFocusOwner ? {} : null))
+      querySelector: vi.fn(() => (args?.activeContainerHasFocusOwner ? focusOwner : null))
     }
     const manager = {
       fitAllPanes: vi.fn(),
       getActivePane: () => ({ terminal, container }),
       getPanes: () => [{ terminal, container }]
     } as unknown as PaneManager
-    return { manager, terminal }
+    return { manager, terminal, focusOwner }
   }
 
   function stubDocument(activeElement: Element | null, renameInputMounted = false): void {
@@ -139,13 +142,14 @@ describe('fitAndFocusPanes', () => {
     expect(terminal.focus).toHaveBeenCalled()
   })
 
-  it('does not steal focus from a pane showing the native chat composer', () => {
+  it('focuses the chat surface, not xterm, for a pane showing the native chat composer', () => {
     stubDocument(null)
-    const { manager, terminal } = makeManager({ activeContainerHasFocusOwner: true })
+    const { manager, terminal, focusOwner } = makeManager({ activeContainerHasFocusOwner: true })
 
     fitAndFocusPanes(manager)
 
     expect(manager.fitAllPanes).toHaveBeenCalled()
     expect(terminal.focus).not.toHaveBeenCalled()
+    expect(focusOwner.focus).toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -1,4 +1,5 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import { paneContainerOwnsFocus } from '@/lib/pane-manager/pane-pointer-focus'
 
 export function fitPanes(manager: PaneManager): void {
   manager.fitAllPanes()
@@ -16,6 +17,11 @@ export function focusActivePane(manager: PaneManager): void {
   }
   const panes = manager.getPanes()
   const activePane = manager.getActivePane() ?? panes[0]
+  // Why: a pane showing the native chat composer owns its own focus (see
+  // shouldAutofocusNativeChatComposer) — the xterm underneath must stay blurred.
+  if (activePane && paneContainerOwnsFocus(activePane.container)) {
+    return
+  }
   activePane?.terminal.focus()
 }
 

--- a/src/renderer/src/components/terminal-pane/pane-helpers.ts
+++ b/src/renderer/src/components/terminal-pane/pane-helpers.ts
@@ -1,5 +1,5 @@
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { paneContainerOwnsFocus } from '@/lib/pane-manager/pane-pointer-focus'
+import { focusPaneSurface } from '@/lib/pane-manager/pane-surface-focus'
 
 export function fitPanes(manager: PaneManager): void {
   manager.fitAllPanes()
@@ -17,12 +17,11 @@ export function focusActivePane(manager: PaneManager): void {
   }
   const panes = manager.getPanes()
   const activePane = manager.getActivePane() ?? panes[0]
-  // Why: a pane showing the native chat composer owns its own focus (see
-  // shouldAutofocusNativeChatComposer) — the xterm underneath must stay blurred.
-  if (activePane && paneContainerOwnsFocus(activePane.container)) {
+  if (!activePane) {
     return
   }
-  activePane?.terminal.focus()
+  // Why: a chat-owned pane gets its composer, not the hidden xterm.
+  focusPaneSurface(activePane.container, () => activePane.terminal.focus())
 }
 
 export function fitAndFocusPanes(manager: PaneManager): void {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-context-menu.ts
@@ -3,6 +3,7 @@
 import { useCallback, useEffect, useRef, useState } from 'react'
 import { toast } from 'sonner'
 import type { ManagedPane, PaneManager } from '@/lib/pane-manager/pane-manager'
+import { focusPaneSurface } from '@/lib/pane-manager/pane-surface-focus'
 import type { PtyTransport } from './pty-transport'
 import { getConnectionId } from '@/lib/connection-context'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
@@ -168,7 +169,7 @@ export function useTerminalPaneContextMenu({
       // close, but xterm.js only accepts input when its own helper textarea is
       // focused. Without this, the user has to click the pane again before
       // typing works (see #592).
-      focus: () => pane.terminal.focus()
+      focus: () => focusPaneSurface(pane.container, () => pane.terminal.focus())
     })
   }
 
@@ -198,7 +199,7 @@ export function useTerminalPaneContextMenu({
             'Unable to copy pane ID'
           )
         ),
-      focus: () => pane.terminal.focus()
+      focus: () => focusPaneSurface(pane.container, () => pane.terminal.focus())
     })
   }
 
@@ -301,7 +302,7 @@ export function useTerminalPaneContextMenu({
         )
       )
     } finally {
-      pane.terminal.focus()
+      focusPaneSurface(pane.container, () => pane.terminal.focus())
     }
   }
 
@@ -337,7 +338,7 @@ export function useTerminalPaneContextMenu({
     // Why: Radix returns focus to the menu trigger (the pane container) on
     // close. Refocus only after a completed paste so rejected async targets
     // do not steal focus from the user's new control.
-    pane.terminal.focus()
+    focusPaneSurface(pane.container, () => pane.terminal.focus())
   }
 
   const onPaste = async (): Promise<void> => pasteResolvedPane('context-menu')
@@ -392,7 +393,7 @@ export function useTerminalPaneContextMenu({
       return
     }
     manager.equalizePaneSizes()
-    pane.terminal.focus()
+    focusPaneSurface(pane.container, () => pane.terminal.focus())
   }
 
   const onClosePane = (): void => {

--- a/src/renderer/src/hooks/useModalReturnFocus.test.tsx
+++ b/src/renderer/src/hooks/useModalReturnFocus.test.tsx
@@ -198,10 +198,11 @@ describe('useModalReturnFocus', () => {
     expect(focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', 'leaf-1')
   })
 
-  it('does not steal focus from a pane whose composer owns focus in the generic surface fallback', async () => {
+  it('focuses the composer, not the hidden xterm, for a chat-owned pane in the surface fallback', async () => {
     // Why: regression — the generic 'surface' fallback used a document-wide
     // .xterm-helper-textarea query with no awareness of the native chat
-    // composer owning that pane's focus.
+    // composer owning that pane's focus. It must redirect there, not merely
+    // skip (a veto would leave focus nowhere).
     installAnimationFrameStubs()
     useAppStore.setState({
       activeWorktreeId: 'wt-1',
@@ -213,6 +214,10 @@ describe('useModalReturnFocus', () => {
     pane.className = 'pane'
     const owner = document.createElement('div')
     owner.setAttribute('data-pane-prevent-terminal-focus', 'true')
+    owner.tabIndex = -1
+    const composer = document.createElement('textarea')
+    composer.setAttribute('data-native-chat-composer-input', 'true')
+    owner.append(composer)
     pane.append(owner)
     const terminalTextarea = document.createElement('textarea')
     terminalTextarea.className = 'xterm-helper-textarea'
@@ -223,7 +228,7 @@ describe('useModalReturnFocus', () => {
     await renderProbe(false)
     flushAnimationFrames()
 
-    expect(document.activeElement).not.toBe(terminalTextarea)
+    expect(document.activeElement).toBe(composer)
   })
 
   it('skips return focus when the close action already moved focus', async () => {

--- a/src/renderer/src/hooks/useModalReturnFocus.test.tsx
+++ b/src/renderer/src/hooks/useModalReturnFocus.test.tsx
@@ -198,6 +198,34 @@ describe('useModalReturnFocus', () => {
     expect(focusTerminalTabSurface).toHaveBeenCalledWith('terminal-1', 'leaf-1')
   })
 
+  it('does not steal focus from a pane whose composer owns focus in the generic surface fallback', async () => {
+    // Why: regression — the generic 'surface' fallback used a document-wide
+    // .xterm-helper-textarea query with no awareness of the native chat
+    // composer owning that pane's focus.
+    installAnimationFrameStubs()
+    useAppStore.setState({
+      activeWorktreeId: 'wt-1',
+      activeTabType: 'terminal',
+      activeTabId: null,
+      activeTabIdByWorktree: {}
+    })
+    const pane = document.createElement('div')
+    pane.className = 'pane'
+    const owner = document.createElement('div')
+    owner.setAttribute('data-pane-prevent-terminal-focus', 'true')
+    pane.append(owner)
+    const terminalTextarea = document.createElement('textarea')
+    terminalTextarea.className = 'xterm-helper-textarea'
+    pane.append(terminalTextarea)
+    document.body.append(pane)
+
+    await renderProbe(true)
+    await renderProbe(false)
+    flushAnimationFrames()
+
+    expect(document.activeElement).not.toBe(terminalTextarea)
+  })
+
   it('skips return focus when the close action already moved focus', async () => {
     installAnimationFrameStubs()
     useAppStore.setState({ activeWorktreeId: 'wt-1', activeTabType: 'editor' })

--- a/src/renderer/src/hooks/useModalReturnFocus.ts
+++ b/src/renderer/src/hooks/useModalReturnFocus.ts
@@ -2,6 +2,7 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { useAppStore } from '../store'
 import { focusTerminalTabSurface } from '../lib/focus-terminal-tab-surface'
+import { isInsideFocusOwnedPane } from '../lib/pane-manager/pane-pointer-focus'
 import {
   ORCA_BROWSER_FOCUS_REQUEST_EVENT,
   queueBrowserFocusRequest,
@@ -67,7 +68,9 @@ export function useModalReturnFocus(visible: boolean): {
           innerFrameRef.current = null
           for (const selector of selectors) {
             const target = document.querySelector(selector) as HTMLElement | null
-            if (!target) {
+            // Why: an xterm-helper-textarea candidate can belong to a pane
+            // whose native chat composer owns focus — don't steal it back.
+            if (!target || isInsideFocusOwnedPane(target)) {
               continue
             }
             target.focus()

--- a/src/renderer/src/hooks/useModalReturnFocus.ts
+++ b/src/renderer/src/hooks/useModalReturnFocus.ts
@@ -2,7 +2,7 @@ import { useCallback, useEffect, useRef } from 'react'
 
 import { useAppStore } from '../store'
 import { focusTerminalTabSurface } from '../lib/focus-terminal-tab-surface'
-import { isInsideFocusOwnedPane } from '../lib/pane-manager/pane-pointer-focus'
+import { resolveVisibleTerminalSurfaceTarget } from '../lib/pane-manager/pane-surface-focus'
 import {
   ORCA_BROWSER_FOCUS_REQUEST_EVENT,
   queueBrowserFocusRequest,
@@ -67,10 +67,14 @@ export function useModalReturnFocus(visible: boolean): {
         innerFrameRef.current = requestAnimationFrame(() => {
           innerFrameRef.current = null
           for (const selector of selectors) {
-            const target = document.querySelector(selector) as HTMLElement | null
-            // Why: an xterm-helper-textarea candidate can belong to a pane
-            // whose native chat composer owns focus — don't steal it back.
-            if (!target || isInsideFocusOwnedPane(target)) {
+            // Why: terminal candidates route through the visible-surface
+            // resolver so hidden panes are skipped and a chat-owned pane
+            // yields its composer instead of the hidden xterm.
+            const target =
+              selector === '.xterm-helper-textarea'
+                ? resolveVisibleTerminalSurfaceTarget(document)
+                : (document.querySelector(selector) as HTMLElement | null)
+            if (!target) {
               continue
             }
             target.focus()

--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -3,7 +3,7 @@ import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 
 const mocks = vi.hoisted(() => ({
   refreshTerminalImeInputContext: vi.fn(),
-  paneContainerOwnsFocus: vi.fn(() => false)
+  isInsideFocusOwnedPane: vi.fn(() => false)
 }))
 
 vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => ({
@@ -11,11 +11,12 @@ vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => (
 }))
 
 vi.mock('@/lib/pane-manager/pane-pointer-focus', () => ({
-  paneContainerOwnsFocus: mocks.paneContainerOwnsFocus
+  isInsideFocusOwnedPane: mocks.isInsideFocusOwnedPane
 }))
 
-// Why: `helper` is outside `.pane` in real DOM checks (paneContainerOwnsFocus
-// mock above stands in), so the fake only needs `closest` to resolve `.pane`.
+// Why: `closest` is unused directly (isInsideFocusOwnedPane mock above stands
+// in for the real .pane lookup) but kept so callers matching a `.closest`
+// shape don't throw.
 function fakeHelper(): { focus: ReturnType<typeof vi.fn>; closest: ReturnType<typeof vi.fn> } {
   return { focus: vi.fn(), closest: vi.fn(() => ({})) }
 }
@@ -23,7 +24,7 @@ function fakeHelper(): { focus: ReturnType<typeof vi.fn>; closest: ReturnType<ty
 describe('focusTerminalTabSurface', () => {
   afterEach(() => {
     mocks.refreshTerminalImeInputContext.mockClear()
-    mocks.paneContainerOwnsFocus.mockReset().mockReturnValue(false)
+    mocks.isInsideFocusOwnedPane.mockReset().mockReturnValue(false)
     vi.unstubAllGlobals()
   })
 
@@ -99,7 +100,7 @@ describe('focusTerminalTabSurface', () => {
     // ancestor of the helper textarea, so this must check the shared .pane
     // container rather than helper.closest(marker) directly.
     flushAnimationFrames()
-    mocks.paneContainerOwnsFocus.mockReturnValue(true)
+    mocks.isInsideFocusOwnedPane.mockReturnValue(true)
     const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
@@ -109,7 +110,7 @@ describe('focusTerminalTabSurface', () => {
 
     focusTerminalTabSurface('tab-1')
 
-    expect(textarea.closest).toHaveBeenCalledWith('.pane')
+    expect(mocks.isInsideFocusOwnedPane).toHaveBeenCalledWith(textarea)
     expect(textarea.focus).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -3,20 +3,20 @@ import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 
 const mocks = vi.hoisted(() => ({
   refreshTerminalImeInputContext: vi.fn(),
-  isInsideFocusOwnedPane: vi.fn(() => false)
+  resolvePaneSurfaceFocusTarget: vi.fn((): { focus: () => void } | null => null)
 }))
 
 vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => ({
   refreshTerminalImeInputContext: mocks.refreshTerminalImeInputContext
 }))
 
-vi.mock('@/lib/pane-manager/pane-pointer-focus', () => ({
-  isInsideFocusOwnedPane: mocks.isInsideFocusOwnedPane
+vi.mock('@/lib/pane-manager/pane-surface-focus', () => ({
+  PANE_CONTAINER_SELECTOR: '.pane',
+  resolvePaneSurfaceFocusTarget: mocks.resolvePaneSurfaceFocusTarget
 }))
 
-// Why: `closest` is unused directly (isInsideFocusOwnedPane mock above stands
-// in for the real .pane lookup) but kept so callers matching a `.closest`
-// shape don't throw.
+// Why: `closest` resolves the fake .pane container handed to the (mocked)
+// pane-surface resolver.
 function fakeHelper(): { focus: ReturnType<typeof vi.fn>; closest: ReturnType<typeof vi.fn> } {
   return { focus: vi.fn(), closest: vi.fn(() => ({})) }
 }
@@ -24,7 +24,7 @@ function fakeHelper(): { focus: ReturnType<typeof vi.fn>; closest: ReturnType<ty
 describe('focusTerminalTabSurface', () => {
   afterEach(() => {
     mocks.refreshTerminalImeInputContext.mockClear()
-    mocks.isInsideFocusOwnedPane.mockReset().mockReturnValue(false)
+    mocks.resolvePaneSurfaceFocusTarget.mockReset().mockReturnValue(null)
     vi.unstubAllGlobals()
   })
 
@@ -94,13 +94,14 @@ describe('focusTerminalTabSurface', () => {
     expect(textarea.focus).not.toHaveBeenCalled()
   })
 
-  it('does not steal focus onto a pane whose composer owns focus', () => {
+  it('redirects to the composer for a pane whose chat surface owns focus', () => {
     // Why: regression for the real-world miss — the composer overlay is a DOM
     // sibling of the xterm container (both children of .pane), not an
-    // ancestor of the helper textarea, so this must check the shared .pane
-    // container rather than helper.closest(marker) directly.
+    // ancestor of the helper textarea, so this must resolve the shared .pane
+    // container; and it must redirect, not veto, or focus lands nowhere.
     flushAnimationFrames()
-    mocks.isInsideFocusOwnedPane.mockReturnValue(true)
+    const composer = { focus: vi.fn() }
+    mocks.resolvePaneSurfaceFocusTarget.mockReturnValue(composer)
     const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
@@ -110,7 +111,8 @@ describe('focusTerminalTabSurface', () => {
 
     focusTerminalTabSurface('tab-1')
 
-    expect(mocks.isInsideFocusOwnedPane).toHaveBeenCalledWith(textarea)
+    expect(textarea.closest).toHaveBeenCalledWith('.pane')
+    expect(composer.focus).toHaveBeenCalled()
     expect(textarea.focus).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.test.ts
@@ -2,16 +2,28 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { focusTerminalTabSurface } from './focus-terminal-tab-surface'
 
 const mocks = vi.hoisted(() => ({
-  refreshTerminalImeInputContext: vi.fn()
+  refreshTerminalImeInputContext: vi.fn(),
+  paneContainerOwnsFocus: vi.fn(() => false)
 }))
 
 vi.mock('@/components/terminal-pane/terminal-ime-input-context-refresh', () => ({
   refreshTerminalImeInputContext: mocks.refreshTerminalImeInputContext
 }))
 
+vi.mock('@/lib/pane-manager/pane-pointer-focus', () => ({
+  paneContainerOwnsFocus: mocks.paneContainerOwnsFocus
+}))
+
+// Why: `helper` is outside `.pane` in real DOM checks (paneContainerOwnsFocus
+// mock above stands in), so the fake only needs `closest` to resolve `.pane`.
+function fakeHelper(): { focus: ReturnType<typeof vi.fn>; closest: ReturnType<typeof vi.fn> } {
+  return { focus: vi.fn(), closest: vi.fn(() => ({})) }
+}
+
 describe('focusTerminalTabSurface', () => {
   afterEach(() => {
     mocks.refreshTerminalImeInputContext.mockClear()
+    mocks.paneContainerOwnsFocus.mockReset().mockReturnValue(false)
     vi.unstubAllGlobals()
   })
 
@@ -25,7 +37,7 @@ describe('focusTerminalTabSurface', () => {
 
   it('focuses the scoped xterm helper textarea', () => {
     flushAnimationFrames()
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
         selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea' ? textarea : null
@@ -39,7 +51,7 @@ describe('focusTerminalTabSurface', () => {
 
   it('optionally refreshes the focused helper native input context', () => {
     flushAnimationFrames()
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
         selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea' ? textarea : null
@@ -61,7 +73,7 @@ describe('focusTerminalTabSurface', () => {
       return frames.length
     })
     vi.stubGlobal('cancelAnimationFrame', vi.fn())
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     const body = {}
     const outside = {}
     const documentState = {
@@ -81,9 +93,29 @@ describe('focusTerminalTabSurface', () => {
     expect(textarea.focus).not.toHaveBeenCalled()
   })
 
+  it('does not steal focus onto a pane whose composer owns focus', () => {
+    // Why: regression for the real-world miss — the composer overlay is a DOM
+    // sibling of the xterm container (both children of .pane), not an
+    // ancestor of the helper textarea, so this must check the shared .pane
+    // container rather than helper.closest(marker) directly.
+    flushAnimationFrames()
+    mocks.paneContainerOwnsFocus.mockReturnValue(true)
+    const textarea = fakeHelper()
+    vi.stubGlobal('document', {
+      querySelector: vi.fn((selector: string) =>
+        selector === '[data-terminal-tab-id="tab-1"] .xterm-helper-textarea' ? textarea : null
+      )
+    })
+
+    focusTerminalTabSurface('tab-1')
+
+    expect(textarea.closest).toHaveBeenCalledWith('.pane')
+    expect(textarea.focus).not.toHaveBeenCalled()
+  })
+
   it('does not steal focus while inline tab rename is open', () => {
     flushAnimationFrames()
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) => {
         if (selector === '[data-tab-rename-input="true"]') {
@@ -102,7 +134,7 @@ describe('focusTerminalTabSurface', () => {
 
   it('falls back to the single tab helper when an old leaf id was reminted', () => {
     flushAnimationFrames()
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
         selector === '[data-terminal-tab-id="tab-1"]' ? { getAttribute: () => 'new-leaf' } : null
@@ -121,7 +153,7 @@ describe('focusTerminalTabSurface', () => {
 
   it('does not focus a mounted sibling while a requested split leaf is still expected', () => {
     flushAnimationFrames()
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
         selector === '[data-terminal-tab-id="tab-1"]'
@@ -142,7 +174,7 @@ describe('focusTerminalTabSurface', () => {
 
   it('does not use stale-leaf fallback while the expected layout still has multiple leaves', () => {
     flushAnimationFrames()
-    const textarea = { focus: vi.fn() }
+    const textarea = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
         selector === '[data-terminal-tab-id="tab-1"]'
@@ -163,8 +195,8 @@ describe('focusTerminalTabSurface', () => {
 
   it('does not focus a sibling when a stale leaf id has multiple helpers in the tab', () => {
     flushAnimationFrames()
-    const first = { focus: vi.fn() }
-    const second = { focus: vi.fn() }
+    const first = fakeHelper()
+    const second = fakeHelper()
     vi.stubGlobal('document', {
       querySelector: vi.fn((selector: string) =>
         selector === '[data-terminal-tab-id="tab-1"]'

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,5 +1,8 @@
 import { refreshTerminalImeInputContext } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
-import { isInsideFocusOwnedPane } from '@/lib/pane-manager/pane-pointer-focus'
+import {
+  PANE_CONTAINER_SELECTOR,
+  resolvePaneSurfaceFocusTarget
+} from '@/lib/pane-manager/pane-surface-focus'
 
 /**
  * Move keyboard focus into the xterm instance for a freshly-mounted terminal
@@ -27,10 +30,13 @@ function focusTerminalHelper(helper: HTMLElement, options: FocusTerminalTabSurfa
       return
     }
   }
-  // Why: a pane showing the native chat composer owns its own focus (see
-  // shouldAutofocusNativeChatComposer) — this double-rAF-delayed reclaim must
-  // not steal it back onto the hidden xterm underneath.
-  if (isInsideFocusOwnedPane(helper)) {
+  // Why: a chat-owned pane's keyboard surface is its composer — redirect this
+  // delayed reclaim there instead of stealing onto the hidden xterm (or, with
+  // a veto, leaving focus nowhere).
+  const pane = helper.closest(PANE_CONTAINER_SELECTOR) as HTMLElement | null
+  const ownedTarget = pane ? resolvePaneSurfaceFocusTarget(pane) : null
+  if (ownedTarget) {
+    ownedTarget.focus()
     return
   }
   helper.focus()

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,4 +1,5 @@
 import { refreshTerminalImeInputContext } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
+import { paneContainerOwnsFocus } from '@/lib/pane-manager/pane-pointer-focus'
 
 /**
  * Move keyboard focus into the xterm instance for a freshly-mounted terminal
@@ -25,6 +26,15 @@ function focusTerminalHelper(helper: HTMLElement, options: FocusTerminalTabSurfa
     if (active !== helper && active !== null && active !== document.body) {
       return
     }
+  }
+  // Why: a pane showing the native chat composer owns its own focus (see
+  // shouldAutofocusNativeChatComposer) — this double-rAF-delayed reclaim must
+  // not steal it back onto the hidden xterm underneath. The composer overlay
+  // is a DOM sibling of the xterm container (both children of .pane), not an
+  // ancestor of `helper`, so check the shared pane container, not `closest`.
+  const paneContainer = helper.closest('.pane') as HTMLElement | null
+  if (paneContainer && paneContainerOwnsFocus(paneContainer)) {
+    return
   }
   helper.focus()
   if (options.refreshImeContext) {

--- a/src/renderer/src/lib/focus-terminal-tab-surface.ts
+++ b/src/renderer/src/lib/focus-terminal-tab-surface.ts
@@ -1,5 +1,5 @@
 import { refreshTerminalImeInputContext } from '@/components/terminal-pane/terminal-ime-input-context-refresh'
-import { paneContainerOwnsFocus } from '@/lib/pane-manager/pane-pointer-focus'
+import { isInsideFocusOwnedPane } from '@/lib/pane-manager/pane-pointer-focus'
 
 /**
  * Move keyboard focus into the xterm instance for a freshly-mounted terminal
@@ -29,11 +29,8 @@ function focusTerminalHelper(helper: HTMLElement, options: FocusTerminalTabSurfa
   }
   // Why: a pane showing the native chat composer owns its own focus (see
   // shouldAutofocusNativeChatComposer) — this double-rAF-delayed reclaim must
-  // not steal it back onto the hidden xterm underneath. The composer overlay
-  // is a DOM sibling of the xterm container (both children of .pane), not an
-  // ancestor of `helper`, so check the shared pane container, not `closest`.
-  const paneContainer = helper.closest('.pane') as HTMLElement | null
-  if (paneContainer && paneContainerOwnsFocus(paneContainer)) {
+  // not steal it back onto the hidden xterm underneath.
+  if (isInsideFocusOwnedPane(helper)) {
     return
   }
   helper.focus()

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -22,6 +22,7 @@ import { cancelActivePaneDrag, createDragReorderState, handlePaneDrop } from './
 import { beginPaneDragFromPointerDown } from './pane-drag-pointer'
 import { createPaneDOM, openTerminal, setLigaturesEnabled, disposePane } from './pane-lifecycle'
 import { shouldFollowMouseFocus } from './focus-follows-mouse'
+import { paneContainerOwnsFocus } from './pane-pointer-focus'
 import { getTerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
 import {
   equalizePaneSplitSizes,
@@ -319,7 +320,9 @@ export class PaneManager {
     this.activePaneId = paneId
     applyPaneOpacity(this.panes.values(), this.activePaneId, this.styleOptions)
 
-    if (opts?.focus !== false) {
+    // Why: a pane whose app control (e.g. the native chat composer) owns
+    // focus must not have it stolen back onto the hidden xterm underneath.
+    if (opts?.focus !== false && !paneContainerOwnsFocus(pane.container)) {
       pane.terminal.focus()
     }
 

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -22,7 +22,7 @@ import { cancelActivePaneDrag, createDragReorderState, handlePaneDrop } from './
 import { beginPaneDragFromPointerDown } from './pane-drag-pointer'
 import { createPaneDOM, openTerminal, setLigaturesEnabled, disposePane } from './pane-lifecycle'
 import { shouldFollowMouseFocus } from './focus-follows-mouse'
-import { paneContainerOwnsFocus } from './pane-pointer-focus'
+import { focusPaneSurface } from './pane-surface-focus'
 import { getTerminalWebglAutoDecision } from './terminal-webgl-auto-policy'
 import {
   equalizePaneSplitSizes,
@@ -320,10 +320,9 @@ export class PaneManager {
     this.activePaneId = paneId
     applyPaneOpacity(this.panes.values(), this.activePaneId, this.styleOptions)
 
-    // Why: a pane whose app control (e.g. the native chat composer) owns
-    // focus must not have it stolen back onto the hidden xterm underneath.
-    if (opts?.focus !== false && !paneContainerOwnsFocus(pane.container)) {
-      pane.terminal.focus()
+    // Why: a chat-owned pane gets its composer, not the hidden xterm.
+    if (opts?.focus !== false) {
+      focusPaneSurface(pane.container, () => pane.terminal.focus())
     }
 
     if (changed) {

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  isInsideFocusOwnedPane,
   paneContainerOwnsFocus,
   shouldFocusTerminalFromPanePointerDown
 } from './pane-pointer-focus'
@@ -52,5 +53,27 @@ describe('paneContainerOwnsFocus', () => {
 
   it('is true when the pane hosts a focus-owning app control (e.g. the native chat composer)', () => {
     expect(paneContainerOwnsFocus(fakeContainer(true))).toBe(true)
+  })
+})
+
+describe('isInsideFocusOwnedPane', () => {
+  function fakeCandidate(paneHasMatch: boolean | null): Element {
+    const pane =
+      paneHasMatch === null
+        ? null
+        : ({ querySelector: vi.fn(() => (paneHasMatch ? {} : null)) } as unknown as HTMLElement)
+    return { closest: vi.fn(() => pane) } as unknown as Element
+  }
+
+  it('is false when the candidate has no .pane ancestor', () => {
+    expect(isInsideFocusOwnedPane(fakeCandidate(null))).toBe(false)
+  })
+
+  it('is false when the ancestor pane has no focus-owning app control', () => {
+    expect(isInsideFocusOwnedPane(fakeCandidate(false))).toBe(false)
+  })
+
+  it('is true when the ancestor pane hosts a focus-owning app control', () => {
+    expect(isInsideFocusOwnedPane(fakeCandidate(true))).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
@@ -1,6 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
-  isInsideFocusOwnedPane,
   paneContainerOwnsFocus,
   shouldFocusTerminalFromPanePointerDown
 } from './pane-pointer-focus'
@@ -53,27 +52,5 @@ describe('paneContainerOwnsFocus', () => {
 
   it('is true when the pane hosts a focus-owning app control (e.g. the native chat composer)', () => {
     expect(paneContainerOwnsFocus(fakeContainer(true))).toBe(true)
-  })
-})
-
-describe('isInsideFocusOwnedPane', () => {
-  function fakeCandidate(paneHasMatch: boolean | null): Element {
-    const pane =
-      paneHasMatch === null
-        ? null
-        : ({ querySelector: vi.fn(() => (paneHasMatch ? {} : null)) } as unknown as HTMLElement)
-    return { closest: vi.fn(() => pane) } as unknown as Element
-  }
-
-  it('is false when the candidate has no .pane ancestor', () => {
-    expect(isInsideFocusOwnedPane(fakeCandidate(null))).toBe(false)
-  })
-
-  it('is false when the ancestor pane has no focus-owning app control', () => {
-    expect(isInsideFocusOwnedPane(fakeCandidate(false))).toBe(false)
-  })
-
-  it('is true when the ancestor pane hosts a focus-owning app control', () => {
-    expect(isInsideFocusOwnedPane(fakeCandidate(true))).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.test.ts
@@ -1,5 +1,8 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { shouldFocusTerminalFromPanePointerDown } from './pane-pointer-focus'
+import {
+  paneContainerOwnsFocus,
+  shouldFocusTerminalFromPanePointerDown
+} from './pane-pointer-focus'
 
 class FakeElement {
   constructor(private readonly closestResult: FakeElement | null = null) {}
@@ -33,5 +36,21 @@ describe('shouldFocusTerminalFromPanePointerDown', () => {
     const target = new FakeElement(control)
 
     expect(shouldFocusTerminalFromPanePointerDown(target as unknown as Element)).toBe(false)
+  })
+})
+
+describe('paneContainerOwnsFocus', () => {
+  function fakeContainer(hasMatch: boolean): HTMLElement {
+    return {
+      querySelector: vi.fn(() => (hasMatch ? {} : null))
+    } as unknown as HTMLElement
+  }
+
+  it('is false for an ordinary terminal pane container', () => {
+    expect(paneContainerOwnsFocus(fakeContainer(false))).toBe(false)
+  })
+
+  it('is true when the pane hosts a focus-owning app control (e.g. the native chat composer)', () => {
+    expect(paneContainerOwnsFocus(fakeContainer(true))).toBe(true)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
@@ -29,3 +29,13 @@ export function shouldFocusTerminalFromPanePointerDown(target: EventTarget | nul
 export function paneContainerOwnsFocus(container: HTMLElement): boolean {
   return container.querySelector(PANE_PREVENT_TERMINAL_FOCUS_SELECTOR) !== null
 }
+
+/** Whether `element` (typically a candidate .xterm-helper-textarea found via
+ *  an unscoped `document.querySelector`) sits inside a pane whose app control
+ *  owns focus. Global "restore terminal focus" fallbacks — command palettes,
+ *  modal close, sidebar keyboard navigation — must skip such candidates
+ *  rather than stealing focus back from e.g. the native chat composer. */
+export function isInsideFocusOwnedPane(element: Element): boolean {
+  const pane = element.closest('.pane') as HTMLElement | null
+  return pane !== null && paneContainerOwnsFocus(pane)
+}

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
@@ -23,19 +23,9 @@ export function shouldFocusTerminalFromPanePointerDown(target: EventTarget | nul
 }
 
 /** Whether a pane's own app control (e.g. the native chat composer overlay)
- *  currently claims focus ownership — imperative focus calls (tab switch,
- *  visibility resume, setActivePane) must not steal it back onto the hidden
- *  xterm underneath. */
+ *  currently claims focus ownership. Imperative focus paths route through
+ *  focusPaneSurface (pane-surface-focus.ts), which uses this to pick the
+ *  owning surface instead of the hidden xterm. */
 export function paneContainerOwnsFocus(container: HTMLElement): boolean {
   return container.querySelector(PANE_PREVENT_TERMINAL_FOCUS_SELECTOR) !== null
-}
-
-/** Whether `element` (typically a candidate .xterm-helper-textarea found via
- *  an unscoped `document.querySelector`) sits inside a pane whose app control
- *  owns focus. Global "restore terminal focus" fallbacks — command palettes,
- *  modal close, sidebar keyboard navigation — must skip such candidates
- *  rather than stealing focus back from e.g. the native chat composer. */
-export function isInsideFocusOwnedPane(element: Element): boolean {
-  const pane = element.closest('.pane') as HTMLElement | null
-  return pane !== null && paneContainerOwnsFocus(pane)
 }

--- a/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-pointer-focus.ts
@@ -1,3 +1,5 @@
+const PANE_PREVENT_TERMINAL_FOCUS_SELECTOR = '[data-pane-prevent-terminal-focus]'
+
 const APP_CONTROL_SELECTOR = [
   'input:not(.xterm-helper-textarea)',
   'textarea:not(.xterm-helper-textarea)',
@@ -7,7 +9,7 @@ const APP_CONTROL_SELECTOR = [
   '[contenteditable=""]',
   '[contenteditable="true"]',
   '[contenteditable="plaintext-only"]',
-  '[data-pane-prevent-terminal-focus]'
+  PANE_PREVENT_TERMINAL_FOCUS_SELECTOR
 ].join(',')
 
 export function shouldFocusTerminalFromPanePointerDown(target: EventTarget | null): boolean {
@@ -18,4 +20,12 @@ export function shouldFocusTerminalFromPanePointerDown(target: EventTarget | nul
   // Why: pane-local app controls (for example the title editor) are portaled
   // into the pane container; focusing xterm from their pointerdown blurs them.
   return target.closest(APP_CONTROL_SELECTOR) === null
+}
+
+/** Whether a pane's own app control (e.g. the native chat composer overlay)
+ *  currently claims focus ownership — imperative focus calls (tab switch,
+ *  visibility resume, setActivePane) must not steal it back onto the hidden
+ *  xterm underneath. */
+export function paneContainerOwnsFocus(container: HTMLElement): boolean {
+  return container.querySelector(PANE_PREVENT_TERMINAL_FOCUS_SELECTOR) !== null
 }

--- a/src/renderer/src/lib/pane-manager/pane-split-close.ts
+++ b/src/renderer/src/lib/pane-manager/pane-split-close.ts
@@ -16,6 +16,7 @@ import {
 } from './pane-tree-ops'
 import { applyDividerStyles, applyPaneOpacity } from './pane-divider'
 import { disposePane, openTerminal } from './pane-lifecycle'
+import { focusPaneSurface } from './pane-surface-focus'
 import { disposeWebgl } from './pane-webgl-renderer'
 import { clearPendingSplitScrollRestore, scheduleSplitScrollRestore } from './pane-split-scroll'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
@@ -240,6 +241,9 @@ function activateReplacementPane(args: CloseManagedPaneArgs): number | null {
   const next = args.panes.values().next().value as ManagedPaneInternal | undefined
   const nextActivePaneId = next?.id ?? null
   args.setActivePaneId(nextActivePaneId)
-  next?.terminal.focus()
+  if (next) {
+    // Why: the surviving pane can be chat-owned; its composer gets the focus.
+    focusPaneSurface(next.container, () => next.terminal.focus())
+  }
   return nextActivePaneId
 }

--- a/src/renderer/src/lib/pane-manager/pane-surface-focus.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-surface-focus.test.ts
@@ -1,0 +1,124 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  focusPaneSurface,
+  resolvePaneSurfaceFocusTarget,
+  resolveVisibleTerminalSurfaceTarget
+} from './pane-surface-focus'
+
+afterEach(() => {
+  document.body.innerHTML = ''
+})
+
+function buildPane(args: { chatOwner?: boolean; composerDisabled?: boolean; hidden?: boolean }): {
+  pane: HTMLElement
+  helper: HTMLElement
+  composer: HTMLElement | null
+  root: HTMLElement | null
+} {
+  const pane = document.createElement('div')
+  pane.className = 'pane'
+  if (args.hidden) {
+    pane.style.display = 'none'
+  }
+  const xtermContainer = document.createElement('div')
+  xtermContainer.className = 'xterm-container'
+  const helper = document.createElement('textarea')
+  helper.className = 'xterm-helper-textarea'
+  xtermContainer.append(helper)
+  pane.append(xtermContainer)
+  let composer: HTMLElement | null = null
+  let root: HTMLElement | null = null
+  if (args.chatOwner) {
+    root = document.createElement('div')
+    root.setAttribute('data-native-chat-root', 'true')
+    root.setAttribute('data-pane-prevent-terminal-focus', 'true')
+    root.tabIndex = -1
+    const composerTextarea = document.createElement('textarea')
+    composerTextarea.setAttribute('data-native-chat-composer-input', 'true')
+    if (args.composerDisabled) {
+      composerTextarea.setAttribute('disabled', '')
+    }
+    root.append(composerTextarea)
+    pane.append(root)
+    composer = composerTextarea
+  }
+  document.body.append(pane)
+  return { pane, helper, composer, root }
+}
+
+describe('focusPaneSurface', () => {
+  it('focuses the terminal for a plain terminal pane', () => {
+    const { pane } = buildPane({})
+    const focusTerminal = vi.fn()
+
+    focusPaneSurface(pane, focusTerminal)
+
+    expect(focusTerminal).toHaveBeenCalled()
+  })
+
+  it('focuses the composer input for a chat-owned pane', () => {
+    const { pane, composer } = buildPane({ chatOwner: true })
+    const focusTerminal = vi.fn()
+
+    focusPaneSurface(pane, focusTerminal)
+
+    expect(document.activeElement).toBe(composer)
+    expect(focusTerminal).not.toHaveBeenCalled()
+  })
+
+  it('falls back to the chat root while the composer is disabled', () => {
+    const { pane, root } = buildPane({ chatOwner: true, composerDisabled: true })
+    const focusTerminal = vi.fn()
+
+    focusPaneSurface(pane, focusTerminal)
+
+    expect(document.activeElement).toBe(root)
+    expect(focusTerminal).not.toHaveBeenCalled()
+  })
+})
+
+describe('resolvePaneSurfaceFocusTarget', () => {
+  it('returns null for a plain terminal pane', () => {
+    const { pane } = buildPane({})
+
+    expect(resolvePaneSurfaceFocusTarget(pane)).toBeNull()
+  })
+
+  it('returns the composer input for a chat-owned pane', () => {
+    const { pane, composer } = buildPane({ chatOwner: true })
+
+    expect(resolvePaneSurfaceFocusTarget(pane)).toBe(composer)
+  })
+})
+
+describe('resolveVisibleTerminalSurfaceTarget', () => {
+  it('returns the first visible plain terminal helper', () => {
+    const hidden = buildPane({ hidden: true })
+    const visible = buildPane({})
+
+    expect(resolveVisibleTerminalSurfaceTarget(document)).toBe(visible.helper)
+    expect(resolveVisibleTerminalSurfaceTarget(document)).not.toBe(hidden.helper)
+  })
+
+  it('redirects a visible chat-owned pane to its composer', () => {
+    const chat = buildPane({ chatOwner: true })
+
+    expect(resolveVisibleTerminalSurfaceTarget(document)).toBe(chat.composer)
+  })
+
+  it('skips a hidden chat pane so it cannot mask the visible plain terminal', () => {
+    // Why: hidden tabs keep chat portals mounted; the old first-match veto
+    // either focused the hidden pane's xterm or gave up entirely.
+    buildPane({ chatOwner: true, hidden: true })
+    const visible = buildPane({})
+
+    expect(resolveVisibleTerminalSurfaceTarget(document)).toBe(visible.helper)
+  })
+
+  it('returns null when no terminal is visible', () => {
+    buildPane({ hidden: true })
+
+    expect(resolveVisibleTerminalSurfaceTarget(document)).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-surface-focus.ts
+++ b/src/renderer/src/lib/pane-manager/pane-surface-focus.ts
@@ -1,0 +1,85 @@
+import { paneContainerOwnsFocus } from './pane-pointer-focus'
+
+/** Pane container class assigned in pane-dom-creation.ts. */
+export const PANE_CONTAINER_SELECTOR = '.pane'
+
+const FOCUS_OWNER_SELECTOR = '[data-pane-prevent-terminal-focus]'
+const COMPOSER_INPUT_SELECTOR = '[data-native-chat-composer-input="true"]:not([disabled])'
+const TERMINAL_HELPER_SELECTOR = '.xterm-helper-textarea'
+
+/**
+ * Focus whatever surface owns keyboard input for a pane. A pane hosting a
+ * focus-owning app control (the native chat composer overlay) gets that
+ * control focused; a plain terminal pane gets the caller-supplied terminal
+ * focus. Every imperative "give this pane keyboard focus" path should route
+ * here so chat panes receive the composer instead of the hidden xterm — and
+ * instead of nothing, which is what a veto-only guard would leave behind.
+ */
+export function focusPaneSurface(container: HTMLElement, focusTerminal: () => void): void {
+  const target = resolvePaneSurfaceFocusTarget(container)
+  if (!target) {
+    focusTerminal()
+    return
+  }
+  target.focus()
+}
+
+/** The element to focus when this pane's app control owns focus, or null for
+ *  a plain terminal pane (caller focuses xterm). With the composer unmounted
+ *  or disabled (pty still binding, question card active), the chat root
+ *  (tabIndex=-1) is the safe neutral — typing redirect still routes keys
+ *  once the composer returns. */
+export function resolvePaneSurfaceFocusTarget(container: HTMLElement): HTMLElement | null {
+  if (!paneContainerOwnsFocus(container)) {
+    return null
+  }
+  const owner = focusableElement(container.querySelector(FOCUS_OWNER_SELECTOR))
+  if (!owner) {
+    return null
+  }
+  return focusableElement(owner.querySelector(COMPOSER_INPUT_SELECTOR)) ?? owner
+}
+
+/**
+ * Document-wide fallback target for "focus some reasonable terminal surface"
+ * paths (palette close, modal return focus, sidebar Enter). Picks the first
+ * VISIBLE xterm helper — hidden tabs keep panes (and chat portals) mounted,
+ * so an unscoped first-match can land on a background pane — then redirects
+ * to the pane's focus owner when one is mounted.
+ */
+export function resolveVisibleTerminalSurfaceTarget(doc: Document = document): HTMLElement | null {
+  for (const candidate of Array.from(doc.querySelectorAll(TERMINAL_HELPER_SELECTOR))) {
+    const helper = focusableElement(candidate)
+    if (!helper || !isDisplayed(helper)) {
+      continue
+    }
+    const pane = helper.closest(PANE_CONTAINER_SELECTOR) as HTMLElement | null
+    const owned = pane ? resolvePaneSurfaceFocusTarget(pane) : null
+    return owned ?? helper
+  }
+  return null
+}
+
+// Why: duck-typed instead of `instanceof HTMLElement` so node-environment
+// tests with fake elements don't hit a missing DOM global.
+function focusableElement(value: Element | null): HTMLElement | null {
+  if (value && typeof (value as HTMLElement).focus === 'function') {
+    return value as HTMLElement
+  }
+  return null
+}
+
+function isDisplayed(element: HTMLElement): boolean {
+  const view = element.ownerDocument.defaultView
+  if (!view) {
+    return true
+  }
+  let node: HTMLElement | null = element
+  while (node) {
+    if (view.getComputedStyle(node).display === 'none') {
+      return false
+    }
+    node = node.parentElement
+  }
+  return true
+}


### PR DESCRIPTION
## Motivation

The ask was simple: when a native-chat session opens — or when you switch to an existing chat tab — the "Send a message…" composer should already be focused so you can just start typing. On paper this is one `autoFocus` attribute.

In practice it turned out to be much more involved, and the diff size reflects the real reason: **the composer is the first non-xterm element that wants to own keyboard focus inside a terminal pane, and the codebase had ~10 independent code paths that imperatively grab focus for the xterm** — pane activation, visibility resume, window-wake recovery, the tab-switch reclaim, Cmd+J palette restore, modal return-focus, the sidebar's Enter key, the pane context menu, expand/collapse, pane keyboard shortcuts, and split-close. Several of them run on delayed timers (double-rAF, retry loops) specifically to win focus races against React mounting, and several use unscoped `document.querySelector('.xterm-helper-textarea')`. A naive `autoFocus` (or a one-off `focus()` call) gets silently overwritten milliseconds later by whichever of these fires next — which is exactly what happened in testing, three separate times, each fix surfacing the next stealer.

Two additional wrinkles made it harder than "focus on mount":
- On a brand-new session the composer is **disabled until the PTY binds**, so focus must be deferred and retried at the right moment — but only once, so an unrelated enable-flip minutes later (e.g. a mobile presence-lock releasing) can't yank focus.
- Focus must be **polite**: never stolen from a rename field, a dialog, or anything else the user is actually typing in — while still recognizing this same pane's hidden xterm as fair game.

So the end state is not "added autofocus" but "gave panes a notion of which surface owns their keyboard focus". That's the honest cost of the feature; the upside is that the next pane-hosted input surface gets this for ~free.

## Summary
- Autofocus the native chat composer when a new chat session opens and when switching back to a chat tab/pane (click, Cmd+Shift+[/] cycle, palette, sidebar), so the user can type immediately.
- **Focus routing is centralized in `pane-surface-focus.ts`**: `focusPaneSurface(container, focusTerminal)` focuses whatever surface owns a pane's keyboard input — the chat composer (marked `data-pane-prevent-terminal-focus` / `data-native-chat-composer-input`) or the xterm terminal. All imperative "give this pane focus" paths route through it: `PaneManager.setActivePane`, `focusActivePane` (visibility resume/wake), `focusTerminalTabSurface` (tab switch/modal/IPC), Cmd+J palette restore, modal-return-focus fallback, sidebar Enter, context-menu refocus callbacks, expand/collapse, pane keyboard shortcuts, and split-close survivor focus.
- Document-wide fallbacks use `resolveVisibleTerminalSurfaceTarget`, which skips hidden panes (background tabs keep chat portals mounted) and redirects chat-owned panes to their composer — fixing both "focus lands on a hidden pane" and "focus lands nowhere".
- The composer autofocus itself (`useNativeChatComposerAutofocus`) is a **one-shot activation intent**: arming on surface activation, deferred until the pty binds / question card closes (double-rAF paint boundary for the IPC tab-cycle blur race), consumed on first attempt so async enable flips (mobile presence-lock release) can't steal focus later. Politeness check reuses `shouldFocusMobileDriverAction`.
- **Plain terminal panes are unaffected**: without the focus-owner marker, every path focuses xterm exactly as before.

## Review process
Implementation was reviewed twice (self-review + an xhigh-effort Codex review); the initial per-call-site veto approach was replaced with this centralized redirect per both reviews' findings (missed call sites in the chat context menu; vetoes leaving focus nowhere; hidden-pane stranding; late-steal window).

## Commits
1. `feat`: autofocus composer on new session and tab switch (prop threading + hook + politeness gate)
2. `fix`: stop the tab-switch focus reclaim (`focus-terminal-tab-surface`) from stealing the composer
3. `fix`: stop remaining global xterm-focus reclaims (Cmd+J palette, modal return-focus, sidebar Enter) from stealing the composer
4. `fix`: wait a paint before the autofocus focus check (Cmd+Shift+[/] IPC tab-cycle blur race)
5. `refactor`: centralize pane focus routing in `focusPaneSurface` (redirect instead of veto; covers chat context menu, expand/collapse, pane shortcuts, split close; one-shot autofocus intent)

## Test plan
- [x] Unit tests for `pane-surface-focus`, autofocus one-shot semantics, palette/modal/tab-surface redirects (7,163 tests across the touched renderer suites: native-chat, terminal-pane, pane-manager, cmd-j, hooks, sidebar)
- [x] oxlint / typecheck:web / max-lines ratchet clean
- [x] Live-verified on the dev build via CDP: chat tab switch → composer focused; `focusTerminalTabSurface` on chat tab → composer (not nowhere); visible-surface fallback → composer; markerless pane → xterm unchanged
- [ ] Manual retest: new session, tab switching (click + Cmd+Shift+[/]), splits, chat context menu, Cmd+J close