### PR TITLE
fix(ssh): contain reattach to existing panes, quarantine orphans

### DIFF
--- a/src/main/persistence-ssh-reattach-containment.test.ts
+++ b/src/main/persistence-ssh-reattach-containment.test.ts
@@ -3,6 +3,7 @@ import { mkdtempSync, rmSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { getDefaultWorkspaceSession } from '../shared/constants'
+import { LOCAL_EXECUTION_HOST_ID } from '../shared/execution-host'
 import type { TerminalTab, WorkspaceSessionState } from '../shared/types'
 
 const testState = { dir: '' }
@@ -152,7 +153,7 @@ describe('Store SSH reattach containment', () => {
     }
   })
 
-  it('resolves panes only from the requested SSH host partition', async () => {
+  it('resolves panes from the target partition and reports it', async () => {
     const store = await createStore()
     const binding = {
       targetId: 'target-1',
@@ -167,8 +168,57 @@ describe('Store SSH reattach containment', () => {
     expect(store.resolveExistingSshPtyBinding(binding)).toEqual({
       worktreeId: 'wt-1',
       tabId: 'tab-1',
-      leafId: LEAF_1
+      leafId: LEAF_1,
+      hostId: SSH_HOST_ID
     })
+  })
+
+  // Why: buildHostIdByWorktreeId collapses repo-only SSH ownership onto the local partition, so a
+  // pane the user still has open can be durable there while the target partition never saw it.
+  it('falls back to the local spill partition and binds back into it', async () => {
+    const store = await createStore()
+    const binding = {
+      targetId: 'target-1',
+      ptyId: APP_PTY_ID,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: LEAF_1
+    }
+    store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID))
+
+    const resolved = store.resolveExistingSshPtyBinding(binding)
+    expect(resolved).toEqual({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: LEAF_1,
+      hostId: LOCAL_EXECUTION_HOST_ID
+    })
+    expect(
+      store.persistPtyBinding(
+        { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, ptyId: 'pty-new' },
+        resolved?.hostId,
+        { mayCreate: false }
+      )
+    ).toBe('bound')
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId['tab-1'].ptyIdsByLeafId).toEqual({
+      [LEAF_1]: 'pty-new'
+    })
+  })
+
+  it('prefers the target partition when both partitions hold the pane', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID))
+    store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID), SSH_HOST_ID)
+
+    expect(
+      store.resolveExistingSshPtyBinding({
+        targetId: 'target-1',
+        ptyId: APP_PTY_ID,
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: LEAF_1
+      })?.hostId
+    ).toBe(SSH_HOST_ID)
   })
 
   it('resolves incomplete legacy leases only from a unique durable PTY binding', async () => {
@@ -182,9 +232,9 @@ describe('Store SSH reattach containment', () => {
         worktreeId: 'wt-1',
         tabId: 'tab-1'
       })
-    ).toEqual({ worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1 })
+    ).toEqual({ worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, hostId: SSH_HOST_ID })
     expect(store.resolveExistingSshPtyBinding({ targetId: 'target-1', ptyId: APP_PTY_ID })).toEqual(
-      { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1 }
+      { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, hostId: SSH_HOST_ID }
     )
 
     const ambiguous = sessionWithExistingPane(APP_PTY_ID)

--- a/src/main/persistence-ssh-reattach-containment.test.ts
+++ b/src/main/persistence-ssh-reattach-containment.test.ts
@@ -169,7 +169,8 @@ describe('Store SSH reattach containment', () => {
       worktreeId: 'wt-1',
       tabId: 'tab-1',
       leafId: LEAF_1,
-      hostId: SSH_HOST_ID
+      hostId: SSH_HOST_ID,
+      ptyId: APP_PTY_ID
     })
   })
 
@@ -191,7 +192,8 @@ describe('Store SSH reattach containment', () => {
       worktreeId: 'wt-1',
       tabId: 'tab-1',
       leafId: LEAF_1,
-      hostId: LOCAL_EXECUTION_HOST_ID
+      hostId: LOCAL_EXECUTION_HOST_ID,
+      ptyId: APP_PTY_ID
     })
     expect(
       store.persistPtyBinding(
@@ -221,6 +223,53 @@ describe('Store SSH reattach containment', () => {
     ).toBe(SSH_HOST_ID)
   })
 
+  it('refuses a complete lease when the pane is bound to a replacement PTY', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithExistingPane('ssh:target-1@@pty-new'), SSH_HOST_ID)
+
+    expect(
+      store.resolveExistingSshPtyBinding({
+        targetId: 'target-1',
+        ptyId: APP_PTY_ID,
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: LEAF_1
+      })
+    ).toBeNull()
+  })
+
+  it('refuses a stale single-leaf tab summary when the leaf binding is newer', async () => {
+    const store = await createStore()
+    const session = sessionWithExistingPane('ssh:target-1@@pty-new')
+    session.tabsByWorktree['wt-1'][0].ptyId = APP_PTY_ID
+    store.setWorkspaceSession(session, SSH_HOST_ID)
+
+    expect(
+      store.resolveExistingSshPtyBinding({
+        targetId: 'target-1',
+        ptyId: APP_PTY_ID,
+        worktreeId: 'wt-1',
+        tabId: 'tab-1'
+      })
+    ).toBeNull()
+  })
+
+  it('refuses conflicting copies of the same pane across host partitions', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID), SSH_HOST_ID)
+    store.setWorkspaceSession(sessionWithExistingPane('ssh:target-1@@pty-new'))
+
+    expect(
+      store.resolveExistingSshPtyBinding({
+        targetId: 'target-1',
+        ptyId: APP_PTY_ID,
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: LEAF_1
+      })
+    ).toBeNull()
+  })
+
   it('resolves incomplete legacy leases only from a unique durable PTY binding', async () => {
     const store = await createStore()
     store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID), SSH_HOST_ID)
@@ -232,9 +281,21 @@ describe('Store SSH reattach containment', () => {
         worktreeId: 'wt-1',
         tabId: 'tab-1'
       })
-    ).toEqual({ worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, hostId: SSH_HOST_ID })
+    ).toEqual({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: LEAF_1,
+      hostId: SSH_HOST_ID,
+      ptyId: APP_PTY_ID
+    })
     expect(store.resolveExistingSshPtyBinding({ targetId: 'target-1', ptyId: APP_PTY_ID })).toEqual(
-      { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, hostId: SSH_HOST_ID }
+      {
+        worktreeId: 'wt-1',
+        tabId: 'tab-1',
+        leafId: LEAF_1,
+        hostId: SSH_HOST_ID,
+        ptyId: APP_PTY_ID
+      }
     )
 
     const ambiguous = sessionWithExistingPane(APP_PTY_ID)
@@ -283,6 +344,34 @@ describe('Store SSH reattach containment', () => {
     expect(flush).toHaveBeenCalledOnce()
   })
 
+  it('compare-and-set refuses a pane that was replaced during reattach', async () => {
+    const store = await createStore()
+    const session = sessionWithExistingPane('pty-new')
+    session.terminalPtyIncarnationsByPaneKey = { [`tab-1:${LEAF_1}`]: 'incarnation-new' }
+    store.setWorkspaceSession(session)
+    const before = structuredClone(store.getWorkspaceSession())
+    const flush = vi.spyOn(store, 'flushOrThrow')
+
+    expect(
+      store.persistPtyBinding(
+        {
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          leafId: LEAF_1,
+          ptyId: 'pty-old',
+          incarnationId: 'incarnation-reattached'
+        },
+        undefined,
+        {
+          mayCreate: false,
+          expectedBinding: { ptyId: 'pty-old', incarnationId: 'incarnation-old' }
+        }
+      )
+    ).toBe('refused')
+    expect(store.getWorkspaceSession()).toEqual(before)
+    expect(flush).not.toHaveBeenCalled()
+  })
+
   it('rolls back an existing-only bind when its durable flush fails', async () => {
     const store = await createStore()
     store.setWorkspaceSession(sessionWithExistingPane())
@@ -307,7 +396,7 @@ describe('Store SSH reattach containment', () => {
     expect(store.getWorkspaceSession()).toEqual(before)
   })
 
-  it('collapses duplicate panes deterministically and persists the terminal losers', async () => {
+  it('leaves pane duplicates active until durable binding can arbitrate reattach', async () => {
     const store = await createStore()
     const timestamps = [
       ['pty-updated-old', 900, 100],
@@ -340,18 +429,8 @@ describe('Store SSH reattach containment', () => {
 
     const reloaded = await createStore()
     const collapsed = reloaded.getSshRemotePtyLeases('target-1')
-    expect(collapsed.find((lease) => lease.ptyId === 'pty-z')?.state).toBe('detached')
-    expect(collapsed.find((lease) => lease.ptyId === 'pty-identity-incomplete')?.state).toBe(
-      'detached'
-    )
-    for (const ptyId of ['pty-updated-old', 'pty-created-old', 'pty-a']) {
-      expect(collapsed.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('expired')
-    }
-
-    reloaded.flush()
-    const persisted = (await createStore()).getSshRemotePtyLeases('target-1')
-    for (const ptyId of ['pty-updated-old', 'pty-created-old', 'pty-a']) {
-      expect(persisted.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('expired')
+    for (const ptyId of [...timestamps.map(([ptyId]) => ptyId), 'pty-identity-incomplete']) {
+      expect(collapsed.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('detached')
     }
   })
 
@@ -362,7 +441,9 @@ describe('Store SSH reattach containment', () => {
       ptyId: 'pty-discarded',
       state: 'attached'
     })
-    store.quarantineSshRemotePtyLeases('target-1', ['pty-discarded'])
+    const syncFlush = vi.spyOn(store, 'flush')
+    await store.quarantineSshRemotePtyLeasesAsync('target-1', ['pty-discarded'])
+    expect(syncFlush).not.toHaveBeenCalled()
 
     store.markSshRemotePtyLease('target-1', 'pty-discarded', 'detached')
     await store.markSshRemotePtyLeasesAttachedAsync('target-1', ['pty-discarded'])
@@ -370,5 +451,50 @@ describe('Store SSH reattach containment', () => {
     expect(store.getSshRemotePtyLeases('target-1')[0]).toEqual(
       expect.objectContaining({ ptyId: 'pty-discarded', state: 'expired' })
     )
+  })
+
+  it('rolls back an in-memory quarantine when its durable write fails', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'target-1',
+      ptyId: 'pty-discarded',
+      state: 'attached'
+    })
+    vi.spyOn(
+      store as unknown as { flushDurableStateOrThrowAsync(): Promise<void> },
+      'flushDurableStateOrThrowAsync'
+    ).mockRejectedValueOnce(new Error('disk unavailable'))
+
+    await expect(
+      store.quarantineSshRemotePtyLeasesAsync('target-1', ['pty-discarded'])
+    ).rejects.toThrow('disk unavailable')
+
+    expect(store.getSshRemotePtyLeases('target-1')[0]).toEqual(
+      expect.objectContaining({ ptyId: 'pty-discarded', state: 'attached' })
+    )
+  })
+
+  it('coalesces target reassignment collisions by remote PTY identity', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'target-old',
+      ptyId: 'pty-shared',
+      state: 'detached',
+      createdAt: 1,
+      updatedAt: 1
+    })
+    store.upsertSshRemotePtyLease({
+      targetId: 'target-new',
+      ptyId: 'pty-shared',
+      state: 'attached',
+      createdAt: 2,
+      updatedAt: 2
+    })
+
+    store.reassignSshTargetId('target-old', 'target-new')
+
+    expect(store.getSshRemotePtyLeases('target-new')).toEqual([
+      expect.objectContaining({ ptyId: 'pty-shared', state: 'attached', updatedAt: 2 })
+    ])
   })
 })

--- a/src/main/persistence-ssh-reattach-containment.test.ts
+++ b/src/main/persistence-ssh-reattach-containment.test.ts
@@ -1,0 +1,283 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { getDefaultWorkspaceSession } from '../shared/constants'
+import type { TerminalTab, WorkspaceSessionState } from '../shared/types'
+
+const testState = { dir: '' }
+const LEAF_1 = '11111111-1111-4111-8111-111111111111'
+const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(`encrypted:${value}`),
+    decryptString: (value: Buffer) => value.toString().slice('encrypted:'.length)
+  }
+}))
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(),
+  sshConfigHostsToTargets: vi.fn()
+}))
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn(() => ({})) }))
+
+async function createStore() {
+  vi.resetModules()
+  const { Store } = await import('./persistence')
+  return new Store({ dataFile: join(testState.dir, 'orca-data.json') })
+}
+
+function terminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id: 'tab-1',
+    worktreeId: 'wt-1',
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1,
+    ptyId: 'pty-old',
+    ...overrides
+  }
+}
+
+function sessionWithExistingPane(): WorkspaceSessionState {
+  return {
+    ...getDefaultWorkspaceSession(),
+    tabsByWorktree: { 'wt-1': [terminalTab()] },
+    terminalLayoutsByTabId: {
+      'tab-1': {
+        root: { type: 'leaf', leafId: LEAF_1 },
+        activeLeafId: LEAF_1,
+        expandedLeafId: null,
+        ptyIdsByLeafId: { [LEAF_1]: 'pty-old' }
+      }
+    },
+    terminalTopologyRevisionByRepoId: { 'wt-1': 7 }
+  }
+}
+
+describe('Store SSH reattach containment', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-ssh-reattach-'))
+  })
+
+  afterEach(() => {
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('refuses every creating bind branch without mutation or flush', async () => {
+    const store = await createStore()
+    const cases: {
+      name: string
+      session: WorkspaceSessionState
+      tabId: string
+      leafId: string
+    }[] = [
+      {
+        name: 'missing tab',
+        session: getDefaultWorkspaceSession(),
+        tabId: 'tab-missing',
+        leafId: LEAF_1
+      },
+      {
+        name: 'missing legacy tab',
+        session: getDefaultWorkspaceSession(),
+        tabId: 'tab-missing',
+        leafId: 'pane:legacy'
+      },
+      {
+        name: 'missing layout',
+        session: {
+          ...getDefaultWorkspaceSession(),
+          tabsByWorktree: { 'wt-1': [terminalTab()] }
+        },
+        tabId: 'tab-1',
+        leafId: LEAF_1
+      },
+      {
+        name: 'empty layout root',
+        session: {
+          ...getDefaultWorkspaceSession(),
+          tabsByWorktree: { 'wt-1': [terminalTab()] },
+          terminalLayoutsByTabId: {
+            'tab-1': {
+              root: null,
+              activeLeafId: null,
+              expandedLeafId: null,
+              ptyIdsByLeafId: {}
+            }
+          }
+        },
+        tabId: 'tab-1',
+        leafId: LEAF_1
+      },
+      {
+        name: 'missing leaf',
+        session: sessionWithExistingPane(),
+        tabId: 'tab-1',
+        leafId: LEAF_2
+      }
+    ]
+    const flush = vi.spyOn(store, 'flushOrThrow')
+
+    for (const [optionIndex, options] of [
+      { mayCreate: false },
+      { mayCreate: false, dryRun: true }
+    ].entries()) {
+      for (const [caseIndex, testCase] of cases.entries()) {
+        const hostId = `ssh:test-${optionIndex}-${caseIndex}`
+        store.setWorkspaceSession(structuredClone(testCase.session), hostId)
+        const before = structuredClone(store.getWorkspaceSession(hostId))
+        flush.mockClear()
+
+        const outcome = store.persistPtyBinding(
+          {
+            worktreeId: 'wt-1',
+            tabId: testCase.tabId,
+            leafId: testCase.leafId,
+            ptyId: 'pty-new',
+            incarnationId: 'incarnation-new'
+          },
+          hostId,
+          options
+        )
+
+        expect(outcome, testCase.name).toBe('refused')
+        expect(store.getWorkspaceSession(hostId), testCase.name).toEqual(before)
+        expect(flush, testCase.name).not.toHaveBeenCalled()
+      }
+    }
+  })
+
+  it('dry-runs an existing bind without writing and binds existing-only without topology growth', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithExistingPane())
+    const before = structuredClone(store.getWorkspaceSession())
+    const flush = vi.spyOn(store, 'flushOrThrow')
+
+    expect(
+      store.persistPtyBinding(
+        { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, ptyId: 'pty-new' },
+        undefined,
+        { mayCreate: false, dryRun: true }
+      )
+    ).toBe('bound')
+    expect(store.getWorkspaceSession()).toEqual(before)
+    expect(flush).not.toHaveBeenCalled()
+
+    expect(
+      store.persistPtyBinding(
+        {
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          leafId: LEAF_1,
+          ptyId: 'pty-new',
+          incarnationId: 'incarnation-new'
+        },
+        undefined,
+        { mayCreate: false }
+      )
+    ).toBe('bound')
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId['tab-1'].root).toEqual(
+      before.terminalLayoutsByTabId['tab-1'].root
+    )
+    expect(store.getWorkspaceSession().terminalLayoutsByTabId['tab-1'].ptyIdsByLeafId).toEqual({
+      [LEAF_1]: 'pty-new'
+    })
+    expect(store.getWorkspaceSession().terminalTopologyRevisionByRepoId?.['wt-1']).toBe(7)
+    expect(flush).toHaveBeenCalledOnce()
+  })
+
+  it('rolls back an existing-only bind when its durable flush fails', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithExistingPane())
+    const before = structuredClone(store.getWorkspaceSession())
+    vi.spyOn(store, 'flushOrThrow').mockImplementationOnce(() => {
+      throw new Error('disk full')
+    })
+
+    expect(() =>
+      store.persistPtyBinding(
+        {
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          leafId: LEAF_1,
+          ptyId: 'pty-new',
+          incarnationId: 'incarnation-new'
+        },
+        undefined,
+        { mayCreate: false }
+      )
+    ).toThrow('disk full')
+    expect(store.getWorkspaceSession()).toEqual(before)
+  })
+
+  it('collapses duplicate panes deterministically and persists the terminal losers', async () => {
+    const store = await createStore()
+    const timestamps = [
+      ['pty-updated-old', 900, 100],
+      ['pty-created-old', 100, 200],
+      ['pty-a', 300, 200],
+      ['pty-z', 300, 200]
+    ] as const
+    for (const [ptyId, createdAt, updatedAt] of timestamps) {
+      store.upsertSshRemotePtyLease({
+        targetId: 'target-1',
+        ptyId,
+        state: 'detached',
+        createdAt,
+        updatedAt
+      })
+    }
+    store.upsertSshRemotePtyLease({
+      targetId: 'target-1',
+      ptyId: 'pty-identity-incomplete',
+      state: 'detached',
+      createdAt: 1,
+      updatedAt: 1
+    })
+    for (const lease of store.getSshRemotePtyLeases('target-1')) {
+      if (lease.ptyId !== 'pty-identity-incomplete') {
+        Object.assign(lease, { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1 })
+      }
+    }
+    store.flush()
+
+    const reloaded = await createStore()
+    const collapsed = reloaded.getSshRemotePtyLeases('target-1')
+    expect(collapsed.find((lease) => lease.ptyId === 'pty-z')?.state).toBe('detached')
+    expect(collapsed.find((lease) => lease.ptyId === 'pty-identity-incomplete')?.state).toBe(
+      'detached'
+    )
+    for (const ptyId of ['pty-updated-old', 'pty-created-old', 'pty-a']) {
+      expect(collapsed.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('terminated')
+    }
+
+    reloaded.flush()
+    const persisted = (await createStore()).getSshRemotePtyLeases('target-1')
+    for (const ptyId of ['pty-updated-old', 'pty-created-old', 'pty-a']) {
+      expect(persisted.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('terminated')
+    }
+  })
+
+  it('keeps a duplicate exclusion terminal across source-recovery state writes', async () => {
+    const store = await createStore()
+    store.upsertSshRemotePtyLease({
+      targetId: 'target-1',
+      ptyId: 'pty-discarded',
+      state: 'attached'
+    })
+    store.excludeDuplicateSshRemotePtyLeases('target-1', ['pty-discarded'])
+
+    store.markSshRemotePtyLease('target-1', 'pty-discarded', 'detached')
+    await store.markSshRemotePtyLeasesAttachedAsync('target-1', ['pty-discarded'])
+
+    expect(store.getSshRemotePtyLeases('target-1')[0]).toEqual(
+      expect.objectContaining({ ptyId: 'pty-discarded', state: 'terminated' })
+    )
+  })
+})

--- a/src/main/persistence-ssh-reattach-containment.test.ts
+++ b/src/main/persistence-ssh-reattach-containment.test.ts
@@ -8,6 +8,8 @@ import type { TerminalTab, WorkspaceSessionState } from '../shared/types'
 const testState = { dir: '' }
 const LEAF_1 = '11111111-1111-4111-8111-111111111111'
 const LEAF_2 = '22222222-2222-4222-8222-222222222222'
+const APP_PTY_ID = 'ssh:target-1@@pty-old'
+const SSH_HOST_ID = 'ssh:target-1'
 
 vi.mock('electron', () => ({
   app: { getPath: () => testState.dir },
@@ -44,16 +46,16 @@ function terminalTab(overrides: Partial<TerminalTab> = {}): TerminalTab {
   }
 }
 
-function sessionWithExistingPane(): WorkspaceSessionState {
+function sessionWithExistingPane(ptyId = 'pty-old'): WorkspaceSessionState {
   return {
     ...getDefaultWorkspaceSession(),
-    tabsByWorktree: { 'wt-1': [terminalTab()] },
+    tabsByWorktree: { 'wt-1': [terminalTab({ ptyId })] },
     terminalLayoutsByTabId: {
       'tab-1': {
         root: { type: 'leaf', leafId: LEAF_1 },
         activeLeafId: LEAF_1,
         expandedLeafId: null,
-        ptyIdsByLeafId: { [LEAF_1]: 'pty-old' }
+        ptyIdsByLeafId: { [LEAF_1]: ptyId }
       }
     },
     terminalTopologyRevisionByRepoId: { 'wt-1': 7 }
@@ -124,10 +126,7 @@ describe('Store SSH reattach containment', () => {
     ]
     const flush = vi.spyOn(store, 'flushOrThrow')
 
-    for (const [optionIndex, options] of [
-      { mayCreate: false },
-      { mayCreate: false, dryRun: true }
-    ].entries()) {
+    for (const [optionIndex, options] of [{ mayCreate: false }].entries()) {
       for (const [caseIndex, testCase] of cases.entries()) {
         const hostId = `ssh:test-${optionIndex}-${caseIndex}`
         store.setWorkspaceSession(structuredClone(testCase.session), hostId)
@@ -153,21 +152,63 @@ describe('Store SSH reattach containment', () => {
     }
   })
 
-  it('dry-runs an existing bind without writing and binds existing-only without topology growth', async () => {
+  it('resolves panes only from the requested SSH host partition', async () => {
+    const store = await createStore()
+    const binding = {
+      targetId: 'target-1',
+      ptyId: APP_PTY_ID,
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: LEAF_1
+    }
+
+    expect(store.resolveExistingSshPtyBinding(binding)).toBeNull()
+    store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID), SSH_HOST_ID)
+    expect(store.resolveExistingSshPtyBinding(binding)).toEqual({
+      worktreeId: 'wt-1',
+      tabId: 'tab-1',
+      leafId: LEAF_1
+    })
+  })
+
+  it('resolves incomplete legacy leases only from a unique durable PTY binding', async () => {
+    const store = await createStore()
+    store.setWorkspaceSession(sessionWithExistingPane(APP_PTY_ID), SSH_HOST_ID)
+
+    expect(
+      store.resolveExistingSshPtyBinding({
+        targetId: 'target-1',
+        ptyId: 'pty-old',
+        worktreeId: 'wt-1',
+        tabId: 'tab-1'
+      })
+    ).toEqual({ worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1 })
+    expect(store.resolveExistingSshPtyBinding({ targetId: 'target-1', ptyId: APP_PTY_ID })).toEqual(
+      { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1 }
+    )
+
+    const ambiguous = sessionWithExistingPane(APP_PTY_ID)
+    ambiguous.tabsByWorktree['wt-2'] = [
+      terminalTab({ id: 'tab-2', worktreeId: 'wt-2', ptyId: APP_PTY_ID })
+    ]
+    ambiguous.terminalLayoutsByTabId['tab-2'] = {
+      root: { type: 'leaf', leafId: LEAF_2 },
+      activeLeafId: LEAF_2,
+      expandedLeafId: null,
+      ptyIdsByLeafId: { [LEAF_2]: APP_PTY_ID }
+    }
+    store.setWorkspaceSession(ambiguous, SSH_HOST_ID)
+
+    expect(
+      store.resolveExistingSshPtyBinding({ targetId: 'target-1', ptyId: APP_PTY_ID })
+    ).toBeNull()
+  })
+
+  it('binds existing-only without topology growth', async () => {
     const store = await createStore()
     store.setWorkspaceSession(sessionWithExistingPane())
     const before = structuredClone(store.getWorkspaceSession())
     const flush = vi.spyOn(store, 'flushOrThrow')
-
-    expect(
-      store.persistPtyBinding(
-        { worktreeId: 'wt-1', tabId: 'tab-1', leafId: LEAF_1, ptyId: 'pty-new' },
-        undefined,
-        { mayCreate: false, dryRun: true }
-      )
-    ).toBe('bound')
-    expect(store.getWorkspaceSession()).toEqual(before)
-    expect(flush).not.toHaveBeenCalled()
 
     expect(
       store.persistPtyBinding(
@@ -254,30 +295,30 @@ describe('Store SSH reattach containment', () => {
       'detached'
     )
     for (const ptyId of ['pty-updated-old', 'pty-created-old', 'pty-a']) {
-      expect(collapsed.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('terminated')
+      expect(collapsed.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('expired')
     }
 
     reloaded.flush()
     const persisted = (await createStore()).getSshRemotePtyLeases('target-1')
     for (const ptyId of ['pty-updated-old', 'pty-created-old', 'pty-a']) {
-      expect(persisted.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('terminated')
+      expect(persisted.find((lease) => lease.ptyId === ptyId)?.state, ptyId).toBe('expired')
     }
   })
 
-  it('keeps a duplicate exclusion terminal across source-recovery state writes', async () => {
+  it('keeps a duplicate quarantine final across source-recovery state writes', async () => {
     const store = await createStore()
     store.upsertSshRemotePtyLease({
       targetId: 'target-1',
       ptyId: 'pty-discarded',
       state: 'attached'
     })
-    store.excludeDuplicateSshRemotePtyLeases('target-1', ['pty-discarded'])
+    store.quarantineSshRemotePtyLeases('target-1', ['pty-discarded'])
 
     store.markSshRemotePtyLease('target-1', 'pty-discarded', 'detached')
     await store.markSshRemotePtyLeasesAttachedAsync('target-1', ['pty-discarded'])
 
     expect(store.getSshRemotePtyLeases('target-1')[0]).toEqual(
-      expect.objectContaining({ ptyId: 'pty-discarded', state: 'terminated' })
+      expect.objectContaining({ ptyId: 'pty-discarded', state: 'expired' })
     )
   })
 })

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -107,7 +107,7 @@ import {
   type SshRemotePtyLeaseState,
   type SshTarget
 } from '../shared/ssh-types'
-import { selectSshRemotePtyLeasesForReattach } from './ssh/ssh-remote-pty-lease-selection'
+import { coalesceSshRemotePtyLeasesByIdentity } from './ssh/ssh-remote-pty-lease-selection'
 import { isFolderRepo } from '../shared/repo-kind'
 import {
   getRepoExecutionHostId,
@@ -3649,16 +3649,11 @@ export class Store {
             const leases = (parsed.sshRemotePtyLeases ?? [])
               .map(normalizeSshRemotePtyLease)
               .filter((lease): lease is SshRemotePtyLease => lease !== null)
-            const { discardedDuplicates } = selectSshRemotePtyLeasesForReattach(leases)
-            if (discardedDuplicates.length > 0) {
-              const now = Date.now()
-              for (const lease of discardedDuplicates) {
-                lease.state = 'expired'
-                lease.updatedAt = now
-              }
+            const coalesced = coalesceSshRemotePtyLeasesByIdentity(leases)
+            if (coalesced.length !== leases.length) {
               this.loadNeedsSave = true
             }
-            return leases
+            return coalesced
           })(),
           sshPtyConsumerRecoveries: parsed.sshPtyConsumerRecoveries,
           claudeLivePtySessionIds: normalizeClaudeLivePtySessionIds(parsed.claudeLivePtySessionIds),
@@ -6656,13 +6651,33 @@ export class Store {
     worktreeId?: string
     tabId?: string
     leafId?: string
-  }): { worktreeId: string; tabId: string; leafId: string; hostId: ExecutionHostId } | null {
+  }): {
+    worktreeId: string
+    tabId: string
+    leafId: string
+    hostId: ExecutionHostId
+    ptyId: string
+    incarnationId?: string
+  } | null {
     const partitions: ExecutionHostId[] = [
       toSshExecutionHostId(args.targetId),
       LOCAL_EXECUTION_HOST_ID
     ]
+    const scans = partitions.map((hostId) =>
+      this.resolveExistingSshPtyBindingsInPartition(args, hostId)
+    )
+    if (scans.some((scan) => scan.conflictingRequestedPane)) {
+      return null
+    }
+    const matches = scans.flatMap((scan) => scan.matches)
+    const paneKeys = new Set(
+      matches.map((match) => `${match.worktreeId}\0${match.tabId}\0${match.leafId}`)
+    )
+    if (paneKeys.size !== 1) {
+      return null
+    }
     for (const hostId of partitions) {
-      const resolved = this.resolveExistingSshPtyBindingInPartition(args, hostId)
+      const resolved = matches.find((match) => match.hostId === hostId)
       if (resolved) {
         return resolved
       }
@@ -6670,7 +6685,7 @@ export class Store {
     return null
   }
 
-  private resolveExistingSshPtyBindingInPartition(
+  private resolveExistingSshPtyBindingsInPartition(
     args: {
       targetId: string
       ptyId: string
@@ -6679,7 +6694,17 @@ export class Store {
       leafId?: string
     },
     hostId: ExecutionHostId
-  ): { worktreeId: string; tabId: string; leafId: string; hostId: ExecutionHostId } | null {
+  ): {
+    matches: {
+      worktreeId: string
+      tabId: string
+      leafId: string
+      hostId: ExecutionHostId
+      ptyId: string
+      incarnationId?: string
+    }[]
+    conflictingRequestedPane: boolean
+  } {
     const session = this.getWorkspaceSession(hostId)
     const requestedLeafId =
       typeof args.leafId === 'string' && isTerminalLeafId(args.leafId) ? args.leafId : undefined
@@ -6688,9 +6713,38 @@ export class Store {
         (candidate) => candidate.id === args.tabId
       )
       const layout = session.terminalLayoutsByTabId?.[args.tabId]
-      return tab && layoutContainsLeafId(layout?.root ?? null, requestedLeafId)
-        ? { worktreeId: args.worktreeId, tabId: args.tabId, leafId: requestedLeafId, hostId }
-        : null
+      if (!tab || !layoutContainsLeafId(layout?.root ?? null, requestedLeafId)) {
+        return { matches: [], conflictingRequestedPane: false }
+      }
+      const leafIds = this.getTerminalLayoutLeafIds(layout?.root ?? null)
+      const boundPtyId = this.resolvePersistedPanePtyId(tab, layout, leafIds, requestedLeafId)
+      if (!boundPtyId) {
+        return { matches: [], conflictingRequestedPane: false }
+      }
+      if (
+        this.getRelayPtyIdForSshLeaseComparison(args.targetId, boundPtyId) !==
+        this.getRelayPtyIdForSshLeaseComparison(args.targetId, args.ptyId)
+      ) {
+        return { matches: [], conflictingRequestedPane: true }
+      }
+      return {
+        matches: [
+          {
+            worktreeId: args.worktreeId,
+            tabId: args.tabId,
+            leafId: requestedLeafId,
+            hostId,
+            ptyId: boundPtyId,
+            ...(session.terminalPtyIncarnationsByPaneKey?.[`${args.tabId}:${requestedLeafId}`]
+              ? {
+                  incarnationId:
+                    session.terminalPtyIncarnationsByPaneKey[`${args.tabId}:${requestedLeafId}`]
+                }
+              : {})
+          }
+        ],
+        conflictingRequestedPane: false
+      }
     }
 
     const relayPtyId = this.getRelayPtyIdForSshLeaseComparison(args.targetId, args.ptyId)
@@ -6699,7 +6753,10 @@ export class Store {
       tabId: string
       leafId: string
       hostId: ExecutionHostId
+      ptyId: string
+      incarnationId?: string
     }[] = []
+    let conflictingRequestedPane = false
     for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
       if (args.worktreeId && args.worktreeId !== worktreeId) {
         continue
@@ -6714,25 +6771,48 @@ export class Store {
           if (requestedLeafId && requestedLeafId !== leafId) {
             continue
           }
-          const boundPtyId = layout?.ptyIdsByLeafId?.[leafId]
-          const singleLeafTabPtyId = leafIds.size === 1 ? tab.ptyId : null
-          if (
-            ![boundPtyId, singleLeafTabPtyId].some(
-              (ptyId) =>
-                typeof ptyId === 'string' &&
-                this.getRelayPtyIdForSshLeaseComparison(args.targetId, ptyId) === relayPtyId
-            )
-          ) {
+          const boundPtyId = this.resolvePersistedPanePtyId(tab, layout, leafIds, leafId)
+          if (!boundPtyId) {
             continue
           }
-          matches.push({ worktreeId, tabId: tab.id, leafId, hostId })
-          if (matches.length > 1) {
-            return null
+          if (this.getRelayPtyIdForSshLeaseComparison(args.targetId, boundPtyId) !== relayPtyId) {
+            if (
+              requestedLeafId ||
+              (args.worktreeId === worktreeId && args.tabId === tab.id && leafIds.size === 1)
+            ) {
+              conflictingRequestedPane = true
+            }
+            continue
           }
+          matches.push({
+            worktreeId,
+            tabId: tab.id,
+            leafId,
+            hostId,
+            ptyId: boundPtyId,
+            ...(session.terminalPtyIncarnationsByPaneKey?.[`${tab.id}:${leafId}`]
+              ? { incarnationId: session.terminalPtyIncarnationsByPaneKey[`${tab.id}:${leafId}`] }
+              : {})
+          })
         }
       }
     }
-    return matches[0] ?? null
+    return { matches, conflictingRequestedPane }
+  }
+
+  private resolvePersistedPanePtyId(
+    tab: TerminalTab,
+    layout: TerminalLayoutSnapshot | undefined,
+    leafIds: ReadonlySet<string>,
+    leafId: string
+  ): string | null {
+    const leafPtyId = layout?.ptyIdsByLeafId?.[leafId]
+    if (typeof leafPtyId === 'string' && leafPtyId.length > 0) {
+      return leafPtyId
+    }
+    return leafIds.size === 1 && typeof tab.ptyId === 'string' && tab.ptyId.length > 0
+      ? tab.ptyId
+      : null
   }
 
   // Why: sync-flush the pty binding before pty:spawn returns to close the spawn/persist SIGKILL race (Issue #217).
@@ -6747,7 +6827,10 @@ export class Store {
       startupCwd?: string
     },
     hostId?: string | null,
-    options?: { mayCreate?: boolean }
+    options?: {
+      mayCreate?: boolean
+      expectedBinding?: { ptyId: string; incarnationId?: string }
+    }
   ): 'bound' | 'refused' {
     const mayCreate = options?.mayCreate ?? true
     const resolvedHostId = this.resolveHostId(hostId)
@@ -6758,8 +6841,26 @@ export class Store {
         [resolvedHostId]: session
       }
     }
-    const sessionBeforeBinding = cloneWorkspaceSessionState(session)
     const paneKey = `${args.tabId}:${args.leafId}`
+    const expectedBinding = options?.expectedBinding
+    if (expectedBinding) {
+      const tab = session.tabsByWorktree?.[args.worktreeId]?.find(
+        (candidate) => candidate.id === args.tabId
+      )
+      const layout = session.terminalLayoutsByTabId?.[args.tabId]
+      const leafIds = this.getTerminalLayoutLeafIds(layout?.root ?? null)
+      const currentPtyId = tab
+        ? this.resolvePersistedPanePtyId(tab, layout, leafIds, args.leafId)
+        : null
+      const currentIncarnationId = session.terminalPtyIncarnationsByPaneKey?.[paneKey]
+      if (
+        currentPtyId !== expectedBinding.ptyId ||
+        currentIncarnationId !== expectedBinding.incarnationId
+      ) {
+        return 'refused'
+      }
+    }
+    const sessionBeforeBinding = cloneWorkspaceSessionState(session)
     let terminalMembershipChanged = false
     const advanceTopologyAfterMembershipChange = (): void => {
       const repoId = getRepoIdFromWorktreeId(args.worktreeId)
@@ -7078,6 +7179,11 @@ export class Store {
         carrierChanged = true
       }
     }
+    if (carrierChanged && this.state.sshRemotePtyLeases) {
+      this.state.sshRemotePtyLeases = coalesceSshRemotePtyLeasesByIdentity(
+        this.state.sshRemotePtyLeases
+      )
+    }
     const recoveries = this.state.sshPtyConsumerRecoveries ?? []
     const retainedRecoveries = recoveries.filter((record) => record.targetId !== oldTargetId)
     if (retainedRecoveries.length !== recoveries.length) {
@@ -7164,12 +7270,19 @@ export class Store {
     return leases.filter((lease) => targetId === undefined || lease.targetId === targetId)
   }
 
-  quarantineSshRemotePtyLeases(targetId: string, ptyIds: readonly string[]): void {
+  async quarantineSshRemotePtyLeasesAsync(
+    targetId: string,
+    ptyIds: readonly string[]
+  ): Promise<void> {
     const relayPtyIds = new Set(
       ptyIds.map((ptyId) => this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId))
     )
     const now = Date.now()
-    let changed = false
+    const changed: {
+      lease: SshRemotePtyLease
+      state: SshRemotePtyLease['state']
+      updatedAt: number
+    }[] = []
     for (const lease of this.state.sshRemotePtyLeases ?? []) {
       if (
         lease.targetId !== targetId ||
@@ -7179,12 +7292,23 @@ export class Store {
       ) {
         continue
       }
+      changed.push({ lease, state: lease.state, updatedAt: lease.updatedAt })
       lease.state = 'expired'
       lease.updatedAt = now
-      changed = true
     }
-    if (changed) {
-      this.flush()
+    if (changed.length === 0) {
+      return
+    }
+    try {
+      await this.flushDurableStateOrThrowAsync()
+    } catch (error) {
+      for (const previous of changed) {
+        if (previous.lease.state === 'expired' && previous.lease.updatedAt === now) {
+          previous.lease.state = previous.state
+          previous.lease.updatedAt = previous.updatedAt
+        }
+      }
+      throw error
     }
   }
 
@@ -7192,7 +7316,9 @@ export class Store {
     lease: Omit<SshRemotePtyLease, 'createdAt' | 'updatedAt'> &
       Partial<Pick<SshRemotePtyLease, 'createdAt' | 'updatedAt'>>
   ): void {
-    this.state.sshRemotePtyLeases ??= []
+    this.state.sshRemotePtyLeases = coalesceSshRemotePtyLeasesByIdentity(
+      this.state.sshRemotePtyLeases ?? []
+    )
     const normalizedLease = { ...lease }
     if (normalizedLease.leafId !== undefined && !isTerminalLeafId(normalizedLease.leafId)) {
       delete normalizedLease.leafId

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -3653,7 +3653,7 @@ export class Store {
             if (discardedDuplicates.length > 0) {
               const now = Date.now()
               for (const lease of discardedDuplicates) {
-                lease.state = 'terminated'
+                lease.state = 'expired'
                 lease.updatedAt = now
               }
               this.loadNeedsSave = true
@@ -6646,6 +6646,63 @@ export class Store {
     return this.state.repos.find((repo) => repo.id === repoId)?.connectionId ?? null
   }
 
+  resolveExistingSshPtyBinding(args: {
+    targetId: string
+    ptyId: string
+    worktreeId?: string
+    tabId?: string
+    leafId?: string
+  }): { worktreeId: string; tabId: string; leafId: string } | null {
+    const session = this.getWorkspaceSession(toSshExecutionHostId(args.targetId))
+    const requestedLeafId =
+      typeof args.leafId === 'string' && isTerminalLeafId(args.leafId) ? args.leafId : undefined
+    if (args.worktreeId && args.tabId && requestedLeafId) {
+      const tab = session.tabsByWorktree?.[args.worktreeId]?.find(
+        (candidate) => candidate.id === args.tabId
+      )
+      const layout = session.terminalLayoutsByTabId?.[args.tabId]
+      return tab && layoutContainsLeafId(layout?.root ?? null, requestedLeafId)
+        ? { worktreeId: args.worktreeId, tabId: args.tabId, leafId: requestedLeafId }
+        : null
+    }
+
+    const relayPtyId = this.getRelayPtyIdForSshLeaseComparison(args.targetId, args.ptyId)
+    const matches: { worktreeId: string; tabId: string; leafId: string }[] = []
+    for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
+      if (args.worktreeId && args.worktreeId !== worktreeId) {
+        continue
+      }
+      for (const tab of tabs) {
+        if (args.tabId && args.tabId !== tab.id) {
+          continue
+        }
+        const layout = session.terminalLayoutsByTabId?.[tab.id]
+        const leafIds = this.getTerminalLayoutLeafIds(layout?.root ?? null)
+        for (const leafId of leafIds) {
+          if (requestedLeafId && requestedLeafId !== leafId) {
+            continue
+          }
+          const boundPtyId = layout?.ptyIdsByLeafId?.[leafId]
+          const singleLeafTabPtyId = leafIds.size === 1 ? tab.ptyId : null
+          if (
+            ![boundPtyId, singleLeafTabPtyId].some(
+              (ptyId) =>
+                typeof ptyId === 'string' &&
+                this.getRelayPtyIdForSshLeaseComparison(args.targetId, ptyId) === relayPtyId
+            )
+          ) {
+            continue
+          }
+          matches.push({ worktreeId, tabId: tab.id, leafId })
+          if (matches.length > 1) {
+            return null
+          }
+        }
+      }
+    }
+    return matches[0] ?? null
+  }
+
   // Why: sync-flush the pty binding before pty:spawn returns to close the spawn/persist SIGKILL race (Issue #217).
   // Reattach uses mayCreate:false because an absent durable pane never authorizes creating UI.
   persistPtyBinding(
@@ -6658,10 +6715,9 @@ export class Store {
       startupCwd?: string
     },
     hostId?: string | null,
-    options?: { mayCreate?: boolean; dryRun?: boolean }
+    options?: { mayCreate?: boolean }
   ): 'bound' | 'refused' {
     const mayCreate = options?.mayCreate ?? true
-    const dryRun = options?.dryRun ?? false
     const resolvedHostId = this.resolveHostId(hostId)
     const session = this.getWorkspaceSession(resolvedHostId)
     if (resolvedHostId !== LOCAL_EXECUTION_HOST_ID) {
@@ -6738,10 +6794,6 @@ export class Store {
         restoreSession()
         return 'refused'
       }
-      if (dryRun) {
-        restoreSession()
-        return 'bound'
-      }
       advanceTopologyAfterMembershipChange()
       try {
         this.flushOrThrow()
@@ -6793,10 +6845,6 @@ export class Store {
     if (!mayCreate && terminalMembershipChanged) {
       restoreSession()
       return 'refused'
-    }
-    if (dryRun) {
-      restoreSession()
-      return 'bound'
     }
     advanceTopologyAfterMembershipChange()
     try {
@@ -7084,7 +7132,7 @@ export class Store {
     return leases.filter((lease) => targetId === undefined || lease.targetId === targetId)
   }
 
-  excludeDuplicateSshRemotePtyLeases(targetId: string, ptyIds: readonly string[]): void {
+  quarantineSshRemotePtyLeases(targetId: string, ptyIds: readonly string[]): void {
     const relayPtyIds = new Set(
       ptyIds.map((ptyId) => this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId))
     )
@@ -7094,12 +7142,12 @@ export class Store {
       if (
         lease.targetId !== targetId ||
         !relayPtyIds.has(lease.ptyId) ||
-        !canAdvanceSshRemotePtyLeaseState(lease.state, 'terminated') ||
-        lease.state === 'terminated'
+        !canAdvanceSshRemotePtyLeaseState(lease.state, 'expired') ||
+        lease.state === 'expired'
       ) {
         continue
       }
-      lease.state = 'terminated'
+      lease.state = 'expired'
       lease.updatedAt = now
       changed = true
     }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -104,8 +104,10 @@ import {
   type RemovedSshTargetTombstone,
   type SshPtyConsumerRecovery,
   type SshRemotePtyLease,
+  type SshRemotePtyLeaseState,
   type SshTarget
 } from '../shared/ssh-types'
+import { selectSshRemotePtyLeasesForReattach } from './ssh/ssh-remote-pty-lease-selection'
 import { isFolderRepo } from '../shared/repo-kind'
 import {
   getRepoExecutionHostId,
@@ -1607,6 +1609,20 @@ function normalizeSshRemotePtyLease(value: unknown): SshRemotePtyLease | null {
     ...(typeof raw.lastAttachedAt === 'number' ? { lastAttachedAt: raw.lastAttachedAt } : {}),
     ...(typeof raw.lastDetachedAt === 'number' ? { lastDetachedAt: raw.lastDetachedAt } : {})
   }
+}
+
+const SSH_REMOTE_PTY_LEASE_FINALITY: Record<SshRemotePtyLeaseState, number> = {
+  attached: 0,
+  detached: 0,
+  expired: 1,
+  terminated: 2
+}
+
+function canAdvanceSshRemotePtyLeaseState(
+  from: SshRemotePtyLeaseState,
+  to: SshRemotePtyLeaseState
+): boolean {
+  return SSH_REMOTE_PTY_LEASE_FINALITY[to] >= SSH_REMOTE_PTY_LEASE_FINALITY[from]
 }
 
 const SSH_PTY_OWNER_LEASE_MAX_LENGTH = 512
@@ -3629,9 +3645,21 @@ export class Store {
                 (alias): alias is string => typeof alias === 'string'
               )
             : [],
-          sshRemotePtyLeases: (parsed.sshRemotePtyLeases ?? [])
-            .map(normalizeSshRemotePtyLease)
-            .filter((lease): lease is SshRemotePtyLease => lease !== null),
+          sshRemotePtyLeases: (() => {
+            const leases = (parsed.sshRemotePtyLeases ?? [])
+              .map(normalizeSshRemotePtyLease)
+              .filter((lease): lease is SshRemotePtyLease => lease !== null)
+            const { discardedDuplicates } = selectSshRemotePtyLeasesForReattach(leases)
+            if (discardedDuplicates.length > 0) {
+              const now = Date.now()
+              for (const lease of discardedDuplicates) {
+                lease.state = 'terminated'
+                lease.updatedAt = now
+              }
+              this.loadNeedsSave = true
+            }
+            return leases
+          })(),
           sshPtyConsumerRecoveries: parsed.sshPtyConsumerRecoveries,
           claudeLivePtySessionIds: normalizeClaudeLivePtySessionIds(parsed.claudeLivePtySessionIds),
           migrationUnsupportedPtyEntries: normalizeMigrationUnsupportedPtyEntries(
@@ -6619,6 +6647,7 @@ export class Store {
   }
 
   // Why: sync-flush the pty binding before pty:spawn returns to close the spawn/persist SIGKILL race (Issue #217).
+  // Reattach uses mayCreate:false because an absent durable pane never authorizes creating UI.
   persistPtyBinding(
     args: {
       worktreeId: string
@@ -6628,8 +6657,11 @@ export class Store {
       incarnationId?: string
       startupCwd?: string
     },
-    hostId?: string | null
-  ): void {
+    hostId?: string | null,
+    options?: { mayCreate?: boolean; dryRun?: boolean }
+  ): 'bound' | 'refused' {
+    const mayCreate = options?.mayCreate ?? true
+    const dryRun = options?.dryRun ?? false
     const resolvedHostId = this.resolveHostId(hostId)
     const session = this.getWorkspaceSession(resolvedHostId)
     if (resolvedHostId !== LOCAL_EXECUTION_HOST_ID) {
@@ -6702,6 +6734,14 @@ export class Store {
     }
     if (!isTerminalLeafId(args.leafId)) {
       // Why: keep legacy renderer-local pane ids out of durable leaf-keyed layout state after the UUID migration.
+      if (!mayCreate && terminalMembershipChanged) {
+        restoreSession()
+        return 'refused'
+      }
+      if (dryRun) {
+        restoreSession()
+        return 'bound'
+      }
       advanceTopologyAfterMembershipChange()
       try {
         this.flushOrThrow()
@@ -6709,7 +6749,7 @@ export class Store {
         restoreSession()
         throw err
       }
-      return
+      return 'bound'
     }
     const layout = session.terminalLayoutsByTabId?.[args.tabId]
     if (layout) {
@@ -6750,6 +6790,14 @@ export class Store {
         }
       }
     }
+    if (!mayCreate && terminalMembershipChanged) {
+      restoreSession()
+      return 'refused'
+    }
+    if (dryRun) {
+      restoreSession()
+      return 'bound'
+    }
     advanceTopologyAfterMembershipChange()
     try {
       this.flushOrThrow()
@@ -6757,6 +6805,7 @@ export class Store {
       restoreSession()
       throw err
     }
+    return 'bound'
   }
 
   // ── SSH Targets ────────────────────────────────────────────────────
@@ -7035,6 +7084,30 @@ export class Store {
     return leases.filter((lease) => targetId === undefined || lease.targetId === targetId)
   }
 
+  excludeDuplicateSshRemotePtyLeases(targetId: string, ptyIds: readonly string[]): void {
+    const relayPtyIds = new Set(
+      ptyIds.map((ptyId) => this.getRelayPtyIdForSshLeaseStorage(targetId, ptyId))
+    )
+    const now = Date.now()
+    let changed = false
+    for (const lease of this.state.sshRemotePtyLeases ?? []) {
+      if (
+        lease.targetId !== targetId ||
+        !relayPtyIds.has(lease.ptyId) ||
+        !canAdvanceSshRemotePtyLeaseState(lease.state, 'terminated') ||
+        lease.state === 'terminated'
+      ) {
+        continue
+      }
+      lease.state = 'terminated'
+      lease.updatedAt = now
+      changed = true
+    }
+    if (changed) {
+      this.flush()
+    }
+  }
+
   upsertSshRemotePtyLease(
     lease: Omit<SshRemotePtyLease, 'createdAt' | 'updatedAt'> &
       Partial<Pick<SshRemotePtyLease, 'createdAt' | 'updatedAt'>>
@@ -7110,10 +7183,7 @@ export class Store {
       if (lease.targetId !== targetId || (ptyIds && !ptyIds.has(lease.ptyId))) {
         continue
       }
-      if (state === 'attached' && (lease.state === 'terminated' || lease.state === 'expired')) {
-        continue
-      }
-      if (state === 'detached' && lease.state !== 'attached') {
+      if (!canAdvanceSshRemotePtyLeaseState(lease.state, state)) {
         continue
       }
       if (lease.state !== state) {
@@ -7145,7 +7215,7 @@ export class Store {
       return
     }
     const shouldClearBindings = state === 'terminated' || state === 'expired'
-    if (lease.state === state) {
+    if (lease.state === state || !canAdvanceSshRemotePtyLeaseState(lease.state, state)) {
       if (shouldClearBindings && this.clearSshRemotePtyBindingsForLeases(targetId, [lease])) {
         this.flush()
       }

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -6646,14 +6646,41 @@ export class Store {
     return this.state.repos.find((repo) => repo.id === repoId)?.connectionId ?? null
   }
 
+  // Why: the renderer partitions an SSH worktree by worktree.hostId but collapses repo-only
+  // ownership onto the local partition, so a live pane is durable in either one. Search the
+  // owning partition first and report which one matched, else a pane the user still has open
+  // resolves to nothing and reattach quarantines its surviving remote shell.
   resolveExistingSshPtyBinding(args: {
     targetId: string
     ptyId: string
     worktreeId?: string
     tabId?: string
     leafId?: string
-  }): { worktreeId: string; tabId: string; leafId: string } | null {
-    const session = this.getWorkspaceSession(toSshExecutionHostId(args.targetId))
+  }): { worktreeId: string; tabId: string; leafId: string; hostId: ExecutionHostId } | null {
+    const partitions: ExecutionHostId[] = [
+      toSshExecutionHostId(args.targetId),
+      LOCAL_EXECUTION_HOST_ID
+    ]
+    for (const hostId of partitions) {
+      const resolved = this.resolveExistingSshPtyBindingInPartition(args, hostId)
+      if (resolved) {
+        return resolved
+      }
+    }
+    return null
+  }
+
+  private resolveExistingSshPtyBindingInPartition(
+    args: {
+      targetId: string
+      ptyId: string
+      worktreeId?: string
+      tabId?: string
+      leafId?: string
+    },
+    hostId: ExecutionHostId
+  ): { worktreeId: string; tabId: string; leafId: string; hostId: ExecutionHostId } | null {
+    const session = this.getWorkspaceSession(hostId)
     const requestedLeafId =
       typeof args.leafId === 'string' && isTerminalLeafId(args.leafId) ? args.leafId : undefined
     if (args.worktreeId && args.tabId && requestedLeafId) {
@@ -6662,12 +6689,17 @@ export class Store {
       )
       const layout = session.terminalLayoutsByTabId?.[args.tabId]
       return tab && layoutContainsLeafId(layout?.root ?? null, requestedLeafId)
-        ? { worktreeId: args.worktreeId, tabId: args.tabId, leafId: requestedLeafId }
+        ? { worktreeId: args.worktreeId, tabId: args.tabId, leafId: requestedLeafId, hostId }
         : null
     }
 
     const relayPtyId = this.getRelayPtyIdForSshLeaseComparison(args.targetId, args.ptyId)
-    const matches: { worktreeId: string; tabId: string; leafId: string }[] = []
+    const matches: {
+      worktreeId: string
+      tabId: string
+      leafId: string
+      hostId: ExecutionHostId
+    }[] = []
     for (const [worktreeId, tabs] of Object.entries(session.tabsByWorktree ?? {})) {
       if (args.worktreeId && args.worktreeId !== worktreeId) {
         continue
@@ -6693,7 +6725,7 @@ export class Store {
           ) {
             continue
           }
-          matches.push({ worktreeId, tabId: tab.id, leafId })
+          matches.push({ worktreeId, tabId: tab.id, leafId, hostId })
           if (matches.length > 1) {
             return null
           }

--- a/src/main/ssh/ssh-relay-session-reattach-quarantine.test.ts
+++ b/src/main/ssh/ssh-relay-session-reattach-quarantine.test.ts
@@ -1,0 +1,200 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { randomUUID } from 'node:crypto'
+import type * as NodeCrypto from 'node:crypto'
+import { SshRelaySession } from './ssh-relay-session'
+import { createMockDeps, mockDeploySuccess } from './ssh-relay-session-test-fixtures'
+
+type MockMuxInstance = {
+  requestHandlers: Map<string, (params: Record<string, unknown>) => Promise<unknown>>
+}
+
+const { acceptOutputExitMock, muxRequestMock, openConsumerSessionMock, muxInstancesRaw } =
+  vi.hoisted(() => ({
+    acceptOutputExitMock: vi.fn().mockResolvedValue(undefined),
+    muxRequestMock: vi.fn(),
+    openConsumerSessionMock: vi.fn(
+      async (
+        _mux: unknown,
+        options: { clientInstanceId: string; outputFlowControl?: unknown }
+      ) => ({
+        clientInstanceId: options.clientInstanceId,
+        clientGeneration: 1,
+        ownerGeneration: 1,
+        ownerLease: 'test-owner-lease'
+      })
+    ),
+    muxInstancesRaw: [] as unknown[]
+  }))
+const muxInstances = muxInstancesRaw as MockMuxInstance[]
+
+vi.mock('./ssh-relay-deploy', () => ({ deployAndLaunchRelay: vi.fn() }))
+vi.mock('./ssh-pty-consumer-session', () => ({
+  openSshPtyConsumerSession: openConsumerSessionMock
+}))
+vi.mock('../ipc/ssh-pty-output-intake-registry', () => ({
+  acceptSshPtyOutputData: vi.fn().mockResolvedValue(undefined),
+  acceptSshPtyOutputExit: acceptOutputExitMock,
+  allocateSshPtyProviderGeneration: vi.fn(() => 17),
+  beginSshPtyOutputGenerationMigration: vi.fn(() => ({
+    byPty: new Map(),
+    completion: Promise.resolve()
+  })),
+  closeSshPtyOutputGeneration: vi.fn(),
+  getSshPtyAcceptedSourceCheckpoints: vi.fn(() => []),
+  applySshPtySourceRecoveryCancellationProof: vi.fn(() => true),
+  installSshPtySourceAckPublisher: vi.fn(() => () => {}),
+  installSshPtySourceCancellationPublisher: vi.fn(() => () => {})
+}))
+vi.mock('./ssh-relay-deploy-helpers', () => ({ execCommand: vi.fn().mockResolvedValue('') }))
+vi.mock('node:crypto', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeCrypto>()
+  return { ...actual, randomUUID: vi.fn() }
+})
+vi.mock('./ssh-remote-orca-cli', () => ({
+  runRemoteOrcaCli: vi.fn().mockResolvedValue({ exitCode: 0, stdout: '', stderr: '' })
+}))
+vi.mock('./ssh-channel-multiplexer', () => ({
+  SshChannelMultiplexer: class MockSshChannelMultiplexer {
+    requestHandlers = new Map<string, (params: Record<string, unknown>) => Promise<unknown>>()
+    notify = vi.fn()
+    notifyWithSettlement = vi.fn()
+    request = muxRequestMock
+    onNotification = vi.fn().mockReturnValue(() => {})
+    onNotificationByMethod = vi.fn().mockReturnValue(() => {})
+    onRequest = vi.fn(
+      (method: string, handler: (params: Record<string, unknown>) => Promise<unknown>) => {
+        this.requestHandlers.set(method, handler)
+        return () => this.requestHandlers.delete(method)
+      }
+    )
+    onDispose = vi.fn().mockReturnValue(() => {})
+    dispose = vi.fn()
+    isDisposed = vi.fn().mockReturnValue(false)
+
+    constructor() {
+      muxInstancesRaw.push(this)
+    }
+  }
+}))
+vi.mock('../agent-hooks/remote-managed-hook-installers', () => ({
+  installRemoteManagedAgentHooks: vi.fn()
+}))
+vi.mock('../providers/ssh-pty-provider', () => ({
+  isSshPtyNotFoundError: (error: unknown) => String(error).includes('not found'),
+  isSshPtyIdentityMismatchError: (error: unknown) => String(error).includes('identity mismatch'),
+  SshPtyProvider: class MockSshPtyProvider {
+    onData = vi.fn().mockReturnValue(() => {})
+    onReplay = vi.fn().mockReturnValue(() => {})
+    onExit = vi.fn().mockReturnValue(() => {})
+    attach = vi.fn().mockResolvedValue(undefined)
+    attachForReconnect = vi.fn().mockResolvedValue({})
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-filesystem-provider', () => ({
+  SshFilesystemProvider: class MockSshFilesystemProvider {
+    dispose = vi.fn()
+  }
+}))
+vi.mock('../providers/ssh-git-provider', () => ({
+  SshGitProvider: class MockSshGitProvider {}
+}))
+vi.mock('../ipc/pty', () => ({
+  registerSshPtyProvider: vi.fn(),
+  unregisterSshPtyProvider: vi.fn(),
+  getSshPtyProvider: vi.fn(),
+  getPtyIdsForConnection: vi.fn().mockReturnValue([]),
+  clearPtyOwnershipForConnection: vi.fn(),
+  clearProviderPtyState: vi.fn(),
+  deletePtyOwnership: vi.fn(),
+  setPtyOwnership: vi.fn(),
+  restorePtyIncarnation: vi.fn(),
+  isCurrentPtyExit: vi.fn(() => true),
+  answerStartupTerminalColorQueriesForPty: vi.fn((_id: string, data: string) => data)
+}))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  registerSshFilesystemProvider: vi.fn(),
+  unregisterSshFilesystemProvider: vi.fn(),
+  getSshFilesystemProvider: vi.fn().mockReturnValue({ dispose: vi.fn() })
+}))
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  registerSshGitProvider: vi.fn(),
+  unregisterSshGitProvider: vi.fn()
+}))
+
+const { getSshPtyProvider, getPtyIdsForConnection, deletePtyOwnership, clearProviderPtyState } =
+  await import('../ipc/pty')
+
+const APP_PTY_ID = 'ssh:target-1@@pty-live'
+const INCARNATION_LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function detachedLease() {
+  return {
+    targetId: 'target-1',
+    ptyId: 'pty-live',
+    state: 'detached' as const,
+    worktreeId: 'worktree-1',
+    tabId: 'tab-1',
+    leafId: INCARNATION_LEAF_ID,
+    createdAt: 1,
+    updatedAt: 1
+  }
+}
+
+describe('SshRelaySession reattach quarantine', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    muxInstances.splice(0)
+    delete process.env.ORCA_FEATURE_REMOTE_AGENT_HOOKS
+    muxRequestMock.mockReset()
+    muxRequestMock.mockResolvedValue([])
+    vi.mocked(randomUUID).mockReset()
+    vi.mocked(randomUUID).mockReturnValue('00000000-0000-4000-8000-000000000001')
+    mockDeploySuccess()
+    vi.mocked(getPtyIdsForConnection).mockReturnValue([])
+  })
+
+  it('quarantines an incomplete lease without a unique durable pane', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), leafId: undefined }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue(null)
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(attachForReconnect).not.toHaveBeenCalled()
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
+  })
+
+  it('batches every refused pane into one quarantine write and clears provider state', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), ptyId: 'pty-a' },
+      { ...detachedLease(), ptyId: 'pty-b', tabId: 'tab-2' },
+      { ...detachedLease(), ptyId: 'pty-c', tabId: 'tab-3' }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue(null)
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    // Why: one synchronous whole-profile write per refusal is the regression this guards.
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledTimes(1)
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', [
+      'pty-a',
+      'pty-b',
+      'pty-c'
+    ])
+    for (const ptyId of ['pty-a', 'pty-b', 'pty-c']) {
+      expect(deletePtyOwnership).toHaveBeenCalledWith(`ssh:target-1@@${ptyId}`)
+      expect(clearProviderPtyState).toHaveBeenCalledWith(`ssh:target-1@@${ptyId}`)
+    }
+  })
+})

--- a/src/main/ssh/ssh-relay-session-reattach-quarantine.test.ts
+++ b/src/main/ssh/ssh-relay-session-reattach-quarantine.test.ts
@@ -167,7 +167,9 @@ describe('SshRelaySession reattach quarantine', () => {
     await session.establish(mockConn)
 
     expect(attachForReconnect).not.toHaveBeenCalled()
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).toHaveBeenCalledWith('target-1', [
+      'pty-live'
+    ])
     expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
   })
 
@@ -185,9 +187,9 @@ describe('SshRelaySession reattach quarantine', () => {
 
     await session.establish(mockConn)
 
-    // Why: one synchronous whole-profile write per refusal is the regression this guards.
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledTimes(1)
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', [
+    // Why: persist every refusal in one awaited durable batch.
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).toHaveBeenCalledTimes(1)
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).toHaveBeenCalledWith('target-1', [
       'pty-a',
       'pty-b',
       'pty-c'
@@ -196,5 +198,65 @@ describe('SshRelaySession reattach quarantine', () => {
       expect(deletePtyOwnership).toHaveBeenCalledWith(`ssh:target-1@@${ptyId}`)
       expect(clearProviderPtyState).toHaveBeenCalledWith(`ssh:target-1@@${ptyId}`)
     }
+  })
+
+  it('does not let an older final identity duplicate block its active winner', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn().mockResolvedValue({ incarnationId: 'incarnation-live' })
+    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), state: 'expired', createdAt: 1, updatedAt: 1 },
+      { ...detachedLease(), createdAt: 2, updatedAt: 2 }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(attachForReconnect).toHaveBeenCalledOnce()
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).not.toHaveBeenCalled()
+  })
+
+  it('retains provider state when durable quarantine fails', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), leafId: undefined }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue(null)
+    vi.mocked(mockStore.quarantineSshRemotePtyLeasesAsync).mockRejectedValue(
+      new Error('disk unavailable')
+    )
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await expect(session.establish(mockConn)).rejects.toThrow('disk unavailable')
+
+    expect(clearProviderPtyState).not.toHaveBeenCalled()
+    expect(deletePtyOwnership).not.toHaveBeenCalled()
+  })
+
+  it('fails establishment when a refused attach cannot prove source cancellation', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const sourceActivationLease = {
+      commit: vi.fn(),
+      rollback: vi.fn().mockResolvedValue(false)
+    }
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect: vi.fn().mockResolvedValue({
+        incarnationId: 'incarnation-raced',
+        sourceActivationLease
+      })
+    } as never)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
+      typeof mockStore.getSshRemotePtyLeases
+    >)
+    vi.mocked(mockStore.persistPtyBinding).mockReturnValue('refused')
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await expect(session.establish(mockConn)).rejects.toMatchObject({
+      code: 'ssh_source_recovery_cancellation_failed'
+    })
+
+    expect(sourceActivationLease.rollback).toHaveBeenCalledOnce()
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).not.toHaveBeenCalled()
+    expect(session.getState()).toBe('idle')
   })
 })

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -126,12 +126,14 @@ const {
   registerSshPtyProvider,
   getSshPtyProvider,
   getPtyIdsForConnection,
+  deletePtyOwnership,
   setPtyOwnership,
   restorePtyIncarnation
 } = await import('../ipc/pty')
 const { deployAndLaunchRelay } = await import('./ssh-relay-deploy')
 
 const APP_PTY_ID = 'ssh:target-1@@pty-live'
+const SSH_HOST_ID = 'ssh:target-1'
 const INCARNATION_LEAF_ID = '11111111-1111-4111-8111-111111111111'
 
 function detachedLease() {
@@ -415,19 +417,14 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId
     })
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
-    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(
-      1,
-      {
-        worktreeId: 'worktree-1',
-        tabId: 'tab-1',
-        leafId: INCARNATION_LEAF_ID,
-        ptyId: APP_PTY_ID
-      },
-      undefined,
-      { mayCreate: false, dryRun: true }
-    )
-    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(
-      2,
+    expect(mockStore.resolveExistingSshPtyBinding).toHaveBeenCalledWith({
+      targetId: 'target-1',
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1',
+      leafId: INCARNATION_LEAF_ID,
+      ptyId: APP_PTY_ID
+    })
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
       {
         worktreeId: 'worktree-1',
         tabId: 'tab-1',
@@ -435,10 +432,10 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
         ptyId: APP_PTY_ID,
         incarnationId
       },
-      undefined,
+      SSH_HOST_ID,
       { mayCreate: false }
     )
-    expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[1]).toBeLessThan(
+    expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(mockStore.markSshRemotePtyLeasesAttachedAsync).mock.invocationCallOrder[0]!
     )
   })
@@ -455,7 +452,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
       typeof mockStore.getSshRemotePtyLeases
     >)
-    vi.mocked(mockStore.persistPtyBinding).mockReturnValue('refused')
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue(null)
     const runtime = { onPtyExit: vi.fn(), onPtySpawned: vi.fn(), registerPty: vi.fn() }
     const session = new SshRelaySession(
       'target-1',
@@ -467,11 +464,17 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
 
     await session.establish(mockConn)
 
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ tabId: 'tab-1', leafId: INCARNATION_LEAF_ID }),
-      undefined,
-      { mayCreate: false, dryRun: true }
+    expect(mockStore.resolveExistingSshPtyBinding).toHaveBeenCalledWith(
+      expect.objectContaining({
+        targetId: 'target-1',
+        ptyId: APP_PTY_ID,
+        tabId: 'tab-1',
+        leafId: INCARNATION_LEAF_ID
+      })
     )
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
+    expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
     expect(attachForReconnect).not.toHaveBeenCalled()
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
@@ -510,11 +513,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
 
     expect(session.getState()).toBe('ready')
     expect(attachForReconnect).toHaveBeenCalledTimes(2)
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledOnce()
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(expect.any(Object), undefined, {
-      mayCreate: false,
-      dryRun: true
-    })
+    expect(mockStore.resolveExistingSshPtyBinding).toHaveBeenCalledOnce()
+    expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
     expect(runtime.onPtyExit).not.toHaveBeenCalled()
@@ -543,9 +543,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
       typeof mockStore.getSshRemotePtyLeases
     >)
-    vi.mocked(mockStore.persistPtyBinding)
-      .mockReturnValueOnce('bound')
-      .mockReturnValueOnce('refused')
+    vi.mocked(mockStore.persistPtyBinding).mockReturnValue('refused')
     const runtime = { onPtyExit: vi.fn(), onPtySpawned: vi.fn(), registerPty: vi.fn() }
     const session = new SshRelaySession(
       'target-1',
@@ -558,16 +556,14 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     await session.establish(mockConn)
 
     expect(attachForReconnect).toHaveBeenCalledOnce()
-    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(1, expect.any(Object), undefined, {
-      mayCreate: false,
-      dryRun: true
-    })
-    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(
-      2,
+    expect(mockStore.resolveExistingSshPtyBinding).toHaveBeenCalledOnce()
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
       expect.objectContaining({ incarnationId: 'incarnation-raced' }),
-      undefined,
+      SSH_HOST_ID,
       { mayCreate: false }
     )
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
     expect(runtime.onPtyExit).not.toHaveBeenCalled()
@@ -609,9 +605,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
 
     await session.establish(mockConn)
 
-    expect(mockStore.excludeDuplicateSshRemotePtyLeases).toHaveBeenCalledWith('target-1', [
-      'pty-old'
-    ])
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-old'])
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-old')
     expect(attachForReconnect).toHaveBeenCalledOnce()
     expect(attachForReconnect).toHaveBeenCalledWith(
       'pty-winner',
@@ -621,6 +616,86 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       'pty-winner'
     ])
     expect(shutdown).not.toHaveBeenCalled()
+  })
+
+  it('keeps a quarantined duplicate blocked across later reconnects', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn().mockResolvedValue({ incarnationId: 'incarnation-winner' })
+    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-old', 'pty-winner'])
+    const leases = [
+      { ...detachedLease(), ptyId: 'pty-old', createdAt: 10, updatedAt: 10 },
+      { ...detachedLease(), ptyId: 'pty-winner', createdAt: 20, updatedAt: 20 }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockImplementation(() => leases)
+    vi.mocked(mockStore.quarantineSshRemotePtyLeases).mockImplementation((_targetId, ptyIds) => {
+      for (const lease of leases) {
+        if (ptyIds.includes(lease.ptyId)) {
+          lease.state = 'expired'
+        }
+      }
+    })
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+    await session.reconnect(mockConn)
+
+    expect(attachForReconnect).toHaveBeenCalledTimes(2)
+    expect(attachForReconnect.mock.calls.every(([ptyId]) => ptyId === 'pty-winner')).toBe(true)
+    expect(deletePtyOwnership).toHaveBeenCalledTimes(2)
+    expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-old')
+  })
+
+  it('reattaches an incomplete legacy lease only after resolving its durable pane', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn().mockResolvedValue({ incarnationId: 'incarnation-legacy' })
+    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), leafId: undefined }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue({
+      worktreeId: 'worktree-1',
+      tabId: 'tab-1',
+      leafId: INCARNATION_LEAF_ID
+    })
+    const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }
+    const session = new SshRelaySession(
+      'target-1',
+      getMainWindow,
+      mockStore,
+      mockPortForward,
+      runtime as never
+    )
+
+    await session.establish(mockConn)
+
+    expect(attachForReconnect).toHaveBeenCalledWith(
+      'pty-live',
+      expect.objectContaining({ paneKey: `tab-1:${INCARNATION_LEAF_ID}` })
+    )
+    expect(runtime.registerPty).toHaveBeenCalledWith(APP_PTY_ID, 'worktree-1', 'target-1', {
+      tabId: 'tab-1',
+      leafId: INCARNATION_LEAF_ID,
+      incarnationId: 'incarnation-legacy'
+    })
+    expect(runtime.onPtySpawned).not.toHaveBeenCalled()
+  })
+
+  it('quarantines an incomplete lease without a unique durable pane', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), leafId: undefined }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue(null)
+    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
+
+    await session.establish(mockConn)
+
+    expect(attachForReconnect).not.toHaveBeenCalled()
+    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
   })
 
   it('does not restore a PTY whose matching exit shares the attach reply batch', async () => {
@@ -665,11 +740,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(restorePtyIncarnation).toHaveBeenCalledWith(APP_PTY_ID, incarnationId)
     expect(setPtyOwnership).not.toHaveBeenCalled()
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledOnce()
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(expect.any(Object), undefined, {
-      mayCreate: false,
-      dryRun: true
-    })
+    expect(mockStore.resolveExistingSshPtyBinding).toHaveBeenCalledOnce()
+    expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
     expect(sourceActivationLease.rollback).toHaveBeenCalledOnce()
     expect(sourceActivationLease.commit).not.toHaveBeenCalled()
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
@@ -730,7 +802,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     expect(setPtyOwnership).toHaveBeenCalledWith(APP_PTY_ID, 'target-1')
     expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
       expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId }),
-      undefined,
+      SSH_HOST_ID,
       { mayCreate: false }
     )
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:replay', {
@@ -749,10 +821,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
       typeof mockStore.getSshRemotePtyLeases
     >)
-    vi.mocked(mockStore.persistPtyBinding).mockImplementation((_binding, _hostId, options) => {
-      if (options?.dryRun) {
-        return 'bound'
-      }
+    vi.mocked(mockStore.persistPtyBinding).mockImplementation(() => {
       throw new Error('disk full')
     })
     const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -141,7 +141,9 @@ function detachedLease() {
     state: 'detached' as const,
     worktreeId: 'worktree-1',
     tabId: 'tab-1',
-    leafId: INCARNATION_LEAF_ID
+    leafId: INCARNATION_LEAF_ID,
+    createdAt: 1,
+    updatedAt: 1
   }
 }
 
@@ -413,16 +415,212 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId
     })
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith({
-      worktreeId: 'worktree-1',
-      tabId: 'tab-1',
-      leafId: INCARNATION_LEAF_ID,
-      ptyId: APP_PTY_ID,
-      incarnationId
-    })
-    expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[0]).toBeLessThan(
+    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(
+      1,
+      {
+        worktreeId: 'worktree-1',
+        tabId: 'tab-1',
+        leafId: INCARNATION_LEAF_ID,
+        ptyId: APP_PTY_ID
+      },
+      undefined,
+      { mayCreate: false, dryRun: true }
+    )
+    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(
+      2,
+      {
+        worktreeId: 'worktree-1',
+        tabId: 'tab-1',
+        leafId: INCARNATION_LEAF_ID,
+        ptyId: APP_PTY_ID,
+        incarnationId
+      },
+      undefined,
+      { mayCreate: false }
+    )
+    expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[1]).toBeLessThan(
       vi.mocked(mockStore.markSshRemotePtyLeasesAttachedAsync).mock.invocationCallOrder[0]!
     )
+  })
+
+  it('refuses an absent pane before attach without publishing or destroying anything', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow, mockWindow } = createMockDeps()
+    const attachForReconnect = vi.fn().mockResolvedValue({ incarnationId: 'incarnation-refused' })
+    const shutdown = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect,
+      shutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
+      typeof mockStore.getSshRemotePtyLeases
+    >)
+    vi.mocked(mockStore.persistPtyBinding).mockReturnValue('refused')
+    const runtime = { onPtyExit: vi.fn(), onPtySpawned: vi.fn(), registerPty: vi.fn() }
+    const session = new SshRelaySession(
+      'target-1',
+      getMainWindow,
+      mockStore,
+      mockPortForward,
+      runtime as never
+    )
+
+    await session.establish(mockConn)
+
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
+      expect.objectContaining({ tabId: 'tab-1', leafId: INCARNATION_LEAF_ID }),
+      undefined,
+      { mayCreate: false, dryRun: true }
+    )
+    expect(attachForReconnect).not.toHaveBeenCalled()
+    expect(runtime.registerPty).not.toHaveBeenCalled()
+    expect(runtime.onPtySpawned).not.toHaveBeenCalled()
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(restorePtyIncarnation).not.toHaveBeenCalled()
+    expect(setPtyOwnership).not.toHaveBeenCalled()
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(mockWindow.webContents.send).mock.calls.some(([channel]) => channel === 'pty:exit')
+    ).toBe(false)
+  })
+
+  it('contains a #11005-style reattach failure without permitting a creating bind', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow, mockWindow } = createMockDeps()
+    const attachForReconnect = vi.fn().mockRejectedValue(new Error('output recovery failed'))
+    const shutdown = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect,
+      shutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
+      typeof mockStore.getSshRemotePtyLeases
+    >)
+    const runtime = { onPtyExit: vi.fn(), onPtySpawned: vi.fn(), registerPty: vi.fn() }
+    const session = new SshRelaySession(
+      'target-1',
+      getMainWindow,
+      mockStore,
+      mockPortForward,
+      runtime as never
+    )
+
+    await expect(session.establish(mockConn)).resolves.toBeUndefined()
+
+    expect(session.getState()).toBe('ready')
+    expect(attachForReconnect).toHaveBeenCalledTimes(2)
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledOnce()
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(expect.any(Object), undefined, {
+      mayCreate: false,
+      dryRun: true
+    })
+    expect(runtime.registerPty).not.toHaveBeenCalled()
+    expect(runtime.onPtySpawned).not.toHaveBeenCalled()
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(setPtyOwnership).not.toHaveBeenCalled()
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(
+      vi.mocked(mockWindow.webContents.send).mock.calls.some(([channel]) => channel === 'pty:exit')
+    ).toBe(false)
+  })
+
+  it('contains a post-attach bind race without allowing a creating recovery bind', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow, mockWindow } = createMockDeps()
+    const sourceActivationLease = { commit: vi.fn(), rollback: vi.fn() }
+    const attachForReconnect = vi.fn().mockResolvedValue({
+      incarnationId: 'incarnation-raced',
+      replay: 'unpublished-output',
+      sourceActivationLease
+    })
+    const shutdown = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect,
+      shutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
+      typeof mockStore.getSshRemotePtyLeases
+    >)
+    vi.mocked(mockStore.persistPtyBinding)
+      .mockReturnValueOnce('bound')
+      .mockReturnValueOnce('refused')
+    const runtime = { onPtyExit: vi.fn(), onPtySpawned: vi.fn(), registerPty: vi.fn() }
+    const session = new SshRelaySession(
+      'target-1',
+      getMainWindow,
+      mockStore,
+      mockPortForward,
+      runtime as never
+    )
+
+    await session.establish(mockConn)
+
+    expect(attachForReconnect).toHaveBeenCalledOnce()
+    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(1, expect.any(Object), undefined, {
+      mayCreate: false,
+      dryRun: true
+    })
+    expect(mockStore.persistPtyBinding).toHaveBeenNthCalledWith(
+      2,
+      expect.objectContaining({ incarnationId: 'incarnation-raced' }),
+      undefined,
+      { mayCreate: false }
+    )
+    expect(runtime.registerPty).not.toHaveBeenCalled()
+    expect(runtime.onPtySpawned).not.toHaveBeenCalled()
+    expect(runtime.onPtyExit).not.toHaveBeenCalled()
+    expect(restorePtyIncarnation).not.toHaveBeenCalled()
+    expect(setPtyOwnership).not.toHaveBeenCalled()
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).not.toHaveBeenCalled()
+    expect(sourceActivationLease.commit).not.toHaveBeenCalled()
+    expect(sourceActivationLease.rollback).toHaveBeenCalledOnce()
+    expect(shutdown).not.toHaveBeenCalled()
+    expect(
+      vi
+        .mocked(mockWindow.webContents.send)
+        .mock.calls.some(([channel]) => ['pty:exit', 'pty:replay'].includes(channel))
+    ).toBe(false)
+  })
+
+  it('attaches only the deterministic pane winner and never shuts down discarded duplicates', async () => {
+    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
+    const attachForReconnect = vi.fn().mockResolvedValue({ incarnationId: 'incarnation-winner' })
+    const shutdown = vi.fn()
+    vi.mocked(getSshPtyProvider).mockReturnValue({
+      attachForReconnect,
+      shutdown,
+      dispose: vi.fn()
+    } as unknown as ReturnType<typeof getSshPtyProvider>)
+    vi.mocked(getPtyIdsForConnection).mockReturnValue(['pty-old', 'pty-winner'])
+    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
+      { ...detachedLease(), ptyId: 'pty-old', createdAt: 10, updatedAt: 10 },
+      { ...detachedLease(), ptyId: 'pty-winner', createdAt: 20, updatedAt: 20 }
+    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }
+    const session = new SshRelaySession(
+      'target-1',
+      getMainWindow,
+      mockStore,
+      mockPortForward,
+      runtime as never
+    )
+
+    await session.establish(mockConn)
+
+    expect(mockStore.excludeDuplicateSshRemotePtyLeases).toHaveBeenCalledWith('target-1', [
+      'pty-old'
+    ])
+    expect(attachForReconnect).toHaveBeenCalledOnce()
+    expect(attachForReconnect).toHaveBeenCalledWith(
+      'pty-winner',
+      expect.objectContaining({ paneKey: `tab-1:${INCARNATION_LEAF_ID}` })
+    )
+    expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith('target-1', [
+      'pty-winner'
+    ])
+    expect(shutdown).not.toHaveBeenCalled()
   })
 
   it('does not restore a PTY whose matching exit shares the attach reply batch', async () => {
@@ -467,7 +665,11 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(restorePtyIncarnation).toHaveBeenCalledWith(APP_PTY_ID, incarnationId)
     expect(setPtyOwnership).not.toHaveBeenCalled()
-    expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledOnce()
+    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(expect.any(Object), undefined, {
+      mayCreate: false,
+      dryRun: true
+    })
     expect(sourceActivationLease.rollback).toHaveBeenCalledOnce()
     expect(sourceActivationLease.commit).not.toHaveBeenCalled()
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
@@ -527,7 +729,9 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     })
     expect(setPtyOwnership).toHaveBeenCalledWith(APP_PTY_ID, 'target-1')
     expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId })
+      expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId }),
+      undefined,
+      { mayCreate: false }
     )
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:replay', {
       id: APP_PTY_ID,
@@ -545,7 +749,10 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
       typeof mockStore.getSshRemotePtyLeases
     >)
-    vi.mocked(mockStore.persistPtyBinding).mockImplementationOnce(() => {
+    vi.mocked(mockStore.persistPtyBinding).mockImplementation((_binding, _hostId, options) => {
+      if (options?.dryRun) {
+        return 'bound'
+      }
       throw new Error('disk full')
     })
     const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -656,7 +656,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue({
       worktreeId: 'worktree-1',
       tabId: 'tab-1',
-      leafId: INCARNATION_LEAF_ID
+      leafId: INCARNATION_LEAF_ID,
+      hostId: 'ssh:target-1'
     })
     const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }
     const session = new SshRelaySession(
@@ -679,23 +680,6 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId: 'incarnation-legacy'
     })
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
-  })
-
-  it('quarantines an incomplete lease without a unique durable pane', async () => {
-    const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
-    const attachForReconnect = vi.fn()
-    vi.mocked(getSshPtyProvider).mockReturnValue({ attachForReconnect } as never)
-    vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
-      { ...detachedLease(), leafId: undefined }
-    ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
-    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue(null)
-    const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
-
-    await session.establish(mockConn)
-
-    expect(attachForReconnect).not.toHaveBeenCalled()
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
-    expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
   })
 
   it('does not restore a PTY whose matching exit shares the attach reply batch', async () => {

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -126,6 +126,7 @@ const {
   registerSshPtyProvider,
   getSshPtyProvider,
   getPtyIdsForConnection,
+  clearProviderPtyState,
   deletePtyOwnership,
   setPtyOwnership,
   restorePtyIncarnation
@@ -433,7 +434,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
         incarnationId
       },
       SSH_HOST_ID,
-      { mayCreate: false }
+      { mayCreate: false, expectedBinding: { ptyId: APP_PTY_ID } }
     )
     expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(mockStore.markSshRemotePtyLeasesAttachedAsync).mock.invocationCallOrder[0]!
@@ -472,7 +473,9 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
         leafId: INCARNATION_LEAF_ID
       })
     )
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).toHaveBeenCalledWith('target-1', [
+      'pty-live'
+    ])
     expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
     expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
     expect(attachForReconnect).not.toHaveBeenCalled()
@@ -528,7 +531,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
 
   it('contains a post-attach bind race without allowing a creating recovery bind', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow, mockWindow } = createMockDeps()
-    const sourceActivationLease = { commit: vi.fn(), rollback: vi.fn() }
+    const sourceActivationLease = { commit: vi.fn(), rollback: vi.fn().mockResolvedValue(true) }
     const attachForReconnect = vi.fn().mockResolvedValue({
       incarnationId: 'incarnation-raced',
       replay: 'unpublished-output',
@@ -560,9 +563,11 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
       expect.objectContaining({ incarnationId: 'incarnation-raced' }),
       SSH_HOST_ID,
-      { mayCreate: false }
+      { mayCreate: false, expectedBinding: { ptyId: APP_PTY_ID } }
     )
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-live'])
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).toHaveBeenCalledWith('target-1', [
+      'pty-live'
+    ])
     expect(deletePtyOwnership).toHaveBeenCalledWith(APP_PTY_ID)
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
@@ -605,7 +610,10 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
 
     await session.establish(mockConn)
 
-    expect(mockStore.quarantineSshRemotePtyLeases).toHaveBeenCalledWith('target-1', ['pty-old'])
+    expect(mockStore.quarantineSshRemotePtyLeasesAsync).toHaveBeenCalledWith('target-1', [
+      'pty-old'
+    ])
+    expect(clearProviderPtyState).toHaveBeenCalledWith('ssh:target-1@@pty-old')
     expect(deletePtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-old')
     expect(attachForReconnect).toHaveBeenCalledOnce()
     expect(attachForReconnect).toHaveBeenCalledWith(
@@ -628,13 +636,15 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       { ...detachedLease(), ptyId: 'pty-winner', createdAt: 20, updatedAt: 20 }
     ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>
     vi.mocked(mockStore.getSshRemotePtyLeases).mockImplementation(() => leases)
-    vi.mocked(mockStore.quarantineSshRemotePtyLeases).mockImplementation((_targetId, ptyIds) => {
-      for (const lease of leases) {
-        if (ptyIds.includes(lease.ptyId)) {
-          lease.state = 'expired'
+    vi.mocked(mockStore.quarantineSshRemotePtyLeasesAsync).mockImplementation(
+      async (_targetId, ptyIds) => {
+        for (const lease of leases) {
+          if (ptyIds.includes(lease.ptyId)) {
+            lease.state = 'expired'
+          }
         }
       }
-    })
+    )
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
 
     await session.establish(mockConn)
@@ -657,7 +667,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       worktreeId: 'worktree-1',
       tabId: 'tab-1',
       leafId: INCARNATION_LEAF_ID,
-      hostId: 'ssh:target-1'
+      hostId: 'ssh:target-1',
+      ptyId: APP_PTY_ID
     })
     const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }
     const session = new SshRelaySession(
@@ -787,7 +798,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
       expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId }),
       SSH_HOST_ID,
-      { mayCreate: false }
+      { mayCreate: false, expectedBinding: { ptyId: APP_PTY_ID } }
     )
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:replay', {
       id: APP_PTY_ID,

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -32,7 +32,8 @@ export function createMockDeps(): SshRelaySessionTestDeps {
         ? {
             worktreeId: binding.worktreeId,
             tabId: binding.tabId,
-            leafId: binding.leafId
+            leafId: binding.leafId,
+            hostId: `ssh:${binding.targetId}`
           }
         : null
     ),

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -26,7 +26,8 @@ export function createMockDeps(): SshRelaySessionTestDeps {
     markSshRemotePtyLeases: vi.fn(),
     markSshRemotePtyLeasesAsync: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
-    persistPtyBinding: vi.fn()
+    persistPtyBinding: vi.fn().mockReturnValue('bound'),
+    excludeDuplicateSshRemotePtyLeases: vi.fn()
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -33,11 +33,12 @@ export function createMockDeps(): SshRelaySessionTestDeps {
             worktreeId: binding.worktreeId,
             tabId: binding.tabId,
             leafId: binding.leafId,
-            hostId: `ssh:${binding.targetId}`
+            hostId: `ssh:${binding.targetId}`,
+            ptyId: binding.ptyId
           }
         : null
     ),
-    quarantineSshRemotePtyLeases: vi.fn()
+    quarantineSshRemotePtyLeasesAsync: vi.fn().mockResolvedValue(undefined)
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()

--- a/src/main/ssh/ssh-relay-session-test-fixtures.ts
+++ b/src/main/ssh/ssh-relay-session-test-fixtures.ts
@@ -27,7 +27,16 @@ export function createMockDeps(): SshRelaySessionTestDeps {
     markSshRemotePtyLeasesAsync: vi.fn(),
     markSshRemotePtyLeasesAttachedAsync: vi.fn(),
     persistPtyBinding: vi.fn().mockReturnValue('bound'),
-    excludeDuplicateSshRemotePtyLeases: vi.fn()
+    resolveExistingSshPtyBinding: vi.fn((binding) =>
+      binding.worktreeId && binding.tabId && binding.leafId
+        ? {
+            worktreeId: binding.worktreeId,
+            tabId: binding.tabId,
+            leafId: binding.leafId
+          }
+        : null
+    ),
+    quarantineSshRemotePtyLeases: vi.fn()
   } as unknown as Store
   const mockPortForward = {
     removeAllForwards: vi.fn()

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -520,12 +520,14 @@ describe('SshRelaySession', () => {
         ? {
             worktreeId: 'worktree-1',
             tabId: 'tab-live',
-            leafId: '11111111-1111-4111-8111-111111111111'
+            leafId: '11111111-1111-4111-8111-111111111111',
+            hostId: 'ssh:target-1'
           }
         : {
             worktreeId: 'worktree-1',
             tabId: 'tab-live-2',
-            leafId: '22222222-2222-4222-8222-222222222222'
+            leafId: '22222222-2222-4222-8222-222222222222',
+            hostId: 'ssh:target-1'
           }
     )
 
@@ -558,7 +560,8 @@ describe('SshRelaySession', () => {
     vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue({
       worktreeId: 'worktree-1',
       tabId: 'tab-a',
-      leafId
+      leafId,
+      hostId: 'ssh:target-1'
     })
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -521,13 +521,15 @@ describe('SshRelaySession', () => {
             worktreeId: 'worktree-1',
             tabId: 'tab-live',
             leafId: '11111111-1111-4111-8111-111111111111',
-            hostId: 'ssh:target-1'
+            hostId: 'ssh:target-1',
+            ptyId
           }
         : {
             worktreeId: 'worktree-1',
             tabId: 'tab-live-2',
             leafId: '22222222-2222-4222-8222-222222222222',
-            hostId: 'ssh:target-1'
+            hostId: 'ssh:target-1',
+            ptyId
           }
     )
 
@@ -542,6 +544,7 @@ describe('SshRelaySession', () => {
       'target-1',
       expect.arrayContaining(['pty-live', 'pty-live-2'])
     )
+    expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
   })
 
   it('resolves a legacy tab lease to pane identity before reattach', async () => {
@@ -561,7 +564,8 @@ describe('SshRelaySession', () => {
       worktreeId: 'worktree-1',
       tabId: 'tab-a',
       leafId,
-      hostId: 'ssh:target-1'
+      hostId: 'ssh:target-1',
+      ptyId: 'ssh:target-1@@pty-1'
     })
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)

--- a/src/main/ssh/ssh-relay-session.test.ts
+++ b/src/main/ssh/ssh-relay-session.test.ts
@@ -515,14 +515,25 @@ describe('SshRelaySession', () => {
       { targetId: 'target-1', ptyId: 'pty-live-2', state: 'detached' },
       { targetId: 'target-1', ptyId: 'pty-expired', state: 'expired' }
     ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockImplementation(({ ptyId }) =>
+      ptyId.endsWith('pty-live')
+        ? {
+            worktreeId: 'worktree-1',
+            tabId: 'tab-live',
+            leafId: '11111111-1111-4111-8111-111111111111'
+          }
+        : {
+            worktreeId: 'worktree-1',
+            tabId: 'tab-live-2',
+            leafId: '22222222-2222-4222-8222-222222222222'
+          }
+    )
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
 
     await session.establish(mockConn)
 
-    expect(mockAttach).toHaveBeenCalledWith('pty-live')
-    expect(mockAttach).toHaveBeenCalledWith('pty-live-2')
-    expect(mockAttach).not.toHaveBeenCalledWith('pty-expired')
+    expect(mockAttach.mock.calls.map(([ptyId]) => ptyId)).toEqual(['pty-live', 'pty-live-2'])
     expect(setPtyOwnership).toHaveBeenCalledWith('ssh:target-1@@pty-live', 'target-1')
     expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledOnce()
     expect(mockStore.markSshRemotePtyLeasesAttachedAsync).toHaveBeenCalledWith(
@@ -531,7 +542,7 @@ describe('SshRelaySession', () => {
     )
   })
 
-  it('forwards a lease tab identity to reattach so a reset relay cannot cross-wire it', async () => {
+  it('resolves a legacy tab lease to pane identity before reattach', async () => {
     const { mockConn, mockStore, mockPortForward, getMainWindow } = createMockDeps()
     const { getSshPtyProvider } = await import('../ipc/pty')
     const mockAttach = vi.fn().mockResolvedValue(undefined)
@@ -543,11 +554,20 @@ describe('SshRelaySession', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
       { targetId: 'target-1', ptyId: 'pty-1', state: 'detached', tabId: 'tab-a' }
     ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
+    const leafId = '11111111-1111-4111-8111-111111111111'
+    vi.mocked(mockStore.resolveExistingSshPtyBinding).mockReturnValue({
+      worktreeId: 'worktree-1',
+      tabId: 'tab-a',
+      leafId
+    })
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
     await session.establish(mockConn)
 
-    expect(mockAttach).toHaveBeenCalledWith('pty-1', { tabId: 'tab-a' })
+    expect(mockAttach).toHaveBeenCalledWith('pty-1', {
+      paneKey: `tab-a:${leafId}`,
+      tabId: 'tab-a'
+    })
   })
 
   it('forwards a lease pane identity when leaf identity is available', async () => {
@@ -561,7 +581,14 @@ describe('SshRelaySession', () => {
     vi.mocked(getPtyIdsForConnection).mockReturnValue([])
     const leafId = '11111111-1111-4111-8111-111111111111'
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([
-      { targetId: 'target-1', ptyId: 'pty-1', state: 'detached', tabId: 'tab-a', leafId }
+      {
+        targetId: 'target-1',
+        ptyId: 'pty-1',
+        state: 'detached',
+        worktreeId: 'worktree-1',
+        tabId: 'tab-a',
+        leafId
+      }
     ] as ReturnType<typeof mockStore.getSshRemotePtyLeases>)
 
     const session = new SshRelaySession('target-1', getMainWindow, mockStore, mockPortForward)
@@ -595,6 +622,7 @@ describe('SshRelaySession', () => {
         targetId: 'target-1',
         ptyId: 'pty-1',
         state: 'detached',
+        worktreeId: 'worktree-1',
         tabId: 'tab-old',
         leafId: staleLeafId
       }

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1937,16 +1937,24 @@ export class SshRelaySession {
     if (!ptyProvider || providerGeneration === null || this.mux !== mux || !shouldContinue()) {
       return
     }
-    const { candidates: activeLeases, discardedDuplicates } = selectSshRemotePtyLeasesForReattach(
-      this.store.getSshRemotePtyLeases(this.targetId)
-    )
+    const storedLeases = this.store.getSshRemotePtyLeases(this.targetId)
+    const { candidates: activeLeases, discardedDuplicates } =
+      selectSshRemotePtyLeasesForReattach(storedLeases)
     const discardedDuplicatePtyIds = new Set(discardedDuplicates.map((lease) => lease.ptyId))
+    const blockedPtyIds = new Set(
+      storedLeases
+        .filter((lease) => lease.state === 'terminated' || lease.state === 'expired')
+        .map((lease) => lease.ptyId)
+    )
     if (discardedDuplicatePtyIds.size > 0) {
-      // Why: keep stale ids local-only and let their relay PTYs age out through the existing grace period.
-      this.store.excludeDuplicateSshRemotePtyLeases(
-        this.targetId,
-        Array.from(discardedDuplicatePtyIds)
-      )
+      this.store.quarantineSshRemotePtyLeases(this.targetId, Array.from(discardedDuplicatePtyIds))
+      for (const ptyId of discardedDuplicatePtyIds) {
+        blockedPtyIds.add(ptyId)
+      }
+    }
+    for (const ptyId of blockedPtyIds) {
+      // Why: connection-loss ownership survives reconnects, so drop quarantined ids before a later pass can revive them without lease identity.
+      deletePtyOwnership(toAppSshPtyId(this.targetId, ptyId))
     }
     const activeLeaseByPtyId = new Map(activeLeases.map((lease) => [lease.ptyId, lease]))
     const leasedPtyIds = activeLeases.map((lease) => lease.ptyId)
@@ -1965,7 +1973,7 @@ export class SshRelaySession {
       new Set([
         ...getPtyIdsForConnection(this.targetId)
           .map((ptyId) => toRelaySshPtyId(this.targetId, ptyId))
-          .filter((ptyId) => !discardedDuplicatePtyIds.has(ptyId)),
+          .filter((ptyId) => !blockedPtyIds.has(ptyId)),
         ...leasedPtyIds
       ])
     )
@@ -2031,20 +2039,24 @@ export class SshRelaySession {
       shouldContinue
     } = args
     const appPtyId = toAppSshPtyId(this.targetId, ptyId)
-    const lease = activeLeaseByPtyId.get(ptyId)
-    if (lease?.worktreeId && lease.tabId && lease.leafId) {
-      const bindVerdict = this.store.persistPtyBinding(
-        {
-          worktreeId: lease.worktreeId,
-          tabId: lease.tabId,
-          leafId: lease.leafId,
-          ptyId: appPtyId
-        },
-        undefined,
-        { mayCreate: false, dryRun: true }
-      )
-      if (bindVerdict === 'refused') {
+    let lease = activeLeaseByPtyId.get(ptyId)
+    if (lease) {
+      const binding = this.store.resolveExistingSshPtyBinding({
+        targetId: this.targetId,
+        ptyId: appPtyId,
+        worktreeId: lease.worktreeId,
+        tabId: lease.tabId,
+        leafId: lease.leafId
+      })
+      if (!binding) {
+        this.quarantineSshRemotePtyLease(ptyId, appPtyId)
         return
+      }
+      lease = { ...lease, ...binding }
+      activeLeaseByPtyId.set(ptyId, lease)
+      const expectedIdentity = expectedIdentityForLease(lease)
+      if (expectedIdentity) {
+        expectedIdentityByPtyId.set(ptyId, expectedIdentity)
       }
     }
     const pendingReattach: PendingPtyReattach = {
@@ -2151,9 +2163,10 @@ export class SshRelaySession {
       const restoreOutcome = this.restoreReattachedPtyRuntime(
         appPtyId,
         attachResult.incarnationId,
-        activeLeaseByPtyId.get(ptyId)
+        lease
       )
       if (restoreOutcome === 'refused') {
+        this.quarantineSshRemotePtyLease(ptyId, appPtyId)
         return
       }
       setPtyOwnership(appPtyId, this.targetId)
@@ -2232,7 +2245,7 @@ export class SshRelaySession {
             ptyId: appPtyId,
             ...(incarnationId ? { incarnationId } : {})
           },
-          undefined,
+          toSshExecutionHostId(this.targetId),
           { mayCreate: false }
         )
       } catch (error) {
@@ -2257,6 +2270,11 @@ export class SshRelaySession {
       this.runtime?.onPtySpawned(appPtyId, incarnationId, { awaitsRegistration: false })
     }
     return 'bound'
+  }
+
+  private quarantineSshRemotePtyLease(ptyId: string, appPtyId: string): void {
+    this.store.quarantineSshRemotePtyLeases(this.targetId, [ptyId])
+    deletePtyOwnership(appPtyId)
   }
 
   private async attachPtyWithRetry(

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -115,13 +115,17 @@ import {
   rememberSshPtyConsumerRecovery,
   removeSshPtyConsumerOwnerRecovery
 } from './ssh-pty-consumer-recovery'
-import { selectSshRemotePtyLeasesForReattach } from './ssh-remote-pty-lease-selection'
+import {
+  coalesceSshRemotePtyLeasesByIdentity,
+  selectSshRemotePtyLeasesForReattach
+} from './ssh-remote-pty-lease-selection'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
 
 type SshPtyExitPayload = Parameters<SshPtyExitCallback>[0]
 type SshPtyDataPayload = Parameters<SshPtyDataCallback>[0]
 type SshPtyLease = ReturnType<Store['getSshRemotePtyLeases']>[number]
+type ResolvedSshPtyBinding = NonNullable<ReturnType<Store['resolveExistingSshPtyBinding']>>
 const SSH_PTY_REATTACH_MAX_CONCURRENCY = 8
 const SSH_PTY_REATTACH_ATTEMPT_TIMEOUT_MS = 10_000
 const SSH_PTY_REATTACH_RETRY_MIN_DELAY_MS = 50
@@ -1937,9 +1941,21 @@ export class SshRelaySession {
     if (!ptyProvider || providerGeneration === null || this.mux !== mux || !shouldContinue()) {
       return
     }
-    const storedLeases = this.store.getSshRemotePtyLeases(this.targetId)
-    const { candidates: activeLeases, discardedDuplicates } =
-      selectSshRemotePtyLeasesForReattach(storedLeases)
+    const storedLeases = coalesceSshRemotePtyLeasesByIdentity(
+      this.store.getSshRemotePtyLeases(this.targetId)
+    )
+    const { candidates, discardedDuplicates } = selectSshRemotePtyLeasesForReattach(storedLeases, {
+      isDurablyBound: (lease) =>
+        Boolean(
+          this.store.resolveExistingSshPtyBinding({
+            targetId: this.targetId,
+            ptyId: lease.ptyId,
+            worktreeId: lease.worktreeId,
+            tabId: lease.tabId,
+            leafId: lease.leafId
+          })
+        )
+    })
     const discardedDuplicatePtyIds = new Set(discardedDuplicates.map((lease) => lease.ptyId))
     const blockedPtyIds = new Set(
       storedLeases
@@ -1947,15 +1963,21 @@ export class SshRelaySession {
         .map((lease) => lease.ptyId)
     )
     if (discardedDuplicatePtyIds.size > 0) {
-      this.store.quarantineSshRemotePtyLeases(this.targetId, Array.from(discardedDuplicatePtyIds))
+      await this.store.quarantineSshRemotePtyLeasesAsync(
+        this.targetId,
+        Array.from(discardedDuplicatePtyIds)
+      )
       for (const ptyId of discardedDuplicatePtyIds) {
         blockedPtyIds.add(ptyId)
       }
     }
     for (const ptyId of blockedPtyIds) {
       // Why: connection-loss ownership survives reconnects, so drop quarantined ids before a later pass can revive them without lease identity.
-      deletePtyOwnership(toAppSshPtyId(this.targetId, ptyId))
+      const appPtyId = toAppSshPtyId(this.targetId, ptyId)
+      clearProviderPtyState(appPtyId)
+      deletePtyOwnership(appPtyId)
     }
+    const activeLeases = candidates.filter((lease) => !blockedPtyIds.has(lease.ptyId))
     const activeLeaseByPtyId = new Map(activeLeases.map((lease) => [lease.ptyId, lease]))
     const leasedPtyIds = activeLeases.map((lease) => lease.ptyId)
     // Why: pass pane identity so the relay can reject cross-generation id collisions; tabId falls back for pre-leafId leases.
@@ -2009,16 +2031,25 @@ export class SshRelaySession {
         }
       }
     }
-    try {
-      await Promise.all(
-        Array.from({ length: Math.min(SSH_PTY_REATTACH_MAX_CONCURRENCY, ptyIds.length) }, worker)
+    const workerResults = await Promise.allSettled(
+      Array.from({ length: Math.min(SSH_PTY_REATTACH_MAX_CONCURRENCY, ptyIds.length) }, worker)
+    )
+    if (quarantinedPtyIds.size > 0) {
+      await this.store.quarantineSshRemotePtyLeasesAsync(
+        this.targetId,
+        Array.from(quarantinedPtyIds)
       )
-    } finally {
-      // Why: in finally so a cancelled or failed pass still records the panes it already retired;
-      // ownership is dropped inline, so leaving the lease active would revive them on the next pass.
-      if (quarantinedPtyIds.size > 0) {
-        this.store.quarantineSshRemotePtyLeases(this.targetId, Array.from(quarantinedPtyIds))
+      for (const ptyId of quarantinedPtyIds) {
+        const appPtyId = toAppSshPtyId(this.targetId, ptyId)
+        clearProviderPtyState(appPtyId)
+        deletePtyOwnership(appPtyId)
       }
+    }
+    const workerFailure = workerResults.find(
+      (result): result is PromiseRejectedResult => result.status === 'rejected'
+    )
+    if (workerFailure) {
+      throw workerFailure.reason
     }
     if (attachedLeaseIds.size > 0 && shouldContinue()) {
       await this.store.markSshRemotePtyLeasesAttachedAsync(
@@ -2052,7 +2083,7 @@ export class SshRelaySession {
     } = args
     const appPtyId = toAppSshPtyId(this.targetId, ptyId)
     let lease = activeLeaseByPtyId.get(ptyId)
-    let bindingHostId: ExecutionHostId | undefined
+    let resolvedBinding: ResolvedSshPtyBinding | undefined
     if (lease) {
       const binding = this.store.resolveExistingSshPtyBinding({
         targetId: this.targetId,
@@ -2062,11 +2093,16 @@ export class SshRelaySession {
         leafId: lease.leafId
       })
       if (!binding) {
-        this.quarantineSshRemotePtyLease(ptyId, appPtyId, quarantinedPtyIds)
+        this.quarantineSshRemotePtyLease(ptyId, quarantinedPtyIds)
         return
       }
-      const { hostId, ...paneBinding } = binding
-      bindingHostId = hostId
+      const {
+        hostId: _hostId,
+        ptyId: _ptyId,
+        incarnationId: _incarnationId,
+        ...paneBinding
+      } = binding
+      resolvedBinding = binding
       lease = { ...lease, ...paneBinding }
       activeLeaseByPtyId.set(ptyId, lease)
       const expectedIdentity = expectedIdentityForLease(lease)
@@ -2179,10 +2215,23 @@ export class SshRelaySession {
         appPtyId,
         attachResult.incarnationId,
         lease,
-        bindingHostId
+        resolvedBinding
       )
       if (restoreOutcome === 'refused') {
-        this.quarantineSshRemotePtyLease(ptyId, appPtyId, quarantinedPtyIds)
+        if (recoveryActivationLease) {
+          await this.abandonPtySourceRecovery(ptyId, appPtyId, pendingReattach)
+          recoveryActivationLease.retire()
+          recoveryActivationLease = undefined
+        } else if (sourceActivationLease) {
+          const canceled = await sourceActivationLease.rollback()
+          sourceActivationLease = undefined
+          if (!canceled) {
+            throw sourceRecoveryCancellationError(
+              new Error('ssh_source_activation_cancellation_unproven')
+            )
+          }
+        }
+        this.quarantineSshRemotePtyLease(ptyId, quarantinedPtyIds)
         return
       }
       setPtyOwnership(appPtyId, this.targetId)
@@ -2249,9 +2298,24 @@ export class SshRelaySession {
     appPtyId: string,
     incarnationId: string | undefined,
     lease: SshPtyLease | undefined,
-    bindingHostId?: ExecutionHostId
+    resolvedBinding?: ResolvedSshPtyBinding
   ): 'bound' | 'refused' {
     if (lease?.worktreeId && lease.tabId && lease.leafId) {
+      if (!resolvedBinding) {
+        return 'refused'
+      }
+      if (!incarnationId) {
+        const current = this.store.resolveExistingSshPtyBinding({
+          targetId: this.targetId,
+          ptyId: appPtyId,
+          worktreeId: lease.worktreeId,
+          tabId: lease.tabId,
+          leafId: lease.leafId
+        })
+        return current && this.sameResolvedSshPtyBinding(current, resolvedBinding)
+          ? 'bound'
+          : 'refused'
+      }
       let outcome: 'bound' | 'refused'
       try {
         outcome = this.store.persistPtyBinding(
@@ -2264,8 +2328,16 @@ export class SshRelaySession {
           },
           // Why: bind back into the partition the pane was resolved from; writing to the target's
           // own partition would refuse a pane the renderer durably keeps on the local one.
-          bindingHostId ?? toSshExecutionHostId(this.targetId),
-          { mayCreate: false }
+          resolvedBinding.hostId,
+          {
+            mayCreate: false,
+            expectedBinding: {
+              ptyId: resolvedBinding.ptyId,
+              ...(resolvedBinding.incarnationId
+                ? { incarnationId: resolvedBinding.incarnationId }
+                : {})
+            }
+          }
         )
       } catch (error) {
         console.error('[ssh-relay-session] Failed to persist reconnect incarnation:', error)
@@ -2291,18 +2363,24 @@ export class SshRelaySession {
     return 'bound'
   }
 
+  private sameResolvedSshPtyBinding(
+    left: ResolvedSshPtyBinding,
+    right: ResolvedSshPtyBinding
+  ): boolean {
+    return (
+      left.worktreeId === right.worktreeId &&
+      left.tabId === right.tabId &&
+      left.leafId === right.leafId &&
+      left.hostId === right.hostId &&
+      left.ptyId === right.ptyId &&
+      left.incarnationId === right.incarnationId
+    )
+  }
+
   // Why: the store write is deferred to one batched flush per reattach pass — quarantining inline
   // ran a synchronous whole-profile write per refused pane, on a path that can hold a stalled mount.
-  private quarantineSshRemotePtyLease(
-    ptyId: string,
-    appPtyId: string,
-    quarantinedPtyIds: Set<string>
-  ): void {
+  private quarantineSshRemotePtyLease(ptyId: string, quarantinedPtyIds: Set<string>): void {
     quarantinedPtyIds.add(ptyId)
-    // Why: quarantine retires the id for good, so release the provider-scoped state that
-    // connection_lost teardown deliberately preserved for a reattach that will now never happen.
-    clearProviderPtyState(appPtyId)
-    deletePtyOwnership(appPtyId)
     console.warn(
       `[ssh-relay-session] Quarantined PTY ${ptyId} for ${this.targetId}: no durable pane owns it; its remote shell is left running.`
     )

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -115,6 +115,7 @@ import {
   rememberSshPtyConsumerRecovery,
   removeSshPtyConsumerOwnerRecovery
 } from './ssh-pty-consumer-recovery'
+import { selectSshRemotePtyLeasesForReattach } from './ssh-remote-pty-lease-selection'
 
 export type RelaySessionState = 'idle' | 'deploying' | 'ready' | 'reconnecting' | 'disposed'
 
@@ -1931,9 +1932,22 @@ export class SshRelaySession {
     mux: SshChannelMultiplexer,
     shouldContinue: () => boolean
   ): Promise<void> {
-    const activeLeases = this.store
-      .getSshRemotePtyLeases(this.targetId)
-      .filter((lease) => lease.state !== 'terminated' && lease.state !== 'expired')
+    const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
+    const providerGeneration = this.activePtyProviderGeneration
+    if (!ptyProvider || providerGeneration === null || this.mux !== mux || !shouldContinue()) {
+      return
+    }
+    const { candidates: activeLeases, discardedDuplicates } = selectSshRemotePtyLeasesForReattach(
+      this.store.getSshRemotePtyLeases(this.targetId)
+    )
+    const discardedDuplicatePtyIds = new Set(discardedDuplicates.map((lease) => lease.ptyId))
+    if (discardedDuplicatePtyIds.size > 0) {
+      // Why: keep stale ids local-only and let their relay PTYs age out through the existing grace period.
+      this.store.excludeDuplicateSshRemotePtyLeases(
+        this.targetId,
+        Array.from(discardedDuplicatePtyIds)
+      )
+    }
     const activeLeaseByPtyId = new Map(activeLeases.map((lease) => [lease.ptyId, lease]))
     const leasedPtyIds = activeLeases.map((lease) => lease.ptyId)
     // Why: pass pane identity so the relay can reject cross-generation id collisions; tabId falls back for pre-leafId leases.
@@ -1949,17 +1963,12 @@ export class SshRelaySession {
     // Why: after app restart ptyOwnership is empty, but durable SSH leases still describe grace-window survivors.
     const ptyIds = Array.from(
       new Set([
-        ...getPtyIdsForConnection(this.targetId).map((ptyId) =>
-          toRelaySshPtyId(this.targetId, ptyId)
-        ),
+        ...getPtyIdsForConnection(this.targetId)
+          .map((ptyId) => toRelaySshPtyId(this.targetId, ptyId))
+          .filter((ptyId) => !discardedDuplicatePtyIds.has(ptyId)),
         ...leasedPtyIds
       ])
     )
-    const ptyProvider = getSshPtyProvider(this.targetId) as SshPtyProvider | undefined
-    const providerGeneration = this.activePtyProviderGeneration
-    if (!ptyProvider || providerGeneration === null || this.mux !== mux) {
-      return
-    }
     let nextPtyIndex = 0
     const worker = async (): Promise<void> => {
       while (shouldContinue()) {
@@ -2022,6 +2031,22 @@ export class SshRelaySession {
       shouldContinue
     } = args
     const appPtyId = toAppSshPtyId(this.targetId, ptyId)
+    const lease = activeLeaseByPtyId.get(ptyId)
+    if (lease?.worktreeId && lease.tabId && lease.leafId) {
+      const bindVerdict = this.store.persistPtyBinding(
+        {
+          worktreeId: lease.worktreeId,
+          tabId: lease.tabId,
+          leafId: lease.leafId,
+          ptyId: appPtyId
+        },
+        undefined,
+        { mayCreate: false, dryRun: true }
+      )
+      if (bindVerdict === 'refused') {
+        return
+      }
+    }
     const pendingReattach: PendingPtyReattach = {
       mux,
       providerGeneration,
@@ -2123,15 +2148,15 @@ export class SshRelaySession {
       if (!shouldContinue() || !this.ownsPtyRecoveryAttempt(appPtyId, pendingReattach)) {
         return
       }
-      setPtyOwnership(appPtyId, this.targetId)
-      if (attachResult.incarnationId) {
-        restorePtyIncarnation(appPtyId, attachResult.incarnationId)
-        this.restoreReattachedPtyRuntime(
-          appPtyId,
-          attachResult.incarnationId,
-          activeLeaseByPtyId.get(ptyId)
-        )
+      const restoreOutcome = this.restoreReattachedPtyRuntime(
+        appPtyId,
+        attachResult.incarnationId,
+        activeLeaseByPtyId.get(ptyId)
+      )
+      if (restoreOutcome === 'refused') {
+        return
       }
+      setPtyOwnership(appPtyId, this.targetId)
       attachedLeaseIds.add(ptyId)
       pendingReattach.activated = true
       recoveryActivationLease?.commit()
@@ -2193,29 +2218,45 @@ export class SshRelaySession {
 
   private restoreReattachedPtyRuntime(
     appPtyId: string,
-    incarnationId: string,
+    incarnationId: string | undefined,
     lease: SshPtyLease | undefined
-  ): void {
+  ): 'bound' | 'refused' {
     if (lease?.worktreeId && lease.tabId && lease.leafId) {
-      this.runtime?.registerPty(appPtyId, lease.worktreeId, this.targetId, {
-        tabId: lease.tabId,
-        leafId: lease.leafId,
-        incarnationId
-      })
+      let outcome: 'bound' | 'refused'
       try {
-        this.store.persistPtyBinding({
-          worktreeId: lease.worktreeId,
-          tabId: lease.tabId,
-          leafId: lease.leafId,
-          ptyId: appPtyId,
-          incarnationId
-        })
+        outcome = this.store.persistPtyBinding(
+          {
+            worktreeId: lease.worktreeId,
+            tabId: lease.tabId,
+            leafId: lease.leafId,
+            ptyId: appPtyId,
+            ...(incarnationId ? { incarnationId } : {})
+          },
+          undefined,
+          { mayCreate: false }
+        )
       } catch (error) {
         console.error('[ssh-relay-session] Failed to persist reconnect incarnation:', error)
+        outcome = 'bound'
       }
-      return
+      if (outcome === 'refused') {
+        return 'refused'
+      }
+      if (incarnationId) {
+        restorePtyIncarnation(appPtyId, incarnationId)
+        this.runtime?.registerPty(appPtyId, lease.worktreeId, this.targetId, {
+          tabId: lease.tabId,
+          leafId: lease.leafId,
+          incarnationId
+        })
+      }
+      return 'bound'
     }
-    this.runtime?.onPtySpawned(appPtyId, incarnationId, { awaitsRegistration: false })
+    if (incarnationId) {
+      restorePtyIncarnation(appPtyId, incarnationId)
+      this.runtime?.onPtySpawned(appPtyId, incarnationId, { awaitsRegistration: false })
+    }
+    return 'bound'
   }
 
   private async attachPtyWithRetry(

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -1968,6 +1968,7 @@ export class SshRelaySession {
         .filter((entry): entry is [string, ExpectedPtyIdentity] => entry !== null)
     )
     const attachedLeaseIds = new Set<string>()
+    const quarantinedPtyIds = new Set<string>()
     // Why: after app restart ptyOwnership is empty, but durable SSH leases still describe grace-window survivors.
     const ptyIds = Array.from(
       new Set([
@@ -1991,6 +1992,7 @@ export class SshRelaySession {
             activeLeaseByPtyId,
             expectedIdentityByPtyId,
             attachedLeaseIds,
+            quarantinedPtyIds,
             mux,
             providerGeneration,
             shouldContinue
@@ -2007,9 +2009,17 @@ export class SshRelaySession {
         }
       }
     }
-    await Promise.all(
-      Array.from({ length: Math.min(SSH_PTY_REATTACH_MAX_CONCURRENCY, ptyIds.length) }, worker)
-    )
+    try {
+      await Promise.all(
+        Array.from({ length: Math.min(SSH_PTY_REATTACH_MAX_CONCURRENCY, ptyIds.length) }, worker)
+      )
+    } finally {
+      // Why: in finally so a cancelled or failed pass still records the panes it already retired;
+      // ownership is dropped inline, so leaving the lease active would revive them on the next pass.
+      if (quarantinedPtyIds.size > 0) {
+        this.store.quarantineSshRemotePtyLeases(this.targetId, Array.from(quarantinedPtyIds))
+      }
+    }
     if (attachedLeaseIds.size > 0 && shouldContinue()) {
       await this.store.markSshRemotePtyLeasesAttachedAsync(
         this.targetId,
@@ -2024,6 +2034,7 @@ export class SshRelaySession {
     activeLeaseByPtyId: Map<string, SshPtyLease>
     expectedIdentityByPtyId: Map<string, ExpectedPtyIdentity>
     attachedLeaseIds: Set<string>
+    quarantinedPtyIds: Set<string>
     mux: SshChannelMultiplexer
     providerGeneration: number
     shouldContinue: () => boolean
@@ -2034,12 +2045,14 @@ export class SshRelaySession {
       activeLeaseByPtyId,
       expectedIdentityByPtyId,
       attachedLeaseIds,
+      quarantinedPtyIds,
       mux,
       providerGeneration,
       shouldContinue
     } = args
     const appPtyId = toAppSshPtyId(this.targetId, ptyId)
     let lease = activeLeaseByPtyId.get(ptyId)
+    let bindingHostId: ExecutionHostId | undefined
     if (lease) {
       const binding = this.store.resolveExistingSshPtyBinding({
         targetId: this.targetId,
@@ -2049,10 +2062,12 @@ export class SshRelaySession {
         leafId: lease.leafId
       })
       if (!binding) {
-        this.quarantineSshRemotePtyLease(ptyId, appPtyId)
+        this.quarantineSshRemotePtyLease(ptyId, appPtyId, quarantinedPtyIds)
         return
       }
-      lease = { ...lease, ...binding }
+      const { hostId, ...paneBinding } = binding
+      bindingHostId = hostId
+      lease = { ...lease, ...paneBinding }
       activeLeaseByPtyId.set(ptyId, lease)
       const expectedIdentity = expectedIdentityForLease(lease)
       if (expectedIdentity) {
@@ -2163,10 +2178,11 @@ export class SshRelaySession {
       const restoreOutcome = this.restoreReattachedPtyRuntime(
         appPtyId,
         attachResult.incarnationId,
-        lease
+        lease,
+        bindingHostId
       )
       if (restoreOutcome === 'refused') {
-        this.quarantineSshRemotePtyLease(ptyId, appPtyId)
+        this.quarantineSshRemotePtyLease(ptyId, appPtyId, quarantinedPtyIds)
         return
       }
       setPtyOwnership(appPtyId, this.targetId)
@@ -2232,7 +2248,8 @@ export class SshRelaySession {
   private restoreReattachedPtyRuntime(
     appPtyId: string,
     incarnationId: string | undefined,
-    lease: SshPtyLease | undefined
+    lease: SshPtyLease | undefined,
+    bindingHostId?: ExecutionHostId
   ): 'bound' | 'refused' {
     if (lease?.worktreeId && lease.tabId && lease.leafId) {
       let outcome: 'bound' | 'refused'
@@ -2245,7 +2262,9 @@ export class SshRelaySession {
             ptyId: appPtyId,
             ...(incarnationId ? { incarnationId } : {})
           },
-          toSshExecutionHostId(this.targetId),
+          // Why: bind back into the partition the pane was resolved from; writing to the target's
+          // own partition would refuse a pane the renderer durably keeps on the local one.
+          bindingHostId ?? toSshExecutionHostId(this.targetId),
           { mayCreate: false }
         )
       } catch (error) {
@@ -2272,9 +2291,21 @@ export class SshRelaySession {
     return 'bound'
   }
 
-  private quarantineSshRemotePtyLease(ptyId: string, appPtyId: string): void {
-    this.store.quarantineSshRemotePtyLeases(this.targetId, [ptyId])
+  // Why: the store write is deferred to one batched flush per reattach pass — quarantining inline
+  // ran a synchronous whole-profile write per refused pane, on a path that can hold a stalled mount.
+  private quarantineSshRemotePtyLease(
+    ptyId: string,
+    appPtyId: string,
+    quarantinedPtyIds: Set<string>
+  ): void {
+    quarantinedPtyIds.add(ptyId)
+    // Why: quarantine retires the id for good, so release the provider-scoped state that
+    // connection_lost teardown deliberately preserved for a reattach that will now never happen.
+    clearProviderPtyState(appPtyId)
     deletePtyOwnership(appPtyId)
+    console.warn(
+      `[ssh-relay-session] Quarantined PTY ${ptyId} for ${this.targetId}: no durable pane owns it; its remote shell is left running.`
+    )
   }
 
   private async attachPtyWithRetry(

--- a/src/main/ssh/ssh-remote-pty-lease-selection.test.ts
+++ b/src/main/ssh/ssh-remote-pty-lease-selection.test.ts
@@ -1,0 +1,66 @@
+import { describe, expect, it } from 'vitest'
+import type { SshRemotePtyLease } from '../../shared/ssh-types'
+import {
+  coalesceSshRemotePtyLeasesByIdentity,
+  selectSshRemotePtyLeasesForReattach
+} from './ssh-remote-pty-lease-selection'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+
+function lease(overrides: Partial<SshRemotePtyLease> = {}): SshRemotePtyLease {
+  return {
+    targetId: 'target-1',
+    ptyId: 'pty-1',
+    worktreeId: 'worktree-1',
+    tabId: 'tab-1',
+    leafId: LEAF_ID,
+    state: 'detached',
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+describe('SSH remote PTY lease selection', () => {
+  it('prefers the durable pane binding over a newer unbound lease', () => {
+    const bound = lease({ ptyId: 'pty-bound', createdAt: 1, updatedAt: 1 })
+    const newer = lease({ ptyId: 'pty-newer', createdAt: 2, updatedAt: 2 })
+
+    expect(
+      selectSshRemotePtyLeasesForReattach([bound, newer], {
+        isDurablyBound: (candidate) => candidate === bound
+      })
+    ).toEqual({ candidates: [bound], discardedDuplicates: [newer] })
+  })
+
+  it('lets a newer final lease tombstone an older active pane lease', () => {
+    const active = lease({ ptyId: 'pty-old', createdAt: 1, updatedAt: 1 })
+    const terminated = lease({
+      ptyId: 'pty-new',
+      state: 'terminated',
+      createdAt: 2,
+      updatedAt: 2
+    })
+
+    expect(selectSshRemotePtyLeasesForReattach([active, terminated])).toEqual({
+      candidates: [],
+      discardedDuplicates: [active]
+    })
+    expect(
+      selectSshRemotePtyLeasesForReattach([active, terminated], {
+        isDurablyBound: (candidate) => candidate === active
+      })
+    ).toEqual({ candidates: [], discardedDuplicates: [active] })
+  })
+
+  it('coalesces duplicate remote PTY identities without quarantining the winner', () => {
+    const older = lease({ state: 'expired', createdAt: 1, updatedAt: 1 })
+    const newer = lease({ state: 'attached', createdAt: 2, updatedAt: 2 })
+
+    expect(coalesceSshRemotePtyLeasesByIdentity([older, newer])).toEqual([newer])
+    expect(selectSshRemotePtyLeasesForReattach([older, newer])).toEqual({
+      candidates: [newer],
+      discardedDuplicates: []
+    })
+  })
+})

--- a/src/main/ssh/ssh-remote-pty-lease-selection.ts
+++ b/src/main/ssh/ssh-remote-pty-lease-selection.ts
@@ -5,7 +5,11 @@ export type SshRemotePtyLeaseSelection = {
   discardedDuplicates: SshRemotePtyLease[]
 }
 
-function completePaneKey(lease: SshRemotePtyLease): string | null {
+export type SshRemotePtyLeaseSelectionOptions = {
+  isDurablyBound?: (lease: SshRemotePtyLease) => boolean
+}
+
+export function sshRemotePtyLeasePaneKey(lease: SshRemotePtyLease): string | null {
   if (!lease.worktreeId || !lease.tabId || !lease.leafId) {
     return null
   }
@@ -22,29 +26,76 @@ function isNewerLease(candidate: SshRemotePtyLease, incumbent: SshRemotePtyLease
   return candidate.ptyId > incumbent.ptyId
 }
 
-export function selectSshRemotePtyLeasesForReattach(
-  leases: readonly SshRemotePtyLease[]
-): SshRemotePtyLeaseSelection {
-  const activeLeases = leases.filter(
-    (lease) => lease.state !== 'terminated' && lease.state !== 'expired'
-  )
-  const winnerByPaneKey = new Map<string, SshRemotePtyLease>()
+function newestLease(leases: readonly SshRemotePtyLease[]): SshRemotePtyLease {
+  return leases.reduce((winner, lease) => (isNewerLease(lease, winner) ? lease : winner))
+}
 
-  for (const lease of activeLeases) {
-    const paneKey = completePaneKey(lease)
+function isFinalLease(lease: SshRemotePtyLease): boolean {
+  return lease.state === 'terminated' || lease.state === 'expired'
+}
+
+export function coalesceSshRemotePtyLeasesByIdentity(
+  leases: readonly SshRemotePtyLease[]
+): SshRemotePtyLease[] {
+  const winnerByIdentity = new Map<string, SshRemotePtyLease>()
+  for (const lease of leases) {
+    const identity = `${lease.targetId}\0${lease.ptyId}`
+    const incumbent = winnerByIdentity.get(identity)
+    if (!incumbent || isNewerLease(lease, incumbent)) {
+      winnerByIdentity.set(identity, lease)
+    }
+  }
+  return leases.filter(
+    (lease) => winnerByIdentity.get(`${lease.targetId}\0${lease.ptyId}`) === lease
+  )
+}
+
+export function selectSshRemotePtyLeasesForReattach(
+  leases: readonly SshRemotePtyLease[],
+  options: SshRemotePtyLeaseSelectionOptions = {}
+): SshRemotePtyLeaseSelection {
+  const uniqueLeases = coalesceSshRemotePtyLeasesByIdentity(leases)
+  const leasesByPaneKey = new Map<string, SshRemotePtyLease[]>()
+
+  for (const lease of uniqueLeases) {
+    const paneKey = sshRemotePtyLeasePaneKey(lease)
     if (!paneKey) {
       continue
     }
-    const incumbent = winnerByPaneKey.get(paneKey)
-    if (!incumbent || isNewerLease(lease, incumbent)) {
-      winnerByPaneKey.set(paneKey, lease)
+    const paneLeases = leasesByPaneKey.get(paneKey)
+    if (paneLeases) {
+      paneLeases.push(lease)
+    } else {
+      leasesByPaneKey.set(paneKey, [lease])
     }
+  }
+
+  const winnerByPaneKey = new Map<string, SshRemotePtyLease>()
+  for (const [paneKey, paneLeases] of leasesByPaneKey) {
+    const finalLeases = paneLeases.filter(isFinalLease)
+    const newestFinal = finalLeases.length > 0 ? newestLease(finalLeases) : undefined
+    const liveEpoch = newestFinal
+      ? paneLeases.filter((lease) => isNewerLease(lease, newestFinal))
+      : paneLeases
+    if (liveEpoch.length === 0) {
+      winnerByPaneKey.set(paneKey, newestFinal!)
+      continue
+    }
+    if (liveEpoch.length === 1) {
+      winnerByPaneKey.set(paneKey, liveEpoch[0])
+      continue
+    }
+    const durablyBound = options.isDurablyBound ? liveEpoch.filter(options.isDurablyBound) : []
+    winnerByPaneKey.set(paneKey, newestLease(durablyBound.length > 0 ? durablyBound : liveEpoch))
   }
 
   const candidates: SshRemotePtyLease[] = []
   const discardedDuplicates: SshRemotePtyLease[] = []
-  for (const lease of activeLeases) {
-    const paneKey = completePaneKey(lease)
+  for (const lease of uniqueLeases) {
+    if (isFinalLease(lease)) {
+      continue
+    }
+    const paneKey = sshRemotePtyLeasePaneKey(lease)
     if (!paneKey || winnerByPaneKey.get(paneKey) === lease) {
       candidates.push(lease)
     } else {

--- a/src/main/ssh/ssh-remote-pty-lease-selection.ts
+++ b/src/main/ssh/ssh-remote-pty-lease-selection.ts
@@ -1,0 +1,55 @@
+import type { SshRemotePtyLease } from '../../shared/ssh-types'
+
+export type SshRemotePtyLeaseSelection = {
+  candidates: SshRemotePtyLease[]
+  discardedDuplicates: SshRemotePtyLease[]
+}
+
+function completePaneKey(lease: SshRemotePtyLease): string | null {
+  if (!lease.worktreeId || !lease.tabId || !lease.leafId) {
+    return null
+  }
+  return [lease.targetId, lease.worktreeId, lease.tabId, lease.leafId].join('\0')
+}
+
+function isNewerLease(candidate: SshRemotePtyLease, incumbent: SshRemotePtyLease): boolean {
+  if (candidate.updatedAt !== incumbent.updatedAt) {
+    return candidate.updatedAt > incumbent.updatedAt
+  }
+  if (candidate.createdAt !== incumbent.createdAt) {
+    return candidate.createdAt > incumbent.createdAt
+  }
+  return candidate.ptyId > incumbent.ptyId
+}
+
+export function selectSshRemotePtyLeasesForReattach(
+  leases: readonly SshRemotePtyLease[]
+): SshRemotePtyLeaseSelection {
+  const activeLeases = leases.filter(
+    (lease) => lease.state !== 'terminated' && lease.state !== 'expired'
+  )
+  const winnerByPaneKey = new Map<string, SshRemotePtyLease>()
+
+  for (const lease of activeLeases) {
+    const paneKey = completePaneKey(lease)
+    if (!paneKey) {
+      continue
+    }
+    const incumbent = winnerByPaneKey.get(paneKey)
+    if (!incumbent || isNewerLease(lease, incumbent)) {
+      winnerByPaneKey.set(paneKey, lease)
+    }
+  }
+
+  const candidates: SshRemotePtyLease[] = []
+  const discardedDuplicates: SshRemotePtyLease[] = []
+  for (const lease of activeLeases) {
+    const paneKey = completePaneKey(lease)
+    if (!paneKey || winnerByPaneKey.get(paneKey) === lease) {
+      candidates.push(lease)
+    } else {
+      discardedDuplicates.push(lease)
+    }
+  }
+  return { candidates, discardedDuplicates }
+}


### PR DESCRIPTION
## Summary

SSH reattach now validates each remote PTY lease against durable pane state before restoring it, preventing cross-wiring to wrong panes or creating phantom entries. Unverified leases are quarantined to prevent revival on reconnect.

## Changes

- **New `resolveExistingSshPtyBinding()`**: Searches both SSH target and local partitions for durable pane bindings, preferring target partition when both exist
- **New `quarantineSshRemotePtyLeasesAsync()`**: Marks orphaned leases as `expired` in one batched write per reattach pass
- **Modified `persistPtyBinding()`**: Added `mayCreate: false` option to refuse creating panes during reattach; compare-and-set with `expectedBinding` detects post-attach races
- **New `ssh-remote-pty-lease-selection.ts`**: Coalesces duplicate remote PTY identities and selects winner lease for reattach
- **SSH relay session**: Validates each lease's durable pane before attach; batches quarantine writes; clears provider state for blocked PTYs

## Fixes

STA-3077: Reattach no longer cross-wires to wrong panes or creates orphaned entries. Resolves incomplete legacy leases to pane identity before reattach. Prevents duplicate remote PTY identities from interfering with active sessions.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — added comprehensive tests for lease coalescing, partition-aware pane resolution, quarantine rollback on failure, compare-and-set races, legacy lease resolution, and duplicate blocking across reconnects
- [ ] `pnpm build`

## Notes

- Reattach is now read-only: cannot create or grow topology
- Binds back to the partition the pane was resolved from, respecting SSH partition isolation and folder workspace cases
- Quarantine deferred to batched write to avoid synchronous I/O per pane