### PR TITLE
feat(agent-status): add daemon agent-hook binding store

### DIFF
--- a/src/shared/agent-hook-binding-store.test.ts
+++ b/src/shared/agent-hook-binding-store.test.ts
@@ -1,0 +1,348 @@
+import { describe, expect, it } from 'vitest'
+import {
+  createAgentHookBindingStore,
+  hashAgentLaunchToken,
+  type AgentHookBindingEvent
+} from './agent-hook-binding-store'
+import { AGENT_STATUS_STALE_AFTER_MS, type ParsedAgentStatusPayload } from './agent-status-types'
+
+function payload(
+  state: ParsedAgentStatusPayload['state'],
+  prompt = 'do the thing'
+): ParsedAgentStatusPayload {
+  return { state, prompt, agentType: 'claude' }
+}
+
+function event(overrides: Partial<AgentHookBindingEvent> = {}): AgentHookBindingEvent {
+  return {
+    terminalHandle: 'term_a',
+    terminalIncarnationId: 'inc_1',
+    receivedAt: 1_000,
+    payload: payload('working'),
+    ...overrides
+  }
+}
+
+describe('agent hook binding store', () => {
+  it('replaces the binding in place as an agent moves working → done', () => {
+    const store = createAgentHookBindingStore()
+
+    const first = store.applyEvent(event({ payload: payload('working'), receivedAt: 1_000 }))
+    const second = store.applyEvent(event({ payload: payload('done'), receivedAt: 2_000 }))
+
+    expect(first.accepted).toBe(true)
+    expect(second.accepted).toBe(true)
+    const snapshot = store.snapshot()
+    expect(snapshot.bindings).toHaveLength(1)
+    expect(snapshot.bindings[0].payload.state).toBe('done')
+    expect(snapshot.bindings[0].receivedAt).toBe(2_000)
+    expect(snapshot.bindings[0].revision).toBe(2)
+    expect(snapshot.revision).toBe(2)
+  })
+
+  it('keeps latest-wins per terminal identity and rejects an out-of-order same-launch event', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ launchToken: 'tok', receivedAt: 2_000, payload: payload('done') }))
+
+    const late = store.applyEvent(
+      event({ launchToken: 'tok', receivedAt: 1_500, payload: payload('working') })
+    )
+
+    expect(late).toEqual({ accepted: false, reason: 'stale-event' })
+    expect(store.getBinding('term_a', 'inc_1')?.payload.state).toBe('done')
+    expect(store.snapshot().revision).toBe(1)
+  })
+
+  it('rejects a late event for a cleared incarnation instead of resurrecting it', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ receivedAt: 1_000 }))
+
+    const cleared = store.clearTerminalIncarnation('term_a', 'inc_1')
+    const late = store.applyEvent(event({ receivedAt: 5_000, payload: payload('done') }))
+
+    expect(cleared.removed).toBe(true)
+    expect(late).toEqual({ accepted: false, reason: 'cleared-terminal-incarnation' })
+    expect(store.getBinding('term_a', 'inc_1')).toBeUndefined()
+    expect(store.snapshot().bindings).toEqual([])
+    // Why: the clear bumped the revision; the rejected resurrection did not.
+    expect(store.snapshot().revision).toBe(2)
+  })
+
+  it('never lets a late event from an old launch token overwrite a newer agent', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(
+      event({ launchToken: 'launch-1', receivedAt: 1_000, payload: payload('working', 'first') })
+    )
+
+    const relaunch = store.applyEvent(
+      event({ launchToken: 'launch-2', receivedAt: 2_000, payload: payload('working', 'second') })
+    )
+    const lateFromOldLaunch = store.applyEvent(
+      event({ launchToken: 'launch-1', receivedAt: 1_500, payload: payload('done', 'first') })
+    )
+    const simultaneousFromOldLaunch = store.applyEvent(
+      event({ launchToken: 'launch-1', receivedAt: 2_000, payload: payload('done', 'first') })
+    )
+
+    expect(relaunch.accepted).toBe(true)
+    expect(lateFromOldLaunch).toEqual({ accepted: false, reason: 'stale-launch-token' })
+    expect(simultaneousFromOldLaunch).toEqual({ accepted: false, reason: 'stale-launch-token' })
+    const binding = store.getBinding('term_a', 'inc_1')
+    expect(binding?.payload.prompt).toBe('second')
+    expect(binding?.launchTokenHash).toBe(hashAgentLaunchToken('launch-2'))
+    expect(store.snapshot().revision).toBe(2)
+  })
+
+  it('lets a strictly newer launch token take over the terminal', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ launchToken: 'launch-1', receivedAt: 1_000 }))
+
+    const takeover = store.applyEvent(
+      event({ launchToken: 'launch-2', receivedAt: 1_001, payload: payload('working', 'newer') })
+    )
+
+    expect(takeover.accepted).toBe(true)
+    expect(store.getBinding('term_a', 'inc_1')?.payload.prompt).toBe('newer')
+  })
+
+  it('stores only a launch token hash, never the token itself', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ launchToken: 'super-secret-token' }))
+
+    const binding = store.getBinding('term_a', 'inc_1')
+    expect(binding?.launchTokenHash).toBe(hashAgentLaunchToken('super-secret-token'))
+    expect(JSON.stringify(binding)).not.toContain('super-secret-token')
+  })
+
+  it('accepts a pre-hashed launch token as the same generation identity', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ launchToken: 'launch-1', receivedAt: 1_000 }))
+
+    const sameGeneration = store.applyEvent(
+      event({ launchTokenHash: hashAgentLaunchToken('launch-1'), receivedAt: 1_000 })
+    )
+
+    // Same generation ties are accepted; a mismatched token at the same instant would not be.
+    expect(sameGeneration.accepted).toBe(true)
+  })
+
+  it('allows a fresh incarnation of the same terminal handle after a clear', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ terminalIncarnationId: 'inc_1', receivedAt: 1_000 }))
+    store.clearTerminalIncarnation('term_a', 'inc_1')
+
+    const reused = store.applyEvent(
+      event({
+        terminalIncarnationId: 'inc_2',
+        receivedAt: 500,
+        payload: payload('working', 'new shell')
+      })
+    )
+
+    expect(reused.accepted).toBe(true)
+    expect(store.getBinding('term_a', 'inc_1')).toBeUndefined()
+    // Why: a fresh incarnation starts with no prior binding, so even an older timestamp lands.
+    expect(store.getBinding('term_a', 'inc_2')?.payload.prompt).toBe('new shell')
+    expect(store.snapshot().bindings.map((binding) => binding.terminalIncarnationId)).toEqual([
+      'inc_2'
+    ])
+  })
+
+  it('stores, snapshots, and clears a binding that carries no paneKey', () => {
+    const store = createAgentHookBindingStore()
+
+    const applied = store.applyEvent(event({ paneKey: undefined, receivedAt: 1_000 }))
+    const snapshot = store.snapshot()
+    const cleared = store.clearTerminalIncarnation('term_a', 'inc_1')
+
+    expect(applied.accepted).toBe(true)
+    expect(snapshot.bindings[0].paneKey).toBeUndefined()
+    expect(snapshot.bindings[0].terminalHandle).toBe('term_a')
+    expect(cleared.removed).toBe(true)
+    expect(store.snapshot().bindings).toEqual([])
+  })
+
+  it('keeps a proven paneKey as metadata and drops an unusable one', () => {
+    const store = createAgentHookBindingStore()
+
+    store.applyEvent(event({ paneKey: 'tab-1:leaf-1' }))
+    store.applyEvent(event({ terminalIncarnationId: 'inc_2', paneKey: '   ' }))
+
+    expect(store.getBinding('term_a', 'inc_1')?.paneKey).toBe('tab-1:leaf-1')
+    expect(store.getBinding('term_a', 'inc_2')?.paneKey).toBeUndefined()
+  })
+
+  it('omits a cleared binding from the snapshot and bumps the revision', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ terminalIncarnationId: 'inc_1' }))
+    store.applyEvent(event({ terminalIncarnationId: 'inc_2' }))
+
+    const cleared = store.clearTerminalIncarnation('term_a', 'inc_1')
+    const snapshot = store.snapshot()
+
+    expect(cleared.revision).toBe(3)
+    expect(cleared.binding?.terminalIncarnationId).toBe('inc_1')
+    expect(snapshot.revision).toBe(3)
+    expect(snapshot.bindings.map((binding) => binding.terminalIncarnationId)).toEqual(['inc_2'])
+  })
+
+  it('bumps the revision on accepts and clears but never on rejections', () => {
+    const store = createAgentHookBindingStore()
+    const revisions: number[] = []
+
+    revisions.push(store.snapshot().revision)
+    store.applyEvent(event({ receivedAt: 1_000 }))
+    revisions.push(store.snapshot().revision)
+    store.applyEvent(event({ receivedAt: 500 })) // rejected: older
+    revisions.push(store.snapshot().revision)
+    store.applyEvent(event({ terminalHandle: '', receivedAt: 2_000 })) // rejected: identity
+    revisions.push(store.snapshot().revision)
+    store.applyEvent(event({ receivedAt: 2_000, payload: payload('done') }))
+    revisions.push(store.snapshot().revision)
+    store.clearTerminalIncarnation('term_a', 'inc_1')
+    revisions.push(store.snapshot().revision)
+    store.clearTerminalIncarnation('term_a', 'inc_1') // already cleared: no state change
+    revisions.push(store.snapshot().revision)
+    store.applyEvent(event({ receivedAt: 3_000 })) // rejected: tombstoned
+    revisions.push(store.snapshot().revision)
+
+    expect(revisions).toEqual([0, 1, 1, 1, 2, 3, 3, 3])
+  })
+
+  it('rejects payloads that are not objects carrying a known agent status state', () => {
+    const store = createAgentHookBindingStore()
+
+    const reasons = [
+      store.applyEvent(event({ payload: undefined as never })),
+      store.applyEvent(event({ payload: null as never })),
+      store.applyEvent(event({ payload: 'working' as never })),
+      store.applyEvent(event({ payload: { state: 'exploded', prompt: '' } as never })),
+      store.applyEvent(event({ payload: { state: 'working' } as never }))
+    ]
+
+    expect(reasons).toEqual(reasons.map(() => ({ accepted: false, reason: 'invalid-payload' })))
+    expect(store.snapshot()).toEqual({ revision: 0, bindings: [] })
+  })
+
+  it('rejects unusable terminal identities, including separator-bearing ones', () => {
+    const store = createAgentHookBindingStore()
+
+    const rejections = [
+      store.applyEvent(event({ terminalHandle: '   ' })),
+      store.applyEvent(event({ terminalIncarnationId: undefined as never })),
+      store.applyEvent(event({ terminalHandle: 'a'.repeat(201) })),
+      // Why: without the separator guard these two would collide into one binding key.
+      store.applyEvent(event({ terminalHandle: 'term_a\u0000inc_1', terminalIncarnationId: 'x' }))
+    ]
+
+    expect(rejections).toEqual(
+      rejections.map(() => ({ accepted: false, reason: 'invalid-terminal-identity' }))
+    )
+    expect(store.applyEvent(event({ receivedAt: Number.NaN })).accepted).toBe(false)
+    expect(store.snapshot()).toEqual({ revision: 0, bindings: [] })
+  })
+
+  it('evicts the oldest binding when every tracked binding is live', () => {
+    const store = createAgentHookBindingStore({ maxBindings: 2 })
+    store.applyEvent(event({ terminalIncarnationId: 'oldest', receivedAt: 1_000 }))
+    store.applyEvent(event({ terminalIncarnationId: 'newer', receivedAt: 1_000 }))
+
+    const applied = store.applyEvent(event({ terminalIncarnationId: 'current', receivedAt: 1_000 }))
+
+    expect(applied.accepted && applied.evicted.map((b) => b.terminalIncarnationId)).toEqual([
+      'oldest'
+    ])
+    expect(store.snapshot().bindings.map((b) => b.terminalIncarnationId)).toEqual([
+      'newer',
+      'current'
+    ])
+  })
+
+  it('prefers a done or stale binding over the merely-oldest one, using the injected clock', () => {
+    const store = createAgentHookBindingStore({ maxBindings: 3 })
+    const now = 10 * AGENT_STATUS_STALE_AFTER_MS
+    store.applyEvent(event({ terminalIncarnationId: 'fresh-oldest', receivedAt: now }))
+    store.applyEvent(
+      event({ terminalIncarnationId: 'stale', receivedAt: now - AGENT_STATUS_STALE_AFTER_MS - 1 })
+    )
+    store.applyEvent(
+      event({ terminalIncarnationId: 'done', receivedAt: now, payload: payload('done') })
+    )
+
+    const applied = store.applyEvent(event({ terminalIncarnationId: 'current', receivedAt: now }), {
+      now
+    })
+
+    expect(applied.accepted && applied.evicted.map((b) => b.terminalIncarnationId)).toEqual([
+      'stale'
+    ])
+    expect(store.snapshot().bindings.map((b) => b.terminalIncarnationId)).toEqual([
+      'fresh-oldest',
+      'done',
+      'current'
+    ])
+  })
+
+  it('does not tombstone an evicted binding, so a live terminal can re-bind', () => {
+    const store = createAgentHookBindingStore({ maxBindings: 1 })
+    store.applyEvent(event({ terminalIncarnationId: 'evicted', receivedAt: 1_000 }))
+    store.applyEvent(event({ terminalIncarnationId: 'winner', receivedAt: 1_000 }))
+
+    const rebind = store.applyEvent(event({ terminalIncarnationId: 'evicted', receivedAt: 2_000 }))
+
+    expect(rebind.accepted).toBe(true)
+    expect(store.getBinding('term_a', 'evicted')?.receivedAt).toBe(2_000)
+  })
+
+  it('drops the oldest tombstone once the cleared-incarnation bound is exceeded', () => {
+    const store = createAgentHookBindingStore({ maxClearedIncarnations: 2 })
+    for (const incarnation of ['inc_1', 'inc_2', 'inc_3']) {
+      store.applyEvent(event({ terminalIncarnationId: incarnation, receivedAt: 1_000 }))
+      store.clearTerminalIncarnation('term_a', incarnation)
+    }
+
+    const pastHorizon = store.applyEvent(
+      event({ terminalIncarnationId: 'inc_1', receivedAt: 2_000 })
+    )
+    const stillFenced = store.applyEvent(
+      event({ terminalIncarnationId: 'inc_2', receivedAt: 2_000 })
+    )
+
+    // Why: beyond the documented tombstone horizon a late event is indistinguishable from a
+    // fresh one, so it is allowed through; the two most recent clears stay fenced.
+    expect(pastHorizon.accepted).toBe(true)
+    expect(stillFenced).toEqual({ accepted: false, reason: 'cleared-terminal-incarnation' })
+    expect(store.applyEvent(event({ terminalIncarnationId: 'inc_3', receivedAt: 2_000 }))).toEqual({
+      accepted: false,
+      reason: 'cleared-terminal-incarnation'
+    })
+  })
+
+  it('rejects a non-positive bound instead of silently running unbounded', () => {
+    expect(() => createAgentHookBindingStore({ maxBindings: 0 })).toThrow(RangeError)
+    expect(() => createAgentHookBindingStore({ maxClearedIncarnations: -1 })).toThrow(RangeError)
+  })
+
+  it('hands out copies so a snapshot consumer cannot mutate stored bindings', () => {
+    const store = createAgentHookBindingStore()
+    store.applyEvent(event({ receivedAt: 1_000 }))
+
+    const snapshot = store.snapshot()
+    snapshot.bindings[0].receivedAt = 9_999
+    snapshot.bindings.pop()
+
+    expect(store.getBinding('term_a', 'inc_1')?.receivedAt).toBe(1_000)
+    expect(store.snapshot().bindings).toHaveLength(1)
+  })
+
+  it('keeps stores independent: revisions are per instance', () => {
+    const first = createAgentHookBindingStore()
+    const second = createAgentHookBindingStore()
+
+    first.applyEvent(event({ receivedAt: 1_000 }))
+    first.applyEvent(event({ receivedAt: 2_000, payload: payload('done') }))
+
+    expect(first.snapshot().revision).toBe(2)
+    expect(second.snapshot().revision).toBe(0)
+  })
+})

--- a/src/shared/agent-hook-binding-store.ts
+++ b/src/shared/agent-hook-binding-store.ts
@@ -1,0 +1,302 @@
+// Why: daemon-side authoritative container for the latest agent hook status per terminal
+// incarnation. The PTY owner — not the renderer — decides which agent a terminal is bound to,
+// so this store fences late events from reaped incarnations and superseded launch tokens
+// (the relay ghost-row bug class). Node-only: no Electron, no timers, no ambient clock.
+
+import { createHash } from 'node:crypto'
+
+import type { AgentHookSource } from './agent-hook-relay'
+import { AGENT_STATUS_STATES, type ParsedAgentStatusPayload } from './agent-status-types'
+import {
+  assertAgentHookStatusBound,
+  MAX_AGENT_HOOK_STATUS_ENTRIES,
+  selectAgentHookStatusEvictionKey,
+  type AgentHookStatusEvictionCandidate
+} from './agent-hook-status-eviction-policy'
+
+/** Binding-count bound; shares the pane cache's policy and ceiling. */
+export const MAX_AGENT_HOOK_BINDINGS = MAX_AGENT_HOOK_STATUS_ENTRIES
+/**
+ * Cleared incarnations remembered so late events reject instead of resurrecting a reaped
+ * terminal. Sized well above any realistic live-terminal count so the oldest tombstone is
+ * only dropped long after its terminal could still be emitting; past that horizon a late
+ * event is indistinguishable from a fresh one and is allowed through.
+ */
+export const MAX_CLEARED_TERMINAL_INCARNATIONS = 2000
+/** Identity length cap, matching the hook listener's pane-key ceiling. */
+export const AGENT_HOOK_BINDING_MAX_IDENTITY_LENGTH = 200
+
+const KEY_SEPARATOR = '\u0000'
+const VALID_STATES: ReadonlySet<string> = new Set<string>(AGENT_STATUS_STATES)
+
+export type AgentHookBindingRejectionReason =
+  /** Missing, over-long, or separator-bearing terminal handle / incarnation id. */
+  | 'invalid-terminal-identity'
+  /** receivedAt was not a finite number, so ordering could not be decided. */
+  | 'invalid-received-at'
+  /** Payload was not an object carrying a known agent status state. */
+  | 'invalid-payload'
+  /** The incarnation was cleared (reaped); bindings are never resurrected. */
+  | 'cleared-terminal-incarnation'
+  /** A different launch token that is not strictly newer than the live binding. */
+  | 'stale-launch-token'
+  /** Same launch token, older than the live binding. */
+  | 'stale-event'
+
+export type AgentHookBinding = {
+  terminalHandle: string
+  terminalIncarnationId: string
+  /** Optional metadata: main deletes ORCA_PANE_KEY when the pane is unproven, so a
+   *  binding must work without it. Never part of the identity key. */
+  paneKey?: string
+  /** Hash of the launch token, never the token itself. Used only for generation fencing. */
+  launchTokenHash?: string
+  source?: AgentHookSource
+  receivedAt: number
+  /** Store revision at which this binding was last accepted. */
+  revision: number
+  /** Pre-normalized by the caller (see module contract); treated as immutable. */
+  payload: ParsedAgentStatusPayload
+}
+
+export type AgentHookBindingEvent = {
+  terminalHandle: string
+  terminalIncarnationId: string
+  paneKey?: string
+  /** Raw token; hashed on entry so the store never retains the secret. */
+  launchToken?: string
+  /** Pre-hashed token, for callers that already hashed it upstream. */
+  launchTokenHash?: string
+  source?: AgentHookSource
+  receivedAt: number
+  payload: ParsedAgentStatusPayload
+}
+
+export type AgentHookBindingApplyResult =
+  | {
+      accepted: true
+      binding: AgentHookBinding
+      revision: number
+      /** Bindings dropped to stay under the bound. Evicted ≠ cleared: no tombstone, so a
+       *  later event from the same live terminal re-creates the binding. */
+      evicted: AgentHookBinding[]
+    }
+  | { accepted: false; reason: AgentHookBindingRejectionReason }
+
+export type AgentHookBindingClearResult = {
+  /** True when a live binding was removed (false when only a tombstone was recorded). */
+  removed: boolean
+  revision: number
+  binding?: AgentHookBinding
+}
+
+export type AgentHookBindingSnapshot = {
+  revision: number
+  /** Least-recently-accepted first. Omission is the authoritative "binding is gone" signal. */
+  bindings: AgentHookBinding[]
+}
+
+export type AgentHookBindingStore = {
+  applyEvent(event: AgentHookBindingEvent, options?: { now?: number }): AgentHookBindingApplyResult
+  clearTerminalIncarnation(
+    terminalHandle: string,
+    terminalIncarnationId: string
+  ): AgentHookBindingClearResult
+  getBinding(terminalHandle: string, terminalIncarnationId: string): AgentHookBinding | undefined
+  snapshot(): AgentHookBindingSnapshot
+}
+
+/** Stable, non-reversible launch-token identity for generation fencing. */
+export function hashAgentLaunchToken(launchToken: string): string {
+  return createHash('sha256').update(launchToken).digest('hex').slice(0, 32)
+}
+
+/**
+ * Latest-wins bindings keyed by terminal identity (handle + incarnation id).
+ *
+ * Trust boundary: payloads are assumed already normalized by
+ * `normalizeAgentStatusPayload` — field caps and structure limits are enforced upstream at
+ * ingest. The store only re-checks the shape it depends on (an object with a known state and
+ * a string prompt) so a malformed value can never take a binding slot.
+ */
+export function createAgentHookBindingStore(
+  options: { maxBindings?: number; maxClearedIncarnations?: number } = {}
+): AgentHookBindingStore {
+  const maxBindings = options.maxBindings ?? MAX_AGENT_HOOK_BINDINGS
+  const maxClearedIncarnations = options.maxClearedIncarnations ?? MAX_CLEARED_TERMINAL_INCARNATIONS
+  assertAgentHookStatusBound(maxBindings)
+  assertAgentHookStatusBound(maxClearedIncarnations)
+
+  const bindings = new Map<string, AgentHookBinding>()
+  const clearedIncarnations = new Set<string>()
+  let revision = 0
+
+  function applyEvent(
+    event: AgentHookBindingEvent,
+    applyOptions: { now?: number } = {}
+  ): AgentHookBindingApplyResult {
+    const terminalHandle = normalizeIdentity(event.terminalHandle)
+    const terminalIncarnationId = normalizeIdentity(event.terminalIncarnationId)
+    if (!terminalHandle || !terminalIncarnationId) {
+      return { accepted: false, reason: 'invalid-terminal-identity' }
+    }
+    if (!Number.isFinite(event.receivedAt)) {
+      return { accepted: false, reason: 'invalid-received-at' }
+    }
+    if (!isAgentStatusPayloadShape(event.payload)) {
+      return { accepted: false, reason: 'invalid-payload' }
+    }
+
+    const key = bindingKey(terminalHandle, terminalIncarnationId)
+    if (clearedIncarnations.has(key)) {
+      return { accepted: false, reason: 'cleared-terminal-incarnation' }
+    }
+
+    const launchTokenHash = resolveLaunchTokenHash(event)
+    const current = bindings.get(key)
+    if (current) {
+      // Why: a different launch token means a different agent generation — it may only take
+      // over when strictly newer, so a delayed event from the previous agent (or an untokened
+      // event) can never clobber the agent now living in this terminal.
+      const sameLaunch = current.launchTokenHash === launchTokenHash
+      if (
+        sameLaunch ? event.receivedAt < current.receivedAt : event.receivedAt <= current.receivedAt
+      ) {
+        return { accepted: false, reason: sameLaunch ? 'stale-event' : 'stale-launch-token' }
+      }
+    }
+
+    revision += 1
+    const paneKey = normalizeIdentity(event.paneKey)
+    const binding: AgentHookBinding = {
+      terminalHandle,
+      terminalIncarnationId,
+      receivedAt: event.receivedAt,
+      revision,
+      payload: event.payload,
+      ...(paneKey ? { paneKey } : {}),
+      ...(launchTokenHash ? { launchTokenHash } : {}),
+      ...(event.source ? { source: event.source } : {})
+    }
+    // Why: re-insert so Map iteration order stays acceptance order — the eviction policy's
+    // "oldest inserted" fallback depends on it.
+    bindings.delete(key)
+    bindings.set(key, binding)
+
+    const evicted = evictOverflow(key, applyOptions.now ?? event.receivedAt)
+    return { accepted: true, binding: { ...binding }, revision, evicted }
+  }
+
+  function evictOverflow(protectedKey: string, now: number): AgentHookBinding[] {
+    const evicted: AgentHookBinding[] = []
+    while (bindings.size > maxBindings) {
+      const key = selectAgentHookStatusEvictionKey(evictionCandidates(), protectedKey, now)
+      if (!key) {
+        break
+      }
+      const dropped = bindings.get(key)
+      if (!dropped) {
+        break
+      }
+      bindings.delete(key)
+      evicted.push(dropped)
+    }
+    return evicted
+  }
+
+  function* evictionCandidates(): Iterable<readonly [string, AgentHookStatusEvictionCandidate]> {
+    for (const [key, binding] of bindings) {
+      yield [key, { state: binding.payload.state, receivedAt: binding.receivedAt }]
+    }
+  }
+
+  function clearTerminalIncarnation(
+    terminalHandle: string,
+    terminalIncarnationId: string
+  ): AgentHookBindingClearResult {
+    const handle = normalizeIdentity(terminalHandle)
+    const incarnationId = normalizeIdentity(terminalIncarnationId)
+    if (!handle || !incarnationId) {
+      return { removed: false, revision }
+    }
+    const key = bindingKey(handle, incarnationId)
+    const existing = bindings.get(key)
+    const alreadyTombstoned = clearedIncarnations.has(key)
+    if (!existing && alreadyTombstoned) {
+      return { removed: false, revision }
+    }
+    bindings.delete(key)
+    if (!alreadyTombstoned) {
+      clearedIncarnations.add(key)
+      // FIFO by first-clear time: the longest-dead incarnation is the least likely to still
+      // have an event in flight.
+      while (clearedIncarnations.size > maxClearedIncarnations) {
+        const oldest = clearedIncarnations.values().next()
+        if (oldest.done) {
+          break
+        }
+        clearedIncarnations.delete(oldest.value)
+      }
+    }
+    revision += 1
+    return {
+      removed: Boolean(existing),
+      revision,
+      ...(existing ? { binding: { ...existing } } : {})
+    }
+  }
+
+  return {
+    applyEvent,
+    clearTerminalIncarnation,
+    getBinding(terminalHandle, terminalIncarnationId) {
+      const handle = normalizeIdentity(terminalHandle)
+      const incarnationId = normalizeIdentity(terminalIncarnationId)
+      if (!handle || !incarnationId) {
+        return undefined
+      }
+      const binding = bindings.get(bindingKey(handle, incarnationId))
+      return binding ? { ...binding } : undefined
+    },
+    snapshot() {
+      return { revision, bindings: [...bindings.values()].map((binding) => ({ ...binding })) }
+    }
+  }
+}
+
+function bindingKey(terminalHandle: string, terminalIncarnationId: string): string {
+  return `${terminalHandle}${KEY_SEPARATOR}${terminalIncarnationId}`
+}
+
+/** Rejects the key separator too, so no pair of identities can collide into one key. */
+function normalizeIdentity(value: unknown): string | undefined {
+  if (typeof value !== 'string') {
+    return undefined
+  }
+  const trimmed = value.trim()
+  if (
+    trimmed.length === 0 ||
+    trimmed.length > AGENT_HOOK_BINDING_MAX_IDENTITY_LENGTH ||
+    trimmed.includes(KEY_SEPARATOR)
+  ) {
+    return undefined
+  }
+  return trimmed
+}
+
+function resolveLaunchTokenHash(event: AgentHookBindingEvent): string | undefined {
+  if (typeof event.launchTokenHash === 'string' && event.launchTokenHash.length > 0) {
+    return event.launchTokenHash
+  }
+  return typeof event.launchToken === 'string' && event.launchToken.length > 0
+    ? hashAgentLaunchToken(event.launchToken)
+    : undefined
+}
+
+function isAgentStatusPayloadShape(payload: unknown): payload is ParsedAgentStatusPayload {
+  if (typeof payload !== 'object' || payload === null) {
+    return false
+  }
+  const { state, prompt } = payload as { state?: unknown; prompt?: unknown }
+  return typeof state === 'string' && VALID_STATES.has(state) && typeof prompt === 'string'
+}

--- a/src/shared/agent-hook-status-cache.ts
+++ b/src/shared/agent-hook-status-cache.ts
@@ -1,11 +1,22 @@
+// Migration note: the eviction policy that used to live here now lives in
+// agent-hook-status-eviction-policy.ts, shared with the daemon-side binding store
+// (agent-hook-binding-store.ts). This file stays as the pane-keyed adapter over that policy
+// for HookListenerState; new terminal-scoped callers should use the binding store instead.
+
 import {
   clearPaneCacheState,
   type AgentHookEventPayload,
   type HookListenerState
 } from './agent-hook-listener'
-import { AGENT_STATUS_STALE_AFTER_MS } from './agent-status-types'
+import {
+  assertAgentHookStatusBound,
+  MAX_AGENT_HOOK_STATUS_ENTRIES,
+  selectAgentHookStatusEvictionKey,
+  type AgentHookStatusEvictionCandidate
+} from './agent-hook-status-eviction-policy'
 
-export const MAX_AGENT_HOOK_STATUS_CACHE_PANES = 500
+/** @deprecated Prefer MAX_AGENT_HOOK_STATUS_ENTRIES; kept for existing pane-keyed callers. */
+export const MAX_AGENT_HOOK_STATUS_CACHE_PANES = MAX_AGENT_HOOK_STATUS_ENTRIES
 
 export type AgentHookStatusCacheEviction = {
   paneKey: string
@@ -17,17 +28,15 @@ export function upsertBoundedAgentHookStatus(
   entry: AgentHookEventPayload,
   options: { maxPanes?: number; now?: number } = {}
 ): AgentHookStatusCacheEviction[] {
-  const maxPanes = options.maxPanes ?? MAX_AGENT_HOOK_STATUS_CACHE_PANES
-  if (!Number.isSafeInteger(maxPanes) || maxPanes < 1) {
-    throw new RangeError('Agent hook status cache limit must be a positive safe integer')
-  }
+  const maxPanes = options.maxPanes ?? MAX_AGENT_HOOK_STATUS_ENTRIES
+  assertAgentHookStatusBound(maxPanes)
 
   state.lastStatusByPaneKey.delete(entry.paneKey)
   state.lastStatusByPaneKey.set(entry.paneKey, entry)
   const evicted: AgentHookStatusCacheEviction[] = []
   const now = options.now ?? Date.now()
   while (state.lastStatusByPaneKey.size > maxPanes) {
-    const paneKey = selectEvictionCandidate(state, entry.paneKey, now)
+    const paneKey = selectAgentHookStatusEvictionKey(evictionCandidates(state), entry.paneKey, now)
     if (!paneKey) {
       break
     }
@@ -41,29 +50,17 @@ export function upsertBoundedAgentHookStatus(
   return evicted
 }
 
-function selectEvictionCandidate(
-  state: HookListenerState,
-  currentPaneKey: string,
-  now: number
-): string | undefined {
-  let oldestFallback: string | undefined
+function* evictionCandidates(
+  state: HookListenerState
+): Iterable<readonly [string, AgentHookStatusEvictionCandidate]> {
   for (const [paneKey, entry] of state.lastStatusByPaneKey) {
-    if (paneKey === currentPaneKey) {
-      continue
-    }
-    oldestFallback ??= paneKey
-    if (entry.payload.state === 'done' || isStaleStatus(entry, now)) {
-      return paneKey
-    }
+    const receivedAt = (entry as AgentHookEventPayload & { receivedAt?: unknown }).receivedAt
+    yield [
+      paneKey,
+      {
+        state: entry.payload.state,
+        receivedAt: typeof receivedAt === 'number' ? receivedAt : undefined
+      }
+    ]
   }
-  return oldestFallback
-}
-
-function isStaleStatus(entry: AgentHookEventPayload, now: number): boolean {
-  const receivedAt = (entry as AgentHookEventPayload & { receivedAt?: unknown }).receivedAt
-  return (
-    typeof receivedAt === 'number' &&
-    Number.isFinite(receivedAt) &&
-    now - receivedAt > AGENT_STATUS_STALE_AFTER_MS
-  )
 }

--- a/src/shared/agent-hook-status-eviction-policy.ts
+++ b/src/shared/agent-hook-status-eviction-policy.ts
@@ -1,0 +1,60 @@
+// Why: one eviction policy for every bounded agent-hook status container. The pane-keyed
+// listener cache and the daemon's terminal-keyed binding store must shed entries identically,
+// so the policy lives here and both callers delegate instead of forking their own rules.
+
+import { AGENT_STATUS_STALE_AFTER_MS, type AgentStatusState } from './agent-status-types'
+
+/** Maximum tracked entries in a bounded agent-hook status container. */
+export const MAX_AGENT_HOOK_STATUS_ENTRIES = 500
+
+/** The only entry fields the policy reads; callers project their own rows onto it. */
+export type AgentHookStatusEvictionCandidate = {
+  state: AgentStatusState
+  /** Last refresh time; an entry without one is never treated as stale. */
+  receivedAt?: number
+}
+
+export function assertAgentHookStatusBound(max: number): void {
+  if (!Number.isSafeInteger(max) || max < 1) {
+    throw new RangeError('Agent hook status cache limit must be a positive safe integer')
+  }
+}
+
+/**
+ * Pick the entry to drop when a container exceeds its bound: the first `done` or stale
+ * entry in insertion order, else the oldest inserted. `protectedKey` — the row just
+ * written — is never chosen, so a burst can never evict the event it is delivering.
+ */
+export function selectAgentHookStatusEvictionKey<K>(
+  entries: Iterable<readonly [K, AgentHookStatusEvictionCandidate]>,
+  protectedKey: K,
+  now: number,
+  staleAfterMs: number = AGENT_STATUS_STALE_AFTER_MS
+): K | undefined {
+  let oldestFallback: K | undefined
+  let hasFallback = false
+  for (const [key, candidate] of entries) {
+    if (key === protectedKey) {
+      continue
+    }
+    if (!hasFallback) {
+      oldestFallback = key
+      hasFallback = true
+    }
+    if (candidate.state === 'done' || isStaleCandidate(candidate, now, staleAfterMs)) {
+      return key
+    }
+  }
+  return oldestFallback
+}
+
+function isStaleCandidate(
+  candidate: AgentHookStatusEvictionCandidate,
+  now: number,
+  staleAfterMs: number
+): boolean {
+  const { receivedAt } = candidate
+  return (
+    typeof receivedAt === 'number' && Number.isFinite(receivedAt) && now - receivedAt > staleAfterMs
+  )
+}


### PR DESCRIPTION
## Summary

Adds the daemon-side agent-hook **binding store** — the authoritative container the terminal daemon will host in a follow-up PR — plus the shared eviction policy both bounded agent-hook containers now use. No behavior changes ship in this PR: nothing imports the store yet, no protocol or IPC surface changed, and the existing Electron hook server is untouched.

`src/shared/agent-hook-binding-store.ts` (Node-only, no Electron, no timers, no ambient clock):

- **Identity** is `terminalHandle` + `terminalIncarnationId`. `paneKey` is optional metadata only — main deletes `ORCA_PANE_KEY` when the pane is unproven, so a binding must work without it.
- **`applyEvent`** is latest-wins per terminal identity and returns either the accepted binding or a typed rejection reason (`invalid-terminal-identity`, `invalid-received-at`, `invalid-payload`, `cleared-terminal-incarnation`, `stale-launch-token`, `stale-event`).
- **Launch-token fencing**: an event whose launch token differs from the live binding's may only take over when it is *strictly newer* by `receivedAt`, so a delayed event from a superseded agent generation can never clobber the agent now living in that terminal. Only a hash of the token is retained.
- **No resurrection**: `clearTerminalIncarnation` removes the binding and records the incarnation in a bounded tombstone set (`MAX_CLEARED_TERMINAL_INCARNATIONS = 2000`, FIFO by first-clear time), so late events from a reaped incarnation reject instead of re-creating a ghost row. A *fresh* incarnation id on the same handle is unaffected.
- **`snapshot()`** returns `{ revision, bindings[] }`; `revision` is a store-instance monotonic counter bumped on every accepted mutation (accepts and clears) and never on rejections. Omission from the snapshot is the authoritative "binding is gone" signal.
- **Bounds**: binding count is bounded by the same 500-entry ceiling and staleness-aware policy as the existing pane cache; eviction is deterministic and takes `now` as a parameter.

Cache consolidation (no third implementation): the eviction rules that lived inside `agent-hook-status-cache.ts` moved to a new `agent-hook-status-eviction-policy.ts`. The existing pane-keyed cache is now a thin adapter over that policy, and the new store consumes the same policy. `MAX_AGENT_HOOK_STATUS_CACHE_PANES` is kept as a deprecated alias of `MAX_AGENT_HOOK_STATUS_ENTRIES` so existing importers are unaffected, and a migration note at the top of the cache file points new terminal-scoped callers at the binding store.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — `oxlint` clean on all changed files, plus the code-quality gates (`config/oxlint-code-quality-native-plugins.json` and `--type-aware config/oxlint-code-quality-type-aware.json`, both with `--deny-warnings`) and `oxfmt`. No `max-lines` disables added.
- [x] `pnpm typecheck` — `tsconfig.tc.cli.json` and `tsconfig.tc.web.json` pass clean. `tsconfig.node.json` (which includes both new files and reports no errors in them) surfaces one pre-existing unrelated failure on this machine: `src/main/browser/browser-cookie-import-policy.ts(2,38): Cannot find module 'psl'`. Verified pre-existing by stashing this branch's changes and re-running — identical error on a clean tree.
- [x] `pnpm test` — targeted: `npx vitest run --config config/vitest.config.ts src/shared/agent-hook-binding-store.test.ts src/shared/agent-hook-status-cache.test.ts src/shared/agent-hook-listener-roster-retention.test.ts` → 25 passed (3 files), including the two pre-existing cache tests that pin the eviction policy through the refactor.
- [ ] `pnpm build` — not run; this PR adds two shared modules with no bundler/packaging surface and no new dependency.
- [x] Added or updated high-quality tests that would catch regressions

21 new tests cover: working → done replacing the same binding with an incrementing revision; a late event for a cleared incarnation rejecting and not resurrecting; a late (and a same-instant) event from an old launch token failing to overwrite a newer agent, while a strictly newer token takes over; terminal-handle reuse with a fresh incarnation id starting clean; a binding with no `paneKey` working end to end (store → snapshot → clear); deterministic binding eviction (oldest fallback, and `done`/stale preferred over merely-oldest using the injected clock); evicted ≠ tombstoned, so a live terminal can re-bind; the tombstone bound dropping the oldest entry deterministically; malformed payload rejection (`undefined`, `null`, string, unknown state, missing prompt); identity rejection including a NUL-separator collision attempt; snapshot omission semantics; revision monotonicity across interleaved accepts/clears/rejections; snapshot copies being mutation-isolated; and per-instance revision isolation.

## AI Review Report

Reviewed for correctness of the fencing rules, bound behavior, and the cache consolidation. Main risks checked:

- **Ordering/fencing**: confirmed the token-mismatch path requires *strictly* newer `receivedAt` (so an equal-timestamp event from a superseded generation is rejected), while same-generation events accept ties and reject only strictly-older ones. Both are pinned by tests.
- **Resurrection**: confirmed the tombstone check runs before any mutation, and that eviction does **not** tombstone — evicting a binding under memory pressure must not permanently fence a still-live terminal. Tested both ways.
- **Bound behavior**: confirmed the binding map is re-inserted on every accept so the policy's "oldest inserted" fallback stays meaningful, the just-written key is never evicted, and both bounds reject non-positive/non-integer configuration with a `RangeError` instead of running unbounded. The tombstone bound is FIFO by first-clear time (not LRU), so a re-clear cannot starve the set, and the horizon behavior past the bound is documented and tested rather than silent.
- **Mutation isolation**: `snapshot()`, `getBinding()`, `applyEvent`, and `clearTerminalIncarnation` all hand out shallow copies; `payload` is shared by reference and documented as immutable (it is already a normalized, frozen-by-convention value from `normalizeAgentStatusPayload`).
- **Refactor safety**: the pane cache's two existing tests (protected current row, `done`/stale preference plus related pane-cache clearing) pass unchanged against the extracted policy, and `MAX_AGENT_HOOK_STATUS_CACHE_PANES` still resolves for its existing importer.
- **Cross-platform (macOS + Linux + Windows)**: explicitly checked. This is platform-neutral pure logic — no filesystem or path handling, no shell or process execution, no keyboard shortcuts or shortcut labels, no Electron APIs, no platform branches, and no line-ending or case-sensitivity assumptions. The only Node builtin used is `node:crypto`'s `createHash('sha256')`, which behaves identically on all three platforms. Source files contain no raw control bytes (the key separator is written as the `\u0000` escape), so Git treats them as text everywhere. Nothing here is SSH- or worktree-shaped: the store is transport-agnostic and works the same for local, SSH, and folder-workspace terminals, since it keys on terminal identity rather than on a git worktree or pane.

## Security Audit

- **Input handling**: `applyEvent` is written as an untrusted-input boundary even though normalization happens upstream. It re-validates the fields it depends on — terminal identities must be non-empty strings within a 200-char cap, `receivedAt` must be finite, and the payload must be an object with a known `AgentStatusState` and a string prompt — so a malformed event cannot occupy a binding slot or poison ordering. Full field-cap/structure-limit validation remains `normalizeAgentStatusPayload`'s job at ingest, and that trust boundary is documented in the module header.
- **Key-injection**: binding keys join handle and incarnation id with `\u0000`, and any identity containing that separator is rejected, so no crafted pair of identities can collide into another terminal's binding key.
- **Secrets**: launch tokens are never retained. `applyEvent` hashes the raw token on entry (SHA-256, truncated to 32 hex chars) and stores only `launchTokenHash`; a test asserts the raw token never appears in a serialized binding. Callers that already hashed upstream can pass `launchTokenHash` directly.
- **Resource exhaustion**: both containers are bounded — bindings at 500 with deterministic eviction, tombstones at 2000 with FIFO trim — so a hostile or buggy hook emitter cannot grow the daemon's memory without limit. Payload size is bounded upstream by the existing normalization caps.
- **Not reviewed here / follow-up**: authentication and authorization of hook events are the receiver's responsibility and land with the daemon receiver PR. No command execution, no path handling, no IPC surface, no new dependency, and no network I/O in this change.

## Notes

- This is **groundwork only**. Nothing imports `agent-hook-binding-store.ts` yet; it is consumed by a follow-up PR that starts the hook receiver in the terminal daemon and moves agent-status ownership to the PTY owner. Phase 0 of that effort (hydrated nonterminal statuses restoring as unconfirmed) landed in #12346.
- This is the **first production consumer path for the shared bounded cache policy**. `upsertBoundedAgentHookStatus` had zero production callers; rather than mint a third divergent cache, its policy is now the single shared `agent-hook-status-eviction-policy.ts` that both the pane-keyed cache and the new store delegate to. The relay keeps its own inline cache for now — out of scope, and a natural third adopter of this policy later.
- The tombstone bound is a deliberate trade-off: past 2000 cleared incarnations the oldest tombstone is dropped, after which a very late event for that incarnation would be treated as fresh. The bound is far above any realistic live-terminal count, and the behavior is documented on the constant and pinned by a test rather than left implicit.
- Platform-neutral pure logic; no macOS/Linux/Windows-specific behavior and no SSH- or worktree-specific assumptions.
