### PR TITLE
fix(clipboard): stream the temp root when sweeping expired staged files

### DIFF
--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -13,7 +13,7 @@ const {
   childStdinEndMock,
   resolveAuthorizedPathMock,
   fsMkdirMock,
-  fsReaddirMock,
+  fsOpendirMock,
   fsRmMock,
   fsWriteFileMock,
   fsOpenMock,
@@ -46,7 +46,7 @@ const {
   }),
   resolveAuthorizedPathMock: vi.fn(),
   fsMkdirMock: vi.fn(),
-  fsReaddirMock: vi.fn(),
+  fsOpendirMock: vi.fn(),
   fsRmMock: vi.fn(),
   fsWriteFileMock: vi.fn(),
   fsOpenMock: vi.fn(),
@@ -69,7 +69,7 @@ vi.mock('node:child_process', () => ({
 
 vi.mock('node:fs/promises', () => ({
   mkdir: fsMkdirMock,
-  readdir: fsReaddirMock,
+  opendir: fsOpendirMock,
   rm: fsRmMock,
   open: fsOpenMock,
   stat: fsStatMock,
@@ -133,7 +133,6 @@ import {
   registerClipboardHandlers,
   setTrustedClipboardRendererWebContentsId
 } from './clipboard-ipc-handlers'
-import { cleanupExpiredRemoteClipboardFiles } from './clipboard-remote-file-copy'
 
 function getRegisteredHandlers(): Map<string, (...args: unknown[]) => unknown> {
   const handlers = new Map<string, (...args: unknown[]) => unknown>()
@@ -173,10 +172,6 @@ function trackPromiseSettled(promise: Promise<unknown>): () => boolean {
   return () => settled
 }
 
-function dirent(name: string, directory = true): { name: string; isDirectory: () => boolean } {
-  return { name, isDirectory: () => directory }
-}
-
 function shellIdListArray(childCount: number): Buffer {
   const value = Buffer.alloc(4 + 4 * (childCount + 1))
   value.writeUInt32LE(childCount)
@@ -194,8 +189,12 @@ describe('registerClipboardHandlers', () => {
     resolveAuthorizedPathMock.mockImplementation(async (path: string) => path)
     fsMkdirMock.mockReset()
     fsMkdirMock.mockResolvedValue(undefined)
-    fsReaddirMock.mockReset()
-    fsReaddirMock.mockResolvedValue([])
+    fsOpendirMock.mockReset()
+    // Why: handler registration kicks off the expired-staging sweep; an empty temp root keeps it inert.
+    fsOpendirMock.mockImplementation(async () => ({
+      async *[Symbol.asyncIterator]() {},
+      close: vi.fn().mockResolvedValue(undefined)
+    }))
     fsRmMock.mockReset()
     fsRmMock.mockResolvedValue(undefined)
     fsWriteFileMock.mockReset()
@@ -305,33 +304,6 @@ describe('registerClipboardHandlers', () => {
     } else {
       expect(spawnMock).toHaveBeenCalled()
     }
-  })
-
-  it('sweeps expired remote clipboard staging directories', async () => {
-    const nowMs = 1760000000000
-    fsReaddirMock.mockResolvedValue([
-      dirent('orca-clipboard-file-expired'),
-      dirent('orca-clipboard-file-fresh'),
-      dirent('orca-clipboard-file-plain-file', false),
-      dirent('unrelated-temp')
-    ])
-    fsStatMock.mockImplementation(async (targetPath: string) => {
-      if (targetPath.endsWith('expired')) {
-        return { mtimeMs: nowMs - 60 * 60 * 1000 - 1 }
-      }
-      if (targetPath.endsWith('fresh')) {
-        return { mtimeMs: nowMs - 1000 }
-      }
-      throw new Error(`unexpected stat: ${targetPath}`)
-    })
-
-    await cleanupExpiredRemoteClipboardFiles(nowMs)
-
-    expect(fsRmMock).toHaveBeenCalledTimes(1)
-    expect(fsRmMock).toHaveBeenCalledWith(join('/tmp', 'orca-clipboard-file-expired'), {
-      recursive: true,
-      force: true
-    })
   })
 
   it('materializes remote files before writing them to the OS clipboard', async () => {

--- a/src/main/window/clipboard-remote-file-cleanup.test.ts
+++ b/src/main/window/clipboard-remote-file-cleanup.test.ts
@@ -1,0 +1,153 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
+
+const { opendirMock, rmMock, statMock } = vi.hoisted(() => ({
+  opendirMock: vi.fn(),
+  rmMock: vi.fn(),
+  statMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  mkdir: vi.fn(),
+  opendir: opendirMock,
+  rm: rmMock,
+  stat: statMock
+}))
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
+vi.mock('../providers/ssh-filesystem-dispatch', () => ({
+  requireSshFilesystemProvider: vi.fn()
+}))
+vi.mock('./clipboard-file-copy', () => ({ writeFileToClipboard: vi.fn() }))
+
+import { cleanupExpiredRemoteClipboardFiles } from './clipboard-remote-file-copy'
+
+const TTL_MS = 60 * 60 * 1000
+const NOW_MS = 1_760_000_000_000
+
+function mockTempRoot(entries: Iterable<{ name: string; isDirectory: () => boolean }>): void {
+  opendirMock.mockResolvedValue({
+    async *[Symbol.asyncIterator]() {
+      yield* entries
+    },
+    close: vi.fn().mockResolvedValue(undefined)
+  })
+}
+
+function* orcaStagingDirs(count: number): Generator<{ name: string; isDirectory: () => boolean }> {
+  for (let index = 0; index < count; index += 1) {
+    yield { name: `orca-clipboard-file-expired-${index}`, isDirectory: () => true }
+  }
+}
+
+function* unrelatedTempEntries(
+  count: number
+): Generator<{ name: string; isDirectory: () => boolean }> {
+  for (let index = 0; index < count; index += 1) {
+    // Mirrors a real temp root: mostly foreign entries, both files and directories.
+    yield { name: `unrelated-${index}`, isDirectory: () => index % 2 === 0 }
+  }
+}
+
+describe('cleanupExpiredRemoteClipboardFiles', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    rmMock.mockResolvedValue(undefined)
+    statMock.mockResolvedValue({ mtimeMs: NOW_MS - TTL_MS - 1 })
+  })
+
+  it('streams all entries with at most eight cleanups in flight', async () => {
+    mockTempRoot(orcaStagingDirs(257))
+    let active = 0
+    let peak = 0
+    statMock.mockImplementation(async () => {
+      active += 1
+      peak = Math.max(peak, active)
+      await new Promise<void>((resolve) => setImmediate(resolve))
+      active -= 1
+      return { mtimeMs: NOW_MS - TTL_MS - 1 }
+    })
+
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(rmMock).toHaveBeenCalledTimes(257)
+    expect(peak).toBe(8)
+  })
+
+  it('does no per-entry work for foreign temp-root entries', async () => {
+    mockTempRoot(unrelatedTempEntries(200_000))
+
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(statMock).not.toHaveBeenCalled()
+    expect(rmMock).not.toHaveBeenCalled()
+  })
+
+  it('acts on owned directories while the temp root is still being enumerated', async () => {
+    // Regression: the sweep materialized the whole temp root and built one promise
+    // per entry before doing any work, so a %TEMP% with ~1.2M unrelated entries
+    // froze the main process at startup (#12835). Streaming means an owned
+    // directory is swept before enumeration reaches the end.
+    let sweptDuringEnumeration = false
+    function* enumeration(): Generator<{ name: string; isDirectory: () => boolean }> {
+      yield { name: 'orca-clipboard-file-expired', isDirectory: () => true }
+      for (const entry of unrelatedTempEntries(1_000)) {
+        sweptDuringEnumeration ||= rmMock.mock.calls.length > 0
+        yield entry
+      }
+    }
+    mockTempRoot(enumeration())
+
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(sweptDuringEnumeration).toBe(true)
+    expect(rmMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('removes only expired staging directories it owns', async () => {
+    function* interleaved(): Generator<{ name: string; isDirectory: () => boolean }> {
+      yield* unrelatedTempEntries(50_000)
+      yield { name: 'orca-clipboard-file-expired', isDirectory: () => true }
+      yield* unrelatedTempEntries(50_000)
+      yield { name: 'orca-clipboard-file-fresh', isDirectory: () => true }
+      yield { name: 'orca-clipboard-file-plain-file', isDirectory: () => false }
+    }
+    mockTempRoot(interleaved())
+    statMock.mockImplementation(async (targetPath: string) => ({
+      mtimeMs: targetPath.endsWith('expired') ? NOW_MS - TTL_MS - 1 : NOW_MS - 1000
+    }))
+
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(statMock).toHaveBeenCalledTimes(2)
+    expect(rmMock).toHaveBeenCalledTimes(1)
+    expect(rmMock).toHaveBeenCalledWith(join('/tmp', 'orca-clipboard-file-expired'), {
+      recursive: true,
+      force: true
+    })
+  })
+
+  it('closes the temp-root handle and still sweeps when enumeration fails midway', async () => {
+    const close = vi.fn().mockResolvedValue(undefined)
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield { name: 'orca-clipboard-file-expired', isDirectory: () => true }
+        throw new Error('EIO')
+      },
+      close
+    })
+
+    await expect(cleanupExpiredRemoteClipboardFiles(NOW_MS)).resolves.toBeUndefined()
+
+    expect(rmMock).toHaveBeenCalledTimes(1)
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns quietly when the temp root cannot be opened', async () => {
+    opendirMock.mockRejectedValue(new Error('EACCES'))
+
+    await expect(cleanupExpiredRemoteClipboardFiles(NOW_MS)).resolves.toBeUndefined()
+
+    expect(statMock).not.toHaveBeenCalled()
+    expect(rmMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/clipboard-remote-file-copy.ts
+++ b/src/main/window/clipboard-remote-file-copy.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
-import type { Dirent } from 'node:fs'
-import { mkdir, readdir, rm, stat } from 'node:fs/promises'
+import type { Dir } from 'node:fs'
+import { mkdir, opendir, rm, stat } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { app } from 'electron'
@@ -17,6 +17,7 @@ type RemoteClipboardFileDeps = Omit<ClipboardFileDeps, 'resolveFilePath'>
 
 const REMOTE_CLIPBOARD_FILE_TTL_MS = 60 * 60 * 1000
 const REMOTE_CLIPBOARD_FILE_PREFIX = 'orca-clipboard-file-'
+const REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY = 8
 const WINDOWS_RESERVED_LOCAL_BASENAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i
 const LOCAL_FILENAME_REPLACEMENT_CHARS = new Set(['<', '>', ':', '"', '/', '\\', '|', '?', '*'])
 
@@ -79,32 +80,52 @@ export async function writeRemoteFileToClipboard({
   }
 }
 
+// Why: the OS temp root is shared with every other program and routinely holds
+// millions of unrelated entries on long-lived machines, so this startup sweep
+// streams it and only ever retains work for entries it actually owns.
 export async function cleanupExpiredRemoteClipboardFiles(nowMs = Date.now()): Promise<void> {
   const tempRoot = app.getPath('temp')
-  let entries: Dirent[]
+  let tempRootDir: Dir
   try {
-    entries = await readdir(tempRoot, { withFileTypes: true })
+    tempRootDir = await opendir(tempRoot)
   } catch {
     return
   }
 
-  await Promise.all(
-    entries.map(async (entry) => {
+  const pending = new Set<Promise<void>>()
+  try {
+    for await (const entry of tempRootDir) {
       if (!entry.isDirectory() || !entry.name.startsWith(REMOTE_CLIPBOARD_FILE_PREFIX)) {
-        return
+        continue
       }
-      const tempDir = join(tempRoot, entry.name)
-      try {
-        const tempStats = await stat(tempDir)
-        if (nowMs - tempStats.mtimeMs < REMOTE_CLIPBOARD_FILE_TTL_MS) {
-          return
-        }
-        await rm(tempDir, { recursive: true, force: true })
-      } catch {
-        // Why: stale staged SSH files should not make startup cleanup noisy.
+      const cleanup = cleanupExpiredRemoteClipboardDirectory(join(tempRoot, entry.name), nowMs)
+      pending.add(cleanup)
+      void cleanup.finally(() => pending.delete(cleanup))
+      if (pending.size >= REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY) {
+        await Promise.race(pending)
       }
-    })
-  )
+    }
+  } catch {
+    // Why: a partial best-effort sweep beats failing startup on a temp-root read error.
+  } finally {
+    // Why: exhausting the iterator already closes the handle; closing again is harmless.
+    await tempRootDir.close().catch(() => undefined)
+  }
+  await Promise.all(pending)
+}
+
+async function cleanupExpiredRemoteClipboardDirectory(
+  tempDir: string,
+  nowMs: number
+): Promise<void> {
+  try {
+    const tempStats = await stat(tempDir)
+    if (nowMs - tempStats.mtimeMs >= REMOTE_CLIPBOARD_FILE_TTL_MS) {
+      await rm(tempDir, { recursive: true, force: true })
+    }
+  } catch {
+    // Why: stale staged SSH files should not make startup cleanup noisy.
+  }
 }
 
 function sanitizeLocalClipboardFilename(remoteBasename: string): string {


### PR DESCRIPTION
## Summary

Fixes #12835.

On Windows, Orca's main process could hang at startup — window "not responding", `AppHangB1` in Windows Reliability, one core pegged — when `%TEMP%` held a large number of entries. The reporter measured **1,232,261** entries and root-caused it to a live `Promise.all` of matching size.

`cleanupExpiredRemoteClipboardFiles()` is fired and forgotten from `registerClipboardIpcHandlers` at startup. It read the **entire** OS temp root with `readdir(tempRoot, { withFileTypes: true })`, then did `Promise.all(entries.map(async (entry) => …))` with the `orca-clipboard-file-` prefix check *inside* the mapped callback. So every temp entry — including the ~1.2M that belong to other programs — produced a `Dirent` and a promise before anything was filtered. The microtask flood plus the retained arrays put V8 into a scavenge storm and the main thread stopped pumping messages.

The temp root is shared with every other program on the machine and is never pruned by the OS, so a temp root in the six or seven figures is an ordinary state for a long-lived dev machine, not an exotic one.

**After this change** the sweep streams the root with `opendir`, skips foreign entries before allocating anything, and caps in-flight removals at 8. Memory is flat and independent of temp-root size; the loop yields to the event loop between `readdir` batches, so the message pump keeps running.

### Prior art

This exact function was fixed once before, in #10179 (`opendir` streaming + `REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY = 8`). #10255 reverted that PR wholesale the same day for unrelated reasons, which restored the unbounded version currently shipping. This change re-applies the same shape to this one function and adds the regression coverage that was missing.

No behavior change below the ceiling: the same directories are removed, on the same TTL, in the same best-effort, never-throwing way.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — every gate that runs on this checkout passes; one pre-existing failure, see below
- [x] `pnpm typecheck` — full run (node + cli + web), clean
- [ ] `pnpm test` — ran the affected suites, not the full run; leaving this to CI. Details below.
- [ ] `pnpm build` — not run locally (Electron packaging). No build inputs changed; leaving this to CI.
- [x] Added or updated high-quality tests that would catch regressions

Lint detail, since I'd rather flag this than paper over it: `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:reliability-gates` (69 gates), `check:max-lines-ratchet` (352 grandfathered, no new bypasses), `verify:bundled-skill-guides`, and `verify:localization-catalog` all pass. `verify:skill-bundle-manifest` fails — but it **fails identically on a clean `main` with zero changes** on my Windows checkout, reporting `resources\skills\current-manifest.json` and friends as stale. The backslashes suggest the generator is path-separator or line-ending sensitive on Windows. Nothing in this PR touches `resources/skills/`, and I've left those artifacts untouched rather than regenerate them and add unrelated churn. Happy to open a separate issue if that reproduces for you.

New file `src/main/window/clipboard-remote-file-cleanup.test.ts` (6 tests). I verified these are real regression tests rather than shallow coverage by running them against the pre-fix implementation — **3 of the 6 fail**:

| Test | Against pre-fix code |
| --- | --- |
| streams all entries with at most eight cleanups in flight | ✗ `expected 257 to be 8` |
| acts on owned directories while the temp root is still being enumerated | ✗ `expected false to be true` |
| closes the temp-root handle and still sweeps when enumeration fails midway | ✗ `expected "rm" to be called 1 times, but got 0 times` |
| removes only expired staging directories it owns | ✓ (behavior preserved — this is the assertion moved out of `clipboard-ipc-handlers.test.ts`) |
| does no per-entry work for foreign temp-root entries | ✓ |
| returns quietly when the temp root cannot be opened | ✓ |

The second one is the direct pin for this issue: it asserts an owned directory is swept *while enumeration is still in progress*, which is only true if the root is streamed rather than materialized.

The pre-existing `sweeps expired remote clipboard staging directories` case was moved out of `clipboard-ipc-handlers.test.ts` into the new file next to the rest of the cleanup coverage, keeping its exact `join('/tmp', …)` assertion. That also keeps `clipboard-ipc-handlers.test.ts` under the 800-line `max-lines` limit without a suppression.

Targeted run — `clipboard-remote-file-cleanup`, `clipboard-ipc-handlers`, `clipboard-dashboard-popout-access`: 3 files, 35 tests passed.

## AI Review Report

Reviewed with an AI agent against the risk areas in the checklist.

- **Cross-platform.** `opendir` and `Dir[Symbol.asyncIterator]` are Node core and behave identically on macOS, Linux, and Windows. `entry.isDirectory()` is populated from the directory-entry type on all three (Windows always supplies it; the fallback path is unchanged from the previous `readdir({ withFileTypes: true })`). Paths still go through `path.join`. No shell, no shortcut, no label, no Electron platform branch is touched. The hang is Windows-reported but the defect and the fix are platform-neutral; large temp dirs occur on Linux `/tmp` too.
- **SSH / remote / local.** This function only ever sweeps the **local** `app.getPath('temp')` staging directories created by `writeRemoteFileToClipboard` when copying a file off an SSH host. No remote call, no runtime route, no relay wire format is involved, so there is no mixed-version concern.
- **Agent / integration / git provider.** None touched.
- **Performance.** This is the point of the change: peak memory goes from O(temp-root entries) to O(1) plus at most 8 in-flight removals. Concurrency 8 matches the previously merged value. It flagged that `for await` holds the directory handle open for the duration of the sweep; that is intended and is what bounds memory, and the handle is closed in `finally`.
- **UI quality.** No UI.

Two things it flagged that I changed: the initial `does no per-entry work for foreign temp-root entries` test passed against the pre-fix code too (the early `return` inside the old callback meant no `stat` either), so it was not pinning anything — I added the streaming assertion above as the real regression test. It also flagged the unused `{ close }` return value from the test's `mockTempRoot` helper, now dropped.

## Security Audit

- **Input handling.** The only external input is directory-entry names from the OS temp root, which are matched against a fixed prefix and never parsed or interpolated.
- **Path handling.** Names are joined with `path.join(tempRoot, entry.name)`; `readdir`/`opendir` never return `.` `..` or a separator, so the target stays inside the temp root. This is unchanged from before.
- **Destructive operations.** `rm(..., { recursive: true, force: true })` targets are unchanged: a direct child of the temp root, a directory, prefixed `orca-clipboard-file-`, and older than the 1h TTL. The change makes the sweep *later* per entry, never broader. Since `stat` follows symlinks, a symlinked entry could previously have had its mtime read through the link — `entry.isDirectory()` comes from the entry type and is false for a symlink, so symlinks are rejected before `stat` in both the old and new code. Not a regression, and it stays closed.
- **Command execution / auth / secrets / IPC.** None. No new IPC channel, no new dependency, no lockfile change.
- **Follow-up.** None for this PR. #10179 bounded several other accumulators that #10255 took back out; those are separate functions and out of scope here.

## Notes

- Windows is where this was reported and measured, but nothing in the fix is platform-specific.
- Concurrency is a module constant (`REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY = 8`), matching #10179 — happy to make it configurable if you'd prefer.
- X: n/a
