### PR TITLE
feat(file-explorer): add a setting to turn off rename-on-double-click

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -465,6 +465,9 @@ export function FileExplorerRow({
 }: FileExplorerRowProps): React.JSX.Element {
   const openMarkdownPreview = useAppStore((s) => s.openMarkdownPreview)
   const activeWorktreeId = useAppStore((s) => s.activeWorktreeId)
+  const renameOnDoubleClick = useAppStore(
+    (s) => s.settings?.fileExplorerRenameOnDoubleClick ?? true
+  )
   const copyPathShortcutLabel = useShortcutLabel('fileExplorer.copyPath')
   const copyRelativePathShortcutLabel = useShortcutLabel('fileExplorer.copyRelativePath')
   const findInFolderShortcutLabel = useShortcutLabel('sidebar.search.toggle')
@@ -627,9 +630,11 @@ export function FileExplorerRow({
             </>
           )}
           <span
-            // Why: marks the rename hotspot so the row's click handler can hold
-            // back the directory toggle until the double-click window closes.
-            {...{ [RENAME_HOTSPOT_ATTR]: '' }}
+            // Why: the hotspot marks where a rename gesture lives, so it must
+            // disappear with the gesture — otherwise the row's click handler
+            // keeps holding back the directory toggle for a rename that can no
+            // longer start.
+            {...(renameOnDoubleClick ? { [RENAME_HOTSPOT_ATTR]: '' } : {})}
             className={cn(
               'truncate',
               isSelected && !nodeStatus && !isIgnored && 'text-accent-foreground',
@@ -645,12 +650,16 @@ export function FileExplorerRow({
                   ? { color: 'var(--git-decoration-ignored)' }
                   : undefined
             }
-            onDoubleClick={(e) => {
-              // Why: scope rename to the filename text so "pin preview" and the
-              // directory toggle stay reachable on the icon and empty row area.
-              e.stopPropagation()
-              onStartRename(node)
-            }}
+            onDoubleClick={
+              renameOnDoubleClick
+                ? (e) => {
+                    // Why: scope rename to the filename text so "pin preview" and the
+                    // directory toggle stay reachable on the icon and empty row area.
+                    e.stopPropagation()
+                    onStartRename(node)
+                  }
+                : undefined
+            }
           >
             {node.name}
           </span>

--- a/src/renderer/src/components/right-sidebar/file-explorer-rename-on-double-click.test.tsx
+++ b/src/renderer/src/components/right-sidebar/file-explorer-rename-on-double-click.test.tsx
@@ -1,0 +1,120 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { FileExplorerRow } from './FileExplorerRow'
+import { isRenameHotspotTarget, resolveDirToggleTiming } from './file-explorer-dir-toggle-timing'
+import type { TreeNode } from './file-explorer-types'
+
+const mocks = vi.hoisted(() => ({
+  settings: { fileExplorerRenameOnDoubleClick: true } as Record<string, unknown>
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: Record<string, unknown>) => unknown) =>
+    selector({
+      activeWorktreeId: 'wt-1',
+      keybindings: {},
+      openMarkdownPreview: vi.fn(),
+      settings: mocks.settings
+    })
+}))
+
+const directoryNode: TreeNode = {
+  name: 'components',
+  path: '/repo/src/components',
+  relativePath: 'src/components',
+  isDirectory: true,
+  depth: 1
+}
+
+function renderRow(renameOnDoubleClick: boolean | undefined): {
+  name: HTMLElement
+  onStartRename: ReturnType<typeof vi.fn>
+} {
+  mocks.settings = { fileExplorerRenameOnDoubleClick: renameOnDoubleClick }
+  const onStartRename = vi.fn()
+  const view = render(
+    <FileExplorerRow
+      node={directoryNode}
+      isExpanded={false}
+      isLoading={false}
+      isSelected={false}
+      isFlashing={false}
+      selectedPaths={new Set()}
+      nodeStatus={null}
+      statusColor={null}
+      isIgnored={false}
+      deleteShortcutLabel="Del"
+      canCollapseFolderSubtree={false}
+      targetDir="/repo/src"
+      targetDepth={0}
+      selectionSize={0}
+      onClick={vi.fn()}
+      onDoubleClick={vi.fn()}
+      onViewFile={vi.fn()}
+      onContextMenuSelect={vi.fn()}
+      onCopyPaths={vi.fn()}
+      onStartNew={vi.fn()}
+      onStartRename={onStartRename}
+      onDuplicate={vi.fn()}
+      onAddFolderAsProject={vi.fn()}
+      canAddAsProject={false}
+      onOpenInTerminal={vi.fn()}
+      onRequestDelete={vi.fn()}
+      onCollapseFolderSubtree={vi.fn()}
+      onFindInFolder={vi.fn()}
+      onMoveDrop={vi.fn()}
+      onDragTargetChange={vi.fn()}
+      onDragSourceChange={vi.fn()}
+      onDragExpandDir={vi.fn()}
+      onNativeDragTargetChange={vi.fn()}
+      onNativeDragExpandDir={vi.fn()}
+    />
+  )
+  return { name: view.getByText(directoryNode.name), onStartRename }
+}
+
+describe('file explorer rename-on-double-click setting', () => {
+  afterEach(cleanup)
+
+  it('renames on a filename double-click while the setting is on', () => {
+    const { name, onStartRename } = renderRow(true)
+
+    fireEvent.doubleClick(name)
+
+    expect(onStartRename).toHaveBeenCalledWith(directoryNode)
+  })
+
+  it('defaults to on when the setting was never written', () => {
+    const { name, onStartRename } = renderRow(undefined)
+
+    fireEvent.doubleClick(name)
+
+    expect(onStartRename).toHaveBeenCalledWith(directoryNode)
+  })
+
+  it('drops the rename gesture while the setting is off', () => {
+    const { name, onStartRename } = renderRow(false)
+
+    fireEvent.doubleClick(name)
+
+    expect(onStartRename).not.toHaveBeenCalled()
+  })
+
+  // Why: the whole point of the setting — with the hotspot gone, a filename click
+  // no longer waits out the double-click window before toggling the directory.
+  it('makes a filename click toggle immediately while the setting is off', () => {
+    const { name } = renderRow(false)
+
+    expect(isRenameHotspotTarget(name)).toBe(false)
+    expect(resolveDirToggleTiming({ fromRenameHotspot: false, clickCount: 1 })).toBe('immediate')
+  })
+
+  it('keeps deferring a filename click while the setting is on', () => {
+    const { name } = renderRow(true)
+
+    expect(isRenameHotspotTarget(name)).toBe(true)
+    expect(resolveDirToggleTiming({ fromRenameHotspot: true, clickCount: 1 })).toBe('deferred')
+  })
+})

--- a/src/renderer/src/components/settings/AppearanceFileExplorerSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceFileExplorerSection.tsx
@@ -1,0 +1,86 @@
+import type React from 'react'
+
+import type { GlobalSettings } from '../../../../shared/types'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSubsectionHeader, SettingsSwitchRow } from './SettingsFormControls'
+import { getLayoutEntries } from './appearance-search'
+import { translate } from '@/i18n/i18n'
+
+type AppearanceFileExplorerSectionProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function AppearanceFileExplorerSection({
+  settings,
+  updateSettings
+}: AppearanceFileExplorerSectionProps): React.JSX.Element {
+  const [gitIgnoredEntry, renameOnDoubleClickEntry] = getLayoutEntries()
+  const showGitIgnoredFiles = settings.showGitIgnoredFiles ?? true
+  const renameOnDoubleClick = settings.fileExplorerRenameOnDoubleClick ?? true
+
+  return (
+    <div className="space-y-3">
+      <SettingsSubsectionHeader
+        title={translate('auto.components.settings.AppearancePane.d496901cd0', 'File Explorer')}
+      />
+      <div className="ml-4 divide-y divide-border/40">
+        <SearchableSetting
+          title={
+            gitIgnoredEntry?.title ??
+            translate(
+              'auto.components.settings.AppearancePane.0fafabcf35',
+              'Show Git-Ignored Files'
+            )
+          }
+          description={gitIgnoredEntry?.description}
+          keywords={gitIgnoredEntry?.keywords ?? ['git', 'gitignore', 'ignored']}
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.AppearancePane.0fafabcf35',
+              'Show Git-Ignored Files'
+            )}
+            // Why: define what "git-ignored" matches; the location (file explorer)
+            // is obvious from the section header.
+            description={translate(
+              'auto.components.settings.AppearancePane.gitIgnoredGlossary',
+              'Files matched by .gitignore.'
+            )}
+            checked={showGitIgnoredFiles}
+            onChange={() => updateSettings({ showGitIgnoredFiles: !showGitIgnoredFiles })}
+          />
+        </SearchableSetting>
+
+        <SearchableSetting
+          title={
+            renameOnDoubleClickEntry?.title ??
+            translate(
+              'auto.components.settings.AppearancePane.fileExplorerRenameOnDoubleClick.title',
+              'Rename on Double-Click'
+            )
+          }
+          description={renameOnDoubleClickEntry?.description}
+          keywords={renameOnDoubleClickEntry?.keywords ?? ['rename', 'double click']}
+        >
+          <SettingsSwitchRow
+            label={translate(
+              'auto.components.settings.AppearancePane.fileExplorerRenameOnDoubleClick.title',
+              'Rename on Double-Click'
+            )}
+            // Why: name the cost, not the mechanism — the delay is why anyone
+            // turns this off, and the surviving rename paths are what makes it safe to.
+            description={translate(
+              'auto.components.settings.AppearancePane.fileExplorerRenameOnDoubleClick.description',
+              'Off makes folders expand and collapse instantly. Rename stays available with Enter and the right-click menu.'
+            )}
+            checked={renameOnDoubleClick}
+            onChange={() =>
+              updateSettings({ fileExplorerRenameOnDoubleClick: !renameOnDoubleClick })
+            }
+          />
+        </SearchableSetting>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceWindowSidebarSection.tsx
@@ -4,6 +4,7 @@ import type { GlobalSettings, StatusBarItem } from '../../../../shared/types'
 import type { FeatureInteractionId } from '../../../../shared/feature-interaction-catalog'
 import { SearchableSetting } from './SearchableSetting'
 import { AppearanceAdvancedDisclosure } from './AppearanceAdvancedDisclosure'
+import { AppearanceFileExplorerSection } from './AppearanceFileExplorerSection'
 import { useAppStore } from '../../store'
 import {
   SettingsRow,
@@ -341,46 +342,7 @@ export function AppearanceWindowSidebarSection({
             ) : null}
 
             {showFileExplorerAdvanced ? (
-              <div className="space-y-3">
-                <SettingsSubsectionHeader
-                  title={translate(
-                    'auto.components.settings.AppearancePane.d496901cd0',
-                    'File Explorer'
-                  )}
-                />
-                <div className="ml-4 divide-y divide-border/40">
-                  <SearchableSetting
-                    title={
-                      layoutEntries[0]?.title ??
-                      translate(
-                        'auto.components.settings.AppearancePane.0fafabcf35',
-                        'Show Git-Ignored Files'
-                      )
-                    }
-                    description={layoutEntries[0]?.description}
-                    keywords={layoutEntries[0]?.keywords ?? ['git', 'gitignore', 'ignored']}
-                  >
-                    <SettingsSwitchRow
-                      label={translate(
-                        'auto.components.settings.AppearancePane.0fafabcf35',
-                        'Show Git-Ignored Files'
-                      )}
-                      // Why: define what "git-ignored" matches; the location (file explorer)
-                      // is obvious from the section header.
-                      description={translate(
-                        'auto.components.settings.AppearancePane.gitIgnoredGlossary',
-                        'Files matched by .gitignore.'
-                      )}
-                      checked={settings.showGitIgnoredFiles ?? true}
-                      onChange={() =>
-                        updateSettings({
-                          showGitIgnoredFiles: !(settings.showGitIgnoredFiles ?? true)
-                        })
-                      }
-                    />
-                  </SearchableSetting>
-                </div>
-              </div>
+              <AppearanceFileExplorerSection settings={settings} updateSettings={updateSettings} />
             ) : null}
           </div>
         </AppearanceAdvancedDisclosure>

--- a/src/renderer/src/components/settings/appearance-search.ts
+++ b/src/renderer/src/components/settings/appearance-search.ts
@@ -139,6 +139,42 @@ export const getLayoutEntries = createLocalizedCatalog((): SettingsSearchEntry[]
       ...translateSearchKeyword('auto.components.settings.appearance.search.5bff6a2ef0', 'sidebar'),
       ...translateSearchKeyword('auto.components.settings.appearance.search.648eeada79', 'hide')
     ]
+  },
+  {
+    title: translate(
+      'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.title',
+      'Rename on Double-Click'
+    ),
+    description: translate(
+      'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.description',
+      'Double-clicking a name in the file explorer starts a rename. Turning this off makes folders expand and collapse instantly.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.rename',
+        'rename'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.doubleClick',
+        'double click'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.expand',
+        'expand'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.slow',
+        'slow'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.delay',
+        'delay'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.appearance.search.fileExplorerRenameOnDoubleClick.fileExplorer',
+        'file explorer'
+      )
+    ]
   }
 ])
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -5584,6 +5584,10 @@
           "showPinnedWorktreesInGroups": {
             "title": "Also show pinned worktrees in their original lists",
             "description": "Pinned worktrees stay in Pinned and also appear in All, Project, Status, and PR."
+          },
+          "fileExplorerRenameOnDoubleClick": {
+            "title": "Rename on Double-Click",
+            "description": "Off makes folders expand and collapse instantly. Rename stays available with Enter and the right-click menu."
           }
         },
         "AutoRenameBranchFromWorkSetting": {
@@ -7948,7 +7952,11 @@
             "d6c0a9e2f4": "grok",
             "c5b9f8d1e3": "xai",
             "usagePercentageDisplayTitle": "Usage percentages",
-            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining."
+            "usagePercentageDisplayDescription": "Choose whether provider limits show the percentage used or remaining.",
+            "fileExplorerRenameOnDoubleClick": {
+              "title": "Rename on Double-Click",
+              "description": "Double-clicking a name in the file explorer starts a rename. Turning this off makes folders expand and collapse instantly."
+            }
           }
         },
         "auto": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -270,6 +270,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     openInApplications: [...DEFAULT_OPEN_IN_APPLICATIONS],
     rightSidebarOpenByDefault: true,
     showGitIgnoredFiles: true,
+    fileExplorerRenameOnDoubleClick: true,
     sourceControlViewMode: 'list',
     sourceControlCompareAgainstUpstream: false,
     showTitlebarAppName: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2882,6 +2882,8 @@ export type GlobalSettings = {
   /** Deprecated: migration/backward-compat only. Use PersistedUIState.rightSidebarOpen. */
   rightSidebarOpenByDefault: boolean
   showGitIgnoredFiles?: boolean
+  /** Double-clicking a File Explorer name renames it. Off makes folder toggles fire immediately, since no click has to wait out the double-click window. */
+  fileExplorerRenameOnDoubleClick?: boolean
   /** Preferred Source Control changes layout. Per-user, not per-workspace. */
   sourceControlViewMode: SourceControlViewMode
   /** Compare base defaults to the branch upstream instead of the repo default; affects only the compare/diff view, not the PR/rebase target. Per-user. */


### PR DESCRIPTION
Closes #12800

## Problem

Clicking a folder **name** in the File Explorer defers its expand/collapse by `DIR_TOGGLE_DOUBLE_CLICK_MS` (500 ms), so a slow double-click can become a rename instead of a visible collapse/re-expand. Clicking the icon, the chevron, the empty row area, or using the arrow keys all toggle immediately — which makes the delay easy to miss in testing, and easy to hit in normal use, since the name is the biggest target on the row.

That tradeoff is right for people who use double-click-to-rename. For everyone else it is half a second on the panel's most common gesture, with no way out.

VS Code's folders toggle instantly from anywhere on the row because it has no click-to-rename gesture at all — rename is `F2`, and `Enter` on macOS. Orca is carrying the Finder gesture (click the name of a selected item) inside a VS Code–shaped tree, and paying Finder's latency for it.

## Change

Adds `fileExplorerRenameOnDoubleClick`, **default `true`** — no behavior change unless you turn it off.

When off, `FileExplorerRow` renders neither the `RENAME_HOTSPOT_ATTR` marker nor the `onDoubleClick` rename handler. Removing both together is what makes this safe: `isRenameHotspotTarget` then returns `false`, so `resolveDirToggleTiming` reports `'immediate'` **by construction** — there is no second code path that could hold a toggle back for a rename that can no longer start. `resolveDirToggleTiming` itself is untouched.

Rename stays reachable where Orca already supports it, which is also where VS Code puts it:

- `Enter` on the selected row (`useFileExplorerKeys.ts:225-228`)
- right-click → Rename (`FileExplorerRow.tsx:833`)

Files renamed by double-click also fall through to the row's existing double-click behavior (pin the preview editor), matching VS Code.

## Notes for review

- **Settings extraction.** `AppearanceWindowSidebarSection.tsx` was ~371 counted lines against a 400 cap, so a second switch would have needed a `max-lines` bump — which AGENTS.md forbids. The File Explorer subsection moved to `AppearanceFileExplorerSection.tsx` instead; the parent drops ~40 lines and the new file has room for both settings. No behavior change to the Git-Ignored toggle.
- **Store read in the row.** `FileExplorerRow` already subscribes to `openMarkdownPreview` and `activeWorktreeId`; this adds one primitive boolean selector, which changes ~never, rather than drilling a prop through `FileExplorerVirtualRows`.
- **Search keywords** are registered so the setting is findable by "rename", "double click", "expand", "slow", and "delay" — the words someone hunting for this lag would actually type.
- Renderer-only and transport-agnostic: no change for SSH workspaces, folder workspaces, or the remote wire.
- Locale catalog synced via `pnpm run sync:localization-catalog` (en.json only; the other locales fall back, consistent with the 271-281 keys each is already missing).

## Testing

New `file-explorer-rename-on-double-click.test.tsx` renders the real row and covers: setting on renames, unset defaults to on, setting off drops the gesture, and — the point of the change — setting off leaves no hotspot so the click resolves `'immediate'`. Confirmed the two setting-off cases fail against the unmodified row, so they are not vacuous.

- `pnpm run lint` — pass (includes the max-lines ratchet and all three localization gates)
- `pnpm run typecheck` — pass (node, cli, web)
- `pnpm vitest run src/renderer/src/components/right-sidebar/ src/renderer/src/components/settings/` — 332 files, 2676 tests, pass

Manually verified on macOS against Orca 1.4.168: with the setting off, folder names expand and collapse with no perceptible delay; `Enter` and the context menu still rename.

## Open question

I went with a user-facing setting because that is the smallest change that fully removes the delay for people who don't want the gesture. A narrower fix exists and I'm happy to switch to it: **defer only when the row was already selected before the click** — the real Finder/Windows rule — which would make first clicks instant for everyone with no setting at all. `resolveDirToggleTiming` takes no selection input today, which is why the delay is currently unconditional. Say the word and I'll rework it, or layer it underneath the setting.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
