### PR TITLE
fix(mobile): open host editor from root navigation

### DIFF
--- a/mobile/src/accounts/mobile-accounts-route.test.ts
+++ b/mobile/src/accounts/mobile-accounts-route.test.ts
@@ -45,7 +45,7 @@ describe('mobile accounts route', () => {
 
     navigateToHostStackRoute(
       harness.navigation,
-      { push },
+      { push, replace: vi.fn() },
       'host/one',
       mobileAccountsRouteTarget('host/one')
     )

--- a/mobile/src/navigation/host-stack-navigation.test.ts
+++ b/mobile/src/navigation/host-stack-navigation.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import {
   coordinateHostStackNavigation,
   hostStackHostRoute,
+  hostStackRouteHref,
   navigateToHostStackRoute,
   type HostStackNavigationState
 } from './host-stack-navigation'
@@ -69,7 +70,7 @@ describe('host stack navigation', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
 
-    navigateToHostStackRoute(harness.navigation, { push }, 'host/one', TARGET)
+    navigateToHostStackRoute(harness.navigation, { push, replace: vi.fn() }, 'host/one', TARGET)
     expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
 
@@ -89,7 +90,12 @@ describe('host stack navigation', () => {
       rootLayoutScopedState({ index: 0, routes: [{ name: 'index' }] })
     )
 
-    navigateToHostStackRoute(harness.navigation, { push: vi.fn() }, 'host/one', TARGET)
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      'host/one',
+      TARGET
+    )
     harness.setState(rootLayoutScopedState(committedHostState('host/one')))
 
     expect(harness.navigation.dispatch).toHaveBeenCalledWith({
@@ -103,7 +109,12 @@ describe('host stack navigation', () => {
   it('survives the state emitted before the root navigator has hydrated', () => {
     const harness = navigationHarness(undefined)
 
-    navigateToHostStackRoute(harness.navigation, { push: vi.fn() }, 'host/one', TARGET)
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      'host/one',
+      TARGET
+    )
 
     expect(() => harness.setState(undefined)).not.toThrow()
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
@@ -112,10 +123,30 @@ describe('host stack navigation', () => {
     expect(harness.navigation.dispatch).toHaveBeenCalledTimes(1)
   })
 
+  it('replaces through Expo Router when root state omits the mounted child stack', () => {
+    const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const replace = vi.fn()
+
+    navigateToHostStackRoute(harness.navigation, { push: vi.fn(), replace }, 'host/one', TARGET)
+    harness.setState({
+      index: 0,
+      routes: [{ name: 'h', params: { hostId: 'host/one' } }]
+    })
+
+    expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+    expect(replace).toHaveBeenCalledWith(hostStackRouteHref(TARGET))
+    expect(harness.listenerCount()).toBe(0)
+  })
+
   it('abandons the transition when navigation leaves the host route it was waiting on', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
 
-    navigateToHostStackRoute(harness.navigation, { push: vi.fn() }, 'host/one', TARGET)
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      'host/one',
+      TARGET
+    )
     harness.setState({ index: 0, routes: [{ name: 'h' }] })
     harness.setState({ index: 0, routes: [{ name: 'index' }] })
     harness.setState(committedHostState('host/one'))
@@ -127,7 +158,12 @@ describe('host stack navigation', () => {
   it('ignores a different host whose id merely decodes badly', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
 
-    navigateToHostStackRoute(harness.navigation, { push: vi.fn() }, 'host/one', TARGET)
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      'host/one',
+      TARGET
+    )
     harness.setState(committedHostState('100%'))
 
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
@@ -138,7 +174,7 @@ describe('host stack navigation', () => {
 
     const controller = navigateToHostStackRoute(
       harness.navigation,
-      { push: vi.fn() },
+      { push: vi.fn(), replace: vi.fn() },
       'host/one',
       TARGET
     )
@@ -156,7 +192,7 @@ describe('host stack navigation', () => {
   it('retargets a still-pending transition to the same host instead of pushing twice', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
-    const router = { push }
+    const router = { push, replace: vi.fn() }
 
     const pending = coordinateHostStackNavigation(
       null,

--- a/mobile/src/navigation/host-stack-navigation.ts
+++ b/mobile/src/navigation/host-stack-navigation.ts
@@ -35,8 +35,14 @@ export type HostStackRootNavigation = {
 
 export type HostStackHostRoute = `/h/${string}`
 
+export type HostStackRouteHref = Readonly<{
+  pathname: `/h/${string}`
+  params: Readonly<Record<string, string>>
+}>
+
 export type HostStackRouter = {
   push: (route: HostStackHostRoute) => void
+  replace: (route: HostStackRouteHref) => void
 }
 
 export type HostStackNavigationController = Readonly<{
@@ -52,6 +58,10 @@ export type PendingHostStackNavigation = Readonly<{
 
 export function hostStackHostRoute(hostId: string): HostStackHostRoute {
   return `/h/${encodeURIComponent(hostId)}`
+}
+
+export function hostStackRouteHref(target: HostStackRouteTarget): HostStackRouteHref {
+  return { pathname: `/h/${target.name}`, params: target.params }
 }
 
 // Why: the host is pushed as an encoded segment, so the committed route may hold
@@ -144,6 +154,10 @@ export function navigateToHostStackRoute(
     }
     const hostStack = hostContainer && mountedHostStack(hostContainer, hostId)
     if (!hostStack) {
+      if (hostContainer && hostParamMatches(hostContainer.params?.hostId, hostId)) {
+        dispose()
+        router.replace(hostStackRouteHref(selectedTarget))
+      }
       return
     }
     dispose()

--- a/mobile/src/notifications/notification-route-coordination.test.ts
+++ b/mobile/src/notifications/notification-route-coordination.test.ts
@@ -47,7 +47,12 @@ describe('notification route coordination', () => {
     const harness = navigationHarness(undefined)
     const push = vi.fn()
 
-    navigateToHostStackRoute(harness.navigation, { push }, target!.hostId, target!.sessionTarget!)
+    navigateToHostStackRoute(
+      harness.navigation,
+      { push, replace: vi.fn() },
+      target!.hostId,
+      target!.sessionTarget!
+    )
 
     expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()

--- a/mobile/src/session/mobile-session-route.test.ts
+++ b/mobile/src/session/mobile-session-route.test.ts
@@ -81,7 +81,7 @@ describe('mobile session route', () => {
       name: 'Fix #1'
     })
 
-    navigateToHostStackRoute(harness.navigation, { push }, 'host/one', target)
+    navigateToHostStackRoute(harness.navigation, { push, replace: vi.fn() }, 'host/one', target)
 
     expect(push).toHaveBeenCalledWith(hostStackHostRoute('host/one'))
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()

--- a/mobile/src/tasks/mobile-task-navigation.test.ts
+++ b/mobile/src/tasks/mobile-task-navigation.test.ts
@@ -32,8 +32,9 @@ describe('mobile task navigation', () => {
   it('waits for the expected host commit before navigating to Tasks', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
+    const replace = vi.fn()
 
-    navigateToMobileTasks(harness.navigation, { push }, 'host/1')
+    navigateToMobileTasks(harness.navigation, { push, replace }, 'host/1')
 
     expect(harness.navigation.addListener.mock.invocationCallOrder[0]).toBeLessThan(
       push.mock.invocationCallOrder[0]!
@@ -46,38 +47,25 @@ describe('mobile task navigation', () => {
       routes: [{ name: 'index' }, { name: 'h', params: { hostId: 'host/1' } }]
     })
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
-
-    harness.setState({
-      index: 1,
-      routes: [
-        { name: 'index' },
-        {
-          name: 'h',
-          state: {
-            key: '/h',
-            index: 0,
-            routes: [{ key: 'host-index', name: '[hostId]/index', params: { hostId: 'host/1' } }]
-          }
-        }
-      ]
-    })
-
     expect(harness.unsubscribeState).toHaveBeenCalledOnce()
     expect(harness.unsubscribeState.mock.invocationCallOrder[0]).toBeLessThan(
-      harness.navigation.dispatch.mock.invocationCallOrder[0]!
+      replace.mock.invocationCallOrder[0]!
     )
-    expect(harness.navigation.dispatch).toHaveBeenCalledWith({
-      type: 'REPLACE',
-      target: '/h',
-      source: 'host-index',
-      payload: { name: '[hostId]/tasks', params: { hostId: 'host/1' } }
+    expect(replace).toHaveBeenCalledWith({
+      pathname: '/h/[hostId]/tasks',
+      params: { hostId: 'host/1' }
     })
   })
 
   it('ignores unrelated state events and preserves the provider', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
 
-    navigateToMobileTasks(harness.navigation, { push: vi.fn() }, 'host-1', 'linear')
+    navigateToMobileTasks(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      'host-1',
+      'linear'
+    )
     harness.setState({ index: 1, routes: [{ name: 'index' }, { name: 'settings' }] })
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
     harness.setState({ index: 0, routes: [{ name: 'h', params: { hostId: 'host-2' } }] })
@@ -108,30 +96,37 @@ describe('mobile task navigation', () => {
 
   it('cleanup prevents a stale navigation from replacing', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
-    const controller = navigateToMobileTasks(harness.navigation, { push: vi.fn() }, 'host-1')
+    const replace = vi.fn()
+    const controller = navigateToMobileTasks(
+      harness.navigation,
+      { push: vi.fn(), replace },
+      'host-1'
+    )
 
     controller.cancel()
     harness.setState({ index: 0, routes: [{ name: 'h', params: { hostId: 'host-1' } }] })
 
     expect(harness.unsubscribeState).toHaveBeenCalledOnce()
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('reuses a pending host push and applies the latest provider', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
+    const router = { push, replace: vi.fn() }
 
     const first = coordinateMobileTasksNavigation(
       null,
       harness.navigation,
-      { push },
+      router,
       'host-1',
       'github'
     )
     const second = coordinateMobileTasksNavigation(
       first,
       harness.navigation,
-      { push },
+      router,
       'host-1',
       'linear'
     )
@@ -161,11 +156,12 @@ describe('mobile task navigation', () => {
     )
   })
 
-  it('keeps waiting through host setup and cleans up when navigation leaves', () => {
+  it('keeps waiting through host setup without params and cleans up when navigation leaves', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
+    const replace = vi.fn()
 
-    navigateToMobileTasks(harness.navigation, { push: vi.fn() }, 'host-1')
-    harness.setState({ index: 0, routes: [{ name: 'h', params: { hostId: 'host-1' } }] })
+    navigateToMobileTasks(harness.navigation, { push: vi.fn(), replace }, 'host-1')
+    harness.setState({ index: 0, routes: [{ name: 'h' }] })
     expect(harness.unsubscribeState).not.toHaveBeenCalled()
     harness.setState({ index: 0, routes: [{ name: 'index' }] })
     harness.setState({
@@ -184,6 +180,7 @@ describe('mobile task navigation', () => {
 
     expect(harness.unsubscribeState).toHaveBeenCalledOnce()
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
+    expect(replace).not.toHaveBeenCalled()
   })
 
   it('unsubscribes when mounting the host throws synchronously', () => {
@@ -196,7 +193,8 @@ describe('mobile task navigation', () => {
         {
           push: () => {
             throw error
-          }
+          },
+          replace: vi.fn()
         },
         'host-1'
       )

--- a/mobile/src/transport/host-edit-navigation.test.ts
+++ b/mobile/src/transport/host-edit-navigation.test.ts
@@ -52,7 +52,7 @@ describe('mobile host edit navigation', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
     const push = vi.fn()
 
-    navigateToMobileHostEdit(harness.navigation, { push }, 'host/1')
+    navigateToMobileHostEdit(harness.navigation, { push, replace: vi.fn() }, 'host/1')
 
     expect(push).toHaveBeenCalledWith(mobileHostEditHostRoute('host/1'))
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
@@ -75,7 +75,7 @@ describe('mobile host edit navigation', () => {
   it('does not replace an unrelated host route', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
 
-    navigateToMobileHostEdit(harness.navigation, { push: vi.fn() }, 'host-1')
+    navigateToMobileHostEdit(harness.navigation, { push: vi.fn(), replace: vi.fn() }, 'host-1')
     harness.setState(committedHostState('host-2'))
 
     expect(harness.navigation.dispatch).not.toHaveBeenCalled()
@@ -83,7 +83,7 @@ describe('mobile host edit navigation', () => {
 
   it('disposes itself when navigation leaves the host flow without cancel()', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
-    navigateToMobileHostEdit(harness.navigation, { push: vi.fn() }, 'host-1')
+    navigateToMobileHostEdit(harness.navigation, { push: vi.fn(), replace: vi.fn() }, 'host-1')
 
     // Enter the host flow for a different host, then leave it entirely.
     harness.setState(committedHostState('host-2'))
@@ -97,7 +97,11 @@ describe('mobile host edit navigation', () => {
 
   it('cancels a pending replacement when navigation leaves the host flow', () => {
     const harness = navigationHarness({ index: 0, routes: [{ name: 'index' }] })
-    const controller = navigateToMobileHostEdit(harness.navigation, { push: vi.fn() }, 'host-1')
+    const controller = navigateToMobileHostEdit(
+      harness.navigation,
+      { push: vi.fn(), replace: vi.fn() },
+      'host-1'
+    )
 
     harness.setState(committedHostState('host-2'))
     controller.cancel()


### PR DESCRIPTION
## Summary

- restore Edit host navigation when Expo Router commits the parent `h` route without publishing nested child-stack state
- fall back to typed `router.replace` after confirming the committed `hostId`
- require the shared host-stack router contract and add regression coverage for the live root-state shape

## Screenshots

No visual change. This restores the existing Edit host form.

Live iOS simulator QA on iPhone 17 Pro:
- connected Host 26 opened Edit host with populated Name and Address fields
- disconnected Host 21 opened Edit host with populated Name and Address fields

## Testing

- [ ] `pnpm lint` — not run repo-wide; changed files passed `oxlint`
- [ ] `pnpm typecheck` — not run repo-wide; mobile `tsc --noEmit` passed
- [ ] `pnpm test` — not run through the wrapper; full mobile Vitest passed: 3,300 passed, 3 skipped
- [ ] `pnpm build` — not run; no build-system, dependency, native, or packaging changes
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Post-rebase focused validation: 24 tests passed across host-stack, edit-host, Accounts, notifications, and session routing.

## AI Review Report

Reviewed the shared mount-then-replace navigation flow against the root navigation state captured from the live simulator. The main risk was replacing the wrong host or losing route params when nested state is absent. The fallback is gated by the existing encoded/raw host-id matcher, preserves the typed target params, disposes the pending listener before replacement, and retains the targeted React Navigation dispatch when nested state is available.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change is platform-neutral React Navigation/Expo Router code and does not touch shortcuts, labels, paths, shell behavior, SSH/folder-workspace behavior, or Electron-specific APIs.

## Security Audit

No new command execution, filesystem/path handling, IPC, authentication, secrets, dependencies, or wire-protocol behavior. Existing host IDs still pass through the encoded base-route helper and are compared with the existing guarded decoder before the typed route replacement. No follow-up security work is needed.

## Notes

Electron CDP attachment was unavailable because the active Orca process was not launched with a debugging port, and relaunching it would terminate the active workspace. No OS-level UI automation was substituted.