### PR TITLE
fix(computer): deliver macOS coordinate clicks via the HID event tap (STA-3433)

### DIFF
--- a/config/scripts/computer-use-modifier-safety.test.mjs
+++ b/config/scripts/computer-use-modifier-safety.test.mjs
@@ -28,7 +28,10 @@ describe('computer-use modifier safety', () => {
     )
 
     expect(mouseInput).toContain('event.flags = flags')
-    expect(clickInput.match(/flags: flags/gu)).toHaveLength(3)
+    // Every click event flows through the shared delivery plan and carries
+    // the modifier flags on the mouse event itself.
+    expect(clickInput).toContain('SyntheticMouseClickDelivery.steps(clickCount: count)')
+    expect(clickInput).toContain('event.flags = flags')
     expect(clickInput).not.toContain('down: true')
   })
 

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -740,25 +740,30 @@ final class Provider {
             }
             if let point = center(record.localFrame, in: snapshot.windowBounds) {
                 try Input.click(
-                    pid: snapshot.app.pid,
                     at: point,
                     button: mouseButton(button),
                     count: count,
                     modifiers: modifiers
                 )
-                return actionMetadata(path: "synthetic", fallbackReason: "actionUnsupported")
+                return actionMetadata(
+                    path: "synthetic",
+                    fallbackReason: "actionUnsupported",
+                    verification: unverifiedAction(reason: "synthetic_input")
+                )
             }
             throw ProviderError.coded("element_not_clickable", "element \(record.index) has no clickable frame")
         }
         let point = try coordinatePoint(params: params, xKey: "x", yKey: "y", snapshot: snapshot)
         try Input.click(
-            pid: snapshot.app.pid,
             at: point,
             button: mouseButton(button),
             count: count,
             modifiers: modifiers
         )
-        return actionMetadata(path: "synthetic")
+        return actionMetadata(
+            path: "synthetic",
+            verification: unverifiedAction(reason: "synthetic_input")
+        )
     }
 
     private func performClickAction(record: ElementRecord, mouseButton: String) throws -> String? {
@@ -2286,7 +2291,6 @@ private func resizePng(_ image: CGImage, scale: CGFloat) -> BoundedPNG? {
 
 private enum Input {
     static func click(
-        pid: pid_t,
         at point: CGPoint,
         button: MouseButton,
         count: Int,
@@ -2298,10 +2302,32 @@ private enum Input {
         let flags = modifiers.reduce(into: CGEventFlags()) { result, modifier in
             result.insert(modifier.flag)
         }
-        for _ in 0..<max(count, 1) {
-            try mouse(.mouseMoved, source: source, point: point, button: button.cgButton, flags: flags, pid: pid)
-            try mouse(button.downEvent, source: source, point: point, button: button.cgButton, flags: flags, pid: pid)
-            try mouse(button.upEvent, source: source, point: point, button: button.cgButton, flags: flags, pid: pid)
+        // Why HID tap + pacing: see SyntheticMouseClickDelivery (STA-3433).
+        for step in SyntheticMouseClickDelivery.steps(clickCount: count) {
+            let type: CGEventType
+            switch step {
+            case .move:
+                type = .mouseMoved
+            case .buttonDown:
+                type = button.downEvent
+            case .buttonUp:
+                type = button.upEvent
+            }
+            guard let event = CGEvent(
+                mouseEventSource: source,
+                mouseType: type,
+                mouseCursorPosition: point,
+                mouseButton: button.cgButton
+            ) else {
+                throw ProviderError.coded("accessibility_error", "failed to create mouse event")
+            }
+            event.flags = flags
+            let clickState = SyntheticMouseClickDelivery.clickState(for: step)
+            if clickState > 0 {
+                event.setIntegerValueField(.mouseEventClickState, value: clickState)
+            }
+            event.post(tap: .cghidEventTap)
+            usleep(SyntheticMouseClickDelivery.interEventPauseMicroseconds)
         }
     }
 

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/SyntheticMouseClickDelivery.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/SyntheticMouseClickDelivery.swift
@@ -1,0 +1,40 @@
+/// Event plan for synthetic mouse clicks (STA-3433).
+///
+/// Clicks must be posted to the HID event tap, not `CGEventPostToPid`:
+/// pid-targeted mouse events reach the app with no window association, so
+/// AppKit never routes the press to a view (hover fires, activation never
+/// happens). The window server also drops a mouseUp posted back-to-back
+/// with its mouseDown, so consecutive events need a pause between them.
+public enum SyntheticMouseClickDelivery {
+    public enum Step: Equatable {
+        case move
+        case buttonDown(pressIndex: Int)
+        case buttonUp(pressIndex: Int)
+    }
+
+    /// Pause after posting each event; unpaced posts race the window
+    /// server's routing and the mouseUp is silently dropped.
+    public static let interEventPauseMicroseconds: UInt32 = 50_000
+
+    /// One move, then a paired down/up per press. `pressIndex` becomes the
+    /// event's click state so repeated presses register as double/triple
+    /// clicks instead of independent single clicks.
+    public static func steps(clickCount: Int) -> [Step] {
+        var steps: [Step] = [.move]
+        for press in 1...max(clickCount, 1) {
+            steps.append(.buttonDown(pressIndex: press))
+            steps.append(.buttonUp(pressIndex: press))
+        }
+        return steps
+    }
+
+    /// Click state field value for a step; 0 leaves the field unset.
+    public static func clickState(for step: Step) -> Int64 {
+        switch step {
+        case .move:
+            return 0
+        case let .buttonDown(pressIndex), let .buttonUp(pressIndex):
+            return Int64(pressIndex)
+        }
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/SyntheticMouseClickDeliveryTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/SyntheticMouseClickDeliveryTests.swift
@@ -1,0 +1,43 @@
+import XCTest
+@testable import OrcaComputerUseMacOSCore
+
+final class SyntheticMouseClickDeliveryTests: XCTestCase {
+    func testSingleClickPlanPairsDownAndUpAfterMove() {
+        XCTAssertEqual(
+            SyntheticMouseClickDelivery.steps(clickCount: 1),
+            [.move, .buttonDown(pressIndex: 1), .buttonUp(pressIndex: 1)]
+        )
+    }
+
+    func testMultiClickPlanNumbersEachPressForClickState() {
+        XCTAssertEqual(
+            SyntheticMouseClickDelivery.steps(clickCount: 2),
+            [
+                .move,
+                .buttonDown(pressIndex: 1), .buttonUp(pressIndex: 1),
+                .buttonDown(pressIndex: 2), .buttonUp(pressIndex: 2),
+            ]
+        )
+    }
+
+    func testNonPositiveClickCountStillDeliversOnePress() {
+        for count in [0, -3] {
+            XCTAssertEqual(
+                SyntheticMouseClickDelivery.steps(clickCount: count),
+                [.move, .buttonDown(pressIndex: 1), .buttonUp(pressIndex: 1)]
+            )
+        }
+    }
+
+    func testClickStateMatchesPressIndexAndSkipsMove() {
+        XCTAssertEqual(SyntheticMouseClickDelivery.clickState(for: .move), 0)
+        XCTAssertEqual(SyntheticMouseClickDelivery.clickState(for: .buttonDown(pressIndex: 1)), 1)
+        XCTAssertEqual(SyntheticMouseClickDelivery.clickState(for: .buttonUp(pressIndex: 2)), 2)
+    }
+
+    func testInterEventPauseIsNonZero() {
+        // Unpaced posts race the window server and the mouseUp is dropped,
+        // turning the click into a hover-only no-op (STA-3433).
+        XCTAssertGreaterThan(SyntheticMouseClickDelivery.interEventPauseMicroseconds, 0)
+    }
+}

--- a/tests/e2e/computer-mac.e2e.ts
+++ b/tests/e2e/computer-mac.e2e.ts
@@ -71,6 +71,84 @@ describe.skipIf(!isMac || !e2eOptIn)('computer-use macOS e2e (TextEdit)', () => 
     expect(after.result.snapshot.treeText).toContain(marker)
   })
 
+  test('coordinate double-click activates a control, not just hover (STA-3433)', async () => {
+    // Ten identical short lines: any first-lines click hits a word, and the
+    // whole document stays inside the treeText value preview after editing.
+    const filler = Array(10).fill('wordword').join('\n')
+    await runOrcaCli([
+      'computer',
+      'hotkey',
+      '--app',
+      'TextEdit',
+      '--key',
+      'CmdOrCtrl+A',
+      '--no-screenshot'
+    ])
+    await runOrcaCli([
+      'computer',
+      'paste-text',
+      '--app',
+      'TextEdit',
+      '--text',
+      filler,
+      '--no-screenshot'
+    ])
+
+    // Word-select via coordinates: 40px in, 70px down lands inside a
+    // "wordword" on one of the first lines whether or not the ruler is shown.
+    const clicked = parseJsonOutput<{ result: ComputerActionResult }>(
+      (
+        await runOrcaCli([
+          'computer',
+          'click',
+          '--app',
+          'TextEdit',
+          '--x',
+          '40',
+          '--y',
+          '70',
+          '--click-count',
+          '2',
+          '--no-screenshot',
+          '--json'
+        ])
+      ).stdout
+    )
+    expect(clicked.result.action?.path).toBe('synthetic')
+    expect(clicked.result.action?.verification).toMatchObject({
+      state: 'unverified',
+      reason: 'synthetic_input'
+    })
+
+    const marker = `zz${Date.now()}zz`
+    await runOrcaCli([
+      'computer',
+      'type-text',
+      '--app',
+      'TextEdit',
+      '--text',
+      marker,
+      '--no-screenshot'
+    ])
+
+    const after = parseJsonOutput<{ result: ComputerSnapshotResult }>(
+      (
+        await runOrcaCli([
+          'computer',
+          'get-app-state',
+          '--app',
+          'TextEdit',
+          '--no-screenshot',
+          '--json'
+        ])
+      ).stdout
+    )
+    // The double-click selected a mid-document word, so the typed marker must
+    // be followed by more filler. A dropped press leaves the caret at the end
+    // of the document and the marker only ever appends (the STA-3433 no-op).
+    expect(after.result.snapshot.treeText).toMatch(new RegExp(`${marker}\\s+wordword`))
+  })
+
   test('paste-text and hotkey verify TextEdit text replacement', async () => {
     const first = parseJsonOutput<{ result: ComputerActionResult }>(
       (


### PR DESCRIPTION
## Summary

`orca computer click --x/--y` on macOS returned `ok: true` but never activated the control under the pointer — hover states and tooltips fired, proving the pointer arrived, but the press itself was lost (STA-3433, P0). `--element-index` clicks on the same control worked because they use the accessibility `AXPress` path.

Root cause, established with a controlled A/B rig on macOS 26 (Darwin 25.5.0, same OS family as the reporter): the helper posted mouse events with `CGEventPostToPid`, which delivers events to the app **with no window association** — the receiving `NSEvent` has `window == nil` (its `locationInWindow` comes back in screen coordinates), so AppKit never routes the press to any view. Hover/tracking still reacts, which is exactly the reported symptom. Additionally, a `mouseUp` posted back-to-back with its `mouseDown` is dropped outright, and no click state was stamped on the events.

The fix posts synthetic click events to the HID event tap (`.cghidEventTap`) — the same tap the helper already uses for all synthetic keyboard input — paced 50 ms apart, with `mouseEventClickState` stamped per press so double/triple clicks register. The click path already raises and focuses the target window (`recoverWindow`) before posting, which is the precondition HID delivery needs. Synthetic clicks now also report `verification: { state: "unverified", reason: "synthetic_input" }` from the helper itself, matching the helper's other synthetic actions (the TS sidecar already normalized this in, so the wire shape is unchanged for current clients).

Scope: click delivery only. `drag` and `scroll` still use pid-targeted posting and likely share this defect — called out in Notes as follow-up rather than widening this P0 fix.

### Reproduction (evidence)

Rig: a minimal AppKit app (button + table view) that logs every mouse event AppKit routes to it (type, `clickCount`, `locationInWindow`) and every real activation (button action, table selection change). Same-machine, same-control isolating pairs, mirroring the issue's Preview experiment:

1. **Production Orca 1.4.x CLI, coordinate click** on the rig button and table row → `ok: true`, `action.path: "synthetic"`, events arrive **windowless** (`locationInWindow` = screen coords), **zero activations**. Bug reproduced against the shipped helper.
2. **Production CLI, `--element-index`** on the same button → `AXPress`, activation logged. (The issue's rows 4/5 pair.)
3. **Event-level A/B matrix** replaying the helper's exact `Input.click` sequence: `postToPid` plain / +clickState / +window-number fields 91/92 / +100 ms pacing — all fail (no window association; unpaced `mouseUp` never delivered at all). HID tap + pacing — button activates, table selection moves, double-click arrives with `clickCount == 2`.
4. **Fixed sequence** (exact mirror of the new `Input.click`): 3/3 single clicks activate, double-click word-selection works.

Limitation stated explicitly: the fixed helper binary was exercised at the CGEvent level via a byte-for-byte mirror of the new `Input.click` loop rather than through the socket protocol, because agent-mode peer authorization only accepts the Orca sidecar. The unchanged surrounding code paths (coordinate conversion, `recoverWindow`) were validated against the production helper on the same machine. The new e2e covers the full product path on the mac runner.

## Screenshots

No visual change (native input-synthesis helper; CLI output gains no new fields beyond the verification object the sidecar already synthesized).

## Testing

- [x] `pnpm lint` — passes except a pre-existing `max-lines` error in `mobile/src/session/use-mobile-native-chat-controller.ts` from the branch base; that file is already back under the cap on current `main`, so the merged state is clean. No lint findings in changed files.
- [x] `pnpm typecheck`
- [x] `pnpm test` — scoped: `vitest run src/cli/handlers/computer src/cli/specs/computer src/main/computer` (177 passed), `config/scripts/computer-use-modifier-safety.test.mjs` + `computer-use-smoke.test.mjs` (8 passed), and `swift test` in `native/computer-use-macos` (59 passed, 5 new). Full suite left to CI.
- [x] `pnpm build` — native surface: `node config/scripts/build-computer-macos.mjs` (universal release build + codesign) and `node config/scripts/verify-computer-native.mjs` pass; only pre-existing `CGWindowListCreateImage` deprecation warning remains.
- [x] Added or updated high-quality tests that would catch regressions:
  - `SyntheticMouseClickDeliveryTests` (new Core unit tests): press/step plan, per-press click state, non-positive count clamp, non-zero pacing.
  - `tests/e2e/computer-mac.e2e.ts`: new coordinate **double-click word-replacement** test that fails on the old delivery path (a dropped press leaves the caret at the end and the typed marker only appends) and passes with real delivery. Runs in the `computer-e2e` workflow, which triggers on this PR's paths.
  - `computer-use-modifier-safety.test.mjs` updated to assert the new shape with the same intent: modifier flags ride on every mouse event (now via the shared delivery plan), never as held modifier key events.

## AI Review Report

Self-review focused on: (1) **delivery-semantics change** — HID posting clicks whatever is topmost at the point rather than force-targeting a pid; verified the click path unconditionally raises/focuses the target window first (`recoverWindow`, 0.4 s settle), so the target is topmost at post time, matching how the helper's synthetic keyboard input has always worked; (2) **multi-click correctness** — click state must be stamped per press (1, 2, …) or double-clicks degrade to two singles; encoded in the plan and verified in the rig (`clickCount == 2` observed); (3) **modifier clicks** — flags applied to every event in the plan, source-gated by the updated modifier-safety test; (4) **wire compatibility** — the added `verification` field is optional and already synthesized by the client-side normalizer (`normalizeComputerActionResult`), so old-client/new-helper and new-client/old-helper mixes are both fine; (5) **regression blast radius** — `drag`/`scroll`/element `AXPress` paths untouched; `Input.click`'s `pid` parameter removed only because delivery is no longer pid-targeted, both call sites updated.

Cross-platform check: the change is entirely inside the macOS-only helper (`native/computer-use-macos`); Linux and Windows providers are separate implementations and untouched. No shortcuts, labels, paths, or shell behavior involved; e2e changes are in the mac-only, opt-in suite (`skipIf(!isMac || !e2eOptIn)`). SSH/folder-workspace flows are unaffected (computer-use targets the local desktop via the runtime; no workspace-type assumptions touched).

## Security Audit

The helper synthesizes HID-level input, which is inherently privileged: HID-tap events land wherever the pointer coordinates say, not only in the target app. Mitigations reviewed: coordinates remain window-local and are resolved against the target window's bounds from the app's own snapshot; the click path raises the target window before posting (pre-existing behavior); the helper still requires the user-granted Accessibility TCC permission, and agent-mode requests still require the launch token plus the sidecar peer check (`isAuthorizedAgentPeer`) — none of that is touched. No new input parsing, command execution, path handling, or IPC surface; the only wire delta is an additive, already-normalized metadata field. The keyboard path has posted to the same HID tap since inception, so this does not grant the helper any capability class it didn't already exercise.

## Notes

- **Follow-up**: `drag` and `scroll` still post via `CGEventPostToPid` and very likely no-op the same way on macOS (`drag` shares the defect mechanism exactly). Kept out of this PR to stay scoped to the P0; recommend a follow-up ticket.
- Possibly related cross-platform sibling: STA-3353 (Linux `type-text` silent no-op on Wayland) has the same "reports ok, does nothing" shape but a different mechanism; not addressed here.
- The 50 ms inter-event pause makes a single click ~150 ms slower; the click path already sleeps 400 ms in `recoverWindow`, so end-to-end latency impact is marginal.
- The issue also reports Orca's own window exposing only 5 accessibility elements (no interior tree), which is why coordinate clicks are the only way to drive Orca itself. That is a separate Electron/Chromium AX-tree concern, not addressed here — but with this fix coordinate clicks into Orca's window now actually land.
