### PR TITLE
fix(worktrees): don't tear down terminals when a scan lists no worktrees

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-09",
+  "updatedAt": "2026-08-10",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -1943,6 +1943,107 @@
         "Daemon adapter listing failures remain suppressed by the existing management API, so reported daemon counts are not authoritative verification of every process."
       ],
       "demotionRule": "Keep experimental or demote to protection none if the gate flakes, permits a late-created tab or unrelated PTY to close, duplicates provider shutdown, or performs more than one ownership replan per bounded yield."
+    },
+    {
+      "id": "terminal-session.worktree-scan-teardown-authority",
+      "title": "Unknown worktree scans preserve live terminal sessions",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "terminal-runtime",
+      "layer": "git-main-runtime-renderer-contract",
+      "surfaces": [
+        "worktree discovery",
+        "terminal session teardown",
+        "folder workspace reconciliation",
+        "SSH and paired-runtime worktree refresh"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "daemon", "ssh", "wsl", "remote-runtime"],
+      "coverageNotes": "Deterministic contracts cover local and hydrated terminal identity, folder workspaces, direct SSH, WSL, paired runtimes, retryable empty SSH scans, and nonempty authoritative deletion. Live macOS Electron and Docker SSH evidence remain required before promotion.",
+      "motivatingLinks": [
+        "https://github.com/stablyai/orca/issues/12913",
+        "https://github.com/stablyai/orca/pull/12916"
+      ],
+      "invariant": "A missing, unreadable, disconnected, or otherwise empty worktree scan is non-authoritative and cannot remove workspace rows, tab identity, or provider sessions; a nonempty authoritative scan still retires only worktrees proven absent on the owning host.",
+      "oracle": "Inject empty local, WSL, direct-SSH, paired-runtime, folder-workspace, and hydrated-session results and require exact rows and terminal tab identities to survive with zero teardown RPCs. Then return a nonempty authoritative inventory that omits one linked worktree and require exactly that worktree state and provider session to retire while the main and sibling worktrees survive.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/repo-worktree-resolution-scan.test.ts src/main/runtime/orca-runtime.test.ts --reporter=dot"
+      ],
+      "testFiles": [
+        "src/renderer/src/store/slices/worktrees.test.ts",
+        "src/main/ipc/worktrees.test.ts",
+        "src/main/runtime/repo-worktree-resolution-scan.test.ts",
+        "src/main/runtime/orca-runtime.test.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/renderer/src/store/slices/worktrees.test.ts",
+          "assertions": [
+            "authoritative-empty legacy results preserve exact live and hydrated terminal tab identities with no teardown RPC",
+            "folder-workspace and paired-runtime rows survive empty legacy host results",
+            "a nonempty authoritative result retires one missing linked worktree and keeps the surviving sibling"
+          ]
+        },
+        {
+          "file": "src/main/ipc/worktrees.test.ts",
+          "assertions": [
+            "empty local and direct-SSH scans are published as non-authoritative without guessing between colliding hosts"
+          ]
+        },
+        {
+          "file": "src/main/runtime/repo-worktree-resolution-scan.test.ts",
+          "assertions": [
+            "an empty WSL worktree inventory is classified as non-authoritative"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orca-runtime.test.ts",
+          "assertions": [
+            "empty SSH scans remain retryable and republish persisted rows without terminal teardown",
+            "fresh nonempty revalidation retires only a linked worktree absent from the authoritative inventory"
+          ]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/store/slices/worktrees.test.ts src/main/ipc/worktrees.test.ts src/main/runtime/repo-worktree-resolution-scan.test.ts src/main/runtime/orca-runtime.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 23.63,
+          "summary": "Four affected suites passed 1,604 tests with one skip across empty-scan authority, terminal preservation, host isolation, retry, and real deletion cleanup."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 45,
+        "scope": "four deterministic worktree discovery, runtime, renderer, and teardown suites"
+      },
+      "flakeHistory": {
+        "status": "not-started",
+        "evidence": "One local deterministic run is recorded; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The focused oracle failed on baseline 9060a88dde and the latest-base disabled candidate by publishing empty scans as authoritative and issuing teardown for the exact live worktree. The candidate preserved terminal identity and passed the same nonempty real-deletion control."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "The candidate adds no polling, timers, subprocesses, network calls, or global provider scans. Empty results take an O(1) classification path, warnings are bounded, existing scan caches remain bounded, and empty SSH results reuse persisted metadata while remaining retryable."
+      },
+      "promotionCriteria": [
+        "Collect 100 consecutive focused CI passes or 14 days of soak history.",
+        "Collect a headed macOS Electron run with exact PTY identity and marker liveness across a transient .git outage.",
+        "Collect live Docker SSH and paired headed/headless runtime evidence, plus physical Windows or WSL coverage."
+      ],
+      "knownGaps": [
+        "Physical Linux, Windows, and WSL terminal process evidence is not yet recorded.",
+        "Headed and headless paired-runtime process evidence is not yet recorded.",
+        "The deterministic provider matrix proves ownership and teardown calls, while live SSH and Electron journeys remain pending."
+      ],
+      "demotionRule": "Keep experimental or demote if an empty or unknown scan can issue teardown, a real deletion stops surviving sessions, an empty scan becomes cached as authoritative, provider retry fanout grows, or the focused gate flakes without a product or harness defect."
     },
     {
       "id": "terminal-session.explicit-close-retirement",

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2469,7 +2469,7 @@ describe('registerWorktreeHandlers', () => {
       signal: expect.any(AbortSignal)
     })
     expect(result).toEqual({
-      status: 'complete',
+      status: 'non-authoritative',
       providerRequestId: 'request-1',
       repoId: 'shared-repo',
       authority: {
@@ -2479,8 +2479,8 @@ describe('registerWorktreeHandlers', () => {
       },
       result: {
         repoId: 'shared-repo',
-        authoritative: true,
-        source: 'git',
+        authoritative: false,
+        source: 'metadata-fallback',
         worktrees: []
       }
     })
@@ -2528,7 +2528,7 @@ describe('registerWorktreeHandlers', () => {
     expect(provider.listWorktrees).not.toHaveBeenCalled()
   })
 
-  it('returns a local discriminant without SSH authority fields', async () => {
+  it('treats an empty local Git scan as non-authoritative', async () => {
     listWorktreesMock.mockResolvedValue([])
 
     const result = await handlers['worktrees:listDetected'](ipcEvent, {
@@ -2538,14 +2538,14 @@ describe('registerWorktreeHandlers', () => {
     })
 
     expect(result).toEqual({
-      status: 'complete',
+      status: 'non-authoritative',
       providerRequestId: 'request-1',
       repoId: 'repo-1',
       authority: { kind: 'local', executionHostId: 'local' },
       result: {
         repoId: 'repo-1',
-        authoritative: true,
-        source: 'git',
+        authoritative: false,
+        source: 'metadata-fallback',
         worktrees: []
       }
     })
@@ -2913,7 +2913,7 @@ describe('registerWorktreeHandlers', () => {
       expectedAuthority
     })
 
-    expect(result).toMatchObject({ status: 'complete' })
+    expect(result).toMatchObject({ status: 'non-authoritative' })
     expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
     expect(store.setWorktreeMeta).not.toHaveBeenCalled()
   })
@@ -3206,7 +3206,7 @@ describe('registerWorktreeHandlers', () => {
 
     resolveB([])
     await expect(pendingB).resolves.toMatchObject({
-      status: 'complete',
+      status: 'non-authoritative',
       providerRequestId: 'request-b'
     })
     rotateSshProviderAuthority('target-b')
@@ -3339,7 +3339,7 @@ describe('registerWorktreeHandlers', () => {
           expectedAuthority: getSshProviderAuthority('target-a')
         })
       ).resolves.toMatchObject({
-        status: 'complete',
+        status: 'non-authoritative',
         providerRequestId: 'request-1'
       })
 

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -1229,6 +1229,21 @@ async function listDetectedWorktreesForCapturedRepo(
     if (!isCurrent()) {
       return null
     }
+    if (gitWorktrees.length === 0) {
+      warnOnce(
+        loggedWorktreeListFailures,
+        `${repo.id}:${repo.path}`,
+        `[worktrees] ignoring empty worktree scan for repo "${repo.displayName}" (${repo.id}) at ${repo.path}`
+      )
+      const worktrees = repo.connectionId
+        ? buildDisconnectedDetectedWorktrees(
+            store,
+            repo,
+            listDisconnectedSshWorktrees(store, repo, sshWorktreeMetaIndex)
+          )
+        : []
+      return { repoId: repo.id, authoritative: false, source: 'metadata-fallback', worktrees }
+    }
     const listedWorktreeIds = gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`)
     if (hasConflictingStoredWorktreeOwner(store, repo, listedWorktreeIds)) {
       return {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -38947,13 +38947,14 @@ describe('OrcaRuntimeService', () => {
 
     // Warm the scan cache while the worktree still exists.
     vi.mocked(listWorktrees).mockResolvedValueOnce([
+      makeWorktreeInfo(TEST_REPO_PATH),
       { path: '/tmp/deleted', head: 'abc', branch: 'd', isBare: false, isMainWorktree: false }
     ])
     await runtime.teardownMissingManagedWorktreeTerminals(`id:${TEST_REPO_ID}`, [deletedId])
     expect(localProvider.shutdown).not.toHaveBeenCalled()
 
     // The worktree is now gone; the cached scan must not mask that.
-    vi.mocked(listWorktrees).mockResolvedValue([])
+    vi.mocked(listWorktrees).mockResolvedValue([makeWorktreeInfo(TEST_REPO_PATH)])
     const result = await runtime.teardownMissingManagedWorktreeTerminals(`id:${TEST_REPO_ID}`, [
       deletedId
     ])
@@ -39386,6 +39387,33 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('worktree scan cache: treats empty SSH scans as retryable', async () => {
+    const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
+    const remoteStore = {
+      ...store,
+      getRepo: (id: string) => (id === remoteRepo.id ? remoteRepo : undefined),
+      getRepos: () => [remoteRepo]
+    }
+    const provider = { listWorktrees: vi.fn() }
+    provider.listWorktrees
+      .mockResolvedValueOnce([])
+      .mockResolvedValueOnce([makeWorktreeInfo(TEST_REPO_PATH)])
+    registerSshGitProvider('ssh-1', provider as never)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
+
+    try {
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: false })
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: true })
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
+  })
+
   it('worktree scan cache: invalidates when SSH availability changes', async () => {
     const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
     const remoteStore = {
@@ -39444,7 +39472,7 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('worktree scan cache: SSH state changes invalidate empty resolved snapshots', async () => {
+  it('worktree scan cache: SSH state changes invalidate degraded empty snapshots', async () => {
     const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-empty' }
     const remoteStore = {
       ...store,
@@ -39456,14 +39484,14 @@ describe('OrcaRuntimeService', () => {
     const runtime = new OrcaRuntimeService(remoteStore as never)
 
     try {
-      await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 0 })
+      await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 1 })
       runtime.notifySshStateChanged('ssh-empty', {
         targetId: 'ssh-empty',
         status: 'connected',
         error: null,
         reconnectAttempt: 0
       })
-      await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 0 })
+      await expect(runtime.listManagedWorktrees()).resolves.toMatchObject({ totalCount: 1 })
       expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
     } finally {
       unregisterSshGitProvider('ssh-empty')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -28867,7 +28867,10 @@ export class OrcaRuntimeService {
       return { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
     }
     try {
-      return { ok: true, worktrees: await provider.listWorktrees(repo.path) }
+      const worktrees = await provider.listWorktrees(repo.path)
+      return worktrees.length > 0
+        ? { ok: true, worktrees }
+        : { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
     } catch {
       return { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
     }

--- a/src/main/runtime/repo-worktree-resolution-scan.test.ts
+++ b/src/main/runtime/repo-worktree-resolution-scan.test.ts
@@ -20,12 +20,12 @@ describe('scanLocalRepoWorktreesForResolution', () => {
     })
   })
 
-  it('preserves a successful empty scan verdict', async () => {
+  it('treats an empty WSL scan as non-authoritative', async () => {
     vi.mocked(listWorktreesStrict).mockResolvedValue([])
 
     await expect(
       scanLocalRepoWorktreesForResolution('/repo', { wslDistro: 'Ubuntu' })
-    ).resolves.toEqual({ ok: true, worktrees: [] })
+    ).resolves.toEqual({ ok: false, worktrees: [] })
     expect(listWorktreesStrict).toHaveBeenCalledWith('/repo', { wslDistro: 'Ubuntu' })
   })
 })

--- a/src/main/runtime/repo-worktree-resolution-scan.ts
+++ b/src/main/runtime/repo-worktree-resolution-scan.ts
@@ -14,7 +14,7 @@ export async function scanLocalRepoWorktreesForResolution(
     const worktrees = options.wslDistro
       ? await listWorktreesStrict(repoPath, options)
       : await listWorktreesStrict(repoPath)
-    return { ok: true, worktrees }
+    return worktrees.length > 0 ? { ok: true, worktrees } : { ok: false, worktrees }
   } catch {
     return { ok: false, worktrees: [] }
   }

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -839,6 +839,33 @@ describe('fetchWorktrees', () => {
     expect(store.getState().tabsByWorktree[deleted.id]).toBeUndefined()
   })
 
+  // Why: `listWorktrees` maps "not a git repository" to `[]`, which happens while `.git` is
+  // briefly moved aside. A readable repo always lists its own main worktree, so an empty scan is
+  // a failed read — reconciling against it killed every live terminal in the workspace.
+  it('keeps terminals and rows when an authoritative scan lists no worktrees', async () => {
+    const store = createTestStore()
+    const live = makeWorktree({ id: 'repo1::/p/live', repoId: 'repo1', path: '/p/live' })
+
+    store.setState({
+      repos: [{ id: 'repo1', path: '/p/repo1', displayName: 'R', badgeColor: '#000', addedAt: 0 }],
+      worktreesByRepo: { repo1: [live] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [live]) },
+      tabsByWorktree: { [live.id]: [{ id: 'tab-l', worktreeId: live.id }] }
+    } as unknown as Partial<AppState>)
+
+    mockApi.worktrees.listDetected.mockImplementationOnce(async (args) =>
+      qualifyDetectedResult(args, makeDetectedResult('repo1', []))
+    )
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(mockApi.runtime.call).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.teardownMissingTerminals' })
+    )
+    expect(store.getState().tabsByWorktree[live.id]).toBeDefined()
+    expect(store.getState().worktreesByRepo.repo1).toHaveLength(1)
+  })
+
   // Why: teardown rides outside the scan coalescer, so identical fan-out requests
   // must share one host sweep instead of re-scanning the host per caller.
   it('shares one teardown sweep across identical concurrent refreshes', async () => {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -862,8 +862,69 @@ describe('fetchWorktrees', () => {
     expect(mockApi.runtime.call).not.toHaveBeenCalledWith(
       expect.objectContaining({ method: 'worktree.teardownMissingTerminals' })
     )
-    expect(store.getState().tabsByWorktree[live.id]).toBeDefined()
-    expect(store.getState().worktreesByRepo.repo1).toHaveLength(1)
+    expect(store.getState().tabsByWorktree[live.id]).toEqual([{ id: 'tab-l', worktreeId: live.id }])
+    expect(store.getState().worktreesByRepo.repo1).toEqual([live])
+  })
+
+  it('preserves hydrated terminal identity when no worktree row exists yet', async () => {
+    const store = createTestStore()
+    const worktreeId = 'repo1::/p/hydrated'
+    const tabs = [{ id: 'tab-h', worktreeId }]
+
+    store.setState({
+      repos: [{ id: 'repo1', path: '/p/repo1', displayName: 'R', badgeColor: '#000', addedAt: 0 }],
+      worktreesByRepo: { repo1: [] },
+      tabsByWorktree: { [worktreeId]: tabs }
+    } as unknown as Partial<AppState>)
+    mockApi.worktrees.listDetected.mockImplementationOnce(async (args) =>
+      qualifyDetectedResult(args, makeDetectedResult('repo1', []))
+    )
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(mockApi.runtime.call).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.teardownMissingTerminals' })
+    )
+    expect(store.getState().tabsByWorktree[worktreeId]).toEqual(tabs)
+  })
+
+  it('preserves folder-workspace terminals when a legacy host returns an empty scan', async () => {
+    const store = createTestStore()
+    const live = makeWorktree({
+      id: 'repo-folder::/p/folder::workspace:11111111-1111-1111-1111-111111111111',
+      repoId: 'repo-folder',
+      path: '/p/folder'
+    })
+    const tabs = [{ id: 'tab-f', worktreeId: live.id }]
+
+    store.setState({
+      repos: [
+        {
+          id: 'repo-folder',
+          path: '/p/folder',
+          displayName: 'Folder',
+          badgeColor: '#000',
+          addedAt: 0,
+          kind: 'folder'
+        }
+      ],
+      worktreesByRepo: { 'repo-folder': [live] },
+      detectedWorktreesByRepo: {
+        'repo-folder': makeDetectedResult('repo-folder', [live])
+      },
+      tabsByWorktree: { [live.id]: tabs }
+    } as unknown as Partial<AppState>)
+    mockApi.worktrees.listDetected.mockImplementationOnce(async (args) =>
+      qualifyDetectedResult(args, makeDetectedResult('repo-folder', []))
+    )
+
+    await store.getState().fetchWorktrees('repo-folder')
+
+    expect(mockApi.runtime.call).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.teardownMissingTerminals' })
+    )
+    expect(store.getState().tabsByWorktree[live.id]).toEqual(tabs)
+    expect(store.getState().worktreesByRepo['repo-folder']).toEqual([live])
   })
 
   // Why: teardown rides outside the scan coalescer, so identical fan-out requests
@@ -2463,6 +2524,47 @@ describe('fetchWorktrees', () => {
       timeoutMs: 15_000
     })
     expect(mockApi.worktrees.listDetected).not.toHaveBeenCalled()
+  })
+
+  it('preserves paired-runtime terminals when a legacy host returns an empty scan', async () => {
+    const store = createTestStore()
+    const live = makeWorktree({
+      id: 'repo1::/remote/live',
+      repoId: 'repo1',
+      path: '/remote/live',
+      hostId: 'runtime:env-1'
+    })
+    const tabs = [{ id: 'tab-r', worktreeId: live.id }]
+    store.setState({
+      settings: { activeRuntimeEnvironmentId: 'env-1' } as never,
+      repos: [
+        {
+          id: 'repo1',
+          path: '/remote/repo1',
+          displayName: 'R',
+          badgeColor: '#000',
+          addedAt: 0,
+          executionHostId: 'runtime:env-1'
+        }
+      ],
+      worktreesByRepo: { repo1: [live] },
+      detectedWorktreesByRepo: { repo1: makeDetectedResult('repo1', [live]) },
+      tabsByWorktree: { [live.id]: tabs }
+    } as unknown as Partial<AppState>)
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: makeDetectedResult('repo1', []),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    await store.getState().fetchWorktrees('repo1')
+
+    expect(runtimeEnvironmentCall).not.toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.teardownMissingTerminals' })
+    )
+    expect(store.getState().tabsByWorktree[live.id]).toEqual(tabs)
+    expect(store.getState().worktreesByRepo.repo1).toEqual([live])
   })
 
   it('pins the list fetch to the local host when forceLocalOwner is set', async () => {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -2979,9 +2979,12 @@ function mergeFetchedWorktrees(
       args.setup,
       matchOptions
     )
-    // Why: an empty scan never proves the repo's workspaces are gone (see teardown guard above),
-    // so keep the known rows regardless of the authoritative flag.
-    if (worktrees.length === 0 && currentForHost.length > 0) {
+    // Why: legacy hosts can still label an unreadable repo as authoritative-empty.
+    if (
+      args.refresh.result.worktrees.length === 0 &&
+      (currentForHost.length > 0 ||
+        getKnownWorktreeIdsForPurge(s, args.repoId, args.hostId).length > 0)
+    ) {
       return areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[args.repoId], mergedDetected)
         ? s
         : {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -773,6 +773,12 @@ async function teardownMissingWorktreeTerminalsBestEffort(
   if (!detected.authoritative || !knownWorktreeIds || knownWorktreeIds.length === 0) {
     return
   }
+  // Why: a readable repo always lists its own main worktree, so an empty scan means git could not
+  // read it — `listWorktrees` maps "not a git repository" to `[]`, which happens while `.git` is
+  // briefly moved aside. Reconciling against that marks every workspace missing and kills its terminals.
+  if (detected.worktrees.length === 0) {
+    return
+  }
   const detectedIds = new Set(detected.worktrees.map((worktree) => worktree.id))
   const missingIds = knownWorktreeIds.filter((worktreeId) => !detectedIds.has(worktreeId))
   if (missingIds.length === 0) {
@@ -2973,7 +2979,9 @@ function mergeFetchedWorktrees(
       args.setup,
       matchOptions
     )
-    if (!args.refresh.result.authoritative && worktrees.length === 0 && currentForHost.length > 0) {
+    // Why: an empty scan never proves the repo's workspaces are gone (see teardown guard above),
+    // so keep the known rows regardless of the authoritative flag.
+    if (worktrees.length === 0 && currentForHost.length > 0) {
       return areDetectedWorktreeResultsEqual(s.detectedWorktreesByRepo[args.repoId], mergedDetected)
         ? s
         : {


### PR DESCRIPTION
Fixes #12913

## Problem

`listWorktrees` maps git's "not a git repository" failure to `[]`:

```ts
// src/main/git/worktree.ts — listWorktreesUnshared
if (isNotGitRepositoryError(err)) {
  return []
}
```

So a repo whose `.git` is momentarily unreadable produces an **empty but authoritative** detected scan (`src/main/ipc/worktrees.ts` sees no throw → `authoritative: true`). The reconcile then treats every known workspace as deleted:

```ts
const missingIds = knownWorktreeIds.filter((id) => !detectedIds.has(id))   // → all of them
```

…and asks the host to `worktree.teardownMissingTerminals`, which kills the agent running in the pane.

Observed as a terminal that "randomly bounces": `session-exited (code 0)` + `session-killed`, no crash report, and any long-running process in the pane gets SIGTERM (exit 143). Repro is a one-liner — `mv .git .git_hidden; sleep 30; mv .git_hidden .git` tears the session down within ~1s. Deploy scripts that hide `.git` before uploading (a documented Vercel Hobby-plan workaround) hit this every time.

## Fix

A readable repo always lists its own main worktree, so an empty scan is a **failed read**, not proof the workspaces are gone. Two guards in `src/renderer/src/store/slices/worktrees.ts`:

1. `teardownMissingWorktreeTerminalsBestEffort` — skip the sweep when the scan listed nothing.
2. The row reconcile already kept known rows on `!authoritative && empty`; drop the `!authoritative` qualifier, since an empty scan never proves deletion either way.

I deliberately did **not** change `listWorktrees` or the `authoritative` labelling in `src/main/ipc/worktrees.ts`. Both are arguably the deeper root cause, but `[]` is widely used as a scan stub across the existing suites, and rethinking that flag reaches many more call sites than this bug warrants. Happy to go upstream instead if you'd prefer — the invariant is the same either way.

## Tests

Added a regression test in `worktrees.test.ts`: an authoritative scan that lists no worktrees must not call `worktree.teardownMissingTerminals` and must keep the workspace's tabs and rows. **Verified it fails without the source change.**

- `vitest run src/renderer/src/store/slices/ src/main/ipc/worktrees.test.ts` → 148 files / 2562 tests pass
- `tsc --noEmit -p config/tsconfig.node.json` → clean
- `oxlint` on both changed files → clean
- No existing tests modified

## Environment where this was found

Orca 1.4.173, macOS 14.6 arm64, Claude Code running in a workspace pane, plain git repo (not a worktree). 7 teardowns in ~9 hours in that workspace while other workspaces open at the same time had zero and stayed up 1–3 days.