### PR TITLE
fix(orchestration): allow fresh agents to take over legacy runs

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1,5 +1,6 @@
 /* eslint-disable max-lines -- Why: stateful registration helper + shared mocked IPC/node-pty harness keep spawn-env assertions in one focused file. */
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHash } from 'node:crypto'
 import { userInfo } from 'node:os'
 import { delimiter, join, posix } from 'node:path'
 import { prepareCodexSessionResume } from '../codex/codex-session-resume-preparation'
@@ -7966,6 +7967,114 @@ describe('registerPtyHandlers', () => {
       { tabId: 'tab-1', leafId, incarnationId: expect.any(String) },
       false
     )
+  })
+
+  it.each([
+    {
+      label: 'matching proof',
+      launchToken: 'renderer-launch-token',
+      envLaunchToken: 'renderer-launch-token',
+      hasLaunchConfig: true,
+      launchAgent: 'claude',
+      expectedToken: 'renderer-launch-token'
+    },
+    {
+      label: 'mismatched proof',
+      launchToken: 'renderer-launch-token',
+      envLaunchToken: 'different-process-token',
+      hasLaunchConfig: true,
+      launchAgent: 'claude',
+      expectedToken: null
+    },
+    {
+      label: 'missing top-level proof',
+      launchToken: undefined,
+      envLaunchToken: 'renderer-launch-token',
+      hasLaunchConfig: true,
+      launchAgent: 'claude',
+      expectedToken: null
+    },
+    {
+      label: 'oversized proof',
+      launchToken: 'x'.repeat(129),
+      envLaunchToken: 'x'.repeat(129),
+      hasLaunchConfig: true,
+      launchAgent: 'claude',
+      expectedToken: null
+    },
+    {
+      label: 'untracked launch',
+      launchToken: 'renderer-launch-token',
+      envLaunchToken: 'renderer-launch-token',
+      hasLaunchConfig: false,
+      launchAgent: 'claude',
+      expectedToken: null
+    },
+    {
+      label: 'invalid agent identity',
+      launchToken: 'renderer-launch-token',
+      envLaunchToken: 'renderer-launch-token',
+      hasLaunchConfig: true,
+      launchAgent: 'not-an-agent',
+      expectedToken: null
+    },
+    {
+      label: 'missing agent identity',
+      launchToken: 'renderer-launch-token',
+      envLaunchToken: 'renderer-launch-token',
+      hasLaunchConfig: true,
+      launchAgent: undefined,
+      expectedToken: null
+    }
+  ])('binds only $label from renderer pty:spawn to runtime authority', async (testCase) => {
+    const runtime = new OrcaRuntimeService()
+    registerPtyHandlers(mainWindow as never, runtime)
+    const worktreeId = 'repo-1::/tmp/renderer-authority'
+    const tabId = 'tab-renderer-authority'
+    const leafId = '99999999-9999-4999-8999-999999999999'
+    const paneKey = makePaneKey(tabId, leafId)
+
+    const result = (await handlers.get('pty:spawn')!(mainWindowIpcEvent, {
+      cols: 80,
+      rows: 24,
+      cwd: '/tmp/renderer-authority',
+      command: 'claude',
+      worktreeId,
+      tabId,
+      leafId,
+      env: {
+        ORCA_PANE_KEY: paneKey,
+        ORCA_TAB_ID: tabId,
+        ORCA_WORKTREE_ID: worktreeId,
+        ORCA_AGENT_LAUNCH_TOKEN: testCase.envLaunchToken
+      },
+      ...(testCase.launchToken ? { launchToken: testCase.launchToken } : {}),
+      ...(testCase.hasLaunchConfig
+        ? { launchConfig: { agentCommand: 'claude', agentArgs: '', agentEnv: {} } }
+        : {}),
+      ...(testCase.launchAgent ? { launchAgent: testCase.launchAgent } : {})
+    })) as { id: string; incarnationId: string }
+
+    const handle = runtime.preAllocateHandleForPty(result.id)
+    const authority = runtime.getOrchestrationDispatchAuthority(handle)
+    expect(authority).toMatchObject({ ptyId: result.id, paneKey })
+    expect(authority?.launchTokenHash).toBe(
+      testCase.expectedToken
+        ? createHash('sha256').update(testCase.expectedToken).digest('hex')
+        : null
+    )
+
+    if (testCase.expectedToken) {
+      runtime.registerPty(result.id, worktreeId, null, {
+        tabId,
+        leafId,
+        incarnationId: result.incarnationId,
+        agentLaunchAuthority: { launchToken: 'stale-overwrite', launchAgent: 'claude' }
+      })
+      expect(runtime.getOrchestrationDispatchAuthority(handle)?.launchTokenHash).toBe(
+        createHash('sha256').update(testCase.expectedToken).digest('hex')
+      )
+    }
   })
 
   it('omits the pane identity from registerPty when the leafId is not a terminal leaf (#7587)', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -455,6 +455,33 @@ function isValidPaneKey(paneKey: unknown): paneKey is string {
   return parseValidPaneKey(paneKey) !== null
 }
 
+const AGENT_LAUNCH_TOKEN_MAX_LENGTH = 128
+
+function admitRendererAgentLaunchAuthority(args: {
+  launchToken: unknown
+  spawnEnv: Record<string, string> | undefined
+  launchAgent: unknown
+  launchConfig: SleepingAgentLaunchConfig | undefined
+  isReattach: boolean
+  hasStablePaneOwner: boolean
+  incarnationId: unknown
+}): { launchToken: string; launchAgent: TuiAgent } | null {
+  if (
+    args.isReattach ||
+    args.hasStablePaneOwner ||
+    !args.launchConfig ||
+    !isTuiAgent(args.launchAgent) ||
+    !isPtyIncarnationId(args.incarnationId) ||
+    typeof args.launchToken !== 'string' ||
+    args.launchToken.length === 0 ||
+    args.launchToken.length > AGENT_LAUNCH_TOKEN_MAX_LENGTH ||
+    args.spawnEnv?.ORCA_AGENT_LAUNCH_TOKEN !== args.launchToken
+  ) {
+    return null
+  }
+  return { launchToken: args.launchToken, launchAgent: args.launchAgent }
+}
+
 function shouldRefreshNativeClaudeAgentTeamsEnv(args: {
   command?: string
   launchConfig?: SleepingAgentLaunchConfig
@@ -5595,6 +5622,7 @@ export function registerPtyHandlers(
         commandDelivery?: 'renderer' | 'provider'
         launchConfig?: SleepingAgentLaunchConfig
         resumeProviderSession?: AgentProviderSessionMetadata
+        launchToken?: unknown
         launchAgent?: TuiAgent
         startupCommandDelivery?: StartupCommandDelivery
         connectionId?: string | null
@@ -6482,6 +6510,15 @@ export function registerPtyHandlers(
           args.worktreeId.length > 0 &&
           args.worktreeId.length <= 512
         ) {
+          const agentLaunchAuthority = admitRendererAgentLaunchAuthority({
+            launchToken: args.launchToken,
+            spawnEnv,
+            launchAgent: args.launchAgent,
+            launchConfig: effectiveLaunchConfig,
+            isReattach: result.isReattach === true,
+            hasStablePaneOwner: stablePaneOwner !== null,
+            incarnationId: result.incarnationId
+          })
           runtime?.registerPty(
             result.id,
             args.worktreeId,
@@ -6494,7 +6531,8 @@ export function registerPtyHandlers(
               ? {
                   tabId: args.tabId,
                   leafId: metadataLeafId,
-                  ...(result.incarnationId ? { incarnationId: result.incarnationId } : {})
+                  ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
+                  ...(agentLaunchAuthority ? { agentLaunchAuthority } : {})
                 }
               : undefined,
             !args.connectionId

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -11977,7 +11977,8 @@ export class OrcaRuntimeService {
   }
 
   verifyOrchestrationCompatibilityCaller(
-    evidence: OrchestrationCompatibilityEvidence | null | undefined
+    evidence: OrchestrationCompatibilityEvidence | null | undefined,
+    options?: { currentRuntimeLaunchSufficient?: boolean }
   ): OrchestrationCompatibilityCallerAuthority | null {
     const terminalHandle =
       typeof evidence?.terminalHandle === 'string' ? evidence.terminalHandle.trim() : ''
@@ -12016,6 +12017,19 @@ export class OrcaRuntimeService {
         return null
       }
       terminalProvenance = 'restored'
+    }
+    if (
+      options?.currentRuntimeLaunchSufficient &&
+      terminalProvenance === 'current_runtime' &&
+      claimedPaneKey === terminal.paneKey
+    ) {
+      return Object.freeze({
+        hostScope: Object.freeze({ ...terminal.hostScope }),
+        paneKey: claimedPaneKey,
+        terminalHandle,
+        processIncarnation: terminal.processIncarnation,
+        launchTokenHash
+      })
     }
     const attestation = this.attestAgentHookCompatibilityAuthorityFn?.({
       paneKey: claimedPaneKey,

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -9297,7 +9297,12 @@ export class OrcaRuntimeService {
     ptyId: string,
     worktreeId: string,
     connectionId: string | null = null,
-    binding?: { tabId: string; leafId: string; incarnationId?: PtyIncarnationId },
+    binding?: {
+      tabId: string
+      leafId: string
+      incarnationId?: PtyIncarnationId
+      agentLaunchAuthority?: { launchToken: string; launchAgent: TuiAgent }
+    },
     isWsl?: boolean
   ): void {
     this.assertPtyDidNotExitBeforeRegistration(ptyId, binding?.incarnationId)
@@ -9308,7 +9313,7 @@ export class OrcaRuntimeService {
       binding && isValidTerminalTabId(binding.tabId) && isTerminalLeafId(binding.leafId)
         ? makePaneKey(binding.tabId, binding.leafId)
         : null
-    this.recordPtyWorktree(ptyId, worktreeId, {
+    const pty = this.recordPtyWorktree(ptyId, worktreeId, {
       connected: true,
       connectionId,
       ...(binding && this.pendingMobileTerminalCreatesByKey.has(`${worktreeId}::${binding.tabId}`)
@@ -9318,6 +9323,21 @@ export class OrcaRuntimeService {
       ...(binding && paneKey ? { tabId: binding.tabId, paneKey } : {}),
       ...(binding?.incarnationId ? { incarnationId: binding.incarnationId } : {})
     })
+    const agentLaunchAuthority = binding?.agentLaunchAuthority
+    if (
+      agentLaunchAuthority &&
+      paneKey &&
+      binding.incarnationId &&
+      pty.incarnationId === binding.incarnationId &&
+      pty.paneKey === paneKey &&
+      pty.launchToken === null &&
+      agentLaunchAuthority.launchToken.length > 0 &&
+      agentLaunchAuthority.launchToken.length <= 128 &&
+      isTuiAgent(agentLaunchAuthority.launchAgent)
+    ) {
+      pty.launchToken = agentLaunchAuthority.launchToken
+      pty.launchAgent = agentLaunchAuthority.launchAgent
+    }
     const pendingIncarnation = this.pendingPtyRegistrationIncarnations.get(ptyId)
     if (
       pendingIncarnation === null ||

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -12023,13 +12023,15 @@ export class OrcaRuntimeService {
       terminalProvenance === 'current_runtime' &&
       claimedPaneKey === terminal.paneKey
     ) {
-      return Object.freeze({
-        hostScope: Object.freeze({ ...terminal.hostScope }),
-        paneKey: claimedPaneKey,
+      // Why: the checks above bind a fresh launch to its live PTY, host, and
+      // launch secret. Only an exact live-pane match may skip hook attestation.
+      return this.freezeOrchestrationCompatibilityCallerAuthority(
+        terminal,
+        terminal.processIncarnation,
+        claimedPaneKey,
         terminalHandle,
-        processIncarnation: terminal.processIncarnation,
         launchTokenHash
-      })
+      )
     }
     const attestation = this.attestAgentHookCompatibilityAuthorityFn?.({
       paneKey: claimedPaneKey,
@@ -12040,11 +12042,27 @@ export class OrcaRuntimeService {
     if (!attestation || attestation.paneKey !== terminal.paneKey) {
       return null
     }
+    return this.freezeOrchestrationCompatibilityCallerAuthority(
+      terminal,
+      terminal.processIncarnation,
+      attestation.paneKey,
+      terminalHandle,
+      launchTokenHash
+    )
+  }
+
+  private freezeOrchestrationCompatibilityCallerAuthority(
+    terminal: OrchestrationCompatibilityTerminalAuthority,
+    processIncarnation: string,
+    paneKey: string,
+    terminalHandle: string,
+    launchTokenHash: string
+  ): OrchestrationCompatibilityCallerAuthority {
     return Object.freeze({
       hostScope: Object.freeze({ ...terminal.hostScope }),
-      paneKey: attestation.paneKey,
+      paneKey,
       terminalHandle,
-      processIncarnation: terminal.processIncarnation,
+      processIncarnation,
       launchTokenHash
     })
   }

--- a/src/main/runtime/rpc/orchestration-legacy-compatibility.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-compatibility.ts
@@ -82,8 +82,11 @@ export class OrchestrationLegacyCompatibility {
       return { handled: false }
     }
     if (request.method === 'orchestration.runUse' && values.takeoverLegacy === true) {
+      // Why: takeover is a current-contract recovery action. An exact fresh runtime launch
+      // already proves its live PTY, process, pane, host, handle, and launch secret.
       const callerAuthority = this.runtime.verifyOrchestrationCompatibilityCaller(
-        request.orchestrationCompatibilityEvidence
+        request.orchestrationCompatibilityEvidence,
+        { currentRuntimeLaunchSufficient: true }
       )
       return {
         handled: false,

--- a/src/main/runtime/rpc/orchestration-legacy-takeover-current-authority.test.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-takeover-current-authority.test.ts
@@ -43,18 +43,27 @@ describe('legacy takeover by current runtime authority', () => {
 
     // Legacy compatibility mutations still require a hook observation.
     expect(runtime.verifyOrchestrationCompatibilityCaller(proof)).toBeNull()
-    expect(
-      runtime.verifyOrchestrationCompatibilityCaller(
-        { ...proof, launchToken: 'forged-token' },
-        { currentRuntimeLaunchSufficient: true }
+    for (const [invocationId, forgedProof] of [
+      ['forged-token', { ...proof, launchToken: 'forged-token' }],
+      ['forged-pane', { ...proof, paneKey: 'tab_forged:66666666-6666-4666-8666-666666666666' }]
+    ] as const) {
+      const rejected = await dispatcher.dispatch(
+        request(
+          'orchestration.runUse',
+          {
+            id: harness.adoptedRunId,
+            from: CURRENT_COORDINATOR_HANDLE,
+            takeoverLegacy: true
+          },
+          forgedProof,
+          invocationId
+        )
       )
-    ).toBeNull()
-    expect(
-      runtime.verifyOrchestrationCompatibilityCaller(
-        { ...proof, paneKey: 'tab_forged:66666666-6666-4666-8666-666666666666' },
-        { currentRuntimeLaunchSufficient: true }
-      )
-    ).toBeNull()
+      expect(rejected).toMatchObject({
+        ok: false,
+        error: { code: 'legacy_read_only', data: { effectsApplied: false } }
+      })
+    }
 
     const response = await dispatcher.dispatch(
       request(
@@ -81,7 +90,8 @@ describe('legacy takeover by current runtime authority', () => {
     })
   })
 
-  it('requires a runtime-issued SSH attachment for fresh launch proof', () => {
+  it('requires a runtime-issued SSH attachment for fresh launch proof', async () => {
+    const harness = createHarness()
     const runtime = new OrcaRuntimeService()
     const proof = currentEvidence('coordinator')
     const launchTokenHash = createHash('sha256').update(proof.launchToken!).digest('hex')
@@ -99,18 +109,31 @@ describe('legacy takeover by current runtime authority', () => {
       launchTokenHash,
       hostScope: { kind: 'ssh', targetId: 'saved-target' }
     })
+    runtime.setOrchestrationDb(harness.db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(CURRENT_COORDINATOR_PANE)
+    const dispatcher = new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS })
 
-    expect(
-      runtime.verifyOrchestrationCompatibilityCaller(
-        { ...proof, host },
-        { currentRuntimeLaunchSufficient: true }
-      )
-    ).toMatchObject({ hostScope: { kind: 'ssh', targetId: 'saved-target' } })
-    expect(
-      runtime.verifyOrchestrationCompatibilityCaller(
+    const params = {
+      id: harness.adoptedRunId,
+      from: CURRENT_COORDINATOR_HANDLE,
+      takeoverLegacy: true
+    }
+    const rejected = await dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        params,
         { ...proof, host: { ...host, attachmentId: 'caller-chosen' } },
-        { currentRuntimeLaunchSufficient: true }
+        'forged-ssh-attachment'
       )
-    ).toBeNull()
+    )
+    expect(rejected).toMatchObject({
+      ok: false,
+      error: { code: 'legacy_read_only', data: { effectsApplied: false } }
+    })
+
+    const response = await dispatcher.dispatch(
+      request('orchestration.runUse', params, { ...proof, host }, 'valid-ssh-attachment')
+    )
+    expect(response).toMatchObject({ ok: true })
   })
 })

--- a/src/main/runtime/rpc/orchestration-legacy-takeover-current-authority.test.ts
+++ b/src/main/runtime/rpc/orchestration-legacy-takeover-current-authority.test.ts
@@ -1,0 +1,116 @@
+import { createHash } from 'node:crypto'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer } from '../../agent-hooks/server'
+import { OrcaRuntimeService } from '../orca-runtime'
+import { RpcDispatcher } from './dispatcher'
+import {
+  cleanupLegacyCompatibilityDispatcherHarnesses,
+  createHarness,
+  currentEvidence,
+  CURRENT_COORDINATOR_HANDLE,
+  CURRENT_COORDINATOR_PANE,
+  request
+} from './orchestration-legacy-compatibility-dispatcher-test-fixture'
+import { ORCHESTRATION_METHODS } from './methods/orchestration'
+
+afterEach(() => {
+  cleanupLegacyCompatibilityDispatcherHarnesses()
+})
+
+describe('legacy takeover by current runtime authority', () => {
+  it('accepts a fresh current agent before its first hook observation', async () => {
+    const harness = createHarness()
+    const hookServer = new AgentHookServer()
+    const runtime = new OrcaRuntimeService(null, undefined, {
+      attestAgentHookCompatibilityAuthority: (candidate) =>
+        hookServer.attestCompatibilityAuthority(candidate)
+    })
+    const proof = currentEvidence('coordinator')
+    const launchTokenHash = createHash('sha256').update(proof.launchToken!).digest('hex')
+    runtime.setOrchestrationDb(harness.db)
+    vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue(CURRENT_COORDINATOR_PANE)
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
+      runtimeId: 'runtime-current',
+      terminalHandle: CURRENT_COORDINATOR_HANDLE,
+      ptyId: 'pty-current',
+      worktreeId: 'repo::/worktree',
+      processIncarnation: 'process-current',
+      paneKey: CURRENT_COORDINATOR_PANE,
+      launchTokenHash,
+      hostScope: { kind: 'local', hostId: 'local' }
+    })
+    const dispatcher = new RpcDispatcher({ runtime, methods: ORCHESTRATION_METHODS })
+
+    // Legacy compatibility mutations still require a hook observation.
+    expect(runtime.verifyOrchestrationCompatibilityCaller(proof)).toBeNull()
+    expect(
+      runtime.verifyOrchestrationCompatibilityCaller(
+        { ...proof, launchToken: 'forged-token' },
+        { currentRuntimeLaunchSufficient: true }
+      )
+    ).toBeNull()
+    expect(
+      runtime.verifyOrchestrationCompatibilityCaller(
+        { ...proof, paneKey: 'tab_forged:66666666-6666-4666-8666-666666666666' },
+        { currentRuntimeLaunchSufficient: true }
+      )
+    ).toBeNull()
+
+    const response = await dispatcher.dispatch(
+      request(
+        'orchestration.runUse',
+        {
+          id: harness.adoptedRunId,
+          from: CURRENT_COORDINATOR_HANDLE,
+          takeoverLegacy: true
+        },
+        proof,
+        'fresh-current-agent-takeover'
+      )
+    )
+
+    expect(response).toMatchObject({
+      ok: true,
+      result: {
+        run: {
+          id: harness.adoptedRunId,
+          coordinator_handle: CURRENT_COORDINATOR_HANDLE,
+          coordinator_pane_key: CURRENT_COORDINATOR_PANE
+        }
+      }
+    })
+  })
+
+  it('requires a runtime-issued SSH attachment for fresh launch proof', () => {
+    const runtime = new OrcaRuntimeService()
+    const proof = currentEvidence('coordinator')
+    const launchTokenHash = createHash('sha256').update(proof.launchToken!).digest('hex')
+    const host = runtime.registerOrchestrationCompatibilitySshAttachment(
+      'saved-target',
+      'connection-current'
+    )
+    vi.spyOn(runtime, 'getOrchestrationDispatchAuthority').mockReturnValue({
+      runtimeId: 'runtime-current',
+      terminalHandle: CURRENT_COORDINATOR_HANDLE,
+      ptyId: 'pty-current',
+      worktreeId: 'repo::/worktree',
+      processIncarnation: 'process-current',
+      paneKey: CURRENT_COORDINATOR_PANE,
+      launchTokenHash,
+      hostScope: { kind: 'ssh', targetId: 'saved-target' }
+    })
+
+    expect(
+      runtime.verifyOrchestrationCompatibilityCaller(
+        { ...proof, host },
+        { currentRuntimeLaunchSufficient: true }
+      )
+    ).toMatchObject({ hostScope: { kind: 'ssh', targetId: 'saved-target' } })
+    expect(
+      runtime.verifyOrchestrationCompatibilityCaller(
+        { ...proof, host: { ...host, attachmentId: 'caller-chosen' } },
+        { currentRuntimeLaunchSufficient: true }
+      )
+    ).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #12804.

Explicit `orchestration run-use --takeover-legacy` can now bind an adopted Run from a freshly launched current agent before that agent emits its first hook observation.

The recovery path accepts the runtime's existing current-launch authority only when the caller exactly matches the live PTY, process incarnation, terminal handle, stable pane, host scope, and launch-token hash. Restored callers and ordinary legacy compatibility mutations continue to require agent-hook attestation.

The root cause was that explicit takeover, a current-contract recovery action, reused the stricter legacy compatibility verifier. That made `callerAuthority` null until a matching hook observation existed, so the takeover guard always returned `legacy_read_only` even though the runtime already held exact current-launch proof.

An integrated dispatcher regression test reproduces the pre-fix failure without mocking the verifier, proves the fresh local-agent takeover, and covers forged token, forged pane, and caller-chosen SSH attachment rejection.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:

- [x] Focused takeover, authority, CLI, and SSH suites: 5 files / 39 tests passed.
- [x] Cross-version terminal wire suite against `v1.4.175`: 4 tests passed.
- [x] Full suite exercised 47,131 tests: 47,042 passed and 87 skipped. The GitHub project timeout passed on isolated rerun. The only remaining local failure is the unrelated Windows-signing 7za cold-cache test: its external toolset download reaches 100% and then exits on `read ECONNRESET`; a direct diagnostic reproduced the same network failure outside the suite.

## AI Review Report

The AI review checked the authority boundary from CLI evidence through compatibility preflight, the takeover guard, and the Run binding transaction.

- **Cross-platform:** The change is platform-neutral TypeScript with no new paths, shortcuts, labels, shell behavior, or Electron platform branches. Existing local, WSL, and SSH host-scope validation remains shared across macOS, Linux, and Windows.
- **SSH / remote / local:** Local takeover is covered through the real verifier/dispatcher stack. SSH coverage proves that a runtime-issued live attachment is accepted and a caller-chosen attachment is rejected. Existing SSH compatibility tests remain green.
- **Agents and integrations:** The behavior is provider-neutral and does not change hook ingestion, agent-specific lifecycle behavior, integrations, or git providers.
- **Performance:** The option reuses the existing live-terminal lookup and launch-token hash already performed by the verifier. It adds no polling, I/O, dependencies, or background work.
- **UI quality:** Not applicable; there is no renderer or interaction change.
- **Security:** The review rejected a generic fallback. The bypass is opt-in only for explicit takeover and only for `current_runtime` launch provenance with an exact pane match. Default legacy verification remains unchanged.

No additional code changes were required after the final review.

## Security Audit

This PR changes an authorization decision, so the review specifically checked spoofing and authority downgrade risks.

- Caller-supplied IDs alone do not grant authority. The runtime must resolve a connected PTY with a live process incarnation and matching handle, pane, host scope, and launch-token hash.
- SSH callers must also present a runtime-issued live attachment; a fabricated attachment remains rejected.
- Restored terminals cannot use the current-launch path and still require their durable receipt plus hook attestation.
- Ordinary legacy compatibility mutations still use the original strict verifier.
- The raw launch token is neither logged nor stored by this change; returned authority contains only its SHA-256 hash.
- No commands, paths, IPC schemas, dependencies, credentials, network listeners, or persistence formats were added.

No security follow-up is needed.

## Notes

This PR addresses the primary stuck-takeover recovery bug. The issue's secondary request for a general Run deletion/archive surface is intentionally left out to keep this authorization fix focused.

X handle: @Avichal2205
