### PR TITLE
Change question card submit button label to 'Submit'

### DIFF
--- a/mobile/src/session/MobileNativeChatAsk.tsx
+++ b/mobile/src/session/MobileNativeChatAsk.tsx
@@ -187,7 +187,7 @@ export function MobileNativeChatAsk({ prompt, onAnswer, onCancel }: Props): Reac
           disabled={!canAdvance}
         >
           <Text style={[styles.nextText, !canAdvance && styles.nextTextDisabled]}>
-            {isLast ? 'Send answer' : 'Next'}
+            {isLast ? 'Submit' : 'Next'}
           </Text>
         </Pressable>
       </View>

--- a/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatInteractiveCard.test.tsx
@@ -101,7 +101,7 @@ function askResultMessage(): NativeChatMessage {
 
 function chooseSpacesAndSubmit(): void {
   fireEvent.click(screen.getByRole('button', { name: /Spaces/ }))
-  fireEvent.click(screen.getByRole('button', { name: 'Send answer' }))
+  fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
 }
 
 describe('NativeChatInteractiveCard answer lifecycle', () => {
@@ -122,7 +122,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
     chooseSpacesAndSubmit()
     expect(screen.getByText('Tabs or spaces?')).toBeInTheDocument()
 
-    fireEvent.click(screen.getByRole('button', { name: 'Send answer' }))
+    fireEvent.click(screen.getByRole('button', { name: 'Submit' }))
     expect(mocks.sendAnswer).toHaveBeenCalledTimes(2)
   })
 
@@ -205,7 +205,7 @@ describe('NativeChatInteractiveCard answer lifecycle', () => {
     chooseSpacesAndSubmit()
     act(() => settleDelivery?.(false))
 
-    expect(screen.getByRole('button', { name: 'Send answer' })).toBeEnabled()
+    expect(screen.getByRole('button', { name: 'Submit' })).toBeEnabled()
     expect(screen.getByText('Tabs or spaces?')).toBeInTheDocument()
   })
 })

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.test.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.test.tsx
@@ -75,7 +75,7 @@ describe('NativeChatQuestionCard', () => {
     render(tabsOrSpaces, onAnswer)
 
     clickOption('Spaces')
-    clickAction('Send answer')
+    clickAction('Submit')
 
     expect(onAnswer).toHaveBeenCalledWith([{ indices: [1], other: '' }])
   })
@@ -97,7 +97,7 @@ describe('NativeChatQuestionCard', () => {
 
     clickOption('Cherry')
     clickOption('Apple')
-    clickAction('Send answer')
+    clickAction('Submit')
 
     expect(onAnswer).toHaveBeenCalledWith([{ indices: [0, 2], other: '' }])
   })
@@ -118,7 +118,7 @@ describe('NativeChatQuestionCard', () => {
     )
 
     clickOptionAt(1)
-    clickAction('Send answer')
+    clickAction('Submit')
 
     expect(onAnswer).toHaveBeenCalledWith([{ indices: [1], other: '' }])
   })
@@ -133,7 +133,7 @@ describe('NativeChatQuestionCard', () => {
       setter.call(input, 'four spaces')
       input.dispatchEvent(new Event('input', { bubbles: true }))
     })
-    clickAction('Send answer')
+    clickAction('Submit')
 
     expect(onAnswer).toHaveBeenCalledWith([{ indices: [], other: 'four spaces' }])
   })

--- a/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatQuestionCard.tsx
@@ -209,7 +209,7 @@ export function NativeChatQuestionCard({
                 disabled={isSubmitting}
                 onClick={() => confirm()}
                 className={cn(
-                  'w-24 shrink-0 rounded-md px-3 py-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50',
+                  'shrink-0 whitespace-nowrap rounded-md px-3 py-1 text-xs font-semibold transition-colors focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring disabled:cursor-default disabled:opacity-50',
                   currentAnswered
                     ? 'bg-primary text-primary-foreground hover:bg-primary/90'
                     : 'text-muted-foreground hover:bg-accent hover:text-accent-foreground'
@@ -219,7 +219,7 @@ export function NativeChatQuestionCard({
                   ? translate('components.native-chat.question.sending', 'Sending…')
                   : currentAnswered
                     ? isLast
-                      ? translate('components.native-chat.question.send', 'Send answer')
+                      ? translate('components.native-chat.question.send', 'Submit')
                       : translate('components.native-chat.question.next', 'Next')
                     : translate('components.native-chat.question.skip', 'Skip')}
               </button>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -14856,7 +14856,7 @@
         "other": "Other…",
         "otherPlaceholder": "Type your answer",
         "cancel": "Cancel",
-        "send": "Send answer",
+        "send": "Submit",
         "next": "Next",
         "skip": "Skip",
         "sending": "Sending…"

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -14526,7 +14526,7 @@
         "other": "Otro…",
         "otherPlaceholder": "Escribe tu respuesta",
         "cancel": "Cancelar",
-        "send": "Enviar respuesta",
+        "send": "Enviar",
         "next": "Siguiente",
         "skip": "Omitir",
         "sending": "Enviando…"

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -14526,7 +14526,7 @@
         "other": "他の…",
         "otherPlaceholder": "答えを入力してください",
         "cancel": "キャンセル",
-        "send": "回答を送信する",
+        "send": "送信",
         "next": "次へ",
         "skip": "スキップ",
         "sending": "送信中…"

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -14537,7 +14537,7 @@
         "other": "다른…",
         "otherPlaceholder": "답변을 입력하세요",
         "cancel": "취소",
-        "send": "답변 보내기",
+        "send": "제출",
         "next": "다음",
         "skip": "건너뛰기",
         "sending": "전송 중…"

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -14546,7 +14546,7 @@
         "other": "其他…",
         "otherPlaceholder": "输入你的回答",
         "cancel": "取消",
-        "send": "发送回答",
+        "send": "提交",
         "next": "下一步",
         "skip": "跳过",
         "sending": "正在发送…"

--- a/tests/e2e/native-chat-ask-user-question-card.spec.ts
+++ b/tests/e2e/native-chat-ask-user-question-card.spec.ts
@@ -146,10 +146,10 @@ test.describe('Desktop chat AskUserQuestion card (#11761)', () => {
       // The submit button reads "Skip" until an option is chosen; picking one is
       // what proves the card is answerable rather than merely rendered.
       await orcaPage.getByRole('button', { name: /Spaces/ }).click()
-      await expect(orcaPage.getByRole('button', { name: 'Send answer' })).toBeVisible()
+      await expect(orcaPage.getByRole('button', { name: 'Submit' })).toBeVisible()
       await orcaPage.screenshot({ path: path.join(screenshotDir, '02-option-selected.png') })
 
-      await orcaPage.getByRole('button', { name: 'Send answer' }).click()
+      await orcaPage.getByRole('button', { name: 'Submit' }).click()
       // The card owns the composer slot, so its disappearance is the visible
       // signal that the answer was accepted and chat input came back.
       await expect(orcaPage.getByText(QUESTION)).toHaveCount(0, { timeout: 20_000 })


### PR DESCRIPTION
## Problem

The question card submit button uses 'Send answer' label which is verbose and inconsistent with standard UI conventions for form submission.

## Solution

Renamed the submit button from 'Send answer' to 'Submit' for clarity and consistency. Removed the fixed width constraint (`w-24`) and added `whitespace-nowrap` to ensure proper text rendering across locales. Updated all 5 language localizations and corresponding test assertions.

## Screenshots

No visual change beyond button label text.

## Testing

- [x] Button label updated across mobile and desktop implementations
- [x] All 5 locale files (en, es, ja, ko, zh) updated with shorter translations
- [x] Unit tests (`NativeChatQuestionCard.test.tsx`, `NativeChatInteractiveCard.test.tsx`) updated
- [x] E2E tests (`native-chat-ask-user-question-card.spec.ts`) updated
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`

## AI Review Report

TODO

## Security Audit

TODO

## Notes

Button styling improved to use `whitespace-nowrap` instead of fixed width for better text wrapping behavior across locales.