### PR TITLE
feat(ai-vault): let OMP task subagent rows resume as their own sessions

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultSessionDetails.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionDetails.tsx
@@ -30,7 +30,8 @@ export function SessionInlineDetails({
   onResumeInWorktree,
   onResumeInNewTab,
   onContinueInNewSession,
-  onOpenLog
+  onOpenLog,
+  onResumeSubagent
 }: {
   id: string
   session: AiVaultSession
@@ -44,6 +45,7 @@ export function SessionInlineDetails({
   onResumeInNewTab: () => void
   onContinueInNewSession?: () => void
   onOpenLog?: () => void
+  onResumeSubagent?: (subagent: AiVaultSession) => void
 }): React.JSX.Element {
   // A zero-turn transcript would resume into an empty conversation, so the plain
   // resume affordances are withheld and a distinct "not saved" state is shown.
@@ -185,7 +187,7 @@ export function SessionInlineDetails({
           <SessionUnsavedConversationNotice session={session} logAvailable={Boolean(onOpenLog)} />
         )}
 
-        <SessionSubagentsSection session={session} />
+        <SessionSubagentsSection session={session} onResumeSubagent={onResumeSubagent} />
 
         {shouldShowAiVaultSessionWorktreeLine(worktreeDisplay, {
           vaultScope

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.tsx
@@ -51,7 +51,8 @@ export function VaultSessionRow({
   onCopyPath,
   onOpenLog,
   onRevealLog,
-  onOpenCwd
+  onOpenCwd,
+  onResumeSubagent
 }: {
   session: AiVaultSession
   liveState: AgentStatusState | null
@@ -77,6 +78,7 @@ export function VaultSessionRow({
   onOpenLog?: () => void
   onRevealLog?: () => void
   onOpenCwd?: () => void
+  onResumeSubagent?: (subagent: AiVaultSession) => void
 }) {
   const updatedAt = session.updatedAt ?? session.modifiedAt
   const detailsId = getSessionDetailsId(session.id)
@@ -213,6 +215,7 @@ export function VaultSessionRow({
               onResumeInNewTab={onResumeInNewTab}
               onContinueInNewSession={onContinueInNewSession}
               onOpenLog={onOpenLog}
+              onResumeSubagent={onResumeSubagent}
             />
           ) : null}
         </div>

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.test.tsx
@@ -56,6 +56,23 @@ function makeSubagent(title: string): AiVaultSession {
   })
 }
 
+function makeOmpSubagent(title: string, overrides: Partial<AiVaultSession> = {}): AiVaultSession {
+  const filePath = `/tmp/2026-05-01T10-00-00-000Z_${'c'.repeat(8)}-dddd-4eee-8fff-000000000000/${title}.jsonl`
+  return makeSession({
+    id: `local:omp:${title}:${filePath}`,
+    agent: 'omp',
+    // OMP children carry their own session id, which is why they resume to
+    // themselves rather than to the parent.
+    sessionId: `child-${title}`,
+    title,
+    filePath,
+    resumeCommand: `cd '/repo' && omp --resume '${filePath}'`,
+    subagent: { parentSessionId: 'parent-session', agentType: null, status: null },
+    subagentTranscriptCount: 0,
+    ...overrides
+  })
+}
+
 describe('SessionSubagentsSection', () => {
   it('keeps the loaded list visible while a rescan-triggered refetch is in flight', async () => {
     listSubagentSessions.mockResolvedValueOnce({
@@ -84,6 +101,55 @@ describe('SessionSubagentsSection', () => {
     })
     expect(queryByText('Second pass')).not.toBeNull()
     expect(queryByText('First pass')).toBeNull()
+  })
+
+  it('offers resume on an OMP subagent row and launches that child, not its parent', async () => {
+    const child = makeOmpSubagent('ReadAgents')
+    listSubagentSessions.mockResolvedValueOnce({ sessions: [child], issues: [] })
+    const onResumeSubagent = vi.fn()
+    const { getByTitle } = render(
+      <SessionSubagentsSection
+        session={makeSession({ agent: 'omp' })}
+        onResumeSubagent={onResumeSubagent}
+      />
+    )
+    await act(async () => {})
+
+    getByTitle('Resume Subagent in New Tab').click()
+
+    expect(onResumeSubagent).toHaveBeenCalledTimes(1)
+    expect(onResumeSubagent.mock.calls[0][0]).toMatchObject({
+      filePath: child.filePath,
+      sessionId: child.sessionId
+    })
+  })
+
+  it('withholds resume on a Claude subagent row, which would reopen the parent', async () => {
+    // Claude subagents share the parent's sessionId and resume by id, so a
+    // resume affordance here would silently relaunch the parent session.
+    listSubagentSessions.mockResolvedValueOnce({
+      sessions: [makeSubagent('Explore')],
+      issues: []
+    })
+    const { queryByTitle } = render(
+      <SessionSubagentsSection session={makeSession()} onResumeSubagent={vi.fn()} />
+    )
+    await act(async () => {})
+
+    expect(queryByTitle('Resume Subagent in New Tab')).toBeNull()
+  })
+
+  it('withholds resume on a zero-turn OMP subagent row', async () => {
+    listSubagentSessions.mockResolvedValueOnce({
+      sessions: [makeOmpSubagent('Empty', { messageCount: 0, previewMessages: [] })],
+      issues: []
+    })
+    const { queryByTitle } = render(
+      <SessionSubagentsSection session={makeSession({ agent: 'omp' })} onResumeSubagent={vi.fn()} />
+    )
+    await act(async () => {})
+
+    expect(queryByTitle('Resume Subagent in New Tab')).toBeNull()
   })
 
   it('does not fetch for remote sessions even when the scan counted transcripts', async () => {

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.tsx
@@ -1,10 +1,14 @@
 import { useEffect, useState } from 'react'
 import type React from 'react'
-import { Bot, FileJson } from 'lucide-react'
+import { Bot, FileJson, Play } from 'lucide-react'
 import { Badge } from '@/components/ui/badge'
 import { Button } from '@/components/ui/button'
 import { AgentStateDot, agentStateLabel, type AgentDotState } from '@/components/AgentStateDot'
-import type { AiVaultSession, AiVaultSubagentRunStatus } from '../../../../shared/ai-vault-types'
+import {
+  isAiVaultSubagentResumable,
+  type AiVaultSession,
+  type AiVaultSubagentRunStatus
+} from '../../../../shared/ai-vault-types'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../../shared/execution-host'
 import { canOpenAiVaultSessionLogInOrca } from './ai-vault-session-path-actions'
 import { openAiVaultSessionLogInOrca } from './ai-vault-session-log-open'
@@ -14,13 +18,19 @@ type SubagentListState = { status: 'loading' } | { status: 'loaded'; sessions: A
 
 /**
  * Lists the Task subagent transcripts spawned by one session, fetched on
- * demand when the parent's details expand. Subagents share the parent's
- * sessionId and aren't independently resumable, so rows are view-only.
+ * demand when the parent's details expand. Rows are view-only unless the agent
+ * resumes subagents by transcript path (see isAiVaultSubagentResumable) — for
+ * everyone else a subagent shares its parent's sessionId and has nothing of its
+ * own to resume into.
  */
 export function SessionSubagentsSection({
-  session
+  session,
+  onResumeSubagent
 }: {
   session: AiVaultSession
+  // Pre-bound to the parent's resume target: a subagent transcript sits beside
+  // its parent and shares its cwd, so it resolves to the same workspace.
+  onResumeSubagent?: (subagent: AiVaultSession) => void
 }): React.JSX.Element | null {
   const subagents = useSubagentSessions(session)
 
@@ -44,7 +54,15 @@ export function SessionSubagentsSection({
       </div>
       <div className="space-y-1.5">
         {subagents.sessions.map((subagentSession) => (
-          <SubagentSessionLine key={subagentSession.id} session={subagentSession} />
+          <SubagentSessionLine
+            key={subagentSession.id}
+            session={subagentSession}
+            onResume={
+              onResumeSubagent && isAiVaultSubagentResumable(subagentSession)
+                ? () => onResumeSubagent(subagentSession)
+                : undefined
+            }
+          />
         ))}
       </div>
     </section>
@@ -112,7 +130,13 @@ const SUBAGENT_DOT_STATES: Record<AiVaultSubagentRunStatus, AgentDotState> = {
   stopped: 'interrupted'
 }
 
-function SubagentSessionLine({ session }: { session: AiVaultSession }): React.JSX.Element {
+function SubagentSessionLine({
+  session,
+  onResume
+}: {
+  session: AiVaultSession
+  onResume?: () => void
+}): React.JSX.Element {
   const dotState = session.subagent?.status ? SUBAGENT_DOT_STATES[session.subagent.status] : null
 
   return (
@@ -145,6 +169,25 @@ function SubagentSessionLine({ session }: { session: AiVaultSession }): React.JS
           { value0: session.messageCount }
         )}
       </span>
+      {onResume ? (
+        <Button
+          type="button"
+          variant="ghost"
+          size="icon-xs"
+          draggable={false}
+          title={translate(
+            'auto.components.right.sidebar.AiVaultSessionSubagents.resumeSubagent',
+            'Resume Subagent in New Tab'
+          )}
+          onClick={(event) => {
+            event.stopPropagation()
+            onResume()
+          }}
+          className="shrink-0 text-muted-foreground"
+        >
+          <Play className="size-3.5" />
+        </Button>
+      ) : null}
       {canOpenAiVaultSessionLogInOrca(session) ? (
         <Button
           type="button"

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionVirtualList.tsx
@@ -401,6 +401,17 @@ function AiVaultVirtualRow({
           onOpenCwd={
             canOpenLocalSessionPaths && row.session.cwd ? () => onOpenCwd(row.session) : undefined
           }
+          // A subagent transcript sits beside its parent and shares its cwd, so
+          // it resumes into the same workspace the parent resolved to.
+          onResumeSubagent={
+            resumeState?.worktreeId
+              ? (subagent) => {
+                  if (resumeState.worktreeId) {
+                    onResume(subagent, resumeState.worktreeId)
+                  }
+                }
+              : undefined
+          }
         />
       )}
     </div>

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11582,7 +11582,8 @@
           "AiVaultSessionSubagents": {
             "subagentsCount": "Subagents ({{value0}})",
             "messageCount": "{{value0}} msgs",
-            "viewLog": "View Log"
+            "viewLog": "View Log",
+            "resumeSubagent": "Resume Subagent in New Tab"
           },
           "aiVaultSessionLogOpen": {
             "workspaceGone": "Couldn't open log — workspace is no longer available.",

--- a/src/shared/ai-vault-types.test.ts
+++ b/src/shared/ai-vault-types.test.ts
@@ -3,7 +3,10 @@ import {
   aiVaultSessionRecoverableSignalCount,
   isAiVaultSessionRecoverableEmpty,
   isAiVaultSessionResumableContent,
-  type AiVaultSessionPreviewMessage
+  isAiVaultSubagentResumable,
+  type AiVaultAgent,
+  type AiVaultSessionPreviewMessage,
+  type AiVaultSessionSubagentInfo
 } from './ai-vault-types'
 
 type SignalFields = {
@@ -84,5 +87,44 @@ describe('aiVaultSessionRecoverableSignalCount', () => {
         subagentTranscriptCount: 3
       })
     ).toBe(3)
+  })
+})
+
+describe('isAiVaultSubagentResumable', () => {
+  const child: AiVaultSessionSubagentInfo = {
+    parentSessionId: 'parent-session',
+    agentType: null,
+    status: null
+  }
+
+  function row(overrides: {
+    agent?: AiVaultAgent
+    subagent?: AiVaultSessionSubagentInfo | null
+    messageCount?: number
+  }) {
+    return {
+      agent: overrides.agent ?? 'omp',
+      subagent: overrides.subagent === undefined ? child : overrides.subagent,
+      messageCount: overrides.messageCount ?? 3,
+      previewMessages: []
+    }
+  }
+
+  it('resumes an OMP subagent, which has its own session id and resumes by path', () => {
+    expect(isAiVaultSubagentResumable(row({}))).toBe(true)
+  })
+
+  it('refuses a Claude subagent, whose resume would reopen the parent', () => {
+    // Claude subagents share the parent's sessionId and resume by id, so
+    // offering resume here relaunches the parent rather than the row clicked.
+    expect(isAiVaultSubagentResumable(row({ agent: 'claude' }))).toBe(false)
+  })
+
+  it('refuses a zero-turn subagent, which would resume into an empty session', () => {
+    expect(isAiVaultSubagentResumable(row({ messageCount: 0 }))).toBe(false)
+  })
+
+  it('refuses a top-level session, which has its own resume affordances', () => {
+    expect(isAiVaultSubagentResumable(row({ subagent: null }))).toBe(false)
   })
 })

--- a/src/shared/ai-vault-types.ts
+++ b/src/shared/ai-vault-types.ts
@@ -161,6 +161,26 @@ export function isAiVaultSessionResumableContent(
   )
 }
 
+// Agents whose subagent transcripts resume to themselves. Must stay in step with
+// buildAiVaultResumeCommand's `resumeFilePath` branch: every other agent resumes
+// by sessionId, and a subagent shares its parent's id — so offering resume on
+// such a row would silently reopen the PARENT, not the row the user clicked.
+const SELF_RESUMABLE_SUBAGENT_AGENTS = new Set<AiVaultAgent>(['omp'])
+
+/**
+ * Whether a listed subagent row can be resumed as its own session. True only for
+ * agents that resume by transcript path AND whose transcript holds real turns.
+ */
+export function isAiVaultSubagentResumable(
+  session: Pick<AiVaultSession, 'agent' | 'subagent' | 'messageCount' | 'previewMessages'>
+): boolean {
+  return (
+    session.subagent !== null &&
+    SELF_RESUMABLE_SUBAGENT_AGENTS.has(session.agent) &&
+    isAiVaultSessionResumableContent(session)
+  )
+}
+
 export function aiVaultSessionRecoverableSignalCount(
   session: Pick<AiVaultSession, 'queuedMessageCount' | 'subagentTranscriptCount'>
 ): number {


### PR DESCRIPTION
**What:** OMP task subagent rows in Agent Session History can now be resumed as their own sessions, restoring an affordance #12803 dropped. Claude subagent rows stay view-only — deliberately.
**Risk:** One new optional prop threaded through three existing components; no main-process change. Claude behaviour byte-identical and pinned by a new negative test.
**State:** Based on today's `main`; tsc/lint clean; 8 new tests; verified in the running app.

---

Closes #12885.

## Why

#12803 stopped OMP task-worker transcripts from flooding the history by pruning them from the top-level scan and listing them under their coordinator. Correct fix for the flooding, but the rows it introduced are view-only — so an OMP child *lost* a working resume it had as a top-level row.

That loss was avoidable. `listOmpSubagentSessions` already builds a valid resume command for every child and ships it to the renderer; `AiVaultSessionSubagents.tsx` simply discarded it.

## The part that isn't plumbing

The gate is on **agent**, not merely on being a subagent:

- **OMP** children carry their own session id and resume by transcript path (`ai-vault-resume-command.ts` — the `resumeFilePath` branch), so a child resumes into itself.
- **Every other agent** resumes by `sessionId`, and a subagent shares its parent's. A resume button on a Claude subagent row would silently reopen **the parent**, not the row the user clicked — worse than no button at all.

`isAiVaultSubagentResumable` lives beside the resume-command builder whose behaviour it mirrors, with the coupling stated in a comment, so the two can't drift if another agent gains path-resume later.

Zero-turn children are also withheld, reusing the existing `isAiVaultSessionResumableContent`.

## Changes

- `src/shared/ai-vault-types.ts` — `isAiVaultSubagentResumable` + the agent set it keys off.
- `src/renderer/src/components/right-sidebar/AiVaultSessionSubagents.tsx` — optional `onResumeSubagent`, resume control on qualifying rows.
- `AiVaultSessionDetails.tsx` / `AiVaultSessionRow.tsx` — pass the prop through.
- `AiVaultSessionVirtualList.tsx` — bind it to the parent's already-resolved resume target. A subagent transcript sits beside its parent and shares its cwd, so it resolves to the same workspace; no separate worktree resolution.
- `i18n/locales/en.json` — one key.

No main-process changes: the data was already there.

## Verified in the running app

- An OMP coordinator with 3 children renders **3 resume controls**, and each child's resume command targets **its own** transcript (`…/ReadAgents.jsonl`), distinct from the parent's.
- A Claude session with 9 children renders **9 View Log and 0 resume controls**.

I verified launch targeting by asserting the built resume commands rather than spawning agent processes into a live workspace; the callback payload is pinned by unit test. Screenshots were captured locally during review and are not attached here.

## Tests

- `ai-vault-types.test.ts` — resumable for OMP; refused for Claude, zero-turn, and top-level rows.
- `AiVaultSessionSubagents.test.tsx` — OMP row offers resume and hands back the **child** session; Claude row offers none; zero-turn OMP row offers none.

## Not in scope

Nested expansion for grandchild transcripts (the other half of #12885). That needs per-row expand state and depth/indent decisions inside a virtualised list — a design conversation, and it addresses the rarer regression. The backend already supports it: child rows carry their own accurate `subagentTranscriptCount`.
