### PR TITLE
fix(claude-accounts): derive the Claude Keychain account the way Claude Code does

### DIFF
--- a/src/main/claude-accounts/keychain.test.ts
+++ b/src/main/claude-accounts/keychain.test.ts
@@ -15,6 +15,10 @@ vi.mock('node:child_process', () => ({
 
 const execFileMock = vi.mocked(execFile)
 const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
+// Why: the Keychain account name is derived from the environment, so pin it here
+// instead of recomputing it in every assertion — otherwise the expectations only
+// hold on machines whose own username happens to take the same branch.
+const TEST_KEYCHAIN_ACCOUNT = 'orca-test-user'
 
 function setPlatform(platform: NodeJS.Platform): void {
   Object.defineProperty(process, 'platform', {
@@ -42,10 +46,13 @@ describe('Claude Keychain credentials', () => {
   beforeEach(() => {
     setPlatform('darwin')
     execFileMock.mockReset()
+    vi.stubEnv('USER', TEST_KEYCHAIN_ACCOUNT)
+    vi.stubEnv('USERNAME', TEST_KEYCHAIN_ACCOUNT)
   })
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllEnvs()
     if (originalPlatform) {
       Object.defineProperty(process, 'platform', originalPlatform)
     }
@@ -69,7 +76,7 @@ describe('Claude Keychain credentials', () => {
       '-s',
       scopedService,
       '-a',
-      process.env.USER || process.env.USERNAME || 'user',
+      TEST_KEYCHAIN_ACCOUNT,
       '-w'
     ])
   })
@@ -94,7 +101,7 @@ describe('Claude Keychain credentials', () => {
       '-s',
       'Claude Code-credentials',
       '-a',
-      process.env.USER || process.env.USERNAME || 'user',
+      TEST_KEYCHAIN_ACCOUNT,
       '-w'
     ])
   })
@@ -115,7 +122,7 @@ describe('Claude Keychain credentials', () => {
       '-s',
       scopedService,
       '-a',
-      process.env.USER || process.env.USERNAME || 'user',
+      TEST_KEYCHAIN_ACCOUNT,
       '-w',
       'credentials-json'
     ])
@@ -138,7 +145,7 @@ describe('Claude Keychain credentials', () => {
         '-s',
         scopedService,
         '-a',
-        process.env.USER || process.env.USERNAME || 'user',
+        TEST_KEYCHAIN_ACCOUNT,
         '-w',
         'credentials-json'
       ],
@@ -148,7 +155,7 @@ describe('Claude Keychain credentials', () => {
         '-s',
         'Claude Code-credentials',
         '-a',
-        process.env.USER || process.env.USERNAME || 'user',
+        TEST_KEYCHAIN_ACCOUNT,
         '-w',
         'credentials-json'
       ]
@@ -171,9 +178,39 @@ describe('Claude Keychain credentials', () => {
       '-s',
       scopedService,
       '-a',
-      process.env.USER || process.env.USERNAME || 'user',
+      TEST_KEYCHAIN_ACCOUNT,
       '-w'
     ])
+  })
+
+  it('looks up the Claude Code fallback account when $USER is not a valid keychain account', async () => {
+    // Why: Claude Code rejects account names outside /^[a-zA-Z0-9._-]+$/ and stores
+    // the item under 'claude-code-user' instead. Reading with the raw value misses
+    // it, so account add fails with "no OAuth credentials were captured".
+    vi.stubEnv('USER', 'first@example.com')
+    vi.stubEnv('USERNAME', 'first@example.com')
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, 'scoped\n', '')
+      return null as never
+    })
+
+    await expect(
+      readActiveClaudeKeychainCredentialsStrict('/tmp/orca-claude-login-test')
+    ).resolves.toBe('scoped')
+
+    expect(execFileMock.mock.calls[0][1]).toContain('claude-code-user')
+  })
+
+  it('keeps a valid $USER as the keychain account', async () => {
+    vi.stubEnv('USER', 'first.last_1-2')
+    execFileMock.mockImplementationOnce((_file, _args, _options, callback) => {
+      invokeExecFileCallback(callback, null, 'scoped\n', '')
+      return null as never
+    })
+
+    await readActiveClaudeKeychainCredentialsStrict('/tmp/orca-claude-login-test')
+
+    expect(execFileMock.mock.calls[0][1]).toContain('first.last_1-2')
   })
 
   it('rejects when a keychain read never reports completion', async () => {
@@ -217,20 +254,8 @@ describe('Claude Keychain credentials', () => {
     await deleteActiveClaudeKeychainCredentials(configDir)
 
     expect(execFileMock.mock.calls.map((call) => call[1])).toEqual([
-      [
-        'delete-generic-password',
-        '-s',
-        scopedService,
-        '-a',
-        process.env.USER || process.env.USERNAME || 'user'
-      ],
-      [
-        'delete-generic-password',
-        '-s',
-        'Claude Code-credentials',
-        '-a',
-        process.env.USER || process.env.USERNAME || 'user'
-      ]
+      ['delete-generic-password', '-s', scopedService, '-a', TEST_KEYCHAIN_ACCOUNT],
+      ['delete-generic-password', '-s', 'Claude Code-credentials', '-a', TEST_KEYCHAIN_ACCOUNT]
     ])
   })
 })

--- a/src/main/claude-accounts/keychain.ts
+++ b/src/main/claude-accounts/keychain.ts
@@ -1,9 +1,16 @@
 import { execFile } from 'node:child_process'
 import { createHash } from 'node:crypto'
+import { userInfo } from 'node:os'
 
 const ACTIVE_CLAUDE_SERVICE = 'Claude Code-credentials'
 const ORCA_CLAUDE_SERVICE = 'Orca Claude Code Managed Credentials'
 const KEYCHAIN_COMMAND_TIMEOUT_MS = 3_000
+// Why: Claude Code only accepts a Keychain account name matching this pattern and
+// substitutes CLAUDE_CODE_FALLBACK_USER for anything else, so an SSO-provisioned
+// `$USER` like `first@example.com` is stored under the fallback. Deriving the name
+// any other way makes every lookup miss the item Claude Code actually wrote.
+const KEYCHAIN_ACCOUNT_PATTERN = /^[a-zA-Z0-9._-]+$/
+const CLAUDE_CODE_FALLBACK_USER = 'claude-code-user'
 
 type SecurityCommandResult = {
   stdout: string
@@ -79,7 +86,13 @@ export async function deleteManagedClaudeKeychainCredentials(accountId: string):
 }
 
 function getKeychainUser(): string {
-  return process.env.USER || process.env.USERNAME || 'user'
+  let user: string | undefined
+  try {
+    user = process.env.USER || process.env.USERNAME || userInfo().username
+  } catch {
+    return CLAUDE_CODE_FALLBACK_USER
+  }
+  return user && KEYCHAIN_ACCOUNT_PATTERN.test(user) ? user : CLAUDE_CODE_FALLBACK_USER
 }
 
 function getActiveClaudeService(configDir?: string): string {


### PR DESCRIPTION
Fixes #12857

## Summary

On macOS, adding a Claude account always fails with

```
Claude login completed, but no OAuth credentials were captured.
```

when `$USER` contains a character outside `[a-zA-Z0-9._-]` — e.g. an SSO-provisioned username like `first@example.com`. The browser sign-in succeeds and `claude auth login` exits 0; Orca just cannot find the Keychain item.

`getKeychainUser()` used `$USER` verbatim, but Claude Code validates the account name and substitutes a fixed fallback when it does not match:

```js
// claude 2.1.223 bundle
KXg = /^[a-zA-Z0-9._-]+$/
function hG() {
  let e
  try { e = process.env.USER || os.userInfo().username } catch { e = "claude-code-user" }
  if (!KXg.test(e)) return "claude-code-user"
  return e
}
```

So Claude Code writes the item under `claude-code-user` while Orca looks up `first@example.com`. Every `find-generic-password -a <account>` misses, `readKeychainPassword` maps `errSecItemNotFound` to `null`, and all three sources in `readCapturedCredentials` come up empty: the config-scoped item, the legacy unsuffixed item (so the "changed since snapshot" branch cannot fire either), and `<configDir>/.credentials.json` which does not exist on macOS.

This PR mirrors Claude Code's derivation so both sides agree on one account name.

Beyond account add, `writeActiveClaudeKeychainCredentialsForRuntime` was materializing managed credentials under the same unreadable account, so a managed account would not have authenticated the spawned agent either — on affected machines the feature could not work at all. Cleanup missed the item for the same reason, so `deleteActiveClaudeKeychainCredentialsStrict(configDir)` silently no-opped and every failed attempt leaked an orphaned `Claude Code-credentials-<hash>` entry into the login keychain.

Note the **service** name derivation was already correct — Claude Code builds it the same way (`Claude Code-credentials[-sha256(configDir)[0:8]]`). Only the account name was wrong.

### Verified on the affected machine

Same RPC call, nothing changed but the account name Orca derives:

```console
# before
$ accounts.addClaudeFromConfigDir '{"configDir":"…","previousLegacyCredentialsSha256":null}'
{ "ok": false, "error": { "message": "Claude login completed, but no OAuth credentials were captured." } }

# after (Orca relaunched with a $USER that satisfies the pattern)
$ accounts.addClaudeFromConfigDir '{"configDir":"…","previousLegacyCredentialsSha256":null}'
{ "ok": true, "result": { "accounts": [ { "email": "…", "authMethod": "subscription-oauth", … } ] } }
```

`previousLegacyCredentialsSha256: null` forces the legacy-Keychain branch to be accepted, which isolates the failure to the lookup itself rather than the scoped/legacy fallback logic.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — `oxlint` clean on both changed files
- [x] `pnpm typecheck` — `tsc --noEmit -p config/tsconfig.node.json` clean
- [x] `pnpm test` — `vitest run src/main/claude-accounts/keychain.test.ts`, 9 passed
- [ ] `pnpm build` — not run; the change is a pure function in `src/main`, no build-surface change
- [x] Added or updated high-quality tests that would catch regressions

Two new cases in `keychain.test.ts`: an `$USER` that fails the pattern must look up `claude-code-user`, and one that passes it must be used as-is. The first fails on `main` and passes with this change — reverting only `keychain.ts` gives `1 failed | 8 passed`.

The existing assertions recomputed `process.env.USER || process.env.USERNAME || 'user'` inline, which meant they only held on machines whose username took the same branch — exactly the case this bug is about. They now stub `USER`/`USERNAME` to a fixed value so the expectations are machine-independent.

## AI Review Report

Reviewed with Claude Opus 5, focused on:

- **Cross-platform.** `readKeychainPassword` / `writeKeychainPassword` / `deleteKeychainPassword` all return early when `process.platform !== 'darwin'`, so `getKeychainUser()` is only reachable on macOS and Windows/Linux behavior is unchanged. `process.env.USERNAME` is kept in the chain even though it is Windows-only, to avoid changing the resolution order.
- **Behavior change for existing users.** For any username already matching `[a-zA-Z0-9._-]` — the overwhelming majority — `getKeychainUser()` returns exactly what it returned before, so no existing Keychain item is orphaned by this change. Affected users have no working state to preserve, because nothing Orca wrote under the bad account name was ever readable by Claude Code.
- **Fallback ordering.** `userInfo()` replaces the previous literal `'user'` tail so the derivation matches Claude Code's, including its `try`/`catch`. `userInfo()` can throw when the uid has no passwd entry (containers), which is why it is inside the `try`.
- **Not addressed here:** Claude Code hashes `configDir.normalize('NFC')` when building the service suffix, while `getActiveClaudeService` hashes the raw string. macOS paths are frequently NFD, so a managed-auth dir containing non-ASCII characters would still mismatch. It is a separate one-line change with its own migration question, so I left it out — happy to send it as a follow-up.

## Security Audit

- **Command execution.** No change to how `security` is invoked. Arguments still go through `execFile` with an array (no shell), so the account name is never interpolated into a command string.
- **Input handling.** The new value is either an environment-derived string already constrained to `[a-zA-Z0-9._-]` or the literal `claude-code-user`; the regex is anchored at both ends and has no backtracking risk.
- **Secrets.** No change to what is read, written, or logged. The account name is not a secret and never appears in output.
- **Blast radius.** One pure function, no IPC surface, no path handling, no new dependency.

## Notes

macOS-only. `KEYCHAIN_ACCOUNT_PATTERN` and `CLAUDE_CODE_FALLBACK_USER` reproduce an undocumented Claude Code internal, so they will need to track upstream if Anthropic changes the derivation again. A more durable shape would be to drop `-a` from the read path and resolve by service alone; I did not do that here because multiple items can share a service (the orphans this bug created are proof), and `security` would then return an arbitrary one. Worth considering alongside a cleanup pass for those orphans.
