### PR TITLE
fix(wsl-cli): pass CLI arguments to the WSL bridge out of band

### DIFF
--- a/src/main/cli/wsl-cli-bridge-argument-forwarding.test.ts
+++ b/src/main/cli/wsl-cli-bridge-argument-forwarding.test.ts
@@ -1,0 +1,218 @@
+import { execFileSync } from 'node:child_process'
+import { chmod, mkdir, mkdtemp, readFile, realpath, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+import {
+  WSL_BRIDGE_INVOCATION_FLAG,
+  buildWslBridgeScript,
+  buildWslLauncher
+} from './wsl-cli-scripts'
+
+const WINDOWS_LAUNCHER = 'C:\\Program Files\\Orca\\resources\\bin\\orca.exe'
+const BRIDGE_PATH = '/home/alice/.local/share/orca/orca-wsl-bridge.ps1'
+
+// The reported failure: `--for` is a prefix of the bridge's former -ForwardArgs
+// parameter, so PowerShell bound it as a parameter name and the leading
+// subcommands lost their positional slot.
+const REGRESSION_ARGV = [
+  'terminal',
+  'wait',
+  '--terminal',
+  'HANDLE',
+  '--for',
+  'tui-idle',
+  '--timeout-ms',
+  '1000'
+]
+
+// Flags that collided with the bridge's own parameters or with the common
+// parameters CmdletBinding used to add. These were dropped without any error.
+const COLLIDING_ARGV = [
+  '--for',
+  'a',
+  '--forwardargs',
+  'b',
+  '--orcalauncher',
+  'c',
+  '--wslcwd',
+  'd',
+  '--verbose',
+  '--debug',
+  '--erroraction',
+  'Stop',
+  '--ov',
+  'e'
+]
+
+const HOSTILE_ARGV = [
+  'say "hi"',
+  "it's",
+  'sp ace',
+  '',
+  '-',
+  '--',
+  '--%',
+  'amp&and',
+  'pct%var%',
+  'caret^x',
+  'dollar$x',
+  'back`tick',
+  'semi;colon',
+  'ünïcødé 한글',
+  'trailing\\',
+  'new\nline',
+  'tab\there'
+]
+
+function splitTerminatedRecords(payload: string): string[] {
+  // Every record is NUL-terminated, so the split always leaves a trailing slot.
+  return payload.split('\0').slice(0, -1)
+}
+
+type LauncherRun = {
+  powershellArgv: string[]
+  target: string
+  cwd: string
+  expectedCwd: string
+  forwarded: string[]
+}
+
+/**
+ * Runs the generated launcher under real bash with stubbed Windows interop and
+ * returns the payload it hands PowerShell.
+ *
+ * Scope: this stops at the launcher. It does not execute the bridge, and it says
+ * nothing about `& $OrcaLauncher @ForwardArgs`, where PowerShell 5.1 still drops
+ * ASCII quotes and empty strings when building native argv (#12231).
+ */
+async function runGeneratedLauncher(argv: string[]): Promise<LauncherRun> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-wsl-bridge-argv-'))
+  try {
+    const binDir = join(root, 'bin')
+    const workDir = join(root, 'work')
+    await mkdir(binDir, { recursive: true })
+    await mkdir(workDir, { recursive: true })
+
+    const argvFile = join(root, 'powershell-argv')
+    await writeFile(join(binDir, 'wslpath'), '#!/usr/bin/env bash\nprintf "WIN:%s" "$2"\n', 'utf8')
+    await writeFile(
+      join(binDir, 'powershell.exe'),
+      `#!/usr/bin/env bash\nfor a in "$@"; do printf '%s\\0' "$a"; done > ${JSON.stringify(argvFile)}\n`,
+      'utf8'
+    )
+    await chmod(join(binDir, 'wslpath'), 0o755)
+    await chmod(join(binDir, 'powershell.exe'), 0o755)
+
+    const launcherPath = join(root, 'orca-ide')
+    await writeFile(launcherPath, buildWslLauncher(WINDOWS_LAUNCHER, BRIDGE_PATH), 'utf8')
+
+    execFileSync('bash', [launcherPath, ...argv], {
+      cwd: workDir,
+      env: { ...process.env, PATH: `${binDir}:${process.env.PATH ?? ''}` }
+    })
+
+    const powershellArgv = splitTerminatedRecords(await readFile(argvFile, 'utf8'))
+    const encoded = powershellArgv.at(-1) ?? ''
+    const records = splitTerminatedRecords(Buffer.from(encoded, 'base64').toString('utf8'))
+    return {
+      powershellArgv,
+      target: records[0] ?? '',
+      cwd: records[1] ?? '',
+      expectedCwd: `WIN:${await realpath(workDir)}`,
+      forwarded: records.slice(2)
+    }
+  } finally {
+    await rm(root, { recursive: true, force: true })
+  }
+}
+
+describe('WSL CLI bridge argument forwarding', () => {
+  it('keeps forwarded arguments away from the PowerShell parameter binder', () => {
+    const bridge = buildWslBridgeScript()
+
+    // Why: the bug was a param() block. Any declared parameter makes PowerShell
+    // prefix-match forwarded flags against it, so re-adding one silently breaks
+    // every multi-flag command again.
+    expect(bridge).not.toMatch(/^\s*param\s*\(/mu)
+    expect(bridge).not.toContain('CmdletBinding')
+    expect(bridge).not.toContain('ValueFromRemainingArguments')
+    expect(bridge).toContain(`$args[0] -eq '${WSL_BRIDGE_INVOCATION_FLAG}'`)
+  })
+
+  it('guards the payload decode', () => {
+    // Why: no test executes PowerShell, so pin the two decode invariants by
+    // shape — a short payload must be rejected rather than indexed into, and the
+    // trailing slot from the launcher's final NUL must be dropped.
+    const bridge = buildWslBridgeScript()
+
+    expect(bridge).toContain('$records.Count -lt 3')
+    expect(bridge).toContain('$records[0..($records.Count - 2)]')
+  })
+
+  it('still reads the previous launcher calling convention', () => {
+    // Why: the installer publishes the bridge before the launcher, so an
+    // interrupted upgrade leaves this bridge paired with the old launcher.
+    const bridge = buildWslBridgeScript()
+
+    expect(bridge).toContain("$ForwardArgs[0] -eq '-WslCwd'")
+    expect(bridge).toContain('$OrcaLauncher = $args[0]')
+  })
+
+  it.skipIf(process.platform === 'win32')(
+    'forwards the reported multi-flag command unchanged',
+    async () => {
+      const run = await runGeneratedLauncher(REGRESSION_ARGV)
+
+      expect(run.forwarded).toEqual(REGRESSION_ARGV)
+      expect(run.target).toBe(WINDOWS_LAUNCHER)
+      expect(run.powershellArgv.slice(0, 4)).toEqual([
+        '-NoProfile',
+        '-ExecutionPolicy',
+        'Bypass',
+        '-File'
+      ])
+      expect(run.powershellArgv[4]).toBe(`WIN:${BRIDGE_PATH}`)
+      expect(run.powershellArgv[5]).toBe(WSL_BRIDGE_INVOCATION_FLAG)
+      // Why: exactly one opaque record reaches PowerShell, so no CLI token can
+      // ever be read as a parameter name.
+      expect(run.powershellArgv).toHaveLength(7)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')(
+    'forwards flags that collide with the bridge and CmdletBinding parameter names',
+    async () => {
+      const run = await runGeneratedLauncher(COLLIDING_ARGV)
+
+      expect(run.forwarded).toEqual(COLLIDING_ARGV)
+    }
+  )
+
+  // Why: encoding only. These same arguments are still corrupted later at
+  // `& $OrcaLauncher @ForwardArgs` (#12231), so a pass here must not be read as
+  // proof that quotes and empty strings reach the CLI.
+  it.skipIf(process.platform === 'win32')(
+    'encodes quoting, empty, and non-ASCII arguments into the payload without loss',
+    async () => {
+      const run = await runGeneratedLauncher(HOSTILE_ARGV)
+
+      expect(run.forwarded).toEqual(HOSTILE_ARGV)
+    }
+  )
+
+  it.skipIf(process.platform === 'win32')('forwards an empty argument list', async () => {
+    const run = await runGeneratedLauncher([])
+
+    expect(run.forwarded).toEqual([])
+    expect(run.target).toBe(WINDOWS_LAUNCHER)
+  })
+
+  it.skipIf(process.platform === 'win32')('carries the resolved WSL cwd', async () => {
+    const run = await runGeneratedLauncher(['terminal', 'list', '--json'])
+
+    expect(run.cwd).toBe(run.expectedCwd)
+    expect(run.forwarded).toEqual(['terminal', 'list', '--json'])
+  })
+})

--- a/src/main/cli/wsl-cli-installer.test.ts
+++ b/src/main/cli/wsl-cli-installer.test.ts
@@ -331,12 +331,13 @@ describe('WslCliInstaller', () => {
     expect(launcher.indexOf('ORCA_WSL_CWD=$(pwd -P')).toBeLessThan(
       launcher.indexOf('ORCA_BRIDGE_PS1_WIN=$(wslpath')
     )
-    expect(launcher).toContain('"$ORCA_WIN_LAUNCHER" -WslCwd "$ORCA_WSL_CWD_WIN" "$@"')
+    expect(launcher).toContain(
+      `ORCA_INVOCATION_B64=$(printf '%s\\0' "$ORCA_WIN_LAUNCHER" "$ORCA_WSL_CWD_WIN" "$@" | base64 | tr -d '\\n')`
+    )
+    expect(launcher).toContain(
+      '-File "$ORCA_BRIDGE_PS1_WIN" --orca-invocation-b64 "$ORCA_INVOCATION_B64"'
+    )
     expect(launcher).not.toContain('-Command')
-    expect(bridge).toContain('[CmdletBinding(PositionalBinding=$false)]')
-    expect(bridge).toContain('[Parameter(Mandatory=$true, Position=0)]')
-    expect(bridge).toContain('[string]$WslCwd')
-    expect(bridge).toContain('[Parameter(ValueFromRemainingArguments=$true)]')
     expect(bridge).toContain('if ([string]::IsNullOrEmpty($WslCwd))')
     expect(bridge).toContain('$env:ORCA_CLI_CWD = $WslCwd')
     expect(bridge).toContain('Push-Location -LiteralPath (Split-Path -Parent $OrcaLauncher)')

--- a/src/main/cli/wsl-cli-scripts.ts
+++ b/src/main/cli/wsl-cli-scripts.ts
@@ -1,6 +1,11 @@
 const MANAGED_MARKER = '# Orca managed WSL CLI launcher'
 const BRIDGE_MANAGED_MARKER = '# Orca managed WSL CLI PowerShell bridge'
 
+// Why: PowerShell's binder prefix-matches parameter names, so forwarding argv as
+// real arguments lets a CLI flag bind the bridge's own parameters -- `--for` is a
+// prefix of `-ForwardArgs`. One opaque record keeps every token out of the binder.
+export const WSL_BRIDGE_INVOCATION_FLAG = '--orca-invocation-b64'
+
 export function buildWslLauncher(
   windowsLauncherPath: string,
   bridgePath = '${XDG_DATA_HOME:-$HOME/.local/share}/orca/orca-wsl-bridge.ps1'
@@ -28,25 +33,40 @@ ORCA_WSL_CWD=$(pwd -P 2>/dev/null) || {
 }
 ORCA_BRIDGE_PS1_WIN=$(wslpath -w "$ORCA_BRIDGE_PS1")
 ORCA_WSL_CWD_WIN=$(wslpath -w "$ORCA_WSL_CWD")
-exec "$ORCA_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$ORCA_BRIDGE_PS1_WIN" "$ORCA_WIN_LAUNCHER" -WslCwd "$ORCA_WSL_CWD_WIN" "$@"
+# Why: every record is NUL-terminated so an empty trailing argument survives.
+ORCA_INVOCATION_B64=$(printf '%s\\0' "$ORCA_WIN_LAUNCHER" "$ORCA_WSL_CWD_WIN" "$@" | base64 | tr -d '\\n')
+exec "$ORCA_POWERSHELL" -NoProfile -ExecutionPolicy Bypass -File "$ORCA_BRIDGE_PS1_WIN" ${WSL_BRIDGE_INVOCATION_FLAG} "$ORCA_INVOCATION_B64"
 `
 }
 
 export function buildWslBridgeScript(): string {
+  // Why: no param() block. A declared parameter makes PowerShell's binder read
+  // forwarded flags as parameter names, which corrupts or drops CLI arguments.
   return `${BRIDGE_MANAGED_MARKER}
-[CmdletBinding(PositionalBinding=$false)]
-param(
-  [Parameter(Mandatory=$true, Position=0)]
-  [string]$OrcaLauncher,
-
-  [string]$WslCwd,
-
-  [Parameter(ValueFromRemainingArguments=$true)]
-  [string[]]$ForwardArgs
-)
-
 $exitCode = 0
 try {
+  if ($args.Count -eq 2 -and $args[0] -eq '${WSL_BRIDGE_INVOCATION_FLAG}') {
+    $records = @([Text.Encoding]::UTF8.GetString([Convert]::FromBase64String($args[1])).Split([char]0))
+    if ($records.Count -lt 3) {
+      throw 'Orca WSL bridge received a malformed invocation payload.'
+    }
+    # Why: the launcher terminates every record, leaving one trailing empty slot.
+    $records = @($records[0..($records.Count - 2)])
+    $OrcaLauncher = $records[0]
+    $WslCwd = $records[1]
+    $ForwardArgs = @($records | Select-Object -Skip 2)
+  } else {
+    # Why: an interrupted upgrade can pair this bridge with the previous launcher,
+    # which passed the target positionally ahead of -WslCwd.
+    $OrcaLauncher = $args[0]
+    $ForwardArgs = @($args | Select-Object -Skip 1)
+    $WslCwd = ''
+    if ($ForwardArgs.Count -ge 2 -and $ForwardArgs[0] -eq '-WslCwd') {
+      $WslCwd = $ForwardArgs[1]
+      $ForwardArgs = @($ForwardArgs | Select-Object -Skip 2)
+    }
+  }
+
   if ([string]::IsNullOrEmpty($WslCwd)) {
     Remove-Item Env:ORCA_CLI_CWD -ErrorAction SilentlyContinue
   } else {


### PR DESCRIPTION
## Summary

Fixes #12196. From WSL, any Orca CLI command containing `--for` died before reaching `orca.exe`:

```
$ orca-ide terminal wait --terminal <handle> --for tui-idle --timeout-ms 1000
orca-wsl-bridge.ps1 : A positional parameter cannot be found that accepts argument 'terminal'.
    + FullyQualifiedErrorId : PositionalParameterNotFound,orca-wsl-bridge.ps1
```

PowerShell's parameter binder prefix-matches parameter names, so `--for` bound the bridge's own `-ForwardArgs`, consumed `tui-idle` as its value, and stopped remaining-argument collection — leaving `terminal wait` with no positional slot. This breaks the wait idiom documented throughout the bundled `orchestration` and `orca-cli` skill guides, so an agent following shipped guidance on WSL hits it immediately.

**The collision was wider than `--for`.** Verified against Windows PowerShell 5.1.26100.8875 on WSL2:

| Forwarded flag | Old behavior |
| --- | --- |
| `--for tui-idle` | binds `-ForwardArgs`; crash, or **silent** loss of `--for` when no positional precedes it |
| `--orcalauncher <path>` | rebinds `-OrcaLauncher`, so the bridge executes **a different program** |
| `--wslcwd <x>` | `ParameterAlreadyBound` error |
| `--verbose`, `--debug`, `--erroraction`, `--ov` | swallowed by CmdletBinding common parameters, **no error at all** |

Renaming the parameter only moves the collision, and nothing can be renamed out of the way of PowerShell's built-in common parameters.

**This change removes the whole class instead.** The launcher NUL-terminates the target path, the cwd, and every argument, base64-encodes them, and passes the bridge exactly one opaque token behind a fixed sentinel. No CLI token ever reaches the parameter binder. The bridge drops its `param()` block entirely and reads `$args`.

Two details worth review:

- The bridge still understands the previous positional + `-WslCwd` convention. The installer publishes the bridge before the launcher (asserted in `wsl-cli-installer.test.ts`), so an interrupted upgrade can pair a new bridge with an old launcher.
- `base64` is not a new dependency: every WSL command Orca runs already goes through `printf %s '<b64>' | base64 -d | bash` in `buildEncodedWslBashCommand`.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — see note below
- [ ] `pnpm build` — not run locally; this host cannot build the native modules (`node-gyp` unavailable)
- [x] Added or updated high-quality tests that would catch regressions

`src/main/cli/` and `src/cli/` are fully green (68 files, 841 tests). On a full local run, `src/main/updater.test.ts` and `src/main/daemon/pty-subprocess.test.ts` fail — these reproduce identically on the unmodified parent commit on this WSL host and are unrelated to this change.

New `src/main/cli/wsl-cli-bridge-argument-forwarding.test.ts` runs the **generated** launcher under real `bash` with stubbed interop and asserts byte-exact argv in the payload handed to PowerShell, for the reported command, the previously swallowed flag set, and quoting/empty/non-ASCII arguments. All 7 tests fail against the pre-fix scripts.

Its scope is deliberately named: it covers the launcher's encoding and does **not** execute the bridge. The bridge's decode branch, its malformed-payload guard, and the legacy fallback are covered by string assertions plus the manual runs below, not by an executing test — adding one needs a PowerShell binary the Linux CI job may not have. Calling that out rather than letting the green checkmarks imply more than they cover.

Manually verified end-to-end on WSL2 → Windows PowerShell 5.1.26100.8875 with the real generated scripts:

- the reported command forwards all 8 arguments intact, with cwd preserved
- `-w VALUE` went from a hard `ParameterAlreadyBound` failure to forwarding correctly
- previously swallowed flags now forward as data, including `--orcalauncher`, which no longer changes what is executed
- empty-string arguments, a bare `-`, embedded `"`, `&`, `%var%`, and non-ASCII arguments reach the bridge's forwarded argument list byte-identically
- exit codes 0 / 7 / 42 propagate; malformed payload, truncated payload, no arguments, and a nonexistent target each exit 1 with a clear message
- the old launcher's calling convention still works against the new bridge, including when the user's own arguments begin with a literal `-WslCwd`

**Scope correction, stated plainly:** those quoted and empty arguments arrive intact *at the bridge*, not at `orca.exe`. Measured against a native argv-dumping exe, `--config '{"name":"x","n":1}'` still arrives as `{name:x,n:1}` and `--text 'echo "hello world"'` still splits into an extra argument. That is the pre-existing #12231 hop, byte-identical before and after this change — but it means this PR does not make quoted or empty arguments work end-to-end, and I did not want the test names or this description to suggest otherwise.

## AI Review Report

Reviewed with an AI coding agent across the dimensions below. Everything marked verified was executed against Windows PowerShell 5.1.26100.8875 on WSL2 using the **generated** scripts, not a hand-written approximation.

**Cross-platform (macOS / Linux / Windows).** The change only alters the two scripts Orca installs inside a WSL distro; no macOS or Linux code path is touched, and no UI, shortcut, label, or path-construction code is involved. The bash side uses `printf '%s\0'`, `base64`, and `tr`, all present in both GNU coreutils and busybox; `base64` is already required by this same code path (`buildEncodedWslBashCommand` runs `printf %s '<b64>' | base64 -d | bash`). Verified the emitted bash is correct under `set -euo pipefail`, including the empty-`$@` case.

**Upgrade / mixed-version compatibility.** This is the real compatibility surface here: the installer publishes the bridge before the launcher, so an interrupted upgrade pairs a new bridge with an old launcher. Verified the new bridge still executes correctly when invoked with the previous positional + `-WslCwd` convention, cwd included. This is not a remote client/host wire, so `docs/reference/remote-wire-compatibility.md` does not apply.

**Error handling.** Verified every failure path exits non-zero rather than looking like success: malformed base64, a truncated payload, the bridge invoked with no arguments, and a nonexistent target all exit 1 with a clear message; the happy path exits 0. Exit-code propagation through the bridge is unchanged and verified for 0, 7, and 42.

**Performance.** One extra `base64` encode per CLI invocation, dominated by PowerShell process startup by orders of magnitude. The decode is a single `Split` plus two `Select-Object` calls over a handful of elements.

**Agent / integration / git-provider compatibility.** Nothing provider- or agent-specific: this is argument transport. It unblocks the `terminal wait --for` idiom that the bundled `orchestration` and `orca-cli` skill guides already document.

**UI.** No visual change.

## Security Audit

**Argument injection — fixed, and this was the sharpest issue.** Before, a forwarded `--orcalauncher <path>` rebound `-OrcaLauncher` and the bridge executed that path instead of Orca. Verified this no longer happens: the flag now arrives as inert data. Note the pre-existing severity was limited — the arguments originate from the user's own command line, so this was argument *corruption* rather than a privilege boundary — but it did mean a mistyped or agent-generated flag could redirect execution.

**Sentinel spoofing — verified closed.** Ran `orca-ide --orca-invocation-b64 <crafted valid base64> real-arg`. The crafted payload is forwarded as three ordinary arguments and never interpreted, because the launcher always emits exactly two arguments and the user's tokens live *inside* the outer record. The legacy branch cannot be reached this way either, since its `$args[0]` is always the launcher path.

**Command injection in the generated bash.** The base64 value is expanded double-quoted (`"$ORCA_INVOCATION_B64"`) and its alphabet cannot contain shell metacharacters. Argument values reach `printf` as positional parameters and are never re-parsed by the shell. Verified with arguments containing `&`, `;`, `^`, `%var%`, `$`, backticks, quotes, newlines, and tabs.

**Path handling.** `Split-Path -Parent` and `Push-Location -LiteralPath` operate on the launcher path that Orca itself wrote into the script, not on user input — and user input can no longer reach that variable, which is the point of the change. A nonexistent target fails loudly with exit 1.

**Resilience.** Malformed and truncated payloads are rejected with an explicit error and exit 1. Command-line overflow fails loudly (see Notes) rather than silently truncating, which is the failure mode that would actually be dangerous here.

**Unchanged.** `-NoProfile -ExecutionPolicy Bypass` and the bridge's install location and permissions are untouched by this PR.

## Notes

- Windows/WSL only. No macOS or Linux behavior changes; nothing outside `src/main/cli/` reads this contract.
- **Tradeoff, measured:** base64 costs 4/3 of the Windows command-line budget. On this host the largest single argument that survives went from ~32000 chars to ~24000. Both before and after, exceeding it fails loudly (`powershell.exe: Invalid argument`, exit 1) rather than truncating silently, and #12239's `--text-stdin` covers the large-payload case. Flagging it explicitly so it is a deliberate call rather than a surprise.
- Relationship to open work: #12234 fixes the same issue by renaming `$ForwardArgs` to `$OrcaForwardArgs` and adding a CI guard that cross-checks CLI flags against bridge parameter names. That resolves today's symptom; this PR takes the alternative of removing the binder from the path entirely, which also covers the `-OrcaLauncher`/`-WslCwd`/common-parameter cases and needs no ongoing guard. Happy to close this in favor of #12234 if maintainers prefer the smaller change.
- This does **not** fix #12231 (PowerShell 5.1 dropping ASCII `"` and empty strings when building native argv for `orca.exe`). That is a separate boundary — the `& $OrcaLauncher @ForwardArgs` call — and #12582 addresses it. The two changes are complementary; #12582 touches the same line, so whichever lands second will need a trivial rebase.
- While adversarially testing this change I confirmed #12231 is fixable rather than an inherent Windows limit: a CRT-correct escaper (escape `"` as `\"`, double backslash runs preceding a quote, wrap when the value contains whitespace or a quote, emit `""` for empty) driven through `[Diagnostics.ProcessStartInfo]` delivers `{"name":"x","n":1}`, an empty argument, and `echo "hello world"` all byte-exact. Offering that in case it is useful to #12582.
- Also ruled out, so nobody re-finds it and misfiles it here: a `.cmd` target does suffer `%VAR%` expansion and genuine command injection, but `getBundledLauncherPath('win32')` resolves to `resources/bin/orca.exe` (`cli-installer.ts:1213-1214`), so the WSL bridge never targets `orca.cmd`. Not on this code path, and identical before this change.
