### PR TITLE
fix(gitlab): include bridge/child pipeline jobs in Checks

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -398,10 +398,22 @@ describe('gitlab client — MR operations', () => {
       expect(glabExecFileAsyncMock).toHaveBeenCalledWith(
         [
           'api',
-          'projects/g%2Fp/merge_requests?source_branch=feature%2Ffoo&order_by=updated_at&sort=desc&per_page=1'
+          'projects/g%2Fp/merge_requests?source_branch=feature%2Ffoo&order_by=updated_at&sort=desc&per_page=1&with_merge_status_recheck=true'
         ],
         { cwd: '/repo' }
       )
+    })
+
+    // Why: GitLab does not proactively recompute merge status on list endpoints, so without the
+    // recheck request the row can sit at `unchecked` forever and the sidebar merge button — which
+    // gates on MERGEABLE — never becomes available.
+    it('asks GitLab to recheck merge status on the branch lookup', async () => {
+      getProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'g/p' })
+      glabExecFileAsyncMock.mockResolvedValueOnce({ stdout: '[]' })
+
+      await getMergeRequestForBranch('/repo', 'feature/recheck')
+      const callArgs = glabExecFileAsyncMock.mock.calls[0][0] as string[]
+      expect(callArgs[1]).toContain('with_merge_status_recheck=true')
     })
 
     it('uses legacy pipeline payloads when branch MR lists omit head_pipeline', async () => {

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -321,7 +321,11 @@ export async function getMergeRequestForBranch(
         [
           'api',
           ...glabHostnameArgs(projectRef, connectionId),
-          `projects/${encodedProject(projectRef.path)}/merge_requests?source_branch=${encodeURIComponent(branchName)}&order_by=updated_at&sort=desc&per_page=1`
+          // Why: GitLab does not proactively recompute merge status on list endpoints, so this row
+          // can sit at `unchecked` forever — and the sidebar merge button gates on MERGEABLE. Ask
+          // for the async recalculation (best-effort; ignored for non-Developers when
+          // `restrict_merge_status_recheck` is on) so polling converges instead of stalling.
+          `projects/${encodedProject(projectRef.path)}/merge_requests?source_branch=${encodeURIComponent(branchName)}&order_by=updated_at&sort=desc&per_page=1&with_merge_status_recheck=true`
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -183,6 +183,39 @@ describe('mapMRInfo', () => {
     expect(info.mergeStateStatus).toBe('checking')
   })
 
+  // Why: GitLab < 15.6 has no detailed_merge_status. Without the legacy fallback these MRs stay
+  // UNKNOWN, and the merge UI (which gates on MERGEABLE) shows "Checking" with no merge button.
+  it('falls back to legacy merge_status when detailed_merge_status is absent', () => {
+    const info = mapMRInfo(
+      { iid: 1, title: 't', state: 'opened', merge_status: 'can_be_merged' },
+      'success'
+    )
+    expect(info.mergeable).toBe('MERGEABLE')
+  })
+
+  it('does not let legacy merge_status override a present detailed_merge_status', () => {
+    const info = mapMRInfo(
+      {
+        iid: 1,
+        title: 't',
+        state: 'opened',
+        detailed_merge_status: 'not_approved',
+        merge_status: 'can_be_merged'
+      },
+      'success'
+    )
+    expect(info.mergeable).toBe('UNKNOWN')
+    expect(info.mergeStateStatus).toBe('not_approved')
+  })
+
+  it('keeps legacy cannot_be_merged as UNKNOWN rather than guessing a conflict', () => {
+    const info = mapMRInfo(
+      { iid: 1, title: 't', state: 'opened', merge_status: 'cannot_be_merged' },
+      'success'
+    )
+    expect(info.mergeable).toBe('UNKNOWN')
+  })
+
   it('returns draft state when draft flag is set', () => {
     const info = mapMRInfo({ iid: 1, title: 't', state: 'opened', draft: true }, 'neutral')
     expect(info.state).toBe('draft')

--- a/src/main/gitlab/mappers.test.ts
+++ b/src/main/gitlab/mappers.test.ts
@@ -154,6 +154,7 @@ describe('mapMRInfo', () => {
       pipelineStatus: 'success',
       updatedAt: '2026-05-05T10:00:00Z',
       mergeable: 'MERGEABLE',
+      mergeStateStatus: 'mergeable',
       headSha: 'deadbeef'
     })
   })
@@ -170,6 +171,7 @@ describe('mapMRInfo', () => {
       'pending'
     )
     expect(info.mergeable).toBe('CONFLICTING')
+    expect(info.mergeStateStatus).toBe('conflict')
   })
 
   it('marks UNKNOWN when detailed_merge_status is non-mergeable but not a conflict', () => {
@@ -178,6 +180,7 @@ describe('mapMRInfo', () => {
       'pending'
     )
     expect(info.mergeable).toBe('UNKNOWN')
+    expect(info.mergeStateStatus).toBe('checking')
   })
 
   it('returns draft state when draft flag is set', () => {

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -97,6 +97,8 @@ type GitLabMRRaw = {
   sha?: string
   has_conflicts?: boolean
   detailed_merge_status?: string
+  /** Deprecated since GitLab 15.6, but the only merge signal older instances return. */
+  merge_status?: string
   description?: string | null
   target_branch?: string
   author?: { username?: string | null; avatar_url?: string | null } | null
@@ -139,6 +141,13 @@ function deriveMergeable(data: GitLabMRRaw): MRInfo['mergeable'] {
   }
   if (data.detailed_merge_status === 'broken_status' || data.detailed_merge_status === 'conflict') {
     return 'CONFLICTING'
+  }
+  // Why: `detailed_merge_status` only exists from GitLab 15.6. Without this fallback an older
+  // instance reports UNKNOWN forever, and the merge UI (which now gates on MERGEABLE) would
+  // permanently show "Checking" with no merge button. Only the positive legacy value is trusted;
+  // `cannot_be_merged` stays UNKNOWN because `has_conflicts` above already owns the conflict case.
+  if (data.detailed_merge_status === undefined && data.merge_status === 'can_be_merged') {
+    return 'MERGEABLE'
   }
   return 'UNKNOWN'
 }

--- a/src/main/gitlab/mappers.ts
+++ b/src/main/gitlab/mappers.ts
@@ -103,6 +103,8 @@ type GitLabMRRaw = {
 }
 
 export function mapMRInfo(data: GitLabMRRaw, pipelineStatus: CheckStatus): MRInfo {
+  const mergeable = deriveMergeable(data)
+  const mergeStateStatus = deriveMergeStateStatus(data, mergeable)
   return {
     number: data.iid ?? data.number ?? 0,
     title: data.title,
@@ -110,7 +112,8 @@ export function mapMRInfo(data: GitLabMRRaw, pipelineStatus: CheckStatus): MRInf
     url: data.web_url ?? data.url ?? '',
     pipelineStatus,
     updatedAt: data.updated_at ?? data.updatedAt ?? '',
-    mergeable: deriveMergeable(data),
+    mergeable,
+    ...(mergeStateStatus ? { mergeStateStatus } : {}),
     headSha: data.sha,
     baseRefName: data.target_branch,
     // Why: detail-endpoint payloads include `description`; list endpoints
@@ -138,6 +141,24 @@ function deriveMergeable(data: GitLabMRRaw): MRInfo['mergeable'] {
     return 'CONFLICTING'
   }
   return 'UNKNOWN'
+}
+
+/** Project GitLab detailed_merge_status onto a short reason the merge UI can label. */
+function deriveMergeStateStatus(
+  data: GitLabMRRaw,
+  mergeable: MRInfo['mergeable']
+): string | undefined {
+  if (mergeable === 'CONFLICTING') {
+    return 'conflict'
+  }
+  if (mergeable === 'MERGEABLE') {
+    return 'mergeable'
+  }
+  const status = data.detailed_merge_status?.toLowerCase()
+  if (!status) {
+    return undefined
+  }
+  return status
 }
 
 // ── Pipeline rollup (parallel to GitHub deriveCheckStatus) ──────────

--- a/src/main/gitlab/work-item-details.test.ts
+++ b/src/main/gitlab/work-item-details.test.ts
@@ -252,6 +252,70 @@ describe('getWorkItemDetails', () => {
     })
   })
 
+  // Why: each fetch spawns a `glab` binary (a remote exec over SSH) and this runs on the Checks
+  // poll timer, so a bridge-heavy MR must trickle its children rather than burst them.
+  it('bounds concurrent child-pipeline fetches', async () => {
+    const BRIDGE_COUNT = 25
+    let inFlightJobPages = 0
+    let peakJobPages = 0
+
+    glabExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.at(-1) as string
+      if (endpoint === 'projects/g%2Fp/merge_requests/12') {
+        return {
+          stdout: JSON.stringify({
+            iid: 12,
+            title: 'Fan out',
+            state: 'opened',
+            web_url: 'https://gitlab.com/g/p/-/merge_requests/12',
+            updated_at: '2026-05-31T12:00:00Z',
+            source_branch: 'f',
+            target_branch: 'main',
+            sha: 'head-sha',
+            head_pipeline: { id: 99 }
+          })
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/pipelines/99/bridges?per_page=100') {
+        return {
+          stdout: JSON.stringify(
+            Array.from({ length: BRIDGE_COUNT }, (_, i) => ({
+              id: 500 + i,
+              name: `trigger-${i}`,
+              stage: 'trigger',
+              status: 'success',
+              downstream_pipeline: {
+                id: 1000 + i,
+                status: 'running',
+                web_url: `https://gitlab.com/g/p/-/pipelines/${1000 + i}`
+              }
+            }))
+          )
+        }
+      }
+      if (/pipelines\/\d+\/jobs/.test(endpoint)) {
+        inFlightJobPages += 1
+        peakJobPages = Math.max(peakJobPages, inFlightJobPages)
+        await new Promise((resolve) => setTimeout(resolve, 2))
+        inFlightJobPages -= 1
+        return { stdout: '[]' }
+      }
+      if (endpoint.endsWith('/approvals')) {
+        return { stdout: JSON.stringify({ approvals_required: 0, approvals_left: 0 }) }
+      }
+      if (endpoint.endsWith('/approval_state')) {
+        return { stdout: JSON.stringify({ rules: [] }) }
+      }
+      return { stdout: '[]' }
+    })
+
+    const details = await getWorkItemDetails('/repo', 12, 'mr')
+    // Parent page can overlap the capped child pool, so allow one above the child limit.
+    expect(peakJobPages).toBeLessThanOrEqual(5)
+    // Every bridge still gets a rollup row even past the 20-child expansion cap.
+    expect(details?.pipelineJobs).toHaveLength(BRIDGE_COUNT)
+  })
+
   it('routes local WSL MR detail fetches through project resolution and glab options', async () => {
     const localGitOptions = { wslDistro: 'Ubuntu' }
     glabExecFileAsyncMock.mockImplementation(async (args: string[]) => {

--- a/src/main/gitlab/work-item-details.test.ts
+++ b/src/main/gitlab/work-item-details.test.ts
@@ -102,6 +102,9 @@ describe('getWorkItemDetails', () => {
           ])
         }
       }
+      if (endpoint === 'projects/g%2Fp/pipelines/99/bridges?per_page=100') {
+        return { stdout: '[]' }
+      }
       if (endpoint === 'projects/g%2Fp/merge_requests/12/reviewers') {
         return { stdout: '[]' }
       }
@@ -140,6 +143,113 @@ describe('getWorkItemDetails', () => {
       'projects/g%2Fp/merge_requests/12/diffs?per_page=100'
     ])
     expect(glabExecFileAsyncMock.mock.calls.flatMap(([args]) => args)).not.toContain('--paginate')
+  })
+
+  it('expands bridge child-pipeline jobs into the checks list', async () => {
+    glabExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      const endpoint = args.at(-1)
+      if (endpoint === 'projects/g%2Fp/merge_requests/12') {
+        return {
+          stdout: JSON.stringify({
+            id: 120,
+            iid: 12,
+            title: 'Bridge pipeline',
+            state: 'opened',
+            web_url: 'https://gitlab.com/g/p/-/merge_requests/12',
+            updated_at: '2026-05-31T12:00:00Z',
+            source_branch: 'feature/bridges',
+            target_branch: 'main',
+            description: 'MR body',
+            sha: 'head-sha',
+            head_pipeline: { id: 99 }
+          })
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/discussions?per_page=100') {
+        return { stdout: '[]' }
+      }
+      if (endpoint === 'projects/g%2Fp/pipelines/99/jobs?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              id: 10,
+              name: 'semgrep-sast',
+              stage: 'test',
+              status: 'success',
+              web_url: 'https://gitlab.com/g/p/-/jobs/10',
+              duration: 12
+            }
+          ])
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/pipelines/99/bridges?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              id: 50,
+              name: 'trigger-ci',
+              stage: 'test',
+              status: 'success',
+              web_url: 'https://gitlab.com/g/p/-/jobs/50',
+              downstream_pipeline: {
+                id: 200,
+                status: 'failed',
+                web_url: 'https://gitlab.com/g/p/-/pipelines/200'
+              }
+            }
+          ])
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/pipelines/200/jobs?per_page=100') {
+        return {
+          stdout: JSON.stringify([
+            {
+              id: 300,
+              name: 'unit',
+              stage: 'test',
+              status: 'failed',
+              web_url: 'https://gitlab.com/g/p/-/jobs/300',
+              duration: 40
+            },
+            {
+              id: 301,
+              name: 'lint',
+              stage: 'test',
+              status: 'success',
+              web_url: 'https://gitlab.com/g/p/-/jobs/301',
+              duration: 20
+            }
+          ])
+        }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/reviewers') {
+        return { stdout: '[]' }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/approvals') {
+        return { stdout: JSON.stringify({ approvals_required: 0, approvals_left: 0 }) }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/approval_state') {
+        return { stdout: JSON.stringify({ rules: [] }) }
+      }
+      if (endpoint === 'projects/g%2Fp/merge_requests/12/diffs?per_page=100') {
+        return { stdout: '[]' }
+      }
+      throw new Error(`unexpected glab call: ${args.join(' ')}`)
+    })
+
+    const details = await getWorkItemDetails('/repo', 12, 'mr')
+    const names = (details?.pipelineJobs ?? []).map((job) => job.name).sort()
+    expect(names).toEqual(['lint', 'semgrep-sast', 'trigger-ci', 'unit'])
+    expect(details?.pipelineJobs?.find((job) => job.name === 'unit')).toMatchObject({
+      id: 300,
+      status: 'failed',
+      pipelineId: 200
+    })
+    expect(details?.pipelineJobs?.find((job) => job.name === 'trigger-ci')).toMatchObject({
+      id: 0,
+      status: 'failed',
+      pipelineId: 99
+    })
   })
 
   it('routes local WSL MR detail fetches through project resolution and glab options', async () => {

--- a/src/main/gitlab/work-item-details.ts
+++ b/src/main/gitlab/work-item-details.ts
@@ -113,6 +113,10 @@ async function fetchDiscussions(
 const PIPELINE_JOB_PAGE_SIZE = 100
 /** Cap expanded child-pipeline fan-out so one MR details load stays bounded. */
 const MAX_CHILD_PIPELINES_TO_EXPAND = 20
+// Why: every fetch spawns a `glab` binary (a remote exec over SSH), and this runs on
+// the Checks poll timer. Match gl-utils' MAX_CONCURRENT so a bridge-heavy MR trickles
+// its children instead of bursting 20 processes at once.
+const MAX_CONCURRENT_CHILD_FETCHES = 4
 
 type GitLabRawJob = {
   id?: number
@@ -262,6 +266,26 @@ function childPipelineTarget(
   return { projectRef: parentProjectRef, pipelineId: childId }
 }
 
+/** Results stay in input order; a shared cursor keeps fast workers from idling behind a slow batch. */
+async function mapWithConcurrencyLimit<T, R>(
+  items: T[],
+  limit: number,
+  run: (item: T) => Promise<R>
+): Promise<R[]> {
+  const out = Array.from({ length: items.length }) as R[]
+  let cursor = 0
+  await Promise.all(
+    Array.from({ length: Math.min(limit, items.length) }, async () => {
+      while (cursor < items.length) {
+        const index = cursor
+        cursor += 1
+        out[index] = await run(items[index])
+      }
+    })
+  )
+  return out
+}
+
 async function fetchPipelineJobs(
   repoPath: string,
   projectRef: ProjectRef,
@@ -291,8 +315,10 @@ async function fetchPipelineJobs(
     }
   }
 
-  const childJobBatches = await Promise.all(
-    childTargets.map((target) =>
+  const childJobBatches = await mapWithConcurrencyLimit(
+    childTargets,
+    MAX_CONCURRENT_CHILD_FETCHES,
+    (target) =>
       fetchPipelineJobPage(
         repoPath,
         target.projectRef,
@@ -300,7 +326,6 @@ async function fetchPipelineJobs(
         connectionId,
         localGitOptions
       ).catch(() => [] as GitLabPipelineJob[])
-    )
   )
 
   // Parent jobs first, then each child's jobs. Bridge rollup rows last and only

--- a/src/main/gitlab/work-item-details.ts
+++ b/src/main/gitlab/work-item-details.ts
@@ -105,6 +105,14 @@ async function fetchDiscussions(
 }
 
 // ── Pipeline jobs ──────────────────────────────────────────────────
+// Why: GitLab's `/pipelines/:id/jobs` only returns jobs owned by that pipeline.
+// Trigger/include bridges live under `/bridges` and their real CI jobs live on
+// the child pipeline — Orca used to show only the parent (often just SAST), so
+// Checks looked empty next to gitlab.com's full graph.
+
+const PIPELINE_JOB_PAGE_SIZE = 100
+/** Cap expanded child-pipeline fan-out so one MR details load stays bounded. */
+const MAX_CHILD_PIPELINES_TO_EXPAND = 20
 
 type GitLabRawJob = {
   id?: number
@@ -113,6 +121,21 @@ type GitLabRawJob = {
   status?: string
   web_url?: string
   duration?: number | null
+}
+
+type GitLabRawBridge = {
+  id?: number
+  name?: string
+  stage?: string
+  status?: string
+  web_url?: string
+  duration?: number | null
+  downstream_pipeline?: {
+    id?: number
+    project_id?: number
+    status?: string
+    web_url?: string
+  } | null
 }
 
 type GitLabRawUser = {
@@ -148,6 +171,97 @@ function mapPipelineJob(raw: GitLabRawJob, pipelineId: number): GitLabPipelineJo
   }
 }
 
+function mapBridgeAsJob(raw: GitLabRawBridge, pipelineId: number): GitLabPipelineJob {
+  const childStatus = raw.downstream_pipeline?.status
+  return {
+    // Why: bridges are not real jobs — omit a positive id so Checks won't try
+    // job-trace/retry APIs on them. Rows still render via name + webUrl.
+    id: 0,
+    pipelineId,
+    name: raw.name ?? 'bridge',
+    stage: raw.stage ?? '',
+    // Prefer the child pipeline's rollup when present — the bridge job itself
+    // often stays `success` while the downstream graph is still running/failed.
+    status: childStatus || raw.status || '',
+    webUrl: raw.downstream_pipeline?.web_url ?? raw.web_url ?? '',
+    duration: typeof raw.duration === 'number' ? raw.duration : null
+  }
+}
+
+async function fetchPipelineJobPage(
+  repoPath: string,
+  projectRef: ProjectRef,
+  pipelineId: number,
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): Promise<GitLabPipelineJob[]> {
+  const { stdout } = await glabExecFileAsync(
+    [
+      'api',
+      ...glabHostnameArgs(projectRef, connectionId),
+      `projects/${encodedProject(projectRef.path)}/pipelines/${pipelineId}/jobs?per_page=${PIPELINE_JOB_PAGE_SIZE}`
+    ],
+    glabRepoExecOptions(repoPath, connectionId, localGitOptions)
+  )
+  const data = JSON.parse(stdout) as GitLabRawJob[]
+  if (!Array.isArray(data)) {
+    return []
+  }
+  return data.map((job) => mapPipelineJob(job, pipelineId))
+}
+
+async function fetchPipelineBridges(
+  repoPath: string,
+  projectRef: ProjectRef,
+  pipelineId: number,
+  connectionId: string | null | undefined,
+  localGitOptions: LocalGitExecOptions
+): Promise<GitLabRawBridge[]> {
+  const { stdout } = await glabExecFileAsync(
+    [
+      'api',
+      ...glabHostnameArgs(projectRef, connectionId),
+      `projects/${encodedProject(projectRef.path)}/pipelines/${pipelineId}/bridges?per_page=${PIPELINE_JOB_PAGE_SIZE}`
+    ],
+    glabRepoExecOptions(repoPath, connectionId, localGitOptions)
+  )
+  const data = JSON.parse(stdout) as GitLabRawBridge[]
+  return Array.isArray(data) ? data : []
+}
+
+function childPipelineTarget(
+  bridge: GitLabRawBridge,
+  parentProjectRef: ProjectRef
+): { projectRef: ProjectRef; pipelineId: number } | null {
+  const childId = bridge.downstream_pipeline?.id
+  if (typeof childId !== 'number') {
+    return null
+  }
+  // Why: prefer path from web_url so same- and cross-project children both work
+  // without a project-id lookup. If the URL is missing/unparseable, fall back to
+  // the parent project (same-project triggers); wrong-project calls fail soft.
+  const webUrl = bridge.downstream_pipeline?.web_url
+  if (webUrl) {
+    try {
+      const url = new URL(webUrl)
+      // web_url shape: https://host/group/project/-/pipelines/123
+      const marker = url.pathname.indexOf('/-/pipelines/')
+      if (marker > 0) {
+        const path = url.pathname.slice(1, marker).replace(/\/$/, '')
+        if (path) {
+          return {
+            projectRef: { host: url.host || parentProjectRef.host, path },
+            pipelineId: childId
+          }
+        }
+      }
+    } catch {
+      // fall through to parent project
+    }
+  }
+  return { projectRef: parentProjectRef, pipelineId: childId }
+}
+
 async function fetchPipelineJobs(
   repoPath: string,
   projectRef: ProjectRef,
@@ -155,18 +269,67 @@ async function fetchPipelineJobs(
   connectionId?: string | null,
   localGitOptions: LocalGitExecOptions = {}
 ): Promise<GitLabPipelineJob[]> {
-  const { stdout } = await glabExecFileAsync(
-    [
-      'api',
-      ...glabHostnameArgs(projectRef, connectionId),
-      // Why: one MR details load should not fetch every job page from very
-      // large pipelines; the first 100 jobs match the visible summary budget.
-      `projects/${encodedProject(projectRef.path)}/pipelines/${pipelineId}/jobs?per_page=100`
-    ],
-    glabRepoExecOptions(repoPath, connectionId, localGitOptions)
+  const [parentJobs, bridges] = await Promise.all([
+    fetchPipelineJobPage(repoPath, projectRef, pipelineId, connectionId, localGitOptions),
+    fetchPipelineBridges(repoPath, projectRef, pipelineId, connectionId, localGitOptions).catch(
+      () => [] as GitLabRawBridge[]
+    )
+  ])
+
+  const bridgeRows = bridges.map((bridge) => mapBridgeAsJob(bridge, pipelineId))
+  const childTargets: { projectRef: ProjectRef; pipelineId: number }[] = []
+  const seenChildIds = new Set<number>()
+  for (const bridge of bridges) {
+    const target = childPipelineTarget(bridge, projectRef)
+    if (!target || seenChildIds.has(target.pipelineId)) {
+      continue
+    }
+    seenChildIds.add(target.pipelineId)
+    childTargets.push(target)
+    if (childTargets.length >= MAX_CHILD_PIPELINES_TO_EXPAND) {
+      break
+    }
+  }
+
+  const childJobBatches = await Promise.all(
+    childTargets.map((target) =>
+      fetchPipelineJobPage(
+        repoPath,
+        target.projectRef,
+        target.pipelineId,
+        connectionId,
+        localGitOptions
+      ).catch(() => [] as GitLabPipelineJob[])
+    )
   )
-  const data = JSON.parse(stdout) as GitLabRawJob[]
-  return data.map((job) => mapPipelineJob(job, pipelineId))
+
+  // Parent jobs first, then each child's jobs. Bridge rollup rows last and only
+  // when no expanded child job already carries the same name (avoid duplicates).
+  const seenJobIds = new Set<number>()
+  const seenNames = new Set<string>()
+  const out: GitLabPipelineJob[] = []
+  for (const job of [...parentJobs, ...childJobBatches.flat()]) {
+    if (job.id) {
+      if (seenJobIds.has(job.id)) {
+        continue
+      }
+      seenJobIds.add(job.id)
+    }
+    out.push(job)
+    if (job.name) {
+      seenNames.add(job.name)
+    }
+  }
+  for (const bridge of bridgeRows) {
+    if (bridge.name && seenNames.has(bridge.name)) {
+      continue
+    }
+    out.push(bridge)
+    if (bridge.name) {
+      seenNames.add(bridge.name)
+    }
+  }
+  return out
 }
 
 /**

--- a/src/main/source-control/forge-review-mappers.ts
+++ b/src/main/source-control/forge-review-mappers.ts
@@ -26,6 +26,7 @@ export function mapGitLabReview(mr: MRInfo): HostedReviewInfo {
     status: mr.pipelineStatus,
     updatedAt: mr.updatedAt,
     mergeable: mr.mergeable,
+    ...(mr.mergeStateStatus !== undefined ? { mergeStateStatus: mr.mergeStateStatus } : {}),
     ...(mr.headSha ? { headSha: mr.headSha } : {}),
     ...(mr.conflictSummary ? { conflictSummary: mr.conflictSummary } : {})
   }

--- a/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts
@@ -51,6 +51,33 @@ describe('presentGitLabMRMergeState', () => {
     })
   })
 
+  // Why: GitLab keeps adding detailed_merge_status values, so a reason we have never seen must
+  // degrade the same way an absent one does rather than falling through to a merge-ready label.
+  it('treats an unrecognised merge reason like an absent one', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'failure',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'some_future_gitlab_status'
+      })
+    ).toMatchObject({
+      label: 'Checks failed',
+      directMergeAvailable: false
+    })
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'success',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'some_future_gitlab_status'
+      })
+    ).toMatchObject({
+      label: 'Checking',
+      directMergeAvailable: false
+    })
+  })
+
   it('still reports Checking when there is no reason and no failing pipeline', () => {
     expect(
       presentGitLabMRMergeState({

--- a/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts
@@ -35,6 +35,44 @@ describe('presentGitLabMRMergeState', () => {
     ).toBe('Unresolved threads')
   })
 
+  // Why: an unrecognised/absent reason used to render a bare "Checking", hiding the red pipeline
+  // that is the actual thing the user has to act on.
+  it('surfaces a failed pipeline when GitLab reports no usable merge reason', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'failure',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: undefined
+      })
+    ).toMatchObject({
+      label: 'Checks failed',
+      directMergeAvailable: false
+    })
+  })
+
+  it('still reports Checking when there is no reason and no failing pipeline', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'pending',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: undefined
+      }).label
+    ).toBe('Checking')
+  })
+
+  it('keeps an explicit GitLab reason ahead of the pipeline result', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'failure',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'not_approved'
+      }).label
+    ).toBe('Approval required')
+  })
+
   it('only offers direct merge when GitLab reports MERGEABLE', () => {
     expect(
       presentGitLabMRMergeState({

--- a/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import { presentGitLabMRMergeState } from './gitlab-mr-merge-state'
+
+describe('presentGitLabMRMergeState', () => {
+  it('does not treat UNKNOWN as able to merge', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'success',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'not_approved'
+      })
+    ).toMatchObject({
+      label: 'Approval required',
+      directMergeAvailable: false
+    })
+  })
+
+  it('labels common blocked detailed_merge_status values', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'pending',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'ci_still_running'
+      }).label
+    ).toBe('Checks pending')
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'success',
+        mergeable: 'UNKNOWN',
+        mergeStateStatus: 'discussions_not_resolved'
+      }).label
+    ).toBe('Unresolved threads')
+  })
+
+  it('only offers direct merge when GitLab reports MERGEABLE', () => {
+    expect(
+      presentGitLabMRMergeState({
+        state: 'open',
+        status: 'success',
+        mergeable: 'MERGEABLE',
+        mergeStateStatus: 'mergeable'
+      })
+    ).toMatchObject({
+      label: 'Able to merge',
+      directMergeAvailable: true
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.ts
@@ -1,13 +1,134 @@
 import type { HostedReviewInfo } from '../../../../shared/hosted-review'
 import { translate } from '@/i18n/i18n'
 
-type GitLabMRMergeStateReview = Pick<HostedReviewInfo, 'state' | 'status' | 'mergeable'>
+type GitLabMRMergeStateReview = Pick<
+  HostedReviewInfo,
+  'state' | 'status' | 'mergeable' | 'mergeStateStatus'
+>
 
-export function presentGitLabMRMergeState(review: GitLabMRMergeStateReview): {
+type MergePresentation = {
   label: string
   tooltip: string
   directMergeAvailable: boolean
-} {
+}
+
+function blockedPresentation(label: string, tooltip: string): MergePresentation {
+  return { label, tooltip, directMergeAvailable: false }
+}
+
+/** Map GitLab detailed_merge_status (stored on mergeStateStatus) to a blocked/checking label. */
+function presentUnknownMergeState(mergeStateStatus: string | null | undefined): MergePresentation {
+  const status = (mergeStateStatus ?? '').toLowerCase()
+  switch (status) {
+    case 'not_approved':
+      return blockedPresentation(
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.approval.required',
+          'Approval required'
+        ),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.approval.required.tip',
+          'GitLab requires approval before this MR can merge'
+        )
+      )
+    case 'requested_changes':
+      return blockedPresentation(
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.changes.requested',
+          'Changes requested'
+        ),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.changes.requested.tip',
+          'A reviewer requested changes on this merge request'
+        )
+      )
+    case 'discussions_not_resolved':
+      return blockedPresentation(
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.unresolved',
+          'Unresolved threads'
+        ),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.unresolved.tip',
+          'GitLab requires unresolved discussions to be resolved before merge'
+        )
+      )
+    case 'ci_must_pass':
+      return blockedPresentation(
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.checks.must.pass',
+          'Checks must pass'
+        ),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.checks.must.pass.tip',
+          'GitLab requires the pipeline to succeed before this MR can merge'
+        )
+      )
+    case 'ci_still_running':
+      return blockedPresentation(
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.65c847ad1e',
+          'Checks pending'
+        ),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.pipeline.running.tip',
+          'The pipeline is still running'
+        )
+      )
+    case 'need_rebase':
+      return blockedPresentation(
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.behind', 'Behind'),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.behind.tip',
+          'Update the branch before merging'
+        )
+      )
+    case 'draft_status':
+      return blockedPresentation(
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.b2715092c6', 'Draft'),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.d63bb6f76e',
+          'This merge request is still a draft'
+        )
+      )
+    case 'checking':
+    case 'unchecked':
+    case 'preparing':
+      return blockedPresentation(
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.checking', 'Checking'),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.checking.tip',
+          'GitLab is still computing this merge request status'
+        )
+      )
+    case 'blocked_status':
+    case 'policies_denied':
+    case 'external_status_checks':
+    case 'security_policy_violations':
+    case 'locked_paths':
+    case 'locked_lfs_files':
+    case 'jira_association_missing':
+    case 'title_regex':
+    case 'not_open':
+      return blockedPresentation(
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.blocked', 'Blocked'),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.blocked.tip',
+          'GitLab reports this merge request is blocked'
+        )
+      )
+    default:
+      return blockedPresentation(
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.checking', 'Checking'),
+        translate(
+          'auto.components.right.sidebar.gitlab.mr.merge.state.unknown.tip',
+          'GitLab has not reported a final merge status'
+        )
+      )
+  }
+}
+
+export function presentGitLabMRMergeState(review: GitLabMRMergeStateReview): MergePresentation {
   if (review.state === 'merged') {
     return {
       label: translate('auto.components.right.sidebar.gitlab.mr.merge.state.fae95ae20d', 'Merged'),
@@ -51,6 +172,11 @@ export function presentGitLabMRMergeState(review: GitLabMRMergeStateReview): {
       directMergeAvailable: false
     }
   }
+  // Why: only GitLab's explicit `mergeable` projects to MERGEABLE. UNKNOWN used to fall through
+  // to "Able to merge", so not_approved / discussions_not_resolved / ci_must_pass looked ready.
+  if (review.mergeable !== 'MERGEABLE') {
+    return presentUnknownMergeState(review.mergeStateStatus)
+  }
   if (review.status === 'failure') {
     return {
       label: translate(
@@ -82,10 +208,7 @@ export function presentGitLabMRMergeState(review: GitLabMRMergeStateReview): {
       'auto.components.right.sidebar.gitlab.mr.merge.state.04a3015a12',
       'Able to merge'
     ),
-    tooltip:
-      review.mergeable === 'UNKNOWN'
-        ? 'GitLab has not reported a final merge status'
-        : 'GitLab says this MR can merge',
+    tooltip: 'GitLab says this MR can merge',
     directMergeAvailable: true
   }
 }

--- a/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.ts
@@ -23,44 +23,44 @@ function presentUnknownMergeState(mergeStateStatus: string | null | undefined): 
     case 'not_approved':
       return blockedPresentation(
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.approval.required',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.5105b0e584',
           'Approval required'
         ),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.approval.required.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.46dc85711b',
           'GitLab requires approval before this MR can merge'
         )
       )
     case 'requested_changes':
       return blockedPresentation(
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.changes.requested',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.893a999c8c',
           'Changes requested'
         ),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.changes.requested.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.c65408a99d',
           'A reviewer requested changes on this merge request'
         )
       )
     case 'discussions_not_resolved':
       return blockedPresentation(
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.unresolved',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.01ab632a21',
           'Unresolved threads'
         ),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.unresolved.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.4191fdfcec',
           'GitLab requires unresolved discussions to be resolved before merge'
         )
       )
     case 'ci_must_pass':
       return blockedPresentation(
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.checks.must.pass',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.bf628700f6',
           'Checks must pass'
         ),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.checks.must.pass.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.37d8637c70',
           'GitLab requires the pipeline to succeed before this MR can merge'
         )
       )
@@ -71,15 +71,15 @@ function presentUnknownMergeState(mergeStateStatus: string | null | undefined): 
           'Checks pending'
         ),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.pipeline.running.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.049ea91a82',
           'The pipeline is still running'
         )
       )
     case 'need_rebase':
       return blockedPresentation(
-        translate('auto.components.right.sidebar.gitlab.mr.merge.state.behind', 'Behind'),
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.382c70faeb', 'Behind'),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.behind.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.2c61100b3a',
           'Update the branch before merging'
         )
       )
@@ -95,9 +95,9 @@ function presentUnknownMergeState(mergeStateStatus: string | null | undefined): 
     case 'unchecked':
     case 'preparing':
       return blockedPresentation(
-        translate('auto.components.right.sidebar.gitlab.mr.merge.state.checking', 'Checking'),
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.195917574e', 'Checking'),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.checking.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.ff6db2db63',
           'GitLab is still computing this merge request status'
         )
       )
@@ -111,17 +111,17 @@ function presentUnknownMergeState(mergeStateStatus: string | null | undefined): 
     case 'title_regex':
     case 'not_open':
       return blockedPresentation(
-        translate('auto.components.right.sidebar.gitlab.mr.merge.state.blocked', 'Blocked'),
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.4ecc0d90ee', 'Blocked'),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.blocked.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.a0f3de7023',
           'GitLab reports this merge request is blocked'
         )
       )
     default:
       return blockedPresentation(
-        translate('auto.components.right.sidebar.gitlab.mr.merge.state.checking', 'Checking'),
+        translate('auto.components.right.sidebar.gitlab.mr.merge.state.195917574e', 'Checking'),
         translate(
-          'auto.components.right.sidebar.gitlab.mr.merge.state.unknown.tip',
+          'auto.components.right.sidebar.gitlab.mr.merge.state.804ecf93e8',
           'GitLab has not reported a final merge status'
         )
       )
@@ -208,7 +208,10 @@ export function presentGitLabMRMergeState(review: GitLabMRMergeStateReview): Mer
       'auto.components.right.sidebar.gitlab.mr.merge.state.04a3015a12',
       'Able to merge'
     ),
-    tooltip: 'GitLab says this MR can merge',
+    tooltip: translate(
+      'auto.components.right.sidebar.gitlab.mr.merge.state.a5c049afe4',
+      'GitLab says this MR can merge'
+    ),
     directMergeAvailable: true
   }
 }

--- a/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.ts
+++ b/src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.ts
@@ -17,7 +17,10 @@ function blockedPresentation(label: string, tooltip: string): MergePresentation 
 }
 
 /** Map GitLab detailed_merge_status (stored on mergeStateStatus) to a blocked/checking label. */
-function presentUnknownMergeState(mergeStateStatus: string | null | undefined): MergePresentation {
+function presentUnknownMergeState(
+  mergeStateStatus: string | null | undefined,
+  checksStatus: GitLabMRMergeStateReview['status']
+): MergePresentation {
   const status = (mergeStateStatus ?? '').toLowerCase()
   switch (status) {
     case 'not_approved':
@@ -118,6 +121,20 @@ function presentUnknownMergeState(mergeStateStatus: string | null | undefined): 
         )
       )
     default:
+      // Why: with no usable reason from GitLab, a red pipeline is the most actionable thing we
+      // know — reporting a bare "Checking" hid the failure the user actually has to fix.
+      if (checksStatus === 'failure') {
+        return blockedPresentation(
+          translate(
+            'auto.components.right.sidebar.gitlab.mr.merge.state.49ac4fec10',
+            'Checks failed'
+          ),
+          translate(
+            'auto.components.right.sidebar.gitlab.mr.merge.state.804ecf93e8',
+            'GitLab has not reported a final merge status'
+          )
+        )
+      }
       return blockedPresentation(
         translate('auto.components.right.sidebar.gitlab.mr.merge.state.195917574e', 'Checking'),
         translate(
@@ -175,7 +192,7 @@ export function presentGitLabMRMergeState(review: GitLabMRMergeStateReview): Mer
   // Why: only GitLab's explicit `mergeable` projects to MERGEABLE. UNKNOWN used to fall through
   // to "Able to merge", so not_approved / discussions_not_resolved / ci_must_pass looked ready.
   if (review.mergeable !== 'MERGEABLE') {
-    return presentUnknownMergeState(review.mergeStateStatus)
+    return presentUnknownMergeState(review.mergeStateStatus, review.status)
   }
   if (review.status === 'failure') {
     return {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11121,7 +11121,24 @@
                   "2388413f28": "This merge request is closed",
                   "88d044c42f": "Closed",
                   "ee482a2bad": "This merge request is already merged",
-                  "fae95ae20d": "Merged"
+                  "fae95ae20d": "Merged",
+                  "5105b0e584": "Approval required",
+                  "46dc85711b": "GitLab requires approval before this MR can merge",
+                  "893a999c8c": "Changes requested",
+                  "c65408a99d": "A reviewer requested changes on this merge request",
+                  "01ab632a21": "Unresolved threads",
+                  "4191fdfcec": "GitLab requires unresolved discussions to be resolved before merge",
+                  "bf628700f6": "Checks must pass",
+                  "37d8637c70": "GitLab requires the pipeline to succeed before this MR can merge",
+                  "049ea91a82": "The pipeline is still running",
+                  "382c70faeb": "Behind",
+                  "2c61100b3a": "Update the branch before merging",
+                  "195917574e": "Checking",
+                  "ff6db2db63": "GitLab is still computing this merge request status",
+                  "4ecc0d90ee": "Blocked",
+                  "a0f3de7023": "GitLab reports this merge request is blocked",
+                  "804ecf93e8": "GitLab has not reported a final merge status",
+                  "a5c049afe4": "GitLab says this MR can merge"
                 }
               }
             }

--- a/src/shared/gitlab-types.ts
+++ b/src/shared/gitlab-types.ts
@@ -37,6 +37,8 @@ export type MRInfo = {
   pipelineStatus: CheckStatus
   updatedAt: string
   mergeable: MRMergeableState
+  /** GitLab `detailed_merge_status` (or a short alias) for UI that needs more than MERGEABLE/CONFLICTING/UNKNOWN. */
+  mergeStateStatus?: string | null
   /** Full markdown description. Optional — list endpoints omit it; populated on single-MR fetch (`getMR`). */
   description?: string
   /** Author username (GitLab `username`). Optional for the same reason. */


### PR DESCRIPTION
## Summary

Fixes incomplete GitLab **Checks** for multi-pipeline MRs and a related merge-button false positive.

1. **Checks panel only loaded parent pipeline jobs.**  
   `/pipelines/:id/jobs` does not include trigger/include **bridge** children. Orca showed a tiny subset (often only Auto DevOps SAST) while gitlab.com showed the full graph.  
   Now we also fetch `/bridges`, expand up to 20 child pipelines’ jobs, and merge them into the Checks list. Bridge rows use `id: 0` so job-trace/retry APIs are not called on non-jobs.

2. **UNKNOWN merge status was treated as “Able to merge”.**  
   GitLab `detailed_merge_status` values like `not_approved` / `discussions_not_resolved` / `ci_must_pass` collapsed to `UNKNOWN` and the UI offered direct merge.  
   We pass through `mergeStateStatus` and only offer direct merge when `mergeable === 'MERGEABLE'`, with clearer blocked labels.

Closes #12856

## Screenshots

Visual change: GitLab Checks job list (more complete vs parent-only).

- Before (Orca): only a few parent jobs (e.g. SAST).  
- After (expected): parent jobs + expanded child-pipeline jobs, closer to the GitLab MR pipeline graph.  
- Issue #12856 has the original Orca vs GitLab comparison screenshots.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] Targeted tests (see below)
- [ ] `pnpm test` (full suite) — not re-run to green on this machine; earlier full run hit unrelated timeouts/failures outside this change
- [ ] `pnpm build` — not run (Node engine warning: wanted 24, local 26)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Targeted:

```bash
pnpm exec vitest run --config config/vitest.config.ts \
  src/main/gitlab/work-item-details.test.ts \
  src/main/gitlab/mappers.test.ts \
  src/renderer/src/components/right-sidebar/gitlab-mr-merge-state.test.ts \
  src/main/source-control/hosted-review.test.ts
```

58 passed.

## AI Review Report

Reviewed with an AI coding agent against CONTRIBUTING / AGENTS requirements.

**Checked**
- **Cross-platform (macOS / Linux / Windows):** Change is glab REST API + pure mapping/UI presentation. No shortcuts, menu accelerators, path separators, or shell differences.
- **SSH / remote / local:** Uses existing `glabExecFileAsync` + `glabHostnameArgs` / `glabRepoExecOptions` / connectionId / WSL localGit options already used for MR details — same execution path as before.
- **Providers:** GitLab-only; GitHub/Bitbucket/etc. paths untouched. Hosted-review mapper only adds optional `mergeStateStatus` for GitLab.
- **Performance:** Extra bridge call + up to 20 child job pages, parallelized; failures on bridges/children fail soft to `[]`. No unbounded pagination / no `--paginate`.
- **UI:** Checks list gains rows; merge button labels become more accurate when status is UNKNOWN. Localization uses flat hash keys (catalog verified).
- **Wire / RPC:** No RPC schema or stream opcode changes; only richer fields on existing MR detail / hosted review shapes (`mergeStateStatus` optional).

**Flagged / addressed**
- Negative bridge job ids would break job-trace → use `id: 0` and omit `gitlabJobId`.
- Nested i18n keys (`approval.required` + `.tip`) broke the catalog → switched to hash keys + `sync:localization-catalog`.
- Cross-project children: resolve path from `downstream_pipeline.web_url` when possible; otherwise same-project fallback, fail soft.

## Security Audit

- **Command execution:** Continues to use the existing glab API wrapper; no new shell interpolation of user paths into free-form commands.
- **Input handling:** Parses JSON from glab; guards non-array payloads; URL parse for child path is try/catch.
- **Auth / secrets:** No new credentials, tokens, or logging of secrets.
- **IPC:** No new IPC channels; optional field only on existing hosted-review / MR info types.
- **IDs:** Bridge rows intentionally have non-positive ids so trace/retry cannot target fake job IDs.

No follow-up security work identified for this change.

## Notes

- Child expansion is **one level** (parent bridges → child jobs), capped at **20** children × **100** jobs/page.
- Grandchild pipelines are not expanded (keeps MR details load bounded).
- X: n/a (optional shoutout)