### PR TITLE
fix(settings): recover HTTP proxy settings from safeStorage failures (STA-3442)

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2098,7 +2098,11 @@ void app.whenReady().then(async () => {
   }
   try {
     // Why: Dock/Launchpad launches don't inherit shell proxy env vars, so apply the persisted proxy before any app-owned network fetchers run.
-    await applyElectronProxySettings(store.getSettings())
+    const proxyApplyResult = await applyElectronProxySettings(store.getSettings())
+    if (proxyApplyResult.source === 'invalid-settings') {
+      // Why (STA-3442): a silent DIRECT fallback made a dead configured proxy undiagnosable.
+      console.warn('[proxy] persisted proxy settings are invalid; using direct networking')
+    }
   } catch {
     console.warn('[proxy] Failed to apply network proxy settings')
   }

--- a/src/main/persistence-proxy-secret-recovery.test.ts
+++ b/src/main/persistence-proxy-secret-recovery.test.ts
@@ -1,0 +1,186 @@
+// STA-3442: httpProxyUrl is the only network setting stored via safeStorage.
+// On macOS a keychain reset/denial makes decryptString throw at load, and the
+// raw ciphertext then masqueraded as a configured proxy: applyElectronProxySettings
+// silently fell back to DIRECT and the garbage re-persisted forever. These tests
+// pin the recovery contract: undecryptable values are cleared (never applied,
+// never re-saved as garbage), plaintext values survive as the upgrade path, and
+// a throwing safeStorage.isEncryptionAvailable() cannot kill the whole save.
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { existsSync, mkdirSync, readFileSync, rmSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { dirname, join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { randomUUID } from 'node:crypto'
+
+const testState = { dir: '' }
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(),
+  sshConfigHostsToTargets: vi.fn()
+}))
+
+const cipherState = {
+  encryptionAvailable: true,
+  availabilityThrows: false,
+  decryptAlwaysThrows: false
+}
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => testState.dir
+  },
+  session: { defaultSession: undefined },
+  safeStorage: {
+    isEncryptionAvailable: () => {
+      if (cipherState.availabilityThrows) {
+        throw new Error('safeStorage cannot be used before the app is ready')
+      }
+      return cipherState.encryptionAvailable
+    },
+    encryptString: (plaintext: string) => Buffer.from(`enc:${randomUUID()}:${plaintext}`, 'utf-8'),
+    decryptString: (ciphertext: Buffer) => {
+      if (cipherState.decryptAlwaysThrows) {
+        throw new Error('keychain access denied')
+      }
+      const decoded = ciphertext.toString('utf-8')
+      if (!decoded.startsWith('enc:')) {
+        throw new Error('invalid ciphertext')
+      }
+      return decoded.slice('enc:'.length + 36 + 1)
+    }
+  }
+}))
+
+vi.mock('./telemetry/client', () => ({
+  track: vi.fn()
+}))
+
+vi.mock('./telemetry/cohort-classifier', () => ({
+  getCohortAtEmit: vi.fn().mockReturnValue({ nth_repo_added: 2 })
+}))
+
+async function createStore() {
+  vi.resetModules()
+  const { Store, initDataPath } = await import('./persistence')
+  initDataPath()
+  return new Store()
+}
+
+function dataFile(): string {
+  return join(testState.dir, 'orca-data.json')
+}
+
+const PROXY_URL = 'http://127.0.0.1:8080'
+const BYPASS_RULES = '<local>'
+
+describe('httpProxyUrl secret recovery (STA-3442)', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-test-'))
+    cipherState.encryptionAvailable = true
+    cipherState.availabilityThrows = false
+    cipherState.decryptAlwaysThrows = false
+    vi.useFakeTimers()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  async function seedConfiguredProxy() {
+    const store = await createStore()
+    store.updateSettings({ httpProxyUrl: PROXY_URL, httpProxyBypassRules: BYPASS_RULES })
+    vi.advanceTimersByTime(1000)
+    await store.waitForPendingWrite()
+    return store
+  }
+
+  it('persists the configured proxy across a restart and applies it as fixed_servers', async () => {
+    await seedConfiguredProxy()
+
+    const persisted = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+      settings: { httpProxyUrl: string; httpProxyBypassRules: string }
+    }
+    // On disk the URL is ciphertext (base64 of the mock's enc: payload), never plaintext.
+    expect(persisted.settings.httpProxyUrl).not.toBe(PROXY_URL)
+    expect(Buffer.from(persisted.settings.httpProxyUrl, 'base64').toString('utf-8')).toMatch(
+      /^enc:/
+    )
+    expect(persisted.settings.httpProxyBypassRules).toBe(BYPASS_RULES)
+
+    const reloaded = await createStore()
+    expect(reloaded.getSettings().httpProxyUrl).toBe(PROXY_URL)
+    expect(reloaded.getSettings().httpProxyBypassRules).toBe(BYPASS_RULES)
+
+    const { applyElectronProxySettings, resetProxyApplicationForTests } =
+      await import('./network/proxy-settings')
+    resetProxyApplicationForTests()
+    const setProxy = vi.fn(async () => {})
+    const result = await applyElectronProxySettings(reloaded.getSettings(), {
+      proxySession: { resolveProxy: async () => 'DIRECT', setProxy },
+      env: {}
+    })
+    expect(result).toEqual({
+      source: 'settings',
+      proxyRules: PROXY_URL,
+      proxyBypassRules: BYPASS_RULES
+    })
+    expect(setProxy).toHaveBeenCalledWith({
+      mode: 'fixed_servers',
+      proxyRules: PROXY_URL,
+      proxyBypassRules: BYPASS_RULES
+    })
+  })
+
+  it('clears an undecryptable httpProxyUrl instead of surfacing ciphertext as settings', async () => {
+    await seedConfiguredProxy()
+
+    // Keychain reset/denial: every decrypt now fails.
+    cipherState.decryptAlwaysThrows = true
+    const reloaded = await createStore()
+
+    expect(reloaded.getSettings().httpProxyUrl).toBe('')
+    // Bypass rules are not encrypted and must survive.
+    expect(reloaded.getSettings().httpProxyBypassRules).toBe(BYPASS_RULES)
+
+    // The cleanup must reach disk so garbage never round-trips back in.
+    vi.advanceTimersByTime(2000)
+    await reloaded.waitForPendingWrite()
+    const persisted = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+      settings: { httpProxyUrl: string }
+    }
+    expect(persisted.settings.httpProxyUrl).toBe('')
+  })
+
+  it('keeps a plaintext httpProxyUrl on disk readable (pre-encryption/hand-edited upgrade path)', async () => {
+    mkdirSync(dirname(dataFile()), { recursive: true })
+    writeFileSync(
+      dataFile(),
+      JSON.stringify({ settings: { httpProxyUrl: PROXY_URL, httpProxyBypassRules: BYPASS_RULES } }),
+      'utf-8'
+    )
+
+    const store = await createStore()
+    expect(store.getSettings().httpProxyUrl).toBe(PROXY_URL)
+    expect(store.getSettings().httpProxyBypassRules).toBe(BYPASS_RULES)
+  })
+
+  it('still saves and reloads the proxy when safeStorage.isEncryptionAvailable throws', async () => {
+    cipherState.availabilityThrows = true
+
+    const store = await createStore()
+    store.updateSettings({ httpProxyUrl: PROXY_URL, httpProxyBypassRules: BYPASS_RULES })
+    vi.advanceTimersByTime(1000)
+    await store.waitForPendingWrite()
+
+    // Encryption degraded to plaintext passthrough; the save must not be lost.
+    expect(existsSync(dataFile())).toBe(true)
+    const persisted = JSON.parse(readFileSync(dataFile(), 'utf-8')) as {
+      settings: { httpProxyUrl: string; httpProxyBypassRules: string }
+    }
+    expect(persisted.settings.httpProxyUrl).toBe(PROXY_URL)
+    expect(persisted.settings.httpProxyBypassRules).toBe(BYPASS_RULES)
+
+    const reloaded = await createStore()
+    expect(reloaded.getSettings().httpProxyUrl).toBe(PROXY_URL)
+  })
+})

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -38,6 +38,7 @@ import {
 } from '../shared/automation-schedules'
 import { getAutomationLegacyRepoId } from '../shared/automation-run-identity'
 import { normalizeAutomationPrecheck } from '../shared/automation-precheck'
+import { normalizeProxyUrl } from '../shared/network-proxy'
 import type {
   PersistedState,
   Project,
@@ -279,8 +280,19 @@ import { track } from './telemetry/client'
 import { getCohortAtEmit } from './telemetry/cohort-classifier'
 import { isStartupDiagnosticsEnabled, logStartupDiagnostic } from './startup/startup-diagnostics'
 
+// Why (STA-3442): isEncryptionAvailable() itself can throw (keychain/API errors, pre-ready
+// use); an uncaught throw here failed the entire save/load, silently losing every setting.
+function safeStorageEncryptionAvailable(): boolean {
+  try {
+    return safeStorage.isEncryptionAvailable()
+  } catch (err) {
+    console.warn('[persistence] safeStorage availability check failed:', err)
+    return false
+  }
+}
+
 function encrypt(plaintext: string): string {
-  if (!plaintext || !safeStorage.isEncryptionAvailable()) {
+  if (!plaintext || !safeStorageEncryptionAvailable()) {
     return plaintext
   }
   try {
@@ -292,7 +304,7 @@ function encrypt(plaintext: string): string {
 }
 
 function decrypt(ciphertext: string): string {
-  if (!ciphertext || !safeStorage.isEncryptionAvailable()) {
+  if (!ciphertext || !safeStorageEncryptionAvailable()) {
     return ciphertext
   }
   try {
@@ -3067,7 +3079,19 @@ export class Store {
           parsed.settings.opencodeSessionCookie = decrypt(parsed.settings.opencodeSessionCookie)
         }
         if (parsed.settings?.httpProxyUrl) {
-          parsed.settings.httpProxyUrl = decrypt(parsed.settings.httpProxyUrl)
+          const decryptedProxyUrl = decrypt(parsed.settings.httpProxyUrl)
+          // Why (STA-3442): after a keychain reset decrypt returns raw ciphertext; a non-URL
+          // value must not masquerade as a configured proxy (silent DIRECT fallback) or
+          // re-persist as garbage. Plaintext URLs still pass, preserving the upgrade path.
+          if (normalizeProxyUrl(decryptedProxyUrl).ok) {
+            parsed.settings.httpProxyUrl = decryptedProxyUrl
+          } else {
+            console.warn(
+              '[persistence] httpProxyUrl could not be decrypted — clearing the stored proxy URL. Re-enter it in Settings > Advanced > Network.'
+            )
+            parsed.settings.httpProxyUrl = ''
+            this.loadNeedsSave = true
+          }
         }
         if (parsed.ui?.browserKagiSessionLink) {
           parsed.ui.browserKagiSessionLink = decryptOptionalSecret(parsed.ui.browserKagiSessionLink)


### PR DESCRIPTION
## Summary

Fixes STA-3442 / #12620: HTTP proxy settings configured in Settings > Network could be silently lost or ignored on macOS.

`httpProxyUrl` is the only network setting stored encrypted via Electron `safeStorage`, and two safeStorage failure modes killed the configured proxy with no signal to the user:

1. **Keychain reset/denial (macOS's canonical safeStorage hazard):** when `decryptString` throws at load, `decrypt()` returns the raw ciphertext (intentionally, as the pre-encryption upgrade path for cookies). For the proxy URL that base64 blob then *masqueraded as the configured proxy*: `applyElectronProxySettings` → `normalizeProxyUrl` fails → silent fallback to DIRECT networking, and the garbage re-persisted on every save, so the install never self-healed.
2. **`safeStorage.isEncryptionAvailable()` throwing** (keychain/API errors, pre-ready use): the call sits outside any try/catch in `encrypt()`/`decrypt()`, so a throw failed `buildStateToSave()` and the **entire settings save was silently dropped** (`[persistence] Failed to write state`) — producing exactly the reported "orca-data.json contains neither `httpProxyUrl` nor `httpProxyBypassRules` after configuring".

Changes (all in the main process, platform-neutral, guarded by behavior rather than platform checks):
- `src/main/persistence.ts`: load now validates the decrypted proxy URL with `normalizeProxyUrl`; undecryptable ciphertext is cleared (with a loud warn + persisted cleanup via `loadNeedsSave`) instead of masquerading as config. Plaintext URLs still pass, preserving the hand-edit/pre-encryption upgrade path. `safeStorageEncryptionAvailable()` wraps the availability check so a throw degrades to plaintext passthrough instead of killing every save.
- `src/main/index.ts`: startup logs when persisted proxy settings are invalid instead of silently using direct networking (the silent DIRECT fallback is what made this undiagnosable).

### Reproduction / evidence

Could not reproduce on the reporter's exact environment (macOS 26.5.2 + a keychain in the failing state), so per the repro-first rule the broken behavior is encoded as tests that fail on `main` and pass with this fix (`src/main/persistence-proxy-secret-recovery.test.ts`):

- `clears an undecryptable httpProxyUrl instead of surfacing ciphertext as settings` — **fails on main** (ciphertext survives as the proxy URL; apply silently degrades to DIRECT; garbage re-persists).
- `still saves and reloads the proxy when safeStorage.isEncryptionAvailable throws` — **fails on main** (the data file is never written at all; `existsSync(dataFile) === false`).
- `persists the configured proxy across a restart and applies it as fixed_servers` — passes on main and here; documents that the mainline persist→restart→apply chain is sound, narrowing the field failure to the safeStorage boundary.
- `keeps a plaintext httpProxyUrl on disk readable` — guards the upgrade path the reporter's own hand-edit experiment exercised (plaintext values in `orca-data.json` worked while app-written encrypted values did not — the exact discriminator these two failure modes predict).

Also verified during investigation (explains the reporter's file inspection): since the Orca-profiles migration, the live data file is `profiles/<id>/orca-data.json`; the legacy `~/Library/Application Support/orca/orca-data.json` is a frozen pre-migration copy that never receives new keys, so inspecting it cannot distinguish persist success from failure.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — oxlint on changed files clean; changed-code quality gate (`check-changed-code-quality.mjs`): 0 new findings (native, type-aware, React Doctor)
- [x] `pnpm typecheck` — `typecheck:node`, `typecheck:cli`, `typecheck:web` all clean
- [x] `pnpm test` — new suite (4 tests) plus the adjacent persistence/proxy suites: `persistence.test.ts`, `persistence-single-serialize.test.ts`, `persistence-async-write-syscalls.test.ts`, `persistence-right-sidebar-tab.test.ts`, `persistence-duplicate-repo-id-host-scope.test.ts`, `network/proxy-settings.test.ts`, `ipc/settings.test.ts`, `shared/network-proxy.test.ts` — 538 tests passed. Full suite left to CI (the dev machine's disk was critically full during this work).
- [ ] `pnpm build` — not run locally (disk-full guard); no build-surface changes (main-process logic only)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

Reviewed the full persist→load→apply chain for the proxy settings: renderer commit (`AdvancedNetworkSettingsSection`) → `settings:set` IPC normalization → `Store.updateSettings` → debounced/quit-flush save (`buildStateToSave` sentinel encryption) → load-time decrypt → startup `applyElectronProxySettings`. Main risks checked: (a) the fix must not clear a *valid* plaintext URL (pre-encryption files, hand edits) — covered by the upgrade-path test; (b) `opencodeSessionCookie` semantics deliberately unchanged (ciphertext-on-failure remains the cookie's upgrade path; only the proxy URL gets URL-shape validation because only it is consumed as a URL); (c) the `loadNeedsSave` cleanup write must not race backup rotation — it reuses the existing migration flag consumed in the constructor like every other migration; (d) no double-encryption regression — cleared value is `''`, which `encryptToSentinel` passes through unencrypted. Cross-platform: no platform-conditional code added; keychain-reset (macOS), keyring failures (Linux), and DPAPI failures (Windows) all take the same hardened path; no shortcuts, labels, paths, or shell behavior touched. Remote wire compatibility: no RPC params, stream frames, or published content changed (the runtime `SettingsUpdate` schema never carried proxy keys; web clients keep their local fallback).

## Security Audit

- Secrets handling: the change never logs the proxy URL or its ciphertext (the value can embed `user:pass@` credentials); the new warn logs only the event. Encrypted-at-rest storage for valid values is unchanged.
- Degradation path: when `isEncryptionAvailable()` throws, secrets fall back to plaintext-on-disk — identical to the existing, long-standing `isEncryptionAvailable() === false` behavior, so this adds no new exposure class; it only stops the total save loss.
- Input handling: cleared/invalid values funnel through the existing `normalizeProxyUrl` validator; no new IPC surface, command execution, or path handling.
- Follow-up flagged below (stale legacy-file readers) is a data-staleness issue, not an exposure.

## Notes

- The proxy still cannot be *recovered* after a genuine keychain reset (the plaintext is cryptographically gone); the fix makes the failure visible and self-healing — the field shows empty, the user re-enters the URL once, and it works again. Previously the garbage value wedged the feature permanently.
- Follow-up candidates (out of scope, same investigation): `src/main/startup/configure-process.ts` reads `electronHttp1CompatibilityMode` and `src/cli/handlers/agent-hooks.ts` reads/writes settings from the **legacy** pre-profiles `orca-data.json` path, so both act on stale data on migrated installs. Worth its own ticket.
- STA-3088 (proxy not propagated to Codex rate-limit subprocesses) remains a separate, acknowledged gap.
