### PR TITLE
fix(serve): recognize CLI-form serve args on the Electron process

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -73,6 +73,9 @@
     "../src/main/openclaude/hook-service.ts",
     "../src/main/rolling-file-backup.ts",
     "../src/main/startup/hydrate-shell-path.ts",
+    // Why: serve-electron-flag-parity.test.ts checks the Electron-side serve argv rewrite against this
+    // project's serve spec; the module has no imports, so listing it pulls in nothing else.
+    "../src/main/startup/serve-mode-argv.ts",
     "../src/main/runtime/runtime-metadata.ts",
     "../src/main/win32-utils.ts"
   ],

--- a/config/tsconfig.tc.web.json
+++ b/config/tsconfig.tc.web.json
@@ -16,6 +16,7 @@
     "../src/main/wsl-distro-retry.ts",
     "../src/main/wsl.ts",
     "../src/main/startup/serve-desktop-activation.ts",
+    "../src/main/startup/serve-mode-argv.ts",
     "../src/main/startup/single-instance-lock.ts",
     "../src/main/startup/startup-diagnostics.ts",
     "../src/main/window/focus-existing-window.ts",

--- a/src/cli/serve-electron-flag-parity.test.ts
+++ b/src/cli/serve-electron-flag-parity.test.ts
@@ -1,0 +1,79 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { normalizeServeModeArgv } from '../main/startup/serve-mode-argv'
+import { BOOLEAN_FLAGS, GLOBAL_FLAGS } from './args'
+import { SERVE_COMMAND_SPECS } from './specs/serve'
+
+// Why this test lives under src/cli: the Electron rewrite duplicates the CLI's serve flag list because
+// the main tsconfig cannot import the CLI project, so the parity check has to run from the CLI side.
+// It fails when `orca serve` grows a flag that a direct `<binary> serve …` launch would silently drop (#12677).
+
+// Global flags with no `--serve-*` counterpart:
+// - help: a help launch is refused outright, not translated (see serve-mode-argv's HELP_FLAGS).
+// - pairing-code / environment: nothing in src/main reads them, so they ride through untouched.
+const UNTRANSLATED_GLOBAL_FLAGS = new Set(['help', 'pairing-code', 'environment'])
+
+const serveSpec = SERVE_COMMAND_SPECS.find((spec) => spec.path.join(' ') === 'serve')
+const translatedFlags = [...new Set(serveSpec?.allowedFlags ?? [])].filter(
+  (flag) => !UNTRANSLATED_GLOBAL_FLAGS.has(flag)
+)
+
+describe('serve flag parity between the CLI spec and the Electron argv rewrite', () => {
+  it('has a serve spec to compare against', () => {
+    expect(translatedFlags.length).toBeGreaterThan(0)
+  })
+
+  it.each(translatedFlags)('rewrites CLI-form --%s into the --serve-* form', (flag) => {
+    const takesValue = !BOOLEAN_FLAGS.has(flag)
+    const argv = takesValue
+      ? ['/AppRun', 'serve', `--${flag}`, 'value']
+      : ['/AppRun', 'serve', `--${flag}`]
+    const expected = takesValue
+      ? ['/AppRun', '--serve', `--serve-${flag}`, 'value']
+      : ['/AppRun', '--serve', `--serve-${flag}`]
+
+    expect(normalizeServeModeArgv(argv)).toEqual(expected)
+    if (takesValue) {
+      // The equals form is the other shape `orca serve` accepts, and getServeOptions only reads the next token.
+      expect(normalizeServeModeArgv(['/AppRun', 'serve', `--${flag}=value`])).toEqual(expected)
+    } else {
+      // A boolean with an attached value is not a truthy assertion: the CLI reads these as
+      // `flags.get(name) === true`, so `--no-pairing=false` must not disable pairing here either.
+      // (`--json` is the one flag the CLI reads with `.has()`; erring toward the literal value is
+      // the safe direction and only changes output format.)
+      expect(normalizeServeModeArgv(['/AppRun', 'serve', `--${flag}=false`])).toEqual([
+        '/AppRun',
+        '--serve',
+        `--${flag}=false`
+      ])
+    }
+    // Idempotent: `orca serve` spawns the app already in this shape, and the rewrite runs over it too.
+    expect(normalizeServeModeArgv(expected)).toEqual(expected)
+  })
+
+  it('emits the same --serve-* names the CLI spawns with and the main process reads', () => {
+    // Why source text: serveOrcaApp spawns a real process and getServeOptions is not exported, so
+    // both ends of the contract are only readable statically. Without this leg the rewrite could
+    // emit a name nothing reads and every behavioural assertion above would still pass.
+    const launchSource = readFileSync(join(process.cwd(), 'src/cli/runtime/launch.ts'), 'utf8')
+    const mainSource = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const start = mainSource.indexOf('function getServeOptions(')
+    // Why bound the anchor: an unresolved indexOf slices to EOF and passes vacuously.
+    expect(start).toBeGreaterThanOrEqual(0)
+    const end = mainSource.indexOf('\n}', start)
+    expect(end).toBeGreaterThan(start)
+    const getServeOptionsBody = mainSource.slice(start, end)
+
+    for (const flag of translatedFlags) {
+      expect(launchSource).toContain(`'--serve-${flag}'`)
+      expect(getServeOptionsBody).toContain(`'--serve-${flag}'`)
+    }
+  })
+
+  it('keeps the untranslated allowlist tied to real global flags', () => {
+    for (const flag of UNTRANSLATED_GLOBAL_FLAGS) {
+      expect(GLOBAL_FLAGS).toContain(flag)
+    }
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -381,9 +381,10 @@ let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
 // Why: on Windows a CLI launch that lost ELECTRON_RUN_AS_NODE would boot the GUI and exit silently; redirect to node mode before the lock gate below.
-// Both redirects run before the serve-argv rewrite so they still match on the
-// launch argv verbatim; rewriting first would hide `serve` from their CLI
-// command-name lookup and strand AppImage launches in an in-process serve.
+// Both redirects run before the serve-argv rewrite so they still match on the launch argv verbatim.
+// It is load-bearing for the AppImage one: rewriting first replaces the `serve` positional, so its
+// command-name lookup finds a port number and strands the launch in an in-process serve. The
+// packaged-CLI one matches on the entry path instead, so order cannot affect it either way.
 const packagedCliEntryRedirect = maybeRedirectPackagedCliEntryLaunch({
   isPackaged: app.isPackaged,
   resourcesPath: process.resourcesPath,

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -127,6 +127,7 @@ import {
   installUnhandledRejectionLogging
 } from './startup/main-process-error-guards'
 import { enableRendererHeapHeadroom } from './startup/renderer-heap-headroom'
+import { argvRequestsServeMode, normalizeServeModeArgv } from './startup/serve-mode-argv'
 import { ensureVirtualDisplayForHeadlessServe } from './startup/ensure-virtual-display'
 import {
   readActiveGpuFallbackMarker,
@@ -379,6 +380,11 @@ let gpuFeatureStatus: Electron.GPUFeatureStatus | null = null
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
+// Why: extracted AppRun / binary launches can land CLI-form `serve` args on the
+// Electron process without the CLI rewrite that injects `--serve` (#12677).
+if (argvRequestsServeMode(process.argv) && !process.argv.includes('--serve')) {
+  process.argv = normalizeServeModeArgv(process.argv)
+}
 const isServeMode = process.argv.includes('--serve')
 
 function updateGpuAccelerationAboutPanel(): void {

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -380,9 +380,30 @@ let gpuFeatureStatus: Electron.GPUFeatureStatus | null = null
 let localPtyStartupReady: Promise<void> = Promise.resolve()
 let localPtyProviderStartupReady: Promise<void> = Promise.resolve()
 const AGENT_STATE_CRASH_BREADCRUMB_MIN_INTERVAL_MS = 30_000
+// Why: on Windows a CLI launch that lost ELECTRON_RUN_AS_NODE would boot the GUI and exit silently; redirect to node mode before the lock gate below.
+// Both redirects run before the serve-argv rewrite so they still match on the
+// launch argv verbatim; rewriting first would hide `serve` from their CLI
+// command-name lookup and strand AppImage launches in an in-process serve.
+const packagedCliEntryRedirect = maybeRedirectPackagedCliEntryLaunch({
+  isPackaged: app.isPackaged,
+  resourcesPath: process.resourcesPath,
+  execPath: process.execPath
+})
+if (packagedCliEntryRedirect.redirected) {
+  app.exit(packagedCliEntryRedirect.status)
+}
+const appImageCliRedirect = maybeRedirectAppImageCliLaunch({
+  isPackaged: app.isPackaged,
+  resourcesPath: process.resourcesPath,
+  execPath: process.execPath
+})
+if (appImageCliRedirect.redirected) {
+  app.exit(appImageCliRedirect.status)
+}
 // Why: extracted AppRun / binary launches can land CLI-form `serve` args on the
 // Electron process without the CLI rewrite that injects `--serve` (#12677).
-if (argvRequestsServeMode(process.argv) && !process.argv.includes('--serve')) {
+// Guarded so a normal GUI launch keeps its original argv array identity.
+if (argvRequestsServeMode(process.argv)) {
   process.argv = normalizeServeModeArgv(process.argv)
 }
 const isServeMode = process.argv.includes('--serve')
@@ -418,23 +439,6 @@ const desktopActivationGate = createServeDesktopActivationGate({
   },
   onBlocked: (reason) => console.error(`[serve] Desktop activation blocked: ${reason}`)
 })
-// Why: on Windows a CLI launch that lost ELECTRON_RUN_AS_NODE would boot the GUI and exit silently; redirect to node mode before the lock gate below.
-const packagedCliEntryRedirect = maybeRedirectPackagedCliEntryLaunch({
-  isPackaged: app.isPackaged,
-  resourcesPath: process.resourcesPath,
-  execPath: process.execPath
-})
-if (packagedCliEntryRedirect.redirected) {
-  app.exit(packagedCliEntryRedirect.status)
-}
-const appImageCliRedirect = maybeRedirectAppImageCliLaunch({
-  isPackaged: app.isPackaged,
-  resourcesPath: process.resourcesPath,
-  execPath: process.execPath
-})
-if (appImageCliRedirect.redirected) {
-  app.exit(appImageCliRedirect.status)
-}
 
 // Kill switch for the first-work on-disk folder rename; the renderer reconciles the id change (migrateWorktreeIdentity) so it isn't mistaken for a deletion.
 const ENABLE_FIRST_WORK_FOLDER_RENAME = false

--- a/src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
+++ b/src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
@@ -1,3 +1,5 @@
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
 import { getAppImageCliArgs } from './appimage-cli-redirect'
 import { argvRequestsServeMode, normalizeServeModeArgv } from './serve-mode-argv'
@@ -41,5 +43,22 @@ describe('serve argv rewrite vs AppImage CLI redirect ordering', () => {
     const argv = ['/opt/orca/orca-ide', 'status']
     expect(rewriteAsIndexDoes(argv)).toEqual(argv)
     expect(getAppImageCliArgs(argv, MOUNTED_APPIMAGE_ENV, REDIRECT_OPTIONS)).toEqual(['status'])
+  })
+
+  // Why source text: the ordering only exists as statement order at index.ts module scope, and the
+  // cases above stay green if it is reversed — nothing else would catch the regression.
+  it('keeps index.ts running both CLI redirects before the argv rewrite', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const packagedRedirect = source.indexOf('maybeRedirectPackagedCliEntryLaunch({')
+    const appImageRedirect = source.indexOf('maybeRedirectAppImageCliLaunch({')
+    const rewrite = source.indexOf('process.argv = normalizeServeModeArgv(process.argv)')
+    const serveModeCheck = source.indexOf("const isServeMode = process.argv.includes('--serve')")
+
+    expect(packagedRedirect).toBeGreaterThanOrEqual(0)
+    expect(appImageRedirect).toBeGreaterThanOrEqual(0)
+    expect(rewrite).toBeGreaterThan(packagedRedirect)
+    expect(rewrite).toBeGreaterThan(appImageRedirect)
+    // The rewrite is pointless unless it lands before the flag it exists to inject is read.
+    expect(serveModeCheck).toBeGreaterThan(rewrite)
   })
 })

--- a/src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
+++ b/src/main/startup/serve-mode-argv-cli-redirect-order.test.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { getAppImageCliArgs } from './appimage-cli-redirect'
+import { argvRequestsServeMode, normalizeServeModeArgv } from './serve-mode-argv'
+
+// Why: index.ts must run both CLI redirects before rewriting argv. Rewriting
+// first replaces the `serve` positional with `--serve`, so the redirect's
+// command-name lookup finds a port number instead of a command and bails —
+// silently dropping AppImage serve launches out of the CLI path (#12677).
+
+const REDIRECT_OPTIONS = {
+  platform: 'linux' as const,
+  isPackaged: true,
+  commandNames: ['serve', 'status']
+}
+// A mounted AppImage is the case where the runtime does export these.
+const MOUNTED_APPIMAGE_ENV = { APPIMAGE: '/opt/orca/Orca.AppImage', APPDIR: '/tmp/.mount_ab12' }
+
+function rewriteAsIndexDoes(argv: string[]): string[] {
+  return argvRequestsServeMode(argv) ? normalizeServeModeArgv(argv) : argv
+}
+
+describe('serve argv rewrite vs AppImage CLI redirect ordering', () => {
+  const launchArgv = ['/opt/orca/orca-ide', '--no-sandbox', 'serve', '--port', '7777', '--json']
+
+  it('hands the launch argv to the CLI when the redirect runs first', () => {
+    expect(getAppImageCliArgs(launchArgv, MOUNTED_APPIMAGE_ENV, REDIRECT_OPTIONS)).toEqual([
+      'serve',
+      '--port',
+      '7777',
+      '--json'
+    ])
+  })
+
+  it('loses the redirect if the rewrite runs first', () => {
+    const rewritten = rewriteAsIndexDoes(launchArgv)
+    expect(rewritten).toContain('--serve')
+    expect(getAppImageCliArgs(rewritten, MOUNTED_APPIMAGE_ENV, REDIRECT_OPTIONS)).toBeNull()
+  })
+
+  it('leaves non-serve CLI commands redirectable either way', () => {
+    const argv = ['/opt/orca/orca-ide', 'status']
+    expect(rewriteAsIndexDoes(argv)).toEqual(argv)
+    expect(getAppImageCliArgs(argv, MOUNTED_APPIMAGE_ENV, REDIRECT_OPTIONS)).toEqual(['status'])
+  })
+})

--- a/src/main/startup/serve-mode-argv.test.ts
+++ b/src/main/startup/serve-mode-argv.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it } from 'vitest'
+import { argvRequestsServeMode, normalizeServeModeArgv } from './serve-mode-argv'
+
+describe('serve-mode-argv', () => {
+  it('detects --serve and bare serve subcommand', () => {
+    expect(argvRequestsServeMode(['orca', '--serve'])).toBe(true)
+    expect(argvRequestsServeMode(['/AppRun', 'serve'])).toBe(true)
+    expect(argvRequestsServeMode(['/AppRun', '--no-sandbox', 'serve', '--port', '8080'])).toBe(true)
+    expect(argvRequestsServeMode(['orca'])).toBe(false)
+  })
+
+  it('rewrites CLI-form serve flags into --serve* form', () => {
+    expect(
+      normalizeServeModeArgv([
+        '/AppRun',
+        'serve',
+        '--port',
+        '9090',
+        '--json',
+        '--pairing-address',
+        '0.0.0.0',
+        '--no-pairing'
+      ])
+    ).toEqual([
+      '/AppRun',
+      '--serve',
+      '--serve-port',
+      '9090',
+      '--serve-json',
+      '--serve-pairing-address',
+      '0.0.0.0',
+      '--serve-no-pairing'
+    ])
+  })
+
+  it('leaves already-normalized argv unchanged', () => {
+    const argv = ['orca', '--serve', '--serve-json']
+    expect(normalizeServeModeArgv(argv)).toEqual(argv)
+  })
+})

--- a/src/main/startup/serve-mode-argv.test.ts
+++ b/src/main/startup/serve-mode-argv.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { argvRequestsServeMode, normalizeServeModeArgv } from './serve-mode-argv'
+import {
+  argvRequestsServeMode,
+  findServeSubcommandIndex,
+  normalizeServeModeArgv
+} from './serve-mode-argv'
 
 describe('serve-mode-argv', () => {
   it('detects --serve and bare serve subcommand', () => {
@@ -7,6 +11,21 @@ describe('serve-mode-argv', () => {
     expect(argvRequestsServeMode(['/AppRun', 'serve'])).toBe(true)
     expect(argvRequestsServeMode(['/AppRun', '--no-sandbox', 'serve', '--port', '8080'])).toBe(true)
     expect(argvRequestsServeMode(['orca'])).toBe(false)
+  })
+
+  it('does not treat serve as a subcommand when it is an option value', () => {
+    expect(findServeSubcommandIndex(['app', '--config', 'serve'])).toBe(-1)
+    expect(argvRequestsServeMode(['app', '--config', 'serve'])).toBe(false)
+    expect(normalizeServeModeArgv(['app', '--config', 'serve'])).toEqual([
+      'app',
+      '--config',
+      'serve'
+    ])
+  })
+
+  it('does not treat a later positional serve as the subcommand after another command', () => {
+    expect(findServeSubcommandIndex(['app', 'status', 'serve'])).toBe(-1)
+    expect(argvRequestsServeMode(['app', 'status', 'serve'])).toBe(false)
   })
 
   it('rewrites CLI-form serve flags into --serve* form', () => {

--- a/src/main/startup/serve-mode-argv.test.ts
+++ b/src/main/startup/serve-mode-argv.test.ts
@@ -56,4 +56,46 @@ describe('serve-mode-argv', () => {
     const argv = ['orca', '--serve', '--serve-json']
     expect(normalizeServeModeArgv(argv)).toEqual(argv)
   })
+
+  it('splits `--flag=value` CLI form, which getServeOptions cannot read', () => {
+    expect(
+      normalizeServeModeArgv(['/AppRun', 'serve', '--port=9090', '--pairing-address=0.0.0.0'])
+    ).toEqual(['/AppRun', '--serve', '--serve-port', '9090', '--serve-pairing-address', '0.0.0.0'])
+  })
+
+  it('translates serve flags in the mixed `--serve --port` form', () => {
+    // Why: leaving these untranslated silently kept pairing enabled despite --no-pairing.
+    expect(normalizeServeModeArgv(['orca', '--serve', '--port', '9090', '--no-pairing'])).toEqual([
+      'orca',
+      '--serve',
+      '--serve-port',
+      '9090',
+      '--serve-no-pairing'
+    ])
+  })
+
+  it('leaves a non-serve launch untouched', () => {
+    const argv = ['orca', '--no-sandbox', '/home/u/project']
+    expect(argvRequestsServeMode(argv)).toBe(false)
+    expect(normalizeServeModeArgv(argv)).toEqual(argv)
+  })
+
+  it('does not splice prototype members onto argv for stray positionals', () => {
+    expect(normalizeServeModeArgv(['/AppRun', 'serve', 'toString'])).toEqual([
+      '/AppRun',
+      '--serve',
+      'toString'
+    ])
+  })
+
+  it('passes args after `--` through verbatim', () => {
+    expect(normalizeServeModeArgv(['/AppRun', 'serve', '--json', '--', '--port', '1'])).toEqual([
+      '/AppRun',
+      '--serve',
+      '--serve-json',
+      '--',
+      '--port',
+      '1'
+    ])
+  })
 })

--- a/src/main/startup/serve-mode-argv.test.ts
+++ b/src/main/startup/serve-mode-argv.test.ts
@@ -14,13 +14,68 @@ describe('serve-mode-argv', () => {
   })
 
   it('does not treat serve as a subcommand when it is an option value', () => {
-    expect(findServeSubcommandIndex(['app', '--config', 'serve'])).toBe(-1)
-    expect(argvRequestsServeMode(['app', '--config', 'serve'])).toBe(false)
-    expect(normalizeServeModeArgv(['app', '--config', 'serve'])).toEqual([
+    expect(findServeSubcommandIndex(['app', '--user-data-dir', 'serve'])).toBe(-1)
+    expect(argvRequestsServeMode(['app', '--user-data-dir', 'serve'])).toBe(false)
+    expect(normalizeServeModeArgv(['app', '--user-data-dir', 'serve'])).toEqual([
       'app',
-      '--config',
+      '--user-data-dir',
       'serve'
     ])
+    // The value is skipped, not the subcommand after it.
+    expect(findServeSubcommandIndex(['app', '--user-data-dir', '/tmp/x', 'serve'])).toBe(3)
+  })
+
+  it('refuses a help launch instead of binding a server', () => {
+    // Why: `--help` is not a serve flag, so it used to be swallowed and the launch bound a
+    // network-exposed runtime server with pairing on. The AppImage redirect routes help to the CLI.
+    for (const argv of [
+      ['/AppRun', 'serve', '--help'],
+      ['/AppRun', 'serve', '-h'],
+      ['/AppRun', '--help', 'serve'],
+      ['/AppRun', 'help', 'serve'],
+      // Bare `help` too — the AppImage redirect's own help set includes it.
+      ['/AppRun', 'serve', 'help']
+    ]) {
+      expect(argvRequestsServeMode(argv), argv.join(' ')).toBe(false)
+      expect(normalizeServeModeArgv(argv)).toEqual(argv)
+    }
+    // A directory named `help` is a value, not a help request.
+    expect(argvRequestsServeMode(['/AppRun', 'serve', '--project-root', 'help'])).toBe(true)
+    // Past an operator's terminator nothing is reinterpreted, help flags included.
+    expect(argvRequestsServeMode(['/AppRun', 'serve', '--', '--help'])).toBe(true)
+  })
+
+  it('does not turn `--no-pairing=false` into no-pairing', () => {
+    // Why: the CLI reads serve booleans as `=== true`, so `=false` leaves pairing ON. Translating
+    // the token dropped the value and disabled pairing instead — the inversion of the bug this
+    // module exists to fix.
+    expect(
+      normalizeServeModeArgv(['/AppRun', 'serve', '--port', '6768', '--no-pairing=false'])
+    ).toEqual(['/AppRun', '--serve', '--serve-port', '6768', '--no-pairing=false'])
+    expect(normalizeServeModeArgv(['/AppRun', 'serve', '--mobile-pairing=0'])).toEqual([
+      '/AppRun',
+      '--serve',
+      '--mobile-pairing=0'
+    ])
+  })
+
+  it('leaves real GUI launch argv alone', () => {
+    // Why: a false positive here is the expensive direction — the window never opens and a runtime
+    // server binds instead. These are the argv shapes the desktop actually receives.
+    for (const argv of [
+      ['/Applications/Orca.app/Contents/MacOS/Orca', '-psn_0_123456'],
+      ['C:\\Program Files\\Orca\\Orca.exe', '--squirrel-firstrun'],
+      ['C:\\Program Files\\Orca\\Orca.exe', 'orca://worktree/serve'],
+      ['/opt/orca/orca-ide', '/home/u/serve'],
+      // `--pairing-code` takes the next token, so its value is never the subcommand.
+      ['/opt/orca/orca-ide', '--pairing-code', 'serve'],
+      ['/opt/orca/orca-ide', '--environment=serve'],
+      ['/opt/orca/orca-ide', '--', 'serve'],
+      ['/opt/orca/orca-ide', 'Serve']
+    ]) {
+      expect(argvRequestsServeMode(argv), argv.join(' ')).toBe(false)
+      expect(normalizeServeModeArgv(argv)).toEqual(argv)
+    }
   })
 
   it('does not treat a later positional serve as the subcommand after another command', () => {
@@ -53,7 +108,22 @@ describe('serve-mode-argv', () => {
   })
 
   it('leaves already-normalized argv unchanged', () => {
-    const argv = ['orca', '--serve', '--serve-json']
+    // Why every value flag: the CLI's own `orca serve` spawns the app with exactly this shape
+    // (serveOrcaApp), and the rewrite now runs over it too — a bad mapping would drop the port here.
+    const argv = [
+      'orca',
+      '--serve',
+      '--serve-json',
+      '--serve-port',
+      '6768',
+      '--serve-pairing-address',
+      '100.64.1.20',
+      '--serve-no-pairing',
+      '--serve-mobile-pairing',
+      '--serve-recipe-json',
+      '--serve-project-root',
+      '/srv/repo'
+    ]
     expect(normalizeServeModeArgv(argv)).toEqual(argv)
   })
 
@@ -97,5 +167,42 @@ describe('serve-mode-argv', () => {
       '--port',
       '1'
     ])
+  })
+
+  it('never disagrees with itself about whether a launch is serve mode', () => {
+    // Why exhaustive: index.ts asks `argvRequestsServeMode` and then reads `--serve` out of the
+    // rewrite. If the two halves consume values differently one can swallow the `serve` token the
+    // other is rewriting, and the launch boots a desktop window with every serve flag dropped —
+    // #12677 again. Found by fuzzing `--port --port serve` and `--port -- serve`.
+    const alphabet = [
+      'serve',
+      '--serve',
+      '--port',
+      '--json',
+      '--pairing-code',
+      '--user-data-dir',
+      '--',
+      '-h',
+      'help',
+      'value',
+      '--port=1',
+      '--no-pairing=false'
+    ]
+    const disagreements: string[][] = []
+    const walk = (tail: string[]): void => {
+      const argv = ['/AppRun', ...tail]
+      if (argvRequestsServeMode(argv) !== normalizeServeModeArgv(argv).includes('--serve')) {
+        disagreements.push(argv)
+      }
+      if (tail.length === 4) {
+        return
+      }
+      for (const token of alphabet) {
+        walk([...tail, token])
+      }
+    }
+    walk([])
+
+    expect(disagreements).toEqual([])
   })
 })

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -19,34 +19,55 @@ const CLI_TO_SERVE_VALUE_FLAG: Record<string, string> = {
   '--project-root': '--serve-project-root'
 }
 
+/** Flags that consume the next argv token as a value (CLI-form + Electron passthrough). */
+const VALUE_TAKING_FLAGS = new Set([
+  ...Object.keys(CLI_TO_SERVE_VALUE_FLAG),
+  '--serve-port',
+  '--serve-pairing-address',
+  '--serve-project-root',
+  '--config',
+  '--user-data-dir',
+  '--environment',
+  '--pairing-code'
+])
+
 function isFlagToken(token: string | undefined): boolean {
   return Boolean(token && token.startsWith('-'))
 }
 
-/** True when argv already has `--serve` or a bare `serve` subcommand. */
-export function argvRequestsServeMode(argv: readonly string[]): boolean {
-  if (argv.includes(SERVE_FLAG)) {
-    return true
-  }
-  // Skip executable path; treat a bare `serve` token that is not a flag value as the subcommand.
-  for (let i = 1; i < argv.length; i += 1) {
+/**
+ * Index of the CLI `serve` subcommand: the first positional token after flags
+ * (and their values). Option *values* named `serve` are never treated as the
+ * subcommand.
+ */
+export function findServeSubcommandIndex(argv: readonly string[]): number {
+  let i = 1
+  while (i < argv.length) {
     const token = argv[i]
-    if (token === 'serve') {
-      const prev = argv[i - 1]
-      // Value of a previous flag would be `serve` only for weird paths; still accept.
-      if (
-        prev === undefined ||
-        isFlagToken(prev) ||
-        prev.endsWith('.js') ||
-        prev.endsWith('.mjs')
-      ) {
-        return true
-      }
-      // Previous token was a non-flag path (e.g. AppRun); still a subcommand.
-      return true
+    if (token === '--') {
+      return -1
     }
+    if (isFlagToken(token)) {
+      const eq = token!.indexOf('=')
+      if (eq !== -1) {
+        i += 1
+        continue
+      }
+      if (VALUE_TAKING_FLAGS.has(token!)) {
+        i += 2
+        continue
+      }
+      i += 1
+      continue
+    }
+    return token === 'serve' ? i : -1
   }
-  return false
+  return -1
+}
+
+/** True when argv already has `--serve` or a bare `serve` CLI subcommand. */
+export function argvRequestsServeMode(argv: readonly string[]): boolean {
+  return argv.includes(SERVE_FLAG) || findServeSubcommandIndex(argv) !== -1
 }
 
 /**
@@ -57,7 +78,7 @@ export function normalizeServeModeArgv(argv: readonly string[]): string[] {
   if (argv.includes(SERVE_FLAG)) {
     return [...argv]
   }
-  const serveIndex = argv.findIndex((token, index) => index > 0 && token === 'serve')
+  const serveIndex = findServeSubcommandIndex(argv)
   if (serveIndex === -1) {
     return [...argv]
   }
@@ -78,7 +99,6 @@ export function normalizeServeModeArgv(argv: readonly string[]): string[] {
       }
       continue
     }
-    // Already-normalized --serve-* or unrelated Electron flags pass through.
     next.push(token)
   }
   return next

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -6,22 +6,24 @@
 
 const SERVE_FLAG = '--serve'
 
-const CLI_TO_SERVE_FLAG: Record<string, string> = {
-  '--json': '--serve-json',
-  '--no-pairing': '--serve-no-pairing',
-  '--mobile-pairing': '--serve-mobile-pairing',
-  '--recipe-json': '--serve-recipe-json'
-}
+// Why Map, not a record: `'toString' in {}` is true, so an object lookup turns a
+// stray `serve toString` positional into a function spliced onto argv.
+const CLI_TO_SERVE_FLAG = new Map([
+  ['--json', '--serve-json'],
+  ['--no-pairing', '--serve-no-pairing'],
+  ['--mobile-pairing', '--serve-mobile-pairing'],
+  ['--recipe-json', '--serve-recipe-json']
+])
 
-const CLI_TO_SERVE_VALUE_FLAG: Record<string, string> = {
-  '--port': '--serve-port',
-  '--pairing-address': '--serve-pairing-address',
-  '--project-root': '--serve-project-root'
-}
+const CLI_TO_SERVE_VALUE_FLAG = new Map([
+  ['--port', '--serve-port'],
+  ['--pairing-address', '--serve-pairing-address'],
+  ['--project-root', '--serve-project-root']
+])
 
 /** Flags that consume the next argv token as a value (CLI-form + Electron passthrough). */
 const VALUE_TAKING_FLAGS = new Set([
-  ...Object.keys(CLI_TO_SERVE_VALUE_FLAG),
+  ...CLI_TO_SERVE_VALUE_FLAG.keys(),
   '--serve-port',
   '--serve-pairing-address',
   '--serve-project-root',
@@ -73,33 +75,53 @@ export function argvRequestsServeMode(argv: readonly string[]): boolean {
 /**
  * Rewrite CLI-form `serve` invocations into the `--serve*` flag shape that
  * `getServeOptions` already understands. Idempotent when already in flag form.
+ *
+ * Serve flags are translated whenever serve mode is requested, including the
+ * mixed `--serve --port 6768` form: leaving them untranslated is what makes a
+ * security-shaped flag like `--no-pairing` read as accepted while pairing stays
+ * on (#12677).
  */
 export function normalizeServeModeArgv(argv: readonly string[]): string[] {
-  if (argv.includes(SERVE_FLAG)) {
-    return [...argv]
-  }
   const serveIndex = findServeSubcommandIndex(argv)
-  if (serveIndex === -1) {
+  if (serveIndex === -1 && !argv.includes(SERVE_FLAG)) {
     return [...argv]
   }
 
-  const next = [...argv.slice(0, serveIndex), SERVE_FLAG]
-  for (let i = serveIndex + 1; i < argv.length; i += 1) {
-    const token = argv[i]
-    if (token in CLI_TO_SERVE_FLAG) {
-      next.push(CLI_TO_SERVE_FLAG[token]!)
+  const next: string[] = []
+  for (let i = 0; i < argv.length; i += 1) {
+    const token = argv[i]!
+    if (i === serveIndex) {
+      next.push(SERVE_FLAG)
       continue
     }
-    if (token in CLI_TO_SERVE_VALUE_FLAG) {
-      next.push(CLI_TO_SERVE_VALUE_FLAG[token]!)
-      const value = argv[i + 1]
-      if (value !== undefined && !isFlagToken(value)) {
-        next.push(value)
-        i += 1
-      }
+    if (token === '--') {
+      next.push(...argv.slice(i))
+      break
+    }
+    // Why: the CLI accepts `--port=6768` as well as `--port 6768`, but
+    // getServeOptions only reads the next token, so `=` must be split apart.
+    const eq = token.indexOf('=')
+    const name = eq === -1 ? token : token.slice(0, eq)
+    const booleanFlag = CLI_TO_SERVE_FLAG.get(name)
+    if (booleanFlag) {
+      next.push(booleanFlag)
       continue
     }
-    next.push(token)
+    const valueFlag = CLI_TO_SERVE_VALUE_FLAG.get(name)
+    if (!valueFlag) {
+      next.push(token)
+      continue
+    }
+    if (eq !== -1) {
+      next.push(valueFlag, token.slice(eq + 1))
+      continue
+    }
+    next.push(valueFlag)
+    const value = argv[i + 1]
+    if (value !== undefined && !isFlagToken(value)) {
+      next.push(value)
+      i += 1
+    }
   }
   return next
 }

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -1,0 +1,85 @@
+/**
+ * Detect and normalize headless-serve argv for both Electron flags (`--serve`)
+ * and CLI-form subcommands (`serve --port …`) that land on the main process
+ * when the AppImage/CLI redirect did not rewrite them.
+ */
+
+const SERVE_FLAG = '--serve'
+
+const CLI_TO_SERVE_FLAG: Record<string, string> = {
+  '--json': '--serve-json',
+  '--no-pairing': '--serve-no-pairing',
+  '--mobile-pairing': '--serve-mobile-pairing',
+  '--recipe-json': '--serve-recipe-json'
+}
+
+const CLI_TO_SERVE_VALUE_FLAG: Record<string, string> = {
+  '--port': '--serve-port',
+  '--pairing-address': '--serve-pairing-address',
+  '--project-root': '--serve-project-root'
+}
+
+function isFlagToken(token: string | undefined): boolean {
+  return Boolean(token && token.startsWith('-'))
+}
+
+/** True when argv already has `--serve` or a bare `serve` subcommand. */
+export function argvRequestsServeMode(argv: readonly string[]): boolean {
+  if (argv.includes(SERVE_FLAG)) {
+    return true
+  }
+  // Skip executable path; treat a bare `serve` token that is not a flag value as the subcommand.
+  for (let i = 1; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (token === 'serve') {
+      const prev = argv[i - 1]
+      // Value of a previous flag would be `serve` only for weird paths; still accept.
+      if (
+        prev === undefined ||
+        isFlagToken(prev) ||
+        prev.endsWith('.js') ||
+        prev.endsWith('.mjs')
+      ) {
+        return true
+      }
+      // Previous token was a non-flag path (e.g. AppRun); still a subcommand.
+      return true
+    }
+  }
+  return false
+}
+
+/**
+ * Rewrite CLI-form `serve` invocations into the `--serve*` flag shape that
+ * `getServeOptions` already understands. Idempotent when already in flag form.
+ */
+export function normalizeServeModeArgv(argv: readonly string[]): string[] {
+  if (argv.includes(SERVE_FLAG)) {
+    return [...argv]
+  }
+  const serveIndex = argv.findIndex((token, index) => index > 0 && token === 'serve')
+  if (serveIndex === -1) {
+    return [...argv]
+  }
+
+  const next = [...argv.slice(0, serveIndex), SERVE_FLAG]
+  for (let i = serveIndex + 1; i < argv.length; i += 1) {
+    const token = argv[i]
+    if (token in CLI_TO_SERVE_FLAG) {
+      next.push(CLI_TO_SERVE_FLAG[token]!)
+      continue
+    }
+    if (token in CLI_TO_SERVE_VALUE_FLAG) {
+      next.push(CLI_TO_SERVE_VALUE_FLAG[token]!)
+      const value = argv[i + 1]
+      if (value !== undefined && !isFlagToken(value)) {
+        next.push(value)
+        i += 1
+      }
+      continue
+    }
+    // Already-normalized --serve-* or unrelated Electron flags pass through.
+    next.push(token)
+  }
+  return next
+}

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -21,48 +21,84 @@ const CLI_TO_SERVE_VALUE_FLAG = new Map([
   ['--project-root', '--serve-project-root']
 ])
 
-/** Flags that consume the next argv token as a value (CLI-form + Electron passthrough). */
+/**
+ * Flags that consume the next argv token as a value (CLI-form + Electron passthrough).
+ * Residual class: a flag outside this list whose space-separated value is literally `serve` would
+ * read as the subcommand. Chromium switches are `--flag=value` only, so no real launch does that.
+ */
 const VALUE_TAKING_FLAGS = new Set([
   ...CLI_TO_SERVE_VALUE_FLAG.keys(),
   '--serve-port',
   '--serve-pairing-address',
   '--serve-project-root',
-  '--config',
   '--user-data-dir',
   '--environment',
   '--pairing-code'
 ])
+
+// Why: a CLI-form `serve` is not a serve launch when help was asked for. The AppImage redirect
+// already hands these to the CLI (the same three tokens); without the refusal here,
+// `<binary> serve --help` binds a network-exposed runtime server with pairing on and prints nothing.
+// Scoped to the subcommand form on purpose: `--serve` is the CLI's own contract and never carries
+// `--help`, so widening this would risk the one path that already works.
+const HELP_FLAGS = new Set(['--help', '-h', 'help'])
 
 function isFlagToken(token: string | undefined): boolean {
   return Boolean(token && token.startsWith('-'))
 }
 
 /**
+ * Value consumption for the two scans that walk argv looking for a position: a flag takes the next
+ * token only when that token is not itself flag-shaped. `normalizeServeModeArgv` consumes a strict
+ * subset of this (only the CLI value flags it translates), which is the property
+ * `findServeSubcommandIndex` documents below.
+ */
+function indexAfterToken(argv: readonly string[], i: number): number {
+  return i + (VALUE_TAKING_FLAGS.has(argv[i]!) && !isFlagToken(argv[i + 1]) ? 2 : 1)
+}
+
+function requestsHelp(argv: readonly string[]): boolean {
+  let i = 1
+  while (i < argv.length) {
+    const token = argv[i]!
+    if (token === '--') {
+      return false
+    }
+    // Skipping values matters for the bare `help` token: `serve --project-root help` names a
+    // directory, it does not ask for help.
+    if (HELP_FLAGS.has(token)) {
+      return true
+    }
+    i = indexAfterToken(argv, i)
+  }
+  return false
+}
+
+/**
  * Index of the CLI `serve` subcommand: the first positional token after flags
  * (and their values). Option *values* named `serve` are never treated as the
  * subcommand.
+ *
+ * What the tokens this skips must satisfy: they are a superset of the ones `normalizeServeModeArgv`
+ * consumes as values. That one-directional property is what keeps the serve index off a token the
+ * rewrite treats as a value — if the two ever disagreed, one half would swallow the `serve` token
+ * the other half is rewriting and `--serve` would never be injected: #12677 again in a new shape.
+ * Shrinking VALUE_TAKING_FLAGS to "restore symmetry" breaks it (see `--user-data-dir serve`).
  */
 export function findServeSubcommandIndex(argv: readonly string[]): number {
+  if (requestsHelp(argv)) {
+    return -1
+  }
   let i = 1
   while (i < argv.length) {
     const token = argv[i]
     if (token === '--') {
       return -1
     }
-    if (isFlagToken(token)) {
-      const eq = token!.indexOf('=')
-      if (eq !== -1) {
-        i += 1
-        continue
-      }
-      if (VALUE_TAKING_FLAGS.has(token!)) {
-        i += 2
-        continue
-      }
-      i += 1
-      continue
+    if (!isFlagToken(token)) {
+      return token === 'serve' ? i : -1
     }
-    return token === 'serve' ? i : -1
+    i = indexAfterToken(argv, i)
   }
   return -1
 }
@@ -102,7 +138,11 @@ export function normalizeServeModeArgv(argv: readonly string[]): string[] {
     // getServeOptions only reads the next token, so `=` must be split apart.
     const eq = token.indexOf('=')
     const name = eq === -1 ? token : token.slice(0, eq)
-    const booleanFlag = CLI_TO_SERVE_FLAG.get(name)
+    // Why only the bare form: the CLI reads its serve booleans as `flags.get(name) === true`
+    // (src/cli/handlers/core.ts), so `--no-pairing=false` is NOT no-pairing there. Translating it
+    // anyway dropped the value and disabled pairing for an operator who wrote `=false` — the
+    // security-shaped inversion of #12677. Passing it through leaves pairing on, as the CLI does.
+    const booleanFlag = eq === -1 ? CLI_TO_SERVE_FLAG.get(name) : undefined
     if (booleanFlag) {
       next.push(booleanFlag)
       continue

--- a/src/main/startup/single-instance-lock.test.ts
+++ b/src/main/startup/single-instance-lock.test.ts
@@ -85,6 +85,25 @@ describe('shouldActivateDesktopForSecondInstance', () => {
     expect(shouldActivateDesktopForSecondInstance(['/Applications/Orca.app/orca'])).toBe(true)
   })
 
+  it('ignores a duplicate CLI-form serve launch the CLI redirect never rewrote', () => {
+    // Why: the documented systemd unit is `<binary> serve --port 6768 …`; an extracted AppRun/binary
+    // start reaches Electron in that shape, so a flag-only check would open a window on the live server.
+    expect(
+      shouldActivateDesktopForSecondInstance([
+        '/opt/orca/squashfs-root/orca-ide',
+        'serve',
+        '--port',
+        '6768',
+        '--pairing-address',
+        '100.64.1.20'
+      ])
+    ).toBe(false)
+    // A path argument that merely contains `serve` is still a desktop launch.
+    expect(
+      shouldActivateDesktopForSecondInstance(['/opt/orca/orca-ide', '/home/u/serve-repo'])
+    ).toBe(true)
+  })
+
   it('fails open when no argv is available', () => {
     expect(shouldActivateDesktopForSecondInstance([])).toBe(true)
     expect(shouldActivateDesktopForSecondInstance()).toBe(true)

--- a/src/main/startup/single-instance-lock.ts
+++ b/src/main/startup/single-instance-lock.ts
@@ -1,4 +1,5 @@
 import type { App } from 'electron'
+import { argvRequestsServeMode } from './serve-mode-argv'
 import { writeStartupDiagnosticLine, type StartupDiagnosticSink } from './startup-diagnostics'
 
 export const SINGLE_INSTANCE_LOCK_FAILURE_MESSAGE =
@@ -10,13 +11,12 @@ export const SINGLE_INSTANCE_LOCK_BYPASS_MESSAGE =
 // Why: stable "another process owns this profile" contract that systemd RestartPreventExitStatus= keys off; changing it silently un-fixes #11935.
 export const SINGLE_INSTANCE_ALREADY_RUNNING_EXIT_CODE = 3
 
-// Why: `serve` is a CLI subcommand, never Electron argv — an AppImage launched as `orca serve` exits
-// at the CLI redirect before requesting the lock, and the CLI re-spawns the Electron child with `--serve`.
-const SERVE_MODE_ARG = '--serve'
-
 // Why: a duplicate `orca serve` is a supervisor artifact, not a user asking for a window; fail open when argv is unavailable.
+// Why not `argv.includes('--serve')`: the documented systemd unit runs `<binary> serve --port …`, so a
+// duplicate start hands this handler CLI-form argv the CLI redirect never rewrote (#12677) — matching only
+// the flag form would promote the live headless server to a desktop window, un-fixing #11935.
 export function shouldActivateDesktopForSecondInstance(argv: readonly string[] = []): boolean {
-  return !argv.includes(SERVE_MODE_ARG)
+  return !argvRequestsServeMode(argv)
 }
 
 /**


### PR DESCRIPTION
## Description
Recognize CLI-form `serve` argv on the Electron process so headless mode, GPU disable, and serve flags engage when the binary is launched as `… serve …` without the CLI rewrite.

## Focused fix
- In scope: `serve-mode-argv` normalize + early `process.argv` rewrite before `isServeMode`
- Out of scope: changing AppImage/CLI redirect paths that already inject `--serve`

## Preserves
- Existing `--serve*` flag parsing for CLI-spawned Electron children

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/startup/serve-mode-argv.test.ts` (3 passed)

## User-regression-tradeoffs
- None expected for normal GUI launches

Fixes #12677
