### PR TITLE
fix(runtime): close restored PTYs with missing tabs

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -27440,6 +27440,56 @@ describe('OrcaRuntimeService', () => {
     expect(closeTerminalTab).not.toHaveBeenCalled()
   })
 
+  it('closes the exact PTY when its restored renderer tab is no longer persisted', async () => {
+    const kill = vi.fn(() => true)
+    const closeTerminal = vi.fn()
+    const closeTerminalTab = vi.fn(async () => {})
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setNotifier({ closeTerminal, closeTerminalTab } as never)
+    runtime.setPtyController({
+      write: () => true,
+      kill,
+      getForegroundProcess: async () => null,
+      listProcesses: async () => [
+        {
+          id: 'restored-live-pty',
+          cwd: TEST_WORKTREE_PATH,
+          title: 'Codex'
+        }
+      ]
+    })
+    runtime.syncWindowGraph(1, {
+      tabs: [
+        {
+          tabId: 'missing-persisted-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          title: 'Codex',
+          activeLeafId: HEADLESS_LEAF_ID,
+          layout: null
+        }
+      ],
+      leaves: [
+        {
+          tabId: 'missing-persisted-tab',
+          worktreeId: TEST_WORKTREE_ID,
+          leafId: HEADLESS_LEAF_ID,
+          paneRuntimeId: -1,
+          ptyId: 'restored-live-pty'
+        }
+      ]
+    })
+    const [terminal] = (await runtime.listTerminals()).terminals
+
+    await expect(runtime.closeTerminalTab(terminal.handle)).resolves.toEqual({
+      handle: terminal.handle,
+      tabId: 'missing-persisted-tab',
+      ptyKilled: true
+    })
+    expect(kill).toHaveBeenCalledWith('restored-live-pty')
+    expect(closeTerminal).toHaveBeenCalled()
+    expect(closeTerminalTab).not.toHaveBeenCalled()
+  })
+
   it('durably closes every split leaf without a renderer', async () => {
     const { runtimeStore, getSession } = makeRuntimeStoreWithWorkspaceSession(
       makeWorkspaceSessionWithHeadlessTerminal({

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -26815,22 +26815,36 @@ export class OrcaRuntimeService {
 
   async closeTerminalTab(handle: string): Promise<RuntimeTerminalClose> {
     const pty = this.getLivePtyForHandle(handle)
+    let tabId: string
+    let worktreeId: string
     if (pty) {
-      const tabId = pty.pty.tabId
-      if (!tabId) {
+      const registeredTabId = pty.pty.tabId
+      if (!registeredTabId) {
         return this.closeTerminal(handle)
       }
-      // Why: a handle-addressed CLI/automation close is an explicit intent, so
-      // it must stay destructive under the non-user close adjudication gate.
-      await this.closeMobileSessionTab(`id:${pty.pty.worktreeId}`, tabId, { reason: 'user' })
-      this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-      return { handle, tabId, closeMode: 'tab', ptyKilled: false }
+      tabId = registeredTabId
+      worktreeId = pty.pty.worktreeId
+    } else {
+      this.assertGraphReady()
+      const { leaf } = this.getLiveLeafForHandle(handle)
+      tabId = leaf.tabId
+      worktreeId = leaf.worktreeId
     }
-    this.assertGraphReady()
-    const { leaf } = this.getLiveLeafForHandle(handle)
-    await this.closeMobileSessionTab(`id:${leaf.worktreeId}`, leaf.tabId, { reason: 'user' })
+
+    // Why: a handle-addressed CLI/automation close is an explicit intent, so
+    // it must stay destructive under the non-user close adjudication gate.
+    try {
+      await this.closeMobileSessionTab(`id:${worktreeId}`, tabId, { reason: 'user' })
+    } catch (error) {
+      // Why: restored daemon PTYs can outlive their durable renderer tab, whether
+      // registered directly or represented only in the renderer graph.
+      if (error instanceof Error && error.message === 'tab_not_found') {
+        return this.closeTerminal(handle)
+      }
+      throw error
+    }
     this.claudeAgentTeams.removeTeamForLeaderHandle(handle)
-    return { handle, tabId: leaf.tabId, closeMode: 'tab', ptyKilled: false }
+    return { handle, tabId, closeMode: 'tab', ptyKilled: false }
   }
 
   async splitTerminal(


### PR DESCRIPTION
## Summary

- Fixes `orca terminal close` for restored live PTYs whose renderer tab no longer exists in persisted session state.
- Falls back to closing only the addressed PTY when the durable close reports the exact `tab_not_found` error; every other error still surfaces.
- Adds regression coverage for the ghost-terminal state observed in packaged Orca.

## Screenshots

No visual change

## Testing

- [ ] `pnpm lint` (targeted `oxfmt --check`, `oxlint`, and changed-code quality gate passed)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (targeted runtime/shared/CLI tests passed: 13 tests)
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Post-rebase verification:
- Runtime close cluster: 5 passed
- Shared/CLI close coverage: 8 passed
- Node TypeScript check passed
- Formatting, lint, diff check, and changed-code quality gate passed

## AI Review Report

Reviewed the rebased diff against `origin/main`. The review checked exact-handle behavior, split-pane safety, durable-session/renderer-graph divergence, error narrowing, and agent-team cleanup. Only the literal `tab_not_found` condition takes the PTY fallback; other failures are rethrown. The fallback delegates to the existing handle-scoped close path, so sibling panes are not selected for termination.

Cross-platform compatibility was checked for macOS, Linux, and Windows. This change is confined to Electron main-runtime state handling and uses the existing PTY controller abstraction; it adds no shortcuts, labels, paths, shell behavior, or platform-specific branches.

## Security Audit

No new IPC surface, command execution, path handling, authentication, secret handling, or dependency was introduced. Existing RPC authorization and terminal-handle resolution remain in place. The catch is intentionally exact so unrelated runtime or persistence failures are not hidden.

## Notes

The fault was reproduced against packaged Orca 1.4.173 and 1.4.174-rc.0. Inspection of the 1.4.175 source found the same affected path. No installed application bundle was hotpatched.
