### PR TITLE
fix(crash-reporting): stop filing Windows OS shutdown as renderer crashes

### DIFF
--- a/src/main/crash-reporting/expected-teardown-state.test.ts
+++ b/src/main/crash-reporting/expected-teardown-state.test.ts
@@ -1,0 +1,193 @@
+import { performance } from 'node:perf_hooks'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  shouldRecordProcessGoneCrash,
+  shouldRecoverRendererAfterProcessGone
+} from './process-gone-classification'
+import {
+  markSystemSessionEnding,
+  resetExpectedTeardownStateForTest,
+  resolveExpectedTeardownScope,
+  WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+} from './expected-teardown-state'
+
+function shouldRecordKilledRenderer(expectedTeardown: 'none' | 'renderer-reload' | 'app-shutdown') {
+  return shouldRecordProcessGoneCrash({
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'killed',
+    exitCode: 1,
+    expectedTeardown
+  })
+}
+
+let now: number
+
+beforeEach(() => {
+  now = 1_000
+  resetExpectedTeardownStateForTest(() => now)
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetExpectedTeardownStateForTest()
+})
+
+describe('expected teardown state', () => {
+  it('uses a product-chosen five-second harm bound, not a Windows lifetime guarantee', () => {
+    // Restart Manager may wait 30s; tree-kills after this bound remain reportable by design.
+    expect(WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS).toBe(5_000)
+  })
+
+  it('uses the production monotonic clock by default', () => {
+    vi.spyOn(performance, 'now').mockReturnValueOnce(1_000).mockReturnValue(1_001)
+    vi.spyOn(Date, 'now').mockReturnValueOnce(10_000).mockReturnValue(15_000)
+    resetExpectedTeardownStateForTest()
+
+    markSystemSessionEnding()
+
+    expect(
+      resolveExpectedTeardownScope({
+        isQuitting: false,
+        isQuittingForUpdate: false,
+        isExpectedRendererReload: false
+      })
+    ).toBe('app-shutdown')
+  })
+
+  it('does not resurrect session-end after an injected clock rollback and catch-up', () => {
+    now = 3_600_000
+    markSystemSessionEnding()
+    now = 0
+    const rollbackScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+    now = 3_600_001
+    const catchUpScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+
+    expect(rollbackScope).toBe('none')
+    expect(catchUpScope).toBe('none')
+  })
+
+  it('does not resurrect session-end after expiry and an injected backtrack', () => {
+    markSystemSessionEnding()
+    now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+    const expiredScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+    now -= 1
+    const backtrackScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+
+    expect(expiredScope).toBe('none')
+    expect(backtrackScope).toBe('none')
+  })
+
+  it('re-arms the suppression window on repeated session-end events', () => {
+    markSystemSessionEnding()
+    now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS - 1
+    markSystemSessionEnding()
+    now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS - 1
+
+    expect(
+      resolveExpectedTeardownScope({
+        isQuitting: false,
+        isQuittingForUpdate: false,
+        isExpectedRendererReload: false
+      })
+    ).toBe('app-shutdown')
+  })
+
+  it('classifies killed/1 just inside the session-end window as app shutdown', () => {
+    markSystemSessionEnding()
+    now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS - 1
+    const scope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+
+    expect(scope).toBe('app-shutdown')
+    expect(shouldRecordKilledRenderer(scope)).toBe(false)
+  })
+
+  it('keeps killed/1 reportable at and just outside the session-end boundary', () => {
+    markSystemSessionEnding()
+    now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+    const boundaryScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+    now += 1
+    const outsideScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false
+    })
+
+    expect(boundaryScope).toBe('none')
+    expect(outsideScope).toBe('none')
+    expect(shouldRecordKilledRenderer(outsideScope)).toBe(true)
+  })
+
+  it('excludes session-end from recovery while preserving in-app quit suppression', () => {
+    markSystemSessionEnding()
+    const sessionEndScope = resolveExpectedTeardownScope({
+      isQuitting: false,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false,
+      includeSystemSessionEnd: false
+    })
+    const inAppQuitScope = resolveExpectedTeardownScope({
+      isQuitting: true,
+      isQuittingForUpdate: false,
+      isExpectedRendererReload: false,
+      includeSystemSessionEnd: false
+    })
+
+    expect(sessionEndScope).toBe('none')
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'killed',
+        expectedTeardown: sessionEndScope
+      })
+    ).toBe(true)
+    expect(inAppQuitScope).toBe('app-shutdown')
+    expect(
+      shouldRecoverRendererAfterProcessGone({
+        reason: 'killed',
+        expectedTeardown: inAppQuitScope
+      })
+    ).toBe(false)
+  })
+
+  it('preserves existing update and renderer-reload scopes', () => {
+    expect(
+      resolveExpectedTeardownScope({
+        isQuitting: false,
+        isQuittingForUpdate: true,
+        isExpectedRendererReload: false
+      })
+    ).toBe('app-shutdown')
+    expect(
+      resolveExpectedTeardownScope({
+        isQuitting: false,
+        isQuittingForUpdate: false,
+        isExpectedRendererReload: true,
+        includeSystemSessionEnd: false
+      })
+    ).toBe('renderer-reload')
+  })
+})

--- a/src/main/crash-reporting/expected-teardown-state.ts
+++ b/src/main/crash-reporting/expected-teardown-state.ts
@@ -1,0 +1,58 @@
+import { performance } from 'node:perf_hooks'
+import type { ExpectedTeardownScope } from './process-gone-classification'
+
+// Why: 5s bounds harm; Restart Manager may wait 30s, so later kills remain reportable.
+export const WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS = 5_000
+
+type Clock = () => number
+
+// Windows performance.now is monotonic and includes time spent suspended.
+const monotonicNow = (): number => performance.now()
+let now: Clock = monotonicNow
+let systemSessionEndedAt: number | null = null
+
+export function markSystemSessionEnding(): void {
+  systemSessionEndedAt = now()
+}
+
+function isRecentSystemSessionEnd(): boolean {
+  if (systemSessionEndedAt === null) {
+    return false
+  }
+  const elapsed = now() - systemSessionEndedAt
+  if (elapsed < 0) {
+    systemSessionEndedAt = null
+    return false
+  }
+  if (elapsed >= WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS) {
+    systemSessionEndedAt = null
+    return false
+  }
+  return true
+}
+
+export function resolveExpectedTeardownScope({
+  isQuitting,
+  isQuittingForUpdate,
+  isExpectedRendererReload,
+  includeSystemSessionEnd = true
+}: {
+  isQuitting: boolean
+  isQuittingForUpdate: boolean
+  isExpectedRendererReload: boolean
+  includeSystemSessionEnd?: boolean
+}): ExpectedTeardownScope {
+  if (
+    isQuitting ||
+    isQuittingForUpdate ||
+    (includeSystemSessionEnd && isRecentSystemSessionEnd())
+  ) {
+    return 'app-shutdown'
+  }
+  return isExpectedRendererReload ? 'renderer-reload' : 'none'
+}
+
+export function resetExpectedTeardownStateForTest(clock: Clock = monotonicNow): void {
+  now = clock
+  systemSessionEndedAt = null
+}

--- a/src/main/crash-reporting/process-gone-killed-one-ordering.test.ts
+++ b/src/main/crash-reporting/process-gone-killed-one-ordering.test.ts
@@ -1,0 +1,149 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('electron', () => ({
+  app: {
+    getVersion: () => '1.2.3-test',
+    getAppMetrics: () => []
+  }
+}))
+
+import { clearCrashBreadcrumbsForTest } from './crash-breadcrumb-store'
+import {
+  markSystemSessionEnding,
+  resetExpectedTeardownStateForTest,
+  resolveExpectedTeardownScope,
+  WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+} from './expected-teardown-state'
+import { ProcessGoneDedupe } from './process-gone-dedupe'
+import { recordProcessGoneCrash, type ProcessGoneCrashEvent } from './process-gone-recorder'
+
+function event(overrides: Partial<ProcessGoneCrashEvent> = {}): ProcessGoneCrashEvent {
+  return {
+    source: 'renderer',
+    processType: 'renderer',
+    reason: 'killed',
+    exitCode: 1,
+    expectedTeardown: 'none',
+    details: { processType: 'renderer' },
+    ...overrides
+  }
+}
+
+const gpuKill = event({
+  source: 'child',
+  processType: 'GPU',
+  details: { serviceName: 'GPU', type: 'GPU' }
+})
+const networkServiceKill = event({
+  source: 'child',
+  processType: 'Utility',
+  details: {
+    name: 'Network Service',
+    serviceName: 'network.mojom.NetworkService',
+    type: 'Utility'
+  }
+})
+const rendererKill = event()
+
+function currentTeardownScope() {
+  return resolveExpectedTeardownScope({
+    isQuitting: false,
+    isQuittingForUpdate: false,
+    isExpectedRendererReload: false
+  })
+}
+
+let now: number
+
+beforeEach(() => {
+  now = 1_000
+  resetExpectedTeardownStateForTest(() => now)
+  clearCrashBreadcrumbsForTest()
+})
+
+afterEach(() => {
+  vi.restoreAllMocks()
+  resetExpectedTeardownStateForTest()
+  clearCrashBreadcrumbsForTest()
+})
+
+describe('recordProcessGoneCrash killed/1 ordering', () => {
+  it('reports a genuine lone renderer killed/1 without teardown intent', () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+
+    recordProcessGoneCrash({ record } as never, rendererKill, new ProcessGoneDedupe())
+
+    expect(record).toHaveBeenCalledOnce()
+  })
+
+  it('reports R3 after matching recoverable sibling churn', () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+
+    recordProcessGoneCrash({ record } as never, gpuKill, dedupe)
+    recordProcessGoneCrash({ record } as never, networkServiceKill, dedupe)
+    recordProcessGoneCrash({ record } as never, rendererKill, dedupe)
+
+    expect(record).toHaveBeenCalledOnce()
+  })
+
+  it('suppresses the fleet sequence only after independent session-end intent', () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const dedupe = new ProcessGoneDedupe()
+    markSystemSessionEnding()
+    const expectedTeardown = currentTeardownScope()
+
+    recordProcessGoneCrash({ record } as never, event({ ...gpuKill, expectedTeardown }), dedupe)
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ ...networkServiceKill, expectedTeardown }),
+      dedupe
+    )
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ ...rendererKill, expectedTeardown }),
+      dedupe
+    )
+
+    expect(expectedTeardown).toBe('app-shutdown')
+    expect(record).not.toHaveBeenCalled()
+  })
+
+  it('durably reports killed/1 after the session-end window expires', () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    markSystemSessionEnding()
+    now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+    const expectedTeardown = currentTeardownScope()
+
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ ...rendererKill, expectedTeardown }),
+      new ProcessGoneDedupe()
+    )
+
+    expect(expectedTeardown).toBe('none')
+    expect(record).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a renderer report filed when session-end intent arrives later', () => {
+    const record = vi.fn().mockResolvedValue({ id: 'report-1' })
+    const scopeBeforeSessionEnd = currentTeardownScope()
+
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ ...rendererKill, expectedTeardown: scopeBeforeSessionEnd }),
+      new ProcessGoneDedupe()
+    )
+    markSystemSessionEnding()
+    const scopeAfterSessionEnd = currentTeardownScope()
+    recordProcessGoneCrash(
+      { record } as never,
+      event({ ...rendererKill, expectedTeardown: scopeAfterSessionEnd }),
+      new ProcessGoneDedupe()
+    )
+
+    expect(scopeBeforeSessionEnd).toBe('none')
+    expect(scopeAfterSessionEnd).toBe('app-shutdown')
+    expect(record).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -290,6 +290,7 @@ import {
   type ExpectedTeardownScope
 } from './crash-reporting/process-gone-classification'
 import { recordProcessGoneCrash as recordProcessGoneCrashEvent } from './crash-reporting/process-gone-recorder'
+import { resolveExpectedTeardownScope } from './crash-reporting/expected-teardown-state'
 import {
   advanceSyntheticTitleSpinnerEntries,
   type SyntheticTitleSpinnerEntry
@@ -678,14 +679,17 @@ function clearExpectedRendererReload(webContentsId?: number): void {
   expectedRendererReload.clear(webContentsId)
 }
 
-function getExpectedTeardownScope(webContentsId?: number): ExpectedTeardownScope {
-  if (isQuitting || isQuittingForUpdate()) {
-    return 'app-shutdown'
-  }
-  if (webContentsId === undefined) {
-    return 'none'
-  }
-  return expectedRendererReload.matches(webContentsId) ? 'renderer-reload' : 'none'
+function getExpectedTeardownScope(
+  webContentsId?: number,
+  includeSystemSessionEnd = true
+): ExpectedTeardownScope {
+  return resolveExpectedTeardownScope({
+    isQuitting,
+    isQuittingForUpdate: isQuittingForUpdate(),
+    isExpectedRendererReload:
+      webContentsId !== undefined && expectedRendererReload.matches(webContentsId),
+    includeSystemSessionEnd
+  })
 }
 
 function markRecoveryReloadInFlight(webContentsId: number, durationMs = 10_000): void {
@@ -1244,7 +1248,7 @@ function openMainWindow(): BrowserWindow {
     shouldRecoverRenderer: (details, webContentsId) =>
       shouldRecoverRendererAfterProcessGone({
         reason: details.reason,
-        expectedTeardown: getExpectedTeardownScope(webContentsId)
+        expectedTeardown: getExpectedTeardownScope(webContentsId, false)
       }),
     onRendererRecoveryExhausted: ({ details, recentRecoveryCount }) => {
       recordDurableCrashBreadcrumb('renderer_recovery_circuit_breaker_open', {

--- a/src/main/startup/desktop-startup-ordering.test.ts
+++ b/src/main/startup/desktop-startup-ordering.test.ts
@@ -156,6 +156,33 @@ describe('startup ordering', () => {
     expect(startIndex).toBeGreaterThan(attachIndex)
   })
 
+  it('wires bounded teardown state to reporting but not recovery or close behavior', () => {
+    const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
+    const scopeStart = source.indexOf('function getExpectedTeardownScope(')
+    const scopeEnd = source.indexOf('function markRecoveryReloadInFlight(', scopeStart)
+    const scope = source.slice(scopeStart, scopeEnd)
+    const windowStart = source.indexOf('const window = createMainWindow(store, {')
+    const windowEnd = source.indexOf('onRendererRecoveryExhausted:', windowStart)
+    const windowOptions = source.slice(windowStart, windowEnd)
+    const recorderStart = source.indexOf('function recordProcessGoneCrash(')
+    const recorderEnd = source.indexOf('function shutdownWatchersOnce(', recorderStart)
+    const recorder = source.slice(recorderStart, recorderEnd)
+
+    expect(scopeStart).toBeGreaterThanOrEqual(0)
+    expect(scopeEnd).toBeGreaterThan(scopeStart)
+    expect(scope).toContain('resolveExpectedTeardownScope({')
+    expect(scope).toContain('includeSystemSessionEnd')
+    expect(windowStart).toBeGreaterThanOrEqual(0)
+    expect(windowEnd).toBeGreaterThan(windowStart)
+    expect(windowOptions).toContain('getIsQuitting: () => isQuitting')
+    expect(windowOptions).toContain(
+      'expectedTeardown: getExpectedTeardownScope(webContentsId, false)'
+    )
+    expect(recorderStart).toBeGreaterThanOrEqual(0)
+    expect(recorderEnd).toBeGreaterThan(recorderStart)
+    expect(recorder).toContain('expectedTeardown: getExpectedTeardownScope(webContentsId)')
+  })
+
   it('attaches renderer services before starting the TCC prompt watcher', () => {
     const source = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
     const attachIndex = source.indexOf('attachMainWindowServices(')

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -74,6 +74,11 @@ import {
 } from './createMainWindow'
 import { ipcMain } from 'electron'
 import { shouldRecoverRendererAfterProcessGone } from '../crash-reporting/process-gone-classification'
+import {
+  resetExpectedTeardownStateForTest,
+  resolveExpectedTeardownScope,
+  WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+} from '../crash-reporting/expected-teardown-state'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const original = process.platform
@@ -102,6 +107,7 @@ describe('createMainWindow', () => {
     vi.mocked(ipcMain.removeListener).mockReset()
     vi.mocked(ipcMain.handle).mockReset()
     vi.mocked(ipcMain.removeHandler).mockReset()
+    resetExpectedTeardownStateForTest()
     vi.useRealTimers()
   })
 
@@ -3143,6 +3149,40 @@ describe('createMainWindow', () => {
     consoleError.mockRestore()
   })
 
+  it('still preserves PTYs and reloads after Windows session-end', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+    const onBeforeRecoveryReload = vi.fn()
+
+    withPlatform('win32', () => {
+      createMainWindow(null, {
+        onBeforeRecoveryReload,
+        shouldRecoverRenderer: (details) =>
+          shouldRecoverRendererAfterProcessGone({
+            reason: details.reason,
+            expectedTeardown: resolveExpectedTeardownScope({
+              isQuitting: false,
+              isQuittingForUpdate: false,
+              isExpectedRendererReload: false,
+              includeSystemSessionEnd: false
+            })
+          })
+      })
+    })
+    windowHandlers['session-end']?.({} as never)
+    windowHandlers['render-process-gone']?.(
+      {} as never,
+      { reason: 'killed', exitCode: 1 } as Electron.RenderProcessGoneDetails
+    )
+    vi.runAllTimers()
+
+    expect(onBeforeRecoveryReload).toHaveBeenCalledWith(143)
+    expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(2)
+    consoleError.mockRestore()
+  })
+
   it('does not reload after renderer loss when recovery is disabled', () => {
     vi.useFakeTimers()
 
@@ -3728,6 +3768,60 @@ describe('createMainWindow', () => {
 
     afterEach(() => {
       setPlatform(originalPlatform)
+    })
+
+    it('marks production teardown state on irrevocable Windows session end', () => {
+      setPlatform('win32')
+      resetExpectedTeardownStateForTest(() => 1_000)
+      const { windowHandlers } = setupCloseWindow()
+
+      createMainWindow(null)
+      windowHandlers['session-end']?.({} as never)
+
+      expect(
+        resolveExpectedTeardownScope({
+          isQuitting: false,
+          isQuittingForUpdate: false,
+          isExpectedRendererReload: false
+        })
+      ).toBe('app-shutdown')
+    })
+
+    it.each(['darwin', 'linux'] as const)(
+      'does not mark session teardown state on %s',
+      (platform) => {
+        setPlatform(platform)
+        const { windowHandlers } = setupCloseWindow()
+
+        createMainWindow(null)
+
+        expect(windowHandlers['session-end']).toBeUndefined()
+        expect(
+          resolveExpectedTeardownScope({
+            isQuitting: false,
+            isQuittingForUpdate: false,
+            isExpectedRendererReload: false
+          })
+        ).toBe('none')
+      }
+    )
+
+    it('still minimizes to tray after the session-end reporting window expires', () => {
+      setPlatform('win32')
+      let now = 1_000
+      resetExpectedTeardownStateForTest(() => now)
+      const { windowHandlers, webContents, instance } = setupCloseWindow()
+      const store = makeStore(true, true)
+
+      createMainWindow(store as never)
+      windowHandlers['session-end']?.({} as never)
+      now += WINDOWS_SESSION_END_CRASH_SUPPRESSION_WINDOW_MS
+      const preventDefault = vi.fn()
+      windowHandlers.close({ preventDefault } as never)
+
+      expect(preventDefault).toHaveBeenCalledOnce()
+      expect(instance.hide).toHaveBeenCalledOnce()
+      expect(webContents.send).not.toHaveBeenCalledWith('window:close-requested', expect.anything())
     })
 
     it('hides to the tray instead of closing when the setting is on', () => {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -19,6 +19,7 @@ import { translateMain } from '../i18n/main-i18n'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
 import { ORCA_BROWSER_GUEST_WEB_PREFERENCES } from '../../shared/browser-guest-web-preferences'
 import { isCrashReportReason } from '../../shared/crash-reporting'
+import { markSystemSessionEnding } from '../crash-reporting/expected-teardown-state'
 import {
   DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES,
   DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
@@ -303,6 +304,11 @@ export function createMainWindow(
   const rendererWebContentsId = mainWindow.webContents.id
   // Why: native paste fallback is privileged IPC; only the top-level renderer may request it.
   setTrustedUIRendererWebContentsId(rendererWebContentsId)
+
+  // Unlike query-session-end, session-end cannot be canceled before this signal is recorded.
+  if (process.platform === 'win32') {
+    mainWindow.on('session-end', markSystemSessionEnding)
+  }
 
   if (process.platform === 'darwin') {
     // Why: preserve hidden-window power savings; stable native sizing and frame-only invalidation


### PR DESCRIPTION
## Summary

Renderer `killed` / `exitCode 1` on Windows is currently filed as a renderer crash when it is actually the whole application being terminated by the OS. This is **147 reports — 8% of all Orca crash reports in the fleet** — from 63+ named users, still occurring on 1.4.171.

These are not crashes. They are noise that dilutes every other cluster in crash triage.

This change records Windows `BrowserWindow.session-end` as a **monotonic** timestamp and suppresses crash *reporting* inside a half-open 5,000 ms window. It affects crash-report classification only — it deliberately does not touch renderer recovery or quit state, so PTY-preserving recovery and tray behaviour are unaffected. Independent review confirmed the recovery path explicitly excludes session-end.

**Scope correction (from independent review):** the earlier wording "renderer reports only" was not literally accurate. `recordProcessGoneCrash()` resolves session-end state for renderer *and* `app.on('child-process-gone')` events, so within the 5 s window a non-recoverable child dying with `killed` is also classified as expected shutdown. GPU and the common recoverable utility services were already suppressed independently. This is consistent with an actual OS session ending and does not affect recovery, but it is broader than the original summary implied.

No visual change.

## Evidence

From a sweep of 1,928 crash reports (2026-07-06 → 2026-08-05, 569 distinct reporting identities), clustered by behaviour rather than by Electron's `reason` string.

The GPU process, the Network Service utility process, and the renderer all die with `exitCode=1` within the same ~250 ms window:

```
13:35:14.715  process_gone_suppressed (source=child, processType=GPU, reason=killed,
                exitCode=1, expectedTeardown=none, serviceName=GPU)
13:35:14.953  process_gone_suppressed (source=child, processType=Utility, reason=killed,
                exitCode=1, expectedTeardown=none, name=Network Service)
```

Supporting signals: only **4%** show any JS heap pressure (median peak heap 2% of limit); short lifetimes from main-process start; a large share are pre-login ("No GitHub identity"), consistent with users quitting during onboarding.

## Root cause

`shouldRecordProcessGoneCrash` suppresses `killed` only for `exitCode === 15` and the Windows control-termination codes, or when `expectedTeardown` is already `app-shutdown` / `renderer-reload`.

`before-quit` → `isQuitting` → `app-shutdown` correctly covers **in-app** quit. The gap is **externally initiated** teardown: no `session-end` / `query-session-end` / `WM_QUERYENDSESSION` handler existed anywhere, so an OS-driven shutdown reached this boundary as `expectedTeardown: 'none'` — indistinguishable from a renderer that died alone.

This is the recurring shape where a boundary returns one undifferentiated answer for two different situations and the caller has to guess. The fix is to make the boundary say which.

## Two rejected approaches, recorded so they are not retried

**1. Sibling-death correlation (rejected).** Implemented, then blocked in review for two independent reasons:
- **It hid genuine crashes.** GPU `killed/1` → Network Service `killed/1` (both on the *recoverable churn* lists, so this occurs in healthy apps) → an unrelated genuine renderer `killed/1` was silently suppressed.
- **Wrong shape for the data.** It required siblings to die *before* the renderer, but across 152 full diagnostic bundles the ordering is 62 all-after / 56 mixed / 15 all-before — the renderer usually dies **first**. It fired on only **21/152 = 14%**, measured using the synchronous `electron.process_gone` renderer span.

**2. A process-lifetime shutdown latch (rejected).** Electron's `WM_ENDSESSION` handler emits the event and returns — it does **not** terminate the process, and Restart Manager can leave a responsive app pending, or the shutdown can be cancelled. A stalled shutdown turned the latch into a permanent crash-report kill switch that also stranded the renderer with no recovery, and it leaked into unrelated behaviour (minimize-to-tray stopped working).

## Carve-out — please do not auto-close the tracking issue on merge

This is a **partial fix**. It still misfiles renderer `killed/1` when the renderer `process-gone` event arrives before Windows `session-end`, more than 5 seconds after it, or when `session-end` is never delivered — including Task Manager / process-tree kills, installers or Restart Manager paths that do not emit it, antivirus termination, and some OS shutdown orderings — and on non-Windows platforms.

A genuine Restart Manager tree-kill between 5 s and 30 s is intentionally left reportable, as the cost of bounding false suppression.

The 5,000 ms bound is a **product-chosen conservative harm bound, not a Windows-documented budget** (Microsoft's 5-second figure concerns `WM_QUERYENDSESSION` UI; `RmShutdown` documents up to 30 s before force-killing unresponsive apps).

**Coverage cannot be quantified.** `session-end` is a new signal and is absent from all existing diagnostic bundles, so no percentage of the 147-report cluster can be claimed in advance. Validate by fleet volume after release, not by prediction.

## Landing conflict

Unmerged commit `5159eb61cb` touches the same recorder/classifier files. It **applies textually without conflict but is semantically incompatible**: it reintroduces sibling-death suppression and defers *every* killed-renderer persistence by 250 ms, reintroducing a hard-kill data-loss window. It must not be merged alongside this change.

## Testing

- [x] `pnpm lint` — `oxlint` clean (exit 0). The remaining `pnpm lint` sub-steps (native/type-aware audits, localization verifiers) were **not** run locally.
- [x] `pnpm typecheck` — `tsconfig.node.json` clean. Web/CLI projects not run; this change is main-process only.
- [x] `pnpm test` — scoped: 4 files / **111 tests pass** (`expected-teardown-state`, `process-gone-killed-one-ordering`, `desktop-startup-ordering`, `createMainWindow`). Full suite not run locally.
- [ ] `pnpm build` — **not run.**
- [x] Added tests that would catch regressions — see below.

Test coverage added: suppression inside the window; **no** suppression outside it; monotonic-clock behaviour under an injected clock; non-Windows platforms unaffected; startup ordering so the handler is registered before a renderer can die.

Note on prior review findings, since they shaped the current shape of this fix: an earlier revision used `Date.now()`, where a wall-clock rollback could resurrect an expired window. It now uses `performance.now()` via an injectable clock. A source comment in an earlier revision incorrectly claimed `performance.now()` may pause during Windows sleep; Windows QPC is monotonic **and** suspend-inclusive, and the comment was corrected rather than the code.

## AI Review Report

Reviewed by an agent that did not write the code, instructed to break it rather than confirm it. Three successive revisions were **rejected**: (1) correlation-based suppression hid genuine crashes; (2) a process-lifetime latch became a permanent crash-report kill switch and broke minimize-to-tray; (3) wall-clock rollback could resurrect an expired window. The current revision is the fourth.

Cross-platform: the suppression path is explicitly Windows-gated and tested to be inert on macOS and Linux. No shortcuts, labels, or path handling are touched. The Electron-specific detail that `session-end` lives on `BrowserWindow`/`BaseWindow` and **not** on `app` is covered by the startup-ordering test.

**Independent review is now complete, and its verdict is "safe to merge: yes" with no blockers.** Conducted by a reviewer that did not write the code, using a temporary transform-time harness (deleted afterwards; source unchanged).

- **Independent mutation result: 12/12 killed, 100%, no survivors.** Killed mutants include wall clock, widened window, rollback resurrection, closed 5,000 ms boundary, process-lifetime latch, failed re-arm, recovery coupling, session-end omitted by default, missing registration, wrong event owner/name, reversed platform guard, and unguarded cross-platform registration. A separate reproduction lane killed a further 13-mutant set including genuine `killed/1` suppression and the rejected 250 ms deferral. This is the only PR in this batch whose self-assessment and the independent count agree.
- **Tested on real Windows, partially.** The exact PR head ran on a physical `win32/x64` host. A genuine renderer crash was induced via CDP `Page.crash` and **was still persisted and reported** (`reason=crashed`, `exitCode=-2147483645`) — so the new state does not suppress unrelated real crashes on Windows. A real forced restart was also initiated, but the host did not auto-start Orca at the locked login screen, so the post-restart suppression artifacts could not be read. **The core shutdown suppression therefore remains proven by code, tests and mutation — not by a completed real-Windows shutdown oracle.**
- Full `pnpm lint` (including the native/type-aware audits, reliability gates, max-lines ratchet and localization verifiers) and `pnpm typecheck` for node, CLI and web all passed on the rebased candidate; focused tests 131/131.
- Confirmed `5159eb61cb` is **not** an ancestor of this branch or of current `main`; it lives only on `origin/crashfix/w2-sibling-kill`. Its future arrival should reopen this verdict.

## Security Audit

No new IPC surface, no command execution, no path handling, no auth or secrets. The change reads an Electron-provided window event and writes an in-process timestamp. The only security-adjacent consideration is the deliberate suppression of crash *reports* within a bounded window, which reduces diagnostic visibility by design; the carve-out above states exactly which real failures remain reportable. Crash-report content is treated as untrusted data throughout and is never interpreted as instructions.

## Notes

Correct longer-term design, deferred and worth its own issue: have `session-end` initiate Orca's own coordinated quit, so real quit state — not a bounded proxy — owns reporting suppression. Deferred here because Windows shutdown can be cancelled, and quitting anyway would destroy healthy live sessions.

Found during the 2026-08-05/06 fleet crash sweep.
