### PR TITLE
fix(orchestration): prefer renderer-backed PTY for worker-start agents

### DIFF
--- a/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-topology.ts
@@ -67,7 +67,12 @@ export async function createExistingWorktreeWorkerTerminal(args: {
     title: `worker-${args.taskId}`,
     // Why: dispatching a worker is background work; it must not pull the sidebar
     // to the worker's workspace while the user is reading somewhere else.
-    surfaceOwner: false
+    surfaceOwner: false,
+    // Why: pure background create on some macOS setups produced a shell whose
+    // stdin was /dev/null, so the agent never launched and terminal send was a
+    // no-op (#12630). Prefer the renderer-backed PTY path when a window exists;
+    // with no window, createTerminal still falls back to background spawn.
+    rendererBacked: true
   })
   args.effects.push({
     kind: 'terminal',


### PR DESCRIPTION
## Description
Prefer renderer-backed terminal create for `worker-start --agent` on existing worktrees so the shell gets a real PTY stdin (avoid /dev/null) while still not stealing workspace focus.

## Focused fix
- In scope: `createExistingWorktreeWorkerTerminal` options (`rendererBacked: true`, keep `surfaceOwner: false`)
- Out of scope: rewriting low-level node-pty spawn

## Preserves
- Background fallback when no authoritative window exists (serve/headless)
- Non-focus workspace switch (`surfaceOwner: false`)

## Evidence
- Logic-level fix with existing createTerminal window/background branching; focused topology change only

## User-regression-tradeoffs
- When a window exists, worker panes go through renderer path (still non-focus)

Fixes #12630
