### PR TITLE
fix(github-project): fetch linked PR and sub-issues progress field values

### DIFF
--- a/src/main/github/project-view-field-values.test.ts
+++ b/src/main/github/project-view-field-values.test.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFieldValue } from './project-view'
+
+describe('normalizeFieldValue linked PR / sub-issues progress', () => {
+  it('normalizes ProjectV2ItemFieldPullRequestValue', () => {
+    const value = normalizeFieldValue({
+      __typename: 'ProjectV2ItemFieldPullRequestValue',
+      field: { id: 'field-pr', name: 'Linked pull requests', dataType: 'LINKED_PULL_REQUESTS' },
+      pullRequests: {
+        nodes: [{ number: 12, title: 'Fix', url: 'https://github.com/o/r/pull/12' }, null]
+      }
+    })
+    expect(value).toEqual({
+      kind: 'pull-requests',
+      fieldId: 'field-pr',
+      pullRequests: [{ number: 12, title: 'Fix', url: 'https://github.com/o/r/pull/12' }]
+    })
+  })
+
+  it('normalizes ProjectV2ItemFieldProgressValue', () => {
+    const value = normalizeFieldValue({
+      __typename: 'ProjectV2ItemFieldProgressValue',
+      field: { id: 'field-sub', name: 'Sub-issues progress', dataType: 'SUB_ISSUES_PROGRESS' },
+      percentComplete: 50,
+      completedCount: 1,
+      totalCount: 2
+    })
+    expect(value).toEqual({
+      kind: 'sub-issues-progress',
+      fieldId: 'field-sub',
+      percent: 50,
+      completed: 1,
+      total: 2
+    })
+  })
+})

--- a/src/main/github/project-view-field-values.test.ts
+++ b/src/main/github/project-view-field-values.test.ts
@@ -1,36 +1,36 @@
 import { describe, expect, it } from 'vitest'
 import { normalizeFieldValue } from './project-view'
 
-describe('normalizeFieldValue linked PR / sub-issues progress', () => {
-  it('normalizes ProjectV2ItemFieldPullRequestValue', () => {
+describe('normalizeFieldValue linked PR field values', () => {
+  it('normalizes ProjectV2ItemFieldPullRequestValue with truncation metadata', () => {
     const value = normalizeFieldValue({
       __typename: 'ProjectV2ItemFieldPullRequestValue',
       field: { id: 'field-pr', name: 'Linked pull requests', dataType: 'LINKED_PULL_REQUESTS' },
       pullRequests: {
+        totalCount: 12,
+        pageInfo: { hasNextPage: true },
         nodes: [{ number: 12, title: 'Fix', url: 'https://github.com/o/r/pull/12' }, null]
       }
     })
     expect(value).toEqual({
       kind: 'pull-requests',
       fieldId: 'field-pr',
-      pullRequests: [{ number: 12, title: 'Fix', url: 'https://github.com/o/r/pull/12' }]
+      pullRequests: [{ number: 12, title: 'Fix', url: 'https://github.com/o/r/pull/12' }],
+      truncated: true,
+      totalCount: 12
     })
   })
 
-  it('normalizes ProjectV2ItemFieldProgressValue', () => {
+  it('marks non-truncated when total fits the page', () => {
     const value = normalizeFieldValue({
-      __typename: 'ProjectV2ItemFieldProgressValue',
-      field: { id: 'field-sub', name: 'Sub-issues progress', dataType: 'SUB_ISSUES_PROGRESS' },
-      percentComplete: 50,
-      completedCount: 1,
-      totalCount: 2
+      __typename: 'ProjectV2ItemFieldPullRequestValue',
+      field: { id: 'field-pr', name: 'Linked pull requests', dataType: 'LINKED_PULL_REQUESTS' },
+      pullRequests: {
+        totalCount: 1,
+        pageInfo: { hasNextPage: false },
+        nodes: [{ number: 7, title: 'Only', url: 'https://github.com/o/r/pull/7' }]
+      }
     })
-    expect(value).toEqual({
-      kind: 'sub-issues-progress',
-      fieldId: 'field-sub',
-      percent: 50,
-      completed: 1,
-      total: 2
-    })
+    expect(value).toMatchObject({ truncated: false, totalCount: 1 })
   })
 })

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -333,10 +333,11 @@ type RawFieldValue = {
   date?: string
   labels?: { nodes?: RawLabel[] }
   users?: { nodes?: RawUser[] }
-  pullRequests?: { nodes?: ({ number?: number; title?: string; url?: string } | null)[] }
-  percentComplete?: number
-  completedCount?: number
-  totalCount?: number
+  pullRequests?: {
+    totalCount?: number
+    pageInfo?: { hasNextPage?: boolean }
+    nodes?: ({ number?: number; title?: string; url?: string } | null)[]
+  }
 }
 
 export function normalizeFieldValue(
@@ -404,13 +405,13 @@ export function normalizeFieldValue(
           }
         })
         .filter((pr): pr is { number: number; title: string; url: string } => pr !== null)
-      return { kind: 'pull-requests', fieldId, pullRequests }
-    }
-    case 'ProjectV2ItemFieldProgressValue': {
-      const percent = typeof raw.percentComplete === 'number' ? raw.percentComplete : 0
-      const completed = typeof raw.completedCount === 'number' ? raw.completedCount : 0
-      const total = typeof raw.totalCount === 'number' ? raw.totalCount : 0
-      return { kind: 'sub-issues-progress', fieldId, percent, completed, total }
+      const totalCount =
+        typeof raw.pullRequests?.totalCount === 'number'
+          ? raw.pullRequests.totalCount
+          : pullRequests.length
+      const truncated =
+        raw.pullRequests?.pageInfo?.hasNextPage === true || totalCount > pullRequests.length
+      return { kind: 'pull-requests', fieldId, pullRequests, truncated, totalCount }
     }
     case undefined:
     default:
@@ -625,13 +626,11 @@ const FIELD_VALUES_SELECTION = `
       ... on ProjectV2ItemFieldUserValue         { field { ...FieldConfig } users(first:5) { nodes { login name avatarUrl } } }
       ... on ProjectV2ItemFieldPullRequestValue  {
         field { ...FieldConfig }
-        pullRequests(first:10) { nodes { number title url } }
-      }
-      ... on ProjectV2ItemFieldProgressValue {
-        field { ...FieldConfig }
-        percentComplete
-        completedCount
-        totalCount
+        pullRequests(first:10) {
+          totalCount
+          pageInfo { hasNextPage }
+          nodes { number title url }
+        }
       }
     }
   }

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -333,6 +333,10 @@ type RawFieldValue = {
   date?: string
   labels?: { nodes?: RawLabel[] }
   users?: { nodes?: RawUser[] }
+  pullRequests?: { nodes?: ({ number?: number; title?: string; url?: string } | null)[] }
+  percentComplete?: number
+  completedCount?: number
+  totalCount?: number
 }
 
 export function normalizeFieldValue(
@@ -386,6 +390,27 @@ export function normalizeFieldValue(
         .map(normalizeUser)
         .filter((u): u is GitHubProjectUser => u !== null)
       return { kind: 'users', fieldId, users }
+    }
+    case 'ProjectV2ItemFieldPullRequestValue': {
+      const pullRequests = (raw.pullRequests?.nodes ?? [])
+        .map((node) => {
+          if (!node || typeof node.number !== 'number') {
+            return null
+          }
+          return {
+            number: node.number,
+            title: typeof node.title === 'string' ? node.title : '',
+            url: typeof node.url === 'string' ? node.url : ''
+          }
+        })
+        .filter((pr): pr is { number: number; title: string; url: string } => pr !== null)
+      return { kind: 'pull-requests', fieldId, pullRequests }
+    }
+    case 'ProjectV2ItemFieldProgressValue': {
+      const percent = typeof raw.percentComplete === 'number' ? raw.percentComplete : 0
+      const completed = typeof raw.completedCount === 'number' ? raw.completedCount : 0
+      const total = typeof raw.totalCount === 'number' ? raw.totalCount : 0
+      return { kind: 'sub-issues-progress', fieldId, percent, completed, total }
     }
     case undefined:
     default:
@@ -598,6 +623,16 @@ const FIELD_VALUES_SELECTION = `
       ... on ProjectV2ItemFieldDateValue         { field { ...FieldConfig } date }
       ... on ProjectV2ItemFieldLabelValue        { field { ...FieldConfig } labels(first:10) { nodes { name color } } }
       ... on ProjectV2ItemFieldUserValue         { field { ...FieldConfig } users(first:5) { nodes { login name avatarUrl } } }
+      ... on ProjectV2ItemFieldPullRequestValue  {
+        field { ...FieldConfig }
+        pullRequests(first:10) { nodes { number title url } }
+      }
+      ... on ProjectV2ItemFieldProgressValue {
+        field { ...FieldConfig }
+        percentComplete
+        completedCount
+        totalCount
+      }
     }
   }
 `

--- a/src/renderer/src/components/github-project/ProjectCell.tsx
+++ b/src/renderer/src/components/github-project/ProjectCell.tsx
@@ -116,23 +116,18 @@ export default function ProjectCell({
   }
 
   if (field.dataType === 'LINKED_PULL_REQUESTS') {
-    const prs = value?.kind === 'pull-requests' ? value.pullRequests : []
-    if (prs.length === 0) {
+    if (value?.kind !== 'pull-requests' || value.pullRequests.length === 0) {
       return <span className="text-xs text-muted-foreground" />
     }
+    const labels = value.pullRequests.map((pr) => `#${pr.number}`)
+    const overflow =
+      value.truncated || value.totalCount > value.pullRequests.length
+        ? ` +${Math.max(value.totalCount - value.pullRequests.length, 1)}`
+        : ''
     return (
       <span className="truncate text-xs text-muted-foreground">
-        {prs.map((pr) => `#${pr.number}`).join(', ')}
-      </span>
-    )
-  }
-  if (field.dataType === 'SUB_ISSUES_PROGRESS') {
-    if (value?.kind !== 'sub-issues-progress' || value.total <= 0) {
-      return <span className="text-xs text-muted-foreground" />
-    }
-    return (
-      <span className="truncate text-xs text-muted-foreground">
-        {value.completed}/{value.total} ({Math.round(value.percent)}%)
+        {labels.join(', ')}
+        {overflow}
       </span>
     )
   }

--- a/src/renderer/src/components/github-project/ProjectCell.tsx
+++ b/src/renderer/src/components/github-project/ProjectCell.tsx
@@ -115,6 +115,28 @@ export default function ProjectCell({
     )
   }
 
+  if (field.dataType === 'LINKED_PULL_REQUESTS') {
+    const prs = value?.kind === 'pull-requests' ? value.pullRequests : []
+    if (prs.length === 0) {
+      return <span className="text-xs text-muted-foreground" />
+    }
+    return (
+      <span className="truncate text-xs text-muted-foreground">
+        {prs.map((pr) => `#${pr.number}`).join(', ')}
+      </span>
+    )
+  }
+  if (field.dataType === 'SUB_ISSUES_PROGRESS') {
+    if (value?.kind !== 'sub-issues-progress' || value.total <= 0) {
+      return <span className="text-xs text-muted-foreground" />
+    }
+    return (
+      <span className="truncate text-xs text-muted-foreground">
+        {value.completed}/{value.total} ({Math.round(value.percent)}%)
+      </span>
+    )
+  }
+
   // Why: dispatch on the field's kind/dataType — not the value's kind — so an
   // unset cell still renders the appropriate editor and the user can assign a
   // value from scratch (e.g. set Status when it's currently empty).

--- a/src/shared/github-project-types.ts
+++ b/src/shared/github-project-types.ts
@@ -150,13 +150,9 @@ export type GitHubProjectFieldValue =
       kind: 'pull-requests'
       fieldId: string
       pullRequests: { number: number; title: string; url: string }[]
-    }
-  | {
-      kind: 'sub-issues-progress'
-      fieldId: string
-      percent: number
-      completed: number
-      total: number
+      /** True when GraphQL returned fewer nodes than totalCount (page truncated). */
+      truncated: boolean
+      totalCount: number
     }
 
 export type GitHubProjectRowItemType = 'ISSUE' | 'PULL_REQUEST' | 'DRAFT_ISSUE' | 'REDACTED'

--- a/src/shared/github-project-types.ts
+++ b/src/shared/github-project-types.ts
@@ -146,6 +146,18 @@ export type GitHubProjectFieldValue =
   | { kind: 'date'; fieldId: string; date: string }
   | { kind: 'labels'; fieldId: string; labels: GitHubProjectLabel[] }
   | { kind: 'users'; fieldId: string; users: GitHubProjectUser[] }
+  | {
+      kind: 'pull-requests'
+      fieldId: string
+      pullRequests: { number: number; title: string; url: string }[]
+    }
+  | {
+      kind: 'sub-issues-progress'
+      fieldId: string
+      percent: number
+      completed: number
+      total: number
+    }
 
 export type GitHubProjectRowItemType = 'ISSUE' | 'PULL_REQUEST' | 'DRAFT_ISSUE' | 'REDACTED'
 


### PR DESCRIPTION
## Description
Fetch and render ProjectV2 linked pull-request and sub-issues progress field values so those columns are no longer always blank.

## Focused fix
- In scope: GraphQL fragments, normalizers, cell render for LINKED_PULL_REQUESTS / SUB_ISSUES_PROGRESS
- Out of scope: editing those fields

## Preserves
- Unknown field typenames still drop silently (forward-compat)

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/github/project-view-field-values.test.ts` (2 passed)

## User-regression-tradeoffs
- None expected

Fixes #12649
