### PR TITLE
Refactor hosts and projects filters to consistent submenu layout

### DIFF
--- a/src/renderer/src/components/sidebar/SidebarHostScopeMenuSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarHostScopeMenuSection.tsx
@@ -1,8 +1,6 @@
 import type React from 'react'
 import {
   DropdownMenuCheckboxItem,
-  DropdownMenuLabel,
-  DropdownMenuSeparator,
   DropdownMenuSub,
   DropdownMenuSubContent,
   DropdownMenuSubTrigger
@@ -13,7 +11,6 @@ import { getSidebarHostHealthLabel, type SidebarHostOption } from './sidebar-hos
 import { translate } from '@/i18n/i18n'
 
 type SidebarHostScopeMenuSectionProps = {
-  hostOptionsCount: number
   hostVisibilityLabel: string
   hostOptions: readonly SidebarHostOption[]
   preserveWorkspaceBoardOpen: boolean
@@ -54,7 +51,6 @@ function getHostMetadata(host: SidebarHostOption): string {
 }
 
 export function SidebarHostScopeMenuSection({
-  hostOptionsCount,
   hostVisibilityLabel,
   hostOptions,
   preserveWorkspaceBoardOpen,
@@ -93,63 +89,60 @@ export function SidebarHostScopeMenuSection({
     setVisibleWorkspaceHostIds(next.size === hostOptions.length ? null : [...next])
   }
 
+  // Why: one Sort-by-style row (label left, value right) — nested panel holds
+  // the multi-select, so the parent menu stays a flat list of single rows.
   return (
-    <>
-      <DropdownMenuLabel>
-        {translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.hosts', 'Hosts')}
-      </DropdownMenuLabel>
-      <DropdownMenuSub>
-        <DropdownMenuSubTrigger>
-          <span className="flex flex-1 items-center justify-between gap-3">
-            <span className="min-w-0 truncate">{hostVisibilityLabel}</span>
-            <span className="text-[11px] font-medium text-muted-foreground">
-              {hostOptionsCount}
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        <span className="flex flex-1 items-center justify-between gap-3">
+          <span>
+            {translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.hosts', 'Hosts')}
+          </span>
+          <span className="min-w-0 truncate text-[11px] font-medium text-muted-foreground">
+            {hostVisibilityLabel}
+          </span>
+        </span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent
+        className="w-56"
+        data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
+      >
+        <DropdownMenuCheckboxItem
+          checked={allVisible}
+          onCheckedChange={toggleAllHosts}
+          onSelect={(e) => e.preventDefault()}
+          className="min-h-11 items-start py-1.5"
+        >
+          <span className="flex min-w-0 flex-col gap-0.5">
+            <span className="truncate">
+              {translate('auto.components.sidebar.sidebarHostOptions.3e102f111c', 'All hosts')}
+            </span>
+            <span className="truncate text-[11px] font-normal text-muted-foreground">
+              {translate(
+                'auto.components.sidebar.SidebarWorkspaceOptionsMenu.allHostsDetail',
+                'Show every host'
+              )}
             </span>
           </span>
-        </DropdownMenuSubTrigger>
-        <DropdownMenuSubContent
-          className="w-56"
-          data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
-        >
+        </DropdownMenuCheckboxItem>
+        {hostOptions.map((host) => (
           <DropdownMenuCheckboxItem
-            checked={allVisible}
-            onCheckedChange={toggleAllHosts}
+            key={host.id}
+            checked={visibleHostIdSet.has(host.id)}
+            disabled={!allVisible && visibleHostIdSet.has(host.id) && visibleHostIdSet.size <= 1}
+            onCheckedChange={() => toggleHost(host.id)}
             onSelect={(e) => e.preventDefault()}
             className="min-h-11 items-start py-1.5"
           >
             <span className="flex min-w-0 flex-col gap-0.5">
-              <span className="truncate">
-                {translate('auto.components.sidebar.sidebarHostOptions.3e102f111c', 'All hosts')}
-              </span>
-              <span className="truncate text-[11px] font-normal text-muted-foreground">
-                {translate(
-                  'auto.components.sidebar.SidebarWorkspaceOptionsMenu.allHostsDetail',
-                  'Show every host'
-                )}
+              <span className="truncate">{host.label}</span>
+              <span className="text-[11px] font-normal text-muted-foreground">
+                {getHostMetadata(host)}
               </span>
             </span>
           </DropdownMenuCheckboxItem>
-          {hostOptions.map((host) => (
-            <DropdownMenuCheckboxItem
-              key={host.id}
-              checked={visibleHostIdSet.has(host.id)}
-              disabled={!allVisible && visibleHostIdSet.has(host.id) && visibleHostIdSet.size <= 1}
-              onCheckedChange={() => toggleHost(host.id)}
-              onSelect={(e) => e.preventDefault()}
-              className="min-h-11 items-start py-1.5"
-            >
-              <span className="flex min-w-0 flex-col gap-0.5">
-                <span className="truncate">{host.label}</span>
-                <span className="text-[11px] font-normal text-muted-foreground">
-                  {getHostMetadata(host)}
-                </span>
-              </span>
-            </DropdownMenuCheckboxItem>
-          ))}
-        </DropdownMenuSubContent>
-      </DropdownMenuSub>
-
-      <DropdownMenuSeparator />
-    </>
+        ))}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   )
 }

--- a/src/renderer/src/components/sidebar/SidebarProjectFilterPanel.tsx
+++ b/src/renderer/src/components/sidebar/SidebarProjectFilterPanel.tsx
@@ -1,0 +1,245 @@
+import React, { useCallback, useEffect, useRef, useState } from 'react'
+import { Server, X } from 'lucide-react'
+import { Badge } from '@/components/ui/badge'
+import { Button } from '@/components/ui/button'
+import {
+  Command,
+  CommandEmpty,
+  CommandInput,
+  CommandItem,
+  CommandList
+} from '@/components/ui/command'
+import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
+import { searchRepos } from '@/lib/repo-search'
+import type { Repo } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+function projectCommandFilter(_value: string, search: string, keywords?: string[]): number {
+  const query = search.trim().toLowerCase()
+  if (!query) {
+    return 1
+  }
+
+  const [displayName = '', path = ''] = keywords ?? []
+  const displayNameIndex = displayName.toLowerCase().indexOf(query)
+  if (displayNameIndex !== -1) {
+    return 2 + 1 / (displayNameIndex + 1)
+  }
+
+  const pathIndex = path.toLowerCase().indexOf(query)
+  if (pathIndex !== -1) {
+    return 1 + 1 / (pathIndex + 1)
+  }
+
+  return 0
+}
+
+type SidebarProjectFilterPanelProps = {
+  availableRepos: Repo[]
+  selectedRepos: Repo[]
+  hasRepoFilter: boolean
+  filterRepoIds: readonly string[]
+  setFilterRepoIds: (ids: string[]) => void
+}
+
+/**
+ * Search + selection body of the Projects filter. Lives in its own component so
+ * it mounts and unmounts with the submenu panel, which resets the query instead
+ * of reopening onto a stale, pre-filtered list.
+ */
+export function SidebarProjectFilterPanel({
+  availableRepos,
+  selectedRepos,
+  hasRepoFilter,
+  filterRepoIds,
+  setFilterRepoIds
+}: SidebarProjectFilterPanelProps): React.JSX.Element {
+  const [query, setQuery] = useState('')
+  const [highlightedRepoId, setHighlightedRepoId] = useState('')
+  const inputRef = useRef<HTMLInputElement>(null)
+
+  // Why: `autoFocus` cannot survive here — it fires during commit, while the
+  // root menu's trapped focus scope is still active and yanks focus back to the
+  // sub-trigger (the submenu only pauses that scope in a later passive effect).
+  // A frame later both focus scopes have settled, so this focus sticks.
+  useEffect(() => {
+    const frame = requestAnimationFrame(() => inputRef.current?.focus())
+    return () => cancelAnimationFrame(frame)
+  }, [])
+
+  const handleSelectRepo = useCallback(
+    (repoId: string) => {
+      if (!filterRepoIds.includes(repoId)) {
+        setFilterRepoIds([...filterRepoIds, repoId])
+      }
+      setQuery('')
+    },
+    [filterRepoIds, setFilterRepoIds]
+  )
+
+  const handleRemoveProject = useCallback(
+    (repoId: string) => {
+      setFilterRepoIds(filterRepoIds.filter((id) => id !== repoId))
+    },
+    [filterRepoIds, setFilterRepoIds]
+  )
+
+  const handleInputKeyDown = useCallback(
+    (event: React.KeyboardEvent<HTMLInputElement>) => {
+      // Why: this command is embedded in a Radix dropdown; text keys should
+      // stay in the search field instead of triggering menu typeahead.
+      if (event.key === 'Backspace' && query === '' && selectedRepos.length > 0) {
+        const lastRepo = selectedRepos.at(-1)
+        if (lastRepo) {
+          event.preventDefault()
+          event.stopPropagation()
+          handleRemoveProject(lastRepo.id)
+        }
+        return
+      }
+
+      if (event.key === 'Enter') {
+        const highlightedRepo = availableRepos.find((repo) => repo.id === highlightedRepoId)
+        const repo = highlightedRepo ?? searchRepos(availableRepos, query)[0]
+        if (repo) {
+          event.preventDefault()
+          event.stopPropagation()
+          handleSelectRepo(repo.id)
+        }
+        return
+      }
+
+      // Why: swallowing every ArrowLeft would trap keyboard users in the panel,
+      // since that is the key Radix uses to step back to the parent menu. Only
+      // claim it while the caret still has somewhere to move.
+      if (event.key === 'ArrowLeft') {
+        const { selectionStart, selectionEnd } = event.currentTarget
+        const caretAtStart = selectionStart === 0 && selectionEnd === 0
+        if (!caretAtStart) {
+          event.stopPropagation()
+        }
+        return
+      }
+
+      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
+        event.stopPropagation()
+      }
+    },
+    [availableRepos, handleRemoveProject, handleSelectRepo, highlightedRepoId, query, selectedRepos]
+  )
+
+  return (
+    <Command
+      filter={projectCommandFilter}
+      onValueChange={setHighlightedRepoId}
+      className="bg-transparent"
+    >
+      <SelectedProjectPills selectedRepos={selectedRepos} onRemoveProject={handleRemoveProject} />
+      <CommandInput
+        ref={inputRef}
+        placeholder={
+          selectedRepos.length > 0
+            ? translate(
+                'auto.components.sidebar.SidebarRepositoryFilterSection.5a273fbfce',
+                'Add project...'
+              )
+            : translate(
+                'auto.components.sidebar.SidebarRepositoryFilterSection.83a820fa71',
+                'Filter projects...'
+              )
+        }
+        value={query}
+        onValueChange={setQuery}
+        onKeyDown={handleInputKeyDown}
+        className="h-8 py-2 text-xs"
+        wrapperClassName="mx-1 rounded-[7px] border border-border/70 px-2"
+        iconClassName="h-3.5 w-3.5"
+      />
+      <CommandList className="max-h-48 py-1">
+        <CommandEmpty className="py-4 text-[11px]">
+          {hasRepoFilter
+            ? translate(
+                'auto.components.sidebar.SidebarRepositoryFilterSection.bbbc6e8e3b',
+                'No unselected projects match'
+              )
+            : translate(
+                'auto.components.sidebar.SidebarRepositoryFilterSection.4815c70605',
+                'No projects match'
+              )}
+        </CommandEmpty>
+        {availableRepos.map((repo) => (
+          <CommandItem
+            key={repo.id}
+            value={repo.id}
+            keywords={[repo.displayName, repo.path]}
+            onSelect={() => handleSelectRepo(repo.id)}
+            className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
+          >
+            <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
+              <RepoBadgeLabel
+                name={repo.displayName}
+                color={repo.badgeColor}
+                className="max-w-full"
+              />
+              {repo.connectionId && (
+                <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
+                  <Server className="size-2.5" />
+                  {translate(
+                    'auto.components.sidebar.SidebarRepositoryFilterSection.2656053db4',
+                    'SSH'
+                  )}
+                </span>
+              )}
+            </span>
+          </CommandItem>
+        ))}
+      </CommandList>
+    </Command>
+  )
+}
+
+function SelectedProjectPills({
+  selectedRepos,
+  onRemoveProject
+}: {
+  selectedRepos: Repo[]
+  onRemoveProject: (repoId: string) => void
+}) {
+  if (selectedRepos.length === 0) {
+    return null
+  }
+
+  return (
+    <div className="scrollbar-sleek mx-1 mb-1 flex max-h-16 flex-wrap gap-1 overflow-y-auto rounded-[7px] border border-border/70 bg-muted/25 p-1">
+      {selectedRepos.map((repo) => (
+        <Badge
+          key={repo.id}
+          variant="outline"
+          className="h-5 max-w-full gap-1 border-border/70 bg-background px-1.5 py-0 text-[11px] font-medium"
+        >
+          <RepoBadgeLabel
+            name={repo.displayName}
+            color={repo.badgeColor}
+            className="max-w-[8rem]"
+            badgeClassName="size-1.5"
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon-xs"
+            aria-label={translate(
+              'auto.components.sidebar.SidebarRepositoryFilterSection.f10ca29601',
+              'Remove {{value0}} filter',
+              { value0: repo.displayName }
+            )}
+            className="-mr-1 size-4 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
+            onMouseDown={(event) => event.preventDefault()}
+            onClick={() => onRemoveProject(repo.id)}
+          >
+            <X className="size-2.5" strokeWidth={2.5} />
+          </Button>
+        </Badge>
+      ))}
+    </div>
+  )
+}

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.test.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.test.tsx
@@ -1,0 +1,209 @@
+// @vitest-environment happy-dom
+
+/**
+ * The Projects filter lives in a Radix submenu, which breaks two things that
+ * work fine in a flat menu: React's `autoFocus` loses a race with the root
+ * menu's trapped focus scope, and search state outlives a panel close. Both are
+ * invisible to typecheck, so pin them here.
+ */
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({
+  state: {} as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) => selector(mocks.state)
+}))
+
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import SidebarRepositoryFilterSection from './SidebarRepositoryFilterSection'
+
+const REPOS = [
+  { id: 'r1', displayName: 'alpha', path: '/tmp/alpha' },
+  { id: 'r2', displayName: 'beta', path: '/tmp/beta' },
+  { id: 'r3', displayName: 'gamma', path: '/tmp/gamma' }
+]
+
+let container: HTMLDivElement
+let root: Root
+let setFilterRepoIds: ReturnType<typeof vi.fn>
+
+function setState(overrides: Record<string, unknown> = {}): void {
+  setFilterRepoIds = vi.fn()
+  mocks.state = {
+    repos: REPOS,
+    filterRepoIds: [],
+    setFilterRepoIds,
+    ...overrides
+  }
+}
+
+function render(): void {
+  act(() => {
+    root.render(
+      <DropdownMenu defaultOpen>
+        <DropdownMenuTrigger>Options</DropdownMenuTrigger>
+        <DropdownMenuContent>
+          <DropdownMenuItem>Sort by</DropdownMenuItem>
+          <SidebarRepositoryFilterSection />
+        </DropdownMenuContent>
+      </DropdownMenu>
+    )
+  })
+}
+
+/** Radix's trigger opens on pointer, the real path users take with a mouse. */
+function openSubmenu(): void {
+  const trigger = document.querySelector<HTMLElement>('[data-slot="dropdown-menu-sub-trigger"]')
+  if (!trigger) {
+    throw new Error('sub-trigger not rendered')
+  }
+  act(() => {
+    trigger.dispatchEvent(new PointerEvent('pointerdown', { bubbles: true, pointerType: 'mouse' }))
+    trigger.dispatchEvent(new PointerEvent('pointerup', { bubbles: true, pointerType: 'mouse' }))
+    trigger.click()
+  })
+}
+
+function closeSubmenu(): void {
+  const content = document.querySelector<HTMLElement>('[data-slot="dropdown-menu-sub-content"]')
+  if (!content) {
+    throw new Error('sub-content not rendered')
+  }
+  act(() => {
+    content.dispatchEvent(
+      new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true })
+    )
+  })
+}
+
+function searchInput(): HTMLInputElement | null {
+  return document.querySelector<HTMLInputElement>('[data-slot="command-input"]')
+}
+
+/** The focus fix lands in a rAF, so let one frame plus a macrotask elapse. */
+async function settle(): Promise<void> {
+  await act(async () => {
+    await new Promise((resolve) => requestAnimationFrame(() => setTimeout(resolve, 0)))
+  })
+}
+
+/** Types into whatever currently holds focus, so routing is part of the assertion. */
+function typeIntoFocused(value: string): void {
+  const input = document.activeElement
+  if (!(input instanceof HTMLInputElement)) {
+    throw new Error(`focus is on ${document.activeElement?.nodeName ?? 'nothing'}, not an input`)
+  }
+  act(() => {
+    const setter = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+    setter?.call(input, value)
+    input.dispatchEvent(new Event('input', { bubbles: true }))
+  })
+}
+
+beforeEach(() => {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  // Radix probes pointer capture and scrolling that happy-dom does not model.
+  Element.prototype.hasPointerCapture ??= () => false
+  Element.prototype.setPointerCapture ??= () => {}
+  Element.prototype.releasePointerCapture ??= () => {}
+  Element.prototype.scrollIntoView ??= () => {}
+  globalThis.ResizeObserver ??= class {
+    observe(): void {}
+    unobserve(): void {}
+    disconnect(): void {}
+  } as unknown as typeof ResizeObserver
+  setState()
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+  vi.restoreAllMocks()
+})
+
+describe('SidebarRepositoryFilterSection', () => {
+  it('focuses the search input when the submenu opens', async () => {
+    render()
+    openSubmenu()
+    await settle()
+
+    expect(searchInput()).not.toBeNull()
+    expect(document.activeElement).toBe(searchInput())
+  })
+
+  it('routes typing into the search box rather than menu typeahead', async () => {
+    render()
+    openSubmenu()
+    await settle()
+    typeIntoFocused('alp')
+
+    expect(searchInput()?.value).toBe('alp')
+  })
+
+  it('resets the query when the panel is reopened', async () => {
+    render()
+    openSubmenu()
+    await settle()
+    typeIntoFocused('alp')
+    expect(searchInput()?.value).toBe('alp')
+
+    closeSubmenu()
+    expect(searchInput()).toBeNull()
+
+    openSubmenu()
+    await settle()
+    expect(searchInput()?.value).toBe('')
+  })
+
+  it('keeps ArrowLeft in the text field while the caret can still move', async () => {
+    render()
+    openSubmenu()
+    await settle()
+    typeIntoFocused('alp')
+
+    const input = searchInput()
+    input?.setSelectionRange(3, 3)
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true })
+      )
+    })
+
+    expect(searchInput()).not.toBeNull()
+  })
+
+  it('lets ArrowLeft close the panel once the caret is at the start', async () => {
+    render()
+    openSubmenu()
+    await settle()
+
+    const input = searchInput()
+    input?.setSelectionRange(0, 0)
+    act(() => {
+      input?.dispatchEvent(
+        new KeyboardEvent('keydown', { key: 'ArrowLeft', bubbles: true, cancelable: true })
+      )
+    })
+
+    expect(searchInput()).toBeNull()
+  })
+
+  it('hides itself when only one project exists', () => {
+    setState({ repos: [REPOS[0]] })
+    render()
+
+    expect(document.querySelector('[data-slot="dropdown-menu-sub-trigger"]')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
+++ b/src/renderer/src/components/sidebar/SidebarRepositoryFilterSection.tsx
@@ -1,47 +1,47 @@
-import React, { useCallback, useMemo, useState } from 'react'
-import { Server, X } from 'lucide-react'
+import React, { useCallback, useMemo } from 'react'
 import { useAppStore } from '@/store'
-import { Badge } from '@/components/ui/badge'
-import { Button } from '@/components/ui/button'
 import {
-  Command,
-  CommandEmpty,
-  CommandInput,
-  CommandItem,
-  CommandList
-} from '@/components/ui/command'
-import RepoBadgeLabel from '@/components/repo/RepoBadgeLabel'
-import { searchRepos } from '@/lib/repo-search'
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import { SidebarProjectFilterPanel } from './SidebarProjectFilterPanel'
 import type { Repo } from '../../../../shared/types'
 import { translate } from '@/i18n/i18n'
 
-function projectCommandFilter(_value: string, search: string, keywords?: string[]): number {
-  const query = search.trim().toLowerCase()
-  if (!query) {
-    return 1
+function getProjectFilterVisibilityLabel({
+  selectedCount,
+  selectedRepos
+}: {
+  selectedCount: number
+  selectedRepos: readonly Repo[]
+}): string {
+  if (selectedCount === 0) {
+    return translate(
+      'auto.components.sidebar.SidebarRepositoryFilterSection.allProjects',
+      'All projects'
+    )
   }
-
-  const [displayName = '', path = ''] = keywords ?? []
-  const displayNameIndex = displayName.toLowerCase().indexOf(query)
-  if (displayNameIndex !== -1) {
-    return 2 + 1 / (displayNameIndex + 1)
+  if (selectedCount === 1) {
+    return selectedRepos[0]?.displayName ?? 'Projects'
   }
-
-  const pathIndex = path.toLowerCase().indexOf(query)
-  if (pathIndex !== -1) {
-    return 1 + 1 / (pathIndex + 1)
-  }
-
-  return 0
+  return translate(
+    'auto.components.sidebar.SidebarRepositoryFilterSection.selectedProjectsCount',
+    '{{value0}} projects',
+    { value0: selectedCount }
+  )
 }
 
-const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilterSection() {
+type SidebarRepositoryFilterSectionProps = {
+  preserveWorkspaceBoardOpen?: boolean
+}
+
+const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilterSection({
+  preserveWorkspaceBoardOpen = false
+}: SidebarRepositoryFilterSectionProps) {
   const filterRepoIds = useAppStore((s) => s.filterRepoIds)
   const setFilterRepoIds = useAppStore((s) => s.setFilterRepoIds)
   const repos = useAppStore((s) => s.repos)
-
-  const [query, setQuery] = useState('')
-  const [highlightedRepoId, setHighlightedRepoId] = useState('')
 
   const canFilterRepos = repos.length > 1
   // Why: derive from current repos so stale ids (e.g. lingering after a repo
@@ -65,230 +65,68 @@ const SidebarRepositoryFilterSection = React.memo(function SidebarRepositoryFilt
     () => repos.filter((repo) => !selectedRepoIdSet.has(repo.id)),
     [repos, selectedRepoIdSet]
   )
-  const matchingAvailableRepos = useMemo(
-    () => searchRepos(availableRepos, query),
-    [availableRepos, query]
-  )
-
-  const handleSelectRepo = useCallback(
-    (repoId: string) => {
-      if (!filterRepoIds.includes(repoId)) {
-        setFilterRepoIds([...filterRepoIds, repoId])
-      }
-      setQuery('')
-    },
-    [filterRepoIds, setFilterRepoIds]
-  )
-
-  const handleRemoveProject = useCallback(
-    (repoId: string) => {
-      setFilterRepoIds(filterRepoIds.filter((id) => id !== repoId))
-    },
-    [filterRepoIds, setFilterRepoIds]
-  )
+  const visibilityLabel = getProjectFilterVisibilityLabel({ selectedCount, selectedRepos })
 
   const clearRepos = useCallback(() => setFilterRepoIds([]), [setFilterRepoIds])
-
-  const handleInputKeyDown = useCallback(
-    (event: React.KeyboardEvent<HTMLInputElement>) => {
-      // Why: this command is embedded in a Radix dropdown; text keys should
-      // stay in the search field instead of triggering menu typeahead.
-      if (event.key === 'Backspace' && query === '' && selectedRepos.length > 0) {
-        const lastRepo = selectedRepos.at(-1)
-        if (lastRepo) {
-          event.preventDefault()
-          event.stopPropagation()
-          handleRemoveProject(lastRepo.id)
-        }
-        return
-      }
-
-      if (event.key === 'Enter') {
-        const highlightedRepo = availableRepos.find((repo) => repo.id === highlightedRepoId)
-        const repo = highlightedRepo ?? matchingAvailableRepos[0]
-        if (repo) {
-          event.preventDefault()
-          event.stopPropagation()
-          handleSelectRepo(repo.id)
-        }
-        return
-      }
-
-      if (event.key !== 'ArrowDown' && event.key !== 'ArrowUp') {
-        event.stopPropagation()
-      }
-    },
-    [
-      availableRepos,
-      handleRemoveProject,
-      handleSelectRepo,
-      highlightedRepoId,
-      matchingAvailableRepos,
-      query,
-      selectedRepos
-    ]
-  )
 
   if (!canFilterRepos) {
     return null
   }
 
+  // Why: same Sort-by-style single row as Hosts — label left, current value
+  // right; search/selection lives in the nested panel only.
   return (
-    <>
-      <ProjectFilterHeader
-        hasRepoFilter={hasRepoFilter}
-        selectedCount={selectedCount}
-        onClear={clearRepos}
-      />
-
-      <Command
-        filter={projectCommandFilter}
-        onValueChange={setHighlightedRepoId}
-        className="bg-transparent"
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger>
+        <span className="flex flex-1 items-center justify-between gap-3">
+          <span>
+            {translate(
+              'auto.components.sidebar.SidebarRepositoryFilterSection.7679f0c268',
+              'Projects'
+            )}
+          </span>
+          <span className="min-w-0 truncate text-[11px] font-medium text-muted-foreground">
+            {visibilityLabel}
+          </span>
+        </span>
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent
+        className="w-64"
+        data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
       >
-        <SelectedProjectPills selectedRepos={selectedRepos} onRemoveProject={handleRemoveProject} />
-        <CommandInput
-          autoFocus
-          placeholder={
-            selectedRepos.length > 0
-              ? translate(
-                  'auto.components.sidebar.SidebarRepositoryFilterSection.5a273fbfce',
-                  'Add project...'
-                )
-              : translate(
-                  'auto.components.sidebar.SidebarRepositoryFilterSection.83a820fa71',
-                  'Filter projects...'
-                )
-          }
-          value={query}
-          onValueChange={setQuery}
-          onKeyDown={handleInputKeyDown}
-          className="h-8 py-2 text-xs"
-          wrapperClassName="mx-1 rounded-[7px] border border-border/70 px-2"
-          iconClassName="h-3.5 w-3.5"
+        <div className="flex items-center justify-between px-2 py-1">
+          <span className="text-[11px] font-semibold text-muted-foreground">
+            {translate(
+              'auto.components.sidebar.SidebarRepositoryFilterSection.7679f0c268',
+              'Projects'
+            )}
+            {hasRepoFilter && (
+              <span className="ml-1.5 font-medium text-foreground">· {selectedCount}</span>
+            )}
+          </span>
+          <button
+            type="button"
+            onClick={clearRepos}
+            className="rounded-full px-2 py-0.5 text-[11px] font-medium text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
+            disabled={!hasRepoFilter}
+          >
+            {translate(
+              'auto.components.sidebar.SidebarRepositoryFilterSection.d3a9c4cea1',
+              'Clear'
+            )}
+          </button>
+        </div>
+
+        <SidebarProjectFilterPanel
+          availableRepos={availableRepos}
+          selectedRepos={selectedRepos}
+          hasRepoFilter={hasRepoFilter}
+          filterRepoIds={filterRepoIds}
+          setFilterRepoIds={setFilterRepoIds}
         />
-        <CommandList className="max-h-40 py-1">
-          <CommandEmpty className="py-4 text-[11px]">
-            {hasRepoFilter
-              ? translate(
-                  'auto.components.sidebar.SidebarRepositoryFilterSection.bbbc6e8e3b',
-                  'No unselected projects match'
-                )
-              : translate(
-                  'auto.components.sidebar.SidebarRepositoryFilterSection.4815c70605',
-                  'No projects match'
-                )}
-          </CommandEmpty>
-          {availableRepos.map((repo) => (
-            <CommandItem
-              key={repo.id}
-              value={repo.id}
-              keywords={[repo.displayName, repo.path]}
-              onSelect={() => handleSelectRepo(repo.id)}
-              className="mx-1 my-0.5 items-center gap-2 rounded-[7px] px-2 py-1 text-[12px] leading-5 font-medium data-[selected=true]:bg-black/8 dark:data-[selected=true]:bg-white/14"
-            >
-              <span className="inline-flex min-w-0 flex-1 items-center gap-1.5">
-                <RepoBadgeLabel
-                  name={repo.displayName}
-                  color={repo.badgeColor}
-                  className="max-w-full"
-                />
-                {repo.connectionId && (
-                  <span className="shrink-0 inline-flex items-center gap-0.5 rounded bg-muted px-1 py-0.5 text-[9px] font-medium leading-none text-muted-foreground">
-                    <Server className="size-2.5" />
-                    {translate(
-                      'auto.components.sidebar.SidebarRepositoryFilterSection.2656053db4',
-                      'SSH'
-                    )}
-                  </span>
-                )}
-              </span>
-            </CommandItem>
-          ))}
-        </CommandList>
-      </Command>
-    </>
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
   )
 })
-
-function SelectedProjectPills({
-  selectedRepos,
-  onRemoveProject
-}: {
-  selectedRepos: Repo[]
-  onRemoveProject: (repoId: string) => void
-}) {
-  if (selectedRepos.length === 0) {
-    return null
-  }
-
-  return (
-    <div className="scrollbar-sleek mx-1 mb-1 flex max-h-16 flex-wrap gap-1 overflow-y-auto rounded-[7px] border border-border/70 bg-muted/25 p-1">
-      {selectedRepos.map((repo) => (
-        <Badge
-          key={repo.id}
-          variant="outline"
-          className="h-5 max-w-full gap-1 border-border/70 bg-background px-1.5 py-0 text-[11px] font-medium"
-        >
-          <RepoBadgeLabel
-            name={repo.displayName}
-            color={repo.badgeColor}
-            className="max-w-[8rem]"
-            badgeClassName="size-1.5"
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon-xs"
-            aria-label={translate(
-              'auto.components.sidebar.SidebarRepositoryFilterSection.f10ca29601',
-              'Remove {{value0}} filter',
-              { value0: repo.displayName }
-            )}
-            className="-mr-1 size-4 rounded-full text-muted-foreground hover:bg-muted hover:text-foreground"
-            onMouseDown={(event) => event.preventDefault()}
-            onClick={() => onRemoveProject(repo.id)}
-          >
-            <X className="size-2.5" strokeWidth={2.5} />
-          </Button>
-        </Badge>
-      ))}
-    </div>
-  )
-}
-
-function ProjectFilterHeader({
-  hasRepoFilter,
-  selectedCount,
-  onClear
-}: {
-  hasRepoFilter: boolean
-  selectedCount: number
-  onClear: () => void
-}) {
-  return (
-    <div className="flex items-center justify-between px-2 py-1">
-      <span className="inline-flex items-center gap-1 text-[11px] font-semibold text-muted-foreground">
-        {translate('auto.components.sidebar.SidebarRepositoryFilterSection.7679f0c268', 'Projects')}
-        {hasRepoFilter && (
-          <Badge
-            variant="outline"
-            className="h-4 min-w-4 px-1 py-0 text-[10px] font-semibold leading-none text-foreground"
-          >
-            {selectedCount}
-          </Badge>
-        )}
-      </span>
-      <button
-        type="button"
-        onClick={onClear}
-        className="rounded-full px-2 py-0.5 text-[11px] text-muted-foreground hover:bg-muted hover:text-foreground focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring disabled:opacity-40 disabled:hover:bg-transparent"
-        disabled={!hasRepoFilter}
-      >
-        {translate('auto.components.sidebar.SidebarRepositoryFilterSection.d3a9c4cea1', 'Clear')}
-      </button>
-    </div>
-  )
-}
 
 export default SidebarRepositoryFilterSection

--- a/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
+++ b/src/renderer/src/components/sidebar/SidebarWorkspaceOptionsMenu.tsx
@@ -168,16 +168,28 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
         className="w-72 pb-2"
         data-workspace-board-preserve-open={preserveWorkspaceBoardOpen ? '' : undefined}
       >
-        {showHostScopeControls && (
-          <SidebarHostScopeMenuSection
-            hostOptionsCount={hostOptions.length}
-            hostVisibilityLabel={hostVisibilityLabel}
-            hostOptions={hostOptions}
-            preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen}
-            setWorkspaceHostScope={setWorkspaceHostScope}
-            visibleWorkspaceHostIds={visibleWorkspaceHostIds}
-            setVisibleWorkspaceHostIds={setVisibleWorkspaceHostIds}
-          />
+        {/* Why: host + project filters share one section and the same single-row
+            shell as Sort by (label left, value right) so the menu stays flat. */}
+        {(showHostScopeControls || repos.length > 1) && (
+          <>
+            <DropdownMenuLabel>
+              {translate('auto.components.sidebar.SidebarWorkspaceOptionsMenu.showSection', 'Show')}
+            </DropdownMenuLabel>
+            {showHostScopeControls && (
+              <SidebarHostScopeMenuSection
+                hostVisibilityLabel={hostVisibilityLabel}
+                hostOptions={hostOptions}
+                preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen}
+                setWorkspaceHostScope={setWorkspaceHostScope}
+                visibleWorkspaceHostIds={visibleWorkspaceHostIds}
+                setVisibleWorkspaceHostIds={setVisibleWorkspaceHostIds}
+              />
+            )}
+            <SidebarRepositoryFilterSection
+              preserveWorkspaceBoardOpen={preserveWorkspaceBoardOpen}
+            />
+            <DropdownMenuSeparator />
+          </>
         )}
 
         <DropdownMenuLabel>
@@ -286,9 +298,6 @@ const SidebarWorkspaceOptionsMenu = React.memo(function SidebarWorkspaceOptionsM
 
         <DropdownMenuSeparator />
         <SidebarWorkspaceFilterSection />
-
-        <DropdownMenuSeparator />
-        <SidebarRepositoryFilterSection />
       </DropdownMenuContent>
     </DropdownMenu>
   )

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4398,7 +4398,9 @@
           "83a820fa71": "Filter projects...",
           "5a273fbfce": "Add project...",
           "4815c70605": "No projects match",
-          "bbbc6e8e3b": "No unselected projects match"
+          "bbbc6e8e3b": "No unselected projects match",
+          "allProjects": "All projects",
+          "selectedProjectsCount": "{{value0}} projects"
         },
         "SidebarSettingsHelpMenu": {
           "ad3d3ed7f1": "Restart Orca",
@@ -4445,6 +4447,7 @@
         },
         "SidebarWorkspaceOptionsMenu": {
           "hosts": "Hosts",
+          "showSection": "Show",
           "allHostsDetail": "Show every host",
           "configuredSshHost": "Configured SSH",
           "projectSshHost": "Project SSH",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4286,7 +4286,9 @@
           "83a820fa71": "Filtrar proyectos...",
           "5a273fbfce": "Agregar proyecto...",
           "4815c70605": "Ningún proyecto coincide",
-          "bbbc6e8e3b": "Ningún proyecto no seleccionado coincide"
+          "bbbc6e8e3b": "Ningún proyecto no seleccionado coincide",
+          "allProjects": "Todos los proyectos",
+          "selectedProjectsCount": "{{value0}} proyectos"
         },
         "SidebarSettingsHelpMenu": {
           "ad3d3ed7f1": "Reiniciar Orca",
@@ -4364,6 +4366,7 @@
           "680043342f": "compacto",
           "c7591b6014": "repositorio",
           "hosts": "Hosts",
+          "showSection": "Mostrar",
           "allHostsDetail": "Mostrar todos los hosts",
           "configuredSshHost": "SSH configurado",
           "projectSshHost": "SSH del proyecto",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4267,7 +4267,9 @@
           "83a820fa71": "プロジェクトをフィルタリング...",
           "5a273fbfce": "プロジェクトを追加...",
           "4815c70605": "一致するプロジェクトはありません",
-          "bbbc6e8e3b": "選択されていないプロジェクトは一致しません"
+          "bbbc6e8e3b": "選択されていないプロジェクトは一致しません",
+          "allProjects": "すべてのプロジェクト",
+          "selectedProjectsCount": "{{value0}} 件のプロジェクト"
         },
         "SidebarSettingsHelpMenu": {
           "ad3d3ed7f1": "Orca を再起動",
@@ -4345,6 +4347,7 @@
           "680043342f": "コンパクト",
           "c7591b6014": "repo",
           "hosts": "ホスト",
+          "showSection": "表示",
           "allHostsDetail": "すべてのホストを表示",
           "configuredSshHost": "設定済み SSH",
           "projectSshHost": "プロジェクト SSH",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4267,7 +4267,9 @@
           "83a820fa71": "프로젝트 필터링...",
           "5a273fbfce": "프로젝트 추가...",
           "4815c70605": "일치하는 프로젝트가 없습니다.",
-          "bbbc6e8e3b": "선택되지 않은 일치하는 프로젝트가 없습니다."
+          "bbbc6e8e3b": "선택되지 않은 일치하는 프로젝트가 없습니다.",
+          "allProjects": "모든 프로젝트",
+          "selectedProjectsCount": "프로젝트 {{value0}}개"
         },
         "SidebarSettingsHelpMenu": {
           "ad3d3ed7f1": "Orca 재시작",
@@ -4345,6 +4347,7 @@
           "680043342f": "콤팩트",
           "c7591b6014": "repo",
           "hosts": "호스트",
+          "showSection": "표시",
           "allHostsDetail": "모든 호스트 표시",
           "configuredSshHost": "구성된 SSH",
           "projectSshHost": "프로젝트 SSH",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4279,7 +4279,9 @@
           "83a820fa71": "筛选项目...",
           "5a273fbfce": "添加项目...",
           "4815c70605": "没有匹配的项目",
-          "bbbc6e8e3b": "没有匹配的未选择项目"
+          "bbbc6e8e3b": "没有匹配的未选择项目",
+          "allProjects": "所有项目",
+          "selectedProjectsCount": "{{value0}} 个项目"
         },
         "SidebarSettingsHelpMenu": {
           "ad3d3ed7f1": "重启 Orca",
@@ -4357,6 +4359,7 @@
           "680043342f": "紧凑",
           "c7591b6014": "仓库",
           "hosts": "主机",
+          "showSection": "显示",
           "allHostsDetail": "显示所有主机",
           "configuredSshHost": "已配置 SSH",
           "projectSshHost": "项目 SSH",


### PR DESCRIPTION
## Summary

Restructures the sidebar hosts and projects filters to follow a consistent single-row submenu trigger pattern (label left, current value/status right) with detailed selection panels nested inside the submenu content. Both filters are now grouped under a shared "Show" section at the top of the workspace options menu.

## Changes

- **SidebarHostScopeMenuSection**: Removed section label and separator; now renders as a single-row submenu trigger showing "Hosts" and visibility status
- **SidebarRepositoryFilterSection**: Refactored to match the hosts filter structure; label and current filter state display as trigger row
- **SidebarProjectFilterPanel** (new): Extracted search and selection logic into dedicated component that mounts/unmounts with the submenu, resetting query state on close
- **Menu organization**: Hosts and Projects filters now grouped under "Show" section header; moved above other menu items for consistent filter section layout
- **i18n**: Added "showSection" label and project count display keys across all locales

## Testing

- Added `SidebarRepositoryFilterSection.test.tsx` covering focus behavior, query reset on submenu close, and keyboard navigation (ArrowLeft, Backspace, Enter)
- Layout changes are visual only; filtering logic unchanged