### PR TITLE
Allow quick commands to open in background tabs

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1601,7 +1601,8 @@ describe('OrcaRuntimeService', () => {
         action: 'agent-prompt' as const,
         agent: 'codex' as const,
         prompt: 'Review this diff',
-        scope: { type: 'global' as const }
+        scope: { type: 'global' as const },
+        openInBackground: true
       }
     ]
     const runtime = new OrcaRuntimeService({
@@ -1623,7 +1624,16 @@ describe('OrcaRuntimeService', () => {
       minimaxUsageModels: 'general,abab6.5'
     })
     expect(runtime.getClientSettings()).not.toHaveProperty('terminalQuickCommands')
-    expect(runtime.getClientTerminalQuickCommands()).toEqual(terminalQuickCommands)
+    expect(runtime.getClientTerminalQuickCommands()).toEqual([
+      {
+        id: 'review',
+        label: 'Review',
+        action: 'agent-prompt',
+        agent: 'codex',
+        prompt: 'Review this diff',
+        scope: { type: 'global' }
+      }
+    ])
   })
 
   it('updates quick commands without widening general paired settings payloads', () => {
@@ -1660,6 +1670,37 @@ describe('OrcaRuntimeService', () => {
       { notifyListeners: true }
     )
     expect(runtime.getClientSettings()).not.toHaveProperty('terminalQuickCommands')
+  })
+
+  it('preserves desktop background presentation across paired-client edits', () => {
+    const existing = {
+      id: 'status',
+      label: 'Status',
+      action: 'terminal-command' as const,
+      command: 'git status',
+      appendEnter: true,
+      scope: { type: 'global' as const },
+      openInBackground: true
+    }
+    let settings = { ...store.getSettings(), terminalQuickCommands: [existing] }
+    const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
+      settings = { ...settings, ...updates }
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => settings,
+      updateSettings
+    } as never)
+
+    runtime.updateClientTerminalQuickCommands({
+      type: 'upsert',
+      command: { ...existing, label: 'Edited', openInBackground: undefined }
+    })
+
+    expect(settings.terminalQuickCommands).toEqual([
+      { ...existing, label: 'Edited', openInBackground: true }
+    ])
+    expect(runtime.getClientTerminalQuickCommands()[0]).not.toHaveProperty('openInBackground')
   })
 
   it('rejects a concurrent add after the quick command limit is reached', () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -3621,7 +3621,11 @@ export class OrcaRuntimeService {
     if (!this.store?.getSettings) {
       throw new Error('runtime_unavailable')
     }
-    return this.store.getSettings().terminalQuickCommands ?? []
+    return (this.store.getSettings().terminalQuickCommands ?? []).map((command) => {
+      // Why: mobile clients predate desktop presentation fields and reject extra canonical keys.
+      const { openInBackground: _openInBackground, ...clientCommand } = command
+      return clientCommand
+    })
   }
 
   updateClientTerminalQuickCommands(
@@ -3630,7 +3634,7 @@ export class OrcaRuntimeService {
     if (!this.store?.getSettings || !this.store.updateSettings) {
       throw new Error('runtime_unavailable')
     }
-    const current = this.getClientTerminalQuickCommands()
+    const current = this.store.getSettings().terminalQuickCommands ?? []
     if (
       mutation.type === 'upsert' &&
       !current.some((command) => command.id === mutation.command.id) &&
@@ -10749,10 +10753,7 @@ export class OrcaRuntimeService {
     // A spawn published (or admission pending) this generation already
     // attaches the provider stream; a replacement under a reused id must not
     // read as the discovered never-attached session it replaced.
-    if (
-      this.spawnPublishedPtys.has(ptyId) ||
-      this.pendingPtyRegistrationIncarnations.has(ptyId)
-    ) {
+    if (this.spawnPublishedPtys.has(ptyId) || this.pendingPtyRegistrationIncarnations.has(ptyId)) {
       return false
     }
     // SSH panes have their own lease/reattach machinery.

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAdvancedSection.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandAdvancedSection.tsx
@@ -7,6 +7,7 @@ import { Button } from '@/components/ui/button'
 import { cn } from '@/lib/utils'
 import { translate } from '@/i18n/i18n'
 import { TerminalQuickCommandAppendEnterSwitch } from './TerminalQuickCommandAppendEnterSwitch'
+import { TerminalQuickCommandBackgroundSwitch } from './TerminalQuickCommandBackgroundSwitch'
 import { TerminalQuickCommandScopeField } from './TerminalQuickCommandScopeField'
 
 type TerminalQuickCommandAdvancedSectionProps = {
@@ -20,6 +21,7 @@ type TerminalQuickCommandAdvancedSectionProps = {
   setAdvancedOpen: Dispatch<SetStateAction<boolean>>
   setDraft: Dispatch<SetStateAction<TerminalQuickCommand>>
   toggleAppendEnter: () => void
+  toggleOpenInBackground: () => void
 }
 
 export function TerminalQuickCommandAdvancedSection({
@@ -32,7 +34,8 @@ export function TerminalQuickCommandAdvancedSection({
   lastRepoScopeIdRef,
   setAdvancedOpen,
   setDraft,
-  toggleAppendEnter
+  toggleAppendEnter,
+  toggleOpenInBackground
 }: TerminalQuickCommandAdvancedSectionProps): React.JSX.Element {
   return (
     <div>
@@ -66,6 +69,10 @@ export function TerminalQuickCommandAdvancedSection({
                 : '-translate-y-1 opacity-0 delay-0'
             )}
           >
+            <TerminalQuickCommandBackgroundSwitch
+              openInBackground={draft.openInBackground === true}
+              onToggle={toggleOpenInBackground}
+            />
             {!isTerminalAgentQuickCommand(draft) ? (
               <TerminalQuickCommandAppendEnterSwitch
                 appendEnter={draft.appendEnter}

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandBackgroundSwitch.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandBackgroundSwitch.tsx
@@ -1,0 +1,49 @@
+import { translate } from '@/i18n/i18n'
+
+type TerminalQuickCommandBackgroundSwitchProps = {
+  openInBackground: boolean
+  onToggle: () => void
+}
+
+export function TerminalQuickCommandBackgroundSwitch({
+  openInBackground,
+  onToggle
+}: TerminalQuickCommandBackgroundSwitchProps): React.JSX.Element {
+  return (
+    <div className="flex items-start justify-between gap-4">
+      <div className="space-y-0.5">
+        <div className="text-sm font-medium">
+          {translate(
+            'auto.components.terminal.quick.commands.TerminalQuickCommandBackgroundSwitch.cf0b237949',
+            'Open in background'
+          )}
+        </div>
+        <div className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.terminal.quick.commands.TerminalQuickCommandBackgroundSwitch.6f8f01b606',
+            'Run in a new terminal without switching to it.'
+          )}
+        </div>
+      </div>
+      <button
+        type="button"
+        role="switch"
+        aria-checked={openInBackground}
+        aria-label={translate(
+          'auto.components.terminal.quick.commands.TerminalQuickCommandBackgroundSwitch.bbcfd77bb5',
+          'Toggle open in background'
+        )}
+        onClick={onToggle}
+        className={`relative inline-flex h-5 w-9 shrink-0 cursor-pointer items-center rounded-full border border-transparent transition-colors ${
+          openInBackground ? 'bg-foreground' : 'bg-muted-foreground/30'
+        }`}
+      >
+        <span
+          className={`pointer-events-none block size-3.5 rounded-full bg-background shadow-sm transition-transform ${
+            openInBackground ? 'translate-x-4' : 'translate-x-0.5'
+          }`}
+        />
+      </button>
+    </div>
+  )
+}

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.test.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.test.tsx
@@ -6,9 +6,14 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { TerminalQuickCommand } from '../../../../shared/types'
 import { TerminalQuickCommandDialog } from './TerminalQuickCommandDialog'
 
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
 const mountedRoots: Root[] = []
 
-async function renderDialog(command: TerminalQuickCommand): Promise<void> {
+async function renderDialog(
+  command: TerminalQuickCommand,
+  onSave = vi.fn()
+): Promise<{ onSave: ReturnType<typeof vi.fn> }> {
   const container = document.createElement('div')
   document.body.appendChild(container)
   const root = createRoot(container)
@@ -22,10 +27,11 @@ async function renderDialog(command: TerminalQuickCommand): Promise<void> {
         command={command}
         repos={[]}
         onOpenChange={vi.fn()}
-        onSave={vi.fn()}
+        onSave={onSave}
       />
     )
   })
+  return { onSave }
 }
 
 function findAnimatedRowContaining(text: string): HTMLElement {
@@ -66,5 +72,38 @@ describe('TerminalQuickCommandDialog animation structure', () => {
     expect(agentRow.className).toContain('grid-rows-[0fr]')
     expect(promptHelpRow.getAttribute('aria-hidden')).toBe('true')
     expect(promptHelpRow.className).toContain('grid-rows-[0fr]')
+  })
+
+  it('saves background presentation for agent prompt commands', async () => {
+    const { onSave } = await renderDialog({
+      id: 'qc-1',
+      label: 'Review',
+      action: 'agent-prompt',
+      agent: 'codex',
+      prompt: 'Review this diff',
+      scope: { type: 'global' }
+    })
+    const advanced = Array.from(document.body.querySelectorAll('button')).find(
+      (button) => button.textContent?.trim() === 'Advanced'
+    )
+    const background = document.body.querySelector<HTMLButtonElement>(
+      'button[aria-label="Toggle open in background"]'
+    )
+    const save = document.body.querySelector<HTMLButtonElement>('button[title^="Save ("]')
+
+    expect(advanced).toBeTruthy()
+    expect(background).toBeTruthy()
+    expect(save).toBeTruthy()
+    await act(async () => {
+      advanced!.click()
+      background!.click()
+    })
+    await act(async () => {
+      save!.click()
+    })
+
+    expect(onSave).toHaveBeenCalledWith(
+      expect.objectContaining({ openInBackground: true, action: 'agent-prompt' })
+    )
   })
 })

--- a/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
+++ b/src/renderer/src/components/terminal-quick-commands/TerminalQuickCommandDialog.tsx
@@ -125,6 +125,13 @@ export function TerminalQuickCommandDialog({
     )
   }
 
+  const toggleOpenInBackground = (): void => {
+    setDraft((current) => ({
+      ...current,
+      ...(current.openInBackground ? { openInBackground: undefined } : { openInBackground: true })
+    }))
+  }
+
   const saveDraft = (): void => {
     const next: TerminalQuickCommand = isTerminalAgentQuickCommand(draft)
       ? {
@@ -133,7 +140,8 @@ export function TerminalQuickCommandDialog({
           action: 'agent-prompt',
           agent: draft.agent,
           prompt: draft.prompt.trimEnd(),
-          scope: selectedScope
+          scope: selectedScope,
+          ...(draft.openInBackground ? { openInBackground: true } : {})
         }
       : {
           id: draft.id,
@@ -141,7 +149,8 @@ export function TerminalQuickCommandDialog({
           action: 'terminal-command',
           command: draft.command.trimEnd(),
           appendEnter: draft.appendEnter,
-          scope: selectedScope
+          scope: selectedScope,
+          ...(draft.openInBackground ? { openInBackground: true } : {})
         }
     if (
       !next.label ||
@@ -228,6 +237,7 @@ export function TerminalQuickCommandDialog({
             setAdvancedOpen={setAdvancedOpen}
             setDraft={setDraft}
             toggleAppendEnter={toggleAppendEnter}
+            toggleOpenInBackground={toggleOpenInBackground}
           />
         </div>
 

--- a/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.test.ts
@@ -115,6 +115,32 @@ describe('terminal quick command dialog draft transitions', () => {
       appendEnter: true
     })
   })
+
+  it('preserves background presentation across action changes', () => {
+    const command: TerminalQuickCommand = {
+      id: 'qc-1',
+      label: 'Background work',
+      action: 'terminal-command',
+      command: 'pnpm test',
+      appendEnter: true,
+      scope: { type: 'global' },
+      openInBackground: true
+    }
+
+    const toAgent = switchTerminalQuickCommandDialogAction(
+      command,
+      'agent-prompt',
+      createTerminalQuickCommandDialogDraftMemory(command, 'codex')
+    )
+    const backToTerminal = switchTerminalQuickCommandDialogAction(
+      toAgent.draft,
+      'terminal-command',
+      toAgent.memory
+    )
+
+    expect(toAgent.draft.openInBackground).toBe(true)
+    expect(backToTerminal.draft.openInBackground).toBe(true)
+  })
 })
 
 describe('terminal quick command dialog scope transitions', () => {

--- a/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.ts
+++ b/src/renderer/src/components/terminal-quick-commands/terminal-quick-command-dialog-draft.ts
@@ -63,7 +63,8 @@ export function switchTerminalQuickCommandDialogAction(
   const base = {
     id: draft.id,
     label: draft.label,
-    scope: getTerminalQuickCommandScope(draft)
+    scope: getTerminalQuickCommandScope(draft),
+    ...(draft.openInBackground ? { openInBackground: true } : {})
   }
 
   // Why: action modes are independent editors; toggling should not transform

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2700,6 +2700,11 @@
               "c936c2d6d2": "Submit immediately instead of only inserting text.",
               "5fa607d807": "Append Enter"
             },
+            "TerminalQuickCommandBackgroundSwitch": {
+              "bbcfd77bb5": "Toggle open in background",
+              "6f8f01b606": "Run in a new terminal without switching to it.",
+              "cf0b237949": "Open in background"
+            },
             "TerminalQuickCommandDialog": {
               "925b8e0f6e": "Advanced",
               "97e96cc027": "/goal",

--- a/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab-web-runtime.test.ts
@@ -135,4 +135,21 @@ describe('launchAgentInNewTab paired web runtime', () => {
     })
     expect(mocks.createTab).not.toHaveBeenCalled()
   })
+
+  it('creates paired agent terminals without selecting them when activation is disabled', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'claude',
+      worktreeId: 'wt-1',
+      groupId: 'group-1',
+      activate: false
+    })
+
+    expect(mocks.createWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ activate: false })
+    )
+    await Promise.resolve()
+    expect(mocks.setActiveTabType).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -353,6 +353,22 @@ describe('launchAgentInNewTab', () => {
     })
   })
 
+  it('creates inactive local agent tabs without changing the active view', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+
+    launchAgentInNewTab({
+      agent: 'codex',
+      worktreeId: 'wt-1',
+      activate: false
+    })
+
+    expect(mockCreateTab).toHaveBeenCalledWith('wt-1', undefined, undefined, {
+      launchAgent: 'codex',
+      activate: false
+    })
+    expect(mockSetActiveTabType).not.toHaveBeenCalled()
+  })
+
   it('preserves paired-host draft delivery and supported launch preferences', async () => {
     mockIsWebRuntimeSessionActive.mockReturnValue(true)
     store.settings = {

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -35,6 +35,8 @@ export type LaunchAgentInNewTabArgs = {
   worktreeId: string
   /** Tab group the user launched from; keeps split-group launches in that pane instead of the active group. */
   groupId?: string
+  /** Whether the new terminal becomes the active tab. */
+  activate?: boolean
   /** Optional initial prompt; delivery depends on `promptDelivery` and the agent's prompt mode. */
   prompt?: string
   /** Optional CLI arguments appended to the selected agent command. */
@@ -74,6 +76,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     agent,
     worktreeId,
     groupId,
+    activate = true,
     prompt,
     agentArgs,
     initialCwd,
@@ -154,6 +157,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       worktreeId,
       environmentId: runtimeEnvironmentId,
       groupId,
+      activate,
       cwd: initialCwd,
       startupPlan,
       prompt: trimmedPrompt,
@@ -181,6 +185,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   const tab = store.createTab(worktreeId, groupId, undefined, {
     launchAgent: agent,
     quickCommandLabel,
+    ...(!activate ? { activate: false } : {}),
     ...initialViewModeProps
   })
   seedNativeChatAppliedSessionOptions(tab.id, agent, startupPlan.sessionOptions)
@@ -251,7 +256,9 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
   }
 
   // Why: without setActiveTabType('terminal') a worktree showing an editor keeps rendering it and the new tab stays hidden.
-  store.setActiveTabType('terminal')
+  if (activate) {
+    store.setActiveTabType('terminal')
+  }
 
   // Why: persist tab-bar order so reconcileTabOrder doesn't fall back to terminals-first and jump the new tab to index 0.
   const fresh = useAppStore.getState()

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -36,6 +36,7 @@ export function launchAgentInWebHostTab(args: {
   worktreeId: string
   environmentId: string | null
   groupId?: string
+  activate?: boolean
   cwd?: string | null
   startupPlan: AgentStartupPlan
   prompt: string
@@ -51,6 +52,7 @@ export function launchAgentInWebHostTab(args: {
     worktreeId,
     environmentId,
     groupId,
+    activate = true,
     cwd,
     startupPlan,
     prompt,
@@ -70,7 +72,7 @@ export function launchAgentInWebHostTab(args: {
     worktreeId,
     environmentId,
     targetGroupId: groupId,
-    activate: true,
+    activate,
     ...(cwd?.trim() ? { cwd } : {}),
     ...(viewMode ? { viewMode } : {}),
     agentSessionKind: 'fresh',
@@ -114,7 +116,9 @@ export function launchAgentInWebHostTab(args: {
       )
       return { delivered: false, failureNotified: true }
     }
-    useAppStore.getState().setActiveTabType('terminal')
+    if (activate) {
+      useAppStore.getState().setActiveTabType('terminal')
+    }
     if (hasPrompt && promptDelivered) {
       onPromptDelivered?.()
     }

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.test.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.test.ts
@@ -19,7 +19,8 @@ type MockStoreState = {
 }
 
 const mocks = vi.hoisted(() => ({
-  launchAgentInNewTab: vi.fn()
+  launchAgentInNewTab: vi.fn(),
+  requestBackgroundTerminalWorktreeMount: vi.fn()
 }))
 
 let mockState: MockStoreState
@@ -32,6 +33,10 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/lib/launch-agent-in-new-tab', () => ({
   launchAgentInNewTab: mocks.launchAgentInNewTab
+}))
+
+vi.mock('@/components/terminal/background-terminal-worktree-mount', () => ({
+  requestBackgroundTerminalWorktreeMount: mocks.requestBackgroundTerminalWorktreeMount
 }))
 
 function createStoreState(): MockStoreState {
@@ -56,6 +61,7 @@ describe('runQuickCommandInNewTab', () => {
   beforeEach(() => {
     mockState = createStoreState()
     mocks.launchAgentInNewTab.mockReset()
+    mocks.requestBackgroundTerminalWorktreeMount.mockReset()
   })
 
   it('flattens multiline quick commands before queuing', () => {
@@ -97,6 +103,31 @@ describe('runQuickCommandInNewTab', () => {
     expect(mockState.queueTabStartupCommand).toHaveBeenCalledWith('tab-new', {
       command: 'git status'
     })
+  })
+
+  it('runs terminal commands in a mounted background tab without changing the active view', () => {
+    runQuickCommandInNewTab({
+      command: {
+        id: 'test',
+        label: 'Test',
+        action: 'terminal-command',
+        command: 'pnpm test',
+        appendEnter: true,
+        openInBackground: true
+      },
+      worktreeId: 'wt-1',
+      groupId: 'group-1'
+    })
+
+    expect(mockState.createTab).toHaveBeenCalledWith('wt-1', 'group-1', undefined, {
+      quickCommandLabel: 'Test',
+      activate: false
+    })
+    expect(mocks.requestBackgroundTerminalWorktreeMount).toHaveBeenCalledWith({
+      worktreeId: 'wt-1',
+      tabIds: ['tab-new']
+    })
+    expect(mockState.setActiveTabType).not.toHaveBeenCalled()
   })
 
   it('launches agent quick commands through the programmatic agent prompt path', () => {
@@ -159,6 +190,40 @@ describe('runQuickCommandInNewTab', () => {
       'active-group',
       'agent-review'
     )
+  })
+
+  it('runs agent prompts in a mounted background tab without activating it', () => {
+    mocks.launchAgentInNewTab.mockReturnValue({ tabId: 'tab-agent' })
+    mockState.unifiedTabsByWorktree['repo::worktree'] = [
+      { entityId: 'tab-agent', contentType: 'terminal', groupId: 'group-1' }
+    ]
+
+    runQuickCommandInNewTab({
+      command: {
+        id: 'agent-review',
+        label: 'Review',
+        action: 'agent-prompt',
+        agent: 'codex',
+        prompt: 'Review this diff',
+        openInBackground: true
+      },
+      worktreeId: 'repo::worktree',
+      groupId: 'group-1'
+    })
+
+    expect(mocks.launchAgentInNewTab).toHaveBeenCalledWith({
+      agent: 'codex',
+      prompt: 'Review this diff',
+      worktreeId: 'repo::worktree',
+      groupId: 'group-1',
+      activate: false,
+      launchSource: 'quick_command',
+      quickCommandLabel: 'Review'
+    })
+    expect(mocks.requestBackgroundTerminalWorktreeMount).toHaveBeenCalledWith({
+      worktreeId: 'repo::worktree',
+      tabIds: ['tab-agent']
+    })
   })
 
   it('does not launch post-start-only agent quick commands', () => {

--- a/src/renderer/src/lib/run-quick-command-in-new-tab.ts
+++ b/src/renderer/src/lib/run-quick-command-in-new-tab.ts
@@ -1,9 +1,11 @@
 import { useAppStore } from '@/store'
+import { requestBackgroundTerminalWorktreeMount } from '@/components/terminal/background-terminal-worktree-mount'
 import { reconcileTabOrder } from '@/components/tab-bar/reconcile-order'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import {
   flattenTerminalQuickCommand,
   isTerminalAgentQuickCommand,
+  shouldOpenTerminalQuickCommandInBackground,
   supportsTerminalAgentQuickCommand
 } from '../../../shared/terminal-quick-commands'
 import type { TerminalQuickCommand } from '../../../shared/types'
@@ -50,6 +52,7 @@ export function runQuickCommandInNewTab({
   groupId
 }: RunQuickCommandInNewTabArgs): { tabId: string } | null {
   const targetGroupId = groupId ?? undefined
+  const openInBackground = shouldOpenTerminalQuickCommandInBackground(command)
   if (isTerminalAgentQuickCommand(command)) {
     if (!command.prompt.trim() || !supportsTerminalAgentQuickCommand(command.agent)) {
       return null
@@ -59,10 +62,14 @@ export function runQuickCommandInNewTab({
       prompt: command.prompt,
       worktreeId,
       groupId: targetGroupId,
+      ...(openInBackground ? { activate: false } : {}),
       launchSource: 'quick_command',
       quickCommandLabel: command.label
     })
     if (result?.tabId) {
+      if (openInBackground) {
+        requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [result.tabId] })
+      }
       const launchedGroupId = resolveQuickCommandGroupId(worktreeId, result.tabId, groupId)
       if (launchedGroupId) {
         useAppStore.getState().setRecentQuickCommandForGroup(launchedGroupId, command.id)
@@ -82,17 +89,23 @@ export function runQuickCommandInNewTab({
   }
   const store = useAppStore.getState()
   const tab = store.createTab(worktreeId, targetGroupId, undefined, {
-    quickCommandLabel: command.label
+    quickCommandLabel: command.label,
+    ...(openInBackground ? { activate: false } : {})
   })
 
   store.queueTabStartupCommand(tab.id, {
     command: flattenTerminalQuickCommand(command).command
   })
+  if (openInBackground) {
+    requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [tab.id] })
+  }
 
   // Why: match `+` button's createNewTerminalTab — without this, a worktree
   // currently showing an editor file keeps rendering the editor and the new
   // terminal tab stays invisible.
-  store.setActiveTabType('terminal')
+  if (!openInBackground) {
+    store.setActiveTabType('terminal')
+  }
 
   // Why: persist tab-bar order with the new terminal appended. Without this,
   // reconcileTabOrder falls back to terminals-first when the stored order is

--- a/src/shared/terminal-quick-commands.test.ts
+++ b/src/shared/terminal-quick-commands.test.ts
@@ -161,6 +161,28 @@ describe('terminal quick commands', () => {
     ])
   })
 
+  it('preserves only enabled background-tab presentation', () => {
+    expect(
+      normalizeTerminalQuickCommands([
+        {
+          id: 'background',
+          label: 'Background',
+          command: 'pnpm test',
+          openInBackground: true
+        },
+        {
+          id: 'foreground',
+          label: 'Foreground',
+          command: 'pnpm lint',
+          openInBackground: false
+        }
+      ])
+    ).toEqual([
+      expect.objectContaining({ id: 'background', openInBackground: true }),
+      expect.not.objectContaining({ openInBackground: expect.anything() })
+    ])
+  })
+
   it('keeps larger reusable agent prompts while bounding shell commands separately', () => {
     const largePrompt = 'Review this diff.\n'.repeat(320)
     const overLimitPrompt = 'x'.repeat(6001)
@@ -244,6 +266,26 @@ describe('terminal quick commands', () => {
     expect(
       applyTerminalQuickCommandMutation([first!, second!], { type: 'delete', id: first!.id })
     ).toEqual([second])
+  })
+
+  it('keeps desktop background presentation when an older client edits a command', () => {
+    const [background] = normalizeTerminalQuickCommands([
+      {
+        id: 'background',
+        label: 'Background',
+        command: 'pnpm test',
+        openInBackground: true
+      }
+    ])
+    const edited = { ...background!, label: 'Edited' }
+    delete edited.openInBackground
+
+    expect(
+      applyTerminalQuickCommandMutation([background!], {
+        type: 'upsert',
+        command: edited
+      })
+    ).toEqual([{ ...edited, openInBackground: true }])
   })
 
   it('matches global commands everywhere and repo commands only in their repo', () => {

--- a/src/shared/terminal-quick-commands.ts
+++ b/src/shared/terminal-quick-commands.ts
@@ -48,6 +48,10 @@ export function getTerminalQuickCommandScope(
   return normalizeTerminalQuickCommandScope(command.scope)
 }
 
+export function shouldOpenTerminalQuickCommandInBackground(command: TerminalQuickCommand): boolean {
+  return command.openInBackground === true
+}
+
 export function terminalQuickCommandMatchesRepo(
   command: TerminalQuickCommand,
   repoId: string | null
@@ -127,7 +131,8 @@ export function normalizeTerminalQuickCommands(input: unknown): TerminalQuickCom
     const base = {
       id,
       label: label.slice(0, MAX_QUICK_COMMAND_LABEL_LENGTH),
-      scope: normalizeTerminalQuickCommandScope(record.scope)
+      scope: normalizeTerminalQuickCommandScope(record.scope),
+      ...(record.openInBackground === true ? { openInBackground: true } : {})
     }
 
     if (action === 'agent-prompt') {
@@ -199,17 +204,35 @@ function isNormalizedTerminalQuickCommand(value: unknown, expected: TerminalQuic
   }
   if (isTerminalAgentQuickCommand(expected)) {
     return (
-      hasExactKeys(command, ['id', 'label', 'action', 'agent', 'prompt', 'scope']) &&
+      hasExactKeys(command, [
+        'id',
+        'label',
+        'action',
+        'agent',
+        'prompt',
+        'scope',
+        ...(expected.openInBackground ? ['openInBackground'] : [])
+      ]) &&
       command.action === 'agent-prompt' &&
       command.agent === expected.agent &&
-      command.prompt === expected.prompt
+      command.prompt === expected.prompt &&
+      command.openInBackground === expected.openInBackground
     )
   }
   return (
-    hasExactKeys(command, ['id', 'label', 'action', 'command', 'appendEnter', 'scope']) &&
+    hasExactKeys(command, [
+      'id',
+      'label',
+      'action',
+      'command',
+      'appendEnter',
+      'scope',
+      ...(expected.openInBackground ? ['openInBackground'] : [])
+    ]) &&
     command.action === 'terminal-command' &&
     command.command === expected.command &&
-    command.appendEnter === expected.appendEnter
+    command.appendEnter === expected.appendEnter &&
+    command.openInBackground === expected.openInBackground
   )
 }
 
@@ -244,7 +267,12 @@ export function applyTerminalQuickCommandMutation(
   if (existingIndex === -1) {
     return [...commands, mutation.command]
   }
-  return commands.map((command, index) => (index === existingIndex ? mutation.command : command))
+  const existing = commands[existingIndex]
+  const next =
+    existing.openInBackground && mutation.command.openInBackground === undefined
+      ? { ...mutation.command, openInBackground: true }
+      : mutation.command
+  return commands.map((command, index) => (index === existingIndex ? next : command))
 }
 
 export function buildTerminalQuickCommandInput(command: TerminalCommandQuickCommand): string {

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2676,6 +2676,8 @@ export type TerminalQuickCommandBase = {
   id: string
   label: string
   scope?: TerminalQuickCommandScope
+  /** Create the terminal without changing the active tab. */
+  openInBackground?: boolean
 }
 
 export type TerminalCommandQuickCommand = TerminalQuickCommandBase & {


### PR DESCRIPTION
## Summary

- Add an **Open in background** option to the advanced Quick Command editor for terminal commands and agent prompts.
- Create an inactive terminal tab while explicitly mounting hidden local terminals so the configured command actually starts without stealing focus.
- Support local, SSH, and paired-host launches while preserving compatibility with strict older mobile clients.

## Why

Quick Commands always activated their new terminal tab, interrupting the current task. This opt-in setting keeps the current tab focused while the command or agent prompt runs in a normal, visible terminal tab that remains available for later inspection.

## Validation

- `pnpm run typecheck`
- Targeted Vitest coverage for persistence, dialog editing, terminal commands, agent prompts, local launches, and paired-host launches
- `pnpm run check:code-quality:changed -- upstream/main`
- Localization catalog, extraction, and coverage checks
- Max-lines and reliability gates
- `pnpm run build:electron-vite`
- Full suite: 46,346 tests passed. Three unrelated current-main root-directory guard tests fail on macOS because the script uses Bash associative arrays unsupported by the system Bash 3.2. The two generated-CLI failures from the initial run pass after rebuilding the CLI.
