### PR TITLE
fix(source-control): keep COMMITS expand and height across worktrees

### DIFF
--- a/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/GitHistoryPanel.tsx
@@ -17,6 +17,13 @@ import {
   type GitHistoryCommitAction
 } from './GitHistoryCommitContextMenu'
 import type { SourceControlRowOpenEvent } from './source-control-split-open'
+import {
+  clampSourceControlHistoryHeight,
+  getSessionSourceControlHistoryHeight,
+  MAX_SOURCE_CONTROL_HISTORY_HEIGHT as MAX_GIT_HISTORY_PANEL_HEIGHT,
+  MIN_SOURCE_CONTROL_HISTORY_HEIGHT as MIN_GIT_HISTORY_PANEL_HEIGHT,
+  setSessionSourceControlHistoryHeight
+} from './source-control-history-layout'
 import { translate } from '@/i18n/i18n'
 
 export type GitHistoryPanelState =
@@ -24,9 +31,6 @@ export type GitHistoryPanelState =
   | { status: 'refreshing' | 'ready'; result: GitHistoryResult; error?: string }
   | { status: 'error'; result?: GitHistoryResult; error: string }
 
-const DEFAULT_GIT_HISTORY_PANEL_HEIGHT = 256
-const MIN_GIT_HISTORY_PANEL_HEIGHT = 96
-const MAX_GIT_HISTORY_PANEL_HEIGHT = 520
 const MAX_GIT_HISTORY_PANEL_VIEWPORT_HEIGHT = '33vh'
 
 type GitHistoryResizeSession = {
@@ -37,7 +41,7 @@ type GitHistoryResizeSession = {
 }
 
 function clampGitHistoryPanelHeight(height: number): number {
-  return Math.min(MAX_GIT_HISTORY_PANEL_HEIGHT, Math.max(MIN_GIT_HISTORY_PANEL_HEIGHT, height))
+  return clampSourceControlHistoryHeight(height)
 }
 
 export function GitHistoryPanel({
@@ -82,7 +86,14 @@ export function GitHistoryPanel({
 
   const loading = state.status === 'loading' || state.status === 'refreshing'
   const count = result?.items.length ?? 0
-  const [panelHeight, setPanelHeight] = useState(DEFAULT_GIT_HISTORY_PANEL_HEIGHT)
+  const [panelHeight, setPanelHeightState] = useState(() => getSessionSourceControlHistoryHeight())
+  const setPanelHeight = useCallback((value: number | ((prev: number) => number)): void => {
+    setPanelHeightState((prev) => {
+      const next = clampGitHistoryPanelHeight(typeof value === 'function' ? value(prev) : value)
+      setSessionSourceControlHistoryHeight(next)
+      return next
+    })
+  }, [])
   const resizeSessionRef = useRef<GitHistoryResizeSession | null>(null)
 
   const [expanded, setExpanded] = useState<Set<string>>(() => new Set())

--- a/src/renderer/src/components/right-sidebar/SourceControl.tsx
+++ b/src/renderer/src/components/right-sidebar/SourceControl.tsx
@@ -196,6 +196,10 @@ import { getRuntimeRepoBaseRefDefault } from '@/runtime/runtime-repo-client'
 import { stripBaseRef, useCreatePullRequestDialogFields } from './useCreatePullRequestDialogFields'
 import { resolveCreateReviewDraftTitle } from './create-review-draft-title'
 import { GitHistoryPanel, type GitHistoryPanelState } from './GitHistoryPanel'
+import {
+  getSessionSourceControlHistoryExpanded,
+  setSessionSourceControlHistoryExpanded
+} from './source-control-history-layout'
 import { useGitHistoryCommitActions } from './useGitHistoryCommitActions'
 import { normalizeHostedReviewHeadRef } from '../../../../shared/hosted-review-refs'
 import {
@@ -553,6 +557,17 @@ const SUBMODULE_ERROR_LABEL = 'Failed to load submodule changes'
 
 function createDefaultCollapsedSections(): Set<string> {
   return new Set(DEFAULT_COLLAPSED_SECTIONS)
+}
+
+function createCollapsedSectionsFromSession(): Set<string> {
+  const next = createDefaultCollapsedSections()
+  // Why: worktree switches used to re-collapse COMMITS; restore the session choice.
+  if (getSessionSourceControlHistoryExpanded()) {
+    next.delete('history')
+  } else {
+    next.add('history')
+  }
+  return next
 }
 
 function useCopyFeedbackState<T>(resetValue: T): [T, (value: T) => void] {
@@ -1061,7 +1076,7 @@ function SourceControlInner(): React.JSX.Element {
 
   const [filterExpanded, setFilterExpanded] = useState(false)
   const [collapsedSections, setCollapsedSections] = useState<Set<string>>(
-    createDefaultCollapsedSections
+    createCollapsedSectionsFromSession
   )
   const persistedSourceControlViewMode = normalizeSourceControlViewMode(
     settings?.sourceControlViewMode
@@ -2075,7 +2090,8 @@ function SourceControlInner(): React.JSX.Element {
   // Why: reset worktree-specific state manually instead of key-remounting on switch (which caused a Windows IPC storm).
   useEffect(() => {
     setFilterExpanded(false)
-    setCollapsedSections(createDefaultCollapsedSections())
+    // Why: COMMITS expand is a user layout preference, not worktree-local draft state.
+    setCollapsedSections(createCollapsedSectionsFromSession())
     setCollapsedTreeDirs(new Set())
     setBaseRefDialogOpen(false)
     setPendingDiscard(null)
@@ -5130,6 +5146,9 @@ function SourceControlInner(): React.JSX.Element {
         next.delete(section)
       } else {
         next.add(section)
+      }
+      if (section === 'history') {
+        setSessionSourceControlHistoryExpanded(!next.has('history'))
       }
       return next
     })

--- a/src/renderer/src/components/right-sidebar/source-control-history-layout.test.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-history-layout.test.ts
@@ -1,0 +1,32 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  _resetSessionSourceControlHistoryLayoutForTests,
+  clampSourceControlHistoryHeight,
+  DEFAULT_SOURCE_CONTROL_HISTORY_HEIGHT,
+  getSessionSourceControlHistoryExpanded,
+  getSessionSourceControlHistoryHeight,
+  MAX_SOURCE_CONTROL_HISTORY_HEIGHT,
+  MIN_SOURCE_CONTROL_HISTORY_HEIGHT,
+  setSessionSourceControlHistoryExpanded,
+  setSessionSourceControlHistoryHeight
+} from './source-control-history-layout'
+
+afterEach(() => {
+  _resetSessionSourceControlHistoryLayoutForTests()
+})
+
+describe('source-control-history-layout', () => {
+  it('clamps height into the closed panel range', () => {
+    expect(clampSourceControlHistoryHeight(10)).toBe(MIN_SOURCE_CONTROL_HISTORY_HEIGHT)
+    expect(clampSourceControlHistoryHeight(9999)).toBe(MAX_SOURCE_CONTROL_HISTORY_HEIGHT)
+    expect(clampSourceControlHistoryHeight(Number.NaN)).toBe(DEFAULT_SOURCE_CONTROL_HISTORY_HEIGHT)
+  })
+
+  it('remembers expanded state and height across getters/setters', () => {
+    expect(getSessionSourceControlHistoryExpanded()).toBe(false)
+    setSessionSourceControlHistoryExpanded(true)
+    setSessionSourceControlHistoryHeight(480)
+    expect(getSessionSourceControlHistoryExpanded()).toBe(true)
+    expect(getSessionSourceControlHistoryHeight()).toBe(480)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/source-control-history-layout.ts
+++ b/src/renderer/src/components/right-sidebar/source-control-history-layout.ts
@@ -1,0 +1,43 @@
+/** Session + durable defaults for Source Control COMMITS section layout. */
+
+export const DEFAULT_SOURCE_CONTROL_HISTORY_HEIGHT = 256
+export const MIN_SOURCE_CONTROL_HISTORY_HEIGHT = 96
+export const MAX_SOURCE_CONTROL_HISTORY_HEIGHT = 520
+
+// Why: Source Control resets section state on worktree switch and unmounts on
+// tab changes; keep the last user-chosen COMMITS expand/height for the session
+// so project switching does not force re-expand and re-drag every time.
+let sessionHistoryExpanded = false
+let sessionHistoryHeight = DEFAULT_SOURCE_CONTROL_HISTORY_HEIGHT
+
+export function clampSourceControlHistoryHeight(height: number): number {
+  if (!Number.isFinite(height)) {
+    return DEFAULT_SOURCE_CONTROL_HISTORY_HEIGHT
+  }
+  return Math.min(
+    MAX_SOURCE_CONTROL_HISTORY_HEIGHT,
+    Math.max(MIN_SOURCE_CONTROL_HISTORY_HEIGHT, Math.round(height))
+  )
+}
+
+export function getSessionSourceControlHistoryExpanded(): boolean {
+  return sessionHistoryExpanded
+}
+
+export function setSessionSourceControlHistoryExpanded(expanded: boolean): void {
+  sessionHistoryExpanded = expanded
+}
+
+export function getSessionSourceControlHistoryHeight(): number {
+  return sessionHistoryHeight
+}
+
+export function setSessionSourceControlHistoryHeight(height: number): void {
+  sessionHistoryHeight = clampSourceControlHistoryHeight(height)
+}
+
+/** Test-only reset. */
+export function _resetSessionSourceControlHistoryLayoutForTests(): void {
+  sessionHistoryExpanded = false
+  sessionHistoryHeight = DEFAULT_SOURCE_CONTROL_HISTORY_HEIGHT
+}


### PR DESCRIPTION
## Description
Remember the Source Control **COMMITS** section expanded state and panel height across worktree/project switches within a session.

Previously every switch reset the section to collapsed + default height.

## Focused fix
- In scope: session layout module + SourceControl/GitHistoryPanel wiring
- Out of scope: durable `orca-data.json` keys (can follow separately)

## Preserves
- First-run default remains collapsed until the user expands
- Height stays within the existing min/max panel bounds

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/source-control-history-layout.test.ts` (2 passed)

## User-regression-tradeoffs
- Preference is session-scoped (not yet written to profile UI state)

Fixes #12591
