### PR TITLE
fix(repo-icon): fall back to a lucide icon when an image icon fails to load

### DIFF
--- a/src/renderer/src/components/repo/repo-icon.test.tsx
+++ b/src/renderer/src/components/repo/repo-icon.test.tsx
@@ -1,0 +1,63 @@
+// @vitest-environment happy-dom
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it } from 'vitest'
+import { RepoIconGlyph } from './repo-icon'
+
+afterEach(() => {
+  cleanup()
+})
+
+const GHE_AVATAR = 'https://ghe.example.com/acme.png?size=64'
+
+describe('RepoIconGlyph', () => {
+  it('falls back to a lucide icon when an image icon fails to load', () => {
+    const { container } = render(
+      <RepoIconGlyph repoIcon={{ type: 'image', src: GHE_AVATAR, source: 'github' }} />
+    )
+
+    const image = container.querySelector('img')
+    expect(image).not.toBeNull()
+
+    fireEvent.error(image as HTMLImageElement)
+
+    expect(container.querySelector('img')).toBeNull()
+    expect(container.querySelector('svg')).not.toBeNull()
+  })
+
+  it('retries the image when the icon changes to a different src', () => {
+    const { container, rerender } = render(
+      <RepoIconGlyph repoIcon={{ type: 'image', src: GHE_AVATAR, source: 'github' }} />
+    )
+    fireEvent.error(container.querySelector('img') as HTMLImageElement)
+    expect(container.querySelector('img')).toBeNull()
+
+    rerender(
+      <RepoIconGlyph
+        repoIcon={{ type: 'image', src: 'https://github.com/acme.png?size=64', source: 'github' }}
+      />
+    )
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(
+      'https://github.com/acme.png?size=64'
+    )
+  })
+
+  it('keeps rendering a loadable image icon', () => {
+    const { container } = render(
+      <RepoIconGlyph repoIcon={{ type: 'image', src: GHE_AVATAR, source: 'github' }} />
+    )
+
+    expect(container.querySelector('img')?.getAttribute('src')).toBe(GHE_AVATAR)
+    expect(container.querySelector('svg')).toBeNull()
+  })
+
+  it('renders emoji and lucide icons unchanged', () => {
+    const { container: emoji } = render(<RepoIconGlyph repoIcon={{ type: 'emoji', emoji: '🐙' }} />)
+    expect(emoji.textContent).toBe('🐙')
+
+    const { container: lucide } = render(
+      <RepoIconGlyph repoIcon={{ type: 'lucide', name: 'Database' }} />
+    )
+    expect(lucide.querySelector('svg')).not.toBeNull()
+  })
+})

--- a/src/renderer/src/components/repo/repo-icon.test.tsx
+++ b/src/renderer/src/components/repo/repo-icon.test.tsx
@@ -21,7 +21,7 @@ describe('RepoIconGlyph', () => {
     fireEvent.error(image as HTMLImageElement)
 
     expect(container.querySelector('img')).toBeNull()
-    expect(container.querySelector('svg')).not.toBeNull()
+    expect(container.querySelector('svg')?.getAttribute('class')).toContain('lucide-folder')
   })
 
   it('retries the image when the icon changes to a different src', () => {
@@ -58,6 +58,12 @@ describe('RepoIconGlyph', () => {
     const { container: lucide } = render(
       <RepoIconGlyph repoIcon={{ type: 'lucide', name: 'Database' }} />
     )
-    expect(lucide.querySelector('svg')).not.toBeNull()
+    expect(lucide.querySelector('svg')?.getAttribute('class')).toContain('lucide-database')
+  })
+
+  it('falls back to Folder for an unknown lucide name', () => {
+    const { container } = render(<RepoIconGlyph repoIcon={{ type: 'lucide', name: 'NotAnIcon' }} />)
+
+    expect(container.querySelector('svg')?.getAttribute('class')).toContain('lucide-folder')
   })
 })

--- a/src/renderer/src/components/repo/repo-icon.tsx
+++ b/src/renderer/src/components/repo/repo-icon.tsx
@@ -141,14 +141,20 @@ export function RepoIconGlyph({
   iconClassName?: string
   color?: string
 }): React.JSX.Element {
-  if (repoIcon?.type === 'image') {
+  const imageSrc = repoIcon?.type === 'image' ? repoIcon.src : null
+  // Why: private-mode GHES avatars need a session cookie, so the load fails and would
+  // render blank — track the failed src so a different icon still renders.
+  const [failedImageSrc, setFailedImageSrc] = React.useState<string | null>(null)
+
+  if (imageSrc !== null && failedImageSrc !== imageSrc) {
     return (
       <span className={cn('inline-flex items-center justify-center overflow-hidden', className)}>
         <img
-          src={repoIcon.src}
+          src={imageSrc}
           alt=""
           className={cn('size-full object-contain', iconClassName)}
           draggable={false}
+          onError={() => setFailedImageSrc(imageSrc)}
         />
       </span>
     )


### PR DESCRIPTION
## Summary

On a self-hosted GitHub Enterprise instance in private mode, every repo in the sidebar renders an empty icon slot. Orca stores the GHE org avatar URL as the repo icon, that URL requires a logged-in web session, and the image branch of `RepoIconGlyph` had no `onError` handling — so a failed load rendered as blank space.

This makes the image branch fall back the same way the other branches already do: on load failure it falls through to the lucide `Folder` icon.

The failed `src` is tracked in state, so switching a repo to a different icon still renders that new icon instead of staying on the fallback.

Fixes #11211

## Screenshots

No new UI was added — the change only makes an already-defined fallback reachable.

**Before** — every sidebar project shows an empty icon slot on private-mode GHE (screenshot from #11211):

![Repo icons render blank on private-mode GitHub Enterprise](https://github.com/user-attachments/assets/8d1abbc3-f294-49ca-b0a8-18fb5f3627dc)

**After** — those slots render the same lucide `Folder` icon that a repo with no `repoIcon` already gets.

I don't have a private-mode GHES instance set up for a clean "after" capture, so the behavior is covered by unit tests instead: firing `error` on the `<img>` removes it and renders the lucide `svg` in its place. The issue reporter offered to test a patch against their GHE setup, which would confirm it end to end.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Added `src/renderer/src/components/repo/repo-icon.test.tsx` with four cases: fallback on load failure, retry when the icon changes to a different `src`, loadable images still render, and the emoji/lucide branches unchanged.

**Verified the tests actually catch the regression** — with the component change reverted, 2 of the 4 fail; with it, all 4 pass.

Also ran the `lint-staged` steps directly on both files (`oxlint`, `oxlint --config config/oxlint-react-doctor.json`, `oxfmt --write`); all clean, and `oxfmt` reported no changes.

Pre-existing failures in the full suite, unrelated to this change — reproduced on a clean checkout with this change stashed:

- `config/scripts/check-root-directory-entries.test.mjs` (3 tests) — `.github/scripts/check-root-directory-entries.sh` uses `declare -A`, which macOS's default bash 3.2 doesn't support, so it exits 2 locally. Fine on CI's bash 5.x. See Notes.
- `src/relay/agent-exec-handler.test.ts` (2 tests) — spawn env/arg expectations. Also flaky: 6 failures on one run, 5 on the next.

Environment note: local runs used node 26.3.0 while `engines` asks for node 24.

## AI Review Report

Reviewed with Claude Code. Checks and outcomes:

- **Cross-platform (macOS/Linux/Windows)** — pure React state. No `metaKey`, keyboard shortcut, shortcut label, file path, or shell behavior is touched, so there is nothing platform-dependent to guard.
- **SSH/remote/local** — renderer-local rendering only. No RPC params, stream frames, or host-published content change, so `docs/reference/remote-wire-compatibility.md` doesn't apply. Behavior is identical against local repos, remote servers, and SSH worktrees.
- **Folder workspaces** — unchanged. A workspace with no `repoIcon` still falls through to `Folder`, which is exactly the state a failed image now reaches.
- **Agents / integrations / git providers** — provider-neutral. The fallback applies to every `RepoIconImageSource` (`github`, `favicon`, `upload`, `file`), not just GHE, and no GitHub-specific branch was added.
- **Performance** — one string held in state and a single re-render on failure. Not in a hot path, no new network or filesystem work, no resource to clean up.
- **UI quality** — no new color values, font sizes, or shadow tiers; reuses the existing lucide `Folder` that the other branches already fall back to, per `docs/STYLEGUIDE.md`. Light/dark mode is unaffected since the fallback inherits the same `color` prop path as the lucide branch.
- **Hooks correctness** — `useState` is placed above every conditional return so hook order stays stable across renders.

Flagged and accepted as a trade-off: the failed-`src` state is per component instance rather than a shared cache, so an unreachable avatar is requested once per mounted instance. A global opt-out and skipping unloadable avatars at import time (suggestions 2 and 3 in #11211) would address that; both are left out to keep this PR to a single topic.

Also flagged during review: an earlier draft of the code comment implied that any icon change retries. It doesn't — returning to a previously failed `src` stays on the fallback. The comment was corrected to match.

## Security Audit

- **Input handling** — `repoIcon.src` is already validated by `sanitizeRepoIcon` in `src/shared/repo-icon.ts` (https-only, owner-avatar path pattern, no credentials, length caps). This change adds no new input path and no new parsing.
- **Data exposure** — `onError` records the URL in local component state only. Nothing is logged, transmitted, or persisted, so an internal GHES hostname does not leave the renderer.
- **Command execution / path handling / auth / secrets / IPC** — none touched.
- **Dependencies** — no additions or version changes.

No follow-up needed.

## Notes

Reported and root-caused by @daemin-hwang in #11211; this implements suggestion 1 from that issue.

Separate follow-up worth flagging: `pnpm test` can't pass on macOS with the system bash, because `.github/scripts/check-root-directory-entries.sh` relies on `declare -A` (bash 4+) and macOS ships bash 3.2. Since CONTRIBUTING asks contributors to run `pnpm test` before opening a PR and macOS is a supported platform, that script looks worth fixing on its own — happy to send a follow-up PR if you'd like.
