### PR TITLE
feat(diff): teach the file tree with a one-shot callout that sets the default

### DIFF
--- a/src/main/runtime/rpc/methods/client-ui-dismissal-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-dismissal-schemas.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod'
+
+// Why: one-shot dismissals the renderer writes through ui.set; each was a
+// whole-payload rejection for paired clients while unlisted.
+export const OneShotDismissalFields = {
+  setupGuideSidebarDismissed: z.boolean().optional(),
+  setupGuideBrowserMilestoneMigrated: z.boolean().optional(),
+  setupGuideBrowserMilestoneLegacyComplete: z.boolean().optional(),
+  browserImportHintHidden: z.boolean().optional(),
+  mobileEmulatorTabIntroDismissed: z.boolean().optional(),
+  combinedDiffFileTreeHintDismissed: z.boolean().optional(),
+  mobileEmulatorAgentSetupDismissed: z.boolean().optional(),
+  projectOrderManualDefaultNoticeDismissed: z.boolean().optional(),
+  usagePercentageDisplayChangeNoticeDismissed: z.boolean().optional(),
+  usageEmptyStateDismissed: z.boolean().optional()
+}

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -19,6 +19,7 @@ import {
 } from '../../../../shared/worktree-card-properties'
 import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
 import type { TaskProvider } from '../../../../shared/types'
+import { OneShotDismissalFields } from './client-ui-dismissal-schemas'
 import { TaskResumeState } from './task-resume-state-schema'
 import { omitUndefinedValues, tolerateUnknownValues } from './ui-update-value-tolerance'
 
@@ -282,17 +283,7 @@ const UiUpdateFields = z
     _inlineAgentsDefaultedForAllUsers: z.boolean().optional(),
     trustedOrcaHooks: z.record(z.string(), z.unknown()).optional(),
     setupScriptPromptDismissedRepoIds: StringArray.optional(),
-    // Why: one-shot dismissals the renderer writes through ui.set; each was a
-    // whole-payload rejection for paired clients while unlisted.
-    setupGuideSidebarDismissed: z.boolean().optional(),
-    setupGuideBrowserMilestoneMigrated: z.boolean().optional(),
-    setupGuideBrowserMilestoneLegacyComplete: z.boolean().optional(),
-    browserImportHintHidden: z.boolean().optional(),
-    mobileEmulatorTabIntroDismissed: z.boolean().optional(),
-    mobileEmulatorAgentSetupDismissed: z.boolean().optional(),
-    projectOrderManualDefaultNoticeDismissed: z.boolean().optional(),
-    usagePercentageDisplayChangeNoticeDismissed: z.boolean().optional(),
-    usageEmptyStateDismissed: z.boolean().optional(),
+    ...OneShotDismissalFields,
     petVisible: z.boolean().optional(),
     petId: z.string().optional(),
     customPets: UnknownRecordArray.optional(),

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -555,6 +555,7 @@ describe('client UI RPC methods', () => {
     ],
     ['browserImportHintHidden', { browserImportHintHidden: true }],
     ['mobileEmulatorTabIntroDismissed', { mobileEmulatorTabIntroDismissed: true }],
+    ['combinedDiffFileTreeHintDismissed', { combinedDiffFileTreeHintDismissed: true }],
     ['mobileEmulatorAgentSetupDismissed', { mobileEmulatorAgentSetupDismissed: true }],
     ['alwaysShowDefaultBranchWorkspace', { alwaysShowDefaultBranchWorkspace: false }]
   ])('accepts %s, which the renderer persists through ui.set', async (_label, payload) => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -30,7 +30,10 @@ import {
   shouldRenderDesktopWindowChrome
 } from '@/lib/desktop-window-chrome'
 import { resolveLeftTitlebarChromeLayout } from '@/lib/titlebar-left-chrome'
-import { shouldShowWorktreeCreationSurface } from '@/lib/worktree-creation-surface'
+import {
+  isTerminalWorkbenchVisible,
+  shouldShowWorktreeCreationSurface
+} from '@/lib/worktree-creation-surface'
 import { buildAppFontFamily } from '@/lib/app-font-family'
 import { toast } from 'sonner'
 import { Toaster } from '@/components/ui/sonner'
@@ -558,8 +561,12 @@ function App(): React.JSX.Element {
   })
   const workspaceChromeActive =
     activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
-  const terminalWorkbenchVisible =
-    activeView === 'terminal' && activeWorktreeId !== null && !creationLayoutActive
+  const terminalWorkbenchVisible = isTerminalWorkbenchVisible({
+    activeView,
+    activeWorktreeId,
+    activePendingCreationId,
+    hasActivePendingCreation: activePendingCreationExists
+  })
   // Why: once the floating workspace owns tabs, keep it mounted while closed so hidden terminal/browser/editor panes retain local state.
   const shouldMountFloatingTerminalPanel =
     floatingTerminalEnabled && (floatingTerminalOpen || floatingVisibleTabCount > 0)

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -34,7 +34,6 @@ import {
   MessageSquare,
   MessageSquarePlus,
   MoveRight,
-  PanelLeftOpen,
   Pencil,
   Plus,
   RefreshCw,
@@ -87,6 +86,8 @@ import {
   getCombinedDiffBranchEntriesInTreeOrder,
   type CombinedDiffFileTreeEntry
 } from '@/components/editor/combined-diff-file-tree-model'
+import { isCombinedDiffFileTreeCollapsedByDefault } from '@/components/editor/combined-diff-file-tree-default'
+import { CombinedDiffFileTreeHintButton } from '@/components/editor/CombinedDiffFileTreeHintButton'
 import {
   getStoredTextDiffContent,
   getStoredTextDiffResult
@@ -1391,6 +1392,9 @@ function PRFilesCombinedDiffViewer({
   onViewedChange
 }: PRFilesCombinedDiffViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
+  // Why: this surface renders inline under the Tasks view (not a Radix dialog), and Radix
+  // unmounts the inactive Files tab — so the view check is the whole visibility gate.
+  const tasksViewActive = useAppStore((s) => s.activeView === 'tasks')
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -1471,7 +1475,15 @@ function PRFilesCombinedDiffViewer({
   )
   const [sections, setSections] = useState<DiffSection[]>([])
   const [sideBySide, setSideBySide] = useState(false)
-  const [fileTreeCollapsed, setFileTreeCollapsed] = useState(false)
+  // Why no sync effect (unlike CombinedDiffViewer): this dialog is only opened from an
+  // already-hydrated app, so the initializer never reads a pre-hydration `undefined`.
+  const [fileTreeCollapsed, setFileTreeCollapsedState] = useState(() =>
+    isCombinedDiffFileTreeCollapsedByDefault(settings?.combinedDiffFileTreeVisibleByDefault)
+  )
+  const setFileTreeCollapsed = useCallback((collapsed: boolean) => {
+    setFileTreeCollapsedState(collapsed)
+    useAppStore.getState().recordFeatureInteraction('diff-file-tree')
+  }, [])
   const [sectionHeights, setSectionHeights] = useState<Record<number, number>>({})
   const [activeTreeSectionKey, setActiveTreeSectionKey] = useState<string | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -1810,25 +1822,16 @@ function PRFilesCombinedDiffViewer({
       <div className="flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background/50 px-3 py-1.5">
         <div className="flex min-w-0 items-center gap-2">
           {fileTreeCollapsed && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={translate(
-                    'auto.components.GitHubItemDialog.1257d1435d',
-                    'Show file tree'
-                  )}
-                  onClick={() => setFileTreeCollapsed(false)}
-                >
-                  <PanelLeftOpen className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {translate('auto.components.GitHubItemDialog.1257d1435d', 'Show file tree')}
-              </TooltipContent>
-            </Tooltip>
+            <CombinedDiffFileTreeHintButton
+              label={translate('auto.components.GitHubItemDialog.1257d1435d', 'Show file tree')}
+              surfaceActive={tasksViewActive}
+              fileTreeCollapsed={fileTreeCollapsed}
+              // Why: sections are rebuilt from `entries`, so only a list that already matches
+              // the current entries reflects the real changed-file count.
+              sectionsLoaded={sections.length > 0 && sections.length === entries.length}
+              changedFileCount={sections.length}
+              onSetFileTreeCollapsed={setFileTreeCollapsed}
+            />
           )}
           <span className="truncate text-xs text-muted-foreground">
             {files.filter(isPRFileViewed).length} / {files.length}{' '}

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -31,7 +31,6 @@ import {
   LoaderCircle,
   MessageSquare,
   MessageSquarePlus,
-  PanelLeftOpen,
   Pencil,
   Plus,
   RefreshCw,
@@ -82,6 +81,8 @@ import {
   getCombinedDiffBranchEntriesInTreeOrder,
   type CombinedDiffFileTreeEntry
 } from '@/components/editor/combined-diff-file-tree-model'
+import { isCombinedDiffFileTreeCollapsedByDefault } from '@/components/editor/combined-diff-file-tree-default'
+import { CombinedDiffFileTreeHintButton } from '@/components/editor/CombinedDiffFileTreeHintButton'
 import {
   getStoredTextDiffContent,
   getStoredTextDiffResult
@@ -1452,6 +1453,9 @@ function PRFilesCombinedDiffViewer({
   onViewedChange
 }: PRFilesCombinedDiffViewerProps): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
+  // Why: this page only ever mounts under the Tasks view, and Radix unmounts the inactive
+  // Files tab — so the view check is the whole visibility gate the hint callout needs.
+  const tasksViewActive = useAppStore((s) => s.activeView === 'tasks')
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -1536,7 +1540,15 @@ function PRFilesCombinedDiffViewer({
   )
   const [sections, setSections] = useState<DiffSection[]>([])
   const [sideBySide, setSideBySide] = useState(false)
-  const [fileTreeCollapsed, setFileTreeCollapsed] = useState(false)
+  // Why no sync effect (unlike CombinedDiffViewer): this page is only reachable by navigating
+  // an already-hydrated app, so the initializer never reads a pre-hydration `undefined`.
+  const [fileTreeCollapsed, setFileTreeCollapsedState] = useState(() =>
+    isCombinedDiffFileTreeCollapsedByDefault(settings?.combinedDiffFileTreeVisibleByDefault)
+  )
+  const setFileTreeCollapsed = useCallback((collapsed: boolean) => {
+    setFileTreeCollapsedState(collapsed)
+    useAppStore.getState().recordFeatureInteraction('diff-file-tree')
+  }, [])
   const [sectionHeights, setSectionHeights] = useState<Record<number, number>>({})
   const [activeTreeSectionKey, setActiveTreeSectionKey] = useState<string | null>(null)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -1562,7 +1574,7 @@ function PRFilesCombinedDiffViewer({
       setSections(restoredSections)
       setSectionHeights(cached.sectionHeights)
       setSideBySide(cached.sideBySide)
-      setFileTreeCollapsed(cached.fileTreeCollapsed)
+      setFileTreeCollapsedState(cached.fileTreeCollapsed)
       setActiveTreeSectionKey(cached.activeTreeSectionKey)
       pendingRestoreScrollTopRef.current =
         prFilesDiffScrollTopCache.get(viewStateKey) ?? cached.scrollTop
@@ -1982,25 +1994,16 @@ function PRFilesCombinedDiffViewer({
       <div className="sticky top-0 z-20 flex shrink-0 items-center justify-between gap-3 border-b border-border bg-background px-3 py-1.5">
         <div className="flex min-w-0 items-center gap-2">
           {fileTreeCollapsed && (
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  type="button"
-                  variant="ghost"
-                  size="icon-xs"
-                  aria-label={translate(
-                    'auto.components.PullRequestPage.319cf2d54b',
-                    'Show file tree'
-                  )}
-                  onClick={() => setFileTreeCollapsed(false)}
-                >
-                  <PanelLeftOpen className="size-3.5" />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {translate('auto.components.PullRequestPage.319cf2d54b', 'Show file tree')}
-              </TooltipContent>
-            </Tooltip>
+            <CombinedDiffFileTreeHintButton
+              label={translate('auto.components.PullRequestPage.319cf2d54b', 'Show file tree')}
+              surfaceActive={tasksViewActive}
+              fileTreeCollapsed={fileTreeCollapsed}
+              // Why: sections are rebuilt from `entries`, so only a list that already matches
+              // the current entries reflects the real changed-file count.
+              sectionsLoaded={sections.length > 0 && sections.length === entries.length}
+              changedFileCount={sections.length}
+              onSetFileTreeCollapsed={setFileTreeCollapsed}
+            />
           )}
           <span className="truncate text-xs text-muted-foreground">
             {files.filter(isPRFileViewed).length} / {files.length}{' '}

--- a/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.keyboard.test.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.keyboard.test.tsx
@@ -1,0 +1,79 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { CombinedDiffFileTreeHintButton } from './CombinedDiffFileTreeHintButton'
+import { resetCombinedDiffFileTreeHintClaim } from './combined-diff-file-tree-hint-claim'
+
+// Why the real Popover here: this covers the Tab-into-callout path, which only exists because
+// the portaled content is otherwise unreachable from the trigger.
+const mocks = vi.hoisted(() => ({ state: {} as Partial<AppState> }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Partial<AppState>) => unknown) => selector(mocks.state)
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.state = {
+    updateSettings: vi.fn(),
+    dismissCombinedDiffFileTreeHint: vi.fn(),
+    persistedUIReady: true,
+    combinedDiffFileTreeHintDismissed: false,
+    featureInteractions: {},
+    settings: { combinedDiffFileTreeVisibleByDefault: false },
+    activeContextualTourId: null,
+    contextualToursOnboardingVisible: false,
+    contextualToursBlockingSurfaceVisible: false
+  } as unknown as Partial<AppState>
+  resetCombinedDiffFileTreeHintClaim()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('CombinedDiffFileTreeHintButton keyboard reach', () => {
+  it('keeps focus on the diff until Tab moves it into the callout', () => {
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <CombinedDiffFileTreeHintButton
+            label="Show file tree"
+            surfaceActive
+            fileTreeCollapsed
+            sectionsLoaded
+            changedFileCount={5}
+            onSetFileTreeCollapsed={vi.fn()}
+          />
+        </TooltipProvider>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+
+    const trigger = container.querySelector('button[aria-label="Show file tree"]') as HTMLElement
+    // Why: the callout is uninvited, so opening it must not steal focus from the diff.
+    expect(document.activeElement).not.toBe(trigger)
+
+    act(() => {
+      trigger.focus()
+      trigger.dispatchEvent(new KeyboardEvent('keydown', { key: 'Tab', bubbles: true }))
+    })
+
+    expect(document.activeElement?.getAttribute('role')).toBe('radio')
+    expect(document.activeElement?.textContent).toBe('Shown')
+  })
+})

--- a/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.test.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.test.tsx
@@ -1,0 +1,212 @@
+// @vitest-environment happy-dom
+
+import { act, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi, type Mock } from 'vitest'
+import type { AppState } from '@/store'
+import { CombinedDiffFileTreeHintButton } from './CombinedDiffFileTreeHintButton'
+import { resetCombinedDiffFileTreeHintClaim } from './combined-diff-file-tree-hint-claim'
+
+const mocks = vi.hoisted(() => ({
+  updateSettings: vi.fn(),
+  dismissCombinedDiffFileTreeHint: vi.fn(),
+  tooltipOpen: undefined as boolean | undefined,
+  popoverOpen: false,
+  state: {} as Partial<AppState>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Partial<AppState>) => unknown) => selector(mocks.state)
+}))
+
+vi.mock('@/components/ui/popover', () => ({
+  Popover: ({ children, open }: { children: ReactNode; open?: boolean }) => {
+    mocks.popoverOpen = open === true
+    return <div>{children}</div>
+  },
+  PopoverTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  PopoverContent: ({ children }: { children: ReactNode }) =>
+    mocks.popoverOpen ? <div data-callout>{children}</div> : null
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children, open }: { children: ReactNode; open?: boolean }) => {
+    mocks.tooltipOpen = open
+    return <>{children}</>
+  },
+  TooltipTrigger: ({ children }: { children: ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: ReactNode }) => <span>{children}</span>
+}))
+
+const HINT_DELAY_MS = 600
+
+let container: HTMLDivElement
+let root: Root
+let onSetFileTreeCollapsed: Mock<(collapsed: boolean) => void>
+
+function renderButton(overrides: { changedFileCount?: number } = {}): void {
+  act(() => {
+    root.render(
+      <CombinedDiffFileTreeHintButton
+        label="Show file tree"
+        surfaceActive
+        fileTreeCollapsed
+        sectionsLoaded
+        changedFileCount={overrides.changedFileCount ?? 5}
+        onSetFileTreeCollapsed={onSetFileTreeCollapsed}
+      />
+    )
+  })
+}
+
+function openCallout(): void {
+  act(() => {
+    vi.advanceTimersByTime(HINT_DELAY_MS)
+  })
+}
+
+function calloutButton(text: string): HTMLElement {
+  const match = [...container.querySelectorAll('[data-callout] button')].find(
+    (node) => node.textContent === text
+  )
+  if (!match) {
+    throw new Error(`No callout button labelled ${text}`)
+  }
+  return match as HTMLElement
+}
+
+function click(node: HTMLElement): void {
+  act(() => {
+    node.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+  })
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.updateSettings.mockClear()
+  mocks.dismissCombinedDiffFileTreeHint.mockClear()
+  mocks.tooltipOpen = undefined
+  mocks.popoverOpen = false
+  mocks.state = {
+    updateSettings: mocks.updateSettings,
+    dismissCombinedDiffFileTreeHint: mocks.dismissCombinedDiffFileTreeHint,
+    persistedUIReady: true,
+    combinedDiffFileTreeHintDismissed: false,
+    featureInteractions: {},
+    settings: { combinedDiffFileTreeVisibleByDefault: false },
+    activeContextualTourId: null,
+    contextualToursOnboardingVisible: false,
+    contextualToursBlockingSurfaceVisible: false
+  } as unknown as Partial<AppState>
+  resetCombinedDiffFileTreeHintClaim()
+  onSetFileTreeCollapsed = vi.fn<(collapsed: boolean) => void>()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('CombinedDiffFileTreeHintButton', () => {
+  it('opens the callout for an eligible diff', () => {
+    renderButton()
+    expect(container.querySelector('[data-callout]')).toBeNull()
+
+    openCallout()
+
+    expect(container.querySelector('[data-callout]')).not.toBeNull()
+    expect(mocks.dismissCombinedDiffFileTreeHint).toHaveBeenCalledTimes(1)
+  })
+
+  it('points the trigger at the callout text so the uninvited layer is announced', () => {
+    renderButton()
+    openCallout()
+
+    const describedBy = container
+      .querySelector('button[aria-label="Show file tree"]')
+      ?.getAttribute('aria-describedby')
+
+    expect(describedBy).toBeTruthy()
+    expect(container.querySelector(`[data-callout] #${CSS.escape(describedBy!)}`)).not.toBeNull()
+  })
+
+  it('stays quiet on a diff too small to need a tree', () => {
+    renderButton({ changedFileCount: 2 })
+    openCallout()
+
+    expect(container.querySelector('[data-callout]')).toBeNull()
+    expect(mocks.dismissCombinedDiffFileTreeHint).not.toHaveBeenCalled()
+  })
+
+  it('stays quiet while a contextual tour owns the screen', () => {
+    mocks.state = {
+      ...mocks.state,
+      activeContextualTourId: 'workspace-agent-sessions'
+    } as unknown as Partial<AppState>
+    renderButton()
+    openCallout()
+
+    expect(container.querySelector('[data-callout]')).toBeNull()
+    expect(mocks.dismissCombinedDiffFileTreeHint).not.toHaveBeenCalled()
+  })
+
+  it('suppresses the button tooltip while the callout explains the same button', () => {
+    renderButton()
+    expect(mocks.tooltipOpen).toBe(false)
+
+    openCallout()
+
+    expect(mocks.tooltipOpen).toBe(false)
+  })
+
+  it('saves the shown default and reveals the tree immediately', () => {
+    renderButton()
+    openCallout()
+
+    click(calloutButton('Shown'))
+
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      combinedDiffFileTreeVisibleByDefault: true
+    })
+    expect(onSetFileTreeCollapsed).toHaveBeenCalledWith(false)
+    expect(container.querySelector('[data-callout]')).toBeNull()
+  })
+
+  it('saves the hidden default without opening the tree', () => {
+    renderButton()
+    openCallout()
+
+    click(calloutButton('Hidden'))
+
+    expect(mocks.updateSettings).toHaveBeenCalledWith({
+      combinedDiffFileTreeVisibleByDefault: false
+    })
+    expect(onSetFileTreeCollapsed).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-callout]')).toBeNull()
+  })
+
+  it('changes no setting when the callout is dismissed', () => {
+    renderButton()
+    openCallout()
+
+    click(calloutButton('Dismiss'))
+
+    expect(mocks.updateSettings).not.toHaveBeenCalled()
+    expect(onSetFileTreeCollapsed).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-callout]')).toBeNull()
+  })
+
+  it('still opens the tree when the trigger itself is clicked', () => {
+    renderButton()
+    openCallout()
+
+    click(container.querySelector('button[aria-label="Show file tree"]') as HTMLElement)
+
+    expect(onSetFileTreeCollapsed).toHaveBeenCalledWith(false)
+    expect(container.querySelector('[data-callout]')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.tooltip.test.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.tooltip.test.tsx
@@ -1,0 +1,87 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '@/store'
+import { TooltipProvider } from '@/components/ui/tooltip'
+import { CombinedDiffFileTreeHintButton } from './CombinedDiffFileTreeHintButton'
+import { resetCombinedDiffFileTreeHintClaim } from './combined-diff-file-tree-hint-claim'
+
+// Why the real Tooltip here: Radix only warns about a controlled/uncontrolled switch from
+// inside its own hook, so a mocked Tooltip cannot catch it.
+const mocks = vi.hoisted(() => ({ state: {} as Partial<AppState> }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Partial<AppState>) => unknown) => selector(mocks.state)
+}))
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.state = {
+    updateSettings: vi.fn(),
+    dismissCombinedDiffFileTreeHint: vi.fn(),
+    persistedUIReady: true,
+    combinedDiffFileTreeHintDismissed: false,
+    featureInteractions: {},
+    settings: { combinedDiffFileTreeVisibleByDefault: false },
+    activeContextualTourId: null,
+    contextualToursOnboardingVisible: false,
+    contextualToursBlockingSurfaceVisible: false
+  } as unknown as Partial<AppState>
+  resetCombinedDiffFileTreeHintClaim()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+function dismissButton(): HTMLElement {
+  const match = [...document.body.querySelectorAll('button')].find(
+    (node) => node.textContent === 'Dismiss'
+  )
+  if (!match) {
+    throw new Error('No Dismiss button in the callout')
+  }
+  return match
+}
+
+describe('CombinedDiffFileTreeHintButton tooltip lifecycle', () => {
+  it('never switches the tooltip between controlled and uncontrolled', () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    act(() => {
+      root.render(
+        <TooltipProvider>
+          <CombinedDiffFileTreeHintButton
+            label="Show file tree"
+            surfaceActive
+            fileTreeCollapsed
+            sectionsLoaded
+            changedFileCount={5}
+            onSetFileTreeCollapsed={vi.fn()}
+          />
+        </TooltipProvider>
+      )
+    })
+    act(() => {
+      vi.advanceTimersByTime(600)
+    })
+    act(() => {
+      dismissButton().dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    })
+
+    expect(
+      warn.mock.calls.filter(([message]) => String(message).includes('uncontrolled'))
+    ).toHaveLength(0)
+    warn.mockRestore()
+  })
+})

--- a/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffFileTreeHintButton.tsx
@@ -1,0 +1,224 @@
+import React from 'react'
+import { PanelLeftOpen } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { Popover, PopoverContent, PopoverTrigger } from '@/components/ui/popover'
+import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
+import { SettingsSegmentedControl } from '@/components/settings/SettingsFormControls'
+import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
+import { translate } from '@/i18n/i18n'
+import { hasFeatureInteraction } from '../../../../shared/feature-interactions'
+import {
+  applyCombinedDiffFileTreeHintChoice,
+  type CombinedDiffFileTreeHintChoice
+} from './combined-diff-file-tree-hint-choice'
+import { shouldShowCombinedDiffFileTreeHint } from './combined-diff-file-tree-hint-visibility'
+import { useCombinedDiffFileTreeHint } from './use-combined-diff-file-tree-hint'
+
+export type CombinedDiffFileTreeHintButtonProps = {
+  /** Each diff surface keeps its own translation key for the same "Show file tree" label. */
+  label: string
+  /**
+   * Whether this viewer is on the visible workspace surface. Required (no default)
+   * so a mounted-but-hidden pane can never force-open a portaled layer.
+   */
+  surfaceActive: boolean
+  fileTreeCollapsed: boolean
+  sectionsLoaded: boolean
+  changedFileCount: number
+  onSetFileTreeCollapsed: (collapsed: boolean) => void
+}
+
+// "Show file tree" toolbar button plus the one-shot discovery callout that asks, in
+// place, what the default should be.
+export function CombinedDiffFileTreeHintButton({
+  label,
+  surfaceActive,
+  fileTreeCollapsed,
+  sectionsLoaded,
+  changedFileCount,
+  onSetFileTreeCollapsed
+}: CombinedDiffFileTreeHintButtonProps): React.JSX.Element {
+  const defaultLabel = translate(
+    'auto.components.editor.CombinedDiffFileTreeHintButton.4c1f0a7d92',
+    'Default in diff views'
+  )
+  const updateSettings = useAppStore((s) => s.updateSettings)
+  const visibleByDefault = useAppStore(
+    (s) => s.settings?.combinedDiffFileTreeVisibleByDefault === true
+  )
+  const persistedUIReady = useAppStore((s) => s.persistedUIReady)
+  const hintDismissed = useAppStore((s) => s.combinedDiffFileTreeHintDismissed)
+  // Why a boolean and not the map: recordFeatureInteraction rebuilds featureInteractions on
+  // every call, and this viewer holds thousands of diff lines.
+  const fileTreeAlreadyUsed = useAppStore((s) =>
+    hasFeatureInteraction(s.featureInteractions, 'diff-file-tree')
+  )
+  const activeContextualTourId = useAppStore((s) => s.activeContextualTourId)
+  const contextualToursOnboardingVisible = useAppStore((s) => s.contextualToursOnboardingVisible)
+  const contextualToursBlockingSurfaceVisible = useAppStore(
+    (s) => s.contextualToursBlockingSurfaceVisible
+  )
+  const [tooltipOpen, setTooltipOpen] = React.useState(false)
+  const contentRef = React.useRef<HTMLDivElement>(null)
+  const titleId = React.useId()
+  const descriptionId = React.useId()
+
+  const { hintOpen, dismissHint } = useCombinedDiffFileTreeHint({
+    eligible: shouldShowCombinedDiffFileTreeHint({
+      persistedUIReady,
+      combinedDiffFileTreeHintDismissed: hintDismissed,
+      surfaceActive,
+      fileTreeCollapsed,
+      sectionsLoaded,
+      changedFileCount,
+      combinedDiffFileTreeVisibleByDefault: visibleByDefault,
+      fileTreeAlreadyUsed,
+      activeContextualTourId,
+      contextualToursOnboardingVisible,
+      contextualToursBlockingSurfaceVisible
+    }),
+    surfaceActive
+  })
+
+  if (hintOpen && tooltipOpen) {
+    // Why: Radix stops re-firing onOpenChange(false) once `open` is pinned false, so a hover
+    // landed during the callout would leave this true and pop the tooltip on dismiss.
+    setTooltipOpen(false)
+  }
+
+  const showFileTree = (): void => {
+    dismissHint()
+    onSetFileTreeCollapsed(false)
+  }
+
+  const chooseDefault = (choice: CombinedDiffFileTreeHintChoice): void => {
+    applyCombinedDiffFileTreeHintChoice({
+      choice,
+      updateSettings,
+      setFileTreeCollapsed: onSetFileTreeCollapsed,
+      dismissHint
+    })
+  }
+
+  const focusCallout = (event: React.KeyboardEvent<HTMLButtonElement>): void => {
+    // Why Tab-into instead of autofocus: the callout is uninvited, so ripping focus out of a
+    // diff mid-read is hostile; the trigger keeps focus and Tab is the announced way in
+    // (aria-describedby names the callout, and Esc still closes it from anywhere).
+    if (!hintOpen || event.key !== 'Tab' || event.shiftKey) {
+      return
+    }
+    const target = contentRef.current?.querySelector<HTMLElement>('[role="radio"], button')
+    if (!target) {
+      return
+    }
+    event.preventDefault()
+    target.focus()
+  }
+
+  // Why: Popover wrapping Tooltip keeps one persistent tree, so the trigger button is
+  // not unmounted at the exact moment the hint points at it.
+  return (
+    <Popover
+      modal={false}
+      open={hintOpen}
+      onOpenChange={(open) => {
+        if (!open) {
+          dismissHint()
+        }
+      }}
+    >
+      {/* Why forced closed while the hint is open: hovering the highlighted trigger would
+          otherwise stack the tooltip on top of the callout explaining the same button.
+          Kept controlled for its whole life so Radix never warns about the switch. */}
+      <Tooltip open={hintOpen ? false : tooltipOpen} onOpenChange={setTooltipOpen}>
+        <TooltipTrigger asChild>
+          <PopoverTrigger asChild>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon-xs"
+              aria-label={label}
+              aria-describedby={hintOpen ? descriptionId : undefined}
+              className={cn(hintOpen && 'ring-2 ring-ring/45 ring-offset-1 ring-offset-background')}
+              onClick={showFileTree}
+              onKeyDown={focusCallout}
+            >
+              <PanelLeftOpen className="size-3.5" />
+            </Button>
+          </PopoverTrigger>
+        </TooltipTrigger>
+        <TooltipContent side="bottom" sideOffset={6}>
+          {label}
+        </TooltipContent>
+      </Tooltip>
+      <PopoverContent
+        ref={contentRef}
+        side="bottom"
+        align="start"
+        sideOffset={6}
+        className="w-80 p-3.5"
+        aria-labelledby={titleId}
+        aria-describedby={descriptionId}
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+        }}
+      >
+        <div id={titleId} className="text-sm font-medium text-foreground">
+          {translate(
+            'auto.components.editor.CombinedDiffFileTreeHintButton.8b3e6c1af0',
+            'Browse changes as a file tree'
+          )}
+        </div>
+        <p id={descriptionId} className="mt-1 text-xs leading-5 text-muted-foreground">
+          {translate(
+            'auto.components.editor.CombinedDiffFileTreeHintButton.d05a92be74',
+            'See every changed file at once and jump between them without scrolling.'
+          )}
+        </p>
+        <div className="mt-3 rounded-md border border-border/70 bg-muted/35 px-3 py-2.5">
+          <div className="text-xs font-medium text-foreground">{defaultLabel}</div>
+          <div className="mt-2">
+            <SettingsSegmentedControl
+              size="sm"
+              equalWidth
+              ariaLabel={defaultLabel}
+              value={visibleByDefault ? 'shown' : 'hidden'}
+              onChange={chooseDefault}
+              options={[
+                {
+                  value: 'shown',
+                  label: translate(
+                    'auto.components.editor.CombinedDiffFileTreeHintButton.1e7c40b3d6',
+                    'Shown'
+                  )
+                },
+                {
+                  value: 'hidden',
+                  label: translate(
+                    'auto.components.editor.CombinedDiffFileTreeHintButton.6f2a83c5e1',
+                    'Hidden'
+                  )
+                }
+              ]}
+            />
+          </div>
+        </div>
+        <div className="mt-3 flex justify-end">
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            className="h-7 px-2.5 text-xs text-muted-foreground hover:text-foreground"
+            onClick={dismissHint}
+          >
+            {translate(
+              'auto.components.editor.CombinedDiffFileTreeHintButton.a91d0f7b23',
+              'Dismiss'
+            )}
+          </Button>
+        </div>
+      </PopoverContent>
+    </Popover>
+  )
+}

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -46,7 +46,7 @@ import type {
   GitDiffResult,
   GitStatusEntry
 } from '../../../../shared/types'
-import { Check, Copy, MessageSquare, PanelLeftOpen, Sparkles, Trash2, WrapText } from 'lucide-react'
+import { Check, Copy, MessageSquare, Sparkles, Trash2, WrapText } from 'lucide-react'
 import { toast } from 'sonner'
 import { DiffSectionItem } from './DiffSectionItem'
 import { DiffNotesSendMenu } from './DiffNotesSendMenu'
@@ -56,6 +56,9 @@ import {
   handleCombinedDiffFileTreeNavigation
 } from './CombinedDiffFileTree'
 import { getCombinedDiffFileTreeSectionKey } from './combined-diff-file-tree-model'
+import { CombinedDiffFileTreeHintButton } from './CombinedDiffFileTreeHintButton'
+import { isCombinedDiffFileTreeCollapsedByDefault } from './combined-diff-file-tree-default'
+import { isTerminalWorkbenchVisible } from '@/lib/worktree-creation-surface'
 import {
   ORCA_EDITOR_EXTERNAL_FILE_CHANGE_EVENT,
   type EditorPathMutationTarget
@@ -214,16 +217,21 @@ function getInitialCombinedDiffSideBySide(diffDefaultView: string | undefined): 
 function getInitialCombinedDiffFileTreeCollapsed(
   combinedDiffFileTreeVisibleByDefault: boolean | undefined
 ): boolean {
-  // Why: the tree is opt-in; only an explicit saved setting should open it while settings are still loading.
-  return combinedDiffFileTreeCollapsedPreference ?? combinedDiffFileTreeVisibleByDefault !== true
+  return (
+    combinedDiffFileTreeCollapsedPreference ??
+    isCombinedDiffFileTreeCollapsedByDefault(combinedDiffFileTreeVisibleByDefault)
+  )
 }
 
 export default function CombinedDiffViewer({
   file,
-  viewStateKey
+  viewStateKey,
+  viewStateId
 }: {
   file: OpenFile
   viewStateKey: string
+  /** Unified-tab id of the pane hosting this viewer; identifies which split group owns it. */
+  viewStateId: string
 }): React.JSX.Element {
   const settings = useAppStore((s) => s.settings)
   const gitStatusEntries = useAppStore(
@@ -245,6 +253,21 @@ export default function CombinedDiffViewer({
     selectWorktreeDiffCommentsOrEmpty(s, file.worktreeId)
   )
   const activeGroupId = useAppStore((s) => s.activeGroupIdByWorktree[file.worktreeId])
+  const recordFeatureInteraction = useAppStore((s) => s.recordFeatureInteraction)
+  // Why: no isActive prop reaches this viewer (EditorPanel -> EditorContent thread none)
+  // and hidden worktrees stay mounted behind `hidden`, so reuse App's own visibility rule
+  // instead of anchoring the hint to an offscreen toolbar.
+  const workbenchVisible = useAppStore((s) =>
+    isTerminalWorkbenchVisible({
+      activeView: s.activeView,
+      activeWorktreeId: s.activeWorktreeId,
+      activePendingCreationId: s.activePendingCreationId,
+      hasActivePendingCreation:
+        s.activePendingCreationId !== null &&
+        s.pendingWorktreeCreations[s.activePendingCreationId] !== undefined
+    })
+  )
+  const isActiveWorktree = useAppStore((s) => s.activeWorktreeId === file.worktreeId)
   const isDark =
     settings?.theme === 'dark' ||
     (settings?.theme === 'system' && window.matchMedia('(prefers-color-scheme: dark)').matches)
@@ -283,6 +306,19 @@ export default function CombinedDiffViewer({
   const [fileTreeCollapsed, setFileTreeCollapsedState] = useState(() =>
     getInitialCombinedDiffFileTreeCollapsed(settings?.combinedDiffFileTreeVisibleByDefault)
   )
+  // Why gated on fileTreeCollapsed: this runs on every store notification, and surfaceActive
+  // only feeds the hint, which cannot render while the tree is open.
+  const paneGroupId = useAppStore((s) =>
+    fileTreeCollapsed
+      ? (s.unifiedTabsByWorktree[file.worktreeId] ?? []).find((tab) => tab.id === viewStateId)
+          ?.groupId
+      : undefined
+  )
+  // Why the undefined tolerance: a single-group workspace never writes activeGroupId, and a
+  // floating-panel pane is not listed under this worktree — neither means "unfocused".
+  const paneFocused =
+    paneGroupId === undefined || activeGroupId === undefined || paneGroupId === activeGroupId
+  const surfaceActive = workbenchVisible && isActiveWorktree && paneFocused
   // Why: generation (state) keys DiffSectionItem remounts; generationRef mirrors it so loadSection's stale-async check avoids a stale closure.
   const [generation, setGeneration] = useState(0)
   const scrollContainerRef = useRef<HTMLDivElement>(null)
@@ -408,10 +444,14 @@ export default function CombinedDiffViewer({
     }
   }, [settings?.combinedDiffFileTreeVisibleByDefault])
 
-  const setFileTreeCollapsed = useCallback((collapsed: boolean) => {
-    combinedDiffFileTreeCollapsedPreference = collapsed
-    setFileTreeCollapsedState(collapsed)
-  }, [])
+  const setFileTreeCollapsed = useCallback(
+    (collapsed: boolean) => {
+      combinedDiffFileTreeCollapsedPreference = collapsed
+      setFileTreeCollapsedState(collapsed)
+      recordFeatureInteraction('diff-file-tree')
+    },
+    [recordFeatureInteraction]
+  )
 
   const isBranchMode = file.diffSource === 'combined-branch'
   const isCommitMode = file.diffSource === 'combined-commit'
@@ -1829,28 +1869,19 @@ export default function CombinedDiffViewer({
         <div className="flex items-center justify-between gap-3 px-3 py-1.5 border-b border-border bg-background/50 shrink-0">
           <div className="flex min-w-0 items-center gap-2">
             {fileTreeCollapsed && (
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <Button
-                    type="button"
-                    variant="ghost"
-                    size="icon-xs"
-                    aria-label={translate(
-                      'auto.components.editor.CombinedDiffViewer.b6c3b84476',
-                      'Show file tree'
-                    )}
-                    onClick={() => setFileTreeCollapsed(false)}
-                  >
-                    <PanelLeftOpen className="size-3.5" />
-                  </Button>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate(
-                    'auto.components.editor.CombinedDiffViewer.b6c3b84476',
-                    'Show file tree'
-                  )}
-                </TooltipContent>
-              </Tooltip>
+              <CombinedDiffFileTreeHintButton
+                label={translate(
+                  'auto.components.editor.CombinedDiffViewer.b6c3b84476',
+                  'Show file tree'
+                )}
+                surfaceActive={surfaceActive}
+                fileTreeCollapsed={fileTreeCollapsed}
+                // Why: sections are rebuilt from `entries` in a layout effect, so only a list
+                // that already matches the current entries reflects the real file count.
+                sectionsLoaded={sections.length > 0 && sections.length === entries.length}
+                changedFileCount={sections.length}
+                onSetFileTreeCollapsed={setFileTreeCollapsed}
+              />
             )}
             <span className="truncate text-xs text-muted-foreground">
               {sections.length}{' '}

--- a/src/renderer/src/components/editor/ConflictComponents.tsx
+++ b/src/renderer/src/components/editor/ConflictComponents.tsx
@@ -12,6 +12,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
 import { cn } from '@/lib/utils'
+import { useAppStore } from '@/store'
 import type { ConflictReviewEntry, OpenFile } from '@/store/slices/editor'
 import type { GitConflictKind, GitStatusEntry } from '../../../../shared/types'
 import { ConflictReviewFileTree } from './ConflictReviewFileTree'
@@ -251,6 +252,7 @@ export function ConflictReviewPanel({
   const setFileTreeCollapsed = React.useCallback((collapsed: boolean) => {
     conflictReviewFileTreeCollapsedPreference = collapsed
     setFileTreeCollapsedState(collapsed)
+    useAppStore.getState().recordFeatureInteraction('diff-file-tree')
   }, [])
 
   if (snapshotEntries.length > 0 && unresolvedCount === 0) {

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -680,6 +680,7 @@ export function EditorContent({
         key={viewStateScopeId}
         file={activeFile}
         viewStateKey={diffViewStateKey}
+        viewStateId={viewStateScopeId}
       />
     )
   }

--- a/src/renderer/src/components/editor/combined-diff-file-tree-default.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-default.test.ts
@@ -1,0 +1,34 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { isCombinedDiffFileTreeCollapsedByDefault } from './combined-diff-file-tree-default'
+
+const COMPONENTS_ROOT = join(__dirname, '..')
+
+function componentSource(relativePath: string): string {
+  return readFileSync(join(COMPONENTS_ROOT, relativePath), 'utf8')
+}
+
+describe('isCombinedDiffFileTreeCollapsedByDefault', () => {
+  it('opens the tree only for an explicit shown default', () => {
+    expect(isCombinedDiffFileTreeCollapsedByDefault(true)).toBe(false)
+    expect(isCombinedDiffFileTreeCollapsedByDefault(false)).toBe(true)
+    expect(isCombinedDiffFileTreeCollapsedByDefault(undefined)).toBe(true)
+  })
+})
+
+describe('diff surfaces seed their file tree from the saved default', () => {
+  // Why source-level: both PR viewers previously hardcoded useState(false), which made
+  // Settings > "Default Diff File Tree" a lie on the pull request surfaces.
+  it.each(['PullRequestPage.tsx', 'GitHubItemDialog.tsx'])('%s', (file) => {
+    const source = componentSource(file)
+
+    expect(source).toContain(
+      'isCombinedDiffFileTreeCollapsedByDefault(settings?.combinedDiffFileTreeVisibleByDefault)'
+    )
+    expect(source).not.toContain(
+      'const [fileTreeCollapsed, setFileTreeCollapsed] = useState(false)'
+    )
+    expect(source).toContain("recordFeatureInteraction('diff-file-tree')")
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-file-tree-default.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-default.ts
@@ -1,0 +1,7 @@
+// Why: the tree is opt-in, so only an explicit saved setting opens it — an absent
+// setting (still loading, or never touched) must not flash the tree open.
+export function isCombinedDiffFileTreeCollapsedByDefault(
+  combinedDiffFileTreeVisibleByDefault: boolean | undefined
+): boolean {
+  return combinedDiffFileTreeVisibleByDefault !== true
+}

--- a/src/renderer/src/components/editor/combined-diff-file-tree-hint-choice.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-hint-choice.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it, vi } from 'vitest'
+import { applyCombinedDiffFileTreeHintChoice } from './combined-diff-file-tree-hint-choice'
+
+function harness() {
+  return {
+    updateSettings: vi.fn(),
+    setFileTreeCollapsed: vi.fn(),
+    dismissHint: vi.fn()
+  }
+}
+
+describe('applyCombinedDiffFileTreeHintChoice', () => {
+  it('saves the shown default, opens the tree, and closes the hint', () => {
+    const calls = harness()
+
+    applyCombinedDiffFileTreeHintChoice({ choice: 'shown', ...calls })
+
+    expect(calls.updateSettings).toHaveBeenCalledWith({
+      combinedDiffFileTreeVisibleByDefault: true
+    })
+    expect(calls.setFileTreeCollapsed).toHaveBeenCalledWith(false)
+    expect(calls.dismissHint).toHaveBeenCalledTimes(1)
+  })
+
+  it('saves the hidden default without pinning the session tree override', () => {
+    const calls = harness()
+
+    applyCombinedDiffFileTreeHintChoice({ choice: 'hidden', ...calls })
+
+    expect(calls.updateSettings).toHaveBeenCalledWith({
+      combinedDiffFileTreeVisibleByDefault: false
+    })
+    expect(calls.setFileTreeCollapsed).not.toHaveBeenCalled()
+    expect(calls.dismissHint).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-file-tree-hint-choice.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-hint-choice.ts
@@ -1,0 +1,25 @@
+export type CombinedDiffFileTreeHintChoice = 'shown' | 'hidden'
+
+export type CombinedDiffFileTreeHintChoiceInput = {
+  choice: CombinedDiffFileTreeHintChoice
+  updateSettings: (settings: { combinedDiffFileTreeVisibleByDefault: boolean }) => unknown
+  setFileTreeCollapsed: (collapsed: boolean) => void
+  dismissHint: () => void
+}
+
+// Answers the hint in place: writes the same setting Settings > Editor writes, and
+// only reveals the tree when the user asked to see it.
+export function applyCombinedDiffFileTreeHintChoice({
+  choice,
+  updateSettings,
+  setFileTreeCollapsed,
+  dismissHint
+}: CombinedDiffFileTreeHintChoiceInput): void {
+  updateSettings({ combinedDiffFileTreeVisibleByDefault: choice === 'shown' })
+  if (choice === 'shown') {
+    setFileTreeCollapsed(false)
+  }
+  // Why "hidden" skips setFileTreeCollapsed: it pins the module-level session
+  // override, which would stop later Settings changes from reaching open diff tabs.
+  dismissHint()
+}

--- a/src/renderer/src/components/editor/combined-diff-file-tree-hint-claim.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-hint-claim.ts
@@ -1,0 +1,18 @@
+// Why module-level: the workspace diff, the PR page, and the PR item view can all be
+// mounted at once (split panes multiply that further), and only one of them may open the
+// one-shot callout. The persisted flag lands a render too late to arbitrate.
+let claimedThisSession = false
+
+/** Returns true only for the first caller in this session; every later caller loses. */
+export function claimCombinedDiffFileTreeHint(): boolean {
+  if (claimedThisSession) {
+    return false
+  }
+  claimedThisSession = true
+  return true
+}
+
+/** Test-only: module state outlives a single render tree. */
+export function resetCombinedDiffFileTreeHintClaim(): void {
+  claimedThisSession = false
+}

--- a/src/renderer/src/components/editor/combined-diff-file-tree-hint-visibility.test.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-hint-visibility.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import {
+  shouldShowCombinedDiffFileTreeHint,
+  type CombinedDiffFileTreeHintVisibilityInput
+} from './combined-diff-file-tree-hint-visibility'
+
+function eligibleInput(
+  overrides: Partial<CombinedDiffFileTreeHintVisibilityInput> = {}
+): CombinedDiffFileTreeHintVisibilityInput {
+  return {
+    persistedUIReady: true,
+    combinedDiffFileTreeHintDismissed: false,
+    surfaceActive: true,
+    fileTreeCollapsed: true,
+    sectionsLoaded: true,
+    changedFileCount: 3,
+    combinedDiffFileTreeVisibleByDefault: false,
+    fileTreeAlreadyUsed: false,
+    activeContextualTourId: null,
+    contextualToursOnboardingVisible: false,
+    contextualToursBlockingSurfaceVisible: false,
+    ...overrides
+  }
+}
+
+describe('shouldShowCombinedDiffFileTreeHint', () => {
+  it('shows the hint for an undiscovered file tree on a visible diff', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput())).toBe(true)
+  })
+
+  it('waits for persisted UI so a pre-hydration default cannot nag', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput({ persistedUIReady: false }))).toBe(
+      false
+    )
+  })
+
+  it('never re-arms once the hint has been shown', () => {
+    expect(
+      shouldShowCombinedDiffFileTreeHint(eligibleInput({ combinedDiffFileTreeHintDismissed: true }))
+    ).toBe(false)
+  })
+
+  it('stays closed on a mounted but hidden surface', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput({ surfaceActive: false }))).toBe(false)
+  })
+
+  it('stays closed when the tree is already open', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput({ fileTreeCollapsed: false }))).toBe(
+      false
+    )
+  })
+
+  it('waits for the section list to settle', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput({ sectionsLoaded: false }))).toBe(false)
+  })
+
+  it('skips diffs too small to need a tree', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput({ changedFileCount: 2 }))).toBe(false)
+  })
+
+  it('skips users whose default already shows the tree', () => {
+    expect(
+      shouldShowCombinedDiffFileTreeHint(
+        eligibleInput({ combinedDiffFileTreeVisibleByDefault: true })
+      )
+    ).toBe(false)
+    expect(
+      shouldShowCombinedDiffFileTreeHint(
+        eligibleInput({ combinedDiffFileTreeVisibleByDefault: undefined })
+      )
+    ).toBe(true)
+  })
+
+  it('skips users who already toggled a diff file tree', () => {
+    expect(shouldShowCombinedDiffFileTreeHint(eligibleInput({ fileTreeAlreadyUsed: true }))).toBe(
+      false
+    )
+  })
+
+  it('yields to a running contextual tour, which paints above this popover', () => {
+    expect(
+      shouldShowCombinedDiffFileTreeHint(
+        eligibleInput({ activeContextualTourId: 'workspace-agent-sessions' })
+      )
+    ).toBe(false)
+  })
+
+  it('yields to contextual-tour onboarding', () => {
+    expect(
+      shouldShowCombinedDiffFileTreeHint(eligibleInput({ contextualToursOnboardingVisible: true }))
+    ).toBe(false)
+  })
+
+  it('yields to a blocking surface', () => {
+    expect(
+      shouldShowCombinedDiffFileTreeHint(
+        eligibleInput({ contextualToursBlockingSurfaceVisible: true })
+      )
+    ).toBe(false)
+  })
+
+  it('still shows once a tour has finished, since this hint is outside the tour budget', () => {
+    expect(
+      shouldShowCombinedDiffFileTreeHint(eligibleInput({ activeContextualTourId: null }))
+    ).toBe(true)
+  })
+})

--- a/src/renderer/src/components/editor/combined-diff-file-tree-hint-visibility.ts
+++ b/src/renderer/src/components/editor/combined-diff-file-tree-hint-visibility.ts
@@ -1,0 +1,53 @@
+// Below this, scrolling the diff is fine and the tree is not worth interrupting for.
+export const COMBINED_DIFF_FILE_TREE_HINT_MIN_CHANGED_FILES = 3
+
+export type CombinedDiffFileTreeHintVisibilityInput = {
+  persistedUIReady: boolean
+  combinedDiffFileTreeHintDismissed: boolean
+  surfaceActive: boolean
+  fileTreeCollapsed: boolean
+  sectionsLoaded: boolean
+  changedFileCount: number
+  combinedDiffFileTreeVisibleByDefault: boolean | undefined
+  fileTreeAlreadyUsed: boolean
+  activeContextualTourId: string | null
+  contextualToursOnboardingVisible: boolean
+  contextualToursBlockingSurfaceVisible: boolean
+}
+
+export function shouldShowCombinedDiffFileTreeHint({
+  persistedUIReady,
+  combinedDiffFileTreeHintDismissed,
+  surfaceActive,
+  fileTreeCollapsed,
+  sectionsLoaded,
+  changedFileCount,
+  combinedDiffFileTreeVisibleByDefault,
+  fileTreeAlreadyUsed,
+  activeContextualTourId,
+  contextualToursOnboardingVisible,
+  contextualToursBlockingSurfaceVisible
+}: CombinedDiffFileTreeHintVisibilityInput): boolean {
+  return (
+    persistedUIReady &&
+    !combinedDiffFileTreeHintDismissed &&
+    // Why: this popover sits at z-60, under the tour scrim (z-70) and panel (z-80), so a
+    // callout fired mid-tour would be buried; onboarding and blocking surfaces own the
+    // screen for the same reason. Deliberately NOT gated on contextualTourShownThisSession:
+    // this hint is outside the tour budget, and one unrelated tour would mute it all session.
+    activeContextualTourId === null &&
+    !contextualToursOnboardingVisible &&
+    !contextualToursBlockingSurfaceVisible &&
+    // Why: hidden worktrees keep this viewer mounted, and a popover anchored to an
+    // offscreen trigger lands at the viewport origin.
+    surfaceActive &&
+    fileTreeCollapsed &&
+    // Why: the section list is rebuilt asynchronously, so an unsettled list would
+    // judge the file count against a stale or empty diff.
+    sectionsLoaded &&
+    changedFileCount >= COMBINED_DIFF_FILE_TREE_HINT_MIN_CHANGED_FILES &&
+    // Why: an explicit "shown" default means the user already knows the tree exists.
+    combinedDiffFileTreeVisibleByDefault !== true &&
+    !fileTreeAlreadyUsed
+  )
+}

--- a/src/renderer/src/components/editor/use-combined-diff-file-tree-hint.test.tsx
+++ b/src/renderer/src/components/editor/use-combined-diff-file-tree-hint.test.tsx
@@ -1,0 +1,140 @@
+// @vitest-environment happy-dom
+
+import React, { StrictMode, act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { resetCombinedDiffFileTreeHintClaim } from './combined-diff-file-tree-hint-claim'
+import { useCombinedDiffFileTreeHint } from './use-combined-diff-file-tree-hint'
+
+const mocks = vi.hoisted(() => ({ dismiss: vi.fn() }))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: { dismissCombinedDiffFileTreeHint: () => void }) => unknown) =>
+    selector({ dismissCombinedDiffFileTreeHint: mocks.dismiss })
+}))
+
+const HINT_DELAY_MS = 600
+
+function Probe({
+  eligible,
+  surfaceActive,
+  name
+}: {
+  eligible: boolean
+  surfaceActive: boolean
+  name: string
+}): React.JSX.Element {
+  const { hintOpen } = useCombinedDiffFileTreeHint({ eligible, surfaceActive })
+  return <span data-probe={name}>{hintOpen ? 'open' : 'closed'}</span>
+}
+
+let container: HTMLDivElement
+let root: Root
+
+function render(node: React.ReactNode): void {
+  act(() => {
+    root.render(node)
+  })
+}
+
+function advance(ms: number): void {
+  act(() => {
+    vi.advanceTimersByTime(ms)
+  })
+}
+
+function probeStates(): string[] {
+  return [...container.querySelectorAll('[data-probe]')].map((node) => node.textContent ?? '')
+}
+
+beforeEach(() => {
+  vi.useFakeTimers()
+  mocks.dismiss.mockClear()
+  resetCombinedDiffFileTreeHintClaim()
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.useRealTimers()
+})
+
+describe('useCombinedDiffFileTreeHint', () => {
+  it('opens once the settle delay elapses and persists the one-shot flag', () => {
+    render(<Probe name="a" eligible surfaceActive />)
+    expect(probeStates()).toEqual(['closed'])
+
+    advance(HINT_DELAY_MS)
+
+    expect(probeStates()).toEqual(['open'])
+    expect(mocks.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the pending timer when the viewer unmounts first', () => {
+    render(<Probe name="a" eligible surfaceActive />)
+    act(() => root.render(null))
+
+    advance(HINT_DELAY_MS)
+
+    expect(mocks.dismiss).not.toHaveBeenCalled()
+  })
+
+  it('drops the hint when eligibility disappears mid-timer, leaving the claim unspent', () => {
+    render(<Probe name="a" eligible surfaceActive />)
+    advance(HINT_DELAY_MS / 2)
+    render(<Probe name="a" eligible={false} surfaceActive />)
+    advance(HINT_DELAY_MS)
+
+    expect(probeStates()).toEqual(['closed'])
+    expect(mocks.dismiss).not.toHaveBeenCalled()
+
+    render(<Probe name="a" eligible surfaceActive />)
+    advance(HINT_DELAY_MS)
+
+    expect(probeStates()).toEqual(['open'])
+  })
+
+  it('lets only one surface win the shared one-shot claim', () => {
+    render(
+      <>
+        <Probe name="split-left" eligible surfaceActive />
+        <Probe name="split-right" eligible surfaceActive />
+      </>
+    )
+
+    advance(HINT_DELAY_MS)
+
+    expect(probeStates().filter((state) => state === 'open')).toHaveLength(1)
+    expect(mocks.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('shows once under StrictMode double-invoked effects', () => {
+    render(
+      <StrictMode>
+        <Probe name="a" eligible surfaceActive />
+      </StrictMode>
+    )
+
+    advance(HINT_DELAY_MS)
+
+    expect(probeStates()).toEqual(['open'])
+    expect(mocks.dismiss).toHaveBeenCalledTimes(1)
+  })
+
+  it('closes when the surface is hidden and never re-opens on return', () => {
+    render(<Probe name="a" eligible surfaceActive />)
+    advance(HINT_DELAY_MS)
+    expect(probeStates()).toEqual(['open'])
+
+    render(<Probe name="a" eligible={false} surfaceActive={false} />)
+    expect(probeStates()).toEqual(['closed'])
+
+    render(<Probe name="a" eligible={false} surfaceActive />)
+    advance(HINT_DELAY_MS)
+
+    expect(probeStates()).toEqual(['closed'])
+  })
+})

--- a/src/renderer/src/components/editor/use-combined-diff-file-tree-hint.ts
+++ b/src/renderer/src/components/editor/use-combined-diff-file-tree-hint.ts
@@ -1,0 +1,55 @@
+import { useCallback, useEffect, useRef, useState } from 'react'
+import { useAppStore } from '@/store'
+import { claimCombinedDiffFileTreeHint } from './combined-diff-file-tree-hint-claim'
+
+// Why: let the diff finish loading and the toolbar settle (SSH hosts are slower)
+// before anchoring a popover to the file-tree button.
+const COMBINED_DIFF_FILE_TREE_HINT_DELAY_MS = 600
+
+export type CombinedDiffFileTreeHintInput = {
+  eligible: boolean
+  /** Whether this surface is on screen; a mounted-but-hidden pane must never hold the callout. */
+  surfaceActive: boolean
+}
+
+export type CombinedDiffFileTreeHint = { hintOpen: boolean; dismissHint: () => void }
+
+// One-shot discovery callout for the combined-diff file tree. The persisted flag is
+// written on first show, not on dismiss, so closing the tab without answering still
+// counts as shown.
+export function useCombinedDiffFileTreeHint({
+  eligible,
+  surfaceActive
+}: CombinedDiffFileTreeHintInput): CombinedDiffFileTreeHint {
+  const dismissCombinedDiffFileTreeHint = useAppStore((s) => s.dismissCombinedDiffFileTreeHint)
+  const [hintOpen, setHintOpen] = useState(false)
+  // Why: showing writes the store flag, which immediately drops `eligible`; without
+  // this the same effect would close the popover it just opened.
+  const shownRef = useRef(false)
+
+  useEffect(() => {
+    if (shownRef.current || !eligible) {
+      return
+    }
+    const timer = window.setTimeout(() => {
+      // Why claim inside the timer: two split panes share this deadline, so the winner is
+      // only decided when a callback actually runs.
+      if (!claimCombinedDiffFileTreeHint()) {
+        return
+      }
+      shownRef.current = true
+      dismissCombinedDiffFileTreeHint()
+      setHintOpen(true)
+    }, COMBINED_DIFF_FILE_TREE_HINT_DELAY_MS)
+    return () => window.clearTimeout(timer)
+  }, [dismissCombinedDiffFileTreeHint, eligible])
+
+  if (hintOpen && !surfaceActive) {
+    // Why close during render, not in an effect: the workbench is CSS-hidden rather than
+    // unmounted, so a callout left open would reappear on every return to the workspace.
+    setHintOpen(false)
+  }
+
+  const dismissHint = useCallback(() => setHintOpen(false), [])
+  return { hintOpen: hintOpen && surfaceActive, dismissHint }
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13472,6 +13472,14 @@
               }
             }
           }
+        },
+        "CombinedDiffFileTreeHintButton": {
+          "4c1f0a7d92": "Default in diff views",
+          "8b3e6c1af0": "Browse changes as a file tree",
+          "d05a92be74": "See every changed file at once and jump between them without scrolling.",
+          "1e7c40b3d6": "Shown",
+          "6f2a83c5e1": "Hidden",
+          "a91d0f7b23": "Dismiss"
         }
       },
       "diff": {

--- a/src/renderer/src/lib/worktree-creation-surface.test.ts
+++ b/src/renderer/src/lib/worktree-creation-surface.test.ts
@@ -1,5 +1,8 @@
 import { describe, expect, it } from 'vitest'
-import { shouldShowWorktreeCreationSurface } from './worktree-creation-surface'
+import {
+  isTerminalWorkbenchVisible,
+  shouldShowWorktreeCreationSurface
+} from './worktree-creation-surface'
 
 describe('shouldShowWorktreeCreationSurface', () => {
   it('shows the creation surface as soon as an active pending creation exists', () => {
@@ -28,6 +31,49 @@ describe('shouldShowWorktreeCreationSurface', () => {
         activeView: 'settings',
         activePendingCreationId: 'creation-1',
         hasActivePendingCreation: true
+      })
+    ).toBe(false)
+  })
+})
+
+describe('isTerminalWorkbenchVisible', () => {
+  it('is visible for an open workspace with no creation flow in front of it', () => {
+    expect(
+      isTerminalWorkbenchVisible({
+        activeView: 'terminal',
+        activeWorktreeId: 'wt-1',
+        activePendingCreationId: null,
+        hasActivePendingCreation: false
+      })
+    ).toBe(true)
+  })
+
+  it('is hidden while creation covers the still-mounted previous workspace', () => {
+    expect(
+      isTerminalWorkbenchVisible({
+        activeView: 'terminal',
+        activeWorktreeId: 'wt-1',
+        activePendingCreationId: 'creation-1',
+        hasActivePendingCreation: true
+      })
+    ).toBe(false)
+  })
+
+  it('is hidden on another view and with no active workspace', () => {
+    expect(
+      isTerminalWorkbenchVisible({
+        activeView: 'tasks',
+        activeWorktreeId: 'wt-1',
+        activePendingCreationId: null,
+        hasActivePendingCreation: false
+      })
+    ).toBe(false)
+    expect(
+      isTerminalWorkbenchVisible({
+        activeView: 'terminal',
+        activeWorktreeId: null,
+        activePendingCreationId: null,
+        hasActivePendingCreation: false
       })
     ).toBe(false)
   })

--- a/src/renderer/src/lib/worktree-creation-surface.ts
+++ b/src/renderer/src/lib/worktree-creation-surface.ts
@@ -13,3 +13,17 @@ export function shouldShowWorktreeCreationSurface({
 }: WorktreeCreationSurfaceInput): boolean {
   return activeView === 'terminal' && activePendingCreationId !== null && hasActivePendingCreation
 }
+
+export type TerminalWorkbenchVisibilityInput = WorktreeCreationSurfaceInput & {
+  activeWorktreeId: string | null
+}
+
+// Why: App renders the workbench with `hidden` instead of unmounting it, so a mounted pane
+// must consult this before anchoring a portaled layer to its own toolbar.
+export function isTerminalWorkbenchVisible(input: TerminalWorkbenchVisibilityInput): boolean {
+  return (
+    input.activeView === 'terminal' &&
+    input.activeWorktreeId !== null &&
+    !shouldShowWorktreeCreationSurface(input)
+  )
+}

--- a/src/renderer/src/store/slices/ui.test.ts
+++ b/src/renderer/src/store/slices/ui.test.ts
@@ -2701,6 +2701,41 @@ describe('createUISlice mobile emulator tab intro dismissal', () => {
   })
 })
 
+describe('createUISlice combined diff file tree hint dismissal', () => {
+  it('persists the combined diff file tree hint dismissal once', () => {
+    const setMock = vi.fn(() => Promise.resolve())
+    vi.stubGlobal('window', {
+      api: {
+        ui: {
+          set: setMock
+        }
+      }
+    })
+    const store = createUIStore()
+
+    store.getState().dismissCombinedDiffFileTreeHint()
+    store.getState().dismissCombinedDiffFileTreeHint()
+
+    expect(store.getState().combinedDiffFileTreeHintDismissed).toBe(true)
+    expect(setMock).toHaveBeenCalledTimes(1)
+    expect(setMock).toHaveBeenCalledWith({ combinedDiffFileTreeHintDismissed: true })
+  })
+
+  it('hydrates only explicit combined diff file tree hint dismissals', () => {
+    const store = createUIStore()
+
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ combinedDiffFileTreeHintDismissed: true }))
+    expect(store.getState().combinedDiffFileTreeHintDismissed).toBe(true)
+
+    store
+      .getState()
+      .hydratePersistedUI(makePersistedUI({ combinedDiffFileTreeHintDismissed: undefined }))
+    expect(store.getState().combinedDiffFileTreeHintDismissed).toBe(false)
+  })
+})
+
 describe('createUISlice browser import hint dismissal', () => {
   it('persists browser import hint dismissal changes once', () => {
     const setMock = vi.fn(() => Promise.resolve())

--- a/src/renderer/src/store/slices/ui.ts
+++ b/src/renderer/src/store/slices/ui.ts
@@ -843,6 +843,8 @@ export type UISlice = {
   setBrowserImportHintHidden: (hidden: boolean) => void
   mobileEmulatorTabIntroDismissed: boolean
   dismissMobileEmulatorTabIntro: () => void
+  combinedDiffFileTreeHintDismissed: boolean
+  dismissCombinedDiffFileTreeHint: () => void
   mobileEmulatorAgentSetupDismissed: boolean
   dismissMobileEmulatorAgentSetup: () => void
   projectOrderManualDefaultNoticeDismissed: boolean
@@ -1957,6 +1959,15 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
       window.api.ui.set({ mobileEmulatorTabIntroDismissed: true }).catch(console.error)
       return { mobileEmulatorTabIntroDismissed: true }
     }),
+  combinedDiffFileTreeHintDismissed: false,
+  dismissCombinedDiffFileTreeHint: () =>
+    set((s) => {
+      if (s.combinedDiffFileTreeHintDismissed) {
+        return s
+      }
+      window.api.ui.set({ combinedDiffFileTreeHintDismissed: true }).catch(console.error)
+      return { combinedDiffFileTreeHintDismissed: true }
+    }),
   mobileEmulatorAgentSetupDismissed: false,
   dismissMobileEmulatorAgentSetup: () =>
     set((s) => {
@@ -2540,6 +2551,7 @@ export const createUISlice: StateCreator<AppState, [], [], UISlice> = (set, get)
           ui.setupGuideBrowserMilestoneLegacyComplete === true,
         browserImportHintHidden: ui.browserImportHintHidden === true,
         mobileEmulatorTabIntroDismissed: ui.mobileEmulatorTabIntroDismissed === true,
+        combinedDiffFileTreeHintDismissed: ui.combinedDiffFileTreeHintDismissed === true,
         mobileEmulatorAgentSetupDismissed: ui.mobileEmulatorAgentSetupDismissed === true,
         projectOrderManualDefaultNoticeDismissed:
           ui.projectOrderManualDefaultNoticeDismissed === true,

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -513,6 +513,7 @@ export function getDefaultUIState(): PersistedUIState {
     // Why: fresh profiles start on the new default, so nothing was overridden to report.
     osc52ClipboardDefaultOnNoticePending: false,
     mobileEmulatorTabIntroDismissed: false,
+    combinedDiffFileTreeHintDismissed: false,
     mobileEmulatorAgentSetupDismissed: false,
     // Why: only upgraded profiles saw the old ordering, so only they get the one-time notice.
     projectOrderManualDefaultNoticeDismissed: true,

--- a/src/shared/feature-interaction-catalog.ts
+++ b/src/shared/feature-interaction-catalog.ts
@@ -21,6 +21,7 @@ export type FeatureInteractionId =
   | 'browser-annotations'
   | 'browser-annotations-sent-to-agent'
   | 'browser-grab'
+  | 'diff-file-tree'
   | 'markdown-file-created'
   | 'workspace-creation'
   | 'agent-browser-setup'
@@ -93,6 +94,7 @@ export const FEATURE_INTERACTIONS = [
     interaction: 'browser annotations sent to an agent'
   },
   { id: 'browser-grab', interaction: 'browser element grab or screenshot used' },
+  { id: 'diff-file-tree', interaction: 'combined diff file tree shown or hidden' },
   { id: 'markdown-file-created', interaction: 'untitled markdown file explicitly created' },
   { id: 'workspace-creation', interaction: 'workspace creation flow opened' },
   { id: 'agent-browser-setup', interaction: 'Agent Browser Use setup enabled or opened' },

--- a/src/shared/feature-interaction-categories.ts
+++ b/src/shared/feature-interaction-categories.ts
@@ -42,6 +42,7 @@ export const FEATURE_INTERACTION_CATEGORY_BY_ID = {
   'browser-annotations': 'browser',
   'browser-annotations-sent-to-agent': 'browser',
   'browser-grab': 'browser',
+  'diff-file-tree': 'review',
   'markdown-file-created': 'notes',
   'workspace-creation': 'workspace',
   'agent-browser-setup': 'setup',

--- a/src/shared/feature-interactions.test.ts
+++ b/src/shared/feature-interactions.test.ts
@@ -53,6 +53,7 @@ describe('feature interactions', () => {
       'browser-annotations',
       'browser-annotations-sent-to-agent',
       'browser-grab',
+      'diff-file-tree',
       'markdown-file-created',
       'workspace-creation',
       'agent-browser-setup',

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -3471,6 +3471,8 @@ export type PersistedUIState = {
   osc52ClipboardDefaultOnNoticePending?: boolean
   /** User dismissed the first-run Mobile Emulator intro; reversible only by re-enabling the feature in Settings. */
   mobileEmulatorTabIntroDismissed?: boolean
+  /** One-shot diff file-tree discovery hint; written on first show so it never re-arms, even if the user never answers. */
+  combinedDiffFileTreeHintDismissed?: boolean
   /** User deferred the in-pane Mobile Emulator CLI + skill setup guide. */
   mobileEmulatorAgentSetupDismissed?: boolean
   /** One-shot rollout notice for manual project ordering default; absent or true keeps the sidebar callout hidden. */


### PR DESCRIPTION
## Why

The combined-diff file tree is opt-in and hidden by default, so most people never find it. Rather than adding another "you can configure this in Settings" line, this points at the toolbar toggle once and resolves the preference in place.


## What

A dismissable popover anchored to the **Show file tree** trigger:

- **Title** "Browse changes as a file tree", one line of body copy, a `Shown | Hidden` segmented control labelled "Default in diff views", and a single quiet **Dismiss**.
- Choosing **Shown** writes `combinedDiffFileTreeVisibleByDefault: true` *and* opens the tree immediately. Choosing **Hidden** writes `false` and deliberately does not call `setFileTreeCollapsed`, so the module-level session override stays unpinned and later Settings changes still reach open diff tabs.
- No arrow: `PopoverContent` is `overflow-hidden`, so a Radix arrow is clipped. A `ring-2 ring-ring/45` on the trigger does the pointing instead.

### Eligibility

Fires at most once per install, and only when the tree is genuinely undiscovered:

```
persistedUIReady && !hintDismissed
&& activeContextualTourId === null && !onboardingVisible && !blockingSurfaceVisible
&& surfaceActive && fileTreeCollapsed && sectionsLoaded && changedFileCount >= 3
&& combinedDiffFileTreeVisibleByDefault !== true && !fileTreeAlreadyUsed
```

- The tour/onboarding clauses matter: the popover sits at `z-60`, below the tour scrim (`z-70`) and panel (`z-80`), so a callout fired mid-tour would render buried. Deliberately **not** gated on `contextualTourShownThisSession` — this hint is outside the tour budget, and one unrelated tour would otherwise mute it for the whole session.
- `surfaceActive` reuses App's own workbench-visibility rule via a new `isTerminalWorkbenchVisible()`, so the callout cannot anchor to a `display:none` trigger during workspace creation.
- The dismissal flag persists on **first show**, not on dismiss, so closing the tab early doesn't re-arm it. A module-level claim taken inside the settle timer means split panes and multiple surfaces resolve to exactly one winner.
- A new `diff-file-tree` feature interaction is recorded on open **and** close across all four diff surfaces, so anyone already using the tree is excluded.

## Notes for reviewers

- **PR/MR diff surfaces now follow `combinedDiffFileTreeVisibleByDefault` (default hidden), where they previously always showed the tree.** This is intentional and product-approved — a shared "default in diff views" preference was untrue while `PullRequestPage` and `GitHubItemDialog` hardcoded `useState(false)`. The hint renders on those surfaces too, so the tree stays discoverable there.
- **Existing file-tree users get the hint once on upgrade.** `diff-file-tree` is a new interaction id with no backfill, so `fileTreeAlreadyUsed` is false for everyone initially — including people who have been opening the tree by hand for months. The `combinedDiffFileTreeVisibleByDefault !== true` clause only excludes users who flipped the *setting*, not users who merely used the feature.
- **Against an older paired host, the dismissal does not persist.** `UiUpdateFields` is `.strict()` (`client-ui-schemas.ts`), so an old server rejects the unknown `combinedDiffFileTreeHintDismissed` key. Blast radius is contained: it is sent as its own single-key payload rather than through App's debounced batch, so no unrelated UI state is dropped alongside it. Only user-visible effect is the hint re-arming once per session against an old host.
- `client-ui-schemas.ts` crossed the 300-line limit, so the ten one-shot dismissal booleans moved to `client-ui-dismissal-schemas.ts` and are spread back in. Schema shape and `.strict()` are unchanged.
- Known limitation: `recordFeatureInteraction` early-returns before `persistedUIReady`, so a tree toggle during startup isn't recorded. Forwarding those broke five unrelated tests in `restored-editor-owner-save-lifecycle.test.ts`, so it's left alone. Worst case is one extra callout.

## Accessibility

`onOpenAutoFocus` is prevented — the callout is uninvited, and pulling focus out of a diff mid-read is hostile. Instead the trigger keeps focus, carries `aria-describedby` pointing at the callout body while open, and Tab from the trigger moves into the first control. Esc closes from anywhere. The tooltip is held controlled for its whole life so it never stacks on the callout and Radix never warns about a controlled/uncontrolled switch.

## Testing

`pnpm run typecheck`, `pnpm run lint`, `pnpm run check:max-lines-ratchet`, and `pnpm run check:code-quality:changed` all pass (0 new findings across 31 changed files). 256 tests pass across the 11 changed/new test files, covering every eligibility clause, the choice handlers, timer cleanup, the cross-surface one-shot claim, StrictMode double-mount, keyboard entry against the real Radix popover, and the tooltip lifecycle.

No max-lines suppressions or lint disables were added.

Made with [Orca](https://github.com/stablyai/orca) 🐋

