### PR TITLE
fix(remote-workspace): keep local tabs when a pulled snapshot reports none for a populated worktree

### DIFF
--- a/src/renderer/src/hooks/remote-workspace-session-merge.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.test.ts
@@ -135,6 +135,19 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
     expect(merged.activeTabId).toBe('tab-1')
   })
 
+  it('narrows the replace scope itself when the caller hands it an un-narrowed set', () => {
+    const localTabs = [tab('tab-1', WT)]
+    const merged = mergeDirectSshRemoteWorkspaceSession(
+      session({ tabsByWorktree: { [WT]: localTabs } }),
+      session({ tabsByWorktree: { [WT]: [] } }),
+      new Set([WT]),
+      { [WT]: localTabs },
+      new Set()
+    )
+
+    expect(merged.tabsByWorktree[WT]).toEqual(localTabs)
+  })
+
   it('still replaces a worktree when the remote snapshot has tabs for it', () => {
     const localTabs = [tab('tab-old', WT)]
     const remoteTabs = [tab('tab-new', WT, { generation: 2 })]

--- a/src/renderer/src/hooks/remote-workspace-session-merge.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
-import type { TerminalTab, WorkspaceSessionState } from '../../../shared/types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
+import type { WorkspaceSessionState } from '../../../shared/workspace-session-state-types'
 import {
   mergeDirectSshRemoteWorkspaceSession,
   narrowDirectSshReplaceWorktreeIds
@@ -79,6 +80,7 @@ describe('narrowDirectSshReplaceWorktreeIds', () => {
 describe('mergeDirectSshRemoteWorkspaceSession', () => {
   it('keeps local state for a worktree the narrowing removed from the replace scope', () => {
     const localTabs = [tab('tab-1', WT), tab('tab-2', WT)]
+    const expectedTabs = structuredClone(localTabs)
     const current = session({
       tabsByWorktree: { [WT]: localTabs },
       terminalLayoutsByTabId: { 'tab-1': { activeLeafId: 'leaf-1' } as never },
@@ -98,7 +100,7 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
     })
 
     expect([...replaceWorktreeIds]).toEqual([])
-    expect(merged.tabsByWorktree[WT]).toEqual(localTabs)
+    expect(merged.tabsByWorktree[WT]).toEqual(expectedTabs)
     expect(merged.terminalLayoutsByTabId['tab-1']).toEqual({ activeLeafId: 'leaf-1' })
     expect(merged.activeTabIdByWorktree?.[WT]).toBe('tab-1')
     expect(merged.lastVisitedAtByWorktreeId?.[WT]).toBe(111)
@@ -108,12 +110,13 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
 
   it('keeps local tabs for an in-scope worktree the remote snapshot omits entirely', () => {
     const localTabs = [tab('tab-1', WT)]
+    const expectedTabs = structuredClone(localTabs)
     const current = session({ tabsByWorktree: { [WT]: localTabs } })
     const remote = session()
 
     const { merged } = narrowAndMerge(current, remote, new Set([WT]), { [WT]: localTabs })
 
-    expect(merged.tabsByWorktree[WT]).toEqual(localTabs)
+    expect(merged.tabsByWorktree[WT]).toEqual(expectedTabs)
   })
 
   it('keeps current active-tab state when the active worktree left the replace scope', () => {
@@ -137,6 +140,8 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
 
   it('narrows the replace scope itself when the caller hands it an un-narrowed set', () => {
     const localTabs = [tab('tab-1', WT)]
+    // Why: the expectation must not alias the merge input — a merge that mutates the array would otherwise compare the value against itself.
+    const expectedTabs = structuredClone(localTabs)
     const merged = mergeDirectSshRemoteWorkspaceSession(
       session({ tabsByWorktree: { [WT]: localTabs } }),
       session({ tabsByWorktree: { [WT]: [] } }),
@@ -145,7 +150,8 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
       new Set()
     )
 
-    expect(merged.tabsByWorktree[WT]).toEqual(localTabs)
+    expect(merged.tabsByWorktree[WT]).toEqual(expectedTabs)
+    expect(localTabs).toEqual(expectedTabs)
   })
 
   it('still replaces a worktree when the remote snapshot has tabs for it', () => {
@@ -173,6 +179,7 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
 
   it('scopes the guard per worktree, replacing populated ones while keeping the emptied one', () => {
     const keptTabs = [tab('tab-kept', WT)]
+    const expectedKeptTabs = structuredClone(keptTabs)
     const replacedRemote = [tab('tab-remote', OTHER_WT, { generation: 3 })]
     const current = session({
       tabsByWorktree: { [WT]: keptTabs, [OTHER_WT]: [tab('tab-old', OTHER_WT)] },
@@ -192,7 +199,7 @@ describe('mergeDirectSshRemoteWorkspaceSession', () => {
     )
 
     expect([...replaceWorktreeIds]).toEqual([OTHER_WT])
-    expect(merged.tabsByWorktree[WT]).toEqual(keptTabs)
+    expect(merged.tabsByWorktree[WT]).toEqual(expectedKeptTabs)
     expect(merged.tabsByWorktree[OTHER_WT].map((t) => t.id)).toEqual(['tab-remote'])
     // Per-worktree records follow the same scope: the kept worktree's entries stay local, the
     // replaced worktree's entries come from the remote.

--- a/src/renderer/src/hooks/remote-workspace-session-merge.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.test.ts
@@ -1,0 +1,191 @@
+import { describe, expect, it } from 'vitest'
+import type { TerminalTab, WorkspaceSessionState } from '../../../shared/types'
+import {
+  mergeDirectSshRemoteWorkspaceSession,
+  narrowDirectSshReplaceWorktreeIds
+} from './remote-workspace-session-merge'
+
+function tab(id: string, worktreeId: string, overrides: Partial<TerminalTab> = {}): TerminalTab {
+  return {
+    id,
+    worktreeId,
+    title: id,
+    ptyId: `pty-${id}`,
+    generation: 1,
+    ...overrides
+  } as TerminalTab
+}
+
+function session(overrides: Partial<WorkspaceSessionState> = {}): WorkspaceSessionState {
+  return {
+    activeRepoId: null,
+    activeWorktreeId: null,
+    activeTabId: null,
+    tabsByWorktree: {},
+    terminalLayoutsByTabId: {},
+    ...overrides
+  }
+}
+
+const WT = 'repo-1::/home/user/worktree-a'
+const OTHER_WT = 'repo-1::/home/user/worktree-b'
+
+// Mirrors the production caller: narrow the requested scope first, then merge with the result.
+function narrowAndMerge(
+  current: WorkspaceSessionState,
+  remote: WorkspaceSessionState,
+  requested: ReadonlySet<string>,
+  liveTabsByWorktree: Record<string, TerminalTab[]>
+): { merged: WorkspaceSessionState; replaceWorktreeIds: ReadonlySet<string> } {
+  const replaceWorktreeIds = narrowDirectSshReplaceWorktreeIds(
+    requested,
+    current,
+    remote,
+    liveTabsByWorktree
+  )
+  const merged = mergeDirectSshRemoteWorkspaceSession(
+    current,
+    remote,
+    replaceWorktreeIds,
+    liveTabsByWorktree,
+    new Set()
+  )
+  return { merged, replaceWorktreeIds }
+}
+
+describe('narrowDirectSshReplaceWorktreeIds', () => {
+  it('drops a worktree with local tabs the remote snapshot reports no tabs for', () => {
+    const localTabs = [tab('tab-1', WT)]
+    const narrowed = narrowDirectSshReplaceWorktreeIds(
+      new Set([WT]),
+      session({ tabsByWorktree: { [WT]: localTabs } }),
+      session({ tabsByWorktree: { [WT]: [] } }),
+      { [WT]: localTabs }
+    )
+    expect([...narrowed]).toEqual([])
+  })
+
+  it('keeps a worktree when the remote snapshot has tabs, or local has none', () => {
+    const narrowed = narrowDirectSshReplaceWorktreeIds(
+      new Set([WT, OTHER_WT]),
+      session({ tabsByWorktree: { [WT]: [tab('tab-1', WT)], [OTHER_WT]: [] } }),
+      session({ tabsByWorktree: { [WT]: [tab('tab-r', WT)], [OTHER_WT]: [] } }),
+      { [WT]: [tab('tab-1', WT)], [OTHER_WT]: [] }
+    )
+    expect([...narrowed].sort()).toEqual([WT, OTHER_WT].sort())
+  })
+})
+
+describe('mergeDirectSshRemoteWorkspaceSession', () => {
+  it('keeps local state for a worktree the narrowing removed from the replace scope', () => {
+    const localTabs = [tab('tab-1', WT), tab('tab-2', WT)]
+    const current = session({
+      tabsByWorktree: { [WT]: localTabs },
+      terminalLayoutsByTabId: { 'tab-1': { activeLeafId: 'leaf-1' } as never },
+      activeTabIdByWorktree: { [WT]: 'tab-1' },
+      lastVisitedAtByWorktreeId: { [WT]: 111 },
+      activeWorktreeIdsOnShutdown: [WT],
+      defaultTerminalTabsAppliedByWorktreeId: { [WT]: true }
+    })
+    const remote = session({
+      tabsByWorktree: { [WT]: [] },
+      activeTabIdByWorktree: { [WT]: null },
+      lastVisitedAtByWorktreeId: { [WT]: 999 }
+    })
+
+    const { merged, replaceWorktreeIds } = narrowAndMerge(current, remote, new Set([WT]), {
+      [WT]: localTabs
+    })
+
+    expect([...replaceWorktreeIds]).toEqual([])
+    expect(merged.tabsByWorktree[WT]).toEqual(localTabs)
+    expect(merged.terminalLayoutsByTabId['tab-1']).toEqual({ activeLeafId: 'leaf-1' })
+    expect(merged.activeTabIdByWorktree?.[WT]).toBe('tab-1')
+    expect(merged.lastVisitedAtByWorktreeId?.[WT]).toBe(111)
+    expect(merged.activeWorktreeIdsOnShutdown).toEqual([WT])
+    expect(merged.defaultTerminalTabsAppliedByWorktreeId?.[WT]).toBe(true)
+  })
+
+  it('keeps local tabs for an in-scope worktree the remote snapshot omits entirely', () => {
+    const localTabs = [tab('tab-1', WT)]
+    const current = session({ tabsByWorktree: { [WT]: localTabs } })
+    const remote = session()
+
+    const { merged } = narrowAndMerge(current, remote, new Set([WT]), { [WT]: localTabs })
+
+    expect(merged.tabsByWorktree[WT]).toEqual(localTabs)
+  })
+
+  it('keeps current active-tab state when the active worktree left the replace scope', () => {
+    const localTabs = [tab('tab-1', WT)]
+    const current = session({
+      activeWorktreeId: WT,
+      activeTabId: 'tab-1',
+      tabsByWorktree: { [WT]: localTabs }
+    })
+    const remote = session({
+      activeWorktreeId: null,
+      activeTabId: null,
+      tabsByWorktree: { [WT]: [] }
+    })
+
+    const { merged } = narrowAndMerge(current, remote, new Set([WT]), { [WT]: localTabs })
+
+    expect(merged.activeWorktreeId).toBe(WT)
+    expect(merged.activeTabId).toBe('tab-1')
+  })
+
+  it('still replaces a worktree when the remote snapshot has tabs for it', () => {
+    const localTabs = [tab('tab-old', WT)]
+    const remoteTabs = [tab('tab-new', WT, { generation: 2 })]
+    const current = session({ tabsByWorktree: { [WT]: localTabs } })
+    const remote = session({ tabsByWorktree: { [WT]: remoteTabs } })
+
+    const { merged, replaceWorktreeIds } = narrowAndMerge(current, remote, new Set([WT]), {
+      [WT]: localTabs
+    })
+
+    expect([...replaceWorktreeIds]).toEqual([WT])
+    expect(merged.tabsByWorktree[WT].map((t) => t.id)).toEqual(['tab-new'])
+  })
+
+  it('accepts an empty remote worktree when local has no tabs either', () => {
+    const current = session({ tabsByWorktree: { [WT]: [] } })
+    const remote = session({ tabsByWorktree: { [WT]: [] } })
+
+    const { merged } = narrowAndMerge(current, remote, new Set([WT]), {})
+
+    expect(merged.tabsByWorktree[WT]).toEqual([])
+  })
+
+  it('scopes the guard per worktree, replacing populated ones while keeping the emptied one', () => {
+    const keptTabs = [tab('tab-kept', WT)]
+    const replacedRemote = [tab('tab-remote', OTHER_WT, { generation: 3 })]
+    const current = session({
+      tabsByWorktree: { [WT]: keptTabs, [OTHER_WT]: [tab('tab-old', OTHER_WT)] },
+      activeWorktreeIdsOnShutdown: [WT],
+      defaultTerminalTabsAppliedByWorktreeId: { [WT]: true, [OTHER_WT]: true }
+    })
+    const remote = session({
+      tabsByWorktree: { [WT]: [], [OTHER_WT]: replacedRemote },
+      activeWorktreeIdsOnShutdown: [WT, OTHER_WT]
+    })
+
+    const { merged, replaceWorktreeIds } = narrowAndMerge(
+      current,
+      remote,
+      new Set([WT, OTHER_WT]),
+      { [WT]: keptTabs, [OTHER_WT]: [tab('tab-old', OTHER_WT)] }
+    )
+
+    expect([...replaceWorktreeIds]).toEqual([OTHER_WT])
+    expect(merged.tabsByWorktree[WT]).toEqual(keptTabs)
+    expect(merged.tabsByWorktree[OTHER_WT].map((t) => t.id)).toEqual(['tab-remote'])
+    // Per-worktree records follow the same scope: the kept worktree's entries stay local, the
+    // replaced worktree's entries come from the remote.
+    expect(merged.activeWorktreeIdsOnShutdown).toEqual([WT, OTHER_WT])
+    expect(merged.defaultTerminalTabsAppliedByWorktreeId?.[WT]).toBe(true)
+    // Remote-authoritative for the replaced worktree: the remote carries no entry, so none survives.
+    expect(merged.defaultTerminalTabsAppliedByWorktreeId?.[OTHER_WT]).toBeUndefined()
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-session-merge.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.ts
@@ -16,14 +16,10 @@ function preserveNewerLocalTerminalFields(remote: TerminalTab, local: TerminalTa
 }
 
 // Why a worktree with local tabs but no remote tabs leaves the replace scope: the snapshot carries
-// no tombstones, so "no tabs" from the remote is indistinguishable from a snapshot that regressed
-// or was poisoned by an earlier export bug — and honoring it deletes terminal surfaces the user can
-// see, unrecoverably. Keeping local state for that worktree is always recoverable: the next push
-// re-exports it, and a genuinely emptied worktree converges once the remote reports any tab for it.
-//
-// The caller must pass the narrowed set both to the merge and to every hydration step keyed by
-// replace scope (replaceWorkspaceKeys) — a protected worktree left in that scope still gets its live
-// tabs reset and swept into PTY reconnect by the hydration pipeline.
+// no tombstones, so "no tabs" cannot be told apart from a regressed or poisoned one, and honoring it
+// deletes live terminal surfaces unrecoverably. Resurrected tabs are visible and closable. See #12447.
+// Why callers need the narrowed set as a value: every hydration step keyed by replace scope
+// (replaceWorkspaceKeys) resets and reconnect-sweeps the worktrees left in it.
 export function narrowDirectSshReplaceWorktreeIds(
   requestedReplaceWorktreeIds: ReadonlySet<string>,
   current: WorkspaceSessionState,
@@ -41,12 +37,20 @@ export function narrowDirectSshReplaceWorktreeIds(
 export function mergeDirectSshRemoteWorkspaceSession(
   current: WorkspaceSessionState,
   remote: WorkspaceSessionState,
-  replaceWorktreeIds: ReadonlySet<string>,
+  requestedReplaceWorktreeIds: ReadonlySet<string>,
   liveTabsByWorktree: AppState['tabsByWorktree'],
   preserveLocalTerminalTabIds: ReadonlySet<string>
 ): WorkspaceSessionState {
+  // Why the merge narrows again: this is a data-loss boundary, and narrowing is idempotent, so a
+  // caller that already narrowed pays nothing while one that did not still cannot delete tabs here.
+  const replaceWorktreeIds = narrowDirectSshReplaceWorktreeIds(
+    requestedReplaceWorktreeIds,
+    current,
+    remote,
+    liveTabsByWorktree
+  )
   // Why remote records are filtered to the replace scope: the remote session may still carry entries
-  // for worktrees the caller narrowed out (e.g. an empty tab list), and spreading those over current
+  // for worktrees the narrowing removed (e.g. an empty tab list), and spreading those over current
   // would delete the very state the narrowing protects.
   const inReplaceScope = (worktreeId: string): boolean => replaceWorktreeIds.has(worktreeId)
   const scopedRemoteRecord = <T>(record: Record<string, T> | undefined): [string, T][] =>

--- a/src/renderer/src/hooks/remote-workspace-session-merge.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.ts
@@ -15,6 +15,29 @@ function preserveNewerLocalTerminalFields(remote: TerminalTab, local: TerminalTa
     : preserved
 }
 
+// Why a worktree with local tabs but no remote tabs leaves the replace scope: the snapshot carries
+// no tombstones, so "no tabs" from the remote is indistinguishable from a snapshot that regressed
+// or was poisoned by an earlier export bug — and honoring it deletes terminal surfaces the user can
+// see, unrecoverably. Keeping local state for that worktree is always recoverable: the next push
+// re-exports it, and a genuinely emptied worktree converges once the remote reports any tab for it.
+//
+// The caller must pass the narrowed set both to the merge and to every hydration step keyed by
+// replace scope (replaceWorkspaceKeys) — a protected worktree left in that scope still gets its live
+// tabs reset and swept into PTY reconnect by the hydration pipeline.
+export function narrowDirectSshReplaceWorktreeIds(
+  requestedReplaceWorktreeIds: ReadonlySet<string>,
+  current: WorkspaceSessionState,
+  remote: WorkspaceSessionState,
+  liveTabsByWorktree: AppState['tabsByWorktree']
+): ReadonlySet<string> {
+  return new Set(
+    [...requestedReplaceWorktreeIds].filter((worktreeId) => {
+      const localTabs = liveTabsByWorktree[worktreeId] ?? current.tabsByWorktree[worktreeId] ?? []
+      return localTabs.length === 0 || (remote.tabsByWorktree[worktreeId] ?? []).length > 0
+    })
+  )
+}
+
 export function mergeDirectSshRemoteWorkspaceSession(
   current: WorkspaceSessionState,
   remote: WorkspaceSessionState,
@@ -22,6 +45,12 @@ export function mergeDirectSshRemoteWorkspaceSession(
   liveTabsByWorktree: AppState['tabsByWorktree'],
   preserveLocalTerminalTabIds: ReadonlySet<string>
 ): WorkspaceSessionState {
+  // Why remote records are filtered to the replace scope: the remote session may still carry entries
+  // for worktrees the caller narrowed out (e.g. an empty tab list), and spreading those over current
+  // would delete the very state the narrowing protects.
+  const inReplaceScope = (worktreeId: string): boolean => replaceWorktreeIds.has(worktreeId)
+  const scopedRemoteRecord = <T>(record: Record<string, T> | undefined): [string, T][] =>
+    Object.entries(record ?? {}).filter(([worktreeId]) => inReplaceScope(worktreeId))
   const currentTabsById = new Map(
     [...replaceWorktreeIds]
       .flatMap((worktreeId) => liveTabsByWorktree[worktreeId] ?? [])
@@ -29,7 +58,7 @@ export function mergeDirectSshRemoteWorkspaceSession(
   )
   const locallyPreservedTabIds = new Set<string>()
   const tabsByWorktree = Object.fromEntries(
-    Object.entries(remote.tabsByWorktree).map(([worktreeId, tabs]) => [
+    scopedRemoteRecord(remote.tabsByWorktree).map(([worktreeId, tabs]) => [
       worktreeId,
       tabs.map((tab) => {
         const local = currentTabsById.get(tab.id)
@@ -90,11 +119,11 @@ export function mergeDirectSshRemoteWorkspaceSession(
     terminalLayoutsByTabId,
     activeWorktreeIdsOnShutdown: [
       ...(current.activeWorktreeIdsOnShutdown ?? []).filter((id) => !replaceWorktreeIds.has(id)),
-      ...(remote.activeWorktreeIdsOnShutdown ?? [])
+      ...(remote.activeWorktreeIdsOnShutdown ?? []).filter(inReplaceScope)
     ],
     activeTabIdByWorktree: {
       ...omitTargetWorktrees(current.activeTabIdByWorktree),
-      ...remote.activeTabIdByWorktree
+      ...Object.fromEntries(scopedRemoteRecord(remote.activeTabIdByWorktree))
     },
     remoteSessionIdsByTabId: {
       ...Object.fromEntries(
@@ -110,11 +139,11 @@ export function mergeDirectSshRemoteWorkspaceSession(
     },
     lastVisitedAtByWorktreeId: {
       ...omitTargetWorktrees(current.lastVisitedAtByWorktreeId),
-      ...remote.lastVisitedAtByWorktreeId
+      ...Object.fromEntries(scopedRemoteRecord(remote.lastVisitedAtByWorktreeId))
     },
     defaultTerminalTabsAppliedByWorktreeId: {
       ...omitTargetWorktrees(current.defaultTerminalTabsAppliedByWorktreeId),
-      ...remote.defaultTerminalTabsAppliedByWorktreeId
+      ...Object.fromEntries(scopedRemoteRecord(remote.defaultTerminalTabsAppliedByWorktreeId))
     }
   }
 }

--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
@@ -14,6 +14,7 @@ import {
 import { directSshAuthoritiesEqual } from './direct-ssh-reconnect-tokens'
 import {
   mergeDirectSshRemoteWorkspaceSession,
+  narrowDirectSshReplaceWorktreeIds,
   uniqueWorktreeIdByPath
 } from './remote-workspace-session-merge'
 
@@ -111,12 +112,22 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
   const remoteSession = importRemoteWorkspaceSession(snapshot.session, {
     resolveWorktreeId: uniqueWorktreeIdByPath(worktreeIds)
   })
-  const merged = mergeDirectSshRemoteWorkspaceSession(
-    buildWorkspaceSessionPayload(state),
-    remoteSession,
+  const currentSession = buildWorkspaceSessionPayload(state)
+  // Why the narrowed set drives every step below: a worktree kept out of the replace scope must not
+  // reach hydration either — hydrateWorkspaceSession resets and reconnect-sweeps every worktree in
+  // replaceWorkspaceKeys, which would churn the live terminals the narrowing protects.
+  const replaceWorktreeIds = narrowDirectSshReplaceWorktreeIds(
     worktreeIds,
+    currentSession,
+    remoteSession,
+    state.tabsByWorktree
+  )
+  const merged = mergeDirectSshRemoteWorkspaceSession(
+    currentSession,
+    remoteSession,
+    replaceWorktreeIds,
     state.tabsByWorktree,
-    currentRecoveryTabIds(state, authority, worktreeIds)
+    currentRecoveryTabIds(state, authority, replaceWorktreeIds)
   )
   if (!isArrivalCurrent(authority.targetId, arrival) || !isPreparationTokenCurrent(token)) {
     return
@@ -124,7 +135,7 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
   snapshotApplyDepth += 1
   try {
     const currentStore = store.getState()
-    const replaceWorkspaceKeys = [...worktreeIds]
+    const replaceWorkspaceKeys = [...replaceWorktreeIds]
     currentStore.hydrateWorkspaceSession(merged, {
       directSshAuthority: authority,
       replaceWorkspaceKeys

--- a/src/renderer/src/hooks/remote-workspace-snapshot-empty-worktree-guard.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-empty-worktree-guard.test.ts
@@ -1,0 +1,191 @@
+/**
+ * Drives the real snapshot apply against a real store. A pulled snapshot that
+ * reports no tabs for a worktree the renderer is showing tabs in must leave that
+ * worktree's live terminals untouched, while a worktree the snapshot does carry
+ * tabs for still replaces.
+ *
+ * The merge alone cannot express this: a merge that protects the worktree still
+ * loses its live PTY bindings if the worktree stays in the hydration replace
+ * scope, so the assertions below read post-apply store state and the scope handed
+ * to reconnect rather than the merge result.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
+import type { DirectSshAuthority, SshProviderEpoch } from '../../../shared/ssh-types'
+import type { TerminalTab } from '../../../shared/types'
+import { createTestStore, makeTab, makeWorktree } from '../store/slices/store-test-helpers'
+import type { DirectSshSnapshotApplyToken } from './direct-ssh-reconnect-coordinator-types'
+import { applyDirectSshRemoteWorkspaceSnapshot } from './remote-workspace-snapshot-apply'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+
+const TARGET_ID = 'target-a'
+const REPO_ID = 'repo-a'
+const KEPT_PATH = '/remote/work'
+const REPLACED_PATH = '/remote/other'
+const KEPT_ID = `${REPO_ID}::${KEPT_PATH}`
+const REPLACED_ID = `${REPO_ID}::${REPLACED_PATH}`
+
+const authority: DirectSshAuthority = {
+  targetId: TARGET_ID,
+  providerEpoch: 'epoch-a' as SshProviderEpoch,
+  connectionGeneration: 1
+}
+
+function ptyId(tabId: string): string {
+  return `ssh:${TARGET_ID}@@pty-${tabId}`
+}
+
+function liveTab(id: string, worktreeId: string, sortOrder = 0): TerminalTab {
+  return makeTab({ id, worktreeId, ptyId: ptyId(id), title: id, sortOrder, createdAt: 1 })
+}
+
+function token(snapshotRevision: number): DirectSshSnapshotApplyToken {
+  return {
+    authority,
+    catalogRevision: 0,
+    repoFingerprint: 'fp',
+    authorityRequirement: 'required',
+    snapshotRevision,
+    outcome: 'complete'
+  }
+}
+
+function snapshot(
+  tabsByWorktreePath: RemoteWorkspaceSnapshot['session']['tabsByWorktreePath']
+): RemoteWorkspaceSnapshot {
+  return {
+    namespace: 'workspace',
+    revision: 1,
+    updatedAt: 1,
+    schemaVersion: 1,
+    session: {
+      activeWorktreePath: null,
+      activeTabId: null,
+      tabsByWorktreePath,
+      terminalLayoutsByTabId: {},
+      activeWorktreePathsOnShutdown: [],
+      activeTabIdByWorktreePath: {},
+      remoteSessionIdsByTabId: {},
+      lastVisitedAtByWorktreePath: {},
+      defaultTerminalTabsAppliedByWorktreePath: {}
+    }
+  }
+}
+
+function remoteTab(worktreePath: string, id: string) {
+  return {
+    id,
+    worktreePath,
+    ptyId: ptyId(id),
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function createHarness() {
+  const store = createTestStore()
+  const reconnectWorkspaceKeys: string[][] = []
+  store.setState({
+    repos: [
+      {
+        id: REPO_ID,
+        path: '/remote/repo-a',
+        displayName: 'Repo A',
+        badgeColor: '#000',
+        addedAt: 0,
+        connectionId: TARGET_ID
+      } as never
+    ],
+    worktreesByRepo: {
+      [REPO_ID]: [
+        makeWorktree({
+          id: KEPT_ID,
+          repoId: REPO_ID,
+          path: KEPT_PATH,
+          hostId: `ssh:${TARGET_ID}`
+        } as never),
+        makeWorktree({
+          id: REPLACED_ID,
+          repoId: REPO_ID,
+          path: REPLACED_PATH,
+          hostId: `ssh:${TARGET_ID}`
+        } as never)
+      ]
+    },
+    tabsByWorktree: {
+      [KEPT_ID]: [liveTab('tab-kept', KEPT_ID)],
+      [REPLACED_ID]: [liveTab('tab-stale', REPLACED_ID)]
+    },
+    ptyIdsByTabId: { 'tab-kept': [ptyId('tab-kept')], 'tab-stale': [ptyId('tab-stale')] },
+    activeWorktreeId: KEPT_ID,
+    activeTabId: 'tab-kept',
+    activeTabIdByWorktree: { [KEPT_ID]: 'tab-kept' },
+    reconnectPersistedTerminals: (async (_signal, options) => {
+      reconnectWorkspaceKeys.push([...(options?.workspaceKeys ?? [])])
+    }) as never,
+    markRemoteWorkspaceHydrated: (() => {}) as never,
+    setRemoteWorkspaceSyncStatus: (() => {}) as never
+  })
+  return { store, reconnectWorkspaceKeys }
+}
+
+async function applySnapshot(
+  store: ReturnType<typeof createTestStore>,
+  snap: RemoteWorkspaceSnapshot
+): Promise<void> {
+  await applyDirectSshRemoteWorkspaceSnapshot({
+    store,
+    snapshot: snap,
+    token: token(snap.revision),
+    arrival: 1,
+    isArrivalCurrent: () => true,
+    isPreparationTokenCurrent: () => true,
+    waitForWorkspaceSessionReady: async () => true,
+    finalizeHydratedTerminals: () => 0
+  })
+}
+
+describe('direct-SSH snapshot apply, worktree the snapshot reports no tabs for', () => {
+  it('leaves the live terminals and the hydration scope alone', async () => {
+    const { store, reconnectWorkspaceKeys } = createHarness()
+
+    await applySnapshot(
+      store,
+      snapshot({
+        [KEPT_PATH]: [],
+        [REPLACED_PATH]: [remoteTab(REPLACED_PATH, 'tab-remote')]
+      })
+    )
+
+    const state = store.getState()
+    expect(state.tabsByWorktree[KEPT_ID].map((tab) => tab.id)).toEqual(['tab-kept'])
+    // Live PTY binding, not a rehydrated placeholder: hydration clears ptyId and arms
+    // pendingActivationSpawn for every tab inside the replace scope.
+    expect(state.tabsByWorktree[KEPT_ID][0].ptyId).toBe(ptyId('tab-kept'))
+    expect(state.tabsByWorktree[KEPT_ID][0].pendingActivationSpawn).toBeUndefined()
+    expect(state.ptyIdsByTabId['tab-kept']).toEqual([ptyId('tab-kept')])
+    expect(state.pendingReconnectWorktreeIds).not.toContain(KEPT_ID)
+    expect(reconnectWorkspaceKeys).toEqual([[REPLACED_ID]])
+
+    // The remote stays authoritative for the worktree it does report tabs for.
+    expect(state.tabsByWorktree[REPLACED_ID].map((tab) => tab.id)).toEqual(['tab-remote'])
+  })
+
+  it('leaves the live terminals alone when the snapshot omits the worktree entirely', async () => {
+    const { store, reconnectWorkspaceKeys } = createHarness()
+
+    await applySnapshot(
+      store,
+      snapshot({ [REPLACED_PATH]: [remoteTab(REPLACED_PATH, 'tab-remote')] })
+    )
+
+    const state = store.getState()
+    expect(state.tabsByWorktree[KEPT_ID][0].ptyId).toBe(ptyId('tab-kept'))
+    expect(state.ptyIdsByTabId['tab-kept']).toEqual([ptyId('tab-kept')])
+    expect(reconnectWorkspaceKeys).toEqual([[REPLACED_ID]])
+  })
+})

--- a/src/renderer/src/hooks/remote-workspace-snapshot-empty-worktree-guard.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-empty-worktree-guard.test.ts
@@ -12,7 +12,7 @@
 import { describe, expect, it, vi } from 'vitest'
 import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
 import type { DirectSshAuthority, SshProviderEpoch } from '../../../shared/ssh-types'
-import type { TerminalTab } from '../../../shared/types'
+import type { TerminalTab } from '../../../shared/terminal-tab-types'
 import { createTestStore, makeTab, makeWorktree } from '../store/slices/store-test-helpers'
 import type { DirectSshSnapshotApplyToken } from './direct-ssh-reconnect-coordinator-types'
 import { applyDirectSshRemoteWorkspaceSnapshot } from './remote-workspace-snapshot-apply'


### PR DESCRIPTION
Fixes #12748

A pulled direct-SSH workspace snapshot that carries zero tabs for a worktree the renderer is showing tabs in leaves those tabs in place.

`narrowDirectSshReplaceWorktreeIds` removes such worktrees from the replace scope: local state wins until the remote reports at least one tab for the worktree. The snapshot carries no tombstones, so "no tabs" is indistinguishable from a regressed or corrupted snapshot — honoring it deletes terminal surfaces the user can see, unrecoverably, while keeping local state leaves surfaces the user can still close.

The narrowed scope drives every step of the apply: the merge (remote per-worktree records are filtered to the scope, so a spread cannot undo the narrowing), `replaceWorkspaceKeys` for `hydrateWorkspaceSession`/`hydrateTabsSession`, and `reconnectPersistedTerminals` — a protected worktree left in the hydration scope would still get its live tabs reset and swept into PTY reconnect.

`mergeDirectSshRemoteWorkspaceSession` applies the narrowing itself rather than relying on the caller to have done it. The narrowing predicate depends only on the worktree id and the three session inputs, never on the input set, so applying it twice is a no-op: the caller — which still needs the narrowed set as a value for `replaceWorkspaceKeys` — pays nothing, and no caller can delete a populated worktree's tabs by handing the merge a wider scope.

Worktrees with tabs on both sides are unaffected; the remote stays authoritative for them.

## Bounded regression, not convergence

Single-client this converges: the next push re-exports the protected worktree, and a genuinely emptied worktree replaces once the remote reports any tab for it.

Multi-client it does not. Two clients against one SSH box is the point of a shared snapshot: if client B closes every tab in worktree W while client A still holds them, A protects, A pushes, and B's tabs come back. That repeats until the tabs are closed on the holding client too.

The trade is deliberate — resurrected tabs are visible and one click to close, deleted tabs are silent and permanent — but it is a bounded regression, not convergence. Real convergence needs tombstones plus a monotonic per-scope revision, tracked in #12447.

## Testing

`pnpm run typecheck:web` and `npx oxlint` are clean; the renderer hook, store, and lib vitest suites pass.

Coverage runs at two levels. `remote-workspace-session-merge.test.ts` pins the merge, including that it narrows a replace scope handed to it un-narrowed. `remote-workspace-snapshot-empty-worktree-guard.test.ts` drives `applyDirectSshRemoteWorkspaceSnapshot` against a real store and asserts on post-apply state — live PTY bindings, `pendingReconnectWorktreeIds`, and the workspace keys handed to `reconnectPersistedTerminals` — so the hydration scope is pinned and not only the merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
