### PR TITLE
fix(hermes): notify only after turn finalization

### DIFF
--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3200,7 +3200,7 @@ describe('shared agent-hook-listener', () => {
     expect(next?.payload.toolInput).toBeUndefined()
   })
 
-  it('normalizes Hermes post_llm_call to done with assistant text', () => {
+  it('keeps Hermes working through post_llm_call and completes on session end', () => {
     normalizeHookPayload(
       state,
       'hermes',
@@ -3213,7 +3213,7 @@ describe('shared agent-hook-listener', () => {
       },
       'production'
     )
-    const done = normalizeHookPayload(
+    const finalizing = normalizeHookPayload(
       state,
       'hermes',
       {
@@ -3225,10 +3225,39 @@ describe('shared agent-hook-listener', () => {
       },
       'production'
     )
+    expect(finalizing?.payload.state).toBe('working')
+    expect(finalizing?.payload.prompt).toBe('summarize')
+    expect(finalizing?.payload.lastAssistantMessage).toBe('Hermes is wired up.')
+
+    const done = normalizeHookPayload(
+      state,
+      'hermes',
+      {
+        paneKey: PANE_KEY,
+        payload: { hook_event_name: 'on_session_end' }
+      },
+      'production'
+    )
     expect(done?.payload.state).toBe('done')
-    expect(done?.payload.prompt).toBe('summarize')
     expect(done?.payload.lastAssistantMessage).toBe('Hermes is wired up.')
   })
+
+  it.each(['on_session_start', 'on_session_finalize', 'on_session_reset'])(
+    'ignores Hermes %s as a task status event',
+    (hookEventName) => {
+      expect(
+        normalizeHookPayload(
+          state,
+          'hermes',
+          {
+            paneKey: PANE_KEY,
+            payload: { hook_event_name: hookEventName }
+          },
+          'production'
+        )
+      ).toBeNull()
+    }
+  )
 
   describe('claude subagent tracking', () => {
     const claudeEvent = (

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -4047,16 +4047,14 @@ function normalizeHermesEvent(
   paneKey: string,
   hookPayload: Record<string, unknown>
 ): ParsedAgentStatusPayload | null {
+  // Why: Hermes still finalizes after post_llm_call; on_session_end is its turn boundary.
   const stateName =
     eventName === 'pre_approval_request'
       ? 'waiting'
-      : eventName === 'post_llm_call' ||
-          eventName === 'on_session_end' ||
-          eventName === 'on_session_finalize' ||
-          eventName === 'on_session_reset'
+      : eventName === 'on_session_end'
         ? 'done'
-        : eventName === 'on_session_start' ||
-            eventName === 'pre_llm_call' ||
+        : eventName === 'pre_llm_call' ||
+            eventName === 'post_llm_call' ||
             eventName === 'pre_tool_call' ||
             eventName === 'post_tool_call' ||
             eventName === 'post_approval_response'


### PR DESCRIPTION
## Summary

- keep Hermes `working` through `post_llm_call`
- use `on_session_end` as the completed-turn boundary
- ignore session start, reset, and finalize events as task-status transitions
- retain the final assistant response captured at `post_llm_call` without emitting a premature completion

## Why

Hermes emits `post_llm_call` before turn finalization has finished and may continue into tool or auxiliary work. Mapping that event to `done` can notify while Hermes is still active, then notify again at the real session end. The corrected lifecycle is `post_llm_call -> working`; only `on_session_end` produces `done`.

## Screenshots

No visual change.

## Testing

Exact published head: `c3f12723ab47ebc0a6ce8c93ff2de2906494ff4a` on base `f71373953baa1d384b75bbdf4845fda17a847da5`.

- `src/shared/agent-hook-listener.test.ts`: 127/127 on the contribution branch
- targeted Oxlint passed
- Node TypeScript project passed
- red-first assertions cover premature `post_llm_call` completion plus session start, reset, and finalize

The contribution is also installed in stable integration `e13fa51f38102e1c3bf972e206e68fd323927406`. Its predecessor stack passed the full lint chain, all three TypeScript projects, 3,563 focused desktop tests, and 55 mobile tests. The final delta was isolated to #10046, passed 8/8 focused tests plus the web TypeScript project, and the rebuilt package passed the Ubuntu 20.04 glibc floor, daemon-entry, and bundled-plugin gates. Live desktop restart acceptance preserved all five terminal handles/incarnations and both running Hermes TUIs.

## AI Review Report

The review traced Hermes managed-hook emission through normalization, status ingestion, completion notification timing, and cached assistant-message handling. The change is provider-specific, constant-time, and does not alter other agent lifecycles, UI state, SSH ownership, or folder-workspace behavior.

## Security Audit

No new dependency, command execution, credential path, filesystem access, network request, IPC surface, or permission is introduced. Existing managed-hook validation remains authoritative.

## Notes

- This PR fixes Orca's Hermes turn-boundary mapping.
- Suppressing Hermes' private `bg-review` thread before it posts a hook is a separate installed local safeguard and is not included in this contribution.
- The PR remains draft while maintainers decide whether this lifecycle policy should land independently.
