### PR TITLE
fix(runtime): stop a stalled tick from forgiving banked missed probes (STA-3320)

### DIFF
--- a/src/main/runtime/rpc/remote-runtime-server-heartbeat-missed-probe-tolerance.test.ts
+++ b/src/main/runtime/rpc/remote-runtime-server-heartbeat-missed-probe-tolerance.test.ts
@@ -53,7 +53,9 @@ describe('RemoteRuntimeServerHeartbeat missed-probe tolerance', () => {
     for (let probe = 0; probe < 6; probe += 1) {
       now += INTERVAL_MS
       await vi.advanceTimersByTimeAsync(INTERVAL_MS)
-      missesBeforeReap.push((socket.terminate as unknown as ReturnType<typeof vi.fn>).mock.calls.length)
+      missesBeforeReap.push(
+        (socket.terminate as unknown as ReturnType<typeof vi.fn>).mock.calls.length
+      )
     }
 
     // Silence must be tolerated for more than a single probe, and must eventually end the socket.
@@ -85,7 +87,7 @@ describe('RemoteRuntimeServerHeartbeat missed-probe tolerance', () => {
     heartbeat.stop()
   })
 
-  it('clears accumulated misses when the server event loop resumes from a pause', async () => {
+  it('charges no miss for a paused tick but keeps the ones already banked', async () => {
     vi.useFakeTimers()
     let now = 1_000
     const socket = makeSocket()
@@ -114,8 +116,9 @@ describe('RemoteRuntimeServerHeartbeat missed-probe tolerance', () => {
     expect(toleratedMisses).toBeGreaterThan(1)
     heartbeat.stop()
 
-    // Replay on a fresh socket: bank misses to one short of the limit, suspend, then bank the same
-    // number again. The pause must write the earlier misses off, not top them up to the limit.
+    // Replay on a fresh socket: bank misses to one short of the limit, then suspend. The stalled tick
+    // must charge nothing — the client had no chance to answer it — but it must not forgive the misses
+    // already banked, or a host that stalls periodically could shelter a dead socket indefinitely.
     const resumed = new RemoteRuntimeServerHeartbeat(INTERVAL_MS, () => now)
     const resumedSocket = makeSocket()
     resumed.noteAlive(resumedSocket)
@@ -129,11 +132,36 @@ describe('RemoteRuntimeServerHeartbeat missed-probe tolerance', () => {
 
     now += 3_600_000
     await vi.advanceTimersByTimeAsync(INTERVAL_MS)
-    for (let miss = 0; miss < toleratedMisses - 1; miss += 1) {
-      await sweep()
+    // The suspend itself costs the socket nothing.
+    expect(reaped(resumedSocket)).toBe(false)
+
+    // But the pre-suspend evidence survives, so the very next unanswered probe completes the budget.
+    await sweep()
+    expect(reaped(resumedSocket)).toBe(true)
+    resumed.stop()
+  })
+
+  // Why: pre-fix the pardon cleared banked misses, so a host stalling once every few ticks reset the
+  // budget forever and a dead socket was never reaped — the connection leak the reaper exists to stop.
+  it('still reaps a dead socket when the host stalls repeatedly', async () => {
+    vi.useFakeTimers()
+    let now = 1_000
+    const socket = makeSocket()
+    const heartbeat = new RemoteRuntimeServerHeartbeat(INTERVAL_MS, () => now)
+    heartbeat.noteAlive(socket)
+    heartbeat.start(() => [socket])
+    heartbeat.noteAlive(socket)
+
+    const reaped = (): boolean =>
+      (socket.terminate as unknown as ReturnType<typeof vi.fn>).mock.calls.length > 0
+
+    // Stall every third tick — the worst case the old pardon could not survive.
+    for (let tick = 0; tick < 30 && !reaped(); tick += 1) {
+      now += tick % 3 === 2 ? INTERVAL_MS * 2 : INTERVAL_MS
+      await vi.advanceTimersByTimeAsync(INTERVAL_MS)
     }
 
-    expect(reaped(resumedSocket)).toBe(false)
-    resumed.stop()
+    expect(reaped()).toBe(true)
+    heartbeat.stop()
   })
 })

--- a/src/main/runtime/rpc/remote-runtime-server-heartbeat.ts
+++ b/src/main/runtime/rpc/remote-runtime-server-heartbeat.ts
@@ -52,21 +52,20 @@ export class RemoteRuntimeServerHeartbeat {
     const tickAt = this.now()
     const elapsedMs = tickAt - (this.lastTickAt ?? tickAt)
     this.lastTickAt = tickAt
-    const resumedFromPause = elapsedMs < 0 || elapsedMs > this.intervalMs * 1.5
+    // Why: a delayed tick cannot infer that clients missed a probe they had no chance to answer, so
+    // this sweep must not charge one. It must not *forgive* either: clearing banked misses lets a host
+    // that stalls once every few ticks protect a dead socket forever, which is the connection leak the
+    // reaper exists to prevent. Skipping the charge is enough — a live client clears its own count by
+    // answering the probe still sent below.
+    const stalledTick = elapsedMs < 0 || elapsedMs > this.intervalMs * 1.5
     let reaped = 0
     let clientCount = 0
     for (const socket of clients) {
       clientCount += 1
-      if (resumedFromPause) {
-        // Why: a delayed server tick cannot infer that clients missed a probe they had no chance to
-        // answer. Seeding alive also clears any misses banked before the pause, so a suspend can never
-        // top up a budget the client was never given a chance to defend.
-        this.alive.add(socket)
-      }
       if (this.alive.has(socket)) {
         this.alive.delete(socket)
         this.missedProbes.delete(socket)
-      } else {
+      } else if (!stalledTick) {
         const missed = (this.missedProbes.get(socket) ?? 0) + 1
         if (missed >= this.missedProbeLimit) {
           this.missedProbes.delete(socket)


### PR DESCRIPTION
Fix-forward on #12790, from its post-merge adversarial review. That review's verdict was **SOUND — do not revert**, and this addresses the one real defect it demonstrated.

## The defect

#12790's resume-from-pause pardon **cleared banked misses outright**. So a host whose sweep stalls once every three ticks reset the budget forever and a dead socket was never reaped.

Demonstrated by the reviewer: a permanently dead peer, with a `> intervalMs * 1.5` gap every third tick, ran **300 sweeps (50 simulated minutes) with zero `terminate()` calls.** Boundary confirmed — a stall every 4th tick still reaps; every 3rd tick never does.

Pre-#12790 this required a stall on *every* tick to prevent a reap. The consecutive counter widened the pathological window 3×, and the failure mode is permanent non-reaping — exactly the `MAX_WS_CONNECTIONS = 128` leak the reaper exists to prevent.

## The fix

A stalled tick now **charges no miss but forgives nothing**.

That is all the original rationale ever needed: a delayed tick cannot infer that clients missed a probe they had no chance to answer, so it must not charge one. Clearing the count as well was over-generous — those earlier misses were banked while the server was running normally, so they are real evidence.

A live client still clears its own count by answering the probe that is still sent on the stalled tick, so a genuine suspend costs a healthy peer nothing.

## Verification

The tolerance test's pause case is **rewritten to assert the new contract**, not weakened — it now pins both halves: the suspend itself costs the socket nothing, *and* the pre-suspend evidence survives so the next unanswered probe completes the budget. Renamed accordingly (`charges no miss for a paused tick but keeps the ones already banked`).

A new test pins the leak directly: a host stalling every third tick must still reap a dead socket.

Mutation-proven: forcing `stalledTick` to `false` fails the pause test; restored by re-applying the edit, never `git checkout`.

Suites: `src/main/runtime/rpc/` — 124 files, 1220 passing. Includes the pre-existing real-socket half-open reap test (`ws-transport.test.ts`, kernel-level `_socket.pause()`), untouched and still green.

Also corrects a stale comment in `ws-transport.test.ts` that still said "two consecutive ping ticks" — it has been four since #12790.

## Not addressed here

The review also noted that `elapsedMs < 0` reads a **wall clock** (`Date.now`), so a backward NTP or VM-migration step grants a one-off pardon. Harmless in isolation now that a pardon no longer forgives banked misses, but it means the reaper's correctness still depends on a clock a user can change. Moving to a monotonic source is a separate change with its own suspend-semantics questions (`CLOCK_MONOTONIC` excludes suspend time, `CLOCK_BOOTTIME` includes it), so it should not ride along with this.

The review's other observation — that a flapping device can now hold 2-3 connection slots instead of 1-2, because the client's own 25s watchdog redials while the server holds the stale socket up to 60s — is by design (`hasOtherConnections`) and absorbed by the 128-slot budget, but it is worth its own look if slot pressure is ever reported.
