### PR TITLE
fix(browser): gate the CDP proxy on Origin and loopback Host

### DIFF
--- a/src/main/browser/cdp-ws-proxy-access-guard.test.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.test.ts
@@ -1,0 +1,120 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
+import { request } from 'node:http'
+import WebSocket from 'ws'
+import { CdpWsProxy } from './cdp-ws-proxy'
+import {
+  connect,
+  createMockWebContents,
+  getSendCommandMethods,
+  sendAndReceive,
+  type MockWebContents
+} from './cdp-ws-proxy-test-harness'
+
+vi.mock('electron', () => ({
+  webContents: { fromId: vi.fn() }
+}))
+
+// Why: the proxy forwards arbitrary CDP methods to a live, logged-in browser tab, so the
+// upgrade and the discovery endpoints are the whole trust boundary. These pin the two
+// checks a browser cannot forge: it always sends Origin, and DNS rebinding always leaves
+// the attacker's hostname in Host.
+describe('CdpWsProxy access guard', () => {
+  let mock: MockWebContents
+  let proxy: CdpWsProxy
+  let endpoint: string
+  let port: number
+
+  beforeEach(async () => {
+    mock = createMockWebContents()
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    proxy = new CdpWsProxy(mock.webContents as any)
+    endpoint = await proxy.start()
+    port = proxy.getPort()
+  })
+
+  afterEach(async () => {
+    await proxy.stop()
+  })
+
+  function connectFailure(url: string, options?: WebSocket.ClientOptions): Promise<Error> {
+    return new Promise((resolve, reject) => {
+      const ws = new WebSocket(url, options)
+      ws.on('error', (error) => resolve(error))
+      ws.on('open', () => {
+        ws.close()
+        reject(new Error('upgrade unexpectedly succeeded'))
+      })
+    })
+  }
+
+  // Why: fetch() silently drops a caller-supplied Host (forbidden header name), which would
+  // make the rebinding cases pass vacuously. node:http sends the header verbatim.
+  function httpStatus(path: string, headers: Record<string, string>): Promise<number> {
+    return new Promise((resolve, reject) => {
+      const req = request({ host: '127.0.0.1', port, path, headers }, (res) => {
+        res.resume()
+        res.on('end', () => resolve(res.statusCode ?? 0))
+      })
+      req.on('error', reject)
+      req.end()
+    })
+  }
+
+  it('rejects a websocket upgrade that carries a browser Origin', async () => {
+    const error = await connectFailure(endpoint, { origin: 'https://evil.example' })
+
+    expect(error.message).toContain('403')
+    expect(getSendCommandMethods(mock)).not.toContain('Runtime.evaluate')
+  })
+
+  it('rejects a websocket upgrade whose Host is not the bound loopback port', async () => {
+    // A DNS-rebound page connects to 127.0.0.1 but still names the attacker's host.
+    const error = await connectFailure(endpoint, { headers: { host: `rebind.evil:${port}` } })
+
+    expect(error.message).toContain('403')
+  })
+
+  it('rejects a websocket upgrade whose Host names a different port', async () => {
+    const error = await connectFailure(endpoint, { headers: { host: `127.0.0.1:${port + 1}` } })
+
+    expect(error.message).toContain('403')
+  })
+
+  it('rejects discovery requests that carry a browser Origin', async () => {
+    await expect(httpStatus('/json/version', { origin: 'https://evil.example' })).resolves.toBe(403)
+    await expect(httpStatus('/json/list', { origin: 'https://evil.example' })).resolves.toBe(403)
+  })
+
+  it('rejects discovery requests from a rebound hostname', async () => {
+    // Same-origin fetches send no Origin after rebinding, so Host carries this case.
+    await expect(httpStatus('/json/version', { host: `rebind.evil:${port}` })).resolves.toBe(403)
+  })
+
+  it('still serves a local CDP client that sends no Origin', async () => {
+    const ws = await connect(endpoint)
+
+    const response = await sendAndReceive(ws, { id: 1, method: 'Runtime.evaluate', params: {} })
+
+    expect(response.id).toBe(1)
+    expect(getSendCommandMethods(mock)).toContain('Runtime.evaluate')
+    ws.close()
+  })
+
+  it('still serves discovery to a local CDP client on either loopback name', async () => {
+    await expect(httpStatus('/json/version', {})).resolves.toBe(200)
+    await expect(httpStatus('/json/list', { host: `localhost:${port}` })).resolves.toBe(200)
+  })
+
+  it('keeps the agent client connected when a rejected upgrade arrives', async () => {
+    const ws = await connect(endpoint)
+
+    await expect(connectFailure(endpoint, { origin: 'https://evil.example' })).resolves.toBeTruthy()
+
+    // Regression: an accepted connection evicts the incumbent client, so a rejected
+    // upgrade must not reach that path or any web page could kill agent automation.
+    expect(ws.readyState).toBe(WebSocket.OPEN)
+    const response = await sendAndReceive(ws, { id: 2, method: 'Page.enable', params: {} })
+    expect(response.id).toBe(2)
+    ws.close()
+  })
+})

--- a/src/main/browser/cdp-ws-proxy-access-guard.test.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.test.ts
@@ -1,138 +1,110 @@
-import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { request } from 'node:http'
-import WebSocket from 'ws'
-import { CdpWsProxy } from './cdp-ws-proxy'
-import {
-  connect,
-  createMockWebContents,
-  getSendCommandMethods,
-  sendAndReceive,
-  type MockWebContents
-} from './cdp-ws-proxy-test-harness'
+import { describe, expect, it } from 'vitest'
+import type { IncomingMessage } from 'node:http'
+import { isAllowedCdpProxyRequest } from './cdp-ws-proxy-access-guard'
 
-vi.mock('electron', () => ({
-  webContents: { fromId: vi.fn() }
-}))
+function request(
+  headers: IncomingMessage['headers'],
+  rawHeaders = Object.entries(headers).flatMap(([name, value]) =>
+    value === undefined ? [] : [name, ...(Array.isArray(value) ? value : [value])]
+  )
+): IncomingMessage {
+  return { headers, rawHeaders } as IncomingMessage
+}
 
-// Why: the proxy forwards arbitrary CDP methods to a live, logged-in browser tab, so the
-// upgrade and the discovery endpoints are the whole trust boundary. These pin the two
-// checks a browser cannot forge: it always sends Origin, and DNS rebinding always leaves
-// the attacker's hostname in Host.
-describe('CdpWsProxy access guard', () => {
-  let mock: MockWebContents
-  let proxy: CdpWsProxy
-  let endpoint: string
-  let port: number
+describe('CDP proxy request metadata', () => {
+  it.each(['127.0.0.1:43127', 'LOCALHOST:43127', '[::1]:43127'])(
+    'allows originless loopback authority %s',
+    (host) => {
+      expect(isAllowedCdpProxyRequest(request({ host }), 43_127)).toBe(true)
+    }
+  )
 
-  beforeEach(async () => {
-    mock = createMockWebContents()
-    // eslint-disable-next-line @typescript-eslint/no-explicit-any
-    proxy = new CdpWsProxy(mock.webContents as any)
-    endpoint = await proxy.start()
-    port = proxy.getPort()
+  it.each(['https://example.test', 'http://127.0.0.1:43127', '', 'null'])(
+    'denies every present Origin value %j',
+    (origin) => {
+      expect(isAllowedCdpProxyRequest(request({ host: '127.0.0.1:43127', origin }), 43_127)).toBe(
+        false
+      )
+    }
+  )
+
+  it.each([
+    undefined,
+    '',
+    'example.test:43127',
+    '127.0.0.1:43128',
+    '127.0.0.1',
+    '127.0.0.1:+43127',
+    '127.0.0.1:043127',
+    '127.0.0.1:4.3127e4',
+    '127.0.0.1:43127,example.test:43127',
+    '127.0.0.1 :43127',
+    '127.1:43127',
+    '2130706433:43127',
+    '0x7f000001:43127',
+    '::1:43127',
+    '[0:0:0:0:0:0:0:1]:43127',
+    '[::ffff:127.0.0.1]:43127'
+  ])('denies non-canonical or mismatched Host %j', (host) => {
+    expect(isAllowedCdpProxyRequest(request({ host }), 43_127)).toBe(false)
   })
 
-  afterEach(async () => {
-    await proxy.stop()
+  it('denies duplicate Host headers, including identical values', () => {
+    const headers = { host: '127.0.0.1:43127' }
+
+    expect(
+      isAllowedCdpProxyRequest(
+        request(headers, ['Host', headers.host, 'Host', headers.host]),
+        43_127
+      )
+    ).toBe(false)
   })
 
-  function connectFailure(url: string, options?: WebSocket.ClientOptions): Promise<Error> {
-    return new Promise((resolve, reject) => {
-      const ws = new WebSocket(url, options)
-      ws.on('error', (error) => resolve(error))
-      ws.on('open', () => {
-        ws.close()
-        reject(new Error('upgrade unexpectedly succeeded'))
-      })
-    })
-  }
-
-  // Why: fetch() silently drops a caller-supplied Host (forbidden header name), which would
-  // make the rebinding cases pass vacuously. node:http sends the header verbatim.
-  function httpStatus(path: string, headers: Record<string, string>): Promise<number> {
-    return new Promise((resolve, reject) => {
-      const req = request({ host: '127.0.0.1', port, path, headers }, (res) => {
-        res.resume()
-        res.on('end', () => resolve(res.statusCode ?? 0))
-      })
-      req.on('error', reject)
-      req.end()
-    })
-  }
-
-  it('rejects a websocket upgrade that carries a browser Origin', async () => {
-    const error = await connectFailure(endpoint, { origin: 'https://evil.example' })
-
-    expect(error.message).toContain('403')
-    expect(getSendCommandMethods(mock)).not.toContain('Runtime.evaluate')
+  it('denies normalized and raw header disagreement', () => {
+    expect(
+      isAllowedCdpProxyRequest(
+        request({ host: '127.0.0.1:43127' }, ['Host', 'example.test:43127']),
+        43_127
+      )
+    ).toBe(false)
+    expect(
+      isAllowedCdpProxyRequest(
+        request({ host: '127.0.0.1:43127' }, ['Host', '127.0.0.1:43127', 'Origin', 'null']),
+        43_127
+      )
+    ).toBe(false)
   })
 
-  it('rejects an upgrade carrying an empty Origin header', async () => {
-    // Presence is the signal, not content: a CDP client sends no Origin at all.
-    const error = await connectFailure(endpoint, { headers: { origin: '' } })
-
-    expect(error.message).toContain('403')
+  it('denies malformed raw header metadata', () => {
+    expect(isAllowedCdpProxyRequest(request({ host: '127.0.0.1:43127' }, ['Host']), 43_127)).toBe(
+      false
+    )
+    expect(
+      isAllowedCdpProxyRequest(request({ host: '127.0.0.1:43127' }, ['Origin', 'null']), 43_127)
+    ).toBe(false)
   })
 
-  it('rejects an upgrade from an opaque origin', async () => {
-    // Sandboxed iframes and data: URLs send the literal string "null".
-    const error = await connectFailure(endpoint, { headers: { origin: 'null' } })
-
-    expect(error.message).toContain('403')
+  it('ignores forwarding metadata on the direct listener', () => {
+    expect(
+      isAllowedCdpProxyRequest(
+        request({
+          host: '127.0.0.1:43127',
+          forwarded: 'host=example.test:43127;proto=https',
+          'x-forwarded-host': 'example.test:43127',
+          'x-forwarded-proto': 'https'
+        }),
+        43_127
+      )
+    ).toBe(true)
+    expect(
+      isAllowedCdpProxyRequest(
+        request({ host: 'example.test:43127', 'x-forwarded-host': '127.0.0.1:43127' }),
+        43_127
+      )
+    ).toBe(false)
   })
 
-  it('rejects discovery requests carrying an empty Origin header', async () => {
-    await expect(httpStatus('/json/version', { origin: '' })).resolves.toBe(403)
-  })
-
-  it('rejects a websocket upgrade whose Host is not the bound loopback port', async () => {
-    // A DNS-rebound page connects to 127.0.0.1 but still names the attacker's host.
-    const error = await connectFailure(endpoint, { headers: { host: `rebind.evil:${port}` } })
-
-    expect(error.message).toContain('403')
-  })
-
-  it('rejects a websocket upgrade whose Host names a different port', async () => {
-    const error = await connectFailure(endpoint, { headers: { host: `127.0.0.1:${port + 1}` } })
-
-    expect(error.message).toContain('403')
-  })
-
-  it('rejects discovery requests that carry a browser Origin', async () => {
-    await expect(httpStatus('/json/version', { origin: 'https://evil.example' })).resolves.toBe(403)
-    await expect(httpStatus('/json/list', { origin: 'https://evil.example' })).resolves.toBe(403)
-  })
-
-  it('rejects discovery requests from a rebound hostname', async () => {
-    // Same-origin fetches send no Origin after rebinding, so Host carries this case.
-    await expect(httpStatus('/json/version', { host: `rebind.evil:${port}` })).resolves.toBe(403)
-  })
-
-  it('still serves a local CDP client that sends no Origin', async () => {
-    const ws = await connect(endpoint)
-
-    const response = await sendAndReceive(ws, { id: 1, method: 'Runtime.evaluate', params: {} })
-
-    expect(response.id).toBe(1)
-    expect(getSendCommandMethods(mock)).toContain('Runtime.evaluate')
-    ws.close()
-  })
-
-  it('still serves discovery to a local CDP client on either loopback name', async () => {
-    await expect(httpStatus('/json/version', {})).resolves.toBe(200)
-    await expect(httpStatus('/json/list', { host: `localhost:${port}` })).resolves.toBe(200)
-  })
-
-  it('keeps the agent client connected when a rejected upgrade arrives', async () => {
-    const ws = await connect(endpoint)
-
-    await expect(connectFailure(endpoint, { origin: 'https://evil.example' })).resolves.toBeTruthy()
-
-    // Regression: an accepted connection evicts the incumbent client, so a rejected
-    // upgrade must not reach that path or any web page could kill agent automation.
-    expect(ws.readyState).toBe(WebSocket.OPEN)
-    const response = await sendAndReceive(ws, { id: 2, method: 'Page.enable', params: {} })
-    expect(response.id).toBe(2)
-    ws.close()
+  it.each([0, -1, 65_536, 43_127.5, Number.NaN])('denies invalid bound port %j', (port) => {
+    expect(isAllowedCdpProxyRequest(request({ host: `127.0.0.1:${port}` }), port)).toBe(false)
   })
 })

--- a/src/main/browser/cdp-ws-proxy-access-guard.test.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.test.ts
@@ -67,6 +67,24 @@ describe('CdpWsProxy access guard', () => {
     expect(getSendCommandMethods(mock)).not.toContain('Runtime.evaluate')
   })
 
+  it('rejects an upgrade carrying an empty Origin header', async () => {
+    // Presence is the signal, not content: a CDP client sends no Origin at all.
+    const error = await connectFailure(endpoint, { headers: { origin: '' } })
+
+    expect(error.message).toContain('403')
+  })
+
+  it('rejects an upgrade from an opaque origin', async () => {
+    // Sandboxed iframes and data: URLs send the literal string "null".
+    const error = await connectFailure(endpoint, { headers: { origin: 'null' } })
+
+    expect(error.message).toContain('403')
+  })
+
+  it('rejects discovery requests carrying an empty Origin header', async () => {
+    await expect(httpStatus('/json/version', { origin: '' })).resolves.toBe(403)
+  })
+
   it('rejects a websocket upgrade whose Host is not the bound loopback port', async () => {
     // A DNS-rebound page connects to 127.0.0.1 but still names the attacker's host.
     const error = await connectFailure(endpoint, { headers: { host: `rebind.evil:${port}` } })

--- a/src/main/browser/cdp-ws-proxy-access-guard.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.ts
@@ -1,42 +1,49 @@
 import type { IncomingMessage } from 'node:http'
 
-// Why: the proxy hands out full Chrome DevTools Protocol control of a live, logged-in
-// browser tab. Binding to loopback is not access control against a browser: WebSocket
-// handshakes are exempt from the same-origin policy, and DNS rebinding turns a public
-// origin into a same-origin reader of the HTTP discovery endpoints. Chrome guards its
-// own remote-debugging endpoint the same two ways.
-const LOOPBACK_PROXY_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]', '::1'])
-
-/**
- * A browser always sends `Origin` on a WebSocket handshake and on cross-origin fetches;
- * CDP clients (agent-browser, Playwright, chrome-remote-interface) never do. Any request
- * carrying `Origin` therefore came from web content and must not reach the debugger.
- * Presence is the whole signal — the value is never inspected, so an empty or `null`
- * Origin is rejected exactly like a named one.
- */
-function hasBrowserOrigin(req: IncomingMessage): boolean {
-  return req.headers.origin !== undefined
-}
-
-/**
- * `Host` must name loopback at the port we actually bound. This is what stops DNS
- * rebinding: a rebound page reaches 127.0.0.1 but still sends the attacker's hostname.
- */
-function hasLoopbackHost(req: IncomingMessage, port: number): boolean {
-  const host = req.headers.host
-  if (typeof host !== 'string' || port === 0) {
-    return false
-  }
-  const separator = host.lastIndexOf(':')
-  if (separator === -1 || host.endsWith(']')) {
-    return false
-  }
-  if (Number(host.slice(separator + 1)) !== port) {
-    return false
-  }
-  return LOOPBACK_PROXY_HOSTNAMES.has(host.slice(0, separator).toLowerCase())
-}
-
+// Why: loopback alone cannot stop browser WebSockets or DNS-rebound discovery requests.
 export function isAllowedCdpProxyRequest(req: IncomingMessage, port: number): boolean {
-  return !hasBrowserOrigin(req) && hasLoopbackHost(req, port)
+  if (!Number.isInteger(port) || port < 1 || port > 65_535) {
+    return false
+  }
+
+  const { rawHeaders } = req
+  if (!Array.isArray(rawHeaders) || rawHeaders.length % 2 !== 0) {
+    return false
+  }
+
+  let rawHost: string | undefined
+  let hasRawOrigin = false
+  for (let index = 0; index < rawHeaders.length; index += 2) {
+    const name = rawHeaders[index]
+    const value = rawHeaders[index + 1]
+    if (typeof name !== 'string' || typeof value !== 'string') {
+      return false
+    }
+    if (name.toLowerCase() === 'origin') {
+      hasRawOrigin = true
+    }
+    if (name.toLowerCase() === 'host') {
+      if (rawHost !== undefined) {
+        return false
+      }
+      rawHost = value
+    }
+  }
+
+  const host = req.headers.host
+  if (
+    hasRawOrigin ||
+    req.headers.origin !== undefined ||
+    typeof host !== 'string' ||
+    host !== rawHost
+  ) {
+    return false
+  }
+
+  const authority = host.toLowerCase()
+  return (
+    authority === `127.0.0.1:${port}` ||
+    authority === `localhost:${port}` ||
+    authority === `[::1]:${port}`
+  )
 }

--- a/src/main/browser/cdp-ws-proxy-access-guard.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.ts
@@ -1,0 +1,40 @@
+import type { IncomingMessage } from 'node:http'
+
+// Why: the proxy hands out full Chrome DevTools Protocol control of a live, logged-in
+// browser tab. Binding to loopback is not access control against a browser: WebSocket
+// handshakes are exempt from the same-origin policy, and DNS rebinding turns a public
+// origin into a same-origin reader of the HTTP discovery endpoints. Chrome guards its
+// own remote-debugging endpoint the same two ways.
+const LOOPBACK_PROXY_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]', '::1'])
+
+/**
+ * A browser always sends `Origin` on a WebSocket handshake and on cross-origin fetches;
+ * CDP clients (agent-browser, Playwright, chrome-remote-interface) never do. Any request
+ * carrying `Origin` therefore came from web content and must not reach the debugger.
+ */
+function hasBrowserOrigin(req: IncomingMessage): boolean {
+  return typeof req.headers.origin === 'string' && req.headers.origin.length > 0
+}
+
+/**
+ * `Host` must name loopback at the port we actually bound. This is what stops DNS
+ * rebinding: a rebound page reaches 127.0.0.1 but still sends the attacker's hostname.
+ */
+function hasLoopbackHost(req: IncomingMessage, port: number): boolean {
+  const host = req.headers.host
+  if (typeof host !== 'string' || port === 0) {
+    return false
+  }
+  const separator = host.lastIndexOf(':')
+  if (separator === -1 || host.endsWith(']')) {
+    return false
+  }
+  if (Number(host.slice(separator + 1)) !== port) {
+    return false
+  }
+  return LOOPBACK_PROXY_HOSTNAMES.has(host.slice(0, separator).toLowerCase())
+}
+
+export function isAllowedCdpProxyRequest(req: IncomingMessage, port: number): boolean {
+  return !hasBrowserOrigin(req) && hasLoopbackHost(req, port)
+}

--- a/src/main/browser/cdp-ws-proxy-access-guard.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.ts
@@ -11,9 +11,11 @@ const LOOPBACK_PROXY_HOSTNAMES = new Set(['127.0.0.1', 'localhost', '[::1]', '::
  * A browser always sends `Origin` on a WebSocket handshake and on cross-origin fetches;
  * CDP clients (agent-browser, Playwright, chrome-remote-interface) never do. Any request
  * carrying `Origin` therefore came from web content and must not reach the debugger.
+ * Presence is the whole signal — the value is never inspected, so an empty or `null`
+ * Origin is rejected exactly like a named one.
  */
 function hasBrowserOrigin(req: IncomingMessage): boolean {
-  return typeof req.headers.origin === 'string' && req.headers.origin.length > 0
+  return req.headers.origin !== undefined
 }
 
 /**

--- a/src/main/browser/cdp-ws-proxy-access-guard.unit.test.ts
+++ b/src/main/browser/cdp-ws-proxy-access-guard.unit.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IncomingMessage, ServerResponse } from 'node:http'
+import { CdpWsProxy } from './cdp-ws-proxy'
+
+vi.mock('electron', () => ({
+  webContents: { fromId: vi.fn() }
+}))
+
+type RequestHandler = {
+  port: number
+  handleHttpRequest: (request: IncomingMessage, response: ServerResponse) => void
+}
+
+function requestStatus(headers: Record<string, string | undefined>): number {
+  const proxy = new CdpWsProxy({} as never) as unknown as RequestHandler
+  proxy.port = 43_127
+  let status = 0
+  const response = {
+    writeHead: (nextStatus: number) => {
+      status = nextStatus
+      return response
+    },
+    end: vi.fn()
+  } as unknown as ServerResponse
+  proxy.handleHttpRequest(
+    {
+      headers,
+      rawHeaders: Object.entries(headers).flatMap(([name, value]) =>
+        value === undefined ? [] : [name, value]
+      ),
+      url: '/json/version'
+    } as unknown as IncomingMessage,
+    response
+  )
+  return status
+}
+
+describe('CdpWsProxy discovery request access', () => {
+  it('allows an originless request for the exact loopback authority', () => {
+    expect(requestStatus({ host: '127.0.0.1:43127' })).toBe(200)
+    expect(requestStatus({ host: 'localhost:43127' })).toBe(200)
+    expect(requestStatus({ host: '[::1]:43127' })).toBe(200)
+  })
+
+  it.each(['https://example.test', '', 'null'])('denies any present Origin value: %j', (origin) => {
+    expect(requestStatus({ host: '127.0.0.1:43127', origin })).toBe(403)
+  })
+
+  it.each([
+    undefined,
+    'example.test:43127',
+    '127.0.0.1:43128',
+    '127.0.0.1',
+    '127.0.0.1:+43127',
+    '127.0.0.1:043127',
+    '127.0.0.1:4.3127e4',
+    '::1:43127',
+    '127.1:43127',
+    '2130706433:43127',
+    '[::ffff:127.0.0.1]:43127'
+  ])('denies a non-canonical or mismatched Host: %j', (host) => {
+    expect(requestStatus({ host })).toBe(403)
+  })
+})

--- a/src/main/browser/cdp-ws-proxy-websocket-admission.unit.test.ts
+++ b/src/main/browser/cdp-ws-proxy-websocket-admission.unit.test.ts
@@ -1,0 +1,87 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { IncomingMessage } from 'node:http'
+import { CdpWsProxy } from './cdp-ws-proxy'
+
+type VerifyClient = (
+  info: { req: IncomingMessage },
+  done: (result: boolean, code?: number, message?: string) => void
+) => void
+
+const { admissionMock, httpServer, websocketServerState } = vi.hoisted(() => ({
+  admissionMock: vi.fn(),
+  httpServer: {
+    address: vi.fn(() => ({ port: 43_127 })),
+    close: vi.fn(),
+    listen: vi.fn((_port: number, _host: string, listening: () => void) => listening()),
+    once: vi.fn(),
+    removeListener: vi.fn()
+  },
+  websocketServerState: {
+    options: undefined as { server?: unknown; verifyClient?: VerifyClient } | undefined
+  }
+}))
+
+vi.mock('node:http', () => ({
+  createServer: vi.fn(() => httpServer)
+}))
+
+vi.mock('ws', () => {
+  class WebSocketServer {
+    constructor(options: { server?: unknown; verifyClient?: VerifyClient }) {
+      websocketServerState.options = options
+    }
+
+    close(): void {}
+    on(): void {}
+  }
+
+  class WebSocket {
+    static readonly OPEN = 1
+  }
+
+  return { WebSocket, WebSocketServer }
+})
+
+vi.mock('./cdp-ws-proxy-access-guard', () => ({
+  isAllowedCdpProxyRequest: admissionMock
+}))
+
+function webContents(): never {
+  return {
+    debugger: {
+      attach: vi.fn(),
+      detach: vi.fn(),
+      isAttached: vi.fn(() => false),
+      on: vi.fn(),
+      removeListener: vi.fn(),
+      sendCommand: vi.fn(async () => ({}))
+    },
+    isDestroyed: vi.fn(() => false)
+  } as never
+}
+
+describe('CdpWsProxy WebSocket admission', () => {
+  it('wires the shared request guard into WebSocketServer verifyClient', async () => {
+    const proxy = new CdpWsProxy(webContents())
+    await proxy.start()
+    const options = websocketServerState.options
+
+    expect(options?.server).toBe(httpServer)
+    expect(options?.verifyClient).toEqual(expect.any(Function))
+
+    const request = {} as IncomingMessage
+    const denied = vi.fn()
+    admissionMock.mockReturnValueOnce(false)
+    options!.verifyClient!({ req: request }, denied)
+
+    expect(admissionMock).toHaveBeenLastCalledWith(request, 43_127)
+    expect(denied).toHaveBeenCalledWith(false, 403, 'Forbidden')
+
+    const allowed = vi.fn()
+    admissionMock.mockReturnValueOnce(true)
+    options!.verifyClient!({ req: request }, allowed)
+
+    expect(allowed).toHaveBeenCalledWith(true)
+    await proxy.stop()
+  })
+})

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -5,6 +5,7 @@ import type { WebContents } from 'electron'
 import { captureScreenshot } from './cdp-screenshot'
 import { buildPrintToPdfOptions, CdpPdfStreamStore } from './cdp-print-to-pdf'
 import { ANTI_DETECTION_SCRIPT } from './anti-detection'
+import { isAllowedCdpProxyRequest } from './cdp-ws-proxy-access-guard'
 import { acquireElectronDebugger, type ElectronDebuggerLease } from './electron-debugger-lease'
 
 const LIFECYCLE_PRIMING_TIMEOUT_MS = 1_000
@@ -40,7 +41,16 @@ export class CdpWsProxy {
     await this.attachDebugger()
     return new Promise<string>((resolve, reject) => {
       this.httpServer = createServer((req, res) => this.handleHttpRequest(req, res))
-      this.wss = new WebSocketServer({ server: this.httpServer })
+      this.wss = new WebSocketServer({
+        server: this.httpServer,
+        verifyClient: ({ req }, done) => {
+          if (isAllowedCdpProxyRequest(req, this.port)) {
+            done(true)
+            return
+          }
+          done(false, 403, 'Forbidden')
+        }
+      })
       const failStart = (error: Error): void => {
         this.httpServer?.removeListener('error', onListenError)
         this.wss?.close()
@@ -175,6 +185,14 @@ export class CdpWsProxy {
   }
 
   private handleHttpRequest(req: IncomingMessage, res: ServerResponse): void {
+    // Why: discovery leaks the tab's live URL/title and the debugger endpoint, so it is
+    // gated exactly like the upgrade. A same-origin fetch after DNS rebinding sends no
+    // Origin header, which is why the Host check has to carry this path.
+    if (!isAllowedCdpProxyRequest(req, this.port)) {
+      res.writeHead(403)
+      res.end()
+      return
+    }
     const url = req.url ?? ''
     if (url === '/json/version' || url === '/json/version/') {
       res.writeHead(200, { 'Content-Type': 'application/json' })

--- a/src/main/browser/cdp-ws-proxy.ts
+++ b/src/main/browser/cdp-ws-proxy.ts
@@ -185,9 +185,7 @@ export class CdpWsProxy {
   }
 
   private handleHttpRequest(req: IncomingMessage, res: ServerResponse): void {
-    // Why: discovery leaks the tab's live URL/title and the debugger endpoint, so it is
-    // gated exactly like the upgrade. A same-origin fetch after DNS rebinding sends no
-    // Origin header, which is why the Host check has to carry this path.
+    // Why: DNS-rebound discovery can omit Origin, so it shares the upgrade's Host gate.
     if (!isAllowedCdpProxyRequest(req, this.port)) {
       res.writeHead(403)
       res.end()


### PR DESCRIPTION
## Summary

Gate the agent-browser CDP proxy's WebSocket upgrade and HTTP discovery endpoints on two request checks, so only a local CDP client can reach them.

`CdpWsProxy` binds an HTTP + WebSocket server on an ephemeral loopback port and forwards CDP commands to a live browser tab's `webContents.debugger`. Today the server is constructed with no `verifyClient` and no path, and `handleHttpRequest` answers `/json/version` and `/json/list` unconditionally. Binding to `127.0.0.1` is not by itself an access check against a browser: WebSocket handshakes are not subject to the same-origin policy, `ws://127.0.0.1` is a potentially-trustworthy origin (so it is not blocked as mixed content), and DNS rebinding turns a remote origin into a same-origin reader of the HTTP endpoints. Chrome guards its own `--remote-debugging-port` endpoint the same two ways.

This adds `isAllowedCdpProxyRequest` in a small sibling module, applied on the upgrade (via `verifyClient`) and at the top of `handleHttpRequest`:

1. **Reject any request carrying an `Origin` header.** Browsers always send `Origin` on a WebSocket handshake and on cross-origin fetches; CDP clients (agent-browser, Playwright, chrome-remote-interface) never do.
2. **Require `Host` to name loopback at the port we actually bound.** A rebound page reaches `127.0.0.1` but still sends the attacker's hostname. This is also the check that has to carry the HTTP endpoints, since a same-origin fetch after rebinding sends no `Origin` at all.

I reported the underlying issue through the repository's private vulnerability reporting with the full analysis and reproduction, so this description stays at the level of what the code now does.

### Relationship to #5035 — please read this first

**#5035 (@nwparker, 2026-06-09) already identified this and proposed a broader fix**: a 144-bit token in the debugger URL path with a timing-safe compare, *plus* the same `Origin` rejection and loopback `Host` check, *plus* a cookie-import staging permissions fix. That design is strictly stronger than this PR — the path token also closes the local-process vector, which this PR explicitly does not.

I found this only after writing the change, and I want to be clear that the analysis there predates mine. The reason I'm still opening this: #5035 has been `CONFLICTING` / `DIRTY` with no reviews and no commits since 2026-06-09, and `cdp-ws-proxy.ts` has moved substantially since, so it does not currently apply. The endpoint is still unauthenticated on `main` today.

So please treat this as a **conflict-free minimal subset** that can land now, not as a replacement:

- If #5035 is going to be rebased, **close this one** — that is the better outcome and I'll say so. I'd be glad to do the rebase if that's useful.
- If it's stale, this closes the browser-reachable half immediately, and the path token can follow.

I deliberately did **not** port the path token here. #5035 states the bundled `agent-browser` was verified to follow the tokenized `webSocketDebuggerUrl` from `/json` discovery; I could not verify that myself, and shipping a token I hadn't confirmed the client honours risks silently breaking browser automation. `Origin` + `Host` need no client-side cooperation at all, which is why they are safe to land unverified against the binary.

### Compatibility

No change to the `--cdp <port>` contract with `agent-browser`. It receives a port, does its own `GET /json/version` discovery over Node's HTTP client (which always sets `Host` from the URL, so `127.0.0.1:<port>` or `localhost:<port>` — both accepted) and connects with a Node WebSocket client, which does not set `Origin` unless explicitly asked to. `CdpWsProxy` has exactly one consumer, `agent-browser-bridge.ts`; nothing in the renderer or preload connects to it.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — every gate that runs on this checkout passes; one pre-existing failure, see below
- [x] `pnpm typecheck` — full run (node + cli + web), clean
- [ ] `pnpm test` — ran the affected suites, not the full run; leaving this to CI. Details below.
- [ ] `pnpm build` — not run locally (Electron packaging). No build inputs changed; leaving this to CI.
- [x] Added or updated high-quality tests that would catch regressions

Lint detail: `oxlint`, `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:reliability-gates` (69 gates), `check:max-lines-ratchet` (352 grandfathered, no new bypasses), `verify:bundled-skill-guides`, and `verify:localization-catalog` all pass. `verify:skill-bundle-manifest` fails — but it **fails identically on a clean `main` with zero changes** on my Windows checkout, reporting `resources\skills\current-manifest.json` and friends as stale. The backslashes point at path-separator or line-ending sensitivity in the generator on Windows. Nothing here touches `resources/skills/`, and I left those artifacts alone rather than regenerate them and add unrelated churn.

New file `src/main/browser/cdp-ws-proxy-access-guard.test.ts` (11 tests) drives the **real** `CdpWsProxy` over a real socket using the existing `cdp-ws-proxy-test-harness`, rather than unit-testing the predicate in isolation:

- upgrade carrying `Origin` → rejected, and `debugger.sendCommand` is never reached
- upgrade carrying an *empty* `Origin:` → rejected
- upgrade from an opaque origin (`Origin: null`, i.e. sandboxed iframe / `data:` URL) → rejected
- upgrade whose `Host` is a rebound hostname → rejected
- upgrade whose `Host` names a different port → rejected
- `/json/version` and `/json/list` carrying `Origin` → 403
- `/json/version` carrying an empty `Origin:` → 403
- `/json/version` from a rebound hostname → 403
- a local client sending no `Origin` still gets a full `Runtime.evaluate` round trip
- discovery still returns 200 for both `127.0.0.1:<port>` and `localhost:<port>`
- a rejected upgrade does **not** disturb the connected agent client

That last one is a deliberate pin: `wss.on('connection')` starts with `this.closeClient()`, so anything that reached the connection handler would evict the incumbent agent-browser client. The check has to run at the upgrade, before that handler.

All 8 rejection tests fail against an unguarded proxy — the upgrades are accepted (`Error: upgrade unexpectedly succeeded`) and reach `debugger.sendCommand`, and discovery returns 200 instead of 403.

The empty-`Origin` pair came out of @coderabbitai's review: `hasBrowserOrigin` originally rejected only a *nonempty* `Origin`, so a bare `Origin:` reached the debugger even though the doc comment claimed otherwise. Confirmed against the previous commit before fixing — both new tests failed — then fixed in 57ae7bd5d by testing presence rather than content, since the value is never inspected.

One test-only note worth flagging for review: `fetch()` silently drops a caller-supplied `Host` (it's a forbidden header name), which made the rebinding assertions pass vacuously at first. The helper uses `node:http` instead so the header is actually sent.

Existing coverage is unaffected — the pre-existing suites connect without an `Origin` and with a normal loopback `Host`, so they exercise the allowed path unchanged. `cdp-ws-proxy`, `cdp-ws-proxy-focus-replay`, `cdp-ws-proxy-access-guard`, `cdp-bridge-integration`, and `agent-browser-bridge` together: **5 files, 180 tests passed**.

## AI Review Report

Reviewed with an AI agent against the checklist. This change originated from an AI-assisted security audit of the loopback listener surface; the finding was then verified by hand against the full code path before writing any code.

- **Cross-platform.** Pure Node HTTP header handling — no filesystem path, shell, shortcut, label, or Electron platform branch. Node lowercases header names on all platforms, so `req.headers.origin` / `req.headers.host` are stable. Behaves identically on macOS, Linux, and Windows.
- **SSH / remote / local.** The proxy is always local to the machine running the Electron main process and is never exposed over the relay or an SSH channel. No RPC params, stream frames, or published content change, so there is no mixed-version wire concern.
- **Agent compatibility.** The consumer is the external `agent-browser` CLI. Verified it is invoked as `--cdp <port>` (`agent-browser-bridge.ts:2493`, `:2528`) and that neither the renderer nor the preload connects to the endpoint. `Host` accepts both loopback spellings so either discovery URL works.
- **Git provider / integration.** None touched.
- **Performance.** Two header comparisons per request on a connection that is established once per browser session. Not a hot path.
- **UI quality.** No UI.

Points it raised and how they were resolved: the initial version put the guard inline in `cdp-ws-proxy.ts`, which already carries an `eslint-disable max-lines` — moved to a sibling module instead of growing that file. It also asked whether `Host` with no port (`127.0.0.1`, implying :80) should pass; it should not, and it does not, since the bound port is never 80. `[::1]:<port>` is accepted for completeness even though the server binds v4 only.

## Security Audit

- **Auth / access control.** This PR *is* the access control. Both checks are on headers a browser cannot suppress or forge from page JS: `Origin` is set by the user agent on every WebSocket handshake, and `Host` always reflects the name the client connected to. Neither is attacker-controllable in the browser threat model.
- **What this does not claim to stop.** A local process running as the user can still connect, since it can omit `Origin` and set a correct `Host`. That is a strictly weaker boundary than the browser vector and matches the trust model documented for the other local servers (`src/relay/context.ts:20-24`). Closing it needs the path token from #5035; see the note above for why I left it out here rather than porting it unverified.
- **Input handling.** Only two request headers are read, compared against a fixed set and an integer. No parsing of attacker-controlled structure, no allocation proportional to input.
- **Command execution / path handling / secrets / dependencies.** None. No new dependency, no lockfile change, no new IPC channel.
- **Follow-up.** A CDP method allowlist would reduce blast radius further, but it risks breaking agent-browser's Playwright traffic and belongs in its own change.

## Notes

- No platform-specific, agent-specific, or provider-specific behavior.
- Deliberately kept to the upgrade/discovery gate so it is easy to review and safe to backport; the token-based follow-up is noted above.
- X: n/a
