### PR TITLE
Strengthen plain-node-entry-guard with entry name validation

### DIFF
--- a/.github/workflows/win-crash-survival-e2e.yml
+++ b/.github/workflows/win-crash-survival-e2e.yml
@@ -77,7 +77,6 @@ jobs:
               '!config/reliability-gates.jsonc',
               '!config/max-lines-baseline.txt',
               '!config/vitest.config.ts',
-              'config/build-plugins/**',
               'native/**',
               'resources/**',
               'electron.vite.config.ts',

--- a/config/build-plugins/plain-node-entry-guard.ts
+++ b/config/build-plugins/plain-node-entry-guard.ts
@@ -2,6 +2,7 @@ import { spawnSync } from 'node:child_process'
 import { join } from 'node:path'
 import type { Plugin, Rollup } from 'vite'
 
+type NormalizedInputOptions = Rollup.NormalizedInputOptions
 type NormalizedOutputOptions = Rollup.NormalizedOutputOptions
 type OutputBundle = Rollup.OutputBundle
 type OutputChunk = Rollup.OutputChunk
@@ -42,9 +43,34 @@ const WORKER_THREAD_ENTRY_NAMES = [
   'port-scan-command-worker-entry'
 ] as const
 
+export const GUARDED_ENTRY_NAMES = [
+  ...PLAIN_NODE_ENTRY_NAMES,
+  ...WORKER_THREAD_ENTRY_NAMES
+] as const
+
 type EntryRuntime = 'plain-Node process' | 'worker thread'
 
-const ELECTRON_REQUIRE_RE = /require\(\s*["']electron["']\s*\)/
+// Subpaths (electron/main) are as unloadable as the bare module under plain Node.
+const ELECTRON_REQUIRE_RE = /require\(\s*["'`]electron(?:\/[^"'`]+)?["'`]\s*\)/
+
+// Why: writeBundle skips any name missing from the bundle, so a renamed or
+// removed rollup input would silently drop that entry from the guard and let the
+// regression back in. Pin the lists to the input keys at build start instead.
+function assertEntryNamesAreRollupInputs(input: NormalizedInputOptions['input']): void {
+  if (typeof input === 'string' || Array.isArray(input)) {
+    return
+  }
+  const inputNames = new Set(Object.keys(input))
+  const missing = GUARDED_ENTRY_NAMES.filter((name) => !inputNames.has(name))
+  if (missing.length > 0) {
+    throw new Error(
+      `[plain-node-entry-guard] guarded ${missing.map((name) => `"${name}"`).join(', ')} ` +
+        `${missing.length === 1 ? 'is not a rollup input' : 'are not rollup inputs'} anymore. ` +
+        `Update PLAIN_NODE_ENTRY_NAMES/WORKER_THREAD_ENTRY_NAMES in plain-node-entry-guard.ts to ` +
+        `the current entry names — a stale name silently stops guarding that entry.`
+    )
+  }
+}
 
 function collectReachableChunks(
   entry: OutputChunk,
@@ -89,6 +115,11 @@ function assertNoElectronRequire(
   }
 }
 
+// Owned by the argv parser in src/main/daemon/daemon-entry.ts — keep in sync.
+const DAEMON_USAGE_PREFIX = 'Usage: daemon-entry'
+
+const SMOKE_TIMEOUT_MS = 15_000
+
 // Why: proves the whole daemon-entry graph resolves under plain Node (no
 // unresolved requires). require("electron") does not throw in a dev tree with
 // node_modules present, so the static scan above — not this smoke — is the
@@ -97,12 +128,20 @@ function smokeLoadDaemonEntry(outputDir: string): void {
   const entryPath = join(outputDir, 'daemon-entry.js')
   const result = spawnSync(process.execPath, [entryPath], {
     encoding: 'utf8',
-    timeout: 15_000
+    timeout: SMOKE_TIMEOUT_MS
   })
   if (result.error) {
     throw new Error(
       `[plain-node-entry-guard] could not smoke-load daemon-entry.js under plain Node: ` +
         `${result.error.message}`
+    )
+  }
+  // A signal here is almost always the timeout above: the daemon stopped
+  // rejecting an empty argv and started listening instead.
+  if (result.signal) {
+    throw new Error(
+      `[plain-node-entry-guard] daemon-entry.js was killed by ${result.signal} under plain Node ` +
+        `(it did not exit within ${SMOKE_TIMEOUT_MS}ms on an empty argv).`
     )
   }
   const stderr = result.stderr ?? ''
@@ -111,10 +150,11 @@ function smokeLoadDaemonEntry(outputDir: string): void {
       `[plain-node-entry-guard] daemon-entry.js failed to load under plain Node:\n${stderr}`
     )
   }
-  if (!stderr.includes('Usage: daemon-entry')) {
+  if (result.status === 0 || !stderr.includes(DAEMON_USAGE_PREFIX)) {
     throw new Error(
-      `[plain-node-entry-guard] daemon-entry.js did not reach argv parsing under plain Node ` +
-        `(expected the "Usage: daemon-entry" error). stderr:\n${stderr}`
+      `[plain-node-entry-guard] daemon-entry.js did not reject an empty argv under plain Node ` +
+        `(expected a non-zero exit and the "${DAEMON_USAGE_PREFIX}" error, got exit ` +
+        `${result.status}). stderr:\n${stderr}`
     )
   }
 }
@@ -124,6 +164,9 @@ export function createPlainNodeEntryGuardPlugin(): Plugin {
 
   return {
     name: 'orca-plain-node-entry-guard',
+    buildStart(options: NormalizedInputOptions) {
+      assertEntryNamesAreRollupInputs(options.input)
+    },
     writeBundle(options: NormalizedOutputOptions, bundle: OutputBundle) {
       // Why: skip in `electron-vite dev` watch mode — the smoke would respawn on
       // every rebuild, and the guard only needs to gate produced builds.

--- a/config/build-plugins/plain-node-entry-guard.ts
+++ b/config/build-plugins/plain-node-entry-guard.ts
@@ -1,4 +1,4 @@
-import { spawnSync } from 'node:child_process'
+import { spawn } from 'node:child_process'
 import { join } from 'node:path'
 import type { Plugin, Rollup } from 'vite'
 
@@ -118,33 +118,98 @@ function assertNoElectronRequire(
 // Owned by the argv parser in src/main/daemon/daemon-entry.ts — keep in sync.
 const DAEMON_USAGE_PREFIX = 'Usage: daemon-entry'
 
-const SMOKE_TIMEOUT_MS = 15_000
+export type SmokeTimings = {
+  timeoutMs: number
+  // daemon-entry traps SIGTERM and awaits a native shutdown, so the deadline
+  // needs an uncatchable follow-up to stay a deadline.
+  killGraceMs: number
+}
+
+const DEFAULT_SMOKE_TIMINGS: SmokeTimings = { timeoutMs: 15_000, killGraceMs: 2_000 }
+
+// Bound the wait for stderr to flush after exit; a grandchild inheriting stdio
+// can hold the pipes open long after the child is gone.
+const SMOKE_STDERR_DRAIN_MS = 250
+
+type SmokeResult = {
+  status: number | null
+  signal: NodeJS.Signals | null
+  stderr: string
+  error?: Error
+  timedOut: boolean
+}
+
+// Why not spawnSync({ timeout }): its timeout only sends killSignal and then
+// keeps blocking until the child exits, so a child that traps SIGTERM hangs the
+// build forever. Escalate to SIGKILL instead.
+function runDaemonEntry(entryPath: string, timings: SmokeTimings): Promise<SmokeResult> {
+  return new Promise((resolve) => {
+    const child = spawn(process.execPath, [entryPath], { stdio: ['ignore', 'ignore', 'pipe'] })
+    let stderr = ''
+    let timedOut = false
+    let settled = false
+    let forceKillTimer: NodeJS.Timeout | undefined
+    let drainTimer: NodeJS.Timeout | undefined
+
+    child.stderr.setEncoding('utf8')
+    child.stderr.on('data', (chunk: string) => {
+      stderr += chunk
+    })
+
+    const deadlineTimer = setTimeout(() => {
+      timedOut = true
+      child.kill('SIGTERM')
+      forceKillTimer = setTimeout(() => child.kill('SIGKILL'), timings.killGraceMs)
+    }, timings.timeoutMs)
+
+    const finish = (status: number | null, signal: NodeJS.Signals | null, error?: Error): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(deadlineTimer)
+      clearTimeout(forceKillTimer)
+      clearTimeout(drainTimer)
+      resolve({ status, signal, stderr, error, timedOut })
+    }
+
+    child.on('error', (error: Error) => finish(null, null, error))
+    // 'close' gives the full stderr; 'exit' is the fallback so a held-open pipe
+    // cannot outlast the process itself.
+    child.on('close', (status, signal) => finish(status, signal))
+    child.on('exit', (status, signal) => {
+      drainTimer = setTimeout(() => finish(status, signal), SMOKE_STDERR_DRAIN_MS)
+    })
+  })
+}
 
 // Why: proves the whole daemon-entry graph resolves under plain Node (no
 // unresolved requires). require("electron") does not throw in a dev tree with
 // node_modules present, so the static scan above — not this smoke — is the
 // electron regression guard; this only catches gross load failures.
-function smokeLoadDaemonEntry(outputDir: string): void {
+async function smokeLoadDaemonEntry(outputDir: string, timings: SmokeTimings): Promise<void> {
   const entryPath = join(outputDir, 'daemon-entry.js')
-  const result = spawnSync(process.execPath, [entryPath], {
-    encoding: 'utf8',
-    timeout: SMOKE_TIMEOUT_MS
-  })
+  const result = await runDaemonEntry(entryPath, timings)
   if (result.error) {
     throw new Error(
       `[plain-node-entry-guard] could not smoke-load daemon-entry.js under plain Node: ` +
         `${result.error.message}`
     )
   }
-  // A signal here is almost always the timeout above: the daemon stopped
-  // rejecting an empty argv and started listening instead.
-  if (result.signal) {
+  // Almost always means the daemon stopped rejecting an empty argv and started
+  // listening instead.
+  if (result.timedOut) {
     throw new Error(
-      `[plain-node-entry-guard] daemon-entry.js was killed by ${result.signal} under plain Node ` +
-        `(it did not exit within ${SMOKE_TIMEOUT_MS}ms on an empty argv).`
+      `[plain-node-entry-guard] daemon-entry.js did not exit within ${timings.timeoutMs}ms on an ` +
+        `empty argv under plain Node, so the smoke killed it.`
     )
   }
-  const stderr = result.stderr ?? ''
+  if (result.signal) {
+    throw new Error(
+      `[plain-node-entry-guard] daemon-entry.js was killed by ${result.signal} under plain Node.`
+    )
+  }
+  const stderr = result.stderr
   if (/Cannot find module|MODULE_NOT_FOUND/.test(stderr)) {
     throw new Error(
       `[plain-node-entry-guard] daemon-entry.js failed to load under plain Node:\n${stderr}`
@@ -159,7 +224,9 @@ function smokeLoadDaemonEntry(outputDir: string): void {
   }
 }
 
-export function createPlainNodeEntryGuardPlugin(): Plugin {
+export function createPlainNodeEntryGuardPlugin(
+  smokeTimings: SmokeTimings = DEFAULT_SMOKE_TIMINGS
+): Plugin {
   let daemonOutputDir: string | undefined
 
   return {
@@ -202,11 +269,11 @@ export function createPlainNodeEntryGuardPlugin(): Plugin {
         daemonOutputDir = options.dir
       }
     },
-    closeBundle() {
+    async closeBundle() {
       if (daemonOutputDir) {
         const outputDir = daemonOutputDir
         daemonOutputDir = undefined
-        smokeLoadDaemonEntry(outputDir)
+        await smokeLoadDaemonEntry(outputDir, smokeTimings)
       }
     }
   }

--- a/config/scripts/plain-node-entry-guard.test.ts
+++ b/config/scripts/plain-node-entry-guard.test.ts
@@ -3,7 +3,10 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import type { Plugin, Rollup } from 'vite'
 import { afterEach, describe, expect, it } from 'vitest'
-import { createPlainNodeEntryGuardPlugin } from '../build-plugins/plain-node-entry-guard'
+import {
+  createPlainNodeEntryGuardPlugin,
+  GUARDED_ENTRY_NAMES
+} from '../build-plugins/plain-node-entry-guard'
 
 let outputDir: string | undefined
 
@@ -83,6 +86,55 @@ describe('plain Node entry guard', () => {
     expect(() => runWriteBundle(plugin, createOutputDir(), 'require("electron")')).toThrow(
       'requires electron'
     )
+  })
+
+  it('rejects Electron subpath requires', () => {
+    const plugin = createPlainNodeEntryGuardPlugin()
+
+    expect(() => runWriteBundle(plugin, createOutputDir(), 'require("electron/main")')).toThrow(
+      'requires electron'
+    )
+  })
+
+  it('fails the smoke when the daemon exits zero on an empty argv', () => {
+    const dir = createOutputDir()
+    const plugin = createPlainNodeEntryGuardPlugin()
+
+    runWriteBundle(plugin, dir)
+    writeFileSync(join(dir, 'daemon-entry.js'), 'console.error("Usage: daemon-entry <socket>")\n')
+
+    expect(() => runCloseBundle(plugin)).toThrow('did not reject an empty argv')
+  })
+})
+
+// Why: writeBundle skips names absent from the bundle, so a renamed rollup input
+// would silently stop guarding that entry instead of failing the build.
+describe('guarded entry names', () => {
+  function runBuildStart(plugin: Plugin, input: unknown): void {
+    const hook = plugin.buildStart
+    if (typeof hook !== 'function') {
+      throw new Error('Expected buildStart hook')
+    }
+    hook.call({} as never, { input } as Rollup.NormalizedInputOptions)
+  }
+
+  it('rejects a guarded name that is no longer a rollup input', () => {
+    const plugin = createPlainNodeEntryGuardPlugin()
+    const input = Object.fromEntries(
+      GUARDED_ENTRY_NAMES.filter((name) => name !== 'stt-worker').map((name) => [
+        name,
+        `${name}.ts`
+      ])
+    )
+
+    expect(() => runBuildStart(plugin, input)).toThrow('"stt-worker"')
+  })
+
+  it('passes when every guarded name is a rollup input', () => {
+    const plugin = createPlainNodeEntryGuardPlugin()
+    const input = Object.fromEntries(GUARDED_ENTRY_NAMES.map((name) => [name, `${name}.ts`]))
+
+    expect(() => runBuildStart(plugin, input)).not.toThrow()
   })
 })
 

--- a/config/scripts/plain-node-entry-guard.test.ts
+++ b/config/scripts/plain-node-entry-guard.test.ts
@@ -48,16 +48,16 @@ function runWriteBundle(plugin: Plugin, dir: string, code = ''): void {
   )
 }
 
-function runCloseBundle(plugin: Plugin): void {
+async function runCloseBundle(plugin: Plugin): Promise<void> {
   const hook = plugin.closeBundle
   if (typeof hook !== 'function') {
     throw new Error('Expected closeBundle hook')
   }
-  hook.call({} as never)
+  await hook.call({} as never)
 }
 
 describe('plain Node entry guard', () => {
-  it('smoke-loads the daemon after output files are written', () => {
+  it('smoke-loads the daemon after output files are written', async () => {
     const dir = createOutputDir()
     const plugin = createPlainNodeEntryGuardPlugin()
 
@@ -67,17 +67,17 @@ describe('plain Node entry guard', () => {
       'console.error("Usage: daemon-entry <socket>"); process.exit(1)\n'
     )
 
-    expect(() => runCloseBundle(plugin)).not.toThrow()
+    await expect(runCloseBundle(plugin)).resolves.toBeUndefined()
   })
 
-  it('runs the deferred smoke from closeBundle', () => {
+  it('runs the deferred smoke from closeBundle', async () => {
     const dir = createOutputDir()
     const plugin = createPlainNodeEntryGuardPlugin()
 
     runWriteBundle(plugin, dir)
     writeFileSync(join(dir, 'daemon-entry.js'), "require('./missing-module')\n")
 
-    expect(() => runCloseBundle(plugin)).toThrow('failed to load under plain Node')
+    await expect(runCloseBundle(plugin)).rejects.toThrow('failed to load under plain Node')
   })
 
   it('rejects Electron imports during the static bundle scan', () => {
@@ -96,15 +96,30 @@ describe('plain Node entry guard', () => {
     )
   })
 
-  it('fails the smoke when the daemon exits zero on an empty argv', () => {
+  it('fails the smoke when the daemon exits zero on an empty argv', async () => {
     const dir = createOutputDir()
     const plugin = createPlainNodeEntryGuardPlugin()
 
     runWriteBundle(plugin, dir)
     writeFileSync(join(dir, 'daemon-entry.js'), 'console.error("Usage: daemon-entry <socket>")\n')
 
-    expect(() => runCloseBundle(plugin)).toThrow('did not reject an empty argv')
+    await expect(runCloseBundle(plugin)).rejects.toThrow('did not reject an empty argv')
   })
+
+  // daemon-entry installs a SIGTERM handler, so the smoke deadline only holds if
+  // it escalates to SIGKILL — spawnSync's own timeout would block here forever.
+  it('kills a daemon that traps SIGTERM and never exits', async () => {
+    const dir = createOutputDir()
+    const plugin = createPlainNodeEntryGuardPlugin({ timeoutMs: 250, killGraceMs: 250 })
+
+    runWriteBundle(plugin, dir)
+    writeFileSync(
+      join(dir, 'daemon-entry.js'),
+      "process.on('SIGTERM', () => {}); setInterval(() => {}, 1000)\n"
+    )
+
+    await expect(runCloseBundle(plugin)).rejects.toThrow('did not exit within 250ms')
+  }, 10_000)
 })
 
 // Why: writeBundle skips names absent from the bundle, so a renamed rollup input


### PR DESCRIPTION
## Problem

PR #12758 only landed the `build-plugins/` → `config/build-plugins/` move. The follow-up hardening of `plain-node-entry-guard` (entry-name validation, broader electron require detection, and stronger smoke assertions) was still on the branch and not included in that PR.

`writeBundle` skips any guarded entry name missing from the bundle, so a renamed or removed rollup input could silently stop guarding that entry and let the electron-require regression back in.

## Solution

- Fail the build at `buildStart` when any guarded entry name is not a current rollup input
- Detect `require("electron/...")` subpaths as well as the bare module
- Tighten the daemon smoke: require a non-zero exit and treat signal/timeout kills as failures
- Add unit coverage for entry validation, subpath requires, and the zero-exit smoke case
- Drop the redundant `config/build-plugins/**` installer cache pathspec (already covered by `config/**`)

## Summary

Closes the gap left by #12758 by shipping the remaining plain-node-entry-guard hardening on a clean branch off current `main`.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Extended `config/scripts/plain-node-entry-guard.test.ts` for entry-name validation, electron subpath requires, and zero-exit smoke failure

## AI Review Report

TODO: Summarize the code review you ran with your AI coding agent. Include the main risks it checked, what it flagged, and what you changed or verified as a result.
Confirm that the review explicitly checked cross-platform compatibility for macOS, Linux, and Windows, including shortcuts, labels, paths, shell behavior, and any Electron-specific platform differences touched by this PR.

## Security Audit

TODO: Provide a basic security audit summary from your AI coding agent. Call out any input handling, command execution, path handling, auth, secrets, dependency, or IPC risks that were reviewed, plus any follow-up needed.

## Notes

- Supersedes the leftover commit on `move-build-plugins-to-config` after #12758 was squash-merged
- No runtime product behavior change; this only tightens the build-time guard that protects plain-Node and worker-thread entries from electron requires