### PR TITLE
fix(runtime): degrade focused terminal create on a windowless host (STA-2585)

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -13948,6 +13948,212 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  // Why (#10333): `orca serve` publishes a ready graph under
+  // HEADLESS_RUNTIME_WINDOW_ID with no BrowserWindow behind it, so every
+  // focus-requested create used to fall through to getAuthoritativeWindow().
+  const wireHeadlessServeRuntime = (): OrcaRuntimeService => {
+    const runtime = new OrcaRuntimeService(store)
+    electronMocks.BrowserWindow.fromId.mockReturnValue(null as never)
+    runtime.syncWindowGraph(HEADLESS_RUNTIME_WINDOW_ID, { tabs: [], leaves: [] })
+    return runtime
+  }
+
+  it('spawns focus-requested CLI terminal creates in background on headless serve', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-focus-headless' })
+    const runtime = wireHeadlessServeRuntime()
+    const revealTerminalSession = vi.fn()
+    runtime.setNotifier({
+      worktreesChanged: vi.fn(),
+      reposChanged: vi.fn(),
+      activateWorktree: vi.fn(),
+      createTerminal: vi.fn(),
+      revealTerminalSession,
+      splitTerminal: vi.fn(),
+      renameTerminal: vi.fn(),
+      focusTerminal: vi.fn(),
+      closeTerminal: vi.fn(),
+      sleepWorktree: vi.fn(),
+      resumeSleepingAgents: vi.fn(),
+      terminalFitOverrideChanged: vi.fn(),
+      terminalDriverChanged: vi.fn()
+    } as never)
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    // `orca terminal create --worktree <wt> --command "echo test" --focus`
+    await expect(
+      runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        command: 'echo test',
+        focus: true
+      })
+    ).resolves.toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      handle: expect.stringMatching(/^term_/)
+    })
+    expect(spawn).toHaveBeenCalledWith(
+      expect.objectContaining({
+        command: 'echo test',
+        cwd: TEST_WORKTREE_PATH,
+        worktreeId: TEST_WORKTREE_ID,
+        persistHostSessionBinding: true
+      })
+    )
+    // Why: degrading the create must not silently drop the focus request — the
+    // host still asks whatever surface exists to activate the new pane.
+    expect(revealTerminalSession).toHaveBeenCalledWith(
+      TEST_WORKTREE_ID,
+      expect.objectContaining({ activate: true, presentation: 'focused' })
+    )
+  })
+
+  it('spawns presentation:focused terminal creates in background on headless serve', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-presentation-headless' })
+    const runtime = wireHeadlessServeRuntime()
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    // Paired desktop `+` button: clients send presentation:'focused', not focus.
+    await expect(
+      runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+        command: 'codex',
+        presentation: 'focused'
+      })
+    ).resolves.toMatchObject({
+      worktreeId: TEST_WORKTREE_ID,
+      surface: 'background',
+      handle: expect.stringMatching(/^term_/)
+    })
+    expect(spawn).toHaveBeenCalled()
+  })
+
+  it('spawns focused agent-session creates in background on headless serve', async () => {
+    // Why: RPC only downgrades `focused` for clients that report a clientKind
+    // (#10193), so loopback/CLI callers still reach the runtime asking for focus.
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-agent-headless' })
+    const runtime = wireHeadlessServeRuntime()
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await expect(
+      runtime.createAgentSession({
+        clientOperationId: `${Date.now()}-0123456789abcdef0123456789abcdef`,
+        worktree: `path:${TEST_WORKTREE_PATH}`,
+        agent: 'codex',
+        prompt: 'hello',
+        presentation: 'focused'
+      })
+    ).resolves.toMatchObject({
+      disposition: 'created',
+      terminal: expect.objectContaining({
+        worktreeId: TEST_WORKTREE_ID,
+        handle: expect.stringMatching(/^term_/)
+      })
+    })
+    expect(spawn).toHaveBeenCalled()
+  })
+
+  it('activates the paired mobile session tab for a degraded focused headless create', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-focus-publish' })
+    const runtime = wireHeadlessServeRuntime()
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    const created = await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      command: 'echo test',
+      focus: true
+    })
+
+    // Why: with no renderer notifier on a serve host, the session-tab publish is
+    // the only channel a paired client learns about the terminal on — a degraded
+    // focused create must still land there selected, or focus is silently lost.
+    const tabs = await runtime.listMobileSessionTabs(`id:${TEST_WORKTREE_ID}`)
+    const published = tabs.tabs.find(
+      (tab) => tab.type === 'terminal' && tab.parentTabId === created.tabId
+    )
+    expect(published).toBeDefined()
+    expect(published?.isActive).toBe(true)
+    expect(tabs.activeTabId).toBe(published?.id)
+  })
+
+  it('keeps focus-requested terminal creates on the renderer when a window exists', async () => {
+    const spawn = vi.fn().mockResolvedValue({ id: 'pty-should-not-spawn' })
+    const webContents = { send: vi.fn() }
+    const send = vi.fn((_channel: string, payload: { requestId: string }) => {
+      runtime.syncWindowGraph(1, {
+        tabs: [
+          {
+            tabId: 'tab-focused',
+            worktreeId: TEST_WORKTREE_ID,
+            title: 'Focused Terminal',
+            activeLeafId: 'pane:1',
+            layout: null
+          }
+        ],
+        leaves: [
+          {
+            tabId: 'tab-focused',
+            worktreeId: TEST_WORKTREE_ID,
+            leafId: 'pane:1',
+            paneRuntimeId: 1,
+            ptyId: 'pty-focused',
+            paneTitle: null
+          }
+        ]
+      })
+      ipcMain.emit(
+        'terminal:tabCreateReply',
+        { sender: webContents },
+        { requestId: payload.requestId, tabId: 'tab-focused', title: 'Focused Terminal' }
+      )
+    })
+    webContents.send = send
+    const runtime = new OrcaRuntimeService(store)
+    runtime.attachWindow(1)
+    runtime.syncWindowGraph(1, { tabs: [], leaves: [] })
+    electronMocks.BrowserWindow.fromId.mockReturnValue({
+      isDestroyed: () => false,
+      webContents
+    })
+    runtime.setPtyController({
+      spawn,
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess: async () => null
+    })
+
+    await expect(
+      runtime.createTerminal(`id:${TEST_WORKTREE_ID}`, {
+        command: 'echo test',
+        focus: true
+      })
+    ).resolves.toMatchObject({
+      tabId: 'tab-focused',
+      worktreeId: TEST_WORKTREE_ID,
+      surface: 'visible'
+    })
+    expect(send).toHaveBeenCalledWith(
+      'terminal:requestTabCreate',
+      expect.objectContaining({ activate: true, presentation: 'focused' })
+    )
+    expect(spawn).not.toHaveBeenCalled()
+  })
+
   it('accepts renderer-backed terminal create replies only from the target renderer', async () => {
     const webContents = { send: vi.fn() }
     const send = vi.fn((_channel: string, payload: { requestId: string }) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -25058,9 +25058,12 @@ export class OrcaRuntimeService {
       (Boolean(opts.agentSessionClaim) ||
         (!requiresRendererFocus && opts.rendererBacked !== true) ||
         // Why: `orca serve` exposes the local runtime without a renderer
-        // window. Renderer-backed Codex terminals are preferred for the app,
-        // but headless CLI users still need a usable terminal handle.
-        (opts.rendererBacked === true && rendererWindow === null))
+        // window. Renderer-backed and focus-requested creates are preferred on
+        // the renderer, but with no window a background spawn is the only
+        // usable path — otherwise getAuthoritativeWindow() below throws and the
+        // caller gets no terminal at all (#10333). Focus is not lost: the
+        // spawned pane is still published and revealed with `activate`.
+        availableAuthoritativeWindow === null)
 
     if (shouldCreateInBackground) {
       if (!this.ptyController?.spawn) {

--- a/tests/e2e/headless-serve-focused-terminal-create.spec.ts
+++ b/tests/e2e/headless-serve-focused-terminal-create.spec.ts
@@ -1,0 +1,57 @@
+import { expect, test } from './helpers/orca-app'
+import { launchHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+
+// Why (#10333): a windowless `orca serve` host answered every focus-requested
+// create with "No renderer window available", so `terminal create --focus` had
+// no workaround. Drive the real RPC a remote CLI sends, against a real serve
+// process, so the degrade is proven on the topology that broke.
+test('creates a focus-requested terminal against a headless serve host', async ({
+  testRepoPath
+}) => {
+  test.setTimeout(180_000)
+  const host = await launchHeadlessPairedRuntimeHost()
+  try {
+    const added = await host.client.call<{ repo: { id: string } }>('repo.add', {
+      path: testRepoPath,
+      kind: 'git'
+    })
+    let worktreeId = ''
+    await expect
+      .poll(
+        async () => {
+          const listed = await host.client.call<{ worktrees: { id: string }[] }>('worktree.list', {
+            repo: `id:${added.result.repo.id}`
+          })
+          worktreeId = listed.result.worktrees[0]?.id ?? ''
+          return worktreeId
+        },
+        { timeout: 30_000 }
+      )
+      .not.toBe('')
+
+    // Exactly what `orca --environment <remote> terminal create --worktree <wt>
+    // --command "echo test" --focus --json` puts on the wire.
+    const created = await host.client.call<{
+      terminal: { handle: string; worktreeId: string; ptyId?: string }
+    }>('terminal.create', {
+      worktree: `id:${worktreeId}`,
+      command: 'echo orca-10333-focus',
+      focus: true,
+      presentation: 'focused'
+    })
+
+    expect(created.result.terminal.handle).toMatch(/^term_/)
+    expect(created.result.terminal.worktreeId).toBe(worktreeId)
+
+    // Why: a handle the host cannot resolve back to a live PTY would be a
+    // hollow pass — confirm the degraded create really produced a terminal.
+    const listedTerminals = await host.client.call<{
+      terminals: { handle: string }[]
+    }>('terminal.list', { worktree: `id:${worktreeId}` })
+    expect(listedTerminals.result.terminals.map((terminal) => terminal.handle)).toContain(
+      created.result.terminal.handle
+    )
+  } finally {
+    await host.dispose()
+  }
+})


### PR DESCRIPTION
Fixes GitHub #10333 / Linear STA-2585 (STA-2498 is its duplicate — one fix closes both).

## Symptom

A focus-requested `terminal create` against a headless `orca serve` host throws **"No renderer window available"**. P0, reported with no workaround.

## Reproduction — red on `origin/main` (`ae1ed5e886`)

Against a **real headless `orca serve` host**, driving the exact RPC the remote CLI puts on the wire:

```
npx playwright test tests/e2e/headless-serve-focused-terminal-create.spec.ts \
  --config tests/playwright.config.ts --project=electron-headless --workers=1
```
```
✘ creates a focus-requested terminal against a headless serve host
  Error: No renderer window available
     at ../../src/cli/runtime/client.ts:130
```

In-process, same state (`orca serve` publishes a ready graph under `HEADLESS_RUNTIME_WINDOW_ID = 0` with no `BrowserWindow`, `src/main/index.ts:2862`):
```
❯ OrcaRuntimeService.getAuthoritativeWindow src/main/runtime/orca-runtime.ts:34743:13
❯ OrcaRuntimeService.createTerminal       src/main/runtime/orca-runtime.ts:25395:40
```

## Change — `orca-runtime.ts:25056`

Rather than bolt on a fourth clause, this collapses the window check, because `rendererWindow === null` was already `availableAuthoritativeWindow === null` in disguise (`rendererWindow` is itself gated on `rendererBacked`):

```ts
(opts.rendererBacked === true && rendererWindow === null)   // before
availableAuthoritativeWindow === null                       // after
```

That is provably the old clause **plus exactly the missing focus case** — the difference set is `no window && !rendererBacked`, where non-focus creates already went background via clause 2. So it removes a footgun at zero extra behavior change.

Focus is degraded in **placement, not dropped**: the background path already honors it, publishing with `activate: presentation === 'focused'` (`:25336`) and revealing with `activate`/`presentation` (`:25360`) — the in-tree precedent at `:25757`.

## The reported Mac UI `+` half no longer reproduces — scoped out with evidence

Worth stating, because closing #10333 on a fix for the UI half would be wrong. On current main the desktop client never asks the host for focus, at two independent layers:

- `runtime-agent-background-create.ts:52` and `remote-runtime-pty-transport.ts:1988` send `presentation: 'background'` / `focus: false` outright (#9687).
- `withExecutionHostAgentPresentation` (`rpc/methods/agent-session.ts:218`) downgrades `focused`→`background` for any client reporting a `clientKind` — every paired socket — from #10193, landed **after** the reporter's v1.4.152.

So the surviving P0 is the **CLI/RPC half**. The runtime-layer hole is still reachable by any caller with no `clientKind` (loopback CLI, orchestration internals), so it is closed at the runtime layer regardless.

## On the two existing community PRs — neither should merge as-is

Both diagnose the bug correctly. Verified individually:

- **#10370** — production change is logically equivalent to this one, but **its tests are vacuous**: they import only the extracted pure function and assert its own boolean truth table. Revert its `orca-runtime.ts` call site and keep the helper, and **all 7 tests still pass**. Nothing in it constructs a runtime, calls `createTerminal`, or observes the throw.
- **#10557** — the one-clause production change is correct, but its tests never wire the headless-serve state (no `syncWindowGraph`/`attachWindow`), so `graphStatus` stays `'unavailable'`. Replicating its test shape against unfixed main yields `Error: runtime_unavailable`, not `No renderer window available` — **red on main for the wrong reason**, never demonstrating the reported bug. It also has no headed-host regression test, which is the stated main risk.

## Mutation evidence

- Revert the clause → all 4 headless tests red, each `Caused by: Error: No renderer window available`; the E2E goes red with the same error over the wire. Restored by re-applying the edit.
- Replace the clause with `true` (unconditional degrade) → the headed test `keeps focus-requested terminal creates on the renderer when a window exists` goes red, **plus two pre-existing renderer-path tests**. The headed guard is real, not decorative.

`src/main/runtime` suite: 241 files, 3694 tests green. `pnpm typecheck` clean, `oxlint` clean.

## Risk

**Headed desktop: none.** The clause fires only when `getAvailableAuthoritativeWindow()` returns null; with a window the renderer IPC path is byte-identical, proven by the second mutation. Renderer *reload* is unaffected — the window still exists.

One deliberate behavior change beyond the bug: a headed host with **all windows closed** (macOS app alive) previously threw `runtime_unavailable` on a focused create and now spawns in background. That is correct rather than a regression — a non-focus create in that state already does exactly this, and `persistWindowlessPtyBindingsForDesktopAttach` (`:5369`) exists precisely because "a promoted serve can close and later reopen its window while new background PTYs keep arriving."

## Pre-existing, deliberately not touched

The degraded create returns a misleading warning ("could not make it discoverable") even though the terminal **is** published to the session tabs; and `terminal.create` with no `worktree` still throws raw on a headless host — unreachable from the remote CLI, which hard-requires `--worktree` (`src/cli/handlers/terminal.ts:130`).
