### PR TITLE
fix(terminal): clear stranded link hover tooltip

### DIFF
--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -6,11 +6,16 @@
   position: relative;
 }
 
+/* Why: .pane-manager-root matches no live element, so a var declared there
+   never resolves and every calc() using it is dropped. Keep it on :root. */
+:root {
+  --orca-terminal-link-tooltip-height: 25px;
+}
+
 /* Ensure pane manager root fills its absolutely-positioned container */
 .pane-manager-root {
   width: 100% !important;
   height: 100% !important;
-  --orca-terminal-link-tooltip-height: 25px;
 }
 
 /* Reset the global border/outline base rule inside terminal panes */
@@ -501,7 +506,7 @@
   box-sizing: border-box;
   position: relative;
   width: calc(100% - var(--pane-padding-x, 4px));
-  height: calc(100% - var(--pane-padding-y, 4px) - var(--orca-terminal-link-tooltip-height));
+  height: calc(100% - var(--pane-padding-y, 4px) - var(--orca-terminal-link-tooltip-height, 25px));
   margin-top: var(--pane-padding-y, 4px);
   margin-left: var(--pane-padding-x, 4px);
 }
@@ -513,7 +518,7 @@
 .pane[data-has-title] .xterm-container {
   margin-top: var(--orca-pane-title-height);
   height: calc(
-    100% - var(--orca-pane-title-height) - var(--orca-terminal-link-tooltip-height)
+    100% - var(--orca-pane-title-height) - var(--orca-terminal-link-tooltip-height, 25px)
   ); /* match margin-top and the tooltip reserve */
 }
 

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -10,6 +10,7 @@
 .pane-manager-root {
   width: 100% !important;
   height: 100% !important;
+  --orca-terminal-link-tooltip-height: 25px;
 }
 
 /* Reset the global border/outline base rule inside terminal panes */
@@ -497,9 +498,10 @@
    so Ghostty-imported window-padding-x/y can be applied without inline styles.
    The fallback 4px preserves the legacy default. */
 .xterm-container {
+  box-sizing: border-box;
   position: relative;
   width: calc(100% - var(--pane-padding-x, 4px));
-  height: calc(100% - var(--pane-padding-y, 4px));
+  height: calc(100% - var(--pane-padding-y, 4px) - var(--orca-terminal-link-tooltip-height));
   margin-top: var(--pane-padding-y, 4px);
   margin-left: var(--pane-padding-x, 4px);
 }
@@ -510,12 +512,15 @@
    same amount to prevent overflow/clipping. */
 .pane[data-has-title] .xterm-container {
   margin-top: var(--orca-pane-title-height);
-  height: calc(100% - var(--orca-pane-title-height)); /* match margin-top */
+  height: calc(
+    100% - var(--orca-pane-title-height) - var(--orca-terminal-link-tooltip-height)
+  ); /* match margin-top and the tooltip reserve */
 }
 
 /* Ghostty-style URL hover: glued to the pane's true bottom-left corner. */
 .pane-link-tooltip {
   position: absolute;
+  box-sizing: border-box;
   bottom: 0;
   left: 0;
   z-index: 40;
@@ -526,6 +531,8 @@
   border-bottom: none;
   border-left: none;
   padding: 4px 8px;
+  height: var(--orca-terminal-link-tooltip-height);
+  line-height: 15px;
   max-width: 80%;
   overflow: hidden;
   text-overflow: ellipsis;

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -9,7 +9,10 @@ import { cancelDeferredScrollRestore } from './pane-scroll'
 import { activateOrcaTerminalUnicodeProvider } from '../../../../shared/terminal-unicode-provider'
 import { attachTerminalMouseWheelMultiplier } from './pane-terminal-mouse-wheel'
 import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent-dom-tracking'
-import { installTerminalLinkifierHoverResetOnMouseLeave } from './terminal-linkifier-hover-reset-on-mouseleave'
+import {
+  installTerminalLinkifierHoverResetOnMouseLeave,
+  installTerminalLinkifierHoverResetOnWindowBlur
+} from './terminal-linkifier-hover-reset-on-mouseleave'
 import { installTerminalLinkifierHoverResetOnWrite } from './terminal-linkifier-hover-reset-on-write'
 import { attachDomRendererFocusClassSync } from './pane-dom-focus-class-sync'
 import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-webgl-renderer'
@@ -63,7 +66,14 @@ export function openTerminal(pane: ManagedPaneInternal): void {
   // line; invalidate the linkifier hover cache when output lands so the next
   // pointer move re-linkifies it.
   pane.linkifierHoverResetDisposable = installTerminalLinkifierHoverResetOnWrite(terminal)
-  pane.linkifierMouseLeaveResetDisposable = installTerminalLinkifierHoverResetOnMouseLeave(terminal)
+  pane.linkifierMouseLeaveResetDisposable = installTerminalLinkifierHoverResetOnMouseLeave(
+    terminal,
+    linkTooltip
+  )
+  pane.linkifierWindowBlurResetDisposable = installTerminalLinkifierHoverResetOnWindowBlur(
+    terminal,
+    linkTooltip
+  )
 
   // Activate Orca's Unicode 11 width shim *before* any caller-driven write. CJK / emoji /
   // ZWJ codepoints get baked into the buffer at the active unicode version on
@@ -187,6 +197,8 @@ export function disposePane(
   pane.linkifierHoverResetDisposable = null
   pane.linkifierMouseLeaveResetDisposable?.dispose()
   pane.linkifierMouseLeaveResetDisposable = null
+  pane.linkifierWindowBlurResetDisposable?.dispose()
+  pane.linkifierWindowBlurResetDisposable = null
   // Deregister the RTL shaping joiner: terminal.dispose() below does not.
   try {
     pane.arabicShapingJoinerCleanup?.()

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -176,6 +176,9 @@ export type ManagedPaneInternal = {
   linkifierHoverResetDisposable?: IDisposable | null
   // Stored because mouseleave does not bubble from xterm's screen.
   linkifierMouseLeaveResetDisposable?: IDisposable | null
+  // Stored because a window blur may strand xterm's active link without a
+  // follow-up mouse event.
+  linkifierWindowBlurResetDisposable?: IDisposable | null
   // Stored so disposePane() can deregister the joiner; terminal.dispose()
   // does not remove registered character joiners.
   arabicShapingJoinerCleanup?: (() => void) | null

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.test.ts
@@ -1,43 +1,73 @@
 import type { Terminal } from '@xterm/xterm'
 import { describe, expect, it, vi } from 'vitest'
-import { installTerminalLinkifierHoverResetOnMouseLeave } from './terminal-linkifier-hover-reset-on-mouseleave'
+import {
+  installTerminalLinkifierHoverResetOnMouseLeave,
+  installTerminalLinkifierHoverResetOnWindowBlur
+} from './terminal-linkifier-hover-reset-on-mouseleave'
 
-type FakeLinkifier = { _lastBufferCell?: unknown; _activeLine?: number }
+type FakeLinkifier = {
+  _lastBufferCell?: unknown
+  _activeLine?: number
+  _clearCurrentLink?: () => void
+  _currentLink?: unknown
+}
 
 function createHarness(hasScreen = true) {
   let mouseLeaveHandler: (() => void) | null = null
+  let blurHandler: (() => void) | null = null
   const addEventListener = vi.fn((_event: string, handler: () => void) => {
-    mouseLeaveHandler = handler
+    if (_event === 'mouseleave') {
+      mouseLeaveHandler = handler
+    }
   })
   const removeEventListener = vi.fn((_event: string, handler: () => void) => {
-    if (mouseLeaveHandler === handler) {
+    if (_event === 'mouseleave' && mouseLeaveHandler === handler) {
       mouseLeaveHandler = null
     }
   })
-  const screen = { addEventListener, removeEventListener }
+  const screen = { addEventListener, removeEventListener, classList: { remove: vi.fn() } }
   const querySelector = vi.fn(() => (hasScreen ? screen : null))
+  const rendererWindow = {
+    addEventListener: vi.fn((_event: string, handler: () => void) => {
+      blurHandler = handler
+    }),
+    removeEventListener: vi.fn((_event: string, handler: () => void) => {
+      if (blurHandler === handler) {
+        blurHandler = null
+      }
+    })
+  }
   const linkifier: FakeLinkifier = {
     _lastBufferCell: { x: 2, y: 3 },
-    _activeLine: 3
+    _activeLine: 3,
+    _clearCurrentLink: vi.fn(),
+    _currentLink: { link: 'https://example.com' }
   }
   const terminal = {
-    element: { querySelector },
+    element: { querySelector, ownerDocument: { defaultView: rendererWindow } },
     _core: { linkifier }
   } as unknown as Terminal
+  const linkTooltip = {
+    ownerDocument: { defaultView: rendererWindow },
+    style: { display: '' }
+  } as unknown as HTMLElement
   return {
     terminal,
     linkifier,
+    linkTooltip,
+    rendererWindow,
     querySelector,
     addEventListener,
     removeEventListener,
-    dispatchMouseLeave: () => mouseLeaveHandler?.()
+    dispatchMouseLeave: () => mouseLeaveHandler?.(),
+    dispatchBlur: () => blurHandler?.()
   }
 }
 
 describe('installTerminalLinkifierHoverResetOnMouseLeave', () => {
   it('resets the hover cache when the terminal surface loses the pointer', () => {
     const harness = createHarness()
-    installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
+    installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal, harness.linkTooltip)
 
     expect(harness.querySelector).toHaveBeenCalledWith('.xterm-screen')
     expect(harness.addEventListener).toHaveBeenCalledWith('mouseleave', expect.any(Function))
@@ -45,6 +75,9 @@ describe('installTerminalLinkifierHoverResetOnMouseLeave', () => {
 
     expect(harness.linkifier._lastBufferCell).toBeUndefined()
     expect(harness.linkifier._activeLine).toBe(-1)
+    expect(harness.linkifier._clearCurrentLink).toHaveBeenCalledTimes(1)
+    expect(harness.linkifier._currentLink).toBeUndefined()
+    expect(harness.linkTooltip.style.display).toBe('none')
   })
 
   it('removes the listener on dispose', () => {
@@ -78,5 +111,31 @@ describe('installTerminalLinkifierHoverResetOnMouseLeave', () => {
     installTerminalLinkifierHoverResetOnMouseLeave(harness.terminal)
 
     expect(harness.dispatchMouseLeave).not.toThrow()
+  })
+
+  it('clears the active link and tooltip when the renderer window blurs', () => {
+    const harness = createHarness()
+    const disposable = installTerminalLinkifierHoverResetOnWindowBlur(
+      harness.terminal,
+      harness.linkTooltip
+    )
+
+    harness.dispatchBlur()
+
+    expect(harness.rendererWindow.addEventListener).toHaveBeenCalledWith(
+      'blur',
+      expect.any(Function)
+    )
+    expect(harness.linkifier._clearCurrentLink).toHaveBeenCalledTimes(1)
+    expect(harness.linkifier._currentLink).toBeUndefined()
+    expect(harness.linkifier._lastBufferCell).toBeUndefined()
+    expect(harness.linkifier._activeLine).toBe(-1)
+    expect(harness.linkTooltip.style.display).toBe('none')
+
+    disposable.dispose()
+    expect(harness.rendererWindow.removeEventListener).toHaveBeenCalledWith(
+      'blur',
+      expect.any(Function)
+    )
   })
 })

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset-on-mouseleave.ts
@@ -1,16 +1,43 @@
 import type { IDisposable, Terminal } from '@xterm/xterm'
 import { resetTerminalLinkifierHoverState } from './terminal-linkifier-hover-reset'
 
-export function installTerminalLinkifierHoverResetOnMouseLeave(terminal: Terminal): IDisposable {
+export function installTerminalLinkifierHoverResetOnMouseLeave(
+  terminal: Terminal,
+  linkTooltip?: HTMLElement
+): IDisposable {
   const screen = terminal.element?.querySelector<HTMLElement>('.xterm-screen')
   if (!screen) {
     return { dispose: () => undefined }
   }
 
-  const resetHover = (): void => resetTerminalLinkifierHoverState(terminal)
+  const resetHover = (): void => {
+    if (linkTooltip) {
+      linkTooltip.style.display = 'none'
+    }
+    resetTerminalLinkifierHoverState(terminal)
+  }
   // Why: xterm clears its active link but keeps the cell cache on mouseleave.
   screen.addEventListener('mouseleave', resetHover)
   return {
     dispose: () => screen.removeEventListener('mouseleave', resetHover)
+  }
+}
+
+export function installTerminalLinkifierHoverResetOnWindowBlur(
+  terminal: Terminal,
+  linkTooltip: HTMLElement
+): IDisposable {
+  const ownerWindow = linkTooltip.ownerDocument?.defaultView
+  if (!ownerWindow) {
+    return { dispose: () => undefined }
+  }
+
+  const resetHover = (): void => {
+    linkTooltip.style.display = 'none'
+    resetTerminalLinkifierHoverState(terminal)
+  }
+  ownerWindow.addEventListener('blur', resetHover)
+  return {
+    dispose: () => ownerWindow.removeEventListener('blur', resetHover)
   }
 }

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset.ts
@@ -3,6 +3,9 @@ import type { Terminal } from '@xterm/xterm'
 type LinkifierHoverCache = {
   _lastBufferCell?: unknown
   _activeLine?: number
+  // Private xterm cleanup that invokes the active provider's leave callback
+  // and removes its pointer cursor decoration.
+  _clearCurrentLink?: () => void
   // Set while xterm is showing a hovered link; cleared on mouseleave / when the
   // pointer moves off the link (Linkifier `_clearCurrentLink`).
   _currentLink?: unknown
@@ -34,15 +37,23 @@ type TerminalCoreWithLinkifier = {
 export function resetTerminalLinkifierHoverState(terminal: Terminal): void {
   try {
     const linkifier = (terminal as unknown as TerminalCoreWithLinkifier)._core?.linkifier
-    if (!linkifier) {
-      return
+    // Why: window blur can strand xterm's active link without another mouse
+    // event, so invoke its own leave path before invalidating the cache.
+    linkifier?._clearCurrentLink?.()
+    if (linkifier && '_currentLink' in linkifier) {
+      linkifier._currentLink = undefined
     }
-    if ('_lastBufferCell' in linkifier) {
+    if (linkifier && '_lastBufferCell' in linkifier) {
       linkifier._lastBufferCell = undefined
     }
-    if ('_activeLine' in linkifier) {
+    if (linkifier && '_activeLine' in linkifier) {
       linkifier._activeLine = -1
     }
+    // Why: keep the cursor recoverable if a future xterm build omits the
+    // private cleanup method or has no last mouse event for it to use.
+    terminal.element
+      ?.querySelector<HTMLElement>('.xterm-screen')
+      ?.classList.remove('xterm-cursor-pointer')
   } catch {
     /* linkifier internals unavailable — link recovers on the next cell change */
   }

--- a/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-linkifier-hover-reset.ts
@@ -38,8 +38,14 @@ export function resetTerminalLinkifierHoverState(terminal: Terminal): void {
   try {
     const linkifier = (terminal as unknown as TerminalCoreWithLinkifier)._core?.linkifier
     // Why: window blur can strand xterm's active link without another mouse
-    // event, so invoke its own leave path before invalidating the cache.
-    linkifier?._clearCurrentLink?.()
+    // event, so invoke its own leave path before invalidating the cache. Its
+    // own try: this runs provider leave() callbacks, and a throwing one must
+    // not skip the cache invalidation below.
+    try {
+      linkifier?._clearCurrentLink?.()
+    } catch {
+      /* provider leave() threw — cache invalidation below still applies */
+    }
     if (linkifier && '_currentLink' in linkifier) {
       linkifier._currentLink = undefined
     }

--- a/tests/e2e/issue-12656-terminal-link-tooltip.spec.ts
+++ b/tests/e2e/issue-12656-terminal-link-tooltip.spec.ts
@@ -161,8 +161,14 @@ test.describe('Issue #12656 terminal link tooltip', () => {
     expect(hovered.text).toContain(url)
     expect(hovered.tooltipHeight).toBeGreaterThan(0)
     expect(hovered.tooltipTop).toBeGreaterThanOrEqual(hovered.terminalBottom - 1)
+    // Why: bound the gap on both sides. A lower bound alone also passes when the
+    // reserve var fails to resolve and .xterm-container collapses to height:auto,
+    // which leaves a huge gap and an undersized terminal.
     expect(hovered.paneBottom - hovered.terminalBottom).toBeGreaterThanOrEqual(
       hovered.reserveHeight - 1
+    )
+    expect(hovered.paneBottom - hovered.terminalBottom).toBeLessThanOrEqual(
+      hovered.reserveHeight + 1
     )
     await captureProof(orcaPage, testInfo, 'issue-12656-fixed-hover.png')
 

--- a/tests/e2e/issue-12656-terminal-link-tooltip.spec.ts
+++ b/tests/e2e/issue-12656-terminal-link-tooltip.spec.ts
@@ -1,0 +1,179 @@
+import { randomUUID } from 'node:crypto'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForSessionReady } from './helpers/store'
+import {
+  getTerminalContent,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { waitForPtyShellEcho } from './terminal-pty-readiness'
+
+type LinkProbe = {
+  tabId: string
+  col: number
+  row: number
+}
+
+type TooltipState = {
+  display: string
+  text: string
+  currentLinkText: string | null
+  cursor: string
+  paneBottom: number
+  terminalBottom: number
+  tooltipTop: number
+  tooltipHeight: number
+  reserveHeight: number
+}
+
+async function locateUrl(page: Page, url: string): Promise<LinkProbe | null> {
+  return page.evaluate((url) => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? (state.activeTabId ?? null)
+        : worktreeId
+          ? (state.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!tabId || !pane) {
+      return null
+    }
+
+    const buffer = pane.terminal.buffer.active
+    for (let row = 0; row < pane.terminal.rows; row += 1) {
+      const line = buffer.getLine(buffer.viewportY + row)
+      const col = line?.translateToString(true).indexOf(url) ?? -1
+      if (col >= 0) {
+        return {
+          tabId,
+          col: col + Math.floor(url.length / 2),
+          row
+        }
+      }
+    }
+    return null
+  }, url)
+}
+
+async function moveToLink(page: Page, probe: LinkProbe): Promise<void> {
+  await page.evaluate(({ col, row, tabId }) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const screen = pane?.terminal.element?.querySelector<HTMLElement>('.xterm-screen')
+    if (!pane || !screen) {
+      throw new Error('xterm-screen element unavailable')
+    }
+    const rect = screen.getBoundingClientRect()
+    screen.dispatchEvent(
+      new MouseEvent('mousemove', {
+        bubbles: true,
+        cancelable: true,
+        clientX: rect.left + (col + 0.5) * (rect.width / pane.terminal.cols),
+        clientY: rect.top + (row + 0.5) * (rect.height / pane.terminal.rows)
+      })
+    )
+  }, probe)
+}
+
+async function readTooltipState(page: Page, tabId: string): Promise<TooltipState> {
+  return page.evaluate((tabId) => {
+    const manager = window.__paneManagers?.get(tabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const screen = pane?.terminal.element?.querySelector<HTMLElement>('.xterm-screen')
+    if (!pane || !screen) {
+      throw new Error('terminal pane unavailable')
+    }
+
+    const linkifier = (
+      pane.terminal as unknown as {
+        _core?: { linkifier?: { currentLink?: { link?: { text?: string } } } }
+      }
+    )._core?.linkifier
+    const paneRect = pane.container.getBoundingClientRect()
+    const terminalRect = pane.terminal.element?.parentElement?.getBoundingClientRect()
+    const tooltipRect = pane.linkTooltip.getBoundingClientRect()
+    const reserveHeight = tooltipRect.height
+
+    return {
+      display: pane.linkTooltip.style.display,
+      text: pane.linkTooltip.textContent ?? '',
+      currentLinkText: linkifier?.currentLink?.link?.text ?? null,
+      cursor: getComputedStyle(screen).cursor,
+      paneBottom: paneRect.bottom,
+      terminalBottom: terminalRect?.bottom ?? 0,
+      tooltipTop: tooltipRect.top,
+      tooltipHeight: tooltipRect.height,
+      reserveHeight
+    }
+  }, tabId)
+}
+
+async function captureProof(page: Page, testInfo: TestInfo, name: string): Promise<void> {
+  await page.screenshot({ path: testInfo.outputPath(name), animations: 'disabled' })
+}
+
+test.describe('Issue #12656 terminal link tooltip', () => {
+  test('clears hover state on window blur and reserves the tooltip strip', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage)
+
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    await waitForPtyShellEcho(orcaPage, ptyId, 15_000)
+
+    const url = `https://example.com/orca-issue-12656-${randomUUID().slice(0, 8)}`
+    await sendToTerminal(
+      orcaPage,
+      ptyId,
+      `printf 'issue-12656-output-%02d\\n' $(seq 1 64); printf '${url}\\n'\r`
+    )
+    await waitForTerminalOutput(orcaPage, url)
+
+    let probe: LinkProbe | null = null
+    await expect
+      .poll(
+        async () => {
+          probe = await locateUrl(orcaPage, url)
+          return probe
+        },
+        { timeout: 5_000, message: 'URL did not become visible in the terminal viewport' }
+      )
+      .not.toBeNull()
+    if (!probe) {
+      throw new Error('URL probe disappeared before hover')
+    }
+    await expect
+      .poll(async () => {
+        await moveToLink(orcaPage, probe)
+        return readTooltipState(orcaPage, probe.tabId)
+      })
+      .toMatchObject({ display: '', currentLinkText: url })
+
+    const hovered = await readTooltipState(orcaPage, probe.tabId)
+    expect(hovered.text).toContain(url)
+    expect(hovered.tooltipHeight).toBeGreaterThan(0)
+    expect(hovered.tooltipTop).toBeGreaterThanOrEqual(hovered.terminalBottom - 1)
+    expect(hovered.paneBottom - hovered.terminalBottom).toBeGreaterThanOrEqual(
+      hovered.reserveHeight - 1
+    )
+    await captureProof(orcaPage, testInfo, 'issue-12656-fixed-hover.png')
+
+    await orcaPage.evaluate(() => window.dispatchEvent(new Event('blur')))
+    await expect
+      .poll(() => readTooltipState(orcaPage, probe.tabId))
+      .toMatchObject({ display: 'none', currentLinkText: null, cursor: 'text' })
+    await captureProof(orcaPage, testInfo, 'issue-12656-fixed-after-blur.png')
+
+    // Keep the output assertion adjacent to the visual state checks so the
+    // reserved strip cannot hide the final terminal line without detection.
+    await expect.poll(() => getTerminalContent(orcaPage)).toContain(url)
+  })
+})


### PR DESCRIPTION
## Summary

- Clear xterm's stranded active link, pointer cursor, and shared tooltip on terminal mouseleave and renderer-window blur.
- Reserve the fixed tooltip strip in terminal FitAddon geometry so the last output row is never covered.
- Add unit and E2E regression coverage for issue #12656.

Fixes #12656

## ELI5

Imagine the terminal is a whiteboard, and when you point at a link a little sticky note pops up in the bottom-left corner saying "click to open."

Two things were wrong with that sticky note:

1. **It never came off.** The note stayed stuck to the board even after you moved your finger away, and your mouse pointer kept its "hand" shape forever. That's because xterm (the library that draws the terminal) only takes the note down when it notices you moved off the link — and if you tabbed to another app instead, it never noticed, so the note was orphaned.
2. **It covered up writing.** The note was taped *on top* of the bottom line of the whiteboard, so whatever was written there was hidden underneath it.

This PR fixes both:

1. **Take the note down whenever the pointer leaves, including when the whole window loses focus.** We now also listen for the window blurring, and when that happens we ask xterm to run its own "you left the link" cleanup, then hide the note and reset the cursor ourselves as a backstop.
2. **Leave a permanent 25px shelf at the bottom for the note.** Instead of taping the note over the writing, we make the whiteboard 25px shorter so the note has its own empty strip to sit in.

**The tradeoff, stated plainly:** every terminal permanently gives up that 25px — roughly 1–2 rows depending on your font size — whether or not a link is hovered. That's what issue #12656 asked for ("reserve the last terminal row for the tooltip"), and it's a deliberate divergence from Ghostty, which overlays its tooltip instead. The reduced row count is what gets sent to the PTY, including on SSH/remote hosts.

### The bug this review caught

The first pass put the `--orca-terminal-link-tooltip-height` variable on `.pane-manager-root` — a CSS class **nothing in the app actually carries** (it appears only in this stylesheet and in test fakes; the real PaneManager root is `<div className="absolute inset-0 min-h-0 min-w-0">`). In CSS, a `var()` that points at a variable that doesn't exist and has no fallback doesn't just skip that one bit — it throws the *entire* declaration away. So `.xterm-container`'s `height` silently became `auto`.

That element is exactly the one FitAddon measures to decide how many rows fit, so the terminal would have been measuring its own content height and concluding "I'm already the right size" — a fixed point where terminals never resize to their pane again. Fixed by declaring the variable on `:root` (where `--orca-pane-title-height` already lives) and giving both `calc()`s an explicit fallback.

## Visual proof

Broken before: the tooltip remains over the last terminal row after the window blurs.

![Broken before](https://github.com/user-attachments/assets/96507c11-4ab7-489f-8e53-2e2a1242a8c6)

Fixed hover: the tooltip is visible in its reserved strip below the terminal output.

![Fixed hover](https://github.com/user-attachments/assets/3bb88263-6ea9-4d25-8a6d-68bc991296cf)

Fixed after window blur: the tooltip and link-hover cursor are cleared.

![Fixed after blur](https://github.com/user-attachments/assets/9290914c-e49e-4fee-9ffc-5c531e69f783)

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/pane-manager/` — 632 passed
- `pnpm run typecheck:web`
- Targeted oxlint
- `pnpm exec playwright test tests/e2e/issue-12656-terminal-link-tooltip.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1` (E2E-mode build)
- Headless Chromium geometry probe against the real `terminal.css`: untitled pane `400 − 4 − 25 = 371px`, titled pane `400 − 24 − 25 = 351px`, tooltip occupying exactly the 25px strip with no overlap.

## Known follow-ups (not blocking, filed as notes)

- `restoreScrollbackBuffers` (`layout-serialization.ts`) is the only replay path that writes a serialized buffer without first resizing the destination to the source grid — sibling paths do this and cite #7279. A permanently shorter destination makes the last restored line overwritable on the first boot after upgrade.
- `canMeasurePaneForFit` requires ≥4 proposed rows, and `terminal.updateViewport` validates `rows` at min 8 for remote hosts; the 25px reserve pushes a slightly wider band of very short panes into those silent-skip ranges.