### PR TITLE
fix(github-project): fall back when search-index lag returns zero items

### DIFF
--- a/src/main/github/project-view-index-lag-fallback.test.ts
+++ b/src/main/github/project-view-index-lag-fallback.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { preferSuccessfulIndexLagFallback } from './project-view'
+
+describe('preferSuccessfulIndexLagFallback', () => {
+  it('keeps the initial empty ok when the fallback fails', () => {
+    const initial = { ok: true as const, totalCount: 0, rows: [] as never[] }
+    const fallback = {
+      ok: false as const,
+      error: { type: 'rate_limited' as const, message: 'slow' }
+    }
+    expect(preferSuccessfulIndexLagFallback(initial, fallback)).toBe(initial)
+  })
+
+  it('uses a successful fallback over the empty index result', () => {
+    const initial = { ok: true as const, totalCount: 0, rows: [] as never[] }
+    const fallback = {
+      ok: true as const,
+      totalCount: 2,
+      rows: [{ id: 'a' }, { id: 'b' }] as never[]
+    }
+    expect(preferSuccessfulIndexLagFallback(initial, fallback)).toBe(fallback)
+  })
+})

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -1196,6 +1196,26 @@ async function fetchItemsCountOnly(args: {
 
 // ─── Public: getProjectViewTable ──────────────────────────────────────
 
+/** Prefer a successful no-search retry; keep the initial empty ok result if the retry fails. */
+export function preferSuccessfulIndexLagFallback<T extends { ok: boolean }>(
+  initial: T,
+  fallback: T
+): T {
+  return fallback.ok ? fallback : initial
+}
+
+async function fetchAllItemsWithoutSearchQuery(args: {
+  owner: string
+  ownerType: GitHubProjectOwnerType
+  projectNumber: number
+  host?: string
+}): Promise<
+  | { ok: true; rows: GitHubProjectRow[]; totalCount: number; parentFieldDropped: boolean }
+  | { ok: false; error: GitHubProjectViewError; totalCount?: number }
+> {
+  return fetchAllItems({ ...args, query: null })
+}
+
 export async function getProjectViewTable(
   args: GetProjectViewTableArgs
 ): Promise<GetProjectViewTableResult> {
@@ -1327,12 +1347,15 @@ export async function getProjectViewTable(
     effectiveQuery === '' &&
     typeof args.queryOverride !== 'string'
   ) {
-    items = await fetchAllItemsWithoutSearchQuery({
+    // Why: keep a successful empty index response if the no-search retry fails
+    // (rate limit/network) so a genuinely empty board does not become an error (#12819 CR).
+    const fallbackItems = await fetchAllItemsWithoutSearchQuery({
       owner: args.owner,
       ownerType: args.ownerType,
       projectNumber: args.projectNumber,
       host: args.host
     })
+    items = preferSuccessfulIndexLagFallback(items, fallbackItems)
   }
   if (!items.ok) {
     return {

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -842,7 +842,7 @@ async function fetchItemsPageWithRaw(args: {
   owner: string
   ownerType: GitHubProjectOwnerType
   projectNumber: number
-  query: string
+  query: string | null
   first: number
   after: string | null
   includeParent: boolean
@@ -863,11 +863,12 @@ async function fetchItemsPageWithRaw(args: {
   const root = ownerQueryRoot(args.ownerType)
   const afterArg = args.after ? `, after: $after` : ''
   const afterVar = args.after ? `$after:String!, ` : ''
+  const useSearchQuery = args.query !== null
   const query = `
-    query(${afterVar}$owner:String!, $num:Int!, $q:String!, $first:Int!) {
+    query(${afterVar}$owner:String!, $num:Int!${useSearchQuery ? ', $q:String!' : ''}, $first:Int!) {
       ${root}(login:$owner) {
         projectV2(number:$num) {
-          items(first:$first${afterArg}, query:$q, orderBy:{ field: POSITION, direction: ASC }) {
+          items(first:$first${afterArg}${useSearchQuery ? ', query:$q' : ''}, orderBy:{ field: POSITION, direction: ASC }) {
             totalCount
             pageInfo { hasNextPage endCursor }
             nodes {
@@ -886,7 +887,9 @@ async function fetchItemsPageWithRaw(args: {
   const argsArr: string[] = ['api', 'graphql', '-f', `query=${query}`]
   argsArr.push('-f', `owner=${args.owner}`)
   argsArr.push('-F', `num=${args.projectNumber}`)
-  argsArr.push('-f', `q=${args.query}`)
+  if (useSearchQuery) {
+    argsArr.push('-f', `q=${args.query}`)
+  }
   argsArr.push('-F', `first=${args.first}`)
   if (args.after) {
     argsArr.push('-f', `after=${args.after}`)
@@ -979,7 +982,8 @@ async function fetchAllItems(args: {
   owner: string
   ownerType: GitHubProjectOwnerType
   projectNumber: number
-  query: string
+  /** null omits the GraphQL `query` argument (plain items list, no search index). */
+  query: string | null
   host?: string
 }): Promise<
   | { ok: true; rows: GitHubProjectRow[]; totalCount: number; parentFieldDropped: boolean }
@@ -1306,13 +1310,30 @@ export async function getProjectViewTable(
   }
 
   // Fetch items.
-  const items = await fetchAllItems({
+  let items = await fetchAllItems({
     owner: args.owner,
     ownerType: args.ownerType,
     projectNumber: args.projectNumber,
     query: effectiveQuery,
     host: args.host
   })
+  // Why: unfiltered views still pass query:"" which routes through GitHub's
+  // Projects search index. Fresh boards can lag and return totalCount:0 while
+  // plain items(first:N) still has every card (#12648). Retry once without the
+  // query argument only for the empty unfiltered case so real empty boards stay empty.
+  if (
+    items.ok &&
+    items.totalCount === 0 &&
+    effectiveQuery === '' &&
+    typeof args.queryOverride !== 'string'
+  ) {
+    items = await fetchAllItemsWithoutSearchQuery({
+      owner: args.owner,
+      ownerType: args.ownerType,
+      projectNumber: args.projectNumber,
+      host: args.host
+    })
+  }
   if (!items.ok) {
     return {
       ok: false,


### PR DESCRIPTION
## Description
When an unfiltered Project view returns totalCount 0 via the search-index `query:""` path, retry once with plain `items(first:N)` so index lag does not show a false empty board.

## Focused fix
- In scope: empty unfiltered fetch fallback in `getProjectViewTable`
- Out of scope: changing filtered view query semantics

## Preserves
- Real empty boards stay empty; real filters still use `query`

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/github/project-view.test.ts src/main/github/project-view-host-auth.test.ts src/main/github/project-view/mutations.test.ts` (44 passed)

## User-regression-tradeoffs
- One extra GraphQL page only when unfiltered index returns zero

Fixes #12648
