### PR TITLE
chore(mobile): prepare 0.0.41 releases

### DIFF
--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.37",
+    "version": "0.0.41",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",
@@ -75,7 +75,7 @@
       "allowBackup": false,
       "permissions": ["RECORD_AUDIO", "MODIFY_AUDIO_SETTINGS"],
       "package": "com.stably.orca.mobile",
-      "versionCode": 10
+      "versionCode": 11
     },
     "plugins": [
       "expo-router",


### PR DESCRIPTION
## Summary

- align the checked-in mobile marketing version from 0.0.37 to 0.0.41
- increment Android versionCode from 10 to 11 for an installable upgrade
- keep the iOS build number CI-managed; TestFlight already has 0.0.41 build 1, so the next dispatch should resolve build 2

## Backward compatibility

- mobile protocol remains 3 with minimum desktop protocol 2
- #12763 only batches bytes client-side and sends the existing terminal.send terminal/text payload
- #12773 only changes local pairing-journal recovery and adds no RPC fields or server requirements
- old protocol-2 desktops remain explicitly accepted
- legacy mobile E2EE fixtures remain unchanged and passing

## Validation

- 428 mobile test files passed: 3,323 tests passed, 3 skipped
- 54 desktop protocol, legacy E2EE, and terminal-send tests passed
- 19 focused release, compatibility, pairing-recovery, and terminal-queue tests passed
- 11 iOS release-version tests passed
- mobile typecheck, lint, format check, and Android release preparation passed
- physical Android smoke testing completed for #12763 together with #12773

## Release plan

Dispatch Mobile iOS Release from this branch with release_version 0.0.41. Android release is not started by this PR.

## Residual risk

The live-input local preview cannot detect remote terminal echo mode, so password input may be visible in the mobile input bar. This is not a wire-compatibility issue, but remains a release UX/privacy caveat.