### PR TITLE
feat(native-chat): add model and effort pickers for grok

### DIFF
--- a/mobile/src/session/use-mobile-native-chat-session-options.ts
+++ b/mobile/src/session/use-mobile-native-chat-session-options.ts
@@ -102,6 +102,9 @@ export function useMobileNativeChatSessionOptions(args: {
 }): MobileNativeChatSessionOptionsController {
   const { agent, scopeKey, reportedModel, dispatchCommand, onAgentPicker } = args
   const catalog = useMemo(
+    // Widening this to a `defaultModelIsCliDefault` catalog (grok) also needs the
+    // effective-model resolution desktop does — `previousModelId` below is tracked-only,
+    // so a CLI-default model would render option rows that do nothing when tapped.
     () => (agent === 'claude' || agent === 'codex' ? getAgentSessionOptionCatalog(agent) : null),
     [agent]
   )

--- a/src/main/text-generation/commit-message-agent-environment.ts
+++ b/src/main/text-generation/commit-message-agent-environment.ts
@@ -53,7 +53,9 @@ function prepareShellConfigDirEnv(agentId: string): { ok: true; env?: NodeJS.Pro
       ? 'OPENCODE_CONFIG_DIR'
       : agentId === 'pi' || agentId === 'omp'
         ? 'PI_CODING_AGENT_DIR'
-        : null
+        : agentId === 'grok'
+          ? 'GROK_HOME'
+          : null
   if (!configVar) {
     return null
   }
@@ -86,6 +88,8 @@ export async function prepareLocalCommitMessageAgentEnv(
   resolvers: CommitMessageAgentEnvironmentResolvers | undefined,
   target?: CommitMessageAgentRuntimeTarget
 ): Promise<{ ok: true; env?: NodeJS.ProcessEnv } | { ok: false; error: string }> {
+  // Why: a non-null result short-circuits the resolvers below, so any agent added
+  // to prepareShellConfigDirEnv must not also need a Codex/Claude-style resolver.
   const shellConfigEnv = target?.runtime === 'wsl' ? null : prepareShellConfigDirEnv(agentId)
   if (shellConfigEnv) {
     return shellConfigEnv

--- a/src/main/text-generation/commit-message-text-generation.ts
+++ b/src/main/text-generation/commit-message-text-generation.ts
@@ -28,11 +28,14 @@ import {
   sanitizeBranchSlug,
   type BranchNameWorkContext
 } from '../../shared/branch-name-from-work'
-import {
-  getCommitMessageAgentSpec,
-  type CommitMessageAgentCapability,
-  type CommitMessageModelCapability
+import type {
+  CommitMessageAgentCapability,
+  CommitMessageModelCapability
 } from '../../shared/commit-message-agent-spec'
+import {
+  getAgentModelProbeSpec,
+  type AgentModelProbeSpec
+} from '../../shared/agent-model-probe-spec'
 import {
   planAgentBinary,
   planCommitMessageGeneration,
@@ -229,7 +232,7 @@ function userFacingUnsafeWindowsBatchArgs(label: string): string {
 }
 
 function toModelDiscoveryCapability(
-  spec: NonNullable<ReturnType<typeof getCommitMessageAgentSpec>>,
+  spec: AgentModelProbeSpec,
   models = spec.models,
   defaultModelId = spec.defaultModelId,
   catalogOrigin: 'probe' | 'spec' = 'spec'
@@ -250,7 +253,7 @@ function toModelDiscoveryCapability(
 }
 
 function finalizeModelDiscoveryOutput(
-  spec: NonNullable<ReturnType<typeof getCommitMessageAgentSpec>>,
+  spec: AgentModelProbeSpec,
   stdout: string,
   stderr: string,
   code: number | null
@@ -289,7 +292,7 @@ function finalizeModelDiscoveryOutput(
 }
 
 function planModelDiscovery(
-  spec: NonNullable<ReturnType<typeof getCommitMessageAgentSpec>>,
+  spec: AgentModelProbeSpec,
   agentCommandOverride?: string
 ): { ok: true; plan: CommitMessagePlan } | { ok: false; error: string } {
   const modelDiscovery = spec.modelDiscovery
@@ -317,9 +320,9 @@ export async function discoverCommitMessageModelsLocal(
   agentCommandOverride?: string,
   options: CommitMessageModelDiscoveryLocalOptions = {}
 ): Promise<DiscoverCommitMessageModelsResult> {
-  const spec = getCommitMessageAgentSpec(agentId)
+  const spec = getAgentModelProbeSpec(agentId)
   if (!spec) {
-    return { success: false, error: `Agent "${agentId}" does not support AI commit messages.` }
+    return { success: false, error: `Agent "${agentId}" does not support model discovery.` }
   }
 
   if (spec.modelSource === 'static' || !spec.modelDiscovery) {
@@ -504,9 +507,9 @@ export async function discoverCommitMessageModelsRemote(
   ) => Promise<RemoteCommitMessageExecResult>,
   agentCommandOverride?: string
 ): Promise<DiscoverCommitMessageModelsResult> {
-  const spec = getCommitMessageAgentSpec(agentId)
+  const spec = getAgentModelProbeSpec(agentId)
   if (!spec) {
-    return { success: false, error: `Agent "${agentId}" does not support AI commit messages.` }
+    return { success: false, error: `Agent "${agentId}" does not support model discovery.` }
   }
   if (spec.modelSource === 'static' || !spec.modelDiscovery) {
     return toModelDiscoveryCapability(spec)

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalWindowControls.tsx
@@ -20,7 +20,7 @@ import {
 } from '../../../../shared/tui-agent-launch-defaults'
 import { translate } from '@/i18n/i18n'
 import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
-import { resolveNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
+import { resolveNativeChatLaunchSessionOptions } from '@/components/native-chat/native-chat-session-option-enrichment'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 
 type FloatingTerminalWindowControlsProps = {
@@ -80,7 +80,7 @@ export function FloatingTerminalWindowControls({
       cmdOverrides: state.settings?.agentCmdOverrides ?? {},
       agentArgs: resolveTuiAgentLaunchArgs(defaultAgent, state.settings?.agentDefaultArgs),
       agentEnv: resolveTuiAgentLaunchEnv(defaultAgent, state.settings?.agentDefaultEnv),
-      sessionOptions: resolveNativeChatSessionOptionDefaults(
+      sessionOptions: resolveNativeChatLaunchSessionOptions(
         state.settings?.nativeChatSessionOptions,
         defaultAgent
       ),

--- a/src/renderer/src/components/native-chat/native-chat-pty-retired-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-retired-model.test.ts
@@ -1,0 +1,96 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { mergeDiscoveredAuthoritativeModels } from '../../../../shared/agent-session-option-catalog'
+import { GROK_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-grok'
+import { updateNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
+import {
+  clearNativeChatSessionOptionCacheForTests,
+  readNativeChatSessionOptionCache,
+  seedNativeChatAppliedSessionOptions
+} from './native-chat-session-option-cache'
+import {
+  createNativeChatPtySessionOptions,
+  type CreateNativeChatPtySessionOptionsArgs,
+  type NativeChatPtySessionOptionsSurface
+} from './native-chat-pty-session-options'
+
+const discoveredGrok5 = (): ReturnType<typeof mergeDiscoveredAuthoritativeModels> =>
+  mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [
+    { id: 'grok-5', label: 'Grok 5', isDefault: true, options: [] }
+  ])
+
+function createGrokSurface(args?: Partial<CreateNativeChatPtySessionOptionsArgs>): {
+  surface: NativeChatPtySessionOptionsSurface
+  persisted: () => PersistedNativeChatSessionOptions
+} {
+  let persisted: PersistedNativeChatSessionOptions = {}
+  const surface = createNativeChatPtySessionOptions({
+    agent: 'grok',
+    scopeKey: 'pty-1',
+    mode: 'live',
+    dispatchCommand: vi.fn(),
+    persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
+      persisted = updateNativeChatSessionOptionDefaults({
+        persisted,
+        agent: 'grok',
+        modelId,
+        optionId,
+        value,
+        modelIsUnverifiedDefault
+      })
+    },
+    ...args
+  })!
+  return { surface, persisted: () => persisted }
+}
+
+/** Retirement clears settings, but the session-tracked model is what option writes
+ *  re-persist — left tracked, a retired id re-enters the picker via re-injection and
+ *  restores the fatal `-m <retired>` the retirement just removed. */
+describe('retired grok model untracking', () => {
+  beforeEach(() => clearNativeChatSessionOptionCacheForTests())
+
+  it('untracks a picked model an authoritative discovery dropped', async () => {
+    seedNativeChatAppliedSessionOptions('pty-1', 'grok', { model: 'grok-4.5' })
+    const { surface, persisted } = createGrokSurface()
+
+    surface.replaceModels(discoveredGrok5())
+
+    // The retired id is gone from the picker, not kept as a reconciled row.
+    expect(surface.getSnapshot()[0].kind).toMatchObject({
+      currentValue: 'grok-5',
+      choices: [expect.objectContaining({ value: 'grok-5' })]
+    })
+    expect(readNativeChatSessionOptionCache('pty-1')?.model).toBeUndefined()
+
+    // A later option write persists under the surviving default, never the retired id.
+    await surface.setOption('effort', 'low')
+    expect(persisted().grok?.model).toBe('grok-5')
+  })
+
+  it('untracks a cached retired model at surface creation', () => {
+    // The probe can settle before this pane mounts; the cache handoff then restores a
+    // tracked id the authoritative list already dropped.
+    seedNativeChatAppliedSessionOptions('pty-1', 'grok', { model: 'grok-4.5' })
+    const { surface } = createGrokSurface({ initialModels: discoveredGrok5() })
+
+    expect(surface.getSnapshot()[0].kind).toMatchObject({
+      currentValue: 'grok-5',
+      choices: [expect.objectContaining({ value: 'grok-5' })]
+    })
+    expect(readNativeChatSessionOptionCache('pty-1')?.model).toBeUndefined()
+  })
+
+  it('never persists a typed model the authoritative list lacks', () => {
+    // `/model <retired>` is tracked for display, but adopting it as the persisted
+    // launch default would recreate the fatal `-m` retirement just cleared.
+    const { surface, persisted } = createGrokSurface({ initialModels: discoveredGrok5() })
+
+    surface.recordOutgoingCommand('/model grok-4.5')
+
+    expect(persisted().grok?.model).toBeUndefined()
+    // A typed id the list does carry still persists as before.
+    surface.recordOutgoingCommand('/model grok-5')
+    expect(persisted().grok?.model).toBe('grok-5')
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pty-retired-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-retired-model.test.ts
@@ -29,14 +29,14 @@ function createGrokSurface(args?: Partial<CreateNativeChatPtySessionOptionsArgs>
     scopeKey: 'pty-1',
     mode: 'live',
     dispatchCommand: vi.fn(),
-    persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
+    persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) => {
       persisted = updateNativeChatSessionOptionDefaults({
         persisted,
         agent: 'grok',
         modelId,
         optionId,
         value,
-        modelIsUnverifiedDefault
+        adoptModelAsLaunchDefault
       })
     },
     ...args

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -126,7 +126,7 @@ describe('native chat PTY session options', () => {
       optionId: 'effort',
       value: 'high',
       // Claude tracks a real model here, so this stays a persistable selection.
-      modelIsCliDefault: false
+      modelIsUnverifiedDefault: false
     })
   })
 
@@ -733,24 +733,25 @@ describe('native chat PTY session options', () => {
     })
   })
 
-  it('does not adopt grok’s CLI default as a persisted launch model', async () => {
+  it('does not adopt grok’s unprobed seed default as a persisted launch model', async () => {
     // Regression: setting an option under the CLI default wrote `model` into settings,
     // so every later grok launch app-wide emitted `-m grok-4.5` — on an account without
-    // that model, a fatal launch the user never opted into.
+    // that model, a fatal launch the user never opted into. No discovery has run here,
+    // so `grok-4.5` is still only the seed's guess.
     let persisted: PersistedNativeChatSessionOptions = {}
     const surface = createNativeChatPtySessionOptions({
       agent: 'grok',
       scopeKey: 'pty-1',
       mode: 'live',
       dispatchCommand: vi.fn(),
-      persistSelection: ({ modelId, optionId, value, modelIsCliDefault }) => {
+      persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
         persisted = updateNativeChatSessionOptionDefaults({
           persisted,
           agent: 'grok',
           modelId,
           optionId,
           value,
-          modelIsCliDefault
+          modelIsUnverifiedDefault
         })
       }
     })!
@@ -846,9 +847,44 @@ describe('native chat PTY session options', () => {
       expect.objectContaining({ modelId: 'grok-5', optionId: 'effort', value: 'low' })
     )
     // A tracked model is returned verbatim by the resolver, so this re-resolution can
-    // only ever move an untracked, never-selected id — never one the user picked.
+    // only ever move an untracked, never-selected id — never one the user picked. The
+    // probe that landed mid-dispatch also confirmed grok-5, so it is safe to adopt.
     expect(persistSelection).toHaveBeenCalledWith(
-      expect.objectContaining({ modelIsCliDefault: true })
+      expect.objectContaining({ modelIsUnverifiedDefault: false })
     )
+  })
+
+  it('carries an effort set under a probe-confirmed default into later launches', async () => {
+    // Regression: the value persisted under the model id while `model` stayed unset, so
+    // resolveNativeChatSessionOptionDefaults bailed and every new grok tab reverted to
+    // the catalog default — the setting silently never survived a relaunch.
+    let persisted: PersistedNativeChatSessionOptions = {}
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'grok',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      initialModels: mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [
+        { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true, options: [] }
+      ]),
+      dispatchCommand: vi.fn(),
+      persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
+        persisted = updateNativeChatSessionOptionDefaults({
+          persisted,
+          agent: 'grok',
+          modelId,
+          optionId,
+          value,
+          modelIsUnverifiedDefault
+        })
+      }
+    })!
+
+    await surface.setOption('effort', 'low')
+
+    expect(persisted.grok?.model).toBe('grok-4.5')
+    expect(resolveNativeChatSessionOptionDefaults(persisted, 'grok')).toMatchObject({
+      model: 'grok-4.5',
+      effort: 'low'
+    })
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -126,7 +126,7 @@ describe('native chat PTY session options', () => {
       optionId: 'effort',
       value: 'high',
       // Claude tracks a real model here, so this stays a persistable selection.
-      modelIsUnverifiedDefault: false
+      adoptModelAsLaunchDefault: true
     })
   })
 
@@ -744,14 +744,14 @@ describe('native chat PTY session options', () => {
       scopeKey: 'pty-1',
       mode: 'live',
       dispatchCommand: vi.fn(),
-      persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
+      persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) => {
         persisted = updateNativeChatSessionOptionDefaults({
           persisted,
           agent: 'grok',
           modelId,
           optionId,
           value,
-          modelIsUnverifiedDefault
+          adoptModelAsLaunchDefault
         })
       }
     })!
@@ -850,7 +850,7 @@ describe('native chat PTY session options', () => {
     // only ever move an untracked, never-selected id — never one the user picked. The
     // probe that landed mid-dispatch also confirmed grok-5, so it is safe to adopt.
     expect(persistSelection).toHaveBeenCalledWith(
-      expect.objectContaining({ modelIsUnverifiedDefault: false })
+      expect.objectContaining({ adoptModelAsLaunchDefault: true })
     )
   })
 
@@ -867,14 +867,14 @@ describe('native chat PTY session options', () => {
         { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true, options: [] }
       ]),
       dispatchCommand: vi.fn(),
-      persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
+      persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) => {
         persisted = updateNativeChatSessionOptionDefaults({
           persisted,
           agent: 'grok',
           modelId,
           optionId,
           value,
-          modelIsUnverifiedDefault
+          adoptModelAsLaunchDefault
         })
       }
     })!

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.test.ts
@@ -5,6 +5,13 @@ import {
   seedNativeChatAppliedSessionOptions
 } from './native-chat-session-option-cache'
 import { createNativeChatPtySessionOptions } from './native-chat-pty-session-options'
+import { mergeDiscoveredAuthoritativeModels } from '../../../../shared/agent-session-option-catalog'
+import { GROK_SESSION_OPTION_CATALOG } from '../../../../shared/agent-session-option-catalog-grok'
+import {
+  resolveNativeChatSessionOptionDefaults,
+  updateNativeChatSessionOptionDefaults
+} from '../../../../shared/native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
 
 describe('native chat PTY session options', () => {
   beforeEach(() => clearNativeChatSessionOptionCacheForTests())
@@ -117,7 +124,9 @@ describe('native chat PTY session options', () => {
     expect(persist).toHaveBeenCalledWith({
       modelId: 'opus',
       optionId: 'effort',
-      value: 'high'
+      value: 'high',
+      // Claude tracks a real model here, so this stays a persistable selection.
+      modelIsCliDefault: false
     })
   })
 
@@ -696,5 +705,150 @@ describe('native chat PTY session options', () => {
       valueSource: 'dispatched',
       kind: { currentValue: 'high' }
     })
+  })
+
+  it('names grok’s CLI default on load and still applies the rows it draws', async () => {
+    const dispatch = vi.fn()
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'grok',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: dispatch
+    })!
+    // Nothing tracked means no `-m` was emitted, so grok is on its own default.
+    expect(surface.getSnapshot()[0]).toMatchObject({
+      id: 'model',
+      valueSource: 'default',
+      kind: { currentValue: 'grok-4.5' }
+    })
+
+    // Regression: the effort row hangs off that default model, so resolving the apply
+    // from the tracked model alone threw `Unknown session option: effort` on click.
+    await surface.setOption('effort', 'low')
+
+    expect(dispatch).toHaveBeenCalledWith('/effort low')
+    expect(surface.getSnapshot().find(({ id }) => id === 'effort')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { currentValue: 'low' }
+    })
+  })
+
+  it('does not adopt grok’s CLI default as a persisted launch model', async () => {
+    // Regression: setting an option under the CLI default wrote `model` into settings,
+    // so every later grok launch app-wide emitted `-m grok-4.5` — on an account without
+    // that model, a fatal launch the user never opted into.
+    let persisted: PersistedNativeChatSessionOptions = {}
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'grok',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(),
+      persistSelection: ({ modelId, optionId, value, modelIsCliDefault }) => {
+        persisted = updateNativeChatSessionOptionDefaults({
+          persisted,
+          agent: 'grok',
+          modelId,
+          optionId,
+          value,
+          modelIsCliDefault
+        })
+      }
+    })!
+
+    await surface.setOption('effort', 'low')
+
+    expect(persisted.grok?.model).toBeUndefined()
+    // The scoped value is still remembered for a later explicit pick of that model.
+    expect(persisted.grok?.valuesByModel?.['grok-4.5']?.effort).toBe('low')
+    expect(resolveNativeChatSessionOptionDefaults(persisted, 'grok')).toBeUndefined()
+
+    // A model the user actually picks still becomes the launch default.
+    await surface.setOption('model', 'grok-4.5')
+    expect(persisted.grok?.model).toBe('grok-4.5')
+  })
+
+  it('commits an effort grok accepted even when discovery lands mid-dispatch', async () => {
+    // Regression: the staleness guard resolved through the model list, so a probe
+    // settling mid-dispatch moved which row is `isDefault` and looked like a model
+    // switch — discarding a value the agent had already applied.
+    let release = (): void => {}
+    let markDispatched = (): void => {}
+    const dispatched = new Promise<void>((resolve) => {
+      markDispatched = resolve
+    })
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'grok',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      dispatchCommand: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = () => resolve()
+            markDispatched()
+          })
+      )
+    })!
+
+    const pending = surface.setOption('effort', 'low')
+    await dispatched
+    surface.replaceModels(
+      mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [
+        { id: 'grok-4.5', label: 'Grok 4.5', options: [] },
+        { id: 'grok-5', label: 'Grok 5', isDefault: true, options: [] }
+      ])
+    )
+    release()
+    await pending
+
+    expect(surface.getSnapshot().find(({ id }) => id === 'effort')).toMatchObject({
+      valueSource: 'dispatched',
+      kind: { currentValue: 'low' }
+    })
+  })
+
+  it('files a dispatched effort under the default the probe reported, not the seed guess', async () => {
+    // With nothing tracked the session launched without `-m`, so it is running whatever
+    // grok defaults to — a fact only `grok models` knows. The pre-dispatch id is the
+    // seed's guess; committing under it would file the value against a model that was
+    // never running and blank the pill the user just set.
+    const persistSelection = vi.fn()
+    let release = (): void => {}
+    let markDispatched = (): void => {}
+    const dispatched = new Promise<void>((resolve) => {
+      markDispatched = resolve
+    })
+    const surface = createNativeChatPtySessionOptions({
+      agent: 'grok',
+      scopeKey: 'pty-1',
+      mode: 'live',
+      persistSelection,
+      dispatchCommand: vi.fn(
+        () =>
+          new Promise<void>((resolve) => {
+            release = () => resolve()
+            markDispatched()
+          })
+      )
+    })!
+
+    const pending = surface.setOption('effort', 'low')
+    await dispatched
+    surface.replaceModels(
+      mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [
+        { id: 'grok-5', label: 'Grok 5', isDefault: true, options: [] },
+        { id: 'grok-build', label: 'Grok Build', options: [] }
+      ])
+    )
+    release()
+    await pending
+
+    expect(persistSelection).toHaveBeenCalledWith(
+      expect.objectContaining({ modelId: 'grok-5', optionId: 'effort', value: 'low' })
+    )
+    // A tracked model is returned verbatim by the resolver, so this re-resolution can
+    // only ever move an untracked, never-selected id — never one the user picked.
+    expect(persistSelection).toHaveBeenCalledWith(
+      expect.objectContaining({ modelIsCliDefault: true })
+    )
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -116,6 +116,8 @@ export function createNativeChatPtySessionOptions(
       resolveEffectiveNativeChatModelId(catalog, activeModels(), record)
     )
 
+  // Same load-bearing guard as the apply path: a truthy `modelId` implies a tracked
+  // model for every agent without a CLI default, keeping the ungated flag false there.
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {
     if (modelId) {
       void args.persistSelection?.({

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -77,6 +77,23 @@ export function createNativeChatPtySessionOptions(
   if (args.reportedValues && applyNativeChatReportedSessionOptions(record, args.reportedValues)) {
     writeNativeChatSessionOptionCache(args.scopeKey, record)
   }
+  /** Why: an authoritative probe proved this id gone; left tracked it would re-enter
+   *  the picker via re-injection and re-persist the fatal `-m` on any later option
+   *  write, undoing the settings retirement. */
+  const untrackRetiredModel = (): boolean => {
+    if (!catalog.discoveredModelsAreAuthoritative || !modelsAreDiscovered) {
+      return false
+    }
+    const trackedId = typeof record.model?.value === 'string' ? record.model.value : null
+    if (!trackedId || models.some((model) => model.id === trackedId)) {
+      return false
+    }
+    clearNativeChatSessionModel(record)
+    return true
+  }
+  if (untrackRetiredModel()) {
+    writeNativeChatSessionOptionCache(args.scopeKey, record)
+  }
   const activeModels = (): CatalogModel[] => withTrackedNativeChatModel(catalog, models, record)
   let snapshot = buildNativeChatSessionOptionSnapshot({
     catalog,
@@ -124,9 +141,25 @@ export function createNativeChatPtySessionOptions(
   // model for every agent without a CLI default, keeping the ungated flag false there.
   const modelIsUnverifiedDefault = (): boolean => record.model === undefined && !modelsAreDiscovered
 
+  /** Every persist path — picker applies and typed commands — funnels through this
+   *  gate: a typed `/model <retired>` or a probe landing mid-pick can still hand it
+   *  an id the authoritative list lacks, and adopting that as the launch default
+   *  would recreate the fatal `-m` the retirement just cleared. */
+  const persistSelection: PersistSelection | undefined = args.persistSelection
+    ? (selection) =>
+        args.persistSelection?.({
+          ...selection,
+          modelIsUnverifiedDefault:
+            selection.modelIsUnverifiedDefault ||
+            (modelsAreDiscovered &&
+              catalog.discoveredModelsAreAuthoritative === true &&
+              !models.some((model) => model.id === selection.modelId))
+        })
+    : undefined
+
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {
     if (modelId) {
-      void args.persistSelection?.({
+      void persistSelection?.({
         modelId,
         optionId,
         value,
@@ -142,7 +175,7 @@ export function createNativeChatPtySessionOptions(
     getRecord: () => record,
     dispatchCommand: args.dispatchCommand,
     onAgentPicker: args.onAgentPicker,
-    persistSelection: args.persistSelection,
+    persistSelection,
     onDraftValuesChanged: args.onDraftValuesChanged,
     publish,
     clearModelTruth,
@@ -181,6 +214,7 @@ export function createNativeChatPtySessionOptions(
     replaceModels: (nextModels) => {
       models = [...nextModels]
       modelsAreDiscovered = true
+      untrackRetiredModel()
       publish()
     }
   }

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -32,8 +32,9 @@ type PersistSelection = (args: {
   modelId: string
   optionId: string
   value: SessionOptionValue
-  /** The model only scopes this value; it must not become a persisted launch flag. */
-  modelIsCliDefault?: boolean
+  /** The model is the seed's unprobed guess at the CLI default, so it only scopes this
+   *  value; it must not become a persisted launch flag. */
+  modelIsUnverifiedDefault?: boolean
 }) => Promise<void> | void
 
 export type NativeChatPtySessionOptionsSurface = SessionOptionsSurface & {
@@ -63,6 +64,9 @@ export function createNativeChatPtySessionOptions(
     return null
   }
   let models = [...(args.initialModels ?? catalog.models)]
+  // The enrichment cache only ever holds probe output, so being handed a list at all
+  // means `isDefault` below names the account's real default rather than the seed guess.
+  let modelsAreDiscovered = args.initialModels !== undefined
   let record =
     readNativeChatSessionOptionCache(args.scopeKey, args.fallbackScopeKey) ??
     createNativeChatSessionOptionRecord(args.agent)
@@ -118,13 +122,15 @@ export function createNativeChatPtySessionOptions(
 
   // Same load-bearing guard as the apply path: a truthy `modelId` implies a tracked
   // model for every agent without a CLI default, keeping the ungated flag false there.
+  const modelIsUnverifiedDefault = (): boolean => record.model === undefined && !modelsAreDiscovered
+
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {
     if (modelId) {
       void args.persistSelection?.({
         modelId,
         optionId,
         value,
-        modelIsCliDefault: record.model === undefined
+        modelIsUnverifiedDefault: modelIsUnverifiedDefault()
       })
     }
   }
@@ -140,7 +146,8 @@ export function createNativeChatPtySessionOptions(
     onDraftValuesChanged: args.onDraftValuesChanged,
     publish,
     clearModelTruth,
-    setTrackedValue
+    setTrackedValue,
+    modelIsUnverifiedDefault
   })
 
   return {
@@ -173,6 +180,7 @@ export function createNativeChatPtySessionOptions(
     },
     replaceModels: (nextModels) => {
       models = [...nextModels]
+      modelsAreDiscovered = true
       publish()
     }
   }

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -22,6 +22,7 @@ import {
 import { createSessionOptionAppliers } from './native-chat-session-option-apply'
 import {
   buildNativeChatSessionOptionSnapshot,
+  resolveEffectiveNativeChatModelId,
   withTrackedNativeChatModel,
   type NativeChatSessionOptionMode
 } from './native-chat-session-option-snapshot'
@@ -31,6 +32,8 @@ type PersistSelection = (args: {
   modelId: string
   optionId: string
   value: SessionOptionValue
+  /** The model only scopes this value; it must not become a persisted launch flag. */
+  modelIsCliDefault?: boolean
 }) => Promise<void> | void
 
 export type NativeChatPtySessionOptionsSurface = SessionOptionsSurface & {
@@ -97,15 +100,30 @@ export function createNativeChatPtySessionOptions(
     clearNativeChatSessionModel(record)
   }
 
+  /** Resolved at commit, not pre-dispatch: with nothing tracked the pre-dispatch id was
+   *  only the seed's guess at grok's default, and a probe landing mid-dispatch replaces
+   *  it with the id the CLI actually reported — the model the command truly reached. */
   const setTrackedValue = (
     optionId: string,
     value: SessionOptionValue,
     source: 'applied' | 'dispatched'
-  ): string | null => setTrackedSessionOption(record, optionId, value, source)
+  ): string | null =>
+    setTrackedSessionOption(
+      record,
+      optionId,
+      value,
+      source,
+      resolveEffectiveNativeChatModelId(catalog, activeModels(), record)
+    )
 
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {
     if (modelId) {
-      void args.persistSelection?.({ modelId, optionId, value })
+      void args.persistSelection?.({
+        modelId,
+        optionId,
+        value,
+        modelIsCliDefault: record.model === undefined
+      })
     }
   }
 

--- a/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pty-session-options.ts
@@ -32,9 +32,8 @@ type PersistSelection = (args: {
   modelId: string
   optionId: string
   value: SessionOptionValue
-  /** The model is the seed's unprobed guess at the CLI default, so it only scopes this
-   *  value; it must not become a persisted launch flag. */
-  modelIsUnverifiedDefault?: boolean
+  /** False leaves the model scoping this value only, never a persisted launch flag. */
+  adoptModelAsLaunchDefault: boolean
 }) => Promise<void> | void
 
 export type NativeChatPtySessionOptionsSurface = SessionOptionsSurface & {
@@ -137,33 +136,24 @@ export function createNativeChatPtySessionOptions(
       resolveEffectiveNativeChatModelId(catalog, activeModels(), record)
     )
 
-  // Same load-bearing guard as the apply path: a truthy `modelId` implies a tracked
-  // model for every agent without a CLI default, keeping the ungated flag false there.
-  const modelIsUnverifiedDefault = (): boolean => record.model === undefined && !modelsAreDiscovered
+  /** The sole answer to "may this id become the persisted `-m` launch flag?", read at
+   *  persist time because a probe can settle mid-pick. Before one, `isDefault` is just
+   *  the seed's guess, so only an id the session actually tracks is evidence of
+   *  anything; after one, an authoritative list that omits the id proves it retired —
+   *  adopting either would emit an `-m` that is fatal on an account without it. */
+  const modelIsAdoptableAsLaunchDefault = (modelId: string): boolean =>
+    modelsAreDiscovered
+      ? !catalog.discoveredModelsAreAuthoritative || models.some((model) => model.id === modelId)
+      : record.model !== undefined
 
-  /** Every persist path — picker applies and typed commands — funnels through this
-   *  gate: a typed `/model <retired>` or a probe landing mid-pick can still hand it
-   *  an id the authoritative list lacks, and adopting that as the launch default
-   *  would recreate the fatal `-m` the retirement just cleared. */
-  const persistSelection: PersistSelection | undefined = args.persistSelection
-    ? (selection) =>
-        args.persistSelection?.({
-          ...selection,
-          modelIsUnverifiedDefault:
-            selection.modelIsUnverifiedDefault ||
-            (modelsAreDiscovered &&
-              catalog.discoveredModelsAreAuthoritative === true &&
-              !models.some((model) => model.id === selection.modelId))
-        })
-    : undefined
-
+  /** Every persist path — picker applies and typed commands — funnels through here. */
   const persist = (modelId: string | null, optionId: string, value: SessionOptionValue): void => {
     if (modelId) {
-      void persistSelection?.({
+      void args.persistSelection?.({
         modelId,
         optionId,
         value,
-        modelIsUnverifiedDefault: modelIsUnverifiedDefault()
+        adoptModelAsLaunchDefault: modelIsAdoptableAsLaunchDefault(modelId)
       })
     }
   }
@@ -175,12 +165,11 @@ export function createNativeChatPtySessionOptions(
     getRecord: () => record,
     dispatchCommand: args.dispatchCommand,
     onAgentPicker: args.onAgentPicker,
-    persistSelection,
+    persist,
     onDraftValuesChanged: args.onDraftValuesChanged,
     publish,
     clearModelTruth,
-    setTrackedValue,
-    modelIsUnverifiedDefault
+    setTrackedValue
   })
 
   return {

--- a/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
@@ -1,17 +1,36 @@
+// @vitest-environment happy-dom
+
+import { renderHook } from '@testing-library/react'
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { CatalogModel } from '../../../../shared/agent-session-option-catalog'
 import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
+import {
+  clearNativeChatModelEnrichmentForTests,
+  ensureNativeChatModelEnrichment,
+  readNativeChatEnrichedModels
+} from './native-chat-session-option-enrichment'
 
 const mocks = vi.hoisted(() => ({
   storeState: {
     settings: {} as { nativeChatSessionOptions?: PersistedNativeChatSessionOptions },
     updateSettings: vi.fn()
-  }
+  },
+  createNativeChatPtySessionOptions: vi.fn(),
+  discoverNativeChatCatalogModels: vi.fn()
 }))
 
 vi.mock('../../store', () => ({ useAppStore: { getState: () => mocks.storeState } }))
 
-const { retirePersistedModelMissingFromDiscovery } =
+vi.mock('./native-chat-pty-session-options', () => ({
+  createNativeChatPtySessionOptions: mocks.createNativeChatPtySessionOptions
+}))
+
+vi.mock('./native-chat-session-option-discovery', () => ({
+  resolveNativeChatModelDiscoveryContext: () => ({ hostKey: 'local', runtime: {} }),
+  discoverNativeChatCatalogModels: mocks.discoverNativeChatCatalogModels
+}))
+
+const { retirePersistedModelMissingFromDiscovery, useNativeChatSessionOptions } =
   await import('./use-native-chat-session-options')
 
 const models = (...ids: string[]): CatalogModel[] =>
@@ -80,5 +99,64 @@ describe('retirePersistedModelMissingFromDiscovery', () => {
     expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
       nativeChatSessionOptions: { grok: {}, claude: { model: 'opus' } }
     })
+  })
+})
+
+/** The enrichment subscription never replays, so a pane that mounts after the
+ *  once-per-host probe settled would otherwise never reach retirement. */
+describe('useNativeChatSessionOptions retirement on mount', () => {
+  const mountPane = (): void => {
+    renderHook(() =>
+      useNativeChatSessionOptions({
+        agent: 'grok',
+        terminalTabId: 'tab-1',
+        targetPtyId: 'pty-1',
+        dispatchCommand: () => undefined
+      })
+    )
+  }
+
+  beforeEach(() => {
+    clearNativeChatModelEnrichmentForTests()
+    mocks.storeState.updateSettings.mockReset().mockResolvedValue(undefined)
+    mocks.storeState.settings = {}
+    mocks.discoverNativeChatCatalogModels.mockReset().mockResolvedValue(null)
+    // A stable snapshot reference: useSyncExternalStore re-renders forever otherwise.
+    const emptySnapshot: never[] = []
+    mocks.createNativeChatPtySessionOptions.mockReset().mockImplementation(() => ({
+      subscribe: () => () => {},
+      getSnapshot: () => emptySnapshot,
+      recordOutgoingCommand: () => {},
+      reportSessionOptions: () => {},
+      replaceModels: () => {}
+    }))
+  })
+
+  it('retires a persisted id against models the probe already cached', async () => {
+    persist({ grok: { model: 'grok-build' } })
+    ensureNativeChatModelEnrichment({
+      agent: 'grok',
+      hostKey: 'local',
+      discover: async () => models('grok-4.5')
+    })
+    await vi.waitFor(() => expect(readNativeChatEnrichedModels('grok', 'local')).not.toBeNull())
+
+    mountPane()
+
+    await vi.waitFor(() =>
+      expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
+        nativeChatSessionOptions: { grok: {} }
+      })
+    )
+  })
+
+  it('leaves the persisted id alone while the probe is still in flight', async () => {
+    persist({ grok: { model: 'grok-build' } })
+    mocks.discoverNativeChatCatalogModels.mockReturnValue(new Promise(() => {}))
+
+    mountPane()
+
+    await Promise.resolve()
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
@@ -1,0 +1,84 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { CatalogModel } from '../../../../shared/agent-session-option-catalog'
+import type { PersistedNativeChatSessionOptions } from '../../../../shared/native-chat-session-options'
+
+const mocks = vi.hoisted(() => ({
+  storeState: {
+    settings: {} as { nativeChatSessionOptions?: PersistedNativeChatSessionOptions },
+    updateSettings: vi.fn()
+  }
+}))
+
+vi.mock('../../store', () => ({ useAppStore: { getState: () => mocks.storeState } }))
+
+const { retirePersistedModelMissingFromDiscovery } =
+  await import('./use-native-chat-session-options')
+
+const models = (...ids: string[]): CatalogModel[] =>
+  ids.map((id) => ({ id, label: id, options: [] }))
+
+function persist(options: PersistedNativeChatSessionOptions): void {
+  mocks.storeState.settings = { nativeChatSessionOptions: options }
+}
+
+/** The persisted model becomes `-m <id>` at every launch site, including ones that
+ *  never render the picker, and grok exits fatally on an id it no longer lists. */
+describe('retirePersistedModelMissingFromDiscovery', () => {
+  beforeEach(() => {
+    mocks.storeState.updateSettings.mockReset().mockResolvedValue(undefined)
+    mocks.storeState.settings = {}
+  })
+
+  it('clears a persisted id the authoritative probe no longer lists', async () => {
+    persist({ grok: { model: 'grok-build', valuesByModel: { 'grok-build': { effort: 'low' } } } })
+    await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
+    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
+      // Why keep valuesByModel: the option values are still valid if the user
+      // reselects that model on another host.
+      nativeChatSessionOptions: {
+        grok: { valuesByModel: { 'grok-build': { effort: 'low' } } }
+      }
+    })
+  })
+
+  it('keeps a persisted id the probe still lists', async () => {
+    persist({ grok: { model: 'grok-4.5' } })
+    await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5', 'grok-build'))
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('treats an empty list as a failed probe, not an empty account', async () => {
+    persist({ grok: { model: 'grok-build' } })
+    await retirePersistedModelMissingFromDiscovery('grok', [])
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('leaves additive agents alone, whose lists extend the seed rather than replace it', async () => {
+    // Cursor's probe not listing a model is no evidence the model is gone.
+    persist({ cursor: { model: 'gpt-5.3-codex' } })
+    await retirePersistedModelMissingFromDiscovery('cursor', models('auto'))
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when no model was ever persisted', async () => {
+    persist({ grok: { valuesByModel: { 'grok-4.5': { effort: 'high' } } } })
+    await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('survives settings that were never written', async () => {
+    mocks.storeState.settings = {}
+    await expect(
+      retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
+    ).resolves.toBeUndefined()
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
+  it('retires only the named agent, leaving other agents’ picks intact', async () => {
+    persist({ grok: { model: 'grok-build' }, claude: { model: 'opus' } })
+    await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))
+    expect(mocks.storeState.updateSettings).toHaveBeenCalledWith({
+      nativeChatSessionOptions: { grok: {}, claude: { model: 'opus' } }
+    })
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-retire-persisted-model.test.ts
@@ -93,6 +93,16 @@ describe('retirePersistedModelMissingFromDiscovery', () => {
     expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
   })
 
+  it('re-reads live settings at apply so a pick landing mid-retirement survives', async () => {
+    // Regression: retirement captured the settings snapshot before its write was
+    // queued, so a pick landing in between was clobbered back to the old shape.
+    persist({ grok: { model: 'grok-build' } })
+    const pending = retirePersistedModelMissingFromDiscovery('grok', models('grok-5'))
+    persist({ grok: { model: 'grok-5' } })
+    await pending
+    expect(mocks.storeState.updateSettings).not.toHaveBeenCalled()
+  })
+
   it('retires only the named agent, leaving other agents’ picks intact', async () => {
     persist({ grok: { model: 'grok-build' }, claude: { model: 'opus' } })
     await retirePersistedModelMissingFromDiscovery('grok', models('grok-4.5'))

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -38,7 +38,7 @@ type SessionOptionApplyContext = {
     modelId: string
     optionId: string
     value: SessionOptionValue
-    modelIsCliDefault?: boolean
+    modelIsUnverifiedDefault?: boolean
   }) => Promise<void> | void
   onDraftValuesChanged?: (values: Record<string, SessionOptionValue>) => void
   publish: () => SessionOptionDescriptor[]
@@ -48,6 +48,9 @@ type SessionOptionApplyContext = {
     value: SessionOptionValue,
     source: 'applied' | 'dispatched'
   ) => string | null
+  /** Read at commit: a probe settling mid-dispatch turns the seed's guess into a
+   *  confirmed id, and only then may this value's model be adopted as a launch flag. */
+  modelIsUnverifiedDefault: () => boolean
 }
 
 /** Why: ordered applies make a later absolute target observe the result of an
@@ -101,9 +104,7 @@ function persist(
       modelId,
       optionId,
       value,
-      // An untracked record means no `-m` was ever emitted, so this id is the CLI's
-      // own default standing in as a scope — not a selection to persist.
-      modelIsCliDefault: ctx.getRecord().model === undefined
+      modelIsUnverifiedDefault: ctx.modelIsUnverifiedDefault()
     })
   }
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -34,12 +34,9 @@ type SessionOptionApplyContext = {
   getRecord: () => NativeChatSessionOptionRecord
   dispatchCommand: NativeChatSessionOptionDispatchCommand
   onAgentPicker?: () => void
-  persistSelection?: (args: {
-    modelId: string
-    optionId: string
-    value: SessionOptionValue
-    modelIsUnverifiedDefault?: boolean
-  }) => Promise<void> | void
+  /** The one persist entry point, shared with typed commands: it owns both the
+   *  null-model guard and whether the id may be adopted as the launch default. */
+  persist: (modelId: string | null, optionId: string, value: SessionOptionValue) => void
   onDraftValuesChanged?: (values: Record<string, SessionOptionValue>) => void
   publish: () => SessionOptionDescriptor[]
   clearModelTruth: () => void
@@ -48,9 +45,6 @@ type SessionOptionApplyContext = {
     value: SessionOptionValue,
     source: 'applied' | 'dispatched'
   ) => string | null
-  /** Read at commit: a probe settling mid-dispatch turns the seed's guess into a
-   *  confirmed id, and only then may this value's model be adopted as a launch flag. */
-  modelIsUnverifiedDefault: () => boolean
 }
 
 /** Why: ordered applies make a later absolute target observe the result of an
@@ -90,25 +84,6 @@ function trackedModelId(record: NativeChatSessionOptionRecord): string | null {
   return typeof record.model?.value === 'string' ? record.model.value : null
 }
 
-function persist(
-  ctx: SessionOptionApplyContext,
-  modelId: string | null,
-  optionId: string,
-  value: SessionOptionValue
-): void {
-  // The guard below is load-bearing, not just a null check: without a CLI default a
-  // truthy `modelId` implies a tracked model, which is what keeps the ungated flag
-  // false for every other agent. Widening it would change their persistence too.
-  if (modelId) {
-    void ctx.persistSelection?.({
-      modelId,
-      optionId,
-      value,
-      modelIsUnverifiedDefault: ctx.modelIsUnverifiedDefault()
-    })
-  }
-}
-
 function finish(
   ctx: SessionOptionApplyContext,
   args?: {
@@ -119,7 +94,7 @@ function finish(
   }
 ): SessionOptionSetResult {
   if (args && !args.skipPersist) {
-    persist(ctx, args.modelId, args.optionId, args.value)
+    ctx.persist(args.modelId, args.optionId, args.value)
   }
   const snapshot = ctx.publish()
   const record = ctx.getRecord()

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -93,6 +93,9 @@ function persist(
   optionId: string,
   value: SessionOptionValue
 ): void {
+  // The guard below is load-bearing, not just a null check: without a CLI default a
+  // truthy `modelId` implies a tracked model, which is what keeps the ungated flag
+  // false for every other agent. Widening it would change their persistence too.
   if (modelId) {
     void ctx.persistSelection?.({
       modelId,

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -23,6 +23,7 @@ import type {
 } from './native-chat-session-option-command-dispatch'
 import {
   flattenNativeChatSessionOptionRecord,
+  resolveEffectiveNativeChatModelId,
   type NativeChatSessionOptionMode
 } from './native-chat-session-option-snapshot'
 
@@ -37,6 +38,7 @@ type SessionOptionApplyContext = {
     modelId: string
     optionId: string
     value: SessionOptionValue
+    modelIsCliDefault?: boolean
   }) => Promise<void> | void
   onDraftValuesChanged?: (values: Record<string, SessionOptionValue>) => void
   publish: () => SessionOptionDescriptor[]
@@ -66,16 +68,23 @@ function currentApply(
   ctx: SessionOptionApplyContext,
   optionId: string
 ): { apply: CatalogOptionApply; modelId: string | null } | null {
-  const record = ctx.getRecord()
-  const modelId = typeof record.model?.value === 'string' ? record.model.value : null
+  const models = ctx.getModels()
+  // Why: the snapshot renders each option under the effective model, so resolving from
+  // the tracked model alone would fail to find the very rows a CLI default just drew.
+  const modelId = resolveEffectiveNativeChatModelId(ctx.catalog, models, ctx.getRecord())
   if (optionId === 'model') {
     return { apply: ctx.catalog.modelApply, modelId }
   }
-  const model = modelId
-    ? findCatalogModel({ ...ctx.catalog, models: ctx.getModels() }, modelId)
-    : undefined
+  const model = modelId ? findCatalogModel({ ...ctx.catalog, models }, modelId) : undefined
   const option = findCatalogOption(model, optionId)
   return option ? { apply: option.apply, modelId } : null
+}
+
+/** Why: the mid-dispatch guards watch for *record* changes. Resolving through the model
+ *  list would also trip when discovery lands mid-dispatch and moves which row carries
+ *  `isDefault` — nothing the agent saw changed, but the value would be discarded. */
+function trackedModelId(record: NativeChatSessionOptionRecord): string | null {
+  return typeof record.model?.value === 'string' ? record.model.value : null
 }
 
 function persist(
@@ -85,7 +94,14 @@ function persist(
   value: SessionOptionValue
 ): void {
   if (modelId) {
-    void ctx.persistSelection?.({ modelId, optionId, value })
+    void ctx.persistSelection?.({
+      modelId,
+      optionId,
+      value,
+      // An untracked record means no `-m` was ever emitted, so this id is the CLI's
+      // own default standing in as a scope — not a selection to persist.
+      modelIsCliDefault: ctx.getRecord().model === undefined
+    })
   }
 }
 
@@ -213,6 +229,7 @@ async function applySetOption(
 
   // Why: baseline for detecting a model switch, typed command, or agent report
   // that lands mid-dispatch, so the commit below never overwrites newer state.
+  const trackedModelBeforeDispatch = trackedModelId(ctx.getRecord())
   const trackedBeforeDispatch =
     ctx.mode === 'live' && id !== 'model'
       ? getTrackedOption(ctx.getRecord(), previousModelId, id)
@@ -247,8 +264,7 @@ async function applySetOption(
   if (liveFlipOnly) {
     // Why: typed flips, reports, or model changes during dispatch supersede the
     // baseline this absolute target was computed from.
-    const modelStill = typeof record.model?.value === 'string' ? record.model.value : null
-    if (modelStill !== previousModelId) {
+    if (trackedModelId(record) !== trackedModelBeforeDispatch) {
       return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })
     }
     if (getTrackedOption(record, previousModelId, id) !== trackedToggle) {
@@ -263,9 +279,8 @@ async function applySetOption(
     // Why: a model switch, typed command, or agent report during dispatch supersedes
     // the baseline this commit was computed from — committing now would overwrite
     // newer state and could write/persist a model-scoped value under the new model.
-    const modelStill = typeof record.model?.value === 'string' ? record.model.value : null
     if (
-      modelStill !== previousModelId ||
+      trackedModelId(record) !== trackedModelBeforeDispatch ||
       getTrackedOption(record, previousModelId, id) !== trackedBeforeDispatch
     ) {
       return finish(ctx, { modelId: previousModelId, optionId: id, value, skipPersist: true })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-apply.ts
@@ -123,8 +123,9 @@ function finish(
   }
   const snapshot = ctx.publish()
   const record = ctx.getRecord()
-  if (ctx.mode === 'draft' && typeof record.model?.value === 'string') {
-    ctx.onDraftValuesChanged?.(flattenNativeChatSessionOptionRecord(record, record.model.value))
+  const draftModelId = trackedModelId(record)
+  if (ctx.mode === 'draft' && draftModelId !== null) {
+    ctx.onDraftValuesChanged?.(flattenNativeChatSessionOptionRecord(record, draftModelId))
   }
   return { snapshot }
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   createClaudeCatalogOptions,
+  getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
 import {
@@ -73,10 +74,14 @@ export async function discoverNativeChatCatalogModels(
   context: RuntimeGitContext
 ): Promise<CatalogModel[] | null> {
   const result = await discoverRuntimeCommitMessageModels(context, agent)
+  const catalog = getAgentSessionOptionCatalog(agent)
   if (
     !result.success ||
     result.models.length === 0 ||
-    (agent === 'claude' && result.catalogOrigin !== 'probe')
+    // Why: a spec's static fallback list must never pass as a probe result for an
+    // agent whose published list replaces rather than extends the seed.
+    ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
+      result.catalogOrigin !== 'probe')
   ) {
     return null
   }
@@ -84,6 +89,7 @@ export async function discoverNativeChatCatalogModels(
     id: model.id,
     label: model.label,
     ...(model.description ? { description: model.description } : {}),
+    ...(model.isDefault ? { isDefault: true as const } : {}),
     options:
       agent === 'claude'
         ? createClaudeCatalogOptions({

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -302,32 +302,6 @@ describe('native chat session option enrichment', () => {
     ).toEqual({ model: 'retired' })
   })
 
-  it('still drops the retired launch model after its probe host is evicted', async () => {
-    // Regression: the probe evidence lived in the evictable host cache, so evicting the
-    // host that proved the model retired made the resolver read "never probed" and hand
-    // the fatal `-m <retired>` back to composer and source-control launches.
-    const persisted = { grok: { model: 'grok-4.5' } }
-    const discover = vi.fn().mockResolvedValue([{ id: 'grok-5', label: 'Grok 5', options: [] }])
-    ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'local', discover })
-    await vi.waitFor(() => expect(readNativeChatEnrichedModels('grok', 'local')).not.toBeNull())
-    expect(resolveNativeChatLaunchSessionOptions(persisted, 'grok')).toBeUndefined()
-
-    // Push past the cache cap; the settled, listener-less grok row is the first evicted.
-    for (let index = 0; index < 64; index += 1) {
-      ensureNativeChatModelEnrichment({
-        agent: 'cursor',
-        hostKey: `ssh:${index}`,
-        discover: vi.fn().mockResolvedValue([{ id: 'auto', label: 'Auto', options: [] }])
-      })
-    }
-    expect(readNativeChatEnrichedModels('grok', 'local')).toBeNull()
-
-    expect(resolveNativeChatLaunchSessionOptions(persisted, 'grok')).toBeUndefined()
-    expect(resolveNativeChatLaunchSessionOptions({ grok: { model: 'grok-5' } }, 'grok')).toEqual({
-      model: 'grok-5'
-    })
-  })
-
   it('does not advertise the Claude spec fallback when probing is unavailable', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -8,6 +8,7 @@ import {
   clearNativeChatModelEnrichmentForTests,
   ensureNativeChatModelEnrichment,
   readNativeChatEnrichedModels,
+  resolveNativeChatLaunchSessionOptions,
   subscribeNativeChatEnrichedModels
 } from './native-chat-session-option-enrichment'
 
@@ -271,6 +272,34 @@ describe('native chat session option enrichment', () => {
 
     expect(readNativeChatEnrichedModels('grok', 'm')!.map(({ id }) => id)).toEqual(['grok-5'])
     expect(readNativeChatEnrichedModels('cursor', 'm')!.map(({ id }) => id)).toContain('auto')
+  })
+
+  it('drops a persisted grok launch model missing from every settled probe', async () => {
+    // Regression: launch sites resolved the persisted model with no discovery gate,
+    // so the first launch after a probe (but before async settings retirement
+    // landed) still emitted the fatal `-m <retired>`.
+    const persisted = {
+      grok: { model: 'grok-4.5', valuesByModel: { 'grok-4.5': { effort: 'low' } } }
+    }
+    // No probe data: the pick is honored — absence of data is not proof of absence.
+    expect(resolveNativeChatLaunchSessionOptions(persisted, 'grok')).toMatchObject({
+      model: 'grok-4.5',
+      effort: 'low'
+    })
+
+    const discover = vi.fn().mockResolvedValue([{ id: 'grok-5', label: 'Grok 5', options: [] }])
+    ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'local', discover })
+    await vi.waitFor(() => expect(readNativeChatEnrichedModels('grok', 'local')).not.toBeNull())
+
+    expect(resolveNativeChatLaunchSessionOptions(persisted, 'grok')).toBeUndefined()
+    // A model any settled host still lists keeps resolving.
+    expect(resolveNativeChatLaunchSessionOptions({ grok: { model: 'grok-5' } }, 'grok')).toEqual({
+      model: 'grok-5'
+    })
+    // Non-authoritative agents are untouched by the gate.
+    expect(
+      resolveNativeChatLaunchSessionOptions({ claude: { model: 'retired' } }, 'claude')
+    ).toEqual({ model: 'retired' })
   })
 
   it('does not advertise the Claude spec fallback when probing is unavailable', async () => {

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -302,6 +302,32 @@ describe('native chat session option enrichment', () => {
     ).toEqual({ model: 'retired' })
   })
 
+  it('still drops the retired launch model after its probe host is evicted', async () => {
+    // Regression: the probe evidence lived in the evictable host cache, so evicting the
+    // host that proved the model retired made the resolver read "never probed" and hand
+    // the fatal `-m <retired>` back to composer and source-control launches.
+    const persisted = { grok: { model: 'grok-4.5' } }
+    const discover = vi.fn().mockResolvedValue([{ id: 'grok-5', label: 'Grok 5', options: [] }])
+    ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'local', discover })
+    await vi.waitFor(() => expect(readNativeChatEnrichedModels('grok', 'local')).not.toBeNull())
+    expect(resolveNativeChatLaunchSessionOptions(persisted, 'grok')).toBeUndefined()
+
+    // Push past the cache cap; the settled, listener-less grok row is the first evicted.
+    for (let index = 0; index < 64; index += 1) {
+      ensureNativeChatModelEnrichment({
+        agent: 'cursor',
+        hostKey: `ssh:${index}`,
+        discover: vi.fn().mockResolvedValue([{ id: 'auto', label: 'Auto', options: [] }])
+      })
+    }
+    expect(readNativeChatEnrichedModels('grok', 'local')).toBeNull()
+
+    expect(resolveNativeChatLaunchSessionOptions(persisted, 'grok')).toBeUndefined()
+    expect(resolveNativeChatLaunchSessionOptions({ grok: { model: 'grok-5' } }, 'grok')).toEqual({
+      model: 'grok-5'
+    })
+  })
+
   it('does not advertise the Claude spec fallback when probing is unavailable', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -159,6 +159,120 @@ describe('native chat session option enrichment', () => {
     expect(readNativeChatEnrichedModels('claude', 'local')).toBeNull()
   })
 
+  it('carries grok’s probed default through discovery to the published rows', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        { id: 'grok-build', label: 'Grok Build' },
+        { id: 'grok-5', label: 'Grok 5', isDefault: true }
+      ]
+    })
+    const discover = vi.fn(() =>
+      discoverNativeChatCatalogModels('grok', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    )
+    const listener = vi.fn()
+    subscribeNativeChatEnrichedModels('grok', 'ssh:host', listener)
+
+    ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'ssh:host', discover })
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+
+    const models = readNativeChatEnrichedModels('grok', 'ssh:host')!
+    // The seed's grok-4.5 is gone (discovery is authoritative) and its default flag
+    // did not survive onto a row the account no longer calls default.
+    expect(models.map(({ id, isDefault }) => [id, isDefault])).toEqual([
+      ['grok-build', undefined],
+      ['grok-5', true]
+    ])
+    // Effort is a global grok flag, so both unseeded rows still get the menu.
+    expect(models.map((model) => model.options.map(({ id }) => id))).toEqual([
+      ['effort'],
+      ['effort']
+    ])
+  })
+
+  it('publishes no default when an older host omits the flag entirely', async () => {
+    // A remote Orca predating `isDefault` sends rows without it; the picker must
+    // name no model rather than fall back to a seed row the account may have retired.
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [{ id: 'grok-4.5', label: 'Grok 4.5' }]
+    })
+    const discover = vi.fn(() =>
+      discoverNativeChatCatalogModels('grok', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    )
+    const listener = vi.fn()
+    subscribeNativeChatEnrichedModels('grok', 'ssh:legacy', listener)
+
+    ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'ssh:legacy', discover })
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+
+    const published = readNativeChatEnrichedModels('grok', 'ssh:legacy')!
+    expect(published.map(({ id }) => id)).toEqual(['grok-4.5'])
+    expect(published[0]!.isDefault).toBeUndefined()
+  })
+
+  it('rejects a spec fallback for grok too, not just claude', async () => {
+    // Grok's list replaces the seed rather than extending it, so letting a static
+    // fallback through would retire real models and blank the picker.
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'spec',
+      models: [{ id: 'grok-4.5', label: 'Grok 4.5' }]
+    })
+
+    await expect(
+      discoverNativeChatCatalogModels('grok', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    ).resolves.toBeNull()
+  })
+
+  it('still lets a spec fallback through for an additive agent', async () => {
+    // Cursor merges onto its seed, so a fallback list costs nothing and dropping it
+    // would be a regression — the probe guard must stay scoped to authoritative agents.
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'spec',
+      models: [{ id: 'auto', label: 'Auto' }]
+    })
+
+    await expect(
+      discoverNativeChatCatalogModels('cursor', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    ).resolves.toEqual([{ id: 'auto', label: 'Auto', options: [] }])
+  })
+
+  it('uses the authoritative merge for grok and the additive one for cursor', async () => {
+    // Both branches of the same ternary: deleting the authoritative arm typechecks
+    // and leaves every additive-agent test passing.
+    const discoverGrok = vi.fn().mockResolvedValue([{ id: 'grok-5', label: 'Grok 5', options: [] }])
+    const discoverCursor = vi.fn().mockResolvedValue([{ id: 'extra', label: 'Extra', options: [] }])
+    ensureNativeChatModelEnrichment({ agent: 'grok', hostKey: 'm', discover: discoverGrok })
+    ensureNativeChatModelEnrichment({ agent: 'cursor', hostKey: 'm', discover: discoverCursor })
+    await vi.waitFor(() => {
+      expect(readNativeChatEnrichedModels('grok', 'm')).not.toBeNull()
+      expect(readNativeChatEnrichedModels('cursor', 'm')).not.toBeNull()
+    })
+
+    expect(readNativeChatEnrichedModels('grok', 'm')!.map(({ id }) => id)).toEqual(['grok-5'])
+    expect(readNativeChatEnrichedModels('cursor', 'm')!.map(({ id }) => id)).toContain('auto')
+  })
+
   it('does not advertise the Claude spec fallback when probing is unavailable', async () => {
     mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
       success: true,

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -12,33 +12,13 @@ import type {
 } from '../../../../shared/native-chat-session-options'
 
 type CatalogEnrichmentEntry = {
+  agent: AgentType
   state: 'idle' | 'pending' | 'settled'
   models: CatalogModel[] | null
   listeners: Set<(models: CatalogModel[]) => void>
 }
 
 const enrichmentByAgentHost = new Map<string, CatalogEnrichmentEntry>()
-
-// Why separate from the evictable cache above: this is launch-validation evidence, and
-// evicting the host rows that prove a persisted model retired would silently re-authorize
-// the fatal `-m`. Keyed by agent, not host, so it stays bounded as host keys grow.
-const probedAuthoritativeModelIdsByAgent = new Map<AgentType, Set<string>>()
-
-// Host keys are unbounded (one per SSH host), so cap the process-lifetime cache.
-// An evicted host simply re-probes on its next visit; live listeners are kept.
-const MAX_ENRICHMENT_ENTRIES = 64
-
-function evictSettledEnrichmentEntry(): void {
-  if (enrichmentByAgentHost.size < MAX_ENRICHMENT_ENTRIES) {
-    return
-  }
-  for (const [key, entry] of enrichmentByAgentHost) {
-    if (entry.state === 'settled' && entry.listeners.size === 0) {
-      enrichmentByAgentHost.delete(key)
-      return
-    }
-  }
-}
 
 function enrichmentKey(agent: AgentType, hostKey: string): string {
   return JSON.stringify([agent, hostKey])
@@ -59,6 +39,7 @@ export function subscribeNativeChatEnrichedModels(
 ): () => void {
   const key = enrichmentKey(agent, hostKey)
   const entry = enrichmentByAgentHost.get(key) ?? {
+    agent,
     state: 'idle' as const,
     models: null,
     listeners: new Set<(models: CatalogModel[]) => void>()
@@ -68,7 +49,6 @@ export function subscribeNativeChatEnrichedModels(
   return () => entry.listeners.delete(listener)
 }
 
-// Why: drop a persisted `-m` only when every settled host probe omits it; no probe yet → keep it.
 export function resolveNativeChatLaunchSessionOptions(
   persisted: PersistedNativeChatSessionOptions | null | undefined,
   agent: AgentType
@@ -77,11 +57,16 @@ export function resolveNativeChatLaunchSessionOptions(
   if (!values || !getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative) {
     return values
   }
-  const probedModelIds = probedAuthoritativeModelIdsByAgent.get(agent)
-  if (!probedModelIds) {
-    return values
+  let probed = false
+  for (const entry of enrichmentByAgentHost.values()) {
+    if (entry.agent === agent && entry.models) {
+      probed = true
+      if (entry.models.some((model) => model.id === values.model)) {
+        return values
+      }
+    }
   }
-  return probedModelIds.has(String(values.model)) ? values : undefined
+  return probed ? undefined : values
 }
 
 export function ensureNativeChatModelEnrichment(args: {
@@ -99,14 +84,12 @@ export function ensureNativeChatModelEnrichment(args: {
     return
   }
   const entry: CatalogEnrichmentEntry = existing ?? {
+    agent: args.agent,
     state: 'idle',
     models: null,
     listeners: new Set()
   }
   entry.state = 'pending'
-  if (!existing) {
-    evictSettledEnrichmentEntry()
-  }
   enrichmentByAgentHost.set(key, entry)
 
   // Why: model discovery must never delay rendering or launching; the seed is
@@ -124,14 +107,6 @@ export function ensureNativeChatModelEnrichment(args: {
           : catalog.discoveredModelsAreAuthoritative
             ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
             : mergeCatalogModels(catalog.models, discovered)
-      if (catalog.discoveredModelsAreAuthoritative) {
-        const probedModelIds =
-          probedAuthoritativeModelIdsByAgent.get(args.agent) ?? new Set<string>()
-        for (const model of entry.models) {
-          probedModelIds.add(model.id)
-        }
-        probedAuthoritativeModelIdsByAgent.set(args.agent, probedModelIds)
-      }
       for (const listener of entry.listeners) {
         listener([...entry.models])
       }
@@ -143,5 +118,4 @@ export function ensureNativeChatModelEnrichment(args: {
 
 export function clearNativeChatModelEnrichmentForTests(): void {
   enrichmentByAgentHost.clear()
-  probedAuthoritativeModelIdsByAgent.clear()
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -12,13 +12,17 @@ import type {
 } from '../../../../shared/native-chat-session-options'
 
 type CatalogEnrichmentEntry = {
-  agent: AgentType
   state: 'idle' | 'pending' | 'settled'
   models: CatalogModel[] | null
   listeners: Set<(models: CatalogModel[]) => void>
 }
 
 const enrichmentByAgentHost = new Map<string, CatalogEnrichmentEntry>()
+
+// Why separate from the evictable cache above: this is launch-validation evidence, and
+// evicting the host rows that prove a persisted model retired would silently re-authorize
+// the fatal `-m`. Keyed by agent, not host, so it stays bounded as host keys grow.
+const probedAuthoritativeModelIdsByAgent = new Map<AgentType, Set<string>>()
 
 // Host keys are unbounded (one per SSH host), so cap the process-lifetime cache.
 // An evicted host simply re-probes on its next visit; live listeners are kept.
@@ -55,7 +59,6 @@ export function subscribeNativeChatEnrichedModels(
 ): () => void {
   const key = enrichmentKey(agent, hostKey)
   const entry = enrichmentByAgentHost.get(key) ?? {
-    agent,
     state: 'idle' as const,
     models: null,
     listeners: new Set<(models: CatalogModel[]) => void>()
@@ -65,15 +68,7 @@ export function subscribeNativeChatEnrichedModels(
   return () => entry.listeners.delete(listener)
 }
 
-/**
- * Why: every launch site turns the persisted model into a verbatim `-m` flag,
- * fatal for an authoritative-catalog agent once the id retires. Settings
- * retirement is asynchronous and only runs after a chat pane mounts, so a
- * launch must not trust a persisted id no settled probe still lists. The id
- * must be missing from *every* probed host — hosts can see different models,
- * and launching without `-m` is safe while dropping a valid pick is not.
- * With no probe data at all the pick is honored: only discovery proves staleness.
- */
+// Why: drop a persisted `-m` only when every settled host probe omits it; no probe yet → keep it.
 export function resolveNativeChatLaunchSessionOptions(
   persisted: PersistedNativeChatSessionOptions | null | undefined,
   agent: AgentType
@@ -82,16 +77,11 @@ export function resolveNativeChatLaunchSessionOptions(
   if (!values || !getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative) {
     return values
   }
-  let probed = false
-  for (const entry of enrichmentByAgentHost.values()) {
-    if (entry.agent === agent && entry.models) {
-      probed = true
-      if (entry.models.some((model) => model.id === values.model)) {
-        return values
-      }
-    }
+  const probedModelIds = probedAuthoritativeModelIdsByAgent.get(agent)
+  if (!probedModelIds) {
+    return values
   }
-  return probed ? undefined : values
+  return probedModelIds.has(String(values.model)) ? values : undefined
 }
 
 export function ensureNativeChatModelEnrichment(args: {
@@ -109,7 +99,6 @@ export function ensureNativeChatModelEnrichment(args: {
     return
   }
   const entry: CatalogEnrichmentEntry = existing ?? {
-    agent: args.agent,
     state: 'idle',
     models: null,
     listeners: new Set()
@@ -135,6 +124,14 @@ export function ensureNativeChatModelEnrichment(args: {
           : catalog.discoveredModelsAreAuthoritative
             ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
             : mergeCatalogModels(catalog.models, discovered)
+      if (catalog.discoveredModelsAreAuthoritative) {
+        const probedModelIds =
+          probedAuthoritativeModelIdsByAgent.get(args.agent) ?? new Set<string>()
+        for (const model of entry.models) {
+          probedModelIds.add(model.id)
+        }
+        probedAuthoritativeModelIdsByAgent.set(args.agent, probedModelIds)
+      }
       for (const listener of entry.listeners) {
         listener([...entry.models])
       }
@@ -146,4 +143,5 @@ export function ensureNativeChatModelEnrichment(args: {
 
 export function clearNativeChatModelEnrichmentForTests(): void {
   enrichmentByAgentHost.clear()
+  probedAuthoritativeModelIdsByAgent.clear()
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -2,6 +2,7 @@ import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   getAgentSessionOptionCatalog,
   mergeCatalogModels,
+  mergeDiscoveredAuthoritativeModels,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
 
@@ -73,7 +74,11 @@ export function ensureNativeChatModelEnrichment(args: {
         return
       }
       entry.models =
-        args.agent === 'claude' ? [...discovered] : mergeCatalogModels(catalog.models, discovered)
+        args.agent === 'claude'
+          ? [...discovered]
+          : catalog.discoveredModelsAreAuthoritative
+            ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)
+            : mergeCatalogModels(catalog.models, discovered)
       for (const listener of entry.listeners) {
         listener([...entry.models])
       }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -12,6 +12,7 @@ import type {
 } from '../../../../shared/native-chat-session-options'
 
 type CatalogEnrichmentEntry = {
+  agent: AgentType
   state: 'idle' | 'pending' | 'settled'
   models: CatalogModel[] | null
   listeners: Set<(models: CatalogModel[]) => void>
@@ -54,6 +55,7 @@ export function subscribeNativeChatEnrichedModels(
 ): () => void {
   const key = enrichmentKey(agent, hostKey)
   const entry = enrichmentByAgentHost.get(key) ?? {
+    agent,
     state: 'idle' as const,
     models: null,
     listeners: new Set<(models: CatalogModel[]) => void>()
@@ -81,8 +83,8 @@ export function resolveNativeChatLaunchSessionOptions(
     return values
   }
   let probed = false
-  for (const [key, entry] of enrichmentByAgentHost) {
-    if (entry.models && (JSON.parse(key) as [AgentType])[0] === agent) {
+  for (const entry of enrichmentByAgentHost.values()) {
+    if (entry.agent === agent && entry.models) {
       probed = true
       if (entry.models.some((model) => model.id === values.model)) {
         return values
@@ -107,6 +109,7 @@ export function ensureNativeChatModelEnrichment(args: {
     return
   }
   const entry: CatalogEnrichmentEntry = existing ?? {
+    agent: args.agent,
     state: 'idle',
     models: null,
     listeners: new Set()

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -5,6 +5,11 @@ import {
   mergeDiscoveredAuthoritativeModels,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
+import { resolveNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
+import type {
+  PersistedNativeChatSessionOptions,
+  SessionOptionValue
+} from '../../../../shared/native-chat-session-options'
 
 type CatalogEnrichmentEntry = {
   state: 'idle' | 'pending' | 'settled'
@@ -13,6 +18,22 @@ type CatalogEnrichmentEntry = {
 }
 
 const enrichmentByAgentHost = new Map<string, CatalogEnrichmentEntry>()
+
+// Host keys are unbounded (one per SSH host), so cap the process-lifetime cache.
+// An evicted host simply re-probes on its next visit; live listeners are kept.
+const MAX_ENRICHMENT_ENTRIES = 64
+
+function evictSettledEnrichmentEntry(): void {
+  if (enrichmentByAgentHost.size < MAX_ENRICHMENT_ENTRIES) {
+    return
+  }
+  for (const [key, entry] of enrichmentByAgentHost) {
+    if (entry.state === 'settled' && entry.listeners.size === 0) {
+      enrichmentByAgentHost.delete(key)
+      return
+    }
+  }
+}
 
 function enrichmentKey(agent: AgentType, hostKey: string): string {
   return JSON.stringify([agent, hostKey])
@@ -42,6 +63,35 @@ export function subscribeNativeChatEnrichedModels(
   return () => entry.listeners.delete(listener)
 }
 
+/**
+ * Why: every launch site turns the persisted model into a verbatim `-m` flag,
+ * fatal for an authoritative-catalog agent once the id retires. Settings
+ * retirement is asynchronous and only runs after a chat pane mounts, so a
+ * launch must not trust a persisted id no settled probe still lists. The id
+ * must be missing from *every* probed host — hosts can see different models,
+ * and launching without `-m` is safe while dropping a valid pick is not.
+ * With no probe data at all the pick is honored: only discovery proves staleness.
+ */
+export function resolveNativeChatLaunchSessionOptions(
+  persisted: PersistedNativeChatSessionOptions | null | undefined,
+  agent: AgentType
+): Record<string, SessionOptionValue> | undefined {
+  const values = resolveNativeChatSessionOptionDefaults(persisted, agent)
+  if (!values || !getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative) {
+    return values
+  }
+  let probed = false
+  for (const [key, entry] of enrichmentByAgentHost) {
+    if (entry.models && (JSON.parse(key) as [AgentType])[0] === agent) {
+      probed = true
+      if (entry.models.some((model) => model.id === values.model)) {
+        return values
+      }
+    }
+  }
+  return probed ? undefined : values
+}
+
 export function ensureNativeChatModelEnrichment(args: {
   agent: AgentType
   hostKey: string
@@ -62,6 +112,9 @@ export function ensureNativeChatModelEnrichment(args: {
     listeners: new Set()
   }
   entry.state = 'pending'
+  if (!existing) {
+    evictSettledEnrichmentEntry()
+  }
   enrichmentByAgentHost.set(key, entry)
 
   // Why: model discovery must never delay rendering or launching; the seed is

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import { nativeChatModelPillLabel } from './native-chat-session-option-labels'
+import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
+
+function modelDescriptor(
+  valueSource: SessionOptionDescriptor['valueSource'],
+  currentValue?: string
+): SessionOptionDescriptor {
+  return {
+    id: 'model',
+    label: 'Model',
+    valueSource,
+    settable: true,
+    kind: {
+      type: 'select',
+      ...(currentValue ? { currentValue } : {}),
+      choices: [{ value: 'grok-4.5', label: 'Grok 4.5' }]
+    }
+  }
+}
+
+describe('nativeChatModelPillLabel', () => {
+  it('names a model the CLI defaulted to, not the bare category', () => {
+    // This is the last step between `defaultModelIsCliDefault` and pixels: withholding
+    // `default` here would silently undo the whole load-time default display.
+    expect(nativeChatModelPillLabel(modelDescriptor('default', 'grok-4.5'))).toBe('Grok 4.5')
+  })
+
+  it('names a model the user picked', () => {
+    expect(nativeChatModelPillLabel(modelDescriptor('applied', 'grok-4.5'))).toBe('Grok 4.5')
+  })
+
+  it('withholds a value it has no evidence for', () => {
+    expect(nativeChatModelPillLabel(modelDescriptor('unknown', 'grok-4.5'))).toBe('Model')
+    expect(nativeChatModelPillLabel(modelDescriptor('default'))).toBe('Model')
+  })
+
+  it('falls back to the raw id when the list no longer offers it', () => {
+    // A discovered list can drop an id the record still tracks; showing the id beats
+    // showing "Model" while a real model is running.
+    expect(nativeChatModelPillLabel(modelDescriptor('reported', 'grok-build'))).toBe('grok-build')
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-session-option-labels.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-labels.ts
@@ -63,6 +63,8 @@ export function nativeChatSessionOptionDisabledReason(
 export function nativeChatModelPillLabel(descriptor: SessionOptionDescriptor): string {
   // Why: show the value only (Codex/Conductor style). "Model:" is redundant —
   // the control's aria-label/tooltip already names the category.
+  // Only `unknown` withholds the value; a `default` source still names the model
+  // the launch will use, so it renders like any observed one.
   if (
     descriptor.valueSource === 'unknown' ||
     descriptor.kind.type !== 'select' ||

--- a/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-snapshot.ts
@@ -5,6 +5,7 @@ import type {
 import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
 import {
   buildNativeChatSessionOptionSnapshot as buildSharedSnapshot,
+  resolveEffectiveNativeChatModelId,
   withTrackedNativeChatModel,
   type NativeChatSessionOptionMode
 } from '../../../../shared/native-chat-session-option-snapshot'
@@ -15,7 +16,11 @@ import {
 import { translate } from '@/i18n/i18n'
 
 export type { NativeChatSessionOptionMode }
-export { flattenNativeChatSessionOptionRecord, withTrackedNativeChatModel }
+export {
+  flattenNativeChatSessionOptionRecord,
+  resolveEffectiveNativeChatModelId,
+  withTrackedNativeChatModel
+}
 
 export function buildNativeChatSessionOptionSnapshot(args: {
   catalog: AgentSessionOptionCatalog

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -8,7 +8,10 @@ import {
   clearNativeChatSessionOptionModel,
   updateNativeChatSessionOptionDefaults
 } from '../../../../shared/native-chat-session-option-defaults'
-import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
+import type {
+  PersistedNativeChatSessionOptions,
+  SessionOptionDescriptor
+} from '../../../../shared/native-chat-session-options'
 import { useAppStore } from '../../store'
 import {
   createNativeChatPtySessionOptions,
@@ -31,6 +34,31 @@ const subscribeEmpty = (): (() => void) => () => {}
 const getEmptySnapshot = (): SessionOptionDescriptor[] => EMPTY_SNAPSHOT
 
 /**
+ * Why: every nativeChatSessionOptions writer — a pick from any pane, a probe
+ * retirement — serializes on this one chain and re-reads live settings at apply
+ * time. updateSettings shallow-merges the whole object, so an interleaved write
+ * from a snapshot captured earlier would silently clobber a concurrent pick.
+ * The update runs against the settled base and may return null to skip writing.
+ */
+let settingsWrite: Promise<unknown> = Promise.resolve()
+function enqueueSessionOptionSettingsWrite(
+  update: (
+    base: PersistedNativeChatSessionOptions | undefined
+  ) => PersistedNativeChatSessionOptions | null
+): Promise<void> {
+  const write = settingsWrite
+    .catch(() => undefined)
+    .then(() => {
+      const next = update(useAppStore.getState().settings?.nativeChatSessionOptions)
+      return next
+        ? useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
+        : undefined
+    })
+  settingsWrite = write
+  return write
+}
+
+/**
  * Why: the picker drops a retired model, but the persisted default is what launches
  * become `-m <id>` — every launch site reads it, including the ones that never show
  * the picker. Left alone the id is invisible and still fatal, so an authoritative
@@ -47,13 +75,11 @@ export async function retirePersistedModelMissingFromDiscovery(
   if (models.length === 0) {
     return
   }
-  const persisted = useAppStore.getState().settings?.nativeChatSessionOptions
-  const modelId = persisted?.[agent]?.model
-  if (typeof modelId !== 'string' || !modelId || models.some((model) => model.id === modelId)) {
-    return
-  }
-  await useAppStore.getState().updateSettings({
-    nativeChatSessionOptions: clearNativeChatSessionOptionModel(persisted, agent)
+  await enqueueSessionOptionSettingsWrite((persisted) => {
+    const modelId = persisted?.[agent]?.model
+    return typeof modelId === 'string' && modelId && !models.some((model) => model.id === modelId)
+      ? clearNativeChatSessionOptionModel(persisted, agent)
+      : null
   })
 }
 
@@ -94,7 +120,6 @@ export function useNativeChatSessionOptions(args: {
             discoveredModels ?? undefined
           )
         : null
-    let settingsWrite = Promise.resolve()
     return createNativeChatPtySessionOptions({
       agent,
       scopeKey,
@@ -107,29 +132,17 @@ export function useNativeChatSessionOptions(args: {
       reportedValues,
       dispatchCommand,
       onAgentPicker,
-      persistSelection: async ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
-        // Why: read the live persisted defaults at write time (after any prior
-        // write in this chain settles) and merge only this selection onto them,
-        // rather than a baseline captured once at surface creation. A frozen
-        // baseline would let a second same-agent pane's write be clobbered,
-        // since updateSettings shallow-merges nativeChatSessionOptions. Chaining
-        // still keeps rapid consecutive picks in selection order.
-        settingsWrite = settingsWrite
-          .catch(() => undefined)
-          .then(() => {
-            const base = useAppStore.getState().settings?.nativeChatSessionOptions
-            const next = updateNativeChatSessionOptionDefaults({
-              persisted: base,
-              agent,
-              modelId,
-              optionId,
-              value,
-              modelIsUnverifiedDefault
-            })
-            return useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
+      persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) =>
+        enqueueSessionOptionSettingsWrite((persisted) =>
+          updateNativeChatSessionOptionDefaults({
+            persisted,
+            agent,
+            modelId,
+            optionId,
+            value,
+            modelIsUnverifiedDefault
           })
-        await settingsWrite
-      }
+        )
     })
   }, [
     agent,

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -209,6 +209,12 @@ export function useNativeChatSessionOptions(args: {
         void retirePersistedModelMissingFromDiscovery(agent, models).catch(() => undefined)
       }
     )
+    // Why: the subscription never replays, so a probe that settled before this
+    // pane mounted would leave a retired persisted model in place forever.
+    const cached = readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+    if (cached) {
+      void retirePersistedModelMissingFromDiscovery(agent, cached).catch(() => undefined)
+    }
     ensureNativeChatModelEnrichment({
       agent,
       hostKey: discoveryContext.hostKey,

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -132,7 +132,7 @@ export function useNativeChatSessionOptions(args: {
       reportedValues,
       dispatchCommand,
       onAgentPicker,
-      persistSelection: ({ modelId, optionId, value, modelIsUnverifiedDefault }) =>
+      persistSelection: ({ modelId, optionId, value, adoptModelAsLaunchDefault }) =>
         enqueueSessionOptionSettingsWrite((persisted) =>
           updateNativeChatSessionOptionDefaults({
             persisted,
@@ -140,7 +140,7 @@ export function useNativeChatSessionOptions(args: {
             modelId,
             optionId,
             value,
-            modelIsUnverifiedDefault
+            adoptModelAsLaunchDefault
           })
         )
     })

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -107,7 +107,7 @@ export function useNativeChatSessionOptions(args: {
       reportedValues,
       dispatchCommand,
       onAgentPicker,
-      persistSelection: async ({ modelId, optionId, value, modelIsCliDefault }) => {
+      persistSelection: async ({ modelId, optionId, value, modelIsUnverifiedDefault }) => {
         // Why: read the live persisted defaults at write time (after any prior
         // write in this chain settles) and merge only this selection onto them,
         // rather than a baseline captured once at surface creation. A frozen
@@ -124,7 +124,7 @@ export function useNativeChatSessionOptions(args: {
               modelId,
               optionId,
               value,
-              modelIsCliDefault
+              modelIsUnverifiedDefault
             })
             return useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
           })

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -1,6 +1,13 @@
 import { useEffect, useMemo, useRef, useSyncExternalStore } from 'react'
 import type { AgentType } from '../../../../shared/agent-status-types'
-import { updateNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
+import {
+  getAgentSessionOptionCatalog,
+  type CatalogModel
+} from '../../../../shared/agent-session-option-catalog'
+import {
+  clearNativeChatSessionOptionModel,
+  updateNativeChatSessionOptionDefaults
+} from '../../../../shared/native-chat-session-option-defaults'
 import type { SessionOptionDescriptor } from '../../../../shared/native-chat-session-options'
 import { useAppStore } from '../../store'
 import {
@@ -22,6 +29,33 @@ import { readClaudeSessionOptionsFromTerminalScreen } from './claude-terminal-se
 const EMPTY_SNAPSHOT: SessionOptionDescriptor[] = []
 const subscribeEmpty = (): (() => void) => () => {}
 const getEmptySnapshot = (): SessionOptionDescriptor[] => EMPTY_SNAPSHOT
+
+/**
+ * Why: the picker drops a retired model, but the persisted default is what launches
+ * become `-m <id>` — every launch site reads it, including the ones that never show
+ * the picker. Left alone the id is invisible and still fatal, so an authoritative
+ * probe that no longer lists it must retire it here too.
+ */
+export async function retirePersistedModelMissingFromDiscovery(
+  agent: AgentType,
+  models: readonly CatalogModel[]
+): Promise<void> {
+  if (!getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative) {
+    return
+  }
+  // An empty list means the probe failed, not that the account has no models.
+  if (models.length === 0) {
+    return
+  }
+  const persisted = useAppStore.getState().settings?.nativeChatSessionOptions
+  const modelId = persisted?.[agent]?.model
+  if (typeof modelId !== 'string' || !modelId || models.some((model) => model.id === modelId)) {
+    return
+  }
+  await useAppStore.getState().updateSettings({
+    nativeChatSessionOptions: clearNativeChatSessionOptionModel(persisted, agent)
+  })
+}
 
 export function useNativeChatSessionOptions(args: {
   agent: AgentType
@@ -73,7 +107,7 @@ export function useNativeChatSessionOptions(args: {
       reportedValues,
       dispatchCommand,
       onAgentPicker,
-      persistSelection: async ({ modelId, optionId, value }) => {
+      persistSelection: async ({ modelId, optionId, value, modelIsCliDefault }) => {
         // Why: read the live persisted defaults at write time (after any prior
         // write in this chain settles) and merge only this selection onto them,
         // rather than a baseline captured once at surface creation. A frozen
@@ -89,7 +123,8 @@ export function useNativeChatSessionOptions(args: {
               agent,
               modelId,
               optionId,
-              value
+              value,
+              modelIsCliDefault
             })
             return useAppStore.getState().updateSettings({ nativeChatSessionOptions: next })
           })
@@ -170,6 +205,8 @@ export function useNativeChatSessionOptions(args: {
         if (reportedValues) {
           surface.reportSessionOptions(reportedValues)
         }
+        // A failed settings write must not surface as an unhandled rejection.
+        void retirePersistedModelMissingFromDiscovery(agent, models).catch(() => undefined)
       }
     )
     ensureNativeChatModelEnrichment({

--- a/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
+++ b/src/renderer/src/components/right-sidebar/buildSourceControlAgentDeliveryPlan.ts
@@ -3,7 +3,7 @@ import { useAppStore } from '@/store'
 import type { TuiAgent } from '../../../../shared/types'
 import type { SourceControlAgentActionDeliveryPlanState } from './SourceControlAgentActionDialogForm'
 import { buildSourceControlAgentConnectionErrorPlan } from './source-control-agent-action-dialog-support'
-import { resolveNativeChatSessionOptionDefaults } from '../../../../shared/native-chat-session-option-defaults'
+import { resolveNativeChatLaunchSessionOptions } from '@/components/native-chat/native-chat-session-option-enrichment'
 
 type BuildSourceControlAgentDeliveryPlanArgs = {
   selectedAgent: TuiAgent | null
@@ -36,7 +36,7 @@ export function buildSourceControlAgentDeliveryPlan({
     commandInput,
     agentArgs,
     sessionOptions: selectedAgent
-      ? resolveNativeChatSessionOptionDefaults(
+      ? resolveNativeChatLaunchSessionOptions(
           useAppStore.getState().settings?.nativeChatSessionOptions,
           selectedAgent
         )

--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -676,6 +676,13 @@ function TerminalPane(
     }
     toggleNativeChatForLeaf(activeLeafId)
   }, [toggleNativeChatForLeaf])
+  // Stable identity: this reaches the session-option surface's useMemo deps, so an
+  // inline arrow would rebuild the surface on every TerminalPane render.
+  const switchNativeChatToTerminal = useCallback(() => {
+    if (chatLeafId) {
+      toggleNativeChatForLeaf(chatLeafId)
+    }
+  }, [chatLeafId, toggleNativeChatForLeaf])
   const readNativeChatTerminalScreen = useCallback((): string | null => {
     if (!chatLeafId) {
       return null
@@ -2952,7 +2959,7 @@ function TerminalPane(
                 targetPtyId={chatPanePtyId}
                 launchAgent={chatPaneLaunchAgent}
                 resolvedAgent={chatPaneResolvedAgent}
-                onSwitchToTerminal={() => toggleNativeChatForLeaf(chatPane.leafId)}
+                onSwitchToTerminal={switchNativeChatToTerminal}
                 readTerminalScreen={readNativeChatTerminalScreen}
                 contextMenuActions={{
                   onSplitRight: () => contextMenu.runForPane(chatPane.id, contextMenu.onSplitRight),

--- a/src/renderer/src/hooks/useComposerState.ts
+++ b/src/renderer/src/hooks/useComposerState.ts
@@ -23,7 +23,7 @@ import { buildAgentDraftLaunchPlan, buildAgentStartupPlan } from '@/lib/tui-agen
 import { filterEnabledTuiAgents, isTuiAgentEnabled } from '../../../shared/tui-agent-selection'
 import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { resolveLocalWindowsAgentStartupShell } from '../../../shared/windows-terminal-shell'
-import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
+import { resolveNativeChatLaunchSessionOptions } from '@/components/native-chat/native-chat-session-option-enrichment'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 import {
   resolveTuiAgentLaunchArgs,
@@ -3462,7 +3462,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             : undefined,
           agentEnv: agent ? resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv) : undefined,
           sessionOptions: agent
-            ? resolveNativeChatSessionOptionDefaults(settings?.nativeChatSessionOptions, agent)
+            ? resolveNativeChatLaunchSessionOptions(settings?.nativeChatSessionOptions, agent)
             : undefined,
           terminalWindowsShell: settings?.terminalWindowsShell,
           isRemote: folderTargetIsRemote,
@@ -3768,7 +3768,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
         cmdOverrides: settings?.agentCmdOverrides ?? {},
         agentArgs: resolveTuiAgentLaunchArgs(tuiAgent, settings?.agentDefaultArgs),
         agentEnv: resolveTuiAgentLaunchEnv(tuiAgent, settings?.agentDefaultEnv),
-        sessionOptions: resolveNativeChatSessionOptionDefaults(
+        sessionOptions: resolveNativeChatLaunchSessionOptions(
           settings?.nativeChatSessionOptions,
           tuiAgent
         ),
@@ -4319,7 +4319,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
                 cmdOverrides: settings?.agentCmdOverrides ?? {},
                 agentArgs: resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs),
                 agentEnv: resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv),
-                sessionOptions: resolveNativeChatSessionOptionDefaults(
+                sessionOptions: resolveNativeChatLaunchSessionOptions(
                   settings?.nativeChatSessionOptions,
                   agent
                 ),
@@ -4351,7 +4351,7 @@ export function useComposerState(options: UseComposerStateOptions): UseComposerS
             cmdOverrides: settings?.agentCmdOverrides ?? {},
             agentArgs: resolveTuiAgentLaunchArgs(agent, settings?.agentDefaultArgs),
             agentEnv: resolveTuiAgentLaunchEnv(agent, settings?.agentDefaultEnv),
-            sessionOptions: resolveNativeChatSessionOptionDefaults(
+            sessionOptions: resolveNativeChatLaunchSessionOptions(
               settings?.nativeChatSessionOptions,
               agent
             ),

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -27,7 +27,7 @@ import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-
 import type { TuiAgent } from '../../../shared/types'
 import type { LaunchSource } from '../../../shared/telemetry-events'
 import { getConnectionIdFromState } from '@/lib/connection-context'
-import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
+import { resolveNativeChatLaunchSessionOptions } from '@/components/native-chat/native-chat-session-option-enrichment'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
 
 export type LaunchAgentInNewTabArgs = {
@@ -115,7 +115,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     isRemote,
     agentArgs: effectiveAgentArgs,
     agentEnv,
-    sessionOptions: resolveNativeChatSessionOptionDefaults(
+    sessionOptions: resolveNativeChatLaunchSessionOptions(
       store.settings?.nativeChatSessionOptions,
       agent
     )

--- a/src/renderer/src/lib/launch-work-item-direct-agent.ts
+++ b/src/renderer/src/lib/launch-work-item-direct-agent.ts
@@ -16,7 +16,7 @@ import {
   resolveTuiAgentLaunchEnv
 } from '../../../shared/tui-agent-launch-defaults'
 import { translate } from '@/i18n/i18n'
-import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
+import { resolveNativeChatLaunchSessionOptions } from '@/components/native-chat/native-chat-session-option-enrichment'
 import type { PersistedNativeChatSessionOptions } from '../../../shared/native-chat-session-options'
 
 export function buildDirectWorkItemAgentStartupPlan(args: {
@@ -51,7 +51,7 @@ export function buildDirectWorkItemAgentStartupPlan(args: {
       ? resolveTuiAgentLaunchArgs(args.agent, args.settings?.agentDefaultArgs)
       : args.agentArgs
   const effectiveAgentEnv = resolveTuiAgentLaunchEnv(args.agent, args.settings?.agentDefaultEnv)
-  const sessionOptions = resolveNativeChatSessionOptionDefaults(
+  const sessionOptions = resolveNativeChatLaunchSessionOptions(
     args.settings?.nativeChatSessionOptions,
     args.agent
   )

--- a/src/renderer/src/lib/onboarding-folder-agent-startup.ts
+++ b/src/renderer/src/lib/onboarding-folder-agent-startup.ts
@@ -9,7 +9,7 @@ import type { AgentStartedTelemetry } from '@/lib/worktree-activation'
 import type { StartupCommandDelivery } from '../../../shared/codex-startup-delivery'
 import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-resume'
 import type { GlobalSettings, OnboardingState, TuiAgent } from '../../../shared/types'
-import { resolveNativeChatSessionOptionDefaults } from '../../../shared/native-chat-session-option-defaults'
+import { resolveNativeChatLaunchSessionOptions } from '@/components/native-chat/native-chat-session-option-enrichment'
 import type { SessionOptionValue } from '../../../shared/native-chat-session-options'
 
 export type OnboardingFolderAgentStartup = {
@@ -48,10 +48,7 @@ export function buildOnboardingFolderAgentStartup(
     cmdOverrides: settings.agentCmdOverrides ?? {},
     agentArgs: resolveTuiAgentLaunchArgs(agent, settings.agentDefaultArgs),
     agentEnv: resolveTuiAgentLaunchEnv(agent, settings.agentDefaultEnv),
-    sessionOptions: resolveNativeChatSessionOptionDefaults(
-      settings.nativeChatSessionOptions,
-      agent
-    ),
+    sessionOptions: resolveNativeChatLaunchSessionOptions(settings.nativeChatSessionOptions, agent),
     platform: getClientPlatform(),
     allowEmptyPromptLaunch: true
   })

--- a/src/shared/agent-cli-flag-detection.test.ts
+++ b/src/shared/agent-cli-flag-detection.test.ts
@@ -40,6 +40,12 @@ describe('hasFlag', () => {
     expect(hasFlag(['--debug', '--yolo', '--model', 'grok-build'], MODEL_FLAGS)).toBe(true)
   })
 
+  it('stops scanning at the option terminator', () => {
+    expect(hasFlag(['--', '--model'], MODEL_FLAGS)).toBe(false)
+    expect(hasFlag(['--', '-mgrok-build'], MODEL_FLAGS)).toBe(false)
+    expect(hasFlag(['--model', 'grok-build', '--', '--model'], MODEL_FLAGS)).toBe(true)
+  })
+
   it('detects either spelling of grok effort flags', () => {
     const effortFlags = ['--effort', '--reasoning-effort']
     expect(hasFlag(['--effort', 'low'], effortFlags)).toBe(true)

--- a/src/shared/agent-cli-flag-detection.test.ts
+++ b/src/shared/agent-cli-flag-detection.test.ts
@@ -1,0 +1,49 @@
+import { describe, expect, it } from 'vitest'
+import { hasFlag } from './agent-cli-flag-detection'
+
+const MODEL_FLAGS = ['-m', '--model']
+
+describe('hasFlag', () => {
+  it('matches an exact token', () => {
+    expect(hasFlag(['-m', 'grok-build'], MODEL_FLAGS)).toBe(true)
+    expect(hasFlag(['--model', 'grok-build'], MODEL_FLAGS)).toBe(true)
+  })
+
+  it('matches the flag=value form', () => {
+    expect(hasFlag(['--model=grok-build'], MODEL_FLAGS)).toBe(true)
+    expect(hasFlag(['-m=grok-build'], MODEL_FLAGS)).toBe(true)
+  })
+
+  it('matches a clustered single-dash flag', () => {
+    expect(hasFlag(['-mgrok-build'], MODEL_FLAGS)).toBe(true)
+  })
+
+  it('does not clusters-match a long flag that merely shares the prefix', () => {
+    // `--model-context` is its own option; treating it as `--model` would silently
+    // discard the picker's model from the launch record.
+    expect(hasFlag(['--model-context', '8000'], MODEL_FLAGS)).toBe(false)
+    expect(hasFlag(['--models'], MODEL_FLAGS)).toBe(false)
+  })
+
+  it('ignores positional args that merely contain a flag substring', () => {
+    expect(hasFlag(['summarize-my-diff'], MODEL_FLAGS)).toBe(false)
+    expect(hasFlag(['fix -m please'], MODEL_FLAGS)).toBe(false)
+    expect(hasFlag(['/tmp/-m'], MODEL_FLAGS)).toBe(false)
+  })
+
+  it('is false for empty token lists and unrelated flags', () => {
+    expect(hasFlag([], MODEL_FLAGS)).toBe(false)
+    expect(hasFlag(['--reasoning-effort', 'low'], MODEL_FLAGS)).toBe(false)
+  })
+
+  it('scans every token, not just the first', () => {
+    expect(hasFlag(['--debug', '--yolo', '--model', 'grok-build'], MODEL_FLAGS)).toBe(true)
+  })
+
+  it('detects either spelling of grok effort flags', () => {
+    const effortFlags = ['--effort', '--reasoning-effort']
+    expect(hasFlag(['--effort', 'low'], effortFlags)).toBe(true)
+    expect(hasFlag(['--reasoning-effort=low'], effortFlags)).toBe(true)
+    expect(hasFlag(['--effortless'], effortFlags)).toBe(false)
+  })
+})

--- a/src/shared/agent-cli-flag-detection.ts
+++ b/src/shared/agent-cli-flag-detection.ts
@@ -1,0 +1,11 @@
+/** Matches an exact token, the `flag=value` form, and clustered single-dash flags (`-mopus`). */
+export function hasFlag(tokens: readonly string[], flags: readonly string[]): boolean {
+  return tokens.some((token) =>
+    flags.some(
+      (flag) =>
+        token === flag ||
+        token.startsWith(`${flag}=`) ||
+        (flag.startsWith('-') && !flag.startsWith('--') && token.startsWith(flag))
+    )
+  )
+}

--- a/src/shared/agent-cli-flag-detection.ts
+++ b/src/shared/agent-cli-flag-detection.ts
@@ -1,11 +1,19 @@
 /** Matches an exact token, the `flag=value` form, and clustered single-dash flags (`-mopus`). */
 export function hasFlag(tokens: readonly string[], flags: readonly string[]): boolean {
-  return tokens.some((token) =>
-    flags.some(
+  for (const token of tokens) {
+    // Everything past the option terminator is positional, however flag-shaped it looks.
+    if (token === '--') {
+      return false
+    }
+    const matches = flags.some(
       (flag) =>
         token === flag ||
         token.startsWith(`${flag}=`) ||
         (flag.startsWith('-') && !flag.startsWith('--') && token.startsWith(flag))
     )
-  )
+    if (matches) {
+      return true
+    }
+  }
+  return false
 }

--- a/src/shared/agent-cli-flag-detection.ts
+++ b/src/shared/agent-cli-flag-detection.ts
@@ -1,19 +1,13 @@
+import { agentArgOptionTokens } from './agent-session-option-agent-args'
+
 /** Matches an exact token, the `flag=value` form, and clustered single-dash flags (`-mopus`). */
 export function hasFlag(tokens: readonly string[], flags: readonly string[]): boolean {
-  for (const token of tokens) {
-    // Everything past the option terminator is positional, however flag-shaped it looks.
-    if (token === '--') {
-      return false
-    }
-    const matches = flags.some(
+  return agentArgOptionTokens(tokens).some((token) =>
+    flags.some(
       (flag) =>
         token === flag ||
         token.startsWith(`${flag}=`) ||
         (flag.startsWith('-') && !flag.startsWith('--') && token.startsWith(flag))
     )
-    if (matches) {
-      return true
-    }
-  }
-  return false
+  )
 }

--- a/src/shared/agent-model-probe-spec.test.ts
+++ b/src/shared/agent-model-probe-spec.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import { getAgentModelProbeSpec } from './agent-model-probe-spec'
+import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
+import { getCommitMessageAgentSpec, listCommitMessageAgentIds } from './commit-message-agent-spec'
+
+describe('getAgentModelProbeSpec', () => {
+  it('resolves grok as a discovery-only probe with no static model list', () => {
+    const spec = getAgentModelProbeSpec('grok')
+    expect(spec).toMatchObject({
+      id: 'grok',
+      binary: 'grok',
+      modelSource: 'dynamic',
+      models: [],
+      defaultModelId: 'grok-4.5'
+    })
+    expect(spec?.modelDiscovery).toMatchObject({ binary: 'grok', args: ['models'] })
+  })
+
+  it('wires that probe to the parser that reads a real listing', () => {
+    // Pinning binary and args alone would still pass with the wrong parser attached,
+    // leaving discovery to publish nothing on every host.
+    const parsed = getAgentModelProbeSpec('grok')!.modelDiscovery!.parse(
+      'You are logged in with grok.com.\n\nDefault model: grok-4.5\n\nAvailable models:\n  * grok-4.5 (default)\n'
+    )
+    expect(parsed).toEqual([{ id: 'grok-4.5', label: 'Grok 4.5', isDefault: true }])
+  })
+
+  it('keeps the grok probe default in step with the catalog seed', () => {
+    expect(getAgentModelProbeSpec('grok')!.defaultModelId).toBe(
+      GROK_SESSION_OPTION_CATALOG.models[0].id
+    )
+  })
+
+  it('aliases commit-message agents by identity rather than copying them', () => {
+    // A lossy adapter here would silently drop fields like
+    // `modelDiscovery.stdinPayload` and break Claude discovery.
+    for (const id of listCommitMessageAgentIds()) {
+      expect(getAgentModelProbeSpec(id)).toBe(getCommitMessageAgentSpec(id))
+    }
+  })
+
+  it('keeps grok out of the commit-message registry', () => {
+    expect(getCommitMessageAgentSpec('grok')).toBeUndefined()
+    expect(listCommitMessageAgentIds()).not.toContain('grok')
+  })
+
+  it('is undefined for an agent in neither registry', () => {
+    expect(getAgentModelProbeSpec('aider')).toBeUndefined()
+  })
+})

--- a/src/shared/agent-model-probe-spec.ts
+++ b/src/shared/agent-model-probe-spec.ts
@@ -1,0 +1,30 @@
+import { getCommitMessageAgentSpec, type CommitMessageAgentSpec } from './commit-message-agent-spec'
+import { GROK_MODEL_LIST_ARGS, parseGrokModelList } from './grok-model-list-probe'
+import type { TuiAgent } from './types'
+
+/** Why: model discovery reads only these fields; excluding the prompt-delivery
+ *  half is what keeps a probe-only agent out of the commit-message registry. */
+export type AgentModelProbeSpec = Omit<CommitMessageAgentSpec, 'promptDelivery' | 'buildArgs'>
+
+/** Agents that support model discovery but are not commit-message agents. */
+const MODEL_DISCOVERY_ONLY_SPECS: Partial<Record<TuiAgent, AgentModelProbeSpec>> = {
+  grok: {
+    id: 'grok',
+    label: 'Grok',
+    binary: 'grok',
+    modelSource: 'dynamic',
+    modelDiscovery: {
+      binary: 'grok',
+      args: GROK_MODEL_LIST_ARGS,
+      parse: parseGrokModelList
+    },
+    // Why: empty so a failed probe degrades to the catalog seed instead of a
+    // second model list here that can drift from it.
+    models: [],
+    defaultModelId: 'grok-4.5'
+  }
+}
+
+export function getAgentModelProbeSpec(agentId: TuiAgent): AgentModelProbeSpec | undefined {
+  return getCommitMessageAgentSpec(agentId) ?? MODEL_DISCOVERY_ONLY_SPECS[agentId]
+}

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -9,17 +9,7 @@ import {
   CLAUDE_MODEL_LIST_STDIN,
   parseClaudeModelList
 } from './claude-model-list-probe'
-
-function hasFlag(tokens: readonly string[], flags: readonly string[]): boolean {
-  return agentArgOptionTokens(tokens).some((token) =>
-    flags.some(
-      (flag) =>
-        token === flag ||
-        token.startsWith(`${flag}=`) ||
-        (flag.startsWith('-') && !flag.startsWith('--') && token.startsWith(flag))
-    )
-  )
-}
+import { hasFlag } from './agent-cli-flag-detection'
 
 function hasCodexEffortOverride(tokens: readonly string[]): boolean {
   if (hasFlag(tokens, ['--reasoning-effort'])) {

--- a/src/shared/agent-session-option-catalog-gemini-cursor.ts
+++ b/src/shared/agent-session-option-catalog-gemini-cursor.ts
@@ -1,20 +1,12 @@
+import { hasFlag } from './agent-cli-flag-detection'
 import type {
   AgentSessionOptionCatalog,
   CatalogModel,
   CatalogOption
 } from './agent-session-option-catalog-types'
-import { agentArgOptionTokens, removeAgentArgOption } from './agent-session-option-agent-args'
+import { removeAgentArgOption } from './agent-session-option-agent-args'
 
-function hasModelFlag(tokens: readonly string[]): boolean {
-  return agentArgOptionTokens(tokens).some(
-    (token) =>
-      token === '-m' ||
-      token === '--model' ||
-      token.startsWith('-m=') ||
-      (token.startsWith('-m') && !token.startsWith('--')) ||
-      token.startsWith('--model=')
-  )
-}
+const hasModelFlag = (tokens: readonly string[]): boolean => hasFlag(tokens, ['-m', '--model'])
 
 export const GEMINI_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
   models: [

--- a/src/shared/agent-session-option-catalog-grok.test.ts
+++ b/src/shared/agent-session-option-catalog-grok.test.ts
@@ -1,0 +1,274 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getAgentSessionOptionCatalog,
+  mergeCatalogModels,
+  mergeDiscoveredAuthoritativeModels,
+  type CatalogModel,
+  type CatalogOption
+} from './agent-session-option-catalog'
+import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
+import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
+import { parseBuiltSessionOptionCommand } from './native-chat-session-option-commands'
+
+function grokEffortOption(): CatalogOption {
+  return GROK_SESSION_OPTION_CATALOG.models[0].options.find((option) => option.id === 'effort')!
+}
+
+describe('grok session option catalog', () => {
+  it('is registered for the grok agent', () => {
+    expect(getAgentSessionOptionCatalog('grok')).toBe(GROK_SESSION_OPTION_CATALOG)
+  })
+
+  it('seeds only the one verified model, with an effort menu', () => {
+    expect(GROK_SESSION_OPTION_CATALOG.models.map(({ id, label }) => ({ id, label }))).toEqual([
+      { id: 'grok-4.5', label: 'Grok 4.5' }
+    ])
+    expect(GROK_SESSION_OPTION_CATALOG.models[0].isDefault).toBe(true)
+    const effort = grokEffortOption()
+    // The id must stay `effort`: `LaunchPreferences` is a strict zod object, so a
+    // novel id is dropped client-side and rejected on the wire.
+    expect(effort.id).toBe('effort')
+    expect(effort.category).toBe('thought_level')
+    expect(effort.kind).toMatchObject({ type: 'select', defaultValue: 'high' })
+    expect(effort.kind.type === 'select' ? effort.kind.choices.map((c) => c.value) : []).toEqual([
+      'low',
+      'medium',
+      'high'
+    ])
+  })
+
+  it('offers only effort values the shared option labels localize', () => {
+    const localized = ['minimal', 'low', 'medium', 'high', 'xhigh', 'max']
+    const effort = grokEffortOption()
+    for (const choice of effort.kind.type === 'select' ? effort.kind.choices : []) {
+      expect(localized).toContain(choice.value)
+    }
+  })
+
+  it('treats a successful discovery as authoritative, unlike the other agents', () => {
+    expect(GROK_SESSION_OPTION_CATALOG.discoveredModelsAreAuthoritative).toBe(true)
+    for (const agent of ['claude', 'codex', 'gemini', 'cursor'] as const) {
+      expect(getAgentSessionOptionCatalog(agent)?.discoveredModelsAreAuthoritative).toBeUndefined()
+    }
+  })
+})
+
+describe('grok launch args', () => {
+  it('emits the model flag first, then effort', () => {
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5', effort: 'low' })).toEqual({
+      args: ['-m', 'grok-4.5', '--reasoning-effort', 'low'],
+      appliedValues: { model: 'grok-4.5', effort: 'low' }
+    })
+  })
+
+  it('emits exactly the two model tokens', () => {
+    expect(GROK_SESSION_OPTION_CATALOG.modelApply.launchArgs!('grok-4.5')).toEqual([
+      '-m',
+      'grok-4.5'
+    ])
+  })
+
+  it('falls back to the seeded effort default when none is stored', () => {
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5' }).args).toEqual([
+      '-m',
+      'grok-4.5',
+      '--reasoning-effort',
+      'high'
+    ])
+  })
+
+  it('emits only -m for a persisted model the seed does not carry', () => {
+    // The flag still goes out for a model this host may no longer have, and grok
+    // exits fatally on an unknown id. Launch resolves against the static seed, so
+    // the guard lives upstream: an authoritative probe retires the persisted id
+    // (clearNativeChatSessionOptionModel) before it can reach this call.
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-build' })).toEqual({
+      args: ['-m', 'grok-build'],
+      appliedValues: { model: 'grok-build' }
+    })
+  })
+
+  it('spawns vanilla when no model was ever picked', () => {
+    expect(resolveAgentSessionOptionLaunch('grok', undefined)).toEqual({
+      args: [],
+      appliedValues: {}
+    })
+  })
+})
+
+describe('grok agentArgsOverride', () => {
+  const modelOverride = GROK_SESSION_OPTION_CATALOG.modelApply.agentArgsOverride!
+  const effortOverride = grokEffortOption().apply.agentArgsOverride!
+
+  it('detects a user-supplied model flag in every spelling', () => {
+    for (const tokens of [
+      ['-m', 'grok-build'],
+      ['-mgrok-build'],
+      ['--model', 'grok-build'],
+      ['--model=grok-build']
+    ]) {
+      expect(modelOverride(tokens)).toBe(true)
+    }
+  })
+
+  it('does not fire on a different flag or a positional that contains -m', () => {
+    expect(modelOverride(['--model-context', '8000'])).toBe(false)
+    expect(modelOverride(['summarize-my-diff'])).toBe(false)
+    expect(modelOverride(['--reasoning-effort', 'low'])).toBe(false)
+    expect(modelOverride([])).toBe(false)
+  })
+
+  it('detects both effort spellings', () => {
+    expect(effortOverride(['--effort', 'low'])).toBe(true)
+    expect(effortOverride(['--reasoning-effort=low'])).toBe(true)
+    expect(effortOverride(['--effortless'])).toBe(false)
+  })
+
+  it('drops only the overridden key from the launch record', () => {
+    expect(
+      resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5', effort: 'high' }, [
+        '--reasoning-effort=low'
+      ])
+    ).toEqual({
+      args: ['-m', 'grok-4.5', '--reasoning-effort', 'high'],
+      appliedValues: { model: 'grok-4.5' }
+    })
+  })
+
+  it('cascades a model override onto the effort entry', () => {
+    // A user-supplied `-m` can select a model whose effort menu differs, so the
+    // picker's effort is no longer evidence about what actually launched.
+    expect(
+      resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5', effort: 'high' }, [
+        '-m',
+        'grok-build'
+      ]).appliedValues
+    ).toEqual({})
+  })
+
+  it('keeps the record intact when a lookalike flag is present', () => {
+    expect(
+      resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5', effort: 'low' }, [
+        '--model-context',
+        '8000'
+      ]).appliedValues
+    ).toEqual({ model: 'grok-4.5', effort: 'low' })
+  })
+})
+
+describe('grok mid-session commands', () => {
+  it('round-trips the model command through the built-command parser', () => {
+    const midSession = GROK_SESSION_OPTION_CATALOG.modelApply.midSession!
+    if (midSession.kind !== 'command') {
+      throw new Error('grok model changes must be a typed command, not an agent picker')
+    }
+    expect(midSession.build('grok-4.5')).toBe('/model grok-4.5')
+    expect(parseBuiltSessionOptionCommand(midSession.build, '/model grok-4.5')).toBe('grok-4.5')
+    expect(parseBuiltSessionOptionCommand(midSession.build, '/effort low')).toBeNull()
+  })
+
+  it('round-trips the effort command', () => {
+    const midSession = grokEffortOption().apply.midSession!
+    if (midSession.kind !== 'command') {
+      throw new Error('grok effort changes must be a typed command')
+    }
+    expect(midSession.build('low')).toBe('/effort low')
+    expect(parseBuiltSessionOptionCommand(midSession.build, '/effort low')).toBe('low')
+    expect(parseBuiltSessionOptionCommand(midSession.build, '/effort ')).toBeNull()
+  })
+})
+
+describe('mergeDiscoveredAuthoritativeModels', () => {
+  const seed = GROK_SESSION_OPTION_CATALOG.models
+  const discovered = (...ids: string[]): CatalogModel[] =>
+    ids.map((id) => ({ id, label: id, options: [] }))
+
+  it('keeps a matched seed model’s option menu, which discovery never carries', () => {
+    const merged = mergeDiscoveredAuthoritativeModels(seed, [
+      { id: 'grok-4.5', label: 'Grok 4.5 (live)', options: [] }
+    ])
+    expect(merged).toHaveLength(1)
+    expect(merged[0]).toMatchObject({ id: 'grok-4.5', label: 'Grok 4.5 (live)' })
+    expect(merged[0].options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('takes the default flag from the probe and drops the seed’s stale one', () => {
+    // The seed marks grok-4.5; once the account's listing marks another row, the
+    // picker must follow it or it names a model an unflagged launch will not run.
+    const merged = mergeDiscoveredAuthoritativeModels(seed, [
+      { id: 'grok-4.5', label: 'Grok 4.5', options: [] },
+      { id: 'grok-5', label: 'Grok 5', isDefault: true, options: [] }
+    ])
+    expect(merged.map(({ id, isDefault }) => [id, isDefault])).toEqual([
+      ['grok-4.5', undefined],
+      ['grok-5', true]
+    ])
+  })
+
+  it('names no default when the probe marks none, rather than reviving the seed’s', () => {
+    const merged = mergeDiscoveredAuthoritativeModels(seed, discovered('grok-4.5'))
+    expect(merged[0].isDefault).toBeUndefined()
+    // The seed's menu still survives — only the default claim is discovery's to make.
+    expect(merged[0].options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('gives a matched seed row its own menu, not the default row’s', () => {
+    // Only a seed carrying two distinct menus can tell inheritance apart from a
+    // real match; grok's one-model seed makes the two branches look identical.
+    const multiSeed: CatalogModel[] = [
+      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true, options: seed[0].options },
+      { id: 'grok-lite', label: 'Grok Lite', options: [] }
+    ]
+    const merged = mergeDiscoveredAuthoritativeModels(multiSeed, discovered('grok-lite'))
+    expect(merged.map(({ id }) => id)).toEqual(['grok-lite'])
+    expect(merged[0].options).toEqual([])
+  })
+
+  it('drops a seed model the account no longer lists', () => {
+    const merged = mergeDiscoveredAuthoritativeModels(seed, discovered('grok-build'))
+    expect(merged.map(({ id }) => id)).toEqual(['grok-build'])
+  })
+
+  it('adds discovered models absent from the seed, lending them the default’s options', () => {
+    // Effort is a global grok flag rather than a per-model capability, so an
+    // unseeded model still gets the menu instead of rendering an option-less pill.
+    const merged = mergeDiscoveredAuthoritativeModels(seed, discovered('grok-4.5', 'grok-build'))
+    expect(merged.map(({ id }) => id)).toEqual(['grok-4.5', 'grok-build'])
+    expect(merged[1].options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('takes the inherited options from the default seed row, not the first one', () => {
+    const multiSeed: CatalogModel[] = [
+      { id: 'legacy', label: 'Legacy', options: [] },
+      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true, options: seed[0].options }
+    ]
+    const merged = mergeDiscoveredAuthoritativeModels(multiSeed, discovered('grok-build'))
+    expect(merged[0].options.map(({ id }) => id)).toEqual(['effort'])
+  })
+
+  it('lends no options when the seed is empty', () => {
+    expect(mergeDiscoveredAuthoritativeModels([], discovered('grok-build'))).toEqual([
+      { id: 'grok-build', label: 'grok-build', options: [] }
+    ])
+  })
+
+  it('preserves discovery order rather than seed order', () => {
+    const merged = mergeDiscoveredAuthoritativeModels(seed, discovered('grok-build', 'grok-4.5'))
+    expect(merged.map(({ id }) => id)).toEqual(['grok-build', 'grok-4.5'])
+  })
+
+  it('publishes an empty list for an empty discovery, so callers must gate on it', () => {
+    // Only enrichment's non-empty guard keeps a failed probe from blanking the picker.
+    expect(mergeDiscoveredAuthoritativeModels(seed, [])).toEqual([])
+  })
+
+  it('drops the unmatched seed row the additive merge would have kept', () => {
+    expect(mergeCatalogModels(seed, discovered('grok-build')).map(({ id }) => id)).toEqual([
+      'grok-4.5',
+      'grok-build'
+    ])
+    expect(
+      mergeDiscoveredAuthoritativeModels(seed, discovered('grok-build')).map(({ id }) => id)
+    ).toEqual(['grok-build'])
+  })
+})

--- a/src/shared/agent-session-option-catalog-grok.ts
+++ b/src/shared/agent-session-option-catalog-grok.ts
@@ -1,0 +1,65 @@
+import { hasFlag } from './agent-cli-flag-detection'
+import type {
+  AgentSessionOptionCatalog,
+  CatalogModel,
+  CatalogOption
+} from './agent-session-option-catalog-types'
+import { parseGrokModelList } from './grok-model-list-probe'
+
+const GROK_EFFORT: CatalogOption = {
+  // Why: `LaunchPreferences` is a strict zod object over model/effort/mode, so a
+  // novel id is dropped client-side and rejected on the wire.
+  id: 'effort',
+  label: 'Reasoning effort',
+  category: 'thought_level',
+  kind: {
+    type: 'select',
+    // Why: only values `native-chat-session-option-labels.ts` localizes; grok's
+    // `none` tier and per-model menu ids would render untranslated.
+    choices: [
+      { value: 'low', label: 'Low' },
+      { value: 'medium', label: 'Medium' },
+      { value: 'high', label: 'High' }
+    ],
+    defaultValue: 'high'
+  },
+  apply: {
+    launchArgs: (value) => ['--reasoning-effort', String(value)],
+    agentArgsOverride: (tokens) => hasFlag(tokens, ['--effort', '--reasoning-effort']),
+    midSession: { kind: 'command', build: (value) => `/effort ${String(value)}` }
+  }
+}
+
+// The enrichment gate reads only `listModels`' presence; the probe itself parses
+// through `agent-model-probe-spec.ts`, so keep this private to that gate.
+function parseGrokCatalogModels(stdout: string): CatalogModel[] {
+  return parseGrokModelList(stdout).map((model) => ({ ...model, options: [] }))
+}
+
+export const GROK_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
+  // Why: Grok model access depends on the signed-in account and on [model.*]
+  // config. Seed only what is verified; discovery supplies the rest.
+  models: [
+    {
+      id: 'grok-4.5',
+      label: 'Grok 4.5',
+      description: "xAI's frontier model",
+      isDefault: true,
+      options: [GROK_EFFORT]
+    }
+  ],
+  modelApply: {
+    launchArgs: (value) => ['-m', String(value)],
+    agentArgsOverride: (tokens) => hasFlag(tokens, ['-m', '--model']),
+    // Why: `agent-picker` would replace the whole model list with "Choose in
+    // agent picker…" and never persist a model, so `-m` would never be emitted.
+    midSession: { kind: 'command', build: (value) => `/model ${String(value)}` }
+  },
+  // Why: grok's selectable ids retire between releases, so a stale seed entry
+  // must be droppable — picking one is a fatal launch, not a warning.
+  discoveredModelsAreAuthoritative: true,
+  // Why: `grok models` prints `Default model: grok-4.5` and marks the row `(default)`,
+  // so the seed states the CLI's own choice rather than a preference of ours.
+  defaultModelIsCliDefault: true,
+  listModels: { command: 'grok models', parse: parseGrokCatalogModels }
+}

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -69,16 +69,13 @@ export type AgentSessionOptionCatalog = {
    * decorative: agents whose default comes from account or user config would otherwise
    * present a guess as the launch's model.
    *
+   * Setting an option under this default adopts the model as a persisted launch flag,
+   * but only once a probe has confirmed it — until then the id is the seed's guess and
+   * the value stays scoped to it, reaching no later launch. See `modelIsUnverifiedDefault`.
+   *
    * Known gap: "no model flag" is unverified. A user `-m` in `agentArgs` launches that
    * model while the picker, which never reads launch args, still names the CLI default.
-   * Harmless today — `modelIsCliDefault` keeps it out of persisted launch flags — but a
-   * real fix means threading `modelApply.agentArgsOverride` through to the surface.
-   *
-   * Known gap: options set under this default are honored in-session but reach no later
-   * launch. They persist under the model's id while `model` stays unset — deliberately,
-   * since setting it would emit `-m` — and both `resolveNativeChatSessionOptionDefaults`
-   * and `resolveAgentSessionOptionLaunch` bail without it. Closing this means teaching
-   * both to resolve options from the default model while still refusing to emit `-m`. */
+   * A real fix means threading `modelApply.agentArgsOverride` through to the surface. */
   defaultModelIsCliDefault?: true
   listModels?: {
     command: string

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -67,11 +67,8 @@ export type AgentSessionOptionCatalog = {
   /** Set only when the `isDefault` model is provably what the CLI runs with no model
    * flag, so an untouched draft may show it as selected. Off means `isDefault` stays
    * decorative: agents whose default comes from account or user config would otherwise
-   * present a guess as the launch's model.
-   *
-   * Setting an option under this default adopts the model as a persisted launch flag,
-   * but only once a probe has confirmed it — until then the id is the seed's guess and
-   * the value stays scoped to it, reaching no later launch. See `modelIsUnverifiedDefault`.
+   * present a guess as the launch's model. Adopting this default as a persisted launch
+   * flag additionally requires a probe to confirm it — see `modelIsUnverifiedDefault`.
    *
    * Known gap: "no model flag" is unverified. A user `-m` in `agentArgs` launches that
    * model while the picker, which never reads launch args, still names the CLI default.

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -68,7 +68,7 @@ export type AgentSessionOptionCatalog = {
    * flag, so an untouched draft may show it as selected. Off means `isDefault` stays
    * decorative: agents whose default comes from account or user config would otherwise
    * present a guess as the launch's model. Adopting this default as a persisted launch
-   * flag additionally requires a probe to confirm it — see `modelIsUnverifiedDefault`.
+   * flag additionally requires a probe to confirm it — see `adoptModelAsLaunchDefault`.
    *
    * Known gap: "no model flag" is unverified. A user `-m` in `agentArgs` launches that
    * model while the picker, which never reads launch args, still names the CLI default.

--- a/src/shared/agent-session-option-catalog-types.ts
+++ b/src/shared/agent-session-option-catalog-types.ts
@@ -60,6 +60,26 @@ export type AgentSessionOptionCatalog = {
   /** Launch-safe options for opaque model ids that are absent from the static catalog. */
   unknownModelOptions?: CatalogOption[]
   composeModelValue?: (modelId: string, values: Record<string, SessionOptionValue>) => string
+  /** Why: a seeded id the CLI has retired is a fatal launch, so a successful probe
+   * must be able to drop it rather than only add. Membership only — option menus
+   * still come from the seed. */
+  discoveredModelsAreAuthoritative?: true
+  /** Set only when the `isDefault` model is provably what the CLI runs with no model
+   * flag, so an untouched draft may show it as selected. Off means `isDefault` stays
+   * decorative: agents whose default comes from account or user config would otherwise
+   * present a guess as the launch's model.
+   *
+   * Known gap: "no model flag" is unverified. A user `-m` in `agentArgs` launches that
+   * model while the picker, which never reads launch args, still names the CLI default.
+   * Harmless today — `modelIsCliDefault` keeps it out of persisted launch flags — but a
+   * real fix means threading `modelApply.agentArgsOverride` through to the surface.
+   *
+   * Known gap: options set under this default are honored in-session but reach no later
+   * launch. They persist under the model's id while `model` stays unset — deliberately,
+   * since setting it would emit `-m` — and both `resolveNativeChatSessionOptionDefaults`
+   * and `resolveAgentSessionOptionLaunch` bail without it. Closing this means teaching
+   * both to resolve options from the default model while still refusing to emit `-m`. */
+  defaultModelIsCliDefault?: true
   listModels?: {
     command: string
     parse: (stdout: string) => CatalogModel[]

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -8,6 +8,7 @@ import {
   CURSOR_SESSION_OPTION_CATALOG,
   GEMINI_SESSION_OPTION_CATALOG
 } from './agent-session-option-catalog-gemini-cursor'
+import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
 import type {
   AgentSessionOptionCatalog,
   AgentSessionOptionCatalogMap,
@@ -30,7 +31,8 @@ const CATALOGS: AgentSessionOptionCatalogMap = {
   claude: CLAUDE_SESSION_OPTION_CATALOG,
   codex: CODEX_SESSION_OPTION_CATALOG,
   gemini: GEMINI_SESSION_OPTION_CATALOG,
-  cursor: CURSOR_SESSION_OPTION_CATALOG
+  cursor: CURSOR_SESSION_OPTION_CATALOG,
+  grok: GROK_SESSION_OPTION_CATALOG
 }
 
 export function getAgentSessionOptionCatalog(agent: AgentType): AgentSessionOptionCatalog | null {
@@ -66,6 +68,25 @@ export function mergeCatalogModels(
     return { ...model, ...live, options: model.options }
   })
   return [...merged, ...discoveredById.values()]
+}
+
+/** Discovery decides membership; the seed keeps its option menus, which discovery never carries.
+ *  Why: an unseeded model inherits the default seed's options because these catalogs' options are
+ *  global CLI flags, not per-model capabilities — dropping them would hide the picker entirely. */
+export function mergeDiscoveredAuthoritativeModels(
+  seed: readonly CatalogModel[],
+  discovered: readonly CatalogModel[]
+): CatalogModel[] {
+  const inheritedOptions = (seed.find((model) => model.isDefault) ?? seed[0])?.options ?? []
+  return discovered.map((disc) => {
+    const seedMatch = seed.find((model) => model.id === disc.id)
+    const { isDefault: _seeded, ...merged } = seedMatch
+      ? { ...seedMatch, ...disc, options: seedMatch.options }
+      : { ...disc, options: inheritedOptions }
+    // Why: the probe reports which id the CLI defaults to today; a seed flag frozen at
+    // release would keep naming the old one after the account's default moves.
+    return disc.isDefault ? { ...merged, isDefault: true } : merged
+  })
 }
 
 export function sessionOptionValueIsValid(value: unknown): value is SessionOptionValue {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -6,6 +6,7 @@ import {
   CLAUDE_MODEL_LIST_STDIN,
   parseClaudeModelList
 } from './claude-model-list-probe'
+import { labelFromModelId } from './model-id-label'
 
 /* eslint-disable max-lines -- Why: this is the single registry for non-interactive commit-message agents, their model discovery parsers, and UI capabilities. */
 
@@ -29,6 +30,9 @@ export type CommitMessageModel = {
   defaultThinkingLevel?: string
   /** Whether the model exposes Claude's mid-session Fast mode toggle. */
   supportsFastMode?: boolean
+  /** Set when the listing marks this as the id the CLI runs with no --model flag.
+   *  Optional so an older remote host that never reports it simply omits it. */
+  isDefault?: boolean
 }
 
 export type CommitMessageAgentSpec = {
@@ -61,6 +65,8 @@ export type CommitMessageModelCapability = {
   thinkingLevels?: ThinkingLevel[]
   defaultThinkingLevel?: string
   supportsFastMode?: boolean
+  /** Absent from an older remote host, which simply yields no default to display. */
+  isDefault?: boolean
 }
 
 export type CommitMessageAgentCapability = {
@@ -96,21 +102,6 @@ const CLAUDE_THINKING_LEVELS: ThinkingLevel[] = [
   { id: 'xhigh', label: 'Extra High' },
   { id: 'max', label: 'Max' }
 ]
-
-function labelFromModelId(id: string): string {
-  return id
-    .split(/[/-]/)
-    .filter(Boolean)
-    .map((part) => {
-      if (/^gpt$/i.test(part)) {
-        return 'GPT'
-      }
-      return part.length <= 3 && /^\d/.test(part)
-        ? part.toUpperCase()
-        : part.charAt(0).toUpperCase() + part.slice(1)
-    })
-    .join(' ')
-}
 
 function uniqueModels(models: CommitMessageModel[]): CommitMessageModel[] {
   const seen = new Set<string>()

--- a/src/shared/grok-model-list-probe.test.ts
+++ b/src/shared/grok-model-list-probe.test.ts
@@ -1,0 +1,139 @@
+import { describe, expect, it } from 'vitest'
+import { GROK_MODEL_LIST_ARGS, parseGrokModelList } from './grok-model-list-probe'
+
+// Captured byte-for-byte from `grok models` on a signed-in account (`sed -n l`),
+// blank lines and the two-space bullet indent included.
+const SIGNED_IN_STDOUT = [
+  'You are logged in with grok.com.',
+  '',
+  'Default model: grok-4.5',
+  '',
+  'Available models:',
+  '  * grok-4.5 (default)',
+  ''
+].join('\n')
+
+describe('parseGrokModelList', () => {
+  it('probes with the only listing subcommand grok exposes', () => {
+    expect(GROK_MODEL_LIST_ARGS).toEqual(['models'])
+  })
+
+  it('parses the signed-in listing into exactly the bulleted models', () => {
+    expect(parseGrokModelList(SIGNED_IN_STDOUT)).toEqual([
+      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true }
+    ])
+  })
+
+  it('marks only the row the listing itself annotates', () => {
+    const parsed = parseGrokModelList(
+      'Available models:\n  * grok-build\n  * grok-4.5 (default)\n  * grok-mini\n'
+    )
+    expect(parsed.map(({ id, isDefault }) => [id, isDefault])).toEqual([
+      ['grok-build', undefined],
+      ['grok-4.5', true],
+      ['grok-mini', undefined]
+    ])
+  })
+
+  it('names no default when the listing annotates none', () => {
+    // Better to show nothing than to promote the first row: an unflagged launch
+    // would run whichever model the CLI picks, not this one.
+    const parsed = parseGrokModelList('Available models:\n  * grok-4.5\n  * grok-build\n')
+    expect(parsed.every(({ isDefault }) => isDefault === undefined)).toBe(true)
+  })
+
+  it('does not treat another parenthetical as the default marker', () => {
+    const parsed = parseGrokModelList('Available models:\n  * grok-build (beta)\n')
+    expect(parsed[0]!.isDefault).toBeUndefined()
+  })
+
+  it('ignores the decoy ids that sit above the header', () => {
+    // `Default model: grok-4.5` is a valid-looking id and the login line holds a
+    // dotted token; both precede the header, so neither may become a model.
+    const parsed = parseGrokModelList(SIGNED_IN_STDOUT)
+    expect(parsed).toHaveLength(1)
+    expect(parsed.some(({ id }) => id.includes('grok.com'))).toBe(false)
+  })
+
+  it('strips a trailing parenthetical annotation from the id, spaced or not', () => {
+    const parsed = parseGrokModelList(
+      'Available models:\n  * grok-4.5 (default)\n  * grok-build(beta)\n'
+    )
+    expect(parsed.map(({ id }) => id)).toEqual(['grok-4.5', 'grok-build'])
+  })
+
+  it('keeps hyphens and dots inside an id', () => {
+    const parsed = parseGrokModelList('Available models:\n  * grok-4.5-fast-2026.07.19\n')
+    expect(parsed).toEqual([{ id: 'grok-4.5-fast-2026.07.19', label: 'Grok 4.5 Fast 2026.07.19' }])
+  })
+
+  it('parses several models in listing order and deduplicates', () => {
+    const parsed = parseGrokModelList(
+      'Available models:\n  * grok-4.5 (default)\n  * grok-build\n  * grok-4.5\n'
+    )
+    expect(parsed.map(({ id }) => id)).toEqual(['grok-4.5', 'grok-build'])
+  })
+
+  it('tolerates CRLF line endings', () => {
+    expect(parseGrokModelList('Available models:\r\n  * grok-4.5 (default)\r\n')).toEqual([
+      { id: 'grok-4.5', label: 'Grok 4.5', isDefault: true }
+    ])
+  })
+
+  it('returns nothing when the header is missing, whatever follows', () => {
+    // A bullet list with no header is the shape a reworded CLI would emit; half
+    // a parse here would publish phantom models as an authoritative list.
+    expect(parseGrokModelList('Models:\n  * grok-4.5 (default)\n')).toEqual([])
+    expect(parseGrokModelList('Default model: grok-4.5\n')).toEqual([])
+  })
+
+  it('returns nothing for a header with no bullets under it', () => {
+    expect(parseGrokModelList('Available models:\n')).toEqual([])
+    expect(parseGrokModelList('Available models:\n\n  (none)\n')).toEqual([])
+  })
+
+  it('returns nothing for empty, signed-out, or arbitrary output', () => {
+    expect(parseGrokModelList('')).toEqual([])
+    expect(parseGrokModelList('\n\n   \n')).toEqual([])
+    // Synthetic: the live signed-out path was never run against a real account.
+    expect(parseGrokModelList('You are not logged in. Run `grok login` to continue.\n')).toEqual([])
+    expect(parseGrokModelList("error: unexpected argument '--json' found\n")).toEqual([])
+  })
+
+  it('stops at the blank line that ends the listing section', () => {
+    // A footer bullet parsed as a model becomes a selectable row, and picking it
+    // launches `-m Set` — so the section boundary has to be respected.
+    expect(
+      parseGrokModelList(
+        'Available models:\n  * grok-4.5 (default)\n\nTips:\n  * Set a default with `grok config`\n'
+      ).map(({ id }) => id)
+    ).toEqual(['grok-4.5'])
+  })
+
+  it('takes the default marker from a repeated row it would otherwise skip', () => {
+    expect(parseGrokModelList('Available models:\n  * grok-4.5\n  * grok-4.5 (default)\n')).toEqual(
+      [{ id: 'grok-4.5', label: 'Grok 4.5', isDefault: true }]
+    )
+  })
+
+  it('still reads a listing whose bullets start after a blank line', () => {
+    expect(
+      parseGrokModelList('Available models:\n\n  * grok-4.5 (default)\n').map(({ id }) => id)
+    ).toEqual(['grok-4.5'])
+  })
+
+  it('never emits an entry without both an id and a label', () => {
+    const stdouts = [
+      SIGNED_IN_STDOUT,
+      'Available models:\n  * \n  *\n  * grok-4.5\n',
+      'Available models:\n  * (default)\n'
+    ]
+    for (const stdout of stdouts) {
+      for (const model of parseGrokModelList(stdout)) {
+        expect(model.id.length).toBeGreaterThan(0)
+        expect(model.label.length).toBeGreaterThan(0)
+        expect(model.id).not.toMatch(/[\s(]/)
+      }
+    }
+  })
+})

--- a/src/shared/grok-model-list-probe.ts
+++ b/src/shared/grok-model-list-probe.ts
@@ -1,0 +1,48 @@
+import type { CommitMessageModel } from './commit-message-agent-spec'
+import { labelFromModelId } from './model-id-label'
+
+// Why: `grok models` has no --json and no --format, so its human-readable
+// listing is the only machine surface available.
+export const GROK_MODEL_LIST_ARGS = ['models']
+
+const AVAILABLE_MODELS_HEADER = 'Available models:'
+const MODEL_BULLET = /^\s*\*\s+([^\s(]+)(.*)$/
+// Why: read off the row rather than the earlier `Default model:` line, so the marker
+// cannot name an id the listing does not actually offer.
+const DEFAULT_MARKER = /\(default\)/
+
+export function parseGrokModelList(stdout: string): CommitMessageModel[] {
+  const lines = stdout.split(/\r?\n/)
+  // Why: `Default model: grok-4.5` precedes the header and the login line holds a
+  // dotted token, so anything scanning the whole output invents phantom models.
+  const headerIndex = lines.findIndex((line) => line.trim() === AVAILABLE_MODELS_HEADER)
+  if (headerIndex === -1) {
+    return []
+  }
+  const models: CommitMessageModel[] = []
+  const indexById = new Map<string, number>()
+  for (const line of lines.slice(headerIndex + 1)) {
+    // Why: grok separates sections with a blank line, so ending there keeps a trailing
+    // hint or footer bullet from entering the list as a selectable — and launchable — id.
+    if (line.trim() === '' && models.length > 0) {
+      break
+    }
+    const match = MODEL_BULLET.exec(line)
+    const id = match?.[1]
+    if (!id) {
+      continue
+    }
+    const isDefault = DEFAULT_MARKER.test(match[2])
+    const existingIndex = indexById.get(id)
+    if (existingIndex !== undefined) {
+      // A repeat row still carries the marker's news, even though the id is not new.
+      if (isDefault) {
+        models[existingIndex]!.isDefault = true
+      }
+      continue
+    }
+    indexById.set(id, models.length)
+    models.push({ id, label: labelFromModelId(id), ...(isDefault ? { isDefault: true } : {}) })
+  }
+  return models
+}

--- a/src/shared/grok-model-list-probe.ts
+++ b/src/shared/grok-model-list-probe.ts
@@ -19,12 +19,11 @@ export function parseGrokModelList(stdout: string): CommitMessageModel[] {
   if (headerIndex === -1) {
     return []
   }
-  const models: CommitMessageModel[] = []
-  const indexById = new Map<string, number>()
+  const byId = new Map<string, CommitMessageModel>()
   for (const line of lines.slice(headerIndex + 1)) {
     // Why: grok separates sections with a blank line, so ending there keeps a trailing
     // hint or footer bullet from entering the list as a selectable — and launchable — id.
-    if (line.trim() === '' && models.length > 0) {
+    if (line.trim() === '' && byId.size > 0) {
       break
     }
     const match = MODEL_BULLET.exec(line)
@@ -32,17 +31,12 @@ export function parseGrokModelList(stdout: string): CommitMessageModel[] {
     if (!id) {
       continue
     }
-    const isDefault = DEFAULT_MARKER.test(match[2])
-    const existingIndex = indexById.get(id)
-    if (existingIndex !== undefined) {
-      // A repeat row still carries the marker's news, even though the id is not new.
-      if (isDefault) {
-        models[existingIndex]!.isDefault = true
-      }
-      continue
+    const model = byId.get(id) ?? { id, label: labelFromModelId(id) }
+    // A repeat row still carries the marker's news, even though the id is not new.
+    if (DEFAULT_MARKER.test(match[2])) {
+      model.isDefault = true
     }
-    indexById.set(id, models.length)
-    models.push({ id, label: labelFromModelId(id), ...(isDefault ? { isDefault: true } : {}) })
+    byId.set(id, model)
   }
-  return models
+  return [...byId.values()]
 }

--- a/src/shared/model-id-label.test.ts
+++ b/src/shared/model-id-label.test.ts
@@ -1,0 +1,34 @@
+import { describe, expect, it } from 'vitest'
+import { labelFromModelId } from './model-id-label'
+
+describe('labelFromModelId', () => {
+  it('titlecases hyphenated segments', () => {
+    expect(labelFromModelId('grok-build')).toBe('Grok Build')
+    expect(labelFromModelId('grok')).toBe('Grok')
+  })
+
+  it('keeps short numeric segments verbatim', () => {
+    expect(labelFromModelId('grok-4.5')).toBe('Grok 4.5')
+    expect(labelFromModelId('grok-4.5-fast')).toBe('Grok 4.5 Fast')
+  })
+
+  it('special-cases the gpt segment', () => {
+    expect(labelFromModelId('gpt-5.3-codex')).toBe('GPT 5.3 Codex')
+    expect(labelFromModelId('GPT-5')).toBe('GPT 5')
+  })
+
+  it('splits provider-prefixed ids on the slash', () => {
+    expect(labelFromModelId('xai/grok-4.5')).toBe('Xai Grok 4.5')
+  })
+
+  it('drops empty segments from repeated or edge separators', () => {
+    expect(labelFromModelId('grok--4.5')).toBe('Grok 4.5')
+    expect(labelFromModelId('-grok-')).toBe('Grok')
+    expect(labelFromModelId('')).toBe('')
+  })
+
+  it('uppercases only digit-led segments of three characters or fewer', () => {
+    expect(labelFromModelId('grok-4o')).toBe('Grok 4O')
+    expect(labelFromModelId('grok-2026.07.19')).toBe('Grok 2026.07.19')
+  })
+})

--- a/src/shared/model-id-label.ts
+++ b/src/shared/model-id-label.ts
@@ -1,0 +1,16 @@
+// Why: kept out of `commit-message-agent-spec.ts` so the renderer's session-option
+// path can label model ids without pulling in the commit-message agent registry.
+export function labelFromModelId(id: string): string {
+  return id
+    .split(/[/-]/)
+    .filter(Boolean)
+    .map((part) => {
+      if (/^gpt$/i.test(part)) {
+        return 'GPT'
+      }
+      return part.length <= 3 && /^\d/.test(part)
+        ? part.toUpperCase()
+        : part.charAt(0).toUpperCase() + part.slice(1)
+    })
+    .join(' ')
+}

--- a/src/shared/native-chat-session-option-commands.test.ts
+++ b/src/shared/native-chat-session-option-commands.test.ts
@@ -1,8 +1,9 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import {
   CLAUDE_SESSION_OPTION_CATALOG,
   CODEX_SESSION_OPTION_CATALOG
 } from './agent-session-option-catalog-claude-codex'
+import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
 import {
   buildNativeChatSessionOptionCommand,
   parseBuiltSessionOptionCommand,
@@ -227,5 +228,146 @@ describe('recordNativeChatSessionOptionCommand', () => {
         command: '/clear'
       })
     ).toEqual({ changed: false, opensAgentPicker: false })
+  })
+})
+
+describe('recordNativeChatSessionOptionCommand for grok', () => {
+  function grokRecord(model?: string): NativeChatSessionOptionRecord {
+    const record = createNativeChatSessionOptionRecord('grok')
+    if (model) {
+      record.model = { value: model, source: 'dispatched' }
+    }
+    return record
+  }
+
+  function recordGrok(record: NativeChatSessionOptionRecord, command: string) {
+    return recordNativeChatSessionOptionCommand({
+      catalog: GROK_SESSION_OPTION_CATALOG,
+      models: GROK_SESSION_OPTION_CATALOG.models,
+      record,
+      command
+    })
+  }
+
+  it('tracks a typed /model without signalling an agent picker', () => {
+    const record = grokRecord()
+    expect(recordGrok(record, '/model grok-4.5')).toEqual({
+      changed: true,
+      opensAgentPicker: false
+    })
+    expect(record.model).toEqual({ value: 'grok-4.5', source: 'dispatched' })
+  })
+
+  it('persists the typed model through the caller’s persist hook', () => {
+    const persist = vi.fn()
+    recordNativeChatSessionOptionCommand({
+      catalog: GROK_SESSION_OPTION_CATALOG,
+      models: GROK_SESSION_OPTION_CATALOG.models,
+      record: grokRecord(),
+      command: '/model grok-4.5',
+      persist
+    })
+    expect(persist).toHaveBeenCalledWith('grok-4.5', 'model', 'grok-4.5')
+  })
+
+  it('tracks effort under the current model', () => {
+    const record = grokRecord('grok-4.5')
+    expect(recordGrok(record, '/effort medium')).toEqual({
+      changed: true,
+      opensAgentPicker: false
+    })
+    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+      value: 'medium',
+      source: 'dispatched'
+    })
+  })
+
+  it('tracks nothing for an effort tier outside the seeded choices', () => {
+    // grok accepts `xhigh`, but the picker only offers values the shared labels
+    // localize, so tracking it would render an untranslated pill.
+    const record = grokRecord('grok-4.5')
+    recordGrok(record, '/effort xhigh')
+    expect(record.valuesByModel['grok-4.5']?.effort).toBeUndefined()
+  })
+
+  it('rejects grok’s two-argument /model form and any other prose', () => {
+    // `/model Reasoning X high` is real grok syntax; whitespace means we cannot
+    // tell a model id from a prompt, so track nothing rather than guess.
+    const record = grokRecord('grok-4.5')
+    expect(recordGrok(record, '/model Reasoning X high')).toEqual({
+      changed: false,
+      opensAgentPicker: false
+    })
+    expect(record.model).toEqual({ value: 'grok-4.5', source: 'dispatched' })
+  })
+
+  it('does not open an agent picker for a bare /model', () => {
+    const record = grokRecord('grok-4.5')
+    expect(recordGrok(record, '/model')).toEqual({ changed: false, opensAgentPicker: false })
+    expect(record.model).toEqual({ value: 'grok-4.5', source: 'dispatched' })
+  })
+
+  it('tracks a typed effort under the CLI default when no model was picked', () => {
+    // Regression: the picker draws the effort row under grok's own default, so reading
+    // the tracked model alone dropped the very command that row's pill reports on —
+    // leaving it `unknown` right after the user set it.
+    const record = grokRecord()
+    const persist = vi.fn()
+    expect(
+      recordNativeChatSessionOptionCommand({
+        catalog: GROK_SESSION_OPTION_CATALOG,
+        models: GROK_SESSION_OPTION_CATALOG.models,
+        record,
+        command: '/effort low',
+        persist
+      })
+    ).toEqual({ changed: true, opensAgentPicker: false })
+    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+      value: 'low',
+      source: 'dispatched'
+    })
+    expect(persist).toHaveBeenCalledWith('grok-4.5', 'effort', 'low')
+  })
+
+  it('does not reset tracked state when the typed model is the CLI default already shown', () => {
+    // Regression: an untracked record read as `null`, so re-typing the model the picker
+    // already displays looked like a switch and deleted that model's options.
+    const record = grokRecord()
+    recordGrok(record, '/effort low')
+    recordGrok(record, '/model grok-4.5')
+    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+      value: 'low',
+      source: 'dispatched'
+    })
+  })
+
+  it('still resets tracked state when the typed model is a real switch', () => {
+    const record = grokRecord()
+    recordGrok(record, '/effort low')
+    recordNativeChatSessionOptionCommand({
+      catalog: GROK_SESSION_OPTION_CATALOG,
+      models: [
+        ...GROK_SESSION_OPTION_CATALOG.models,
+        { id: 'grok-build', label: 'Grok Build', options: [] }
+      ],
+      record,
+      command: '/model grok-build'
+    })
+    expect(record.model).toEqual({ value: 'grok-build', source: 'dispatched' })
+    expect(record.valuesByModel['grok-4.5']?.effort).toEqual({
+      value: 'low',
+      source: 'dispatched'
+    })
+  })
+
+  it('still tracks a model the discovered list dropped', () => {
+    const record = grokRecord()
+    recordNativeChatSessionOptionCommand({
+      catalog: GROK_SESSION_OPTION_CATALOG,
+      models: [{ id: 'grok-build', label: 'Grok Build', options: [] }],
+      record,
+      command: '/model grok-4.5'
+    })
+    expect(record.model).toEqual({ value: 'grok-4.5', source: 'dispatched' })
   })
 })

--- a/src/shared/native-chat-session-option-commands.ts
+++ b/src/shared/native-chat-session-option-commands.ts
@@ -13,6 +13,7 @@ import {
   matchNativeChatCatalogModelId,
   type NativeChatSessionOptionRecord
 } from './native-chat-session-option-state'
+import { resolveEffectiveNativeChatModelId } from './native-chat-session-option-snapshot'
 
 export function parseBuiltSessionOptionCommand(
   build: (value: SessionOptionValue) => string,
@@ -90,15 +91,18 @@ function recordCommandApply(args: {
    *  "/model is a weird word"), and tracking that renders raw prose as the
    *  current value — and, for the model, drops every option the model owns. */
   canonicalize: (value: string) => string | null
+  /** The model the picker draws this option under. Reading the tracked model alone
+   *  would drop a typed `/effort low` under a CLI default, and treat a typed
+   *  `/model <that default>` as a switch that resets the model's tracked state. */
+  effectiveModelId: string | null
   persist?: PersistSessionOption
 }): boolean {
-  const { record, optionId, midSession, command, canonicalize, persist } = args
+  const { record, optionId, midSession, command, canonicalize, effectiveModelId, persist } = args
   if (!midSession || midSession.kind === 'unsupported') {
     return false
   }
   if (isFlipOnlyMidSession(midSession) && command === midSession.command) {
-    const modelId = typeof record.model?.value === 'string' ? record.model.value : null
-    clearTrackedSessionOption(record, modelId, optionId)
+    clearTrackedSessionOption(record, effectiveModelId, optionId)
     return true
   }
   if (isSessionOptionAgentPickerCommand(midSession, command)) {
@@ -116,7 +120,7 @@ function recordCommandApply(args: {
   if (!value) {
     return false
   }
-  const previousModelId = typeof record.model?.value === 'string' ? record.model.value : null
+  const previousModelId = effectiveModelId
   if (optionId === 'model') {
     if (previousModelId !== value) {
       // Why: a model command can reset model-scoped state, so an older value
@@ -166,9 +170,11 @@ export function recordNativeChatSessionOptionCommand(args: {
           // the list (withTrackedNativeChatModel) rather than blanking the row.
           (matchNativeChatCatalogModelId({ ...catalog, models: [...models] }, value) ??
           matchNativeChatCatalogModelId(catalog, value)),
+    effectiveModelId: resolveEffectiveNativeChatModelId(catalog, models, record),
     persist
   })
-  const modelId = typeof record.model?.value === 'string' ? record.model.value : null
+  // Re-resolved: the command above may have just tracked a model.
+  const modelId = resolveEffectiveNativeChatModelId(catalog, models, record)
   const model = modelId ? models.find((candidate) => candidate.id === modelId) : undefined
   for (const option of model?.options ?? []) {
     opensAgentPicker =
@@ -184,6 +190,7 @@ export function recordNativeChatSessionOptionCommand(args: {
           !option.kind.choices.some((choice) => choice.value === value)
             ? null
             : value,
+        effectiveModelId: modelId,
         persist
       }) || changed
   }

--- a/src/shared/native-chat-session-option-defaults.test.ts
+++ b/src/shared/native-chat-session-option-defaults.test.ts
@@ -1,0 +1,76 @@
+import { describe, expect, it } from 'vitest'
+import {
+  clearNativeChatSessionOptionModel,
+  resolveNativeChatSessionOptionDefaults,
+  updateNativeChatSessionOptionDefaults
+} from './native-chat-session-option-defaults'
+import type { PersistedNativeChatSessionOptions } from './native-chat-session-options'
+
+const persistedGrok = (
+  model: string | undefined,
+  valuesByModel: Record<string, Record<string, string>> = {}
+): PersistedNativeChatSessionOptions => ({
+  grok: { ...(model ? { model } : {}), valuesByModel }
+})
+
+describe('clearNativeChatSessionOptionModel', () => {
+  it('drops the model a retired id would otherwise launch as -m', () => {
+    const cleared = clearNativeChatSessionOptionModel(
+      persistedGrok('grok-build', { 'grok-build': { effort: 'low' } }),
+      'grok'
+    )
+    expect(cleared.grok?.model).toBeUndefined()
+    // Resolution keys off `model`, so clearing it is what stops the flag going out.
+    expect(resolveNativeChatSessionOptionDefaults(cleared, 'grok')).toBeUndefined()
+  })
+
+  it('keeps the per-model values so a reselect restores the old effort', () => {
+    const cleared = clearNativeChatSessionOptionModel(
+      persistedGrok('grok-build', { 'grok-build': { effort: 'low' } }),
+      'grok'
+    )
+    expect(cleared.grok?.valuesByModel).toEqual({ 'grok-build': { effort: 'low' } })
+    const reselected = updateNativeChatSessionOptionDefaults({
+      persisted: cleared,
+      agent: 'grok',
+      modelId: 'grok-build',
+      optionId: 'model',
+      value: 'grok-build'
+    })
+    expect(resolveNativeChatSessionOptionDefaults(reselected, 'grok')).toEqual({
+      model: 'grok-build',
+      effort: 'low'
+    })
+  })
+
+  it('leaves every other agent untouched', () => {
+    const cleared = clearNativeChatSessionOptionModel(
+      { ...persistedGrok('grok-build'), claude: { model: 'opus', valuesByModel: {} } },
+      'grok'
+    )
+    expect(cleared.claude).toEqual({ model: 'opus', valuesByModel: {} })
+  })
+
+  it('is a no-op when nothing is persisted for the agent', () => {
+    expect(clearNativeChatSessionOptionModel(undefined, 'grok')).toEqual({})
+    expect(clearNativeChatSessionOptionModel({}, 'grok')).toEqual({})
+    const untouched = persistedGrok(undefined, { 'grok-4.5': { effort: 'high' } })
+    expect(clearNativeChatSessionOptionModel(untouched, 'grok')).toEqual(untouched)
+  })
+})
+
+describe('resolveNativeChatSessionOptionDefaults', () => {
+  it('emits nothing until a model is explicitly picked, preserving the CLI default', () => {
+    expect(resolveNativeChatSessionOptionDefaults(undefined, 'grok')).toBeUndefined()
+    expect(resolveNativeChatSessionOptionDefaults(persistedGrok(undefined), 'grok')).toBeUndefined()
+    expect(resolveNativeChatSessionOptionDefaults(persistedGrok('   '), 'grok')).toBeUndefined()
+  })
+
+  it('returns a stale id verbatim, which is why retirement happens upstream', () => {
+    // Nothing here validates the id against the host; a retired one still resolves
+    // and becomes `-m <id>`. Only clearing the persisted value prevents that.
+    expect(resolveNativeChatSessionOptionDefaults(persistedGrok('grok-build'), 'grok')).toEqual({
+      model: 'grok-build'
+    })
+  })
+})

--- a/src/shared/native-chat-session-option-defaults.ts
+++ b/src/shared/native-chat-session-option-defaults.ts
@@ -28,12 +28,30 @@ export function resolveNativeChatSessionOptionDefaults(
   return values
 }
 
+/** Why: an authoritative probe proved this id gone, and a stale `model` is emitted
+ *  verbatim as a launch flag — grok exits fatally on an unknown one. Dropping only
+ *  `model` keeps the per-model option values for a later reselect. */
+export function clearNativeChatSessionOptionModel(
+  persisted: PersistedNativeChatSessionOptions | null | undefined,
+  agent: AgentType
+): PersistedNativeChatSessionOptions {
+  const currentAgent = persisted?.[agent]
+  if (!currentAgent?.model) {
+    return { ...persisted }
+  }
+  const { model: _dropped, ...rest } = currentAgent
+  return { ...persisted, [agent]: rest }
+}
+
 export function updateNativeChatSessionOptionDefaults(args: {
   persisted: PersistedNativeChatSessionOptions | null | undefined
   agent: AgentType
   modelId: string
   optionId: string
   value: SessionOptionValue
+  /** The model only scopes this value; the user never picked it. Adopting it would
+   *  emit `-m` on every later launch — see the invariant above. */
+  modelIsCliDefault?: boolean
 }): PersistedNativeChatSessionOptions {
   const currentAgent = args.persisted?.[args.agent]
   const currentModelValues = currentAgent?.valuesByModel?.[args.modelId] ?? {}
@@ -49,7 +67,9 @@ export function updateNativeChatSessionOptionDefaults(args: {
     ...args.persisted,
     [args.agent]: {
       ...currentAgent,
-      model: args.optionId === 'model' ? String(args.value) : args.modelId,
+      ...(args.modelIsCliDefault
+        ? {}
+        : { model: args.optionId === 'model' ? String(args.value) : args.modelId }),
       valuesByModel
     }
   }

--- a/src/shared/native-chat-session-option-defaults.ts
+++ b/src/shared/native-chat-session-option-defaults.ts
@@ -49,9 +49,11 @@ export function updateNativeChatSessionOptionDefaults(args: {
   modelId: string
   optionId: string
   value: SessionOptionValue
-  /** The model only scopes this value; the user never picked it. Adopting it would
-   *  emit `-m` on every later launch — see the invariant above. */
-  modelIsCliDefault?: boolean
+  /** The model is the seed's unprobed guess at the CLI default, so it only scopes this
+   *  value — adopting it would emit `-m <guess>` on every later launch, fatal on an
+   *  account without it. A probe-confirmed default is adopted instead: the user set this
+   *  option against that model, and without a `model` no launch resolves the value at all. */
+  modelIsUnverifiedDefault?: boolean
 }): PersistedNativeChatSessionOptions {
   const currentAgent = args.persisted?.[args.agent]
   const currentModelValues = currentAgent?.valuesByModel?.[args.modelId] ?? {}
@@ -67,7 +69,7 @@ export function updateNativeChatSessionOptionDefaults(args: {
     ...args.persisted,
     [args.agent]: {
       ...currentAgent,
-      ...(args.modelIsCliDefault
+      ...(args.modelIsUnverifiedDefault
         ? {}
         : { model: args.optionId === 'model' ? String(args.value) : args.modelId }),
       valuesByModel

--- a/src/shared/native-chat-session-option-defaults.ts
+++ b/src/shared/native-chat-session-option-defaults.ts
@@ -49,11 +49,11 @@ export function updateNativeChatSessionOptionDefaults(args: {
   modelId: string
   optionId: string
   value: SessionOptionValue
-  /** The model is the seed's unprobed guess at the CLI default, so it only scopes this
-   *  value — adopting it would emit `-m <guess>` on every later launch, fatal on an
-   *  account without it. A probe-confirmed default is adopted instead: the user set this
-   *  option against that model, and without a `model` no launch resolves the value at all. */
-  modelIsUnverifiedDefault?: boolean
+  /** Defaults to adopting, since without a `model` no launch resolves the value at all.
+   *  Only the picker surface, which can tell a probe-confirmed id from the seed's guess
+   *  at the CLI default, withholds it: adopting a guess would emit `-m <guess>` on every
+   *  later launch, fatal on an account without that model. */
+  adoptModelAsLaunchDefault?: boolean
 }): PersistedNativeChatSessionOptions {
   const currentAgent = args.persisted?.[args.agent]
   const currentModelValues = currentAgent?.valuesByModel?.[args.modelId] ?? {}
@@ -69,7 +69,7 @@ export function updateNativeChatSessionOptionDefaults(args: {
     ...args.persisted,
     [args.agent]: {
       ...currentAgent,
-      ...(args.modelIsUnverifiedDefault
+      ...(args.adoptModelAsLaunchDefault === false
         ? {}
         : { model: args.optionId === 'model' ? String(args.value) : args.modelId }),
       valuesByModel

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -1,9 +1,12 @@
 import { describe, expect, it } from 'vitest'
 import type { SessionOptionDescriptor } from './native-chat-session-options'
+import { mergeDiscoveredAuthoritativeModels } from './agent-session-option-catalog'
 import {
   CLAUDE_SESSION_OPTION_CATALOG,
   CODEX_SESSION_OPTION_CATALOG
 } from './agent-session-option-catalog-claude-codex'
+import { GROK_SESSION_OPTION_CATALOG } from './agent-session-option-catalog-grok'
+import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
   createNativeChatSessionOptionRecord,
   type NativeChatSessionOptionRecord
@@ -170,6 +173,37 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
         )
       ).toEqual([...CLAUDE_SESSION_OPTION_CATALOG.models])
     })
+
+    it('re-injects a grok seed model an authoritative discovery dropped', () => {
+      // This asserts the limitation, not a fix: dropping `grok-4.5` from the
+      // offered list does not un-pick it, so the fatal launch is still reachable.
+      const record = createNativeChatSessionOptionRecord('grok')
+      record.model = { value: 'grok-4.5', source: 'dispatched' }
+      const discovered = mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [
+        { id: 'grok-build', label: 'Grok Build', options: [] }
+      ])
+      expect(discovered.map(({ id }) => id)).toEqual(['grok-build'])
+
+      const reconciled = withTrackedNativeChatModel(GROK_SESSION_OPTION_CATALOG, discovered, record)
+      expect(reconciled.map(({ id }) => id)).toEqual(['grok-build', 'grok-4.5'])
+      expect(reconciled.at(-1)).toBe(GROK_SESSION_OPTION_CATALOG.models[0])
+      expect(reconciled.at(-1)!.options.map(({ id }) => id)).toEqual(['effort'])
+
+      const snapshot = buildNativeChatSessionOptionSnapshot({
+        catalog: GROK_SESSION_OPTION_CATALOG,
+        models: reconciled,
+        record,
+        mode: 'live',
+        modelLabel: 'Model'
+      })
+      expect(snapshot.map((descriptor) => descriptor.id)).toEqual(['model', 'effort'])
+      expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-4.5' }).args).toEqual([
+        '-m',
+        'grok-4.5',
+        '--reasoning-effort',
+        'high'
+      ])
+    })
   })
 
   it('exposes Codex model changes as native selectable values', () => {
@@ -200,5 +234,113 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     })
     const fastMode = snapshot.find((descriptor) => descriptor.id === 'fastMode')
     expect(fastMode).toMatchObject({ action: { type: 'toggle-command' } })
+  })
+})
+
+describe('defaults on load', () => {
+  const grokDraft = (
+    models = GROK_SESSION_OPTION_CATALOG.models,
+    mode: 'draft' | 'live' = 'draft'
+  ): SessionOptionDescriptor[] =>
+    buildNativeChatSessionOptionSnapshot({
+      catalog: GROK_SESSION_OPTION_CATALOG,
+      models,
+      record: createNativeChatSessionOptionRecord('grok'),
+      mode,
+      modelLabel: 'Model'
+    })
+
+  it('shows the default model before anything is picked', () => {
+    const model = grokDraft()[0]!
+    expect(model).toMatchObject({ id: 'model', valueSource: 'default' })
+    expect(model.kind.type === 'select' ? model.kind.currentValue : null).toBe('grok-4.5')
+  })
+
+  it('offers the effort row under that default model without naming its value', () => {
+    // `grok --help` documents no default for --reasoning-effort, and with no model
+    // picked the launch sends the flag nowhere, so grok's own choice is unknowable.
+    const effort = grokDraft().find((descriptor) => descriptor.id === 'effort')
+    expect(effort).toMatchObject({ valueSource: 'unknown' })
+    expect(effort?.kind.type === 'select' ? effort.kind.currentValue : null).toBeUndefined()
+  })
+
+  it('names the CLI default in a live session too, where the picker actually renders', () => {
+    // No tracked model means no `-m` was emitted, so the CLI is running its own
+    // default — as true of a running session as of a draft.
+    const live = grokDraft(GROK_SESSION_OPTION_CATALOG.models, 'live')
+    expect(live[0]).toMatchObject({ id: 'model', valueSource: 'default' })
+    expect(live[0]!.kind.type === 'select' ? live[0]!.kind.currentValue : null).toBe('grok-4.5')
+    expect(live.find((descriptor) => descriptor.id === 'effort')).toMatchObject({
+      valueSource: 'unknown'
+    })
+  })
+
+  it('names no model when discovery retired the one the catalog marks default', () => {
+    // Guessing a replacement would misreport which model the launch actually picks.
+    const retired = mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [
+      { id: 'grok-build', label: 'Grok Build', options: [] }
+    ])
+    const snapshot = grokDraft(retired)
+    expect(snapshot).toHaveLength(1)
+    expect(snapshot[0]).toMatchObject({ valueSource: 'unknown' })
+  })
+
+  it('leaves a tracked pick as the authority over the default', () => {
+    const record = createNativeChatSessionOptionRecord('grok')
+    record.model = { value: 'grok-build', source: 'dispatched' }
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: GROK_SESSION_OPTION_CATALOG,
+      models: [
+        ...GROK_SESSION_OPTION_CATALOG.models,
+        { id: 'grok-build', label: 'Grok Build', options: [] }
+      ],
+      record,
+      mode: 'draft',
+      modelLabel: 'Model'
+    })
+    expect(snapshot[0]).toMatchObject({ valueSource: 'dispatched' })
+    expect(snapshot[0]!.kind.type === 'select' ? snapshot[0]!.kind.currentValue : null).toBe(
+      'grok-build'
+    )
+  })
+
+  it('shows no default for an agent whose isDefault is only decorative', () => {
+    // Claude's real default comes from the account and the user's settings, and an
+    // untouched draft sends no --model, so naming the seed's `sonnet` would be a guess.
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: CLAUDE_SESSION_OPTION_CATALOG.models,
+      record: claudeRecord(),
+      mode: 'draft',
+      modelLabel: 'Model'
+    })
+    expect(CLAUDE_SESSION_OPTION_CATALOG.models.some((model) => model.isDefault)).toBe(true)
+    expect(CLAUDE_SESSION_OPTION_CATALOG.defaultModelIsCliDefault).toBeUndefined()
+    expect(snapshot).toHaveLength(1)
+    expect(snapshot[0]).toMatchObject({ valueSource: 'unknown' })
+  })
+
+  it('still shows an option default once a model is actually picked', () => {
+    // Not a guess: launch reads `values[id] ?? defaultValue`, so this is the flag it emits.
+    const record = claudeRecord()
+    record.model = { value: 'sonnet', source: 'applied' }
+    const snapshot = buildNativeChatSessionOptionSnapshot({
+      catalog: CLAUDE_SESSION_OPTION_CATALOG,
+      models: CLAUDE_SESSION_OPTION_CATALOG.models,
+      record,
+      mode: 'draft',
+      modelLabel: 'Model'
+    })
+    const effort = snapshot.find((descriptor) => descriptor.id === 'effort')
+    expect(effort).toMatchObject({ valueSource: 'default' })
+    expect(effort?.kind.type === 'select' ? effort.kind.currentValue : null).toBeDefined()
+  })
+
+  it('does not turn a shown default into a launch flag', () => {
+    // Display is not authorization: only a persisted pick may emit `-m`.
+    expect(resolveAgentSessionOptionLaunch('grok', undefined)).toEqual({
+      args: [],
+      appliedValues: {}
+    })
   })
 })

--- a/src/shared/native-chat-session-option-snapshot.test.ts
+++ b/src/shared/native-chat-session-option-snapshot.test.ts
@@ -175,8 +175,9 @@ describe('buildNativeChatSessionOptionSnapshot', () => {
     })
 
     it('re-injects a grok seed model an authoritative discovery dropped', () => {
-      // This asserts the limitation, not a fix: dropping `grok-4.5` from the
-      // offered list does not un-pick it, so the fatal launch is still reachable.
+      // Reconciliation alone never un-picks: the PTY surface untracks a retired id
+      // when an authoritative discovery lands (see native-chat-pty-session-options),
+      // while this shared layer keeps a pre-discovery persisted pick labelled.
       const record = createNativeChatSessionOptionRecord('grok')
       record.model = { value: 'grok-4.5', source: 'dispatched' }
       const discovered = mergeDiscoveredAuthoritativeModels(GROK_SESSION_OPTION_CATALOG.models, [

--- a/src/shared/native-chat-session-option-snapshot.ts
+++ b/src/shared/native-chat-session-option-snapshot.ts
@@ -67,16 +67,28 @@ function optionDescriptor(args: {
   option: CatalogOption
   tracked: TrackedNativeChatSessionOption | undefined
   mode: NativeChatSessionOptionMode
+  modelIsCliDefault: boolean
   composedModelApply: AgentSessionOptionCatalog['modelApply']
 }): SessionOptionDescriptor | null {
-  const { option, tracked, mode, composedModelApply } = args
+  const { option, tracked, mode, modelIsCliDefault, composedModelApply } = args
   const action = actionForApply(option.apply, tracked, mode)
   const settable = settableState({ mode, apply: option.apply, composedModelApply })
+  // Why: the launch only emits `values[id] ?? defaultValue` alongside a model flag, so
+  // a draft names this option's value exactly when a model was picked. Under the CLI's
+  // own default no flag is sent at all, and the CLI's unstated choice is not ours to name.
+  const showDefault = mode === 'draft' && !tracked && !modelIsCliDefault
+  const valueSource = tracked?.source ?? (showDefault ? 'default' : 'unknown')
   if (option.kind.type === 'select') {
     const choices = choiceWithCurrent(option.kind.choices, tracked)
     if (choices.length <= 1) {
       return null
     }
+    const currentValue =
+      typeof tracked?.value === 'string'
+        ? tracked.value
+        : showDefault
+          ? option.kind.defaultValue
+          : undefined
     return {
       id: option.id,
       label: option.label,
@@ -84,14 +96,20 @@ function optionDescriptor(args: {
       ...(option.category ? { category: option.category } : {}),
       kind: {
         type: 'select',
-        ...(typeof tracked?.value === 'string' ? { currentValue: tracked.value } : {}),
+        ...(currentValue === undefined ? {} : { currentValue }),
         choices
       },
-      valueSource: tracked?.source ?? 'unknown',
+      valueSource,
       ...settable,
       ...(action ? { action } : {})
     }
   }
+  const currentValue =
+    typeof tracked?.value === 'boolean'
+      ? tracked.value
+      : showDefault
+        ? option.kind.defaultValue
+        : undefined
   return {
     id: option.id,
     label: option.label,
@@ -99,9 +117,9 @@ function optionDescriptor(args: {
     ...(option.category ? { category: option.category } : {}),
     kind: {
       type: 'boolean',
-      ...(typeof tracked?.value === 'boolean' ? { currentValue: tracked.value } : {})
+      ...(currentValue === undefined ? {} : { currentValue })
     },
-    valueSource: tracked?.source ?? 'unknown',
+    valueSource,
     ...settable,
     ...(action ? { action } : {})
   }
@@ -147,6 +165,30 @@ export function withTrackedNativeChatModel(
   return [...models, seeded ?? { id: trackedId, label: trackedId, options: [] }]
 }
 
+/** Why: no tracked model means no `-m` was ever emitted, so the CLI is running its
+ *  own default — nameable only for a catalog that proves the seed states it. */
+function cliDefaultModelId(
+  catalog: AgentSessionOptionCatalog,
+  models: readonly CatalogModel[],
+  trackedModelId: string | null
+): string | null {
+  if (trackedModelId || !catalog.defaultModelIsCliDefault) {
+    return null
+  }
+  return models.find((model) => model.isDefault)?.id ?? null
+}
+
+/** The model the picker is showing, tracked or CLI default. Shared so applying an
+ *  option resolves the same row the snapshot rendered it under. */
+export function resolveEffectiveNativeChatModelId(
+  catalog: AgentSessionOptionCatalog,
+  models: readonly CatalogModel[],
+  record: NativeChatSessionOptionRecord
+): string | null {
+  const trackedModelId = typeof record.model?.value === 'string' ? record.model.value : null
+  return trackedModelId ?? cliDefaultModelId(catalog, models, trackedModelId)
+}
+
 export function buildNativeChatSessionOptionSnapshot(args: {
   catalog: AgentSessionOptionCatalog
   models: readonly CatalogModel[]
@@ -167,6 +209,9 @@ export function buildNativeChatSessionOptionSnapshot(args: {
     label,
     ...(description ? { description } : {})
   }))
+  const trackedModelId = typeof modelTracked?.value === 'string' ? modelTracked.value : null
+  const defaultModelId = cliDefaultModelId(catalog, models, trackedModelId)
+  const effectiveModelId = trackedModelId ?? defaultModelId
   const modelAction = actionForApply(catalog.modelApply, modelTracked, mode)
   const snapshot: SessionOptionDescriptor[] = [
     {
@@ -175,24 +220,25 @@ export function buildNativeChatSessionOptionSnapshot(args: {
       category: 'model',
       kind: {
         type: 'select',
-        ...(typeof modelTracked?.value === 'string' ? { currentValue: modelTracked.value } : {}),
+        ...(effectiveModelId ? { currentValue: effectiveModelId } : {}),
         choices: modelChoices
       },
-      valueSource: modelTracked?.source ?? 'unknown',
+      valueSource: modelTracked?.source ?? (defaultModelId ? 'default' : 'unknown'),
       ...settableState({ mode, apply: catalog.modelApply }),
       ...(modelAction ? { action: modelAction } : {})
     }
   ]
-  if (typeof modelTracked?.value !== 'string') {
+  if (!effectiveModelId) {
     return snapshot
   }
-  const model = models.find((candidate) => candidate.id === modelTracked.value)
-  const trackedValues = record.valuesByModel[modelTracked.value] ?? {}
+  const model = models.find((candidate) => candidate.id === effectiveModelId)
+  const trackedValues = record.valuesByModel[effectiveModelId] ?? {}
   for (const option of model?.options ?? []) {
     const descriptor = optionDescriptor({
       option,
       tracked: trackedValues[option.id],
       mode,
+      modelIsCliDefault: effectiveModelId === defaultModelId,
       composedModelApply: catalog.modelApply
     })
     if (descriptor) {

--- a/src/shared/native-chat-session-option-state.ts
+++ b/src/shared/native-chat-session-option-state.ts
@@ -84,13 +84,17 @@ export function setTrackedSessionOption(
   record: NativeChatSessionOptionRecord,
   optionId: string,
   value: SessionOptionValue,
-  source: TrackedNativeChatSessionOption['source']
+  source: TrackedNativeChatSessionOption['source'],
+  /** The model the picker drew this option under when none is tracked — without it a
+   *  value set against a CLI default would be dispatched and then silently forgotten. */
+  fallbackModelId: string | null = null
 ): string | null {
   if (optionId === 'model') {
     record.model = { value, source }
     return typeof value === 'string' ? value : null
   }
-  const modelId = typeof record.model?.value === 'string' ? record.model.value : null
+  const modelId =
+    (typeof record.model?.value === 'string' ? record.model.value : null) ?? fallbackModelId
   if (!modelId) {
     return null
   }

--- a/src/shared/native-chat-session-options.ts
+++ b/src/shared/native-chat-session-options.ts
@@ -6,7 +6,9 @@ export type SessionOptionSelectChoice = {
   description?: string
 }
 
-export type SessionOptionValueSource = 'applied' | 'dispatched' | 'reported' | 'unknown'
+/** `default` is the catalog's own value shown before anything is observed —
+ *  truthful to display, but never evidence about a running agent. */
+export type SessionOptionValueSource = 'applied' | 'dispatched' | 'reported' | 'default' | 'unknown'
 
 /** Closed set of reasons an option is not settable in the current mode. A key
  *  (not free English) so the producer and the localized label stay in sync —


### PR DESCRIPTION
## Summary

Grok had no session-option catalog, so the native chat composer showed no pills for it and every launch ran the CLI's own defaults with no way to change them. This adds a model picker and a reasoning-effort picker, using the same per-agent catalog pipeline that claude/codex/gemini/cursor already go through.

- **Model** — `-m` at launch, `/model` mid-session.
- **Reasoning effort** — `--reasoning-effort` at launch, `/effort` mid-session.

Grok's selectable ids depend on the signed-in account and on `[model.*]` config, so the seed carries only `grok-4.5` and a runtime `grok models` probe supplies the rest as **authoritative** — a retired id must be droppable, because passing one to `-m` is a fatal grok exit rather than a warning.

Because `grok models` publishes `Default model:` and marks the row `(default)`, the picker can name the model a fresh session is actually running instead of showing a bare "Model" pill. Two new catalog flags carry this: `discoveredModelsAreAuthoritative` (membership) and `defaultModelIsCliDefault` (default naming).

**The central invariant:** a displayed default is never a selection. That CLI default scopes the effort row but is never written to persisted settings, because that field is what authorizes `-m` on every later launch — adopting a model the user never picked would pin today's default forever, fatally so on an account that lacks it.

## Screenshots

No screenshots. Live Electron validation was explicitly skipped for this change, so the pills have not been visually confirmed. There **is** a visual change: a model pill and an effort pill now appear in the native chat composer for grok sessions. The pill-label logic is covered by unit tests (`native-chat-session-option-labels.test.ts`) rather than by screenshots.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Full suite: **46457 passed, 5 failed across 3 files — none from this change.** Verified rather than assumed:

| File | Fails | Evidence |
|---|---|---|
| `src/relay/agent-exec-handler.test.ts` | 2 | fails identically at the merge-base `eea0bb64db` |
| `src/shared/remote-runtime-shared-control-connection.test.ts` | 1 | fails identically at the merge-base |
| `src/main/ssh/ssh-relay-upload-stage-commands.test.ts` | 2 | passes in isolation on this branch (21/21); only fails under full-suite load, at 161s |

The three Round-3 fixes were mutation-verified — each fix reverted, the test confirmed failing, then restored and diffed byte-for-byte.

## AI Review Report

Four review rounds plus a readiness round. Five defects found; four fixed, one rejected after investigation.

| Round | Finding | Outcome |
|---|---|---|
| 3 | Setting effort under the CLI default persisted it as a launch model — fatal launch on an account lacking that id | fixed, mutation-verified |
| 3 | Typed `/effort low` silently dropped; typed `/model <current default>` wiped the model's stored values | fixed, mutation-verified |
| 3 | A value grok had accepted was discarded when a discovery probe landed mid-dispatch | fixed, mutation-verified |
| 4 | Claim that the commit misattributes a value to the newly-discovered default | **rejected** — see below |
| Readiness | Option set under the CLI default reaches no later launch | documented, deferred |

**On the rejected finding.** The reviewer argued the pre-dispatch model id is "the model the command was sent for." It isn't: with nothing tracked, the session launched without `-m`, so it runs grok's own default — an id only `grok models` knows. The seed's `grok-4.5` is a guess, and the catalog declares discovery authoritative. Implementing the proposed fix broke a test pinning a confirmed bug: it blanked the user's effort from the picker right after grok accepted it. Two properties bound the risk, both verified in code: `resolveEffectiveNativeChatModelId` is `trackedModelId ?? cliDefaultModelId(...)` with the latter returning null whenever a model is tracked, so a user-selected model is returned verbatim and can never be re-resolved; and `mergeDiscoveredAuthoritativeModels` gives every discovered model the seed default's options, so there is no per-model option divergence to mis-bind. The reviewer withdrew the finding.

**Regression risk to the four existing agents** was the hard-blocker category, and it came back clean. Both new flags are set only in the grok catalog, and all read sites are catalog-gated: without `defaultModelIsCliDefault`, `cliDefaultModelId` returns null, `effectiveModelId` collapses to `trackedModelId`, and every new path reduces to prior behavior. The extracted `hasFlag` was hand-checked against gemini/cursor's previous `hasModelFlag` across all five branches.

**Cross-platform (macOS, Linux, Windows)** — explicitly checked. No shortcuts, accelerators, or platform labels are touched. The probe runs as argv (`binary: 'grok'`, `args: ['models']`), not a shell string, so there is no Windows quoting hazard. No path construction is added.

**SSH, remote, WSL, and folder workspaces** — the probe does not assume local execution. It reuses the existing commit-message model-discovery infrastructure, keyed per host (`getCommitMessageModelDiscoveryHostKeyForLocalRuntime` / `...ForScope`) and crossing the runtime RPC for remote hosts. A probe failure is swallowed and degrades to the seed, so a host without grok installed simply keeps the seeded model.

**Remote wire compatibility** — reviewed against `docs/reference/remote-wire-compatibility.md` and independently confirmed. The new `'default'` `SessionOptionValueSource` never crosses a boundary: snapshots are built renderer-side and mobile-side, and no relay, RPC, IPC, or zod schema references `SessionOptionValueSource` or `SessionOptionDescriptor`. The change does touch one real wire surface, `git.discoverCommitMessageModels`, and it is safe in both directions: new client to old host gets `{success:false}` and falls back to the seed; new host to old client passes through `callRuntimeRpc<T>` as an unvalidated cast, so the new optional `isDefault` is ignored. No new stream opcodes, so no capability negotiation is needed.

## Security Audit

- **Command execution** — one new subprocess, `grok models`, spawned argv-style with a constant argument array. No shell interpolation, no user-controlled input in the command.
- **Input handling** — `parseGrokModelList` parses untrusted CLI stdout. It is anchored-regex based, allocates only from matched groups, and is covered by fixture tests. Model ids parsed from stdout can reach argv as `-m <id>`, but only after the user explicitly selects that id in the picker; ids are never auto-adopted from the probe.
- **Path handling / auth / secrets / IPC** — none added. No new IPC channels, no credential or token handling, no filesystem writes beyond the existing settings store.
- **Dependencies** — none added.
- **Follow-up** — none required.

## Notes

**Known gaps, both documented in the commit message and on the `defaultModelIsCliDefault` declaration:**

1. **An option set while on the CLI default reaches no later launch.** It is dispatched and honored in-session, but persists under the default's id with `model` deliberately left unset — and both `resolveNativeChatSessionOptionDefaults` and `resolveAgentSessionOptionLaunch` bail without that key. Measured, not inferred: `launchValues` is `null` and `args` is `[]`. Picking a model explicitly persists normally. Deferred rather than patched late because the fix spans both the pure resolver and the launch resolver, and the launch-args path is the one place where a mistake is fatal rather than cosmetic. It deserves its own review cycle.

2. **The picker infers "no `-m` was emitted" from its own in-memory record.** A model reaching argv from outside that record — the user's own `agentDefaultArgs`, or a renderer reload that drops the record while the flagged PTY lives on — leaves the pill naming the CLI default while another model runs. No wrong model is persisted.

**Not validated against a real grok binary.** The `-m` and `--reasoning-effort` flags and the `grok models` output shape are pinned only by fixtures authored in this commit. Since a wrong model id is a fatal exit rather than a warning, one manual `grok models` run against the real CLI is worth doing before merge.

Made with [Orca](https://github.com/stablyai/orca) 🐋
