### PR TITLE
fix(runtime): emit a typed exited frame before the terminal stream ends

### DIFF
--- a/src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts
+++ b/src/main/runtime/orca-runtime-tests/terminal-listing.spec.ts
@@ -103,6 +103,80 @@ describe('OrcaRuntimeService', () => {
     ).toMatchObject({ persisted: false, rendererMounted: false })
   })
 
+  it('derives terminal tab lifecycle from the pty connected/lastExitCode state', () => {
+    const runtime = createRuntime()
+    const internals = runtime as unknown as {
+      recordPtyWorktree: (
+        ptyId: string,
+        worktreeId: string,
+        state?: Record<string, unknown>
+      ) => void
+      ptysById: Map<string, { connected: boolean; lastExitCode: number | null }>
+      mobileSessionTabsByWorktree: Map<string, unknown>
+      getMobileSessionTabsForWorktree: (worktreeId: string) => {
+        tabs: { type: string; leafId?: string; lifecycle?: string }[]
+      }
+    }
+    // Bind each lifecycle assertion to an exact PTY identity.
+    internals.recordPtyWorktree('pty-live', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'lc',
+      paneKey: 'lc:leaf-live'
+    })
+    internals.recordPtyWorktree('pty-exited', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'lc',
+      paneKey: 'lc:leaf-exited'
+    })
+    internals.recordPtyWorktree('pty-disc', TEST_WORKTREE_ID, {
+      connected: true,
+      tabId: 'lc',
+      paneKey: 'lc:leaf-disc'
+    })
+    internals.recordPtyWorktree('pty-fallback', TEST_WORKTREE_ID, { connected: true })
+    const exited = internals.ptysById.get('pty-exited')!
+    exited.connected = false
+    exited.lastExitCode = 7
+    const disconnected = internals.ptysById.get('pty-disc')!
+    disconnected.connected = false
+    disconnected.lastExitCode = null
+    const fallback = internals.ptysById.get('pty-fallback')!
+    fallback.connected = false
+    fallback.lastExitCode = 9
+
+    const terminalTab = (leafId: string, ptyId: string, isActive: boolean) => ({
+      type: 'terminal' as const,
+      id: `lc::${leafId}`,
+      parentTabId: 'lc',
+      leafId,
+      ptyId,
+      title: 'T',
+      isActive
+    })
+    internals.mobileSessionTabsByWorktree.set(TEST_WORKTREE_ID, {
+      worktree: TEST_WORKTREE_ID,
+      publicationEpoch: 'renderer:test:1',
+      snapshotVersion: 1,
+      activeGroupId: null,
+      activeTabId: 'lc::leaf-live',
+      activeTabType: 'terminal',
+      tabs: [
+        terminalTab('leaf-live', 'pty-live', true),
+        terminalTab('leaf-exited', 'pty-exited', false),
+        terminalTab('leaf-disc', 'pty-disc', false),
+        terminalTab('leaf-fallback', 'pty-fallback', false)
+      ]
+    })
+
+    const result = internals.getMobileSessionTabsForWorktree(TEST_WORKTREE_ID)
+    const byLeaf = (leafId: string) =>
+      result.tabs.find((tab) => tab.type === 'terminal' && tab.leafId === leafId)
+    expect(byLeaf('leaf-live')?.lifecycle).toBe('live')
+    expect(byLeaf('leaf-exited')?.lifecycle).toBe('exited')
+    expect(byLeaf('leaf-disc')?.lifecycle).toBe('disconnected')
+    expect(byLeaf('leaf-fallback')?.lifecycle).toBeUndefined()
+  })
+
   it('keeps targeted terminal lists from adopting controller PTYs for other worktrees', async () => {
     vi.mocked(listWorktrees).mockResolvedValue([
       ...MOCK_GIT_WORKTREES,

--- a/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
+++ b/src/main/runtime/rpc/methods/terminal/stream-schemas.ts
@@ -54,6 +54,7 @@ export const TerminalMultiplexSubscribeFrame = TerminalHandle.extend({
       ackOutputSourceRanges: z.literal(1).optional(),
       desktopViewportClaims: z.literal(1).optional(),
       outputPause: z.literal(1).optional(),
+      terminalExited: z.literal(1).optional(),
       writeUnavailable: z.literal(1).optional()
     })
     .optional()

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-initial-snapshot.ts
@@ -60,10 +60,13 @@ export async function publishMultiplexInitialSnapshot(
     rows: serialized?.rows ?? size?.rows,
     displayMode,
     seq: layoutSeq,
-    ...((stream.ackOutputSourceRanges || stream.supportsOutputPause) && {
+    ...((stream.ackOutputSourceRanges ||
+      stream.supportsOutputPause ||
+      stream.supportsTerminalExited) && {
       capabilities: {
         ...(stream.ackOutputSourceRanges ? { ackOutputSourceRanges: 1 as const } : {}),
-        ...(stream.supportsOutputPause ? { outputPause: 1 as const } : {})
+        ...(stream.supportsOutputPause ? { outputPause: 1 as const } : {}),
+        ...(stream.supportsTerminalExited ? { terminalExited: 1 as const } : {})
       }
     }),
     ...(stream.ackOutputSourceRanges ? { streamGeneration: stream.streamGeneration } : {}),

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-live-stream.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-live-stream.ts
@@ -128,15 +128,12 @@ export function activateMultiplexStream(
     })
     .then((wait) => {
       if (streams.get(request.streamId) === stream) {
-        if (stream.supportsTerminalExited) {
+        // Same proven-exit gate as the end verdict: unknown liveness is not a process exit.
+        const provenExit = wait.satisfied && wait.condition === 'exit' && wait.status === 'exited'
+        if (stream.supportsTerminalExited && provenExit) {
           emit({ type: 'exited', streamId: request.streamId, exitCode: wait.exitCode })
         }
-        state.detachStream(
-          request.streamId,
-          wait.satisfied && wait.condition === 'exit' && wait.status === 'exited'
-            ? 'exited'
-            : 'unverifiable'
-        )
+        state.detachStream(request.streamId, provenExit ? 'exited' : 'unverifiable')
       }
     })
     .catch(() => {

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-live-stream.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-live-stream.ts
@@ -128,6 +128,9 @@ export function activateMultiplexStream(
     })
     .then((wait) => {
       if (streams.get(request.streamId) === stream) {
+        if (stream.supportsTerminalExited) {
+          emit({ type: 'exited', streamId: request.streamId, exitCode: wait.exitCode })
+        }
         state.detachStream(
           request.streamId,
           wait.satisfied && wait.condition === 'exit' && wait.status === 'exited'

--- a/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-multiplex-stream-initialization.ts
@@ -54,6 +54,7 @@ export async function initializeMultiplexStream(
     ackInFlightBytes: 0,
     ackWindowBytes: TERMINAL_MULTIPLEX_ACK_STREAM_INITIAL_WINDOW_BYTES,
     supportsOutputPause: request.capabilities?.outputPause === 1,
+    supportsTerminalExited: request.capabilities?.terminalExited === 1,
     supportsWriteUnavailable: request.capabilities?.writeUnavailable === 1,
     outputPaused: false,
     supportsDesktopViewportClaims: request.capabilities?.desktopViewportClaims === 1,

--- a/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
+++ b/src/main/runtime/rpc/methods/terminal/terminal-stream-types.ts
@@ -68,6 +68,7 @@ export type TerminalMultiplexStream = {
   ackInFlightBytes: number
   ackWindowBytes: number
   supportsOutputPause: boolean
+  supportsTerminalExited: boolean
   supportsWriteUnavailable: boolean
   outputPaused: boolean
   supportsDesktopViewportClaims: boolean

--- a/src/main/runtime/rpc/terminal-multiplex-exit-capability.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-exit-capability.test.ts
@@ -1,0 +1,114 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeTerminalWait } from '../../../shared/runtime-types'
+import {
+  sendDesktopMultiplexSubscribe,
+  startDesktopMultiplexSubscribe
+} from './terminal-multiplex-test-harness'
+
+const EXIT_WAIT = {
+  handle: 'terminal-1',
+  condition: 'exit',
+  satisfied: true,
+  status: 'exited',
+  exitCode: 42
+} satisfies RuntimeTerminalWait
+
+function results(messages: readonly string[]): Record<string, unknown>[] {
+  return messages.map((message) => JSON.parse(message).result as Record<string, unknown>)
+}
+
+describe('terminal multiplex exit capability', () => {
+  it('does not emit exited to a legacy subscriber', async () => {
+    const harness = startDesktopMultiplexSubscribe({
+      waitForTerminal: vi.fn().mockResolvedValue(EXIT_WAIT)
+    })
+    await vi.waitFor(() =>
+      expect(harness.messages.some((message) => JSON.parse(message).result?.type === 'ready')).toBe(
+        true
+      )
+    )
+
+    sendDesktopMultiplexSubscribe(harness.handlers)
+
+    await vi.waitFor(() =>
+      expect(harness.messages.some((message) => JSON.parse(message).result?.type === 'end')).toBe(
+        true
+      )
+    )
+    expect(results(harness.messages).some((event) => event.type === 'exited')).toBe(false)
+    harness.registry.cleanupSubscription('terminal-multiplex:conn-desktop-first-paint')
+    await harness.dispatchPromise
+  })
+
+  it('echoes terminalExited and emits exited before end when negotiated', async () => {
+    const harness = startDesktopMultiplexSubscribe({
+      waitForTerminal: vi.fn().mockResolvedValue(EXIT_WAIT)
+    })
+    await vi.waitFor(() =>
+      expect(harness.messages.some((message) => JSON.parse(message).result?.type === 'ready')).toBe(
+        true
+      )
+    )
+
+    sendDesktopMultiplexSubscribe(harness.handlers, {
+      ackOutput: 1,
+      desktopViewportClaims: 1,
+      terminalExited: 1
+    })
+
+    await vi.waitFor(() =>
+      expect(harness.messages.some((message) => JSON.parse(message).result?.type === 'end')).toBe(
+        true
+      )
+    )
+    const events = results(harness.messages)
+    expect(events.find((event) => event.type === 'subscribed')).toMatchObject({
+      capabilities: { terminalExited: 1 }
+    })
+    const exitedIndex = events.findIndex((event) => event.type === 'exited' && event.streamId === 7)
+    const endIndex = events.findIndex((event) => event.type === 'end' && event.streamId === 7)
+    expect(events[exitedIndex]).toMatchObject({
+      type: 'exited',
+      streamId: 7,
+      exitCode: 42
+    })
+    expect(endIndex).toBeGreaterThan(exitedIndex)
+    harness.registry.cleanupSubscription('terminal-multiplex:conn-desktop-first-paint')
+    await harness.dispatchPromise
+  })
+
+  it('never emits exited when the terminal handle is stale', async () => {
+    const harness = startDesktopMultiplexSubscribe({
+      resolveLiveLeafForHandle: vi.fn(() => {
+        throw new Error('terminal_handle_stale')
+      })
+    })
+    await vi.waitFor(() =>
+      expect(harness.messages.some((message) => JSON.parse(message).result?.type === 'ready')).toBe(
+        true
+      )
+    )
+
+    sendDesktopMultiplexSubscribe(harness.handlers, { terminalExited: 1 })
+
+    await vi.waitFor(() =>
+      expect(
+        harness.messages.some(
+          (message) =>
+            JSON.parse(message).result?.type === 'end' && JSON.parse(message).result?.streamId === 7
+        )
+      ).toBe(true)
+    )
+    const events = results(harness.messages)
+    expect(events.some((event) => event.type === 'exited')).toBe(false)
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'error',
+        streamId: 7,
+        message: 'terminal_handle_stale'
+      })
+    )
+    harness.registry.cleanupSubscription('terminal-multiplex:conn-desktop-first-paint')
+    await harness.dispatchPromise
+  })
+})

--- a/src/main/runtime/rpc/terminal-multiplex-exit-capability.test.ts
+++ b/src/main/runtime/rpc/terminal-multiplex-exit-capability.test.ts
@@ -77,6 +77,35 @@ describe('terminal multiplex exit capability', () => {
     await harness.dispatchPromise
   })
 
+  it('does not report process exit when the exit wait becomes unverifiable', async () => {
+    const harness = startDesktopMultiplexSubscribe({
+      waitForTerminal: vi.fn().mockResolvedValue({
+        ...EXIT_WAIT,
+        satisfied: true,
+        status: 'unknown',
+        exitCode: null
+      } satisfies RuntimeTerminalWait)
+    })
+    await vi.waitFor(() =>
+      expect(results(harness.messages).some((event) => event.type === 'ready')).toBe(true)
+    )
+    sendDesktopMultiplexSubscribe(harness.handlers, { terminalExited: 1 })
+    await vi.waitFor(() =>
+      expect(results(harness.messages).some((event) => event.type === 'end')).toBe(true)
+    )
+    const events = results(harness.messages)
+    expect(events.some((event) => event.type === 'exited')).toBe(false)
+    expect(events).toContainEqual(
+      expect.objectContaining({
+        type: 'end',
+        streamId: 7,
+        verdict: 'unverifiable'
+      })
+    )
+    harness.registry.cleanupSubscription('terminal-multiplex:conn-desktop-first-paint')
+    await harness.dispatchPromise
+  })
+
   it('never emits exited when the terminal handle is stale', async () => {
     const harness = startDesktopMultiplexSubscribe({
       resolveLiveLeafForHandle: vi.fn(() => {

--- a/src/main/runtime/runtime-mobile-session-projection.ts
+++ b/src/main/runtime/runtime-mobile-session-projection.ts
@@ -247,6 +247,22 @@ export function projectRuntimeMobileSessionTabs(
     const clientAgentStatus: { agentStatus?: AgentStatusEntry } = projectedStatusEntry
       ? { agentStatus: clientStatusFields as AgentStatusEntry }
       : {}
+    const lifecyclePty =
+      liveLeafPty ??
+      (pty &&
+      pty.worktreeId === snapshot.worktree &&
+      pty.tabId === tab.parentTabId &&
+      pty.paneKey === paneKey
+        ? pty
+        : null)
+    // Host-owned lifecycle distinguishes a process exit from a lost PTY record.
+    const lifecycle: 'live' | 'disconnected' | 'exited' | undefined = terminalHandle
+      ? 'live'
+      : lifecyclePty
+        ? lifecyclePty.lastExitCode !== null
+          ? 'exited'
+          : 'disconnected'
+        : undefined
     tabs.push({
       type: 'terminal',
       id: tab.id,
@@ -267,6 +283,7 @@ export function projectRuntimeMobileSessionTabs(
       ...(tab.launchDraftCreatedAt !== undefined
         ? { launchDraftCreatedAt: tab.launchDraftCreatedAt }
         : {}),
+      ...(lifecycle ? { lifecycle } : {}),
       isActive: tab.isActive,
       ...(terminalHandle
         ? { status: 'ready' as const, terminal: terminalHandle }

--- a/src/shared/runtime-mobile-session-tab-contracts.ts
+++ b/src/shared/runtime-mobile-session-tab-contracts.ts
@@ -27,6 +27,8 @@ export type RuntimeMobileSessionTerminalTab = {
   viewMode?: 'terminal' | 'chat'
   launchDraft?: string
   launchDraftCreatedAt?: number
+  /** Host-owned PTY lifecycle; optional for mixed-version clients. */
+  lifecycle?: 'live' | 'disconnected' | 'exited'
   isActive: boolean
 }
 


### PR DESCRIPTION
## Summary

Add an opt-in terminal-stream exit notification. A subscriber requesting `terminalExited: 1` receives the capability in its subscription acknowledgement and a JSON `exited` event with the exit code before stream end, only when terminal exit is proven. A resolved wait with unknown liveness stays `unverifiable` and never emits `exited`.

Mobile session tabs also expose an optional `live`, `disconnected` or `exited` lifecycle value from the matching PTY, preserving tab/pane/worktree identity. This is a host capability: current desktop clients do not advertise it yet. Legacy subscribers keep their existing event sequence; there is no new binary stream opcode.

## Testing and review

At `e0cc8fa293eecf843b69bbe885da2e970b632355`, independent verification passed 1,336 tests with 2 skipped across 17 files, including the full runtime harness and terminal multiplex suites. Tests cover negotiated and legacy streams, exit ordering, unknown liveness and mobile lifecycle projection. An independent failing reproduction caught the earlier unconditional exit event; the repaired predicate and regression passed on this commit.

CLI, Node and Web TypeScript checks (`--composite false`), all changed-file lint/format, diff whitespace and native preflight/postflight passed. Independent Cursor review passed on this exact commit.

Full repository tests, packaging, live SSH and mixed-version binary smoke were not run. No current-client consumption or rendered mobile behavior is claimed.

## AI disclosure

Cursor ported and independently reviewed the change; Codex checked the original requirements, reproduced the unknown-liveness defect and independently verified the repair.
