### PR TITLE
fix(terminal): render the vertical scrollbar again while keeping the gutter transparent

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -586,8 +586,11 @@
 
 /* ── Editor-style scrollbar (matches Monaco) ────────── */
 
-.scrollbar-editor,
-.xterm .xterm-viewport {
+/* Why: standard scrollbar-width/color disable ::-webkit-scrollbar* in
+   Chromium >=121. Keep them on .scrollbar-editor (Firefox/non-webkit), but
+   style .xterm .xterm-viewport with webkit pseudos only so the custom thumb
+   paints and the gutter/track stays transparent (#7876 intent, fixes #12635). */
+.scrollbar-editor {
   scrollbar-width: thin;
   scrollbar-color: rgba(121, 121, 121, 0.4) transparent;
 }

--- a/src/renderer/src/assets/terminal-scrollbar-style.test.ts
+++ b/src/renderer/src/assets/terminal-scrollbar-style.test.ts
@@ -4,14 +4,55 @@ import { describe, expect, it } from 'vitest'
 const terminalCss = fs.readFileSync(new URL('./terminal.css', import.meta.url), 'utf8')
 const mainCss = fs.readFileSync(new URL('./main.css', import.meta.url), 'utf8')
 
+/** Split simple top-level `{...}` rule blocks (no nested rules in these selectors). */
+function cssRuleBlocks(css: string): { selector: string; body: string }[] {
+  const blocks: { selector: string; body: string }[] = []
+  const re = /([^{}]+)\{([^{}]*)\}/g
+  let match: RegExpExecArray | null
+  while ((match = re.exec(css)) !== null) {
+    blocks.push({ selector: match[1].trim(), body: match[2] })
+  }
+  return blocks
+}
+
+function isViewportSelector(selector: string): boolean {
+  // Matches ".xterm .xterm-viewport" alone or comma-listed, but not ::-webkit-scrollbar*
+  return (
+    /(?:^|,)\s*\.xterm\s+\.xterm-viewport\s*(?:,|$)/.test(selector) &&
+    !selector.includes('::-webkit-scrollbar')
+  )
+}
+
 describe('terminal scrollbar styling', () => {
   it('reuses the canonical editor scrollbar with a transparent gutter', () => {
+    // Editor keeps standard scrollbar props for non-webkit engines.
     expect(mainCss).toMatch(
-      /\.scrollbar-editor,\s*\.xterm \.xterm-viewport\s*{[^}]*scrollbar-color:\s*rgba\(121, 121, 121, 0\.4\) transparent/s
+      /\.scrollbar-editor\s*{[^}]*scrollbar-color:\s*rgba\(121, 121, 121, 0\.4\) transparent/s
     )
+    // Terminal viewport shares the webkit track/thumb (transparent gutter).
     expect(mainCss).toMatch(
       /\.scrollbar-editor::-webkit-scrollbar-track,\s*\.xterm \.xterm-viewport::-webkit-scrollbar-track\s*{[^}]*background:\s*transparent/s
     )
+    expect(mainCss).toMatch(
+      /\.scrollbar-editor::-webkit-scrollbar-thumb,\s*\.xterm \.xterm-viewport::-webkit-scrollbar-thumb\s*{[^}]*background:\s*rgba\(121, 121, 121, 0\.4\)/s
+    )
     expect(terminalCss).not.toContain('--xterm-scrollbar-thumb')
+  })
+
+  // Why: Chromium (>=121) disables ::-webkit-scrollbar* when the element also
+  // sets standard scrollbar-width/scrollbar-color. #7876 folded the viewport
+  // into both rule sets; the custom thumb never painted (#12635).
+  it('does not set standard scrollbar properties on the viewport that also uses webkit pseudos', () => {
+    const hasWebkitViewport = /\.xterm\s+\.xterm-viewport::-webkit-scrollbar/.test(mainCss)
+    expect(hasWebkitViewport).toBe(true)
+
+    const conflicts = cssRuleBlocks(mainCss).filter(({ selector, body }) => {
+      if (!isViewportSelector(selector)) {
+        return false
+      }
+      return /\bscrollbar-width\s*:/.test(body) || /\bscrollbar-color\s*:/.test(body)
+    })
+
+    expect(conflicts).toEqual([])
   })
 })


### PR DESCRIPTION
## Summary

The terminal vertical scrollbar no longer rendered on any theme after #7876 folded the xterm viewport into both standard `scrollbar-*` properties and `::-webkit-scrollbar*` rules.
Fixes #12635.

## Screenshots

No screenshot available. Reviewer will see: a visible vertical scrollbar **thumb** over a **transparent** gutter/track in the terminal; horizontal scrollbar unchanged; editor/Monaco `.scrollbar-editor` behavior unchanged.

## Testing

- [x] `pnpm lint` — ran `pnpm exec oxlint` on `terminal-scrollbar-style.test.ts` (0 errors); CSS has no oxlint surface
- [ ] `pnpm typecheck` — skipped (CSS + style unit test only; no TS production changes)
- [x] `pnpm test` — focused: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/assets/terminal-scrollbar-style.test.ts` (2/2 pass). Repository-wide suite not run.
- [ ] `pnpm build` — not run (renderer CSS + test-only change; build would not exercise the regression)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed — mutual-exclusion assertion: viewport must not set standard `scrollbar-width`/`scrollbar-color` when it also uses `::-webkit-scrollbar*` (the hole #7876's greps missed). RED on origin/main before the CSS fix; GREEN after.

## ELI5

Clicking around in a terminal, the thin grey bar on the right edge that shows scroll position disappeared. Browsers (and Electron's Chromium) ignore custom scrollbar paint rules when you also set the newer standard scrollbar properties on the same element. We keep the transparent track from the original fix, but stop setting those standard properties on the terminal viewport so the thumb can paint again.

## AI Review Report

Self-review of a renderer-only CSS + unit-test change:
- **Mechanism:** Chromium ≥121 disables `::-webkit-scrollbar*` when `scrollbar-width` / `scrollbar-color` are present; Electron 43.1.0 ships Chromium ~140, so the conflict applies.
- **Scope:** removed `.xterm .xterm-viewport` only from the standard-props rule; left it on all webkit track/thumb rules so #7876's transparent gutter remains.
- **Colors:** reused existing `rgba(121, 121, 121, 0.4|0.7)` already defined for this scrollbar — no invented tokens (STYLEGUIDE).
- **Cross-platform:** macOS / Linux / Windows all use Electron Chromium for the terminal DOM scrollbar; no shortcuts, paths, shell, or native scrollbars touched. Horizontal scrollbar lives on a different element and was never broken.
- **Risks checked:** over-reverting #7876 (avoided); breaking `.scrollbar-editor` Firefox path (standard props kept there); test false positives on multi-selector blocks (selector parser excludes `::-webkit-scrollbar*`).

## Security Audit

No security surface. No IPC, command execution, filesystem, auth, secrets, network, or dependency changes — pure renderer CSS styling and a style-source unit test.

## Notes

**Mechanism:** #7876 added `.xterm .xterm-viewport` to both the standard `scrollbar-width`/`scrollbar-color` block and the `::-webkit-scrollbar*` blocks. In Chromium ≥121, standard scrollbar properties disable webkit pseudo styling, so the custom thumb never applied; with `terminal.css` making the viewport background transparent, the UA thin thumb over a transparent track was effectively invisible. Horizontal scrollbar is a different element, which is why it survived.

Supersedes nothing; #7876's transparent-gutter intent is preserved (webkit track remains `background: transparent`; only standard props were removed from the viewport selector).
