### PR TITLE
fix(terminal): cap distinct error surface growth

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
@@ -90,4 +90,11 @@ describe('appendTerminalErrorMessage', () => {
     expect(bounded.length).toBeLessThanOrEqual(MAX_TERMINAL_ERROR_CHARS)
     expect(bounded.endsWith('x')).toBe(true)
   })
+
+  it('drops a clipped leading line after character truncation', () => {
+    const latestLine = 'SSH connection failed: host unreachable'
+    const huge = `${'x'.repeat(MAX_TERMINAL_ERROR_CHARS + 500)}\n${latestLine}`
+
+    expect(boundTerminalErrorSurface(huge)).toBe(latestLine)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
@@ -1,5 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { appendTerminalErrorMessage } from './terminal-error-accumulation'
+import {
+  appendTerminalErrorMessage,
+  boundTerminalErrorSurface,
+  MAX_TERMINAL_ERROR_CHARS,
+  MAX_TERMINAL_ERROR_LINES
+} from './terminal-error-accumulation'
 import { stripSshReconnectOwnedErrorLines } from './TerminalErrorToast'
 
 const MULTILINE_ERROR = 'Remote terminal write failed.\nThe remote runtime rejected the request.'
@@ -66,5 +71,23 @@ describe('appendTerminalErrorMessage', () => {
       MULTILINE_ERROR
     )
     expect(stripSshReconnectOwnedErrorLines(accumulated)).toBe(MULTILINE_ERROR)
+  })
+
+  it('caps a distinct single-line error storm to the newest lines', () => {
+    let accumulated: string | null = null
+    for (let i = 0; i < MAX_TERMINAL_ERROR_LINES + 12; i += 1) {
+      accumulated = appendTerminalErrorMessage(accumulated, `timeout #${i}`)
+    }
+    const lines = accumulated!.split('\n')
+    expect(lines).toHaveLength(MAX_TERMINAL_ERROR_LINES)
+    expect(lines[0]).toBe('timeout #12')
+    expect(lines.at(-1)).toBe(`timeout #${MAX_TERMINAL_ERROR_LINES + 11}`)
+  })
+
+  it('keeps a closed character budget for oversized surfaces', () => {
+    const huge = 'x'.repeat(MAX_TERMINAL_ERROR_CHARS + 500)
+    const bounded = boundTerminalErrorSurface(huge)
+    expect(bounded.length).toBeLessThanOrEqual(MAX_TERMINAL_ERROR_CHARS)
+    expect(bounded.endsWith('x')).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
@@ -13,10 +13,45 @@ function containsWholeLineRun(accumulated: string, message: string): boolean {
   )
 }
 
+/** Hard cap on distinct newline-separated lines kept on the aggregated surface. */
+export const MAX_TERMINAL_ERROR_LINES = 24
+
+/** Closed character budget so a few huge multi-line messages cannot grow without bound. */
+export const MAX_TERMINAL_ERROR_CHARS = 4_000
+
+/**
+ * Prefer newest content. Snap to a newline after truncation so per-line SSH
+ * reconnect filters never see a partial leading line.
+ */
+export function boundTerminalErrorSurface(
+  surface: string,
+  maxLines: number = MAX_TERMINAL_ERROR_LINES,
+  maxChars: number = MAX_TERMINAL_ERROR_CHARS
+): string {
+  let next = surface
+  if (maxLines > 0) {
+    const lines = next.split('\n')
+    if (lines.length > maxLines) {
+      next = lines.slice(lines.length - maxLines).join('\n')
+    }
+  }
+  if (maxChars > 0 && next.length > maxChars) {
+    const suffix = next.slice(next.length - maxChars)
+    const firstNl = suffix.indexOf('\n')
+    // Why: drop a clipped leading line when possible; if the suffix is one long
+    // line, keep it so the newest error remains visible.
+    next = firstNl === -1 ? suffix : suffix.slice(firstNl + 1) || suffix
+  }
+  return next
+}
+
 /** Appends an error to the aggregated surface, keeping the first occurrence of an already-present message. */
 export function appendTerminalErrorMessage(accumulated: string | null, message: string): string {
   if (!accumulated) {
-    return message
+    return boundTerminalErrorSurface(message)
   }
-  return containsWholeLineRun(accumulated, message) ? accumulated : `${accumulated}\n${message}`
+  if (containsWholeLineRun(accumulated, message)) {
+    return accumulated
+  }
+  return boundTerminalErrorSurface(`${accumulated}\n${message}`)
 }


### PR DESCRIPTION
## Description
Cap the aggregated terminal error surface so a storm of **distinct** messages cannot grow without bound.

#12650 added whole-line dedup; this adds a closed line + character budget preferring newest content.

## Focused fix
- In scope: `appendTerminalErrorMessage` / `boundTerminalErrorSurface` hard caps
- Out of scope: paste-path routing, transport-level suppression changes

## Preserves
- Whole-message dedup (`containsWholeLineRun`)
- Newline-joined shape for per-line SSH reconnect toast filters

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts` (10 passed)

## User-regression-tradeoffs
- Older distinct errors drop first under a multi-message storm (bounded newest window)

Fixes #12685
