### PR TITLE
Show SSH worktrees immediately via persisted metadata

### DIFF
--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2682,6 +2682,117 @@ describe('registerWorktreeHandlers', () => {
     expect(getSshGitProviderMock).not.toHaveBeenCalled()
   })
 
+  it('stops listing SSH worktrees once an authoritative scan retires their metadata', async () => {
+    const sshHostId = toSshExecutionHostId('target-a')
+    const sshRepo = {
+      id: 'repo-1',
+      path: '/remote/repo',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'target-a'
+    }
+    const metaById: Record<string, Record<string, unknown>> = {
+      'repo-1::/remote/repo': makeWorktreeMeta({ displayName: 'main', hostId: sshHostId }),
+      'repo-1::/remote/deleted': makeWorktreeMeta({ displayName: 'deleted', hostId: sshHostId }),
+      'repo-1::/remote/other-host': makeWorktreeMeta({
+        displayName: 'other host',
+        hostId: toSshExecutionHostId('target-b')
+      }),
+      'repo-2::/remote/other-repo': makeWorktreeMeta({ displayName: 'other repo' })
+    }
+    store.getRepos.mockReturnValue([sshRepo])
+    store.getProjectHostSetups.mockReturnValue([])
+    store.getAllWorktreeMeta.mockReturnValue(metaById)
+    store.getWorktreeMeta.mockImplementation((worktreeId: string) => metaById[worktreeId])
+    store.removeWorktreeMeta.mockImplementation((worktreeId: string) => {
+      delete metaById[worktreeId]
+    })
+
+    const forgotten = await handlers['worktrees:forgetRemovedForExecutionHost'](null, {
+      repoId: sshRepo.id,
+      executionHostId: sshHostId,
+      // Only the first is this host's row; the rest must survive an over-broad request.
+      worktreeIds: [
+        'repo-1::/remote/deleted',
+        'repo-1::/remote/other-host',
+        'repo-2::/remote/other-repo',
+        'repo-1::/remote/never-persisted'
+      ]
+    })
+
+    expect(forgotten).toEqual({ forgottenWorktreeIds: ['repo-1::/remote/deleted'] })
+    expect(store.removeWorktreeMeta).toHaveBeenCalledTimes(1)
+    expect(store.removeWorktreeMeta).toHaveBeenCalledWith('repo-1::/remote/deleted', sshHostId)
+
+    // Why: the renderer's suppression memory is session-scoped, so the next launch must not re-list the row.
+    const relisted = (await handlers['worktrees:listKnownForExecutionHost'](null, {
+      repoId: sshRepo.id,
+      executionHostId: sshHostId
+    })) as { result: { worktrees: { path: string }[] } }
+
+    expect(relisted.result.worktrees.map((worktree) => worktree.path)).toEqual(['/remote/repo'])
+  })
+
+  it('never retires folder workspace metadata, which is the workspace record itself', async () => {
+    const sshHostId = toSshExecutionHostId('target-a')
+    const folderRepo = {
+      id: 'repo-1',
+      path: '/remote/folder',
+      displayName: 'folder',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'target-a',
+      kind: 'folder' as const
+    }
+    const instanceId = `${folderRepo.id}::${folderRepo.path}::workspace:11111111-2222-3333-4444-555555555555`
+    store.getRepos.mockReturnValue([folderRepo])
+    store.getAllWorktreeMeta.mockReturnValue({
+      [instanceId]: makeWorktreeMeta({ displayName: 'second workspace', hostId: sshHostId })
+    })
+
+    const forgotten = await handlers['worktrees:forgetRemovedForExecutionHost'](null, {
+      repoId: folderRepo.id,
+      executionHostId: sshHostId,
+      worktreeIds: [instanceId]
+    })
+
+    expect(forgotten).toEqual({ forgottenWorktreeIds: [] })
+    expect(store.removeWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('refuses to retire metadata for non-SSH hosts and unowned repos', async () => {
+    const sshRepo = {
+      id: 'repo-1',
+      path: '/remote/repo-a',
+      displayName: 'repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'target-a'
+    }
+    store.getRepos.mockReturnValue([sshRepo, { ...sshRepo, path: '/remote/repo-b' }])
+    store.getAllWorktreeMeta.mockReturnValue({
+      'repo-1::/remote/deleted': makeWorktreeMeta({})
+    })
+
+    expect(
+      await handlers['worktrees:forgetRemovedForExecutionHost'](null, {
+        repoId: sshRepo.id,
+        executionHostId: LOCAL_EXECUTION_HOST_ID,
+        worktreeIds: ['repo-1::/remote/deleted']
+      })
+    ).toEqual({ forgottenWorktreeIds: [] })
+    // Ambiguous SSH ownership fails closed the same way the metadata read does.
+    expect(
+      await handlers['worktrees:forgetRemovedForExecutionHost'](null, {
+        repoId: sshRepo.id,
+        executionHostId: toSshExecutionHostId('target-a'),
+        worktreeIds: ['repo-1::/remote/deleted']
+      })
+    ).toEqual({ forgottenWorktreeIds: [] })
+    expect(store.removeWorktreeMeta).not.toHaveBeenCalled()
+  })
+
   it('rejects metadata-only reads for non-SSH execution hosts', async () => {
     const result = await handlers['worktrees:listKnownForExecutionHost'](null, {
       repoId: 'repo-1',

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -49,6 +49,8 @@ import {
 import {
   PROVIDER_REQUEST_ID_MAX_UTF8_BYTES,
   type DirectSshDetectedWorktreeRequest,
+  type ForgetRemovedWorktreesForExecutionHostArgs,
+  type ForgetRemovedWorktreesForExecutionHostResult,
   type HostQualifiedKnownWorktreeResult,
   type HostQualifiedDetectedWorktreeResult,
   type ListKnownWorktreesForExecutionHostArgs,
@@ -1846,6 +1848,7 @@ export function registerWorktreeHandlers(
   ipcMain.removeHandler('worktrees:list')
   ipcMain.removeHandler('worktrees:listDetected')
   ipcMain.removeHandler('worktrees:listKnownForExecutionHost')
+  ipcMain.removeHandler('worktrees:forgetRemovedForExecutionHost')
   ipcMain.removeHandler('worktrees:cancelListDetected')
   ipcMain.removeHandler('worktrees:create')
   ipcMain.removeHandler('worktrees:prefetchCreateBase')
@@ -2047,6 +2050,51 @@ export function registerWorktreeHandlers(
           listDisconnectedSshWorktrees(store, repo, metaIndex)
         )
       )
+    }
+  )
+
+  // Why: gcStaleWorktreeMeta cannot stat a remote path, so SSH metadata outlives the worktree and the fallback
+  // above re-lists a worktree deleted outside Orca on every launch. An authoritative scan is the only proof of
+  // absence, so the renderer reports what it retired here and the row is dropped like a local GC would.
+  ipcMain.handle(
+    'worktrees:forgetRemovedForExecutionHost',
+    (
+      _event,
+      args: ForgetRemovedWorktreesForExecutionHostArgs
+    ): ForgetRemovedWorktreesForExecutionHostResult => {
+      const nothingForgotten: ForgetRemovedWorktreesForExecutionHostResult = {
+        forgottenWorktreeIds: []
+      }
+      const requestedExecutionHostId = args?.executionHostId ?? 'ssh:'
+      const worktreeIds = Array.isArray(args?.worktreeIds) ? args.worktreeIds : []
+      const parsedHost = parseExecutionHostId(requestedExecutionHostId)
+      if (parsedHost?.kind !== 'ssh' || worktreeIds.length === 0) {
+        return nothingForgotten
+      }
+      const repo = findExactRepoOwner(store, args?.repoId ?? '', requestedExecutionHostId)
+      if (!repo || repo.connectionId !== parsedHost.targetId) {
+        return nothingForgotten
+      }
+      // Why: a folder workspace's meta IS the workspace record, not a checkout row — gcStaleWorktreeMeta skips
+      // those keys for the same reason, and no remote scan can retire one.
+      if (isFolderRepo(repo)) {
+        return nothingForgotten
+      }
+      const allMeta = store.getAllWorktreeMeta()
+      const forgottenWorktreeIds: string[] = []
+      for (const worktreeId of worktreeIds) {
+        const meta = typeof worktreeId === 'string' ? allMeta[worktreeId] : undefined
+        if (!meta || getRepoIdFromWorktreeId(worktreeId) !== repo.id) {
+          continue
+        }
+        // An unhosted meta belongs to this repo's only owner; a foreign hostId needs that host's own scan.
+        if (meta.hostId && meta.hostId !== requestedExecutionHostId) {
+          continue
+        }
+        store.removeWorktreeMeta(worktreeId, requestedExecutionHostId)
+        forgottenWorktreeIds.push(worktreeId)
+      }
+      return { forgottenWorktreeIds }
     }
   )
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -30,6 +30,8 @@ import type { ReadClipboardTextOptions } from '../shared/clipboard-text'
 import type { AppIdentity } from '../shared/app-identity'
 import type { ReleaseChannel } from '../shared/release-channel'
 import type {
+  ForgetRemovedWorktreesForExecutionHostArgs,
+  ForgetRemovedWorktreesForExecutionHostResult,
   HostQualifiedKnownWorktreeResult,
   HostQualifiedDetectedWorktreeResult,
   LegacyDetectedWorktreeRequest,
@@ -1404,6 +1406,10 @@ export type PreloadApi = {
     listKnownForExecutionHost?: (
       args: ListKnownWorktreesForExecutionHostArgs
     ) => Promise<HostQualifiedKnownWorktreeResult>
+    /** Retires the persisted metadata an authoritative scan proved gone, so it stops feeding the read above. */
+    forgetRemovedForExecutionHost?: (
+      args: ForgetRemovedWorktreesForExecutionHostArgs
+    ) => Promise<ForgetRemovedWorktreesForExecutionHostResult>
     cancelListDetected?: (args: { providerRequestId: ProviderRequestId }) => Promise<void>
     listAll: () => Promise<Worktree[]>
     create: (args: CreateWorktreeArgs) => Promise<CreateWorktreeResult>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -769,6 +769,9 @@ const api = {
     listKnownForExecutionHost: (args) =>
       ipcRenderer.invoke('worktrees:listKnownForExecutionHost', args),
 
+    forgetRemovedForExecutionHost: (args) =>
+      ipcRenderer.invoke('worktrees:forgetRemovedForExecutionHost', args),
+
     cancelListDetected: (args) => ipcRenderer.invoke('worktrees:cancelListDetected', args),
 
     listAll: () => ipcRenderer.invoke('worktrees:listAll'),

--- a/src/preload/ssh-authority-forwarding.test.ts
+++ b/src/preload/ssh-authority-forwarding.test.ts
@@ -78,6 +78,20 @@ describe('native preload SSH authority forwarding', () => {
     expect(invoke).toHaveBeenCalledWith('worktrees:listKnownForExecutionHost', args)
   })
 
+  it('forwards metadata retirement for authoritatively removed worktrees', async () => {
+    await import('./index')
+    const api = exposeInMainWorld.mock.calls.find(([name]) => name === 'api')?.[1] as PreloadApi
+    const args = {
+      repoId: 'repo-1',
+      executionHostId: 'ssh:ssh-1' as const,
+      worktreeIds: ['repo-1::/remote/deleted']
+    }
+
+    await api.worktrees.forgetRemovedForExecutionHost?.(args)
+
+    expect(invoke).toHaveBeenCalledWith('worktrees:forgetRemovedForExecutionHost', args)
+  })
+
   it('forwards full-pair get and push states without cloning away authority', async () => {
     const state: SshConnectionState = {
       targetId: 'ssh-1',

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -20,6 +20,8 @@ import {
 import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import type {
+  ForgetRemovedWorktreesForExecutionHostArgs,
+  ForgetRemovedWorktreesForExecutionHostResult,
   HostQualifiedDetectedWorktreeResult,
   HostQualifiedKnownWorktreeResult,
   ListKnownWorktreesForExecutionHostArgs,
@@ -111,6 +113,12 @@ const listKnownForExecutionHostMock = vi.fn<
   (args: ListKnownWorktreesForExecutionHostArgs) => Promise<HostQualifiedKnownWorktreeResult>
 >(async (args) => ({ status: 'rejected', ...args }))
 
+const forgetRemovedForExecutionHostMock = vi.fn<
+  (
+    args: ForgetRemovedWorktreesForExecutionHostArgs
+  ) => Promise<ForgetRemovedWorktreesForExecutionHostResult>
+>(async () => ({ forgottenWorktreeIds: [] }))
+
 const mockApi = {
   worktrees: {
     create: vi.fn(),
@@ -118,6 +126,7 @@ const mockApi = {
     list: worktreeListMock,
     listDetected: listDetectedMock,
     listKnownForExecutionHost: listKnownForExecutionHostMock,
+    forgetRemovedForExecutionHost: forgetRemovedForExecutionHostMock,
     cancelListDetected: vi.fn().mockResolvedValue(undefined),
     listLineage: vi.fn().mockResolvedValue({}),
     remove: vi.fn().mockResolvedValue(undefined),
@@ -183,6 +192,12 @@ function resetRemoteRuntimeMocks() {
     return createCompatibleRuntimeStatusResponseIfNeeded(args) ?? runtimeEnvironmentCall(args)
   })
 }
+
+// Why: both the metadata fallback and removeWorktree write this module-level memory, so a leaked entry from an
+// earlier describe would silently suppress a row here. Reset for every case, not just the fetch suites.
+beforeEach(() => {
+  resetAuthoritativelyRemovedWorktreeMemoryForTests()
+})
 
 function createTestStore() {
   return create<AppState>()(
@@ -447,7 +462,6 @@ describe('fetchWorktrees', () => {
     vi.clearAllMocks()
     resetRemoteRuntimeMocks()
     clearHugeRepoWarningDismissalsForTests()
-    resetAuthoritativelyRemovedWorktreeMemoryForTests()
   })
 
   it('does not notify subscribers when the fetched payload is unchanged', async () => {
@@ -1716,6 +1730,109 @@ describe('fetchWorktrees', () => {
     await store.getState().fetchWorktrees(sshRepo.id)
 
     expect(store.getState().worktreesByRepo[sshRepo.id]).toEqual([live])
+  })
+
+  it('retires persisted metadata for worktrees an authoritative SSH scan proved gone', async () => {
+    const store = createTestStore()
+    const sshRepo = {
+      id: 'repo-ssh',
+      path: '/home/orca/repo',
+      displayName: 'SSH Repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    const live = makeWorktree({
+      id: 'repo-ssh::/home/orca/live',
+      repoId: 'repo-ssh',
+      path: '/home/orca/live',
+      hostId: 'ssh:ssh-1'
+    })
+    const deletedOnRemote = makeWorktree({
+      id: 'repo-ssh::/home/orca/deleted',
+      repoId: 'repo-ssh',
+      path: '/home/orca/deleted'
+    })
+    const connectedStates = createTestStore().getState().sshConnectionStates
+    listKnownForExecutionHostMock.mockResolvedValueOnce({
+      status: 'complete',
+      repoId: sshRepo.id,
+      executionHostId: 'ssh:ssh-1',
+      result: makeDetectedResult(sshRepo.id, [deletedOnRemote], {
+        authoritative: false,
+        source: 'metadata-fallback'
+      })
+    })
+    store.setState({ repos: [sshRepo], sshConnectionStates: new Map() } as Partial<AppState>)
+    await store.getState().fetchWorktrees(sshRepo.id)
+
+    worktreeListMock.mockResolvedValueOnce([live])
+    store.setState({ sshConnectionStates: connectedStates } as Partial<AppState>)
+    await store.getState().fetchWorktrees(sshRepo.id)
+
+    // Why: the renderer's suppression memory dies with the reload, so the metadata itself has to go.
+    expect(forgetRemovedForExecutionHostMock).toHaveBeenCalledWith({
+      repoId: sshRepo.id,
+      executionHostId: 'ssh:ssh-1',
+      worktreeIds: [deletedOnRemote.id]
+    })
+  })
+
+  it('leaves local metadata to the persistence GC after an authoritative local scan', async () => {
+    const store = createTestStore()
+    const localRepo = {
+      id: 'repo-local',
+      path: '/local/repo',
+      displayName: 'Local Repo',
+      badgeColor: '#000',
+      addedAt: 0
+    }
+    const removed = makeWorktree({
+      id: 'repo-local::/local/removed',
+      repoId: localRepo.id,
+      path: '/local/removed'
+    })
+    const survivor = makeWorktree({
+      id: 'repo-local::/local/survivor',
+      repoId: localRepo.id,
+      path: '/local/survivor'
+    })
+    store.setState({
+      repos: [localRepo],
+      worktreesByRepo: { [localRepo.id]: [removed, survivor] }
+    } as Partial<AppState>)
+    worktreeListMock.mockResolvedValueOnce([survivor])
+
+    await store.getState().fetchWorktrees(localRepo.id)
+
+    expect(store.getState().worktreesByRepo[localRepo.id]).toEqual([survivor])
+    // Local metas are GC-eligible on their own; only the SSH exemption needs this IPC.
+    expect(forgetRemovedForExecutionHostMock).not.toHaveBeenCalled()
+  })
+
+  it('skips the metadata fallback entirely for authoritative-only callers', async () => {
+    const store = createTestStore()
+    const sshRepo = {
+      id: 'repo-ssh',
+      path: '/home/orca/repo',
+      displayName: 'SSH Repo',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'ssh-1'
+    }
+    store.setState({ repos: [sshRepo], sshConnectionStates: new Map() } as Partial<AppState>)
+    const worktreesByRepo = store.getState().worktreesByRepo
+    const detectedWorktreesByRepo = store.getState().detectedWorktreesByRepo
+
+    await expect(
+      store.getState().fetchWorktrees(sshRepo.id, { requireAuthoritative: true })
+    ).resolves.toBe(false)
+
+    // Why: these callers asked for authoritative-or-nothing; non-authoritative rows must not land as a side effect.
+    expect(listKnownForExecutionHostMock).not.toHaveBeenCalled()
+    expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
+    expect(store.getState().worktreesByRepo).toBe(worktreesByRepo)
+    expect(store.getState().detectedWorktreesByRepo).toBe(detectedWorktreesByRepo)
   })
 
   it('keeps worktree maps byte-identical for stale and malformed direct results', async () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -1766,12 +1766,15 @@ describe('fetchWorktrees', () => {
     store.setState({ repos: [sshRepo], sshConnectionStates: new Map() } as Partial<AppState>)
     await store.getState().fetchWorktrees(sshRepo.id)
 
+    // The non-authoritative fallback saw the same absence but must not act on it.
+    expect(forgetRemovedForExecutionHostMock).not.toHaveBeenCalled()
+
     worktreeListMock.mockResolvedValueOnce([live])
     store.setState({ sshConnectionStates: connectedStates } as Partial<AppState>)
     await store.getState().fetchWorktrees(sshRepo.id)
 
     // Why: the renderer's suppression memory dies with the reload, so the metadata itself has to go.
-    expect(forgetRemovedForExecutionHostMock).toHaveBeenCalledWith({
+    expect(forgetRemovedForExecutionHostMock).toHaveBeenCalledExactlyOnceWith({
       repoId: sshRepo.id,
       executionHostId: 'ssh:ssh-1',
       worktreeIds: [deletedOnRemote.id]

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2990,13 +2990,14 @@ function mergeFetchedWorktrees(
     // Why: applied outside the updater so a repeated updater call cannot double-apply the removal memory.
     forgetAuthoritativelyRemovedWorktrees(args.hostId, authoritativelySeenIds)
     rememberAuthoritativelyRemovedWorktrees(args.hostId, authoritativelyRemovedIds)
+    forgetPersistedWorktreeMetaForRemovals(args.repoId, args.hostId, authoritativelyRemovedIds)
   }
   return admitted
 }
 
-// Why: an authoritative scan is the only proof a remote worktree is gone, but SSH WorktreeMeta is exempt from
-// gcStaleWorktreeMeta (persistence.ts:407,415), so without this memory the metadata fallback re-appends every
-// deleted row on the next disconnect — forever.
+// Why: main retires the persisted SSH metadata a scan proved gone, but that IPC is async and the next fallback
+// read can already be in flight, so this session memory covers the window until the delete lands. It is not the
+// durable half: reloads start empty and rely on the metadata itself being gone.
 const AUTHORITATIVE_REMOVAL_MEMORY_LIMIT = 512
 const authoritativelyRemovedWorktreeIdsByHost = new Map<ExecutionHostId, Set<string>>()
 
@@ -3042,6 +3043,29 @@ function forgetAuthoritativelyRemovedWorktrees(
 /** Test-only: module-level removal memory would otherwise leak across cases in one file. */
 export function resetAuthoritativelyRemovedWorktreeMemoryForTests(): void {
   authoritativelyRemovedWorktreeIdsByHost.clear()
+}
+
+// Why: SSH WorktreeMeta is exempt from gcStaleWorktreeMeta (persistence.ts:407,415) and outlives the remote
+// worktree, so a scan-proven removal must retire the metadata itself — otherwise the next launch's fallback
+// re-lists the deleted row before the host connects, and the in-memory suppression above is already gone.
+function forgetPersistedWorktreeMetaForRemovals(
+  repoId: string,
+  hostId: ExecutionHostId,
+  worktreeIds: readonly string[]
+): void {
+  const parsedHost = parseExecutionHostId(hostId)
+  if (worktreeIds.length === 0 || parsedHost?.kind !== 'ssh') {
+    return
+  }
+  const forget = window.api.worktrees.forgetRemovedForExecutionHost
+  if (typeof forget !== 'function') {
+    return
+  }
+  void forget({ repoId, executionHostId: parsedHost.id, worktreeIds: [...worktreeIds] }).catch(
+    (err) => {
+      console.warn(`Failed to forget metadata for removed worktrees in repo ${repoId}:`, err)
+    }
+  )
 }
 
 function appendMissingWorktreesForHost<
@@ -3099,7 +3123,7 @@ async function fetchKnownSshWorktreesForRepo(
   repoId: string,
   executionHostId: SshExecutionHostId
 ): Promise<DetectedWorktreeListResult | null> {
-  const coalesceKey = `${repoId} ${executionHostId}`
+  const coalesceKey = `${repoId}\0${executionHostId}`
   const inflight = inflightKnownSshWorktreeFetches.get(coalesceKey)
   if (inflight) {
     return await inflight

--- a/src/shared/detected-worktree-provider-contract.ts
+++ b/src/shared/detected-worktree-provider-contract.ts
@@ -41,6 +41,17 @@ export type HostQualifiedKnownWorktreeResult =
       executionHostId: SshExecutionHostId
     }
 
+export type ForgetRemovedWorktreesForExecutionHostArgs = {
+  repoId: string
+  executionHostId: SshExecutionHostId
+  /** Ids an authoritative scan of this host proved gone — the only evidence that retires persisted metadata. */
+  worktreeIds: readonly string[]
+}
+
+export type ForgetRemovedWorktreesForExecutionHostResult = {
+  forgottenWorktreeIds: string[]
+}
+
 export type AuthoritativeDetectedWorktreeHost =
   | {
       kind: 'local'


### PR DESCRIPTION
## Problem
SSH worktrees were invisible until the SSH connection established and a full scan completed. Users had to wait for connectivity before seeing remote worktrees.

## Solution
Added metadata-based fallback listing for SSH worktrees while connection is pending:
- New IPC handlers `listKnownForExecutionHost` and `forgetRemovedForExecutionHost` read and retire persisted worktree metadata
- Renderer calls metadata fallback when SSH authority isn't available
- Session-scoped removal memory prevents resurrecting worktrees an authoritative scan proved deleted
- Main process automatically retires metadata after authoritative scans complete
- Folder workspaces exempt from retirement (metadata IS the workspace record)
- Strict validation ensures only SSH hosts and correctly-owned repos can use this path

## Screenshots
No visual change.

## Testing
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Comprehensive test coverage: metadata-only reads, folder workspace handling, retirement after authoritative scans, authorization checks, coalescing of concurrent reads, interaction with local repos, hydration-time behavior

## AI Review Report
TBD

## Security Audit
TBD

## Notes
Metadata-fallback results are marked `authoritative: false` so they don't suppress workspace session hydration or demote authoritative scans. Folder workspace instance IDs are synthesized without the suffix to match the git-worktree synthesizer's output format.