### PR TITLE
test(terminal): pin IME cursor-chord relocation regressions (carries #12732)

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-deferred-input.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-deferred-input.test.tsx
@@ -1,0 +1,229 @@
+// @vitest-environment happy-dom
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
+import {
+  installTerminalImeCompositionRoute,
+  XTERM_COMPOSITION_SESSION_END_EVENT,
+  XTERM_COMPOSITION_SESSION_START_EVENT
+} from './terminal-ime-composition-route'
+
+type KeyboardHandlersDeps = Parameters<typeof useTerminalKeyboardShortcuts>[0]
+
+function keyboardEvent(
+  type: 'keydown' | 'keyup',
+  overrides: KeyboardEventInit & { keyCode: number; timeStamp: number; isComposing?: boolean }
+): KeyboardEvent {
+  const event = new KeyboardEvent(type, { bubbles: true, cancelable: true, ...overrides })
+  Object.defineProperties(event, {
+    isComposing: { value: overrides.isComposing ?? false },
+    keyCode: { value: overrides.keyCode },
+    timeStamp: { value: overrides.timeStamp }
+  })
+  return event
+}
+
+function createHarness(): {
+  deps: KeyboardHandlersDeps
+  order: string[]
+  startComposition: () => void
+  commitComposition: (data: string) => void
+  terminalInput: HTMLTextAreaElement
+  dispose: () => void
+} {
+  const scope = document.createElement('div')
+  const terminalElement = document.createElement('div')
+  const terminalInput = document.createElement('textarea')
+  terminalInput.className = 'xterm-helper-textarea'
+  terminalElement.append(terminalInput)
+  scope.append(terminalElement)
+  document.body.append(scope)
+
+  const order: string[] = []
+  const transport = {
+    getPtyId: () => 'pty-1',
+    sendInput: vi.fn((data: string) => {
+      order.push(`pty:${JSON.stringify(data)}`)
+      return true
+    })
+  } as unknown as PtyTransport
+  const pane = {
+    id: 1,
+    leafId: '00000000-0000-4000-8000-000000000001',
+    terminal: {
+      element: terminalElement,
+      focus: vi.fn(),
+      getSelection: vi.fn(() => '')
+    }
+  }
+  const manager = {
+    getActivePane: () => pane,
+    getPanes: () => [pane]
+  } as unknown as PaneManager
+  const route = installTerminalImeCompositionRoute({
+    terminalElement,
+    terminal: {
+      input: vi.fn((data: string) => {
+        order.push(`commit:${data}`)
+      })
+    },
+    capturedTransport: transport,
+    getCurrentTransport: () => transport
+  })
+  const deps: KeyboardHandlersDeps = {
+    tabId: 'tab-1',
+    worktreeId: 'worktree-1',
+    isActive: true,
+    keyboardScopeRef: { current: scope },
+    managerRef: { current: manager },
+    paneTransportsRef: { current: new Map([[pane.id, transport]]) },
+    panePtyBindingsRef: { current: new Map() },
+    paneCwdRef: { current: new Map() },
+    fallbackCwd: '',
+    expandedPaneIdRef: { current: null },
+    setExpandedPane: vi.fn(),
+    restoreExpandedLayout: vi.fn(),
+    refreshPaneSizes: vi.fn(),
+    persistLayoutSnapshot: vi.fn(),
+    toggleExpandPane: vi.fn(),
+    setSearchOpen: vi.fn(),
+    onSearchSelectedText: vi.fn(),
+    onRequestClosePane: vi.fn(),
+    onClearPaneScrollback: vi.fn(),
+    onSetTitle: vi.fn(),
+    onClearPaneTitle: vi.fn(),
+    searchOpenRef: { current: false },
+    searchStateRef: { current: { query: '', caseSensitive: false, regex: false } },
+    macOptionAsAltRef: { current: 'false' }
+  }
+  return {
+    deps,
+    order,
+    terminalInput,
+    startComposition: () => {
+      terminalElement.dispatchEvent(
+        new CustomEvent(XTERM_COMPOSITION_SESSION_START_EVENT, { detail: { id: 1 } })
+      )
+    },
+    commitComposition: (data) => {
+      terminalElement.dispatchEvent(
+        new CustomEvent(XTERM_COMPOSITION_SESSION_END_EVENT, {
+          cancelable: true,
+          detail: { id: 1, data }
+        })
+      )
+    },
+    dispose: () => {
+      route.dispose()
+      scope.remove()
+    }
+  }
+}
+
+describe('terminal shortcut bytes during an IME composition', () => {
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+  })
+
+  function usePlatform(userAgent: string): void {
+    vi.useFakeTimers()
+    vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(userAgent)
+  }
+
+  // "가" already reached the pty; "나" is still in the preedit. The shell reads
+  // these bytes against the line it has, so they must not overtake the commit.
+  it.each([
+    {
+      name: 'Cmd+Backspace line kill',
+      key: 'Backspace',
+      keyCode: 8,
+      mods: { metaKey: true },
+      sent: '\x15'
+    },
+    {
+      name: 'Cmd+Delete kill to end',
+      key: 'Delete',
+      keyCode: 46,
+      mods: { metaKey: true },
+      sent: '\x0b'
+    },
+    {
+      name: 'Cmd+ArrowLeft line start',
+      key: 'ArrowLeft',
+      keyCode: 37,
+      mods: { metaKey: true },
+      sent: '\x01'
+    }
+  ])('defers a macOS $name until the trailing syllable commits', ({ key, keyCode, mods, sent }) => {
+    usePlatform('Macintosh')
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key,
+        code: key,
+        keyCode,
+        timeStamp: 10,
+        isComposing: true,
+        ...mods
+      })
+    )
+    harness.commitComposition('나')
+    vi.runAllTimers()
+
+    expect(harness.order).toEqual(['commit:나', `pty:${JSON.stringify(sent)}`])
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('defers Ctrl+Backspace word kill on Linux too', () => {
+    usePlatform('X11; Linux x86_64')
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+    harness.startComposition()
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Backspace',
+        code: 'Backspace',
+        keyCode: 8,
+        timeStamp: 10,
+        isComposing: true,
+        ctrlKey: true
+      })
+    )
+    harness.commitComposition('나')
+    vi.runAllTimers()
+
+    expect(harness.order).toEqual(['commit:나', 'pty:"\\u0017"'])
+    hook.unmount()
+    harness.dispose()
+  })
+
+  it('still sends immediately when no composition is pending', () => {
+    usePlatform('Macintosh')
+    const harness = createHarness()
+    const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+
+    harness.terminalInput.dispatchEvent(
+      keyboardEvent('keydown', {
+        key: 'Backspace',
+        code: 'Backspace',
+        keyCode: 8,
+        timeStamp: 10,
+        metaKey: true
+      })
+    )
+
+    expect(harness.order).toEqual(['pty:"\\u0015"'])
+    hook.unmount()
+    harness.dispose()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-deferred-input.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-ime-deferred-input.test.tsx
@@ -226,4 +226,108 @@ describe('terminal shortcut bytes during an IME composition', () => {
     hook.unmount()
     harness.dispose()
   })
+
+  // Issue #12871: with "가나 다라 마바" committed and "사" still composing, a
+  // cursor-movement chord relocated the composing syllable to wherever the
+  // cursor landed — Option+← produced "가나 '사'다라 마바" and Cmd+← produced
+  // "'사'가나 다라 마바". The shell applies the movement bytes to the line it
+  // already has, so the commit must land before the chord travels.
+  describe('cursor-movement chords do not relocate the composing character', () => {
+    it.each([
+      {
+        name: 'Option+ArrowLeft word jump',
+        key: 'ArrowLeft',
+        keyCode: 37,
+        mods: { altKey: true },
+        sent: '\x1bb'
+      },
+      {
+        name: 'Option+ArrowRight word jump',
+        key: 'ArrowRight',
+        keyCode: 39,
+        mods: { altKey: true },
+        sent: '\x1bf'
+      },
+      {
+        name: 'Cmd+ArrowRight line-end jump',
+        key: 'ArrowRight',
+        keyCode: 39,
+        mods: { metaKey: true },
+        sent: '\x05'
+      }
+    ])('sequences a macOS $name behind the composing syllable', ({ key, keyCode, mods, sent }) => {
+      usePlatform('Macintosh')
+      const harness = createHarness()
+      const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+      harness.startComposition()
+
+      harness.terminalInput.dispatchEvent(
+        keyboardEvent('keydown', {
+          key,
+          code: key,
+          keyCode,
+          timeStamp: 10,
+          isComposing: true,
+          ...mods
+        })
+      )
+      harness.commitComposition('사')
+      vi.runAllTimers()
+
+      expect(harness.order).toEqual([`commit:사`, `pty:${JSON.stringify(sent)}`])
+      hook.unmount()
+      harness.dispose()
+    })
+
+    // A Japanese preedit spans several characters before it commits; the
+    // relocated preedit overwrote the glyph at the destination cell. The
+    // whole preedit must commit in place before the cursor moves.
+    it('sequences a Cmd+ArrowLeft line-start jump behind a multi-character Japanese preedit', () => {
+      usePlatform('Macintosh')
+      const harness = createHarness()
+      const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+      harness.startComposition()
+
+      harness.terminalInput.dispatchEvent(
+        keyboardEvent('keydown', {
+          key: 'ArrowLeft',
+          code: 'ArrowLeft',
+          keyCode: 37,
+          timeStamp: 10,
+          isComposing: true,
+          metaKey: true
+        })
+      )
+      harness.commitComposition('かな')
+      vi.runAllTimers()
+
+      expect(harness.order).toEqual(['commit:かな', 'pty:"\\u0001"'])
+      hook.unmount()
+      harness.dispose()
+    })
+
+    it('sequences a Ctrl+ArrowLeft word jump behind the composing syllable on Windows', () => {
+      usePlatform('Windows NT 10.0; Win64; x64')
+      const harness = createHarness()
+      const hook = renderHook(() => useTerminalKeyboardShortcuts(harness.deps))
+      harness.startComposition()
+
+      harness.terminalInput.dispatchEvent(
+        keyboardEvent('keydown', {
+          key: 'ArrowLeft',
+          code: 'ArrowLeft',
+          keyCode: 37,
+          timeStamp: 10,
+          isComposing: true,
+          ctrlKey: true
+        })
+      )
+      harness.commitComposition('사')
+      vi.runAllTimers()
+
+      expect(harness.order).toEqual(['commit:사', 'pty:"\\u001bb"'])
+      hook.unmount()
+      harness.dispose()
+    })
+  })
 })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -15,7 +15,8 @@ import {
   getTerminalImeModifiedEnterKind,
   isTerminalImeConsumedKey,
   isTerminalImeEnterKeyUp,
-  isTerminalImeProcessEnter
+  isTerminalImeProcessEnter,
+  sendTerminalInputAfterComposition
 } from './terminal-ime-deferred-newline'
 import { hasPendingTerminalImeComposition } from './terminal-ime-composition-route'
 import {
@@ -589,14 +590,22 @@ export function useTerminalKeyboardShortcuts({
           return
         }
         const sendResolvedInput = createCapturedInputSender(pane, action.data)
-        if ((e.isComposing || hasPendingImeComposition) && (e.key === 'Enter' || imeProcessEnter)) {
-          if (isWindows) {
-            const chord = getModifiedEnterChord(e)
-            if (chord && !modifiedEnterChordOwner.claim(chord)) {
-              return
+        if (e.isComposing || hasPendingImeComposition) {
+          if (e.key === 'Enter' || imeProcessEnter) {
+            if (isWindows) {
+              const chord = getModifiedEnterChord(e)
+              if (chord && !modifiedEnterChordOwner.claim(chord)) {
+                return
+              }
             }
+            deferredNewlineSender.defer(e, pane.terminal.element, sendResolvedInput)
+            return
           }
-          deferredNewlineSender.defer(e, pane.terminal.element, sendResolvedInput)
+          // Why: xterm sends the committed glyph on a timer while these bytes go out
+          // synchronously, and the shell reads them against the line it already has —
+          // an unsequenced kill or cursor move lands before the trailing syllable.
+          // The Enter path keeps its own sender for the Windows redispatch ledger.
+          sendTerminalInputAfterComposition(pane.terminal.element, sendResolvedInput)
           return
         }
         sendResolvedInput()


### PR DESCRIPTION
## Summary

Regression tests for the user-visible symptom reported in #12871: with committed text on the line and a syllable still composing, a cursor-movement chord relocated the composing character to wherever the cursor landed — `Option+←` turned `가나 다라 마바[사]` into `가나 [사]다라 마바`, `Cmd+←` moved the syllable to the line start, and with a Japanese preedit the relocated text also overwrote the glyph at the destination cell.

This branch **carries #12732 unchanged** (`359fd2e09` by @kunsanglee, authorship preserved — that commit is the fix and the ordering mechanism is entirely theirs) and adds one test-only commit on top, pinning the resolver branches the existing suite does not cover:

- `Option+ArrowLeft` / `Option+ArrowRight` word jumps (`\eb` / `\ef`) — the chord in the original report
- `Cmd+ArrowRight` line-end jump (`\x05`)
- a multi-character Japanese preedit (`かな`) committing before the chord byte — pins the overwrite variant
- `Ctrl+ArrowLeft` word jump on Windows (`\eb`)

Not meant to supersede #12732 — if maintainers prefer to land it directly, I am happy to rebase this to a test-only follow-up (or for the tests to be cherry-picked into #12732; also fine with closing this if that is easier).

## Screenshots

No visual change.

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/keyboard-handlers-ime-deferred-input.test.tsx` — 10/10 pass (5 existing + 5 new)
- [x] Non-vacuity: with `keyboard-handlers.ts` reverted to its pre-#12732 state, all five new cases fail with the chord byte recorded ahead of the commit (`['pty:...', 'commit:사']` instead of `['commit:사', 'pty:...']`)
- [x] `oxlint` (default + react-doctor config) and `oxfmt` — clean via lint-staged pre-commit
- [x] `pnpm run typecheck:web` — clean
- [x] `pnpm test` (full suite, clean shell, macOS arm64) — 46,345 passed / 83 skipped; the 5 failures are unrelated to this change and accounted for:
  - `src/main/native-chat/transcript-watch.test.ts` + `transcript-watch-liveness.test.ts` — load-dependent flakes: both pass in isolation (28/28 and 7/7), and repeated full runs fail *different* unrelated files each time (`src/relay/agent-exec-handler.test.ts`, a GitHub project-view suite) while this PR's area stays green
  - `config/scripts/check-root-directory-entries.test.mjs` (3 cases) — fails on stock macOS regardless of this change: the guard script uses `declare -A` (bash 4+) but the test spawns plain `bash`, which resolves to `/bin/bash` 3.2 on macOS, so the script exits 2 before asserting anything
  - side note for anyone running the suite from an AI-agent terminal: `src/relay/agent-exec-handler.test.ts` asserts spawn env against `process.env`, so session-injected variables make it fail there; it passes in a clean shell
- [ ] `pnpm build` — not run; test-only change, no production code touched
- [x] Added or updated high-quality tests that would catch regressions

The new cases reuse the file's existing harness and assert relative order on the same recorded list, so they pin behavior (commit before chord byte) rather than implementation details.

## AI Review Report

Reviewed for vacuity (all five new cases verified to fail against the pre-fix handler), for whether the assertions are behavioral rather than structural (they assert the recorded commit/pty order, not internals), and for platform assumptions (the Windows case forces the platform via the same `userAgent` stub the neighboring suites use; `macOptionAsAlt` stays `'false'`, matching the harness default, and the `Alt+Arrow` resolver branch does not consult it). No production code, shortcuts, labels, paths, or shell behavior are touched.

## Security Audit

Test-only change. No input handling at a trust boundary, no command execution, no path handling, no auth, no secrets, no IPC, and no dependency changes.

## Notes

- Verifies #12871 (reproduction steps and the Korean/Japanese variants are documented there).
- The carried fix commit is byte-identical to #12732's head at the time of branching; if #12732 gains changes I will rebase.
