### PR TITLE
fix(terminal): preserve pinned scroll across live redraws

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -166,6 +166,10 @@ import { recordTerminalOutput } from '@/lib/pane-manager/pane-scroll'
 import { ensureArabicShapingJoinerForText } from '@/lib/pane-manager/terminal-arabic-shaping-joiner'
 import { clearTerminalScrollbackAndFollowOutput } from '@/lib/pane-manager/terminal-scrollback-clear'
 import {
+  installTerminalLiveScrollbackRestore,
+  type TerminalLiveScrollbackRestore
+} from '@/lib/pane-manager/terminal-live-scrollback-restore'
+import {
   enforceTerminalCurrentScrollIntent,
   getTerminalScrollIntentKind,
   markTerminalFollowOutput,
@@ -4463,6 +4467,7 @@ export function connectPanePty(
   // override, which legitimately parks the PTY at phone dims). See
   // pty-size-reconcile.ts for the convergence loop.
   let ptySizeReconcileHandle: PtySizeReconcileHandle | null = null
+  let liveScrollbackRestore: TerminalLiveScrollbackRestore | null = null
   const reconcilePtySizeAfterSpawn = (
     ptyId: string,
     spawnCols: number,
@@ -6400,6 +6405,12 @@ export function connectPanePty(
       deps.paneLastThemeModeRef.current.set(pane.id, mode)
       recordHiddenMode2031Reply()
     }
+
+    // Why installed here: the handler observes CSI 3 J inside xterm's parse, so a
+    // redraw split across PTY chunks is reported once, with the pane's rows for
+    // this write already applied.
+    liveScrollbackRestore?.dispose()
+    liveScrollbackRestore = installTerminalLiveScrollbackRestore(pane.terminal)
 
     function writePtyOutputToXterm(
       data: string,
@@ -9321,6 +9332,8 @@ export function connectPanePty(
       unregisterUndeliverableWriteHandler()
       unsubscribeRemoteDesktopActivationClaim()
       cancelHiddenOutputSnapshotScrollRestore()
+      liveScrollbackRestore?.dispose()
+      liveScrollbackRestore = null
       structuralReplayCoordinator.dispose()
       cancelFreshSpawnFollowReset()
       // Why: cancel the post-spawn reconcile's pending rAF so a torn-down pane can't keep fitting/resizing after disposal.

--- a/src/renderer/src/lib/pane-manager/terminal-live-scrollback-restore.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-live-scrollback-restore.ts
@@ -1,0 +1,227 @@
+import { guardParserHandler } from '@/components/terminal-pane/terminal-parser-handler-guard'
+import {
+  isTerminalViewportAtBottom,
+  readTerminalScrollBufferSnapshot
+} from './terminal-scroll-buffer-snapshot'
+import {
+  captureTerminalStructuralScrollIntent,
+  isTerminalStructuralScrollIntentCurrent,
+  restoreTerminalStructuralScrollIntent,
+  type TerminalScrollIntentTarget,
+  type TerminalStructuralScrollIntentSnapshot
+} from './terminal-scroll-intent'
+
+const ERASE_IN_DISPLAY_FINAL = 'J'
+const ERASE_SCROLLBACK_PARAMETER = 3
+
+// Why a quiet period rather than "the buffer stopped growing": a redraw streams
+// over many parsed writes and any one of them can carry only cursor or colour
+// bytes, so a single non-growing write is not the end of the rebuild.
+const REDRAW_SETTLE_MS = 120
+
+// Why a hard cap: output that never goes quiet would defer the pin forever.
+// Restore once at the cap instead, so a long redraw still lands the reader.
+const MAX_PENDING_RESTORE_MS = 1_000
+
+type CancelScheduled = () => void
+type ScheduleSettle = (run: () => void, delayMs: number) => CancelScheduled
+
+const scheduleSettleWithTimeout: ScheduleSettle = (run, delayMs) => {
+  const timer = setTimeout(run, delayMs)
+  return () => clearTimeout(timer)
+}
+
+export type TerminalLiveScrollbackRestoreTarget = TerminalScrollIntentTarget & {
+  parser?: {
+    registerCsiHandler?: (
+      id: { prefix?: string; final: string },
+      handler: (params: (number | number[])[]) => boolean
+    ) => { dispose: () => void }
+  }
+  onWriteParsed?: (listener: () => void) => { dispose: () => void }
+}
+
+export type TerminalLiveScrollbackRestore = {
+  dispose: () => void
+}
+
+type PendingRestore = {
+  snapshot: TerminalStructuralScrollIntentSnapshot
+  bottomOffset: number
+  deadline: number
+  cancelSettle: CancelScheduled
+}
+
+/**
+ * Preserves a pinned viewport across a live CSI 3 J that erases scrollback.
+ *
+ * Why a parser handler and not a scan of the outgoing bytes: xterm's parser
+ * already carries sequence state across writes, so a redraw split over several
+ * PTY chunks is reported once, at the exact point the erase is about to run.
+ * That is also the only place where the rows written earlier in the same chunk
+ * are already reflected in `baseY`, so the captured distance from the bottom is
+ * the reader's true position — and where the buffer type tells us whether the
+ * erase touches the scrollback we pinned at all.
+ *
+ * The pin fires exactly once, after the redraw goes quiet. Re-applying it per
+ * write would turn a pinned viewport into follow-output-at-an-offset and drag
+ * the reader through whatever the program printed next.
+ *
+ * Capture and restore both hang off xterm's own events, so installing this is
+ * the whole integration — there is no per-write wiring a caller can drop.
+ */
+export function installTerminalLiveScrollbackRestore(
+  terminal: TerminalLiveScrollbackRestoreTarget,
+  options: { now?: () => number; scheduleSettle?: ScheduleSettle } = {}
+): TerminalLiveScrollbackRestore {
+  const now = options.now ?? (() => performance.now())
+  const scheduleSettle = options.scheduleSettle ?? scheduleSettleWithTimeout
+  let pending: PendingRestore | null = null
+
+  function disarm(): void {
+    pending?.cancelSettle()
+    pending = null
+  }
+
+  function applyPendingRestore(active: PendingRestore): void {
+    // Why the identity check: a superseded pin's timer may still be in flight
+    // if a scheduler ever cancels late, and it must not spend its replacement.
+    if (pending !== active) {
+      return
+    }
+    const current = readTerminalScrollBufferSnapshot(terminal)
+    if (!current) {
+      disarm()
+      return
+    }
+    // These two restate guards that restoreTerminalStructuralScrollIntent also
+    // enforces, so no test can tell them apart from it — they are kept so this
+    // module's own preconditions do not depend on that one staying honest.
+    // The reader scrolled again, so their newer intent supersedes the pin.
+    if (!isTerminalStructuralScrollIntentCurrent(terminal, active.snapshot)) {
+      disarm()
+      return
+    }
+    // The app switched screens before the redraw finished; the pin no longer
+    // refers to the buffer in front of the reader.
+    if (current.bufferType !== active.snapshot.bufferType) {
+      disarm()
+      return
+    }
+    // Why keep waiting: a stalled frame mid-redraw would otherwise spend the pin
+    // against a half-rebuilt buffer and clamp the reader to the top for good.
+    if (current.baseY < active.bottomOffset && now() < active.deadline) {
+      armSettle(active)
+      return
+    }
+    // Single shot: re-applying per write would turn the pin into a follow.
+    disarm()
+    // Why no retry when a structural rebuild is in flight: the replay
+    // coordinator owns the viewport in that window and restores this same
+    // intent itself, so a retry here would only fight it.
+    restoreTerminalStructuralScrollIntent(terminal, active.snapshot, {
+      restoreBy: 'bottomOffset'
+    })
+  }
+
+  function armSettle(active: PendingRestore): void {
+    active.cancelSettle()
+    const delay = Math.max(0, Math.min(REDRAW_SETTLE_MS, active.deadline - now()))
+    active.cancelSettle = scheduleSettle(() => applyPendingRestore(active), delay)
+  }
+
+  function observeEraseInDisplay(params: (number | number[])[]): boolean {
+    // Why params[0] is enough for the subparameter form: xterm reports CSI 3:1 J
+    // as [3, [1]], so the leading parameter still compares equal.
+    if (params[0] !== ERASE_SCROLLBACK_PARAMETER) {
+      return false
+    }
+    const current = readTerminalScrollBufferSnapshot(terminal)
+    // Why: on the alternate screen the erase never reaches the scrollback we
+    // pinned, so there is nothing to rebuild and nothing to restore. The gate
+    // below happens to cover this too (the alt buffer keeps no scrollback, so
+    // its viewport always reads as bottomed); state the real reason anyway.
+    if (!current || current.bufferType !== 'normal') {
+      return false
+    }
+    // Why read the live viewport and not just the stored intent: a durable pin
+    // kept across a remount still reads pinnedViewport for a reader who has
+    // since returned to the bottom, and arming there would stop follow-output.
+    if (isTerminalViewportAtBottom(current.viewportY, current.baseY)) {
+      return false
+    }
+    const live = pending
+    // Why reuse the armed pin: a second erase inside the window would otherwise
+    // recapture from the buffer the first erase already wiped, pinning the
+    // reader to an offset measured against a stub of a screen. Keeping the
+    // original deadline also stops a repeating clear from deferring it forever.
+    if (live && isTerminalStructuralScrollIntentCurrent(terminal, live.snapshot)) {
+      armSettle(live)
+      return false
+    }
+    const captured = captureTerminalStructuralScrollIntent(terminal)
+    // Why skip follow-output: xterm already keeps a bottomed viewport at the
+    // bottom, and re-latching it would only churn the intent revision.
+    if (!captured || captured.kind !== 'pinnedViewport') {
+      return false
+    }
+    disarm()
+    const active: PendingRestore = {
+      // Why live coordinates: capture can substitute durable pre-remount ones,
+      // which measure the offset against a buffer the reader is not looking at.
+      snapshot: {
+        kind: 'pinnedViewport',
+        bufferType: current.bufferType,
+        viewportY: current.viewportY,
+        baseY: current.baseY,
+        revision: captured.revision
+      },
+      bottomOffset: current.baseY - current.viewportY,
+      deadline: now() + MAX_PENDING_RESTORE_MS,
+      cancelSettle: () => {}
+    }
+    pending = active
+    armSettle(active)
+    // Why false: this observes the erase, it does not implement it — xterm's
+    // own handler still has to clear the scrollback.
+    return false
+  }
+
+  // Why guarded: xterm runs custom handlers inside WriteBuffer._innerWrite with
+  // no try/catch, and one throw there wedges the pane's write pipeline for good.
+  const observeEraseInDisplayGuarded = guardParserHandler(
+    'csi-erase-scrollback',
+    observeEraseInDisplay
+  )
+
+  // Why both forms: xterm routes the private `CSI ? 3 J` to its own handler, and
+  // that one erases scrollback too — a plain-only registration misses it.
+  const registrations = [
+    terminal.parser?.registerCsiHandler?.(
+      { final: ERASE_IN_DISPLAY_FINAL },
+      observeEraseInDisplayGuarded
+    ),
+    terminal.parser?.registerCsiHandler?.(
+      { prefix: '?', final: ERASE_IN_DISPLAY_FINAL },
+      observeEraseInDisplayGuarded
+    )
+  ]
+
+  // Each parsed write pushes the quiet period out, so the pin lands after the
+  // rebuild rather than partway through it.
+  const parsedSubscription = terminal.onWriteParsed?.(() => {
+    if (pending) {
+      armSettle(pending)
+    }
+  })
+
+  return {
+    dispose(): void {
+      disarm()
+      parsedSubscription?.dispose()
+      for (const registration of registrations) {
+        registration?.dispose()
+      }
+    }
+  }
+}

--- a/src/renderer/src/lib/pane-manager/xterm-user-scrolling-contract.test.ts
+++ b/src/renderer/src/lib/pane-manager/xterm-user-scrolling-contract.test.ts
@@ -11,10 +11,12 @@
  * If an xterm upgrade breaks any assertion here, the live write path loses
  * its follow/pin semantics silently — fix the write path before bumping.
  */
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { Terminal } from '@xterm/headless'
 import packageJson from '../../../../../package.json'
 import { clearTerminalScrollbackAndFollowOutput } from './terminal-scrollback-clear'
+import { installTerminalLiveScrollbackRestore } from './terminal-live-scrollback-restore'
+import { markTerminalFollowOutput, markTerminalPinnedViewport } from './terminal-scroll-intent'
 
 type TerminalWithBufferService = Terminal & {
   _core?: {
@@ -31,6 +33,20 @@ async function writeLines(term: Terminal, count: number, label: string): Promise
   for (let i = 0; i < count; i += 1) {
     await write(term, `${label}${i}\r\n`)
   }
+}
+
+/** 100 lines of scrollback with the viewport pinned 30 rows up and that pin recorded. */
+async function pinnedScrollbackTerminal(): Promise<TerminalWithBufferService> {
+  const term = new Terminal({
+    rows: 10,
+    cols: 40,
+    scrollback: 1000,
+    allowProposedApi: true
+  }) as TerminalWithBufferService
+  await writeLines(term, 100, 'before')
+  term.scrollLines(-30)
+  markTerminalPinnedViewport(term)
+  return term
 }
 
 describe('xterm native user-scrolling contract (vendored 6.1.0-beta.287)', () => {
@@ -178,5 +194,573 @@ describe('xterm native user-scrolling contract (vendored 6.1.0-beta.287)', () =>
 
     await writeLines(term, 15, 'after-clear')
     expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+  })
+})
+
+/**
+ * Drives the settle timer off a virtual clock so tests can prove the debounce
+ * itself. Every schedule is its own live timer, as with setTimeout, so a
+ * missing cancel shows up as an extra timer firing rather than being absorbed.
+ */
+function manualSettleScheduler(): {
+  now: () => number
+  scheduleSettle: (run: () => void, delayMs: number) => () => void
+  advance: (ms: number) => void
+  scheduleCount: () => number
+  cancelCount: () => number
+  liveTimerCount: () => number
+} {
+  type FakeTimer = { run: () => void; dueAt: number; dead: boolean }
+  const timers: FakeTimer[] = []
+  let nowMs = 0
+  let scheduleCount = 0
+  let cancelCount = 0
+  return {
+    now: () => nowMs,
+    scheduleSettle: (run, delayMs) => {
+      const timer: FakeTimer = { run, dueAt: nowMs + delayMs, dead: false }
+      timers.push(timer)
+      scheduleCount += 1
+      return () => {
+        if (!timer.dead) {
+          cancelCount += 1
+        }
+        timer.dead = true
+      }
+    },
+    advance: (ms) => {
+      nowMs += ms
+      // A regression that re-arms with no delay would otherwise spin here and
+      // read as a stuck CI job rather than a failing assertion.
+      for (let fired = 0; ; fired += 1) {
+        if (fired > 1_000) {
+          throw new Error('settle scheduler livelocked: zero-delay re-arm loop')
+        }
+        let due: FakeTimer | null = null
+        for (const timer of timers) {
+          if (!timer.dead && timer.dueAt <= nowMs && (!due || timer.dueAt < due.dueAt)) {
+            due = timer
+          }
+        }
+        if (!due) {
+          return
+        }
+        due.dead = true
+        due.run()
+      }
+    },
+    scheduleCount: () => scheduleCount,
+    cancelCount: () => cancelCount,
+    liveTimerCount: () => timers.filter((timer) => !timer.dead).length
+  }
+}
+
+const SETTLE_MS = 120
+
+async function pinnedTerminalWithRestore(): Promise<{
+  term: TerminalWithBufferService
+  advance: (ms: number) => void
+  settle: () => void
+  bottomOffset: number
+  restore: { dispose: () => void }
+  scheduleCount: () => number
+  cancelCount: () => number
+}> {
+  const term = await pinnedScrollbackTerminal()
+  const scheduler = manualSettleScheduler()
+  const restore = installTerminalLiveScrollbackRestore(term, {
+    now: scheduler.now,
+    scheduleSettle: scheduler.scheduleSettle
+  })
+  return {
+    term,
+    advance: scheduler.advance,
+    settle: () => scheduler.advance(SETTLE_MS),
+    bottomOffset: term.buffer.active.baseY - term.buffer.active.viewportY,
+    restore,
+    scheduleCount: scheduler.scheduleCount,
+    cancelCount: scheduler.cancelCount
+  }
+}
+
+describe('live scrollback-erase pin (CSI 3 J)', () => {
+  it('restores a pinned viewport after a live full-screen scrollback clear', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[?2026h\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(50)}\x1b[?2026l`)
+    expect(term.buffer.active.viewportY).toBe(0)
+    settle()
+
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY - bottomOffset)
+    expect(term._core?._bufferService?.isUserScrolling).toBe(true)
+  })
+
+  it('triggers on a bare erase-scrollback with no screen clear alongside it', async () => {
+    const { term, settle, bottomOffset, scheduleCount } = await pinnedTerminalWithRestore()
+
+    // No \x1b[2J prefix: the scrollback erase alone is the trigger.
+    await write(term, `\x1b[3J${'after\r\n'.repeat(150)}`)
+    expect(scheduleCount()).toBeGreaterThan(0)
+    settle()
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('ignores erase-in-display forms that keep the scrollback', async () => {
+    const { term, settle, scheduleCount } = await pinnedTerminalWithRestore()
+    const pinnedY = term.buffer.active.viewportY
+
+    // Every one of these is a routine TUI repaint; none erases scrollback.
+    for (const sequence of [
+      '\x1b[J',
+      '\x1b[0J',
+      '\x1b[1J',
+      '\x1b[2J',
+      '\x1b[?0J',
+      '\x1b[?1J',
+      '\x1b[?2J'
+    ]) {
+      await write(term, sequence)
+    }
+    // Grow the buffer so a spurious bottom-offset restore would be visible.
+    await writeLines(term, 200, 'after')
+    expect(scheduleCount()).toBe(0)
+    settle()
+
+    expect(term.buffer.active.viewportY).toBe(pinnedY)
+  })
+
+  it('detects a clear split across writes', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // xterm's parser carries the half-parsed sequence across the write boundary.
+    await write(term, '\x1b[2J\x1b[H\x1b[')
+    await write(term, `3J${'after\r\n'.repeat(50)}`)
+    settle()
+
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY - bottomOffset)
+  })
+
+  it('holds the pin while the redraw keeps arriving and lands it once quiet', async () => {
+    const { term, advance, bottomOffset } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(60)}`)
+    // Each frame lands inside the quiet period, so the pin must not fire yet.
+    for (let frame = 0; frame < 5; frame += 1) {
+      advance(SETTLE_MS - 60)
+      expect(term.buffer.active.viewportY).toBe(0)
+      await write(term, 'after\r\n'.repeat(40))
+    }
+    advance(SETTLE_MS)
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('lands the pin after a redraw that outgrows the erased scrollback over several writes', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // Each batch alone would settle the pin at the wrong distance from the bottom.
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(101)}`)
+    await write(term, 'after\r\n'.repeat(199))
+    settle()
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('survives a mid-redraw write that adds no rows', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(50)}`)
+    // A cursor/attribute-only frame is normal mid-repaint and must not end the pin.
+    await write(term, '\x1b[K')
+    await write(term, 'after\r\n'.repeat(250))
+    settle()
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('spends the pin once even when the rebuild stays shorter than the old scrollback', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // A rebuild shorter than the pre-erase buffer skips the intent re-latch, so
+    // only the single-shot disarm stops this from becoming a follow-at-offset.
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(60)}`)
+    settle()
+    const restoredY = term.buffer.active.viewportY
+    expect(restoredY).toBe(term.buffer.active.baseY - bottomOffset)
+
+    await writeLines(term, 200, 'later')
+    settle()
+    expect(term.buffer.active.viewportY).toBe(restoredY)
+  })
+
+  it('does not drag the reader through output that arrives after the pin lands', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(120)}`)
+    settle()
+    const restoredY = term.buffer.active.viewportY
+    expect(restoredY).toBe(term.buffer.active.baseY - bottomOffset)
+
+    // The pin is spent: the reader holds position while the program keeps printing.
+    await writeLines(term, 200, 'later')
+    settle()
+    expect(term.buffer.active.viewportY).toBe(restoredY)
+  })
+
+  it('measures the pin from the rows already written earlier in the same chunk', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+    const rowsBeforeErase = 20
+
+    // Those rows push the reader further from the bottom before the erase runs;
+    // capturing at the write boundary instead would undercount them.
+    await write(
+      term,
+      `${'pre\r\n'.repeat(rowsBeforeErase)}\x1b[2J\x1b[H\x1b[3J${'post\r\n'.repeat(120)}`
+    )
+    settle()
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(
+      bottomOffset + rowsBeforeErase
+    )
+  })
+
+  it('keeps the original pin when a second erase lands inside the settle window', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // The first redraw regrows past a screenful, so at the second erase the
+    // reader reads as detached at line 0. Re-measuring there would capture the
+    // whole rebuilt height as the offset and strand them at the top.
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'first\r\n'.repeat(160)}`)
+    expect(term.buffer.active.viewportY).toBe(0)
+    expect(term.buffer.active.baseY).toBeGreaterThan(0)
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'second\r\n'.repeat(160)}`)
+    settle()
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it("re-captures from the reader's new position when they move between two erases", async () => {
+    const { term, advance, scheduleCount } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'first\r\n'.repeat(300)}`)
+    expect(scheduleCount()).toBeGreaterThan(0)
+
+    // The reader moves during the rebuild, so the armed pin is superseded and
+    // the next erase has to measure them where they are now.
+    term.scrollLines(250)
+    markTerminalPinnedViewport(term)
+    const movedOffset = term.buffer.active.baseY - term.buffer.active.viewportY
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'second\r\n'.repeat(300)}`)
+    advance(2_000)
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(movedOffset)
+  })
+
+  it('keeps one deadline across a repeating clear so the pin still lands', async () => {
+    const { term, advance, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // A clear loop re-arms faster than the settle, so the pin only ever lands
+    // because the deadline stays anchored to the first erase. Ten 100ms cycles
+    // reach MAX_PENDING_RESTORE_MS exactly.
+    for (let cycle = 0; cycle < 10; cycle += 1) {
+      await write(term, `\x1b[2J\x1b[H\x1b[3J${'redraw\r\n'.repeat(140)}`)
+      expect(term.buffer.active.viewportY).toBe(0)
+      advance(100)
+    }
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('does not spend the pin on a redraw that stalls half-built', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // A delivery gap mid-redraw fires the settle while the rebuild is too short.
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'partial\r\n'.repeat(5)}`)
+    settle()
+    expect(term.buffer.active.viewportY).toBe(0)
+
+    await write(term, 'rest\r\n'.repeat(140))
+    settle()
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('gives up on a rebuild that never reaches the offset before the deadline', async () => {
+    const { term, advance, bottomOffset, scheduleCount } = await pinnedTerminalWithRestore()
+
+    // Land inside 0 < baseY < bottomOffset, the band a partial rebuild sits in.
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'partial\r\n'.repeat(20)}`)
+    expect(term.buffer.active.baseY).toBeGreaterThan(0)
+    expect(term.buffer.active.baseY).toBeLessThan(bottomOffset)
+
+    advance(2_000)
+    const schedulesAfterGiveUp = scheduleCount()
+    // The erase already clamped the reader here; giving up must not move them.
+    expect(term.buffer.active.viewportY).toBe(0)
+
+    // The pin is spent, so a later rebuild tall enough to honor it must not fire.
+    await writeLines(term, 300, 'later')
+    advance(2_000)
+    expect(scheduleCount()).toBe(schedulesAfterGiveUp)
+    expect(term.buffer.active.viewportY).toBe(0)
+  })
+
+  it('does not arm for a reader who is back at the bottom under a stale durable pin', async () => {
+    const term = await pinnedScrollbackTerminal()
+    const scheduler = manualSettleScheduler()
+    installTerminalLiveScrollbackRestore(term, {
+      now: scheduler.now,
+      scheduleSettle: scheduler.scheduleSettle
+    })
+
+    // A remount/replay leaves the live buffer shorter than the durable pin, so
+    // capture prefers the stored pre-remount coordinates even though the reader
+    // is now following live output at the bottom.
+    term.clear()
+    term.scrollToBottom()
+    await writeLines(term, 40, 'replayed')
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+    expect(term.buffer.active.baseY).toBeLessThan(91)
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(200)}`)
+    // No pin is armed at all, so nothing can later pull them off the bottom.
+    expect(scheduler.scheduleCount()).toBe(0)
+    scheduler.advance(SETTLE_MS)
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+  })
+
+  it('measures the pin from live coordinates, not stale durable ones', async () => {
+    const term = await pinnedScrollbackTerminal()
+    const scheduler = manualSettleScheduler()
+    installTerminalLiveScrollbackRestore(term, {
+      now: scheduler.now,
+      scheduleSettle: scheduler.scheduleSettle
+    })
+
+    // A remount/replay leaves the durable intent describing a taller buffer than
+    // the one on screen, so its offset no longer matches what the reader sees.
+    term.clear()
+    term.scrollToBottom()
+    await writeLines(term, 40, 'replayed')
+    term.scrollLines(-5)
+    const liveOffset = term.buffer.active.baseY - term.buffer.active.viewportY
+    expect(liveOffset).toBe(5)
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(200)}`)
+    scheduler.advance(SETTLE_MS)
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(liveOffset)
+  })
+
+  it('restores after the private CSI ? 3 J erase', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    // xterm routes the private form to its own handler and it erases scrollback too.
+    await write(term, `\x1b[2J\x1b[H\x1b[?3J${'after\r\n'.repeat(50)}`)
+    settle()
+
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY - bottomOffset)
+  })
+
+  it('restores after the subparameter erase form', async () => {
+    const { term, settle, bottomOffset } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3:1J${'after\r\n'.repeat(120)}`)
+    settle()
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+  })
+
+  it('does not arm for an erase on the alternate screen', async () => {
+    const { term, settle, scheduleCount } = await pinnedTerminalWithRestore()
+    const pinnedY = term.buffer.active.viewportY
+
+    await write(term, '\x1b[?1049h\x1b[H\x1b[2J\x1b[3Jframe')
+    expect(scheduleCount()).toBe(0)
+
+    await write(term, '\x1b[?1049l')
+    await writeLines(term, 60, 'after')
+    settle()
+
+    // xterm carries the pin itself; a restore firing here would drag the reader.
+    expect(term.buffer.active.viewportY).toBe(pinnedY)
+  })
+
+  it('drops the pin when the app switches to the alternate screen before it settles', async () => {
+    const { term, settle } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(120)}`)
+    await write(term, '\x1b[?1049h')
+    const altY = term.buffer.active.viewportY
+    settle()
+
+    expect(term.buffer.active.viewportY).toBe(altY)
+  })
+
+  it('abandons the pin once the reader scrolls again', async () => {
+    const { term, settle } = await pinnedTerminalWithRestore()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(120)}`)
+    term.scrollLines(-2)
+    markTerminalPinnedViewport(term)
+    const afterUserScrollY = term.buffer.active.viewportY
+
+    settle()
+    expect(term.buffer.active.viewportY).toBe(afterUserScrollY)
+  })
+
+  it('leaves a follow-output pane following', async () => {
+    const term = new Terminal({
+      rows: 10,
+      cols: 40,
+      scrollback: 1000,
+      allowProposedApi: true
+    }) as TerminalWithBufferService
+    await writeLines(term, 100, 'before')
+    markTerminalFollowOutput(term)
+    const scheduler = manualSettleScheduler()
+    installTerminalLiveScrollbackRestore(term, {
+      now: scheduler.now,
+      scheduleSettle: scheduler.scheduleSettle
+    })
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(50)}`)
+    expect(scheduler.scheduleCount()).toBe(0)
+    scheduler.advance(SETTLE_MS)
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+  })
+
+  it('cancels an armed pin on dispose', async () => {
+    const term = await pinnedScrollbackTerminal()
+    const scheduler = manualSettleScheduler()
+    const restore = installTerminalLiveScrollbackRestore(term, {
+      now: scheduler.now,
+      scheduleSettle: scheduler.scheduleSettle
+    })
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(120)}`)
+    expect(scheduler.scheduleCount()).toBeGreaterThan(0)
+    const cancelsBeforeDispose = scheduler.cancelCount()
+    const clampedY = term.buffer.active.viewportY
+
+    restore.dispose()
+    // The live timer is released, not just neutered, so nothing survives the pane.
+    expect(scheduler.cancelCount()).toBeGreaterThan(cancelsBeforeDispose)
+    scheduler.advance(SETTLE_MS)
+    expect(term.buffer.active.viewportY).toBe(clampedY)
+  })
+
+  it('stops observing erases after dispose', async () => {
+    const { term, settle, restore } = await pinnedTerminalWithRestore()
+    restore.dispose()
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(50)}`)
+    settle()
+    // Without the pin the reader is stranded where the erase clamped them.
+    expect(term.buffer.active.viewportY).toBe(0)
+  })
+
+  it('lands the pin on the real timer when no scheduler is injected', async () => {
+    const term = await pinnedScrollbackTerminal()
+    const restore = installTerminalLiveScrollbackRestore(term)
+    const bottomOffset = term.buffer.active.baseY - term.buffer.active.viewportY
+
+    await write(term, `\x1b[2J\x1b[H\x1b[3J${'after\r\n'.repeat(120)}`)
+    await new Promise((resolve) => setTimeout(resolve, 400))
+
+    expect(term.buffer.active.baseY - term.buffer.active.viewportY).toBe(bottomOffset)
+    restore.dispose()
+  })
+})
+
+describe('live scrollback-erase pin wiring', () => {
+  type StubRegistration = { id: { prefix?: string; final: string }; disposed: boolean }
+
+  function stubTerminal(options: { throwOnBuffer?: boolean } = {}): {
+    target: Parameters<typeof installTerminalLiveScrollbackRestore>[0]
+    registrations: StubRegistration[]
+    handlers: ((params: (number | number[])[]) => boolean)[]
+    parsedDisposed: () => boolean
+  } {
+    const registrations: StubRegistration[] = []
+    const handlers: ((params: (number | number[])[]) => boolean)[] = []
+    let parsedDisposed = false
+    const target = {
+      get buffer() {
+        if (options.throwOnBuffer) {
+          throw new Error('buffer is gone')
+        }
+        return { active: { type: 'normal', viewportY: 10, baseY: 50 } }
+      },
+      parser: {
+        registerCsiHandler: (
+          id: { prefix?: string; final: string },
+          handler: (params: (number | number[])[]) => boolean
+        ) => {
+          const registration: StubRegistration = { id, disposed: false }
+          registrations.push(registration)
+          handlers.push(handler)
+          return {
+            dispose: () => {
+              registration.disposed = true
+            }
+          }
+        }
+      },
+      onWriteParsed: () => ({
+        dispose: () => {
+          parsedDisposed = true
+        }
+      })
+    }
+    return {
+      target: target as Parameters<typeof installTerminalLiveScrollbackRestore>[0],
+      registrations,
+      handlers,
+      parsedDisposed: () => parsedDisposed
+    }
+  }
+
+  it('registers both the plain and private erase idents', () => {
+    const stub = stubTerminal()
+    installTerminalLiveScrollbackRestore(stub.target)
+
+    expect(stub.registrations.map((registration) => registration.id)).toEqual([
+      { final: 'J' },
+      { prefix: '?', final: 'J' }
+    ])
+  })
+
+  it('degrades a throwing capture to "not handled" instead of wedging the parser', () => {
+    const stub = stubTerminal({ throwOnBuffer: true })
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    installTerminalLiveScrollbackRestore(stub.target)
+
+    // xterm has no try/catch around parser handlers, so a throw here would stop
+    // the pane's write pipeline for good.
+    for (const handler of stub.handlers) {
+      expect(() => handler([3])).not.toThrow()
+      expect(handler([3])).toBe(false)
+    }
+    expect(consoleError).toHaveBeenCalled()
+    consoleError.mockRestore()
+  })
+
+  it('releases both registrations and the parsed subscription on dispose', () => {
+    const stub = stubTerminal()
+    const restore = installTerminalLiveScrollbackRestore(stub.target)
+
+    restore.dispose()
+    expect(stub.registrations.every((registration) => registration.disposed)).toBe(true)
+    expect(stub.parsedDisposed()).toBe(true)
+  })
+
+  it('does nothing when the terminal exposes no parser or parsed event', () => {
+    const restore = installTerminalLiveScrollbackRestore({
+      buffer: { active: { type: 'normal', viewportY: 10, baseY: 50 } }
+    } as Parameters<typeof installTerminalLiveScrollbackRestore>[0])
+    expect(() => restore.dispose()).not.toThrow()
   })
 })


### PR DESCRIPTION
Fixes #12663

## Summary

Preserve a reader's pinned terminal viewport when a live TUI redraw erases the scrollback, including redraws split across PTY delivery and scheduler chunks.

Orca registers guarded CSI handlers on the pane's terminal. When xterm is about to run an erase-scrollback, the handler records how far from the bottom the reader is; once the redraw goes quiet, that distance is restored — once. Capture and restore both hang off xterm's own events (`registerCsiHandler` and `onWriteParsed`), so installing it is the whole integration.

## Root cause

Pi compaction emits a full-screen redraw containing:

```text
ESC[2J ESC[H ESC[3J
```

xterm's `eraseInDisplay(3)` clamps a scrolled-up viewport to line 0 and leaves `isUserScrolling` latched, so the pane never resumes following on its own — the reader is stranded wherever the erase dropped them. Orca's PTY scheduler can parse the clear in one chunk and the rest of the redraw in later chunks, so the position is lost regardless of where the chunk boundary falls.

## ELI5

Imagine bookmarking page 50 of a book. Pi throws the book away and prints a new copy. This notes how far from the end you were reading when the old copy was discarded, waits for the new copy to finish printing, and puts you back the same distance from the end — once. If the new copy never gets that long, it leaves you where you already were rather than holding the bookmark forever.

## Behaviour

| Situation | Result |
|---|---|
| Redraw completes | Reader restored to their distance from the bottom |
| Redraw spans many writes | Pin waits for the quiet period, then lands once |
| Redraw never goes quiet | Pin lands once at a 1s cap |
| Rebuild stays shorter than the offset | Pin is dropped; reader left where the erase clamped them |
| Reader scrolls during the window | Pin abandoned — their new position wins |
| Alternate screen (`vim`, `less`) | Never armed; an erase there touches no scrollback we pinned |
| Pane following output | Never armed |
| Repeated clear loop | One deadline per pin, so it still lands |

The pin fires exactly once. Re-applying it per write would turn a pinned viewport into follow-output-at-an-offset and drag the reader through whatever printed next.

## Reproduction

1. Run Pi in an Orca terminal with enough context for compaction.
2. Start `/compact`.
3. Scroll up while Pi waits for its summary.
4. Let compaction finish.
5. The terminal stays pinned instead of jumping away.

Reproduced against a live Electron Orca session with Pi v0.83.0 (compacted `32,354` tokens; after the redraw xterm remained pinned with `baseY=316`, `viewportY=262`, `isUserScrolling=true`).

## Review

Six rounds of readiness review with adversarial verification ran against successive revisions. Rounds 1–3 found real defects, each now fixed — several by deleting the machinery they lived in rather than patching it:

- **Byte-scanning the PTY stream** (r1) defeated the output scheduler's callback dedupe and could stitch a `CSI 3 J` out of a replayed byte range, yanking a pinned viewport. Replaced by observing the erase inside xterm's parser, so there is no scanner and no pre-write hook — `beforeWrite` is untouched by this PR.
- **Re-applying the pin while the buffer grew** (r2) dragged the reader through live output, self-cancelled via the intent revision bump, and died on any write that added no rows — the common case for a redraw streamed token by token. Replaced by a single shot after a quiet period.
- **Capturing from the wrong place** (r3): a second erase re-measured against the stub the first had already left; durable pre-remount coordinates were trusted over what the reader could actually see; the deadline restarted on every erase; and a stalled frame spent the pin against a half-rebuilt buffer.
- **Unguarded parser handlers** (r2): xterm runs custom handlers inside `WriteBuffer._innerWrite` with no try/catch, where one throw wedges the pane's write pipeline permanently. Both handlers now use the repo's `guardParserHandler`.
- **`CSI ? 3 J` was missed entirely** — xterm routes the private form to its own handler and it erases scrollback too.

Rounds 4–6 found no behavioural defects; their findings were test-coverage gaps, proven by mutation and now closed. Round 6 returned clean and measured the feature against a control (installed vs not) on headless xterm: identical end position for short and slow rebuilds, strictly better for a long rebuild. Because `eraseInDisplay(3)` always clamps to line 0 and the restore target is `clamp(baseY - bottomOffset)`, the pin can only ever move the reader *down* from row 0 — never up, and never onto the bottom.

Security, back-compat and cross-platform: three renderer files, no dependency, lockfile, schema, migration, persisted state, settings, wire surface, mobile or relay consumer, and no network sink.

## Validation

- `xterm-user-scrolling-contract`: **39 passed** (30 covering this path).
- `src/renderer/src/lib/pane-manager/`: **662 passed, 1 skipped** across 58 files.
- `src/renderer/src/components/terminal-pane/`: **3154 passed** across 245 files.
- `pnpm run typecheck:web`, oxlint, React Doctor, oxfmt, `git diff --check`.

Tests drive real escape sequences through xterm's parser — the same path production uses. Each guard is mutation-verified: removing it fails a test. Four guards are deliberately redundant with checks inside `restoreTerminalStructuralScrollIntent` or with the live-at-bottom gate, and are commented as such so nobody mistakes them for independently covered.

## Known trade-offs

- The reader sits at the clamped position for the settle window (120ms, up to the 1s cap) before the pin lands.
- The pin restores a row offset, not content — the content the reader was on is destroyed by the erase, so "same distance from the bottom" is an approximation by construction.
- Cancellation depends on a scroll-intent revision bump. Every current scroll path bumps it; a future scroll-to-bottom path added without an intent write would need the same.