### PR TITLE
fix(terminal): repaint after scrollback replay settles on fresh mount

### DIFF
--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -441,7 +441,8 @@ describe('restoreScrollbackBuffers', () => {
     }
     const manager = {
       getPanes: vi.fn(() => [pane]),
-      hasWebglRenderer: vi.fn(() => true)
+      hasWebglRenderer: vi.fn(() => true),
+      scheduleRevealRepaint: vi.fn()
     }
     const replayingPanesRef = { current: new Map<number, number>() }
     const restoredViewportBlankingPanesRef = { current: new Set<number>() }

--- a/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.test.ts
@@ -460,6 +460,46 @@ describe('restoreScrollbackBuffers', () => {
     expect(restoredViewportBlankingPanesRef.current.has(1)).toBe(true)
     expect(replayingPanesRef.current.size).toBe(0)
   })
+
+  it('defers scheduleRevealRepaint until every replay write has actually parsed', async () => {
+    const callbacks: (() => void)[] = []
+    const pane = {
+      id: 1,
+      terminal: {
+        write: vi.fn((_data: string, callback?: () => void) => {
+          if (callback) {
+            callbacks.push(callback)
+          }
+        })
+      }
+    }
+    const manager = {
+      getPanes: vi.fn(() => [pane]),
+      hasWebglRenderer: vi.fn(() => true),
+      scheduleRevealRepaint: vi.fn()
+    }
+    const replayingPanesRef = { current: new Map<number, number>() }
+    const restoredViewportBlankingPanesRef = { current: new Set<number>() }
+
+    restoreScrollbackBuffers(
+      manager as unknown as Parameters<typeof restoreScrollbackBuffers>[0],
+      { [LEAF_1]: 'restored output' },
+      new Map([[LEAF_1, 1]]),
+      replayingPanesRef,
+      restoredViewportBlankingPanesRef
+    )
+
+    // Why: the mount-time reveal repaint must not fire before scrollback has
+    // actually parsed (#12047) — only the fix's follow-up repaint should run.
+    expect(manager.scheduleRevealRepaint).not.toHaveBeenCalled()
+    expect(callbacks.length).toBe(3)
+
+    callbacks.forEach((callback) => callback())
+    await Promise.resolve()
+    await Promise.resolve()
+
+    expect(manager.scheduleRevealRepaint).toHaveBeenCalledTimes(1)
+  })
 })
 
 // ---------------------------------------------------------------------------

--- a/src/renderer/src/components/terminal-pane/layout-serialization.ts
+++ b/src/renderer/src/components/terminal-pane/layout-serialization.ts
@@ -5,7 +5,7 @@ import type {
 } from '../../../../shared/types'
 import { isTerminalLeafId } from '../../../../shared/stable-pane-id'
 import type { PaneManager } from '@/lib/pane-manager/pane-manager'
-import { replayIntoTerminal, type ReplayingPanesRef } from './replay-guard'
+import { replayIntoTerminalAsync, type ReplayingPanesRef } from './replay-guard'
 import type { RestoredViewportBlankingPanesRef } from './terminal-restored-viewport'
 import { isXtermInstanceDisposed } from '@/lib/pane-manager/xterm-instance-disposed'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
@@ -183,6 +183,7 @@ export function restoreScrollbackBuffers(
   }
   const ALT_SCREEN_ON = '\x1b[?1049h'
   const ALT_SCREEN_OFF = '\x1b[?1049l'
+  const replayed: Promise<void>[] = []
   for (const [oldLeafId, buffer] of Object.entries(savedBuffers)) {
     const newPaneId = restoredPaneByLeafId.get(oldLeafId)
     if (newPaneId == null || !buffer) {
@@ -211,12 +212,14 @@ export function restoreScrollbackBuffers(
         buf = buf.slice(0, lastOn)
       }
       if (buf.length > 0) {
-        // replayIntoTerminal: buffer queries (DA1/DECRQM/CPR) would auto-reply into the new shell's stdin. See replay-guard.ts.
-        replayIntoTerminal(pane, replayingPanesRef, buf, renderOptions)
+        // replayIntoTerminalAsync: buffer queries (DA1/DECRQM/CPR) would auto-reply into the new shell's stdin. See replay-guard.ts.
+        replayed.push(replayIntoTerminalAsync(pane, replayingPanesRef, buf, renderOptions))
         // Newline first so the new shell prompt doesn't trigger zsh's PROMPT_EOL_MARK (%) indicator.
-        replayIntoTerminal(pane, replayingPanesRef, '\r\n', renderOptions)
+        replayed.push(replayIntoTerminalAsync(pane, replayingPanesRef, '\r\n', renderOptions))
         // Clear mode bits the buffer replayed: the fresh shell has no TUI to consume them. See POST_REPLAY_MODE_RESET.
-        replayIntoTerminal(pane, replayingPanesRef, POST_REPLAY_MODE_RESET, renderOptions)
+        replayed.push(
+          replayIntoTerminalAsync(pane, replayingPanesRef, POST_REPLAY_MODE_RESET, renderOptions)
+        )
         // Why: connection resolution runs after layout replay; only fresh-shell paths move these rows into scrollback.
         restoredViewportBlankingPanesRef?.current.add(pane.id)
       }
@@ -228,6 +231,15 @@ export function restoreScrollbackBuffers(
         errorMessage: error instanceof Error ? error.message : String(error)
       })
     }
+  }
+  if (replayed.length > 0) {
+    // Why: scheduleRevealRepaint() on mount fires before this async scrollback
+    // replay finishes, so its double-rAF atlas reset misses chunks written
+    // after the window and leaves stale WebGL cells (#12047). Repaint again
+    // once every replay write has actually parsed.
+    void Promise.all(replayed).then(() => {
+      manager.scheduleRevealRepaint()
+    })
   }
 }
 

--- a/tests/e2e/terminal-wake-reveal-scrollback-visual-restore.spec.ts
+++ b/tests/e2e/terminal-wake-reveal-scrollback-visual-restore.spec.ts
@@ -1,0 +1,139 @@
+/**
+ * E2E visual regression for #12047: a freshly-mounted terminal pane's
+ * restored scrollback replays asynchronously (see
+ * `restoreScrollbackBuffers` in `layout-serialization.ts`), but the
+ * mount-time visibility effect's WebGL reveal repaint fires once, before
+ * that replay settles. A worktree wake exercises the same fresh-mount +
+ * scrollback-restore path as a mobile client's first reveal of a
+ * cold/background-mounted tab, so it's the fastest single-launch repro.
+ */
+
+import { randomUUID } from 'node:crypto'
+import { rmSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  ensureTerminalVisible,
+  getAllWorktreeIds,
+  switchToWorktree,
+  waitForActiveWorktree,
+  waitForSessionReady
+} from './helpers/store'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+
+async function sleepWorktreeTerminals(page: Page, worktreeId: string): Promise<void> {
+  await page.evaluate(async (id) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('store unavailable')
+    }
+    const state = store.getState()
+    await state.shutdownWorktreeBrowsers(id)
+    await state.shutdownWorktreeTerminals(id, { keepIdentifiers: true })
+  }, worktreeId)
+}
+
+async function readLivePtyCountForWorktree(page: Page, worktreeId: string): Promise<number> {
+  return page.evaluate((id) => {
+    const store = window.__store
+    if (!store) {
+      return 0
+    }
+    const state = store.getState()
+    const tabs = state.tabsByWorktree[id] ?? []
+    return tabs.reduce((count, tab) => count + (state.ptyIdsByTabId[tab.id]?.length ?? 0), 0)
+  }, worktreeId)
+}
+
+// Why: a large, densely colored full-screen grid makes stale WebGL glyph
+// atlas cells (from #12047) visually obvious as ghost rectangles instead of
+// a subtle one-cell diff a screenshot review could miss.
+function denseColoredFrame(runId: string): string {
+  const shortId = runId.slice(0, 8)
+  const bgCodes = [41, 42, 43, 44, 45, 46, 100, 101]
+  const rows: string[] = ['\x1b[2J\x1b[H']
+  for (let row = 0; row < 40; row++) {
+    const bg = bgCodes[row % bgCodes.length]
+    const label = `OpenCode visual restore ${shortId} row ${String(row).padStart(2, '0')}`
+    rows.push(`\x1b[${bg}m\x1b[97m${label.padEnd(78, ' ')}\x1b[0m`)
+  }
+  rows.push(`WAKE_REVEAL_RESTORE_${runId}`)
+  return rows.join('\r\n')
+}
+
+function writeFrameScript(scriptPath: string, payload: string): void {
+  const encodedPayload = Buffer.from(payload, 'utf8').toString('base64')
+  writeFileSync(
+    scriptPath,
+    `process.stdout.write(Buffer.from(${JSON.stringify(encodedPayload)}, 'base64').toString('utf8'))\n`,
+    'utf8'
+  )
+}
+
+async function attachTerminalScreenshot(page: Page, testInfo: TestInfo, name: string) {
+  const screenshotPath = testInfo.outputPath(name)
+  await page.screenshot({ path: screenshotPath, fullPage: true })
+  await testInfo.attach(name, { path: screenshotPath, contentType: 'image/png' })
+}
+
+test.describe('Terminal wake reveal scrollback visual restore', () => {
+  test('freshly-mounted pane repaints cleanly after wake-reveal scrollback replay', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await waitForSessionReady(orcaPage)
+    const firstWorktreeId = await waitForActiveWorktree(orcaPage)
+    const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
+      (id) => id !== firstWorktreeId
+    )
+    test.skip(!secondWorktreeId, 'wake reveal visual restore needs the seeded secondary worktree')
+    if (!secondWorktreeId) {
+      return
+    }
+
+    await switchToWorktree(orcaPage, secondWorktreeId)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    const ptyId = await waitForActivePanePtyId(orcaPage)
+    const runId = randomUUID()
+    const restoreMarker = `WAKE_REVEAL_RESTORE_${runId}`
+    const scriptPath = path.join(testRepoPath, `.orca-wake-reveal-visual-${runId}.mjs`)
+    writeFrameScript(scriptPath, denseColoredFrame(runId))
+
+    try {
+      await sendToTerminal(orcaPage, ptyId, `node ${JSON.stringify(scriptPath)}\r`)
+      await waitForTerminalOutput(orcaPage, restoreMarker, 10_000, 20_000)
+
+      await switchToWorktree(orcaPage, firstWorktreeId)
+      await sleepWorktreeTerminals(orcaPage, secondWorktreeId)
+      await expect
+        .poll(() => readLivePtyCountForWorktree(orcaPage, secondWorktreeId), {
+          timeout: 10_000,
+          message: 'sleep did not release live PTYs for the background worktree'
+        })
+        .toBe(0)
+
+      // Why: switch back and screenshot immediately (no extra settle wait) to
+      // catch the fresh-mount reveal-repaint race described in #12047 —
+      // waiting for the terminal content to settle would mask the timing bug.
+      await switchToWorktree(orcaPage, secondWorktreeId)
+      await ensureTerminalVisible(orcaPage)
+      await waitForActiveTerminalManager(orcaPage, 30_000)
+      await attachTerminalScreenshot(orcaPage, testInfo, 'wake-reveal-immediate.png')
+
+      // Why: a second screenshot once things settle documents the same pane
+      // isn't just slow to paint — it should look identical to the immediate
+      // one once the fix's follow-up repaint has actually run.
+      await waitForTerminalOutput(orcaPage, restoreMarker, 15_000, 20_000)
+      await attachTerminalScreenshot(orcaPage, testInfo, 'wake-reveal-settled.png')
+    } finally {
+      rmSync(scriptPath, { force: true })
+    }
+  })
+})


### PR DESCRIPTION
## Summary

Fixes #12047: mobile terminal renders garbled/misaligned (stale ghost cells) after tab reveal, and also on first launch of a background/cold-mounted tab.

Root cause: a freshly-mounted terminal pane's restored scrollback replays asynchronously (`replayIntoTerminal`), but the mount-time visibility effect's one-shot double-rAF WebGL atlas reset (`scheduleRevealRepaint()`, from #7058) fires before that replay finishes. Later replay chunks land after the repaint window and never get a follow-up atlas reset/present, leaving stale grid-aligned cells behind real content.

`restoreScrollbackBuffers` now uses `replayIntoTerminalAsync` (already existed in `replay-guard.ts`), awaits all replay writes, and triggers a follow-up `manager.scheduleRevealRepaint()` once scrollback has actually parsed — anchoring the repaint to replay completion rather than a fixed timing window.

## Screenshots

- No screenshot embedded by the agent — the reporter's repro screenshot (ghost/stale color-block rectangles bleeding through behind real terminal text) will be attached directly to this PR by @aashishtamsya.
- The bug is specific to xterm's WebGL renderer. Headless e2e (used for the added regression test) runs with `--disable-gpu`/`--disable-gpu-compositing`, so WebGL never activates there and the artifact can't be captured via automated headless screenshots — visual confirmation needs a GPU-accelerated (real device/desktop) session.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (clean for changed files)
- [x] `pnpm test` — `layout-serialization.test.ts` and `replay-guard.test.ts` pass (63 tests, including a new test asserting `scheduleRevealRepaint` is deferred until every replay write has actually parsed)
- [ ] `pnpm build`
- [x] Added regression coverage: a unit test verifying the follow-up repaint doesn't fire until replay write callbacks resolve, plus a new e2e spec (`terminal-wake-reveal-scrollback-visual-restore.spec.ts`) exercising the same fresh-mount + scrollback-restore path via worktree sleep/wake

## AI Review Report

Reviewed the change with Claude Code. Main risk checked: whether anchoring the repaint to `Promise.all(replayed)` could regress the case where a pane's replay never resolves (e.g. certified-dead write pipeline) — confirmed `replayIntoTerminalAsync` always resolves in that path (see `replay-guard.ts`), so the repaint chain can't hang. Also verified `scheduleRevealRepaint()` no-ops safely if the pane manager is destroyed before the promise settles (checked internally via a private `destroyed` flag), so no explicit guard was needed at the call site. Cross-platform: this is a renderer-only change to write/replay sequencing and WebGL repaint timing — no OS-specific paths, shortcuts, or shell behavior involved, so macOS/Linux/Windows are equally affected and equally fixed.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface changes — this only reorders when an existing internal repaint call fires relative to existing internal replay writes. No new follow-up needed.

## Notes

- Fix is renderer/WebGL-timing specific; behavior is unchanged for non-WebGL (canvas/DOM) terminal renderers, since `scheduleRevealRepaint()` already no-ops when WebGL isn't in use.
- On-device visual confirmation from the reporter is the last verification step before merge.
