### PR TITLE
Allow worktree lineage across repo and project boundaries

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -36915,25 +36915,11 @@ describe('OrcaRuntimeService', () => {
 
   it.each([
     {
-      boundary: 'repository',
-      childRepoId: 'repo-child',
-      parentRepoId: 'repo-parent',
-      childMeta: {},
-      parentMeta: {}
-    },
-    {
       boundary: 'known host',
       childRepoId: TEST_REPO_ID,
       parentRepoId: TEST_REPO_ID,
       childMeta: { hostId: 'runtime:child-host' as const },
       parentMeta: { hostId: 'runtime:parent-host' as const }
-    },
-    {
-      boundary: 'known project',
-      childRepoId: TEST_REPO_ID,
-      parentRepoId: TEST_REPO_ID,
-      childMeta: { projectId: 'project-child' },
-      parentMeta: { projectId: 'project-parent' }
     }
   ])('rejects manual lineage writes across a $boundary boundary', async (scenario) => {
     const repos = [...new Set([scenario.childRepoId, scenario.parentRepoId])].map((id) => ({
@@ -36979,12 +36965,80 @@ describe('OrcaRuntimeService', () => {
       runtime.updateManagedWorktreeMeta(`id:${childId}`, {
         lineage: { parentWorktree: `id:${parentId}` }
       })
-    ).rejects.toThrow(
-      'Parent worktree must belong to the same repository, execution host, and project.'
-    )
+    ).rejects.toThrow('Parent worktree must belong to the same execution host.')
 
     expect(setWorktreeLineage).not.toHaveBeenCalled()
     expect(setWorkspaceLineage).not.toHaveBeenCalled()
+  })
+
+  // Regression (#11007): CLI agents routinely create a child workspace in a sibling repo.
+  it.each([
+    {
+      boundary: 'repository',
+      childRepoId: 'repo-child',
+      parentRepoId: 'repo-parent',
+      childMeta: {},
+      parentMeta: {}
+    },
+    {
+      boundary: 'known project',
+      childRepoId: TEST_REPO_ID,
+      parentRepoId: TEST_REPO_ID,
+      childMeta: { projectId: 'project-child' },
+      parentMeta: { projectId: 'project-parent' }
+    }
+  ])('accepts manual lineage writes across a $boundary boundary', async (scenario) => {
+    const repos = [...new Set([scenario.childRepoId, scenario.parentRepoId])].map((id) => ({
+      id,
+      path: join(tmpdir(), id),
+      displayName: id,
+      badgeColor: 'blue' as const,
+      addedAt: 1
+    }))
+    const childRepoPath = repos.find((repo) => repo.id === scenario.childRepoId)!.path
+    const parentRepoPath = repos.find((repo) => repo.id === scenario.parentRepoId)!.path
+    const childPath = join(childRepoPath, 'child')
+    const parentPath = join(parentRepoPath, 'parent')
+    const childId = `${scenario.childRepoId}::${childPath}`
+    const parentId = `${scenario.parentRepoId}::${parentPath}`
+    const metaById: Record<string, WorktreeMeta> = {
+      [childId]: makeWorktreeMeta({ instanceId: 'child-instance', ...scenario.childMeta }),
+      [parentId]: makeWorktreeMeta({ instanceId: 'parent-instance', ...scenario.parentMeta })
+    }
+    const setWorktreeLineage = vi.fn()
+    const setWorkspaceLineage = vi.fn()
+    const runtimeStore = {
+      ...store,
+      getRepos: () => repos,
+      getRepo: (id: string) => repos.find((repo) => repo.id === id),
+      getAllWorktreeMeta: () => metaById,
+      getWorktreeMeta: (worktreeId: string) => metaById[worktreeId],
+      setWorktreeMeta: (worktreeId: string, meta: Partial<WorktreeMeta>) => {
+        metaById[worktreeId] = { ...metaById[worktreeId], ...meta }
+        return metaById[worktreeId]
+      },
+      getWorktreeLineage: () => undefined,
+      setWorktreeLineage,
+      setWorkspaceLineage
+    }
+    vi.mocked(listWorktrees).mockImplementation(async (repoPath) => [
+      ...(repoPath === childRepoPath ? [makeWorktreeInfo(childPath)] : []),
+      ...(repoPath === parentRepoPath ? [makeWorktreeInfo(parentPath)] : [])
+    ])
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    await runtime.updateManagedWorktreeMeta(`id:${childId}`, {
+      lineage: { parentWorktree: `id:${parentId}` }
+    })
+
+    expect(setWorktreeLineage).toHaveBeenCalledWith(
+      childId,
+      expect.objectContaining({
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: 'parent-instance'
+      })
+    )
+    expect(setWorkspaceLineage).toHaveBeenCalled()
   })
 
   it('clears workspace lineage when manually removing a parent', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -10749,10 +10749,7 @@ export class OrcaRuntimeService {
     // A spawn published (or admission pending) this generation already
     // attaches the provider stream; a replacement under a reused id must not
     // read as the discovered never-attached session it replaced.
-    if (
-      this.spawnPublishedPtys.has(ptyId) ||
-      this.pendingPtyRegistrationIncarnations.has(ptyId)
-    ) {
+    if (this.spawnPublishedPtys.has(ptyId) || this.pendingPtyRegistrationIncarnations.has(ptyId)) {
       return false
     }
     // SSH panes have their own lease/reattach machinery.
@@ -27902,7 +27899,7 @@ export class OrcaRuntimeService {
     if (!sharesResolvedWorktreeLineageBoundary(child, parent)) {
       throw new RuntimeLineageError(
         'LINEAGE_PARENT_CONTEXT_CONFLICT',
-        'Parent worktree must belong to the same repository, execution host, and project.'
+        'Parent worktree must belong to the same execution host.'
       )
     }
     const instanceByWorktreeId = new Map(

--- a/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts
+++ b/src/renderer/src/components/right-sidebar/folder-workspace-attached-worktrees.test.ts
@@ -221,7 +221,7 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
     expect(result.lineageChildrenByParentId.size).toBe(0)
   })
 
-  it('rejects nested descendants across host or project boundaries', () => {
+  it('rejects nested descendants across a host boundary while keeping cross-project ones', () => {
     const parent = makeWorktree({
       id: 'repo-1::/parent',
       instanceId: 'parent',
@@ -251,7 +251,14 @@ describe('getAttachedWorktreesForFolderWorkspace', () => {
       worktreesByRepo: { 'repo-1': [parent, hostChild, projectChild] }
     })
 
-    expect(result.lineageChildrenByParentId.size).toBe(0)
+    expect(
+      new Map(
+        [...result.lineageChildrenByParentId].map(([parentId, children]) => [
+          parentId,
+          children.map((child) => child.id)
+        ])
+      )
+    ).toEqual(new Map([[parent.id, [projectChild.id]]]))
   })
 
   it('does not attach cyclic legacy descendants', () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.test.tsx
@@ -199,6 +199,8 @@ describe('DeleteWorktreeDialog lineage copy', () => {
       <DeleteWorktreeLineageNotice
         descendants={[child]}
         dirtyChangeCountsByWorktreeId={new Map()}
+        repoMap={new Map()}
+        targetRepoId={child.repoId}
       />
     )
 
@@ -206,6 +208,41 @@ describe('DeleteWorktreeDialog lineage copy', () => {
     expect(markup).toContain('mt-2 min-w-0 max-w-full space-y-1 overflow-hidden')
     expect(markup).toContain('min-w-0 overflow-hidden')
     expect(markup).toContain('truncate text-muted-foreground')
+  })
+
+  // Regression (#11007): lineage can now cross repos, so "delete all" must say so.
+  it('names the repo of a cross-repo descendant in the lineage notice', async () => {
+    const sameRepoChild = makeWorktree('same-repo-child', '/projects/orca/same-repo-child')
+    const crossRepoChild = {
+      ...makeWorktree('cross-repo-child', '/projects/baseline/cross-repo-child'),
+      repoId: 'repo-baseline'
+    }
+    const { DeleteWorktreeLineageNotice } = await import('./DeleteWorktreeLineageNotice')
+
+    const markup = renderToStaticMarkup(
+      <DeleteWorktreeLineageNotice
+        descendants={[sameRepoChild, crossRepoChild]}
+        dirtyChangeCountsByWorktreeId={new Map()}
+        repoMap={
+          new Map([
+            [
+              'repo-baseline',
+              {
+                id: 'repo-baseline',
+                path: '/projects/baseline',
+                displayName: 'baseline',
+                badgeColor: 'blue',
+                addedAt: 1
+              }
+            ]
+          ])
+        }
+        targetRepoId={sameRepoChild.repoId}
+      />
+    )
+
+    expect(markup).toContain('baseline')
+    expect(markup.match(/truncate lowercase/g)).toHaveLength(1)
   })
 
   it('uses non-destructive disk copy for folder workspace deletes', async () => {

--- a/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeDialog.tsx
@@ -405,6 +405,8 @@ const DeleteWorktreeDialog = React.memo(function DeleteWorktreeDialog() {
           <DeleteWorktreeLineageNotice
             descendants={lineageDelete.descendants}
             dirtyChangeCountsByWorktreeId={dirtyChangeCountsByWorktreeId}
+            repoMap={repoMap}
+            targetRepoId={worktree?.repoId}
           />
         )}
 

--- a/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
+++ b/src/renderer/src/components/sidebar/DeleteWorktreeLineageNotice.tsx
@@ -1,17 +1,22 @@
 import { Workflow } from 'lucide-react'
 import type { JSX } from 'react'
-import type { Worktree } from '../../../../shared/types'
+import type { Repo, Worktree } from '../../../../shared/types'
 import { DeleteWorktreeDirtyChangeHint } from './DeleteWorktreeDirtyChangeHint'
+import { RepoBadgeMark } from '@/components/repo/RepoBadgeLabel'
 import { translate } from '@/i18n/i18n'
 
 type DeleteWorktreeLineageNoticeProps = {
   descendants: readonly Worktree[]
   dirtyChangeCountsByWorktreeId: ReadonlyMap<string, number>
+  repoMap: ReadonlyMap<string, Repo>
+  targetRepoId: string | undefined
 }
 
 export function DeleteWorktreeLineageNotice({
   descendants,
-  dirtyChangeCountsByWorktreeId
+  dirtyChangeCountsByWorktreeId,
+  repoMap,
+  targetRepoId
 }: DeleteWorktreeLineageNoticeProps): JSX.Element | null {
   const childWorkspaceCount = descendants.length
   if (childWorkspaceCount === 0) {
@@ -44,15 +49,31 @@ export function DeleteWorktreeLineageNotice({
           {/* Why: long nowrap paths can otherwise give this grid child an
              intrinsic width wider than the modal. */}
           <div className="mt-2 min-w-0 max-w-full space-y-1 overflow-hidden rounded-sm border border-border/60 bg-background/60 px-2 py-1.5">
-            {descendants.slice(0, 4).map((child) => (
-              <div key={child.id} className="min-w-0 overflow-hidden">
-                <div className="truncate font-medium text-foreground">{child.displayName}</div>
-                <div className="truncate text-muted-foreground">{child.path}</div>
-                <DeleteWorktreeDirtyChangeHint
-                  changeCount={dirtyChangeCountsByWorktreeId.get(child.id)}
-                />
-              </div>
-            ))}
+            {descendants.slice(0, 4).map((child) => {
+              // Why: a cascade that reaches outside the deleted workspace's repo is a much
+              // bigger action than the same-repo case, so name that repo explicitly.
+              const foreignRepo =
+                child.repoId === targetRepoId ? undefined : repoMap.get(child.repoId)
+              return (
+                <div key={child.id} className="min-w-0 overflow-hidden">
+                  <div className="flex min-w-0 items-center gap-1.5">
+                    <span className="truncate font-medium text-foreground">
+                      {child.displayName}
+                    </span>
+                    {foreignRepo ? (
+                      <span className="inline-flex min-w-0 max-w-[8rem] shrink-0 items-center gap-1 rounded border border-border bg-accent px-1.5 py-0.5 text-[10px] font-semibold text-foreground">
+                        <RepoBadgeMark color={foreignRepo.badgeColor} />
+                        <span className="truncate lowercase">{foreignRepo.displayName}</span>
+                      </span>
+                    ) : null}
+                  </div>
+                  <div className="truncate text-muted-foreground">{child.path}</div>
+                  <DeleteWorktreeDirtyChangeHint
+                    changeCount={dirtyChangeCountsByWorktreeId.get(child.id)}
+                  />
+                </div>
+              )
+            })}
             {descendants.length > 4 ? (
               <div className="text-muted-foreground">
                 +{descendants.length - 4}{' '}

--- a/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
+++ b/src/renderer/src/components/sidebar/folder-workspace-card-pr-display.test.ts
@@ -220,9 +220,8 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
 
   it.each([
     ['repository', { repoId: 'repo-2' }, {}],
-    ['known host', { hostId: 'ssh:remote' as const }, { hostId: 'local' as const }],
     ['known project', { projectId: 'project-b' }, { projectId: 'project-a' }]
-  ])('excludes nested PRs across a %s boundary', (_boundary, childOverrides, parentOverrides) => {
+  ])('includes nested PRs across a %s boundary', (_boundary, childOverrides, parentOverrides) => {
     const parent = makeWorktree({ id: 'parent', instanceId: 'parent', ...parentOverrides })
     const nested = makeWorktree({
       id: 'nested',
@@ -246,6 +245,31 @@ describe('getFolderWorkspaceCardPrDisplay', () => {
       ]),
       hostedReviewCache: null,
       prCache: { [`${nested.repoId}::nested`]: makePrEntry(4, 'success') }
+    })
+
+    expect(display).toMatchObject({ number: 4, status: 'success' })
+  })
+
+  it('excludes nested PRs across a known host boundary', () => {
+    const parent = makeWorktree({ id: 'parent', instanceId: 'parent', hostId: 'local' })
+    const nested = makeWorktree({
+      id: 'nested',
+      instanceId: 'nested',
+      linkedPR: 4,
+      hostId: 'ssh:remote'
+    })
+
+    const display = getFolderWorkspaceCardPrDisplay({
+      folderWorkspaceId: 'folder-1',
+      workspaceLineageByChildKey: { [parent.id]: makeWorkspaceLineage(parent) },
+      worktreeLineageById: { [nested.id]: makeWorktreeLineage(nested, parent) },
+      worktreeMap: new Map([
+        [parent.id, parent],
+        [nested.id, nested]
+      ]),
+      repoMap: new Map([[repo.id, repo]]),
+      hostedReviewCache: null,
+      prCache: { 'repo-1::nested': makePrEntry(4, 'success') }
     })
 
     expect(display).toBeNull()

--- a/src/renderer/src/components/sidebar/visible-worktrees.test.ts
+++ b/src/renderer/src/components/sidebar/visible-worktrees.test.ts
@@ -787,7 +787,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([parent.id, child.id])
   })
 
-  it('does not include a cross-repo parent when repo filtering leaves the child visible', () => {
+  it('includes a cross-repo parent when repo filtering leaves the child visible', () => {
     const parent = makeWorktree('parent', 'repo1')
     const child = makeWorktree('child', 'repo2')
     const lineage = makeWorktreeLineage(child, parent)
@@ -801,7 +801,7 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
-    expect(result).toEqual([child.id])
+    expect(result).toEqual([parent.id, child.id])
   })
 
   it('does not include a known cross-host parent after host filtering', () => {
@@ -821,7 +821,7 @@ describe('computeVisibleWorktreeIds', () => {
     expect(result).toEqual([child.id])
   })
 
-  it('does not include a known cross-project parent hidden by another filter', () => {
+  it('includes a known cross-project parent hidden by another filter', () => {
     const parent = Object.assign(makeWorktree('parent'), {
       projectId: 'project-b',
       isMainWorktree: true
@@ -838,6 +838,6 @@ describe('computeVisibleWorktreeIds', () => {
       })
     )
 
-    expect(result).toEqual([child.id])
+    expect(result).toEqual([parent.id, child.id])
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-delete-lineage.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-delete-lineage.test.ts
@@ -99,28 +99,40 @@ describe('getWorkspaceDeleteLineage', () => {
     expect(lineage.deleteAllTargets).toEqual([parent])
   })
 
-  it('rejects cross-repo, cross-host, and cross-project descendants', () => {
+  it('rejects cross-host descendants but keeps cross-repo and cross-project ones', () => {
     const parent: Worktree = {
       ...makeWorktree('parent', '/workspaces/parent'),
       hostId: LOCAL_EXECUTION_HOST_ID,
       projectId: 'project-1'
     }
-    const children: Worktree[] = [
-      { ...makeWorktree('repo-child', '/workspaces/repo-child'), repoId: 'repo-2' },
-      {
-        ...makeWorktree('host-child', '/workspaces/host-child'),
-        hostId: toSshExecutionHostId('other')
-      },
-      { ...makeWorktree('project-child', '/workspaces/project-child'), projectId: 'project-2' }
-    ]
+    const repoChild: Worktree = {
+      ...makeWorktree('repo-child', '/workspaces/repo-child'),
+      repoId: 'repo-2'
+    }
+    const hostChild: Worktree = {
+      ...makeWorktree('host-child', '/workspaces/host-child'),
+      hostId: toSshExecutionHostId('other')
+    }
+    const projectChild: Worktree = {
+      ...makeWorktree('project-child', '/workspaces/project-child'),
+      projectId: 'project-2'
+    }
+    const children = [repoChild, hostChild, projectChild]
     const lineageById = Object.fromEntries(
       children.map((child) => [child.id, makeLineage(child, parent)])
     )
 
     const lineage = getWorkspaceDeleteLineage(parent, [parent, ...children], lineageById)
 
-    expect(lineage.descendants).toEqual([])
-    expect(lineage.deleteAllTargets).toEqual([parent])
+    expect(lineage.descendants.map((worktree) => worktree.id)).toEqual([
+      repoChild.id,
+      projectChild.id
+    ])
+    expect(lineage.deleteAllTargets.map((worktree) => worktree.id)).toEqual([
+      repoChild.id,
+      projectChild.id,
+      parent.id
+    ])
   })
 
   it('does not traverse cyclic projected lineage', () => {

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -3765,17 +3765,12 @@ describe('buildRows workspace lineage nesting', () => {
     expect(rows.find((row) => row.type === 'item')).toMatchObject({ depth: 0 })
   })
 
-  it.each([
-    ['repo', { repoId: 'other-repo' }],
-    ['host', { hostId: 'ssh:other-host' as const }],
-    ['project', { projectId: 'github:other/project' }]
-  ])('does not nest resolved lineage across a known %s boundary', (_label, boundary) => {
+  it('does not nest resolved lineage across a known host boundary', () => {
     const boundedParent = {
       ...parent,
       repoId: 'repo-1',
-      hostId: 'local' as const,
-      projectId: 'github:stablyai/orca',
-      ...boundary
+      hostId: 'ssh:other-host' as const,
+      projectId: 'github:stablyai/orca'
     }
     const boundedChild: ResolvedLineageWorktree = {
       ...child,
@@ -3802,6 +3797,89 @@ describe('buildRows workspace lineage nesting', () => {
     )
 
     expect(rows.filter((row) => row.type === 'item').map((row) => row.depth)).toEqual([0, 0])
+  })
+
+  it.each([
+    ['repo', { repoId: 'repo-2' }],
+    ['project', { projectId: 'github:other/project' }]
+  ])('nests resolved lineage across a %s boundary on the same host', (_label, boundary) => {
+    const boundedParent = {
+      ...parent,
+      repoId: 'repo-1',
+      hostId: 'local' as const,
+      projectId: 'github:stablyai/orca'
+    }
+    const boundedChild: ResolvedLineageWorktree = {
+      ...child,
+      repoId: 'repo-1',
+      hostId: 'local' as const,
+      projectId: 'github:stablyai/orca',
+      lineage,
+      ...boundary
+    }
+    const rows = buildRows(
+      'none',
+      [boundedChild, boundedParent],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map<string, Worktree>([
+        [boundedParent.id, boundedParent],
+        [boundedChild.id, boundedChild]
+      ]),
+      true
+    )
+
+    expect(
+      rows.filter((row) => row.type === 'item').map((row) => [row.worktree.id, row.depth])
+    ).toEqual([
+      [boundedParent.id, 0],
+      [boundedChild.id, 1]
+    ])
+  })
+
+  // Regression (#11007): a CLI agent creates its child in a sibling repo; both cards land
+  // in the same workspace-status section, so the child must nest instead of going flat.
+  it('nests a cross-repo child under its parent inside a shared workspace-status section', () => {
+    const otherRepo: Repo = { ...repo, id: 'repo-2', displayName: 'baseline' }
+    const crossRepoChild: ResolvedLineageWorktree = {
+      ...child,
+      repoId: otherRepo.id,
+      path: '/tmp/baseline/worker',
+      lineage
+    }
+    const rows = buildRows(
+      'workspace-status',
+      [crossRepoChild, parent],
+      new Map([
+        [repo.id, repo],
+        [otherRepo.id, otherRepo]
+      ]),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      { [crossRepoChild.id]: lineage },
+      new Map<string, Worktree>([
+        [parent.id, parent],
+        [crossRepoChild.id, crossRepoChild]
+      ]),
+      true
+    )
+
+    const sectionKeys = new Set(rows.filter((row) => row.type === 'item').map((r) => r.sectionKey))
+    expect(sectionKeys.size).toBe(1)
+    expect(
+      rows.filter((row) => row.type === 'item').map((row) => [row.worktree.id, row.depth])
+    ).toEqual([
+      [parent.id, 0],
+      [crossRepoChild.id, 1]
+    ])
   })
 
   it('keeps the hydrated lineage side-map authoritative when inline metadata disagrees', () => {

--- a/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-candidates.ts
@@ -1,4 +1,5 @@
 import { getWorktreeExecutionHostId } from '../../../../shared/execution-host'
+import { sharesResolvedWorktreeLineageBoundary } from '../../../../shared/resolved-worktree-lineage'
 import type { Repo, Worktree, WorktreeLineage } from '../../../../shared/types'
 import { canAssignWorktreeParent } from './worktree-parent-eligibility'
 import { getCyclicProjectedWorktreeLineageIds } from './worktree-lineage-projection'
@@ -57,12 +58,12 @@ export function isEligibleWorktreeParent({
   childHostId?: string | null
 }): boolean {
   return (
-    candidateParent.repoId === child.repoId &&
+    // Why: the shared boundary is the authority, but repo-derived host resolution is
+    // stricter than its raw hostId, so both must agree before offering a parent the
+    // runtime would then reject.
+    sharesResolvedWorktreeLineageBoundary(child, candidateParent) &&
     childHostId !== null &&
     getWorktreeOwnerHostId(candidateParent, repoMap) === childHostId &&
-    (child.projectId === undefined ||
-      candidateParent.projectId === undefined ||
-      child.projectId === candidateParent.projectId) &&
     !candidateParent.isArchived &&
     canAssignWorktreeParent({
       child,

--- a/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-parent-eligibility.test.ts
@@ -159,7 +159,9 @@ describe('canAssignWorktreeParent', () => {
     ).toBe(false)
   })
 
-  it('stays repo-agnostic while the picker candidate filter is repo and host scoped', () => {
+  // Regression (#11007): the picker must offer the same cross-repo parents the runtime
+  // accepts, otherwise an agent-created cross-repo child can never be re-nested by hand.
+  it('offers a cross-repo candidate on the same host to the picker', () => {
     const child = makeWorktree('child', 'repo-a')
     const sameRepo = makeWorktree('same-repo', 'repo-a')
     const otherRepo = makeWorktree('other-repo', 'repo-b')
@@ -184,7 +186,26 @@ describe('canAssignWorktreeParent', () => {
           { id: 'repo-b', connectionId: null, executionHostId: 'local' }
         ])
       }).map((worktree) => worktree.id)
-    ).toEqual([sameRepo.id])
+    ).toEqual([sameRepo.id, otherRepo.id])
+  })
+
+  it('excludes a cross-repo candidate whose repo runs on another host', () => {
+    const child = makeWorktree('child', 'repo-a')
+    const otherRepo = makeWorktree('other-repo', 'repo-b')
+    const worktrees = [child, otherRepo]
+
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap: makeMap(worktrees),
+        repoMap: makeRepoMap([
+          { id: 'repo-a', connectionId: null, executionHostId: 'local' },
+          { id: 'repo-b', connectionId: null, executionHostId: 'ssh:remote' }
+        ])
+      })
+    ).toEqual([])
   })
 
   it('excludes same-repo candidates owned by a different runtime host', () => {
@@ -209,7 +230,7 @@ describe('canAssignWorktreeParent', () => {
     ).toEqual([sameHost.id])
   })
 
-  it('excludes a candidate across a known project boundary for picker and direct drop checks', () => {
+  it('offers a candidate across a known project boundary for picker and direct drop checks', () => {
     const child = { ...makeWorktree('child'), projectId: 'project-a' }
     const sameProject = { ...makeWorktree('same-project'), projectId: 'project-a' }
     const otherProject = { ...makeWorktree('other-project'), projectId: 'project-b' }
@@ -225,11 +246,38 @@ describe('canAssignWorktreeParent', () => {
         worktreeMap,
         repoMap
       }).map((worktree) => worktree.id)
-    ).toEqual([sameProject.id])
+    ).toEqual([sameProject.id, otherProject.id])
     expect(
       isEligibleWorktreeParent({
         child,
         candidateParent: otherProject,
+        lineageById: {},
+        worktreeMap,
+        repoMap
+      })
+    ).toBe(true)
+  })
+
+  it('excludes a candidate across a known host boundary for picker and direct drop checks', () => {
+    const child = { ...makeWorktree('child'), hostId: 'local' as const }
+    const otherHost = { ...makeWorktree('other-host'), hostId: 'ssh:remote' as const }
+    const worktrees = [child, otherHost]
+    const worktreeMap = makeMap(worktrees)
+    const repoMap = makeRepoMap()
+
+    expect(
+      getEligibleWorktreeParents({
+        child,
+        worktrees,
+        lineageById: {},
+        worktreeMap,
+        repoMap
+      })
+    ).toEqual([])
+    expect(
+      isEligibleWorktreeParent({
+        child,
+        candidateParent: otherHost,
         lineageById: {},
         worktreeMap,
         repoMap

--- a/src/shared/resolved-worktree-lineage.test.ts
+++ b/src/shared/resolved-worktree-lineage.test.ts
@@ -66,13 +66,9 @@ describe('projectResolvedWorktreeLineage', () => {
     ])
   })
 
-  it.each([
-    ['repo', { repoId: 'other-repo' }, {}],
-    ['known host', { hostId: 'local' as const }, { hostId: 'ssh:remote' as const }],
-    ['known project', { projectId: 'github:stablyai/orca' }, { projectId: 'github:other/project' }]
-  ])('rejects a %s boundary mismatch', (_label, childOverrides, parentOverrides) => {
-    const boundedChild = worktree('child', 'child-instance', childOverrides)
-    const boundedParent = worktree('parent', 'parent-instance', parentOverrides)
+  it('rejects a known host boundary mismatch', () => {
+    const boundedChild = worktree('child', 'child-instance', { hostId: 'local' })
+    const boundedParent = worktree('parent', 'parent-instance', { hostId: 'ssh:remote' })
 
     const projected = projectResolvedWorktreeLineage([boundedChild, boundedParent], {
       child: lineage()
@@ -83,6 +79,31 @@ describe('projectResolvedWorktreeLineage', () => {
       { id: 'parent', childWorktreeIds: [] }
     ])
   })
+
+  it.each([
+    ['repo', { repoId: 'other-repo' }, {}],
+    ['project', { projectId: 'github:stablyai/orca' }, { projectId: 'github:other/project' }],
+    [
+      'repo and project on the same host',
+      { repoId: 'other-repo', hostId: 'local' as const, projectId: 'github:stablyai/orca' },
+      { hostId: 'local' as const, projectId: 'github:other/project' }
+    ]
+  ])(
+    'projects a cross-%s edge as valid when the host and instances agree',
+    (_label, childOverrides, parentOverrides) => {
+      const boundedChild = worktree('child', 'child-instance', childOverrides)
+      const boundedParent = worktree('parent', 'parent-instance', parentOverrides)
+
+      const projected = projectResolvedWorktreeLineage([boundedChild, boundedParent], {
+        child: lineage()
+      })
+
+      expect(projected).toMatchObject([
+        { id: 'child', parentWorktreeId: 'parent', lineage: lineage() },
+        { id: 'parent', childWorktreeIds: ['child'] }
+      ])
+    }
+  )
 
   it('accepts legacy records when only one side has host or project identity', () => {
     const legacyChild = worktree('child', 'child-instance', {

--- a/src/shared/resolved-worktree-lineage.ts
+++ b/src/shared/resolved-worktree-lineage.ts
@@ -6,14 +6,11 @@ export type WorktreeWithResolvedLineage<T extends Worktree = Worktree> = T & {
   lineage: WorktreeLineage | null
 }
 
+// Why: only the execution host is a real lineage boundary. Repo and project are
+// not — agents routinely spawn a child workspace in a sibling repo, and worktree
+// ids are already repo-qualified so cross-repo edges cannot alias.
 export function sharesResolvedWorktreeLineageBoundary(child: Worktree, parent: Worktree): boolean {
-  return (
-    child.repoId === parent.repoId &&
-    (child.hostId === undefined || parent.hostId === undefined || child.hostId === parent.hostId) &&
-    (child.projectId === undefined ||
-      parent.projectId === undefined ||
-      child.projectId === parent.projectId)
-  )
+  return child.hostId === undefined || parent.hostId === undefined || child.hostId === parent.hostId
 }
 
 export function isValidResolvedWorktreeLineageEdge(


### PR DESCRIPTION
## ELI5

Command-line coding agents often create a child workspace inside a different repository than its parent, but Orca refused those parent-child links unless both sides belonged to the same repo and project. Agent-created children showed up unconnected, and deleting a parent didn't reach its real children. Parent-child linking now works across repos and projects — the only remaining rule is that both run on the same machine (or same SSH host). When deleting, any affected child living in another repo is now called out by name.

## Problem

CLI agents routinely create child workspaces in sibling repositories, but the current lineage system rejected cross-repo relationships. This prevented proper parent-child nesting, broke cascade deletes for legitimate agent-created children, and forced users to manually handle these workflows.

## Solution

Allow worktree lineage relationships across repo and project boundaries. The only remaining lineage boundary is the execution host—child and parent must run on the same host (local, SSH remote, etc.). This aligns the UI and runtime with legitimate CLI agent workflows while keeping the security boundary of host isolation intact.

### Changes

- Runtime accepts cross-repo and cross-project parent assignments (host boundary only)
- UI visibly names foreign repos in cascade-delete notices to clarify scope
- Worktree visibility, nesting, and lineage projection reflect new boundaries
- Worktree-parent picker offers cross-repo/cross-project candidates on the same host
- Delete-lineage traversal includes cross-repo and cross-project descendants

## Testing

- Updated 14 test cases to validate cross-boundary lineage behavior
- Host boundary rejection remains enforced across all layers (runtime, UI, picker)
- Regression tests for #11007 validate agent-created cross-repo child workflow

## Notes

Fixes #11007. Cross-repo/cross-project lineage has no platform-specific behavior—all changes are boundary logic and UI text.

## Visual Proof (generated by maintainer tooling, 2026-08-22)

Verified on this branch (`3556fe45c0c`) with two local repos, `vp12755-repoA` and `vp12755-repoB`, both on the `local` host:

- Cross-repo lineage write now succeeds: `assignWorktreeParent` linked repoB's `child-b` under repoA's `parent-a` (previously rejected with "must belong to the same repository, execution host, and project").
- Delete dialog for the parent shows the lineage notice with the foreign-repo badge naming `vp12755-repoB` next to the child.

![Delete Workspace dialog for parent-a listing child-b with the vp12755-repoB foreign-repo badge](https://github.com/user-attachments/assets/01f7099d-be67-4d60-96fa-224bdab902b0)

Close-up of the cross-repo lineage notice:

![Close-up: child-b with vp12755-repoB badge in the delete dialog lineage notice](https://github.com/user-attachments/assets/dc190db5-b532-447f-a105-3ffb22fb024c)

The parent picker ("Change Parent Worktree..." on the repoB child) also offers the repoA main worktree as a candidate:

![Parent picker offering cross-repo candidate from vp12755-repoA for a repoB child](https://github.com/user-attachments/assets/74e00705-69a7-4bda-b118-2b95cdc1c76d)
