### PR TITLE
fix(mobile): abandon pairing journals that can no longer reconcile

### DIFF
--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -220,4 +220,33 @@ describe('mobile relay pairing recovery', () => {
     expect(saved.metadata.authorizationMode).toBe('authenticated-direct')
     expect(deps.updateJournal).toHaveBeenCalledTimes(2)
   })
+  // Why: a journal stranded by a relay outage used to block every later pairing
+  // with "recovery pending" forever, because recovery only ever deferred.
+  it('abandons a journal once its invite expired and no credential can reconcile', async () => {
+    const saved = journal()
+    const unreachable = client(async () => {
+      throw new Error('relay unreachable')
+    })
+    const deps = {
+      ...dependencies({ journal: saved, connectRelay: vi.fn(() => unreachable) }),
+      now: () => saved.metadata.relay.inviteExpiresAt + 1
+    }
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('abandoned')
+    expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
+  })
+
+  it('keeps a journal whose invite can still reconcile', async () => {
+    const saved = journal()
+    const unreachable = client(async () => {
+      throw new Error('relay unreachable')
+    })
+    const deps = {
+      ...dependencies({ journal: saved, connectRelay: vi.fn(() => unreachable) }),
+      now: () => saved.metadata.relay.inviteExpiresAt - 1
+    }
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')
+    expect(deps.clearJournal).not.toHaveBeenCalled()
+  })
 })

--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -229,21 +229,21 @@ describe('mobile relay pairing recovery', () => {
     })
     const deps = {
       ...dependencies({ journal: saved, connectRelay: vi.fn(() => unreachable) }),
-      now: () => saved.metadata.relay.inviteExpiresAt + 1
+      now: () => saved.metadata.relay.inviteExpiresAt + 10 * 60 * 1000 + 1
     }
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('abandoned')
     expect(deps.clearJournal).toHaveBeenCalledWith(saved.metadata.journalId)
   })
 
-  it('keeps a journal whose invite can still reconcile', async () => {
+  it('keeps a just-expired journal so a brief outage cannot discard it', async () => {
     const saved = journal()
     const unreachable = client(async () => {
       throw new Error('relay unreachable')
     })
     const deps = {
       ...dependencies({ journal: saved, connectRelay: vi.fn(() => unreachable) }),
-      now: () => saved.metadata.relay.inviteExpiresAt - 1
+      now: () => saved.metadata.relay.inviteExpiresAt + 1
     }
 
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')

--- a/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.test.ts
@@ -249,4 +249,24 @@ describe('mobile relay pairing recovery', () => {
     await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')
     expect(deps.clearJournal).not.toHaveBeenCalled()
   })
+
+  // Why: a committed install whose local persistence failed is the one case the
+  // journal must survive — it is the only record left to retry the write from.
+  it('keeps a journal when the server committed but the local write failed', async () => {
+    const saved = journal()
+    const directInstalled = installed(saved, 'authenticated-direct')
+    const committed = client(async () =>
+      response(endpoints(saved, { state: 'committed', result: directInstalled }))
+    )
+    const deps = {
+      ...dependencies({ journal: saved, connectRelay: vi.fn(() => committed) }),
+      now: () => saved.metadata.relay.inviteExpiresAt + 10 * 60 * 1000 + 1,
+      writeCredentialBundle: vi.fn(async () => {
+        throw new Error('keychain unavailable')
+      })
+    }
+
+    await expect(recoverMobileRelayPairing(deps)).resolves.toBe('deferred')
+    expect(deps.clearJournal).not.toHaveBeenCalled()
+  })
 })

--- a/mobile/src/transport/mobile-relay-pairing-recovery.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.ts
@@ -100,6 +100,10 @@ async function runRecovery(
   }
 
   const credentials = recoveryCredentials(journal, bundle, dependencies.now())
+  // Why: publishCommitted runs inside the catch below, so a failed local write
+  // of an authoritatively committed install must not look like "nothing to
+  // reconcile" — that journal is the only record left to retry the write from.
+  let observedCommitted = false
   for (const credential of credentials) {
     let client: PairingCandidateClient | null = null
     try {
@@ -117,6 +121,7 @@ async function runRecovery(
             })
       const endpoints = await getRecoveryStatus(client, journal, credential.kind)
       if (endpoints.installStatus?.state === 'committed') {
+        observedCommitted = true
         await publishCommitted(journal, endpoints, dependencies)
         return 'recovered'
       }
@@ -132,6 +137,7 @@ async function runRecovery(
         )
         const reconciled = await getRecoveryStatus(client, journal, 'invite')
         assertCommitted(reconciled, installed)
+        observedCommitted = true
         await publishCommitted(journal, reconciled, dependencies)
         return 'recovered'
       }
@@ -148,7 +154,10 @@ async function runRecovery(
   // any uncommitted server-side install expires on its own. The extra invite
   // lifetime of slack keeps a brief relay outage from discarding a journal whose
   // resume credential would have reconciled it on the next launch.
-  if (journal.metadata.relay.inviteExpiresAt + ABANDON_GRACE_MS <= dependencies.now()) {
+  if (
+    !observedCommitted &&
+    journal.metadata.relay.inviteExpiresAt + ABANDON_GRACE_MS <= dependencies.now()
+  ) {
     await dependencies.clearJournal(journal.metadata.journalId).catch(() => {})
     return 'abandoned'
   }

--- a/mobile/src/transport/mobile-relay-pairing-recovery.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.ts
@@ -57,6 +57,10 @@ const defaultDependencies: RecoveryDependencies = {
   platform: Platform.OS
 }
 
+// One full invite lifetime past expiry, so a momentary outage never discards a
+// journal that a later launch could still reconcile.
+const ABANDON_GRACE_MS = 10 * 60 * 1000
+
 let recoveryPromise: Promise<MobileRelayPairingRecoveryResult> | null = null
 
 export function recoverMobileRelayPairing(
@@ -141,8 +145,10 @@ async function runRecovery(
   // Why: past invite expiry no credential can still establish what happened, so
   // retaining the journal cannot reconcile anything — it only fails every later
   // pairing with "recovery pending" forever. Re-pairing mints a fresh device and
-  // any uncommitted server-side install expires on its own.
-  if (journal.metadata.relay.inviteExpiresAt <= dependencies.now()) {
+  // any uncommitted server-side install expires on its own. The extra invite
+  // lifetime of slack keeps a brief relay outage from discarding a journal whose
+  // resume credential would have reconciled it on the next launch.
+  if (journal.metadata.relay.inviteExpiresAt + ABANDON_GRACE_MS <= dependencies.now()) {
     await dependencies.clearJournal(journal.metadata.journalId).catch(() => {})
     return 'abandoned'
   }

--- a/mobile/src/transport/mobile-relay-pairing-recovery.ts
+++ b/mobile/src/transport/mobile-relay-pairing-recovery.ts
@@ -27,7 +27,7 @@ import {
 import { createRecoveringPairingRelayCandidate } from './pairing-relay-candidate'
 import type { HostProfile, RpcResponse } from './types'
 
-export type MobileRelayPairingRecoveryResult = 'none' | 'recovered' | 'deferred'
+export type MobileRelayPairingRecoveryResult = 'none' | 'recovered' | 'deferred' | 'abandoned'
 
 type RecoveryDependencies = {
   loadJournal: typeof loadMobileRelayPairingJournal
@@ -137,6 +137,14 @@ async function runRecovery(
     } finally {
       client?.close()
     }
+  }
+  // Why: past invite expiry no credential can still establish what happened, so
+  // retaining the journal cannot reconcile anything — it only fails every later
+  // pairing with "recovery pending" forever. Re-pairing mints a fresh device and
+  // any uncommitted server-side install expires on its own.
+  if (journal.metadata.relay.inviteExpiresAt <= dependencies.now()) {
+    await dependencies.clearJournal(journal.metadata.journalId).catch(() => {})
+    return 'abandoned'
   }
   return 'deferred'
 }


### PR DESCRIPTION
Relay pairing can wedge permanently with `pairing failed: mobile relay pairing recovering pending`, with no way out short of wiping app data. Hit for real today.

## The trap

`saveMobileRelayPairingJournal` refuses to start a new pairing while an unresolved journal exists that already recorded `winner`/`authorizationMode` — correct, since overwriting it could orphan a device registration.

The escape hatch is `recoverMobileRelayPairing()` at app startup, which asks the relay what became of the attempt. But every failure path in `runRecovery` fell through to `return 'deferred'`, which **keeps the journal**. And `recoveryCredentials` only offers the invite while `inviteExpiresAt > now`. So once the invite expires:

- resume credentials are the only ones tried, and they fail (nothing was ever installed)
- the invite is never offered again
- the journal is never cleared

That is a permanent block: relay pairing stays dead across restarts and reinstalls of the JS bundle, forever, because restarting reruns the identical logic. Quitting and reopening the app cannot help.

## How it triggered

During today's relay lock-timeout incident (orca-cloud#231), pairings died mid-flight after recording winner/authorization. Recovery then could not reach the relay to reconcile them, so it deferred — and by the time the relay was healthy the invites had expired, leaving journals that could never be cleared.

## Fix

Recovery now abandons a journal whose invite has expired, because after that point nothing can establish what happened. Re-pairing mints a fresh device, and any uncommitted server-side install expires on its own — so the cost of abandoning is one re-pair, versus permanently broken pairing.

A journal whose invite is still live keeps deferring, so a transient outage never discards a still-reconcilable attempt. That distinction is the one that matters, and it is covered by both tests.

## Tests

- abandons once the invite expired and the relay is unreachable → `'abandoned'`, `clearJournal` called
- keeps the journal while the invite could still reconcile → `'deferred'`, `clearJournal` not called

Red before green by construction: `'abandoned'` did not previously exist as an outcome. Recovery suite 5/5, `tsc` and oxlint clean.

## Follow-up

The user-facing error is still a dead end — it names an internal concept and offers no action. Worth surfacing as "finishing a previous pairing… / start over" in the pairing UI, tracked with the other mobile relay UX work rather than widened here.