### PR TITLE
fix(mobile): keep hosts visible when credentials are unavailable

### DIFF
--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -10,7 +10,7 @@ import { OrcaLogo } from '../src/components/OrcaLogo'
 import { RpcClientProvider } from '../src/transport/client-context'
 import { getNotificationNavigationTarget } from '../src/notifications/notification-routing'
 import { useOpenNotificationRoute } from '../src/notifications/use-open-notification-route'
-import { loadHosts } from '../src/transport/host-store'
+import { loadHostCatalog } from '../src/transport/host-store'
 import { extractPairingCodeFromUrl } from '../src/transport/pairing'
 import { recoverMobileRelayPairing } from '../src/transport/mobile-relay-pairing-recovery'
 
@@ -95,7 +95,7 @@ export default function RootLayout() {
     }
 
     async function getNavigationTarget(data: unknown) {
-      const hosts = await loadHosts().catch(() => null)
+      const hosts = await loadHostCatalog().catch(() => null)
       return getNotificationNavigationTarget(data, {
         knownHostIds: hosts ? new Set(hosts.map((host) => host.id)) : undefined
       })

--- a/mobile/app/_layout.tsx
+++ b/mobile/app/_layout.tsx
@@ -97,7 +97,10 @@ export default function RootLayout() {
     async function getNavigationTarget(data: unknown) {
       const hosts = await loadHostCatalog().catch(() => null)
       return getNotificationNavigationTarget(data, {
-        knownHostIds: hosts ? new Set(hosts.map((host) => host.id)) : undefined
+        knownHostIds: hosts ? new Set(hosts.map((host) => host.id)) : undefined,
+        credentialStatusByHostId: hosts
+          ? new Map(hosts.map((host) => [host.id, host.credentialStatus]))
+          : undefined
       })
     }
 

--- a/mobile/app/index.tsx
+++ b/mobile/app/index.tsx
@@ -15,7 +15,8 @@ import {
   UsageBar
 } from '../src/components/AccountUsage'
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { loadHosts } from '../src/transport/host-store'
+import { loadHostCatalog } from '../src/transport/host-store'
+import { selectConnectableHostProfiles } from '../src/transport/host-catalog-selection'
 import { useOpenMobileHostEdit } from '../src/transport/use-open-mobile-host-edit'
 import { removeHostAndCloseClient } from '../src/transport/host-removal-lifecycle'
 import { fetchHomeHostWorktreeInfo } from '../src/worktree/home-host-worktree-fetch'
@@ -32,7 +33,7 @@ import {
   loadMobileOnboardingSteps,
   mobileOnboardingDestination
 } from '../src/onboarding/mobile-onboarding-plan'
-import type { ConnectionState, HostProfile } from '../src/transport/types'
+import type { ConnectionState, HostCatalogEntry, HostProfile } from '../src/transport/types'
 import { triggerMediumImpact } from '../src/platform/haptics'
 import { OrcaLogo } from '../src/components/OrcaLogo'
 import { MobileHostCard } from '../src/components/MobileHostCard'
@@ -224,9 +225,9 @@ export default function HomeScreen() {
   const insets = useSafeAreaInsets()
   // Why: cap/center content on wide/tablet canvases so cards don't stretch edge-to-edge on iPad.
   const { isWideLayout, contentMaxWidth } = useResponsiveLayout()
-  const [hosts, setHosts] = useState<HostProfile[]>([])
+  const [hostCatalog, setHostCatalog] = useState<HostCatalogEntry[]>([])
   const [actionTarget, setActionTarget] = useState<HostProfile | null>(null)
-  const [confirmRemove, setConfirmRemove] = useState<HostProfile | null>(null)
+  const [confirmRemove, setConfirmRemove] = useState<{ id: string; name: string } | null>(null)
   const [hostStates, setHostStates] = useState<Record<string, ConnectionState>>({})
   const [hostAttempts, setHostAttempts] = useState<Record<string, number>>({})
   const [hostLastConnected, setHostLastConnected] = useState<Record<string, number | null>>({})
@@ -242,6 +243,7 @@ export default function HomeScreen() {
   const onboardingOptInCheckedRef = useRef(false)
 
   // Why: shared clients from the per-host store, not N independent WebSockets. See docs/mobile-shared-client-per-host.md.
+  const hosts = useMemo(() => selectConnectableHostProfiles(hostCatalog), [hostCatalog])
   const hostIds = useMemo(() => hosts.map((h) => h.id), [hosts])
   // Why: scoped to the paired hosts so an unpaired desktop's cached reply leaves the header total.
   const stats = useMemo(() => totalHomeStats(statsByHost, hostIds), [statsByHost, hostIds])
@@ -308,12 +310,12 @@ export default function HomeScreen() {
   useFocusEffect(
     useCallback(() => {
       let stale = false
-      void loadHosts().then(async (h) => {
+      void loadHostCatalog().then(async (catalog) => {
         if (stale) {
           return
         }
-        setHosts(h)
-        if (h.length === 0 || onboardingOptInCheckedRef.current) {
+        setHostCatalog(catalog)
+        if (catalog.length === 0 || onboardingOptInCheckedRef.current) {
           return
         }
         onboardingOptInCheckedRef.current = true
@@ -350,6 +352,10 @@ export default function HomeScreen() {
   const sortedHosts = useMemo(
     () => [...hosts].sort((a, b) => b.lastConnected - a.lastConnected),
     [hosts]
+  )
+  const sortedHostCatalog = useMemo(
+    () => [...hostCatalog].sort((a, b) => b.lastConnected - a.lastConnected),
+    [hostCatalog]
   )
 
   // Why: mirror per-host connection state into hostStates so existing render code (status dots) keeps working.
@@ -389,13 +395,20 @@ export default function HomeScreen() {
         }
       }
       // Why: reflect hosts that dropped from allClients, but only if already tracked — else the initial-acquire frame flips all to 'disconnected'.
-      for (const host of hosts) {
+      for (const host of hostCatalog) {
         if (liveIds.has(host.id)) {
           continue
         }
-        if (!host.publicKeyB64 || !host.deviceToken) {
+        if (host.credentialStatus === 'missing') {
           if (next[host.id] !== 'auth-failed') {
             next[host.id] = 'auth-failed'
+            changed = true
+          }
+          continue
+        }
+        if (host.credentialStatus === 'temporarily-unavailable') {
+          if (next[host.id] !== 'disconnected') {
+            next[host.id] = 'disconnected'
             changed = true
           }
           continue
@@ -408,14 +421,14 @@ export default function HomeScreen() {
       }
       // Drop entries for hosts we no longer track at all.
       for (const id of Object.keys(next)) {
-        if (!liveIds.has(id) && hosts.some((h) => h.id === id) === false) {
+        if (!liveIds.has(id) && hostCatalog.some((h) => h.id === id) === false) {
           delete next[id]
           changed = true
         }
       }
       return changed ? next : prev
     })
-  }, [allClients, hosts])
+  }, [allClients, hostCatalog])
 
   // Notif/accounts subs + a snapshot read per connect for one host. Lives outside the effect body
   // because react-doctor's effect-needs-cleanup false-positives on `subscribe` inside one; the
@@ -629,7 +642,7 @@ export default function HomeScreen() {
     try {
       await removeHostAndCloseClient(hostToRemove.id, closeHostClient)
       setConfirmRemove(null)
-      setHosts(await loadHosts())
+      setHostCatalog(await loadHostCatalog())
     } catch {
       // Why: ConfirmModal closes on confirm; re-open for retry so the failure isn't silent.
       setConfirmRemove(hostToRemove)
@@ -655,7 +668,7 @@ export default function HomeScreen() {
         </Pressable>
       </View>
 
-      {hosts.length === 0 ? (
+      {hostCatalog.length === 0 ? (
         /* ─── Empty state: onboarding ─── */
         <View
           style={[
@@ -694,7 +707,7 @@ export default function HomeScreen() {
       ) : (
         /* ─── Populated state ─── */
         <FlatList
-          data={sortedHosts}
+          data={sortedHostCatalog}
           keyExtractor={(h) => h.id}
           // Why: reserve insets.bottom so the last row stays reachable above the system nav bar / home indicator.
           contentContainerStyle={[
@@ -744,14 +757,29 @@ export default function HomeScreen() {
             return (
               <MobileHostCard
                 host={item}
+                credentialStatus={item.credentialStatus}
                 state={state}
                 verdict={verdict}
                 path={hostPaths[item.id] ?? 'lan'}
                 worktreeInfo={worktreeInfo[item.id]}
-                onPress={() => router.push(`/h/${item.id}`)}
+                onPress={() => {
+                  if (item.credentialStatus === 'missing') {
+                    router.push('/pair-scan')
+                  } else if (item.credentialStatus === 'temporarily-unavailable') {
+                    void loadHostCatalog()
+                      .then(setHostCatalog)
+                      .catch(() => Alert.alert('Could not check pairing', 'Please try again.'))
+                  } else {
+                    router.push(`/h/${item.id}`)
+                  }
+                }}
                 onLongPress={() => {
                   triggerMediumImpact()
-                  setActionTarget(item)
+                  if (item.profile) {
+                    setActionTarget(item.profile)
+                  } else {
+                    setConfirmRemove(item)
+                  }
                 }}
               />
             )
@@ -928,7 +956,7 @@ export default function HomeScreen() {
           onReconnect: (hostId) => void forceReconnectHost(hostId),
           onDisconnect: closeHostClient,
           onEdit: openMobileHostEdit,
-          onRemove: setConfirmRemove
+          onRemove: (host) => setConfirmRemove(host)
         })}
         onClose={() => setActionTarget(null)}
       />

--- a/mobile/src/components/MobileHostCard.test.tsx
+++ b/mobile/src/components/MobileHostCard.test.tsx
@@ -3,7 +3,7 @@ import { act, create, type ReactTestRenderer } from 'react-test-renderer'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { ConnectionVerdict } from '../transport/connection-health'
 import type { MobileConnectionPath } from '../transport/stable-logical-rpc-client'
-import type { ConnectionState, HostProfile } from '../transport/types'
+import type { ConnectionState, HostCredentialStatus, HostProfile } from '../transport/types'
 import {
   markHomeWorktreeCatalogUnavailable,
   type HostWorktreeInfo
@@ -54,6 +54,7 @@ describe('MobileHostCard', () => {
       state?: ConnectionState
       verdict?: ConnectionVerdict
       path?: MobileConnectionPath
+      credentialStatus?: HostCredentialStatus
     }
   ): Promise<string[]> {
     await act(async () => {
@@ -63,6 +64,7 @@ describe('MobileHostCard', () => {
           state: overrides?.state ?? 'connected',
           verdict: overrides?.verdict ?? verdict,
           path: overrides?.path ?? 'lan',
+          credentialStatus: overrides?.credentialStatus,
           worktreeInfo,
           onPress: () => {},
           onLongPress: () => {}
@@ -138,5 +140,29 @@ describe('MobileHostCard', () => {
 
     expect(lines).not.toContain('0 worktrees')
     expect(lines).not.toContain('Worktree list unavailable')
+  })
+
+  it('offers re-pairing when the credential is missing', async () => {
+    const lines = await renderCard(loaded, {
+      state: 'connected',
+      verdict: { kind: 'auth-failed', label: 'Pairing invalid' },
+      credentialStatus: 'missing'
+    })
+
+    expect(lines).toContain('Pairing invalid')
+    expect(lines).toContain('Tap to re-pair with your desktop')
+    expect(lines).not.toContain('12 worktrees · 2 active')
+  })
+
+  it('offers a retry without declaring a transient read failure invalid', async () => {
+    const lines = await renderCard(undefined, {
+      state: 'disconnected',
+      verdict: { kind: 'normal', label: 'Disconnected' },
+      credentialStatus: 'temporarily-unavailable'
+    })
+
+    expect(lines).toContain('Pairing temporarily unavailable')
+    expect(lines).toContain('Unlock your phone, then tap to retry')
+    expect(lines).not.toContain('Pairing invalid')
   })
 })

--- a/mobile/src/components/MobileHostCard.tsx
+++ b/mobile/src/components/MobileHostCard.tsx
@@ -4,13 +4,14 @@ import type { ConnectionVerdict } from '../transport/connection-health'
 import { verdictDisplayLabel } from '../transport/connection-health'
 import { mobileConnectionPathLabel } from '../transport/mobile-connection-path-label'
 import type { MobileConnectionPath } from '../transport/stable-logical-rpc-client'
-import type { ConnectionState, HostProfile } from '../transport/types'
+import type { ConnectionState, HostCatalogEntry, HostProfile } from '../transport/types'
 import { colors, radii, spacing } from '../theme/mobile-theme'
 import { homeHostWorktreeSummary, type HostWorktreeInfo } from '../worktree/home-worktree-info'
 import { StatusDot } from './StatusDot'
 
 export function MobileHostCard(props: {
-  host: HostProfile
+  host: HostProfile | HostCatalogEntry
+  credentialStatus?: HostCatalogEntry['credentialStatus']
   state: ConnectionState
   verdict: ConnectionVerdict
   path: MobileConnectionPath
@@ -20,13 +21,26 @@ export function MobileHostCard(props: {
   onPress: () => void
   onLongPress: () => void
 }) {
-  const connected = props.state === 'connected'
+  const credentialUnavailable = props.credentialStatus === 'temporarily-unavailable'
+  const credentialMissing = props.credentialStatus === 'missing'
+  const connected = props.state === 'connected' && !credentialUnavailable && !credentialMissing
   // Why: a relay dial can run for seconds behind "Connecting…"/"Reconnecting…"; naming the
   // path mid-wait tells the user the phone is off-LAN rather than hung (F5). Only 'relay' is
   // named — 'lan' doubles as the unknown-path default, so it would be a guess before connect.
   const dialingPath =
     ['connecting', 'handshaking', 'reconnecting'].includes(props.state) && props.path === 'relay'
-  const isError = ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
+  const isError =
+    credentialMissing || ['warning', 'unreachable', 'auth-failed'].includes(props.verdict.kind)
+  const statusLabel = credentialMissing
+    ? 'Pairing invalid'
+    : credentialUnavailable
+      ? 'Pairing temporarily unavailable'
+      : verdictDisplayLabel(props.verdict)
+  const statusVerdict: ConnectionVerdict = credentialMissing
+    ? { kind: 'auth-failed', label: statusLabel }
+    : credentialUnavailable
+      ? { kind: 'warning', label: statusLabel }
+      : props.verdict
   const worktreeSummary = homeHostWorktreeSummary(props.worktreeInfo)
   return (
     <Pressable
@@ -46,10 +60,19 @@ export function MobileHostCard(props: {
           {props.host.name}
         </Text>
         <View style={styles.meta}>
-          <StatusDot state={props.state} verdict={props.verdict} />
-          <Text style={[styles.metaText, isError && { color: colors.statusRed }]} numberOfLines={1}>
-            {verdictDisplayLabel(props.verdict)}
-            {connected || dialingPath ? ` · ${mobileConnectionPathLabel(props.path)}` : ''}
+          <StatusDot state={props.state} verdict={statusVerdict} />
+          <Text
+            style={[
+              styles.metaText,
+              isError && { color: colors.statusRed },
+              credentialUnavailable && { color: colors.statusAmber }
+            ]}
+            numberOfLines={1}
+          >
+            {statusLabel}
+            {!credentialMissing && !credentialUnavailable && (connected || dialingPath)
+              ? ` · ${mobileConnectionPathLabel(props.path)}`
+              : ''}
           </Text>
         </View>
         {connected && worktreeSummary ? (
@@ -60,6 +83,13 @@ export function MobileHostCard(props: {
         {props.verdict.kind === 'unreachable' && !props.host.relay ? (
           <Text style={styles.discoveryHint} numberOfLines={2}>
             Update desktop Orca and sign in to connect from anywhere
+          </Text>
+        ) : null}
+        {credentialMissing || credentialUnavailable ? (
+          <Text style={styles.discoveryHint} numberOfLines={2}>
+            {credentialMissing
+              ? 'Tap to re-pair with your desktop'
+              : 'Unlock your phone, then tap to retry'}
           </Text>
         ) : null}
       </View>

--- a/mobile/src/notifications/notification-routing.test.ts
+++ b/mobile/src/notifications/notification-routing.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { buildLocalNotificationData, getNotificationNavigationTarget } from './notification-routing'
+import {
+  buildLocalNotificationData,
+  getNotificationNavigationTarget,
+  notificationCredentialRecoveryRoute
+} from './notification-routing'
 
 describe('notification routing', () => {
   it('includes the host id in locally scheduled notification data', () => {
@@ -54,5 +58,33 @@ describe('notification routing', () => {
         { knownHostIds: new Set(['host-1']) }
       )
     ).toBeNull()
+  })
+
+  it.each([
+    ['missing', 're-pair'],
+    ['temporarily-unavailable', 'retry']
+  ] as const)('routes %s host credentials to %s recovery', (status, recovery) => {
+    const target = getNotificationNavigationTarget(
+      { hostId: 'host-1', worktreeId: 'repo::/tmp/worktree' },
+      {
+        knownHostIds: new Set(['host-1']),
+        credentialStatusByHostId: new Map([['host-1', status]])
+      }
+    )
+
+    expect(target).toMatchObject({ hostId: 'host-1', credentialRecovery: recovery })
+    expect(notificationCredentialRecoveryRoute(target!)).toBe(
+      status === 'missing' ? '/pair-scan' : '/'
+    )
+  })
+
+  it('keeps ready hosts on the requested notification destination', () => {
+    const target = getNotificationNavigationTarget(
+      { hostId: 'host-1', worktreeId: 'repo::/tmp/worktree' },
+      { credentialStatusByHostId: new Map([['host-1', 'ready']]) }
+    )
+
+    expect(target?.sessionTarget).not.toBeNull()
+    expect(notificationCredentialRecoveryRoute(target!)).toBeNull()
   })
 })

--- a/mobile/src/notifications/notification-routing.ts
+++ b/mobile/src/notifications/notification-routing.ts
@@ -1,5 +1,6 @@
 import type { HostStackRouteTarget } from '../navigation/host-stack-navigation'
 import { mobileSessionRouteTarget } from '../session/mobile-session-route'
+import type { HostCredentialStatus } from '../transport/types'
 
 export type DesktopNotificationSource = 'agent-task-complete' | 'terminal-bell' | 'test'
 
@@ -18,6 +19,7 @@ export type LocalNotificationData = {
 
 export type NotificationNavigationOptions = {
   knownHostIds?: ReadonlySet<string>
+  credentialStatusByHostId?: ReadonlyMap<string, HostCredentialStatus>
 }
 
 function readNonEmptyString(value: unknown): string | null {
@@ -46,7 +48,17 @@ export function buildLocalNotificationData(
 export type NotificationNavigationTarget = Readonly<{
   hostId: string
   sessionTarget: HostStackRouteTarget | null
+  credentialRecovery?: 'retry' | 're-pair'
 }>
+
+export function notificationCredentialRecoveryRoute(
+  target: NotificationNavigationTarget
+): '/' | '/pair-scan' | null {
+  if (target.credentialRecovery === 're-pair') {
+    return '/pair-scan'
+  }
+  return target.credentialRecovery === 'retry' ? '/' : null
+}
 
 export function getNotificationNavigationTarget(
   data: unknown,
@@ -66,8 +78,14 @@ export function getNotificationNavigationTarget(
   }
 
   const worktreeId = readNonEmptyString(record.worktreeId)
+  const credentialStatus = options.credentialStatusByHostId?.get(hostId)
   return {
     hostId,
-    sessionTarget: worktreeId ? mobileSessionRouteTarget({ hostId, worktreeId }) : null
+    sessionTarget: worktreeId ? mobileSessionRouteTarget({ hostId, worktreeId }) : null,
+    ...(credentialStatus === 'missing'
+      ? { credentialRecovery: 're-pair' as const }
+      : credentialStatus === 'temporarily-unavailable'
+        ? { credentialRecovery: 'retry' as const }
+        : {})
   }
 }

--- a/mobile/src/notifications/use-open-notification-route.ts
+++ b/mobile/src/notifications/use-open-notification-route.ts
@@ -2,7 +2,10 @@ import { useCallback } from 'react'
 import { useRouter } from 'expo-router'
 import { hostStackHostRoute } from '../navigation/host-stack-navigation'
 import { useOpenHostStackRoute } from '../navigation/use-open-host-stack-route'
-import type { NotificationNavigationTarget } from './notification-routing'
+import {
+  notificationCredentialRecoveryRoute,
+  type NotificationNavigationTarget
+} from './notification-routing'
 
 export function useOpenNotificationRoute(): (target: NotificationNavigationTarget) => void {
   const openHostStackRoute = useOpenHostStackRoute()
@@ -10,6 +13,11 @@ export function useOpenNotificationRoute(): (target: NotificationNavigationTarge
 
   return useCallback(
     (target) => {
+      const recoveryRoute = notificationCredentialRecoveryRoute(target)
+      if (recoveryRoute) {
+        router.push(recoveryRoute)
+        return
+      }
       if (target.sessionTarget) {
         openHostStackRoute(target.hostId, target.sessionTarget)
         return

--- a/mobile/src/transport/host-catalog-credential-join.ts
+++ b/mobile/src/transport/host-catalog-credential-join.ts
@@ -1,0 +1,52 @@
+import type { MobileRelayHostOverlay } from './mobile-relay-host-overlay'
+import type { HostListSnapshot } from './host-list-load-sharing'
+import type { HostCatalogEntry, StoredHostProfile } from './types'
+
+export async function joinHostCatalogCredentials(args: {
+  storedHosts: readonly StoredHostProfile[]
+  overlays: ReadonlyMap<string, MobileRelayHostOverlay>
+  tokenCache: Map<string, string>
+  readToken: (hostId: string) => Promise<string | null>
+  getRevision: () => number
+}): Promise<HostListSnapshot> {
+  const catalog: HostCatalogEntry[] = []
+  const profiles: HostListSnapshot['profiles'] = []
+  for (const stored of args.storedHosts) {
+    let token = args.tokenCache.get(stored.id)
+    let credentialStatus: HostCatalogEntry['credentialStatus'] = 'ready'
+    if (!token) {
+      const readRevision = args.getRevision()
+      let fetched: string | null
+      try {
+        fetched = await args.readToken(stored.id)
+      } catch {
+        credentialStatus = 'temporarily-unavailable'
+        fetched = null
+      }
+      if (!fetched && credentialStatus === 'ready') {
+        credentialStatus = 'missing'
+      }
+      token = fetched ?? undefined
+      if (token && readRevision === args.getRevision()) {
+        args.tokenCache.set(stored.id, token)
+      }
+    }
+    const overlay = args.overlays.get(stored.id)
+    const base = {
+      ...stored,
+      ...(overlay
+        ? {
+            endpoints: overlay.endpoints,
+            relayHostId: overlay.relayHostId,
+            relay: overlay.relay
+          }
+        : {})
+    }
+    const profile = token ? { ...base, deviceToken: token } : null
+    catalog.push({ ...base, credentialStatus, profile })
+    if (profile) {
+      profiles.push(profile)
+    }
+  }
+  return { catalog, profiles }
+}

--- a/mobile/src/transport/host-catalog-selection.test.ts
+++ b/mobile/src/transport/host-catalog-selection.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import { selectConnectableHostProfiles } from './host-catalog-selection'
+import type { HostCatalogEntry, HostProfile } from './types'
+
+const profile: HostProfile = {
+  id: 'host-ready',
+  name: 'Ready',
+  endpoint: 'ws://127.0.0.1:1',
+  deviceToken: 'token',
+  publicKeyB64: 'key-ready',
+  lastConnected: 0
+}
+
+function unavailable(
+  id: string,
+  credentialStatus: 'temporarily-unavailable' | 'missing'
+): HostCatalogEntry {
+  return {
+    id,
+    name: id,
+    endpoint: `ws://127.0.0.1/${id}`,
+    publicKeyB64: `key-${id}`,
+    lastConnected: 0,
+    credentialStatus,
+    profile: null
+  }
+}
+
+describe('selectConnectableHostProfiles', () => {
+  it('excludes unavailable catalog entries from connection priming', () => {
+    expect(
+      selectConnectableHostProfiles([
+        { ...profile, credentialStatus: 'ready', profile },
+        unavailable('host-locked', 'temporarily-unavailable'),
+        unavailable('host-missing', 'missing')
+      ])
+    ).toEqual([profile])
+  })
+})

--- a/mobile/src/transport/host-catalog-selection.ts
+++ b/mobile/src/transport/host-catalog-selection.ts
@@ -1,0 +1,7 @@
+import type { HostCatalogEntry, HostProfile } from './types'
+
+export function selectConnectableHostProfiles(catalog: readonly HostCatalogEntry[]): HostProfile[] {
+  return catalog.flatMap((entry) =>
+    entry.credentialStatus === 'ready' && entry.profile ? [entry.profile] : []
+  )
+}

--- a/mobile/src/transport/host-credential-cleanup.test.ts
+++ b/mobile/src/transport/host-credential-cleanup.test.ts
@@ -4,6 +4,7 @@ import {
   cancelPendingHostCredentialCleanup,
   loadPendingHostCredentialCleanup,
   loadPendingHostCredentialCleanupIds,
+  recordHostCredentialCleanupIntent,
   resetHostCredentialCleanupForTests,
   retryPendingHostCredentialCleanups,
   scheduleHostCredentialCleanup,
@@ -65,6 +66,12 @@ describe('host credential cleanup', () => {
       await expect(loadPendingHostCredentialCleanupIds()).resolves.toEqual([])
     })
     expect(deleteCredential).toHaveBeenCalledOnce()
+  })
+
+  it('records cleanup intent without starting native deletion', async () => {
+    await recordHostCredentialCleanupIntent('host-1')
+
+    await expect(loadPendingHostCredentialCleanupIds()).resolves.toEqual(['host-1'])
   })
 
   it('persists cleanup intent before a rejected delete for manual retry', async () => {

--- a/mobile/src/transport/host-credential-cleanup.test.ts
+++ b/mobile/src/transport/host-credential-cleanup.test.ts
@@ -1,6 +1,7 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  cancelPendingHostCredentialCleanup,
   loadPendingHostCredentialCleanup,
   loadPendingHostCredentialCleanupIds,
   resetHostCredentialCleanupForTests,
@@ -76,6 +77,18 @@ describe('host credential cleanup', () => {
     await expect(loadPendingHostCredentialCleanupIds()).resolves.toEqual(['host-1'])
     expect(listener).toHaveBeenCalled()
     unsubscribe()
+  })
+
+  it('cancels stale cleanup intent after replacement publication', async () => {
+    const deleteCredential = vi.fn().mockRejectedValue(new Error('superseded'))
+
+    await scheduleHostCredentialCleanup('host-1', deleteCredential, 20)
+    await vi.waitFor(() => expect(deleteCredential).toHaveBeenCalledOnce())
+    await expect(loadPendingHostCredentialCleanupIds()).resolves.toEqual(['host-1'])
+
+    await cancelPendingHostCredentialCleanup('host-1')
+
+    await expect(loadPendingHostCredentialCleanupIds()).resolves.toEqual([])
   })
 
   it('records intent before a stalled delete times out', async () => {

--- a/mobile/src/transport/host-credential-cleanup.ts
+++ b/mobile/src/transport/host-credential-cleanup.ts
@@ -155,11 +155,15 @@ function startOrJoinDelete(hostId: string, deleteCredential: DeleteHostCredentia
 
 async function recordCleanupIntent(hostId: string): Promise<boolean> {
   try {
-    await addPendingId(hostId)
+    await recordHostCredentialCleanupIntent(hostId)
     return true
   } catch {
     return false
   }
+}
+
+export async function recordHostCredentialCleanupIntent(hostId: string): Promise<void> {
+  await addPendingId(hostId)
 }
 
 async function confirmNativeCleanup(

--- a/mobile/src/transport/host-credential-cleanup.ts
+++ b/mobile/src/transport/host-credential-cleanup.ts
@@ -209,6 +209,11 @@ export function subscribePendingHostCredentialCleanup(listener: () => void): () 
   return () => pendingListeners.delete(listener)
 }
 
+export async function cancelPendingHostCredentialCleanup(hostId: string): Promise<void> {
+  clearUnrecordedPending(hostId)
+  await removePendingId(hostId)
+}
+
 /**
  * Record cleanup intent, then fire-and-forget the native keychain delete so
  * removeHost never blocks on SecureStore. If the durable intent write fails,

--- a/mobile/src/transport/host-credential-write-revision.ts
+++ b/mobile/src/transport/host-credential-write-revision.ts
@@ -1,0 +1,21 @@
+let nextRevision = 1
+const revisionByHostId = new Map<string, number>()
+
+export function getHostCredentialWriteRevision(hostId: string): number {
+  return revisionByHostId.get(hostId) ?? 0
+}
+
+export function markHostCredentialWrite(hostId: string): void {
+  revisionByHostId.set(hostId, nextRevision)
+  nextRevision += 1
+}
+
+export function clearHostCredentialWriteRevision(hostId: string): void {
+  revisionByHostId.delete(hostId)
+}
+
+/** Test-only: clear session credential generations between cases. */
+export function resetHostCredentialWriteRevisionsForTests(): void {
+  nextRevision = 1
+  revisionByHostId.clear()
+}

--- a/mobile/src/transport/host-device-token-store.ts
+++ b/mobile/src/transport/host-device-token-store.ts
@@ -1,0 +1,43 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { Platform } from 'react-native'
+import {
+  deletePairingKeychainItem,
+  readPairingKeychainItem,
+  writePairingKeychainItem
+} from './pairing-keychain'
+
+// Why: SecureStore keys must match [A-Za-z0-9._-] (colons rejected), so use dots as the separator.
+const TOKEN_KEY_PREFIX = 'orca.host-token.'
+const WEB_TOKEN_KEY_PREFIX = 'orca:web-host-token:'
+
+function tokenKey(hostId: string): string {
+  return `${TOKEN_KEY_PREFIX}${hostId}`
+}
+
+function webTokenKey(hostId: string): string {
+  return `${WEB_TOKEN_KEY_PREFIX}${hostId}`
+}
+
+export async function readHostDeviceToken(hostId: string): Promise<string | null> {
+  // Why: Expo SecureStore has no working web backend; fall back to AsyncStorage only on web so native still uses the keychain.
+  if (Platform.OS === 'web') {
+    return AsyncStorage.getItem(webTokenKey(hostId))
+  }
+  return readPairingKeychainItem(tokenKey(hostId))
+}
+
+export async function writeHostDeviceToken(hostId: string, token: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.setItem(webTokenKey(hostId), token)
+    return
+  }
+  await writePairingKeychainItem(tokenKey(hostId), token)
+}
+
+export async function deleteHostDeviceToken(hostId: string): Promise<void> {
+  if (Platform.OS === 'web') {
+    await AsyncStorage.removeItem(webTokenKey(hostId))
+    return
+  }
+  await deletePairingKeychainItem(tokenKey(hostId))
+}

--- a/mobile/src/transport/host-list-load-sharing.ts
+++ b/mobile/src/transport/host-list-load-sharing.ts
@@ -1,15 +1,22 @@
-import type { HostProfile } from './types'
+import type { HostCatalogEntry, HostProfile } from './types'
+
+export type HostListSnapshot = {
+  catalog: HostCatalogEntry[]
+  profiles: HostProfile[]
+}
 
 // Why: concurrent callers share a slow Keychain pass; durable writes invalidate
 // it so later loads cannot receive stale snapshots (#8791).
-let inflight: Promise<HostProfile[]> | null = null
+let inflight: Promise<HostListSnapshot> | null = null
 let revision = 0
 
 export function getHostListLoadRevision(): number {
   return revision
 }
 
-export function shareHostListLoad(load: () => Promise<HostProfile[]>): Promise<HostProfile[]> {
+export function shareHostListLoad(
+  load: () => Promise<HostListSnapshot>
+): Promise<HostListSnapshot> {
   if (inflight) {
     return inflight
   }

--- a/mobile/src/transport/host-metadata-store.ts
+++ b/mobile/src/transport/host-metadata-store.ts
@@ -1,0 +1,51 @@
+import AsyncStorage from '@react-native-async-storage/async-storage'
+import { StoredHostProfileSchema, type HostProfile, type StoredHostProfile } from './types'
+
+const STORAGE_KEY = 'orca:hosts'
+
+export async function loadStoredHostProfiles(): Promise<StoredHostProfile[] | null> {
+  return parseStoredHostProfiles(await AsyncStorage.getItem(STORAGE_KEY))
+}
+
+export async function readStoredHostProfilesForMutation(): Promise<StoredHostProfile[]> {
+  try {
+    const parsed = await loadStoredHostProfiles()
+    if (parsed) {
+      return parsed
+    }
+  } catch {
+    // Normalize storage and payload failures for fail-closed mutations.
+  }
+  throw new Error('host list storage unreadable')
+}
+
+export function writeStoredHostProfiles(hosts: readonly StoredHostProfile[]): Promise<void> {
+  return AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(hosts))
+}
+
+export function toStoredHostProfile(host: HostProfile): StoredHostProfile {
+  const { id, name, endpoint, publicKeyB64, lastConnected } = host
+  return { id, name, endpoint, publicKeyB64, lastConnected }
+}
+
+function parseStoredHostProfiles(raw: string | null): StoredHostProfile[] | null {
+  if (!raw) {
+    return []
+  }
+  try {
+    const parsed = JSON.parse(raw) as unknown
+    if (!Array.isArray(parsed)) {
+      return null
+    }
+    return parsed.flatMap((item) => {
+      // Why: pre-v0.0.3 records embedded secrets; users re-pair instead of migrating them.
+      if (item && typeof item === 'object' && 'deviceToken' in item) {
+        return []
+      }
+      const result = StoredHostProfileSchema.safeParse(item)
+      return result.success ? [result.data] : []
+    })
+  } catch {
+    return null
+  }
+}

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -15,6 +15,7 @@ const secureStoreMock = vi.hoisted(() => ({
 
 const scheduleCleanupMock = vi.hoisted(() => vi.fn())
 const cancelCleanupMock = vi.hoisted(() => vi.fn())
+const recordCleanupIntentMock = vi.hoisted(() => vi.fn())
 const platformMock = vi.hoisted(() => ({ OS: 'ios' }))
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
@@ -32,6 +33,7 @@ vi.mock('react-native', () => ({
 
 vi.mock('./host-credential-cleanup', () => ({
   cancelPendingHostCredentialCleanup: (...args: unknown[]) => cancelCleanupMock(...args),
+  recordHostCredentialCleanupIntent: (...args: unknown[]) => recordCleanupIntentMock(...args),
   scheduleHostCredentialCleanup: (...args: unknown[]) => scheduleCleanupMock(...args),
   retryPendingHostCredentialCleanups: vi.fn()
 }))
@@ -92,6 +94,8 @@ describe('host-store list mutations', () => {
     scheduleCleanupMock.mockResolvedValue(undefined)
     cancelCleanupMock.mockReset()
     cancelCleanupMock.mockResolvedValue(undefined)
+    recordCleanupIntentMock.mockReset()
+    recordCleanupIntentMock.mockResolvedValue(undefined)
     storedHostsRaw = JSON.stringify([HOST_ONE, HOST_TWO])
     storedOverlayRaw = null
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {
@@ -253,6 +257,10 @@ describe('host-store list mutations', () => {
     await expect(saveHost(replacement)).rejects.toThrow('metadata write failed')
 
     expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, HOST_TWO])
+    expect(recordCleanupIntentMock).toHaveBeenCalledWith(replacement.id)
+    expect(recordCleanupIntentMock.mock.invocationCallOrder[0]).toBeLessThan(
+      secureStoreMock.setItemAsync.mock.invocationCallOrder[0]!
+    )
     expect(scheduleCleanupMock).toHaveBeenCalledWith(replacement.id, expect.any(Function))
   })
 
@@ -440,6 +448,41 @@ describe('host-store list mutations', () => {
 
     expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
     expect(scheduleCleanupMock).toHaveBeenCalledWith(HOST_ONE.id, expect.any(Function))
+  })
+
+  it('does not cancel cleanup from a removal committed during a stalled save', async () => {
+    let releaseTokenWrite: () => void = () => {}
+    secureStoreMock.setItemAsync.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseTokenWrite = resolve
+      })
+    )
+
+    const save = saveHost({ ...HOST_ONE, deviceToken: 'replacement-token' })
+    await vi.waitFor(() => expect(secureStoreMock.setItemAsync).toHaveBeenCalledOnce())
+    await removeHost(HOST_ONE.id)
+    releaseTokenWrite()
+    await save
+    await loadHostCatalog()
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
+    expect(scheduleCleanupMock).toHaveBeenCalledWith(HOST_ONE.id, expect.any(Function))
+    expect(cancelCleanupMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses an early same-key token write without durable cleanup intent', async () => {
+    const replacement = {
+      ...HOST_TWO,
+      id: 'host-replacement',
+      publicKeyB64: HOST_ONE.publicKeyB64,
+      deviceToken: 'replacement-token'
+    }
+    recordCleanupIntentMock.mockRejectedValueOnce(new Error('intent storage unavailable'))
+
+    await expect(saveHost(replacement)).rejects.toThrow('intent storage unavailable')
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, HOST_TWO])
+    expect(secureStoreMock.setItemAsync).not.toHaveBeenCalled()
   })
 
   it('deletes an unpaired credential when cleanup runs without a newer write', async () => {
@@ -771,6 +814,8 @@ describe('host-store pairing save after an Android encryption rejection', () => 
     scheduleCleanupMock.mockResolvedValue(undefined)
     cancelCleanupMock.mockReset()
     cancelCleanupMock.mockResolvedValue(undefined)
+    recordCleanupIntentMock.mockReset()
+    recordCleanupIntentMock.mockResolvedValue(undefined)
     storedHostsRaw = '[]'
     storedGenerationRaw = null
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -205,6 +205,60 @@ describe('host-store list mutations', () => {
     expect(scheduleCleanupMock).not.toHaveBeenCalled()
   })
 
+  it('serves a committed replacement token when same-key metadata persistence fails', async () => {
+    const duplicate = {
+      ...HOST_TWO,
+      id: 'host-duplicate',
+      publicKeyB64: HOST_ONE.publicKeyB64
+    }
+    storedHostsRaw = JSON.stringify([HOST_ONE, duplicate])
+    await loadHosts()
+    asyncStorageMock.setItem.mockRejectedValueOnce(new Error('metadata write failed'))
+
+    await expect(
+      saveHost({ ...HOST_ONE, endpoint: 'ws://127.0.0.1:3', deviceToken: 'replacement-token' })
+    ).rejects.toThrow('metadata write failed')
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, duplicate])
+    await expect(
+      loadHosts().then((hosts) => hosts.find(({ id }) => id === HOST_ONE.id)?.deviceToken)
+    ).resolves.toBe('replacement-token')
+  })
+
+  it('records cleanup when new same-key metadata fails after its credential commits', async () => {
+    const replacement = {
+      ...HOST_TWO,
+      id: 'host-replacement',
+      publicKeyB64: HOST_ONE.publicKeyB64,
+      deviceToken: 'replacement-token'
+    }
+    asyncStorageMock.setItem.mockRejectedValueOnce(new Error('metadata write failed'))
+
+    await expect(saveHost(replacement)).rejects.toThrow('metadata write failed')
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, HOST_TWO])
+    expect(scheduleCleanupMock).toHaveBeenCalledWith(replacement.id, expect.any(Function))
+  })
+
+  it('does not clean a duplicate id that a later same-key save made authoritative', async () => {
+    const duplicate = {
+      ...HOST_TWO,
+      id: 'host-duplicate',
+      publicKeyB64: HOST_ONE.publicKeyB64
+    }
+    storedHostsRaw = JSON.stringify([HOST_ONE, duplicate])
+    await saveHost({ ...HOST_ONE, deviceToken: 'token-a' })
+    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === duplicate.id)?.[1] as
+      | ((hostId: string) => Promise<void>)
+      | undefined
+
+    await saveHost({ ...duplicate, deviceToken: 'token-b' })
+    await staleCleanup?.(duplicate.id)
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([duplicate])
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
+  })
+
   it('clears stale relay state when an existing host is re-paired direct-only', async () => {
     const overlay: MobileRelayHostOverlay = {
       v: 2,
@@ -275,6 +329,20 @@ describe('host-store list mutations', () => {
 
     expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
     expect(scheduleCleanupMock).toHaveBeenCalledWith(HOST_ONE.id, expect.any(Function))
+  })
+
+  it('deletes an unpaired credential when cleanup runs without a newer write', async () => {
+    await removeHost(HOST_ONE.id)
+    const cleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
+      | ((hostId: string) => Promise<void>)
+      | undefined
+
+    await cleanup?.(HOST_ONE.id)
+
+    expect(secureStoreMock.deleteItemAsync).toHaveBeenCalledWith(
+      'orca.host-token.host-1',
+      expect.anything()
+    )
   })
 
   it('merges v2 endpoints only onto an existing legacy base host', async () => {

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -47,6 +47,7 @@ import {
   updateLastConnected
 } from './host-store'
 import { resetMobileRelayHostOverlayStoreForTests } from './mobile-relay-host-overlay-store'
+import { writeMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
 
 const HOSTS_STORAGE_KEY = 'orca:hosts'
 const OVERLAY_STORAGE_KEY = 'orca:mobile-relay:host-overlays:v2'
@@ -63,6 +64,17 @@ const HOST_TWO = {
   endpoint: 'ws://127.0.0.1:2',
   publicKeyB64: 'key-2',
   lastConnected: 0
+}
+const HOST_ONE_RELAY_BUNDLE = {
+  v: 1 as const,
+  hostId: HOST_ONE.id,
+  deviceToken: 'replacement-token',
+  current: {
+    token: 'A'.repeat(43),
+    hash: 'B'.repeat(43),
+    version: 1,
+    expiresAt: 10_000
+  }
 }
 
 describe('host-store list mutations', () => {
@@ -256,6 +268,85 @@ describe('host-store list mutations', () => {
     await staleCleanup?.(duplicate.id)
 
     expect(JSON.parse(storedHostsRaw)).toEqual([duplicate])
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('does not let stale removal cleanup delete a replacement relay bundle before publication', async () => {
+    await removeHost(HOST_ONE.id)
+    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
+      | ((hostId: string) => Promise<void>)
+      | undefined
+    await writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
+
+    await staleCleanup?.(HOST_ONE.id)
+
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('stops stale cleanup when a replacement relay write starts during token deletion', async () => {
+    await removeHost(HOST_ONE.id)
+    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
+      | ((hostId: string) => Promise<void>)
+      | undefined
+    let releaseTokenDelete: () => void = () => {}
+    secureStoreMock.deleteItemAsync.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseTokenDelete = resolve
+      })
+    )
+
+    const cleanup = staleCleanup?.(HOST_ONE.id)
+    await vi.waitFor(() => {
+      expect(secureStoreMock.deleteItemAsync).toHaveBeenCalledWith(
+        'orca.host-token.host-1',
+        expect.anything()
+      )
+    })
+    const bundleWrite = writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
+    releaseTokenDelete()
+    await Promise.all([cleanup, bundleWrite])
+
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalledWith(
+      'orca.mobile-relay.credentials.host-1',
+      expect.anything()
+    )
+  })
+
+  it('rechecks the write generation immediately before starting credential deletion', async () => {
+    await removeHost(HOST_ONE.id)
+    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
+      | ((hostId: string) => Promise<void>)
+      | undefined
+    let resolveCleanupRead: (raw: string) => void = () => {}
+    const cleanupRead = new Promise<string>((resolve) => {
+      resolveCleanupRead = resolve
+    })
+    let cleanupReadStarted = false
+    asyncStorageMock.getItem.mockImplementation(async (key: string) => {
+      if (key === HOSTS_STORAGE_KEY && !cleanupReadStarted) {
+        cleanupReadStarted = true
+        return cleanupRead
+      }
+      if (key === HOSTS_STORAGE_KEY) {
+        return storedHostsRaw
+      }
+      if (key === OVERLAY_STORAGE_KEY) {
+        return storedOverlayRaw
+      }
+      return null
+    })
+
+    const cleanup = staleCleanup?.(HOST_ONE.id)
+    await vi.waitFor(() => expect(cleanupReadStarted).toBe(true))
+    let bundleWrite: Promise<void> | null = null
+    resolveCleanupRead(storedHostsRaw)
+    queueMicrotask(() => {
+      bundleWrite = writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
+    })
+    await cleanup
+    await vi.waitFor(() => expect(bundleWrite).not.toBeNull())
+    await bundleWrite
+
     expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
   })
 

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -35,6 +35,7 @@ vi.mock('./host-credential-cleanup', () => ({
 }))
 
 import {
+  loadHostCatalog,
   loadHosts,
   MobileRelayUpgradeHostRemovedError,
   removeHost,
@@ -93,6 +94,7 @@ describe('host-store list mutations', () => {
         storedOverlayRaw = raw
       }
     })
+    secureStoreMock.setItemAsync.mockResolvedValue(undefined)
     secureStoreMock.getItemAsync.mockImplementation(async (key: string) =>
       key.endsWith(HOST_ONE.id) || key.endsWith(HOST_TWO.id) ? `token-${key.at(-1)}` : null
     )
@@ -112,6 +114,55 @@ describe('host-store list mutations', () => {
       name: 'Host 3'
     })
     expect(asyncStorageMock.getItem).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a host visible when its credential read temporarily fails', async () => {
+    secureStoreMock.getItemAsync.mockImplementation(async (key: string) => {
+      if (key.endsWith(HOST_ONE.id)) {
+        throw new Error('keychain locked')
+      }
+      return key.endsWith(HOST_TWO.id) ? 'token-2' : null
+    })
+
+    const catalog = await loadHostCatalog()
+    const profiles = await loadHosts()
+
+    expect(catalog.map(({ id }) => id)).toEqual([HOST_ONE.id, HOST_TWO.id])
+    expect(catalog.find(({ id }) => id === HOST_ONE.id)).toMatchObject({
+      credentialStatus: 'temporarily-unavailable',
+      profile: null
+    })
+    expect(profiles.map(({ id }) => id)).toEqual([HOST_TWO.id])
+  })
+
+  it('keeps orphaned metadata visible when its credential is missing', async () => {
+    secureStoreMock.getItemAsync.mockImplementation(async (key: string) =>
+      key.endsWith(HOST_TWO.id) ? 'token-2' : null
+    )
+
+    const catalog = await loadHostCatalog()
+
+    expect(catalog.find(({ id }) => id === HOST_ONE.id)).toMatchObject({
+      credentialStatus: 'missing',
+      profile: null
+    })
+  })
+
+  it('keeps existing metadata when pairing a distinct host', async () => {
+    await saveHost({
+      id: 'host-new',
+      name: 'Host 3',
+      endpoint: 'ws://127.0.0.1:3',
+      publicKeyB64: 'key-new',
+      deviceToken: 'token-new',
+      lastConnected: 0
+    })
+
+    expect(JSON.parse(storedHostsRaw).map(({ id }: { id: string }) => id)).toEqual([
+      HOST_ONE.id,
+      HOST_TWO.id,
+      'host-new'
+    ])
   })
 
   it('fails closed when durable host identity storage is unreadable', async () => {
@@ -135,6 +186,23 @@ describe('host-store list mutations', () => {
 
     expect(JSON.parse(storedHostsRaw)).toEqual([{ ...HOST_ONE, endpoint: 'ws://127.0.0.1:3' }])
     expect(scheduleCleanupMock).toHaveBeenCalledWith('host-duplicate', expect.any(Function))
+  })
+
+  it('does not remove same-key metadata when the replacement credential write fails', async () => {
+    const duplicate = {
+      ...HOST_TWO,
+      id: 'host-duplicate',
+      publicKeyB64: HOST_ONE.publicKeyB64
+    }
+    storedHostsRaw = JSON.stringify([HOST_ONE, duplicate])
+    secureStoreMock.setItemAsync.mockRejectedValue(new Error('keychain write failed'))
+
+    await expect(
+      saveHost({ ...HOST_ONE, endpoint: 'ws://127.0.0.1:3', deviceToken: 'replacement-token' })
+    ).rejects.toThrow('keychain write failed')
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, duplicate])
+    expect(scheduleCleanupMock).not.toHaveBeenCalled()
   })
 
   it('clears stale relay state when an existing host is re-paired direct-only', async () => {

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -81,6 +81,12 @@ const HOST_ONE_RELAY_BUNDLE = {
   }
 }
 
+function scheduledCleanup(hostId: string): (id: string) => Promise<void> {
+  const cleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === hostId)?.[1]
+  expect(cleanup).toBeTypeOf('function')
+  return cleanup as (id: string) => Promise<void>
+}
+
 describe('host-store list mutations', () => {
   let storedHostsRaw: string
   let storedOverlayRaw: string | null
@@ -205,6 +211,9 @@ describe('host-store list mutations', () => {
     })
 
     expect(JSON.parse(storedHostsRaw)).toEqual([{ ...HOST_ONE, endpoint: 'ws://127.0.0.1:3' }])
+    expect(recordCleanupIntentMock.mock.invocationCallOrder[0]).toBeLessThan(
+      asyncStorageMock.setItem.mock.invocationCallOrder[0]!
+    )
     expect(scheduleCleanupMock).toHaveBeenCalledWith('host-duplicate', expect.any(Function))
   })
 
@@ -222,6 +231,7 @@ describe('host-store list mutations', () => {
     ).rejects.toThrow('keychain write failed')
 
     expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, duplicate])
+    expect(cancelCleanupMock).toHaveBeenCalledWith(duplicate.id)
     expect(scheduleCleanupMock).not.toHaveBeenCalled()
   })
 
@@ -272,12 +282,10 @@ describe('host-store list mutations', () => {
     }
     storedHostsRaw = JSON.stringify([HOST_ONE, duplicate])
     await saveHost({ ...HOST_ONE, deviceToken: 'token-a' })
-    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === duplicate.id)?.[1] as
-      | ((hostId: string) => Promise<void>)
-      | undefined
+    const staleCleanup = scheduledCleanup(duplicate.id)
 
     await saveHost({ ...duplicate, deviceToken: 'token-b' })
-    await staleCleanup?.(duplicate.id)
+    await staleCleanup(duplicate.id)
 
     expect(JSON.parse(storedHostsRaw)).toEqual([duplicate])
     expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
@@ -285,36 +293,30 @@ describe('host-store list mutations', () => {
 
   it('does not let stale removal cleanup delete a replacement relay bundle before publication', async () => {
     await removeHost(HOST_ONE.id)
-    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
-      | ((hostId: string) => Promise<void>)
-      | undefined
+    const staleCleanup = scheduledCleanup(HOST_ONE.id)
     await writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
 
-    await expect(staleCleanup?.(HOST_ONE.id)).rejects.toThrow('credential write superseded cleanup')
+    await expect(staleCleanup(HOST_ONE.id)).rejects.toThrow('credential write superseded cleanup')
 
     expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
   })
 
   it('keeps stale cleanup pending when a replacement relay write fails', async () => {
     await removeHost(HOST_ONE.id)
-    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
-      | ((hostId: string) => Promise<void>)
-      | undefined
+    const staleCleanup = scheduledCleanup(HOST_ONE.id)
     secureStoreMock.setItemAsync.mockRejectedValueOnce(new Error('keychain write failed'))
 
     await expect(writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)).rejects.toThrow(
       'keychain write failed'
     )
-    await expect(staleCleanup?.(HOST_ONE.id)).rejects.toThrow('credential write superseded cleanup')
+    await expect(staleCleanup(HOST_ONE.id)).rejects.toThrow('credential write superseded cleanup')
 
     expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
   })
 
   it('stops stale cleanup when a replacement relay write starts during token deletion', async () => {
     await removeHost(HOST_ONE.id)
-    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
-      | ((hostId: string) => Promise<void>)
-      | undefined
+    const staleCleanup = scheduledCleanup(HOST_ONE.id)
     let releaseTokenDelete: () => void = () => {}
     secureStoreMock.deleteItemAsync.mockReturnValueOnce(
       new Promise<void>((resolve) => {
@@ -322,7 +324,7 @@ describe('host-store list mutations', () => {
       })
     )
 
-    const cleanup = staleCleanup?.(HOST_ONE.id)
+    const cleanup = staleCleanup(HOST_ONE.id)
     await vi.waitFor(() => {
       expect(secureStoreMock.deleteItemAsync).toHaveBeenCalledWith(
         'orca.host-token.host-1',
@@ -342,9 +344,7 @@ describe('host-store list mutations', () => {
 
   it('rechecks the write generation immediately before starting credential deletion', async () => {
     await removeHost(HOST_ONE.id)
-    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
-      | ((hostId: string) => Promise<void>)
-      | undefined
+    const staleCleanup = scheduledCleanup(HOST_ONE.id)
     let resolveCleanupRead: (raw: string) => void = () => {}
     const cleanupRead = new Promise<string>((resolve) => {
       resolveCleanupRead = resolve
@@ -364,7 +364,7 @@ describe('host-store list mutations', () => {
       return null
     })
 
-    const cleanup = staleCleanup?.(HOST_ONE.id)
+    const cleanup = staleCleanup(HOST_ONE.id)
     await vi.waitFor(() => expect(cleanupReadStarted).toBe(true))
     let bundleWrite: Promise<void> | null = null
     resolveCleanupRead(storedHostsRaw)
@@ -450,6 +450,15 @@ describe('host-store list mutations', () => {
     expect(scheduleCleanupMock).toHaveBeenCalledWith(HOST_ONE.id, expect.any(Function))
   })
 
+  it('cancels write-ahead cleanup when host metadata removal fails', async () => {
+    asyncStorageMock.setItem.mockRejectedValueOnce(new Error('metadata write failed'))
+
+    await expect(removeHost(HOST_ONE.id)).rejects.toThrow('metadata write failed')
+
+    expect(JSON.parse(storedHostsRaw)).toEqual([HOST_ONE, HOST_TWO])
+    expect(cancelCleanupMock).toHaveBeenCalledWith(HOST_ONE.id)
+  })
+
   it('does not cancel cleanup from a removal committed during a stalled save', async () => {
     let releaseTokenWrite: () => void = () => {}
     secureStoreMock.setItemAsync.mockReturnValueOnce(
@@ -487,11 +496,9 @@ describe('host-store list mutations', () => {
 
   it('deletes an unpaired credential when cleanup runs without a newer write', async () => {
     await removeHost(HOST_ONE.id)
-    const cleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
-      | ((hostId: string) => Promise<void>)
-      | undefined
+    const cleanup = scheduledCleanup(HOST_ONE.id)
 
-    await cleanup?.(HOST_ONE.id)
+    await cleanup(HOST_ONE.id)
 
     expect(secureStoreMock.deleteItemAsync).toHaveBeenCalledWith(
       'orca.host-token.host-1',
@@ -499,7 +506,7 @@ describe('host-store list mutations', () => {
     )
   })
 
-  it('merges v2 endpoints only onto an existing legacy base host', async () => {
+  it('keeps a concurrently re-published orphan overlay authoritative', async () => {
     const overlay: MobileRelayHostOverlay = {
       v: 2,
       hostId: HOST_ONE.id,
@@ -522,8 +529,26 @@ describe('host-store list mutations', () => {
       }
     }
     storedOverlayRaw = JSON.stringify([overlay, { ...overlay, hostId: 'removed-by-old-build' }])
+    let releaseCleanup: () => void = () => {}
+    scheduleCleanupMock.mockReturnValueOnce(
+      new Promise<void>((resolve) => {
+        releaseCleanup = resolve
+      })
+    )
 
-    const hosts = await loadHosts()
+    const hostsLoad = loadHosts()
+    await vi.waitFor(() => expect(scheduleCleanupMock).toHaveBeenCalled())
+    await saveHost({
+      ...HOST_ONE,
+      id: 'removed-by-old-build',
+      publicKeyB64: 'restored-key',
+      deviceToken: 'restored-token',
+      endpoints: overlay.endpoints,
+      relayHostId: overlay.relayHostId,
+      relay: overlay.relay
+    })
+    releaseCleanup()
+    const hosts = await hostsLoad
 
     expect(hosts.find(({ id }) => id === HOST_ONE.id)).toMatchObject({
       endpoints: overlay.endpoints,
@@ -531,6 +556,10 @@ describe('host-store list mutations', () => {
       relay: overlay.relay
     })
     expect(hosts.some(({ id }) => id === 'removed-by-old-build')).toBe(false)
+    expect(JSON.parse(storedOverlayRaw!)).toContainEqual({
+      ...overlay,
+      hostId: 'removed-by-old-build'
+    })
   })
 
   it('refuses to resurrect a removed host during relay upgrade publication', async () => {
@@ -560,7 +589,9 @@ describe('host-store list mutations', () => {
       expect(JSON.parse(storedHostsRaw)).toEqual([HOST_TWO])
     })
     expect(settled).toBe(false)
-    expect(scheduleCleanupMock).toHaveBeenCalledOnce()
+    expect(recordCleanupIntentMock.mock.invocationCallOrder[0]).toBeLessThan(
+      asyncStorageMock.setItem.mock.invocationCallOrder[0]!
+    )
 
     resolveSchedule?.()
     await removal

--- a/mobile/src/transport/host-store.test.ts
+++ b/mobile/src/transport/host-store.test.ts
@@ -14,6 +14,7 @@ const secureStoreMock = vi.hoisted(() => ({
 }))
 
 const scheduleCleanupMock = vi.hoisted(() => vi.fn())
+const cancelCleanupMock = vi.hoisted(() => vi.fn())
 const platformMock = vi.hoisted(() => ({ OS: 'ios' }))
 
 vi.mock('@react-native-async-storage/async-storage', () => ({
@@ -30,6 +31,7 @@ vi.mock('react-native', () => ({
 }))
 
 vi.mock('./host-credential-cleanup', () => ({
+  cancelPendingHostCredentialCleanup: (...args: unknown[]) => cancelCleanupMock(...args),
   scheduleHostCredentialCleanup: (...args: unknown[]) => scheduleCleanupMock(...args),
   retryPendingHostCredentialCleanups: vi.fn()
 }))
@@ -88,6 +90,8 @@ describe('host-store list mutations', () => {
     resetMobileRelayHostOverlayStoreForTests()
     scheduleCleanupMock.mockReset()
     scheduleCleanupMock.mockResolvedValue(undefined)
+    cancelCleanupMock.mockReset()
+    cancelCleanupMock.mockResolvedValue(undefined)
     storedHostsRaw = JSON.stringify([HOST_ONE, HOST_TWO])
     storedOverlayRaw = null
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {
@@ -278,7 +282,22 @@ describe('host-store list mutations', () => {
       | undefined
     await writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
 
-    await staleCleanup?.(HOST_ONE.id)
+    await expect(staleCleanup?.(HOST_ONE.id)).rejects.toThrow('credential write superseded cleanup')
+
+    expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
+  })
+
+  it('keeps stale cleanup pending when a replacement relay write fails', async () => {
+    await removeHost(HOST_ONE.id)
+    const staleCleanup = scheduleCleanupMock.mock.calls.find(([id]) => id === HOST_ONE.id)?.[1] as
+      | ((hostId: string) => Promise<void>)
+      | undefined
+    secureStoreMock.setItemAsync.mockRejectedValueOnce(new Error('keychain write failed'))
+
+    await expect(writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)).rejects.toThrow(
+      'keychain write failed'
+    )
+    await expect(staleCleanup?.(HOST_ONE.id)).rejects.toThrow('credential write superseded cleanup')
 
     expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalled()
   })
@@ -304,7 +323,8 @@ describe('host-store list mutations', () => {
     })
     const bundleWrite = writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
     releaseTokenDelete()
-    await Promise.all([cleanup, bundleWrite])
+    await bundleWrite
+    await expect(cleanup).rejects.toThrow('credential write superseded cleanup')
 
     expect(secureStoreMock.deleteItemAsync).not.toHaveBeenCalledWith(
       'orca.mobile-relay.credentials.host-1',
@@ -343,7 +363,7 @@ describe('host-store list mutations', () => {
     queueMicrotask(() => {
       bundleWrite = writeMobileRelayCredentialBundle(HOST_ONE_RELAY_BUNDLE)
     })
-    await cleanup
+    await expect(cleanup).rejects.toThrow('credential write superseded cleanup')
     await vi.waitFor(() => expect(bundleWrite).not.toBeNull())
     await bundleWrite
 
@@ -749,6 +769,8 @@ describe('host-store pairing save after an Android encryption rejection', () => 
     resetMobileRelayHostOverlayStoreForTests()
     scheduleCleanupMock.mockReset()
     scheduleCleanupMock.mockResolvedValue(undefined)
+    cancelCleanupMock.mockReset()
+    cancelCleanupMock.mockResolvedValue(undefined)
     storedHostsRaw = '[]'
     storedGenerationRaw = null
     asyncStorageMock.getItem.mockImplementation(async (key: string) => {

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -12,6 +12,7 @@ import { joinHostCatalogCredentials } from './host-catalog-credential-join'
 import { resetPairingKeychainForTests } from './pairing-keychain'
 import { readHostDeviceToken, writeHostDeviceToken } from './host-device-token-store'
 import {
+  cancelPendingHostCredentialCleanup,
   retryPendingHostCredentialCleanups,
   scheduleHostCredentialCleanup
 } from './host-credential-cleanup'
@@ -233,6 +234,8 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
     // Why: the catalog can now surface a failed token write for recovery instead of losing the host.
     await commitDeviceToken(stored.id, validated.deviceToken)
   }
+  // Why: publication supersedes stale removal intent; clearing it must not delay pairing.
+  void cancelPendingHostCredentialCleanup(stored.id).catch(() => undefined)
   if (validated.endpoints) {
     await saveMobileRelayHostOverlay({
       v: 2,

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -1,5 +1,4 @@
-import AsyncStorage from '@react-native-async-storage/async-storage'
-import { HostProfileSchema, StoredHostProfileSchema } from './types'
+import { HostProfileSchema } from './types'
 import type { HostCatalogEntry, HostProfile, StoredHostProfile } from './types'
 import { getNextHostNameFromHosts } from './host-names'
 import * as hostListLoads from './host-list-load-sharing'
@@ -25,8 +24,12 @@ import {
   resetHostCredentialWriteRevisionsForTests
 } from './host-credential-write-revision'
 import { createUnpairedHostCredentialDeletion } from './unpaired-host-credential-deletion'
-
-const STORAGE_KEY = 'orca:hosts'
+import {
+  loadStoredHostProfiles,
+  readStoredHostProfilesForMutation,
+  toStoredHostProfile,
+  writeStoredHostProfiles
+} from './host-metadata-store'
 
 async function commitDeviceToken(hostId: string, token: string): Promise<void> {
   markHostCredentialWrite(hostId)
@@ -37,38 +40,12 @@ async function commitDeviceToken(hostId: string, token: string): Promise<void> {
 
 // Why: Keychain reads are slow (50-200ms) and loadHosts() runs on every screen mount; cache per-hostId in memory, invalidate on save/remove.
 const tokenCache = new Map<string, string>()
-// Why: serialize RMW of the shared hosts JSON; without a queue concurrent writers drop writes (resurrect a removed host, drop a rename).
+// Why: serialize host metadata RMW so concurrent writers cannot drop updates.
 let hostListMutation: Promise<void> = Promise.resolve()
 
-function parseStoredHosts(raw: string | null): StoredHostProfile[] | null {
-  if (!raw) {
-    return []
-  }
-  try {
-    const parsed = JSON.parse(raw) as unknown
-    if (!Array.isArray(parsed)) {
-      return null
-    }
-    return parsed.flatMap((item) => {
-      // Why: pre-v0.0.3 records stored deviceToken in AsyncStorage; drop them (users re-pair) rather than carry a migration shim.
-      if (item && typeof item === 'object' && 'deviceToken' in item) {
-        return []
-      }
-      const result = StoredHostProfileSchema.safeParse(item)
-      return result.success ? [result.data] : []
-    })
-  } catch {
-    return null
-  }
-}
-
-export async function loadHosts(): Promise<HostProfile[]> {
-  return (await loadHostListSnapshot()).profiles
-}
-
-export async function loadHostCatalog(): Promise<HostCatalogEntry[]> {
-  return (await loadHostListSnapshot()).catalog
-}
+export const loadHosts = async (): Promise<HostProfile[]> => (await loadHostListSnapshot()).profiles
+export const loadHostCatalog = async (): Promise<HostCatalogEntry[]> =>
+  (await loadHostListSnapshot()).catalog
 
 async function loadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot> {
   // Why: writers hold the mutation chain across their full RMW; wait so a load doesn't race a half-written list.
@@ -78,8 +55,7 @@ async function loadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot> {
 }
 
 async function doLoadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot> {
-  const raw = await AsyncStorage.getItem(STORAGE_KEY)
-  const storedHosts = parseStoredHosts(raw)
+  const storedHosts = await loadStoredHostProfiles()
   if (!storedHosts) {
     return { catalog: [], profiles: [] }
   }
@@ -92,7 +68,8 @@ async function doLoadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot>
   await scheduleOrphanedMobileRelayCleanup({
     hostIds: overlayState.orphanHostIds,
     deleteCredential: (hostId) =>
-      deleteUnpairedHostCredentials(hostId, orphanWriteRevisions.get(hostId) ?? 0)
+      deleteUnpairedHostCredentials(hostId, orphanWriteRevisions.get(hostId) ?? 0),
+    removeOverlay: removeOrphanOverlayIfUnpaired
   })
   return joinHostCatalogCredentials({
     storedHosts,
@@ -109,33 +86,17 @@ export async function resolvePairingHostIdentity(
 ): Promise<{ id: string; name: string }> {
   // Why: one durable read both preserves an existing identity and names a new host, avoiding duplicate cards.
   await hostListMutation
-  const hosts = await readStoredHostsForMutation()
+  const hosts = await readStoredHostProfilesForMutation()
   const match = hosts.find((host) => host.publicKeyB64 === publicKeyB64)
   return match
     ? { id: match.id, name: match.name }
     : { id: newHostId, name: getNextHostNameFromHosts(hosts) }
 }
 
-async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
-  try {
-    const parsed = parseStoredHosts(await AsyncStorage.getItem(STORAGE_KEY))
-    if (!parsed) {
-      // Why: refuse to RMW over unreadable payload — treating it as [] would wipe the durable host list on the next write.
-      throw new Error('host list storage unreadable')
-    }
-    return parsed
-  } catch (error) {
-    if (error instanceof Error && error.message === 'host list storage unreadable') {
-      throw error
-    }
-    throw new Error('host list storage unreadable')
-  }
-}
-
 const deleteUnpairedHostCredentials = createUnpairedHostCredentialDeletion({
   waitForHostMutations: () => hostListMutation,
   hasStoredHost: async (hostId) =>
-    (await readStoredHostsForMutation()).some(({ id }) => id === hostId),
+    (await readStoredHostProfilesForMutation()).some(({ id }) => id === hostId),
   onDeleted: (hostId) => {
     tokenCache.delete(hostId)
     hostListLoads.dropSharedHostListLoad()
@@ -151,7 +112,7 @@ function scheduleUnpairedHostCredentialCleanup(hostId: string): Promise<void> {
 
 function cancelCleanupForStoredHost(hostId: string): void {
   const cancellation = hostListMutation.then(async () => {
-    const hosts = await readStoredHostsForMutation()
+    const hosts = await readStoredHostProfilesForMutation()
     if (hosts.some(({ id }) => id === hostId)) {
       // Register before later removals enqueue their intent, without blocking host loads on cleanup storage.
       void cancelPendingHostCredentialCleanup(hostId).catch(() => undefined)
@@ -160,27 +121,42 @@ function cancelCleanupForStoredHost(hostId: string): void {
   hostListMutation = cancellation.catch(() => {})
 }
 
-async function mutateStoredHosts(
-  update: (hosts: StoredHostProfile[]) => StoredHostProfile[] | Promise<StoredHostProfile[]>
-): Promise<void> {
-  const mutation = hostListMutation.then(async () => {
-    const current = await readStoredHostsForMutation()
-    const next = await update(current)
-    await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next))
-    hostListLoads.dropSharedHostListLoad()
-  })
+async function cancelCleanupForDurablyStoredHosts(hostIds: Iterable<string>): Promise<void> {
+  const targets = [...hostIds]
+  return enqueueHostListMutation(async () => {
+    const storedIds = new Set((await readStoredHostProfilesForMutation()).map(({ id }) => id))
+    await Promise.all(
+      targets
+        .filter((hostId) => storedIds.has(hostId))
+        .map((hostId) => cancelPendingHostCredentialCleanup(hostId).catch(() => undefined))
+    )
+  }).catch(() => undefined)
+}
+
+function enqueueHostListMutation(operation: () => Promise<void>): Promise<void> {
+  const mutation = hostListMutation.then(operation)
   hostListMutation = mutation.catch(() => {})
   return mutation
 }
 
-function toStored(host: HostProfile): StoredHostProfile {
-  return {
-    id: host.id,
-    name: host.name,
-    endpoint: host.endpoint,
-    publicKeyB64: host.publicKeyB64,
-    lastConnected: host.lastConnected
-  }
+function removeOrphanOverlayIfUnpaired(hostId: string): Promise<void> {
+  return enqueueHostListMutation(async () => {
+    const hosts = await readStoredHostProfilesForMutation()
+    if (!hosts.some(({ id }) => id === hostId)) {
+      await removeMobileRelayHostOverlay(hostId)
+    }
+  })
+}
+
+async function mutateStoredHosts(
+  update: (hosts: StoredHostProfile[]) => StoredHostProfile[] | Promise<StoredHostProfile[]>
+): Promise<void> {
+  return enqueueHostListMutation(async () => {
+    const current = await readStoredHostProfilesForMutation()
+    const next = await update(current)
+    await writeStoredHostProfiles(next)
+    hostListLoads.dropSharedHostListLoad()
+  })
 }
 
 export class MobileRelayUpgradeHostRemovedError extends Error {}
@@ -192,7 +168,7 @@ export const saveExistingHostRelayUpgrade = (host: HostProfile): Promise<void> =
 
 async function persistHost(host: HostProfile, requireExisting: boolean): Promise<void> {
   const validated = HostProfileSchema.parse(host)
-  const stored = toStored(validated)
+  const stored = toStoredHostProfile(validated)
   const duplicateHostIds = new Set<string>()
   let updatedExistingHost = false
   let cleanupIntentRecordedBeforeMetadata = false
@@ -224,6 +200,9 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
           await recordHostCredentialCleanupIntent(stored.id)
           cleanupIntentRecordedBeforeMetadata = true
         }
+        for (const duplicateHostId of duplicateHostIds) {
+          await recordHostCredentialCleanupIntent(duplicateHostId)
+        }
         // Why: never remove the only usable same-key row until its replacement credential is durable.
         await commitDeviceToken(stored.id, validated.deviceToken)
         tokenCommittedBeforeMetadata = true
@@ -231,6 +210,7 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
       return next
     })
   } catch (error) {
+    await cancelCleanupForDurablyStoredHosts(duplicateHostIds)
     if (cleanupIntentRecordedBeforeMetadata) {
       try {
         await scheduleUnpairedHostCredentialCleanup(stored.id)
@@ -275,7 +255,23 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
 }
 
 export async function removeHost(hostId: string): Promise<void> {
-  await mutateStoredHosts((hosts) => hosts.filter((h) => h.id !== hostId))
+  let cleanupIntentRecorded = false
+  try {
+    await mutateStoredHosts(async (hosts) => {
+      try {
+        await recordHostCredentialCleanupIntent(hostId)
+        cleanupIntentRecorded = true
+      } catch {
+        // Removal remains authoritative when cleanup intent storage is unavailable.
+      }
+      return hosts.filter((h) => h.id !== hostId)
+    })
+  } catch (error) {
+    if (cleanupIntentRecorded) {
+      await cancelCleanupForDurablyStoredHosts([hostId])
+    }
+    throw error
+  }
   tokenCache.delete(hostId)
   try {
     await removeMobileRelayHostOverlay(hostId)

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -3,11 +3,13 @@ import { Platform } from 'react-native'
 import {
   HostProfileSchema,
   StoredHostProfileSchema,
+  type HostCatalogEntry,
   type HostProfile,
   type StoredHostProfile
 } from './types'
 import { getNextHostNameFromHosts } from './host-names'
 import * as hostListLoads from './host-list-load-sharing'
+import { joinHostCatalogCredentials } from './host-catalog-credential-join'
 import {
   deletePairingKeychainItem,
   readPairingKeychainItem,
@@ -99,17 +101,25 @@ function parseStoredHosts(raw: string | null): StoredHostProfile[] | null {
 }
 
 export async function loadHosts(): Promise<HostProfile[]> {
+  return (await loadHostListSnapshot()).profiles
+}
+
+export async function loadHostCatalog(): Promise<HostCatalogEntry[]> {
+  return (await loadHostListSnapshot()).catalog
+}
+
+async function loadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot> {
   // Why: writers hold the mutation chain across their full RMW; wait so a load doesn't race a half-written list.
   await hostListMutation
   // Why: deduplicate concurrent loadHosts() calls so simultaneously mounting screens share one Keychain read pass.
-  return hostListLoads.shareHostListLoad(doLoadHosts)
+  return hostListLoads.shareHostListLoad(doLoadHostListSnapshot)
 }
 
-async function doLoadHosts(): Promise<HostProfile[]> {
+async function doLoadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot> {
   const raw = await AsyncStorage.getItem(STORAGE_KEY)
   const storedHosts = parseStoredHosts(raw)
   if (!storedHosts) {
-    return []
+    return { catalog: [], profiles: [] }
   }
   const overlayState = await loadMobileRelayHostOverlayState(
     new Set(storedHosts.map(({ id }) => id))
@@ -118,43 +128,13 @@ async function doLoadHosts(): Promise<HostProfile[]> {
     hostIds: overlayState.orphanHostIds,
     deleteCredential: deleteHostCredentials
   })
-  const overlays = overlayState.overlays
-
-  const out: HostProfile[] = []
-  for (const stored of storedHosts) {
-    let token = tokenCache.get(stored.id)
-    if (!token) {
-      const readRevision = hostListLoads.getHostListLoadRevision()
-      let fetched: string | null
-      try {
-        fetched = await readDeviceToken(stored.id)
-      } catch {
-        // Why: a transient Keychain failure for one entry (e.g. errSecInteractionNotAllowed while locked) must not blank the whole host list; skip it.
-        continue
-      }
-      if (!fetched) {
-        // Why: orphaned metadata with no matching keychain entry; skip rather than surface a half-broken host.
-        continue
-      }
-      token = fetched
-      if (readRevision === hostListLoads.getHostListLoadRevision()) {
-        tokenCache.set(stored.id, token)
-      }
-    }
-    const overlay = overlays.get(stored.id)
-    out.push({
-      ...stored,
-      deviceToken: token,
-      ...(overlay
-        ? {
-            endpoints: overlay.endpoints,
-            relayHostId: overlay.relayHostId,
-            relay: overlay.relay
-          }
-        : {})
-    })
-  }
-  return out
+  return joinHostCatalogCredentials({
+    storedHosts,
+    overlays: overlayState.overlays,
+    tokenCache,
+    readToken: readDeviceToken,
+    getRevision: hostListLoads.getHostListLoadRevision
+  })
 }
 
 export async function resolvePairingHostIdentity(
@@ -187,11 +167,11 @@ async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
 }
 
 async function mutateStoredHosts(
-  update: (hosts: StoredHostProfile[]) => StoredHostProfile[]
+  update: (hosts: StoredHostProfile[]) => StoredHostProfile[] | Promise<StoredHostProfile[]>
 ): Promise<void> {
   const mutation = hostListMutation.then(async () => {
     const current = await readStoredHostsForMutation()
-    const next = update(current)
+    const next = await update(current)
     await AsyncStorage.setItem(STORAGE_KEY, JSON.stringify(next))
     hostListLoads.dropSharedHostListLoad()
   })
@@ -224,28 +204,38 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
   const stored = toStored(validated)
   const duplicateHostIds = new Set<string>()
   let updatedExistingHost = false
-  await mutateStoredHosts((hosts) => {
+  let tokenCommittedBeforeMetadata = false
+  await mutateStoredHosts(async (hosts) => {
     const index = hosts.findIndex((h) => h.id === stored.id)
     for (const candidate of hosts) {
       if (candidate.id !== stored.id && candidate.publicKeyB64 === stored.publicKeyB64) {
         duplicateHostIds.add(candidate.id)
       }
     }
+    let next: StoredHostProfile[]
     if (index >= 0) {
       updatedExistingHost = true
       // Why: an authoritative save is the safe point to collapse pre-existing duplicate rows to the preserved host id.
-      return hosts
+      next = hosts
         .filter(({ id }) => !duplicateHostIds.has(id))
         .map((candidate) => (candidate.id === stored.id ? stored : candidate))
-    }
-    if (requireExisting) {
+    } else if (requireExisting) {
       // Why: an in-flight relay upgrade must not resurrect a host the user removed.
       throw new MobileRelayUpgradeHostRemovedError('mobile relay upgrade host was removed')
+    } else {
+      next = [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
     }
-    return [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
+    if (duplicateHostIds.size > 0) {
+      // Why: never remove the only usable same-key row until its replacement credential is durable.
+      await writeDeviceToken(stored.id, validated.deviceToken)
+      tokenCommittedBeforeMetadata = true
+    }
+    return next
   })
-  // Why: write metadata before the keychain token so a crash leaves recoverable orphaned metadata, not an orphaned token that persists forever.
-  await writeDeviceToken(stored.id, validated.deviceToken)
+  if (!tokenCommittedBeforeMetadata) {
+    // Why: the catalog can now surface a failed token write for recovery instead of losing the host.
+    await writeDeviceToken(stored.id, validated.deviceToken)
+  }
   tokenCache.set(stored.id, validated.deviceToken)
   hostListLoads.dropSharedHostListLoad()
   if (validated.endpoints) {

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -1,5 +1,4 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import { Platform } from 'react-native'
 import {
   HostProfileSchema,
   StoredHostProfileSchema,
@@ -10,12 +9,12 @@ import {
 import { getNextHostNameFromHosts } from './host-names'
 import * as hostListLoads from './host-list-load-sharing'
 import { joinHostCatalogCredentials } from './host-catalog-credential-join'
+import { resetPairingKeychainForTests } from './pairing-keychain'
 import {
-  deletePairingKeychainItem,
-  readPairingKeychainItem,
-  resetPairingKeychainForTests,
-  writePairingKeychainItem
-} from './pairing-keychain'
+  deleteHostDeviceToken,
+  readHostDeviceToken,
+  writeHostDeviceToken
+} from './host-device-token-store'
 import {
   retryPendingHostCredentialCleanups,
   scheduleHostCredentialCleanup
@@ -31,50 +30,23 @@ import { deleteMobileRelayDirectUpgradeJournal } from './mobile-relay-direct-upg
 import { scheduleOrphanedMobileRelayCleanup } from './mobile-relay-orphan-cleanup'
 
 const STORAGE_KEY = 'orca:hosts'
-// Why: SecureStore keys must match [A-Za-z0-9._-] (colons rejected), so use dots as the separator.
-const TOKEN_KEY_PREFIX = 'orca.host-token.'
-const WEB_TOKEN_KEY_PREFIX = 'orca:web-host-token:'
 
-function tokenKey(hostId: string): string {
-  return `${TOKEN_KEY_PREFIX}${hostId}`
-}
-
-function webTokenKey(hostId: string): string {
-  return `${WEB_TOKEN_KEY_PREFIX}${hostId}`
-}
-
-async function readDeviceToken(hostId: string): Promise<string | null> {
-  // Why: Expo SecureStore has no working web backend; fall back to AsyncStorage only on web so native still uses the keychain.
-  if (Platform.OS === 'web') {
-    return AsyncStorage.getItem(webTokenKey(hostId))
-  }
-  return readPairingKeychainItem(tokenKey(hostId))
-}
-
-async function writeDeviceToken(hostId: string, token: string): Promise<void> {
-  if (Platform.OS === 'web') {
-    await AsyncStorage.setItem(webTokenKey(hostId), token)
-    return
-  }
-  await writePairingKeychainItem(tokenKey(hostId), token)
-}
-
-async function deleteDeviceToken(hostId: string): Promise<void> {
-  if (Platform.OS === 'web') {
-    await AsyncStorage.removeItem(webTokenKey(hostId))
-    return
-  }
-  await deletePairingKeychainItem(tokenKey(hostId))
+async function commitDeviceToken(hostId: string, token: string): Promise<void> {
+  credentialWriteRevisions.set(hostId, (credentialWriteRevisions.get(hostId) ?? 0) + 1)
+  await writeHostDeviceToken(hostId, token)
+  tokenCache.set(hostId, token)
+  hostListLoads.dropSharedHostListLoad()
 }
 
 async function deleteHostCredentials(hostId: string): Promise<void> {
-  await deleteDeviceToken(hostId)
+  await deleteHostDeviceToken(hostId)
   await deleteMobileRelayCredentialBundle(hostId)
   await deleteMobileRelayDirectUpgradeJournal(hostId)
 }
 
 // Why: Keychain reads are slow (50-200ms) and loadHosts() runs on every screen mount; cache per-hostId in memory, invalidate on save/remove.
 const tokenCache = new Map<string, string>()
+const credentialWriteRevisions = new Map<string, number>()
 // Why: serialize RMW of the shared hosts JSON; without a queue concurrent writers drop writes (resurrect a removed host, drop a rename).
 let hostListMutation: Promise<void> = Promise.resolve()
 
@@ -132,7 +104,7 @@ async function doLoadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot>
     storedHosts,
     overlays: overlayState.overlays,
     tokenCache,
-    readToken: readDeviceToken,
+    readToken: readHostDeviceToken,
     getRevision: hostListLoads.getHostListLoadRevision
   })
 }
@@ -164,6 +136,21 @@ async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
     }
     throw new Error('host list storage unreadable')
   }
+}
+
+async function deleteUnpairedHostCredentials(hostId: string): Promise<void> {
+  const writeRevision = credentialWriteRevisions.get(hostId) ?? 0
+  await hostListMutation
+  const hosts = await readStoredHostsForMutation()
+  if (
+    (credentialWriteRevisions.get(hostId) ?? 0) !== writeRevision ||
+    hosts.some(({ id }) => id === hostId)
+  ) {
+    return
+  }
+  await deleteHostCredentials(hostId)
+  tokenCache.delete(hostId)
+  hostListLoads.dropSharedHostListLoad()
 }
 
 async function mutateStoredHosts(
@@ -205,39 +192,48 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
   const duplicateHostIds = new Set<string>()
   let updatedExistingHost = false
   let tokenCommittedBeforeMetadata = false
-  await mutateStoredHosts(async (hosts) => {
-    const index = hosts.findIndex((h) => h.id === stored.id)
-    for (const candidate of hosts) {
-      if (candidate.id !== stored.id && candidate.publicKeyB64 === stored.publicKeyB64) {
-        duplicateHostIds.add(candidate.id)
+  try {
+    await mutateStoredHosts(async (hosts) => {
+      const index = hosts.findIndex((h) => h.id === stored.id)
+      for (const candidate of hosts) {
+        if (candidate.id !== stored.id && candidate.publicKeyB64 === stored.publicKeyB64) {
+          duplicateHostIds.add(candidate.id)
+        }
+      }
+      let next: StoredHostProfile[]
+      if (index >= 0) {
+        updatedExistingHost = true
+        // Why: an authoritative save is the safe point to collapse pre-existing duplicate rows to the preserved host id.
+        next = hosts
+          .filter(({ id }) => !duplicateHostIds.has(id))
+          .map((candidate) => (candidate.id === stored.id ? stored : candidate))
+      } else if (requireExisting) {
+        // Why: an in-flight relay upgrade must not resurrect a host the user removed.
+        throw new MobileRelayUpgradeHostRemovedError('mobile relay upgrade host was removed')
+      } else {
+        next = [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
+      }
+      if (duplicateHostIds.size > 0) {
+        // Why: never remove the only usable same-key row until its replacement credential is durable.
+        await commitDeviceToken(stored.id, validated.deviceToken)
+        tokenCommittedBeforeMetadata = true
+      }
+      return next
+    })
+  } catch (error) {
+    if (tokenCommittedBeforeMetadata && !updatedExistingHost) {
+      try {
+        await scheduleHostCredentialCleanup(stored.id, deleteUnpairedHostCredentials)
+      } catch {
+        // The replacement remains recoverable through the session cache.
       }
     }
-    let next: StoredHostProfile[]
-    if (index >= 0) {
-      updatedExistingHost = true
-      // Why: an authoritative save is the safe point to collapse pre-existing duplicate rows to the preserved host id.
-      next = hosts
-        .filter(({ id }) => !duplicateHostIds.has(id))
-        .map((candidate) => (candidate.id === stored.id ? stored : candidate))
-    } else if (requireExisting) {
-      // Why: an in-flight relay upgrade must not resurrect a host the user removed.
-      throw new MobileRelayUpgradeHostRemovedError('mobile relay upgrade host was removed')
-    } else {
-      next = [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
-    }
-    if (duplicateHostIds.size > 0) {
-      // Why: never remove the only usable same-key row until its replacement credential is durable.
-      await writeDeviceToken(stored.id, validated.deviceToken)
-      tokenCommittedBeforeMetadata = true
-    }
-    return next
-  })
+    throw error
+  }
   if (!tokenCommittedBeforeMetadata) {
     // Why: the catalog can now surface a failed token write for recovery instead of losing the host.
-    await writeDeviceToken(stored.id, validated.deviceToken)
+    await commitDeviceToken(stored.id, validated.deviceToken)
   }
-  tokenCache.set(stored.id, validated.deviceToken)
-  hostListLoads.dropSharedHostListLoad()
   if (validated.endpoints) {
     await saveMobileRelayHostOverlay({
       v: 2,
@@ -258,9 +254,8 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
     hostListLoads.dropSharedHostListLoad()
   }
   for (const duplicateHostId of duplicateHostIds) {
-    tokenCache.delete(duplicateHostId)
     try {
-      await scheduleHostCredentialCleanup(duplicateHostId, deleteHostCredentials)
+      await scheduleHostCredentialCleanup(duplicateHostId, deleteUnpairedHostCredentials)
     } catch {
       // Metadata is already deduplicated; orphan-token recovery is best-effort.
     }
@@ -278,7 +273,7 @@ export async function removeHost(hostId: string): Promise<void> {
   }
   // Why: keychain delete can stall/reject; await only the durable cleanup intent so removeHost can't freeze the UI.
   try {
-    await scheduleHostCredentialCleanup(hostId, deleteHostCredentials)
+    await scheduleHostCredentialCleanup(hostId, deleteUnpairedHostCredentials)
   } catch {
     // Metadata is already committed; orphan-token recovery is best-effort.
   }
@@ -289,7 +284,7 @@ export async function retryPendingHostCredentialCleanup(): Promise<{
   remainingIds: string[]
   storageUnreadable: boolean
 }> {
-  return retryPendingHostCredentialCleanups(deleteHostCredentials)
+  return retryPendingHostCredentialCleanups(deleteUnpairedHostCredentials)
 }
 
 // Why: single mutation pass commits name + endpoint atomically so a mid-save failure can't persist one without the other.
@@ -332,6 +327,7 @@ export async function updateLastConnected(hostId: string): Promise<void> {
 export function resetHostStoreForTests(): void {
   hostListMutation = Promise.resolve()
   tokenCache.clear()
+  credentialWriteRevisions.clear()
   hostListLoads.dropSharedHostListLoad()
   resetPairingKeychainForTests()
 }

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -10,11 +10,7 @@ import { getNextHostNameFromHosts } from './host-names'
 import * as hostListLoads from './host-list-load-sharing'
 import { joinHostCatalogCredentials } from './host-catalog-credential-join'
 import { resetPairingKeychainForTests } from './pairing-keychain'
-import {
-  deleteHostDeviceToken,
-  readHostDeviceToken,
-  writeHostDeviceToken
-} from './host-device-token-store'
+import { readHostDeviceToken, writeHostDeviceToken } from './host-device-token-store'
 import {
   retryPendingHostCredentialCleanups,
   scheduleHostCredentialCleanup
@@ -25,28 +21,25 @@ import {
   removeMobileRelayHostOverlays,
   saveMobileRelayHostOverlay
 } from './mobile-relay-host-overlay-store'
-import { deleteMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
-import { deleteMobileRelayDirectUpgradeJournal } from './mobile-relay-direct-upgrade-journal'
 import { scheduleOrphanedMobileRelayCleanup } from './mobile-relay-orphan-cleanup'
+import {
+  getHostCredentialWriteRevision,
+  markHostCredentialWrite,
+  resetHostCredentialWriteRevisionsForTests
+} from './host-credential-write-revision'
+import { createUnpairedHostCredentialDeletion } from './unpaired-host-credential-deletion'
 
 const STORAGE_KEY = 'orca:hosts'
 
 async function commitDeviceToken(hostId: string, token: string): Promise<void> {
-  credentialWriteRevisions.set(hostId, (credentialWriteRevisions.get(hostId) ?? 0) + 1)
+  markHostCredentialWrite(hostId)
   await writeHostDeviceToken(hostId, token)
   tokenCache.set(hostId, token)
   hostListLoads.dropSharedHostListLoad()
 }
 
-async function deleteHostCredentials(hostId: string): Promise<void> {
-  await deleteHostDeviceToken(hostId)
-  await deleteMobileRelayCredentialBundle(hostId)
-  await deleteMobileRelayDirectUpgradeJournal(hostId)
-}
-
 // Why: Keychain reads are slow (50-200ms) and loadHosts() runs on every screen mount; cache per-hostId in memory, invalidate on save/remove.
 const tokenCache = new Map<string, string>()
-const credentialWriteRevisions = new Map<string, number>()
 // Why: serialize RMW of the shared hosts JSON; without a queue concurrent writers drop writes (resurrect a removed host, drop a rename).
 let hostListMutation: Promise<void> = Promise.resolve()
 
@@ -96,9 +89,13 @@ async function doLoadHostListSnapshot(): Promise<hostListLoads.HostListSnapshot>
   const overlayState = await loadMobileRelayHostOverlayState(
     new Set(storedHosts.map(({ id }) => id))
   )
+  const orphanWriteRevisions = new Map(
+    overlayState.orphanHostIds.map((hostId) => [hostId, getHostCredentialWriteRevision(hostId)])
+  )
   await scheduleOrphanedMobileRelayCleanup({
     hostIds: overlayState.orphanHostIds,
-    deleteCredential: deleteHostCredentials
+    deleteCredential: (hostId) =>
+      deleteUnpairedHostCredentials(hostId, orphanWriteRevisions.get(hostId) ?? 0)
   })
   return joinHostCatalogCredentials({
     storedHosts,
@@ -138,19 +135,21 @@ async function readStoredHostsForMutation(): Promise<StoredHostProfile[]> {
   }
 }
 
-async function deleteUnpairedHostCredentials(hostId: string): Promise<void> {
-  const writeRevision = credentialWriteRevisions.get(hostId) ?? 0
-  await hostListMutation
-  const hosts = await readStoredHostsForMutation()
-  if (
-    (credentialWriteRevisions.get(hostId) ?? 0) !== writeRevision ||
-    hosts.some(({ id }) => id === hostId)
-  ) {
-    return
+const deleteUnpairedHostCredentials = createUnpairedHostCredentialDeletion({
+  waitForHostMutations: () => hostListMutation,
+  hasStoredHost: async (hostId) =>
+    (await readStoredHostsForMutation()).some(({ id }) => id === hostId),
+  onDeleted: (hostId) => {
+    tokenCache.delete(hostId)
+    hostListLoads.dropSharedHostListLoad()
   }
-  await deleteHostCredentials(hostId)
-  tokenCache.delete(hostId)
-  hostListLoads.dropSharedHostListLoad()
+})
+
+function scheduleUnpairedHostCredentialCleanup(hostId: string): Promise<void> {
+  const writeRevision = getHostCredentialWriteRevision(hostId)
+  return scheduleHostCredentialCleanup(hostId, (id) =>
+    deleteUnpairedHostCredentials(id, writeRevision)
+  )
 }
 
 async function mutateStoredHosts(
@@ -223,7 +222,7 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
   } catch (error) {
     if (tokenCommittedBeforeMetadata && !updatedExistingHost) {
       try {
-        await scheduleHostCredentialCleanup(stored.id, deleteUnpairedHostCredentials)
+        await scheduleUnpairedHostCredentialCleanup(stored.id)
       } catch {
         // The replacement remains recoverable through the session cache.
       }
@@ -255,7 +254,7 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
   }
   for (const duplicateHostId of duplicateHostIds) {
     try {
-      await scheduleHostCredentialCleanup(duplicateHostId, deleteUnpairedHostCredentials)
+      await scheduleUnpairedHostCredentialCleanup(duplicateHostId)
     } catch {
       // Metadata is already deduplicated; orphan-token recovery is best-effort.
     }
@@ -273,7 +272,7 @@ export async function removeHost(hostId: string): Promise<void> {
   }
   // Why: keychain delete can stall/reject; await only the durable cleanup intent so removeHost can't freeze the UI.
   try {
-    await scheduleHostCredentialCleanup(hostId, deleteUnpairedHostCredentials)
+    await scheduleUnpairedHostCredentialCleanup(hostId)
   } catch {
     // Metadata is already committed; orphan-token recovery is best-effort.
   }
@@ -284,7 +283,9 @@ export async function retryPendingHostCredentialCleanup(): Promise<{
   remainingIds: string[]
   storageUnreadable: boolean
 }> {
-  return retryPendingHostCredentialCleanups(deleteUnpairedHostCredentials)
+  return retryPendingHostCredentialCleanups((hostId) =>
+    deleteUnpairedHostCredentials(hostId, getHostCredentialWriteRevision(hostId))
+  )
 }
 
 // Why: single mutation pass commits name + endpoint atomically so a mid-save failure can't persist one without the other.
@@ -327,7 +328,7 @@ export async function updateLastConnected(hostId: string): Promise<void> {
 export function resetHostStoreForTests(): void {
   hostListMutation = Promise.resolve()
   tokenCache.clear()
-  credentialWriteRevisions.clear()
+  resetHostCredentialWriteRevisionsForTests()
   hostListLoads.dropSharedHostListLoad()
   resetPairingKeychainForTests()
 }

--- a/mobile/src/transport/host-store.ts
+++ b/mobile/src/transport/host-store.ts
@@ -1,11 +1,6 @@
 import AsyncStorage from '@react-native-async-storage/async-storage'
-import {
-  HostProfileSchema,
-  StoredHostProfileSchema,
-  type HostCatalogEntry,
-  type HostProfile,
-  type StoredHostProfile
-} from './types'
+import { HostProfileSchema, StoredHostProfileSchema } from './types'
+import type { HostCatalogEntry, HostProfile, StoredHostProfile } from './types'
 import { getNextHostNameFromHosts } from './host-names'
 import * as hostListLoads from './host-list-load-sharing'
 import { joinHostCatalogCredentials } from './host-catalog-credential-join'
@@ -13,6 +8,7 @@ import { resetPairingKeychainForTests } from './pairing-keychain'
 import { readHostDeviceToken, writeHostDeviceToken } from './host-device-token-store'
 import {
   cancelPendingHostCredentialCleanup,
+  recordHostCredentialCleanupIntent,
   retryPendingHostCredentialCleanups,
   scheduleHostCredentialCleanup
 } from './host-credential-cleanup'
@@ -153,6 +149,17 @@ function scheduleUnpairedHostCredentialCleanup(hostId: string): Promise<void> {
   )
 }
 
+function cancelCleanupForStoredHost(hostId: string): void {
+  const cancellation = hostListMutation.then(async () => {
+    const hosts = await readStoredHostsForMutation()
+    if (hosts.some(({ id }) => id === hostId)) {
+      // Register before later removals enqueue their intent, without blocking host loads on cleanup storage.
+      void cancelPendingHostCredentialCleanup(hostId).catch(() => undefined)
+    }
+  })
+  hostListMutation = cancellation.catch(() => {})
+}
+
 async function mutateStoredHosts(
   update: (hosts: StoredHostProfile[]) => StoredHostProfile[] | Promise<StoredHostProfile[]>
 ): Promise<void> {
@@ -178,19 +185,17 @@ function toStored(host: HostProfile): StoredHostProfile {
 
 export class MobileRelayUpgradeHostRemovedError extends Error {}
 
-export async function saveHost(host: HostProfile): Promise<void> {
-  await persistHost(host, false)
-}
+export const saveHost = (host: HostProfile): Promise<void> => persistHost(host, false)
 
-export async function saveExistingHostRelayUpgrade(host: HostProfile): Promise<void> {
-  await persistHost(host, true)
-}
+export const saveExistingHostRelayUpgrade = (host: HostProfile): Promise<void> =>
+  persistHost(host, true)
 
 async function persistHost(host: HostProfile, requireExisting: boolean): Promise<void> {
   const validated = HostProfileSchema.parse(host)
   const stored = toStored(validated)
   const duplicateHostIds = new Set<string>()
   let updatedExistingHost = false
+  let cleanupIntentRecordedBeforeMetadata = false
   let tokenCommittedBeforeMetadata = false
   try {
     await mutateStoredHosts(async (hosts) => {
@@ -214,6 +219,11 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
         next = [...hosts.filter(({ id }) => !duplicateHostIds.has(id)), stored]
       }
       if (duplicateHostIds.size > 0) {
+        if (index < 0) {
+          // Why: process death between the early token write and metadata publication must leave cleanup discoverable.
+          await recordHostCredentialCleanupIntent(stored.id)
+          cleanupIntentRecordedBeforeMetadata = true
+        }
         // Why: never remove the only usable same-key row until its replacement credential is durable.
         await commitDeviceToken(stored.id, validated.deviceToken)
         tokenCommittedBeforeMetadata = true
@@ -221,11 +231,11 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
       return next
     })
   } catch (error) {
-    if (tokenCommittedBeforeMetadata && !updatedExistingHost) {
+    if (cleanupIntentRecordedBeforeMetadata) {
       try {
         await scheduleUnpairedHostCredentialCleanup(stored.id)
       } catch {
-        // The replacement remains recoverable through the session cache.
+        // The write-ahead cleanup intent remains available for retry.
       }
     }
     throw error
@@ -234,8 +244,8 @@ async function persistHost(host: HostProfile, requireExisting: boolean): Promise
     // Why: the catalog can now surface a failed token write for recovery instead of losing the host.
     await commitDeviceToken(stored.id, validated.deviceToken)
   }
-  // Why: publication supersedes stale removal intent; clearing it must not delay pairing.
-  void cancelPendingHostCredentialCleanup(stored.id).catch(() => undefined)
+  // Why: a later removal owns its cleanup intent; cancel only while this publication remains authoritative.
+  cancelCleanupForStoredHost(stored.id)
   if (validated.endpoints) {
     await saveMobileRelayHostOverlay({
       v: 2,

--- a/mobile/src/transport/mobile-relay-credential-bundle.ts
+++ b/mobile/src/transport/mobile-relay-credential-bundle.ts
@@ -7,6 +7,7 @@ import {
   readPairingKeychainItem,
   writePairingKeychainItem
 } from './pairing-keychain'
+import { markHostCredentialWrite } from './host-credential-write-revision'
 
 const Base64Url32ByteSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/)
 const ResumeCredentialSchema = z
@@ -91,6 +92,7 @@ export async function writeMobileRelayCredentialBundle(
 ): Promise<void> {
   requireNativeSecretStore()
   const validated = MobileRelayCredentialBundleSchema.parse(bundle)
+  markHostCredentialWrite(validated.hostId)
   await writePairingKeychainItem(credentialKey(validated.hostId), JSON.stringify(validated))
 }
 

--- a/mobile/src/transport/mobile-relay-direct-upgrade-journal.ts
+++ b/mobile/src/transport/mobile-relay-direct-upgrade-journal.ts
@@ -6,6 +6,7 @@ import {
   readPairingKeychainItem,
   writePairingKeychainItem
 } from './pairing-keychain'
+import { markHostCredentialWrite } from './host-credential-write-revision'
 
 const Base64Url32ByteSchema = z.string().regex(/^[A-Za-z0-9_-]{43}$/)
 
@@ -60,6 +61,7 @@ export async function writeMobileRelayDirectUpgradeJournal(
 ): Promise<void> {
   requireNativeSecretStore()
   const parsed = MobileRelayDirectUpgradeJournalSchema.parse(journal)
+  markHostCredentialWrite(parsed.hostId)
   await writePairingKeychainItem(journalKey(parsed.hostId), JSON.stringify(parsed))
 }
 

--- a/mobile/src/transport/types.ts
+++ b/mobile/src/transport/types.ts
@@ -75,6 +75,13 @@ export type HostProfile = {
   relay?: MobileRelayHostOverlay['relay']
 }
 
+export type HostCredentialStatus = 'ready' | 'temporarily-unavailable' | 'missing'
+
+export type HostCatalogEntry = Omit<HostProfile, 'deviceToken'> & {
+  credentialStatus: HostCredentialStatus
+  profile: HostProfile | null
+}
+
 export const HostProfileSchema = z.object({
   id: z.string().min(1),
   name: z.string().min(1),

--- a/mobile/src/transport/unpaired-host-credential-deletion.ts
+++ b/mobile/src/transport/unpaired-host-credential-deletion.ts
@@ -17,33 +17,41 @@ export function createUnpairedHostCredentialDeletion(dependencies: DeletionDepen
     return getHostCredentialWriteRevision(hostId) !== writeRevision
   }
 
+  function assertWriteRevisionUnchanged(hostId: string, writeRevision: number): void {
+    if (writeRevisionChanged(hostId, writeRevision)) {
+      throw new Error('credential write superseded cleanup')
+    }
+  }
+
   async function shouldSkip(hostId: string, writeRevision: number): Promise<boolean> {
-    if (writeRevisionChanged(hostId, writeRevision)) {
-      return true
-    }
     await dependencies.waitForHostMutations()
-    if (writeRevisionChanged(hostId, writeRevision)) {
+    if (await dependencies.hasStoredHost(hostId)) {
       return true
     }
-    return (await dependencies.hasStoredHost(hostId)) || writeRevisionChanged(hostId, writeRevision)
+    assertWriteRevisionUnchanged(hostId, writeRevision)
+    return false
   }
 
   return async (hostId: string, writeRevision: number): Promise<void> => {
-    if ((await shouldSkip(hostId, writeRevision)) || writeRevisionChanged(hostId, writeRevision)) {
+    if (await shouldSkip(hostId, writeRevision)) {
       return
     }
+    assertWriteRevisionUnchanged(hostId, writeRevision)
     await deleteHostDeviceToken(hostId)
-    if ((await shouldSkip(hostId, writeRevision)) || writeRevisionChanged(hostId, writeRevision)) {
+    if (await shouldSkip(hostId, writeRevision)) {
       return
     }
+    assertWriteRevisionUnchanged(hostId, writeRevision)
     await deleteMobileRelayCredentialBundle(hostId)
-    if ((await shouldSkip(hostId, writeRevision)) || writeRevisionChanged(hostId, writeRevision)) {
+    if (await shouldSkip(hostId, writeRevision)) {
       return
     }
+    assertWriteRevisionUnchanged(hostId, writeRevision)
     await deleteMobileRelayDirectUpgradeJournal(hostId)
-    if (writeRevisionChanged(hostId, writeRevision)) {
+    if (await shouldSkip(hostId, writeRevision)) {
       return
     }
+    assertWriteRevisionUnchanged(hostId, writeRevision)
     clearHostCredentialWriteRevision(hostId)
     dependencies.onDeleted(hostId)
   }

--- a/mobile/src/transport/unpaired-host-credential-deletion.ts
+++ b/mobile/src/transport/unpaired-host-credential-deletion.ts
@@ -1,0 +1,50 @@
+import { deleteHostDeviceToken } from './host-device-token-store'
+import {
+  clearHostCredentialWriteRevision,
+  getHostCredentialWriteRevision
+} from './host-credential-write-revision'
+import { deleteMobileRelayCredentialBundle } from './mobile-relay-credential-bundle'
+import { deleteMobileRelayDirectUpgradeJournal } from './mobile-relay-direct-upgrade-journal'
+
+type DeletionDependencies = {
+  waitForHostMutations: () => Promise<void>
+  hasStoredHost: (hostId: string) => Promise<boolean>
+  onDeleted: (hostId: string) => void
+}
+
+export function createUnpairedHostCredentialDeletion(dependencies: DeletionDependencies) {
+  function writeRevisionChanged(hostId: string, writeRevision: number): boolean {
+    return getHostCredentialWriteRevision(hostId) !== writeRevision
+  }
+
+  async function shouldSkip(hostId: string, writeRevision: number): Promise<boolean> {
+    if (writeRevisionChanged(hostId, writeRevision)) {
+      return true
+    }
+    await dependencies.waitForHostMutations()
+    if (writeRevisionChanged(hostId, writeRevision)) {
+      return true
+    }
+    return (await dependencies.hasStoredHost(hostId)) || writeRevisionChanged(hostId, writeRevision)
+  }
+
+  return async (hostId: string, writeRevision: number): Promise<void> => {
+    if ((await shouldSkip(hostId, writeRevision)) || writeRevisionChanged(hostId, writeRevision)) {
+      return
+    }
+    await deleteHostDeviceToken(hostId)
+    if ((await shouldSkip(hostId, writeRevision)) || writeRevisionChanged(hostId, writeRevision)) {
+      return
+    }
+    await deleteMobileRelayCredentialBundle(hostId)
+    if ((await shouldSkip(hostId, writeRevision)) || writeRevisionChanged(hostId, writeRevision)) {
+      return
+    }
+    await deleteMobileRelayDirectUpgradeJournal(hostId)
+    if (writeRevisionChanged(hostId, writeRevision)) {
+      return
+    }
+    clearHostCredentialWriteRevision(hostId)
+    dependencies.onDeleted(hostId)
+  }
+}


### PR DESCRIPTION
## Summary

- preserve paired-host metadata when SecureStore credentials are missing or temporarily unreadable
- render explicit retry/re-pair states without opening unavailable host clients
- route unavailable-host notifications into retry/re-pair recovery
- commit replacement credentials before same-key duplicate cleanup
- prevent stale token, relay-bundle, and upgrade-journal cleanup from deleting later authoritative credentials
- retain durable cleanup intent when replacement credential publication fails
- keep notification routing aware of unavailable catalog hosts

## Root cause

Host metadata and device tokens are stored separately. The previous host-list join silently omitted metadata whenever SecureStore threw or returned null, so a refresh after pairing could make an existing host disappear. Same-key pairing cleanup also mutated metadata before the replacement credential was durable, and stale cleanup could delete newer credentials or clear retry intent after a failed replacement write.

## Testing

- full mobile suite: 427 files passed; 3,318 tests passed; 3 skipped
- mobile TypeScript typecheck
- focused oxlint, React hook, formatting, and diff checks
- Electron/CDP validation from the exact PR worktree with isolated user data
- iPhone 17 Pro simulator validation for missing and temporarily unreadable credentials
- screenshot evidence: https://github.com/stablyai/orca/pull/12775#issuecomment-5197627424