### PR TITLE
feat(diff): separate row wash from word chip for readable diffs

### DIFF
--- a/src/renderer/src/assets/diff-view-style.test.ts
+++ b/src/renderer/src/assets/diff-view-style.test.ts
@@ -1,0 +1,76 @@
+import fs from 'node:fs'
+import { describe, expect, it } from 'vitest'
+
+const css = fs.readFileSync(new URL('./diff-view.css', import.meta.url), 'utf8')
+const mainCss = fs.readFileSync(new URL('./main.css', import.meta.url), 'utf8')
+
+describe('diff view styling', () => {
+  it('is loaded by the renderer entry stylesheet', () => {
+    expect(mainCss).toContain("@import './diff-view.css';")
+  })
+
+  // Ratio is free to change; deriving from the theme's own chip color is not.
+  it('derives the row wash from the theme chip color instead of a literal', () => {
+    expect(css).toMatch(
+      /--vscode-diffEditor-insertedLineBackground:\s*color-mix\(\s*in srgb,\s*var\(--vscode-diffEditor-insertedTextBackground\)\s*\d+%,\s*transparent\s*\)/s
+    )
+    expect(css).toMatch(
+      /--vscode-diffEditor-removedLineBackground:\s*color-mix\(\s*in srgb,\s*var\(--vscode-diffEditor-removedTextBackground\)\s*\d+%,\s*transparent\s*\)/s
+    )
+  })
+
+  it('writes no hex color literal, so the active Monaco theme keeps every hue', () => {
+    expect(css).not.toMatch(/#[0-9a-f]{3,8}\b/i)
+  })
+
+  it('suppresses the full-width char decoration that stacks on the row wash', () => {
+    expect(css).toMatch(/\.cdr\.char-insert\[style\*='100%'\]/)
+    expect(css).toMatch(/\.cdr\.char-delete\[style\*='100%'\]/)
+  })
+
+  it('hides the duplicated unified-mode delete sign', () => {
+    expect(css).toMatch(
+      /\.monaco-diff-editor:not\(\.side-by-side\) \.margin-view-overlays \.delete-sign\s*{[^}]*display:\s*none\s*!important/s
+    )
+  })
+
+  // `overflow: hidden` here would make the panel a scroll container and drop the
+  // sticky file header out of the outer scrollport.
+  it('rounds the section panel without breaking its sticky header', () => {
+    const panelRule = css.match(/\.diff-section-panel\s*{[^}]*}/s)?.[0] ?? ''
+    expect(panelRule).toContain('overflow: clip')
+    expect(panelRule).not.toContain('overflow: hidden')
+    expect(panelRule).not.toContain('overflow: auto')
+  })
+
+  // Scrollport top padding reappears as a gap above the stuck file header.
+  it('keeps the scroll container free of top padding', () => {
+    const containerRule = (
+      css.match(/\.combined-diff-scroll-container\s*{[^}]*}/s)?.[0] ?? ''
+    ).replace(/\/\*[\s\S]*?\*\//g, '')
+    expect(containerRule).toContain('padding-bottom')
+    expect(containerRule).not.toMatch(/\bpadding(-block|-top)?\s*:/)
+  })
+
+  it('scopes every Monaco rule under .monaco-diff-editor so plain editors are untouched', () => {
+    const selectors = css
+      .replace(/\/\*[\s\S]*?\*\//g, '')
+      .split('}')
+      .map((block) => block.split('{')[0]?.trim())
+      .filter((selector): selector is string => Boolean(selector))
+      .flatMap((selector) => selector.split(',').map((part) => part.trim()))
+      .filter(Boolean)
+
+    for (const selector of selectors) {
+      if (!selector.includes('monaco')) {
+        continue
+      }
+      // A bare `.monaco-editor` root would leak diff styling into plain editors.
+      expect(selector.startsWith('.monaco-editor')).toBe(false)
+      expect(
+        selector.startsWith('.monaco-diff-editor') ||
+          selector.startsWith('.combined-diff-scroll-container')
+      ).toBe(true)
+    }
+  })
+})

--- a/src/renderer/src/assets/diff-view.css
+++ b/src/renderer/src/assets/diff-view.css
@@ -1,0 +1,136 @@
+/* Theme-agnostic on purpose: no hue is written here, so the active Monaco theme
+   keeps background, foreground, line-number color and syntax. */
+
+/* Monaco emits every theme color as a custom property on
+   `.monaco-editor, .monaco-diff-editor` at 0,1,0 — overriding at 0,2,0 on the
+   sub-editors retints diffs alone. */
+.monaco-diff-editor .monaco-editor {
+  /* Wash and chip shipped at the same weight, hiding changed words inside a
+     changed row. Derived from the chip so it tracks the theme. */
+  --vscode-diffEditor-insertedLineBackground: color-mix(
+    in srgb,
+    var(--vscode-diffEditor-insertedTextBackground) 30%,
+    transparent
+  );
+  --vscode-diffEditor-removedLineBackground: color-mix(
+    in srgb,
+    var(--vscode-diffEditor-removedTextBackground) 30%,
+    transparent
+  );
+  --vscode-diffEditor-unchangedCodeBackground: transparent;
+  /* The ribbon below replaces Monaco's full-width gutter fill. */
+  --vscode-diffEditorGutter-insertedLineBackground: transparent;
+  --vscode-diffEditorGutter-removedLineBackground: transparent;
+}
+
+.monaco-diff-editor {
+  --orca-diff-delete-bar: repeating-linear-gradient(
+    to bottom,
+    var(--git-decoration-deleted) 0 2px,
+    transparent 2px 3.5px
+  );
+}
+
+/* `gutter-*` lives on the margin decoration; the `line-*` classes are content-side. */
+.monaco-diff-editor .monaco-editor .margin-view-overlays .gutter-insert {
+  box-shadow: inset 3px 0 0 var(--git-decoration-added);
+}
+
+/* One owner per mode, else the bar doubles. `no-repeat` keeps the 3px background
+   from tiling across the margin. */
+.monaco-diff-editor:not(.side-by-side) .inline-deleted-margin-view-zone,
+.monaco-diff-editor.side-by-side .margin-view-overlays .gutter-delete {
+  background-image: var(--orca-diff-delete-bar);
+  background-size: 3px 100%;
+  background-repeat: no-repeat;
+}
+
+/* The view zone renders its own "−"; this one would land on top of the ribbon. */
+.monaco-diff-editor:not(.side-by-side) .margin-view-overlays .delete-sign {
+  display: none !important;
+}
+
+/* Monaco pins the opacity with !important. */
+.monaco-diff-editor .monaco-editor .insert-sign,
+.monaco-diff-editor .monaco-editor .delete-sign {
+  justify-content: center;
+  opacity: 0.95 !important;
+}
+
+.monaco-diff-editor .monaco-editor .insert-sign {
+  color: var(--git-decoration-added);
+}
+
+.monaco-diff-editor .monaco-editor .delete-sign {
+  color: var(--git-decoration-deleted);
+}
+
+.monaco-diff-editor .monaco-editor .margin-view-overlays .line-numbers {
+  font-weight: 600;
+}
+
+/* The margin decoration is a *sibling* of `.line-numbers`, so this reaches up. */
+.monaco-diff-editor .monaco-editor .margin-view-overlays > div:has(.gutter-insert) .line-numbers {
+  color: var(--git-decoration-added);
+}
+
+.monaco-diff-editor .monaco-editor .margin-view-overlays > div:has(.gutter-delete) .line-numbers {
+  color: var(--git-decoration-deleted);
+}
+
+/* A line with no inner char changes still gets a full-width char decoration on
+   top of the row wash; that stacking is what made all-add blocks shout. Monaco
+   gives both cases the same class, so the inline style is the only discriminator.
+   Tradeoff: a word chip wrapping onto the next visual line is also 100% wide and
+   loses its chip. Narrowing to `left:0;width:100%` did NOT match in Chromium —
+   verify in the running app before trying again. */
+.monaco-diff-editor .monaco-editor .cdr.char-insert[style*='100%'],
+.monaco-diff-editor .monaco-editor .cdr.char-delete[style*='100%'],
+.monaco-diff-editor .monaco-editor .view-line.char-delete {
+  background-color: transparent;
+}
+
+.monaco-diff-editor .char-insert,
+.monaco-diff-editor .char-delete {
+  border-radius: 3px;
+}
+
+.monaco-diff-editor .diff-hidden-lines {
+  font-family: var(--font-sans, system-ui, sans-serif);
+}
+
+.monaco-diff-editor .diff-hidden-lines .center {
+  border-radius: var(--radius-sm);
+  font-size: 12px;
+}
+
+.combined-diff-scroll-container {
+  background: var(--background);
+  /* No top padding: Chromium insets sticky children by the scrollport padding,
+     so any here reappears as a gap above the stuck file header. */
+  padding-bottom: 8px;
+}
+
+/* Padding sits on the row itself because the virtualizer measures it, and the
+   top 8px is where the first panel's breathing room lives. */
+.combined-diff-scroll-container [data-combined-diff-section-row] {
+  padding: 8px 12px 6px;
+}
+
+/* Targets DiffSectionItem's own class, not whatever div happens to be first. */
+.combined-diff-scroll-container [data-combined-diff-section-row] .diff-section-panel {
+  border: 1px solid color-mix(in srgb, var(--border) 80%, transparent);
+  border-radius: var(--radius-xl);
+  /* `clip`, not `hidden`: `hidden` makes the panel a scroll container, which
+     kills the sticky file header inside it. Both round off the corners. */
+  overflow: clip;
+  background: var(--editor-surface);
+}
+
+.combined-diff-scroll-container
+  [data-combined-diff-section-row]
+  .diff-section-panel
+  .monaco-editor
+  .margin {
+  background: transparent;
+}

--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -5,6 +5,7 @@
 @import './rich-markdown-editor.css';
 @import './markdown-preview.css';
 @import './terminal.css';
+@import './diff-view.css';
 @import './mobile-page.css';
 
 @font-face {

--- a/src/renderer/src/components/editor/DiffSectionBody.tsx
+++ b/src/renderer/src/components/editor/DiffSectionBody.tsx
@@ -9,6 +9,7 @@ import { combinedDiffSectionScrollbarOptions } from './diff-editor-scrollbar-opt
 import type { DiffSection } from './diff-section-types'
 import { translate } from '@/i18n/i18n'
 import { LargeDiffFallback } from './LargeDiffFallback'
+import { buildDiffEditorAppearanceOptions } from './diff-editor-appearance-options'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { monacoFindOptions } from './monaco-find-options'
 
@@ -195,6 +196,7 @@ export function DiffSectionBody({
             fontFamily: editorFontFamily || 'monospace',
             lineNumbers: 'on',
             ...buildDiffEditorWordWrapOptions(diffWordWrap),
+            ...buildDiffEditorAppearanceOptions(diffEditorFontSize),
             automaticLayout: true,
             renderOverviewRuler: false,
             scrollbar: combinedDiffSectionScrollbarOptions,

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -397,7 +397,7 @@ export function DiffSectionItem({
   }, [index, loadSection])
 
   return (
-    <div ref={setSectionRootNode} className="border-b border-border">
+    <div ref={setSectionRootNode} className="diff-section-panel border-b border-border">
       <DiffSectionHeader
         path={section.path}
         dirty={section.dirty}

--- a/src/renderer/src/components/editor/DiffViewer.tsx
+++ b/src/renderer/src/components/editor/DiffViewer.tsx
@@ -23,6 +23,7 @@ import { getLargeDiffRenderLimit } from './large-diff-render-limit'
 import { useDiffViewerLargeDiffLifecycle } from './useDiffViewerLargeDiffLifecycle'
 import { getDiffViewerLargeDiffSaveAction } from './diff-viewer-large-diff-save-action'
 import type { DiffViewerProps } from './diff-viewer-props'
+import { buildDiffEditorAppearanceOptions } from './diff-editor-appearance-options'
 import { buildDiffEditorWordWrapOptions } from './diff-editor-word-wrap-options'
 import { useDiffEditorRegistration } from './diff-navigation-context'
 import { preserveDiffViewStateAcrossModelSwaps } from './diff-model-swap-view-state'
@@ -426,6 +427,7 @@ export default function DiffViewer({
               fontFamily: resolveEditorFontFamily(settings),
               lineNumbers: 'on',
               ...buildDiffEditorWordWrapOptions(settings?.diffWordWrap),
+              ...buildDiffEditorAppearanceOptions(diffEditorFontSize),
               automaticLayout: true,
               renderOverviewRuler: true,
               scrollbar: diffEditorScrollbarOptions,

--- a/src/renderer/src/components/editor/diff-editor-appearance-options.test.ts
+++ b/src/renderer/src/components/editor/diff-editor-appearance-options.test.ts
@@ -1,0 +1,21 @@
+import { describe, expect, it } from 'vitest'
+import { buildDiffEditorAppearanceOptions } from './diff-editor-appearance-options'
+
+describe('buildDiffEditorAppearanceOptions', () => {
+  it('returns the shared diff chrome and density', () => {
+    expect(buildDiffEditorAppearanceOptions(12)).toEqual({
+      lineHeight: 21,
+      guides: { indentation: false },
+      renderLineHighlight: 'none',
+      glyphMargin: false,
+      lineDecorationsWidth: 26,
+      lineNumbersMinChars: 5
+    })
+  })
+
+  it('scales line height with font size and keeps it an integer', () => {
+    expect(buildDiffEditorAppearanceOptions(14).lineHeight).toBe(25)
+    expect(buildDiffEditorAppearanceOptions(16).lineHeight).toBe(28)
+    expect(buildDiffEditorAppearanceOptions(9).lineHeight).toBe(16)
+  })
+})

--- a/src/renderer/src/components/editor/diff-editor-appearance-options.ts
+++ b/src/renderer/src/components/editor/diff-editor-appearance-options.ts
@@ -1,0 +1,24 @@
+import type { editor } from 'monaco-editor'
+
+/** Chrome + density shared by every diff surface; color lives in assets/diff-view.css. */
+export function buildDiffEditorAppearanceOptions(
+  fontSize: number
+): Pick<
+  editor.IStandaloneDiffEditorConstructionOptions,
+  | 'lineHeight'
+  | 'guides'
+  | 'renderLineHighlight'
+  | 'glyphMargin'
+  | 'lineDecorationsWidth'
+  | 'lineNumbersMinChars'
+> {
+  return {
+    lineHeight: Math.round(fontSize * 1.75),
+    guides: { indentation: false },
+    renderLineHighlight: 'none',
+    glyphMargin: false,
+    lineDecorationsWidth: 26,
+    // Monaco takes max(digitCount, this), so the ribbon clearance is gone at 10k+ lines.
+    lineNumbersMinChars: 5
+  }
+}


### PR DESCRIPTION
## Summary

Makes the Monaco diff view easier to read. The diff surfaces previously rendered every changed row at full chip weight, so an all-add or all-delete block became a solid slab of color and a changed *word* inside a changed row was invisible — the row and the word were painted the same. This pass separates those two signals and gives the gutter a clearer change indicator.

What changes visually:

- **Row wash vs. word chip.** The line background is now derived from the theme's own chip color at 30% instead of shipping at the same weight, so a changed word reads against its row.
- **Gutter ribbon.** A solid 3px bar for insertions, a hatched bar for deletions, replacing Monaco's full-width gutter fill.
- **`+` / `−` indicators** take the git decoration colors and sit centered in their own column.
- **Line numbers** are tinted by change type and given weight, since they're the primary wayfinding in a diff.
- **Combined view** renders one rounded panel per file instead of a single continuous stream.

Both diff surfaces are covered — clicking a file in Changes (`DiffViewer`) and "View all" (`DiffSectionBody`) — so they no longer disagree.

**This change writes no color of its own.** It contains zero hex literals; every color is either derived from Monaco's own `--vscode-*` theme custom properties via `color-mix`, or taken from the existing `--git-decoration-added` / `--git-decoration-deleted` tokens. A test enforces the no-literal rule. This keeps the door open for a Monaco theme feature later: a new theme retints the diff automatically rather than fighting this CSS.

### Implementation note

Monaco's theme is global — `setTheme` retints every editor in the window — so `defineTheme` was not an option for styling diffs alone. Monaco emits every theme color as a CSS custom property at specificity `0,1,0`, so scoped CSS at `0,2,0` under `.monaco-diff-editor` retints diffs only and leaves plain editors untouched.

Production footprint is 6 lines across 4 files; the rest is one new stylesheet, one new options module, and their tests.

## Screenshots

### Combined view ("View all")

One continuous stream of full-weight rows before; one rounded panel per file after.

| Before | After |
| --- | --- |
| <img width="917" height="812" alt="1-combined-before" src="https://github.com/user-attachments/assets/bd53fe0a-443d-4962-85c3-5cea7a5e498b" /> | <img width="841" height="812" alt="2-combined-after" src="https://github.com/user-attachments/assets/b996d59f-089f-4f47-9b7c-87e0160dfb0a" /> |

### Single file, unified

The changed word is invisible before — the row and the word are painted the same. After, the row is a wash and the word keeps the chip.

| Before | After |
| --- | --- |
| <img width="922" height="814" alt="3-unified-before" src="https://github.com/user-attachments/assets/99fbed46-30d4-44e6-a64e-6c0683a8c35d" /> |<img width="851" height="813" alt="4-unified-after" src="https://github.com/user-attachments/assets/5a62628c-0365-4566-bdc6-b829c906aa74" /> |

### Side by side

| Before | After |
| --- | --- |
| <img width="1260" height="808" alt="5-side-by-side-before" src="https://github.com/user-attachments/assets/53fb5290-ebc2-42fe-9717-91c43894a05a" /> | <img width="1202" height="846" alt="6-side-by-side-after" src="https://github.com/user-attachments/assets/74f20ef3-8453-4214-bff6-7002c8b84bd5" /> |

### Light mode

Same derivation, no separate light-mode rules — the wash is mixed from whatever the active theme already publishes.

<img width="852" height="813" alt="7-light-mode-after" src="https://github.com/user-attachments/assets/c4c2f252-2184-4be5-83b7-43f416abcf9d" />

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — see note below
- [x] Added or updated high-quality tests that would catch regressions

`pnpm build` could not be completed locally. The renderer/web build succeeds; `build:native` fails on this machine because `config/scripts/build-native-for-platform.mjs` invokes `process.execPath` with `npm_execpath`, and this machine's pnpm is the standalone `@pnpm/exe` binary, so Node tries to parse a compiled binary as JavaScript. This is a local toolchain artifact, unrelated to the change — nothing here touches native code. Flagging rather than ticking the box.

Unrelated pre-existing test failures on this branch (verified identical with the change stashed): `check-root-directory-entries`, `updater`, `agent-exec-handler`, `posix-command-path-lookup` — 7 tests, all outside the renderer.

New tests:

- `diff-view-style.test.ts` — asserts the wash is a `color-mix` derived from the theme's chip color rather than a literal, that the stylesheet contains **no hex literal anywhere** (the theme-agnostic guarantee), that Monaco rules stay scoped so plain editors can't be hit, and that the stylesheet is actually imported by the renderer entry.
- `diff-editor-appearance-options.test.ts` — pins the shared chrome/density options and the line-height scaling.

## AI Review Report

Reviewed with Claude Code across four angles — reuse, simplification, efficiency, and altitude — with findings verified against the bundled monaco-editor 0.55.1 source rather than accepted on assertion.

**Found and fixed:**

- **Dead CSS.** Two selectors could never match. `.editor.original .inline-deleted-margin-view-zone` is unreachable because Monaco pushes that margin node only into `modViewZones` (`diffEditorViewZones.js:210`); a companion `gutter-delete` rule overrode declarations nothing sets. Both removed after confirming in source, along with a no-op `box-shadow`.
- **Fragile DOM coupling.** The file panel was styled via `[data-combined-diff-section-row] > div` — "whatever div happens to be first," which is `DiffSectionItem`'s root. Any future wrapper would have silently restyled the wrong element. Now targets an explicit class.
- **Style guide compliance.** Panel radius moved off a hardcoded 12px onto `--radius-xl`, matching the `Card` primitive; a per-component `letter-spacing` that restated the global body value was removed.

**Found, verified, and rejected:** a proposed narrowing of the whole-line decoration selector to `[style*='left:0;width:100%']`. Monaco's source emits exactly that string, but the narrowed selector did not match at runtime in Chromium and regressed the wash. Reverted, and the failed attempt is documented in the stylesheet so it isn't retried from the source alone.

**Cross-platform (macOS, Linux, Windows):** no platform-specific risk. The change is renderer CSS plus Monaco editor options — no `metaKey`/`ctrlKey` handling, no keyboard shortcuts or shortcut labels, no path construction, no shell or process invocation, no Electron main-process or menu code. `color-mix` and `:has()` are supported by the bundled Chromium on all three platforms.

**SSH / folder workspaces / git providers:** unaffected. Nothing touches git command construction, provider APIs, or anything assuming locality — the diff editor is styled regardless of where the diff came from.

**Performance:** the selectors run against a bounded set — Monaco virtualizes lines and the combined view virtualizes panels via `@tanstack/react-virtual`, so only visible rows are candidates. The `:has()` rules are scoped to direct children of the margin overlay, and the `[style*=]` match only runs on elements already matching `.cdr.char-insert`/`.char-delete`. No new work on startup or in a hot path.

**UI quality:** verified in light and dark mode. Uses documented tokens and the style guide's prescribed `color-mix`-against-a-token approach rather than new hex values.

## Security Audit

No security-relevant surface is touched. The change adds a stylesheet and a pure function returning static editor options.

- **Input handling:** none. No user input is parsed, and no untrusted content reaches a selector or style value.
- **Command execution / path handling:** none. No shell, process, or filesystem access.
- **Auth / secrets:** none touched.
- **IPC:** none added or modified.
- **Dependencies:** no new dependencies.
- **Injection:** all CSS values are static or `var()`/`color-mix()` over existing tokens; no interpolation of dynamic values into styles.

No follow-up needed.

## Notes

Deliberately scoped to readability. Explicitly **not** in this PR, and better as follow-ups:

- **Monaco theme feature** (theme switcher, popular presets, custom/import/export). This PR is designed to compose with it rather than pre-empt it — because it writes no hue, a future theme retints the diff automatically.
- **Deleted-line numbers in unified mode.** Monaco's inline delete view zone renders no line numbers. Restoring them needs a DOM painter with wrap-aware counting; cut as too invasive for a readability pass.
- **Header restructure** (filename-first, path demoted, stat bar).
- **`hideUnchangedRegions` tuning.**

Known limitations, both documented in the code:

- With word wrap on, a word chip that wraps onto the next visual line is also full-width and loses its chip. Monaco gives whole-line and word-level decorations the same class, so the inline style is the only discriminator available; the precise variant does not match in Chromium (see AI Review Report).
- `lineNumbersMinChars: 5` gives the gutter ribbon clearance from the line number, but Monaco takes `max(digitCount, minChars)`, so that clearance disappears past 10,000 lines. A per-model width would need the re-apply pattern already used in `diff-editor-line-number-options.ts`.

X handle: [@Hazihell](https://x.com/Hazihell)
