### PR TITLE
fix(settings): prevent terminal font size value from clipping

### DIFF
--- a/src/renderer/src/components/settings/TerminalFontSizeSetting.tsx
+++ b/src/renderer/src/components/settings/TerminalFontSizeSetting.tsx
@@ -56,7 +56,7 @@ export function TerminalFontSizeSetting({
                   updateSettings({ terminalFontSize: value })
                 }
               }}
-              className="w-14 text-center tabular-nums"
+              className="w-16 text-center tabular-nums"
             />
             <Button
               variant="outline"


### PR DESCRIPTION
## Summary
Widens the terminal Font Size input in Settings → Terminal → Terminal Typography so the numeric value is no longer clipped. Changed `w-14 text-center` to `w-16 text-center tabular-nums` — kept centered alignment (consistent with the flanking −/+ stepper buttons per the style guide's symmetry rule) and used a fixed width rather than `min-w`/`w-auto`, since the value is bounded to 2 digits (10–24).

Fixes #12877

## Screenshots
- Before: 
<img width="898" height="403" alt="image" src="https://github.com/user-attachments/assets/38e58cb7-159e-4ff8-b466-97ce7827f808" />

- After: 
<img width="1873" height="840" alt="image" src="https://github.com/user-attachments/assets/4b12c518-acf7-400e-9a80-7920b98ebba5" />


## Testing
- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] No new tests added — this is a pure CSS/className width fix with no logic change; existing behavior (min/max clamping, stepper buttons) is untouched and already covered if tested elsewhere.

## AI Review Report
Reviewed the change with claude against `TerminalFontSizeSetting.tsx`. Checked:
- **Cross-platform:** the change is a Tailwind className only — no platform-specific code paths, keyboard handling, or Electron APIs touched. Verified visually in dark mode; no OS-specific rendering risk since it's a plain CSS width/alignment change.
- **SSH/remote:** no data flow, network, or IPC involved — purely local render styling, unaffected by latency.
- **Agent/integration compatibility:** not applicable — no agent or integration code touched.
- **Performance:** negligible; static className change, no re-render or layout thrash introduced.
- **UI quality:** verified against `docs/STYLEGUIDE.md` — center-alignment preserved per the "symmetry is the clearest read" rule for compact stepper controls flanked by icon buttons; fixed `width` (not `min-width`) used per the "pre-reserve footprint" rule.

## Security Audit
No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. The `onChange` validation logic (`Number.parseInt`, min/max clamping) is unchanged. No new attack surface introduced.

## Notes
No visual change beyond the input width increasing by 8px (`w-14` → `w-16`). No platform-specific behavior. No follow-up work identified.