### PR TITLE
fix(tasks): hold dialog-confirmed issue state over stale Tasks list refetches (STA-3343)

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -210,6 +210,7 @@ import {
   validateTaskPageGitHubDuplicateTarget,
   type TaskPageGitHubCloseAction
 } from '@/components/task-page-github-status-actions'
+import { assertTaskPageGitHubDialogStateAuthority } from '@/components/task-page-github-dialog-state-authority'
 import { sortChecksBySeverity } from '../../../shared/pr-check-severity-order'
 import {
   getCheckConclusion,
@@ -2834,6 +2835,14 @@ function PRActionsPanel({
     }
     const previousState = localState
     setStatePending(true)
+    // Why: without registry authority a search-lagged Tasks refetch silently
+    // reverts this row to its pre-mutation state (STA-3343).
+    const authority = assertTaskPageGitHubDialogStateAuthority({
+      repoId: item.repoId,
+      itemId: item.id,
+      state: nextState,
+      sourceContext
+    })
     applyStatePatch(nextState)
     try {
       await runPullRequestStateUpdate({
@@ -2853,6 +2862,7 @@ function PRActionsPanel({
       )
       onMutated()
     } catch (err) {
+      authority.revert()
       applyStatePatch(previousState)
       toast.error(
         err instanceof Error
@@ -2913,6 +2923,13 @@ function PRActionsPanel({
         toast.error(result.error)
         return
       }
+      // Why: merge is confirmed here; hold 'merged' against search-lagged refetches.
+      assertTaskPageGitHubDialogStateAuthority({
+        repoId: item.repoId,
+        itemId: item.id,
+        state: 'merged',
+        sourceContext
+      })
       applyStatePatch('merged')
       if (mergeTarget.kind === 'environment') {
         notifyWorkItemDetailsMutation(
@@ -4175,6 +4192,9 @@ function GHEditSection({
         return
       }
       const prevState = localState
+      // Why: without registry authority a search-lagged Tasks refetch silently
+      // reverts this row to its pre-mutation state (STA-3343).
+      let authority: { revert: () => void } | null = null
       run('state', {
         mutate: () =>
           runIssueUpdate({
@@ -4189,11 +4209,18 @@ function GHEditSection({
                 : { state: newState }
           }),
         onOptimistic: () => {
+          authority = assertTaskPageGitHubDialogStateAuthority({
+            repoId: item.repoId,
+            itemId: item.id,
+            state: newState,
+            sourceContext
+          })
           onStateChange(newState)
           patchWorkItem(item.id, { state: newState }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded({ state: newState })
         },
         onRevert: () => {
+          authority?.revert()
           onStateChange(prevState)
           patchWorkItem(item.id, { state: prevState }, item.repoId, { sourceContext })
           patchProjectRowIfNeeded({ state: prevState })

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -2862,8 +2862,9 @@ function PRActionsPanel({
       )
       onMutated()
     } catch (err) {
-      authority.revert()
-      applyStatePatch(previousState)
+      if (authority.revert()) {
+        applyStatePatch(previousState)
+      }
       toast.error(
         err instanceof Error
           ? err.message
@@ -4194,7 +4195,7 @@ function GHEditSection({
       const prevState = localState
       // Why: without registry authority a search-lagged Tasks refetch silently
       // reverts this row to its pre-mutation state (STA-3343).
-      let authority: { revert: () => void } | null = null
+      let authority: { revert: () => boolean } | null = null
       run('state', {
         mutate: () =>
           runIssueUpdate({
@@ -4220,10 +4221,11 @@ function GHEditSection({
           patchProjectRowIfNeeded({ state: newState })
         },
         onRevert: () => {
-          authority?.revert()
-          onStateChange(prevState)
-          patchWorkItem(item.id, { state: prevState }, item.repoId, { sourceContext })
-          patchProjectRowIfNeeded({ state: prevState })
+          if (authority?.revert()) {
+            onStateChange(prevState)
+            patchWorkItem(item.id, { state: prevState }, item.repoId, { sourceContext })
+            patchProjectRowIfNeeded({ state: prevState })
+          }
         },
         onSuccess: () => {
           useAppStore.getState().recordFeatureInteraction('github-tasks')

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -242,4 +242,23 @@ describe('GitHubItemDialog source host boundaries', () => {
 
     expect(checksTab).toContain('item={displayWorkItem ?? workItem}')
   })
+
+  it('records state authority for dialog state mutations so stale list refetches cannot revert them (STA-3343)', () => {
+    const source = componentSource('GitHubItemDialog.tsx')
+
+    // Issue close/reopen: assert on optimistic apply, revert on failure.
+    const editSection = sourceBetween(source, 'function GHEditSection', 'const closeAsDuplicate')
+    expect(editSection).toContain('assertTaskPageGitHubDialogStateAuthority({')
+    expect(editSection).toContain('authority?.revert()')
+
+    // PR close/reopen + merge: same protection for the shared Tasks list rows.
+    const actionsSection = sourceBetween(
+      source,
+      'function PRActionsPanel',
+      'function CommentReplyForm'
+    )
+    expect(actionsSection.match(/assertTaskPageGitHubDialogStateAuthority\(\{/g)).toHaveLength(2)
+    expect(actionsSection).toContain('authority.revert()')
+    expect(actionsSection).toContain("state: 'merged'")
+  })
 })

--- a/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
+++ b/src/renderer/src/components/github-item-dialog-source-boundary.test.ts
@@ -249,7 +249,7 @@ describe('GitHubItemDialog source host boundaries', () => {
     // Issue close/reopen: assert on optimistic apply, revert on failure.
     const editSection = sourceBetween(source, 'function GHEditSection', 'const closeAsDuplicate')
     expect(editSection).toContain('assertTaskPageGitHubDialogStateAuthority({')
-    expect(editSection).toContain('authority?.revert()')
+    expect(editSection).toContain('if (authority?.revert())')
 
     // PR close/reopen + merge: same protection for the shared Tasks list rows.
     const actionsSection = sourceBetween(
@@ -258,7 +258,7 @@ describe('GitHubItemDialog source host boundaries', () => {
       'function CommentReplyForm'
     )
     expect(actionsSection.match(/assertTaskPageGitHubDialogStateAuthority\(\{/g)).toHaveLength(2)
-    expect(actionsSection).toContain('authority.revert()')
+    expect(actionsSection).toContain('if (authority.revert())')
     expect(actionsSection).toContain("state: 'merged'")
   })
 })

--- a/src/renderer/src/components/task-page-github-dialog-state-authority.test.ts
+++ b/src/renderer/src/components/task-page-github-dialog-state-authority.test.ts
@@ -9,6 +9,7 @@ import {
   reapplyPendingTaskPageGitHubMutationsToCache
 } from './task-page-github-work-item-mutations'
 import {
+  deleteLastConfirmedClientValue,
   getLastConfirmedClientValue,
   getOrCreateQuietRevalidateState,
   resetTaskPageGitHubMutationRegistryForTests,
@@ -150,7 +151,7 @@ describe('dialog state authority (STA-3343)', () => {
       itemId: 'issue:1',
       state: 'closed'
     })
-    fresh.revert()
+    expect(fresh.revert()).toBe(true)
     expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBeUndefined()
 
     setLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state', 'open')
@@ -159,7 +160,28 @@ describe('dialog state authority (STA-3343)', () => {
       itemId: 'issue:1',
       state: 'closed'
     })
-    layered.revert()
+    expect(layered.revert()).toBe(true)
     expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBe('open')
+  })
+
+  it('does not roll back authority released by search or superseded by a newer state', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    const released = assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    deleteLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')
+    expect(released.revert()).toBe(false)
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBeUndefined()
+
+    const superseded = assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    setLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state', 'merged')
+    expect(superseded.revert()).toBe(false)
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBe('merged')
   })
 })

--- a/src/renderer/src/components/task-page-github-dialog-state-authority.test.ts
+++ b/src/renderer/src/components/task-page-github-dialog-state-authority.test.ts
@@ -1,0 +1,165 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import type { GitHubWorkItem } from '../../../shared/types'
+import { getTaskSourceCacheScope } from '../../../shared/task-source-context'
+import { assertTaskPageGitHubDialogStateAuthority } from './task-page-github-dialog-state-authority'
+import {
+  adoptQuietSearchFieldsForItem,
+  applyPendingTaskPageGitHubMutationsToItems,
+  materializeTaskPageItemList,
+  reapplyPendingTaskPageGitHubMutationsToCache
+} from './task-page-github-work-item-mutations'
+import {
+  getLastConfirmedClientValue,
+  getOrCreateQuietRevalidateState,
+  resetTaskPageGitHubMutationRegistryForTests,
+  setLastConfirmedClientValue,
+  setTaskPageGitHubMutationQueryKey,
+  taskPageGitHubFamilyDirtyKey,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+
+function item(overrides: Partial<GitHubWorkItem> = {}): GitHubWorkItem {
+  return {
+    id: 'issue:1',
+    type: 'issue',
+    number: 1,
+    title: 't',
+    state: 'open',
+    url: 'https://github.com/o/r/issues/1',
+    labels: [],
+    updatedAt: '2026-01-01T00:00:00Z',
+    author: 'author',
+    repoId: 'repo-1',
+    ...overrides
+  }
+}
+
+const sourceContext = {
+  kind: 'task-source' as const,
+  provider: 'github' as const,
+  hostId: 'local' as const,
+  projectId: 'proj',
+  projectHostSetupId: 'setup',
+  repoId: 'repo-1'
+}
+
+afterEach(() => resetTaskPageGitHubMutationRegistryForTests())
+
+describe('dialog state authority (STA-3343)', () => {
+  it('without authority a stale search refetch reverts a cache-only patch (external edits adopt)', () => {
+    // Why: documents the pre-fix dialog behavior — patchWorkItem alone gives the
+    // row no registry protection, so the lagging search response wins.
+    const materialized = materializeTaskPageItemList({
+      networkItems: [item({ state: 'open' })],
+      previousItems: [item({ state: 'closed' })],
+      queryKey: 'q'
+    })
+    expect(materialized[0]?.state).toBe('open')
+  })
+
+  it('holds a dialog-confirmed close over a stale search refetch', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    const materialized = materializeTaskPageItemList({
+      networkItems: [item({ state: 'open' })],
+      previousItems: [item({ state: 'closed' })],
+      queryKey: 'q'
+    })
+    expect(materialized[0]?.state).toBe('closed')
+  })
+
+  it('holds the close through the cache re-apply path too', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    const store = new Map<string, GitHubWorkItem>([['issue:1', item({ state: 'open' })]])
+    reapplyPendingTaskPageGitHubMutationsToCache({
+      items: [item({ state: 'open' })],
+      patchWorkItem: (id, patch) => {
+        store.set(id, { ...(store.get(id) ?? item()), ...patch })
+      }
+    })
+    expect(store.get('issue:1')?.state).toBe('closed')
+  })
+
+  it('records authority under the mutation source scope so other scopes are untouched', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed',
+      sourceContext
+    })
+    const scope = getTaskSourceCacheScope(sourceContext)
+    expect(getLastConfirmedClientValue(scope, 'repo-1', 'issue:1', 'state')).toBe('closed')
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBeUndefined()
+    // Why: overlay resolves the remembered scope, so the list row still holds.
+    const overlaid = applyPendingTaskPageGitHubMutationsToItems([item({ state: 'open' })])
+    expect(overlaid[0]?.state).toBe('closed')
+  })
+
+  it('marks the state family dirty so quiet revalidation trails the stale row', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    const before = getOrCreateQuietRevalidateState('q').dirtyGeneration
+    assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    const quiet = getOrCreateQuietRevalidateState('q')
+    expect(quiet.dirtyGeneration).toBe(before + 1)
+    expect(
+      quiet.familyDirtyAt.get(
+        taskPageGitHubFamilyDirtyKey(taskPageGitHubItemKey('repo-1', 'issue:1'), 'state')
+      )
+    ).toBe(quiet.dirtyGeneration)
+  })
+
+  it('releases authority once search reports the confirmed state, so later external edits win', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    const patched: Partial<GitHubWorkItem>[] = []
+    adoptQuietSearchFieldsForItem({
+      item: item({ state: 'closed' }),
+      serverItem: item({ state: 'closed' }),
+      sourceScope: null,
+      queryKey: 'q',
+      fetchStartedAtGeneration: getOrCreateQuietRevalidateState('q').dirtyGeneration,
+      patchWorkItem: (_id, patch) => patched.push(patch)
+    })
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBeUndefined()
+    const overlaid = applyPendingTaskPageGitHubMutationsToItems([item({ state: 'open' })])
+    expect(overlaid[0]?.state).toBe('open')
+  })
+
+  it('revert drops fresh authority and restores a pre-existing value', () => {
+    setTaskPageGitHubMutationQueryKey('q')
+    const fresh = assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    fresh.revert()
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBeUndefined()
+
+    setLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state', 'open')
+    const layered = assertTaskPageGitHubDialogStateAuthority({
+      repoId: 'repo-1',
+      itemId: 'issue:1',
+      state: 'closed'
+    })
+    layered.revert()
+    expect(getLastConfirmedClientValue(null, 'repo-1', 'issue:1', 'state')).toBe('open')
+  })
+})

--- a/src/renderer/src/components/task-page-github-dialog-state-authority.ts
+++ b/src/renderer/src/components/task-page-github-dialog-state-authority.ts
@@ -32,7 +32,7 @@ export function assertTaskPageGitHubDialogStateAuthority(args: {
   itemId: string
   state: GitHubWorkItem['state']
   sourceContext?: TaskSourceContext | null
-}): { revert: () => void } {
+}): { revert: () => boolean } {
   const sourceScope =
     args.sourceContext?.provider === 'github' ? getTaskSourceCacheScope(args.sourceContext) : null
   const previous = getLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state')
@@ -41,6 +41,11 @@ export function assertTaskPageGitHubDialogStateAuthority(args: {
   notifyTaskPageGitHubMutationRegistry()
   return {
     revert: () => {
+      const current = getLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state')
+      // A matching search adopt or newer mutation owns the state now.
+      if (current !== args.state) {
+        return false
+      }
       if (previous === undefined) {
         deleteLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state')
       } else {
@@ -48,6 +53,7 @@ export function assertTaskPageGitHubDialogStateAuthority(args: {
       }
       markStateFamilyDirty(args.repoId, args.itemId)
       notifyTaskPageGitHubMutationRegistry()
+      return true
     }
   }
 }

--- a/src/renderer/src/components/task-page-github-dialog-state-authority.ts
+++ b/src/renderer/src/components/task-page-github-dialog-state-authority.ts
@@ -1,0 +1,53 @@
+import type { GitHubWorkItem } from '../../../shared/types'
+import {
+  getTaskSourceCacheScope,
+  type TaskSourceContext
+} from '../../../shared/task-source-context'
+import {
+  deleteLastConfirmedClientValue,
+  getLastConfirmedClientValue,
+  getTaskPageGitHubMutationQueryKey,
+  markTaskPageGitHubFamiliesDirty,
+  notifyTaskPageGitHubMutationRegistry,
+  setLastConfirmedClientValue,
+  taskPageGitHubItemKey
+} from './task-page-github-work-item-mutation-registry'
+
+function markStateFamilyDirty(repoId: string, itemId: string): void {
+  const queryKey = getTaskPageGitHubMutationQueryKey()
+  if (queryKey !== null) {
+    markTaskPageGitHubFamiliesDirty(queryKey, taskPageGitHubItemKey(repoId, itemId), ['state'])
+  }
+}
+
+/**
+ * Dialog state edits patch `workItemsCache` directly with no pending op, so a
+ * search-lagged list refetch (GitHub search index + `gh` URL cache) silently
+ * reverted them in the Tasks list (STA-3343). Record the confirmed state in the
+ * mutation registry so the list fetch paths re-assert it until search catches
+ * up; quiet adopt releases it on match, so external reverts still win.
+ */
+export function assertTaskPageGitHubDialogStateAuthority(args: {
+  repoId: string
+  itemId: string
+  state: GitHubWorkItem['state']
+  sourceContext?: TaskSourceContext | null
+}): { revert: () => void } {
+  const sourceScope =
+    args.sourceContext?.provider === 'github' ? getTaskSourceCacheScope(args.sourceContext) : null
+  const previous = getLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state')
+  setLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state', args.state)
+  markStateFamilyDirty(args.repoId, args.itemId)
+  notifyTaskPageGitHubMutationRegistry()
+  return {
+    revert: () => {
+      if (previous === undefined) {
+        deleteLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state')
+      } else {
+        setLastConfirmedClientValue(sourceScope, args.repoId, args.itemId, 'state', previous)
+      }
+      markStateFamilyDirty(args.repoId, args.itemId)
+      notifyTaskPageGitHubMutationRegistry()
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Fixes [STA-3343](https://linear.app/stably/issue/STA-3343) / #12381 (P0): an issue closed from the Task panel's detail dialog kept showing **Open** in the Tasks list; only the detail page showed **Closed**.

**Root cause.** Closing/reopening an item from `GitHubItemDialog` patched `workItemsCache` directly (`patchWorkItem`) without recording anything in the Task-page mutation registry. The Tasks list refetches through GitHub's search index, which is eventually consistent — and `gh` additionally caches each search URL for ~120s — so the next list refetch returned the pre-mutation `open` state. List fetch paths (`materializeTaskPageItemList`, `reconcileTaskPagePagesWithWorkItemsCache`, `reapplyPendingTaskPageGitHubMutationsToCache`) re-assert only registry-backed pending ops / confirmed authority, so the unprotected row silently reverted to Open. The detail view resolves the item directly (not via search), which is why it stayed correct. List-row mutations were already protected by the registry (`setLastConfirmedClientValue` on confirm); the dialog path was the only unprotected writer.

**Fix.** New `assertTaskPageGitHubDialogStateAuthority` records the dialog-confirmed state as registry authority (scoped to the mutation's source cache scope so it cannot bleed across hosts/accounts), marks the `state` family dirty so quiet revalidation trails the stale row, and returns a `revert()` used when the mutation fails. Wired into the dialog's issue close/reopen, PR close/reopen, and PR merge paths. The existing quiet-adopt path releases the authority as soon as search reports the confirmed state, so a later external revert still wins — nothing is hidden indefinitely.

## Reproduction

1. Task panel → open an issue's detail dialog → Close it.
2. The list row flips to Closed optimistically, then any list refetch within search-index lag (worse with `gh`'s ~120s URL cache) reverts it to **Open**.
3. Reopening the detail dialog shows **Closed** (direct fetch, not search).

Captured as tests before the fix was wired:

- `github-item-dialog-source-boundary.test.ts` › *records state authority for dialog state mutations…* — **failed red** against the unwired dialog (proves the dialog recorded no authority).
- `task-page-github-dialog-state-authority.test.ts` › *without authority a stale search refetch reverts a cache-only patch* — demonstrates the revert mechanism on the pre-fix behavior (kept as a design assertion: unmanaged rows must still adopt external edits).

Note: the original report tags macOS; the defect is platform-independent renderer state handling, reproduced via unit tests rather than on a specific OS build.

## Screenshots

No visual change (state values now stay consistent; no new UI).

## Testing

- [x] `pnpm lint` — all stages pass except a **pre-existing** failure on the base commit: `mobile/src/session/use-mobile-native-chat-controller.ts` max-lines 303/300 (introduced by #12495 on main, untouched by this PR)
- [x] `pnpm typecheck`
- [x] `pnpm test` — targeted: new suite (19 tests) plus all neighboring Task-page/GitHub suites (13 files, 279 tests) pass; the full local suite could not run because the dev machine hit ENOSPC (483 MB free) — relying on CI for the full run
- [ ] `pnpm build` — blocked locally by the same ENOSPC; renderer-only TS change, no build-config edits
- [x] Added or updated high-quality tests that would catch regressions: authority holds over stale refetch (flat-list and cache-reapply paths), scope isolation, dirty-marking for quiet revalidation, adopt-release on search catch-up, revert semantics, and a source-boundary test pinning the dialog wiring

## AI Review Report

Reviewed the fix against the mutation-registry design invariants before wiring: (1) authority must be scoped to the mutation's source cache scope — verified it uses the same `getTaskSourceCacheScope` resolution as list-row mutations, with a test asserting other scopes stay untouched; (2) authority must not hide external reverts indefinitely — verified quiet adopt (`adoptQuietSearchFieldsForItem`) releases it on match (K21 semantics unchanged), with a test; (3) hard refresh (tier 3) and absent-from-loaded-items sweeps must still clear it — both operate on `lastConfirmedClientValues`, which this fix reuses, so existing behavior applies; (4) failure paths must not leave stale authority — `revert()` restores the exact prior value (or deletes if none). Cross-platform: renderer-only state logic; no keyboard shortcuts, labels, paths, shell behavior, or Electron platform APIs touched, so macOS/Linux/Windows behavior is identical. SSH/remote-source rows are covered by the source-scope handling (`TaskSourceContext` → scope), matching the existing list-row mutation routing; no wire-format changes (no RPC params, stream frames, or published content altered).

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The change adds an in-renderer, in-memory map entry keyed by existing scope/repo/item identifiers; no persistence, no new privileged calls, and mutations still flow through the pre-existing `window.api.gh.*` / runtime RPC paths unchanged. No follow-up needed.

## Notes

- PR close/reopen and merge in the same dialog had the identical unprotected-writer defect (same list, same revert symptom), so they are wired through the same helper — three call sites, one mechanism.
- GitLab dialog (`GitLabItemDialog`) may have an analogous staleness window, but GitLab list fetches don't go through GitHub's search index/`gh` cache; left out of scope for this P0 and worth a separate look.
- Pre-existing lint failure on main (`use-mobile-native-chat-controller.ts` max-lines) blocks a clean local `pnpm lint`; not addressed here per no-drive-by-refactor scope.
