### PR TITLE
feat(worktrees): add fork and child creation actions

### DIFF
--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -214,31 +214,43 @@ function recordWorkspaceLineageForCreatedWorktree(
   args: CreateWorktreeArgs,
   worktree: Worktree,
   createdAt: number
-): CreateWorktreeResult['workspaceLineage'] {
+): Pick<CreateWorktreeResult, 'lineage' | 'workspaceLineage'> {
   if (!args.parentWorkspace || !worktree.instanceId) {
-    return null
+    return { lineage: null, workspaceLineage: null }
   }
   const childWorkspaceKey = worktreeWorkspaceKey(worktree.id)
   if (args.parentWorkspace === childWorkspaceKey) {
     console.warn(`[worktree-create] refusing to attach ${worktree.id} to itself`)
-    return null
+    return { lineage: null, workspaceLineage: null }
   }
   const parentScope = parseWorkspaceKey(args.parentWorkspace)
   if (!parentScope) {
     console.warn(`[worktree-create] ignoring invalid parent workspace ${args.parentWorkspace}`)
-    return null
+    return { lineage: null, workspaceLineage: null }
   }
   if (parentScope.type === 'folder' && !store.getFolderWorkspace(parentScope.folderWorkspaceId)) {
     console.warn(`[worktree-create] parent folder workspace disappeared: ${args.parentWorkspace}`)
-    return null
+    return { lineage: null, workspaceLineage: null }
   }
   const parentWorktreeMeta =
     parentScope.type === 'worktree' ? store.getWorktreeMeta(parentScope.worktreeId) : null
   if (parentScope.type === 'worktree' && !parentWorktreeMeta) {
     console.warn(`[worktree-create] parent worktree workspace disappeared: ${args.parentWorkspace}`)
-    return null
+    return { lineage: null, workspaceLineage: null }
   }
-  return store.setWorkspaceLineage({
+  const lineage =
+    parentScope.type === 'worktree' && parentWorktreeMeta?.instanceId
+      ? store.setWorktreeLineage(worktree.id, {
+          worktreeId: worktree.id,
+          worktreeInstanceId: worktree.instanceId,
+          parentWorktreeId: parentScope.worktreeId,
+          parentWorktreeInstanceId: parentWorktreeMeta.instanceId,
+          origin: 'manual',
+          capture: { source: 'active-workspace', confidence: 'explicit' },
+          createdAt
+        })
+      : null
+  const workspaceLineage = store.setWorkspaceLineage({
     childWorkspaceKey,
     childInstanceId: worktree.instanceId,
     parentWorkspaceKey: args.parentWorkspace,
@@ -247,6 +259,7 @@ function recordWorkspaceLineageForCreatedWorktree(
     capture: { source: 'active-workspace', confidence: 'explicit' },
     createdAt
   })
+  return { lineage, workspaceLineage }
 }
 
 function countNonEmptyGitOutputLines(output: string): number {
@@ -1485,7 +1498,8 @@ export async function createRemoteWorktree(
   args: CreateWorktreeArgsWithSystemProvenance,
   repo: Repo,
   store: Store,
-  mainWindow: BrowserWindow
+  mainWindow: BrowserWindow,
+  runtime?: OrcaRuntimeService
 ): Promise<CreateWorktreeResult> {
   const timing = createWorktreeCreateTimingRecorder()
   const provider = requireSshGitProvider(repo.connectionId!)
@@ -1833,7 +1847,13 @@ export async function createRemoteWorktree(
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
     return { worktree: mergeWorktree(repo.id, created, meta) }
   })
-  const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
+  const { lineage, workspaceLineage } = recordWorkspaceLineageForCreatedWorktree(
+    store,
+    args,
+    worktree,
+    now
+  )
+  runtime?.invalidateWorktreeCachesForRepo(repo.id)
 
   // Why: shared/symlink paths, `orca.yaml` shared directories, and `.worktreeinclude` copies are local-only; remote (SSH) support needs a new relay method + auth surface, so all are skipped here.
 
@@ -1880,7 +1900,12 @@ export async function createRemoteWorktree(
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
-    worktree: { ...worktree, workspaceLineage },
+    worktree: {
+      ...worktree,
+      ...(lineage ? { parentWorktreeId: lineage.parentWorktreeId, lineage } : {}),
+      workspaceLineage
+    },
+    ...(lineage ? { lineage } : {}),
     ...(workspaceLineage ? { workspaceLineage } : {}),
     ...(setup ? { setup } : {}),
     ...(defaultTabs ? { defaultTabs } : {}),
@@ -2441,7 +2466,13 @@ export async function createLocalWorktree(
     const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
     return { worktree: mergeWorktree(repo.id, created, meta) }
   })
-  const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
+  const { lineage, workspaceLineage } = recordWorkspaceLineageForCreatedWorktree(
+    store,
+    args,
+    worktree,
+    now
+  )
+  runtime?.invalidateWorktreeCachesForRepo(repo.id)
   // Why: reuse the roots creation already paid for via `git worktree list` so later IPC doesn't lazily rescan and trip macOS privacy prompts.
   registerWorktreeRootsForRepo(store, repo.id, [
     repo.path,
@@ -2544,7 +2575,12 @@ export async function createLocalWorktree(
 
   notifyWorktreesChanged(mainWindow, repo.id)
   return {
-    worktree: { ...worktree, workspaceLineage },
+    worktree: {
+      ...worktree,
+      ...(lineage ? { parentWorktreeId: lineage.parentWorktreeId, lineage } : {}),
+      workspaceLineage
+    },
+    ...(lineage ? { lineage } : {}),
     ...(workspaceLineage ? { workspaceLineage } : {}),
     ...(stagedStartup.activationSetup
       ? { setup: stagedStartup.activationSetup }

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -309,6 +309,9 @@ describe('registerWorktreeHandlers', () => {
     getWorktreeMeta: vi.fn(),
     getAllWorktreeMeta: vi.fn(),
     setWorktreeMeta: vi.fn(),
+    setWorktreeLineage: vi.fn(),
+    setWorkspaceLineage: vi.fn(),
+    getFolderWorkspace: vi.fn(),
     getProjectHostSetups: vi.fn(),
     removeWorktreeMeta: vi.fn(),
     removeWorkspaceSessionStateForWorktree: vi.fn(),
@@ -332,6 +335,7 @@ describe('registerWorktreeHandlers', () => {
     createTerminal: ReturnType<typeof vi.fn>
     splitTerminal: ReturnType<typeof vi.fn>
     notifyWorktreesChangedForRemoteClients: ReturnType<typeof vi.fn>
+    invalidateWorktreeCachesForRepo: ReturnType<typeof vi.fn>
     closeFileWatchersForRemoval: ReturnType<typeof vi.fn>
     acquireFileWatcherRemoval: ReturnType<typeof vi.fn>
     hydrateInferredWorktreeLineage: ReturnType<typeof vi.fn>
@@ -392,6 +396,9 @@ describe('registerWorktreeHandlers', () => {
       store.getWorktreeMeta,
       store.getAllWorktreeMeta,
       store.setWorktreeMeta,
+      store.setWorktreeLineage,
+      store.setWorkspaceLineage,
+      store.getFolderWorkspace,
       store.getProjectHostSetups,
       store.removeWorktreeMeta,
       store.removeWorkspaceSessionStateForWorktree,
@@ -449,6 +456,9 @@ describe('registerWorktreeHandlers', () => {
     store.getWorktreeMeta.mockReturnValue(undefined)
     store.getAllWorktreeMeta.mockReturnValue({})
     store.setWorktreeMeta.mockReturnValue({})
+    store.setWorktreeLineage.mockImplementation((_worktreeId, lineage) => lineage)
+    store.setWorkspaceLineage.mockImplementation((lineage) => lineage)
+    store.getFolderWorkspace.mockReturnValue(undefined)
     store.getProjectHostSetups.mockReturnValue([
       {
         id: 'repo-1',
@@ -557,6 +567,7 @@ describe('registerWorktreeHandlers', () => {
         paneRuntimeId: -1
       }),
       notifyWorktreesChangedForRemoteClients: vi.fn(),
+      invalidateWorktreeCachesForRepo: vi.fn(),
       closeFileWatchersForRemoval: vi.fn().mockResolvedValue(undefined),
       acquireFileWatcherRemoval: vi.fn(),
       hydrateInferredWorktreeLineage: vi.fn().mockResolvedValue(undefined)
@@ -896,6 +907,54 @@ describe('registerWorktreeHandlers', () => {
     )?.[1]
     expect(persistedMeta).toBeDefined()
     expect(persistedMeta).not.toHaveProperty('automationProvenance')
+  })
+
+  it('records worktree and workspace lineage when creating a child worktree', async () => {
+    const parentId = 'repo-1::/workspace/repo'
+    const childId = 'repo-1::/workspace/child-feature'
+    store.getWorktreeMeta.mockImplementation((worktreeId) =>
+      worktreeId === parentId ? { instanceId: 'parent-instance' } : undefined
+    )
+    store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => ({
+      ...meta,
+      instanceId: 'child-instance'
+    }))
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/child-feature',
+        head: 'abc123',
+        branch: 'child-feature',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    const result = (await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'child-feature',
+      parentWorkspace: `worktree:${parentId}`
+    })) as CreateWorktreeResult
+
+    expect(store.setWorktreeLineage).toHaveBeenCalledWith(
+      childId,
+      expect.objectContaining({
+        worktreeId: childId,
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: parentId,
+        parentWorktreeInstanceId: 'parent-instance'
+      })
+    )
+    expect(store.setWorkspaceLineage).toHaveBeenCalledWith(
+      expect.objectContaining({
+        childWorkspaceKey: `worktree:${childId}`,
+        childInstanceId: 'child-instance',
+        parentWorkspaceKey: `worktree:${parentId}`,
+        parentInstanceId: 'parent-instance'
+      })
+    )
+    expect(runtimeStub.invalidateWorktreeCachesForRepo).toHaveBeenCalledWith('repo-1')
+    expect(result.worktree.parentWorktreeId).toBe(parentId)
+    expect(result.lineage).toBe(result.worktree.lineage)
   })
 
   it('auto-suffixes the branch name when the first choice collides with a remote branch', async () => {
@@ -4555,14 +4614,22 @@ describe('registerWorktreeHandlers', () => {
       request: vi.fn().mockResolvedValue(undefined),
       notify: vi.fn()
     }
-    store.getRepos.mockReturnValue([repo])
-    store.getRepo.mockReturnValue(repo)
+    const localRepo = {
+      ...repo,
+      path: '/local/repo',
+      displayName: 'local',
+      connectionId: undefined,
+      executionHostId: 'local' as const
+    }
+    store.getRepos.mockReturnValue([localRepo, repo])
+    store.getRepo.mockReturnValue(localRepo)
     getSshGitProviderMock.mockReturnValue(provider)
     getActiveMultiplexerMock.mockReturnValue(mux)
     store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
 
     const result = await handlers['worktrees:create'](null, {
       repoId: 'repo-ssh',
+      executionHostId: 'ssh:conn-1',
       name: 'improve-dashboard',
       linkedIssue: 123,
       linkedPR: 456,

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -2176,7 +2176,9 @@ export function registerWorktreeHandlers(
       const args = normalizeLinkedWorkItemFields(rawArgs)
       // Why span here: parent the child git spans for the trace tree; don't attach branch name/remote URL (user content) — repo ID is the safer correlator.
       return withWorktreeSpan({ stage: 'create' }, async () => {
-        const repo = store.getRepo(args.repoId)
+        const repo = args.executionHostId
+          ? findExactRepoOwner(store, args.repoId, args.executionHostId)
+          : store.getRepo(args.repoId)
         if (!repo) {
           throw new Error(`Repo not found: ${args.repoId}`)
         }
@@ -2201,7 +2203,7 @@ export function registerWorktreeHandlers(
           result = isFolderRepo(repo)
             ? createFolderWorkspace(createArgs, repo, store)
             : repo.connectionId
-              ? await createRemoteWorktree(createArgs, repo, store, mainWindow)
+              ? await createRemoteWorktree(createArgs, repo, store, mainWindow, runtime)
               : await createLocalWorktree(createArgs, repo, store, mainWindow, runtime)
         } catch (error) {
           releaseAutomationWorkspaceProvenanceRequest(args.automationProvenanceRequest)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -37982,6 +37982,71 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenCalledTimes(1)
   })
 
+  it('worktree scan cache: does not prune lineage from a cached pre-create scan', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const childId = `${TEST_REPO_ID}::/tmp/worktree-child`
+    const lineageById: Record<string, WorktreeLineage> = {}
+    const removeWorktreeLineage = vi.fn((worktreeId: string) => {
+      delete lineageById[worktreeId]
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeLineage: () => lineageById,
+      removeWorktreeLineage
+    } as never)
+
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    lineageById[childId] = {
+      worktreeId: childId,
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: TEST_WORKTREE_ID,
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 1
+    }
+    await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+
+    expect(listWorktrees).toHaveBeenCalledTimes(1)
+    expect(removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(lineageById[childId]).toBeTruthy()
+  })
+
+  it('worktree scan cache: does not prune lineage from an invalidated in-flight scan', async () => {
+    vi.mocked(listWorktrees).mockClear()
+    const childId = `${TEST_REPO_ID}::/tmp/worktree-child`
+    const pending = deferred<ReturnType<typeof makeWorktreeInfo>[]>()
+    const lineageById: Record<string, WorktreeLineage> = {
+      [childId]: {
+        worktreeId: childId,
+        worktreeInstanceId: 'child-instance',
+        parentWorktreeId: TEST_WORKTREE_ID,
+        parentWorktreeInstanceId: 'parent-instance',
+        origin: 'manual',
+        capture: { source: 'manual-action', confidence: 'explicit' },
+        createdAt: 1
+      }
+    }
+    const removeWorktreeLineage = vi.fn((worktreeId: string) => {
+      delete lineageById[worktreeId]
+    })
+    vi.mocked(listWorktrees).mockReturnValueOnce(pending.promise)
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getAllWorktreeLineage: () => lineageById,
+      removeWorktreeLineage
+    } as never)
+
+    const detected = runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+    await Promise.resolve()
+    runtime.notifyWorktreesChangedForRemoteClients(TEST_REPO_ID)
+    pending.resolve([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+    await detected
+
+    expect(removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(lineageById[childId]).toBeTruthy()
+  })
+
   it('worktree scan cache: rescans immediately after worktree invalidation', async () => {
     vi.mocked(listWorktrees).mockClear()
     const runtime = createRuntime()
@@ -38015,14 +38080,14 @@ describe('OrcaRuntimeService', () => {
     expect(listWorktrees).toHaveBeenNthCalledWith(3, '/tmp/repo-a')
   })
 
-  it('worktree scan cache: metadata invalidation preserves raw scans', async () => {
+  it('worktree scan cache: worktree changes invalidate raw scans', async () => {
     vi.mocked(listWorktrees).mockClear()
     const runtime = createRuntime()
     await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
     runtime.notifyWorktreesChangedForRemoteClients(TEST_REPO_ID)
     await runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
 
-    expect(listWorktrees).toHaveBeenCalledTimes(1)
+    expect(listWorktrees).toHaveBeenCalledTimes(2)
   })
 
   // #11994: the host renderer already applied its own repos:changed, so re-notifying it
@@ -43880,6 +43945,37 @@ describe('OrcaRuntimeService', () => {
 
       expect(worktree.id).toBe(`${TEST_REPO_ID}::${duplicatePath}`)
       expect(worktree.path).toBe(duplicatePath)
+    } finally {
+      getRepos.mockRestore()
+    }
+  })
+
+  it('resolves duplicate repo ids by execution host', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const getRepos = vi.spyOn(store, 'getRepos').mockReturnValue([
+      {
+        id: TEST_REPO_ID,
+        path: TEST_REPO_PATH,
+        displayName: 'local repo',
+        badgeColor: 'blue',
+        addedAt: 1
+      },
+      {
+        id: TEST_REPO_ID,
+        path: '/srv/nested/repo',
+        displayName: 'nested repo',
+        badgeColor: 'red',
+        addedAt: 2,
+        connectionId: 'nested-host'
+      }
+    ] as never)
+
+    try {
+      await expect(runtime.showRepo(TEST_REPO_ID)).rejects.toThrow('selector_ambiguous')
+      await expect(runtime.showRepo(TEST_REPO_ID, 'ssh:nested-host')).resolves.toMatchObject({
+        path: '/srv/nested/repo',
+        connectionId: 'nested-host'
+      })
     } finally {
       getRepos.mockRestore()
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2081,6 +2081,23 @@ function runtimeRepoMatchesExecutionHost(
   return repo.connectionId == null
 }
 
+function runtimeRepoMatchesResolvedExecutionHost(
+  repo: Pick<Repo, 'connectionId' | 'executionHostId'>,
+  executionHostId?: ExecutionHostId | null
+): boolean {
+  if (executionHostId == null) {
+    return true
+  }
+  if (repo.executionHostId != null) {
+    return repo.executionHostId === executionHostId
+  }
+  const parsedHost = parseExecutionHostId(executionHostId)
+  if (parsedHost?.kind === 'ssh') {
+    return repo.connectionId === parsedHost.targetId
+  }
+  return repo.connectionId == null
+}
+
 // Why: this runtime only has local git and local fs, so an ssh: host here would clone and
 // probe the wrong machine and then register the result as remote. SSH setup is owned by the
 // desktop IPC path (addRemoteRepoFromPath / cloneRemoteRepo), which the renderer routes to;
@@ -2572,8 +2589,8 @@ type WorktreeLineageResolution =
     }
 
 type RuntimeWorktreeScanResult =
-  | { ok: true; worktrees: GitWorktreeInfo[] }
-  | { ok: false; worktrees: GitWorktreeInfo[] }
+  | { ok: true; worktrees: GitWorktreeInfo[]; authoritativeForPrune?: boolean }
+  | { ok: false; worktrees: GitWorktreeInfo[]; authoritativeForPrune?: boolean }
 
 type RuntimeWorktreeScanCache = {
   generation: number
@@ -5290,7 +5307,7 @@ export class OrcaRuntimeService {
   // notifier (the renderer already applied them optimistically), but remote
   // clients hold no optimistic copy and need the invalidation event.
   notifyWorktreesChangedForRemoteClients(repoId: string): void {
-    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeCachesForRepo(repoId)
     this.emitClientEvent({ type: 'worktreesChanged', repoId })
   }
 
@@ -5299,6 +5316,11 @@ export class OrcaRuntimeService {
   // got its own repos:changed and must not be re-notified (#11994).
   notifyReposChangedForRemoteClients(): void {
     this.emitClientEvent({ type: 'reposChanged' })
+  }
+
+  invalidateWorktreeCachesForRepo(repoId: string): void {
+    this.invalidateResolvedWorktreeCache()
+    this.invalidateWorktreeScanCacheForRepo(repoId)
   }
 
   private notifyActivateWorktree(
@@ -18775,8 +18797,8 @@ export class OrcaRuntimeService {
     return this.store.getRepo(repo.id) ?? repo
   }
 
-  async showRepo(repoSelector: string): Promise<Repo> {
-    return await this.resolveRepoSelector(repoSelector)
+  async showRepo(repoSelector: string, executionHostId?: ExecutionHostId): Promise<Repo> {
+    return await this.resolveRepoSelector(repoSelector, executionHostId)
   }
 
   async setRepoBaseRef(repoSelector: string, baseRef: string): Promise<Repo> {
@@ -20311,8 +20333,8 @@ export class OrcaRuntimeService {
     }
   }
 
-  async checkRepoHooks(repoSelector: string) {
-    const repo = await this.resolveRepoSelector(repoSelector)
+  async checkRepoHooks(repoSelector: string, executionHostId?: ExecutionHostId) {
+    const repo = await this.resolveRepoSelector(repoSelector, executionHostId)
     if (isFolderRepo(repo)) {
       return { status: 'ok' as const, hasHooks: false, hooks: null, mayNeedUpdate: false }
     }
@@ -20356,8 +20378,8 @@ export class OrcaRuntimeService {
     }
   }
 
-  async inspectRepoSetupScriptImports(repoSelector: string) {
-    const repo = await this.resolveRepoSelector(repoSelector)
+  async inspectRepoSetupScriptImports(repoSelector: string, executionHostId?: ExecutionHostId) {
+    const repo = await this.resolveRepoSelector(repoSelector, executionHostId)
     if (isFolderRepo(repo)) {
       return []
     }
@@ -20388,8 +20410,8 @@ export class OrcaRuntimeService {
     })
   }
 
-  async readRepoIssueCommand(repoSelector: string) {
-    const repo = await this.resolveRepoSelector(repoSelector)
+  async readRepoIssueCommand(repoSelector: string, executionHostId?: ExecutionHostId) {
+    const repo = await this.resolveRepoSelector(repoSelector, executionHostId)
     if (isFolderRepo(repo)) {
       return {
         localContent: null,
@@ -20461,8 +20483,12 @@ export class OrcaRuntimeService {
     }
   }
 
-  async writeRepoIssueCommand(repoSelector: string, content: string): Promise<{ ok: true }> {
-    const repo = await this.resolveRepoSelector(repoSelector)
+  async writeRepoIssueCommand(
+    repoSelector: string,
+    content: string,
+    executionHostId?: ExecutionHostId
+  ): Promise<{ ok: true }> {
+    const repo = await this.resolveRepoSelector(repoSelector, executionHostId)
     if (isFolderRepo(repo)) {
       return { ok: true }
     }
@@ -20608,7 +20634,7 @@ export class OrcaRuntimeService {
     } catch {
       scan = { ok: false, worktrees: [] }
     }
-    if (scan.ok) {
+    if (scan.authoritativeForPrune) {
       this.pruneLineageForMissingRepoWorktrees(repo, scan.worktrees)
     }
     const agentScratchWorktreePathMatcher = createAgentScratchWorktreePathMatcher([
@@ -21388,6 +21414,7 @@ export class OrcaRuntimeService {
 
   async createManagedWorktree(args: {
     repoSelector: string
+    executionHostId?: ExecutionHostId
     name: string
     baseBranch?: string
     compareBaseRef?: string
@@ -21431,7 +21458,7 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
 
-    const repo = await this.resolveRepoSelector(args.repoSelector)
+    const repo = await this.resolveRepoSelector(args.repoSelector, args.executionHostId)
     const createSettings = this.store.getSettings()
     const requestedAgent = args.startupAgent ?? args.createdWithAgent
     const requestedAgentEnabled =
@@ -22580,7 +22607,8 @@ export class OrcaRuntimeService {
       },
       repo,
       this.store as unknown as Store,
-      headlessWindow
+      headlessWindow,
+      this
     )
 
     if (args.comment !== undefined) {
@@ -28407,11 +28435,16 @@ export class OrcaRuntimeService {
     )
   }
 
-  private async resolveRepoSelector(selector: string): Promise<Repo> {
+  private async resolveRepoSelector(
+    selector: string,
+    executionHostId?: ExecutionHostId
+  ): Promise<Repo> {
     if (!this.store) {
       throw new Error('repo_not_found')
     }
-    const candidates = this.selectReposBySelector(selector)
+    const candidates = this.selectReposBySelector(selector).filter((repo) =>
+      runtimeRepoMatchesResolvedExecutionHost(repo, executionHostId)
+    )
 
     if (candidates.length === 1) {
       return candidates[0]
@@ -28571,7 +28604,7 @@ export class OrcaRuntimeService {
             null
           )) ?? { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
         const gitWorktrees = scan.worktrees
-        if (scan.ok) {
+        if (scan.authoritativeForPrune) {
           this.pruneLineageForMissingRepoWorktrees(repo, gitWorktrees)
         }
         return gitWorktrees.map((gitWorktree) => {
@@ -28685,11 +28718,18 @@ export class OrcaRuntimeService {
       cached.runtimeKey === runtimeKey &&
       cached.expiresAt > now
     ) {
-      return cached.result
+      return { ...cached.result, authoritativeForPrune: false }
     }
     const inFlight = this.worktreeScanInFlight.get(repo.id)
     if (inFlight?.generation === generation && inFlight.runtimeKey === runtimeKey) {
-      return inFlight.promise
+      const result = await inFlight.promise
+      return {
+        ...result,
+        authoritativeForPrune:
+          result.ok &&
+          generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
+          this.worktreeScanInFlight.get(repo.id)?.promise === inFlight.promise
+      }
     }
     const promise = this.listRepoWorktreesForResolutionUncached(repo, projectRuntime)
     this.worktreeScanInFlight.set(repo.id, { generation, runtimeKey, promise })
@@ -28707,7 +28747,13 @@ export class OrcaRuntimeService {
           expiresAt: Date.now() + resolveWorktreeScanCacheTtlMs(repo)
         })
       }
-      return result
+      return {
+        ...result,
+        authoritativeForPrune:
+          result.ok &&
+          generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
+          this.worktreeScanInFlight.get(repo.id)?.promise === promise
+      }
     } finally {
       if (this.worktreeScanInFlight.get(repo.id)?.promise === promise) {
         this.worktreeScanInFlight.delete(repo.id)

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -228,13 +228,29 @@ describe('repo RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
 
     const hooksResponse = await dispatcher.dispatch(makeRequest('repo.hooks', { repo: 'repo-1' }))
-    await dispatcher.dispatch(makeRequest('repo.hooksCheck', { repo: 'repo-1' }))
-    await dispatcher.dispatch(makeRequest('repo.setupScriptImports', { repo: 'repo-1' }))
-    await dispatcher.dispatch(makeRequest('repo.issueCommandRead', { repo: 'repo-1' }))
+    await dispatcher.dispatch(
+      makeRequest('repo.hooksCheck', {
+        repo: 'repo-1',
+        executionHostId: 'ssh:nested-host'
+      })
+    )
+    await dispatcher.dispatch(
+      makeRequest('repo.setupScriptImports', {
+        repo: 'repo-1',
+        executionHostId: 'ssh:nested-host'
+      })
+    )
+    await dispatcher.dispatch(
+      makeRequest('repo.issueCommandRead', {
+        repo: 'repo-1',
+        executionHostId: 'ssh:nested-host'
+      })
+    )
     await dispatcher.dispatch(
       makeRequest('repo.issueCommandWrite', {
         repo: 'repo-1',
-        content: 'Fix it'
+        content: 'Fix it',
+        executionHostId: 'ssh:nested-host'
       })
     )
 
@@ -243,10 +259,14 @@ describe('repo RPC methods', () => {
       ok: true,
       result: { setupTrust: { contentHash: 'hash-1', scriptContent: 'pnpm install' } }
     })
-    expect(runtime.checkRepoHooks).toHaveBeenCalledWith('repo-1')
-    expect(runtime.inspectRepoSetupScriptImports).toHaveBeenCalledWith('repo-1')
-    expect(runtime.readRepoIssueCommand).toHaveBeenCalledWith('repo-1')
-    expect(runtime.writeRepoIssueCommand).toHaveBeenCalledWith('repo-1', 'Fix it')
+    expect(runtime.checkRepoHooks).toHaveBeenCalledWith('repo-1', 'ssh:nested-host')
+    expect(runtime.inspectRepoSetupScriptImports).toHaveBeenCalledWith('repo-1', 'ssh:nested-host')
+    expect(runtime.readRepoIssueCommand).toHaveBeenCalledWith('repo-1', 'ssh:nested-host')
+    expect(runtime.writeRepoIssueCommand).toHaveBeenCalledWith(
+      'repo-1',
+      'Fix it',
+      'ssh:nested-host'
+    )
   })
 
   it('persists GitHub issue source preference updates', async () => {

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -1,12 +1,18 @@
 import { z } from 'zod'
 import { defineMethod, type RpcMethod } from '../core'
-import { OptionalFiniteNumber, OptionalString, requiredString } from '../schemas'
+import {
+  OptionalExecutionHostId,
+  OptionalFiniteNumber,
+  OptionalString,
+  requiredString
+} from '../schemas'
 import { PROJECT_RUNTIME_METHODS } from './project-runtime-rpc-methods'
 import { FOLDER_WORKSPACE_METHODS } from './folder-workspace'
 import { createRepoUpdateSchema } from './repo-update-schema'
 
 const RepoSelector = z.object({
-  repo: requiredString('Missing repo selector')
+  repo: requiredString('Missing repo selector'),
+  executionHostId: OptionalExecutionHostId
 })
 
 const RepoPath = z.object({
@@ -250,22 +256,25 @@ export const REPO_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'repo.hooksCheck',
     params: RepoSelector,
-    handler: async (params, { runtime }) => runtime.checkRepoHooks(params.repo)
+    handler: async (params, { runtime }) =>
+      runtime.checkRepoHooks(params.repo, params.executionHostId)
   }),
   defineMethod({
     name: 'repo.setupScriptImports',
     params: RepoSelector,
-    handler: async (params, { runtime }) => runtime.inspectRepoSetupScriptImports(params.repo)
+    handler: async (params, { runtime }) =>
+      runtime.inspectRepoSetupScriptImports(params.repo, params.executionHostId)
   }),
   defineMethod({
     name: 'repo.issueCommandRead',
     params: RepoSelector,
-    handler: async (params, { runtime }) => runtime.readRepoIssueCommand(params.repo)
+    handler: async (params, { runtime }) =>
+      runtime.readRepoIssueCommand(params.repo, params.executionHostId)
   }),
   defineMethod({
     name: 'repo.issueCommandWrite',
     params: RepoIssueCommandWrite,
     handler: async (params, { runtime }) =>
-      runtime.writeRepoIssueCommand(params.repo, params.content)
+      runtime.writeRepoIssueCommand(params.repo, params.content, params.executionHostId)
   })
 ]

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -6,6 +6,7 @@ import { sleepingAgentLaunchConfigSchema } from '../../../../shared/workspace-se
 import { RUNTIME_NAVIGATION_TARGETS } from '../../../../shared/runtime-navigation'
 import {
   OptionalBoolean,
+  OptionalExecutionHostId,
   OptionalFiniteNumber,
   OptionalPlainString,
   OptionalString,
@@ -103,6 +104,7 @@ export const WorktreeCreate = z
       .unknown()
       .transform((v) => (typeof v === 'string' ? v : ''))
       .pipe(z.string().min(1, 'Missing repo selector')),
+    executionHostId: OptionalExecutionHostId,
     name: OptionalString,
     baseBranch: OptionalString,
     compareBaseRef: OptionalString,

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -109,6 +109,7 @@ describe('worktree RPC methods', () => {
     await dispatcher.dispatch(
       makeRequest('worktree.create', {
         repo: 'repo-1',
+        executionHostId: 'ssh:ssh-target-1',
         name: 'feature',
         branchNameOverride: 'feature/something',
         baseBranch: 'origin/main',
@@ -130,6 +131,7 @@ describe('worktree RPC methods', () => {
 
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith({
       repoSelector: 'repo-1',
+      executionHostId: 'ssh:ssh-target-1',
       name: 'feature',
       branchNameOverride: 'feature/something',
       baseBranch: 'origin/main',
@@ -164,6 +166,7 @@ describe('worktree RPC methods', () => {
         orchestrationContext: undefined
       }
     })
+    expect(runtime.showRepo).toHaveBeenCalledWith('repo-1', 'ssh:ssh-target-1')
   })
 
   it('mints automation provenance from a valid dispatch request on worktree creation', async () => {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -101,7 +101,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
       // the same clientMutationId; dedupe so the host returns the in-flight/created
       // worktree instead of spawning a duplicate. No key (desktop/CLI) runs plainly.
       runtime.dedupeWorktreeCreate(params.repo, params.clientMutationId, async () => {
-        const repo = await runtime.showRepo(params.repo)
+        const repo = await runtime.showRepo(params.repo, params.executionHostId)
         const automationProvenance = resolveAutomationWorkspaceProvenance({
           authority: runtime,
           repoSelector: params.repo,
@@ -113,6 +113,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
         try {
           const result = await runtime.createManagedWorktree({
             repoSelector: params.repo,
+            executionHostId: params.executionHostId,
             name: params.name ?? '',
             baseBranch: params.baseBranch,
             compareBaseRef: params.compareBaseRef,

--- a/src/main/runtime/rpc/schemas.ts
+++ b/src/main/runtime/rpc/schemas.ts
@@ -4,6 +4,7 @@
 // target envelope, etc.). Methods compose these to declare their real
 // contract without repeating the same `typeof` gymnastics 90 times.
 import { z } from 'zod'
+import { parseExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
 
 // Why: the original handlers treated non-numeric/NaN limit values as "no
 // limit" rather than as errors. Preserve that forgiving behavior so CLI
@@ -40,6 +41,18 @@ export const OptionalBoolean = z
   .unknown()
   .transform((value) => (typeof value === 'boolean' ? value : undefined))
   .pipe(z.union([z.boolean(), z.undefined()]))
+  .optional()
+
+export const OptionalExecutionHostId = z
+  .string()
+  .transform((value, ctx): ExecutionHostId => {
+    const parsed = parseExecutionHostId(value)
+    if (parsed) {
+      return parsed.id
+    }
+    ctx.addIssue({ code: 'custom', message: 'Invalid execution host id' })
+    return z.NEVER
+  })
   .optional()
 
 // Why: runtime handlers accept `linkedIssue: number | null | undefined` with

--- a/src/renderer/src/components/sidebar/RelativeWorktreeCreateDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/RelativeWorktreeCreateDialog.test.tsx
@@ -1,0 +1,141 @@
+// @vitest-environment happy-dom
+
+import type { ButtonHTMLAttributes, InputHTMLAttributes, ReactNode } from 'react'
+import { cleanup, fireEvent, render, screen, waitFor } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+
+const mocks = vi.hoisted(() => ({
+  createWorktree: vi.fn(),
+  activateAndRevealWorktree: vi.fn(),
+  ensureHooksConfirmed: vi.fn()
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: { getState: () => ({ createWorktree: mocks.createWorktree }) }
+}))
+
+vi.mock('@/lib/ensure-hooks-confirmed', () => ({
+  ensureHooksConfirmed: mocks.ensureHooksConfirmed
+}))
+
+vi.mock('@/lib/worktree-activation', () => ({
+  activateAndRevealWorktree: mocks.activateAndRevealWorktree
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogClose: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <div>{children}</div>
+}))
+
+vi.mock('@/components/ui/button', () => ({
+  Button: ({ children, ...props }: ButtonHTMLAttributes<HTMLButtonElement>) => (
+    <button {...props}>{children}</button>
+  )
+}))
+
+vi.mock('@/components/ui/input', () => ({
+  Input: (props: InputHTMLAttributes<HTMLInputElement>) => <input {...props} />
+}))
+
+vi.mock('@/components/ui/label', () => ({
+  Label: ({ children, ...props }: { children: ReactNode; htmlFor?: string }) => (
+    <label {...props}>{children}</label>
+  )
+}))
+
+import { RelativeWorktreeCreateDialog } from './RelativeWorktreeCreateDialog'
+
+const sourceWorktree = {
+  id: 'repo-1::/remote/source',
+  instanceId: 'source-instance',
+  repoId: 'repo-1',
+  path: '/remote/source',
+  head: 'abc123',
+  branch: 'feature/source',
+  isBare: false,
+  isMainWorktree: false,
+  hostId: 'ssh:ssh-1',
+  displayName: 'source',
+  comment: '',
+  linkedIssue: null,
+  linkedPR: null,
+  linkedLinearIssue: null,
+  isArchived: false,
+  isUnread: false,
+  isPinned: false,
+  sortOrder: 0,
+  lastActivityAt: 1
+} satisfies Worktree
+
+describe('RelativeWorktreeCreateDialog host routing', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllMocks()
+  })
+
+  it('preserves the selected host through creation and activation', async () => {
+    mocks.ensureHooksConfirmed.mockResolvedValue('run')
+    mocks.createWorktree.mockResolvedValue({
+      worktree: { ...sourceWorktree, id: 'repo-1::/remote/child' }
+    })
+
+    render(
+      <RelativeWorktreeCreateDialog
+        kind="child"
+        worktree={sourceWorktree}
+        parentWorkspace={`worktree:${sourceWorktree.id}`}
+        onOpenChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create Child' }))
+
+    await waitFor(() => expect(mocks.createWorktree).toHaveBeenCalled())
+    const createArgs = mocks.createWorktree.mock.calls[0]
+    expect(createArgs?.[25]).toMatchObject({ executionHostId: 'ssh:ssh-1' })
+    expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(
+      'repo-1::/remote/child',
+      expect.objectContaining({ executionHostId: 'ssh:ssh-1' })
+    )
+  })
+
+  it('preserves a nested SSH host and its paired runtime owner', async () => {
+    const nestedWorktree = {
+      ...sourceWorktree,
+      runtimeOwnerEnvironmentId: 'owner-runtime'
+    }
+    mocks.ensureHooksConfirmed.mockResolvedValue('run')
+    mocks.createWorktree.mockResolvedValue({
+      worktree: { ...nestedWorktree, id: 'repo-1::/remote/child' }
+    })
+
+    render(
+      <RelativeWorktreeCreateDialog
+        kind="child"
+        worktree={nestedWorktree}
+        parentWorkspace={`worktree:${nestedWorktree.id}`}
+        onOpenChange={vi.fn()}
+      />
+    )
+    fireEvent.click(screen.getByRole('button', { name: 'Create Child' }))
+
+    await waitFor(() => expect(mocks.createWorktree).toHaveBeenCalled())
+    expect(mocks.ensureHooksConfirmed).toHaveBeenCalledWith(
+      expect.anything(),
+      'repo-1',
+      'setup',
+      'ssh:ssh-1',
+      'owner-runtime'
+    )
+    expect(mocks.createWorktree.mock.calls[0]?.[25]).toMatchObject({
+      parentWorkspace: `worktree:${nestedWorktree.id}`,
+      executionHostId: 'ssh:ssh-1',
+      runtimeOwnerEnvironmentId: 'owner-runtime'
+    })
+  })
+})

--- a/src/renderer/src/components/sidebar/RelativeWorktreeCreateDialog.tsx
+++ b/src/renderer/src/components/sidebar/RelativeWorktreeCreateDialog.tsx
@@ -1,0 +1,198 @@
+import React, { useRef, useState } from 'react'
+import { Loader2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogClose,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { ensureHooksConfirmed } from '@/lib/ensure-hooks-confirmed'
+import { activateAndRevealWorktree } from '@/lib/worktree-activation'
+import { useAppStore } from '@/store'
+import type { WorkspaceKey, Worktree } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import {
+  getRelativeWorktreeDefaultName,
+  type RelativeWorktreeCreateKind
+} from './worktree-relative-create'
+
+type Props = {
+  kind: RelativeWorktreeCreateKind
+  worktree: Worktree
+  parentWorkspace: WorkspaceKey | null
+  onOpenChange: (open: boolean) => void
+}
+
+export function RelativeWorktreeCreateDialog({
+  kind,
+  worktree,
+  parentWorkspace,
+  onOpenChange
+}: Props): React.JSX.Element {
+  const inputRef = useRef<HTMLInputElement>(null)
+  const [name, setName] = useState(() => getRelativeWorktreeDefaultName(worktree, kind))
+  const [creating, setCreating] = useState(false)
+  const [error, setError] = useState<string | null>(null)
+
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen && creating) {
+      return
+    }
+    onOpenChange(nextOpen)
+  }
+
+  const handleCreate = async (event: React.FormEvent): Promise<void> => {
+    event.preventDefault()
+    const branchName = name.trim()
+    const baseBranch = worktree.branch?.trim()
+    if (!baseBranch || !branchName || creating) {
+      return
+    }
+    setCreating(true)
+    setError(null)
+    try {
+      const trustDecision = await ensureHooksConfirmed(
+        useAppStore.getState(),
+        worktree.repoId,
+        'setup',
+        worktree.hostId,
+        worktree.runtimeOwnerEnvironmentId
+      )
+      const result = await useAppStore
+        .getState()
+        .createWorktree(
+          worktree.repoId,
+          branchName,
+          baseBranch,
+          trustDecision === 'skip' ? 'skip' : 'inherit',
+          undefined,
+          'sidebar',
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          branchName,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          undefined,
+          {
+            parentWorkspace,
+            executionHostId: worktree.hostId,
+            runtimeOwnerEnvironmentId: worktree.runtimeOwnerEnvironmentId
+          }
+        )
+      onOpenChange(false)
+      activateAndRevealWorktree(result.worktree.id, {
+        executionHostId: worktree.hostId,
+        sidebarRevealBehavior: 'auto',
+        setup: result.setup,
+        defaultTabs: result.defaultTabs
+      })
+    } catch (cause) {
+      setError(
+        cause instanceof Error
+          ? cause.message
+          : translate(
+              'auto.components.sidebar.RelativeWorktreeCreateDialog.createFailed',
+              'Failed to create worktree.'
+            )
+      )
+    } finally {
+      setCreating(false)
+    }
+  }
+
+  const title =
+    kind === 'fork'
+      ? translate('auto.components.sidebar.RelativeWorktreeCreateDialog.forkTitle', 'Fork Worktree')
+      : translate(
+          'auto.components.sidebar.RelativeWorktreeCreateDialog.childTitle',
+          'Create Child Worktree'
+        )
+  const actionLabel =
+    kind === 'fork'
+      ? translate('auto.components.sidebar.RelativeWorktreeCreateDialog.forkAction', 'Fork')
+      : translate(
+          'auto.components.sidebar.RelativeWorktreeCreateDialog.childAction',
+          'Create Child'
+        )
+
+  return (
+    <Dialog open onOpenChange={handleOpenChange}>
+      <DialogContent
+        className="sm:max-w-md"
+        onOpenAutoFocus={(event) => {
+          event.preventDefault()
+          inputRef.current?.focus()
+          inputRef.current?.select()
+        }}
+      >
+        <form className="space-y-4" onSubmit={(event) => void handleCreate(event)}>
+          <DialogHeader>
+            <DialogTitle>{title}</DialogTitle>
+            <DialogDescription>
+              {translate(
+                'auto.components.sidebar.RelativeWorktreeCreateDialog.description',
+                'Create a new worktree from the current branch.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="space-y-2">
+            <Label htmlFor="relative-worktree-branch-name">
+              {translate(
+                'auto.components.sidebar.RelativeWorktreeCreateDialog.branchName',
+                'Branch name'
+              )}
+            </Label>
+            <Input
+              ref={inputRef}
+              id="relative-worktree-branch-name"
+              value={name}
+              onChange={(event) => {
+                setName(event.target.value)
+                setError(null)
+              }}
+              aria-invalid={Boolean(error)}
+              disabled={creating}
+              autoComplete="off"
+            />
+            {error ? <p className="text-xs text-destructive">{error}</p> : null}
+          </div>
+          <DialogFooter>
+            <DialogClose asChild>
+              <Button type="button" variant="ghost" disabled={creating}>
+                {translate('auto.components.sidebar.RelativeWorktreeCreateDialog.cancel', 'Cancel')}
+              </Button>
+            </DialogClose>
+            <Button type="submit" disabled={!name.trim() || creating}>
+              {creating ? <Loader2 className="size-4 animate-spin" /> : null}
+              {creating
+                ? translate(
+                    'auto.components.sidebar.RelativeWorktreeCreateDialog.creating',
+                    'Creating…'
+                  )
+                : actionLabel}
+            </Button>
+          </DialogFooter>
+        </form>
+      </DialogContent>
+    </Dialog>
+  )
+}

--- a/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeContextMenu.tsx
@@ -28,7 +28,9 @@ import {
   Workflow,
   FolderInput,
   FolderPlus,
-  FolderTree
+  FolderTree,
+  GitBranchPlus,
+  GitFork
 } from 'lucide-react'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
@@ -54,6 +56,11 @@ import { WorktreeOpenInSubMenu } from './WorktreeOpenInMenu'
 import { ProjectGroupNameDialog } from './ProjectGroupNameDialog'
 import { WorktreeParentPickerPopover } from './WorktreeParentPickerPopover'
 import { WorktreeDeveloperMenu } from './WorktreeDeveloperMenu'
+import { RelativeWorktreeCreateDialog } from './RelativeWorktreeCreateDialog'
+import {
+  getRelativeWorktreeParent,
+  type RelativeWorktreeCreateKind
+} from './worktree-relative-create'
 import { getEligibleWorktreeParents } from './worktree-parent-candidates'
 import {
   hasSleepableWorkspaceActivity,
@@ -345,6 +352,10 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     effectiveSelectedWorktrees
   )
   const [createGroupDialogOpen, setCreateGroupDialogOpen] = useState(false)
+  const [relativeCreateRequest, setRelativeCreateRequest] = useState<{
+    kind: RelativeWorktreeCreateKind
+    parentWorkspace: ReturnType<typeof getRelativeWorktreeParent>
+  } | null>(null)
   const [parentPicker, setParentPicker] = useState<{
     childWorktreeId: string
     anchorElement: HTMLElement
@@ -470,6 +481,13 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     [cyclicLineageIds, worktree, worktreeLineageById, worktreeMap]
   )
   const validParentWorktreeId = lineageInfo.state === 'valid' ? lineageInfo.parent.id : null
+  const contextWorkspaceLineage = workspaceLineageByChildKey[worktreeWorkspaceKey(worktree.id)]
+  const relativeCreateDisabled =
+    isDeleting ||
+    repo?.kind === 'folder' ||
+    !worktree.branch?.trim() ||
+    worktree.isArchived ||
+    worktree.isBare
   const hasAnyContextLineage = activeContextWorktrees.some((item) =>
     hasWorktreeParentLink(item, worktreeLineageById, workspaceLineageByChildKey)
   )
@@ -616,6 +634,21 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
     worktree.comment,
     openModal
   ])
+
+  const handleRelativeCreate = useCallback(
+    (kind: RelativeWorktreeCreateKind) => {
+      setRelativeCreateRequest({
+        kind,
+        parentWorkspace: getRelativeWorktreeParent({
+          kind,
+          worktree,
+          workspaceLineage: contextWorkspaceLineage,
+          validParentWorktreeId
+        })
+      })
+    },
+    [contextWorkspaceLineage, validParentWorktreeId, worktree]
+  )
 
   const sleepWorktreesAfterMenuClose = useCallback(
     (worktreeIds: string[]) => {
@@ -832,10 +865,29 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
             {translate('auto.components.sidebar.WorktreeContextMenu.workspaceSection', 'Workspace')}
           </DropdownMenuLabel>
           {!isMultiContext && (
-            <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
-              <Pencil className="size-3.5" />
-              {translate('auto.components.sidebar.WorktreeContextMenu.439fa94d53', 'Update')}
-            </DropdownMenuItem>
+            <>
+              <DropdownMenuItem onSelect={handleRename} disabled={isDeleting}>
+                <Pencil className="size-3.5" />
+                {translate('auto.components.sidebar.WorktreeContextMenu.439fa94d53', 'Update')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => handleRelativeCreate('fork')}
+                disabled={relativeCreateDisabled}
+              >
+                <GitFork className="size-3.5" />
+                {translate('auto.components.sidebar.WorktreeContextMenu.forkWorktree', 'Fork')}
+              </DropdownMenuItem>
+              <DropdownMenuItem
+                onSelect={() => handleRelativeCreate('child')}
+                disabled={relativeCreateDisabled}
+              >
+                <GitBranchPlus className="size-3.5" />
+                {translate(
+                  'auto.components.sidebar.WorktreeContextMenu.createChildWorktree',
+                  'Create Child'
+                )}
+              </DropdownMenuItem>
+            </>
           )}
           <DropdownMenuSub>
             <DropdownMenuSubTrigger disabled={deletingContext}>
@@ -1091,6 +1143,18 @@ const WorktreeContextMenu = React.memo(function WorktreeContextMenu({
         onOpenChange={setCreateGroupDialogOpen}
         onSubmit={handleSubmitNewProjectGroup}
       />
+      {relativeCreateRequest ? (
+        <RelativeWorktreeCreateDialog
+          kind={relativeCreateRequest.kind}
+          worktree={worktree}
+          parentWorkspace={relativeCreateRequest.parentWorkspace}
+          onOpenChange={(open) => {
+            if (!open) {
+              setRelativeCreateRequest(null)
+            }
+          }}
+        />
+      ) : null}
       {/* Why: mounted only while open — one instance of this lives behind every
           worktree card, and each one subscribes to the worktree and lineage
           maps just to compute parent candidates it will never show. Closing

--- a/src/renderer/src/components/sidebar/worktree-relative-create.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-relative-create.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import type { Worktree } from '../../../../shared/types'
+import {
+  getRelativeWorktreeDefaultName,
+  getRelativeWorktreeParent
+} from './worktree-relative-create'
+
+const worktree = {
+  id: 'repo-1::/worktrees/feature',
+  repoId: 'repo-1',
+  branch: 'refs/heads/feature/menu',
+  displayName: 'Menu work',
+  path: '/worktrees/feature'
+} as Worktree
+
+describe('relative worktree create defaults', () => {
+  it('suffixes the source branch for fork and child names', () => {
+    expect(getRelativeWorktreeDefaultName(worktree, 'fork')).toBe('feature/menu_fork')
+    expect(getRelativeWorktreeDefaultName(worktree, 'child')).toBe('feature/menu_child')
+  })
+
+  it('makes a child descend from the selected worktree', () => {
+    expect(getRelativeWorktreeParent({ kind: 'child', worktree })).toBe(`worktree:${worktree.id}`)
+  })
+
+  it('makes a fork inherit the selected worktree parent', () => {
+    expect(
+      getRelativeWorktreeParent({
+        kind: 'fork',
+        worktree,
+        workspaceLineage: {
+          childWorkspaceKey: `worktree:${worktree.id}`,
+          parentWorkspaceKey: 'folder:project-1',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 1
+        }
+      })
+    ).toBe('folder:project-1')
+  })
+
+  it('keeps a top-level fork at the top level', () => {
+    expect(getRelativeWorktreeParent({ kind: 'fork', worktree })).toBeNull()
+  })
+
+  it('inherits a worktree parent only after instance validation succeeds', () => {
+    expect(
+      getRelativeWorktreeParent({
+        kind: 'fork',
+        worktree,
+        workspaceLineage: {
+          childWorkspaceKey: `worktree:${worktree.id}`,
+          childInstanceId: 'child-instance',
+          parentWorkspaceKey: 'worktree:repo-1::/worktrees/parent',
+          parentInstanceId: 'parent-instance',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 1
+        },
+        validParentWorktreeId: 'repo-1::/worktrees/parent'
+      })
+    ).toBe('worktree:repo-1::/worktrees/parent')
+  })
+
+  it('rejects a stale worktree parent that failed instance validation', () => {
+    expect(
+      getRelativeWorktreeParent({
+        kind: 'fork',
+        worktree,
+        workspaceLineage: {
+          childWorkspaceKey: `worktree:${worktree.id}`,
+          childInstanceId: 'child-instance',
+          parentWorkspaceKey: 'worktree:repo-1::/worktrees/reused-parent',
+          parentInstanceId: 'stale-parent-instance',
+          origin: 'manual',
+          capture: { source: 'manual-action', confidence: 'explicit' },
+          createdAt: 1
+        },
+        validParentWorktreeId: null
+      })
+    ).toBeNull()
+  })
+})

--- a/src/renderer/src/components/sidebar/worktree-relative-create.ts
+++ b/src/renderer/src/components/sidebar/worktree-relative-create.ts
@@ -1,0 +1,34 @@
+import type { WorkspaceKey, WorkspaceLineage, Worktree } from '../../../../shared/types'
+import {
+  resolveWorktreeBranchLabel,
+  resolveWorktreeDisplayName
+} from '@/lib/worktree-default-display-name'
+import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../../../shared/workspace-scope'
+
+export type RelativeWorktreeCreateKind = 'fork' | 'child'
+
+export function getRelativeWorktreeDefaultName(
+  worktree: Worktree,
+  kind: RelativeWorktreeCreateKind
+): string {
+  const sourceName = resolveWorktreeBranchLabel(worktree) || resolveWorktreeDisplayName(worktree)
+  return `${sourceName}_${kind}`
+}
+
+export function getRelativeWorktreeParent(args: {
+  kind: RelativeWorktreeCreateKind
+  worktree: Worktree
+  workspaceLineage?: WorkspaceLineage | null
+  validParentWorktreeId?: string | null
+}): WorkspaceKey | null {
+  if (args.kind === 'child') {
+    return worktreeWorkspaceKey(args.worktree.id)
+  }
+  const workspaceParent = args.workspaceLineage
+    ? parseWorkspaceKey(args.workspaceLineage.parentWorkspaceKey)
+    : null
+  if (workspaceParent?.type === 'folder') {
+    return args.workspaceLineage?.parentWorkspaceKey ?? null
+  }
+  return args.validParentWorktreeId ? worktreeWorkspaceKey(args.validParentWorktreeId) : null
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4666,6 +4666,8 @@
           "697d0f6e1b": "Unpin",
           "250de158fd": "Remove Workspace",
           "changeParentWorkspace": "Change Parent Worktree...",
+          "createChildWorktree": "Create Child",
+          "forkWorktree": "Fork",
           "setParentWorkspace": "Set Parent Worktree...",
           "workspaceSection": "Workspace",
           "primaryDeleteDisabled": "Primary worktree — can't be deleted. Remove the project instead.",
@@ -4673,6 +4675,17 @@
           "sleepWithDescendants": "Sleep with Descendants ({{value0}})",
           "sleepWithDescendantsDescription": "Close active panels in this workspace and every nested descendant to free up memory and CPU.",
           "deleteWithDescendants": "Delete with Descendants…"
+        },
+        "RelativeWorktreeCreateDialog": {
+          "branchName": "Branch name",
+          "cancel": "Cancel",
+          "childAction": "Create Child",
+          "childTitle": "Create Child Worktree",
+          "createFailed": "Failed to create worktree.",
+          "creating": "Creating…",
+          "description": "Create a new worktree from the current branch.",
+          "forkAction": "Fork",
+          "forkTitle": "Fork Worktree"
         },
         "WorktreeList": {
           "7a8b9c0d1e": "Update required",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4539,10 +4539,23 @@
           "697d0f6e1b": "取消固定",
           "250de158fd": "移除工作区",
           "changeParentWorkspace": "更改父工作树...",
+          "createChildWorktree": "创建子工作树",
+          "forkWorktree": "Fork 工作树",
           "setParentWorkspace": "设置父工作树...",
           "workspaceSection": "工作区",
           "primaryDeleteDisabled": "主工作树不能删除。请改为移除项目。",
           "deleteWorktree": "删除工作树"
+        },
+        "RelativeWorktreeCreateDialog": {
+          "branchName": "分支名称",
+          "cancel": "取消",
+          "childAction": "创建子工作树",
+          "childTitle": "创建子工作树",
+          "createFailed": "无法创建工作树。",
+          "creating": "正在创建…",
+          "description": "从当前分支创建一个新工作树。",
+          "forkAction": "Fork",
+          "forkTitle": "Fork 工作树"
         },
         "WorktreeList": {
           "d880ea0744": "创建一个组并将该项目移入其中。",

--- a/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.test.ts
@@ -286,6 +286,29 @@ describe('ensureHooksConfirmed', () => {
     expect(pending).toHaveLength(0)
   })
 
+  it('checks nested SSH hooks through the paired runtime owner', async () => {
+    const { state } = createTestState({
+      settings: { activeRuntimeEnvironmentId: 'focused-env' },
+      repos: [{ id: 'repo-1', displayName: 'Nested SSH', connectionId: 'nested-host' }]
+    } as unknown as Partial<AppState>)
+    runtimeEnvironmentCallMock.mockResolvedValue({
+      id: 'rpc-nested-hooks',
+      ok: true,
+      result: { hasHooks: true, hooks: { scripts: {} }, mayNeedUpdate: false },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+
+    await ensureHooksConfirmed(state, 'repo-1', 'archive', 'ssh:nested-host', 'owner-runtime')
+
+    expect(runtimeEnvironmentCallMock).toHaveBeenCalledWith({
+      selector: 'owner-runtime',
+      method: 'repo.hooksCheck',
+      params: { repo: 'repo-1', executionHostId: 'ssh:nested-host' },
+      timeoutMs: 15_000
+    })
+    expect(hooksCheckMock).not.toHaveBeenCalled()
+  })
+
   it('does not prompt for orca.yaml when the repo uses local commands only', async () => {
     const { state, pending } = createTestState({
       repos: [

--- a/src/renderer/src/lib/ensure-hooks-confirmed.ts
+++ b/src/renderer/src/lib/ensure-hooks-confirmed.ts
@@ -247,7 +247,8 @@ export async function ensureHooksConfirmed(
         const result = await readRuntimeIssueCommand(
           settingsForHookRepoOwner(state, repoId, hostId, runtimeOwnerEnvironmentId),
           repoId,
-          hostId
+          hostId,
+          runtimeOwnerEnvironmentId
         )
         if (result.source === 'local') {
           return 'run'
@@ -274,7 +275,8 @@ export async function ensureHooksConfirmed(
         const result = await checkRuntimeHooks(
           settingsForHookRepoOwner(state, repoId, hostId, runtimeOwnerEnvironmentId),
           repoId,
-          hostId
+          hostId,
+          runtimeOwnerEnvironmentId
         )
         if (result.status === 'error') {
           return 'skip'

--- a/src/renderer/src/runtime/runtime-hooks-client.test.ts
+++ b/src/renderer/src/runtime/runtime-hooks-client.test.ts
@@ -153,4 +153,28 @@ describe('runtime hooks client', () => {
       hostId: 'ssh:server'
     })
   })
+
+  it('routes a nested SSH repo through its paired runtime owner', async () => {
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-nested-hooks',
+      ok: true,
+      result: { hasHooks: false, hooks: null, mayNeedUpdate: false },
+      _meta: { runtimeId: 'runtime-owner' }
+    })
+
+    await checkRuntimeHooks(
+      { activeRuntimeEnvironmentId: 'focused-elsewhere' },
+      'same-repo',
+      'ssh:nested-host',
+      'owner-runtime'
+    )
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'owner-runtime',
+      method: 'repo.hooksCheck',
+      params: { repo: 'same-repo', executionHostId: 'ssh:nested-host' },
+      timeoutMs: 15_000
+    })
+    expect(hooksCheck).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/runtime/runtime-hooks-client.ts
+++ b/src/renderer/src/runtime/runtime-hooks-client.ts
@@ -5,8 +5,12 @@ import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
 
 function getHookInspectionTarget(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
-  hostId?: ExecutionHostId
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null
 ): ReturnType<typeof getActiveRuntimeTarget> {
+  if (runtimeOwnerEnvironmentId?.trim()) {
+    return { kind: 'environment', environmentId: runtimeOwnerEnvironmentId.trim() }
+  }
   const parsedHost = parseExecutionHostId(hostId)
   if (parsedHost?.kind === 'runtime') {
     return { kind: 'environment', environmentId: parsedHost.environmentId }
@@ -33,16 +37,17 @@ export type IssueCommandReadResult = {
 export async function checkRuntimeHooks(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   repoId: string,
-  hostId?: ExecutionHostId
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null
 ): Promise<HookCheckResult> {
-  const target = getHookInspectionTarget(settings, hostId)
+  const target = getHookInspectionTarget(settings, hostId, runtimeOwnerEnvironmentId)
   if (target.kind !== 'environment') {
     return window.api.hooks.check({ repoId, ...(hostId ? { hostId } : {}) })
   }
   return callRuntimeRpc<HookCheckResult>(
     target,
     'repo.hooksCheck',
-    { repo: repoId },
+    { repo: repoId, ...(hostId ? { executionHostId: hostId } : {}) },
     { timeoutMs: 15_000 }
   )
 }
@@ -50,16 +55,17 @@ export async function checkRuntimeHooks(
 export async function inspectRuntimeSetupScriptImports(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   repoId: string,
-  hostId?: ExecutionHostId
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null
 ): Promise<SetupScriptImportCandidate[]> {
-  const target = getHookInspectionTarget(settings, hostId)
+  const target = getHookInspectionTarget(settings, hostId, runtimeOwnerEnvironmentId)
   if (target.kind !== 'environment') {
     return window.api.hooks.inspectSetupScriptImports({ repoId, ...(hostId ? { hostId } : {}) })
   }
   return callRuntimeRpc<SetupScriptImportCandidate[]>(
     target,
     'repo.setupScriptImports',
-    { repo: repoId },
+    { repo: repoId, ...(hostId ? { executionHostId: hostId } : {}) },
     { timeoutMs: 15_000 }
   )
 }
@@ -67,16 +73,17 @@ export async function inspectRuntimeSetupScriptImports(
 export async function readRuntimeIssueCommand(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   repoId: string,
-  hostId?: ExecutionHostId
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null
 ): Promise<IssueCommandReadResult> {
-  const target = getActiveRuntimeTarget(settings)
+  const target = getHookInspectionTarget(settings, hostId, runtimeOwnerEnvironmentId)
   if (target.kind !== 'environment') {
     return window.api.hooks.readIssueCommand({ repoId, ...(hostId ? { hostId } : {}) })
   }
   return callRuntimeRpc<IssueCommandReadResult>(
     target,
     'repo.issueCommandRead',
-    { repo: repoId },
+    { repo: repoId, ...(hostId ? { executionHostId: hostId } : {}) },
     { timeoutMs: 15_000 }
   )
 }
@@ -85,9 +92,10 @@ export async function writeRuntimeIssueCommand(
   settings: Pick<GlobalSettings, 'activeRuntimeEnvironmentId'> | null | undefined,
   repoId: string,
   content: string,
-  hostId?: ExecutionHostId
+  hostId?: ExecutionHostId,
+  runtimeOwnerEnvironmentId?: string | null
 ): Promise<void> {
-  const target = getActiveRuntimeTarget(settings)
+  const target = getHookInspectionTarget(settings, hostId, runtimeOwnerEnvironmentId)
   if (target.kind !== 'environment') {
     await window.api.hooks.writeIssueCommand({ repoId, content, ...(hostId ? { hostId } : {}) })
     return
@@ -95,7 +103,7 @@ export async function writeRuntimeIssueCommand(
   await callRuntimeRpc(
     target,
     'repo.issueCommandWrite',
-    { repo: repoId, content },
+    { repo: repoId, content, ...(hostId ? { executionHostId: hostId } : {}) },
     { timeoutMs: 15_000 }
   )
 }

--- a/src/renderer/src/store/slices/worktree-create-parent-workspace.ts
+++ b/src/renderer/src/store/slices/worktree-create-parent-workspace.ts
@@ -1,0 +1,18 @@
+import type { WorkspaceKey } from '../../../../shared/types'
+import { folderWorkspaceKey, parseWorkspaceKey } from '../../../../shared/workspace-scope'
+
+export function resolveCreateParentWorkspace(
+  activeWorkspaceKey: string | null | undefined,
+  requestedParent: WorkspaceKey | null | undefined
+): WorkspaceKey | undefined {
+  if (requestedParent === null) {
+    return undefined
+  }
+  if (requestedParent) {
+    return requestedParent
+  }
+  const activeScope = parseWorkspaceKey(activeWorkspaceKey ?? '')
+  return activeScope?.type === 'folder'
+    ? folderWorkspaceKey(activeScope.folderWorkspaceId)
+    : undefined
+}

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -198,6 +198,10 @@ export type WorktreeSlice = {
       automationProvenanceRequest?: CreateWorktreeArgs['automationProvenanceRequest']
       linkedWorkItem?: WorkspaceLinkedItem | null
       linkedTaskSourceContext?: TaskSourceContext | null
+      /** Explicit lineage placement. null keeps the new worktree at repo root. */
+      parentWorkspace?: CreateWorktreeArgs['parentWorkspace'] | null
+      executionHostId?: ExecutionHostId
+      runtimeOwnerEnvironmentId?: string | null
     }
   ) => Promise<CreateWorktreeResult>
   /** Register an in-flight background creation and make it the active surface. */

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -163,6 +163,7 @@ import {
   resetAuthoritativelyRemovedWorktreeMemoryForTests,
   resetHostedReviewLinkMutationGenerationForTests
 } from './worktrees'
+import { resolveCreateParentWorkspace } from './worktree-create-parent-workspace'
 import type { PendingWorktreeCreation } from '@/lib/pending-worktree-creation'
 import { getHostedReviewCacheKey } from './hosted-review'
 import { getGitHubPRCacheKey, getLegacyGitHubPRCacheKey } from './github-cache-key'
@@ -4541,6 +4542,16 @@ describe('createWorktree base status merge', () => {
     })
   })
 
+  it('honors explicit parent placement over the active folder workspace', () => {
+    expect(
+      resolveCreateParentWorkspace(
+        folderWorkspaceKey('active-folder'),
+        worktreeWorkspaceKey('repo1::/path/parent')
+      )
+    ).toBe(worktreeWorkspaceKey('repo1::/path/parent'))
+    expect(resolveCreateParentWorkspace(folderWorkspaceKey('active-folder'), null)).toBeUndefined()
+  })
+
   it('merges create result metadata into a worktree inserted by the watcher race', async () => {
     const store = createTestStore()
     const watcherWorktree = makeWorktree({
@@ -5557,6 +5568,114 @@ describe('worktree remote runtime mutations', () => {
     expect(mockApi.worktrees.create).not.toHaveBeenCalled()
     expect(store.getState().worktreesByRepo.repo1).toEqual([wt])
   })
+
+  it('routes creation through the selected worktree runtime owner instead of the focused runtime', async () => {
+    const store = createTestStore()
+    const wt = makeWorktree({
+      id: 'repo1::/path/feature',
+      repoId: 'repo1',
+      path: '/path/feature',
+      hostId: 'ssh:ssh-1'
+    })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-create-selected-owner',
+      ok: true,
+      result: { worktree: wt },
+      _meta: { runtimeId: 'runtime-selected' }
+    })
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-focused' } as never,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/focused/repo',
+          displayName: 'focused',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-focused'
+        },
+        {
+          id: 'repo1',
+          path: '/selected/repo',
+          displayName: 'selected',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-selected'
+        }
+      ],
+      worktreesByRepo: { repo1: [] }
+    } as Partial<AppState>)
+    const args: Parameters<AppState['createWorktree']> = ['repo1', 'feature', 'origin/main']
+    args[25] = {
+      executionHostId: 'ssh:ssh-1',
+      runtimeOwnerEnvironmentId: 'env-selected'
+    }
+
+    await store.getState().createWorktree(...args)
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'env-selected',
+        method: 'worktree.create',
+        params: expect.objectContaining({
+          repo: 'repo1',
+          executionHostId: 'ssh:ssh-1'
+        })
+      })
+    )
+    expect(store.getState().worktreesByRepo.repo1[0]).toMatchObject({
+      hostId: 'ssh:ssh-1',
+      runtimeOwnerEnvironmentId: 'env-selected'
+    })
+  })
+
+  it.each(['local', 'ssh:ssh-1'] as const)(
+    'keeps %s creation on the desktop provider when a runtime is focused',
+    async (executionHostId) => {
+      const store = createTestStore()
+      const wt = makeWorktree({
+        id: 'repo1::/path/feature',
+        repoId: 'repo1',
+        path: '/path/feature',
+        hostId: executionHostId
+      })
+      store.setState({
+        settings: { activeRuntimeEnvironmentId: 'env-focused' } as never,
+        repos: [
+          {
+            id: 'repo1',
+            path: '/focused/repo',
+            displayName: 'focused',
+            badgeColor: '#000',
+            addedAt: 0,
+            executionHostId: 'runtime:env-focused'
+          },
+          {
+            id: 'repo1',
+            path: '/selected/repo',
+            displayName: 'selected',
+            badgeColor: '#000',
+            addedAt: 0,
+            ...(executionHostId === 'local'
+              ? { executionHostId: 'local' as const }
+              : { connectionId: 'ssh-1', executionHostId })
+          }
+        ],
+        worktreesByRepo: { repo1: [] }
+      } as Partial<AppState>)
+      mockApi.worktrees.create.mockResolvedValue({ worktree: wt })
+      const args: Parameters<AppState['createWorktree']> = ['repo1', 'feature', 'origin/main']
+      args[25] = { executionHostId }
+
+      await store.getState().createWorktree(...args)
+
+      expect(mockApi.worktrees.create).toHaveBeenCalledWith(
+        expect.objectContaining({ executionHostId })
+      )
+      expect(runtimeEnvironmentCall).not.toHaveBeenCalled()
+      expect(store.getState().worktreesByRepo.repo1[0]?.hostId).toBe(executionHostId)
+    }
+  )
 
   it('persists Jira item and source context through paired-runtime create', async () => {
     const store = createTestStore()

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -83,6 +83,7 @@ import {
   getSettingsFocusedExecutionHostId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
+  toRuntimeExecutionHostId,
   toSshExecutionHostId,
   type ExecutionHostId
 } from '../../../../shared/execution-host'
@@ -103,6 +104,7 @@ import {
   worktreeWorkspaceKey
 } from '../../../../shared/workspace-scope'
 import { folderWorkspaceToWorktree } from '../../../../shared/folder-workspace-worktree'
+import { projectWorkspaceLineageRecord } from '../../../../shared/workspace-lineage-worktree-projection'
 import {
   CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS,
   getClientWorktreeCreateCandidate,
@@ -114,6 +116,7 @@ import {
   isLockedWorktreeRemovalError
 } from '../../../../shared/worktree-removal'
 import { FolderWorkspaceActivityPersistence } from './folder-workspace-activity-persistence'
+import { resolveCreateParentWorkspace } from './worktree-create-parent-workspace'
 import {
   createDetectedWorktreeRefreshLeaseRegistry,
   type DetectedWorktreeRefreshLease
@@ -422,10 +425,16 @@ function withRepoHostOwnership<
     projectId?: string
     projectHostSetupId?: string
   }
->(worktree: T, hostId: ExecutionHostId, setup?: ProjectHostSetup): T {
+>(
+  worktree: T,
+  hostId: ExecutionHostId,
+  setup?: ProjectHostSetup,
+  transportOwnerEnvironmentId?: string | null
+): T {
   const parsedOwner = parseExecutionHostId(hostId)
   const runtimeOwnerEnvironmentId =
-    parsedOwner?.kind === 'runtime' ? parsedOwner.environmentId : undefined
+    transportOwnerEnvironmentId?.trim() ||
+    (parsedOwner?.kind === 'runtime' ? parsedOwner.environmentId : undefined)
   const worktreeHost = parseExecutionHostId(worktree.hostId)
   // Why: an SSH worktree reached through a paired HUB has two owners; retain the SSH execution host and stamp the HUB transport separately.
   const nextHostId =
@@ -1608,8 +1617,14 @@ async function refreshWorktreeLineageForSettings(
 ): Promise<void> {
   const lineage = await listWorktreeLineageForRuntime(settings, options)
   const hostId = getSettingsFocusedExecutionHostId(settings)
+  const projectedWorkspaceLineage = projectWorkspaceLineageRecord(
+    lineage.workspaceLineageByChildKey
+  )
   set((s) => ({
-    worktreeLineageById: mergeLineageForHost(s, hostId, lineage.worktreeLineageById),
+    worktreeLineageById: mergeLineageForHost(s, hostId, {
+      ...projectedWorkspaceLineage,
+      ...lineage.worktreeLineageById
+    }),
     workspaceLineageByChildKey: mergeWorkspaceLineageForHost(
       s,
       hostId,
@@ -1630,8 +1645,14 @@ async function refreshRemoteWorktreeLineageBestEffort(
       reuseRecentCompatibilityFailure: true
     })
     const hostId = getSettingsFocusedExecutionHostId(settings)
+    const projectedWorkspaceLineage = projectWorkspaceLineageRecord(
+      lineage.workspaceLineageByChildKey
+    )
     set((s) => ({
-      worktreeLineageById: mergeLineageForHost(s, hostId, lineage.worktreeLineageById),
+      worktreeLineageById: mergeLineageForHost(s, hostId, {
+        ...projectedWorkspaceLineage,
+        ...lineage.worktreeLineageById
+      }),
       workspaceLineageByChildKey: mergeWorkspaceLineageForHost(
         s,
         hostId,
@@ -3920,6 +3941,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
     const automationProvenanceRequest = options?.automationProvenanceRequest
     const linkedWorkItem = options?.linkedWorkItem
     const linkedTaskSourceContext = options?.linkedTaskSourceContext
+    const runtimeOwnerEnvironmentId = options?.runtimeOwnerEnvironmentId?.trim() || null
     try {
       for (let attempt = 0; attempt < CLIENT_WORKTREE_CREATE_MAX_ATTEMPTS; attempt += 1) {
         const candidateName = getClientWorktreeCreateCandidate(name, attempt)
@@ -3930,13 +3952,13 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
         try {
           // Why: manual sort is user-authored order; stamp new workspaces at the top rather than relying on sortOrder fallback.
           const manualOrder = get().sortBy === 'manual' ? Date.now() : undefined
-          const activeScope = parseWorkspaceKey(get().activeWorkspaceKey ?? '')
-          const parentWorkspace =
-            activeScope?.type === 'folder'
-              ? folderWorkspaceKey(activeScope.folderWorkspaceId)
-              : undefined
+          const parentWorkspace = resolveCreateParentWorkspace(
+            get().activeWorkspaceKey,
+            options?.parentWorkspace
+          )
           const createArgs = {
             repoId,
+            ...(options?.executionHostId ? { executionHostId: options.executionHostId } : {}),
             name: candidateName,
             baseBranch,
             ...(compareBaseRef ? { compareBaseRef } : {}),
@@ -3973,7 +3995,12 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
             ...(creationId ? { creationId } : {}),
             ...(automationProvenanceRequest ? { automationProvenanceRequest } : {})
           }
-          const target = getActiveRuntimeTarget(settingsForRepoOwner(get(), repoId))
+          const ownerSettings = runtimeOwnerEnvironmentId
+            ? get().settings
+              ? { ...get().settings, activeRuntimeEnvironmentId: runtimeOwnerEnvironmentId }
+              : ({ activeRuntimeEnvironmentId: runtimeOwnerEnvironmentId } as AppState['settings'])
+            : settingsForRepoOwner(get(), repoId, options?.executionHostId, true)
+          const target = getActiveRuntimeTarget(ownerSettings)
           if (
             target.kind === 'environment' &&
             (linkedWorkItem?.provider === 'jira' || linkedTaskSourceContext?.provider === 'jira')
@@ -3992,6 +4019,9 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                   'worktree.create',
                   {
                     repo: repoId,
+                    ...(options?.executionHostId
+                      ? { executionHostId: options.executionHostId }
+                      : {}),
                     name: candidateName,
                     baseBranch,
                     ...(compareBaseRef ? { compareBaseRef } : {}),
@@ -4045,26 +4075,53 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                 )
           // Why: worktrees.onChanged can add this worktree before this callback runs; appending blindly would duplicate it (React key clash).
           set((s) => {
-            const hostId = repoHostId(s, repoId)
+            const hostId =
+              options?.executionHostId ??
+              (runtimeOwnerEnvironmentId
+                ? toRuntimeExecutionHostId(runtimeOwnerEnvironmentId)
+                : repoHostId(s, repoId))
             const createdWorktree = withRepoHostOwnership(
               result.worktree,
               hostId,
-              getProjectHostSetupForRepoHost(s, repoId, hostId)
+              getProjectHostSetupForRepoHost(s, repoId, hostId),
+              runtimeOwnerEnvironmentId
             )
             const current = s.worktreesByRepo[repoId] ?? []
-            const alreadyPresent = current.some((w) => w.id === createdWorktree.id)
+            const hostMatchOptions = worktreeHostMatchOptions(s, repoId, hostId)
+            const alreadyPresent = current.some(
+              (worktree) =>
+                worktree.id === createdWorktree.id &&
+                worktreeMatchesHost(worktree, hostId, hostMatchOptions)
+            )
             const nextWorktrees = alreadyPresent
               ? current.map((worktree) =>
-                  worktree.id === createdWorktree.id
+                  worktree.id === createdWorktree.id &&
+                  worktreeMatchesHost(worktree, hostId, hostMatchOptions)
                     ? { ...worktree, ...createdWorktree }
                     : worktree
                 )
               : [...current, createdWorktree]
+            const projectedCreatedLineage = result.workspaceLineage
+              ? projectWorkspaceLineageRecord({
+                  [result.workspaceLineage.childWorkspaceKey]: result.workspaceLineage
+                })
+              : {}
+            const createdLineage = result.lineage
+              ? { [result.lineage.worktreeId]: result.lineage }
+              : projectedCreatedLineage
             return {
               worktreesByRepo: {
                 ...s.worktreesByRepo,
                 [repoId]: nextWorktrees
               },
+              ...(Object.keys(createdLineage).length > 0
+                ? {
+                    worktreeLineageById: {
+                      ...s.worktreeLineageById,
+                      ...createdLineage
+                    }
+                  }
+                : {}),
               ...(result.workspaceLineage
                 ? {
                     workspaceLineageByChildKey: {

--- a/src/shared/project-host-setup-projection.test.ts
+++ b/src/shared/project-host-setup-projection.test.ts
@@ -468,6 +468,51 @@ describe('project host setup projection', () => {
       projectHostSetupId: 'remote-repo'
     })
   })
+
+  it('selects setup ownership from the repo execution host', () => {
+    const targetRepo = repo({
+      id: 'same-repo',
+      path: '/srv/remote/orca',
+      displayName: 'orca',
+      connectionId: 'remote-box'
+    })
+
+    expect(
+      getProjectHostSetupWorktreeMeta(
+        [
+          {
+            id: 'local-setup',
+            projectId: 'project-1',
+            hostId: 'local',
+            repoId: 'same-repo',
+            path: '/Users/alice/orca',
+            displayName: 'orca',
+            setupState: 'ready',
+            setupMethod: 'legacy-repo',
+            createdAt: 1,
+            updatedAt: 1
+          },
+          {
+            id: 'ssh-setup',
+            projectId: 'project-1',
+            hostId: 'ssh:remote-box',
+            repoId: 'same-repo',
+            path: '/srv/remote/orca',
+            displayName: 'orca',
+            setupState: 'ready',
+            setupMethod: 'legacy-repo',
+            createdAt: 1,
+            updatedAt: 1
+          }
+        ],
+        targetRepo
+      )
+    ).toEqual({
+      projectId: 'project-1',
+      hostId: 'ssh:remote-box',
+      projectHostSetupId: 'ssh-setup'
+    })
+  })
 })
 
 describe('isGitHubBackedRepo', () => {

--- a/src/shared/project-host-setup-projection.ts
+++ b/src/shared/project-host-setup-projection.ts
@@ -296,8 +296,9 @@ export function getProjectHostSetupForRepo(
   setups: readonly ProjectHostSetup[],
   repo: Repo
 ): ProjectHostSetup {
+  const hostId = getRepoExecutionHostId(repo)
   return (
-    setups.find((setup) => setup.repoId === repo.id) ??
+    setups.find((setup) => setup.repoId === repo.id && setup.hostId === hostId) ??
     projectHostSetupProjectionFromRepos([repo]).setups[0]
   )
 }

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2233,6 +2233,8 @@ export type SparsePreset = {
 
 export type CreateWorktreeArgs = {
   repoId: string
+  /** Desktop execution host that owns this repo when repo IDs are duplicated across hosts. */
+  executionHostId?: ExecutionHostId
   name: string
   /** Optional user-facing label to persist separately from the git-safe
    *  branch/path seed. Used when a workspace is created from a GitHub or

--- a/src/shared/workspace-lineage-worktree-projection.test.ts
+++ b/src/shared/workspace-lineage-worktree-projection.test.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+import type { WorkspaceLineage } from './types'
+import {
+  projectWorkspaceLineageRecord,
+  projectWorkspaceLineageToWorktreeLineage
+} from './workspace-lineage-worktree-projection'
+
+const worktreeLineage: WorkspaceLineage = {
+  childWorkspaceKey: 'worktree:repo::/child',
+  childInstanceId: 'child-instance',
+  parentWorkspaceKey: 'worktree:repo::/parent',
+  parentInstanceId: 'parent-instance',
+  origin: 'manual',
+  capture: { source: 'manual-action', confidence: 'explicit' },
+  createdAt: 42
+}
+
+describe('workspace lineage worktree projection', () => {
+  it('projects worktree-to-worktree lineage for sidebar nesting', () => {
+    expect(projectWorkspaceLineageToWorktreeLineage(worktreeLineage)).toEqual({
+      worktreeId: 'repo::/child',
+      worktreeInstanceId: 'child-instance',
+      parentWorktreeId: 'repo::/parent',
+      parentWorktreeInstanceId: 'parent-instance',
+      origin: 'manual',
+      capture: { source: 'manual-action', confidence: 'explicit' },
+      createdAt: 42
+    })
+  })
+
+  it('does not project folder lineage into the worktree-only tree', () => {
+    expect(
+      projectWorkspaceLineageToWorktreeLineage({
+        ...worktreeLineage,
+        parentWorkspaceKey: 'folder:project-1',
+        parentInstanceId: null
+      })
+    ).toBeNull()
+  })
+
+  it('indexes projected lineage by child worktree id', () => {
+    expect(
+      projectWorkspaceLineageRecord({ [worktreeLineage.childWorkspaceKey]: worktreeLineage })
+    ).toHaveProperty('repo::/child.parentWorktreeId', 'repo::/parent')
+  })
+})

--- a/src/shared/workspace-lineage-worktree-projection.ts
+++ b/src/shared/workspace-lineage-worktree-projection.ts
@@ -1,0 +1,45 @@
+import type { WorkspaceLineage, WorktreeLineage } from './types'
+import { parseWorkspaceKey } from './workspace-scope'
+
+export function projectWorkspaceLineageToWorktreeLineage(
+  lineage: WorkspaceLineage
+): WorktreeLineage | null {
+  const child = parseWorkspaceKey(lineage.childWorkspaceKey)
+  const parent = parseWorkspaceKey(lineage.parentWorkspaceKey)
+  if (
+    child?.type !== 'worktree' ||
+    parent?.type !== 'worktree' ||
+    !lineage.childInstanceId ||
+    !lineage.parentInstanceId
+  ) {
+    return null
+  }
+  return {
+    worktreeId: child.worktreeId,
+    worktreeInstanceId: lineage.childInstanceId,
+    parentWorktreeId: parent.worktreeId,
+    parentWorktreeInstanceId: lineage.parentInstanceId,
+    origin: lineage.origin,
+    capture: lineage.capture,
+    ...(lineage.taskId ? { taskId: lineage.taskId } : {}),
+    ...(lineage.orchestrationRunId ? { orchestrationRunId: lineage.orchestrationRunId } : {}),
+    ...(lineage.coordinatorHandle ? { coordinatorHandle: lineage.coordinatorHandle } : {}),
+    ...(lineage.createdByTerminalHandle
+      ? { createdByTerminalHandle: lineage.createdByTerminalHandle }
+      : {}),
+    createdAt: lineage.createdAt
+  }
+}
+
+export function projectWorkspaceLineageRecord(
+  workspaceLineageByChildKey: Readonly<Record<string, WorkspaceLineage>>
+): Record<string, WorktreeLineage> {
+  const projected: Record<string, WorktreeLineage> = {}
+  for (const lineage of Object.values(workspaceLineageByChildKey)) {
+    const worktreeLineage = projectWorkspaceLineageToWorktreeLineage(lineage)
+    if (worktreeLineage) {
+      projected[worktreeLineage.worktreeId] = worktreeLineage
+    }
+  }
+  return projected
+}


### PR DESCRIPTION
## Summary

  Add two context-menu actions for quickly creating related worktrees:

  - **Fork** creates a parallel worktree and defaults its name to `<current>_fork`.
  - **Create Child** creates a child worktree and defaults its name to `<current>_child`.
  - Both actions allow editing the branch/worktree name before creation.
  - Child lineage is persisted and displayed immediately in the sidebar.
  - Creation and hook inspection preserve the selected execution host across local, direct SSH, paired-runtime, and nested SSH configurations.
  - Cached or invalidated runtime scans can no longer remove newly-created lineage and turn child worktrees into sibling nodes.

## Why this is needed

  Creating related worktrees previously required users to manually create a branch and worktree, then separately configure its hierarchy. This is repetitive and
  makes it easy to assign an incorrect parent or lose the relationship between related tasks.

  **Quick Fork** is needed when exploring an alternative implementation or running parallel work from the same starting point. The fork should remain at the same
  hierarchy level as the source worktree, making alternative approaches easy to identify and compare.

  **Create Child** is needed when decomposing work into a dependent subtask. Persisting the selected worktree as the parent keeps task ownership and hierarchy
  visible in the sidebar instead of presenting the child as an unrelated sibling.

  Together, these actions make common parallel and hierarchical development workflows available directly from the worktree context menu while removing several
  manual and error-prone steps.

  ## Screenshots

  Attach a screenshot or recording showing:

  1. The new **Fork** and **Create Child** context-menu actions.
  2. A newly-created child rendered beneath its parent in the sidebar.
  
<img width="216" height="416" alt="image" src="https://github.com/user-attachments/assets/1331799b-4e95-40d8-82f3-4a47f65c3b4b" />


  ## Testing

  - [x] `pnpm lint`
  - [x] `pnpm typecheck`
  - [ ] `pnpm test`
  - [x] `pnpm build`
  - [x] Added or updated high-quality tests that would catch regressions

  Targeted regression coverage passed:

  - 8 relevant test files
  - 1,612 tests passed
  - 1 test skipped

  The full test command was started, but the local machine produced widespread unrelated timeout failures across Git, HTTP, PTY, VM, lock, and macOS helper
  tests. These failures were outside the changed files and consistently hit fixed timeout limits under load.

  Manual dev-runtime verification covered:

  - Creating a child after priming the worktree scan cache.
  - Confirming both `parentWorktreeId` and the parent's `childWorktreeIds`.
  - Confirming lineage remains intact after the previous 30-second cache TTL.
  - Cleaning up the temporary verification worktree and branch.

  ## AI Review Report

  The AI review checked:

  - macOS, Linux, and Windows compatibility.
  - Local, direct SSH, paired-runtime, and nested SSH ownership routing.
  - Folder workspace behavior.
  - Duplicate repo IDs across execution hosts.
  - Hook inspection and setup ownership routing.
  - Worktree lineage persistence, stale path reuse, cached scans, and invalidated in-flight scans.
  - UI consistency with the Orca style guide and existing shadcn primitives.
  - Performance impact of worktree scan invalidation and lineage projection.
  - Generic behavior across supported agents, integrations, and Git providers.

  Issues found and addressed:

  - Desktop creation initially dropped the selected execution host.
  - Runtime creation initially dropped the nested SSH execution host.
  - Activation initially used an unqualified worktree lookup.
  - Hook inspection initially preferred the SSH host over its paired runtime owner.
  - Setup ownership initially selected the first matching repo instead of the selected host.
  - Child lineage was written correctly but later removed by a stale 30-second runtime scan cache.
  - Legacy unstamped repos could be incorrectly reused by SSH host-qualified resolution.

  The final implementation scopes repo resolution by execution host, routes nested SSH through its runtime owner, persists both workspace and worktree lineage,
  and only permits fresh authoritative scans to prune lineage.

  No shortcut, shortcut-label, shell syntax, or platform-specific path behavior was introduced.

  ## Security Audit

  Reviewed security-sensitive areas:

  - User-provided worktree names continue through the existing sanitization and branch-conflict handling.
  - Execution host IDs are validated at RPC and IPC boundaries.
  - Host-qualified repo resolution fails closed on missing or ambiguous owners.
  - No new shell interpolation or direct command construction was introduced.
  - No credentials, tokens, or secrets are persisted or logged.
  - Hook trust checks run on the selected execution authority.
  - No new dependencies were added.
  - Cache invalidation is scoped by repository ID and does not widen filesystem or network access.

  No follow-up security work is required.

  ## Notes

  - This PR contains a visible UI change.
  - Fork and Child are disabled for folder workspaces, bare repositories, archived worktrees, and rows without a usable branch.
  - Existing Git creation and setup-hook policies remain unchanged.
  - X/Twitter: **@YOUR_HANDLE**