### PR TITLE
feat: per-project Claude account preference with auto-switch at launch

### DIFF
--- a/src/main/claude-accounts/project-account-preference.test.ts
+++ b/src/main/claude-accounts/project-account-preference.test.ts
@@ -1,0 +1,213 @@
+import { describe, expect, it, vi } from 'vitest'
+import type {
+  ClaudeManagedAccount,
+  GlobalSettings,
+  WorktreeMeta,
+  Project
+} from '../../shared/types'
+import type { Store } from '../persistence'
+import type { ClaudeAccountService } from './service'
+import type { ClaudeRuntimeAuthPreparation } from './runtime-auth-service'
+import {
+  createProjectAwarePrepareClaudeAuth,
+  resolveProjectPreferredClaudeAccountId
+} from './project-account-preference'
+
+const PREPARATION: ClaudeRuntimeAuthPreparation = {
+  configDir: '/home/user/.claude',
+  envPatch: {},
+  stripAuthEnv: true,
+  provenance: 'test'
+}
+
+function makeAccount(overrides: Partial<ClaudeManagedAccount> = {}): ClaudeManagedAccount {
+  return {
+    id: 'acct-b',
+    email: 'b@example.com',
+    managedAuthPath: '/managed/acct-b',
+    authMethod: 'subscription-oauth',
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1,
+    ...overrides
+  }
+}
+
+function makeStore(args: {
+  worktreeProjectId?: string | null
+  project?: Partial<Project> | null
+  accounts?: ClaudeManagedAccount[]
+  selection?: Partial<
+    Pick<GlobalSettings, 'activeClaudeManagedAccountId' | 'activeClaudeManagedAccountIdsByRuntime'>
+  >
+}): Store {
+  const project: Project | null =
+    args.project === null
+      ? null
+      : ({
+          id: 'project-1',
+          displayName: 'Project',
+          badgeColor: '#fff',
+          sourceRepoIds: [],
+          createdAt: 1,
+          updatedAt: 1,
+          ...args.project
+        } as Project)
+  return {
+    getWorktreeMeta: vi
+      .fn()
+      .mockReturnValue(
+        args.worktreeProjectId === null
+          ? undefined
+          : ({ projectId: args.worktreeProjectId ?? 'project-1' } as WorktreeMeta)
+      ),
+    getProjects: vi.fn().mockReturnValue(project ? [project] : []),
+    getSettings: vi.fn().mockReturnValue({
+      claudeManagedAccounts: args.accounts ?? [],
+      activeClaudeManagedAccountId: args.selection?.activeClaudeManagedAccountId ?? null,
+      activeClaudeManagedAccountIdsByRuntime: args.selection?.activeClaudeManagedAccountIdsByRuntime
+    } as GlobalSettings)
+  } as unknown as Store
+}
+
+function makeDeps(store: Store): {
+  prepare: ReturnType<typeof vi.fn>
+  selectAccountForTarget: ReturnType<typeof vi.fn>
+  prepareClaudeAuth: ReturnType<typeof createProjectAwarePrepareClaudeAuth>
+} {
+  const prepare = vi.fn().mockResolvedValue(PREPARATION)
+  const selectAccountForTarget = vi.fn().mockResolvedValue(undefined)
+  const prepareClaudeAuth = createProjectAwarePrepareClaudeAuth({
+    getStore: () => store,
+    getClaudeAccounts: () => ({ selectAccountForTarget }) as unknown as ClaudeAccountService,
+    prepare
+  })
+  return { prepare, selectAccountForTarget, prepareClaudeAuth }
+}
+
+describe('resolveProjectPreferredClaudeAccountId', () => {
+  it('returns null without a worktree id', () => {
+    const store = makeStore({})
+    expect(resolveProjectPreferredClaudeAccountId(store, undefined)).toBeNull()
+  })
+
+  it('returns null when the worktree has no meta', () => {
+    const store = makeStore({ worktreeProjectId: null })
+    expect(resolveProjectPreferredClaudeAccountId(store, 'wt-1')).toBeNull()
+  })
+
+  it('returns null when the project does not exist', () => {
+    const store = makeStore({ project: null })
+    expect(resolveProjectPreferredClaudeAccountId(store, 'wt-1')).toBeNull()
+  })
+
+  it('returns null when the project has no preference', () => {
+    const store = makeStore({ project: {} })
+    expect(resolveProjectPreferredClaudeAccountId(store, 'wt-1')).toBeNull()
+  })
+
+  it('returns the preferred account id', () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'acct-b' } }
+    })
+    expect(resolveProjectPreferredClaudeAccountId(store, 'wt-1')).toBe('acct-b')
+  })
+})
+
+describe('createProjectAwarePrepareClaudeAuth', () => {
+  it('passes through without a preference', async () => {
+    const store = makeStore({ project: {} })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+
+    await expect(prepareClaudeAuth({ runtime: 'host' }, { worktreeId: 'wt-1' })).resolves.toBe(
+      PREPARATION
+    )
+    expect(selectAccountForTarget).not.toHaveBeenCalled()
+    expect(prepare).toHaveBeenCalledWith({ runtime: 'host' })
+  })
+
+  it('falls back to the global selection when the preferred account no longer exists', async () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'gone' } },
+      accounts: [makeAccount()]
+    })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+
+    await prepareClaudeAuth({ runtime: 'host' }, { worktreeId: 'wt-1' })
+    expect(selectAccountForTarget).not.toHaveBeenCalled()
+    expect(prepare).toHaveBeenCalled()
+  })
+
+  it('falls back when the preferred account belongs to a different runtime', async () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'acct-b' } },
+      accounts: [makeAccount({ managedAuthRuntime: 'wsl', wslDistro: 'Ubuntu' })]
+    })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+
+    await prepareClaudeAuth({ runtime: 'host' }, { worktreeId: 'wt-1' })
+    expect(selectAccountForTarget).not.toHaveBeenCalled()
+    expect(prepare).toHaveBeenCalled()
+  })
+
+  it('falls back when the launch names a different WSL distro', async () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'acct-b' } },
+      accounts: [makeAccount({ managedAuthRuntime: 'wsl', wslDistro: 'Ubuntu' })]
+    })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+
+    await prepareClaudeAuth({ runtime: 'wsl', wslDistro: 'Debian' }, { worktreeId: 'wt-1' })
+    expect(selectAccountForTarget).not.toHaveBeenCalled()
+    expect(prepare).toHaveBeenCalled()
+  })
+
+  it('skips the switch when the preferred account is already selected', async () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'acct-b' } },
+      accounts: [makeAccount()],
+      selection: { activeClaudeManagedAccountId: 'acct-b' }
+    })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+
+    await prepareClaudeAuth({ runtime: 'host' }, { worktreeId: 'wt-1' })
+    expect(selectAccountForTarget).not.toHaveBeenCalled()
+    expect(prepare).toHaveBeenCalled()
+  })
+
+  it('switches to the preferred account before preparing', async () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'acct-b' } },
+      accounts: [makeAccount()],
+      selection: { activeClaudeManagedAccountId: 'acct-a' }
+    })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+    const order: string[] = []
+    selectAccountForTarget.mockImplementation(async () => {
+      order.push('select')
+    })
+    prepare.mockImplementation(async () => {
+      order.push('prepare')
+      return PREPARATION
+    })
+
+    await prepareClaudeAuth({ runtime: 'host' }, { worktreeId: 'wt-1' })
+    expect(selectAccountForTarget).toHaveBeenCalledWith('acct-b')
+    expect(order).toEqual(['select', 'prepare'])
+  })
+
+  it('rejects without preparing when the switch fails', async () => {
+    const store = makeStore({
+      project: { claudeAccountPreference: { kind: 'account', accountId: 'acct-b' } },
+      accounts: [makeAccount()],
+      selection: { activeClaudeManagedAccountId: 'acct-a' }
+    })
+    const { prepare, selectAccountForTarget, prepareClaudeAuth } = makeDeps(store)
+    selectAccountForTarget.mockRejectedValue(new Error('switch blocked'))
+
+    await expect(prepareClaudeAuth({ runtime: 'host' }, { worktreeId: 'wt-1' })).rejects.toThrow(
+      /preferred Claude account.*switch blocked/
+    )
+    expect(prepare).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/claude-accounts/project-account-preference.ts
+++ b/src/main/claude-accounts/project-account-preference.ts
@@ -1,0 +1,85 @@
+import type { Store } from '../persistence'
+import type { ClaudeAccountService } from './service'
+import type { ClaudeRuntimeAuthPreparation } from './runtime-auth-service'
+import {
+  getClaudeSelectionTargetForAccount,
+  getSelectedClaudeAccountIdForTarget,
+  normalizeClaudeAccountSelectionTarget,
+  type ClaudeAccountSelectionTarget
+} from './runtime-selection'
+import { getPreferredClaudeAccountId } from '../../shared/project-claude-account-preference'
+
+export function resolveProjectPreferredClaudeAccountId(
+  store: Store,
+  worktreeId: string | undefined
+): string | null {
+  if (!worktreeId) {
+    return null
+  }
+  const projectId = store.getWorktreeMeta(worktreeId)?.projectId
+  if (!projectId) {
+    return null
+  }
+  const project = store.getProjects().find((entry) => entry.id === projectId)
+  return project ? getPreferredClaudeAccountId(project.claudeAccountPreference) : null
+}
+
+type ProjectAwarePrepareClaudeAuthDeps = {
+  getStore: () => Store
+  getClaudeAccounts: () => ClaudeAccountService
+  prepare: (target?: ClaudeAccountSelectionTarget) => Promise<ClaudeRuntimeAuthPreparation>
+}
+
+/**
+ * Wraps prepareForClaudeLaunch so a project's preferred managed account is
+ * selected (globally, via the existing switch machinery) before the launch
+ * materializes credentials. Every unresolvable case falls back to the
+ * inherited global selection rather than blocking the launch.
+ */
+export function createProjectAwarePrepareClaudeAuth(deps: ProjectAwarePrepareClaudeAuthDeps) {
+  return async (
+    target?: ClaudeAccountSelectionTarget,
+    context?: { worktreeId?: string }
+  ): Promise<ClaudeRuntimeAuthPreparation> => {
+    const store = deps.getStore()
+    const preferredAccountId = resolveProjectPreferredClaudeAccountId(store, context?.worktreeId)
+    if (!preferredAccountId) {
+      return deps.prepare(target)
+    }
+
+    const settings = store.getSettings()
+    const account = settings.claudeManagedAccounts.find((entry) => entry.id === preferredAccountId)
+    if (!account) {
+      console.warn(
+        `[claude-accounts] Project prefers Claude account ${preferredAccountId}, but it no longer exists; using the global selection.`
+      )
+      return deps.prepare(target)
+    }
+
+    const accountTarget = normalizeClaudeAccountSelectionTarget(
+      getClaudeSelectionTargetForAccount(account)
+    )
+    const launchTarget = normalizeClaudeAccountSelectionTarget(target)
+    const runtimeMismatch =
+      accountTarget.runtime !== launchTarget.runtime ||
+      (launchTarget.wslDistro !== null && launchTarget.wslDistro !== accountTarget.wslDistro)
+    if (runtimeMismatch) {
+      console.warn(
+        `[claude-accounts] Project prefers Claude account ${account.email}, but it belongs to a different runtime than this launch; using the global selection.`
+      )
+      return deps.prepare(target)
+    }
+
+    if (getSelectedClaudeAccountIdForTarget(settings, accountTarget) !== account.id) {
+      try {
+        await deps.getClaudeAccounts().selectAccountForTarget(account.id)
+      } catch (error) {
+        const reason = error instanceof Error ? error.message : String(error)
+        throw new Error(
+          `Could not switch to this project's preferred Claude account (${account.email}): ${reason}`
+        )
+      }
+    }
+    return deps.prepare(target)
+  }
+}

--- a/src/main/claude-accounts/service.test.ts
+++ b/src/main/claude-accounts/service.test.ts
@@ -495,7 +495,8 @@ describe('ClaudeAccountService credential capture', () => {
       updateSettings: vi.fn((updates: Partial<typeof settings>) => {
         settings = { ...settings, ...updates }
         return settings
-      })
+      }),
+      clearClaudeAccountPreferenceForAccount: vi.fn()
     }
     const runtimeAuth = {
       syncForCurrentSelection: vi.fn(async () => {}),
@@ -518,6 +519,7 @@ describe('ClaudeAccountService credential capture', () => {
     expect(rateLimits.refreshForClaudeAccountChange).toHaveBeenCalledWith('account-1', {
       runtime: 'host'
     })
+    expect(store.clearClaudeAccountPreferenceForAccount).toHaveBeenCalledWith('account-1')
     expect(settings).toMatchObject({
       claudeManagedAccounts: [],
       activeClaudeManagedAccountId: null
@@ -1262,7 +1264,8 @@ describe('ClaudeAccountService credential capture', () => {
       updateSettings: vi.fn((updates: Partial<typeof settings>) => {
         settings = { ...settings, ...updates }
         return settings
-      })
+      }),
+      clearClaudeAccountPreferenceForAccount: vi.fn()
     }
     const runtimeAuth = {
       syncForCurrentSelection: vi.fn(async () => {}),

--- a/src/main/claude-accounts/service.ts
+++ b/src/main/claude-accounts/service.ts
@@ -449,6 +449,7 @@ export class ClaudeAccountService {
           : undefined,
         getClaudeSelectionTargetForAccount(account)
       )
+      this.store.clearClaudeAccountPreferenceForAccount(accountId)
       return this.getSnapshot()
     } catch (error) {
       this.restoreClaudeSettings(settings)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -230,6 +230,7 @@ import { getDefaultWslDistro } from './wsl'
 import { collectWorktreeTrashSweepRoots, sweepStaleWorktreeTrash } from './worktree-trash'
 import { ClaudeAccountService } from './claude-accounts/service'
 import { ClaudeRuntimeAuthService } from './claude-accounts/runtime-auth-service'
+import { createProjectAwarePrepareClaudeAuth } from './claude-accounts/project-account-preference'
 import {
   attachClaudeLivePtyPersistence,
   onLiveClaudePtysDrained,
@@ -1368,7 +1369,11 @@ function openMainWindow(): BrowserWindow {
     store,
     runtime,
     prepareCodexRuntimeHomeForLaunch,
-    (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target),
+    createProjectAwarePrepareClaudeAuth({
+      getStore: () => store!,
+      getClaudeAccounts: () => claudeAccounts!,
+      prepare: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
+    }),
     {
       prepareCodexSessionResume: prepareCodexSessionResumeForLaunch,
       awaitLocalPtyStartup: () => localPtyStartupReady,
@@ -2861,7 +2866,11 @@ void app.whenReady().then(async () => {
       runtime,
       prepareCodexRuntimeHomeForLaunch,
       () => store!.getSettings(),
-      (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target),
+      createProjectAwarePrepareClaudeAuth({
+        getStore: () => store!,
+        getClaudeAccounts: () => claudeAccounts!,
+        prepare: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
+      }),
       store,
       prepareCodexSessionResumeForLaunch
     )

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1909,6 +1909,25 @@ describe('registerPtyHandlers', () => {
       expect(hasLiveClaudePtys()).toBe(false)
     })
 
+    it('passes the launch worktree to prepareClaudeAuth', async () => {
+      const prepareClaudeAuth = vi.fn(async () => ({
+        configDir: '/tmp/claude',
+        envPatch: {},
+        stripAuthEnv: false,
+        provenance: 'managed:account-1'
+      }))
+      registerPtyHandlers(mainWindow as never, undefined, undefined, undefined, prepareClaudeAuth)
+
+      await handlers.get('pty:spawn')!(null, {
+        cols: 80,
+        rows: 24,
+        command: 'claude',
+        worktreeId: 'wt-1'
+      })
+
+      expect(prepareClaudeAuth).toHaveBeenCalledWith(expect.anything(), { worktreeId: 'wt-1' })
+    })
+
     it('clears Claude live-PTY tracking from shared provider teardown', () => {
       markClaudePtySpawned('ssh-claude-pty')
       expect(hasLiveClaudePtys()).toBe(true)

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1910,6 +1910,19 @@ describe('registerPtyHandlers', () => {
     })
 
     it('passes the launch worktree to prepareClaudeAuth', async () => {
+      let exitCb: ((info: { exitCode: number }) => void) | undefined
+      spawnMock.mockReturnValue({
+        onData: vi.fn(() => makeDisposable()),
+        onExit: vi.fn((cb: (info: { exitCode: number }) => void) => {
+          exitCb = cb
+          return makeDisposable()
+        }),
+        write: vi.fn(),
+        resize: vi.fn(),
+        kill: vi.fn(() => exitCb?.({ exitCode: -1 })),
+        process: 'zsh',
+        pid: 12346
+      })
       const prepareClaudeAuth = vi.fn(async () => ({
         configDir: '/tmp/claude',
         envPatch: {},
@@ -1918,14 +1931,16 @@ describe('registerPtyHandlers', () => {
       }))
       registerPtyHandlers(mainWindow as never, undefined, undefined, undefined, prepareClaudeAuth)
 
-      await handlers.get('pty:spawn')!(null, {
+      const spawnResult = (await handlers.get('pty:spawn')!(null, {
         cols: 80,
         rows: 24,
         command: 'claude',
         worktreeId: 'wt-1'
-      })
+      })) as { id: string }
 
       expect(prepareClaudeAuth).toHaveBeenCalledWith(expect.anything(), { worktreeId: 'wt-1' })
+
+      await handlers.get('pty:kill')!(null, { id: spawnResult.id })
     })
 
     it('clears Claude live-PTY tracking from shared provider teardown', () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -1201,8 +1201,10 @@ export type PrepareCodexSessionResume = (args: {
   launchEnv?: NodeJS.ProcessEnv
   workspacePath?: string
 }) => Promise<CodexSessionResumePreparation | null>
+export type ClaudeLaunchContext = { worktreeId?: string }
 type PrepareClaudeAuth = (
-  target?: ClaudeAccountSelectionTarget
+  target?: ClaudeAccountSelectionTarget,
+  context?: ClaudeLaunchContext
 ) => Promise<ClaudeRuntimeAuthPreparation>
 
 function getCodexSelectionTargetForPty(
@@ -4397,7 +4399,9 @@ export function registerPtyHandlers(
       // notifyResumeUnavailable — runtime/relay panes start fresh without the notice.
       const launchCommand = codexResumeLaunch.command
       const claudeAuth =
-        isClaudeLaunch && prepareClaudeAuth ? await prepareClaudeAuth(codexSelectionTarget) : null
+        isClaudeLaunch && prepareClaudeAuth
+          ? await prepareClaudeAuth(codexSelectionTarget, { worktreeId: args.worktreeId })
+          : null
       if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {
         throw new Error('A Claude account switch is in progress. Try again after it finishes.')
       }
@@ -5763,7 +5767,7 @@ export function registerPtyHandlers(
         )
         const claudeAuth =
           isClaudeLaunch && prepareClaudeAuth
-            ? await prepareClaudeAuth(initialSelectionTarget)
+            ? await prepareClaudeAuth(initialSelectionTarget, { worktreeId: args.worktreeId })
             : null
         spawnTiming.mark('auth')
         if (isClaudeLaunch && isClaudeAuthSwitchInProgress()) {

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -841,10 +841,16 @@ const LocalWindowsRuntimePreferenceIpcArgs = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('wsl'), distro: z.string().min(1) })
 ])
 
+const ClaudeAccountPreferenceIpcArgs = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('inherit-global') }),
+  z.object({ kind: z.literal('account'), accountId: z.string().min(1) })
+])
+
 const ProjectUpdateIpcArgs = z.object({
   projectId: z.string().min(1),
   updates: z.object({
-    localWindowsRuntimePreference: LocalWindowsRuntimePreferenceIpcArgs.optional()
+    localWindowsRuntimePreference: LocalWindowsRuntimePreferenceIpcArgs.optional(),
+    claudeAccountPreference: ClaudeAccountPreferenceIpcArgs.optional()
   })
 })
 

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -622,6 +622,33 @@ describe('Store', () => {
     })
   })
 
+  it('keeps a repo-backed project Claude account preference across repo updates and reload', async () => {
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      repos: [makeRepo({ id: 'r1', path: '/repo', displayName: 'Repo' })]
+    })
+    const store = await createStore()
+    expect(store.getProjects().map((project) => project.id)).toEqual(['repo:r1'])
+
+    const updated = store.updateProject('repo:r1', {
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-1' }
+    })
+    expect(updated?.claudeAccountPreference).toEqual({ kind: 'account', accountId: 'acct-1' })
+
+    store.updateRepo('r1', { displayName: 'Repo renamed' })
+    expect(store.getProjects()[0]?.claudeAccountPreference).toEqual({
+      kind: 'account',
+      accountId: 'acct-1'
+    })
+
+    store.flush()
+    const reloaded = await createStore()
+    expect(reloaded.getProjects()[0]?.claudeAccountPreference).toEqual({
+      kind: 'account',
+      accountId: 'acct-1'
+    })
+  })
+
   it('deletes the project Claude account preference for undefined, inherit-global, and malformed updates', async () => {
     const project = makeProject({
       id: 'project-1',

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -594,6 +594,109 @@ describe('Store', () => {
     })
   })
 
+  it('updates and persists a project Claude account preference', async () => {
+    const project = makeProject({ id: 'project-1', sourceRepoIds: ['r1'] })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [project],
+      projectHostSetups: [
+        makeProjectHostSetup({
+          id: 'setup-1',
+          projectId: project.id,
+          repoId: ''
+        })
+      ]
+    })
+    const store = await createStore()
+
+    const updated = store.updateProject('project-1', {
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-1' }
+    })
+
+    expect(updated?.claudeAccountPreference).toEqual({ kind: 'account', accountId: 'acct-1' })
+    store.flush()
+    const reloaded = await createStore()
+    expect(reloaded.getProjects()[0]?.claudeAccountPreference).toEqual({
+      kind: 'account',
+      accountId: 'acct-1'
+    })
+  })
+
+  it('deletes the project Claude account preference for undefined, inherit-global, and malformed updates', async () => {
+    const project = makeProject({
+      id: 'project-1',
+      sourceRepoIds: ['r1'],
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-1' }
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [project],
+      projectHostSetups: [
+        makeProjectHostSetup({
+          id: 'setup-1',
+          projectId: project.id,
+          repoId: ''
+        })
+      ]
+    })
+    const store = await createStore()
+
+    expect(
+      store.updateProject('project-1', { claudeAccountPreference: { kind: 'inherit-global' } })
+        ?.claudeAccountPreference
+    ).toBeUndefined()
+
+    store.updateProject('project-1', {
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-1' }
+    })
+    expect(
+      store.updateProject('project-1', { claudeAccountPreference: undefined })
+        ?.claudeAccountPreference
+    ).toBeUndefined()
+
+    store.updateProject('project-1', {
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-1' }
+    })
+    expect(
+      store.updateProject('project-1', {
+        claudeAccountPreference: { kind: 'account', accountId: '   ' }
+      })?.claudeAccountPreference
+    ).toBeUndefined()
+  })
+
+  it('clears matching project Claude account preferences when an account is removed', async () => {
+    const preferring = makeProject({
+      id: 'project-1',
+      sourceRepoIds: ['r1'],
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-1' }
+    })
+    const other = makeProject({
+      id: 'project-2',
+      sourceRepoIds: ['r2'],
+      claudeAccountPreference: { kind: 'account', accountId: 'acct-2' }
+    })
+    writeDataFile({
+      ...getDefaultPersistedState(testState.dir),
+      projects: [preferring, other],
+      projectHostSetups: [
+        makeProjectHostSetup({ id: 'setup-1', projectId: preferring.id, repoId: '' }),
+        makeProjectHostSetup({ id: 'setup-2', projectId: other.id, repoId: '' })
+      ]
+    })
+    const store = await createStore()
+
+    store.clearClaudeAccountPreferenceForAccount('acct-1')
+
+    const projects = store.getProjects()
+    expect(
+      projects.find((entry) => entry.id === 'project-1')?.claudeAccountPreference
+    ).toBeUndefined()
+    expect(projects.find((entry) => entry.id === 'project-2')?.claudeAccountPreference).toEqual({
+      kind: 'account',
+      accountId: 'acct-2'
+    })
+  })
+
   it('migrates legacy WSL agent settings into the global Windows runtime default', async () => {
     writeDataFile({
       schemaVersion: 1,

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -77,6 +77,7 @@ import {
   deriveGlobalWindowsRuntimeDefaultFromLegacySettings,
   normalizeProjectRuntimePreference
 } from '../shared/project-execution-runtime'
+import { normalizeProjectClaudeAccountPreference } from '../shared/project-claude-account-preference'
 import { projectHostSetupProjectionFromRepos } from '../shared/project-host-setup-projection'
 import { isPluginPanelTabKey } from '../shared/plugins/plugin-manifest'
 import type { GitRemoteIdentity } from '../shared/git-remote-identity'
@@ -4150,9 +4151,35 @@ export class Store {
         )
       }
     }
+    if ('claudeAccountPreference' in updates) {
+      const preference = normalizeProjectClaudeAccountPreference(updates.claudeAccountPreference)
+      if (updates.claudeAccountPreference === undefined || preference.kind === 'inherit-global') {
+        delete project.claudeAccountPreference
+      } else {
+        project.claudeAccountPreference = preference
+      }
+    }
     project.updatedAt = Date.now()
     this.scheduleSave()
     return { ...project }
+  }
+
+  clearClaudeAccountPreferenceForAccount(accountId: string): void {
+    let changed = false
+    for (const project of this.state.projects) {
+      if (project.claudeAccountPreference?.kind !== 'account') {
+        continue
+      }
+      if (project.claudeAccountPreference.accountId !== accountId) {
+        continue
+      }
+      delete project.claudeAccountPreference
+      project.updatedAt = Date.now()
+      changed = true
+    }
+    if (changed) {
+      this.scheduleSave()
+    }
   }
 
   getProjectHostSetups(): ProjectHostSetup[] {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2459,13 +2459,25 @@ function mergeProjectHostSetupCompatibilityState(
     }))
   const projectedProjects = projection.projects.map((project) => {
     const existingProject = existingProjectsById.get(project.id)
-    return existingProject?.localWindowsRuntimePreference
-      ? {
-          ...project,
-          localWindowsRuntimePreference: existingProject.localWindowsRuntimePreference,
-          updatedAt: Math.max(project.updatedAt, existingProject.updatedAt)
-        }
-      : project
+    if (!existingProject) {
+      return project
+    }
+    // Why: projections rebuild projects from repos, so user-set per-project preferences must be carried over or they vanish on every repo sync.
+    const carried: Partial<Project> = {}
+    if (existingProject.localWindowsRuntimePreference) {
+      carried.localWindowsRuntimePreference = existingProject.localWindowsRuntimePreference
+    }
+    if (existingProject.claudeAccountPreference) {
+      carried.claudeAccountPreference = existingProject.claudeAccountPreference
+    }
+    if (Object.keys(carried).length === 0) {
+      return project
+    }
+    return {
+      ...project,
+      ...carried,
+      updatedAt: Math.max(project.updatedAt, existingProject.updatedAt)
+    }
   })
   return {
     projects: [...projectedProjects, ...independentProjects],

--- a/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
+++ b/src/main/runtime/rpc/methods/project-runtime-rpc-methods.ts
@@ -49,10 +49,16 @@ const LocalWindowsRuntimePreference = z.discriminatedUnion('kind', [
   z.object({ kind: z.literal('wsl'), distro: requiredString('Missing WSL distro') })
 ])
 
+const ClaudeAccountPreference = z.discriminatedUnion('kind', [
+  z.object({ kind: z.literal('inherit-global') }),
+  z.object({ kind: z.literal('account'), accountId: requiredString('Missing account ID') })
+])
+
 const ProjectUpdate = z.object({
   projectId: requiredString('Missing project ID'),
   updates: z.object({
-    localWindowsRuntimePreference: LocalWindowsRuntimePreference.optional()
+    localWindowsRuntimePreference: LocalWindowsRuntimePreference.optional(),
+    claudeAccountPreference: ClaudeAccountPreference.optional()
   })
 })
 

--- a/src/main/window/attach-main-window-services.ts
+++ b/src/main/window/attach-main-window-services.ts
@@ -23,6 +23,7 @@ import { registerWorkspaceCleanupHandlers } from '../ipc/workspace-cleanup'
 import {
   getLocalPtyProvider,
   registerPtyHandlers,
+  type ClaudeLaunchContext,
   type GetSelectedCodexHomePath,
   type PrepareCodexSessionResume
 } from '../ipc/pty'
@@ -89,7 +90,8 @@ export function attachMainWindowServices(
   runtime: OrcaRuntimeService,
   getSelectedCodexHomePath?: GetSelectedCodexHomePath,
   prepareClaudeAuth?: (
-    target?: ClaudeAccountSelectionTarget
+    target?: ClaudeAccountSelectionTarget,
+    context?: ClaudeLaunchContext
   ) => Promise<ClaudeRuntimeAuthPreparation>,
   options?: {
     prepareCodexSessionResume?: PrepareCodexSessionResume

--- a/src/renderer/src/components/settings/ProjectClaudeAccountSetting.test.tsx
+++ b/src/renderer/src/components/settings/ProjectClaudeAccountSetting.test.tsx
@@ -1,0 +1,80 @@
+// @vitest-environment happy-dom
+
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { ClaudeManagedAccountSummary, Project } from '../../../../shared/types'
+import { ProjectClaudeAccountSetting } from './ProjectClaudeAccountSetting'
+
+const project: Project = {
+  id: 'project-1',
+  displayName: 'Example Project',
+  badgeColor: '#000000',
+  sourceRepoIds: ['repo-1'],
+  createdAt: 1,
+  updatedAt: 1
+}
+
+const accounts: ClaudeManagedAccountSummary[] = [
+  {
+    id: 'acct-host',
+    email: 'host@example.com',
+    authMethod: 'subscription-oauth',
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1
+  },
+  {
+    id: 'acct-wsl',
+    email: 'wsl@example.com',
+    managedAuthRuntime: 'wsl',
+    wslDistro: 'Ubuntu',
+    authMethod: 'subscription-oauth',
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1
+  }
+]
+
+describe('ProjectClaudeAccountSetting', () => {
+  it('describes the inherited global account when no override is set', () => {
+    const markup = renderToStaticMarkup(
+      <ProjectClaudeAccountSetting project={project} accounts={accounts} updateProject={vi.fn()} />
+    )
+
+    expect(markup).toContain('Claude account')
+    expect(markup).toContain('No project override. Claude Code uses the globally selected account.')
+    expect(markup).toContain('Default (follow global account)')
+    expect(markup).toContain('running terminals keep their current account')
+  })
+
+  it('describes the project override and selects the preferred account', () => {
+    const markup = renderToStaticMarkup(
+      <ProjectClaudeAccountSetting
+        project={{
+          ...project,
+          claudeAccountPreference: { kind: 'account', accountId: 'acct-host' }
+        }}
+        accounts={accounts}
+        updateProject={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Claude Code launches in this project switch to this account first.')
+    expect(markup).toContain('host@example.com')
+  })
+
+  it('surfaces a removed account so the user can clear it', () => {
+    const markup = renderToStaticMarkup(
+      <ProjectClaudeAccountSetting
+        project={{
+          ...project,
+          claudeAccountPreference: { kind: 'account', accountId: 'gone' }
+        }}
+        accounts={accounts}
+        updateProject={vi.fn()}
+      />
+    )
+
+    expect(markup).toContain('Removed account')
+  })
+})

--- a/src/renderer/src/components/settings/ProjectClaudeAccountSetting.tsx
+++ b/src/renderer/src/components/settings/ProjectClaudeAccountSetting.tsx
@@ -1,0 +1,131 @@
+import type {
+  ClaudeManagedAccountSummary,
+  Project,
+  ProjectUpdateArgs
+} from '../../../../shared/types'
+import { normalizeProjectClaudeAccountPreference } from '../../../../shared/project-claude-account-preference'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { SettingsRow } from './SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+
+const INHERIT_GLOBAL_VALUE = '__inherit-global__'
+
+type ProjectClaudeAccountSettingProps = {
+  project: Project
+  accounts: ClaudeManagedAccountSummary[]
+  updateProject: (
+    projectId: string,
+    updates: ProjectUpdateArgs['updates']
+  ) => void | Promise<unknown>
+}
+
+export function ProjectClaudeAccountSetting({
+  project,
+  accounts,
+  updateProject
+}: ProjectClaudeAccountSettingProps): React.JSX.Element {
+  const preference = normalizeProjectClaudeAccountPreference(project.claudeAccountPreference)
+  const selectedValue = preference.kind === 'account' ? preference.accountId : INHERIT_GLOBAL_VALUE
+  const danglingAccountId =
+    preference.kind === 'account' &&
+    !accounts.some((account) => account.id === preference.accountId)
+      ? preference.accountId
+      : null
+
+  const selectedAccount = accounts.find((account) => account.id === selectedValue)
+  const selectedLabel =
+    preference.kind !== 'account'
+      ? translate(
+          'auto.components.settings.ProjectClaudeAccountSetting.defaultAccount',
+          'Default (follow global account)'
+        )
+      : selectedAccount
+        ? getClaudeAccountOptionLabel(selectedAccount)
+        : translate(
+            'auto.components.settings.ProjectClaudeAccountSetting.removedAccount',
+            'Removed account'
+          )
+
+  const handleChange = (value: string): void => {
+    if (value === INHERIT_GLOBAL_VALUE) {
+      void updateProject(project.id, { claudeAccountPreference: { kind: 'inherit-global' } })
+      return
+    }
+    void updateProject(project.id, {
+      claudeAccountPreference: { kind: 'account', accountId: value }
+    })
+  }
+
+  return (
+    <section className="space-y-3">
+      <SettingsRow
+        label={translate(
+          'auto.components.settings.ProjectClaudeAccountSetting.claudeAccount',
+          'Claude account'
+        )}
+        description={
+          preference.kind === 'account'
+            ? translate(
+                'auto.components.settings.ProjectClaudeAccountSetting.projectOverride',
+                'Claude Code launches in this project switch to this account first.'
+              )
+            : translate(
+                'auto.components.settings.ProjectClaudeAccountSetting.inheritedAccount',
+                'No project override. Claude Code uses the globally selected account.'
+              )
+        }
+        control={
+          <Select value={selectedValue} onValueChange={handleChange}>
+            <SelectTrigger size="sm" className="w-full min-w-52">
+              <SelectValue>{selectedLabel}</SelectValue>
+            </SelectTrigger>
+            <SelectContent>
+              <SelectItem value={INHERIT_GLOBAL_VALUE}>
+                {translate(
+                  'auto.components.settings.ProjectClaudeAccountSetting.defaultAccount',
+                  'Default (follow global account)'
+                )}
+              </SelectItem>
+              {danglingAccountId ? (
+                <SelectItem value={danglingAccountId}>
+                  {translate(
+                    'auto.components.settings.ProjectClaudeAccountSetting.removedAccount',
+                    'Removed account'
+                  )}
+                </SelectItem>
+              ) : null}
+              {accounts.map((account) => (
+                <SelectItem key={account.id} value={account.id}>
+                  {getClaudeAccountOptionLabel(account)}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        }
+      />
+      <p className="text-xs text-muted-foreground">
+        {translate(
+          'auto.components.settings.ProjectClaudeAccountSetting.accountChangeHelp',
+          "Applies when launching Claude Code in this project's workspaces. Orca switches the active Claude account before launch; running terminals keep their current account."
+        )}
+      </p>
+    </section>
+  )
+}
+
+function getClaudeAccountOptionLabel(account: ClaudeManagedAccountSummary): string {
+  if (account.managedAuthRuntime === 'wsl') {
+    return account.wslDistro
+      ? translate(
+          'auto.components.settings.ProjectClaudeAccountSetting.wslAccountWithDistro',
+          '{{value0}} (WSL: {{value1}})',
+          { value0: account.email, value1: account.wslDistro }
+        )
+      : translate(
+          'auto.components.settings.ProjectClaudeAccountSetting.wslAccount',
+          '{{value0}} (WSL)',
+          { value0: account.email }
+        )
+  }
+  return account.email
+}

--- a/src/renderer/src/components/settings/RepositoryClaudeAccountSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryClaudeAccountSection.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import type {
+  ClaudeManagedAccountSummary,
+  Project,
+  ProjectUpdateArgs
+} from '../../../../shared/types'
+import { SearchableSetting } from './SearchableSetting'
+import type { SettingsSearchEntry } from './settings-search'
+import { matchesSettingsSearch } from './settings-search'
+import { ProjectClaudeAccountSetting } from './ProjectClaudeAccountSetting'
+import { watchProviderAccounts } from '../../runtime/runtime-provider-accounts-client'
+import { useAppStore } from '../../store'
+import { translate } from '@/i18n/i18n'
+
+type RepositoryClaudeAccountSectionProps = {
+  repoDisplayName: string
+  project: Project | null
+  updateProject?: (
+    projectId: string,
+    updates: ProjectUpdateArgs['updates']
+  ) => void | Promise<unknown>
+  forceVisible: boolean
+  searchQuery: string
+  searchEntries: SettingsSearchEntry[]
+}
+
+export function RepositoryClaudeAccountSection({
+  repoDisplayName,
+  project,
+  updateProject,
+  forceVisible,
+  searchQuery,
+  searchEntries
+}: RepositoryClaudeAccountSectionProps): React.JSX.Element | null {
+  const settings = useAppStore((state) => state.settings)
+  const activeRuntimeEnvironmentId = settings?.activeRuntimeEnvironmentId
+  const [accounts, setAccounts] = useState<ClaudeManagedAccountSummary[]>([])
+
+  useEffect(() => {
+    const watcher = watchProviderAccounts(
+      { activeRuntimeEnvironmentId },
+      {
+        onSnapshot: (snapshot) => setAccounts(snapshot.claude.accounts),
+        // Why: a load failure just hides the section; account errors surface in Settings > Accounts.
+        onError: () => setAccounts([])
+      }
+    )
+    return () => watcher.close()
+  }, [activeRuntimeEnvironmentId])
+
+  if (!project || !updateProject || accounts.length === 0) {
+    return null
+  }
+
+  return (
+    <SearchableSetting
+      title={translate('auto.components.settings.RepositoryPane.claudeAccount', 'Claude Account')}
+      description={translate(
+        'auto.components.settings.RepositoryPane.claudeAccountDescription',
+        'Choose which managed Claude account this project launches Claude Code with.'
+      )}
+      keywords={[repoDisplayName, 'claude', 'account', 'agent account', 'anthropic']}
+      className="space-y-3"
+      forceVisible={forceVisible || matchesSettingsSearch(searchQuery, searchEntries)}
+    >
+      <ProjectClaudeAccountSetting
+        project={project}
+        accounts={accounts}
+        updateProject={updateProject}
+      />
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/RepositoryPane.test.ts
+++ b/src/renderer/src/components/settings/RepositoryPane.test.ts
@@ -70,10 +70,13 @@ beforeEach(() => {
   document.body.appendChild(container)
   root = createRoot(container)
   // WorktreeSymlinksSection reads window.api.fs on mount to suggest directory
-  // paths; provide a minimal renderer bridge so mounting the full pane doesn't
-  // throw in the test environment.
+  // paths, and RepositoryClaudeAccountSection reads the provider account
+  // rosters; provide a minimal renderer bridge so mounting the full pane
+  // doesn't throw in the test environment.
   ;(window as unknown as { api: unknown }).api = {
-    fs: { readDir: () => Promise.resolve([]) }
+    fs: { readDir: () => Promise.resolve([]) },
+    claudeAccounts: { list: () => Promise.resolve({ accounts: [], activeAccountId: null }) },
+    codexAccounts: { list: () => Promise.resolve({ accounts: [], activeAccountId: null }) }
   }
 })
 

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -30,6 +30,7 @@ import { RepoSettingsDraftInput } from './RepositorySettingsDraftInput'
 import { RepositoryForkSyncSection } from './RepositoryForkSyncSection'
 import { translate } from '@/i18n/i18n'
 import { RepositoryWindowsRuntimeSection } from './RepositoryWindowsRuntimeSection'
+import { RepositoryClaudeAccountSection } from './RepositoryClaudeAccountSection'
 import { matchesRepositoryIdentitySearch } from './repository-identity-search'
 import { RepositoryWorktreeDefaultsSection } from './RepositoryWorktreeDefaultsSection'
 import { getProjectRuntimeSessionSummary } from './repository-runtime-session-summary'
@@ -191,6 +192,7 @@ export function RepositoryPane({
   const sourceControlAiEntries = allEntries.filter((entry) => entry.title === 'Git AI Author')
   const hostSetupEntries = allEntries.filter((entry) => entry.title === 'Available Hosts')
   const projectRuntimeEntries = allEntries.filter((entry) => entry.title === 'Project Runtime')
+  const claudeAccountEntries = allEntries.filter((entry) => entry.title === 'Claude Account')
   const removeProjectLabel =
     confirmingRemove === repo.id ? 'Confirm Remove Project' : 'Remove Project'
 
@@ -357,6 +359,15 @@ export function RepositoryPane({
             />
           </>
         ) : null}
+
+        <RepositoryClaudeAccountSection
+          repoDisplayName={repo.displayName}
+          project={project}
+          updateProject={updateProject}
+          forceVisible={forceFullPaneForRepoMatch}
+          searchQuery={searchQuery}
+          searchEntries={claudeAccountEntries}
+        />
       </section>
     ) : null,
     hooksSection,

--- a/src/renderer/src/components/settings/repository-search.ts
+++ b/src/renderer/src/components/settings/repository-search.ts
@@ -162,6 +162,29 @@ export function getRepositoryPaneSearchEntries(
             ]
           }
         ]),
+    {
+      title: translate(
+        'auto.components.settings.repository.search.claudeAccount',
+        'Claude Account'
+      ),
+      description: translate(
+        'auto.components.settings.repository.search.claudeAccountDescription',
+        'Choose which managed Claude account this project launches Claude Code with.'
+      ),
+      keywords: [
+        repo.displayName,
+        ...translateSearchKeyword('auto.components.settings.repository.search.claude', 'claude'),
+        ...translateSearchKeyword('auto.components.settings.repository.search.account', 'account'),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.agentAccount',
+          'agent account'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.anthropic',
+          'anthropic'
+        )
+      ]
+    },
     ...(isFolder ? [] : getRepositoryGitWorktreeSearchEntries(repo)),
     {
       title: translate('auto.components.settings.repository.search.c5266c2c9d', 'Remove Project'),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6795,7 +6795,9 @@
           "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
           "hostStateDisconnected": "Disconnected",
           "hostStateUnknown": "Unknown",
-          "nestedHostLabel": "{{value0}} via {{value1}}"
+          "nestedHostLabel": "{{value0}} via {{value1}}",
+          "claudeAccount": "Claude Account",
+          "claudeAccountDescription": "Choose which managed Claude account this project launches Claude Code with."
         },
         "RepositorySourceControlAiActionRows": {
           "548a6e1281": "Command template",
@@ -8905,7 +8907,9 @@
             "keepForkUpToDate": "Keep Fork Up to Date",
             "keepForkUpToDateDescription": "Safely fast-forward this fork from upstream.",
             "projectRuntime": "Project Runtime",
-            "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL."
+            "projectRuntimeDescription": "Choose whether this project runs on Windows or WSL.",
+            "claudeAccount": "Claude Account",
+            "claudeAccountDescription": "Choose which managed Claude account this project launches Claude Code with."
           }
         },
         "runtime": {
@@ -10295,6 +10299,16 @@
           "body": "The terminal daemon was started by an Orca install that no longer exists, so macOS can’t attribute its commands to Orca — Accessibility and Automation grants are silently ignored (osascript fails with error -25211). Restarting the daemon fixes this; running terminal sessions will close.",
           "openManageSessions": "Open Manage Sessions",
           "title": "macOS permission grants aren’t reaching terminals"
+        },
+        "ProjectClaudeAccountSetting": {
+          "claudeAccount": "Claude account",
+          "projectOverride": "Claude Code launches in this project switch to this account first.",
+          "inheritedAccount": "No project override. Claude Code uses the globally selected account.",
+          "defaultAccount": "Default (follow global account)",
+          "removedAccount": "Removed account",
+          "accountChangeHelp": "Applies when launching Claude Code in this project's workspaces. Orca switches the active Claude account before launch; running terminals keep their current account.",
+          "wslAccountWithDistro": "{{value0}} (WSL: {{value1}})",
+          "wslAccount": "{{value0}} (WSL)"
         }
       },
       "right": {

--- a/src/shared/project-claude-account-preference.ts
+++ b/src/shared/project-claude-account-preference.ts
@@ -1,0 +1,35 @@
+export type ProjectClaudeAccountPreference =
+  | { kind: 'inherit-global' }
+  | { kind: 'account'; accountId: string }
+
+export function normalizeProjectClaudeAccountPreference(
+  value: unknown
+): ProjectClaudeAccountPreference {
+  if (!isRecord(value)) {
+    return { kind: 'inherit-global' }
+  }
+
+  if (value.kind === 'account') {
+    const accountId = normalizeAccountId(value.accountId)
+    return accountId ? { kind: 'account', accountId } : { kind: 'inherit-global' }
+  }
+
+  return { kind: 'inherit-global' }
+}
+
+export function getPreferredClaudeAccountId(value: unknown): string | null {
+  const preference = normalizeProjectClaudeAccountPreference(value)
+  return preference.kind === 'account' ? preference.accountId : null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null
+}
+
+function normalizeAccountId(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  const trimmed = value.trim()
+  return trimmed ? trimmed : null
+}

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -46,6 +46,7 @@ import type {
   GlobalWindowsRuntimeDefault,
   LocalWindowsRuntimePreference
 } from './project-execution-runtime'
+import type { ProjectClaudeAccountPreference } from './project-claude-account-preference'
 import type { UsagePercentageDisplay } from './usage-percentage-display'
 import type { StatusBarUsageMode } from './status-bar-usage-mode'
 import type { PersistedNativeChatSessionOptions } from './native-chat-session-options'
@@ -126,6 +127,8 @@ export type Project = {
   gitRemoteIdentity?: GitRemoteIdentity
   /** Local Windows projects inherit the global runtime default unless this override is set. */
   localWindowsRuntimePreference?: LocalWindowsRuntimePreference
+  /** Claude launches in this project switch to this managed account first; absent inherits the global selection. */
+  claudeAccountPreference?: ProjectClaudeAccountPreference
   sourceRepoIds: string[]
   createdAt: number
   updatedAt: number
@@ -133,7 +136,7 @@ export type Project = {
 
 export type ProjectUpdateArgs = {
   projectId: string
-  updates: Partial<Pick<Project, 'localWindowsRuntimePreference'>>
+  updates: Partial<Pick<Project, 'localWindowsRuntimePreference' | 'claudeAccountPreference'>>
 }
 
 export type ProjectHostSetupState = 'ready' | 'not-set-up' | 'setting-up' | 'error' | 'unsupported'


### PR DESCRIPTION
## What

Adds a per-project Claude account preference. Each project can pick one of the managed Claude accounts in its settings (new "Claude Account" section in the project pane). When a Claude Code terminal is launched in that project's workspaces, Orca selects the preferred account through the existing switch machinery before credentials materialize. Projects without a preference keep inheriting the global selection, and the status bar switcher keeps reflecting the active account as it does today.

## Why

With several managed Claude accounts (for example a personal and a work subscription), the active account is a single global slot, so working across projects means manually switching accounts before each launch. Binding the preference to the project removes that manual step while keeping the deliberate single-slot credential model intact: no `CLAUDE_CONFIG_DIR` forking, and running terminals keep their current account exactly as with a manual switch.

## How

- `Project.claudeAccountPreference` (`inherit-global` | `account`) in shared types, following the `localWindowsRuntimePreference` pattern; normalizer in `src/shared/project-claude-account-preference.ts`. Absent and `inherit-global` both persist as key deletion.
- `createProjectAwarePrepareClaudeAuth` wraps `prepareForClaudeLaunch` at the wiring points in `src/main/index.ts` (desktop and headless serve). Both PTY spawn paths pass `{ worktreeId }`, resolved to the project via worktree meta. If the preferred account differs from the current selection for its runtime lane, `selectAccountForTarget` runs first (full existing machinery: mutation queue, live-PTY gate, rollback); a failed switch fails the spawn instead of silently launching on the wrong account.
- Fallback to the global selection when the preference is absent, dangling, or belongs to a different runtime lane (host vs WSL, or another distro); dangling preferences are also pruned when an account is removed.
- IPC and remote RPC schemas gain the optional field only, so old hosts ignore it (wire-safe per the remote wire compatibility rules).
- UI: `RepositoryClaudeAccountSection` renders only when managed Claude accounts exist, works for folder workspaces too, and surfaces a removed account so it can be cleared.
- Non-PTY consumers (commit-message agent, rate-limit probe) intentionally stay on the global selection.

## Testing

- New unit coverage: resolution and switch ordering matrix in `project-account-preference.test.ts` (12 cases), persistence set/normalize/delete/prune, account-removal pruning in the service, worktree context threading in `pty.test.ts`, and rendering states of the new setting component.
- `pnpm lint`, `pnpm typecheck`, `pnpm build` pass; touched test suites are green (654 tests across claude-accounts, persistence, and the settings pane).
- Not yet manually exercised in a packaged build; happy to run through any launch scenarios reviewers want covered (multi-account switch on launch, inherit fallback, live-terminal continuity).
