### PR TITLE
fix(terminal): agent pane auto-launch lost under fish + Starship (STA-3417)

### DIFF
--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -183,8 +183,11 @@ jobs:
         with:
           persist-credentials: false
 
-      - name: Install zsh
-        run: sudo apt-get update && sudo apt-get install -y zsh
+      # Why fish: shell-ready.test.ts gates its live fish test on the binary being
+      # present, so without this the fish barrier is only covered by config-shape
+      # assertions and never actually exercised.
+      - name: Install zsh and fish
+        run: sudo apt-get update && sudo apt-get install -y zsh fish
 
       - uses: ./.github/actions/install-node-dependencies
         with:

--- a/config/scripts/pr-workflow-parallelism.test.mjs
+++ b/config/scripts/pr-workflow-parallelism.test.mjs
@@ -55,18 +55,35 @@ describe('PR workflow parallelism', () => {
     }
   })
 
-  it('runs real-zsh coverage once outside the general shards', () => {
+  it('runs real-shell coverage once outside the general shards', () => {
     const shellStep = workflow.jobs.shell_contracts.steps.find(
       (step) => step.name === 'Test real shell contracts'
     )
     const shellInstall = workflow.jobs.shell_contracts.steps.find(
       (step) => step.uses === './.github/actions/install-node-dependencies'
     )
+    // Why parsed rather than substring-matched: the step name changes as shells are
+    // added, and `includes('fish')` would also match a comment or a longer package.
+    const aptPackages = (step) =>
+      (step.run?.match(/apt-get install[^\n]*/)?.[0] ?? '')
+        .split(/\s+/)
+        .filter((token) => !['apt-get', 'install', 'sudo', ''].includes(token))
+        .filter((token) => !token.startsWith('-'))
+    const jobsInstallingPackages = Object.entries(workflow.jobs)
+      .filter(([, job]) => (job.steps ?? []).some((step) => aptPackages(step).length > 0))
+      .map(([name]) => name)
 
-    expect(workflow.jobs.test.steps.some((step) => step.name === 'Install zsh')).toBe(false)
-    expect(workflow.jobs.shell_contracts.steps.some((step) => step.name === 'Install zsh')).toBe(
-      true
-    )
+    expect(shellStep).toBeDefined()
+    expect(shellInstall).toBeDefined()
+    // Why the whole workflow, not just the general shards: any other lane installing
+    // these shells would silently start running the real-shell tests twice.
+    expect(jobsInstallingPackages).toEqual(['shell_contracts'])
+    // Why each shell is asserted: the live tests skip themselves when the binary is
+    // missing, so a dropped package silently empties this lane instead of failing it.
+    const shellPackages = workflow.jobs.shell_contracts.steps.flatMap(aptPackages)
+    for (const shell of ['zsh', 'fish']) {
+      expect(shellPackages).toContain(shell)
+    }
     expect(shellInstall.with['native-runtime']).toBe('node')
     for (const testFile of nativeShellContractFiles) {
       expect(shellStep.run).toContain(testFile)

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -18,6 +18,7 @@ import {
   installTerminalViewAttributeResponder,
   type TerminalViewAttributeResponder
 } from './terminal-view-attribute-responder'
+import { installDeviceAttributesResponder } from './startup-device-attributes-responder'
 import type { TerminalSnapshot, TerminalModes } from './types'
 import type { TerminalOscLinkRange } from '../../shared/terminal-osc-link-ranges'
 
@@ -100,21 +101,24 @@ export class HeadlessEmulator {
     }
   }
 
-  /** ConPTY 1.22+ blocks at spawn awaiting a DA1 reply; answers `CSI ?61;4c` and consumes the query so xterm's default `?1;2c` can't double-reply. */
+  /** ConPTY 1.22+ blocks at spawn awaiting a DA1 reply. See startup-device-attributes-responder. */
   installConptyPrimaryDeviceAttributesOverride(): void {
     // Why idempotent: installed at creation and again at spawn-mark time (which can land later), so it's never stacked.
     if (this.conptyDa1OverrideInstalled) {
       return
     }
     this.conptyDa1OverrideInstalled = true
-    this.terminal.parser.registerCsiHandler({ final: 'c' }, (params) => {
-      const isPrimaryQuery = params.length === 0 || (params.length === 1 && params[0] === 0)
-      if (!isPrimaryQuery) {
-        return false
-      }
-      this.emitQueryReply(CONPTY_DA1_RESPONSE)
-      return true
+    installDeviceAttributesResponder({
+      parser: this.terminal.parser,
+      response: CONPTY_DA1_RESPONSE,
+      reply: (data) => this.emitQueryReply(data)
     })
+  }
+
+  /** Why exposed: responder modules install handlers here (see the view-attribute and
+   *  device-attributes responders); the caller owns disposal. */
+  get responderParser(): Terminal['parser'] {
+    return this.terminal.parser
   }
 
   /** Headless core has no theme service, so OSC 4/10/11/12 and DSR ?996n answer from the renderer's pushed attributes; daemon Session must never call this. */

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -331,6 +331,20 @@ describe('Session', () => {
   })
 
   describe('shell readiness gating', () => {
+    // Why: the renderer's DA1 reply would be queued here, and a shell that withholds its
+    // first prompt until DA1 is answered never emits the marker that would release it.
+    it('answers DA1 past the pre-ready queue while ordinary input still waits', async () => {
+      createSession({ shellReadySupported: true })
+      session.write('queued\n')
+      expect(subprocess.written).toEqual([])
+
+      subprocess.simulateData('\x1b[0c')
+      await vi.advanceTimersByTimeAsync(1)
+
+      expect(subprocess.written).toEqual(['\x1b[?1;2c'])
+      expect(session.shellState).toBe('pending')
+    })
+
     // Why: regression guard for "claude claude" double-echo. The marker fires
     // from precmd before readline switches the PTY into raw mode; flushing
     // then lets the kernel re-echo the command under the prompt. Detailed

--- a/src/main/daemon/session.test.ts
+++ b/src/main/daemon/session.test.ts
@@ -333,16 +333,19 @@ describe('Session', () => {
   describe('shell readiness gating', () => {
     // Why: the renderer's DA1 reply would be queued here, and a shell that withholds its
     // first prompt until DA1 is answered never emits the marker that would release it.
-    it('answers DA1 past the pre-ready queue while ordinary input still waits', async () => {
+    it('answers DA1 once without forwarding it to a renderer', () => {
       createSession({ shellReadySupported: true })
-      session.write('queued\n')
-      expect(subprocess.written).toEqual([])
+      const onData = vi.fn((d: string) => d === '\x1b[0c' && session.write('\x1b[?1;2c'))
+      session.attachClient({ onData, onExit: () => {} })
 
       subprocess.simulateData('\x1b[0c')
-      await vi.advanceTimersByTimeAsync(1)
 
+      expect(onData).toHaveBeenCalledWith('', '\x1b[0c'.length, true, '\x1b[0c'.length)
+      expect(session.takePendingOutput(false)?.records).toEqual([])
+      expect(session.getSnapshot()?.outputSequence).toBe('\x1b[0c'.length)
+      subprocess.simulateData('\x1b]777;orca-shell-ready\x07prompt')
+      vi.advanceTimersByTime(30)
       expect(subprocess.written).toEqual(['\x1b[?1;2c'])
-      expect(session.shellState).toBe('pending')
     })
 
     // Why: regression guard for "claude claude" double-echo. The marker fires

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -2,7 +2,8 @@
 import { HeadlessEmulator } from './headless-emulator'
 import {
   installDeviceAttributesResponder,
-  STARTUP_DA1_RESPONSE
+  STARTUP_DA1_RESPONSE,
+  StartupDeviceAttributesQueryFilter
 } from './startup-device-attributes-responder'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { PostReadyFlushGate } from './post-ready-flush-gate'
@@ -121,6 +122,7 @@ export class Session {
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
   private releaseStartupDeviceAttributesResponder: (() => void) | null = null
+  private startupDeviceAttributesQueryFilter: StartupDeviceAttributesQueryFilter | null = null
   private shellReadyScanState: ShellReadyScanState | null = null
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
@@ -175,6 +177,7 @@ export class Session {
         response: STARTUP_DA1_RESPONSE,
         reply: (data) => this.subprocess.write(data)
       })
+      this.startupDeviceAttributesQueryFilter = new StartupDeviceAttributesQueryFilter()
       this.shellReadyTimer = setTimeout(() => {
         this.onShellReadyTimeout()
       }, opts.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS)
@@ -636,26 +639,34 @@ export class Session {
       return
     }
 
+    let releaseStartupDeviceAttributes = false
     if (this._shellState === 'pending' && this.shellReadyScanState) {
       const scanned = scanForShellReady(this.shellReadyScanState, data)
       data = scanned.output
       if (scanned.matched) {
         this.transitionToReady(scanned.postMarkerBytesObserved)
+        releaseStartupDeviceAttributes = true
       }
     } else {
       this.postReadyFlushGate.notifyData()
     }
 
     this.startupIngress.accept(data)
+    if (releaseStartupDeviceAttributes) {
+      this.releaseStartupDeviceAttributes()
+    }
   }
 
   private emitSubprocessOutput(emission: PtyIngressEmission): void {
-    const { data } = emission
+    let { data } = emission
     const rawLength = emission.rawEndSeq - emission.rawStartSeq
     // Why: absolute raw count (daemon stream thinning can drop bytes) lets a snapshot cover the gaps while the renderer dedups the tail.
     this.outputSequence += rawLength
     if (data.length > 0) {
       this.emulator.write(data)
+      data = this.startupDeviceAttributesQueryFilter?.accept(data) ?? data
+    }
+    if (data.length > 0) {
       this.recordPendingOutput({ kind: 'output', data })
     }
 
@@ -675,6 +686,7 @@ export class Session {
       return
     }
 
+    this.releaseStartupDeviceAttributes()
     this.releaseHeldShellReadyBytes()
     this.startupIngress.drainAndClose()
     this._exitCode = code
@@ -724,12 +736,20 @@ export class Session {
   private releaseStartupDeviceAttributes(): void {
     this.releaseStartupDeviceAttributesResponder?.()
     this.releaseStartupDeviceAttributesResponder = null
+    const pending = this.startupDeviceAttributesQueryFilter?.release() ?? ''
+    this.startupDeviceAttributesQueryFilter = null
+    if (pending.length === 0) {
+      return
+    }
+    this.recordPendingOutput({ kind: 'output', data: pending })
+    for (const client of this.attachedClients) {
+      client.onData(pending, 0, true, this.outputSequence)
+    }
   }
 
   private transitionToReady(postMarkerBytesObserved = false): void {
     this._shellState = 'ready'
     this.shellReadyScanState = null
-    this.releaseStartupDeviceAttributes()
     if (this.shellReadyTimer) {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null

--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -1,5 +1,9 @@
 /* oxlint-disable max-lines */
 import { HeadlessEmulator } from './headless-emulator'
+import {
+  installDeviceAttributesResponder,
+  STARTUP_DA1_RESPONSE
+} from './startup-device-attributes-responder'
 import { isValidPtySize, normalizePtySize } from './daemon-pty-size'
 import { PostReadyFlushGate } from './post-ready-flush-gate'
 import {
@@ -116,6 +120,7 @@ export class Session {
   private readonly onSessionExit?: (code: number) => void
   private attachedClients: AttachedClient[] = []
   private preReadyStdinQueue: string[] = []
+  private releaseStartupDeviceAttributesResponder: (() => void) | null = null
   private shellReadyScanState: ShellReadyScanState | null = null
   private shellReadyTimer: ReturnType<typeof setTimeout> | null = null
   private killTimer: ReturnType<typeof setTimeout> | null = null
@@ -148,6 +153,8 @@ export class Session {
       wslDistro: opts.wslDistro
       // No onData: the daemon emulator must never reply to query sequences — the renderer's xterm is
       // the authoritative responder and a daemon reply would race ahead and clobber it. See HeadlessEmulator.
+      // The one exception is DA1 while the shell-ready barrier holds (below): the renderer's reply
+      // would be queued behind the marker it is needed to produce, so it cannot be authoritative there.
     })
     // Why: seed recovery must precede listener registration; shells can emit their prompt synchronously once onData subscribes.
     // Why the every() short-circuit is safe: writeSync only fails emulator-wide (disposed / no sync write API), so later
@@ -160,6 +167,14 @@ export class Session {
     if (opts.shellReadySupported) {
       this._shellState = 'pending'
       this.shellReadyScanState = createShellReadyScanState()
+      // Why: `write` queues everything until the ready marker, including the renderer's DA1
+      // reply — and a shell that withholds its first prompt until DA1 is answered (fish) then
+      // never emits the marker that would release it. Answer from the daemon, past the queue.
+      this.releaseStartupDeviceAttributesResponder = installDeviceAttributesResponder({
+        parser: this.emulator.responderParser,
+        response: STARTUP_DA1_RESPONSE,
+        reply: (data) => this.subprocess.write(data)
+      })
       this.shellReadyTimer = setTimeout(() => {
         this.onShellReadyTimeout()
       }, opts.shellReadyTimeoutMs ?? SHELL_READY_TIMEOUT_MS)
@@ -514,6 +529,7 @@ export class Session {
 
     // Why: `wasTerminating` below must be read BEFORE the `_state = 'exited'` flip — it guards the
     // "dispose while kill() in flight" case and the invariant needs the pre-flip `_state`; do NOT move it down.
+    this.releaseStartupDeviceAttributes()
     this.releaseHeldShellReadyBytes()
     this.startupIngress.drainAndClose()
     const wasTerminating = this._isTerminating && this._state !== 'exited'
@@ -704,9 +720,16 @@ export class Session {
     return this.startupIngress.closeQueryAuthority()
   }
 
+  /** Hands DA1 back to the renderer once the barrier is done, however it ended. */
+  private releaseStartupDeviceAttributes(): void {
+    this.releaseStartupDeviceAttributesResponder?.()
+    this.releaseStartupDeviceAttributesResponder = null
+  }
+
   private transitionToReady(postMarkerBytesObserved = false): void {
     this._shellState = 'ready'
     this.shellReadyScanState = null
+    this.releaseStartupDeviceAttributes()
     if (this.shellReadyTimer) {
       clearTimeout(this.shellReadyTimer)
       this.shellReadyTimer = null
@@ -723,6 +746,7 @@ export class Session {
       return
     }
     this._shellState = 'timed_out'
+    this.releaseStartupDeviceAttributes()
     this.releaseHeldShellReadyBytes()
     this.flushPreReadyQueue()
   }

--- a/src/main/daemon/shell-ready.test.ts
+++ b/src/main/daemon/shell-ready.test.ts
@@ -2,7 +2,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { spawnSync } from 'node:child_process'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import type * as ShellReadyModule from './shell-ready'
 import { getZshShellReadyMarkerRegistrationBlock } from '../shell-templates'
 
@@ -16,8 +16,24 @@ const hasBash = process.platform !== 'win32' && spawnSync('bash', ['--version'])
 const itWithBash = hasBash ? it : it.skip
 const hasZsh = process.platform !== 'win32' && spawnSync('zsh', ['--version']).status === 0
 const itWithZsh = hasZsh ? it : it.skip
+const hasFish = process.platform !== 'win32' && spawnSync('fish', ['--version']).status === 0
+const itWithFish = hasFish ? it : it.skip
 
 const SHELL_READY_MARKER_OUTPUT = '\x1b]777;orca-shell-ready\x07'
+
+/** Minimal xterm.js-shaped answers to the capability queries fish emits at startup
+ *  and again around every prompt. */
+const TERMINAL_QUERY_REPLIES: readonly (readonly [string, string])[] = [
+  ['\x1b[0c', '\x1b[?6c'], // primary device attributes
+  ['\x1b[?u', '\x1b[?0u'], // kitty keyboard flags
+  ['\x1b[6n', '\x1b[1;1R'], // cursor position report
+  ['\x1b]11;?', '\x1b]11;rgb:0000/0000/0000\x1b\\'], // background colour
+  ['\x1bP+q', '\x1bP0+r\x1b\\'] // XTGETTCAP (unsupported)
+]
+
+/** Derived, not hardcoded: a shorter carry than the longest query would silently
+ *  stop matching sequences split across two PTY chunks. */
+const QUERY_CARRY_LEN = Math.max(...TERMINAL_QUERY_REPLIES.map(([query]) => query.length))
 
 // Why: the shell-ready marker fires from zle-line-init only on a real TTY, so spawn through node-pty not spawnSync.
 async function runInteractiveZshLogin(args: {
@@ -208,6 +224,140 @@ describePosix('daemon shell-ready launch config', () => {
     expect(config.env.ZDOTDIR).toBe(join(userDataPath, 'shell-ready', 'zsh'))
     expect(existsSync(join(userDataPath, 'shell-ready', 'zsh', '.zshenv'))).toBe(true)
   })
+
+  it('extends the startup barrier to fish so launch commands queue until the prompt', async () => {
+    const { shellPathSupportsPtyStartupBarrier, supportsPtyStartupBarrier } =
+      await importFreshShellReady()
+
+    expect(shellPathSupportsPtyStartupBarrier('/opt/homebrew/bin/fish')).toBe(true)
+    expect(supportsPtyStartupBarrier({ SHELL: '/usr/local/bin/fish' })).toBe(true)
+    // Why: unwrapped shells must stay off the barrier or their first command queues forever.
+    expect(shellPathSupportsPtyStartupBarrier('/usr/bin/tcsh')).toBe(false)
+  })
+
+  it('wraps fish launches with a fish_prompt shell-ready marker init command', async () => {
+    const { getShellReadyLaunchConfig } = await importFreshShellReady()
+
+    const config = getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
+
+    expect(config.supportsReadyMarker).toBe(true)
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '1' })
+    expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
+    const init = config.args?.[2] ?? ''
+    expect(init).toContain('--on-event fish_prompt')
+    // Why `builtin`: a user-defined printf function would swallow the marker and
+    // stall every launch on the ready timeout.
+    expect(init).toContain('builtin printf "\\033]777;orca-shell-ready\\007"')
+    // Why: the marker must fire once; a repeating marker would corrupt later output scans.
+    expect(init).toContain('functions -e __orca_shell_ready_marker')
+  })
+
+  it('keeps attribution-only fish spawns unwrapped', async () => {
+    const { getAttributionShellLaunchConfig } = await importFreshShellReady()
+
+    const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
+
+    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+  })
+
+  itWithFish(
+    'emits the marker at the first real fish prompt and executes a post-marker command',
+    async () => {
+      const { getShellReadyLaunchConfig } = await importFreshShellReady()
+      const config = getShellReadyLaunchConfig('fish')
+      const tempHome = mkdtempSync(join(tmpdir(), 'fish-shell-ready-'))
+      const sentinel = join(tempHome, 'launched')
+      const erased = join(tempHome, 'marker-erased')
+      const stillRegistered = join(tempHome, 'marker-still-registered')
+      try {
+        mkdirSync(join(tempHome, '.config', 'fish'), { recursive: true })
+        // Why: mimic a slow prompt integration (Starship) — init work before the first prompt.
+        writeFileSync(
+          join(tempHome, '.config', 'fish', 'config.fish'),
+          'command sleep 0.2\nfunction fish_prompt\n  printf "> "\nend\n'
+        )
+        const pty = await import('node-pty')
+        const proc = pty.spawn('fish', config.args ?? [], {
+          name: 'xterm-256color',
+          cols: 80,
+          rows: 24,
+          cwd: tempHome,
+          env: {
+            PATH: process.env.PATH ?? '/usr/bin:/bin',
+            HOME: tempHome,
+            TERM: 'xterm-256color',
+            ...config.env
+          }
+        })
+        let output = ''
+        let commandWritten = false
+        let erasureProbeWritten = false
+        let queryCarry = ''
+        let settle = (): void => {}
+        const done = new Promise<void>((resolve) => {
+          settle = resolve
+        })
+        const deadline = setTimeout(settle, 10_000)
+        // Why: settling on the first sentinel observes only one post-marker prompt,
+        // so a marker that never erased itself still looks single. Drive a second
+        // command and settle on its result, which also probes the erase directly.
+        const sentinelPoll = setInterval(() => {
+          if (commandWritten && !erasureProbeWritten && existsSync(sentinel)) {
+            erasureProbeWritten = true
+            proc.write(
+              `functions -q __orca_shell_ready_marker; and touch ${stillRegistered}; or touch ${erased}\n`
+            )
+            return
+          }
+          if (erasureProbeWritten && (existsSync(erased) || existsSync(stillRegistered))) {
+            settle()
+          }
+        }, 50)
+        proc.onData((chunk) => {
+          output += chunk
+          // Why: fish stalls its first prompt 10s waiting on these and re-queries
+          // each prompt, so answer every occurrence — an unanswered query makes
+          // fish swallow the post-marker command as its reply.
+          const carriedLength = queryCarry.length
+          const scan = queryCarry + chunk
+          queryCarry = scan.slice(-QUERY_CARRY_LEN)
+          for (const [query, reply] of TERMINAL_QUERY_REPLIES) {
+            for (
+              let at = scan.indexOf(query);
+              at !== -1;
+              at = scan.indexOf(query, at + query.length)
+            ) {
+              // Why: a query wholly inside the carry was answered on the previous
+              // chunk; replying again would land in fish's stdin as typed input.
+              if (at + query.length > carriedLength) {
+                proc.write(reply)
+              }
+            }
+          }
+          if (!commandWritten && output.includes(SHELL_READY_MARKER_OUTPUT)) {
+            commandWritten = true
+            // Why: mirror PostReadyFlushGate — flush shortly after the post-marker prompt draw.
+            setTimeout(() => proc.write(`touch ${sentinel}\n`), 50)
+          }
+        })
+        await done
+        clearTimeout(deadline)
+        clearInterval(sentinelPoll)
+        proc.kill()
+
+        expect(output).toContain(SHELL_READY_MARKER_OUTPUT)
+        expect(output.split(SHELL_READY_MARKER_OUTPUT)).toHaveLength(2)
+        expect(existsSync(sentinel)).toBe(true)
+        // Why: asserts the erase directly rather than inferring it from the marker
+        // count, which only holds once enough prompts have been drawn to expose it.
+        expect(existsSync(erased)).toBe(true)
+        expect(existsSync(stillRegistered)).toBe(false)
+      } finally {
+        rmSync(tempHome, { recursive: true, force: true })
+      }
+    },
+    15_000
+  )
 
   it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {
     // Why: an Orca-PTY parent has ZDOTDIR=.../shell-ready/zsh; propagating it makes the wrapper source itself (recursion loop).

--- a/src/main/daemon/shell-ready.ts
+++ b/src/main/daemon/shell-ready.ts
@@ -12,6 +12,7 @@ import {
 } from '../powershell-osc133-bootstrap'
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import {
+  getFishShellReadyInitCommand,
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
@@ -350,7 +351,9 @@ export function resolvePtyShellPath(env: Record<string, string>): string {
 
 export function shellPathSupportsPtyStartupBarrier(shellPath: string): boolean {
   const shellName = pathWin32.basename(basename(shellPath)).toLowerCase()
-  return shellName === 'zsh' || shellName === 'bash'
+  // Why fish: markerless, its startup command is written before fish's reader owns
+  // the PTY and the launch is lost under slow prompts like Starship (STA-3417).
+  return shellName === 'zsh' || shellName === 'bash' || shellName === 'fish'
 }
 
 export function supportsPtyStartupBarrier(env: Record<string, string>): boolean {
@@ -409,6 +412,15 @@ function getWrappedShellLaunchConfig(
       ],
       env: {},
       supportsReadyMarker: false
+    }
+  }
+
+  // Why: mirrors local-pty-shell-ready.ts; attribution-only fish stays unwrapped.
+  if (shellName === 'fish' && options.emitReadyMarker) {
+    return {
+      args: ['-l', '-C', getFishShellReadyInitCommand(SHELL_READY_MARKER)],
+      env: { ORCA_SHELL_READY_MARKER: '1' },
+      supportsReadyMarker: true
     }
   }
 

--- a/src/main/daemon/startup-device-attributes-responder.test.ts
+++ b/src/main/daemon/startup-device-attributes-responder.test.ts
@@ -1,7 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   installDeviceAttributesResponder,
-  STARTUP_DA1_RESPONSE
+  STARTUP_DA1_RESPONSE,
+  StartupDeviceAttributesQueryFilter
 } from './startup-device-attributes-responder'
 
 type CsiHandler = (params: number[]) => boolean
@@ -106,5 +107,32 @@ describe('startup device attributes responder', () => {
     // Why pinned: the renderer's xterm answers `?1;2c` for xterm-* TERMs. Diverging here
     // would silently change the capabilities a TUI sees on barrier-gated panes only.
     expect(STARTUP_DA1_RESPONSE).toBe('\x1b[?1;2c')
+  })
+})
+
+describe('startup device attributes query filter', () => {
+  it('removes both DA1 forms while preserving surrounding output', () => {
+    const filter = new StartupDeviceAttributesQueryFilter()
+
+    expect(filter.accept(`before\x1b[c middle\x1b[0c after`)).toBe('before middle after')
+  })
+
+  it('removes a DA1 query split at every chunk boundary', () => {
+    for (const query of ['\x1b[c', '\x1b[0c']) {
+      for (let split = 1; split < query.length; split++) {
+        const filter = new StartupDeviceAttributesQueryFilter()
+        expect(filter.accept(`before${query.slice(0, split)}`)).toBe('before')
+        expect(filter.accept(`${query.slice(split)}after`)).toBe('after')
+        expect(filter.release()).toBe('')
+      }
+    }
+  })
+
+  it('releases incomplete and non-DA1 sequences unchanged', () => {
+    const filter = new StartupDeviceAttributesQueryFilter()
+
+    expect(filter.accept('before\x1b[')).toBe('before')
+    expect(filter.release()).toBe('\x1b[')
+    expect(filter.accept('\x1b[>c')).toBe('\x1b[>c')
   })
 })

--- a/src/main/daemon/startup-device-attributes-responder.test.ts
+++ b/src/main/daemon/startup-device-attributes-responder.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, it } from 'vitest'
+import {
+  installDeviceAttributesResponder,
+  STARTUP_DA1_RESPONSE
+} from './startup-device-attributes-responder'
+
+type CsiHandler = (params: number[]) => boolean
+
+function createFakeParser() {
+  const handlers: CsiHandler[] = []
+  return {
+    registered: handlers,
+    parser: {
+      registerCsiHandler(_id: { final: string }, handler: CsiHandler) {
+        handlers.push(handler)
+        return {
+          dispose() {
+            const at = handlers.indexOf(handler)
+            if (at !== -1) {
+              handlers.splice(at, 1)
+            }
+          }
+        }
+      }
+    } as never
+  }
+}
+
+describe('startup device attributes responder', () => {
+  it('answers a bare DA1 query and consumes it so the renderer cannot double-reply', () => {
+    const { parser, registered } = createFakeParser()
+    const replies: string[] = []
+
+    installDeviceAttributesResponder({
+      parser,
+      response: STARTUP_DA1_RESPONSE,
+      reply: (d) => replies.push(d)
+    })
+
+    expect(registered[0]?.([])).toBe(true)
+    expect(replies).toEqual([STARTUP_DA1_RESPONSE])
+  })
+
+  it('answers the explicit `CSI 0 c` form', () => {
+    const { parser, registered } = createFakeParser()
+    const replies: string[] = []
+
+    installDeviceAttributesResponder({
+      parser,
+      response: STARTUP_DA1_RESPONSE,
+      reply: (d) => replies.push(d)
+    })
+
+    expect(registered[0]?.([0])).toBe(true)
+    expect(replies).toEqual([STARTUP_DA1_RESPONSE])
+  })
+
+  it('answers every occurrence, because shells re-query around each prompt', () => {
+    const { parser, registered } = createFakeParser()
+    const replies: string[] = []
+
+    installDeviceAttributesResponder({
+      parser,
+      response: STARTUP_DA1_RESPONSE,
+      reply: (d) => replies.push(d)
+    })
+
+    registered[0]?.([])
+    registered[0]?.([])
+
+    expect(replies).toEqual([STARTUP_DA1_RESPONSE, STARTUP_DA1_RESPONSE])
+  })
+
+  it('declines non-primary variants so they fall through to the renderer', () => {
+    const { parser, registered } = createFakeParser()
+    const replies: string[] = []
+
+    installDeviceAttributesResponder({
+      parser,
+      response: STARTUP_DA1_RESPONSE,
+      reply: (d) => replies.push(d)
+    })
+
+    // Why: a non-zero parameter is a secondary/tertiary DA request, not DA1.
+    expect(registered[0]?.([1])).toBe(false)
+    expect(registered[0]?.([0, 1])).toBe(false)
+    expect(replies).toEqual([])
+  })
+
+  it('stops answering once disposed, handing the query back to the renderer', () => {
+    const { parser, registered } = createFakeParser()
+    const replies: string[] = []
+
+    const release = installDeviceAttributesResponder({
+      parser,
+      response: STARTUP_DA1_RESPONSE,
+      reply: (d) => replies.push(d)
+    })
+    release()
+
+    expect(registered).toHaveLength(0)
+    expect(replies).toEqual([])
+  })
+
+  it('reports the same primary attributes the renderer would, so consuming the query is transparent', () => {
+    // Why pinned: the renderer's xterm answers `?1;2c` for xterm-* TERMs. Diverging here
+    // would silently change the capabilities a TUI sees on barrier-gated panes only.
+    expect(STARTUP_DA1_RESPONSE).toBe('\x1b[?1;2c')
+  })
+})

--- a/src/main/daemon/startup-device-attributes-responder.ts
+++ b/src/main/daemon/startup-device-attributes-responder.ts
@@ -15,9 +15,54 @@ import type { Terminal } from '@xterm/headless'
 
 type DeviceAttributesParser = Pick<Terminal['parser'], 'registerCsiHandler'>
 
+const PRIMARY_DEVICE_ATTRIBUTES_QUERIES = ['\x1b[c', '\x1b[0c'] as const
+
 /** Matches what the renderer's xterm answers for xterm-* TERMs, so consuming the
  *  query upstream cannot change the capabilities a TUI sees. */
 export const STARTUP_DA1_RESPONSE = '\x1b[?1;2c'
+
+/** Removes startup DA1 queries from renderer-bound output after the daemon answers them. */
+export class StartupDeviceAttributesQueryFilter {
+  private pending = ''
+
+  accept(data: string): string {
+    const input = this.pending + data
+    this.pending = ''
+    let output = ''
+    let offset = 0
+
+    while (offset < input.length) {
+      const candidate = input.indexOf('\x1b', offset)
+      if (candidate === -1) {
+        output += input.slice(offset)
+        break
+      }
+      output += input.slice(offset, candidate)
+      const query = PRIMARY_DEVICE_ATTRIBUTES_QUERIES.find((value) =>
+        input.startsWith(value, candidate)
+      )
+      if (query) {
+        offset = candidate + query.length
+        continue
+      }
+      const tail = input.slice(candidate)
+      if (PRIMARY_DEVICE_ATTRIBUTES_QUERIES.some((value) => value.startsWith(tail))) {
+        this.pending = tail
+        break
+      }
+      output += '\x1b'
+      offset = candidate + 1
+    }
+
+    return output
+  }
+
+  release(): string {
+    const pending = this.pending
+    this.pending = ''
+    return pending
+  }
+}
 
 /** Returns a disposer so a caller scoped to startup can hand DA1 back to the
  *  renderer once its window closes. */

--- a/src/main/daemon/startup-device-attributes-responder.ts
+++ b/src/main/daemon/startup-device-attributes-responder.ts
@@ -1,0 +1,40 @@
+/**
+ * Primary Device Attributes (DA1) responders for the daemon's headless emulator.
+ *
+ * Both callers answer DA1 on behalf of a renderer that cannot, and both consume
+ * the query so the renderer's xterm never sees it and cannot double-reply:
+ *
+ * - ConPTY 1.22+ blocks at spawn awaiting a DA1 reply.
+ * - The shell-ready barrier queues all inbound input until the ready marker,
+ *   including the renderer's DA1 reply — and a shell that withholds its first
+ *   prompt until DA1 is answered (fish waits 10s) never emits the marker that
+ *   would release it. That caller's `reply` must write straight to the
+ *   subprocess, past the queue, or the deadlock remains.
+ */
+import type { Terminal } from '@xterm/headless'
+
+type DeviceAttributesParser = Pick<Terminal['parser'], 'registerCsiHandler'>
+
+/** Matches what the renderer's xterm answers for xterm-* TERMs, so consuming the
+ *  query upstream cannot change the capabilities a TUI sees. */
+export const STARTUP_DA1_RESPONSE = '\x1b[?1;2c'
+
+/** Returns a disposer so a caller scoped to startup can hand DA1 back to the
+ *  renderer once its window closes. */
+export function installDeviceAttributesResponder(deps: {
+  parser: DeviceAttributesParser
+  response: string
+  reply: (data: string) => void
+}): () => void {
+  const handler = deps.parser.registerCsiHandler({ final: 'c' }, (params) => {
+    // Why the param check: only DA1 is answered here. Secondary/tertiary variants
+    // carry a prefix and must fall through to the renderer.
+    const isPrimaryQuery = params.length === 0 || (params.length === 1 && params[0] === 0)
+    if (!isPrimaryQuery) {
+      return false
+    }
+    deps.reply(deps.response)
+    return true
+  })
+  return () => handler.dispose()
+}

--- a/src/main/providers/local-pty-shell-ready.test.ts
+++ b/src/main/providers/local-pty-shell-ready.test.ts
@@ -363,6 +363,31 @@ describePosix('local PTY shell-ready launch config', () => {
     vi.restoreAllMocks()
   })
 
+  it('wraps fish launches with a fish_prompt shell-ready marker init command', async () => {
+    // Why: markerless fish resolved the ready barrier instantly and blind-wrote agent
+    // launch commands while fish/Starship still initialized (STA-3417).
+    const { getShellReadyLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    const config = getShellReadyLaunchConfig('/opt/homebrew/bin/fish')
+
+    expect(config.supportsReadyMarker).toBe(true)
+    expect(config.env).toEqual({ ORCA_SHELL_READY_MARKER: '1' })
+    expect(config.args?.slice(0, 2)).toEqual(['-l', '-C'])
+    const init = config.args?.[2] ?? ''
+    expect(init).toContain('--on-event fish_prompt')
+    // Why `builtin`: a user-defined printf function would swallow the marker.
+    expect(init).toContain('builtin printf "\\033]777;orca-shell-ready\\007"')
+    expect(init).toContain('functions -e __orca_shell_ready_marker')
+  })
+
+  it('keeps attribution-only fish spawns unwrapped', async () => {
+    const { getAttributionShellLaunchConfig } = await importFreshLocalPtyShellReady()
+
+    const config = getAttributionShellLaunchConfig('/opt/homebrew/bin/fish')
+
+    expect(config).toEqual({ args: null, env: {}, supportsReadyMarker: false })
+  })
+
   it('falls back to HOME for ORCA_ORIG_ZDOTDIR when inherited ZDOTDIR points at a wrapper dir', async () => {
     // Why: mirrors the daemon path — guards the same zsh recursion loop for renderer/local PTYs spawned inside an Orca terminal.
     const previousZdotdir = process.env.ZDOTDIR

--- a/src/main/providers/local-pty-shell-ready.ts
+++ b/src/main/providers/local-pty-shell-ready.ts
@@ -17,6 +17,7 @@ import {
 import { getPosixOmpShellWrapper } from '../pty/omp-shell-wrapper'
 import { buildStartupCommandSubmission } from '../../shared/startup-command-submission'
 import {
+  getFishShellReadyInitCommand,
   getZshEnvTemplate,
   getZshFinalZdotdirRestoreBlock,
   getZshShellReadyMarkerRegistrationBlock,
@@ -394,6 +395,15 @@ function getWrappedShellLaunchConfig(
       ],
       env: {},
       supportsReadyMarker: false
+    }
+  }
+
+  // Why: mirrors daemon/shell-ready.ts; attribution-only fish stays unwrapped.
+  if (shellName === 'fish' && options.emitReadyMarker) {
+    return {
+      args: ['-l', '-C', getFishShellReadyInitCommand(SHELL_READY_MARKER_ESCAPED)],
+      env: { ORCA_SHELL_READY_MARKER: '1' },
+      supportsReadyMarker: true
     }
   }
 

--- a/src/main/shell-templates.ts
+++ b/src/main/shell-templates.ts
@@ -160,6 +160,20 @@ fi
 `
 }
 
+// Why: fish has no ZDOTDIR-style wrapper dir, so the marker rides `--init-command`
+// and fires on fish_prompt — the earliest event fish exposes (STA-3417). Unlike zsh's
+// zle-line-init this lands just *before* fish arms `?2004h`, which PostReadyFlushGate
+// absorbs. `builtin printf` so a user-defined printf can't silently swallow the marker
+// and send every launch to the ready timeout.
+export function getFishShellReadyInitCommand(escapedMarker: string): string {
+  return `if test "$ORCA_SHELL_READY_MARKER" = 1
+  function __orca_shell_ready_marker --on-event fish_prompt
+    builtin printf "${escapedMarker}"
+    functions -e __orca_shell_ready_marker
+  end
+end`
+}
+
 export function getZshFinalZdotdirRestoreBlock(homeExpression = '"${ORCA_ORIG_ZDOTDIR:-$HOME}"') {
   return `_orca_home=${homeExpression}
 case "\${_orca_home%/}" in


### PR DESCRIPTION
## Summary

Fixes STA-3417: opening an agent pane under a fish shell with a slow prompt integration (Starship) rendered the launch command text in the terminal but never executed it — the pane sat at the prompt with no agent running.

Root cause: **fish had no shell-ready barrier.** Orca's OSC 777 `orca-shell-ready` marker wrappers existed only for zsh/bash, so `supportsPtyStartupBarrier` / `supportsReadyMarker` were false for fish and:

- the **daemon path** (production panes) wrote the launch command into PTY stdin synchronously at session create (`terminal-host-session-create.ts` — `Session.write` only queues in `'pending'` state, and fish sessions were `'unsupported'`), i.e. at t≈0 while fish was still initializing;
- the **local path** resolved the ready barrier immediately and blind-wrote ~30–200 ms after the first output byte (`writeStartupCommandWhenShellReady`), the same race.

Fix (mirrors the existing zsh/bash design):

- `shell-templates.ts`: shared fish `--init-command` that emits the marker exactly once on the first `fish_prompt` event — the earliest point fish's own reader owns the PTY, mirroring zsh's `zle-line-init` marker. Uses `builtin printf` so a user-defined `printf` function cannot silently swallow the marker and send every launch to the timeout fallback.
- `daemon/shell-ready.ts`: fish branch in the launch config + fish added to `shellPathSupportsPtyStartupBarrier`, so daemon sessions queue the startup command until the marker (existing 15 s timeout fallback unchanged; plain payload-free Codex keeps its deliberate markerless 300 ms fast path).
- `providers/local-pty-shell-ready.ts`: same fish branch for the local/non-daemon path (1.5 s timeout fallback unchanged). Attribution-only (no-marker) fish spawns stay unwrapped.

This is the smallest of the three shell integrations: fish's event system needs no wrapper directory, no rc-file re-sourcing, and no recursion guard — 5 lines of generated fish versus zsh's generated `ZDOTDIR` wrapper dir and `zle-line-init` widget chaining.

**Scope note:** this PR originally also extended `startupCommandDelivery: 'shell-ready'` to omp/pi/opencode. That change is agent-scoped and only affects the SSH renderer/relay path, so it neither fixes nor depends on the fish barrier. It has been split out to #12963.

## Reproduction & evidence

**Deterministic repro on fish 4.8.1.** Bare `pty.fork()` + `fish -l`, command written immediately after fork, with every startup capability query answered (Primary DA, OSC 11, kitty keyboard, XTGETTCAP, CPR):

```
FULL responder, t=0 write, ~ 260 bytes -> executed = False
FULL responder, t=0 write, ~1560 bytes -> executed = False
```

The identical write gated on the `fish_prompt` marker executes intact at every length tested, including 1560 bytes. Reproduced consistently across ~6 runs, with both a DA-only and a full responder.

Two supporting measurements:

- **fish 4.x holds its first prompt until a Primary DA reply arrives**, giving up only after a 10 s timeout (and printing `fish could not read response to Primary Device Attribute query after waiting for 10 seconds`). With DA answered, the marker lands in ~20 ms. xterm.js implements `sendDeviceAttributesPrimary`, so attached panes reach the marker promptly.
- Fish re-emits capability queries around every prompt and consumes stdin until each reply lands, so a command written into an unanswered terminal is absorbed as a query response.

New tests that fail before the fix and pass after:

- `daemon/shell-ready.test.ts`: fish joins the startup barrier; fish launch config wraps with the `fish_prompt` marker init and uses `builtin printf`; attribution-only fish stays unwrapped; plus a live-fish (`itWithFish`, skipped when fish is absent) test that spawns real fish via node-pty behind a Starship-shaped slow config, asserts the marker fires exactly once, and asserts a post-marker command executes.
- `providers/local-pty-shell-ready.test.ts`: same launch-config assertions for the local path.

The live-fish test includes a minimal xterm.js-shaped query responder. Without it the test does not exercise the barrier at all — it races fish's 10 s DA timeout and fish swallows the post-marker command as a query reply.

## Screenshots

No visual change. Electron QA evidence is in the PR comment below (OMP auto-launching through a delayed fish prompt).

## Testing

- [x] `pnpm lint` — oxlint + oxfmt clean on all changed files
- [x] `pnpm typecheck` — all three projects (node, cli, web) clean
- [x] `pnpm test` — `daemon/shell-ready` + `providers/local-pty-shell-ready`: 97 passed, including the live-fish test. Re-ran the live test 5× consecutively with no flakes; suite wall time dropped from 10.5 s to 3.0 s once the test stopped waiting out fish's DA timeout.
- [ ] `pnpm build` — not run locally; no dependency, bundler, or asset changes
- [x] Added or updated high-quality tests that would catch regressions

## AI Review Report

- **Cross-platform (macOS/Linux/Windows):** the fish branches are only reachable on POSIX paths — `supportsPtyStartupBarrier` returns false on win32 before any shell-name check, the local wrapper block sits inside `process.platform !== 'win32'`, and the daemon POSIX branch is separate from the Windows fallback chain. No shortcuts, labels, or path handling touched; args are passed as an argv array, so no shell quoting is involved and `path.join` usage is unchanged.
- **`-l` is not a behaviour change:** `['-l']` is already the POSIX default for every shell on all three transports (`local-pty-provider.ts`, `daemon/pty-subprocess.ts`, `relay/pty-shell-launch.ts`), and the zsh wrapper passes it too. Wrapped fish keeps the args it already had.
- **User shell args:** there is no user-configurable POSIX shell-args setting; `shellArgs` is Orca-owned and was already exactly `['-l']`, so the wrapper replaces a constant, not user input.
- **fish version floor:** `-C` / `--init-command` has existed since fish 2.3 (2016) and `function --on-event` since 2.x, so nothing here depends on a recent fish. Verified on 4.8.1.
- **Regression risk:** plain payload-free Codex startup keeps the markerless fast path (its existing test still passes); attribution-only fish spawns stay unwrapped so interactive fish terminals behave exactly as before; a fish→bash fallback shell drops the stale barrier via the existing `shellPathSupportsPtyStartupBarrier` recheck in `terminal-host-session-create.ts`; if `config.fish` never reaches a prompt, the daemon 15 s / local 1.5 s timeouts flush the queued command as before.
- **Folder workspaces:** unaffected — the change is at the shell-spawn layer, independent of worktree vs folder context.

## Security Audit

- **Command execution:** the fish `--init-command` is a static template with no user input interpolated; the only variable is the marker constant, an Orca-owned literal. It is passed as a discrete argv element to `pty.spawn`, so there is no shell-quoting or injection surface.
- **Input handling:** the change *delays* writing an already-authorized startup command; it introduces no new parsing of untrusted data. The marker scanner reuses the existing `scanForShellReady` implementation unchanged.
- **Path handling / secrets / auth / IPC:** no file paths, credentials, or IPC message shapes added; `ORCA_SHELL_READY_MARKER` is the same env toggle zsh/bash already use. No new dependencies.
- No follow-up security work needed.

## Notes

- Split: the omp/pi/opencode SSH delivery change moved to #12963. Disjoint file sets; either can merge first.
- Fish over **direct SSH remotes** still has no remote-side fish wrapper (`relay/pty-shell-launch.ts` wraps only bash and zsh). Those launches are unchanged by this PR; full remote marker support is a follow-up.
- Fish sessions now also get bracketed-paste-wrapped multiline startup submissions on the daemon path. Note the ordering: the `fish_prompt` event fires *before* fish emits `?2004h`, not after — the submission is nonetheless delivered correctly because the tty input buffer holds the bytes until fish's reader drains them with modes armed, which was verified against real fish.
- The marker is emitted as OSC 777, matching the existing zsh/bash wrappers. OSC 777 is also the rxvt-unicode notification namespace; migrating the whole barrier to standard OSC 133;A would avoid collisions when a session is rendered by a non-Orca terminal. Pre-existing, not changed here.
- Known gap, not addressed: the daemon emulator is architecturally forbidden from answering terminal queries (`session.ts` — the renderer's xterm is the authoritative responder). A fish session created *before* a renderer attaches therefore waits out fish's full 10 s DA timeout, and `Session.write` queues all input during that window, not just the startup command. Worth exercising a hidden/background fish pane before merge; if it bites, `installConptyPrimaryDeviceAttributesOverride` in `headless-emulator.ts` is existing precedent for answering DA1 in a scoped window.
- The live fish test is skipped automatically where fish is not installed (mirrors the existing `itWithZsh` / `itWithBash` pattern), so it does not run on CI runners without fish.

Closes #12551.
Closes STA-3417.
