### PR TITLE
fix(mobile): stop native-chat send button flicker

### DIFF
--- a/mobile/src/session/MobileNativeChatView.test.ts
+++ b/mobile/src/session/MobileNativeChatView.test.ts
@@ -50,8 +50,13 @@ vi.mock('./MobileAgentWorkingIndicator', () => ({
 vi.mock('./MobileNativeChatComposer', async () => {
   const React = await import('react')
   return {
-    MobileNativeChatComposer: (props: { onSend: (text: string) => Promise<boolean> }) =>
+    MobileNativeChatComposer: (props: {
+      onSend: (text: string) => Promise<boolean>
+      disabled?: boolean
+      placeholder?: string
+    }) =>
       React.createElement('Composer', {
+        ...props,
         accessibilityLabel: 'Send message',
         onPress: () => props.onSend('hi')
       })
@@ -136,6 +141,10 @@ describe('MobileNativeChatView', () => {
     return renderer!.root.findAll((node) => node.props.accessibilityRole === 'alert')
   }
 
+  function composer(): ReactTestInstance {
+    return renderer!.root.find((node) => node.type === 'Composer')
+  }
+
   function bannerText(): string {
     const [alert, ...rest] = banners()
     expect(rest).toHaveLength(0)
@@ -196,5 +205,43 @@ describe('MobileNativeChatView', () => {
     await update({ folded, streaming: 'The tests' })
 
     expect(listIds()).toEqual(['a1', 'streaming'])
+  })
+
+  it('keeps a visible lock through a subscribed-end lease blip', async () => {
+    vi.useFakeTimers()
+    try {
+      await render({ inputLockReason: 'waiting' })
+      await act(async () => vi.advanceTimersByTime(600))
+      expect(composer().props.disabled).toBe(true)
+
+      await update({ inputLockReason: null })
+      expect(composer().props.disabled).toBe(true)
+      await act(async () => vi.advanceTimersByTime(300))
+      await update({ inputLockReason: 'waiting' })
+      await act(async () => vi.advanceTimersByTime(600))
+
+      expect(composer().props.disabled).toBe(true)
+      expect(composer().props.placeholder).toBe('Waiting for terminal…')
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('unlocks after the lease stays ready', async () => {
+    vi.useFakeTimers()
+    try {
+      await render({ inputLockReason: 'waiting' })
+      await act(async () => vi.advanceTimersByTime(600))
+      await update({ inputLockReason: null })
+      await act(async () => vi.advanceTimersByTime(599))
+      expect(composer().props.disabled).toBe(true)
+
+      await act(async () => vi.advanceTimersByTime(1))
+
+      expect(composer().props.disabled).toBe(false)
+      expect(composer().props.placeholder).toBe('Message, @files, /commands')
+    } finally {
+      vi.useRealTimers()
+    }
   })
 })

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -33,6 +33,8 @@ import { MobileNativeChatQuestion } from './MobileNativeChatQuestion'
 import { mobileChatQuestionKey, type MobileChatQuestion } from './mobile-native-chat-question'
 import type { MobileNativeChatStatus } from './use-mobile-native-chat-session'
 
+const INPUT_LOCK_SETTLE_MS = 600
+
 /** Why the composer input is locked: the transport is disconnected, or the
  *  terminal subscription has not acknowledged its input lease yet. */
 export type MobileNativeChatInputLockReason = 'disconnected' | 'waiting'
@@ -250,20 +252,22 @@ export function MobileNativeChatView({
   const emptyState = mobileNativeChatEmptyState(status, agent ?? null, error)
   const showLoading = status === 'loading' && messages.length === 0
 
-  // Composer-lock flicker guard: on a remote link, brief connState blips or lease
-  // hand-offs would otherwise toggle the lock placeholder on and off. Only surface
-  // a lock once it has held ~600ms; drop it instantly so unlocking stays snappy.
+  // A dead PTY emits subscribed→end; settle both edges so its false lease cannot flash the composer enabled.
   const rawLockReason = inputLockReason ?? null
+  const rawLockHeld = rawLockReason !== null
   const [lockHeld, setLockHeld] = useState(false)
+  const lastLockReasonRef = useRef(rawLockReason)
+  if (rawLockReason !== null) {
+    lastLockReasonRef.current = rawLockReason
+  }
   useEffect(() => {
-    if (rawLockReason === null) {
-      setLockHeld(false)
+    if (rawLockHeld === lockHeld) {
       return
     }
-    const timer = setTimeout(() => setLockHeld(true), 600)
+    const timer = setTimeout(() => setLockHeld(rawLockHeld), INPUT_LOCK_SETTLE_MS)
     return () => clearTimeout(timer)
-  }, [rawLockReason])
-  const lockReason = lockHeld ? rawLockReason : null
+  }, [lockHeld, rawLockHeld])
+  const lockReason = lockHeld ? lastLockReasonRef.current : null
 
   return (
     <View style={[styles.root, { paddingBottom: bottomPad }]}>

--- a/mobile/src/session/MobileNativeChatView.tsx
+++ b/mobile/src/session/MobileNativeChatView.tsx
@@ -256,10 +256,6 @@ export function MobileNativeChatView({
   const rawLockReason = inputLockReason ?? null
   const rawLockHeld = rawLockReason !== null
   const [lockHeld, setLockHeld] = useState(false)
-  const lastLockReasonRef = useRef(rawLockReason)
-  if (rawLockReason !== null) {
-    lastLockReasonRef.current = rawLockReason
-  }
   useEffect(() => {
     if (rawLockHeld === lockHeld) {
       return
@@ -267,7 +263,7 @@ export function MobileNativeChatView({
     const timer = setTimeout(() => setLockHeld(rawLockHeld), INPUT_LOCK_SETTLE_MS)
     return () => clearTimeout(timer)
   }, [lockHeld, rawLockHeld])
-  const lockReason = lockHeld ? lastLockReasonRef.current : null
+  const lockReason = lockHeld ? (rawLockReason ?? 'waiting') : null
 
   return (
     <View style={[styles.root, { paddingBottom: bottomPad }]}>


### PR DESCRIPTION
## Summary

- settle both native-chat input-lock edges for 600 ms
- keep the composer locked through a stale terminal's `subscribed` → `end` response
- add regression coverage for the false-ready pulse and healthy unlock path

## Root cause

The existing flicker guard delayed showing a lock but removed it immediately. A stale PTY can briefly acknowledge `subscribed` before emitting `end`, so the send button enabled for roughly 600 ms and then disabled again.

The actual send path remains immediately gated by live connection and lease state; this change only stabilizes the visible composer state.

## Validation

- `pnpm --dir mobile test` — 3,301 passed, 3 skipped
- `pnpm --dir mobile typecheck`
- oxlint and oxfmt on the changed files
- max-lines ratchet
- CDP-attached Electron dev build confirmed the intended worktree
- iPhone 17 Pro simulator loaded the branch bundle and exercised paired native chat with empty and typed composer states

The exact stale `subscribed` → `end` sequence is covered deterministically by the regression test. During live QA, the LAN host later disconnected and returned the app to the desktop list before that stale-pane sequence could be forced manually.

## iOS evidence

Typed draft / enabled send state:

![ios-draft-enabled.png](https://github.com/user-attachments/assets/8bc39fbf-72ca-4d15-88c8-943bf141aaf1)

Empty composer / disabled send state:

![ios-reconnect.png](https://github.com/user-attachments/assets/15635594-c059-4f12-b3c9-90db05716f78)
