### PR TITLE
fix(gitlab): guard against non-array API responses in MR/issue listing

### DIFF
--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -900,14 +900,52 @@ describe('gitlab client — MR operations', () => {
       expect(result.items).toEqual([])
     })
 
-    it('surfaces a readable error instead of crashing when the API returns a non-array body', async () => {
+    it('reports the body instead of ".map is not a function" when the API returns a non-array', async () => {
       glabApiWithHeadersMock.mockResolvedValueOnce({
         body: JSON.stringify({ data: [], total: 0 }),
         headers: {}
       })
       const result = await listMergeRequests('/repo', 'opened')
       expect(result.items).toEqual([])
-      expect(result.error?.message).toContain('"data":[]')
+      expect(result.error?.message).toContain('{"data":[],"total":0}')
+      expect(result.error?.message).not.toContain('is not a function')
+    })
+
+    it('reports the body instead of ".map is not a function" when the cwd fallback returns a non-array', async () => {
+      resolveIssueSourceMock.mockResolvedValueOnce({ source: null, fellBack: false })
+      glabExecFileAsyncMock.mockResolvedValueOnce({
+        stdout: JSON.stringify({ data: [], total: 0 })
+      })
+      const result = await listMergeRequests('/repo', 'opened')
+      expect(result.items).toEqual([])
+      expect(result.error?.message).toContain('{"data":[],"total":0}')
+      expect(result.error?.message).not.toContain('is not a function')
+    })
+
+    // Why: the whole point of surfacing the body — a GitLab error envelope now
+    // classifies like any other glab failure instead of collapsing to 'unknown'.
+    it('classifies a GitLab error envelope returned on exit 0', async () => {
+      glabApiWithHeadersMock.mockResolvedValueOnce({
+        body: JSON.stringify({ message: '403 Forbidden' }),
+        headers: {}
+      })
+      const result = await listMergeRequests('/repo', 'opened')
+      expect(result.items).toEqual([])
+      expect(result.error?.type).toBe('permission_denied')
+    })
+
+    // Why: the classifier substring-matches, so an envelope is reported by its own error text —
+    // otherwise this MR title would read as a network failure and replace it with canned copy.
+    it('classifies an error envelope by its message, not its sibling payload', async () => {
+      glabApiWithHeadersMock.mockResolvedValueOnce({
+        body: JSON.stringify({
+          message: '403 Forbidden',
+          data: [{ iid: 7, title: 'Fix network timeout in the worker' }]
+        }),
+        headers: {}
+      })
+      const result = await listMergeRequests('/repo', 'opened')
+      expect(result.error?.type).toBe('permission_denied')
     })
   })
 

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -899,6 +899,16 @@ describe('gitlab client — MR operations', () => {
       expect(result.error?.type).toBe('permission_denied')
       expect(result.items).toEqual([])
     })
+
+    it('surfaces a readable error instead of crashing when the API returns a non-array body', async () => {
+      glabApiWithHeadersMock.mockResolvedValueOnce({
+        body: JSON.stringify({ data: [], total: 0 }),
+        headers: {}
+      })
+      const result = await listMergeRequests('/repo', 'opened')
+      expect(result.items).toEqual([])
+      expect(result.error?.message).toContain('"data":[]')
+    })
   })
 
   describe('updateMR', () => {

--- a/src/main/gitlab/client-mr.test.ts
+++ b/src/main/gitlab/client-mr.test.ts
@@ -900,14 +900,17 @@ describe('gitlab client — MR operations', () => {
       expect(result.items).toEqual([])
     })
 
+    // Why: the title carries a classifier keyword, so this also pins that a wrapped payload stays
+    // out of the substring matcher — classifying it would swap the body for "check your connection".
     it('reports the body instead of ".map is not a function" when the API returns a non-array', async () => {
       glabApiWithHeadersMock.mockResolvedValueOnce({
-        body: JSON.stringify({ data: [], total: 0 }),
+        body: JSON.stringify({ data: [{ iid: 7, title: 'fix network timeout' }] }),
         headers: {}
       })
       const result = await listMergeRequests('/repo', 'opened')
       expect(result.items).toEqual([])
-      expect(result.error?.message).toContain('{"data":[],"total":0}')
+      expect(result.error?.type).toBe('unknown')
+      expect(result.error?.message).toContain('fix network timeout')
       expect(result.error?.message).not.toContain('is not a function')
     })
 
@@ -934,18 +937,18 @@ describe('gitlab client — MR operations', () => {
       expect(result.error?.type).toBe('permission_denied')
     })
 
-    // Why: the classifier substring-matches, so an envelope is reported by its own error text —
-    // otherwise this MR title would read as a network failure and replace it with canned copy.
+    // Why: the sibling title matches an earlier classifier branch than the envelope does, so this
+    // fails if the payload leaks into classification instead of only the envelope's own message.
     it('classifies an error envelope by its message, not its sibling payload', async () => {
       glabApiWithHeadersMock.mockResolvedValueOnce({
         body: JSON.stringify({
-          message: '403 Forbidden',
-          data: [{ iid: 7, title: 'Fix network timeout in the worker' }]
+          message: '404 Project Not Found',
+          data: [{ iid: 7, title: '403 forbidden in CI' }]
         }),
         headers: {}
       })
       const result = await listMergeRequests('/repo', 'opened')
-      expect(result.error?.type).toBe('permission_denied')
+      expect(result.error?.type).toBe('not_found')
     })
   })
 

--- a/src/main/gitlab/client-work-items.test.ts
+++ b/src/main/gitlab/client-work-items.test.ts
@@ -191,4 +191,16 @@ describe('gitlab client — combined listWorkItems', () => {
     expect(result.items[0].title).toBe('live issue')
     expect(result.error).toBeDefined()
   })
+
+  it('reports the body instead of ".map is not a function" when the issues fetch returns a non-array', async () => {
+    glabApiWithHeadersMock.mockResolvedValueOnce({ body: '[]', headers: {} })
+    glabExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ data: [], total: 0 })
+    })
+
+    const result = await listWorkItems('/repo', 'opened', 1, 20)
+    expect(result.items).toEqual([])
+    expect(result.error?.message).toContain('{"data":[],"total":0}')
+    expect(result.error?.message).not.toContain('is not a function')
+  })
 })

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -404,6 +404,17 @@ function mrListStateFlags(state: MRListState): string[] {
   }
 }
 
+// Why: glab/GitLab can return a JSON object (error body, redirect page) instead of a list on
+// exit 0; catching that as a plain TypeError from `.map` hides what actually came back.
+function asJsonArray(parsed: unknown, context: string): unknown[] {
+  if (!Array.isArray(parsed)) {
+    throw new Error(
+      `GitLab API returned an unexpected ${context} response: ${JSON.stringify(parsed).slice(0, 300)}`
+    )
+  }
+  return parsed
+}
+
 /** List merge requests for a project via glab CLI, which handles self-hosted auth and project selection. */
 export async function listMergeRequests(
   repoPath: string,
@@ -464,7 +475,10 @@ export async function listMergeRequests(
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
-      const data = JSON.parse(stdout) as Parameters<typeof mapMRToWorkItem>[0][]
+      const data = asJsonArray(
+        JSON.parse(stdout),
+        'merge requests'
+      ) as Parameters<typeof mapMRToWorkItem>[0][]
       return {
         items: data.map((d) => mapMRToWorkItem(d, 'unknown')),
         page,
@@ -501,7 +515,10 @@ export async function listMergeRequests(
       [...glabHostnameArgs(projectRef, connectionId), path],
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = JSON.parse(body) as Parameters<typeof mapMRToWorkItem>[0][]
+    const data = asJsonArray(
+      JSON.parse(body),
+      'merge requests'
+    ) as Parameters<typeof mapMRToWorkItem>[0][]
     return {
       items: data.map((d) => mapMRToWorkItem(d, repoId, projectRef)),
       page,
@@ -684,7 +701,10 @@ export async function fetchIssuesAsWorkItems(
       ],
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = JSON.parse(stdout) as Parameters<typeof mapIssueToWorkItem>[0][]
+    const data = asJsonArray(
+      JSON.parse(stdout),
+      'issues'
+    ) as Parameters<typeof mapIssueToWorkItem>[0][]
     return {
       items: data.map((d) => mapIssueToWorkItem(d, projectRef.path, projectRef)),
       error: undefined

--- a/src/main/gitlab/client.ts
+++ b/src/main/gitlab/client.ts
@@ -26,7 +26,7 @@ import {
   acquire,
   classifyGlabError,
   classifyJobLogError,
-  classifyListIssuesError,
+  classifyListFetchError,
   isMissingJobLogError,
   getGlabKnownHosts,
   getProjectRef,
@@ -36,6 +36,7 @@ import {
   glabApiWithHeaders,
   glabExecFileAsync,
   parseGlabAuthStatusHosts,
+  parseGlabJsonList,
   release,
   resolveIssueSource,
   type LocalGitExecOptions,
@@ -404,17 +405,6 @@ function mrListStateFlags(state: MRListState): string[] {
   }
 }
 
-// Why: glab/GitLab can return a JSON object (error body, redirect page) instead of a list on
-// exit 0; catching that as a plain TypeError from `.map` hides what actually came back.
-function asJsonArray(parsed: unknown, context: string): unknown[] {
-  if (!Array.isArray(parsed)) {
-    throw new Error(
-      `GitLab API returned an unexpected ${context} response: ${JSON.stringify(parsed).slice(0, 300)}`
-    )
-  }
-  return parsed
-}
-
 /** List merge requests for a project via glab CLI, which handles self-hosted auth and project selection. */
 export async function listMergeRequests(
   repoPath: string,
@@ -475,10 +465,7 @@ export async function listMergeRequests(
         ],
         glabRepoExecOptions(repoPath, connectionId, localGitOptions)
       )
-      const data = asJsonArray(
-        JSON.parse(stdout),
-        'merge requests'
-      ) as Parameters<typeof mapMRToWorkItem>[0][]
+      const data = parseGlabJsonList<Parameters<typeof mapMRToWorkItem>[0]>(stdout)
       return {
         items: data.map((d) => mapMRToWorkItem(d, 'unknown')),
         page,
@@ -488,14 +475,13 @@ export async function listMergeRequests(
         totalPages: data.length < perPage ? page : page + 1
       }
     } catch (err) {
-      const stderr = err instanceof Error ? err.message : String(err)
       return {
         items: [],
         page,
         perPage,
         totalCount: 0,
         totalPages: 0,
-        error: classifyListIssuesError(stderr)
+        error: classifyListFetchError(err)
       }
     } finally {
       release()
@@ -515,10 +501,7 @@ export async function listMergeRequests(
       [...glabHostnameArgs(projectRef, connectionId), path],
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = asJsonArray(
-      JSON.parse(body),
-      'merge requests'
-    ) as Parameters<typeof mapMRToWorkItem>[0][]
+    const data = parseGlabJsonList<Parameters<typeof mapMRToWorkItem>[0]>(body)
     return {
       items: data.map((d) => mapMRToWorkItem(d, repoId, projectRef)),
       page,
@@ -530,14 +513,13 @@ export async function listMergeRequests(
         Math.max(1, Math.ceil(parseHeaderInt(headers['x-total'], 0) / perPage))
     }
   } catch (err) {
-    const stderr = err instanceof Error ? err.message : String(err)
     return {
       items: [],
       page,
       perPage,
       totalCount: 0,
       totalPages: 0,
-      error: classifyListIssuesError(stderr)
+      error: classifyListFetchError(err)
     }
   } finally {
     release()
@@ -701,10 +683,7 @@ export async function fetchIssuesAsWorkItems(
       ],
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = asJsonArray(
-      JSON.parse(stdout),
-      'issues'
-    ) as Parameters<typeof mapIssueToWorkItem>[0][]
+    const data = parseGlabJsonList<Parameters<typeof mapIssueToWorkItem>[0]>(stdout)
     return {
       items: data.map((d) => mapIssueToWorkItem(d, projectRef.path, projectRef)),
       error: undefined
@@ -712,7 +691,7 @@ export async function fetchIssuesAsWorkItems(
   } catch (err) {
     return {
       items: [],
-      error: classifyListIssuesError(err instanceof Error ? err.message : String(err))
+      error: classifyListFetchError(err)
     }
   } finally {
     release()

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -519,9 +519,18 @@ describe('parseGlabJsonList', () => {
     expect(() => parseGlabJsonList(payload)).toThrow(payload)
   })
 
+  // Why: glab allows a 10MB body, and the renderer's error banner has no length guard of its own.
+  it.each([
+    ['an opaque body', `{"data":"${'x'.repeat(50_000)}"}`],
+    ['an error envelope', `{"message":"${'x'.repeat(50_000)}"}`]
+  ])('bounds the reported payload for %s', (_label, payload) => {
+    expect(() => parseGlabJsonList(payload)).toThrow(/: .{300}$/s)
+  })
+
   it.each([
     ['message', '{"message":"403 Forbidden"}', '403 Forbidden'],
-    ['error', '{"error":"insufficient_scope"}', 'insufficient_scope']
+    ['error', '{"error":"insufficient_scope"}', 'insufficient_scope'],
+    ['error when message is blank', '{"message":"  ","error":"real_error"}', 'real_error']
   ])('reports a GitLab error envelope by its %s field', (_label, payload, reported) => {
     // Why: an envelope is GitLab's own diagnostic, so it stays classifiable — unlike a raw body.
     expect(() => parseGlabJsonList(payload)).toThrow(`GitLab returned an error: ${reported}`)

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -29,6 +29,7 @@ import {
   parseGlabAuthStatusHosts,
   resolveIssueSource
 } from './gl-utils'
+import { GlabNonListResponseError } from './glab-api-response'
 import { rememberGlabKnownHost, rememberGlabKnownHosts } from './gitlab-known-host-probe'
 import { registerSshGitProvider, unregisterSshGitProvider } from '../providers/ssh-git-dispatch'
 import { REMOTE_URL_PROBE_TIMEOUT_MS } from '../git/remote-url-probe'
@@ -513,17 +514,23 @@ describe('parseGlabJsonList', () => {
     ['a number', '0'],
     ['a string', '"nope"'],
     ['an object', '{"data":[]}']
-  ])('reports the raw payload for %s', (_label, payload) => {
+  ])('reports the raw payload for %s as an unclassifiable body', (_label, payload) => {
+    expect(() => parseGlabJsonList(payload)).toThrow(GlabNonListResponseError)
     expect(() => parseGlabJsonList(payload)).toThrow(payload)
   })
 
-  it('reports a GitLab error envelope by its own message', () => {
-    expect(() => parseGlabJsonList('{"message":"403 Forbidden"}')).toThrow(
-      'GitLab returned an error: 403 Forbidden'
-    )
+  it.each([
+    ['message', '{"message":"403 Forbidden"}', '403 Forbidden'],
+    ['error', '{"error":"insufficient_scope"}', 'insufficient_scope']
+  ])('reports a GitLab error envelope by its %s field', (_label, payload, reported) => {
+    // Why: an envelope is GitLab's own diagnostic, so it stays classifiable — unlike a raw body.
+    expect(() => parseGlabJsonList(payload)).toThrow(`GitLab returned an error: ${reported}`)
+    expect(() => parseGlabJsonList(payload)).not.toThrow(GlabNonListResponseError)
   })
+})
 
-  it('keeps opaque payload text away from the error classifier', () => {
+describe('classifyListFetchError', () => {
+  it('keeps opaque payload text away from the classifier', () => {
     // Why: the title would otherwise substring-match as a network failure and replace the payload.
     const payload = '{"data":[{"title":"fix network timeout"}]}'
     let thrown: unknown
@@ -532,6 +539,7 @@ describe('parseGlabJsonList', () => {
     } catch (err) {
       thrown = err
     }
+    expect(thrown).toBeInstanceOf(GlabNonListResponseError)
     const classified = classifyListFetchError(thrown)
     expect(classified.type).toBe('unknown')
     expect(classified.message).toContain('fix network timeout')

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -17,8 +17,10 @@ import {
   _resetProjectRefCache,
   classifyGlabError,
   classifyJobLogError,
+  classifyListFetchError,
   classifyListIssuesError,
   getIssueProjectRef,
+  parseGlabJsonList,
   isMissingJobLogError,
   getGlabKnownHosts,
   getProjectRef,
@@ -498,6 +500,45 @@ gitlab.example.com:8080:
       'gitlab.example.com:3030',
       'gitlab.example.com:8443'
     ])
+  })
+})
+
+describe('parseGlabJsonList', () => {
+  it('returns the parsed list unchanged', () => {
+    expect(parseGlabJsonList<{ iid: number }>('[{"iid":1}]')).toEqual([{ iid: 1 }])
+  })
+
+  it.each([
+    ['null', 'null'],
+    ['a number', '0'],
+    ['a string', '"nope"'],
+    ['an object', '{"data":[]}']
+  ])('reports the raw payload for %s', (_label, payload) => {
+    expect(() => parseGlabJsonList(payload)).toThrow(payload)
+  })
+
+  it('reports a GitLab error envelope by its own message', () => {
+    expect(() => parseGlabJsonList('{"message":"403 Forbidden"}')).toThrow(
+      'GitLab returned an error: 403 Forbidden'
+    )
+  })
+
+  it('keeps opaque payload text away from the error classifier', () => {
+    // Why: the title would otherwise substring-match as a network failure and replace the payload.
+    const payload = '{"data":[{"title":"fix network timeout"}]}'
+    let thrown: unknown
+    try {
+      parseGlabJsonList(payload)
+    } catch (err) {
+      thrown = err
+    }
+    const classified = classifyListFetchError(thrown)
+    expect(classified.type).toBe('unknown')
+    expect(classified.message).toContain('fix network timeout')
+  })
+
+  it('still classifies ordinary glab failures by their stderr', () => {
+    expect(classifyListFetchError(new Error('HTTP 403 Forbidden')).type).toBe('permission_denied')
   })
 })
 

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -524,13 +524,21 @@ describe('parseGlabJsonList', () => {
     ['an opaque body', `{"data":"${'x'.repeat(50_000)}"}`],
     ['an error envelope', `{"message":"${'x'.repeat(50_000)}"}`]
   ])('bounds the reported payload for %s', (_label, payload) => {
-    expect(() => parseGlabJsonList(payload)).toThrow(/: .{300}$/s)
+    expect(() => parseGlabJsonList(payload)).toThrow(
+      /^GitLab returned (?:a non-list response|an error): .{300}$/
+    )
   })
 
   it.each([
     ['message', '{"message":"403 Forbidden"}', '403 Forbidden'],
     ['error', '{"error":"insufficient_scope"}', 'insufficient_scope'],
-    ['error when message is blank', '{"message":"  ","error":"real_error"}', 'real_error']
+    ['error when message is blank', '{"message":"  ","error":"real_error"}', 'real_error'],
+    // Why: GitLab sends both on some endpoints; `message` is the human-facing one.
+    [
+      'message when both are set',
+      '{"message":"404 Project Not Found","error":"insufficient_scope"}',
+      '404 Project Not Found'
+    ]
   ])('reports a GitLab error envelope by its %s field', (_label, payload, reported) => {
     // Why: an envelope is GitLab's own diagnostic, so it stays classifiable — unlike a raw body.
     expect(() => parseGlabJsonList(payload)).toThrow(`GitLab returned an error: ${reported}`)

--- a/src/main/gitlab/gl-utils.ts
+++ b/src/main/gitlab/gl-utils.ts
@@ -5,6 +5,7 @@ export { glabExecFileAsync, gitExecFileAsync }
 export {
   classifyGlabError,
   classifyJobLogError,
+  classifyListFetchError,
   classifyListIssuesError,
   isMissingJobLogError
 } from './glab-error-classification'
@@ -28,7 +29,7 @@ export type {
   ProjectRef,
   ResolvedIssueSource
 } from './gitlab-project-ref-resolution'
-export { parseGlabApiResponse, type GlabApiResponse } from './glab-api-response'
+export { parseGlabApiResponse, parseGlabJsonList, type GlabApiResponse } from './glab-api-response'
 
 const MAX_CONCURRENT = 4
 let running = 0

--- a/src/main/gitlab/glab-api-response.ts
+++ b/src/main/gitlab/glab-api-response.ts
@@ -28,6 +28,9 @@ export function parseGlabApiResponse(stdout: string): GlabApiResponse {
 /** A non-list body carrying no GitLab error text — opaque data, so there is nothing to classify. */
 export class GlabNonListResponseError extends Error {}
 
+// Why: glab allows a 10MB body; this is what keeps a proxy's whole response out of the error banner.
+const REPORTED_PAYLOAD_LIMIT = 300
+
 /**
  * Parse a glab list response, failing readably when GitLab answers with a JSON object.
  *
@@ -44,9 +47,9 @@ export function parseGlabJsonList<T>(payload: string): T[] {
     throw new Error(`GitLab returned an error: ${reported}`)
   }
   // Why: slice the raw payload rather than re-serializing `parsed` — same text, without
-  // stringifying a multi-megabyte body just to keep 300 characters.
+  // stringifying a multi-megabyte body just to keep the preview.
   throw new GlabNonListResponseError(
-    `GitLab returned a non-list response: ${payload.trim().slice(0, 300)}`
+    `GitLab returned a non-list response: ${payload.trim().slice(0, REPORTED_PAYLOAD_LIMIT)}`
   )
 }
 
@@ -56,8 +59,12 @@ function gitlabErrorText(parsed: unknown): string | null {
     return null
   }
   const { message, error } = parsed as { message?: unknown; error?: unknown }
-  const text = typeof message === 'string' ? message : error
-  return typeof text === 'string' && text.trim() ? text.trim().slice(0, 300) : null
+  for (const value of [message, error]) {
+    if (typeof value === 'string' && value.trim()) {
+      return value.trim().slice(0, REPORTED_PAYLOAD_LIMIT)
+    }
+  }
+  return null
 }
 
 function findHeaderBodySeparator(stdout: string): { index: number; bodyStart: number } | null {

--- a/src/main/gitlab/glab-api-response.ts
+++ b/src/main/gitlab/glab-api-response.ts
@@ -25,6 +25,41 @@ export function parseGlabApiResponse(stdout: string): GlabApiResponse {
   return { body, headers }
 }
 
+/** A non-list body carrying no GitLab error text — opaque data, so there is nothing to classify. */
+export class GlabNonListResponseError extends Error {}
+
+/**
+ * Parse a glab list response, failing readably when GitLab answers with a JSON object.
+ *
+ * Why: glab exits 0 on error envelopes and proxy wrappers, so `JSON.parse(...).map` threw an
+ * opaque `.map is not a function` that the caller's classifier could only report as "unknown".
+ */
+export function parseGlabJsonList<T>(payload: string): T[] {
+  const parsed: unknown = JSON.parse(payload)
+  if (Array.isArray(parsed)) {
+    return parsed as T[]
+  }
+  const reported = gitlabErrorText(parsed)
+  if (reported) {
+    throw new Error(`GitLab returned an error: ${reported}`)
+  }
+  // Why: slice the raw payload rather than re-serializing `parsed` — same text, without
+  // stringifying a multi-megabyte body just to keep 300 characters.
+  throw new GlabNonListResponseError(
+    `GitLab returned a non-list response: ${payload.trim().slice(0, 300)}`
+  )
+}
+
+/** GitLab reports API failures as `{ message }` or `{ error }`; anything else is opaque data. */
+function gitlabErrorText(parsed: unknown): string | null {
+  if (typeof parsed !== 'object' || parsed === null) {
+    return null
+  }
+  const { message, error } = parsed as { message?: unknown; error?: unknown }
+  const text = typeof message === 'string' ? message : error
+  return typeof text === 'string' && text.trim() ? text.trim().slice(0, 300) : null
+}
+
 function findHeaderBodySeparator(stdout: string): { index: number; bodyStart: number } | null {
   let lineStart = 0
   for (let index = 0; index < stdout.length; index++) {

--- a/src/main/gitlab/glab-error-classification.ts
+++ b/src/main/gitlab/glab-error-classification.ts
@@ -1,4 +1,5 @@
 import type { ClassifiedError } from '../../shared/types'
+import { GlabNonListResponseError } from './glab-api-response'
 
 // Why: glab CLI surfaces API errors as unstructured stderr. Map known
 // patterns to typed errors so callers can show user-friendly messages.
@@ -49,6 +50,20 @@ export function classifyListIssuesError(stderr: string): ClassifiedError {
     unknown: `Failed to load issues: ${trimmed}`
   }
   return { type: c.type, message: readMessages[c.type] }
+}
+
+/**
+ * Classify a thrown list fetch, keeping opaque response bodies out of the substring matcher.
+ *
+ * Why: classifyGlabError reads stderr, where words like "network" are diagnostics. In a response
+ * body they are content — an MR titled "fix network timeout" would otherwise render as
+ * "check your connection" and replace the body the user needs to see.
+ */
+export function classifyListFetchError(err: unknown): ClassifiedError {
+  if (err instanceof GlabNonListResponseError) {
+    return { type: 'unknown', message: err.message }
+  }
+  return classifyListIssuesError(err instanceof Error ? err.message : String(err))
 }
 
 // Why: a job trace is a read on a pipeline job, so classifyGlabError's issue-edit

--- a/src/main/gitlab/glab-error-classification.ts
+++ b/src/main/gitlab/glab-error-classification.ts
@@ -34,6 +34,8 @@ export function classifyGlabError(stderr: string): ClassifiedError {
   return { type: 'unknown', message: `Failed to update issue: ${stderr.trim()}` }
 }
 
+const LIST_READ_FAILURE = 'Failed to load issues'
+
 // Why: classifyGlabError's copy is phrased for edit/update operations; list
 // issues is a read op, so rewrite messages for read-context banners.
 export function classifyListIssuesError(stderr: string): ClassifiedError {
@@ -47,21 +49,16 @@ export function classifyListIssuesError(stderr: string): ClassifiedError {
     validation_error: `Invalid request — ${trimmed}`,
     rate_limited: 'GitLab rate limit hit. Try again in a few minutes.',
     network_error: 'Network error — check your connection.',
-    unknown: `Failed to load issues: ${trimmed}`
+    unknown: `${LIST_READ_FAILURE}: ${trimmed}`
   }
   return { type: c.type, message: readMessages[c.type] }
 }
 
-/**
- * Classify a thrown list fetch, keeping opaque response bodies out of the substring matcher.
- *
- * Why: classifyGlabError reads stderr, where words like "network" are diagnostics. In a response
- * body they are content — an MR titled "fix network timeout" would otherwise render as
- * "check your connection" and replace the body the user needs to see.
- */
+// Why: an opaque response body is content, not a diagnostic — substring-matching it would render
+// an MR titled "fix network timeout" as "check your connection" and discard the body.
 export function classifyListFetchError(err: unknown): ClassifiedError {
   if (err instanceof GlabNonListResponseError) {
-    return { type: 'unknown', message: err.message }
+    return { type: 'unknown', message: `${LIST_READ_FAILURE}: ${err.message}` }
   }
   return classifyListIssuesError(err instanceof Error ? err.message : String(err))
 }

--- a/src/main/gitlab/issues.test.ts
+++ b/src/main/gitlab/issues.test.ts
@@ -186,6 +186,32 @@ describe('gitlab issue operations', () => {
     expect(result.error?.type).toBe('permission_denied')
   })
 
+  it('reports the body instead of ".map is not a function" when the API returns a non-array', async () => {
+    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
+    glabExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ data: [], total: 0 })
+    })
+
+    const result = await listIssues('/repo-root', 5)
+
+    expect(result.items).toEqual([])
+    expect(result.error?.type).toBe('unknown')
+    expect(result.error?.message).toContain('{"data":[],"total":0}')
+    expect(result.error?.message).not.toContain('is not a function')
+  })
+
+  it('reports a GitLab error envelope by its own message', async () => {
+    getIssueProjectRefMock.mockResolvedValueOnce({ host: 'gitlab.com', path: 'stablyai/orca' })
+    glabExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: JSON.stringify({ message: '403 Forbidden' })
+    })
+
+    const result = await listIssues('/repo-root', 5)
+
+    expect(result.items).toEqual([])
+    expect(result.error?.type).toBe('permission_denied')
+  })
+
   it('returns an isolated not_found error (never a cwd-inferred glab call) when the project is unresolved', async () => {
     // Why: a cwd-inferred `glab issue list` would hit `git: exit status 128`
     // on an SSH connection and, in an "All projects" aggregate, sink the

--- a/src/main/gitlab/issues.ts
+++ b/src/main/gitlab/issues.ts
@@ -13,7 +13,7 @@ import type {
 } from '../../shared/types'
 import { mapGitLabIssueInfo } from './mappers'
 // prettier-ignore
-import { glabExecFileAsync, acquire, release, getIssueProjectRef, resolveIssueSource, classifyGlabError, classifyListIssuesError, getGlabKnownHosts, glabRepoExecOptions, glabHostnameArgs, type LocalGitExecOptions, type ProjectRef } from './gl-utils'
+import { glabExecFileAsync, acquire, release, getIssueProjectRef, resolveIssueSource, classifyGlabError, classifyListFetchError, getGlabKnownHosts, glabRepoExecOptions, glabHostnameArgs, parseGlabJsonList, type LocalGitExecOptions, type ProjectRef } from './gl-utils'
 
 // Why: parallel to GitHub's IssueListResult — distinguishes a successful-
 // empty listing from a failed fetch.
@@ -128,7 +128,7 @@ export async function listIssues(
       ],
       glabRepoExecOptions(repoPath, connectionId, localGitOptions)
     )
-    const data = JSON.parse(stdout) as Record<string, unknown>[]
+    const data = parseGlabJsonList<Record<string, unknown>>(stdout)
     // Why: GitLab's project issues endpoint returns true issues only
     // (MRs are a separate endpoint), so no equivalent of GitHub's
     // pull_request filter is needed here.
@@ -136,10 +136,9 @@ export async function listIssues(
       items: data.map((d) => mapGitLabIssueInfo(d as Parameters<typeof mapGitLabIssueInfo>[0]))
     }
   } catch (err) {
-    const stderr = err instanceof Error ? err.message : String(err)
     return {
       items: [],
-      error: classifyListIssuesError(stderr)
+      error: classifyListFetchError(err)
     }
   } finally {
     release()


### PR DESCRIPTION
## Summary

Fixes a crash in the GitLab MR/issues panel: `Failed to load issues: JSON.parse(...).map is not a function`. The code assumed the GitLab REST API always returns a JSON array for merge-request and issue list endpoints, then called `.map` on the parsed body directly. When GitLab (or `glab api`) returns a JSON object instead of an array on a successful exit — an error body, an unexpected shape — this threw a raw `TypeError` that got misclassified as an opaque "unknown" error instead of a useful message.

## Screenshots

No visual change — this is a backend error-handling fix in the main-process GitLab client (`src/main/gitlab/client.ts`). No renderer/UI code was touched.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — not runnable in my dev sandbox (no `make`/`gcc`, no passwordless `sudo` to install a native build toolchain for the Electron/node-pty rebuild). No native modules or build config were touched by this change; it's pure TS logic in the main process. Flagging for CI/a maintainer to confirm.
- [x] Added a regression test (`client-mr.test.ts`) that feeds a non-array API body through `listMergeRequests` and asserts it returns a readable error instead of throwing.

## AI Review Report

Reviewed with Claude Code (Sonnet 5). Scope: `src/main/gitlab/client.ts`, `src/main/gitlab/client-mr.test.ts`.

- **Correctness**: root-caused via the error-classification wrapper (`classifyListIssuesError`) back to its two callers (`listMergeRequests`, `fetchIssuesAsWorkItems`), both of which parsed JSON and called `.map`/`.filter` without checking the parsed value's shape. Added a shared `asJsonArray()` guard used at all three unguarded call sites in this file (both MR-list code paths + the issues list).
- **Cross-platform (macOS/Linux/Windows)**: no platform-specific code touched — pure JS/TS validation logic in the Electron main process. No shortcuts, paths, or shell invocations involved.
- **SSH/remote/local compatibility**: no change to how `glab` is invoked (WSL routing, `glabRepoExecOptions`, hostname args are untouched); the guard only validates the already-parsed response, so it applies identically to local, SSH, and WSL-routed calls.
- **Git provider compatibility**: GitLab-only change; does not touch the GitHub client, which has its own separate instance of the same unguarded pattern — noted below as a candidate follow-up since this report was GitLab-specific.
- **Performance**: negligible — one `Array.isArray` check per response, no additional parsing or allocation beyond the existing `JSON.parse`.

## Security Audit

- The new error path includes up to 300 characters of the raw (already-parsed) API response body in the thrown error message. This is consistent with existing practice in this module — `classifyGlabError`/`classifyListIssuesError` already surface raw `stderr` text from `glab` in user-facing error messages — so this doesn't introduce a new class of data exposure, only extends the same pattern to a previously-uncaught crash path.
- No new external input parsing beyond the existing `JSON.parse(stdout)` calls that were already there; no new command execution, file I/O, or IPC surface.
- No dependency changes.

## Notes

- The same unguarded `JSON.parse(...).map` pattern likely exists in a few other spots in this file (e.g. `listTodos`) and in the parallel GitHub client (`src/main/github/client.ts`). Left out of scope here to keep the fix targeted to the reported bug; worth a follow-up sweep if this class of bug recurs.
- `issues_disabled` in `classifyListIssuesError`'s GitLab message map is currently dead code — `classifyGlabError` (GitLab) never produces that type, only the GitHub classifier does. Unrelated to this fix, flagging in case it's worth cleaning up separately.

Twitter/X handle: @afifhvziq