### PR TITLE
feat(agents): offer WSL agent detection when the Windows picker is empty

### DIFF
--- a/src/main/codex-accounts/wsl-codex-command.ts
+++ b/src/main/codex-accounts/wsl-codex-command.ts
@@ -73,7 +73,11 @@ export function buildWslCodexLoginArgs(distro: string, linuxHomePath: string): s
 }
 
 function buildCodexPathLookup(): string {
-  return buildPosixCommandPathLookupScript({ kind: 'literal', value: 'codex' })
+  // Why: skip the Windows-drive /mnt tail WSL appends to PATH — slow drvfs stats.
+  return buildPosixCommandPathLookupScript(
+    { kind: 'literal', value: 'codex' },
+    { skipWindowsMountDirs: true }
+  )
 }
 
 function buildWslCodexShellArgs(distro: string, command: string): string[] {

--- a/src/main/ipc/preflight-command-exec.test.ts
+++ b/src/main/ipc/preflight-command-exec.test.ts
@@ -35,7 +35,10 @@ describe('isCommandOnPath', () => {
     expect(runPreflightCommandInWslMock).toHaveBeenCalledOnce()
     const [, command] = runPreflightCommandInWslMock.mock.calls[0] as [{ distro: string }, string]
     expect(command).toContain(
-      buildPosixCommandPathLookupScript({ kind: 'literal', value: 'codex' })
+      buildPosixCommandPathLookupScript(
+        { kind: 'literal', value: 'codex' },
+        { skipWindowsMountDirs: true }
+      )
     )
     expect(command).toContain(
       ['if [ -n "$resolved" ]; then', `printf '${sentinel}%s\\n' "$resolved"`, 'fi'].join('\n')

--- a/src/main/ipc/preflight-command-exec.ts
+++ b/src/main/ipc/preflight-command-exec.ts
@@ -94,7 +94,11 @@ export async function isCommandOnPath(
     const { stdout } = await execCommandInWsl(
       wslTarget,
       [
-        buildPosixCommandPathLookupScript({ kind: 'literal', value: command }),
+        // Why: skip the Windows-drive /mnt tail — slow drvfs stats can stall the probe.
+        buildPosixCommandPathLookupScript(
+          { kind: 'literal', value: command },
+          { skipWindowsMountDirs: true }
+        ),
         'if [ -n "$resolved" ]; then',
         `printf '${WSL_COMMAND_PATH_SENTINEL}%s\\n' "$resolved"`,
         'fi'

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -70,7 +70,7 @@ describe('detectWslCommandsOnPath', () => {
       stderr: ''
     })
 
-    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
+    const { found } = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
     expect(found).toEqual(new Set(['claude', 'codex']))
   })
@@ -81,23 +81,33 @@ describe('detectWslCommandsOnPath', () => {
       stderr: ''
     })
 
-    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
+    const { found } = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
     expect(found).toEqual(new Set())
   })
 
-  it('returns an empty set when the probe fails (e.g. shell parse error)', async () => {
+  it('marks a failed probe as failed instead of returning a plain empty set', async () => {
     execFileAsyncMock.mockRejectedValue(new Error("zsh:1: parse error near `done'"))
 
-    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+    const result = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
-    expect(found).toEqual(new Set())
+    // Why: a timed-out or errored probe must not be indistinguishable from
+    // "no agents installed" — callers surface a retry affordance on failure.
+    expect(result).toEqual({ found: new Set(), failed: true })
+  })
+
+  it('returns a clean empty result (not failed) when nothing is found', async () => {
+    execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
+
+    const result = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
+
+    expect(result).toEqual({ found: new Set(), failed: false })
   })
 
   it('skips the probe entirely when no commands are requested', async () => {
-    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, [])
+    const result = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, [])
 
-    expect(found).toEqual(new Set())
+    expect(result).toEqual({ found: new Set(), failed: false })
     expect(execFileAsyncMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -17,7 +17,6 @@ vi.mock('child_process', () => {
 
 import { detectWslCommandsOnPath } from './preflight-wsl-agent-detection'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
-import { escapeWslShCommandForWindows } from '../../shared/wsl-login-shell-command'
 
 function lastShCommandPayload(): string {
   const call = execFileAsyncMock.mock.calls.at(-1)
@@ -59,10 +58,9 @@ describe('detectWslCommandsOnPath', () => {
       { kind: 'shell-variable', name: 'cmd' },
       { skipWindowsMountDirs: true }
     )
-    expect(payload).toContain(escapeWslShCommandForWindows(lookupScript))
+    expect(payload).toContain(lookupScript)
     // Why: WSL appends the Windows PATH as a slow drvfs /mnt tail; the probe
     // must skip it or the lookup can time out (issue #9725 root cause).
-    expect(payload).toContain('/mnt/[A-Za-z]|/mnt/[A-Za-z]/*)')
     expect(payload).not.toContain('type -P')
   })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -17,13 +17,14 @@ vi.mock('child_process', () => {
 
 import { detectWslCommandsOnPath } from './preflight-wsl-agent-detection'
 import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-path-lookup'
+import { escapeWslShCommandForWindows } from '../../shared/wsl-login-shell-command'
 
 function lastShCommandPayload(): string {
   const call = execFileAsyncMock.mock.calls.at(-1)
   expect(call).toBeDefined()
   const [file, args] = call as [string, string[]]
   expect(file).toBe('wsl.exe')
-  // args: [...distroArgs, '--exec', 'sh', '-c', <payload>]
+  // args: [...distroArgs, '--', 'sh', '-c', <payload>]
   return args.at(-1) as string
 }
 
@@ -48,17 +49,20 @@ describe('detectWslCommandsOnPath', () => {
     expect(payload).toContain('fi\ndone')
   })
 
-  it('uses the shared alias- and function-neutral PATH lookup', async () => {
+  it('uses the shared alias- and function-neutral PATH lookup, skipping /mnt', async () => {
     execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
 
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
 
     const payload = lastShCommandPayload()
-    const lookupScript = buildPosixCommandPathLookupScript({
-      kind: 'shell-variable',
-      name: 'cmd'
-    })
-    expect(payload).toContain(lookupScript)
+    const lookupScript = buildPosixCommandPathLookupScript(
+      { kind: 'shell-variable', name: 'cmd' },
+      { skipWindowsMountDirs: true }
+    )
+    expect(payload).toContain(escapeWslShCommandForWindows(lookupScript))
+    // Why: WSL appends the Windows PATH as a slow drvfs /mnt tail; the probe
+    // must skip it or the lookup can time out (issue #9725 root cause).
+    expect(payload).toContain('/mnt|/mnt/*)')
     expect(payload).not.toContain('type -P')
   })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -62,7 +62,7 @@ describe('detectWslCommandsOnPath', () => {
     expect(payload).toContain(escapeWslShCommandForWindows(lookupScript))
     // Why: WSL appends the Windows PATH as a slow drvfs /mnt tail; the probe
     // must skip it or the lookup can time out (issue #9725 root cause).
-    expect(payload).toContain('/mnt|/mnt/*)')
+    expect(payload).toContain('/mnt/[A-Za-z]|/mnt/[A-Za-z]/*)')
     expect(payload).not.toContain('type -P')
   })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -38,10 +38,15 @@ export async function detectWslCommandsOnPath(
   }
 
   const commandList = uniqueCommands.map(shellQuote).join(' ')
-  const lookupScript = buildPosixCommandPathLookupScript({
-    kind: 'shell-variable',
-    name: 'cmd'
-  })
+  const lookupScript = buildPosixCommandPathLookupScript(
+    {
+      kind: 'shell-variable',
+      name: 'cmd'
+    },
+    // Why: skip the Windows-drive /mnt tail WSL appends to PATH — drvfs stats
+    // are slow enough to time the probe out (issue #9725 root cause).
+    { skipWindowsMountDirs: true }
+  )
   // Newlines keep the loop valid in zsh and every POSIX shell used here.
   const script = [
     `for cmd in ${commandList}; do`,

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -5,20 +5,36 @@ import { buildPosixCommandPathLookupScript } from '../../shared/posix-command-pa
 import { buildWslExecArgs, buildWslLoginShellCommand } from '../../shared/wsl-login-shell-command'
 
 const execFileAsync = promisify(execFile)
-const WSL_AGENT_DETECTION_TIMEOUT_MS = 10000
+// Why: WSL2 cold boots can exceed 10s (VM start + distro init). A timed-out
+// probe previously looked identical to "no agents installed"; give cold boots
+// headroom so a slow first probe does not silently empty the agent picker.
+const WSL_AGENT_DETECTION_TIMEOUT_MS = 30000
 const WSL_AGENT_DETECTION_PREFIX = '__ORCA_AGENT_PATH__'
 
 export type WslPreflightTarget = {
   distro?: string
 }
 
+/**
+ * Result of a WSL agent-path probe.
+ *
+ * `failed` distinguishes a probe that errored or timed out (wsl.exe cold start,
+ * distro stopped, shell parse error) from a probe that ran and found nothing.
+ * Without it, a failed probe is indistinguishable from "no agents installed",
+ * which surfaces as an empty agent picker with no retry affordance.
+ */
+export type WslAgentDetectionResult = {
+  found: ReadonlySet<string>
+  failed: boolean
+}
+
 export async function detectWslCommandsOnPath(
   wslTarget: WslPreflightTarget,
   commands: readonly string[]
-): Promise<Set<string>> {
+): Promise<WslAgentDetectionResult> {
   const uniqueCommands = [...new Set(commands.filter(Boolean))]
   if (uniqueCommands.length === 0) {
-    return new Set()
+    return { found: new Set(), failed: false }
   }
 
   const commandList = uniqueCommands.map(shellQuote).join(' ')
@@ -41,9 +57,9 @@ export async function detectWslCommandsOnPath(
     // cache an empty result. One probe through the distro user's login shell
     // matches zsh/bash PATH customizations from their normal terminals.
     const { stdout } = await execWslAgentDetectionCommand(wslTarget, script)
-    return parseWslDetectedCommands(stdout)
+    return { found: parseWslDetectedCommands(stdout), failed: false }
   } catch {
-    return new Set()
+    return { found: new Set(), failed: true }
   }
 }
 

--- a/src/main/ipc/preflight.ts
+++ b/src/main/ipc/preflight.ts
@@ -91,7 +91,7 @@ async function detectCommandRuntime(
 export async function detectInstalledAgents(context?: PreflightRuntimeContext): Promise<string[]> {
   const wslTarget = getPreflightWslTarget(context)
   if (wslTarget) {
-    const foundCommands = await detectWslCommandsOnPath(
+    const { found: foundCommands } = await detectWslCommandsOnPath(
       wslTarget,
       getTuiAgentDetectionProbeCommands(KNOWN_TUI_AGENT_DETECTION_COMMANDS, 'wsl')
     )

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -974,10 +974,14 @@ describe('NewWorkspaceComposerCard WSL agent detection hint', () => {
     current = null
   })
 
+  /**
+   * Finds the WSL agent hint row by its shared "No agents found" prefix — both
+   * the enable and retry variants start with it.
+   */
   function findWslHint(container: HTMLElement): HTMLElement | null {
     return (
       [...container.querySelectorAll<HTMLElement>('div')].find((node) =>
-        node.textContent?.includes('No agents found on Windows')
+        node.textContent?.includes('No agents found')
       ) ?? null
     )
   }
@@ -1022,10 +1026,28 @@ describe('NewWorkspaceComposerCard WSL agent detection hint', () => {
     expect(findWslHint(current.container)).toBeNull()
   })
 
-  it('hides the hint when the agent runtime is already WSL', () => {
+  it('shows a retry hint when the runtime is already WSL and detection is empty', () => {
     storeSettings.localWindowsRuntimeDefault = { kind: 'wsl', distro: 'Ubuntu' }
     current = renderCard({ detectedAgentIds: new Set() })
-    expect(findWslHint(current.container)).toBeNull()
+    const hint = findWslHint(current.container)
+    expect(hint).toBeTruthy()
+    const action = [...(hint?.querySelectorAll('button') ?? [])].find((button) =>
+      button.textContent?.includes('Retry detection')
+    )
+    expect(action).toBeTruthy()
+  })
+
+  it('clicking the retry hint only refreshes detection', async () => {
+    storeSettings.localWindowsRuntimeDefault = { kind: 'wsl', distro: 'Ubuntu' }
+    current = renderCard({ detectedAgentIds: new Set() })
+    const action = [...current.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Retry detection')
+    )
+    expect(action).toBeTruthy()
+    act(() => action?.click())
+    expect(storeMocks.updateSettings).not.toHaveBeenCalled()
+    await act(async () => {})
+    expect(storeMocks.refreshDetectedAgents).toHaveBeenCalledTimes(1)
   })
 
   it('hides the hint on non-Windows platforms', () => {

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -12,7 +12,15 @@ const storeMocks = vi.hoisted(() => ({
   openModal: vi.fn(),
   openSettingsPage: vi.fn(),
   openSettingsTarget: vi.fn(),
-  setRuntimeEnvironmentStatus: vi.fn()
+  setRuntimeEnvironmentStatus: vi.fn(),
+  updateSettings: vi.fn(),
+  refreshDetectedAgents: vi.fn()
+}))
+
+const storeSettings = vi.hoisted(() => ({
+  defaultTuiAgent: null as string | null,
+  disabledTuiAgents: [] as unknown[],
+  localWindowsRuntimeDefault: undefined as unknown
 }))
 
 const apiMocks = vi.hoisted(() => ({
@@ -29,9 +37,10 @@ vi.mock('@/store', () => ({
         openSettingsPage: storeMocks.openSettingsPage,
         openSettingsTarget: storeMocks.openSettingsTarget,
         setRuntimeEnvironmentStatus: storeMocks.setRuntimeEnvironmentStatus,
+        refreshDetectedAgents: storeMocks.refreshDetectedAgents,
         activeModal: 'none',
-        settings: { defaultTuiAgent: null, disabledTuiAgents: [] },
-        updateSettings: vi.fn(),
+        settings: storeSettings,
+        updateSettings: storeMocks.updateSettings,
         projects: [],
         repos: []
       }),
@@ -45,6 +54,27 @@ vi.mock('@/store', () => ({
 
 vi.mock('@/components/contextual-tours/use-contextual-tour', () => ({
   useContextualTour: vi.fn()
+}))
+
+const platformMock = vi.hoisted(() => vi.fn(() => 'linux'))
+vi.mock('@/lib/renderer-app-platform', () => ({
+  getRendererAppPlatform: platformMock
+}))
+
+const wslCapabilitiesMock = vi.hoisted(() =>
+  vi.fn(
+    (capabilities: unknown) =>
+      capabilities ?? {
+        wslAvailable: false,
+        wslDistros: [],
+        pwshAvailable: false,
+        gitBashAvailable: false,
+        hostPlatform: null
+      }
+  )
+)
+vi.mock('@/lib/windows-terminal-capabilities', () => ({
+  useWindowsTerminalCapabilities: wslCapabilitiesMock
 }))
 
 vi.mock('@/components/ui/tooltip', () => ({
@@ -918,5 +948,89 @@ describe('NewWorkspaceComposerCard note sizing', () => {
     expect(className).toContain('overflow-y-auto')
     expect(className).toContain('scrollbar-sleek')
     expect(className).not.toContain('overflow-hidden')
+  })
+})
+
+describe('NewWorkspaceComposerCard WSL agent detection hint', () => {
+  const WSL_CAPABILITIES = {
+    wslAvailable: true,
+    wslDistros: ['Ubuntu', 'docker-desktop'],
+    pwshAvailable: false,
+    gitBashAvailable: false,
+    hostPlatform: 'win32'
+  }
+
+  beforeEach(() => {
+    platformMock.mockReturnValue('win32')
+    wslCapabilitiesMock.mockReturnValue(WSL_CAPABILITIES)
+    storeMocks.updateSettings.mockClear()
+    storeMocks.refreshDetectedAgents.mockClear()
+    storeSettings.localWindowsRuntimeDefault = undefined
+  })
+
+  afterEach(() => {
+    act(() => current?.root.unmount())
+    current?.container.remove()
+    current = null
+  })
+
+  function findWslHint(container: HTMLElement): HTMLElement | null {
+    return (
+      [...container.querySelectorAll<HTMLElement>('div')].find((node) =>
+        node.textContent?.includes('No agents found on Windows')
+      ) ?? null
+    )
+  }
+
+  it('offers WSL detection when no agents are detected on Windows and WSL is available', () => {
+    const { container } = renderCard({ detectedAgentIds: new Set() })
+    const hint = findWslHint(container)
+    expect(hint).toBeTruthy()
+    const action = [...(hint?.querySelectorAll('button') ?? [])].find((button) =>
+      button.textContent?.includes('Detect in WSL (Ubuntu)')
+    )
+    expect(action).toBeTruthy()
+  })
+
+  it('clicking the hint enables the WSL agent runtime and refreshes detection', async () => {
+    const { container } = renderCard({ detectedAgentIds: new Set() })
+    const action = [...container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Detect in WSL (Ubuntu)')
+    )
+    expect(action).toBeTruthy()
+    act(() => action?.click())
+    expect(storeMocks.updateSettings).toHaveBeenCalledWith({
+      localWindowsRuntimeDefault: { kind: 'wsl', distro: 'Ubuntu' }
+    })
+    await act(async () => {})
+    expect(storeMocks.refreshDetectedAgents).toHaveBeenCalledTimes(1)
+  })
+
+  it('hides the hint when agents are already detected', () => {
+    const { container } = renderCard({ detectedAgentIds: new Set(['claude']) })
+    expect(findWslHint(container)).toBeNull()
+  })
+
+  it('hides the hint while detection is still in flight', () => {
+    const { container } = renderCard({ detectedAgentIds: null })
+    expect(findWslHint(container)).toBeNull()
+  })
+
+  it('hides the hint when WSL is unavailable', () => {
+    wslCapabilitiesMock.mockReturnValue({ ...WSL_CAPABILITIES, wslAvailable: false })
+    const { container } = renderCard({ detectedAgentIds: new Set() })
+    expect(findWslHint(container)).toBeNull()
+  })
+
+  it('hides the hint when the agent runtime is already WSL', () => {
+    storeSettings.localWindowsRuntimeDefault = { kind: 'wsl', distro: 'Ubuntu' }
+    const { container } = renderCard({ detectedAgentIds: new Set() })
+    expect(findWslHint(container)).toBeNull()
+  })
+
+  it('hides the hint on non-Windows platforms', () => {
+    platformMock.mockReturnValue('linux')
+    const { container } = renderCard({ detectedAgentIds: new Set() })
+    expect(findWslHint(container)).toBeNull()
   })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -983,8 +983,8 @@ describe('NewWorkspaceComposerCard WSL agent detection hint', () => {
   }
 
   it('offers WSL detection when no agents are detected on Windows and WSL is available', () => {
-    const { container } = renderCard({ detectedAgentIds: new Set() })
-    const hint = findWslHint(container)
+    current = renderCard({ detectedAgentIds: new Set() })
+    const hint = findWslHint(current.container)
     expect(hint).toBeTruthy()
     const action = [...(hint?.querySelectorAll('button') ?? [])].find((button) =>
       button.textContent?.includes('Detect in WSL (Ubuntu)')
@@ -993,8 +993,8 @@ describe('NewWorkspaceComposerCard WSL agent detection hint', () => {
   })
 
   it('clicking the hint enables the WSL agent runtime and refreshes detection', async () => {
-    const { container } = renderCard({ detectedAgentIds: new Set() })
-    const action = [...container.querySelectorAll('button')].find((button) =>
+    current = renderCard({ detectedAgentIds: new Set() })
+    const action = [...current.container.querySelectorAll('button')].find((button) =>
       button.textContent?.includes('Detect in WSL (Ubuntu)')
     )
     expect(action).toBeTruthy()
@@ -1007,30 +1007,30 @@ describe('NewWorkspaceComposerCard WSL agent detection hint', () => {
   })
 
   it('hides the hint when agents are already detected', () => {
-    const { container } = renderCard({ detectedAgentIds: new Set(['claude']) })
-    expect(findWslHint(container)).toBeNull()
+    current = renderCard({ detectedAgentIds: new Set(['claude']) })
+    expect(findWslHint(current.container)).toBeNull()
   })
 
   it('hides the hint while detection is still in flight', () => {
-    const { container } = renderCard({ detectedAgentIds: null })
-    expect(findWslHint(container)).toBeNull()
+    current = renderCard({ detectedAgentIds: null })
+    expect(findWslHint(current.container)).toBeNull()
   })
 
   it('hides the hint when WSL is unavailable', () => {
     wslCapabilitiesMock.mockReturnValue({ ...WSL_CAPABILITIES, wslAvailable: false })
-    const { container } = renderCard({ detectedAgentIds: new Set() })
-    expect(findWslHint(container)).toBeNull()
+    current = renderCard({ detectedAgentIds: new Set() })
+    expect(findWslHint(current.container)).toBeNull()
   })
 
   it('hides the hint when the agent runtime is already WSL', () => {
     storeSettings.localWindowsRuntimeDefault = { kind: 'wsl', distro: 'Ubuntu' }
-    const { container } = renderCard({ detectedAgentIds: new Set() })
-    expect(findWslHint(container)).toBeNull()
+    current = renderCard({ detectedAgentIds: new Set() })
+    expect(findWslHint(current.container)).toBeNull()
   })
 
   it('hides the hint on non-Windows platforms', () => {
     platformMock.mockReturnValue('linux')
-    const { container } = renderCard({ detectedAgentIds: new Set() })
-    expect(findWslHint(container)).toBeNull()
+    current = renderCard({ detectedAgentIds: new Set() })
+    expect(findWslHint(current.container)).toBeNull()
   })
 })

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -19,6 +19,9 @@ import { SettingsSwitch } from '@/components/settings/SettingsFormControls'
 import type RepoCombobox from '@/components/repo/RepoCombobox'
 import AgentCombobox from '@/components/agent/AgentCombobox'
 import { getAgentCatalog } from '@/lib/agent-catalog'
+import { useWindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
+import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
+import { normalizeGlobalWindowsRuntimeDefault } from '../../../shared/project-execution-runtime'
 import {
   DEFAULT_DISABLED_TUI_AGENTS,
   filterEnabledTuiAgents
@@ -388,6 +391,8 @@ export default function NewWorkspaceComposerCard({
     (s) => s.settings?.disabledTuiAgents ?? DEFAULT_DISABLED_TUI_AGENTS
   )
   const updateSettings = useAppStore((s) => s.updateSettings)
+  const refreshDetectedAgents = useAppStore((s) => s.refreshDetectedAgents)
+  const localWindowsRuntimeDefault = useAppStore((s) => s.settings?.localWindowsRuntimeDefault)
   const nameInputFocusFrameRef = React.useRef<number | null>(null)
   const branchNameInputId = React.useId()
   const submitShortcutModifierLabel = getScreenSubmitModifierLabel()
@@ -441,6 +446,36 @@ export default function NewWorkspaceComposerCard({
     },
     [updateSettings]
   )
+
+  // Why: a Windows host with no detected agents usually has its CLIs installed
+  // in WSL. Offer the existing WSL agent runtime instead of an empty picker.
+  const appPlatform = getRendererAppPlatform()
+  const wslCapabilities = useWindowsTerminalCapabilities(appPlatform === 'win32')
+  const windowsRuntimeDefault = normalizeGlobalWindowsRuntimeDefault(localWindowsRuntimeDefault)
+  const wslDetectionHint = React.useMemo(() => {
+    if (appPlatform !== 'win32') {
+      return null
+    }
+    if (windowsRuntimeDefault.kind === 'wsl') {
+      return null
+    }
+    if (detectedAgentIds === null || detectedAgentIds.size > 0) {
+      return null
+    }
+    if (!wslCapabilities.wslAvailable) {
+      return null
+    }
+    return wslCapabilities.wslDistros.find((distro) => distro.trim().length > 0) ?? null
+  }, [appPlatform, windowsRuntimeDefault, detectedAgentIds, wslCapabilities])
+
+  const handleDetectWslAgents = React.useCallback((): void => {
+    if (!wslDetectionHint) {
+      return
+    }
+    void Promise.resolve(
+      updateSettings({ localWindowsRuntimeDefault: { kind: 'wsl', distro: wslDetectionHint } })
+    ).then(() => refreshDetectedAgents())
+  }, [updateSettings, refreshDetectedAgents, wslDetectionHint])
 
   const cancelNameInputFocusFrame = React.useCallback((): void => {
     if (nameInputFocusFrameRef.current === null) {
@@ -936,6 +971,29 @@ export default function NewWorkspaceComposerCard({
             triggerClassName="h-9 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
             onTriggerEnter={createDisabled ? undefined : onCreate}
           />
+          {wslDetectionHint ? (
+            <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-border px-2 py-1.5">
+              <span className="text-[11px] leading-tight text-muted-foreground">
+                {translate(
+                  'auto.components.NewWorkspaceComposerCard.detectWslAgentsHint',
+                  'No agents found on Windows. Your coding agents may be installed in WSL.'
+                )}
+              </span>
+              <Button
+                type="button"
+                variant="outline"
+                size="xs"
+                onClick={handleDetectWslAgents}
+                className="h-6 shrink-0 whitespace-nowrap text-[11px]"
+              >
+                {translate(
+                  'auto.components.NewWorkspaceComposerCard.detectWslAgentsAction',
+                  'Detect in WSL ({{value0}})',
+                  { value0: wslDetectionHint }
+                )}
+              </Button>
+            </div>
+          ) : null}
         </div>
 
         {/* Why: keep the Advanced disclosure header grouped with the content below while preserving spacing from the Agent field above. */}

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -21,7 +21,10 @@ import AgentCombobox from '@/components/agent/AgentCombobox'
 import { getAgentCatalog } from '@/lib/agent-catalog'
 import { useWindowsTerminalCapabilities } from '@/lib/windows-terminal-capabilities'
 import { getRendererAppPlatform } from '@/lib/renderer-app-platform'
-import { normalizeGlobalWindowsRuntimeDefault } from '../../../shared/project-execution-runtime'
+import {
+  normalizeGlobalWindowsRuntimeDefault,
+  type GlobalWindowsRuntimeDefault
+} from '../../../shared/project-execution-runtime'
 import {
   DEFAULT_DISABLED_TUI_AGENTS,
   filterEnabledTuiAgents
@@ -169,6 +172,45 @@ type NewWorkspaceComposerCardProps = {
   onAddProjectOverride?: () => void
   /** Fires as the nested Set-project-location dialog opens and closes, so the host can stand down its Escape/submit handling. */
   onNestedDialogOpenChange?: (open: boolean) => void
+}
+
+/**
+ * Decides whether the workspace composer should nudge a Windows user toward
+ * WSL-installed agents.
+ *
+ * Returns `{ kind: 'enable', distro }` when the host picker found nothing but
+ * WSL is available and the agent runtime is still the Windows host — one click
+ * switches the runtime and re-detects. Returns `{ kind: 'retry', distro }` when
+ * the runtime is already WSL but detection still came back empty (typically a
+ * cold-start probe timeout) — the probe needs a retry, not a setting change.
+ * Returns null on non-Windows platforms, while detection is in flight, when
+ * agents were found, or when WSL is unavailable.
+ */
+function resolveWslAgentPickerHint(args: {
+  appPlatform: NodeJS.Platform
+  windowsRuntimeDefault: GlobalWindowsRuntimeDefault
+  wslAvailable: boolean
+  wslDistros: readonly string[]
+  detectedAgentIds: Set<TuiAgent> | null
+}): { kind: 'enable' | 'retry'; distro: string } | null {
+  const { appPlatform, windowsRuntimeDefault, wslAvailable, wslDistros, detectedAgentIds } = args
+  if (appPlatform !== 'win32') {
+    return null
+  }
+  if (detectedAgentIds === null || detectedAgentIds.size > 0) {
+    return null
+  }
+  if (!wslAvailable) {
+    return null
+  }
+  const distro =
+    windowsRuntimeDefault.kind === 'wsl' && windowsRuntimeDefault.distro
+      ? windowsRuntimeDefault.distro
+      : (wslDistros.find((candidate) => candidate.trim().length > 0) ?? null)
+  if (!distro) {
+    return null
+  }
+  return { kind: windowsRuntimeDefault.kind === 'wsl' ? 'retry' : 'enable', distro }
 }
 
 const SSH_STATUS_LABELS: Partial<Record<SshConnectionStatus, string>> = {
@@ -448,34 +490,43 @@ export default function NewWorkspaceComposerCard({
   )
 
   // Why: a Windows host with no detected agents usually has its CLIs installed
-  // in WSL. Offer the existing WSL agent runtime instead of an empty picker.
+  // in WSL. Offer the existing WSL agent runtime instead of an empty picker;
+  // when the runtime is already WSL, offer a retry (the probe may have timed
+  // out on a cold start).
   const appPlatform = getRendererAppPlatform()
   const wslCapabilities = useWindowsTerminalCapabilities(appPlatform === 'win32')
   const windowsRuntimeDefault = normalizeGlobalWindowsRuntimeDefault(localWindowsRuntimeDefault)
-  const wslDetectionHint = React.useMemo(() => {
-    if (appPlatform !== 'win32') {
-      return null
-    }
-    if (windowsRuntimeDefault.kind === 'wsl') {
-      return null
-    }
-    if (detectedAgentIds === null || detectedAgentIds.size > 0) {
-      return null
-    }
-    if (!wslCapabilities.wslAvailable) {
-      return null
-    }
-    return wslCapabilities.wslDistros.find((distro) => distro.trim().length > 0) ?? null
-  }, [appPlatform, windowsRuntimeDefault, detectedAgentIds, wslCapabilities])
+  const wslPickerHint = React.useMemo(
+    () =>
+      resolveWslAgentPickerHint({
+        appPlatform,
+        windowsRuntimeDefault,
+        wslAvailable: wslCapabilities.wslAvailable,
+        wslDistros: wslCapabilities.wslDistros,
+        detectedAgentIds
+      }),
+    [appPlatform, windowsRuntimeDefault, wslCapabilities, detectedAgentIds]
+  )
 
-  const handleDetectWslAgents = React.useCallback((): void => {
-    if (!wslDetectionHint) {
+  /**
+   * Applies the picked WSL action: switch the agent runtime to WSL for
+   * `enable`, or simply re-run detection for `retry` (the runtime is already
+   * WSL; the previous probe likely timed out on a cold start).
+   */
+  const handleWslPickerHint = React.useCallback((): void => {
+    if (!wslPickerHint) {
       return
     }
-    void Promise.resolve(
-      updateSettings({ localWindowsRuntimeDefault: { kind: 'wsl', distro: wslDetectionHint } })
-    ).then(() => refreshDetectedAgents())
-  }, [updateSettings, refreshDetectedAgents, wslDetectionHint])
+    if (wslPickerHint.kind === 'enable') {
+      void Promise.resolve(
+        updateSettings({
+          localWindowsRuntimeDefault: { kind: 'wsl', distro: wslPickerHint.distro }
+        })
+      ).then(() => refreshDetectedAgents())
+      return
+    }
+    void refreshDetectedAgents()
+  }, [updateSettings, refreshDetectedAgents, wslPickerHint])
 
   const cancelNameInputFocusFrame = React.useCallback((): void => {
     if (nameInputFocusFrameRef.current === null) {
@@ -971,26 +1022,37 @@ export default function NewWorkspaceComposerCard({
             triggerClassName="h-9 w-full min-w-0 border-input text-sm focus:border-ring focus:ring-[3px] focus:ring-ring/50"
             onTriggerEnter={createDisabled ? undefined : onCreate}
           />
-          {wslDetectionHint ? (
+          {wslPickerHint ? (
             <div className="flex items-center justify-between gap-2 rounded-md border border-dashed border-border px-2 py-1.5">
               <span className="text-[11px] leading-tight text-muted-foreground">
-                {translate(
-                  'auto.components.NewWorkspaceComposerCard.detectWslAgentsHint',
-                  'No agents found on Windows. Your coding agents may be installed in WSL.'
-                )}
+                {wslPickerHint.kind === 'enable'
+                  ? translate(
+                      'auto.components.NewWorkspaceComposerCard.detectWslAgentsHint',
+                      'No agents found on Windows. Your coding agents may be installed in WSL.'
+                    )
+                  : translate(
+                      'auto.components.NewWorkspaceComposerCard.detectWslAgentsRetryHint',
+                      'No agents found in WSL ({{value0}}) yet. Detection may have timed out.',
+                      { value0: wslPickerHint.distro }
+                    )}
               </span>
               <Button
                 type="button"
                 variant="outline"
                 size="xs"
-                onClick={handleDetectWslAgents}
+                onClick={handleWslPickerHint}
                 className="h-6 shrink-0 whitespace-nowrap text-[11px]"
               >
-                {translate(
-                  'auto.components.NewWorkspaceComposerCard.detectWslAgentsAction',
-                  'Detect in WSL ({{value0}})',
-                  { value0: wslDetectionHint }
-                )}
+                {wslPickerHint.kind === 'enable'
+                  ? translate(
+                      'auto.components.NewWorkspaceComposerCard.detectWslAgentsAction',
+                      'Detect in WSL ({{value0}})',
+                      { value0: wslPickerHint.distro }
+                    )
+                  : translate(
+                      'auto.components.NewWorkspaceComposerCard.detectWslAgentsRetryAction',
+                      'Retry detection'
+                    )}
               </Button>
             </div>
           ) : null}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1458,6 +1458,8 @@
         "01d1e8f601": "Agent",
         "detectWslAgentsHint": "No agents found on Windows. Your coding agents may be installed in WSL.",
         "detectWslAgentsAction": "Detect in WSL ({{value0}})",
+        "detectWslAgentsRetryHint": "No agents found in WSL ({{value0}}) yet. Detection may have timed out.",
+        "detectWslAgentsRetryAction": "Retry detection",
         "0c5d6a479c": "[Optional]",
         "b5a0796911": "Connect",
         "dccd26d4e4": "Choose project",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1456,6 +1456,8 @@
         "ba64270bdb": "Configure agents",
         "ab63f25397": "Open agent settings",
         "01d1e8f601": "Agent",
+        "detectWslAgentsHint": "No agents found on Windows. Your coding agents may be installed in WSL.",
+        "detectWslAgentsAction": "Detect in WSL ({{value0}})",
         "0c5d6a479c": "[Optional]",
         "b5a0796911": "Connect",
         "dccd26d4e4": "Choose project",

--- a/src/shared/posix-command-path-lookup.test.ts
+++ b/src/shared/posix-command-path-lookup.test.ts
@@ -230,7 +230,7 @@ describe('buildPosixCommandPathLookupScript', () => {
     expect(script).toContain(`_orca_lookup_command='agent'\\''; echo injected; '\\'''`)
   })
 
-  it('emits the /mnt guard only when skipWindowsMountDirs is set', () => {
+  it('emits the drive-letter /mnt guard only when skipWindowsMountDirs is set', () => {
     const withSkip = buildPosixCommandPathLookupScript(
       { kind: 'literal', value: 'agent' },
       { skipWindowsMountDirs: true }
@@ -238,9 +238,41 @@ describe('buildPosixCommandPathLookupScript', () => {
     const withoutSkip = buildPosixCommandPathLookupScript({ kind: 'literal', value: 'agent' })
 
     expect(withSkip).toContain('case "$_orca_lookup_component" in')
-    expect(withSkip).toContain('/mnt|/mnt/*)')
-    expect(withoutSkip).not.toContain('/mnt|/mnt/*)')
+    expect(withSkip).toContain('/mnt/[A-Za-z]|/mnt/[A-Za-z]/*)')
+    expect(withSkip).not.toContain('/mnt|/mnt/*)')
+    expect(withoutSkip).not.toContain('/mnt/[A-Za-z]|/mnt/[A-Za-z]/*)')
   })
+
+  it.skipIf(executablePath(['/bin/sh']) === null)(
+    'the /mnt guard matches only single-letter drive mounts, not multi-letter /mnt paths',
+    () => {
+      const guard = [
+        'case "$_orca_lookup_component" in',
+        '  /mnt/[A-Za-z]|/mnt/[A-Za-z]/*)',
+        '    printf matched ;;',
+        '  *)',
+        '    printf searchable ;;',
+        'esac'
+      ].join('\n')
+      const execGuard = (component: string): string =>
+        execFileSync('/bin/sh', ['-c', `_orca_lookup_component='${component}'; ${guard}`], {
+          encoding: 'utf8'
+        })
+          .trim()
+          .split('\n')
+          .at(-1) ?? ''
+
+      expect(execGuard('/mnt/c')).toBe('matched')
+      expect(execGuard('/mnt/c/Windows/System32')).toBe('matched')
+      expect(execGuard('/mnt/w')).toBe('matched')
+      // Multi-letter /mnt mounts (custom Linux mounts, WSL internals like
+      // /mnt/wsl and /mnt/wslg) stay searchable.
+      expect(execGuard('/mnt/wsl')).toBe('searchable')
+      expect(execGuard('/mnt/data')).toBe('searchable')
+      expect(execGuard('/mnt/backup/bin')).toBe('searchable')
+      expect(execGuard('/mnt')).toBe('searchable')
+    }
+  )
 
   it.skipIf(executablePath(['/bin/sh']) === null || getWritableMntRoot() === null)(
     'skips Windows-drive /mnt PATH components when skipWindowsMountDirs is set',

--- a/src/shared/posix-command-path-lookup.test.ts
+++ b/src/shared/posix-command-path-lookup.test.ts
@@ -24,6 +24,7 @@ type ShellCase = {
 const isWindows = process.platform === 'win32'
 const WSL_TEST_COMMAND_TIMEOUT_MS = 10_000
 let wslShAvailable: boolean | null = null
+let writableMntRoot: string | null | undefined
 const shellCases: ShellCase[] = [
   { name: 'sh', path: executablePath(['/bin/sh']) },
   { name: 'bash', path: executablePath(['/bin/bash', '/usr/bin/bash']) },
@@ -229,6 +230,69 @@ describe('buildPosixCommandPathLookupScript', () => {
     expect(script).toContain(`_orca_lookup_command='agent'\\''; echo injected; '\\'''`)
   })
 
+  it('emits the /mnt guard only when skipWindowsMountDirs is set', () => {
+    const withSkip = buildPosixCommandPathLookupScript(
+      { kind: 'literal', value: 'agent' },
+      { skipWindowsMountDirs: true }
+    )
+    const withoutSkip = buildPosixCommandPathLookupScript({ kind: 'literal', value: 'agent' })
+
+    expect(withSkip).toContain('case "$_orca_lookup_component" in')
+    expect(withSkip).toContain('/mnt|/mnt/*)')
+    expect(withoutSkip).not.toContain('/mnt|/mnt/*)')
+  })
+
+  it.skipIf(executablePath(['/bin/sh']) === null || getWritableMntRoot() === null)(
+    'skips Windows-drive /mnt PATH components when skipWindowsMountDirs is set',
+    () => {
+      const mntRoot = getWritableMntRoot()!
+      const fixtureDir = join(mntRoot, `orca-mnt-lookup-${process.pid}`)
+      const mntExecutable = join(fixtureDir, 'mnt-agent')
+      const nativeDir = mkdtempSync(join(tmpdir(), 'orca-mnt-native-'))
+      const nativeExecutable = join(nativeDir, 'native-agent')
+      const buildScript = (name: string, skip: boolean): string =>
+        [
+          buildPosixCommandPathLookupScript(
+            { kind: 'literal', value: name },
+            skip ? { skipWindowsMountDirs: true } : {}
+          ),
+          `printf '%s\\n' "$resolved"`
+        ].join('\n')
+      try {
+        mkdirSync(fixtureDir)
+        writeFileSync(mntExecutable, '#!/bin/sh\nexit 0\n')
+        chmodSync(mntExecutable, 0o755)
+        writeFileSync(nativeExecutable, '#!/bin/sh\nexit 0\n')
+        chmodSync(nativeExecutable, 0o755)
+        const path = `${fixtureDir}:${nativeDir}`
+
+        // Without the skip the /mnt component wins the lookup.
+        const foundWithMnt = execFileSync('/bin/sh', ['-c', buildScript('mnt-agent', false)], {
+          encoding: 'utf8',
+          env: { ...process.env, PATH: path }
+        }).trim()
+        expectResolvedExecutable(foundWithMnt, mntExecutable)
+
+        // With the skip the /mnt component is ignored.
+        const skippedMnt = execFileSync('/bin/sh', ['-c', buildScript('mnt-agent', true)], {
+          encoding: 'utf8',
+          env: { ...process.env, PATH: path }
+        }).trim()
+        expect(skippedMnt).toBe('')
+
+        // Native-path agents still resolve with the skip on.
+        const nativeWithSkip = execFileSync('/bin/sh', ['-c', buildScript('native-agent', true)], {
+          encoding: 'utf8',
+          env: { ...process.env, PATH: path }
+        }).trim()
+        expectResolvedExecutable(nativeWithSkip, nativeExecutable)
+      } finally {
+        rmSync(fixtureDir, { force: true, recursive: true })
+        rmSync(nativeDir, { force: true, recursive: true })
+      }
+    }
+  )
+
   it.skipIf(!canRunWslSh())(
     'resolves through the Windows-to-WSL login-shell boundary with inline masks',
     () => {
@@ -276,6 +340,26 @@ function canRunWslSh(): boolean {
     wslShAvailable = false
   }
   return wslShAvailable
+}
+
+/** First writable /mnt/<drive> root, or null when none exists (non-WSL hosts, CI). */
+function getWritableMntRoot(): string | null {
+  if (isWindows || writableMntRoot !== undefined) {
+    return writableMntRoot ?? null
+  }
+  for (const root of ['/mnt/c/Users/Public', '/mnt/c/Windows/Temp']) {
+    try {
+      const probe = join(root, `.orca-wsl-write-${process.pid}`)
+      writeFileSync(probe, '')
+      rmSync(probe, { force: true })
+      writableMntRoot = root
+      return root
+    } catch {
+      // Try the next candidate; none writable means the behavioral /mnt test skips.
+    }
+  }
+  writableMntRoot = null
+  return null
 }
 
 function withExecutableFixture(

--- a/src/shared/posix-command-path-lookup.ts
+++ b/src/shared/posix-command-path-lookup.ts
@@ -4,11 +4,13 @@ export type PosixCommandPathLookupTarget =
 
 export type PosixCommandPathLookupOptions = {
   /**
-   * Skip PATH components under the WSL Windows-drive automount root (`/mnt/<n>`).
-   * drvfs stats cross the WSL↔Windows boundary and are far slower than native
-   * ext4 — especially when cold — so a Windows PATH tail can blow a probe's
-   * timeout. WSL-side probes opt in; never set for SSH remotes, where `/mnt`
-   * can be a real Linux mount.
+   * Skip PATH components under WSL's single-letter Windows drive mounts
+   * (`/mnt/<drive-letter>`, e.g. `/mnt/c`). drvfs stats cross the
+   * WSL↔Windows boundary and are far slower than native ext4 — especially
+   * when cold — so a Windows PATH tail can blow a probe's timeout.
+   * Multi-letter `/mnt` paths (custom Linux mounts like `/mnt/data`, WSL
+   * internals) stay searchable. WSL-side probes opt in; never set for SSH
+   * remotes, where `/mnt` can be a real Linux mount.
    */
   skipWindowsMountDirs?: boolean
 }
@@ -24,8 +26,8 @@ export function buildPosixCommandPathLookupScript(
     options.skipWindowsMountDirs === true
       ? [
           'case "$_orca_lookup_component" in',
-          '  /mnt|/mnt/*)',
-          // Why: continue past Windows-drive mounts; break on the final component.
+          '  /mnt/[A-Za-z]|/mnt/[A-Za-z]/*)',
+          // Why: continue past Windows drive mounts; break on the final component.
           '    [ -n "$_orca_lookup_has_more" ] || break',
           '    continue',
           '    ;;',

--- a/src/shared/posix-command-path-lookup.ts
+++ b/src/shared/posix-command-path-lookup.ts
@@ -2,10 +2,36 @@ export type PosixCommandPathLookupTarget =
   | { kind: 'literal'; value: string }
   | { kind: 'shell-variable'; name: string }
 
+export type PosixCommandPathLookupOptions = {
+  /**
+   * Skip PATH components under the WSL Windows-drive automount root (`/mnt/<n>`).
+   * drvfs stats cross the WSL↔Windows boundary and are far slower than native
+   * ext4 — especially when cold — so a Windows PATH tail can blow a probe's
+   * timeout. WSL-side probes opt in; never set for SSH remotes, where `/mnt`
+   * can be a real Linux mount.
+   */
+  skipWindowsMountDirs?: boolean
+}
+
 const SHELL_VARIABLE_NAME_PATTERN = /^[A-Za-z_][A-Za-z0-9_]*$/
 
-export function buildPosixCommandPathLookupScript(target: PosixCommandPathLookupTarget): string {
+export function buildPosixCommandPathLookupScript(
+  target: PosixCommandPathLookupTarget,
+  options: PosixCommandPathLookupOptions = {}
+): string {
   const commandAssignment = buildCommandAssignment(target)
+  const windowsMountSkip =
+    options.skipWindowsMountDirs === true
+      ? [
+          'case "$_orca_lookup_component" in',
+          '  /mnt|/mnt/*)',
+          // Why: continue past Windows-drive mounts; break on the final component.
+          '    [ -n "$_orca_lookup_has_more" ] || break',
+          '    continue',
+          '    ;;',
+          'esac'
+        ]
+      : []
   // Shell command resolution can be masked by aliases, functions, and builtins, so inspect PATH.
   return [
     `_orca_lookup_command=${commandAssignment}`,
@@ -35,6 +61,7 @@ export function buildPosixCommandPathLookupScript(target: PosixCommandPathLookup
     '          ;;',
     '      esac',
     '      [ -n "$_orca_lookup_component" ] || _orca_lookup_component=.',
+    ...windowsMountSkip,
     '      case "$_orca_lookup_component" in',
     '        /*) _orca_lookup_candidate=$_orca_lookup_component/$_orca_lookup_command ;;',
     '        *) _orca_lookup_candidate=${PWD%/}/$_orca_lookup_component/$_orca_lookup_command ;;',


### PR DESCRIPTION
## ELI5

On Windows, if your coding agents are installed inside WSL rather than on Windows itself, the new-workspace screen's agent picker showed an empty list with no clue why. Now, when nothing is detected and WSL is available, you get a hint — "Your coding agents may be installed in WSL" — with a one-click "Detect in WSL" button. If WSL was already being checked but detection timed out on a slow start, you get a "Retry detection" button instead of a dead end. Detection is also more patient, so fewer false "nothing found" answers.

## Summary

On Windows, agent detection only probes the host PATH unless the runtime context resolves to WSL (repo under a `\\wsl$` path, a per-project runtime preference, or **Settings → Agents → Agent runtime = WSL**). Users whose coding CLIs live in WSL — claude, codex, hermes, omp, kimi, and friends — hit an empty agent picker with no hint that their agents are detectable at all. And when the runtime was *already* set to WSL, a failed/timed-out probe silently looked identical to "no agents installed" with no retry affordance.

This PR adds a hint + one-click action to the workspace composer's agent picker in both cases:

- **Runtime not yet WSL** → "Detect in WSL (Ubuntu)": writes the same setting the existing *Agent runtime* control writes (`localWindowsRuntimeDefault: { kind: 'wsl', distro }`) and re-runs detection.
- **Runtime already WSL but detection empty** → "No agents found in WSL (Ubuntu) yet — Retry detection": re-runs the probe only (never rewrites settings), covering the cold-start-timeout case.

The hint shows only when: platform is win32, WSL is available with a distro, detection completed with zero agents, and (for the enable variant) the runtime is not already WSL.

## Proof (measured against a real WSL distro)

- The WSL probe itself works: `detectWslCommandsOnPath({ distro: 'Ubuntu' }, …)` resolved `claude`, `omp`, `hermes`, `kimi`, `opencode`, `qwen` in **845ms**. So "already-WSL but empty" is not a context-resolution problem.
- A **failed probe is indistinguishable from "no agents"**: probing a nonexistent distro returned a plain empty set. Any timeout/error produced the same silent empty picker — the mechanism behind the already-WSL symptom.
- Timing: bare `wsl.exe` spawn **123ms** vs the login-shell probe wrapper **609ms** (~5x), and the previous **10s** timeout has no headroom for a WSL2 cold boot (VM start alone can exceed 10s).
- **/mnt slowness confirmed**: this WSL's PATH carries **36 `/mnt/` components** from the appended Windows PATH. Per-component `-x` stats on `/mnt/c` cost ~1.8x native warm and far more when cold (empty 9p metadata cache + Defender scanning), so a full walk across the Windows tail for several missing probe commands can blow the timeout. The `skipWindowsMountDirs` behavioral test executes the generated script against a real `/mnt/c` fixture: skipped with the option, resolved without, native PATH unaffected.

## Changes

1. `detectWslCommandsOnPath` now returns `{ found, failed }` instead of a bare `Set` — a timed-out/errored probe is distinguishable from "no agents installed" (unit-tested both ways). The flag is ready for IPC/telemetry wiring later; no wire changes here.
2. Probe timeout raised **10s → 30s** for WSL2 cold-boot headroom. The probe is async and off the UI thread.
3. **Skip the Windows-drive /mnt PATH tail (root cause, per aliuq on #9725).** WSL appends the Windows PATH to the Linux PATH by default, so the lookup walked `/mnt/<n>` drvfs directories; slow cross-boundary stats blew the 10s timeout. `buildPosixCommandPathLookupScript` gains an opt-in `skipWindowsMountDirs` option — WSL callers (agent probe, `isCommandOnPath`, codex lookup) pass it, while SSH remotes keep `/mnt` as a real Linux mount. The PATH walk now continues past `/mnt` components (breaking on the final one).
4. Composer: extracted a documented `resolveWslAgentPickerHint` pure function; retry variant added for the already-WSL case.
5. Docstrings added to the new resolver, handler, and test helper.

## Related

- Fixes #9725 — "Agent detection failed on Windows (WSL)"
- Related to #11797 — "Support mixed Windows + WSL agent runtimes"
- Complements (no file overlap): #9731, #8391, #5149

## Screenshots

No visual changes to shipped UI surfaces beyond the new hint row in the workspace composer's agent field (shown only in the empty-picker + WSL-available case, with a retry variant when the runtime is already WSL). The composer is not covered by a screenshot suite; the hint's presence/absence and both action paths are asserted by tests.

## AI Review Report

- Both CodeRabbit pre-merge warnings addressed: the already-configured-WSL case is now implemented (retry hint, follow-up commit ee6783748), and docstrings cover the new functions.
- The hint only renders when detection completed with zero agents, WSL is available, and the platform is win32; the enable action writes the same `localWindowsRuntimeDefault` shape `AgentRuntimeSetting` writes; the retry action only calls the existing `refreshDetectedAgents` store action. No new IPC, store fields, runtime-type changes, or remote-wire changes.

## Security Audit

- No new dependencies, no new IPC methods, no filesystem or command execution changes. The hint invokes only the existing settings-write + detection-refresh paths. The probe timeout change affects an existing async probe only.
- No secrets, auth flows, or wire-format changes. No follow-up security work required.

## Testing

- `preflight-wsl-agent-detection.test.ts`: 7/7 — including new assertions that a failed probe returns `{ found: Set(), failed: true }` while a clean empty result returns `failed: false`, and that the probe script embeds the /mnt skip guard.
- `posix-command-path-lookup.test.ts`: 18 passed, 2 env-skipped — new string-level test (guard emitted only when opted in) and a real-shell behavioral test that runs the generated script against a real `/mnt/c` fixture (skipped with the option, resolved without, native PATH intact).
- `preflight-command-exec.test.ts`: 5/5 — WSL `isCommandOnPath` builds the lookup with the /mnt skip.
- `NewWorkspaceComposerCard.test.tsx`: 30/30 — enable hint, retry hint (already-WSL), retry never calls `updateSettings`, hidden when agents detected / detection in flight / WSL unavailable / non-Windows.
- `tsc --noEmit` (node + web configs): clean. `oxlint` (code-quality native config): clean on all changed files.
- Localization gates: extraction, catalog, and coverage checks pass (4 keys added to `en.json`).
- `check-max-lines-ratchet` and `check-reliability-gates`: pass.

## Notes

- The Windows-side workaround this PR replaces (documented on #9725): Settings → Agents → Agent runtime → WSL + distro works today without any code change; the PR just makes it discoverable from the exact spot users hit the empty picker, and gives already-configured users a retry when the probe fails.
- macOS/Linux are unaffected (hint gated on win32).
