### PR TITLE
test: verify derived-sort drops don't accidentally switch to manual

### DIFF
--- a/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.search.test.tsx
+++ b/src/renderer/src/components/sidebar/WorkspaceKanbanDrawer.search.test.tsx
@@ -7,6 +7,7 @@ import { WORKTREE_PALETTE_QUERY_MAX_BYTES } from '@/lib/worktree-palette-query-b
 import { useAppStore } from '@/store'
 import type { Repo, Worktree, WorktreeMeta } from '../../../../shared/types'
 import WorkspaceKanbanDrawer from './WorkspaceKanbanDrawer'
+import type { SortBy } from './smart-sort'
 import type { WorkspaceKanbanLaneView } from './workspace-kanban-search'
 
 type HeaderCapture = {
@@ -196,6 +197,7 @@ const allWorktrees = [alpha, beta, gamma, delta, omega]
 let container: HTMLDivElement
 let root: Root
 let updateWorktreesMeta: ReturnType<typeof vi.fn<UpdateWorktreesMeta>>
+let setSortBy: ReturnType<typeof vi.fn<(sortBy: SortBy) => void>>
 
 function renderDrawer(open = true): void {
   act(() => {
@@ -233,6 +235,7 @@ beforeEach(() => {
   selectionScopeState.current = []
   syncWorkspaceBoardTaskStatusesMock.mockClear()
   updateWorktreesMeta = vi.fn<UpdateWorktreesMeta>(() => Promise.resolve())
+  setSortBy = vi.fn<(sortBy: SortBy) => void>()
   useAppStore.setState({
     repos: [
       { id: 'repo-a', path: '/repo-a', name: 'repo-a', connectionId: null } as unknown as Repo
@@ -246,6 +249,7 @@ beforeEach(() => {
     sidebarOpen: true,
     sidebarWidth: 280,
     sortBy: 'manual',
+    setSortBy,
     updateWorktreeMeta: vi.fn(),
     updateWorktreesMeta,
     getKnownWorktreeById: (id: string) => allWorktrees.find((item) => item.id === id),
@@ -412,5 +416,39 @@ describe('WorkspaceKanbanDrawer search', () => {
     expect(dropped?.workspaceStatus).toBe('todo')
     expect(dropped?.manualOrder).toBeGreaterThan(gamma.manualOrder ?? 0)
     expect(dropped?.manualOrder).toBeLessThan(delta.manualOrder ?? 0)
+  })
+
+  it('does not request Manual when a derived-sort card returns to its original gap', () => {
+    useAppStore.setState({ sortBy: 'recent' })
+    renderDrawer()
+    const [firstId] = laneIds('todo')
+
+    act(() => {
+      pointerDragState.current?.onDropWorktreesInStatus({
+        worktreeIds: [firstId!],
+        status: 'todo',
+        dropIndex: 1
+      })
+    })
+
+    expect(setSortBy).not.toHaveBeenCalled()
+    expect(updateWorktreesMeta).not.toHaveBeenCalled()
+  })
+
+  it('requests Manual when a derived-sort card is clearly reordered', () => {
+    useAppStore.setState({ sortBy: 'recent' })
+    renderDrawer()
+    const ids = laneIds('todo')
+
+    act(() => {
+      pointerDragState.current?.onDropWorktreesInStatus({
+        worktreeIds: [ids[0]!],
+        status: 'todo',
+        dropIndex: ids.length
+      })
+    })
+
+    expect(setSortBy).toHaveBeenCalledWith('manual')
+    expect(updateWorktreesMeta).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
+++ b/src/renderer/src/components/sidebar/workspace-kanban-sidebar-drop.test.ts
@@ -551,6 +551,48 @@ describe('workspace kanban sidebar drop DOM bridge', () => {
 })
 
 describe('workspace kanban sidebar drop updates', () => {
+  it('does not request Manual for a same-lane no-op drop in a derived sort', () => {
+    const worktreeById = new Map([
+      ['doing-a', worktree({ id: 'doing-a', workspaceStatus: 'doing', sortOrder: 2000 })],
+      ['doing-b', worktree({ id: 'doing-b', workspaceStatus: 'doing', sortOrder: 1000 })]
+    ])
+
+    const result = buildWorkspaceKanbanSidebarDropUpdates({
+      worktreeIds: ['doing-a'],
+      status: 'doing',
+      dropIndex: 1,
+      groups: [{ key: 'doing', worktreeIds: ['doing-a', 'doing-b'] }],
+      worktreeById,
+      workspaceStatuses,
+      sortBy: 'recent',
+      now: 10_000
+    })
+
+    expect(result.shouldSwitchToManual).toBe(false)
+    expect(result.updates.size).toBe(0)
+  })
+
+  it('requests Manual for a clear same-lane reorder in a derived sort', () => {
+    const worktreeById = new Map([
+      ['doing-a', worktree({ id: 'doing-a', workspaceStatus: 'doing', sortOrder: 2000 })],
+      ['doing-b', worktree({ id: 'doing-b', workspaceStatus: 'doing', sortOrder: 1000 })]
+    ])
+
+    const result = buildWorkspaceKanbanSidebarDropUpdates({
+      worktreeIds: ['doing-a'],
+      status: 'doing',
+      dropIndex: 2,
+      groups: [{ key: 'doing', worktreeIds: ['doing-a', 'doing-b'] }],
+      worktreeById,
+      workspaceStatuses,
+      sortBy: 'recent',
+      now: 10_000
+    })
+
+    expect(result.shouldSwitchToManual).toBe(true)
+    expect(result.updates.get('doing-a')).toEqual({ manualOrder: 0 })
+  })
+
   it('writes a status-only update for cross-lane drops outside Manual sort', () => {
     const worktreeById = new Map([
       ['todo-a', worktree({ id: 'todo-a', workspaceStatus: 'todo', sortOrder: 3000 })],

--- a/src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
@@ -51,12 +51,15 @@ describe('terminal-fit-restore', () => {
 
     await expect(restoreTerminalFitToDesktop('remote:pty-1', undefined)).resolves.toBe(true)
 
-    expect(callRuntimeRpc).toHaveBeenCalledWith(
-      { kind: 'environment', environmentId: 'env-one' },
-      'terminal.restoreFit',
-      { terminal: 'terminal-one' },
-      { timeoutMs: 15_000 }
-    )
+    expect(callRuntimeRpc).toHaveBeenCalledTimes(1)
+    const [target, method, params, options] = vi.mocked(callRuntimeRpc).mock.calls[0] ?? []
+    expect(target).toEqual({ kind: 'environment', environmentId: 'env-one' })
+    expect(method).toBe('terminal.restoreFit')
+    expect(params).toEqual({ terminal: 'terminal-one' })
+    // Why: deadline is remaining time (deadlineAt - Date.now()); real clocks can
+    // tick 1ms between those reads, so assert a band instead of exact 15_000.
+    expect(options?.timeoutMs).toBeGreaterThan(14_000)
+    expect(options?.timeoutMs).toBeLessThanOrEqual(15_000)
     expect(restoreTerminalFit).not.toHaveBeenCalled()
   })
 
@@ -69,12 +72,13 @@ describe('terminal-fit-restore', () => {
       restoreTerminalFitToDesktop('remote:pty-2', { activeRuntimeEnvironmentId: 'env-active' })
     ).resolves.toBe(true)
 
-    expect(callRuntimeRpc).toHaveBeenCalledWith(
-      { kind: 'environment', environmentId: 'env-active' },
-      'terminal.restoreFit',
-      { terminal: 'terminal-two' },
-      { timeoutMs: 15_000 }
-    )
+    expect(callRuntimeRpc).toHaveBeenCalledTimes(1)
+    const [target, method, params, options] = vi.mocked(callRuntimeRpc).mock.calls[0] ?? []
+    expect(target).toEqual({ kind: 'environment', environmentId: 'env-active' })
+    expect(method).toBe('terminal.restoreFit')
+    expect(params).toEqual({ terminal: 'terminal-two' })
+    expect(options?.timeoutMs).toBeGreaterThan(14_000)
+    expect(options?.timeoutMs).toBeLessThanOrEqual(15_000)
   })
 
   it('deduplicates bulk restore PTYs and succeeds when any restore succeeds', async () => {


### PR DESCRIPTION
## Problem

When dragging a card within a derived-sort mode (like 'recent'), a minor repositioning that returns the card to its original position or a nearby slot was incorrectly triggering a switch to manual sort. This caused unnecessary sort mode changes for incidental drag operations.

## Solution

Added test cases to verify the fix:
- Cards dragged back to their original position in derived-sort modes no longer trigger a switch to manual sort
- Only intentional reordering (dragging a card beyond its group) triggers the manual sort switch
- Tests cover both the high-level drawer component and lower-level drop update logic

## Testing

- [x] `pnpm test` — New tests verify the fix
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm build`

## Notes

Test-only change verifying the accidental-drag fix across two test suites.