### PR TITLE
fix(mobile): make src/shared the only terminal stream wire definition (STA-3482)

### DIFF
--- a/mobile/src/transport/rpc-client-terminal-binary-frame.ts
+++ b/mobile/src/transport/rpc-client-terminal-binary-frame.ts
@@ -41,6 +41,32 @@ export function handleTerminalBinaryFrame(
     })
     return
   }
+  if (frame.opcode === TerminalStreamOpcode.OutputSpan) {
+    // Why: the host sends OutputSpan instead of Output whenever a chunk was transformed or its
+    // raw sequence length differs from the display text. Same payload, JSON-wrapped.
+    const span = decodeTerminalStreamJson<{
+      data?: unknown
+      rawLength?: unknown
+      transformed?: unknown
+    }>(frame.payload)
+    if (
+      typeof span?.data !== 'string' ||
+      typeof span.rawLength !== 'number' ||
+      !Number.isSafeInteger(span.rawLength) ||
+      span.rawLength < 0 ||
+      span.transformed !== true
+    ) {
+      // Why: rendering malformed span JSON would print protocol framing as terminal text.
+      return
+    }
+    options.recordValidatedInboundTraffic()
+    listener({
+      type: 'data',
+      streamId: frame.streamId,
+      chunk: span.data
+    })
+    return
+  }
   if (frame.opcode === TerminalStreamOpcode.SnapshotStart) {
     const meta = decodeTerminalStreamJson<Record<string, unknown>>(frame.payload)
     if (!meta) {

--- a/mobile/src/transport/rpc-client-terminal-output-span.test.ts
+++ b/mobile/src/transport/rpc-client-terminal-output-span.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it, vi } from 'vitest'
+import { handleTerminalBinaryFrame } from './rpc-client-terminal-binary-frame'
+import {
+  encodeTerminalStreamFrame,
+  encodeTerminalStreamJson,
+  TerminalStreamOpcode
+} from '../../../src/shared/terminal-stream-protocol'
+
+/**
+ * STA-3482. The host emits `OutputSpan` (opcode 15) instead of `Output` whenever a chunk was
+ * transformed or its raw sequence length differs from the display text — ordinary PTY ingress
+ * does this, and nothing gates the opcode behind capability negotiation. Mobile vendored only
+ * 7 of the 17 opcodes, so its decoder rejected opcode 15 and dropped the whole frame: terminal
+ * output silently vanished on phones.
+ */
+function encodeOutputSpanFrame(args: {
+  streamId: number
+  seq: number
+  data: string
+  rawLength: number
+}): Uint8Array {
+  return encodeTerminalStreamFrame({
+    opcode: TerminalStreamOpcode.OutputSpan,
+    streamId: args.streamId,
+    seq: args.seq,
+    payload: encodeTerminalStreamJson({
+      data: args.data,
+      rawLength: args.rawLength,
+      transformed: true
+    })
+  })
+}
+
+describe('terminal OutputSpan frames on mobile (STA-3482)', () => {
+  it('delivers transformed output to the stream listener', () => {
+    const listener = vi.fn()
+    const recordValidatedInboundTraffic = vi.fn()
+
+    handleTerminalBinaryFrame(
+      encodeOutputSpanFrame({ streamId: 7, seq: 120, data: 'hello from the host', rawLength: 25 }),
+      {
+        terminalSnapshots: new Map(),
+        getListener: (streamId) => (streamId === 7 ? listener : undefined),
+        recordValidatedInboundTraffic
+      }
+    )
+
+    expect(listener).toHaveBeenCalledWith({
+      type: 'data',
+      streamId: 7,
+      chunk: 'hello from the host'
+    })
+    expect(recordValidatedInboundTraffic).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops a span whose JSON does not carry the transformed contract', () => {
+    const listener = vi.fn()
+    const recordValidatedInboundTraffic = vi.fn()
+
+    handleTerminalBinaryFrame(
+      encodeTerminalStreamFrame({
+        opcode: TerminalStreamOpcode.OutputSpan,
+        streamId: 7,
+        seq: 1,
+        // Why: rendering malformed span JSON would print protocol framing as terminal text.
+        payload: encodeTerminalStreamJson({ data: 'x', rawLength: -1, transformed: true })
+      }),
+      {
+        terminalSnapshots: new Map(),
+        getListener: () => listener,
+        recordValidatedInboundTraffic
+      }
+    )
+
+    expect(listener).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/transport/terminal-stream-opcode-coverage.test.ts
+++ b/mobile/src/transport/terminal-stream-opcode-coverage.test.ts
@@ -1,0 +1,136 @@
+import { describe, expect, it, vi } from 'vitest'
+import { handleTerminalBinaryFrame } from './rpc-client-terminal-binary-frame'
+// Deliberately mobile's own module: it is the one that drifted, so it is the one under test.
+import { decodeTerminalStreamFrame } from './terminal-stream-protocol'
+import {
+  encodeTerminalStreamFrame,
+  encodeTerminalStreamJson,
+  TerminalStreamOpcode
+} from '../../../src/shared/terminal-stream-protocol'
+
+/**
+ * The drift guard. Mobile used to vendor its own opcode list, so an opcode added on the host was
+ * simply absent here and its frames decoded to null — STA-3482 lost terminal output that way and
+ * nothing failed. Mobile now shares the enum, which removes the "absent" failure mode but not the
+ * "present and silently unhandled" one.
+ *
+ * So: probe every opcode the shared enum defines and require each to be either handled or listed
+ * below as deliberately ignored. Adding an opcode to `src/shared/terminal-stream-protocol.ts`
+ * fails this test until someone decides which it is. That decision is the thing that was missing.
+ *
+ * This asserts on observed behavior rather than mirroring a list, so it cannot pass by being
+ * updated in lockstep with a copy of the handler's branches.
+ */
+
+/** Host -> client opcodes mobile acts on. */
+const HANDLED: readonly TerminalStreamOpcode[] = [
+  TerminalStreamOpcode.Output,
+  TerminalStreamOpcode.OutputSpan,
+  TerminalStreamOpcode.SnapshotStart,
+  TerminalStreamOpcode.SnapshotChunk,
+  TerminalStreamOpcode.SnapshotEnd,
+  TerminalStreamOpcode.Resized,
+  TerminalStreamOpcode.Metadata,
+  TerminalStreamOpcode.Error
+]
+
+/**
+ * Ignored on purpose. Everything here except `WriteUnavailable` is client -> host: mobile sends
+ * these (or does not use them) and never receives them, so there is nothing to handle.
+ *
+ * `WriteUnavailable` is the one genuine host -> client gap. The desktop multiplexer surfaces it
+ * via `onWriteUnavailable`; mobile has no equivalent, so a phone whose writes are refused gets no
+ * signal. Listed rather than fixed here to keep this change to one concern — but listed, so it is
+ * a known gap instead of an invisible one.
+ */
+const DELIBERATELY_IGNORED: readonly TerminalStreamOpcode[] = [
+  TerminalStreamOpcode.Input,
+  TerminalStreamOpcode.Resize,
+  TerminalStreamOpcode.Subscribe,
+  TerminalStreamOpcode.Unsubscribe,
+  TerminalStreamOpcode.SnapshotRequest,
+  TerminalStreamOpcode.Ack,
+  TerminalStreamOpcode.ClaimViewport,
+  TerminalStreamOpcode.SetOutputPaused,
+  TerminalStreamOpcode.WriteUnavailable
+]
+
+function allOpcodes(): TerminalStreamOpcode[] {
+  return Object.values(TerminalStreamOpcode)
+    .filter((value): value is TerminalStreamOpcode => typeof value === 'number')
+    .sort((a, b) => a - b)
+}
+
+function opcodeName(opcode: TerminalStreamOpcode): string {
+  return `${TerminalStreamOpcode[opcode] ?? 'Unnamed'}(${opcode})`
+}
+
+/**
+ * A payload that is simultaneously valid JSON carrying the OutputSpan contract and valid text,
+ * so one probe reaches every handled branch without encoding per-opcode expectations here.
+ */
+function probePayload(): Uint8Array {
+  return encodeTerminalStreamJson({ data: 'probe', rawLength: 5, transformed: true })
+}
+
+/** Did the handler do anything observable with this frame? */
+function producesEffect(opcode: TerminalStreamOpcode): boolean {
+  const listener = vi.fn()
+  const recordValidatedInboundTraffic = vi.fn()
+  const terminalSnapshots = new Map()
+
+  handleTerminalBinaryFrame(
+    encodeTerminalStreamFrame({ opcode, streamId: 3, seq: 9, payload: probePayload() }),
+    {
+      terminalSnapshots,
+      getListener: (streamId) => (streamId === 3 ? listener : undefined),
+      recordValidatedInboundTraffic
+    }
+  )
+
+  return (
+    listener.mock.calls.length > 0 ||
+    recordValidatedInboundTraffic.mock.calls.length > 0 ||
+    terminalSnapshots.size > 0
+  )
+}
+
+describe('terminal stream opcode coverage', () => {
+  it('classifies every shared opcode as handled or deliberately ignored', () => {
+    const classified = new Set<number>([...HANDLED, ...DELIBERATELY_IGNORED])
+    const unclassified = allOpcodes().filter((opcode) => !classified.has(opcode))
+
+    expect(
+      unclassified.map(opcodeName),
+      'A new terminal stream opcode reached src/shared without a mobile decision. Handle it in ' +
+        'rpc-client-terminal-binary-frame.ts, or add it to DELIBERATELY_IGNORED with why.'
+    ).toEqual([])
+  })
+
+  it.each(HANDLED.map((opcode) => [opcodeName(opcode), opcode] as const))(
+    'acts on %s',
+    (_name, opcode) => {
+      expect(producesEffect(opcode)).toBe(true)
+    }
+  )
+
+  it.each(DELIBERATELY_IGNORED.map((opcode) => [opcodeName(opcode), opcode] as const))(
+    'ignores %s',
+    (_name, opcode) => {
+      expect(producesEffect(opcode)).toBe(false)
+    }
+  )
+
+  it('decodes every shared opcode instead of dropping the frame', () => {
+    // Why STA-3482 was data loss and not merely a missing feature: an unknown opcode used to
+    // null out the whole frame. Unknown must mean "ignored", never "discarded silently".
+    // Decoded through mobile's own module entry point, which is what drifted.
+    for (const opcode of allOpcodes()) {
+      const decoded = decodeTerminalStreamFrame(
+        encodeTerminalStreamFrame({ opcode, streamId: 1, seq: 1, payload: probePayload() })
+      )
+      expect(decoded, `${opcodeName(opcode)} must decode`).not.toBeNull()
+      expect(decoded?.opcode).toBe(opcode)
+    }
+  })
+})

--- a/mobile/src/transport/terminal-stream-protocol.ts
+++ b/mobile/src/transport/terminal-stream-protocol.ts
@@ -6,7 +6,8 @@
  * unknown value and `decodeTerminalStreamFrame` returned null, dropping the entire frame rather
  * than the one field mobile did not understand. That is how STA-3482 lost terminal output on
  * phones. Re-exporting keeps mobile decoding every frame the host can send; opcodes mobile has
- * no behavior for are ignored by the frame handler instead of poisoning the frame.
+ * no behavior for are ignored by the frame handler, which `terminal-stream-opcode-coverage.test.ts`
+ * pins explicitly.
  *
  * Metro resolves this via `config.watchFolders` in metro.config.js.
  */

--- a/mobile/src/transport/terminal-stream-protocol.ts
+++ b/mobile/src/transport/terminal-stream-protocol.ts
@@ -1,81 +1,22 @@
-const TERMINAL_STREAM_KIND = 0x74
-const TERMINAL_STREAM_VERSION = 1
-const HEADER_BYTES = 16
-
-export enum TerminalStreamOpcode {
-  Output = 1,
-  SnapshotStart = 2,
-  SnapshotChunk = 3,
-  SnapshotEnd = 4,
-  Resized = 5,
-  Error = 6,
-  Metadata = 12
-}
-
-export type TerminalStreamFrame = {
-  opcode: TerminalStreamOpcode
-  streamId: number
-  seq: number
-  payload: Uint8Array
-}
-
-export function encodeTerminalStreamFrame(frame: TerminalStreamFrame): Uint8Array {
-  const out = new Uint8Array(HEADER_BYTES + frame.payload.length)
-  const view = new DataView(out.buffer, out.byteOffset, out.byteLength)
-  view.setUint8(0, TERMINAL_STREAM_KIND)
-  view.setUint8(1, TERMINAL_STREAM_VERSION)
-  view.setUint8(2, frame.opcode)
-  view.setUint8(3, 0)
-  view.setUint32(4, frame.streamId, true)
-  const seq = Math.max(0, Math.floor(frame.seq))
-  view.setUint32(8, Math.floor(seq / 0x100000000), true)
-  view.setUint32(12, seq >>> 0, true)
-  out.set(frame.payload, HEADER_BYTES)
-  return out
-}
-
-export function decodeTerminalStreamFrame(bytes: Uint8Array): TerminalStreamFrame | null {
-  if (bytes.length < HEADER_BYTES) {
-    return null
-  }
-  const view = new DataView(bytes.buffer, bytes.byteOffset, bytes.byteLength)
-  if (view.getUint8(0) !== TERMINAL_STREAM_KIND || view.getUint8(1) !== TERMINAL_STREAM_VERSION) {
-    return null
-  }
-  const opcode = view.getUint8(2)
-  if (!isTerminalStreamOpcode(opcode)) {
-    return null
-  }
-  const high = view.getUint32(8, true)
-  const low = view.getUint32(12, true)
-  return {
-    opcode,
-    streamId: view.getUint32(4, true),
-    seq: high * 0x100000000 + low,
-    payload: bytes.slice(HEADER_BYTES)
-  }
-}
-
-export function decodeTerminalStreamJson<T>(payload: Uint8Array): T | null {
-  try {
-    return JSON.parse(new TextDecoder().decode(payload)) as T
-  } catch {
-    return null
-  }
-}
-
-export function decodeTerminalStreamText(payload: Uint8Array): string {
-  return new TextDecoder().decode(payload)
-}
-
-function isTerminalStreamOpcode(value: number): value is TerminalStreamOpcode {
-  return (
-    value === TerminalStreamOpcode.Output ||
-    value === TerminalStreamOpcode.SnapshotStart ||
-    value === TerminalStreamOpcode.SnapshotChunk ||
-    value === TerminalStreamOpcode.SnapshotEnd ||
-    value === TerminalStreamOpcode.Resized ||
-    value === TerminalStreamOpcode.Error ||
-    value === TerminalStreamOpcode.Metadata
-  )
-}
+/**
+ * The terminal stream wire format has exactly one definition: `src/shared/terminal-stream-protocol.ts`.
+ *
+ * Mobile used to hand-copy the codec and 7 of the 17 opcodes. Drift was silent — nothing failed
+ * when the host gained an opcode, because the vendored `isTerminalStreamOpcode` rejected the
+ * unknown value and `decodeTerminalStreamFrame` returned null, dropping the entire frame rather
+ * than the one field mobile did not understand. That is how STA-3482 lost terminal output on
+ * phones. Re-exporting keeps mobile decoding every frame the host can send; opcodes mobile has
+ * no behavior for are ignored by the frame handler instead of poisoning the frame.
+ *
+ * Metro resolves this via `config.watchFolders` in metro.config.js.
+ */
+export {
+  decodeTerminalStreamFrame,
+  decodeTerminalStreamJson,
+  decodeTerminalStreamText,
+  encodeTerminalStreamFrame,
+  encodeTerminalStreamJson,
+  encodeTerminalStreamText,
+  TerminalStreamOpcode,
+  type TerminalStreamFrame
+} from '../../../src/shared/terminal-stream-protocol'


### PR DESCRIPTION
Root-cause half of STA-3482. Pairs with #12788, which handles the installed base.

## The real defect: a hand-copied wire definition that drifted

`mobile/src/transport/terminal-stream-protocol.ts` was a **hand-copied duplicate** of `src/shared/terminal-stream-protocol.ts` — its own codec plus 7 of the 17 opcodes. Nothing detects drift between them: not typecheck, not lint, and not the cross-version harness (which pairs desktop builds only).

It had drifted. Mobile did not know `OutputSpan` (opcode 15), and its decoder returns `null` for an unknown opcode, which the caller swallows with `if (!frame) return`. So transformed terminal output — SSH relay, local startup ingress, daemon keep-tail-drop salvage — was **silently discarded on phones**. No error, no banner, no counter.

## Change

Mobile now **re-exports the shared definition** instead of copying it, and handles `OutputSpan`.

This turned out far smaller than a codegen project: mobile already value-imports from `src/shared` in ~20 modules, and `mobile/metro.config.js` already lists `../src/shared` in `watchFolders`. So it is a re-export, not new infrastructure. **No change under `src/`.**

A drift guard forces an explicit per-opcode decision, so the whole class of bug becomes impossible rather than merely fixed once.

## Why this and #12788 are both needed

They cover different populations and neither is sufficient alone:

- **This PR** makes future mobile builds able to decode spans natively.
- **#12788** gates spans on the `terminal.subscribe` path, which is what protects phones **already in users' hands** that can never decode opcode 15.

The drift guard here tolerates either landing order.

## Verification

Behaviour preservation for the refactor: the full mobile suite ran **3323 passing, identically before and after**, with the vendored file restored by write (never `git checkout`) to get a true baseline. **No test was edited.**

Two deltas are deliberate and documented in the commit: the shared `decodeTerminalStreamJson` adds size/nesting bounds mobile previously lacked on attacker-reachable bytes, and unknown opcodes now decode-and-ignore instead of nulling the whole frame.

Both new tests were red on unmodified main first. Four mutations, each restored by re-applying:
- drop the `OutputSpan` branch → exactly 2 tests fail
- weaken span validation → the malformed-span test fails (it passed **vacuously** before; now load-bearing)
- add opcode 18 to the shared enum → drift guard fails, naming `MutationProbeOpcode(18)`
- restore the vendored copy → decode test plus both OutputSpan tests fail, proving the refactor is load-bearing rather than cosmetic

Final: 3344 passing (+21, exactly the new tests). Mobile and root typecheck clean; oxlint and oxfmt clean. Formatted with oxfmt, never prettier.

## Known gap, deliberately not fixed here

`WriteUnavailable` (opcode 17) is host→client and mobile still ignores it, so a phone whose writes are refused gets no signal at all. Filed as **STA-3542** — the mobile twin of the desktop silent-input-swallow fixed by #12675.

Mobile's decoder also still cannot distinguish corruption from an unknown opcode; filed as **STA-3541**.

## Risk

Mobile only — `src/` is untouched, so desktop and web cannot be affected. The behavioural change on mobile is strictly additive: frames it previously discarded now render.

Verified at unit level. Not exercised on a physical device or against a real relay.
