### PR TITLE
feat: convert non-Git folders to Git repositories from the import dialog

### DIFF
--- a/src/main/git/convert-folder-to-git.test.ts
+++ b/src/main/git/convert-folder-to-git.test.ts
@@ -1,7 +1,7 @@
-import { execFileSync } from 'child_process'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
-import { tmpdir } from 'os'
-import * as path from 'path'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   DEFAULT_CONVERT_GITIGNORE,

--- a/src/main/git/convert-folder-to-git.test.ts
+++ b/src/main/git/convert-folder-to-git.test.ts
@@ -114,7 +114,17 @@ describe('initGitRepoInExistingFolder (real git, regression for unborn-HEAD work
     const result = await initGitRepoInExistingFolder({
       // Pin an identity so the commit succeeds regardless of the host's global config.
       exec: async (args) =>
-        void git(repoDir, ['-c', 'user.email=test@orca.dev', '-c', 'user.name=Orca Test', ...args]),
+        void git(repoDir, [
+          '-c',
+          'user.email=test@orca.dev',
+          '-c',
+          'user.name=Orca Test',
+          '-c',
+          'commit.gpgsign=false',
+          '-c',
+          'core.excludesFile=',
+          ...args
+        ]),
       hasGitignore: async () => existsSync(path.join(repoDir, '.gitignore')),
       writeGitignore: async (content) => writeFileSync(path.join(repoDir, '.gitignore'), content)
     })

--- a/src/main/git/convert-folder-to-git.test.ts
+++ b/src/main/git/convert-folder-to-git.test.ts
@@ -1,0 +1,140 @@
+import { execFileSync } from 'child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import { tmpdir } from 'os'
+import * as path from 'path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  DEFAULT_CONVERT_GITIGNORE,
+  initGitRepoInExistingFolder,
+  type ConvertGitOps
+} from './convert-folder-to-git'
+
+describe('initGitRepoInExistingFolder (injected ops)', () => {
+  function makeOps(overrides: Partial<ConvertGitOps> = {}): {
+    ops: ConvertGitOps
+    calls: string[][]
+  } {
+    const calls: string[][] = []
+    const ops: ConvertGitOps = {
+      exec: vi.fn(async (args: string[]) => {
+        calls.push(args)
+      }),
+      hasGitignore: vi.fn(async () => false),
+      writeGitignore: vi.fn(async () => {}),
+      ...overrides
+    }
+    return { ops, calls }
+  }
+
+  it('runs init, writes a .gitignore when missing, stages, then commits', async () => {
+    const { ops, calls } = makeOps()
+
+    const result = await initGitRepoInExistingFolder(ops)
+
+    expect(result).toEqual({ ok: true })
+    expect(calls).toEqual([
+      ['init'],
+      ['add', '-A'],
+      ['commit', '--allow-empty', '-m', 'Initial commit']
+    ])
+    expect(ops.writeGitignore).toHaveBeenCalledWith(DEFAULT_CONVERT_GITIGNORE)
+  })
+
+  it('does not overwrite an existing .gitignore', async () => {
+    const { ops } = makeOps({ hasGitignore: vi.fn(async () => true) })
+
+    const result = await initGitRepoInExistingFolder(ops)
+
+    expect(result).toEqual({ ok: true })
+    expect(ops.writeGitignore).not.toHaveBeenCalled()
+  })
+
+  it('reports the init step on init failure', async () => {
+    const exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'init') {
+        throw new Error('git not found')
+      }
+    })
+    const { ops } = makeOps({ exec })
+
+    const result = await initGitRepoInExistingFolder(ops)
+
+    expect(result).toMatchObject({ ok: false, step: 'init', isIdentityError: false })
+  })
+
+  it('flags a missing-identity commit failure', async () => {
+    const exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'commit') {
+        throw new Error('Author identity unknown\n\n*** Please tell me who you are.')
+      }
+    })
+    const { ops } = makeOps({ exec })
+
+    const result = await initGitRepoInExistingFolder(ops)
+
+    expect(result).toMatchObject({ ok: false, step: 'commit', isIdentityError: true })
+  })
+
+  it('does not flag a non-identity commit failure', async () => {
+    const exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'commit') {
+        throw new Error('some unrelated commit failure')
+      }
+    })
+    const { ops } = makeOps({ exec })
+
+    const result = await initGitRepoInExistingFolder(ops)
+
+    expect(result).toMatchObject({ ok: false, step: 'commit', isIdentityError: false })
+  })
+})
+
+describe('initGitRepoInExistingFolder (real git, regression for unborn-HEAD worktrees)', () => {
+  let tmpDir: string
+  let repoDir: string
+
+  function git(cwd: string, args: string[]): string {
+    return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+  }
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(path.join(tmpdir(), 'orca-convert-'))
+    repoDir = path.join(tmpDir, 'project')
+    mkdirSync(repoDir)
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  it('commits real files, keeps .env out, and leaves a base commit a worktree can branch from', async () => {
+    writeFileSync(path.join(repoDir, 'index.js'), 'console.log("hi")\n')
+    writeFileSync(path.join(repoDir, '.env'), 'SECRET=should-not-be-committed\n')
+
+    const result = await initGitRepoInExistingFolder({
+      // Pin an identity so the commit succeeds regardless of the host's global config.
+      exec: async (args) =>
+        void git(repoDir, ['-c', 'user.email=test@orca.dev', '-c', 'user.name=Orca Test', ...args]),
+      hasGitignore: async () => existsSync(path.join(repoDir, '.gitignore')),
+      writeGitignore: async (content) => writeFileSync(path.join(repoDir, '.gitignore'), content)
+    })
+
+    expect(result).toEqual({ ok: true })
+
+    const tracked = git(repoDir, ['ls-files']).split('\n').filter(Boolean)
+    expect(tracked).toContain('index.js')
+    expect(tracked).toContain('.gitignore')
+    expect(tracked).not.toContain('.env')
+
+    // A real commit exists (no unborn HEAD) — this is what previously failed
+    // worktree base-ref resolution.
+    expect(() => git(repoDir, ['rev-parse', '--verify', 'HEAD^{commit}'])).not.toThrow()
+
+    // And a worktree can actually be created from it.
+    const worktreePath = path.join(tmpDir, 'wt')
+    expect(() =>
+      git(repoDir, ['worktree', 'add', '--no-track', '-b', 'feature', worktreePath, 'HEAD'])
+    ).not.toThrow()
+    expect(existsSync(path.join(worktreePath, 'index.js'))).toBe(true)
+  })
+})

--- a/src/main/git/convert-folder-to-git.ts
+++ b/src/main/git/convert-folder-to-git.ts
@@ -1,0 +1,103 @@
+// Shared orchestration for turning an existing (non-git) folder into a git
+// repository in place. The git/filesystem calls are injected so the same logic
+// drives both the local path (node fs + gitExecFileAsync) and the SSH/remote
+// path (filesystem + git providers) — see src/main/ipc/repos.ts.
+
+export const CONVERT_INITIAL_COMMIT_MESSAGE = 'Initial commit'
+
+// Why: laid down before the first `add` so a folder with secrets (.env) or
+// heavy generated dirs (node_modules) doesn't bake them into history during
+// conversion. Conservative on purpose — only the near-universal cases — and we
+// never overwrite a .gitignore the user already has.
+export const DEFAULT_CONVERT_GITIGNORE = `# Created by Orca when this folder was converted to a Git repository.
+# Keeps secrets and generated files out of version control — edit as needed.
+
+# Secrets & credentials
+.env
+.env.*
+!.env.example
+!.env.sample
+*.pem
+*.key
+id_rsa
+id_rsa.*
+
+# Dependencies
+node_modules/
+
+# Build output
+dist/
+build/
+.next/
+out/
+
+# Logs
+*.log
+
+# OS files
+.DS_Store
+Thumbs.db
+`
+
+export type ConvertGitStep = 'init' | 'gitignore' | 'stage' | 'commit'
+
+export type ConvertGitOps = {
+  /** Run a git subcommand inside the target folder. */
+  exec: (args: string[]) => Promise<void>
+  /** Whether the folder already has a .gitignore (an existing one is respected). */
+  hasGitignore: () => Promise<boolean>
+  /** Write the default .gitignore into the folder. */
+  writeGitignore: (content: string) => Promise<void>
+}
+
+export type ConvertGitResult =
+  | { ok: true }
+  | { ok: false; step: ConvertGitStep; message: string; isIdentityError: boolean }
+
+// Shown when `git commit` fails because no author identity is configured. The
+// SSH/remote path uses its own host-specific variant.
+export const GIT_IDENTITY_NOT_CONFIGURED_MESSAGE =
+  'Git author identity is not configured. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"`, then try again.'
+
+/** Maps a failed conversion step to a user-facing label (shared by all paths). */
+export function convertStepLabel(step: ConvertGitStep): string {
+  if (step === 'init') {
+    return 'Failed to initialize git repository'
+  }
+  if (step === 'commit') {
+    return 'Failed to create initial commit'
+  }
+  return 'Failed to convert folder to a git repository'
+}
+
+// Matches git's "no author identity" failure so callers can surface a fix-it
+// hint instead of a raw git error.
+const GIT_IDENTITY_HINT = /Please tell me who you are|user\.name|user\.email/i
+
+/**
+ * Initialize git in an already-populated folder: `git init`, write a default
+ * .gitignore (only when absent), stage everything, then create an initial
+ * commit. `--allow-empty` guarantees a base commit even when the folder is
+ * empty or everything is ignored — Orca's worktree features need HEAD to point
+ * at a real commit (an unborn HEAD breaks base-ref resolution).
+ */
+export async function initGitRepoInExistingFolder(ops: ConvertGitOps): Promise<ConvertGitResult> {
+  let step: ConvertGitStep = 'init'
+  try {
+    await ops.exec(['init'])
+    step = 'gitignore'
+    if (!(await ops.hasGitignore())) {
+      await ops.writeGitignore(DEFAULT_CONVERT_GITIGNORE)
+    }
+    step = 'stage'
+    await ops.exec(['add', '-A'])
+    step = 'commit'
+    await ops.exec(['commit', '--allow-empty', '-m', CONVERT_INITIAL_COMMIT_MESSAGE])
+    return { ok: true }
+  } catch (err) {
+    const message = err instanceof Error ? err.message : String(err)
+    // Identity config only matters at commit; init/add never ask "who are you".
+    const isIdentityError = step === 'commit' && GIT_IDENTITY_HINT.test(message)
+    return { ok: false, step, message, isIdentityError }
+  }
+}

--- a/src/main/git/convert-local-folder-to-git.test.ts
+++ b/src/main/git/convert-local-folder-to-git.test.ts
@@ -58,4 +58,20 @@ describe('convertLocalFolderToGit cleanup ownership', () => {
 
     expect(existsSync(join(folderPath, '.git'))).toBe(false)
   })
+
+  it('removes partial repository metadata left by a failed git init', async () => {
+    gitExecFileAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'init') {
+        mkdirSync(join(folderPath, '.git'), { recursive: true })
+        throw new Error('init failed')
+      }
+    })
+
+    await expect(convertLocalFolderToGit(folderPath)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('init failed')
+    })
+
+    expect(existsSync(join(folderPath, '.git'))).toBe(false)
+  })
 })

--- a/src/main/git/convert-local-folder-to-git.test.ts
+++ b/src/main/git/convert-local-folder-to-git.test.ts
@@ -1,0 +1,61 @@
+import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const gitExecFileAsync = vi.hoisted(() => vi.fn())
+const isGitRepo = vi.hoisted(() => vi.fn())
+
+vi.mock('./runner', () => ({ gitExecFileAsync }))
+vi.mock('./repo', () => ({ isGitRepo }))
+
+import { convertLocalFolderToGit } from './convert-local-folder-to-git'
+
+describe('convertLocalFolderToGit cleanup ownership', () => {
+  let folderPath: string
+
+  beforeEach(() => {
+    folderPath = mkdtempSync(join(tmpdir(), 'orca-local-convert-'))
+    gitExecFileAsync.mockReset()
+    isGitRepo.mockReset()
+    isGitRepo.mockReturnValue(false)
+  })
+
+  afterEach(() => {
+    rmSync(folderPath, { recursive: true, force: true })
+  })
+
+  function failCommitAfterInit(): void {
+    gitExecFileAsync.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'init') {
+        mkdirSync(join(folderPath, '.git'), { recursive: true })
+      }
+      if (args[0] === 'commit') {
+        throw new Error('commit failed')
+      }
+    })
+  }
+
+  it('preserves repository metadata that existed before conversion', async () => {
+    mkdirSync(join(folderPath, '.git'))
+    failCommitAfterInit()
+
+    await expect(convertLocalFolderToGit(folderPath)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('commit failed')
+    })
+
+    expect(existsSync(join(folderPath, '.git'))).toBe(true)
+  })
+
+  it('removes repository metadata created by a failed conversion', async () => {
+    failCommitAfterInit()
+
+    await expect(convertLocalFolderToGit(folderPath)).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('commit failed')
+    })
+
+    expect(existsSync(join(folderPath, '.git'))).toBe(false)
+  })
+})

--- a/src/main/git/convert-local-folder-to-git.test.ts
+++ b/src/main/git/convert-local-folder-to-git.test.ts
@@ -1,13 +1,19 @@
 import { existsSync, mkdirSync, mkdtempSync, rmSync } from 'node:fs'
+import type * as NodeFsPromises from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const gitExecFileAsync = vi.hoisted(() => vi.fn())
 const isGitRepo = vi.hoisted(() => vi.fn())
+const rm = vi.hoisted(() => vi.fn())
 
 vi.mock('./runner', () => ({ gitExecFileAsync }))
 vi.mock('./repo', () => ({ isGitRepo }))
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFsPromises>()),
+  rm
+}))
 
 import { convertLocalFolderToGit } from './convert-local-folder-to-git'
 
@@ -19,6 +25,10 @@ describe('convertLocalFolderToGit cleanup ownership', () => {
     gitExecFileAsync.mockReset()
     isGitRepo.mockReset()
     isGitRepo.mockReturnValue(false)
+    rm.mockReset()
+    rm.mockImplementation(async (path: string) => {
+      rmSync(path, { recursive: true, force: true })
+    })
   })
 
   afterEach(() => {
@@ -73,5 +83,18 @@ describe('convertLocalFolderToGit cleanup ownership', () => {
     })
 
     expect(existsSync(join(folderPath, '.git'))).toBe(false)
+  })
+
+  it('reports the conversion and cleanup failures together', async () => {
+    failCommitAfterInit()
+    rm.mockRejectedValueOnce(new Error('permission denied'))
+
+    await expect(convertLocalFolderToGit(folderPath)).resolves.toEqual({
+      ok: false,
+      error:
+        'Failed to create initial commit: commit failed. Failed to remove partial Git metadata: permission denied'
+    })
+
+    expect(existsSync(join(folderPath, '.git'))).toBe(true)
   })
 })

--- a/src/main/git/convert-local-folder-to-git.ts
+++ b/src/main/git/convert-local-folder-to-git.ts
@@ -81,16 +81,22 @@ export async function convertLocalFolderToGit(
       return outcome
     }
 
+    const outcomeError = outcome.isIdentityError
+      ? GIT_IDENTITY_NOT_CONFIGURED_MESSAGE
+      : `${convertStepLabel(outcome.step)}: ${outcome.message}`
+    let cleanupError: string | undefined
     // Why: git init can leave partial metadata when it fails; only preserve a
     // .git path that existed before this conversion attempt.
     if (!gitMetadataExisted) {
-      await rm(gitMetadataPath, { recursive: true, force: true }).catch(() => undefined)
+      await rm(gitMetadataPath, { recursive: true, force: true }).catch((error) => {
+        cleanupError = error instanceof Error ? error.message : String(error)
+      })
     }
     return {
       ok: false,
-      error: outcome.isIdentityError
-        ? GIT_IDENTITY_NOT_CONFIGURED_MESSAGE
-        : `${convertStepLabel(outcome.step)}: ${outcome.message}`
+      error: cleanupError
+        ? `${outcomeError}. Failed to remove partial Git metadata: ${cleanupError}`
+        : outcomeError
     }
   } catch (error) {
     return {

--- a/src/main/git/convert-local-folder-to-git.ts
+++ b/src/main/git/convert-local-folder-to-git.ts
@@ -81,9 +81,9 @@ export async function convertLocalFolderToGit(
       return outcome
     }
 
-    // Why: a malformed or partial .git directory may predate Orca; only remove
-    // repository metadata that this conversion attempt created.
-    if (outcome.step !== 'init' && !gitMetadataExisted) {
+    // Why: git init can leave partial metadata when it fails; only preserve a
+    // .git path that existed before this conversion attempt.
+    if (!gitMetadataExisted) {
       await rm(gitMetadataPath, { recursive: true, force: true }).catch(() => undefined)
     }
     return {

--- a/src/main/git/convert-local-folder-to-git.ts
+++ b/src/main/git/convert-local-folder-to-git.ts
@@ -1,0 +1,103 @@
+import { lstat, rm, writeFile } from 'node:fs/promises'
+import { isAbsolute, join } from 'node:path'
+import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
+import { isGitRepo } from './repo'
+import { gitExecFileAsync } from './runner'
+import {
+  convertStepLabel,
+  GIT_IDENTITY_NOT_CONFIGURED_MESSAGE,
+  initGitRepoInExistingFolder
+} from './convert-folder-to-git'
+
+export type LocalFolderGitConversionResult = { ok: true } | { ok: false; error: string }
+
+// Why: IPC and runtime RPC can target the same local path concurrently; one
+// shared lock prevents a failed attempt from cleaning up another attempt's repo.
+const localConversionsInFlight = new Set<string>()
+
+async function localPathExists(path: string): Promise<boolean> {
+  try {
+    await lstat(path)
+    return true
+  } catch (error) {
+    if (
+      error instanceof Error &&
+      'code' in error &&
+      (error as NodeJS.ErrnoException).code === 'ENOENT'
+    ) {
+      return false
+    }
+    throw error
+  }
+}
+
+async function writeGitignoreExclusive(path: string, content: string): Promise<void> {
+  try {
+    await writeFile(path, content, { encoding: 'utf8', flag: 'wx' })
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined
+    if (code !== 'EEXIST') {
+      throw error
+    }
+  }
+}
+
+export async function convertLocalFolderToGit(
+  path: string
+): Promise<LocalFolderGitConversionResult> {
+  if (path.trim().length === 0) {
+    return { ok: false, error: 'Folder path is required' }
+  }
+  if (!isAbsolute(path)) {
+    return { ok: false, error: 'Folder path must be an absolute path' }
+  }
+
+  const lockKey = normalizeRuntimePathForComparison(path)
+  if (localConversionsInFlight.has(lockKey)) {
+    return { ok: false, error: 'A conversion is already in progress for this folder.' }
+  }
+  localConversionsInFlight.add(lockKey)
+
+  try {
+    if (isGitRepo(path)) {
+      return { ok: true }
+    }
+
+    const gitMetadataPath = join(path, '.git')
+    const gitMetadataExisted = await localPathExists(gitMetadataPath)
+    const gitignorePath = join(path, '.gitignore')
+    const outcome = await initGitRepoInExistingFolder({
+      exec: async (gitArgs) => {
+        await gitExecFileAsync(gitArgs, { cwd: path })
+      },
+      hasGitignore: () => localPathExists(gitignorePath),
+      writeGitignore: (content) => writeGitignoreExclusive(gitignorePath, content)
+    })
+
+    if (outcome.ok) {
+      return outcome
+    }
+
+    // Why: a malformed or partial .git directory may predate Orca; only remove
+    // repository metadata that this conversion attempt created.
+    if (outcome.step !== 'init' && !gitMetadataExisted) {
+      await rm(gitMetadataPath, { recursive: true, force: true }).catch(() => undefined)
+    }
+    return {
+      ok: false,
+      error: outcome.isIdentityError
+        ? GIT_IDENTITY_NOT_CONFIGURED_MESSAGE
+        : `${convertStepLabel(outcome.step)}: ${outcome.message}`
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  } finally {
+    localConversionsInFlight.delete(lockKey)
+  }
+}

--- a/src/main/git/convert-remote-folder-to-git.test.ts
+++ b/src/main/git/convert-remote-folder-to-git.test.ts
@@ -14,7 +14,14 @@ function missingPathError(): NodeJS.ErrnoException {
   return Object.assign(new Error('missing'), { code: 'ENOENT' })
 }
 
-function makeFilesystem(existingPaths: Set<string>): IFilesystemProvider {
+type FilesystemOverrides = Partial<
+  Pick<IFilesystemProvider, 'writeFile' | 'renameNoClobber' | 'deletePath'>
+>
+
+function makeFilesystem(
+  existingPaths: Set<string>,
+  overrides: FilesystemOverrides = {}
+): IFilesystemProvider {
   return {
     lstat: vi.fn(async (path: string) => {
       if (!existingPaths.has(path)) {
@@ -40,7 +47,8 @@ function makeFilesystem(existingPaths: Set<string>): IFilesystemProvider {
     }),
     deletePath: vi.fn(async (path: string) => {
       existingPaths.delete(path)
-    })
+    }),
+    ...overrides
   } as unknown as IFilesystemProvider
 }
 
@@ -100,21 +108,96 @@ describe('convertRemoteFolderToGit cleanup ownership', () => {
     expect(existingPaths.has(GIT_METADATA)).toBe(false)
     expect(fsProvider.deletePath).toHaveBeenCalledWith(GIT_METADATA, true)
   })
+
+  it('removes partial repository metadata left by a failed git init', async () => {
+    exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'init') {
+        existingPaths.add(GIT_METADATA)
+        throw new Error('init failed')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(convert()).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('init failed')
+    })
+
+    expect(existingPaths.has(GIT_METADATA)).toBe(false)
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(GIT_METADATA, true)
+  })
 })
 
 describe('writeGitignoreExclusiveRemote', () => {
+  const TMP = `${FOLDER}/.orca-gitignore.tmp`
+  const GITIGNORE = `${FOLDER}/.gitignore`
+  const CONTENT = '*.tmp\nnode_modules/\n'
+
+  it('writes the tmp file then renameNoClobbers it into place without cleanup', async () => {
+    const existingPaths = new Set<string>()
+    const fsProvider = makeFilesystem(existingPaths)
+
+    await writeGitignoreExclusiveRemote(fsProvider, TMP, GITIGNORE, CONTENT)
+
+    expect(fsProvider.writeFile).toHaveBeenCalledWith(TMP, CONTENT)
+    expect(fsProvider.renameNoClobber).toHaveBeenCalledWith(TMP, GITIGNORE)
+    expect(fsProvider.deletePath).not.toHaveBeenCalled()
+  })
+
   it('respects a .gitignore that appears before the final rename', async () => {
     const existingPaths = new Set<string>()
     const fsProvider = makeFilesystem(existingPaths)
-    const tmpPath = `${FOLDER}/.orca-gitignore.tmp`
-    const gitignorePath = `${FOLDER}/.gitignore`
-    existingPaths.add(gitignorePath)
+    existingPaths.add(GITIGNORE)
 
     await expect(
-      writeGitignoreExclusiveRemote(fsProvider, tmpPath, gitignorePath, '*.log\n')
+      writeGitignoreExclusiveRemote(fsProvider, TMP, GITIGNORE, CONTENT)
     ).resolves.toBeUndefined()
 
-    expect(fsProvider.deletePath).toHaveBeenCalledWith(tmpPath, false)
-    expect(existingPaths.has(gitignorePath)).toBe(true)
+    expect(fsProvider.writeFile).toHaveBeenCalledWith(TMP, CONTENT)
+    expect(fsProvider.renameNoClobber).toHaveBeenCalledWith(TMP, GITIGNORE)
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(TMP, false)
+    expect(existingPaths.has(GITIGNORE)).toBe(true)
+  })
+
+  it('rethrows non-EEXIST errors and still cleans up the tmp file', async () => {
+    const existingPaths = new Set<string>()
+    const unsafe = new Error(
+      'Remote safe rename is unavailable. Reconnect the SSH target and retry.'
+    )
+    const fsProvider = makeFilesystem(existingPaths, {
+      renameNoClobber: vi.fn().mockRejectedValue(unsafe)
+    })
+
+    await expect(
+      writeGitignoreExclusiveRemote(fsProvider, TMP, GITIGNORE, CONTENT)
+    ).rejects.toThrow('Remote safe rename is unavailable')
+
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(TMP, false)
+  })
+
+  it('cleans up the tmp file when writeFile fails and never calls rename', async () => {
+    const existingPaths = new Set<string>()
+    const fsProvider = makeFilesystem(existingPaths, {
+      writeFile: vi.fn().mockRejectedValue(new Error('disk full'))
+    })
+
+    await expect(
+      writeGitignoreExclusiveRemote(fsProvider, TMP, GITIGNORE, CONTENT)
+    ).rejects.toThrow('disk full')
+
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(TMP, false)
+    expect(fsProvider.renameNoClobber).not.toHaveBeenCalled()
+  })
+
+  it('rethrows the original error when tmp cleanup itself rejects', async () => {
+    const existingPaths = new Set<string>()
+    const fsProvider = makeFilesystem(existingPaths, {
+      renameNoClobber: vi.fn().mockRejectedValue(new Error('rename boom')),
+      deletePath: vi.fn().mockRejectedValue(new Error('cleanup failed'))
+    })
+
+    await expect(
+      writeGitignoreExclusiveRemote(fsProvider, TMP, GITIGNORE, CONTENT)
+    ).rejects.toThrow('rename boom')
   })
 })

--- a/src/main/git/convert-remote-folder-to-git.test.ts
+++ b/src/main/git/convert-remote-folder-to-git.test.ts
@@ -126,6 +126,22 @@ describe('convertRemoteFolderToGit cleanup ownership', () => {
     expect(existingPaths.has(GIT_METADATA)).toBe(false)
     expect(fsProvider.deletePath).toHaveBeenCalledWith(GIT_METADATA, true)
   })
+
+  it('reports the conversion and cleanup failures together', async () => {
+    fsProvider = makeFilesystem(existingPaths, {
+      deletePath: vi.fn(async () => {
+        throw new Error('permission denied')
+      })
+    })
+
+    await expect(convert()).resolves.toEqual({
+      ok: false,
+      error:
+        'Failed to create initial commit: commit failed. Failed to remove partial Git metadata: permission denied'
+    })
+
+    expect(existingPaths.has(GIT_METADATA)).toBe(true)
+  })
 })
 
 describe('writeGitignoreExclusiveRemote', () => {

--- a/src/main/git/convert-remote-folder-to-git.test.ts
+++ b/src/main/git/convert-remote-folder-to-git.test.ts
@@ -1,0 +1,120 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { IFilesystemProvider } from '../providers/types'
+import { getRemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import {
+  convertRemoteFolderToGit,
+  writeGitignoreExclusiveRemote
+} from './convert-remote-folder-to-git'
+
+const HOST = getRemoteHostPlatform('linux-x64')
+const FOLDER = '/home/user/project'
+const GIT_METADATA = `${FOLDER}/.git`
+
+function missingPathError(): NodeJS.ErrnoException {
+  return Object.assign(new Error('missing'), { code: 'ENOENT' })
+}
+
+function makeFilesystem(existingPaths: Set<string>): IFilesystemProvider {
+  return {
+    lstat: vi.fn(async (path: string) => {
+      if (!existingPaths.has(path)) {
+        throw missingPathError()
+      }
+      return { size: 0, type: 'directory', mtime: 0 }
+    }),
+    stat: vi.fn(async (path: string) => {
+      if (!existingPaths.has(path)) {
+        throw missingPathError()
+      }
+      return { size: 0, type: 'directory', mtime: 0 }
+    }),
+    writeFile: vi.fn(async (path: string) => {
+      existingPaths.add(path)
+    }),
+    renameNoClobber: vi.fn(async (from: string, to: string) => {
+      if (existingPaths.has(to)) {
+        throw Object.assign(new Error('exists'), { code: 'EEXIST' })
+      }
+      existingPaths.delete(from)
+      existingPaths.add(to)
+    }),
+    deletePath: vi.fn(async (path: string) => {
+      existingPaths.delete(path)
+    })
+  } as unknown as IFilesystemProvider
+}
+
+describe('convertRemoteFolderToGit cleanup ownership', () => {
+  let existingPaths: Set<string>
+  let fsProvider: IFilesystemProvider
+  let exec: (
+    args: string[],
+    cwd: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number }
+  ) => Promise<{ stdout: string; stderr: string }>
+
+  beforeEach(() => {
+    existingPaths = new Set([FOLDER])
+    fsProvider = makeFilesystem(existingPaths)
+    exec = vi.fn(async (args: string[]) => {
+      if (args[0] === 'init') {
+        existingPaths.add(GIT_METADATA)
+      }
+      if (args[0] === 'commit') {
+        throw new Error('commit failed')
+      }
+      return { stdout: '', stderr: '' }
+    })
+  })
+
+  async function convert() {
+    return convertRemoteFolderToGit({
+      connectionId: 'ssh-1',
+      path: FOLDER,
+      host: HOST,
+      fsProvider,
+      gitProvider: {
+        exec,
+        isGitRepoAsync: vi.fn().mockResolvedValue({ isRepo: false, rootPath: null })
+      }
+    })
+  }
+
+  it('preserves repository metadata that existed before conversion', async () => {
+    existingPaths.add(GIT_METADATA)
+
+    await expect(convert()).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('commit failed')
+    })
+
+    expect(existingPaths.has(GIT_METADATA)).toBe(true)
+  })
+
+  it('removes repository metadata created by a failed conversion', async () => {
+    await expect(convert()).resolves.toMatchObject({
+      ok: false,
+      error: expect.stringContaining('commit failed')
+    })
+
+    expect(existingPaths.has(GIT_METADATA)).toBe(false)
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(GIT_METADATA, true)
+  })
+})
+
+describe('writeGitignoreExclusiveRemote', () => {
+  it('respects a .gitignore that appears before the final rename', async () => {
+    const existingPaths = new Set<string>()
+    const fsProvider = makeFilesystem(existingPaths)
+    const tmpPath = `${FOLDER}/.orca-gitignore.tmp`
+    const gitignorePath = `${FOLDER}/.gitignore`
+    existingPaths.add(gitignorePath)
+
+    await expect(
+      writeGitignoreExclusiveRemote(fsProvider, tmpPath, gitignorePath, '*.log\n')
+    ).resolves.toBeUndefined()
+
+    expect(fsProvider.deletePath).toHaveBeenCalledWith(tmpPath, false)
+    expect(existingPaths.has(gitignorePath)).toBe(true)
+  })
+})

--- a/src/main/git/convert-remote-folder-to-git.ts
+++ b/src/main/git/convert-remote-folder-to-git.ts
@@ -109,21 +109,22 @@ export async function convertRemoteFolderToGit(args: {
       return { ok: true, repoPath: path }
     }
 
+    const outcomeError = outcome.isIdentityError
+      ? 'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
+      : `${convertStepLabel(outcome.step)}: ${outcome.message}`
+    let cleanupError: string | undefined
     // Why: git init can leave partial metadata when it fails; only preserve a
     // .git path that existed before this conversion attempt.
     if (!gitMetadataExisted) {
-      await fsProvider.deletePath(gitMetadataPath, true).catch(() => undefined)
-    }
-    if (outcome.isIdentityError) {
-      return {
-        ok: false,
-        error:
-          'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
-      }
+      await fsProvider.deletePath(gitMetadataPath, true).catch((error) => {
+        cleanupError = error instanceof Error ? error.message : String(error)
+      })
     }
     return {
       ok: false,
-      error: `${convertStepLabel(outcome.step)}: ${outcome.message}`
+      error: cleanupError
+        ? `${outcomeError}. Failed to remove partial Git metadata: ${cleanupError}`
+        : outcomeError
     }
   } catch (error) {
     return {

--- a/src/main/git/convert-remote-folder-to-git.ts
+++ b/src/main/git/convert-remote-folder-to-git.ts
@@ -1,0 +1,136 @@
+import { randomUUID } from 'node:crypto'
+import {
+  isRuntimePathAbsolute,
+  normalizeRuntimePathForComparison
+} from '../../shared/cross-platform-path'
+import type { IFilesystemProvider } from '../providers/types'
+import type { IGitProvider } from '../providers/git-provider-contract'
+import { joinRemotePath, type RemoteHostPlatform } from '../ssh/ssh-remote-platform'
+import { convertStepLabel, initGitRepoInExistingFolder } from './convert-folder-to-git'
+
+type RemoteGitConversionProvider = Pick<IGitProvider, 'exec' | 'isGitRepoAsync'>
+
+export type RemoteFolderGitConversionResult =
+  | { ok: true; repoPath: string }
+  | { ok: false; error: string }
+
+const remoteConversionsInFlight = new Set<string>()
+
+async function remotePathExists(fsProvider: IFilesystemProvider, path: string): Promise<boolean> {
+  try {
+    await (fsProvider.lstat?.(path) ?? fsProvider.stat(path))
+    return true
+  } catch (error) {
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined
+    if (code === 'ENOENT') {
+      return false
+    }
+    throw error
+  }
+}
+
+// Why: remote writeFile has no exclusive-create flag, so a sibling temporary
+// file plus renameNoClobber preserves a .gitignore created during the probe.
+export async function writeGitignoreExclusiveRemote(
+  fsProvider: IFilesystemProvider,
+  tmpPath: string,
+  gitignorePath: string,
+  content: string
+): Promise<void> {
+  try {
+    await fsProvider.writeFile(tmpPath, content)
+    await fsProvider.renameNoClobber(tmpPath, gitignorePath)
+  } catch (error) {
+    await fsProvider.deletePath(tmpPath, false).catch(() => undefined)
+    const code =
+      error && typeof error === 'object' && 'code' in error
+        ? (error as NodeJS.ErrnoException).code
+        : undefined
+    if (code !== 'EEXIST') {
+      throw error
+    }
+  }
+}
+
+export async function convertRemoteFolderToGit(args: {
+  connectionId: string
+  path: string
+  host: RemoteHostPlatform
+  gitProvider: RemoteGitConversionProvider
+  fsProvider: IFilesystemProvider
+}): Promise<RemoteFolderGitConversionResult> {
+  const { connectionId, path, host, gitProvider, fsProvider } = args
+  if (path.trim().length === 0) {
+    return { ok: false, error: 'Folder path is required' }
+  }
+  if (!isRuntimePathAbsolute(path, host.pathFlavor)) {
+    return { ok: false, error: 'Folder path must be an absolute path on the SSH host' }
+  }
+
+  const lockKey = `${connectionId}:${normalizeRuntimePathForComparison(path)}`
+  if (remoteConversionsInFlight.has(lockKey)) {
+    return { ok: false, error: 'A conversion is already in progress for this folder.' }
+  }
+  remoteConversionsInFlight.add(lockKey)
+
+  try {
+    let existingRepo
+    try {
+      existingRepo = await gitProvider.isGitRepoAsync(path)
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error)
+      return { ok: false, error: `Failed to inspect folder on the SSH host: ${message}` }
+    }
+    if (existingRepo.isRepo) {
+      return { ok: true, repoPath: existingRepo.rootPath ?? path }
+    }
+
+    const gitMetadataPath = joinRemotePath(host, path, '.git')
+    const gitMetadataExisted = await remotePathExists(fsProvider, gitMetadataPath)
+    const gitignorePath = joinRemotePath(host, path, '.gitignore')
+    const gitignoreTmpPath = joinRemotePath(
+      host,
+      path,
+      `.orca-gitignore-${Date.now()}-${randomUUID()}.tmp`
+    )
+    const outcome = await initGitRepoInExistingFolder({
+      exec: async (gitArgs) => {
+        await gitProvider.exec(gitArgs, path)
+      },
+      hasGitignore: () => remotePathExists(fsProvider, gitignorePath),
+      writeGitignore: (content) =>
+        writeGitignoreExclusiveRemote(fsProvider, gitignoreTmpPath, gitignorePath, content)
+    })
+
+    if (outcome.ok) {
+      return { ok: true, repoPath: path }
+    }
+
+    // Why: preserve repository metadata that existed before Orca, even when it
+    // was incomplete enough for the initial Git probe to reject it.
+    if (outcome.step !== 'init' && !gitMetadataExisted) {
+      await fsProvider.deletePath(gitMetadataPath, true).catch(() => undefined)
+    }
+    if (outcome.isIdentityError) {
+      return {
+        ok: false,
+        error:
+          'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
+      }
+    }
+    return {
+      ok: false,
+      error: `${convertStepLabel(outcome.step)}: ${outcome.message}`
+    }
+  } catch (error) {
+    return {
+      ok: false,
+      error: error instanceof Error ? error.message : String(error)
+    }
+  } finally {
+    remoteConversionsInFlight.delete(lockKey)
+  }
+}

--- a/src/main/git/convert-remote-folder-to-git.ts
+++ b/src/main/git/convert-remote-folder-to-git.ts
@@ -109,9 +109,9 @@ export async function convertRemoteFolderToGit(args: {
       return { ok: true, repoPath: path }
     }
 
-    // Why: preserve repository metadata that existed before Orca, even when it
-    // was incomplete enough for the initial Git probe to reject it.
-    if (outcome.step !== 'init' && !gitMetadataExisted) {
+    // Why: git init can leave partial metadata when it fails; only preserve a
+    // .git path that existed before this conversion attempt.
+    if (!gitMetadataExisted) {
       await fsProvider.deletePath(gitMetadataPath, true).catch(() => undefined)
     }
     if (outcome.isIdentityError) {

--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -26,13 +26,12 @@ vi.mock('../providers/ssh-filesystem-dispatch', () =>
 )
 vi.mock('./ssh', () => moduleMocks.sshModuleMock(reposMocks))
 
-import { registerRepoHandlers, writeGitignoreExclusiveRemote } from './repos'
+import { registerRepoHandlers } from './repos'
 import { clearGitCapabilityStateForTests } from '../git/git-capability-state'
 import { resetSshProviderAuthorities } from '../ssh/ssh-provider-authority'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
 import { clearSubmodulePathsCacheForTests } from '../git/status'
 import { createRepoHandlerHarness, waitForAssertion } from './repos-remote-test-harness'
-import type { IFilesystemProvider } from '../providers/filesystem-provider-contract'
 
 const {
   handleMock,
@@ -728,81 +727,5 @@ describe('repos:addRemote', () => {
       })
     )
     expect(result).toHaveProperty('repo.displayName', 'My Home')
-  })
-})
-
-// Why: the remote converter must mirror writeGitignoreExclusive — never clobber
-// a .gitignore that appears between the hasGitignore() probe and the write.
-describe('writeGitignoreExclusiveRemote', () => {
-  const TMP = '/home/user/project/.orca-gitignore-123.tmp'
-  const GITIGNORE = '/home/user/project/.gitignore'
-  const CONTENT = '*.tmp\nnode_modules/\n'
-
-  function makeFs(overrides: Partial<IFilesystemProvider> = {}): IFilesystemProvider {
-    return {
-      writeFile: vi.fn().mockResolvedValue(undefined),
-      renameNoClobber: vi.fn().mockResolvedValue(undefined),
-      deletePath: vi.fn().mockResolvedValue(undefined),
-      ...overrides
-    } as unknown as IFilesystemProvider
-  }
-
-  it('writes the tmp file then renameNoClobbers it into place without cleanup', async () => {
-    const fs = makeFs()
-
-    await writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)
-
-    expect(fs.writeFile).toHaveBeenCalledWith(TMP, CONTENT)
-    expect(fs.renameNoClobber).toHaveBeenCalledWith(TMP, GITIGNORE)
-    expect(fs.deletePath).not.toHaveBeenCalled()
-  })
-
-  it('respects an existing .gitignore that appears after hasGitignore() (EEXIST) and cleans up the tmp', async () => {
-    const eexist = Object.assign(new Error('exists'), { code: 'EEXIST' })
-    const fs = makeFs({ renameNoClobber: vi.fn().mockRejectedValue(eexist) })
-
-    await expect(
-      writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)
-    ).resolves.toBeUndefined()
-
-    expect(fs.writeFile).toHaveBeenCalledWith(TMP, CONTENT)
-    expect(fs.renameNoClobber).toHaveBeenCalledWith(TMP, GITIGNORE)
-    expect(fs.deletePath).toHaveBeenCalledWith(TMP, false)
-  })
-
-  it('rethrows non-EEXIST errors (e.g. relay lacks safe rename) and still cleans up the tmp', async () => {
-    const unsafe = new Error(
-      'Remote safe rename is unavailable. Reconnect the SSH target and retry.'
-    )
-    const fs = makeFs({ renameNoClobber: vi.fn().mockRejectedValue(unsafe) })
-
-    await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(
-      'Remote safe rename is unavailable'
-    )
-
-    expect(fs.deletePath).toHaveBeenCalledWith(TMP, false)
-  })
-
-  it('cleans up the tmp file when writeFile fails and never calls rename', async () => {
-    const fs = makeFs({ writeFile: vi.fn().mockRejectedValue(new Error('disk full')) })
-
-    await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(
-      'disk full'
-    )
-
-    expect(fs.deletePath).toHaveBeenCalledWith(TMP, false)
-    expect(fs.renameNoClobber).not.toHaveBeenCalled()
-  })
-
-  it('rethrows the original error when tmp cleanup itself rejects', async () => {
-    const boom = new Error('rename boom')
-    const fs = makeFs({
-      renameNoClobber: vi.fn().mockRejectedValue(boom),
-      deletePath: vi.fn().mockRejectedValue(new Error('cleanup failed'))
-    })
-
-    await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(
-      'rename boom'
-    )
   })
 })

--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -798,7 +798,7 @@ describe('writeGitignoreExclusiveRemote', () => {
     const boom = new Error('rename boom')
     const fs = makeFs({
       renameNoClobber: vi.fn().mockRejectedValue(boom),
-      deletePath: vi.fn().mockResolvedValue(undefined)
+      deletePath: vi.fn().mockRejectedValue(new Error('cleanup failed'))
     })
 
     await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(

--- a/src/main/ipc/repos-remote.test.ts
+++ b/src/main/ipc/repos-remote.test.ts
@@ -26,12 +26,13 @@ vi.mock('../providers/ssh-filesystem-dispatch', () =>
 )
 vi.mock('./ssh', () => moduleMocks.sshModuleMock(reposMocks))
 
-import { registerRepoHandlers } from './repos'
+import { registerRepoHandlers, writeGitignoreExclusiveRemote } from './repos'
 import { clearGitCapabilityStateForTests } from '../git/git-capability-state'
 import { resetSshProviderAuthorities } from '../ssh/ssh-provider-authority'
 import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
 import { clearSubmodulePathsCacheForTests } from '../git/status'
 import { createRepoHandlerHarness, waitForAssertion } from './repos-remote-test-harness'
+import type { IFilesystemProvider } from '../providers/filesystem-provider-contract'
 
 const {
   handleMock,
@@ -727,5 +728,81 @@ describe('repos:addRemote', () => {
       })
     )
     expect(result).toHaveProperty('repo.displayName', 'My Home')
+  })
+})
+
+// Why: the remote converter must mirror writeGitignoreExclusive — never clobber
+// a .gitignore that appears between the hasGitignore() probe and the write.
+describe('writeGitignoreExclusiveRemote', () => {
+  const TMP = '/home/user/project/.orca-gitignore-123.tmp'
+  const GITIGNORE = '/home/user/project/.gitignore'
+  const CONTENT = '*.tmp\nnode_modules/\n'
+
+  function makeFs(overrides: Partial<IFilesystemProvider> = {}): IFilesystemProvider {
+    return {
+      writeFile: vi.fn().mockResolvedValue(undefined),
+      renameNoClobber: vi.fn().mockResolvedValue(undefined),
+      deletePath: vi.fn().mockResolvedValue(undefined),
+      ...overrides
+    } as unknown as IFilesystemProvider
+  }
+
+  it('writes the tmp file then renameNoClobbers it into place without cleanup', async () => {
+    const fs = makeFs()
+
+    await writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)
+
+    expect(fs.writeFile).toHaveBeenCalledWith(TMP, CONTENT)
+    expect(fs.renameNoClobber).toHaveBeenCalledWith(TMP, GITIGNORE)
+    expect(fs.deletePath).not.toHaveBeenCalled()
+  })
+
+  it('respects an existing .gitignore that appears after hasGitignore() (EEXIST) and cleans up the tmp', async () => {
+    const eexist = Object.assign(new Error('exists'), { code: 'EEXIST' })
+    const fs = makeFs({ renameNoClobber: vi.fn().mockRejectedValue(eexist) })
+
+    await expect(
+      writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)
+    ).resolves.toBeUndefined()
+
+    expect(fs.writeFile).toHaveBeenCalledWith(TMP, CONTENT)
+    expect(fs.renameNoClobber).toHaveBeenCalledWith(TMP, GITIGNORE)
+    expect(fs.deletePath).toHaveBeenCalledWith(TMP, false)
+  })
+
+  it('rethrows non-EEXIST errors (e.g. relay lacks safe rename) and still cleans up the tmp', async () => {
+    const unsafe = new Error(
+      'Remote safe rename is unavailable. Reconnect the SSH target and retry.'
+    )
+    const fs = makeFs({ renameNoClobber: vi.fn().mockRejectedValue(unsafe) })
+
+    await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(
+      'Remote safe rename is unavailable'
+    )
+
+    expect(fs.deletePath).toHaveBeenCalledWith(TMP, false)
+  })
+
+  it('cleans up the tmp file when writeFile fails and never calls rename', async () => {
+    const fs = makeFs({ writeFile: vi.fn().mockRejectedValue(new Error('disk full')) })
+
+    await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(
+      'disk full'
+    )
+
+    expect(fs.deletePath).toHaveBeenCalledWith(TMP, false)
+    expect(fs.renameNoClobber).not.toHaveBeenCalled()
+  })
+
+  it('rethrows the original error when tmp cleanup itself rejects', async () => {
+    const boom = new Error('rename boom')
+    const fs = makeFs({
+      renameNoClobber: vi.fn().mockRejectedValue(boom),
+      deletePath: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await expect(writeGitignoreExclusiveRemote(fs, TMP, GITIGNORE, CONTENT)).rejects.toThrow(
+      'rename boom'
+    )
   })
 })

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -305,11 +305,22 @@ async function addLocalRepoFromPath(
 
   const resolvedPath = repoKind === 'git' ? getGitRepoRoot(path) : path
   const pathKey = normalizeRuntimePathForComparison(path)
-  const existing = store
-    .getRepos()
-    .find((repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === pathKey)
+  const resolvedPathKey = normalizeRuntimePathForComparison(resolvedPath)
+  const repos = store.getRepos()
+  const existingAtResolvedPath = repos.find(
+    (repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === resolvedPathKey
+  )
+  // Why: selecting a nested folder in a Git repository must resolve to the
+  // canonical root before a same-path folder record can be upgraded.
+  if (repoKind === 'git' && resolvedPathKey !== pathKey && existingAtResolvedPath) {
+    return { repo: existingAtResolvedPath, alreadyExisted: true }
+  }
+
+  const existing = repos.find(
+    (repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === pathKey
+  )
   if (existing) {
-    if (repoKind === 'git' && isFolderRepo(existing)) {
+    if (repoKind === 'git' && resolvedPathKey === pathKey && isFolderRepo(existing)) {
       const detected = await detectRepoIconAndUpstream({ repoPath: resolvedPath, kind: 'git' })
       const updated = store.updateRepo(
         existing.id,
@@ -328,19 +339,8 @@ async function addLocalRepoFromPath(
         return { repo: updated, alreadyExisted: true }
       }
     }
-    return { repo: existing, alreadyExisted: true }
-  }
-
-  const resolvedPathKey = normalizeRuntimePathForComparison(resolvedPath)
-  if (resolvedPathKey !== pathKey) {
-    const existingAfterRootResolve = store
-      .getRepos()
-      .find(
-        (repo) =>
-          !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === resolvedPathKey
-      )
-    if (existingAfterRootResolve) {
-      return { repo: existingAfterRootResolve, alreadyExisted: true }
+    if (resolvedPathKey === pathKey) {
+      return { repo: existing, alreadyExisted: true }
     }
   }
 

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -374,6 +374,28 @@ async function addLocalRepoFromPath(
   return { repo, alreadyExisted: false }
 }
 
+// Why: two concurrent conversions of the SAME target can both pass the non-git
+// probe; if one then fails and runs the `.git` cleanup while the other
+// succeeded, the cleanup destroys the successful repo. Serialize per target so
+// unrelated conversions still run in parallel.
+const conversionsInFlight = new Set<string>()
+
+// Exclusive-create a .gitignore: never clobber one that appears between the
+// hasGitignore() check and this write — respect the existing file instead.
+async function writeGitignoreExclusive(gitignorePath: string, content: string): Promise<void> {
+  try {
+    await writeFile(gitignorePath, content, { encoding: 'utf8', flag: 'wx' })
+  } catch (err) {
+    const code =
+      err && typeof err === 'object' && 'code' in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined
+    if (code !== 'EEXIST') {
+      throw err
+    }
+  }
+}
+
 // Turns an existing non-git LOCAL folder into a git repo (init + .gitignore +
 // initial commit) and registers it as a `git` project. The always-present
 // initial commit is what lets worktree creation resolve a base ref afterwards.
@@ -381,8 +403,10 @@ async function convertLocalFolderToGitRepo(
   store: Store,
   path: string
 ): Promise<{ repo: Repo } | { error: string }> {
-  const targetPath = path?.trim() ?? ''
-  if (!targetPath) {
+  // Don't trim: trailing spaces can be part of a real folder name, so trimming
+  // could touch the wrong path. Only reject empty / whitespace-only input.
+  const targetPath = path ?? ''
+  if (targetPath.trim().length === 0) {
     return { error: 'Folder path is required' }
   }
   // Guard direct IPC use; the renderer always passes absolute picker paths.
@@ -390,47 +414,54 @@ async function convertLocalFolderToGitRepo(
     return { error: 'Folder path must be an absolute path' }
   }
 
-  // Skip init when it's somehow already a repo (e.g. converted out-of-band) and
-  // just add it as git, so the caller still ends up with a usable project.
-  if (!isGitRepo(targetPath)) {
-    const gitignorePath = join(targetPath, '.gitignore')
-    const outcome = await initGitRepoInExistingFolder({
-      exec: async (gitArgs) => {
-        await gitExecFileAsync(gitArgs, { cwd: targetPath })
-      },
-      hasGitignore: async () => {
-        try {
-          await access(gitignorePath)
-          return true
-        } catch {
-          return false
+  const lockKey = `local:${normalizeRuntimePathForComparison(targetPath)}`
+  if (conversionsInFlight.has(lockKey)) {
+    return { error: 'A conversion is already in progress for this folder.' }
+  }
+  conversionsInFlight.add(lockKey)
+  try {
+    // Skip init when it's somehow already a repo (e.g. converted out-of-band)
+    // and just add it as git, so the caller still ends up with a usable project.
+    if (!isGitRepo(targetPath)) {
+      const gitignorePath = join(targetPath, '.gitignore')
+      const outcome = await initGitRepoInExistingFolder({
+        exec: async (gitArgs) => {
+          await gitExecFileAsync(gitArgs, { cwd: targetPath })
+        },
+        hasGitignore: async () => {
+          try {
+            await access(gitignorePath)
+            return true
+          } catch {
+            return false
+          }
+        },
+        writeGitignore: (content) => writeGitignoreExclusive(gitignorePath, content)
+      })
+
+      if (!outcome.ok) {
+        // We never created the user's folder, so only strip a `.git` we just made
+        // — leaving the folder as the user had it. A written .gitignore is
+        // harmless and helps a retry, so it stays.
+        if (outcome.step !== 'init') {
+          await rm(join(targetPath, '.git'), { recursive: true, force: true }).catch(() => {})
         }
-      },
-      writeGitignore: async (content) => {
-        await writeFile(gitignorePath, content, 'utf8')
+        if (outcome.isIdentityError) {
+          return { error: GIT_IDENTITY_NOT_CONFIGURED_MESSAGE }
+        }
+        return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
       }
-    })
-
-    if (!outcome.ok) {
-      // We never created the user's folder, so only strip a `.git` we just made
-      // — leaving the folder as the user had it. A written .gitignore is
-      // harmless and helps a retry, so it stays.
-      if (outcome.step !== 'init') {
-        await rm(join(targetPath, '.git'), { recursive: true, force: true }).catch(() => {})
-      }
-      if (outcome.isIdentityError) {
-        return { error: GIT_IDENTITY_NOT_CONFIGURED_MESSAGE }
-      }
-      return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
     }
-  }
 
-  const result = await addLocalRepoFromPath(store, targetPath, 'git')
-  if ('error' in result) {
-    return result
+    const result = await addLocalRepoFromPath(store, targetPath, 'git')
+    if ('error' in result) {
+      return result
+    }
+    emitRepoAdded('folder_picker', result.alreadyExisted, true)
+    return { repo: result.repo }
+  } finally {
+    conversionsInFlight.delete(lockKey)
   }
-  emitRepoAdded('folder_picker', result.alreadyExisted, true)
-  return { repo: result.repo }
 }
 
 async function addRemoteRepoFromPath(
@@ -811,73 +842,88 @@ async function convertRemoteFolderToGitRepo(
       error: 'SSH host platform is unavailable. Reconnect the SSH target before converting.'
     }
   }
-  const resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath?.trim() ?? '')
-  if (!resolvedPath) {
+  // Don't trim: trailing spaces can be part of a real folder name on the host.
+  const resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath ?? '')
+  if (resolvedPath.trim().length === 0) {
     return { error: 'Folder path is required' }
   }
+  // Mirror the local converter's absolute-path guard; the SSH path otherwise
+  // accepts relative values like "src" and would run git in the host's cwd.
+  if (!isRuntimePathAbsolute(resolvedPath, host.pathFlavor)) {
+    return { error: 'Folder path must be an absolute path on the SSH host' }
+  }
 
-  // Already a repo on the host: skip init and add it (using the detected root).
+  const lockKey = `${args.connectionId}:${normalizeRuntimePathForComparison(resolvedPath)}`
+  if (conversionsInFlight.has(lockKey)) {
+    return { error: 'A conversion is already in progress for this folder.' }
+  }
+  conversionsInFlight.add(lockKey)
   try {
-    const check = await gitProvider.isGitRepoAsync(resolvedPath)
-    if (check.isRepo) {
-      const result = await addRemoteRepoFromPath(store, {
-        connectionId: args.connectionId,
-        remotePath: check.rootPath ?? resolvedPath,
-        kind: 'git'
-      })
-      if ('error' in result) {
-        return result
+    // Already a repo on the host: skip init and add it (using the detected root).
+    try {
+      const check = await gitProvider.isGitRepoAsync(resolvedPath)
+      if (check.isRepo) {
+        const result = await addRemoteRepoFromPath(store, {
+          connectionId: args.connectionId,
+          remotePath: check.rootPath ?? resolvedPath,
+          kind: 'git'
+        })
+        if ('error' in result) {
+          return result
+        }
+        emitRepoAdded('folder_picker', result.alreadyExisted, true)
+        return { repo: result.repo }
       }
-      emitRepoAdded('folder_picker', result.alreadyExisted, true)
-      return { repo: result.repo }
+    } catch {
+      // Probe failed or not a repo — fall through and convert.
     }
-  } catch {
-    // Probe failed or not a repo — fall through and convert.
-  }
 
-  const gitignorePath = joinRemotePath(host, resolvedPath, '.gitignore')
-  const outcome = await initGitRepoInExistingFolder({
-    exec: async (gitArgs) => {
-      await gitProvider.exec(gitArgs, resolvedPath)
-    },
-    hasGitignore: async () => {
-      try {
-        await fsProvider.stat(gitignorePath)
-        return true
-      } catch {
-        return false
+    const gitignorePath = joinRemotePath(host, resolvedPath, '.gitignore')
+    const outcome = await initGitRepoInExistingFolder({
+      exec: async (gitArgs) => {
+        await gitProvider.exec(gitArgs, resolvedPath)
+      },
+      hasGitignore: async () => {
+        try {
+          await fsProvider.stat(gitignorePath)
+          return true
+        } catch {
+          return false
+        }
+      },
+      writeGitignore: async (content) => {
+        await fsProvider.writeFile(gitignorePath, content)
       }
-    },
-    writeGitignore: async (content) => {
-      await fsProvider.writeFile(gitignorePath, content)
-    }
-  })
+    })
 
-  if (!outcome.ok) {
-    if (outcome.step !== 'init') {
-      await fsProvider
-        .deletePath(joinRemotePath(host, resolvedPath, '.git'), true)
-        .catch(() => undefined)
-    }
-    if (outcome.isIdentityError) {
-      return {
-        error:
-          'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
+    if (!outcome.ok) {
+      if (outcome.step !== 'init') {
+        await fsProvider
+          .deletePath(joinRemotePath(host, resolvedPath, '.git'), true)
+          .catch(() => undefined)
       }
+      if (outcome.isIdentityError) {
+        return {
+          error:
+            'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
+        }
+      }
+      return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
     }
-    return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
-  }
 
-  const result = await addRemoteRepoFromPath(store, {
-    connectionId: args.connectionId,
-    remotePath: resolvedPath,
-    kind: 'git'
-  })
-  if ('error' in result) {
-    return result
+    const result = await addRemoteRepoFromPath(store, {
+      connectionId: args.connectionId,
+      remotePath: resolvedPath,
+      kind: 'git'
+    })
+    if ('error' in result) {
+      return result
+    }
+    emitRepoAdded('folder_picker', result.alreadyExisted, true)
+    return { repo: result.repo }
+  } finally {
+    conversionsInFlight.delete(lockKey)
   }
-  emitRepoAdded('folder_picker', result.alreadyExisted, true)
-  return { repo: result.repo }
 }
 
 async function resolveRemoteHomePath(connectionId: string, path: string): Promise<string> {
@@ -1472,6 +1518,8 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
   ipcMain.removeHandler('repos:searchBaseRefs')
   ipcMain.removeHandler('repos:searchBaseRefDetails')
   ipcMain.removeHandler('repos:addRemote')
+  ipcMain.removeHandler('repos:convertToGit')
+  ipcMain.removeHandler('repos:convertRemoteToGit')
   ipcMain.removeHandler('repos:create')
   ipcMain.removeHandler('repos:createRemote')
   ipcMain.removeHandler('sparsePresets:list')

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -44,7 +44,7 @@ import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-
 import { DiffCommentSchema } from '../../shared/diff-comment-schema'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'node:child_process'
-import { access, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
+import { access, mkdir, readdir, rm } from 'node:fs/promises'
 import {
   awaitWindowsHostGitEnvironmentReady,
   gitExecFileAsync,
@@ -52,12 +52,8 @@ import {
   nonInteractiveGitEnv
 } from '../git/runner'
 import { isAbsolute, join, posix } from 'node:path'
-import type { IFilesystemProvider } from '../providers/types'
-import {
-  convertStepLabel,
-  GIT_IDENTITY_NOT_CONFIGURED_MESSAGE,
-  initGitRepoInExistingFolder
-} from '../git/convert-folder-to-git'
+import { convertLocalFolderToGit } from '../git/convert-local-folder-to-git'
+import { convertRemoteFolderToGit } from '../git/convert-remote-folder-to-git'
 import {
   cleanupClaimedCloneTarget,
   claimCloneTarget,
@@ -313,6 +309,25 @@ async function addLocalRepoFromPath(
     .getRepos()
     .find((repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === pathKey)
   if (existing) {
+    if (repoKind === 'git' && isFolderRepo(existing)) {
+      const detected = await detectRepoIconAndUpstream({ repoPath: resolvedPath, kind: 'git' })
+      const updated = store.updateRepo(
+        existing.id,
+        {
+          kind: 'git',
+          ...detected,
+          externalWorktreeVisibility: 'hide',
+          projectHostSetupMethod: existing.projectHostSetupMethod ?? 'imported-existing-folder'
+        },
+        getRepoExecutionHostId(existing)
+      )
+      if (updated) {
+        // Why: conversion retains the tracked folder's identity while enabling
+        // the worktree root required by Git projects.
+        await prepareLocalWorktreeRootForRepo(store, updated)
+        return { repo: updated, alreadyExisted: true }
+      }
+    }
     return { repo: existing, alreadyExisted: true }
   }
 
@@ -375,122 +390,20 @@ async function addLocalRepoFromPath(
   return { repo, alreadyExisted: false }
 }
 
-// Why: two concurrent conversions of the SAME target can both pass the non-git
-// probe; if one then fails and runs the `.git` cleanup while the other
-// succeeded, the cleanup destroys the successful repo. Serialize per target so
-// unrelated conversions still run in parallel.
-const conversionsInFlight = new Set<string>()
-
-// Exclusive-create a .gitignore: never clobber one that appears between the
-// hasGitignore() check and this write — respect the existing file instead.
-async function writeGitignoreExclusive(gitignorePath: string, content: string): Promise<void> {
-  try {
-    await writeFile(gitignorePath, content, { encoding: 'utf8', flag: 'wx' })
-  } catch (err) {
-    const code =
-      err && typeof err === 'object' && 'code' in err
-        ? (err as NodeJS.ErrnoException).code
-        : undefined
-    if (code !== 'EEXIST') {
-      throw err
-    }
-  }
-}
-
-// Remote (SSH) counterpart of writeGitignoreExclusive. The filesystem
-// provider's writeFile accepts no exclusive-create flags, so we write a
-// sibling tmp file then renameNoClobber it into place — atomic on POSIX and
-// fails closed (rather than clobbering) on relays whose fs.renameNoClobber
-// isn't supported. A .gitignore that appears between the hasGitignore() check
-// and this rename is respected (EEXIST), matching the local wx-flag branch.
-export async function writeGitignoreExclusiveRemote(
-  fsProvider: IFilesystemProvider,
-  tmpPath: string,
-  gitignorePath: string,
-  content: string
-): Promise<void> {
-  try {
-    await fsProvider.writeFile(tmpPath, content)
-    await fsProvider.renameNoClobber(tmpPath, gitignorePath)
-  } catch (err) {
-    // Best-effort: a failed rename leaves the tmp behind on the host.
-    await fsProvider.deletePath(tmpPath, false).catch(() => undefined)
-    const code =
-      err && typeof err === 'object' && 'code' in err
-        ? (err as NodeJS.ErrnoException).code
-        : undefined
-    if (code !== 'EEXIST') {
-      throw err
-    }
-  }
-}
-
-// Turns an existing non-git LOCAL folder into a git repo (init + .gitignore +
-// initial commit) and registers it as a `git` project. The always-present
-// initial commit is what lets worktree creation resolve a base ref afterwards.
 async function convertLocalFolderToGitRepo(
   store: Store,
   path: string
 ): Promise<{ repo: Repo } | { error: string }> {
-  // Don't trim: trailing spaces can be part of a real folder name, so trimming
-  // could touch the wrong path. Only reject empty / whitespace-only input.
-  const targetPath = path ?? ''
-  if (targetPath.trim().length === 0) {
-    return { error: 'Folder path is required' }
+  const conversion = await convertLocalFolderToGit(path)
+  if (!conversion.ok) {
+    return { error: conversion.error }
   }
-  // Guard direct IPC use; the renderer always passes absolute picker paths.
-  if (!isAbsolute(targetPath)) {
-    return { error: 'Folder path must be an absolute path' }
+  const result = await addLocalRepoFromPath(store, path, 'git')
+  if ('error' in result) {
+    return result
   }
-
-  const lockKey = `local:${normalizeRuntimePathForComparison(targetPath)}`
-  if (conversionsInFlight.has(lockKey)) {
-    return { error: 'A conversion is already in progress for this folder.' }
-  }
-  conversionsInFlight.add(lockKey)
-  try {
-    // Skip init when it's somehow already a repo (e.g. converted out-of-band)
-    // and just add it as git, so the caller still ends up with a usable project.
-    if (!isGitRepo(targetPath)) {
-      const gitignorePath = join(targetPath, '.gitignore')
-      const outcome = await initGitRepoInExistingFolder({
-        exec: async (gitArgs) => {
-          await gitExecFileAsync(gitArgs, { cwd: targetPath })
-        },
-        hasGitignore: async () => {
-          try {
-            await access(gitignorePath)
-            return true
-          } catch {
-            return false
-          }
-        },
-        writeGitignore: (content) => writeGitignoreExclusive(gitignorePath, content)
-      })
-
-      if (!outcome.ok) {
-        // We never created the user's folder, so only strip a `.git` we just made
-        // — leaving the folder as the user had it. A written .gitignore is
-        // harmless and helps a retry, so it stays.
-        if (outcome.step !== 'init') {
-          await rm(join(targetPath, '.git'), { recursive: true, force: true }).catch(() => {})
-        }
-        if (outcome.isIdentityError) {
-          return { error: GIT_IDENTITY_NOT_CONFIGURED_MESSAGE }
-        }
-        return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
-      }
-    }
-
-    const result = await addLocalRepoFromPath(store, targetPath, 'git')
-    if ('error' in result) {
-      return result
-    }
-    emitRepoAdded('folder_picker', result.alreadyExisted, true)
-    return { repo: result.repo }
-  } finally {
-    conversionsInFlight.delete(lockKey)
-  }
+  emitRepoAdded('folder_picker', result.alreadyExisted, true)
+  return { repo: result.repo }
 }
 
 async function addRemoteRepoFromPath(
@@ -519,7 +432,7 @@ async function addRemoteRepoFromPath(
         normalizeRuntimePathForComparison(repo.path) ===
           normalizeRuntimePathForComparison(resolvedPath)
     )
-  if (existing) {
+  if (existing && (args.kind === 'folder' || !isFolderRepo(existing))) {
     return { repo: existing, alreadyExisted: true }
   }
 
@@ -551,6 +464,32 @@ async function addRemoteRepoFromPath(
           normalizeRuntimePathForComparison(resolvedPath)
     )
   if (existingAfterRootResolve) {
+    if (repoKind === 'git' && isFolderRepo(existingAfterRootResolve)) {
+      const detected = await detectRepoIconAndUpstream({
+        repoPath: resolvedPath,
+        kind: 'git',
+        connectionId: args.connectionId
+      })
+      const updated = store.updateRepo(
+        existingAfterRootResolve.id,
+        {
+          kind: 'git',
+          ...detected,
+          externalWorktreeVisibility: 'hide',
+          projectHostSetupMethod:
+            args.setupMethod ??
+            existingAfterRootResolve.projectHostSetupMethod ??
+            'imported-existing-folder'
+        },
+        getRepoExecutionHostId(existingAfterRootResolve)
+      )
+      if (updated) {
+        getActiveMultiplexer(args.connectionId)?.notify('session.registerRoot', {
+          rootPath: resolvedPath
+        })
+        return { repo: updated, alreadyExisted: true }
+      }
+    }
     return { repo: existingAfterRootResolve, alreadyExisted: true }
   }
 
@@ -853,9 +792,6 @@ async function createRemoteRepo(
   return { repo: result.repo }
 }
 
-// Remote (SSH) counterpart of convertLocalFolderToGitRepo: runs init + commit
-// on the host via the git provider and writes the .gitignore via the filesystem
-// provider, then registers the host folder as a `git` project.
 async function convertRemoteFolderToGitRepo(
   store: Store,
   args: { connectionId: string; remotePath: string }
@@ -871,96 +807,27 @@ async function convertRemoteFolderToGitRepo(
       error: 'SSH host platform is unavailable. Reconnect the SSH target before converting.'
     }
   }
-  // Don't trim: trailing spaces can be part of a real folder name on the host.
   const resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath ?? '')
-  if (resolvedPath.trim().length === 0) {
-    return { error: 'Folder path is required' }
+  const conversion = await convertRemoteFolderToGit({
+    connectionId: args.connectionId,
+    path: resolvedPath,
+    host,
+    gitProvider,
+    fsProvider
+  })
+  if (!conversion.ok) {
+    return { error: conversion.error }
   }
-  // Mirror the local converter's absolute-path guard; the SSH path otherwise
-  // accepts relative values like "src" and would run git in the host's cwd.
-  if (!isRuntimePathAbsolute(resolvedPath, host.pathFlavor)) {
-    return { error: 'Folder path must be an absolute path on the SSH host' }
+  const result = await addRemoteRepoFromPath(store, {
+    connectionId: args.connectionId,
+    remotePath: conversion.repoPath,
+    kind: 'git'
+  })
+  if ('error' in result) {
+    return result
   }
-
-  const lockKey = `${args.connectionId}:${normalizeRuntimePathForComparison(resolvedPath)}`
-  if (conversionsInFlight.has(lockKey)) {
-    return { error: 'A conversion is already in progress for this folder.' }
-  }
-  conversionsInFlight.add(lockKey)
-  try {
-    // Already a repo on the host: skip init and add it (using the detected root).
-    try {
-      const check = await gitProvider.isGitRepoAsync(resolvedPath)
-      if (check.isRepo) {
-        const result = await addRemoteRepoFromPath(store, {
-          connectionId: args.connectionId,
-          remotePath: check.rootPath ?? resolvedPath,
-          kind: 'git'
-        })
-        if ('error' in result) {
-          return result
-        }
-        emitRepoAdded('folder_picker', result.alreadyExisted, true)
-        return { repo: result.repo }
-      }
-    } catch {
-      // Probe failed or not a repo — fall through and convert.
-    }
-
-    const gitignorePath = joinRemotePath(host, resolvedPath, '.gitignore')
-    // Why: a sibling tmp next to the target keeps the write + renameNoClobber
-    // in the same directory so the rename is atomic on POSIX. The UUID suffix
-    // disambiguates concurrent conversion retries on the same host folder.
-    const gitignoreTmpPath = joinRemotePath(
-      host,
-      resolvedPath,
-      `.orca-gitignore-${Date.now()}-${randomUUID()}.tmp`
-    )
-    const outcome = await initGitRepoInExistingFolder({
-      exec: async (gitArgs) => {
-        await gitProvider.exec(gitArgs, resolvedPath)
-      },
-      hasGitignore: async () => {
-        try {
-          await fsProvider.stat(gitignorePath)
-          return true
-        } catch {
-          return false
-        }
-      },
-      writeGitignore: async (content) => {
-        await writeGitignoreExclusiveRemote(fsProvider, gitignoreTmpPath, gitignorePath, content)
-      }
-    })
-
-    if (!outcome.ok) {
-      if (outcome.step !== 'init') {
-        await fsProvider
-          .deletePath(joinRemotePath(host, resolvedPath, '.git'), true)
-          .catch(() => undefined)
-      }
-      if (outcome.isIdentityError) {
-        return {
-          error:
-            'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
-        }
-      }
-      return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
-    }
-
-    const result = await addRemoteRepoFromPath(store, {
-      connectionId: args.connectionId,
-      remotePath: resolvedPath,
-      kind: 'git'
-    })
-    if ('error' in result) {
-      return result
-    }
-    emitRepoAdded('folder_picker', result.alreadyExisted, true)
-    return { repo: result.repo }
-  } finally {
-    conversionsInFlight.delete(lockKey)
-  }
+  emitRepoAdded('folder_picker', result.alreadyExisted, true)
+  return { repo: result.repo }
 }
 
 async function resolveRemoteHomePath(connectionId: string, path: string): Promise<string> {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -52,6 +52,7 @@ import {
   nonInteractiveGitEnv
 } from '../git/runner'
 import { isAbsolute, join, posix } from 'node:path'
+import type { IFilesystemProvider } from '../providers/types'
 import {
   convertStepLabel,
   GIT_IDENTITY_NOT_CONFIGURED_MESSAGE,
@@ -386,6 +387,34 @@ async function writeGitignoreExclusive(gitignorePath: string, content: string): 
   try {
     await writeFile(gitignorePath, content, { encoding: 'utf8', flag: 'wx' })
   } catch (err) {
+    const code =
+      err && typeof err === 'object' && 'code' in err
+        ? (err as NodeJS.ErrnoException).code
+        : undefined
+    if (code !== 'EEXIST') {
+      throw err
+    }
+  }
+}
+
+// Remote (SSH) counterpart of writeGitignoreExclusive. The filesystem
+// provider's writeFile accepts no exclusive-create flags, so we write a
+// sibling tmp file then renameNoClobber it into place — atomic on POSIX and
+// fails closed (rather than clobbering) on relays whose fs.renameNoClobber
+// isn't supported. A .gitignore that appears between the hasGitignore() check
+// and this rename is respected (EEXIST), matching the local wx-flag branch.
+export async function writeGitignoreExclusiveRemote(
+  fsProvider: IFilesystemProvider,
+  tmpPath: string,
+  gitignorePath: string,
+  content: string
+): Promise<void> {
+  try {
+    await fsProvider.writeFile(tmpPath, content)
+    await fsProvider.renameNoClobber(tmpPath, gitignorePath)
+  } catch (err) {
+    // Best-effort: a failed rename leaves the tmp behind on the host.
+    await fsProvider.deletePath(tmpPath, false).catch(() => undefined)
     const code =
       err && typeof err === 'object' && 'code' in err
         ? (err as NodeJS.ErrnoException).code
@@ -879,6 +908,14 @@ async function convertRemoteFolderToGitRepo(
     }
 
     const gitignorePath = joinRemotePath(host, resolvedPath, '.gitignore')
+    // Why: a sibling tmp next to the target keeps the write + renameNoClobber
+    // in the same directory so the rename is atomic on POSIX. The UUID suffix
+    // disambiguates concurrent conversion retries on the same host folder.
+    const gitignoreTmpPath = joinRemotePath(
+      host,
+      resolvedPath,
+      `.orca-gitignore-${Date.now()}-${randomUUID()}.tmp`
+    )
     const outcome = await initGitRepoInExistingFolder({
       exec: async (gitArgs) => {
         await gitProvider.exec(gitArgs, resolvedPath)
@@ -892,7 +929,7 @@ async function convertRemoteFolderToGitRepo(
         }
       },
       writeGitignore: async (content) => {
-        await fsProvider.writeFile(gitignorePath, content)
+        await writeGitignoreExclusiveRemote(fsProvider, gitignoreTmpPath, gitignorePath, content)
       }
     })
 

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -44,7 +44,7 @@ import { isWorkspaceLinkedItemSourceContextMatch } from '../../shared/workspace-
 import { DiffCommentSchema } from '../../shared/diff-comment-schema'
 import { invalidateAuthorizedRootsCache } from './filesystem-auth'
 import type { ChildProcess } from 'node:child_process'
-import { access, mkdir, readdir, rm } from 'node:fs/promises'
+import { access, mkdir, readdir, rm, writeFile } from 'node:fs/promises'
 import {
   awaitWindowsHostGitEnvironmentReady,
   gitExecFileAsync,
@@ -52,6 +52,11 @@ import {
   nonInteractiveGitEnv
 } from '../git/runner'
 import { isAbsolute, join, posix } from 'node:path'
+import {
+  convertStepLabel,
+  GIT_IDENTITY_NOT_CONFIGURED_MESSAGE,
+  initGitRepoInExistingFolder
+} from '../git/convert-folder-to-git'
 import {
   cleanupClaimedCloneTarget,
   claimCloneTarget,
@@ -367,6 +372,65 @@ async function addLocalRepoFromPath(
   store.addRepo(repo)
   await prepareLocalWorktreeRootForRepo(store, repo)
   return { repo, alreadyExisted: false }
+}
+
+// Turns an existing non-git LOCAL folder into a git repo (init + .gitignore +
+// initial commit) and registers it as a `git` project. The always-present
+// initial commit is what lets worktree creation resolve a base ref afterwards.
+async function convertLocalFolderToGitRepo(
+  store: Store,
+  path: string
+): Promise<{ repo: Repo } | { error: string }> {
+  const targetPath = path?.trim() ?? ''
+  if (!targetPath) {
+    return { error: 'Folder path is required' }
+  }
+  // Guard direct IPC use; the renderer always passes absolute picker paths.
+  if (!isAbsolute(targetPath)) {
+    return { error: 'Folder path must be an absolute path' }
+  }
+
+  // Skip init when it's somehow already a repo (e.g. converted out-of-band) and
+  // just add it as git, so the caller still ends up with a usable project.
+  if (!isGitRepo(targetPath)) {
+    const gitignorePath = join(targetPath, '.gitignore')
+    const outcome = await initGitRepoInExistingFolder({
+      exec: async (gitArgs) => {
+        await gitExecFileAsync(gitArgs, { cwd: targetPath })
+      },
+      hasGitignore: async () => {
+        try {
+          await access(gitignorePath)
+          return true
+        } catch {
+          return false
+        }
+      },
+      writeGitignore: async (content) => {
+        await writeFile(gitignorePath, content, 'utf8')
+      }
+    })
+
+    if (!outcome.ok) {
+      // We never created the user's folder, so only strip a `.git` we just made
+      // — leaving the folder as the user had it. A written .gitignore is
+      // harmless and helps a retry, so it stays.
+      if (outcome.step !== 'init') {
+        await rm(join(targetPath, '.git'), { recursive: true, force: true }).catch(() => {})
+      }
+      if (outcome.isIdentityError) {
+        return { error: GIT_IDENTITY_NOT_CONFIGURED_MESSAGE }
+      }
+      return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
+    }
+  }
+
+  const result = await addLocalRepoFromPath(store, targetPath, 'git')
+  if ('error' in result) {
+    return result
+  }
+  emitRepoAdded('folder_picker', result.alreadyExisted, true)
+  return { repo: result.repo }
 }
 
 async function addRemoteRepoFromPath(
@@ -726,6 +790,93 @@ async function createRemoteRepo(
     return result
   }
   emitRepoAdded('folder_picker', result.alreadyExisted)
+  return { repo: result.repo }
+}
+
+// Remote (SSH) counterpart of convertLocalFolderToGitRepo: runs init + commit
+// on the host via the git provider and writes the .gitignore via the filesystem
+// provider, then registers the host folder as a `git` project.
+async function convertRemoteFolderToGitRepo(
+  store: Store,
+  args: { connectionId: string; remotePath: string }
+): Promise<{ repo: Repo } | { error: string }> {
+  const gitProvider = getSshGitProvider(args.connectionId)
+  const fsProvider = getSshFilesystemProvider(args.connectionId)
+  if (!gitProvider || !fsProvider) {
+    return { error: `SSH connection "${args.connectionId}" not found or not connected` }
+  }
+  const host = gitProvider.getHostPlatform?.()
+  if (!host) {
+    return {
+      error: 'SSH host platform is unavailable. Reconnect the SSH target before converting.'
+    }
+  }
+  const resolvedPath = await resolveRemoteHomePath(args.connectionId, args.remotePath?.trim() ?? '')
+  if (!resolvedPath) {
+    return { error: 'Folder path is required' }
+  }
+
+  // Already a repo on the host: skip init and add it (using the detected root).
+  try {
+    const check = await gitProvider.isGitRepoAsync(resolvedPath)
+    if (check.isRepo) {
+      const result = await addRemoteRepoFromPath(store, {
+        connectionId: args.connectionId,
+        remotePath: check.rootPath ?? resolvedPath,
+        kind: 'git'
+      })
+      if ('error' in result) {
+        return result
+      }
+      emitRepoAdded('folder_picker', result.alreadyExisted, true)
+      return { repo: result.repo }
+    }
+  } catch {
+    // Probe failed or not a repo — fall through and convert.
+  }
+
+  const gitignorePath = joinRemotePath(host, resolvedPath, '.gitignore')
+  const outcome = await initGitRepoInExistingFolder({
+    exec: async (gitArgs) => {
+      await gitProvider.exec(gitArgs, resolvedPath)
+    },
+    hasGitignore: async () => {
+      try {
+        await fsProvider.stat(gitignorePath)
+        return true
+      } catch {
+        return false
+      }
+    },
+    writeGitignore: async (content) => {
+      await fsProvider.writeFile(gitignorePath, content)
+    }
+  })
+
+  if (!outcome.ok) {
+    if (outcome.step !== 'init') {
+      await fsProvider
+        .deletePath(joinRemotePath(host, resolvedPath, '.git'), true)
+        .catch(() => undefined)
+    }
+    if (outcome.isIdentityError) {
+      return {
+        error:
+          'Git author identity is not configured on the SSH host. Run `git config --global user.name "Your Name"` and `git config --global user.email "you@example.com"` on that host, then try again.'
+      }
+    }
+    return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
+  }
+
+  const result = await addRemoteRepoFromPath(store, {
+    connectionId: args.connectionId,
+    remotePath: resolvedPath,
+    kind: 'git'
+  })
+  if ('error' in result) {
+    return result
+  }
+  emitRepoAdded('folder_picker', result.alreadyExisted, true)
   return { repo: result.repo }
 }
 
@@ -1861,6 +2012,37 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
       notifyReposChanged(mainWindow)
       emitRepoAdded('folder_picker', result.alreadyExisted, result.repo.kind === 'git')
       return { repo: result.repo }
+    }
+  )
+
+  // Converts an existing non-git folder into a git repo in place, then registers
+  // it as a full git project — the in-dialog alternative to "Open as Folder"
+  // (orca#3839). emitRepoAdded is handled inside the convert helpers.
+  ipcMain.handle(
+    'repos:convertToGit',
+    async (_event, args: { path: string }): Promise<{ repo: Repo } | { error: string }> => {
+      const result = await convertLocalFolderToGitRepo(store, args.path)
+      if ('error' in result) {
+        return result
+      }
+      invalidateAuthorizedRootsCache()
+      notifyReposChanged(mainWindow)
+      return result
+    }
+  )
+
+  ipcMain.handle(
+    'repos:convertRemoteToGit',
+    async (
+      _event,
+      args: { connectionId: string; remotePath: string }
+    ): Promise<{ repo: Repo } | { error: string }> => {
+      const result = await convertRemoteFolderToGitRepo(store, args)
+      if ('error' in result) {
+        return result
+      }
+      notifyReposChanged(mainWindow)
+      return result
     }
   )
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -7822,6 +7822,34 @@ describe('OrcaRuntimeService', () => {
     expect(prepareLocalWorktreeRootForRepoMock).toHaveBeenCalledWith(runtimeStore, repo)
   })
 
+  it('fails a folder-to-git upgrade when the repo disappears during detection', async () => {
+    const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-folder-upgrade-race-'))
+    execFileSync('git', ['init', tempRoot], { stdio: 'ignore' })
+    const existing = {
+      id: 'runtime-folder-upgrade-race',
+      path: tempRoot,
+      displayName: 'folder',
+      badgeColor: 'blue',
+      addedAt: 1,
+      kind: 'folder' as const
+    }
+    const runtimeStore = {
+      ...store,
+      getRepos: () => [existing],
+      updateRepo: vi.fn(() => null)
+    }
+    const runtime = new OrcaRuntimeService(runtimeStore as never)
+
+    try {
+      await expect(runtime.addRepo(tempRoot, 'git')).rejects.toThrow(
+        `Project disappeared before it could be converted to Git: ${existing.id}`
+      )
+      expect(prepareLocalWorktreeRootForRepoMock).not.toHaveBeenCalled()
+    } finally {
+      await rm(tempRoot, { recursive: true, force: true })
+    }
+  })
+
   it('sets up an existing folder on a fresh runtime after importing the repo project', async () => {
     const tempRoot = await mkdtemp(join(tmpdir(), 'orca-runtime-project-setup-'))
     const repos: Record<string, unknown>[] = []

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19210,17 +19210,19 @@ export class OrcaRuntimeService {
     if (existing) {
       if (kind === 'git' && isFolderRepo(existing)) {
         const detected = await detectRepoIconAndUpstream({ repoPath: path, kind: 'git' })
-        const updated =
-          this.store.updateRepo(
-            existing.id,
-            {
-              kind: 'git',
-              ...detected,
-              externalWorktreeVisibility: 'hide',
-              projectHostSetupMethod: existing.projectHostSetupMethod ?? 'imported-existing-folder'
-            },
-            getRepoExecutionHostId(existing)
-          ) ?? existing
+        const updated = this.store.updateRepo(
+          existing.id,
+          {
+            kind: 'git',
+            ...detected,
+            externalWorktreeVisibility: 'hide',
+            projectHostSetupMethod: existing.projectHostSetupMethod ?? 'imported-existing-folder'
+          },
+          getRepoExecutionHostId(existing)
+        )
+        if (!updated) {
+          throw new Error(`Project disappeared before it could be converted to Git: ${existing.id}`)
+        }
         await prepareLocalWorktreeRootForRepo(this.store, updated)
         invalidateAuthorizedRootsCache()
         this.invalidateResolvedWorktreeCache()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -115,7 +115,7 @@ import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fe
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { access, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { lstat, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
 import {
@@ -19394,10 +19394,23 @@ export class OrcaRuntimeService {
         },
         hasGitignore: async () => {
           try {
-            await access(gitignorePath)
+            // Why: lstat doesn't follow symlinks, so a .gitignore symlink
+            // planted between calls can't pretend to exist (or point outside
+            // the folder) and suppress our exclusive-create write below.
+            await lstat(gitignorePath)
             return true
-          } catch {
-            return false
+          } catch (err) {
+            const code =
+              err && typeof err === 'object' && 'code' in err
+                ? (err as NodeJS.ErrnoException).code
+                : undefined
+            // Why: only "missing" should be treated as "no .gitignore". A
+            // permission or I/O error must propagate so the user sees the real
+            // problem instead of a misleading write failure later.
+            if (code === 'ENOENT') {
+              return false
+            }
+            throw err
           }
         },
         writeGitignore: async (content) => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -115,9 +115,14 @@ import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fe
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
+import { access, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
+import {
+  convertStepLabel,
+  GIT_IDENTITY_NOT_CONFIGURED_MESSAGE,
+  initGitRepoInExistingFolder
+} from '../git/convert-folder-to-git'
 import { OrchestrationDb } from './orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
 import {
@@ -19362,6 +19367,54 @@ export class OrcaRuntimeService {
     this.invalidateWorktreeScanCacheForRepo(repo.id)
     this.notifyReposChanged()
     return { repo: this.store.getRepo(repo.id) ?? repo }
+  }
+
+  // Converts an existing non-git folder on this host into a git repo, then
+  // registers it as a git project — the runtime-target counterpart of the
+  // local `repos:convertToGit` IPC (orca#3839).
+  async convertRepoToGit(path: string): Promise<{ repo: Repo } | { error: string }> {
+    if (!this.store) {
+      throw new Error('runtime_unavailable')
+    }
+    const targetPath = path.trim()
+    if (!targetPath) {
+      return { error: 'Folder path is required' }
+    }
+    if (!isAbsolute(targetPath)) {
+      return { error: 'Folder path must be an absolute path' }
+    }
+
+    if (!isGitRepo(targetPath)) {
+      const gitignorePath = join(targetPath, '.gitignore')
+      const outcome = await initGitRepoInExistingFolder({
+        exec: async (gitArgs) => {
+          await gitExecFileAsync(gitArgs, { cwd: targetPath })
+        },
+        hasGitignore: async () => {
+          try {
+            await access(gitignorePath)
+            return true
+          } catch {
+            return false
+          }
+        },
+        writeGitignore: async (content) => {
+          await writeFile(gitignorePath, content, 'utf8')
+        }
+      })
+      if (!outcome.ok) {
+        if (outcome.step !== 'init') {
+          await rm(join(targetPath, '.git'), { recursive: true, force: true }).catch(() => {})
+        }
+        if (outcome.isIdentityError) {
+          return { error: GIT_IDENTITY_NOT_CONFIGURED_MESSAGE }
+        }
+        return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
+      }
+    }
+
+    const repo = await this.addRepo(targetPath, 'git')
+    return { repo }
   }
 
   async cloneRepo(

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -19376,8 +19376,10 @@ export class OrcaRuntimeService {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
-    const targetPath = path.trim()
-    if (!targetPath) {
+    // Don't trim: trailing spaces can be part of a real folder name, so trimming
+    // could touch the wrong path. Only reject empty / whitespace-only input.
+    const targetPath = path
+    if (targetPath.trim().length === 0) {
       return { error: 'Folder path is required' }
     }
     if (!isAbsolute(targetPath)) {
@@ -19399,7 +19401,19 @@ export class OrcaRuntimeService {
           }
         },
         writeGitignore: async (content) => {
-          await writeFile(gitignorePath, content, 'utf8')
+          // Exclusive create so a .gitignore appearing between the check and this
+          // write is respected, not clobbered.
+          try {
+            await writeFile(gitignorePath, content, { encoding: 'utf8', flag: 'wx' })
+          } catch (err) {
+            const code =
+              err && typeof err === 'object' && 'code' in err
+                ? (err as NodeJS.ErrnoException).code
+                : undefined
+            if (code !== 'EEXIST') {
+              throw err
+            }
+          }
         }
       })
       if (!outcome.ok) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -115,14 +115,10 @@ import { GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS } from '../../shared/git-fe
 import { createHash, randomUUID } from 'node:crypto'
 import { homedir } from 'node:os'
 import { isAbsolute, join, resolve } from 'node:path'
-import { lstat, mkdir, readFile, readdir, rm, stat, writeFile } from 'node:fs/promises'
+import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree/base-ref'
-import {
-  convertStepLabel,
-  GIT_IDENTITY_NOT_CONFIGURED_MESSAGE,
-  initGitRepoInExistingFolder
-} from '../git/convert-folder-to-git'
+import { convertLocalFolderToGit } from '../git/convert-local-folder-to-git'
 import { OrchestrationDb } from './orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
 import {
@@ -19212,6 +19208,26 @@ export class OrcaRuntimeService {
       return runtimeRepoMatchesExecutionHost(repo, executionHostId)
     })
     if (existing) {
+      if (kind === 'git' && isFolderRepo(existing)) {
+        const detected = await detectRepoIconAndUpstream({ repoPath: path, kind: 'git' })
+        const updated =
+          this.store.updateRepo(
+            existing.id,
+            {
+              kind: 'git',
+              ...detected,
+              externalWorktreeVisibility: 'hide',
+              projectHostSetupMethod: existing.projectHostSetupMethod ?? 'imported-existing-folder'
+            },
+            getRepoExecutionHostId(existing)
+          ) ?? existing
+        await prepareLocalWorktreeRootForRepo(this.store, updated)
+        invalidateAuthorizedRootsCache()
+        this.invalidateResolvedWorktreeCache()
+        this.invalidateWorktreeScanCacheForRepo(updated.id)
+        this.notifyReposChanged()
+        return updated
+      }
       // Only a runtime host backfills a legacy unstamped repo. An unstamped repo is
       // indistinguishable from a genuine local repo (both have null executionHostId and
       // connectionId), so we never stamp local/ssh onto it — that would re-attribute a
@@ -19242,7 +19258,13 @@ export class OrcaRuntimeService {
       ...detected,
       addedAt: Date.now(),
       kind,
-      ...(kind === 'git' ? { externalWorktreeVisibilityLegacy: false } : {})
+      ...(kind === 'git'
+        ? {
+            externalWorktreeVisibility: 'hide' as const,
+            externalWorktreeVisibilityLegacy: false,
+            projectHostSetupMethod: 'imported-existing-folder' as const
+          }
+        : {})
     }
     this.store.addRepo(repo)
     await prepareLocalWorktreeRootForRepo(this.store, repo)
@@ -19369,78 +19391,16 @@ export class OrcaRuntimeService {
     return { repo: this.store.getRepo(repo.id) ?? repo }
   }
 
-  // Converts an existing non-git folder on this host into a git repo, then
-  // registers it as a git project — the runtime-target counterpart of the
-  // local `repos:convertToGit` IPC (orca#3839).
   async convertRepoToGit(path: string): Promise<{ repo: Repo } | { error: string }> {
     if (!this.store) {
       throw new Error('runtime_unavailable')
     }
-    // Don't trim: trailing spaces can be part of a real folder name, so trimming
-    // could touch the wrong path. Only reject empty / whitespace-only input.
-    const targetPath = path
-    if (targetPath.trim().length === 0) {
-      return { error: 'Folder path is required' }
-    }
-    if (!isAbsolute(targetPath)) {
-      return { error: 'Folder path must be an absolute path' }
+    const conversion = await convertLocalFolderToGit(path)
+    if (!conversion.ok) {
+      return { error: conversion.error }
     }
 
-    if (!isGitRepo(targetPath)) {
-      const gitignorePath = join(targetPath, '.gitignore')
-      const outcome = await initGitRepoInExistingFolder({
-        exec: async (gitArgs) => {
-          await gitExecFileAsync(gitArgs, { cwd: targetPath })
-        },
-        hasGitignore: async () => {
-          try {
-            // Why: lstat doesn't follow symlinks, so a .gitignore symlink
-            // planted between calls can't pretend to exist (or point outside
-            // the folder) and suppress our exclusive-create write below.
-            await lstat(gitignorePath)
-            return true
-          } catch (err) {
-            const code =
-              err && typeof err === 'object' && 'code' in err
-                ? (err as NodeJS.ErrnoException).code
-                : undefined
-            // Why: only "missing" should be treated as "no .gitignore". A
-            // permission or I/O error must propagate so the user sees the real
-            // problem instead of a misleading write failure later.
-            if (code === 'ENOENT') {
-              return false
-            }
-            throw err
-          }
-        },
-        writeGitignore: async (content) => {
-          // Exclusive create so a .gitignore appearing between the check and this
-          // write is respected, not clobbered.
-          try {
-            await writeFile(gitignorePath, content, { encoding: 'utf8', flag: 'wx' })
-          } catch (err) {
-            const code =
-              err && typeof err === 'object' && 'code' in err
-                ? (err as NodeJS.ErrnoException).code
-                : undefined
-            if (code !== 'EEXIST') {
-              throw err
-            }
-          }
-        }
-      })
-      if (!outcome.ok) {
-        if (outcome.step !== 'init') {
-          await rm(join(targetPath, '.git'), { recursive: true, force: true }).catch(() => {})
-        }
-        if (outcome.isIdentityError) {
-          return { error: GIT_IDENTITY_NOT_CONFIGURED_MESSAGE }
-        }
-        return { error: `${convertStepLabel(outcome.step)}: ${outcome.message}` }
-      }
-    }
-
-    const repo = await this.addRepo(targetPath, 'git')
+    const repo = await this.addRepo(path, 'git')
     return { repo }
   }
 

--- a/src/main/runtime/rpc/methods/repo.ts
+++ b/src/main/runtime/rpc/methods/repo.ts
@@ -9,9 +9,7 @@ import {
   projectRepoVisibilityForClient
 } from '../repo-visibility-projection'
 
-const RepoSelector = z.object({
-  repo: requiredString('Missing repo selector')
-})
+const RepoSelector = z.object({ repo: requiredString('Missing repo selector') })
 
 const RepoPath = z.object({
   path: requiredString('Missing repo path'),
@@ -203,6 +201,11 @@ export const REPO_METHODS: RpcMethod[] = [
         await context.runtime.createRepo(params.parentPath, params.name, params.kind),
         context
       )
+  }),
+  defineMethod({
+    name: 'repo.convertToGit',
+    params: RepoPath,
+    handler: async (params, { runtime }) => runtime.convertRepoToGit(params.path)
   }),
   defineMethod({
     name: 'repo.gitAvailable',

--- a/src/preload/api/repository-api.ts
+++ b/src/preload/api/repository-api.ts
@@ -96,6 +96,12 @@ export type RepositoryApi = {
     name: string
     kind: 'git' | 'folder'
   }) => Promise<{ repo: Repo } | { error: string }>
+  // Why: error union matches the IPC handler's return shape; renderer callers branch on `'error' in result`.
+  convertToGit: (args: { path: string }) => Promise<{ repo: Repo } | { error: string }>
+  convertRemoteToGit: (args: {
+    connectionId: string
+    remotePath: string
+  }) => Promise<{ repo: Repo } | { error: string }>
   isGitAvailable: () => Promise<boolean>
   getDefaultCreateProjectParent: () => Promise<string>
   onCloneProgress: (callback: (data: { phase: string; percent: number }) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -659,6 +659,10 @@ const api = {
 
     create: (args) => ipcRenderer.invoke('repos:create', args),
 
+    convertToGit: (args) => ipcRenderer.invoke('repos:convertToGit', args),
+
+    convertRemoteToGit: (args) => ipcRenderer.invoke('repos:convertRemoteToGit', args),
+
     isGitAvailable: (): Promise<boolean> => ipcRenderer.invoke('repos:isGitAvailable'),
 
     getDefaultCreateProjectParent: (): Promise<string> =>

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
@@ -19,6 +19,7 @@ const mocks = vi.hoisted(() => ({
     } as Record<string, unknown>,
     closeModal: vi.fn(),
     addNonGitFolder: vi.fn(),
+    convertNonGitFolderToGit: vi.fn(),
     runtimeEnvironments: [{ id: 'env-1', name: 'Remote Mac' }],
     repos: [] as Repo[],
     projects: [],
@@ -128,6 +129,7 @@ describe('NonGitFolderDialog', () => {
     mocks.state.projectHostSetups = []
     mocks.state.worktreesByRepo = {}
     mocks.state.fetchWorktrees.mockResolvedValue(true)
+    mocks.state.convertNonGitFolderToGit.mockReset()
     mocks.onboardingGet.mockResolvedValue(null)
     vi.stubGlobal('window', {
       api: {
@@ -152,6 +154,48 @@ describe('NonGitFolderDialog', () => {
 
     expect(mocks.state.addNonGitFolder).toHaveBeenCalledWith('/srv/non-git', {
       runtimeEnvironmentId: 'env-1'
+    })
+    expect(mocks.state.closeModal).toHaveBeenCalled()
+  })
+
+  it('converts and reveals the project on the host captured by the dialog', async () => {
+    const repo: Repo = {
+      id: 'shared-repo',
+      path: '/srv/non-git',
+      displayName: 'Remote project',
+      badgeColor: '#111',
+      addedAt: 1,
+      kind: 'git',
+      executionHostId: 'runtime:env-1'
+    }
+    const runtimeWorktree = makeWorktree(
+      'shared-repo::/srv/non-git',
+      '/srv/non-git',
+      'runtime:env-1'
+    )
+    mocks.state.convertNonGitFolderToGit.mockResolvedValue(repo)
+    mocks.state.fetchWorktrees.mockImplementation(async () => {
+      mocks.state.worktreesByRepo = { [repo.id]: [runtimeWorktree] }
+      return true
+    })
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    const button = mocks.buttons.find((entry) => entry.label.includes('Convert to Git Repository'))
+    button?.onClick?.()
+
+    await vi.waitFor(() =>
+      expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(runtimeWorktree.id, {
+        sidebarRevealBehavior: 'auto',
+        executionHostId: 'runtime:env-1'
+      })
+    )
+    expect(mocks.state.convertNonGitFolderToGit).toHaveBeenCalledWith({
+      path: '/srv/non-git',
+      runtimeEnvironmentId: 'env-1'
+    })
+    expect(mocks.state.fetchWorktrees).toHaveBeenCalledWith(repo.id, {
+      requireAuthoritative: true,
+      executionHostId: 'runtime:env-1'
     })
     expect(mocks.state.closeModal).toHaveBeenCalled()
   })

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.test.tsx
@@ -200,6 +200,45 @@ describe('NonGitFolderDialog', () => {
     expect(mocks.state.closeModal).toHaveBeenCalled()
   })
 
+  it('converts and reveals a local folder on the local host', async () => {
+    const repo: Repo = {
+      id: 'shared-repo',
+      path: '/local/non-git',
+      displayName: 'Local project',
+      badgeColor: '#111',
+      addedAt: 1,
+      kind: 'git'
+    }
+    const localWorktree = makeWorktree('shared-repo::/local/non-git', '/local/non-git', 'local')
+    mocks.state.modalData = { folderPath: '/local/non-git' }
+    mocks.state.runtimeEnvironments = []
+    mocks.state.convertNonGitFolderToGit.mockResolvedValue(repo)
+    mocks.state.fetchWorktrees.mockImplementation(async () => {
+      mocks.state.worktreesByRepo = { [repo.id]: [localWorktree] }
+      return true
+    })
+    renderToStaticMarkup(<NonGitFolderDialog />)
+
+    const button = mocks.buttons.find((entry) => entry.label.includes('Convert to Git Repository'))
+    button?.onClick?.()
+
+    await vi.waitFor(() =>
+      expect(mocks.activateAndRevealWorktree).toHaveBeenCalledWith(localWorktree.id, {
+        sidebarRevealBehavior: 'auto',
+        executionHostId: 'local'
+      })
+    )
+    expect(mocks.state.convertNonGitFolderToGit).toHaveBeenCalledWith({
+      path: '/local/non-git',
+      runtimeEnvironmentId: null
+    })
+    expect(mocks.state.fetchWorktrees).toHaveBeenCalledWith(repo.id, {
+      requireAuthoritative: true,
+      executionHostId: 'local'
+    })
+    expect(mocks.state.closeModal).toHaveBeenCalled()
+  })
+
   it('activates only the selected SSH folder when repo IDs collide', async () => {
     const repo: Repo = {
       id: 'shared-repo',

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -129,16 +129,32 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
       try {
         const repo = await convertNonGitFolderToGit({
           path: folderPath,
-          ...(connectionId ? { connectionId } : {})
+          ...(connectionId ? { connectionId } : {}),
+          runtimeEnvironmentId: runtimeEnvironmentId || null
         })
         if (repo) {
+          const ownerOptions = worktreeRefreshOptions(runtimeEnvironmentId || null, connectionId)
+          await useAppStore.getState().fetchWorktrees(repo.id, ownerOptions)
+          const mainWorktree = useAppStore
+            .getState()
+            .worktreesByRepo[repo.id]?.find(
+              (worktree) => worktree.hostId === ownerOptions.executionHostId
+            )
+          if (mainWorktree) {
+            // Why: conversion should visibly replace the folder workflow without
+            // requiring a remove/re-import cycle or a manual sidebar refresh.
+            activateAndRevealWorktree(mainWorktree.id, {
+              sidebarRevealBehavior: 'auto',
+              executionHostId: ownerOptions.executionHostId
+            })
+          }
           closeModal()
         }
       } finally {
         setIsConverting(false)
       }
     })()
-  }, [convertNonGitFolderToGit, closeModal, folderPath, connectionId])
+  }, [convertNonGitFolderToGit, closeModal, folderPath, connectionId, runtimeEnvironmentId])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {
@@ -153,7 +169,7 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-md sm:max-w-md">
+      <DialogContent className="max-w-md">
         <DialogHeader>
           <DialogTitle className="text-sm">
             {translate(
@@ -164,7 +180,7 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
           <DialogDescription className="text-xs">
             {translate(
               'auto.components.sidebar.NonGitFolderDialog.1d9e5c8007',
-              'Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.'
+              'Convert it to a Git repository to use worktrees, source control, and code reviews. Or open it as a plain folder with just the editor, terminal, and search.'
             )}
             <span className="mt-2 block">{checkedHostDescription}</span>
           </DialogDescription>
@@ -179,7 +195,7 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
         <p className="text-xs text-muted-foreground">
           {translate(
             'auto.components.sidebar.NonGitFolderDialog.2bef0e9e6d',
-            "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
+            "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your existing files aren't changed."
           )}
         </p>
 

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -1,4 +1,5 @@
-import React, { useCallback } from 'react'
+import React, { useCallback, useState } from 'react'
+import { Loader2 } from 'lucide-react'
 import { toast } from 'sonner'
 import {
   Dialog,
@@ -24,6 +25,8 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
   const closeModal = useAppStore((s) => s.closeModal)
   const addNonGitFolder = useAppStore((s) => s.addNonGitFolder)
   const runtimeEnvironments = useAppStore((s) => s.runtimeEnvironments)
+  const convertNonGitFolderToGit = useAppStore((s) => s.convertNonGitFolderToGit)
+  const [isConverting, setIsConverting] = useState(false)
 
   const isOpen = activeModal === 'confirm-non-git-folder'
   const folderPath = typeof modalData.folderPath === 'string' ? modalData.folderPath : ''
@@ -117,26 +120,51 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
     closeModal()
   }, [addNonGitFolder, closeModal, folderPath, connectionId, runtimeEnvironmentId])
 
+  const handleConvert = useCallback(() => {
+    if (!folderPath) {
+      return
+    }
+    setIsConverting(true)
+    void (async () => {
+      try {
+        const repo = await convertNonGitFolderToGit({
+          path: folderPath,
+          ...(connectionId ? { connectionId } : {})
+        })
+        if (repo) {
+          closeModal()
+        }
+      } finally {
+        setIsConverting(false)
+      }
+    })()
+  }, [convertNonGitFolderToGit, closeModal, folderPath, connectionId])
+
   const handleOpenChange = useCallback(
     (open: boolean) => {
-      if (!open) {
+      // Don't let the dialog be dismissed mid-conversion — git is mutating the
+      // folder and a half-closed UI would hide the outcome.
+      if (!open && !isConverting) {
         closeModal()
       }
     },
-    [closeModal]
+    [closeModal, isConverting]
   )
 
   return (
     <Dialog open={isOpen} onOpenChange={handleOpenChange}>
-      <DialogContent className="max-w-sm sm:max-w-sm" showCloseButton={false}>
+      <DialogContent className="max-w-md sm:max-w-md">
         <DialogHeader>
           <DialogTitle className="text-sm">
-            {translate('auto.components.sidebar.NonGitFolderDialog.e52454b7f6', 'Open as Folder')}
+            {translate(
+              'auto.components.sidebar.NonGitFolderDialog.15b3ae7310',
+              "This folder isn't a Git repository"
+            )}
           </DialogTitle>
           <DialogDescription className="text-xs">
             {translate(
-              'auto.components.sidebar.NonGitFolderDialog.8fba4b8cbb',
-              "This folder isn't a Git repository. You'll have the editor, terminal, and search, but Git-based features won't be available."
+              'auto.components.sidebar.NonGitFolderDialog.1d9e5c8007',
+              'Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.'
             )}
             <span className="mt-2 block">{checkedHostDescription}</span>
           </DialogDescription>
@@ -148,12 +176,23 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
           </div>
         )}
 
+        <p className="text-xs text-muted-foreground">
+          {translate(
+            'auto.components.sidebar.NonGitFolderDialog.d885e6adbe',
+            "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed."
+          )}
+        </p>
+
         <DialogFooter>
-          <Button variant="outline" onClick={() => handleOpenChange(false)}>
-            {translate('auto.components.sidebar.NonGitFolderDialog.05b33a17a9', 'Cancel')}
-          </Button>
-          <Button onClick={handleConfirm}>
+          <Button variant="outline" onClick={handleConfirm} disabled={isConverting}>
             {translate('auto.components.sidebar.NonGitFolderDialog.e52454b7f6', 'Open as Folder')}
+          </Button>
+          <Button onClick={handleConvert} disabled={isConverting}>
+            {isConverting && <Loader2 className="size-4 animate-spin" />}
+            {translate(
+              'auto.components.sidebar.NonGitFolderDialog.eb079b3809',
+              'Convert to Git Repository'
+            )}
           </Button>
         </DialogFooter>
       </DialogContent>

--- a/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/NonGitFolderDialog.tsx
@@ -178,8 +178,8 @@ const NonGitFolderDialog = React.memo(function NonGitFolderDialog() {
 
         <p className="text-xs text-muted-foreground">
           {translate(
-            'auto.components.sidebar.NonGitFolderDialog.d885e6adbe',
-            "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed."
+            'auto.components.sidebar.NonGitFolderDialog.2bef0e9e6d',
+            "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
           )}
         </p>
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4362,8 +4362,8 @@
           "8851b77327": "This path was checked locally.",
           "eb079b3809": "Convert to Git Repository",
           "15b3ae7310": "This folder isn't a Git repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
-          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and code reviews. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your existing files aren't changed."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Run hooks",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -348,7 +348,9 @@
           "15cf5319ec": "{{path}} was checked on {{hostName}}, but that host did not report a usable folder.",
           "2dcd706774": "Project also exists in another profile",
           "presenceProfileOverflow": "{{names}} +{{count}} more",
-          "removeProjectFailed": "Failed to remove project"
+          "removeProjectFailed": "Failed to remove project",
+          "24424c2102": "Converted to a Git repository",
+          "e6c1e9dba0": "Failed to convert folder to a Git repository"
         },
         "settings": {
           "e12dab333b": "Failed to switch servers",
@@ -4357,7 +4359,11 @@
           "c49fb13492": "Failed to add folder on this host",
           "9a766f33ac": "This path was checked on the SSH host.",
           "79fd02cf5f": "This path was checked on {{hostName}}.",
-          "8851b77327": "This path was checked locally."
+          "8851b77327": "This path was checked locally.",
+          "eb079b3809": "Convert to Git Repository",
+          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
+          "15b3ae7310": "This folder isn't a Git repository",
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Run hooks",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -4361,9 +4361,9 @@
           "79fd02cf5f": "This path was checked on {{hostName}}.",
           "8851b77327": "This path was checked locally.",
           "eb079b3809": "Convert to Git Repository",
-          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
           "15b3ae7310": "This folder isn't a Git repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Run hooks",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4147,9 +4147,9 @@
           "79fd02cf5f": "Esta ruta se verificó en {{hostName}}.",
           "8851b77327": "Esta ruta se verificó localmente.",
           "15b3ae7310": "This folder isn't a Git repository",
-          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Ejecutar hooks",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -4148,8 +4148,8 @@
           "8851b77327": "Esta ruta se verificó localmente.",
           "15b3ae7310": "This folder isn't a Git repository",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
-          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and code reviews. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your existing files aren't changed."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Ejecutar hooks",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -276,7 +276,9 @@
           "3be0f7df04": "No se puede abrir la carpeta en el host seleccionado",
           "15cf5319ec": "{{path}} se verificó en {{hostName}}, pero ese host no reportó ninguna carpeta utilizable.",
           "2dcd706774": "El proyecto también existe en otro perfil",
-          "presenceProfileOverflow": "{{names}} +{{count}} más"
+          "presenceProfileOverflow": "{{names}} +{{count}} más",
+          "24424c2102": "Converted to a Git repository",
+          "e6c1e9dba0": "Failed to convert folder to a Git repository"
         },
         "settings": {
           "e12dab333b": "No se pudo cambiar de servidor",
@@ -4143,7 +4145,11 @@
           "c49fb13492": "No se pudo agregar la carpeta en este host",
           "9a766f33ac": "Esta ruta se verificó en el host SSH.",
           "79fd02cf5f": "Esta ruta se verificó en {{hostName}}.",
-          "8851b77327": "Esta ruta se verificó localmente."
+          "8851b77327": "Esta ruta se verificó localmente.",
+          "15b3ae7310": "This folder isn't a Git repository",
+          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
+          "eb079b3809": "Convert to Git Repository",
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "Ejecutar hooks",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4129,8 +4129,8 @@
           "8851b77327": "このパスはローカルでチェックされました。",
           "15b3ae7310": "This folder isn't a Git repository",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
-          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and code reviews. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your existing files aren't changed."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "フックを実行する",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -4128,9 +4128,9 @@
           "79fd02cf5f": "このパスは {{hostName}} でチェックされました。",
           "8851b77327": "このパスはローカルでチェックされました。",
           "15b3ae7310": "This folder isn't a Git repository",
-          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "フックを実行する",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -276,7 +276,9 @@
           "3be0f7df04": "選択したランタイムでフォルダーを開けません",
           "15cf5319ec": "{{path}} は {{hostName}} でチェックされましたが、そのホストは使用可能なフォルダーを報告しませんでした。",
           "2dcd706774": "プロジェクトは別のプロファイルにも存在します",
-          "presenceProfileOverflow": "{{names}} 他 {{count}} 件"
+          "presenceProfileOverflow": "{{names}} 他 {{count}} 件",
+          "24424c2102": "Converted to a Git repository",
+          "e6c1e9dba0": "Failed to convert folder to a Git repository"
         },
         "settings": {
           "e12dab333b": "サーバーの切り替えに失敗しました",
@@ -4124,7 +4126,11 @@
           "c49fb13492": "このホスト上でのフォルダーの追加に失敗しました",
           "9a766f33ac": "このパスは SSH ホストでチェックされました。",
           "79fd02cf5f": "このパスは {{hostName}} でチェックされました。",
-          "8851b77327": "このパスはローカルでチェックされました。"
+          "8851b77327": "このパスはローカルでチェックされました。",
+          "15b3ae7310": "This folder isn't a Git repository",
+          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
+          "eb079b3809": "Convert to Git Repository",
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "フックを実行する",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4129,8 +4129,8 @@
           "8851b77327": "이 경로는 로컬에서 확인되었습니다.",
           "15b3ae7310": "This folder isn't a Git repository",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
-          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and code reviews. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your existing files aren't changed."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "후크 실행",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -4128,9 +4128,9 @@
           "79fd02cf5f": "이 경로는 {{hostName}}에서 확인되었습니다.",
           "8851b77327": "이 경로는 로컬에서 확인되었습니다.",
           "15b3ae7310": "This folder isn't a Git repository",
-          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "후크 실행",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -276,7 +276,9 @@
           "3be0f7df04": "선택한 런타임에서 폴더를 열 수 없습니다.",
           "15cf5319ec": "{{path}}이(가) {{hostName}}에서 확인되었지만 해당 호스트가 사용 가능한 폴더를 보고하지 않았습니다.",
           "2dcd706774": "프로젝트가 다른 프로필에도 있습니다",
-          "presenceProfileOverflow": "{{names}} 외 {{count}}개"
+          "presenceProfileOverflow": "{{names}} 외 {{count}}개",
+          "24424c2102": "Converted to a Git repository",
+          "e6c1e9dba0": "Failed to convert folder to a Git repository"
         },
         "settings": {
           "e12dab333b": "서버를 전환하지 못했습니다.",
@@ -4124,7 +4126,11 @@
           "c49fb13492": "이 호스트에 폴더를 추가하지 못했습니다.",
           "9a766f33ac": "이 경로는 SSH 호스트에서 확인되었습니다.",
           "79fd02cf5f": "이 경로는 {{hostName}}에서 확인되었습니다.",
-          "8851b77327": "이 경로는 로컬에서 확인되었습니다."
+          "8851b77327": "이 경로는 로컬에서 확인되었습니다.",
+          "15b3ae7310": "This folder isn't a Git repository",
+          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
+          "eb079b3809": "Convert to Git Repository",
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "후크 실행",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4141,8 +4141,8 @@
           "8851b77327": "已在本机检查此路径。",
           "15b3ae7310": "This folder isn't a Git repository",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
-          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and code reviews. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your existing files aren't changed."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "运行钩子",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -276,7 +276,9 @@
           "3be0f7df04": "无法在所选运行时打开文件夹",
           "15cf5319ec": "已在 {{hostName}} 上检查 {{path}}，但该主机未报告可用文件夹。",
           "2dcd706774": "该项目也存在于另一个配置文件中",
-          "presenceProfileOverflow": "{{names}} 及另外 {{count}} 个"
+          "presenceProfileOverflow": "{{names}} 及另外 {{count}} 个",
+          "24424c2102": "Converted to a Git repository",
+          "e6c1e9dba0": "Failed to convert folder to a Git repository"
         },
         "settings": {
           "e12dab333b": "切换服务器失败",
@@ -4136,7 +4138,11 @@
           "c49fb13492": "添加远程文件夹失败",
           "9a766f33ac": "已在 SSH 主机上检查此路径。",
           "79fd02cf5f": "已在 {{hostName}} 上检查此路径。",
-          "8851b77327": "已在本机检查此路径。"
+          "8851b77327": "已在本机检查此路径。",
+          "15b3ae7310": "This folder isn't a Git repository",
+          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
+          "eb079b3809": "Convert to Git Repository",
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "运行钩子",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -4140,9 +4140,9 @@
           "79fd02cf5f": "已在 {{hostName}} 上检查此路径。",
           "8851b77327": "已在本机检查此路径。",
           "15b3ae7310": "This folder isn't a Git repository",
-          "d885e6adbe": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. Your files aren't changed.",
           "eb079b3809": "Convert to Git Repository",
-          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search."
+          "1d9e5c8007": "Convert it to a Git repository to use worktrees, source control, and pull requests. Or open it as a plain folder with just the editor, terminal, and search.",
+          "2bef0e9e6d": "Converting runs git init, adds a .gitignore if one is missing, and makes an initial commit. It won't edit your existing files."
         },
         "OrcaYamlTrustDialog": {
           "f3e2b868fb": "运行钩子",

--- a/src/renderer/src/store/slices/repos-convert-non-git-routing.test.ts
+++ b/src/renderer/src/store/slices/repos-convert-non-git-routing.test.ts
@@ -1,0 +1,127 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+import {
+  createCompatibleRuntimeStatusResponseIfNeeded,
+  type RuntimeEnvironmentCallRequest
+} from '../../runtime/runtime-compatibility-test-fixture'
+import { clearRuntimeCompatibilityCacheForTests } from '../../runtime/runtime-rpc-client'
+import { createTestStore } from './store-test-helpers'
+
+const runtimeEnvironmentTransportCall = vi.fn()
+const convertRemoteToGit = vi.fn()
+
+function runtimeRepo(id: string, path: string): Repo {
+  return {
+    id,
+    path,
+    displayName: 'Converted',
+    badgeColor: '#111',
+    addedAt: 1,
+    kind: 'git'
+  }
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  runtimeEnvironmentTransportCall.mockReset()
+  convertRemoteToGit.mockReset()
+  vi.stubGlobal('window', {
+    api: {
+      repos: { convertRemoteToGit },
+      runtimeEnvironments: { call: runtimeEnvironmentTransportCall }
+    }
+  })
+})
+
+describe('non-Git folder conversion routing', () => {
+  it('stays on the runtime that inspected the folder after focus changes', async () => {
+    const converted = runtimeRepo('repo-1', '/srv/non-git')
+    runtimeEnvironmentTransportCall.mockImplementation(
+      (request: RuntimeEnvironmentCallRequest & { selector?: string; params?: unknown }) => {
+        const status = createCompatibleRuntimeStatusResponseIfNeeded(
+          request,
+          `runtime-${request.selector}`
+        )
+        if (status) {
+          return status
+        }
+        if (request.method === 'repo.convertToGit') {
+          return {
+            id: 'convert',
+            ok: true,
+            result: { repo: converted },
+            _meta: { runtimeId: `runtime-${request.selector}` }
+          }
+        }
+        throw new Error(`Unexpected runtime method ${request.method}`)
+      }
+    )
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-2' } as never
+    })
+
+    await expect(
+      store.getState().convertNonGitFolderToGit({
+        path: '/srv/non-git',
+        runtimeEnvironmentId: 'env-1'
+      })
+    ).resolves.toEqual({ ...converted, executionHostId: 'runtime:env-1' })
+
+    expect(runtimeEnvironmentTransportCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'env-1',
+        method: 'repo.convertToGit',
+        params: { path: '/srv/non-git' },
+        timeoutMs: 60_000
+      })
+    )
+    expect(runtimeEnvironmentTransportCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({
+        selector: 'env-2',
+        method: 'repo.convertToGit'
+      })
+    )
+  })
+
+  it('upserts only the selected SSH host when repo IDs collide', async () => {
+    const localRepo: Repo = {
+      ...runtimeRepo('shared-repo', '/local/non-git'),
+      displayName: 'Local project',
+      executionHostId: 'local'
+    }
+    const sshFolder: Repo = {
+      ...runtimeRepo('shared-repo', '/srv/non-git'),
+      displayName: 'SSH folder',
+      kind: 'folder',
+      connectionId: 'ssh-1',
+      executionHostId: 'ssh:ssh-1'
+    }
+    const convertedSsh: Repo = {
+      ...sshFolder,
+      displayName: 'SSH project',
+      kind: 'git'
+    }
+    convertRemoteToGit.mockResolvedValue({ repo: convertedSsh })
+    const store = createTestStore()
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-2' } as never,
+      repos: [localRepo, sshFolder]
+    })
+
+    await expect(
+      store.getState().convertNonGitFolderToGit({
+        path: '/srv/non-git',
+        connectionId: 'ssh-1',
+        runtimeEnvironmentId: null
+      })
+    ).resolves.toEqual(convertedSsh)
+
+    expect(convertRemoteToGit).toHaveBeenCalledWith({
+      connectionId: 'ssh-1',
+      remotePath: '/srv/non-git'
+    })
+    expect(runtimeEnvironmentTransportCall).not.toHaveBeenCalled()
+    expect(store.getState().repos).toEqual([localRepo, convertedSsh])
+  })
+})

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1836,7 +1836,11 @@ export type RepoSlice = {
   ) => Promise<ProjectHostSetupDeleteResult | null>
   setupProjectClone: (args: ProjectHostSetupCloneArgs) => Promise<ProjectHostSetupResult | null>
   addNonGitFolder: (path: string, options?: AddRepoPathRouteOptions) => Promise<Repo | null>
-  convertNonGitFolderToGit: (args: { path: string; connectionId?: string }) => Promise<Repo | null>
+  convertNonGitFolderToGit: (args: {
+    path: string
+    connectionId?: string
+    runtimeEnvironmentId?: string | null
+  }) => Promise<Repo | null>
   scanNestedRepos: (
     path: string,
     connectionId?: string,
@@ -3592,9 +3596,16 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     }
   },
 
-  convertNonGitFolderToGit: async ({ path, connectionId }) => {
+  convertNonGitFolderToGit: async ({ path, connectionId, runtimeEnvironmentId }) => {
     try {
-      const target = getActiveRuntimeTarget(get().settings)
+      // Why: the active host can change while the confirmation dialog is open;
+      // conversion must stay on the host that inspected the folder.
+      const target = getActiveRuntimeTarget(
+        getAddRepoPathRouteSettings(
+          runtimeEnvironmentId === undefined ? undefined : { runtimeEnvironmentId },
+          get().settings
+        )
+      )
       let repo: Repo
       if (connectionId) {
         // SSH folder: convert on the host via the connection's providers.
@@ -3625,16 +3636,25 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         }
         repo = result.repo
       }
-      repo = repoWithFetchedOwner(repo, target)
+      repo = connectionId
+        ? { ...repo, executionHostId: toSshExecutionHostId(connectionId) }
+        : repoWithFetchedOwner(repo, target)
+      const repoHostId = getRepoExecutionHostId(repo)
       set((s) => {
-        // Upsert: replace an existing entry in place so converting a path that
-        // was already known as a folder doesn't leave stale folder metadata.
-        const nextRepos = s.repos.some((r) => r.id === repo.id)
-          ? s.repos.map((r) => (r.id === repo.id ? repo : r))
+        const nextRepos = s.repos.some((entry) =>
+          repoMatchesHostIdentity(entry, repo.id, repoHostId)
+        )
+          ? s.repos.map((entry) =>
+              repoMatchesHostIdentity(entry, repo.id, repoHostId) ? repo : entry
+            )
           : [...s.repos, repo]
         return {
           repos: nextRepos,
-          ...projectCompatibilityFromRepos(nextRepos),
+          ...mergeProjectCompatibilityForHostRepoChange({
+            previous: { projects: s.projects, projectHostSetups: s.projectHostSetups },
+            nextRepos,
+            hostId: repoHostId
+          }),
           folderWorkspacePathStatuses: {}
         }
       })

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -3627,10 +3627,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
       }
       repo = repoWithFetchedOwner(repo, target)
       set((s) => {
-        if (s.repos.some((r) => r.id === repo.id)) {
-          return s
-        }
-        const nextRepos = [...s.repos, repo]
+        // Upsert: replace an existing entry in place so converting a path that
+        // was already known as a folder doesn't leave stale folder metadata.
+        const nextRepos = s.repos.some((r) => r.id === repo.id)
+          ? s.repos.map((r) => (r.id === repo.id ? repo : r))
+          : [...s.repos, repo]
         return {
           repos: nextRepos,
           ...projectCompatibilityFromRepos(nextRepos),

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -1836,6 +1836,7 @@ export type RepoSlice = {
   ) => Promise<ProjectHostSetupDeleteResult | null>
   setupProjectClone: (args: ProjectHostSetupCloneArgs) => Promise<ProjectHostSetupResult | null>
   addNonGitFolder: (path: string, options?: AddRepoPathRouteOptions) => Promise<Repo | null>
+  convertNonGitFolderToGit: (args: { path: string; connectionId?: string }) => Promise<Repo | null>
   scanNestedRepos: (
     path: string,
     connectionId?: string,
@@ -3587,6 +3588,76 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
         description: message,
         duration: ERROR_TOAST_DURATION
       })
+      return null
+    }
+  },
+
+  convertNonGitFolderToGit: async ({ path, connectionId }) => {
+    try {
+      const target = getActiveRuntimeTarget(get().settings)
+      let repo: Repo
+      if (connectionId) {
+        // SSH folder: convert on the host via the connection's providers.
+        const result = await window.api.repos.convertRemoteToGit({
+          connectionId,
+          remotePath: path
+        })
+        if ('error' in result) {
+          throw new Error(result.error)
+        }
+        repo = result.repo
+      } else if (target.kind === 'environment') {
+        // Non-local runtime target: the folder lives on the runtime host.
+        const result = await callRuntimeRpc<{ repo: Repo } | { error: string }>(
+          target,
+          'repo.convertToGit',
+          { path },
+          { timeoutMs: 60_000 }
+        )
+        if ('error' in result) {
+          throw new Error(result.error)
+        }
+        repo = result.repo
+      } else {
+        const result = await window.api.repos.convertToGit({ path })
+        if ('error' in result) {
+          throw new Error(result.error)
+        }
+        repo = result.repo
+      }
+      repo = repoWithFetchedOwner(repo, target)
+      set((s) => {
+        if (s.repos.some((r) => r.id === repo.id)) {
+          return s
+        }
+        const nextRepos = [...s.repos, repo]
+        return {
+          repos: nextRepos,
+          ...projectCompatibilityFromRepos(nextRepos),
+          folderWorkspacePathStatuses: {}
+        }
+      })
+      await markOnboardingProjectAdded('addedRepo')
+      toast.success(
+        translate('auto.store.slices.repos.24424c2102', 'Converted to a Git repository'),
+        {
+          description: repo.displayName
+        }
+      )
+      return repo
+    } catch (err) {
+      console.error('Failed to convert folder to git:', err)
+      const message = err instanceof Error ? err.message : String(err)
+      toast.error(
+        translate(
+          'auto.store.slices.repos.e6c1e9dba0',
+          'Failed to convert folder to a Git repository'
+        ),
+        {
+          description: message,
+          duration: ERROR_TOAST_DURATION
+        }
+      )
       return null
     }
   },

--- a/src/renderer/src/web/web-preload-api-workspace-catalog.test.ts
+++ b/src/renderer/src/web/web-preload-api-workspace-catalog.test.ts
@@ -83,6 +83,57 @@ describe('web repos preload API', () => {
     ])
   })
 
+  it('attributes converted repos to the paired runtime and allows the longer conversion timeout', async () => {
+    const runtimeCalls: { method: string; params: unknown; options: unknown }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(
+          method: string,
+          params?: unknown,
+          options?: unknown
+        ): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params, options })
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: {
+              repo: {
+                id: 'repo-1',
+                path: '/srv/non-git',
+                displayName: 'non-git',
+                badgeColor: '#000',
+                addedAt: 1,
+                kind: 'git',
+                executionHostId: 'local'
+              }
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      globals.window.api.repos.convertToGit({ path: '/srv/non-git' })
+    ).resolves.toMatchObject({
+      repo: { id: 'repo-1', executionHostId: 'runtime:web-server-a' }
+    })
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'repo.convertToGit',
+        params: { path: '/srv/non-git' },
+        options: { timeoutMs: 60_000 }
+      }
+    ])
+  })
+
   it('does not reassign an in-flight catalog when the browser pairs to another server', async () => {
     let resolveCatalog!: (response: RuntimeRpcResponse<unknown>) => void
     const pendingCatalog = new Promise<RuntimeRpcResponse<unknown>>((resolve) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1756,7 +1756,12 @@ function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
     },
     convertToGit: async ({ path }) => {
       invalidateRuntimeWorktreeCaches()
-      return callRuntimeResult('repo.convertToGit', { path })
+      const owned = await callRuntimeResultWithOwner<{ repo: Repo } | { error: string }>(
+        'repo.convertToGit',
+        { path },
+        60_000
+      )
+      return withRuntimeRepoMutationOwner(owned.result, owned.hostId)
     },
     convertRemoteToGit: async () => {
       // Why: SSH relay conversion is owned by the desktop main process; paired

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1754,6 +1754,15 @@ function createReposApi(): NonNullable<Partial<PreloadApi>['repos']> {
       )
       return withRuntimeRepoMutationOwner(owned.result, owned.hostId)
     },
+    convertToGit: async ({ path }) => {
+      invalidateRuntimeWorktreeCaches()
+      return callRuntimeResult('repo.convertToGit', { path })
+    },
+    convertRemoteToGit: async () => {
+      // Why: SSH relay conversion is owned by the desktop main process; paired
+      // web clients cannot run that local SSH IPC path.
+      throw new Error('Converting SSH-host folders is unavailable in paired web clients.')
+    },
     isGitAvailable: async () =>
       (await callRuntimeResult<{ available: boolean }>('repo.gitAvailable')).available,
     getDefaultCreateProjectParent: async () => {

--- a/tests/e2e/convert-non-git-folder.spec.ts
+++ b/tests/e2e/convert-non-git-folder.spec.ts
@@ -1,0 +1,110 @@
+import { execFileSync } from 'child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
+import os from 'os'
+import path from 'path'
+import { test, expect } from './helpers/orca-app'
+import { waitForSessionReady } from './helpers/store'
+
+// Why: the conversion commits via the app's main process, which reads the host
+// git identity. CI hosts may have none configured, so pin one through the
+// launch env (the fixture forwards launchEnv to the Electron process).
+test.use({
+  launchEnv: {
+    GIT_AUTHOR_NAME: 'E2E Convert',
+    GIT_AUTHOR_EMAIL: 'e2e-convert@test.local',
+    GIT_COMMITTER_NAME: 'E2E Convert',
+    GIT_COMMITTER_EMAIL: 'e2e-convert@test.local'
+  }
+})
+
+const tempRoots: string[] = []
+
+function git(cwd: string, args: string[]): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+}
+
+function createNonGitFolderFixture(): string {
+  const rootPath = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-convert-'))
+  tempRoots.push(rootPath)
+  const folderPath = path.join(rootPath, 'legacy-project')
+  mkdirSync(folderPath, { recursive: true })
+  writeFileSync(path.join(folderPath, 'index.js'), 'console.log("hello")\n')
+  // A secret that must NOT land in history once a .gitignore is generated.
+  writeFileSync(path.join(folderPath, '.env'), 'SECRET=do-not-commit\n')
+  return folderPath
+}
+
+test.afterEach(() => {
+  for (const root of tempRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+test.describe('Convert non-git folder to a Git repository', () => {
+  test('offers Convert in the dialog and turns the folder into a full git project', async ({
+    orcaPage
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    const folderPath = createNonGitFolderFixture()
+    expect(existsSync(path.join(folderPath, '.git'))).toBe(false)
+
+    // Open the non-git dialog directly (the OS folder picker can't be driven in
+    // E2E); this is the same modal the failed add-as-git flow opens.
+    await orcaPage.evaluate((p) => {
+      window.__store?.getState().openModal('confirm-non-git-folder', { folderPath: p })
+    }, folderPath)
+
+    const dialog = orcaPage.getByRole('dialog', { name: /This folder isn.t a Git repository/i })
+    await expect(dialog).toBeVisible()
+
+    // Both actions are present (dismiss is the dialog's top-right close button).
+    await expect(dialog.getByRole('button', { name: 'Open as Folder' })).toBeVisible()
+    const convertButton = dialog.getByRole('button', { name: 'Convert to Git Repository' })
+    await expect(convertButton).toBeVisible()
+
+    await orcaPage.screenshot({ path: path.join(testInfo.outputDir, 'convert-dialog.png') })
+    await testInfo.attach('convert-dialog', {
+      path: path.join(testInfo.outputDir, 'convert-dialog.png'),
+      contentType: 'image/png'
+    })
+
+    await convertButton.click()
+
+    // The dialog closes and the folder is registered as a git project.
+    await expect(dialog).toBeHidden({ timeout: 30_000 })
+    await expect
+      .poll(
+        () =>
+          orcaPage.evaluate((p) => {
+            const repo = window.__store?.getState().repos.find((r) => r.path === p)
+            return repo ? (repo.kind ?? 'git') : null
+          }, folderPath),
+        { timeout: 30_000, message: 'converted folder did not register as a git project' }
+      )
+      .toBe('git')
+
+    await orcaPage.screenshot({ path: path.join(testInfo.outputDir, 'after-convert.png') })
+    await testInfo.attach('after-convert', {
+      path: path.join(testInfo.outputDir, 'after-convert.png'),
+      contentType: 'image/png'
+    })
+
+    // Filesystem truth: real repo, .gitignore written, secret excluded, and a
+    // base commit exists so a worktree can be created (the unborn-HEAD bug).
+    expect(existsSync(path.join(folderPath, '.git'))).toBe(true)
+    expect(existsSync(path.join(folderPath, '.gitignore'))).toBe(true)
+
+    const tracked = git(folderPath, ['ls-files']).split('\n').filter(Boolean)
+    expect(tracked).toContain('index.js')
+    expect(tracked).toContain('.gitignore')
+    expect(tracked).not.toContain('.env')
+
+    expect(() => git(folderPath, ['rev-parse', '--verify', 'HEAD^{commit}'])).not.toThrow()
+
+    const worktreePath = path.join(folderPath, '..', 'wt-feature')
+    expect(() =>
+      git(folderPath, ['worktree', 'add', '--no-track', '-b', 'feature', worktreePath, 'HEAD'])
+    ).not.toThrow()
+    expect(existsSync(path.join(worktreePath, 'index.js'))).toBe(true)
+  })
+})

--- a/tests/e2e/convert-non-git-folder.spec.ts
+++ b/tests/e2e/convert-non-git-folder.spec.ts
@@ -1,7 +1,7 @@
-import { execFileSync } from 'child_process'
-import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'fs'
-import os from 'os'
-import path from 'path'
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import { waitForSessionReady } from './helpers/store'
 
@@ -77,18 +77,15 @@ test.describe('Convert non-git folder to a Git repository', () => {
 
     await convertButton.click()
 
-    // The dialog closes and the folder is registered as a git project.
+    // The dialog closes and the converted project becomes visible in the
+    // sidebar, proving the user no longer needs to remove and re-import it.
     await expect(dialog).toBeHidden({ timeout: 30_000 })
-    await expect
-      .poll(
-        () =>
-          orcaPage.evaluate((p) => {
-            const repo = window.__store?.getState().repos.find((r) => r.path === p)
-            return repo ? (repo.kind ?? 'git') : null
-          }, folderPath),
-        { timeout: 30_000, message: 'converted folder did not register as a git project' }
-      )
-      .toBe('git')
+    await expect(
+      orcaPage
+        .locator('[data-worktree-sidebar]')
+        .getByText('legacy-project', { exact: true })
+        .first()
+    ).toBeVisible({ timeout: 30_000 })
 
     await orcaPage.screenshot({ path: path.join(testInfo.outputDir, 'after-convert.png') })
     await testInfo.attach('after-convert', {

--- a/tests/e2e/convert-non-git-folder.spec.ts
+++ b/tests/e2e/convert-non-git-folder.spec.ts
@@ -20,7 +20,14 @@ test.use({
 const tempRoots: string[] = []
 
 function git(cwd: string, args: string[]): string {
-  return execFileSync('git', args, { cwd, encoding: 'utf-8', stdio: ['pipe', 'pipe', 'pipe'] })
+  // Why: a host-level git lock/prompt could otherwise block a worker forever;
+  // fail fast so CI stays predictable.
+  return execFileSync('git', args, {
+    cwd,
+    encoding: 'utf-8',
+    stdio: ['pipe', 'pipe', 'pipe'],
+    timeout: 30_000
+  })
 }
 
 function createNonGitFolderFixture(): string {


### PR DESCRIPTION
## ELI5

If you add a plain folder to Orca that isn't a Git repository, worktrees don't work — today you'd have to remove it, run Git commands yourself, and import it again. This adds a **Convert to Git Repository** button on the dialog you already see for such folders. One click: Orca sets up Git inside the folder, adds a starter ignore file so secrets like `.env` stay out of history, takes an initial snapshot of your files, and the project becomes fully worktree-ready right where it sits in the sidebar. Works for local folders and folders on remote (SSH) machines. If your Git name/email isn't set up yet, nothing is changed and you're shown exactly what to run.

## Summary

- Add a **Convert to Git Repository** action to the existing non-Git folder dialog.
- Initialize the folder, create a conservative `.gitignore` when needed, stage the files, and create an initial commit so Orca worktrees work immediately.
- Upgrade the existing folder record in place and reveal the converted project in the sidebar, eliminating the remove-and-reimport workaround.
- Support local folders, direct SSH hosts, and runtime environments while keeping the action pinned to the host that originally checked the path.

Supersedes #6171 and fixes #3839.

## Screenshots

The updated dialog and post-conversion sidebar state are exercised by the Electron E2E test, which captures both states as test artifacts. No evidence images are committed to the repository.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Additional validation:

- `pnpm exec vitest run --config config/vitest.config.ts ... --maxWorkers=1` — 128 focused tests passed.
- `pnpm run test:e2e -- tests/e2e/convert-non-git-folder.spec.ts --workers=1` — passed; this also built Electron with `--mode e2e` and built the bundled CLI.
- Full `pnpm test` — 47,074 passed and 5 unrelated local-harness tests failed:
  - 2 relay command-environment tests conflict with executor-injected `GIT_CONFIG_*` variables; both pass when those variables are unset.
  - 3 root-directory guard tests invoke a script that uses Bash 4 associative arrays through macOS Bash 3.2.

## AI Review Report

Reviewed the conversion flow end to end across renderer state, Electron IPC, runtime RPC, local Git execution, SSH providers, persistence, and worktree activation.

The review flagged and fixed:

- host-routing drift if the active runtime changes while the dialog is open;
- repo-ID collisions across local, SSH, and runtime hosts;
- stale `kind: "folder"` records after a successful conversion;
- separate IPC/runtime conversion locks that could race on the same path;
- cleanup that could remove a pre-existing `.git` directory after failure;
- remote probe errors being treated as permission to mutate;
- non-atomic remote `.gitignore` creation;
- an E2E assertion that inspected Zustand instead of user-visible DOM.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. Paths use Node/host-aware path utilities, local and remote absolute-path validation uses the target platform’s path flavor, Git receives argv rather than shell commands, and no platform-specific shortcut or label behavior is introduced. SSH and paired-runtime ownership are handled explicitly.

## Security Audit

- Git commands use argument arrays and fixed subcommands; no user path is interpolated into a shell command.
- Local and SSH paths must be absolute on the target host. SSH operations use the authenticated connection’s filesystem and Git providers.
- Existing `.gitignore` files are never overwritten. Local creation uses exclusive write; remote creation uses a sibling temporary file plus `renameNoClobber`.
- The generated ignore file excludes common secrets such as `.env`, private keys, and generated dependency/build directories before the initial `git add`.
- Conversion is serialized per host/path. Failure cleanup removes `.git` only when it did not exist before Orca started the conversion.
- No dependencies, auth flows, or credential storage were added.

## Notes

- If Git author identity is missing, Orca leaves the user’s existing files intact and shows the exact configuration commands to run on the relevant host.
- The old PR branch is intentionally retained for history; this replacement branch is freshly based on current `main`.
