### PR TITLE
Validate auto-generated PR details; abort with clear errors

### DIFF
--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -264,6 +264,7 @@ import {
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
   resolveCreatePrIntentReviewBase,
+  resolveCreatePrIntentGeneratedReviewFields,
   resolveCreatePrIntentRemoteStep,
   shouldAttemptCreateHostedReviewForIntent,
   shouldGenerateHostedReviewDetailsForIntent,
@@ -3479,17 +3480,33 @@ function SourceControlInner(): React.JSX.Element {
             })
             return false
           }
-          if (generated.success) {
-            fields = {
-              // Why: intent auto-submits, so generated details must not retarget the review without confirmation.
-              base: fields.base,
-              title: generated.fields.title.trim() || fields.title,
-              body: generated.fields.body,
-              draft: generated.fields.draft
-            }
+          const resolved = resolveCreatePrIntentGeneratedReviewFields(fields, generated)
+          if (!resolved.ok) {
+            setCreatePrIntentNoticeForWorktree(token.worktreeId, {
+              tone: 'destructive',
+              message:
+                resolved.error ??
+                translate(
+                  'auto.components.right.sidebar.SourceControl.createPrIntentEmptyGeneratedBody',
+                  'Generated review details did not include a description. Retry Create PR.'
+                )
+            })
+            return false
           }
+          fields = resolved.fields
         } catch (error) {
           console.warn('[SourceControl] Create PR intent detail generation failed', error)
+          setCreatePrIntentNoticeForWorktree(token.worktreeId, {
+            tone: 'destructive',
+            message:
+              error instanceof Error
+                ? error.message
+                : translate(
+                    'auto.components.right.sidebar.SourceControl.createPrIntentGenerateDetailsFailed',
+                    'Could not generate review details. Retry Create PR.'
+                  )
+          })
+          return false
         }
       }
 

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.test.ts
@@ -8,6 +8,7 @@ import {
   getCreatePrIntentCommitFailureNoticeMessage,
   getCreatePrIntentStagePaths,
   resolveCreatePrIntentReviewBase,
+  resolveCreatePrIntentGeneratedReviewFields,
   resolveCreatePrIntentRemoteStep,
   shouldAttemptCreateHostedReviewForIntent,
   shouldGenerateHostedReviewDetailsForIntent
@@ -289,7 +290,7 @@ describe('source-control Create PR intent flow helpers', () => {
     ).toBe('blocked')
   })
 
-  it('uses main preflight as the final lookup authority after preparation', () => {
+  it('generates details while main preflight remains the final lookup authority', () => {
     const unavailable = {
       provider: 'github' as const,
       review: null,
@@ -304,7 +305,10 @@ describe('source-control Create PR intent flow helpers', () => {
     expect(shouldAttemptCreateHostedReviewForIntent({ ...unavailable, head: undefined })).toBe(
       false
     )
-    expect(shouldGenerateHostedReviewDetailsForIntent(unavailable)).toBe(false)
+    expect(shouldGenerateHostedReviewDetailsForIntent(unavailable)).toBe(true)
+    expect(shouldGenerateHostedReviewDetailsForIntent({ ...unavailable, head: undefined })).toBe(
+      false
+    )
     expect(
       shouldGenerateHostedReviewDetailsForIntent({
         ...unavailable,
@@ -322,6 +326,47 @@ describe('source-control Create PR intent flow helpers', () => {
         reviewLookupOutcome: 'unavailable'
       })
     ).toBe(false)
+  })
+
+  it('keeps generated review fields fail-closed', () => {
+    const current = {
+      base: 'main',
+      title: 'Feature branch',
+      body: '',
+      draft: false
+    }
+
+    expect(
+      resolveCreatePrIntentGeneratedReviewFields(current, {
+        success: false,
+        error: 'Agent timed out.'
+      })
+    ).toEqual({ ok: false, error: 'Agent timed out.' })
+    expect(
+      resolveCreatePrIntentGeneratedReviewFields(current, {
+        success: true,
+        fields: { ...current, title: 'Generated title', body: '   ' }
+      })
+    ).toEqual({ ok: false, error: null })
+    expect(
+      resolveCreatePrIntentGeneratedReviewFields(current, {
+        success: true,
+        fields: {
+          base: 'other-base',
+          title: 'Generated title',
+          body: '## Problem\n\nDetails',
+          draft: true
+        }
+      })
+    ).toEqual({
+      ok: true,
+      fields: {
+        base: 'main',
+        title: 'Generated title',
+        body: '## Problem\n\nDetails',
+        draft: true
+      }
+    })
   })
 
   it('surfaces the commit failure summary in the Create PR intent notice', () => {

--- a/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-create-pr-intent-flow.ts
@@ -40,6 +40,21 @@ export type CreatePrIntentCurrentTarget = {
   baseRef?: string | null
 }
 
+type CreatePrIntentReviewFields = {
+  base: string
+  title: string
+  body: string
+  draft: boolean
+}
+
+type CreatePrIntentReviewGeneration =
+  | { success: true; fields: CreatePrIntentReviewFields }
+  | { success: false; error: string }
+
+export type CreatePrIntentGeneratedReviewFields =
+  | { ok: true; fields: CreatePrIntentReviewFields }
+  | { ok: false; error: string | null }
+
 export function createCreatePrIntentRunToken(input: Omit<CreatePrIntentRunToken, 'startedAt'>) {
   return { ...input, startedAt: Date.now() }
 }
@@ -182,7 +197,30 @@ export function shouldAttemptCreateHostedReviewForIntent(
 export function shouldGenerateHostedReviewDetailsForIntent(
   eligibility: HostedReviewCreationEligibility
 ): boolean {
-  return eligibility.canCreate
+  // Why: main rechecks an unavailable lookup immediately before creation; generate first so a recovered create never submits fallback fields.
+  return shouldAttemptCreateHostedReviewForIntent(eligibility)
+}
+
+export function resolveCreatePrIntentGeneratedReviewFields(
+  current: CreatePrIntentReviewFields,
+  generated: CreatePrIntentReviewGeneration
+): CreatePrIntentGeneratedReviewFields {
+  if (!generated.success) {
+    return { ok: false, error: generated.error }
+  }
+  if (!generated.fields.body.trim()) {
+    return { ok: false, error: null }
+  }
+  return {
+    ok: true,
+    fields: {
+      // Why: intent auto-submits, so generated details must not retarget the review without confirmation.
+      base: current.base,
+      title: generated.fields.title.trim() || current.title,
+      body: generated.fields.body,
+      draft: generated.fields.draft
+    }
+  }
 }
 
 export function getCreatePrIntentCommitFailureNoticeMessage(

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -10801,7 +10801,9 @@
             "b8c2e1a904": "{{value0}} → {{value1}}",
             "a4e93c21d7": "Current branch: {{value0}}",
             "c7d4e2f801": "Change base ref: {{value0}}",
-            "f3a1b8c204": "upstream"
+            "f3a1b8c204": "upstream",
+            "createPrIntentEmptyGeneratedBody": "Generated review details did not include a description. Retry Create PR.",
+            "createPrIntentGenerateDetailsFailed": "Could not generate review details. Retry Create PR."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "Could not start the selected agent.",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -10560,7 +10560,9 @@
             "b8c2e1a904": "{{value0}} → {{value1}}",
             "a4e93c21d7": "Rama actual: {{value0}}",
             "c7d4e2f801": "Cambiar ref base: {{value0}}",
-            "f3a1b8c204": "upstream"
+            "f3a1b8c204": "upstream",
+            "createPrIntentEmptyGeneratedBody": "Los detalles de revisión generados no incluyeron una descripción. Reintentar Crear PR.",
+            "createPrIntentGenerateDetailsFailed": "No se pudieron generar los detalles de revisión. Reintentar Crear PR."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "No se pudo iniciar el agente seleccionado.",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -10560,7 +10560,9 @@
             "b8c2e1a904": "{{value0}} → {{value1}}",
             "a4e93c21d7": "現在のブランチ: {{value0}}",
             "c7d4e2f801": "ベース ref を変更: {{value0}}",
-            "f3a1b8c204": "upstream"
+            "f3a1b8c204": "upstream",
+            "createPrIntentEmptyGeneratedBody": "生成されたレビューの詳細に説明が含まれていませんでした。PRの作成を再試行してください。",
+            "createPrIntentGenerateDetailsFailed": "レビューの詳細を生成できませんでした。PRの作成を再試行してください。"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "選択した agent を開始できませんでした。",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -10560,7 +10560,9 @@
             "b8c2e1a904": "{{value0}} → {{value1}}",
             "a4e93c21d7": "현재 브랜치: {{value0}}",
             "c7d4e2f801": "베이스 ref 변경: {{value0}}",
-            "f3a1b8c204": "upstream"
+            "f3a1b8c204": "upstream",
+            "createPrIntentEmptyGeneratedBody": "생성된 검토 세부 정보에 설명이 포함되지 않았습니다. PR 생성을 다시 시도하세요.",
+            "createPrIntentGenerateDetailsFailed": "검토 세부 정보를 생성할 수 없습니다. PR 생성을 다시 시도하세요."
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "선택한 agent를 시작할 수 없습니다.",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -10580,7 +10580,9 @@
             "b8c2e1a904": "{{value0}} → {{value1}}",
             "a4e93c21d7": "当前分支：{{value0}}",
             "c7d4e2f801": "更改基引用：{{value0}}",
-            "f3a1b8c204": "upstream"
+            "f3a1b8c204": "upstream",
+            "createPrIntentEmptyGeneratedBody": "生成的评审详情未包含描述。请重试创建 PR。",
+            "createPrIntentGenerateDetailsFailed": "无法生成评审详情。请重试创建 PR。"
           },
           "SourceControlAgentActionDialog": {
             "8e856842d1": "无法启动选定的智能体。",


### PR DESCRIPTION
## Problem

When auto-generating PR details, the system could submit incomplete pull requests (missing description) or accidentally change the target branch. These issues happened silently without user confirmation.

## Solution

Added validation that:
- Rejects generated details if the description is empty or whitespace-only
- Prevents auto-changing the base branch (always keeps the current selection)
- Shows clear error messages when generation fails: "Generated review details did not include a description. Retry Create PR."
- Blocks PR creation until details are valid

## Testing

- [x] Added tests for validation logic (success, empty body, failed generation, base preservation)
- [x] Verified type exports and imports
- [x] Confirmed error handling paths and user-facing messages