### PR TITLE
fix(browser): recover browser tab when guest WebContents is destroyed (STA-3448)

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -197,6 +197,7 @@ import {
 import { subscribeBrowserSystemResume } from './browser-system-resume'
 import {
   type BrowserReloadTrigger,
+  reloadBrowserPageWebview,
   resolveBrowserReloadButtonLabelKind,
   resolveBrowserReloadIntent
 } from './browser-reload-action'
@@ -2941,6 +2942,20 @@ function BrowserPagePane({
     () => ({ loading: browserTab.loading, loadErrorCode: browserTab.loadError?.code ?? null }),
     [browserTab.loading, browserTab.loadError]
   )
+  const reloadWebviewOrRecoverGuest = useCallback(
+    (ignoreCache: boolean) => {
+      const webview = webviewRef.current
+      if (!webview) {
+        return
+      }
+      if (reloadBrowserPageWebview(webview, { ignoreCache }) === 'guest-missing') {
+        // Why: reload cannot revive a destroyed guest (STA-3448) — recreate it instead.
+        onUpdatePageStateRef.current(browserTab.id, { loading: true })
+        retryGuestRecoveryRef.current()
+      }
+    },
+    [browserTab.id]
+  )
   const runReloadTrigger = useCallback(
     (trigger: BrowserReloadTrigger) => {
       const webview = webviewRef.current
@@ -2959,14 +2974,14 @@ function BrowserPagePane({
           retryBrowserTabLoad(webview, browserTab, onUpdatePageStateRef.current)
           break
         case 'hard-reload':
-          webview.reloadIgnoringCache()
+          reloadWebviewOrRecoverGuest(true)
           break
         case 'reload':
-          webview.reload()
+          reloadWebviewOrRecoverGuest(false)
           break
       }
     },
-    [browserTab, reloadState]
+    [browserTab, reloadState, reloadWebviewOrRecoverGuest]
   )
 
   // Keep the accessible name honest: the same button is Stop mid-load and Retry after a failure.
@@ -3454,7 +3469,12 @@ function BrowserPagePane({
       return false
     }
     addressBarInputRef.current?.blur()
-    webview.focus()
+    try {
+      webview.focus()
+    } catch {
+      // Why: WebViewElement.focus() reads null internals once the guest is destroyed (STA-3448).
+      return false
+    }
     return document.activeElement === webview
   }, [])
 
@@ -3660,15 +3680,11 @@ function BrowserPagePane({
       }
       e.preventDefault()
       e.stopPropagation()
-      if (isHardReload) {
-        webviewRef.current?.reloadIgnoringCache()
-      } else {
-        webviewRef.current?.reload()
-      }
+      reloadWebviewOrRecoverGuest(isHardReload)
     }
     window.addEventListener('keydown', handleKeyDown, true)
     return () => window.removeEventListener('keydown', handleKeyDown, true)
-  }, [isActive, keybindings])
+  }, [isActive, keybindings, reloadWebviewOrRecoverGuest])
 
   // Cmd/Ctrl+R — reload (IPC path: focus inside webview guest)
   // Why: a focused guest is a separate Chromium process, so main forwards the chord back here.
@@ -3677,9 +3693,9 @@ function BrowserPagePane({
       return
     }
     return window.api.ui.onReloadBrowserPage(() => {
-      webviewRef.current?.reload()
+      reloadWebviewOrRecoverGuest(false)
     })
-  }, [isActive])
+  }, [isActive, reloadWebviewOrRecoverGuest])
 
   useEffect(() => {
     if (!isActive) {
@@ -3716,9 +3732,9 @@ function BrowserPagePane({
       return
     }
     return window.api.ui.onHardReloadBrowserPage(() => {
-      webviewRef.current?.reloadIgnoringCache()
+      reloadWebviewOrRecoverGuest(true)
     })
-  }, [isActive])
+  }, [isActive, reloadWebviewOrRecoverGuest])
 
   useEffect(() => {
     onUpdatePageStateRef.current = onUpdatePageState
@@ -4220,9 +4236,17 @@ function BrowserPagePane({
     validateVisibleGuestRegistrationRef.current = guestRecovery.validateAfterResume
     retryGuestRecoveryRef.current = guestRecovery.retryRecovery
 
+    const handleGuestDestroyed = (): void => {
+      // Why: a guest can be destroyed without render-process-gone (detach/reattach race,
+      // guest-side close). Skip intentional teardown, where the element already left the DOM.
+      if (webview.isConnected) {
+        guestRecovery.recoverRenderer()
+      }
+    }
     webview.addEventListener('did-attach', handleDidAttach)
     webview.addEventListener('dom-ready', handleDomReady)
     webview.addEventListener('render-process-gone', guestRecovery.recoverRenderer)
+    webview.addEventListener('destroyed', handleGuestDestroyed)
     webview.addEventListener('focus', dismissAddressBarSuggestions)
     webview.addEventListener('did-start-loading', handleDidStartLoading)
     webview.addEventListener('did-start-navigation', handleDidStartNavigation)
@@ -4259,6 +4283,7 @@ function BrowserPagePane({
       webview.removeEventListener('did-attach', handleDidAttach)
       webview.removeEventListener('dom-ready', handleDomReady)
       webview.removeEventListener('render-process-gone', guestRecovery.recoverRenderer)
+      webview.removeEventListener('destroyed', handleGuestDestroyed)
       webview.removeEventListener('focus', dismissAddressBarSuggestions)
       webview.removeEventListener('did-start-loading', handleDidStartLoading)
       webview.removeEventListener('did-start-navigation', handleDidStartNavigation)
@@ -5161,7 +5186,7 @@ function BrowserPagePane({
                   role="menuitem"
                   className="relative flex w-full cursor-default items-center gap-2 rounded-[7px] px-2 py-0.5 text-[12px] leading-5 font-medium outline-none select-none hover:bg-black/8 dark:hover:bg-white/14"
                   onClick={() => {
-                    webviewRef.current?.reload()
+                    reloadWebviewOrRecoverGuest(false)
                     setContextMenu(null)
                   }}
                 >

--- a/src/renderer/src/components/browser-pane/browser-reload-action.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-reload-action.test.ts
@@ -1,6 +1,7 @@
-import { describe, expect, it } from 'vitest'
+import { describe, expect, it, vi } from 'vitest'
 import { BROWSER_GUEST_RECOVERY_ERROR_CODE } from './browser-page-guest-recovery'
 import {
+  reloadBrowserPageWebview,
   resolveBrowserReloadButtonLabelKind,
   resolveBrowserReloadIntent
 } from './browser-reload-action'
@@ -49,5 +50,46 @@ describe('resolveBrowserReloadButtonLabelKind', () => {
     expect(resolveBrowserReloadButtonLabelKind(loading)).toBe('stop')
     expect(resolveBrowserReloadButtonLabelKind(failed)).toBe('retry')
     expect(resolveBrowserReloadButtonLabelKind(guestFailed)).toBe('retry')
+  })
+})
+
+describe('reloadBrowserPageWebview', () => {
+  function createWebview(overrides: Partial<Electron.WebviewTag> = {}): Electron.WebviewTag {
+    return {
+      getWebContentsId: vi.fn(() => 42),
+      reload: vi.fn(),
+      reloadIgnoringCache: vi.fn(),
+      ...overrides
+    } as unknown as Electron.WebviewTag
+  }
+
+  it('reloads a live guest, honoring the cache flag', () => {
+    const webview = createWebview()
+    expect(reloadBrowserPageWebview(webview, { ignoreCache: false })).toBe('reloaded')
+    expect(webview.reload).toHaveBeenCalledTimes(1)
+
+    expect(reloadBrowserPageWebview(webview, { ignoreCache: true })).toBe('reloaded')
+    expect(webview.reloadIgnoringCache).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: a destroyed guest makes reload() throw uncaught (STA-3448) — callers must recreate the guest instead.
+  it('reports a missing guest without touching reload', () => {
+    const webview = createWebview({
+      getWebContentsId: vi.fn(() => {
+        throw new Error('WebContents is destroyed')
+      })
+    })
+    expect(reloadBrowserPageWebview(webview, { ignoreCache: false })).toBe('guest-missing')
+    expect(webview.reload).not.toHaveBeenCalled()
+  })
+
+  // Why: pre-dom-ready reload throws too, but a live guest is already loading — recovery must not replace it.
+  it('reports not-ready when a live guest rejects the reload', () => {
+    const webview = createWebview({
+      reload: vi.fn(() => {
+        throw new Error('The WebView must be attached to the DOM')
+      })
+    })
+    expect(reloadBrowserPageWebview(webview, { ignoreCache: false })).toBe('not-ready')
   })
 })

--- a/src/renderer/src/components/browser-pane/browser-reload-action.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-reload-action.test.ts
@@ -83,6 +83,24 @@ describe('reloadBrowserPageWebview', () => {
     expect(webview.reload).not.toHaveBeenCalled()
   })
 
+  it('reports a guest destroyed between the liveness probe and reload', () => {
+    const getWebContentsId = vi
+      .fn<() => number>()
+      .mockReturnValueOnce(42)
+      .mockImplementation(() => {
+        throw new Error('WebContents is destroyed')
+      })
+    const webview = createWebview({
+      getWebContentsId,
+      reload: vi.fn(() => {
+        throw new Error('The WebView must be attached to the DOM')
+      })
+    })
+
+    expect(reloadBrowserPageWebview(webview, { ignoreCache: false })).toBe('guest-missing')
+    expect(getWebContentsId).toHaveBeenCalledTimes(2)
+  })
+
   // Why: pre-dom-ready reload throws too, but a live guest is already loading — recovery must not replace it.
   it('reports not-ready when a live guest rejects the reload', () => {
     const webview = createWebview({

--- a/src/renderer/src/components/browser-pane/browser-reload-action.ts
+++ b/src/renderer/src/components/browser-pane/browser-reload-action.ts
@@ -57,6 +57,12 @@ export function reloadBrowserPageWebview(
       webview.reload()
     }
   } catch {
+    try {
+      webview.getWebContentsId()
+    } catch {
+      // Why: the guest can be destroyed between the liveness probe and reload.
+      return 'guest-missing'
+    }
     return 'not-ready'
   }
   return 'reloaded'

--- a/src/renderer/src/components/browser-pane/browser-reload-action.ts
+++ b/src/renderer/src/components/browser-pane/browser-reload-action.ts
@@ -34,6 +34,34 @@ export function resolveBrowserReloadIntent(
   return trigger === 'hard-reload' ? 'hard-reload' : 'reload'
 }
 
+export type BrowserPageWebviewReloadResult = 'reloaded' | 'guest-missing' | 'not-ready'
+
+/**
+ * Why: reload on a guestless webview throws uncaught ("The WebView must be attached to the
+ * DOM…", STA-3448). getWebContentsId() only needs an attached guest, so it separates a dead
+ * guest (route to guest recovery) from a live pre-dom-ready one (a load is already in flight).
+ */
+export function reloadBrowserPageWebview(
+  webview: Electron.WebviewTag,
+  { ignoreCache }: { ignoreCache: boolean }
+): BrowserPageWebviewReloadResult {
+  try {
+    webview.getWebContentsId()
+  } catch {
+    return 'guest-missing'
+  }
+  try {
+    if (ignoreCache) {
+      webview.reloadIgnoringCache()
+    } else {
+      webview.reload()
+    }
+  } catch {
+    return 'not-ready'
+  }
+  return 'reloaded'
+}
+
 /** Accessible name for the toolbar button, which is Stop mid-load and Retry after a failure. */
 export type BrowserReloadButtonLabelKind = 'stop' | 'retry' | 'reload'
 

--- a/src/renderer/src/components/browser-pane/webview-registry.test.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.test.ts
@@ -165,6 +165,45 @@ describe('webview registry drag listeners', () => {
     expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
   })
 
+  it('flags renderer recovery when the guest is destroyed under a still-attached webview', async () => {
+    const { isBrowserPageRendererRecoveryPending, registerPersistentWebview } =
+      await import('./webview-registry')
+    const webview = createWebview({ isConnected: true })
+    registerPersistentWebview('page-1', webview)
+
+    webview.dispatchEvent(new Event('destroyed'))
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(true)
+
+    webview.dispatchEvent(new Event('dom-ready'))
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
+  })
+
+  it('ignores guest destruction caused by intentional webview removal', async () => {
+    const { isBrowserPageRendererRecoveryPending, registerPersistentWebview } =
+      await import('./webview-registry')
+    const webview = createWebview({ isConnected: false })
+    registerPersistentWebview('page-1', webview)
+
+    webview.dispatchEvent(new Event('destroyed'))
+
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
+  })
+
+  it('stops listening for guest destruction after unregistration', async () => {
+    const {
+      isBrowserPageRendererRecoveryPending,
+      registerPersistentWebview,
+      unregisterPersistentWebview
+    } = await import('./webview-registry')
+    const webview = createWebview({ isConnected: true })
+    registerPersistentWebview('page-1', webview)
+    unregisterPersistentWebview('page-1')
+
+    webview.dispatchEvent(new Event('destroyed'))
+
+    expect(isBrowserPageRendererRecoveryPending('page-1')).toBe(false)
+  })
+
   it('preserves the viewport and zoom only while replacing a guest', async () => {
     const { destroyPersistentWebview, registerPersistentWebview, replacePersistentWebview } =
       await import('./webview-registry')

--- a/src/renderer/src/components/browser-pane/webview-registry.ts
+++ b/src/renderer/src/components/browser-pane/webview-registry.ts
@@ -27,6 +27,7 @@ const webviewLifecycleListeners = new Map<
     webview: Electron.WebviewTag
     onRendererGone: EventListener
     onRendererReady: EventListener
+    onGuestDestroyed: EventListener
   }
 >()
 
@@ -163,6 +164,7 @@ export function registerPersistentWebview(
       previousListeners.onRendererGone
     )
     previousListeners.webview.removeEventListener('dom-ready', previousListeners.onRendererReady)
+    previousListeners.webview.removeEventListener('destroyed', previousListeners.onGuestDestroyed)
   }
   const onRendererGone = (): void => {
     rendererRecoveryPendingPageIds.add(browserTabId)
@@ -170,9 +172,22 @@ export function registerPersistentWebview(
   const onRendererReady = (): void => {
     rendererRecoveryPendingPageIds.delete(browserTabId)
   }
+  const onGuestDestroyed = (): void => {
+    // Why: 'destroyed' also fires after an intentional webview.remove(); only a
+    // still-attached element means the guest died under a live tab (STA-3448).
+    if (webview.isConnected) {
+      rendererRecoveryPendingPageIds.add(browserTabId)
+    }
+  }
   webview.addEventListener('render-process-gone', onRendererGone)
   webview.addEventListener('dom-ready', onRendererReady)
-  webviewLifecycleListeners.set(browserTabId, { webview, onRendererGone, onRendererReady })
+  webview.addEventListener('destroyed', onGuestDestroyed)
+  webviewLifecycleListeners.set(browserTabId, {
+    webview,
+    onRendererGone,
+    onRendererReady,
+    onGuestDestroyed
+  })
   webviewRegistry.set(browserTabId, webview)
   applyCurrentDragPassthroughToWebview(webview)
   ensureDragListeners()
@@ -187,6 +202,7 @@ export function unregisterPersistentWebview(browserTabId: string): void {
       lifecycleListeners.onRendererGone
     )
     lifecycleListeners.webview.removeEventListener('dom-ready', lifecycleListeners.onRendererReady)
+    lifecycleListeners.webview.removeEventListener('destroyed', lifecycleListeners.onGuestDestroyed)
     webviewLifecycleListeners.delete(browserTabId)
   }
   rendererRecoveryPendingPageIds.delete(browserTabId)


### PR DESCRIPTION
## Summary

Fixes [STA-3448](https://linear.app/stably/issue/STA-3448) / #12629 (P0, macOS): a browser tab renders solid black forever when its `<webview>` element outlives its guest WebContents.

**Root cause.** The renderer's recovery machinery only reacted to `render-process-gone`, system resume, a tab becoming visible, or an effect re-run. A guest WebContents destroyed *without* a renderer crash (detach/reattach race, guest-side close) while the tab stays visible fires none of those — Electron's `<webview>` `destroyed` event was not listened to anywhere in the codebase. The element stays registered (`browserWebviews`) while the guest registration is gone (`registeredBrowserGuests`), producing exactly the persistent off-by-one from the issue's trace-log table. Reload on the dead guest throws uncaught (`The WebView must be attached to the DOM…`, 15 breadcrumbs) and `webview.focus()` throws `Cannot read properties of null (reading 'focus')` (10 breadcrumbs), so Cmd+R could never recover the tab.

**Fix** (mirrors the existing `render-process-gone` handling at both layers):
- `webview-registry.ts`: listen for `destroyed`; if the element is still connected to the DOM (i.e. not an intentional `webview.remove()`), mark renderer recovery pending so a currently-unmounted pane recovers on remount.
- `BrowserPane.tsx`: wire `destroyed` → `guestRecovery.recoverRenderer()` for mounted panes — reload throws on a destroyed guest, so recovery falls into `replaceGuest()`, which tears down the dead element and rebuilds the webview in place.
- `browser-reload-action.ts` + all five reload entry points (toolbar, Cmd+R renderer path, Cmd+R IPC path, hard-reload IPC path, context menu): `reloadBrowserPageWebview()` distinguishes a dead guest (`getWebContentsId()` throws → route into guest recovery, per the issue's ask "make reload recreate it") from a live pre-dom-ready guest (a load is already in flight → no-op) instead of throwing uncaught.
- `focusWebviewNow`: guard `webview.focus()` against Electron's null-internals throw on a guestless webview.

## Reproduction / evidence

There are no deterministic user-level steps (the guest teardown is a race; destroying a guest without a renderer crash requires `webContents.destroy()` from the main process, which is not reachable from outside the app). Evidence chain, per the issue's "cheap to assert internally" pointer:

1. **Field signature** (from the reporter's `main.trace.ndjson`): `browserWebviews`/`registeredBrowserGuests` off-by-one appears at 08-05 00:08 and persists ~11.5h across unrelated tab churn; 25 `renderer_error` breadcrumbs (15× WebView-must-be-attached, 10× null-focus TypeError). These counters are `webviewRegistry.size` and `registeredWebContentsIds.size` — element alive, guest gone.
2. **Grep proof**: before this PR, no `destroyed` listener existed anywhere under `src/renderer` — the only guest-death signal handled was `render-process-gone`.
3. **Encoded repro (RED before fix)**: `webview-registry.test.ts` "flags renderer recovery when the guest is destroyed under a still-attached webview" fails on main (`isBrowserPageRendererRecoveryPending` stays `false`); passes with the fix. The reload-guard tests encode the two uncaught-throw modes from the breadcrumbs.

## Screenshots

No visual change. Recovery reuses the existing guest-recovery flow and existing failure overlay ("The browser page stopped unexpectedly. Retry to restore it.") when replacement fails.

## Testing

- [x] `pnpm lint` — `oxlint` clean on changed files; `config/scripts/check-changed-code-quality.mjs` (native + type-aware + React Doctor changed-lines gates): 0 new findings across 5 changed files; `oxfmt` clean
- [x] `pnpm typecheck` — all three tsconfigs pass (renderer covered by `tsconfig.tc.web.json`)
- [x] `pnpm test` — scoped run: all 40 test files / 320 tests under `browser-pane`, `crash-diagnostics`, and `store/slices/browser` pass; full suite left to CI (this host false-reds the full suite under Node 26)
- [ ] `pnpm build` — **not run locally**: host disk hit ENOSPC mid-run (machine-wide, unrelated to this change); relying on CI build
- [x] Added or updated high-quality tests that would catch regressions: 3 new registry lifecycle tests (destroyed-under-attached flags recovery / intentional removal ignored / listener removed on unregistration) and 3 new `reloadBrowserPageWebview` tests (live reload honors cache flag / dead guest reported without touching reload / pre-dom-ready live guest reported not-ready)

## AI Review Report

Reviewed the change for: (1) **intentional-teardown false positives** — `removePersistentWebview` calls `webview.remove()` then synchronously unregisters listeners, and both new handlers additionally check `webview.isConnected`, so close/replace paths never trigger spurious recovery; (2) **convergence** — `destroyed` → `recoverRenderer` → `reload()` throws → `replaceGuest()` → generation bump rebuilds the webview; replacement failure lands on the existing recovery-failed overlay with Retry, never a silent black tab; (3) **double-fire** with `render-process-gone` is absorbed by the existing `recoveryStarted` guard; (4) **pre-dom-ready discrimination** — `getWebContentsId()` requires only an attached guest, so a live loading guest is never replaced by a Cmd+R during initial load; (5) **hidden panes** — the registry-level pending flag survives pane unmount and is consumed by the existing remount path.

Cross-platform: renderer-only change; no keyboard shortcuts, labels, file paths, or shell behavior touched; the `destroyed` webview event and `getWebContentsId()` throw semantics are platform-independent Electron behavior (verified against `electron.d.ts` 43.x typings), so macOS/Linux/Windows behave identically. SSH and folder workspaces: the browser pane runs entirely in the local client renderer regardless of workspace type; no RPC params, stream frames, or host-published content changed, so there is no remote wire-compatibility impact.

## Security Audit

No input handling, command execution, path handling, auth, secrets, or dependency changes. No new IPC surface: recovery reuses the existing `registerGuest`/`isGuestRegistered`/`repairGuestRegistration` bridge calls with unchanged payloads. The new try/catch guards are scoped to two known DOM-API throw sites (`getWebContentsId`/`reload`/`focus` on a guestless webview) and cannot mask other failures; the guest-recovery path still surfaces errors through the existing failure overlay. No follow-up needed.

## Notes

- The issue's asks #3 (`orca tab list` not enumerating secondary-sidebar browser tabs) and #4 (per-tab trace spans) are diagnostics improvements intentionally left out of this tightly-scoped P0 fix — they deserve their own tickets.
- Limitation stated explicitly: no live macOS reproduction was possible because triggering guest destruction without a renderer crash requires main-process `webContents.destroy()`; the reproduction is encoded as the RED-before-fix registry test plus the field trace-log signature above.
