### PR TITLE
fix(terminal): re-pin scrolled viewport after inline TUI clears and replays scrollback

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -139,6 +139,7 @@ export function createPaneDOM(
     compositionHandler: null,
     focusClassSyncCleanup: null,
     terminalScrollIntentDisposable: null,
+    terminalScrollIntentAppReplayRepinDisposable: null,
     linkifierMouseLeaveResetDisposable: null,
     arabicShapingJoinerCleanup: null,
     pendingSplitScrollState: null,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -615,7 +615,9 @@ describe('openTerminal — addon and provider wiring', () => {
     openTerminal(pane)
     const disposable = pane.linkifierHoverResetDisposable
     expect(disposable?.dispose).toBeTypeOf('function')
-    expect(pane.terminal.onWriteParsed).toHaveBeenCalledTimes(1)
+    // Two onWriteParsed consumers: the linkifier hover reset and the
+    // app-replay scroll repin (terminal-scroll-intent-app-replay-repin.ts).
+    expect(pane.terminal.onWriteParsed).toHaveBeenCalledTimes(2)
 
     const disposeSpy = vi.spyOn(disposable!, 'dispose')
     disposePane(pane, new Map([[pane.id, pane]]))

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -9,6 +9,7 @@ import { cancelDeferredScrollRestore } from './pane-scroll'
 import { activateOrcaTerminalUnicodeProvider } from '../../../../shared/terminal-unicode-provider'
 import { attachTerminalMouseWheelMultiplier } from './pane-terminal-mouse-wheel'
 import { attachTerminalScrollIntentTracking } from './terminal-scroll-intent-dom-tracking'
+import { attachTerminalScrollIntentAppReplayRepin } from './terminal-scroll-intent-app-replay-repin'
 import {
   installTerminalLinkifierHoverResetOnMouseLeave,
   installTerminalLinkifierHoverResetOnWindowBlur
@@ -61,6 +62,10 @@ export function openTerminal(pane: ManagedPaneInternal): void {
     xtermContainer,
     pane.leafId
   )
+  // Why: inline TUIs (OMP, Pi) repaint on width change by clearing scrollback
+  // and replaying — see terminal-scroll-intent-app-replay-repin.ts (#8715).
+  pane.terminalScrollIntentAppReplayRepinDisposable =
+    attachTerminalScrollIntentAppReplayRepin(terminal)
   // Why: a link streamed into a visible pane under a stationary pointer would
   // otherwise stay un-underlined/un-clickable until the mouse crosses to a new
   // line; invalidate the linkifier hover cache when output lands so the next
@@ -193,6 +198,8 @@ export function disposePane(
   pane.focusClassSyncCleanup = null
   pane.terminalScrollIntentDisposable?.dispose()
   pane.terminalScrollIntentDisposable = null
+  pane.terminalScrollIntentAppReplayRepinDisposable?.dispose()
+  pane.terminalScrollIntentAppReplayRepinDisposable = null
   pane.linkifierHoverResetDisposable?.dispose()
   pane.linkifierHoverResetDisposable = null
   pane.linkifierMouseLeaveResetDisposable?.dispose()

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -176,6 +176,9 @@ export type ManagedPaneInternal = {
   focusClassSyncCleanup?: (() => void) | null
   // Stored so disposePane() can remove user-scroll intent listeners.
   terminalScrollIntentDisposable?: IDisposable | null
+  // Stored so disposePane() can detach the app-replay repin watcher that
+  // restores a pinned viewport after a TUI clears and replays scrollback.
+  terminalScrollIntentAppReplayRepinDisposable?: IDisposable | null
   // Stored so disposePane() can detach the streamed-output hover-cache reset
   // that keeps freshly printed links linkifiable without a scroll.
   linkifierHoverResetDisposable?: IDisposable | null

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-app-replay-repin.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-app-replay-repin.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { Terminal } from '@xterm/headless'
+import { attachTerminalScrollIntentAppReplayRepin } from './terminal-scroll-intent-app-replay-repin'
+import {
+  getTerminalScrollIntentKind,
+  markTerminalPinnedViewport,
+  syncTerminalScrollIntentFromViewport
+} from './terminal-scroll-intent'
+import type { IDisposable } from '@xterm/xterm'
+
+type RepinTerminal = Parameters<typeof attachTerminalScrollIntentAppReplayRepin>[0]
+
+let disposables: IDisposable[] = []
+let terminals: Terminal[] = []
+
+beforeEach(() => {
+  vi.useFakeTimers()
+})
+
+afterEach(() => {
+  for (const disposable of disposables) {
+    disposable.dispose()
+  }
+  disposables = []
+  for (const terminal of terminals) {
+    terminal.dispose()
+  }
+  terminals = []
+  vi.useRealTimers()
+})
+
+function makeTerminal(): Terminal {
+  const term = new Terminal({ cols: 80, rows: 24, scrollback: 1000, allowProposedApi: true })
+  terminals.push(term)
+  return term
+}
+
+function attach(term: Terminal): void {
+  disposables.push(attachTerminalScrollIntentAppReplayRepin(term as unknown as RepinTerminal))
+}
+
+// xterm's write queue schedules on the same (faked) clock; advance it so the
+// chunk parses, then await the parse callback.
+async function writeChunk(term: Terminal, data: string): Promise<void> {
+  const parsed = new Promise<void>((resolve) => term.write(data, resolve))
+  await vi.advanceTimersByTimeAsync(20)
+  await parsed
+}
+
+async function settle(): Promise<void> {
+  await vi.advanceTimersByTimeAsync(500)
+}
+
+function conversationLines(count: number, tag: string): string {
+  let out = ''
+  for (let i = 0; i < count; i++) {
+    out += `${tag} line ${i}\r\n`
+  }
+  return out
+}
+
+async function pinScrolledUpConversation(term: Terminal, line: number): Promise<void> {
+  await writeChunk(term, conversationLines(200, 'msg'))
+  term.scrollToLine(line)
+  markTerminalPinnedViewport(term)
+  syncTerminalScrollIntentFromViewport(term, { allowBufferShrink: true })
+}
+
+// pi-tui's width-change repaint: home + clear scrollback, then a full replay
+// of the conversation (#8715). The clear clamps a scrolled-up viewport to
+// line 0 and xterm keeps it there while the replay appends below.
+describe('attachTerminalScrollIntentAppReplayRepin', () => {
+  it('re-pins a scrolled-up viewport after a clear-scrollback replay', async () => {
+    const term = makeTerminal()
+    attach(term)
+    await pinScrolledUpConversation(term, 50)
+    expect(term.buffer.active.viewportY).toBe(50)
+
+    await writeChunk(term, '\x1b[H\x1b[3J')
+    await writeChunk(term, conversationLines(200, 'replay'))
+    expect(term.buffer.active.viewportY).toBe(0)
+
+    await settle()
+    expect(term.buffer.active.viewportY).toBe(50)
+    expect(getTerminalScrollIntentKind(term)).toBe('pinnedViewport')
+  })
+
+  it('keeps a bottom-following viewport at the bottom', async () => {
+    const term = makeTerminal()
+    attach(term)
+    await writeChunk(term, conversationLines(200, 'msg'))
+    expect(term.buffer.active.viewportY).toBe(term.buffer.active.baseY)
+
+    await writeChunk(term, '\x1b[H\x1b[3J')
+    await writeChunk(term, conversationLines(220, 'replay'))
+    await settle()
+
+    const buf = term.buffer.active
+    expect(buf.viewportY).toBe(buf.baseY)
+    expect(getTerminalScrollIntentKind(term)).toBe('followOutput')
+  })
+
+  it('does not touch a viewport deliberately pinned at the top', async () => {
+    const term = makeTerminal()
+    attach(term)
+    await pinScrolledUpConversation(term, 0)
+    expect(term.buffer.active.viewportY).toBe(0)
+
+    await writeChunk(term, conversationLines(5, 'more'))
+    await settle()
+    expect(term.buffer.active.viewportY).toBe(0)
+  })
+
+  it('leaves alt-screen TUIs alone', async () => {
+    const term = makeTerminal()
+    attach(term)
+    await pinScrolledUpConversation(term, 50)
+
+    // Full-screen overlay: enter alt, repaint frames there.
+    await writeChunk(term, '\x1b[?1049h\x1b[2J\x1b[Hoverlay frame')
+    await writeChunk(term, '\x1b[Hoverlay frame 2')
+    await settle()
+    expect(term.buffer.active.type).toBe('alternate')
+    expect(term.buffer.active.viewportY).toBe(0)
+
+    // Overlay closes: back to the normal buffer, pin intact without a replay.
+    await writeChunk(term, '\x1b[?1049l')
+    await settle()
+    expect(term.buffer.active.type).toBe('normal')
+    expect(term.buffer.active.viewportY).toBe(50)
+  })
+
+  it('caps the settle window under a continuous replay stream', async () => {
+    const term = makeTerminal()
+    attach(term)
+    await pinScrolledUpConversation(term, 50)
+
+    await writeChunk(term, '\x1b[H\x1b[3J')
+    // Chunks arriving faster than the debounce, for longer than the cap: the
+    // repin must not starve.
+    for (let i = 0; i < 20; i++) {
+      const parsed = new Promise<void>((resolve) =>
+        term.write(conversationLines(10, `stream${i}`), resolve)
+      )
+      await vi.advanceTimersByTimeAsync(40)
+      await parsed
+    }
+    await settle()
+    expect(term.buffer.active.viewportY).toBe(50)
+  })
+
+  it('stops re-pinning after dispose', async () => {
+    const term = makeTerminal()
+    const disposable = attachTerminalScrollIntentAppReplayRepin(term as unknown as RepinTerminal)
+    await pinScrolledUpConversation(term, 50)
+
+    disposable.dispose()
+    await writeChunk(term, '\x1b[H\x1b[3J')
+    await writeChunk(term, conversationLines(200, 'replay'))
+    await settle()
+    expect(term.buffer.active.viewportY).toBe(0)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent-app-replay-repin.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent-app-replay-repin.ts
@@ -1,0 +1,101 @@
+import type { IDisposable, Terminal } from '@xterm/xterm'
+import { enforceTerminalCurrentScrollIntent, readStoredIntent } from './terminal-scroll-intent'
+import { isTerminalScrollIntentRebuildInFlight } from './terminal-scroll-intent-rebuild'
+import { readTerminalScrollBufferSnapshot } from './terminal-scroll-buffer-snapshot'
+
+// Debounce to the end of the replay burst: full-conversation repaints arrive
+// as several parsed chunks over one PTY round-trip. The cap bounds how long a
+// continuously streaming app can hold the viewport at the wrong line.
+const REPLAY_SETTLE_MS = 64
+const REPLAY_SETTLE_CAP_MS = 400
+
+/**
+ * Re-enforce a pinned viewport after an app-driven scrollback rebuild.
+ *
+ * Why: inline TUIs that keep their transcript in the normal buffer (OMP, Pi)
+ * repaint on width change by clearing scrollback (`ESC[H ESC[3J`) and
+ * replaying every row. The clear clamps a scrolled-up viewport to line 0 and
+ * xterm keeps it there while the replay appends below — the user lands at the
+ * TOP of the conversation (#8715). The stored scroll intent survives (its
+ * shrink guards were built for exactly this transient), but nothing re-applied
+ * it: reveal-time enforcement runs before the repaint's bytes arrive, and
+ * Orca's rebuild bracket only covers replays Orca itself initiates.
+ *
+ * Detection compares the durable stored pin against the live viewport: parsed
+ * output that leaves a pinned terminal at the hard top arms a settle-debounced
+ * re-enforcement. User gestures during the settle window stay authoritative —
+ * they rewrite the stored intent, and the enforcement applies whatever intent
+ * is current at fire time (a deliberate wheel to the top degrades to a no-op).
+ */
+export function attachTerminalScrollIntentAppReplayRepin(terminal: Terminal): IDisposable {
+  // Why: never let this break pane creation if a Terminal stub or a future
+  // xterm build lacks onWriteParsed — the pin then stays lost on app replays,
+  // as it did before this watcher existed.
+  if (typeof terminal.onWriteParsed !== 'function') {
+    return { dispose: () => undefined }
+  }
+  let settleTimer: ReturnType<typeof setTimeout> | null = null
+  let firstYankAtMs: number | null = null
+
+  const clearPending = (): void => {
+    if (settleTimer !== null) {
+      clearTimeout(settleTimer)
+      settleTimer = null
+    }
+    firstYankAtMs = null
+  }
+
+  const yankedPinnedViewport = (): boolean => {
+    // Orca's own structural replays bracket themselves and re-apply intent
+    // when they complete; never double-enforce underneath one.
+    if (isTerminalScrollIntentRebuildInFlight(terminal)) {
+      return false
+    }
+    // Why: the durable stored pin, not live-derived state — with an idle
+    // agent no output lands between the user's scroll and the replay, so any
+    // watcher-local memory of the pin would never have been primed.
+    const stored = readStoredIntent(terminal)
+    if (stored?.kind !== 'pinnedViewport' || stored.bufferType !== 'normal') {
+      return false
+    }
+    const live = readTerminalScrollBufferSnapshot(terminal)
+    // Why: the hard top is the clear's clamp target; a pin recorded at the top
+    // is already where the user wants to be. Alt-screen owns its own viewport.
+    return (
+      live !== null && live.bufferType === 'normal' && live.viewportY === 0 && stored.viewportY > 0
+    )
+  }
+
+  const fire = (): void => {
+    settleTimer = null
+    firstYankAtMs = null
+    if (yankedPinnedViewport()) {
+      enforceTerminalCurrentScrollIntent(terminal)
+    }
+  }
+
+  const writeParsedDisposable = terminal.onWriteParsed(() => {
+    if (!yankedPinnedViewport()) {
+      clearPending()
+      return
+    }
+    const now = Date.now()
+    firstYankAtMs ??= now
+    if (settleTimer !== null) {
+      // Why: an unbounded per-chunk debounce would let a continuously
+      // streaming replay starve the restore; stop extending at the cap.
+      if (now - firstYankAtMs >= REPLAY_SETTLE_CAP_MS) {
+        return
+      }
+      clearTimeout(settleTimer)
+    }
+    settleTimer = setTimeout(fire, REPLAY_SETTLE_MS)
+  })
+
+  return {
+    dispose: () => {
+      clearPending()
+      writeParsedDisposable.dispose()
+    }
+  }
+}

--- a/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-scroll-intent.ts
@@ -21,7 +21,7 @@ export type TerminalScrollIntentTarget = {
 
 export type TerminalScrollIntentKey = string
 
-type TerminalScrollIntent = {
+export type TerminalScrollIntent = {
   kind: TerminalScrollIntentKind
   bufferType: TerminalScrollBufferType
   viewportY: number
@@ -100,13 +100,15 @@ function writeIntentSnapshot(
   return intent
 }
 
-function readStoredIntent(terminal: TerminalScrollIntentTarget): TerminalScrollIntent | undefined {
-  const terminalIntent = terminalScrollIntentByTerminal.get(terminal)
-  if (terminalIntent) {
-    return terminalIntent
-  }
-  const key = terminalScrollIntentKeyByTerminal.get(terminal)
-  return key ? terminalScrollIntentByKey.get(key) : undefined
+// Exported read-only: the app-replay repin watcher compares the durable stored
+// pin against the live viewport to detect an output-driven yank. Only this
+// module's write paths may mutate the returned object.
+export function readStoredIntent(
+  terminal: TerminalScrollIntentTarget
+): TerminalScrollIntent | undefined {
+  const direct = terminalScrollIntentByTerminal.get(terminal)
+  const key = direct ? undefined : terminalScrollIntentKeyByTerminal.get(terminal)
+  return direct ?? (key ? terminalScrollIntentByKey.get(key) : undefined)
 }
 
 export function bindTerminalScrollIntentKey(


### PR DESCRIPTION
**What:** A viewport scrolled up in an inline TUI (OMP, Pi) no longer snaps to the top of the conversation on tab switches, pane resizes, or large redraws — the terminal re-pins to the user's reading position once the repaint settles.
**Risk:** Additive per-pane watcher reusing the existing intent enforcement; alt-screen TUIs, top-pinned viewports, and Orca's own structural replays are explicitly left alone; the split-path alt-screen skip (#1298) is untouched.
**State:** Based on current `main`; tsc/lint clean; 6 new tests driving real headless xterm; pane-manager + terminal-pane suites green (304 files / 3786 tests).

---

Fixes #8715.

## Root cause (revised from the repro kit)

@nwparker's handoff kit was the entry point — but the alt-screen early-return it documents turned out not to be the mechanism. OMP/Pi keep their transcript in the **normal buffer** (pi-tui borrows the alternate screen only while a fullscreen overlay is up), and their width-change repaint emits `ESC[H ESC[3J` — **clearing xterm's scrollback** — then replays every row.

Traced with real headless xterm against the exact byte sequences from pi-tui's source:

| step | baseY | viewportY |
|---|---|---|
| conversation in scrollback | 177 | 177 |
| user scrolls up (intent pinned) | 177 | 50 |
| `ESC[H ESC[3J` | 0 | 0 |
| replay parses | 177 | **0 — stranded at the top** |

The stored scroll intent **survives** the transient (its shrink guards were built for cleared-buffer replays), but nothing re-applied it:

- reveal-time enforcement (`resumeTerminalVisibility` → `enforceTerminalViewportIntents`) runs before the PTY round-trip delivers the resize-triggered repaint;
- the structural-rebuild bracket (`terminal-scroll-intent-rebuild.ts`) only covers replays Orca itself initiates.

This also explains the second report on the issue (Pi on Windows 11: viewport jumps to top "during long model output / large redraws" and "after pane/tab size changes") — those are the same strategy-2 full repaints landing while the pane is visible, where no reveal hook exists at all.

## Fix

`terminal-scroll-intent-app-replay-repin.ts`: a per-pane `onWriteParsed` watcher. When parsed output leaves a terminal with a durable **pinned** intent sitting at the hard top, it arms a settle-debounced (64ms, 400ms starvation cap) re-run of the **existing** `enforceTerminalCurrentScrollIntent`. Because detection is output-driven rather than reveal-scoped, it covers the tab-switch case and the visible-redraw case with one mechanism.

Correctness anchors:
- **User gestures stay authoritative** — they rewrite the stored intent, and the enforcement applies whatever intent is current at fire time; a deliberate wheel to the top degrades to a no-op scroll.
- **Alt-screen buffers are never scrolled** (vim/less/OMP overlays own their viewport); the `#1298` guard in the split path is not weakened.
- **Orca's own structural replays are skipped** — they bracket themselves and re-apply intent on completion.
- Detection reads the durable stored intent, not watcher-local state, so an idle agent (scroll up, then immediately switch tabs with no output in between) is still recovered — the test suite caught exactly this hole in an earlier design.

Wired in `pane-lifecycle.ts` beside the existing scroll-intent tracking; disposed with the pane. One keyword-level export (`readStoredIntent` + its type) from `terminal-scroll-intent.ts`.

## Tests

`terminal-scroll-intent-app-replay-repin.test.ts` — fake-timer tests driving the real xterm parser + intent modules end to end:
- re-pins a scrolled-up viewport after a clear-scrollback replay
- keeps a bottom-following viewport at the bottom
- leaves a deliberately top-pinned viewport alone
- leaves alt-screen TUIs alone (overlay enter/exit round-trip)
- caps the settle window under a continuous replay stream
- stops re-pinning after dispose

`pane-lifecycle.test.ts` updated for the second `onWriteParsed` consumer.
