### PR TITLE
fix(github-project): index fork upstream slugs for project row matching

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -165,6 +165,8 @@ type RepoSummary = {
   kind?: 'git' | 'folder'
   connectionId?: string | null
   issueSourcePreference?: IssueSourcePreference
+  /** Fork parent resolved by the host; drives upstream Project row matching. */
+  upstream?: { owner: string; repo: string; host?: string } | null
 }
 
 type IssueSourcePreference = 'upstream' | 'origin' | 'auto'

--- a/mobile/src/tasks/github-project-repo-match.test.ts
+++ b/mobile/src/tasks/github-project-repo-match.test.ts
@@ -172,7 +172,12 @@ describe('GitHub project repo matching', () => {
       }
     ]
 
-    expect(findRepoForGitHubProjectRepository('SciPhi-AI/R2R', forks, {})).toBeNull()
+    expect(
+      findRepoForGitHubProjectRepository('SciPhi-AI/R2R', forks, {
+        'repo-1': { path: '/Users/me/a', repository: { owner: 'me', repo: 'a' } },
+        'repo-2': { path: '/Users/me/b', repository: { owner: 'me', repo: 'b' } }
+      })
+    ).toBeNull()
   })
 
   it('does not bind a github.com fork parent to a same-named Enterprise row', () => {
@@ -198,8 +203,23 @@ describe('GitHub project repo matching', () => {
     ).toBeNull()
   })
 
-  // Why: the host is stripped from the persisted `upstream`, so the fork's own
-  // origin host is the only evidence of which server its parent lives on.
+  it('drops the fork alias while its own origin is unresolved', () => {
+    const fork = {
+      id: 'repo-1',
+      path: '/Users/me/widgets-mirror',
+      displayName: 'widgets-mirror',
+      upstream: { owner: 'acme', repo: 'widgets' }
+    }
+
+    for (const slugs of [
+      {},
+      { 'repo-1': { path: '/Users/me/widgets-mirror', repository: null } },
+      { 'repo-1': { path: '/moved', repository: { owner: 'me', repo: 'widgets' } } }
+    ]) {
+      expect(findRepoForGitHubProjectRepository('acme/widgets', [fork], slugs)).toBeNull()
+    }
+  })
+
   it('scopes a host-less fork parent to the host the fork itself was cloned from', () => {
     const enterpriseFork = {
       id: 'repo-1',

--- a/mobile/src/tasks/github-project-repo-match.test.ts
+++ b/mobile/src/tasks/github-project-repo-match.test.ts
@@ -115,6 +115,79 @@ describe('GitHub project repo matching', () => {
     ).toBe(repos[1])
   })
 
+  it('matches an upstream project row against a fork clone', () => {
+    const fork = {
+      id: 'repo-1',
+      path: '/Users/me/r2r-mirror',
+      displayName: 'r2r-mirror',
+      upstream: { owner: 'SciPhi-AI', repo: 'R2R' }
+    }
+
+    expect(
+      findRepoForGitHubProjectRepository('SciPhi-AI/R2R', [fork], {
+        'repo-1': {
+          path: '/Users/me/r2r-mirror',
+          repository: { owner: 'me', repo: 'r2r-mirror' }
+        }
+      })
+    ).toBe(fork)
+  })
+
+  it('prefers the clone that owns the slug over a fork of it', () => {
+    const upstreamClone = { id: 'repo-1', path: '/Users/me/r2r', displayName: 'r2r' }
+    const fork = {
+      id: 'repo-2',
+      path: '/Users/me/r2r-mirror',
+      displayName: 'r2r-mirror',
+      upstream: { owner: 'SciPhi-AI', repo: 'R2R' }
+    }
+
+    expect(
+      findRepoForGitHubProjectRepository('SciPhi-AI/R2R', [upstreamClone, fork], {
+        'repo-1': {
+          path: '/Users/me/r2r',
+          repository: { owner: 'SciPhi-AI', repo: 'R2R' }
+        },
+        'repo-2': {
+          path: '/Users/me/r2r-mirror',
+          repository: { owner: 'me', repo: 'r2r-mirror' }
+        }
+      })
+    ).toBe(upstreamClone)
+  })
+
+  it('does not pick a repo when two forks share the same upstream', () => {
+    const forks = [
+      {
+        id: 'repo-1',
+        path: '/Users/me/a',
+        displayName: 'a',
+        upstream: { owner: 'SciPhi-AI', repo: 'R2R' }
+      },
+      {
+        id: 'repo-2',
+        path: '/Users/me/b',
+        displayName: 'b',
+        upstream: { owner: 'SciPhi-AI', repo: 'R2R' }
+      }
+    ]
+
+    expect(findRepoForGitHubProjectRepository('SciPhi-AI/R2R', forks, {})).toBeNull()
+  })
+
+  it('does not bind a github.com fork parent to a same-named Enterprise row', () => {
+    const fork = {
+      id: 'repo-1',
+      path: '/Users/me/r2r-mirror',
+      displayName: 'r2r-mirror',
+      upstream: { owner: 'SciPhi-AI', repo: 'R2R' }
+    }
+
+    expect(
+      findRepoForGitHubProjectRepository('SciPhi-AI/R2R', [fork], {}, 'github.acme-corp.com')
+    ).toBeNull()
+  })
+
   it('does not use hostless path heuristics for Enterprise Project rows', () => {
     expect(
       findRepoForGitHubProjectRepository(

--- a/mobile/src/tasks/github-project-repo-match.test.ts
+++ b/mobile/src/tasks/github-project-repo-match.test.ts
@@ -184,8 +184,45 @@ describe('GitHub project repo matching', () => {
     }
 
     expect(
-      findRepoForGitHubProjectRepository('SciPhi-AI/R2R', [fork], {}, 'github.acme-corp.com')
+      findRepoForGitHubProjectRepository(
+        'SciPhi-AI/R2R',
+        [fork],
+        {
+          'repo-1': {
+            path: '/Users/me/r2r-mirror',
+            repository: { owner: 'me', repo: 'r2r-mirror', host: 'github.com' }
+          }
+        },
+        'github.acme-corp.com'
+      )
     ).toBeNull()
+  })
+
+  // Why: the host is stripped from the persisted `upstream`, so the fork's own
+  // origin host is the only evidence of which server its parent lives on.
+  it('scopes a host-less fork parent to the host the fork itself was cloned from', () => {
+    const enterpriseFork = {
+      id: 'repo-1',
+      path: '/Users/me/widgets-mirror',
+      displayName: 'widgets-mirror',
+      upstream: { owner: 'acme', repo: 'widgets' }
+    }
+    const slugs = {
+      'repo-1': {
+        path: '/Users/me/widgets-mirror',
+        repository: { owner: 'me', repo: 'widgets', host: 'github.acme-corp.com' }
+      }
+    }
+
+    expect(
+      findRepoForGitHubProjectRepository(
+        'acme/widgets',
+        [enterpriseFork],
+        slugs,
+        'github.acme-corp.com'
+      )
+    ).toBe(enterpriseFork)
+    expect(findRepoForGitHubProjectRepository('acme/widgets', [enterpriseFork], slugs)).toBeNull()
   })
 
   it('does not use hostless path heuristics for Enterprise Project rows', () => {

--- a/mobile/src/tasks/github-project-repo-match.ts
+++ b/mobile/src/tasks/github-project-repo-match.ts
@@ -48,6 +48,22 @@ function cachedSlugStateForRepo(
   return { status: 'resolved', repository: cached.repository }
 }
 
+/** Identity key of the repo's fork parent, or null when it is not a fork.
+ *  Why: the host is stripped from the persisted `upstream`, and a fork's parent
+ *  lives on the fork's own server — without scoping the key to the repo's own
+ *  origin host a GHES parent would collide with github.com. */
+function upstreamIdentityKeyForRepo(
+  repo: GitHubProjectRepoMatch,
+  originState: CachedSlugState | undefined
+): string | null {
+  const upstream = repo.upstream
+  if (!upstream?.owner || !upstream.repo) {
+    return null
+  }
+  const originHost = originState?.status === 'resolved' ? originState.repository?.host : undefined
+  return githubRepoIdentityKey({ ...upstream, host: upstream.host ?? originHost })
+}
+
 export function findRepoForGitHubProjectRepository(
   repository: string | null | undefined,
   repos: GitHubProjectRepoMatch[],
@@ -87,7 +103,7 @@ export function findRepoForGitHubProjectRepository(
   // (#12647). Checked after origin so an open clone of the upstream repo itself
   // always wins over someone's fork of it.
   const upstreamMatches = repos.filter(
-    (repo) => repo.upstream && githubRepoIdentityKey(repo.upstream) === requestedIdentityKey
+    (repo) => upstreamIdentityKeyForRepo(repo, slugStates.get(repo.id)) === requestedIdentityKey
   )
   if (upstreamMatches.length === 1) {
     return upstreamMatches[0]!

--- a/mobile/src/tasks/github-project-repo-match.ts
+++ b/mobile/src/tasks/github-project-repo-match.ts
@@ -48,10 +48,10 @@ function cachedSlugStateForRepo(
   return { status: 'resolved', repository: cached.repository }
 }
 
-/** Identity key of the repo's fork parent, or null when it is not a fork.
- *  Why: the host is stripped from the persisted `upstream`, and a fork's parent
- *  lives on the fork's own server — without scoping the key to the repo's own
- *  origin host a GHES parent would collide with github.com. */
+/** Identity key of the repo's fork parent, or null when it is not a fork or its
+ *  origin has not resolved. Why: the host is stripped from the persisted
+ *  `upstream`, so the fork's own origin is the only evidence of which server its
+ *  parent lives on — a host-less key would let a github.com row bind a GHES clone. */
 function upstreamIdentityKeyForRepo(
   repo: GitHubProjectRepoMatch,
   originState: CachedSlugState | undefined
@@ -60,8 +60,13 @@ function upstreamIdentityKeyForRepo(
   if (!upstream?.owner || !upstream.repo) {
     return null
   }
-  const originHost = originState?.status === 'resolved' ? originState.repository?.host : undefined
-  return githubRepoIdentityKey({ ...upstream, host: upstream.host ?? originHost })
+  if (originState?.status !== 'resolved' || !originState.repository) {
+    return null
+  }
+  return githubRepoIdentityKey({
+    ...upstream,
+    host: upstream.host ?? originState.repository.host
+  })
 }
 
 export function findRepoForGitHubProjectRepository(

--- a/mobile/src/tasks/github-project-repo-match.ts
+++ b/mobile/src/tasks/github-project-repo-match.ts
@@ -49,9 +49,9 @@ function cachedSlugStateForRepo(
 }
 
 /** Identity key of the repo's fork parent, or null when it is not a fork or its
- *  origin has not resolved. Why: the host is stripped from the persisted
- *  `upstream`, so the fork's own origin is the only evidence of which server its
- *  parent lives on — a host-less key would let a github.com row bind a GHES clone. */
+ *  origin has not resolved. Why: when `upstream.host` is absent (older persisted
+ *  forks), the fork's origin host is the fallback so GHES parents do not collapse
+ *  into github.com. Unresolved origins refuse the alias. */
 function upstreamIdentityKeyForRepo(
   repo: GitHubProjectRepoMatch,
   originState: CachedSlugState | undefined

--- a/mobile/src/tasks/github-project-repo-match.ts
+++ b/mobile/src/tasks/github-project-repo-match.ts
@@ -7,6 +7,9 @@ export type GitHubProjectRepoMatch = {
   id: string
   path: string
   displayName: string
+  /** Fork parent resolved by the host and carried on `repo.list`. Absent = not
+   *  a fork or not yet resolved. */
+  upstream?: { owner: string; repo: string; host?: string } | null
 }
 
 export type GitHubRepoSlugCacheEntry = {
@@ -76,6 +79,20 @@ export function findRepoForGitHubProjectRepository(
     return slugMatches[0]!
   }
   if (slugMatches.length > 1) {
+    return null
+  }
+
+  // Why: a Project card references the upstream repo, but a contributor's clone
+  // has their personal fork as `origin`, so origin-only matching hid every row
+  // (#12647). Checked after origin so an open clone of the upstream repo itself
+  // always wins over someone's fork of it.
+  const upstreamMatches = repos.filter(
+    (repo) => repo.upstream && githubRepoIdentityKey(repo.upstream) === requestedIdentityKey
+  )
+  if (upstreamMatches.length === 1) {
+    return upstreamMatches[0]!
+  }
+  if (upstreamMatches.length > 1) {
     return null
   }
 

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4617,6 +4617,43 @@ describe('Store', () => {
     expect(store.getRepos()[0]!.upstream).toBeUndefined()
   })
 
+  it('keeps the upstream host across reloads so it is never re-inferred from origin', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+
+    const updated = store.updateRepo('r1', {
+      upstream: { owner: ' acme ', repo: ' widgets ', host: ' GHE.example:8443 ' }
+    })
+    expect(updated!.upstream).toEqual({
+      owner: 'acme',
+      repo: 'widgets',
+      host: 'GHE.example:8443'
+    })
+
+    store.flush()
+    const reloaded = await createStore()
+    expect(reloaded.getRepo('r1')!.upstream).toEqual({
+      owner: 'acme',
+      repo: 'widgets',
+      host: 'GHE.example:8443'
+    })
+  })
+
+  it('leaves a hostless persisted upstream hostless rather than inventing one', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ upstream: { owner: 'stablyai', repo: 'orca' } }))
+
+    expect(store.getRepo('r1')!.upstream).toEqual({ owner: 'stablyai', repo: 'orca' })
+    expect(store.getRepo('r1')!.upstream).not.toHaveProperty('host')
+  })
+
+  it('drops a blank upstream host instead of persisting an empty string', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo({ upstream: { owner: 'acme', repo: 'widgets', host: '   ' } }))
+
+    expect(store.getRepo('r1')!.upstream).toEqual({ owner: 'acme', repo: 'widgets' })
+  })
+
   it('updateRepo returns null for nonexistent id', async () => {
     const store = await createStore()
     expect(store.updateRepo('nope', { displayName: 'x' })).toBeNull()

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -1411,10 +1411,18 @@ function sanitizeRepoUpstream(value: unknown): Repo['upstream'] | undefined {
   if (!value || typeof value !== 'object') {
     return undefined
   }
-  const candidate = value as { owner?: unknown; repo?: unknown }
+  const candidate = value as { owner?: unknown; repo?: unknown; host?: unknown }
   const owner = typeof candidate.owner === 'string' ? candidate.owner.trim() : ''
   const repo = typeof candidate.repo === 'string' ? candidate.repo.trim() : ''
-  return owner && repo ? { owner, repo } : undefined
+  if (!owner || !repo) {
+    return undefined
+  }
+  // Why: an `upstream` remote may live on a different server than `origin`, so
+  // dropping the host forced consumers to re-infer it from origin and could bind
+  // a GHES parent to a same-named github.com repo. Absent host stays absent so
+  // records written before this survive unchanged.
+  const host = typeof candidate.host === 'string' ? candidate.host.trim() : ''
+  return host ? { owner, repo, host } : { owner, repo }
 }
 
 function sanitizeGitRemoteIdentity(value: unknown): GitRemoteIdentity | null | undefined {

--- a/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
+++ b/src/renderer/src/components/github-project/ProjectViewWrapper.tsx
@@ -141,7 +141,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
   const patchProjectRowIssueType = useAppStore((s) => s.patchProjectRowIssueType)
   const addRepoFromStore = useAppStore((s) => s.addRepo)
   const repos = useAppStore((s) => s.repos)
-  const { lookupSlug, ready: slugIndexReady } = useRepoSlugIndex()
+  const { lookupSlug, lookupSlugMatches, ready: slugIndexReady } = useRepoSlugIndex()
   const mountedRef = useMountedRef()
 
   const activeProject = settings?.githubProjects?.activeProject ?? null
@@ -375,9 +375,14 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
   const filteredTable = useMemo(
     () =>
       table && slugIndexReady
-        ? filterProjectTableRowsBySelectedRepos(table, lookupSlug, slugIndexReady, selectedRepoIds)
+        ? filterProjectTableRowsBySelectedRepos(
+            table,
+            lookupSlugMatches,
+            slugIndexReady,
+            selectedRepoIds
+          )
         : null,
-    [table, slugIndexReady, lookupSlug, selectedRepoIds]
+    [table, slugIndexReady, lookupSlugMatches, selectedRepoIds]
   )
   const lastFilteredTableRef = useRef<CachedVisibleProjectTable | null>(null)
   // Why: ref-cache prevents a blank table while the slug index rebuilds, without forcing a second render.
@@ -528,7 +533,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
       }
       const resolution = resolveSelectedProjectRowRepo({
         row,
-        lookupSlug,
+        lookupSlugMatches,
         host: table.project.host,
         slugIndexReady,
         selectedRepoIds
@@ -584,7 +589,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
       currentCacheKey,
       table,
       buildOrigin,
-      lookupSlug,
+      lookupSlugMatches,
       slugIndexReady,
       selectedRepoIds,
       openProjectRowUrlWithToast
@@ -602,7 +607,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
       }
       const resolution = resolveSelectedProjectRowRepo({
         row,
-        lookupSlug,
+        lookupSlugMatches,
         host: table.project.host,
         slugIndexReady,
         selectedRepoIds
@@ -671,7 +676,7 @@ export default function ProjectViewWrapper({ selectedRepoIds }: Props): React.JS
       currentCacheKey,
       table,
       buildOrigin,
-      lookupSlug,
+      lookupSlugMatches,
       slugIndexReady,
       selectedRepoIds,
       openProjectRowUrlWithToast

--- a/src/renderer/src/components/github-project/project-row-filtering.test.ts
+++ b/src/renderer/src/components/github-project/project-row-filtering.test.ts
@@ -17,6 +17,11 @@ function repo(id: string): Repo {
   }
 }
 
+/** The common case: every match owns the slug through its own origin remote. */
+function originOnly(matches: Repo[]): { origin: Repo[]; upstream: Repo[] } {
+  return { origin: matches, upstream: [] }
+}
+
 function row(id: string, repository: string | null): GitHubProjectRow {
   return {
     id,
@@ -102,7 +107,8 @@ describe('filterProjectTableRowsBySelectedRepos', () => {
     const rows = [row('visible', 'acme/orca'), row('hidden', 'acme/tool')]
     const filtered = filterProjectTableRowsBySelectedRepos(
       table(rows),
-      (slug) => (slug?.toLowerCase() === 'acme/orca' ? [repo('repo-1')] : [repo('repo-2')]),
+      (slug) =>
+        originOnly(slug?.toLowerCase() === 'acme/orca' ? [repo('repo-1')] : [repo('repo-2')]),
       true,
       new Set(['repo-1'])
     )
@@ -115,7 +121,7 @@ describe('filterProjectTableRowsBySelectedRepos', () => {
     const rows = [row('hidden', 'acme/orca')]
     const filtered = filterProjectTableRowsBySelectedRepos(
       table(rows),
-      () => [repo('repo-2')],
+      () => originOnly([repo('repo-2')]),
       true,
       new Set(['repo-1'])
     )
@@ -128,7 +134,7 @@ describe('filterProjectTableRowsBySelectedRepos', () => {
     const rows = [row('ambiguous', 'acme/orca')]
     const filtered = filterProjectTableRowsBySelectedRepos(
       table(rows),
-      () => [repo('repo-1'), repo('repo-2'), repo('repo-3')],
+      () => originOnly([repo('repo-1'), repo('repo-2'), repo('repo-3')]),
       true,
       new Set(['repo-1', 'repo-2'])
     )
@@ -141,7 +147,7 @@ describe('resolveSelectedProjectRowRepo', () => {
   it('reports loading without reading stale slug matches', () => {
     const resolution = resolveSelectedProjectRowRepo({
       row: row('loading', 'acme/orca'),
-      lookupSlug: () => {
+      lookupSlugMatches: () => {
         throw new Error('should not read stale matches')
       },
       slugIndexReady: false,
@@ -154,7 +160,7 @@ describe('resolveSelectedProjectRowRepo', () => {
   it('reports invalid slug for rows without a repository', () => {
     const resolution = resolveSelectedProjectRowRepo({
       row: row('missing-slug', null),
-      lookupSlug: () => [repo('repo-1')],
+      lookupSlugMatches: () => originOnly([repo('repo-1')]),
       slugIndexReady: true,
       selectedRepoIds: new Set(['repo-1'])
     })
@@ -165,7 +171,7 @@ describe('resolveSelectedProjectRowRepo', () => {
   it('reports no global match when Orca has no repo for the slug', () => {
     const resolution = resolveSelectedProjectRowRepo({
       row: row('missing', 'acme/orca'),
-      lookupSlug: () => [],
+      lookupSlugMatches: () => originOnly([]),
       slugIndexReady: true,
       selectedRepoIds: new Set(['repo-1'])
     })
@@ -176,7 +182,7 @@ describe('resolveSelectedProjectRowRepo', () => {
   it('reports global-only matches when the repo is not selected', () => {
     const resolution = resolveSelectedProjectRowRepo({
       row: row('unselected', 'acme/orca'),
-      lookupSlug: () => [repo('repo-2')],
+      lookupSlugMatches: () => originOnly([repo('repo-2')]),
       slugIndexReady: true,
       selectedRepoIds: new Set(['repo-1'])
     })
@@ -187,7 +193,7 @@ describe('resolveSelectedProjectRowRepo', () => {
   it('returns the selected match when exactly one matching repo is selected', () => {
     const resolution = resolveSelectedProjectRowRepo({
       row: row('selected', 'acme/orca'),
-      lookupSlug: () => [repo('repo-1'), repo('repo-2')],
+      lookupSlugMatches: () => originOnly([repo('repo-1'), repo('repo-2')]),
       slugIndexReady: true,
       selectedRepoIds: new Set(['repo-2'])
     })
@@ -196,28 +202,64 @@ describe('resolveSelectedProjectRowRepo', () => {
   })
 
   it('passes the project host into repository matching', () => {
-    const lookupSlug = vi.fn(() => [repo('repo-1')])
+    const lookupSlugMatches = vi.fn(() => originOnly([repo('repo-1')]))
 
     expect(
       resolveSelectedProjectRowRepo({
         row: row('enterprise', 'acme/orca'),
-        lookupSlug,
+        lookupSlugMatches,
         host: 'ghe.example:8443',
         slugIndexReady: true,
         selectedRepoIds: new Set(['repo-1'])
       })
     ).toMatchObject({ status: 'selected_match' })
-    expect(lookupSlug).toHaveBeenCalledWith('acme/orca', 'ghe.example:8443')
+    expect(lookupSlugMatches).toHaveBeenCalledWith('acme/orca', 'ghe.example:8443')
   })
 
   it('reports ambiguity when multiple matching repos are selected', () => {
     const resolution = resolveSelectedProjectRowRepo({
       row: row('ambiguous', 'acme/orca'),
-      lookupSlug: () => [repo('repo-1'), repo('repo-2')],
+      lookupSlugMatches: () => originOnly([repo('repo-1'), repo('repo-2')]),
       slugIndexReady: true,
       selectedRepoIds: new Set(['repo-1', 'repo-2'])
     })
 
     expect(resolution.status).toBe('ambiguous_selected_match')
+  })
+
+  it('falls through to a selected fork when the upstream clone is unselected', () => {
+    const resolution = resolveSelectedProjectRowRepo({
+      row: row('fork-selected', 'acme/orca'),
+      lookupSlugMatches: () => ({ origin: [repo('upstream')], upstream: [repo('fork')] }),
+      slugIndexReady: true,
+      selectedRepoIds: new Set(['fork'])
+    })
+
+    expect(resolution).toMatchObject({ status: 'selected_match', repo: { id: 'fork' } })
+  })
+
+  it('prefers the selected upstream clone over a selected fork of it', () => {
+    const resolution = resolveSelectedProjectRowRepo({
+      row: row('both-selected', 'acme/orca'),
+      lookupSlugMatches: () => ({ origin: [repo('upstream')], upstream: [repo('fork')] }),
+      slugIndexReady: true,
+      selectedRepoIds: new Set(['upstream', 'fork'])
+    })
+
+    expect(resolution).toMatchObject({ status: 'selected_match', repo: { id: 'upstream' } })
+  })
+
+  it('still reports no selection when neither the upstream clone nor the fork is selected', () => {
+    const resolution = resolveSelectedProjectRowRepo({
+      row: row('neither', 'acme/orca'),
+      lookupSlugMatches: () => ({ origin: [repo('upstream')], upstream: [repo('fork')] }),
+      slugIndexReady: true,
+      selectedRepoIds: new Set(['other'])
+    })
+
+    expect(resolution).toMatchObject({
+      status: 'unselected_match',
+      globalMatches: [{ id: 'upstream' }, { id: 'fork' }]
+    })
   })
 })

--- a/src/renderer/src/components/github-project/project-row-filtering.test.ts
+++ b/src/renderer/src/components/github-project/project-row-filtering.test.ts
@@ -130,6 +130,19 @@ describe('filterProjectTableRowsBySelectedRepos', () => {
     expect(filtered.totalCount).toBe(0)
   })
 
+  it('keeps a row whose only selected match is a fork of the row s repo', () => {
+    const rows = [row('fork-only', 'acme/orca')]
+    const filtered = filterProjectTableRowsBySelectedRepos(
+      table(rows),
+      () => ({ origin: [], upstream: [repo('fork')] }),
+      true,
+      new Set(['fork'])
+    )
+
+    expect(filtered.rows.map((r) => r.id)).toEqual(['fork-only'])
+    expect(filtered.totalCount).toBe(1)
+  })
+
   it('keeps a row with multiple selected matches for action ambiguity handling', () => {
     const rows = [row('ambiguous', 'acme/orca')]
     const filtered = filterProjectTableRowsBySelectedRepos(

--- a/src/renderer/src/components/github-project/project-row-filtering.ts
+++ b/src/renderer/src/components/github-project/project-row-filtering.ts
@@ -6,6 +6,13 @@ export type ProjectRowSlugLookup = (
   host?: string
 ) => readonly Repo[]
 
+/** Origin matches own the slug through their own remote; upstream matches are
+ *  forks whose parent the row names. */
+export type ProjectRowSlugMatchLookup = (
+  slug: string | null | undefined,
+  host?: string
+) => { origin: readonly Repo[]; upstream: readonly Repo[] }
+
 export type SelectedProjectRowResolution =
   | { status: 'loading' }
   | { status: 'invalid_slug' }
@@ -20,7 +27,7 @@ export type SelectedProjectRowResolution =
 
 export function resolveSelectedProjectRowRepo(input: {
   row: GitHubProjectRow
-  lookupSlug: ProjectRowSlugLookup
+  lookupSlugMatches: ProjectRowSlugMatchLookup
   host?: string
   slugIndexReady: boolean
   selectedRepoIds: ReadonlySet<string>
@@ -38,12 +45,20 @@ export function resolveSelectedProjectRowRepo(input: {
     return { status: 'invalid_slug' }
   }
 
-  const globalMatches = input.lookupSlug(repository, input.host)
+  const { origin, upstream } = input.lookupSlugMatches(repository, input.host)
+  const globalMatches = [...origin, ...upstream]
   if (globalMatches.length === 0) {
     return { status: 'no_global_match' }
   }
 
-  const selectedMatches = globalMatches.filter((match) => input.selectedRepoIds.has(match.id))
+  // Why: prefer origin only among repos the user actually selected. Applying
+  // that preference globally let an open-but-unselected clone of the upstream
+  // repo hide the selected fork, reproducing #12647 for anyone holding both.
+  const selectedOrigin = origin.filter((match) => input.selectedRepoIds.has(match.id))
+  const selectedMatches =
+    selectedOrigin.length > 0
+      ? selectedOrigin
+      : upstream.filter((match) => input.selectedRepoIds.has(match.id))
   if (selectedMatches.length === 0) {
     return { status: 'unselected_match', globalMatches }
   }
@@ -76,14 +91,14 @@ export function filterProjectTableRowsByOpenRepos(
 
 export function filterProjectTableRowsBySelectedRepos(
   table: GitHubProjectTable,
-  lookupSlug: ProjectRowSlugLookup,
+  lookupSlugMatches: ProjectRowSlugMatchLookup,
   slugIndexReady: boolean,
   selectedRepoIds: ReadonlySet<string>
 ): GitHubProjectTable {
   const rows = table.rows.filter((row) => {
     const resolution = resolveSelectedProjectRowRepo({
       row,
-      lookupSlug,
+      lookupSlugMatches,
       host: table.project.host,
       slugIndexReady,
       selectedRepoIds

--- a/src/renderer/src/lib/repo-slug-cache.test.ts
+++ b/src/renderer/src/lib/repo-slug-cache.test.ts
@@ -73,8 +73,27 @@ describe('repo slug cache host identity', () => {
 
   it('does not route a GHES row to a same-named github.com fork parent', () => {
     const fork = { ...repo('fork'), upstream: { owner: 'acme', repo: 'widgets' } }
+    slugByRepoId.set(
+      slugCacheKey(fork.id, settingsForRepoOwner(fork, null)),
+      githubRepoIdentityKey({ owner: 'me', repo: 'widgets' })
+    )
 
     expect(lookupReposBySlugFromCache([fork], null, 'acme/widgets', 'ghe.example:8443')).toEqual([])
+  })
+
+  // Why: persistence strips `upstream.host`, so the fork's own origin host is the
+  // only evidence of which server its parent lives on.
+  it('scopes a host-less fork parent to the host the fork itself was cloned from', () => {
+    const enterpriseFork = { ...repo('fork'), upstream: { owner: 'acme', repo: 'widgets' } }
+    slugByRepoId.set(
+      slugCacheKey(enterpriseFork.id, settingsForRepoOwner(enterpriseFork, null)),
+      githubRepoIdentityKey({ owner: 'me', repo: 'widgets', host: 'ghe.example:8443' })
+    )
+
+    expect(
+      lookupReposBySlugFromCache([enterpriseFork], null, 'acme/widgets', 'ghe.example:8443')
+    ).toEqual([enterpriseFork])
+    expect(lookupReposBySlugFromCache([enterpriseFork], null, 'acme/widgets')).toEqual([])
   })
 
   it('expires negative slug resolutions so an external GHES login can recover', () => {

--- a/src/renderer/src/lib/repo-slug-cache.test.ts
+++ b/src/renderer/src/lib/repo-slug-cache.test.ts
@@ -81,8 +81,6 @@ describe('repo slug cache host identity', () => {
     expect(lookupReposBySlugFromCache([fork], null, 'acme/widgets', 'ghe.example:8443')).toEqual([])
   })
 
-  // Why: persistence strips `upstream.host`, so the fork's own origin host is the
-  // only evidence of which server its parent lives on.
   it('scopes a host-less fork parent to the host the fork itself was cloned from', () => {
     const enterpriseFork = { ...repo('fork'), upstream: { owner: 'acme', repo: 'widgets' } }
     slugByRepoId.set(
@@ -94,6 +92,14 @@ describe('repo slug cache host identity', () => {
       lookupReposBySlugFromCache([enterpriseFork], null, 'acme/widgets', 'ghe.example:8443')
     ).toEqual([enterpriseFork])
     expect(lookupReposBySlugFromCache([enterpriseFork], null, 'acme/widgets')).toEqual([])
+  })
+
+  it('drops the fork alias while its own origin is unresolved', () => {
+    const fork = { ...repo('fork'), upstream: { owner: 'acme', repo: 'widgets' } }
+
+    expect(lookupReposBySlugFromCache([fork], null, 'acme/widgets')).toEqual([])
+    slugByRepoId.set(slugCacheKey(fork.id, settingsForRepoOwner(fork, null)), null)
+    expect(lookupReposBySlugFromCache([fork], null, 'acme/widgets')).toEqual([])
   })
 
   it('expires negative slug resolutions so an external GHES login can recover', () => {

--- a/src/renderer/src/lib/repo-slug-cache.test.ts
+++ b/src/renderer/src/lib/repo-slug-cache.test.ts
@@ -46,6 +46,37 @@ describe('repo slug cache host identity', () => {
     ).toEqual([enterprise])
   })
 
+  it('routes an upstream project row to the fork clone that tracks it', () => {
+    const fork = { ...repo('fork'), upstream: { owner: 'SciPhi-AI', repo: 'R2R' } }
+    slugByRepoId.set(
+      slugCacheKey(fork.id, settingsForRepoOwner(fork, null)),
+      githubRepoIdentityKey({ owner: 'me', repo: 'r2r-mirror' })
+    )
+
+    expect(lookupReposBySlugFromCache([fork], null, 'SciPhi-AI/R2R')).toEqual([fork])
+  })
+
+  it('prefers the clone that owns the slug over a fork of it', () => {
+    const origin = repo('origin')
+    const fork = { ...repo('fork'), upstream: { owner: 'SciPhi-AI', repo: 'R2R' } }
+    slugByRepoId.set(
+      slugCacheKey(origin.id, settingsForRepoOwner(origin, null)),
+      githubRepoIdentityKey({ owner: 'SciPhi-AI', repo: 'R2R' })
+    )
+    slugByRepoId.set(
+      slugCacheKey(fork.id, settingsForRepoOwner(fork, null)),
+      githubRepoIdentityKey({ owner: 'me', repo: 'r2r-mirror' })
+    )
+
+    expect(lookupReposBySlugFromCache([origin, fork], null, 'SciPhi-AI/R2R')).toEqual([origin])
+  })
+
+  it('does not route a GHES row to a same-named github.com fork parent', () => {
+    const fork = { ...repo('fork'), upstream: { owner: 'acme', repo: 'widgets' } }
+
+    expect(lookupReposBySlugFromCache([fork], null, 'acme/widgets', 'ghe.example:8443')).toEqual([])
+  })
+
   it('expires negative slug resolutions so an external GHES login can recover', () => {
     const key = slugCacheKey('enterprise', null)
     rememberRepoSlug(key, null, 1_000)

--- a/src/renderer/src/lib/repo-slug-cache.ts
+++ b/src/renderer/src/lib/repo-slug-cache.ts
@@ -9,6 +9,16 @@ import { githubRepoIdentityKey } from '../../../shared/github-repository-identit
 /** Lowercased `owner/repo` → Repo[]. */
 export type SlugIndex = Map<string, Repo[]>
 
+/** Identity key of a fork's upstream parent, resolved once at repo-add time and
+ *  persisted on the Repo record (`undefined` = unresolved, `null` = not a fork).
+ *  Why: Project cards reference the upstream repo while a contributor's clone
+ *  has the personal fork as `origin`, so upstream is a second identity a row
+ *  may legitimately match. */
+export function repoUpstreamIdentityKey(repo: Repo): string | null {
+  const upstream = repo.upstream
+  return upstream?.owner && upstream.repo ? githubRepoIdentityKey(upstream) : null
+}
+
 /** Module-scope cache keyed by runtime scope + repo.id. A Repo that has already
  *  failed resolution is recorded as `null` briefly so it is not retried on every
  *  cell mount, while still recovering after an external GHES auth login. */
@@ -87,7 +97,8 @@ export function settingsForRepoOwner(
 /** Synchronous slug → Repo lookup against the already-resolved module cache.
  *  Used by store slices (which can't run the async hook-based index) to route
  *  project-row mutations to the matched repo's owner host; callers fall back to
- *  focused settings when nothing matches. */
+ *  focused settings when nothing matches. Origin matches win over upstream ones
+ *  so a clone of the upstream repo itself is never shadowed by someone's fork. */
 export function lookupReposBySlugFromCache(
   repos: readonly Repo[],
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
@@ -100,11 +111,14 @@ export function lookupReposBySlugFromCache(
   }
   const target = githubRepoIdentityKey({ owner, repo, host })
   const matched: Repo[] = []
+  const upstreamMatched: Repo[] = []
   for (const repo of repos) {
     const cacheKey = slugCacheKey(repo.id, settingsForRepoOwner(repo, settings))
     if (slugByRepoId.get(cacheKey) === target) {
       matched.push(repo)
+    } else if (repoUpstreamIdentityKey(repo) === target) {
+      upstreamMatched.push(repo)
     }
   }
-  return matched
+  return matched.length > 0 ? matched : upstreamMatched
 }

--- a/src/renderer/src/lib/repo-slug-cache.ts
+++ b/src/renderer/src/lib/repo-slug-cache.ts
@@ -21,11 +21,9 @@ export type RepoSlugMatches = { origin: Repo[]; upstream: Repo[] }
  *  may legitimately match, since a contributor's clone has the personal fork as
  *  `origin`. `null` when the repo is not a fork or the key cannot be trusted.
  *
- *  Why `originIdentityKey` is required: persistence strips `upstream.host`
- *  (`sanitizeRepoUpstream`), so the fork's own origin is the only evidence of
- *  which server its parent lives on. Without it the key falls into the
- *  github.com namespace, where a GHES row would never match and an unrelated
- *  public row would bind the Enterprise clone. */
+ *  Why `originIdentityKey` is required: when `upstream.host` is absent (older
+ *  persisted forks), the fork's origin host is the fallback so GHES parents do
+ *  not collapse into github.com. Unresolved origins refuse the alias. */
 export function repoUpstreamIdentityKey(
   repo: Repo,
   originIdentityKey: string | null | undefined

--- a/src/renderer/src/lib/repo-slug-cache.ts
+++ b/src/renderer/src/lib/repo-slug-cache.ts
@@ -4,19 +4,36 @@
 import type { GlobalSettings, Repo } from '../../../shared/types'
 import { getActiveRuntimeTarget } from '@/runtime/runtime-rpc-client'
 import { getSettingsForRepoRuntimeOwner } from './repo-runtime-owner'
-import { githubRepoIdentityKey } from '../../../shared/github-repository-identity-key'
+import {
+  githubHostFromIdentityKey,
+  githubRepoIdentityKey
+} from '../../../shared/github-repository-identity-key'
 
 /** Lowercased `owner/repo` → Repo[]. */
 export type SlugIndex = Map<string, Repo[]>
+
+/** The two ways a slug can match a repo, kept apart so callers that also filter
+ *  by repo selection can fall through to `upstream` instead of letting an
+ *  unselected clone of the upstream repo shadow the selected fork. */
+export type RepoSlugMatches = { origin: Repo[]; upstream: Repo[] }
 
 /** Identity key of a fork's upstream parent, resolved once at repo-add time and
  *  persisted on the Repo record (`undefined` = unresolved, `null` = not a fork).
  *  Why: Project cards reference the upstream repo while a contributor's clone
  *  has the personal fork as `origin`, so upstream is a second identity a row
- *  may legitimately match. */
-export function repoUpstreamIdentityKey(repo: Repo): string | null {
+ *  may legitimately match.
+ *
+ *  `originHost` is the host of the repo's own origin remote. Persistence strips
+ *  `upstream.host` (`sanitizeRepoUpstream`), and a fork's parent always lives on
+ *  the fork's own server — without this the key lands in the github.com
+ *  namespace, so a GHES row would never match and a github.com row would bind
+ *  the wrong clone. */
+export function repoUpstreamIdentityKey(repo: Repo, originHost?: string): string | null {
   const upstream = repo.upstream
-  return upstream?.owner && upstream.repo ? githubRepoIdentityKey(upstream) : null
+  if (!upstream?.owner || !upstream.repo) {
+    return null
+  }
+  return githubRepoIdentityKey({ ...upstream, host: upstream.host ?? originHost })
 }
 
 /** Module-scope cache keyed by runtime scope + repo.id. A Repo that has already
@@ -114,9 +131,10 @@ export function lookupReposBySlugFromCache(
   const upstreamMatched: Repo[] = []
   for (const repo of repos) {
     const cacheKey = slugCacheKey(repo.id, settingsForRepoOwner(repo, settings))
-    if (slugByRepoId.get(cacheKey) === target) {
+    const originKey = slugByRepoId.get(cacheKey)
+    if (originKey === target) {
       matched.push(repo)
-    } else if (repoUpstreamIdentityKey(repo) === target) {
+    } else if (repoUpstreamIdentityKey(repo, githubHostFromIdentityKey(originKey)) === target) {
       upstreamMatched.push(repo)
     }
   }

--- a/src/renderer/src/lib/repo-slug-cache.ts
+++ b/src/renderer/src/lib/repo-slug-cache.ts
@@ -17,23 +17,27 @@ export type SlugIndex = Map<string, Repo[]>
  *  unselected clone of the upstream repo shadow the selected fork. */
 export type RepoSlugMatches = { origin: Repo[]; upstream: Repo[] }
 
-/** Identity key of a fork's upstream parent, resolved once at repo-add time and
- *  persisted on the Repo record (`undefined` = unresolved, `null` = not a fork).
- *  Why: Project cards reference the upstream repo while a contributor's clone
- *  has the personal fork as `origin`, so upstream is a second identity a row
- *  may legitimately match.
+/** Identity key of a fork's upstream parent — the second identity a Project row
+ *  may legitimately match, since a contributor's clone has the personal fork as
+ *  `origin`. `null` when the repo is not a fork or the key cannot be trusted.
  *
- *  `originHost` is the host of the repo's own origin remote. Persistence strips
- *  `upstream.host` (`sanitizeRepoUpstream`), and a fork's parent always lives on
- *  the fork's own server — without this the key lands in the github.com
- *  namespace, so a GHES row would never match and a github.com row would bind
- *  the wrong clone. */
-export function repoUpstreamIdentityKey(repo: Repo, originHost?: string): string | null {
+ *  Why `originIdentityKey` is required: persistence strips `upstream.host`
+ *  (`sanitizeRepoUpstream`), so the fork's own origin is the only evidence of
+ *  which server its parent lives on. Without it the key falls into the
+ *  github.com namespace, where a GHES row would never match and an unrelated
+ *  public row would bind the Enterprise clone. */
+export function repoUpstreamIdentityKey(
+  repo: Repo,
+  originIdentityKey: string | null | undefined
+): string | null {
   const upstream = repo.upstream
-  if (!upstream?.owner || !upstream.repo) {
+  if (!upstream?.owner || !upstream.repo || !originIdentityKey) {
     return null
   }
-  return githubRepoIdentityKey({ ...upstream, host: upstream.host ?? originHost })
+  return githubRepoIdentityKey({
+    ...upstream,
+    host: upstream.host ?? githubHostFromIdentityKey(originIdentityKey)
+  })
 }
 
 /** Module-scope cache keyed by runtime scope + repo.id. A Repo that has already
@@ -134,7 +138,7 @@ export function lookupReposBySlugFromCache(
     const originKey = slugByRepoId.get(cacheKey)
     if (originKey === target) {
       matched.push(repo)
-    } else if (repoUpstreamIdentityKey(repo, githubHostFromIdentityKey(originKey)) === target) {
+    } else if (repoUpstreamIdentityKey(repo, originKey) === target) {
       upstreamMatched.push(repo)
     }
   }

--- a/src/renderer/src/lib/repo-slug-index.test.ts
+++ b/src/renderer/src/lib/repo-slug-index.test.ts
@@ -91,8 +91,6 @@ describe('useRepoSlugIndex fork upstream matching', () => {
     expect(repoSlug).toHaveBeenCalledTimes(1)
   })
 
-  // Why: persistence strips `upstream.host`, so the fork's own origin host is the
-  // only evidence of which server its parent lives on.
   it('scopes a host-less fork parent to the host the fork itself was cloned from', async () => {
     const fork = makeRepo({ id: 'fork', upstream: { owner: 'acme', repo: 'widgets' } })
     setRepos([fork])
@@ -102,6 +100,27 @@ describe('useRepoSlugIndex fork upstream matching', () => {
     await waitFor(() => expect(result.current.ready).toBe(true))
     expect(result.current.lookupSlug('acme/widgets', 'ghe.example')).toEqual([fork])
     expect(result.current.lookupSlug('acme/widgets')).toEqual([])
+  })
+
+  it('drops the fork alias while its own origin is unresolved', async () => {
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'acme', repo: 'widgets' } })
+    setRepos([fork])
+    repoSlug.mockResolvedValue(null)
+
+    expect(await lookup('acme/widgets')).toEqual([])
+  })
+
+  it('lists a repo once when its upstream is its own origin', async () => {
+    const selfAliased = makeRepo({ id: 'self', upstream: { owner: 'acme', repo: 'widgets' } })
+    setRepos([selfAliased])
+    repoSlug.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+
+    const { result } = renderHook(() => useRepoSlugIndex())
+    await waitFor(() => expect(result.current.ready).toBe(true))
+    expect(result.current.lookupSlugMatches('acme/widgets')).toEqual({
+      origin: [selfAliased],
+      upstream: []
+    })
   })
 
   it('reports origin and upstream matches separately for selection filtering', async () => {

--- a/src/renderer/src/lib/repo-slug-index.test.ts
+++ b/src/renderer/src/lib/repo-slug-index.test.ts
@@ -1,11 +1,11 @@
 // @vitest-environment happy-dom
 
-import { renderHook, waitFor } from '@testing-library/react'
+import { act, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../shared/types'
 import { useAppStore } from '@/store'
 import { useRepoSlugIndex } from './repo-slug-index'
-import { clearRepoSlugCacheValues } from './repo-slug-cache'
+import { REPO_SLUG_FAILURE_TTL_MS, clearRepoSlugCacheValues } from './repo-slug-cache'
 
 const repoSlug = vi.fn()
 
@@ -139,5 +139,45 @@ describe('useRepoSlugIndex fork upstream matching', () => {
       origin: [upstreamClone],
       upstream: [fork]
     })
+  })
+})
+
+describe('useRepoSlugIndex failure retry', () => {
+  afterEach(() => vi.useRealTimers())
+
+  it('re-resolves a failed slug after the failure TTL and stops once unmounted', async () => {
+    vi.useFakeTimers()
+    const repo = makeRepo({ id: 'flaky' })
+    setRepos([repo])
+    // Why: a null result is the negative-cached "not a GitHub repo" answer that
+    // arms the bounded retry.
+    repoSlug.mockResolvedValueOnce(null)
+
+    const { result } = renderHook(() => useRepoSlugIndex())
+    await act(async () => void (await vi.advanceTimersByTimeAsync(0)))
+    expect(result.current.ready).toBe(true)
+    expect(result.current.lookupSlug('acme/widgets')).toEqual([])
+    expect(repoSlug).toHaveBeenCalledTimes(1)
+
+    repoSlug.mockResolvedValue({ owner: 'acme', repo: 'widgets' })
+    await act(async () => void (await vi.advanceTimersByTimeAsync(REPO_SLUG_FAILURE_TTL_MS + 10)))
+    expect(repoSlug.mock.calls.length).toBeGreaterThan(1)
+    expect(result.current.lookupSlug('acme/widgets')).toEqual([repo])
+  })
+
+  it('clears the pending retry timer on unmount', async () => {
+    vi.useFakeTimers()
+    setRepos([makeRepo({ id: 'flaky' })])
+    // Why: a permanently failing resolution keeps a retry armed, so an
+    // uncleaned timer is observable after teardown. The hook mounts once per
+    // project row, so such a timer would leak per row.
+    repoSlug.mockResolvedValue(null)
+
+    const { unmount } = renderHook(() => useRepoSlugIndex())
+    await act(async () => void (await vi.advanceTimersByTimeAsync(0)))
+    const armedCount = vi.getTimerCount()
+
+    unmount()
+    expect(vi.getTimerCount()).toBeLessThan(armedCount)
   })
 })

--- a/src/renderer/src/lib/repo-slug-index.test.ts
+++ b/src/renderer/src/lib/repo-slug-index.test.ts
@@ -1,6 +1,6 @@
 // @vitest-environment happy-dom
 
-import { act, renderHook, waitFor } from '@testing-library/react'
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { Repo } from '../../../shared/types'
 import { useAppStore } from '@/store'
@@ -34,7 +34,13 @@ beforeEach(() => {
   Object.assign(window, { api: { gh: { repoSlug } } })
 })
 
-afterEach(() => setRepos([]))
+afterEach(() => {
+  // Why: React schedules work outside the test tick, so a hook left mounted
+  // flushes after the DOM environment is torn down and throws "window is not
+  // defined" as an unhandled error.
+  cleanup()
+  setRepos([])
+})
 
 async function lookup(slug: string): Promise<Repo[]> {
   const { result } = renderHook(() => useRepoSlugIndex())

--- a/src/renderer/src/lib/repo-slug-index.test.ts
+++ b/src/renderer/src/lib/repo-slug-index.test.ts
@@ -90,4 +90,35 @@ describe('useRepoSlugIndex fork upstream matching', () => {
     expect(await lookup('SciPhi-AI/R2R')).toEqual([fork])
     expect(repoSlug).toHaveBeenCalledTimes(1)
   })
+
+  // Why: persistence strips `upstream.host`, so the fork's own origin host is the
+  // only evidence of which server its parent lives on.
+  it('scopes a host-less fork parent to the host the fork itself was cloned from', async () => {
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'acme', repo: 'widgets' } })
+    setRepos([fork])
+    repoSlug.mockResolvedValue({ owner: 'me', repo: 'widgets', host: 'ghe.example' })
+
+    const { result } = renderHook(() => useRepoSlugIndex())
+    await waitFor(() => expect(result.current.ready).toBe(true))
+    expect(result.current.lookupSlug('acme/widgets', 'ghe.example')).toEqual([fork])
+    expect(result.current.lookupSlug('acme/widgets')).toEqual([])
+  })
+
+  it('reports origin and upstream matches separately for selection filtering', async () => {
+    const upstreamClone = makeRepo({ id: 'upstream', upstream: null })
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'SciPhi-AI', repo: 'R2R' } })
+    setRepos([upstreamClone, fork])
+    repoSlug.mockImplementation(async (args: { repoId?: string }) =>
+      args.repoId === 'upstream'
+        ? { owner: 'SciPhi-AI', repo: 'R2R' }
+        : { owner: 'me', repo: 'r2r-mirror' }
+    )
+
+    const { result } = renderHook(() => useRepoSlugIndex())
+    await waitFor(() => expect(result.current.ready).toBe(true))
+    expect(result.current.lookupSlugMatches('SciPhi-AI/R2R')).toEqual({
+      origin: [upstreamClone],
+      upstream: [fork]
+    })
+  })
 })

--- a/src/renderer/src/lib/repo-slug-index.test.ts
+++ b/src/renderer/src/lib/repo-slug-index.test.ts
@@ -1,0 +1,93 @@
+// @vitest-environment happy-dom
+
+import { renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../shared/types'
+import { useAppStore } from '@/store'
+import { useRepoSlugIndex } from './repo-slug-index'
+import { clearRepoSlugCacheValues } from './repo-slug-cache'
+
+const repoSlug = vi.fn()
+
+function makeRepo(overrides: Partial<Repo> & { id: string }): Repo {
+  return {
+    path: `/repos/${overrides.id}`,
+    displayName: overrides.id,
+    badgeColor: '#000',
+    addedAt: 1,
+    executionHostId: 'local',
+    ...overrides
+  }
+}
+
+const initialState = useAppStore.getInitialState()
+
+function setRepos(repos: Repo[]): void {
+  useAppStore.setState({ ...initialState, repos, settings: initialState.settings }, true)
+}
+
+beforeEach(() => {
+  clearRepoSlugCacheValues()
+  repoSlug.mockReset()
+  // Why: origin resolution goes through the preload bridge; the index under
+  // test only reads `repo.upstream` from the store for the fork alias.
+  Object.assign(window, { api: { gh: { repoSlug } } })
+})
+
+afterEach(() => setRepos([]))
+
+async function lookup(slug: string): Promise<Repo[]> {
+  const { result } = renderHook(() => useRepoSlugIndex())
+  await waitFor(() => expect(result.current.ready).toBe(true))
+  return [...result.current.lookupSlug(slug)]
+}
+
+describe('useRepoSlugIndex fork upstream matching', () => {
+  it('matches a project row against a fork clone via its upstream parent', async () => {
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'SciPhi-AI', repo: 'R2R' } })
+    setRepos([fork])
+    repoSlug.mockResolvedValue({ owner: 'me', repo: 'r2r-mirror' })
+
+    expect(await lookup('SciPhi-AI/R2R')).toEqual([fork])
+  })
+
+  it('still matches the fork by its own origin slug', async () => {
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'SciPhi-AI', repo: 'R2R' } })
+    setRepos([fork])
+    repoSlug.mockResolvedValue({ owner: 'me', repo: 'r2r-mirror' })
+
+    expect(await lookup('me/r2r-mirror')).toEqual([fork])
+  })
+
+  it('prefers the clone that owns the slug over a fork of it', async () => {
+    const upstreamClone = makeRepo({ id: 'upstream', upstream: null })
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'SciPhi-AI', repo: 'R2R' } })
+    setRepos([upstreamClone, fork])
+    repoSlug.mockImplementation(async (args: { repoId?: string }) =>
+      args.repoId === 'upstream'
+        ? { owner: 'SciPhi-AI', repo: 'R2R' }
+        : { owner: 'me', repo: 'r2r-mirror' }
+    )
+
+    expect(await lookup('SciPhi-AI/R2R')).toEqual([upstreamClone])
+  })
+
+  it('does not bind a github.com fork parent to a same-named Enterprise row', async () => {
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'SciPhi-AI', repo: 'R2R' } })
+    setRepos([fork])
+    repoSlug.mockResolvedValue({ owner: 'me', repo: 'r2r-mirror' })
+
+    const { result } = renderHook(() => useRepoSlugIndex())
+    await waitFor(() => expect(result.current.ready).toBe(true))
+    expect(result.current.lookupSlug('SciPhi-AI/R2R', 'ghe.example')).toEqual([])
+  })
+
+  it('resolves the slug index without extra upstream IPC', async () => {
+    const fork = makeRepo({ id: 'fork', upstream: { owner: 'SciPhi-AI', repo: 'R2R' } })
+    setRepos([fork])
+    repoSlug.mockResolvedValue({ owner: 'me', repo: 'r2r-mirror' })
+
+    expect(await lookup('SciPhi-AI/R2R')).toEqual([fork])
+    expect(repoSlug).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -26,9 +26,13 @@ import {
   settingsForRepoOwner,
   slugByRepoId,
   slugCacheKey,
+  type RepoSlugMatches,
   type SlugIndex
 } from './repo-slug-cache'
-import { githubRepoIdentityKey } from '../../../shared/github-repository-identity-key'
+import {
+  githubHostFromIdentityKey,
+  githubRepoIdentityKey
+} from '../../../shared/github-repository-identity-key'
 
 export { lookupReposBySlugFromCache } from './repo-slug-cache'
 
@@ -155,9 +159,9 @@ async function buildIndex(
     }
     // Why: a Project card references the upstream repo, but a contributor's
     // clone has their personal fork as `origin`, so the origin-only index
-    // dropped every row (#12647). `repo.upstream` is already resolved at
-    // repo-add time and backfilled at startup, so this costs no extra IPC.
-    const upstreamKey = repoUpstreamIdentityKey(repo)
+    // dropped every row (#12647). `repo.upstream` is already resolved when the
+    // repo is added, so this costs no extra IPC.
+    const upstreamKey = repoUpstreamIdentityKey(repo, githubHostFromIdentityKey(slug))
     if (upstreamKey && upstreamKey !== slug) {
       upstreamNext.set(upstreamKey, [...(upstreamNext.get(upstreamKey) ?? []), repo])
     }
@@ -170,7 +174,9 @@ async function buildIndex(
 }
 
 export type RepoSlugIndexState = {
+  /** Best available matches: origin when anything owns the slug, else forks. */
   lookupSlug: (slug: string | null | undefined, host?: string) => Repo[]
+  lookupSlugMatches: (slug: string | null | undefined, host?: string) => RepoSlugMatches
   ready: boolean
 }
 
@@ -213,22 +219,26 @@ export function useRepoSlugIndex(): RepoSlugIndexState {
     }
   }, [repos, retryGeneration, settings])
 
-  return useMemo(
-    () => ({
+  return useMemo(() => {
+    const lookupSlugMatches = (slug: string | null | undefined, host?: string): RepoSlugMatches => {
+      const [owner, repo] = slug?.split('/') ?? []
+      if (!owner || !repo) {
+        return { origin: [], upstream: [] }
+      }
+      const key = githubRepoIdentityKey({ owner, repo, host })
+      return { origin: index.get(key) ?? [], upstream: upstreamIndex.get(key) ?? [] }
+    }
+    return {
+      lookupSlugMatches,
+      // Why: origin wins — when the upstream repo itself is open, a row must
+      // resolve to that clone rather than becoming ambiguous with someone's
+      // fork of it. Callers that also filter by selection use
+      // `lookupSlugMatches` so an unselected clone cannot hide a selected fork.
       lookupSlug: (slug: string | null | undefined, host?: string): Repo[] => {
-        const [owner, repo] = slug?.split('/') ?? []
-        if (!owner || !repo) {
-          return []
-        }
-        const key = githubRepoIdentityKey({ owner, repo, host })
-        // Why: origin matches win — when the upstream repo itself is open, a
-        // row must resolve to that clone rather than becoming ambiguous with
-        // someone's fork of it. Fall back to forks only when nothing owns the
-        // slug directly.
-        return index.get(key) ?? upstreamIndex.get(key) ?? []
+        const { origin, upstream } = lookupSlugMatches(slug, host)
+        return origin.length > 0 ? origin : upstream
       },
       ready
-    }),
-    [index, upstreamIndex, ready]
-  )
+    }
+  }, [index, upstreamIndex, ready])
 }

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -187,34 +187,43 @@ export function useRepoSlugIndex(): RepoSlugIndexState {
   const [upstreamIndex, setUpstreamIndex] = useState<SlugIndex>(() => new Map())
   const [ready, setReady] = useState(false)
   const [retryGeneration, setRetryGeneration] = useState(0)
+  // Why: schedule retry in a dedicated effect so setTimeout cleanup is owned
+  // synchronously (react-doctor effect-needs-cleanup); async .then assignment
+  // was not statically owned by the buildIndex effect cleanup.
+  const [retryDelayMs, setRetryDelayMs] = useState<number | null>(null)
   // Why: track the current repos snapshot so the effect can ignore stale
   // resolutions when repos change mid-flight.
   const generationRef = useRef(0)
 
   useEffect(() => {
     const gen = ++generationRef.current
-    let retryTimer: ReturnType<typeof setTimeout> | undefined
     setReady(false)
+    setRetryDelayMs(null)
     void buildIndex(repos, settings).then(
-      ({ index: next, upstreamIndex: nextUpstream, retryDelayMs }) => {
+      ({ index: next, upstreamIndex: nextUpstream, retryDelayMs: nextRetryDelayMs }) => {
         if (gen !== generationRef.current) {
           return
         }
         setIndex(next)
         setUpstreamIndex(nextUpstream)
         setReady(true)
-        if (retryDelayMs !== null) {
-          retryTimer = setTimeout(() => setRetryGeneration((value) => value + 1), retryDelayMs)
-        }
+        setRetryDelayMs(nextRetryDelayMs)
       }
     )
     return () => {
       generationRef.current += 1
-      if (retryTimer) {
-        clearTimeout(retryTimer)
-      }
     }
   }, [repos, retryGeneration, settings])
+
+  useEffect(() => {
+    if (retryDelayMs === null) {
+      return
+    }
+    const retryTimer = setTimeout(() => setRetryGeneration((value) => value + 1), retryDelayMs)
+    return () => {
+      clearTimeout(retryTimer)
+    }
+  }, [retryDelayMs])
 
   return useMemo(() => {
     const lookupSlugMatches = (slug: string | null | undefined, host?: string): RepoSlugMatches => {

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -140,16 +140,27 @@ async function buildIndex(
   }
   const next: SlugIndex = new Map()
   const results = await Promise.all(
-    repos.map(async (r) => ({
-      repo: r,
+    repos.map(async (r) => {
+      const ownerSettings = settingsForRepoOwner(r, settings)
       // Why: the project slug index spans repos from multiple hosts; each
       // repo's remote metadata must be read from its owner.
-      slug: await resolveRepoSlug(r, settingsForRepoOwner(r, settings))
-    }))
+      const slug = await resolveRepoSlug(r, ownerSettings)
+      // Why: Project cards often reference the upstream public repo while the
+      // open clone's origin is a personal fork. Index the parent slug too so
+      // filterProjectTableRowsBySelectedRepos does not drop every row (#12647).
+      const upstreamSlug = await resolveRepoUpstreamSlug(r, ownerSettings)
+      return { repo: r, slug, upstreamSlug }
+    })
   )
-  for (const { repo, slug } of results) {
+  for (const { repo, slug, upstreamSlug } of results) {
     if (slug) {
       next.set(slug, [...(next.get(slug) ?? []), repo])
+    }
+    if (upstreamSlug && upstreamSlug !== slug) {
+      const existing = next.get(upstreamSlug) ?? []
+      if (!existing.some((entry) => entry.id === repo.id)) {
+        next.set(upstreamSlug, [...existing, repo])
+      }
     }
   }
   return { index: next, retryDelayMs: nextRepoSlugFailureRetryDelay(liveKeys) }

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -29,10 +29,7 @@ import {
   type RepoSlugMatches,
   type SlugIndex
 } from './repo-slug-cache'
-import {
-  githubHostFromIdentityKey,
-  githubRepoIdentityKey
-} from '../../../shared/github-repository-identity-key'
+import { githubRepoIdentityKey } from '../../../shared/github-repository-identity-key'
 
 export { lookupReposBySlugFromCache } from './repo-slug-cache'
 
@@ -161,7 +158,7 @@ async function buildIndex(
     // clone has their personal fork as `origin`, so the origin-only index
     // dropped every row (#12647). `repo.upstream` is already resolved when the
     // repo is added, so this costs no extra IPC.
-    const upstreamKey = repoUpstreamIdentityKey(repo, githubHostFromIdentityKey(slug))
+    const upstreamKey = repoUpstreamIdentityKey(repo, slug)
     if (upstreamKey && upstreamKey !== slug) {
       upstreamNext.set(upstreamKey, [...(upstreamNext.get(upstreamKey) ?? []), repo])
     }

--- a/src/renderer/src/lib/repo-slug-index.ts
+++ b/src/renderer/src/lib/repo-slug-index.ts
@@ -22,6 +22,7 @@ import {
   nextRepoSlugFailureRetryDelay,
   readRepoSlugCache,
   rememberRepoSlug,
+  repoUpstreamIdentityKey,
   settingsForRepoOwner,
   slugByRepoId,
   slugCacheKey,
@@ -126,7 +127,7 @@ async function resolveRepoSlug(
 async function buildIndex(
   repos: Repo[],
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined
-): Promise<{ index: SlugIndex; retryDelayMs: number | null }> {
+): Promise<{ index: SlugIndex; upstreamIndex: SlugIndex; retryDelayMs: number | null }> {
   // Why: evict cached entries for repos that no longer exist in state so
   // the cache cannot grow unbounded across long sessions where users add
   // and remove repos. Without this, every removed repo's id (and its
@@ -139,31 +140,33 @@ async function buildIndex(
     }
   }
   const next: SlugIndex = new Map()
+  const upstreamNext: SlugIndex = new Map()
   const results = await Promise.all(
-    repos.map(async (r) => {
-      const ownerSettings = settingsForRepoOwner(r, settings)
+    repos.map(async (r) => ({
+      repo: r,
       // Why: the project slug index spans repos from multiple hosts; each
       // repo's remote metadata must be read from its owner.
-      const slug = await resolveRepoSlug(r, ownerSettings)
-      // Why: Project cards often reference the upstream public repo while the
-      // open clone's origin is a personal fork. Index the parent slug too so
-      // filterProjectTableRowsBySelectedRepos does not drop every row (#12647).
-      const upstreamSlug = await resolveRepoUpstreamSlug(r, ownerSettings)
-      return { repo: r, slug, upstreamSlug }
-    })
+      slug: await resolveRepoSlug(r, settingsForRepoOwner(r, settings))
+    }))
   )
-  for (const { repo, slug, upstreamSlug } of results) {
+  for (const { repo, slug } of results) {
     if (slug) {
       next.set(slug, [...(next.get(slug) ?? []), repo])
     }
-    if (upstreamSlug && upstreamSlug !== slug) {
-      const existing = next.get(upstreamSlug) ?? []
-      if (!existing.some((entry) => entry.id === repo.id)) {
-        next.set(upstreamSlug, [...existing, repo])
-      }
+    // Why: a Project card references the upstream repo, but a contributor's
+    // clone has their personal fork as `origin`, so the origin-only index
+    // dropped every row (#12647). `repo.upstream` is already resolved at
+    // repo-add time and backfilled at startup, so this costs no extra IPC.
+    const upstreamKey = repoUpstreamIdentityKey(repo)
+    if (upstreamKey && upstreamKey !== slug) {
+      upstreamNext.set(upstreamKey, [...(upstreamNext.get(upstreamKey) ?? []), repo])
     }
   }
-  return { index: next, retryDelayMs: nextRepoSlugFailureRetryDelay(liveKeys) }
+  return {
+    index: next,
+    upstreamIndex: upstreamNext,
+    retryDelayMs: nextRepoSlugFailureRetryDelay(liveKeys)
+  }
 }
 
 export type RepoSlugIndexState = {
@@ -178,6 +181,7 @@ export function useRepoSlugIndex(): RepoSlugIndexState {
   const repos = useAppStore((s) => s.repos)
   const settings = useAppStore((s) => s.settings)
   const [index, setIndex] = useState<SlugIndex>(() => new Map())
+  const [upstreamIndex, setUpstreamIndex] = useState<SlugIndex>(() => new Map())
   const [ready, setReady] = useState(false)
   const [retryGeneration, setRetryGeneration] = useState(0)
   // Why: track the current repos snapshot so the effect can ignore stale
@@ -188,16 +192,19 @@ export function useRepoSlugIndex(): RepoSlugIndexState {
     const gen = ++generationRef.current
     let retryTimer: ReturnType<typeof setTimeout> | undefined
     setReady(false)
-    void buildIndex(repos, settings).then(({ index: next, retryDelayMs }) => {
-      if (gen !== generationRef.current) {
-        return
+    void buildIndex(repos, settings).then(
+      ({ index: next, upstreamIndex: nextUpstream, retryDelayMs }) => {
+        if (gen !== generationRef.current) {
+          return
+        }
+        setIndex(next)
+        setUpstreamIndex(nextUpstream)
+        setReady(true)
+        if (retryDelayMs !== null) {
+          retryTimer = setTimeout(() => setRetryGeneration((value) => value + 1), retryDelayMs)
+        }
       }
-      setIndex(next)
-      setReady(true)
-      if (retryDelayMs !== null) {
-        retryTimer = setTimeout(() => setRetryGeneration((value) => value + 1), retryDelayMs)
-      }
-    })
+    )
     return () => {
       generationRef.current += 1
       if (retryTimer) {
@@ -213,10 +220,15 @@ export function useRepoSlugIndex(): RepoSlugIndexState {
         if (!owner || !repo) {
           return []
         }
-        return index.get(githubRepoIdentityKey({ owner, repo, host })) ?? []
+        const key = githubRepoIdentityKey({ owner, repo, host })
+        // Why: origin matches win — when the upstream repo itself is open, a
+        // row must resolve to that clone rather than becoming ambiguous with
+        // someone's fork of it. Fall back to forks only when nothing owns the
+        // slug directly.
+        return index.get(key) ?? upstreamIndex.get(key) ?? []
       },
       ready
     }),
-    [index, ready]
+    [index, upstreamIndex, ready]
   )
 }

--- a/src/shared/github-repository-identity-key.ts
+++ b/src/shared/github-repository-identity-key.ts
@@ -21,6 +21,7 @@ export function githubRepoIdentityKey(repo: {
 // Why: callers that only kept the key (not the identity it came from) still need
 // its host segment to scope a second, host-less identity into the same namespace.
 // `owner` and `repo` never contain `/`, so a three-segment key is host-qualified.
+// `undefined` means github.com, so never pass a key that may be unresolved.
 export function githubHostFromIdentityKey(key: string | null | undefined): string | undefined {
   const segments = key?.split('/') ?? []
   return segments.length === 3 ? segments[0] : undefined

--- a/src/shared/github-repository-identity-key.ts
+++ b/src/shared/github-repository-identity-key.ts
@@ -17,3 +17,11 @@ export function githubRepoIdentityKey(repo: {
   const host = repo.host?.trim().toLowerCase()
   return host && !isDefaultGitHubHost(host) ? `${host}/${slug}` : slug
 }
+
+// Why: callers that only kept the key (not the identity it came from) still need
+// its host segment to scope a second, host-less identity into the same namespace.
+// `owner` and `repo` never contain `/`, so a three-segment key is host-qualified.
+export function githubHostFromIdentityKey(key: string | null | undefined): string | undefined {
+  const segments = key?.split('/') ?? []
+  return segments.length === 3 ? segments[0] : undefined
+}


### PR DESCRIPTION
## Description
Index each open repo under both origin and upstream parent slugs so GitHub Project rows for upstream issues still match a local fork clone.

## Focused fix
- In scope: `repo-slug-index` also resolves `github.repoUpstream`
- Out of scope: changing `getRepoSlug` origin-only identity used elsewhere

## Preserves
- Origin-based `getRepoSlug` behavior for non-project callers

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/github-project/project-row-filtering.test.ts` (13 passed)

## User-regression-tradeoffs
- Extra upstream RPC per repo when building the project slug index

Fixes #12647
