### PR TITLE
fix(terminal): stop retained output slices pinning whole parent strings

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
@@ -1,6 +1,9 @@
 import { TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS } from '../../../../shared/terminal-scrollback-policy'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
+const FOREGROUND_BACKLOG_WARNING =
+  '\x18\x1b[0m\r\n[Orca skipped a burst of terminal output because the backlog grew too large.]\r\n'
+
 vi.mock('@/lib/e2e-config', () => ({ e2eConfig: { exposeStore: true } }))
 vi.mock('@/lib/crash-breadcrumb-recorder', () => ({ recordRendererCrashBreadcrumb: vi.fn() }))
 
@@ -115,29 +118,33 @@ describe('terminal scheduler retained-string charge', () => {
       BACKGROUND_CHUNK_CHARS,
       configureTerminalOutputBacklogCap,
       flushTerminalOutput,
+      setRetainedRebaseCopyObserverForTesting,
       writeTerminalOutput
     } = await loadScheduler()
     const terminal = createTerminal()
-    const drained = 'd'.repeat(
+    const source = `${'d'.repeat(
       TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS - BACKGROUND_CHUNK_CHARS
-    )
-    const liveTail = 't'.repeat(BACKGROUND_CHUNK_CHARS)
+    )}${'t'.repeat(BACKGROUND_CHUNK_CHARS)}`
     const appended = 'tail'
+    const copyObserver = vi.fn()
     configureTerminalOutputBacklogCap(1_000)
+    setRetainedRebaseCopyObserverForTesting(copyObserver)
 
-    writeTerminalOutput(terminal as never, drained, { foreground: false })
-    writeTerminalOutput(terminal as never, liveTail, {
+    writeTerminalOutput(terminal as never, source, {
       foreground: true,
       latencySensitive: false
     })
-    flushTerminalOutput(terminal as never, { maxChars: drained.length })
+    flushTerminalOutput(terminal as never, {
+      maxChars: source.length - BACKGROUND_CHUNK_CHARS
+    })
     writeTerminalOutput(terminal as never, appended, {
       foreground: true,
       latencySensitive: false
     })
     flushTerminalOutput(terminal as never)
 
-    expect(readOutput(terminal)).toBe(drained + liveTail + appended)
+    expect(readOutput(terminal)).toBe(source + appended)
+    expect(copyObserver).toHaveBeenCalledTimes(1)
   })
 
   it('preserves pending output behind 63 consumed chunk references', async () => {
@@ -216,13 +223,13 @@ describe('terminal scheduler retained-string charge', () => {
         })
       }
 
+      flushTerminalOutput(terminal as never)
+      expect(readOutput(terminal)).toBe(
+        drops
+          ? `${'d'.repeat(drainedChars)}${FOREGROUND_BACKLOG_WARNING}`
+          : `${'d'.repeat(drainedChars)}${'p'.repeat(pendingChars)}${'a'.repeat(appendedChars)}`
+      )
       expect(readDebugSnapshot().droppedBacklogCount).toBe(drops ? 1 : 0)
-      if (!drops) {
-        flushTerminalOutput(terminal as never)
-        expect(readOutput(terminal)).toBe(
-          `${'d'.repeat(drainedChars)}${'p'.repeat(pendingChars)}${'a'.repeat(appendedChars)}`
-        )
-      }
     }
   )
 
@@ -242,6 +249,59 @@ describe('terminal scheduler retained-string charge', () => {
       queuedChars: BACKGROUND_CHUNK_CHARS,
       retainedChars: BACKGROUND_CHUNK_CHARS
     })
+  })
+
+  it('does not copy an unconsumed indivisible chunk above the cap', async () => {
+    const {
+      configureTerminalOutputBacklogCap,
+      flushTerminalOutput,
+      setRetainedRebaseCopyObserverForTesting,
+      writeTerminalOutput
+    } = await loadScheduler()
+    const terminal = createTerminal()
+    const source = 'x'.repeat(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS + 1)
+    const copyObserver = vi.fn()
+    configureTerminalOutputBacklogCap(1_000)
+    setRetainedRebaseCopyObserverForTesting(copyObserver)
+
+    writeTerminalOutput(terminal as never, source, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never)
+
+    expect(readOutput(terminal)).toBe(FOREGROUND_BACKLOG_WARNING)
+    expect(copyObserver).not.toHaveBeenCalled()
+  })
+
+  it('releases the full retained charge after partial-first prefix compaction', async () => {
+    const { BACKGROUND_CHUNK_CHARS, flushTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+    const partiallyDrained = 'p'.repeat(BACKGROUND_CHUNK_CHARS * 2)
+    const consumedPrefixes = Array.from({ length: 63 }, (_, index) =>
+      String(index).padEnd(BACKGROUND_CHUNK_CHARS, 'x')
+    )
+    const survivor = 's'.repeat(BACKGROUND_CHUNK_CHARS)
+    const source = partiallyDrained + consumedPrefixes.join('') + survivor
+
+    writeTerminalOutput(terminal as never, partiallyDrained, { foreground: false })
+    flushTerminalOutput(terminal as never, { maxChars: 1 })
+    for (const prefix of consumedPrefixes) {
+      writeTerminalOutput(terminal as never, prefix, { foreground: false })
+    }
+    writeTerminalOutput(terminal as never, survivor, { foreground: false })
+    flushTerminalOutput(terminal as never, {
+      maxChars: BACKGROUND_CHUNK_CHARS * 64 - 1
+    })
+
+    expect(readDebugSnapshot()).toMatchObject({
+      queuedChars: BACKGROUND_CHUNK_CHARS,
+      retainedChars: BACKGROUND_CHUNK_CHARS,
+      droppedBacklogCount: 0
+    })
+    flushTerminalOutput(terminal as never)
+    expect(readOutput(terminal)).toBe(source)
   })
 
   it('charges consumed prefixes as retained until compaction releases them', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
@@ -137,6 +137,10 @@ describe('terminal scheduler retained-string charge', () => {
     flushTerminalOutput(terminal as never, {
       maxChars: source.length - BACKGROUND_CHUNK_CHARS
     })
+    expect(readDebugSnapshot()).toMatchObject({
+      queuedChars: BACKGROUND_CHUNK_CHARS,
+      retainedChars: source.length
+    })
     writeTerminalOutput(terminal as never, appended, {
       foreground: true,
       latencySensitive: false

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
@@ -264,10 +264,12 @@ describe('terminal scheduler retained-string charge', () => {
       writeTerminalOutput
     } = await loadScheduler()
     const terminal = createTerminal()
-    const source = 'x'.repeat(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS)
-    const cycleCount = 120
+    const configuredCapChars = 6_000_000
+    const source = 'x'.repeat(configuredCapChars)
+    const appended = 'a'.repeat(BACKGROUND_CHUNK_CHARS)
+    const cycleCount = Math.ceil(configuredCapChars / BACKGROUND_CHUNK_CHARS)
     let copiedChars = 0
-    configureTerminalOutputBacklogCap(1_000)
+    configureTerminalOutputBacklogCap(50_000)
     setRetainedRebaseCopyObserverForTesting((_parent, copy) => {
       copiedChars += copy.length
     })
@@ -278,22 +280,20 @@ describe('terminal scheduler retained-string charge', () => {
     })
     for (let cycle = 0; cycle < cycleCount; cycle += 1) {
       flushTerminalOutput(terminal as never, { maxChars: BACKGROUND_CHUNK_CHARS })
-      expect(readDebugSnapshot().retainedChars).toBeLessThan(
-        TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS * 2
-      )
-      writeTerminalOutput(terminal as never, 'a', {
+      expect(readDebugSnapshot().retainedChars).toBeLessThan(configuredCapChars * 2)
+      writeTerminalOutput(terminal as never, appended, {
         foreground: true,
         latencySensitive: false
       })
       const snapshot = readDebugSnapshot()
       expect(snapshot.retainedChars).toBeLessThanOrEqual(
-        Math.max(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS, snapshot.queuedChars * 2)
+        Math.max(configuredCapChars, snapshot.queuedChars * 2)
       )
-      expect(snapshot.retainedChars).toBeLessThan(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS * 2)
+      expect(snapshot.retainedChars).toBeLessThan(configuredCapChars * 2)
     }
     flushTerminalOutput(terminal as never)
 
-    expect(readOutput(terminal)).toBe(source + 'a'.repeat(cycleCount))
+    expect(readOutput(terminal)).toBe(source + appended.repeat(cycleCount))
     expect(copiedChars).toBeGreaterThan(0)
     expect(copiedChars).toBeLessThanOrEqual(source.length * 2)
   })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
@@ -122,9 +122,10 @@ describe('terminal scheduler retained-string charge', () => {
       writeTerminalOutput
     } = await loadScheduler()
     const terminal = createTerminal()
+    const liveTail = `${'t'.repeat(BACKGROUND_CHUNK_CHARS - 7)}A\ud83dB\ude00C😀`
     const source = `${'d'.repeat(
       TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS - BACKGROUND_CHUNK_CHARS
-    )}${'t'.repeat(BACKGROUND_CHUNK_CHARS)}`
+    )}${liveTail}`
     const appended = 'tail'
     const copyObserver = vi.fn()
     configureTerminalOutputBacklogCap(1_000)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
@@ -255,6 +255,49 @@ describe('terminal scheduler retained-string charge', () => {
     })
   })
 
+  it('bounds retained pressure and repeated rebase copies', async () => {
+    const {
+      BACKGROUND_CHUNK_CHARS,
+      configureTerminalOutputBacklogCap,
+      flushTerminalOutput,
+      setRetainedRebaseCopyObserverForTesting,
+      writeTerminalOutput
+    } = await loadScheduler()
+    const terminal = createTerminal()
+    const source = 'x'.repeat(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS)
+    const cycleCount = 120
+    let copiedChars = 0
+    configureTerminalOutputBacklogCap(1_000)
+    setRetainedRebaseCopyObserverForTesting((_parent, copy) => {
+      copiedChars += copy.length
+    })
+
+    writeTerminalOutput(terminal as never, source, {
+      foreground: true,
+      latencySensitive: false
+    })
+    for (let cycle = 0; cycle < cycleCount; cycle += 1) {
+      flushTerminalOutput(terminal as never, { maxChars: BACKGROUND_CHUNK_CHARS })
+      expect(readDebugSnapshot().retainedChars).toBeLessThan(
+        TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS * 2
+      )
+      writeTerminalOutput(terminal as never, 'a', {
+        foreground: true,
+        latencySensitive: false
+      })
+      const snapshot = readDebugSnapshot()
+      expect(snapshot.retainedChars).toBeLessThanOrEqual(
+        Math.max(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS, snapshot.queuedChars * 2)
+      )
+      expect(snapshot.retainedChars).toBeLessThan(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS * 2)
+    }
+    flushTerminalOutput(terminal as never)
+
+    expect(readOutput(terminal)).toBe(source + 'a'.repeat(cycleCount))
+    expect(copiedChars).toBeGreaterThan(0)
+    expect(copiedChars).toBeLessThanOrEqual(source.length * 2)
+  })
+
   it('does not copy an unconsumed indivisible chunk above the cap', async () => {
     const {
       configureTerminalOutputBacklogCap,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retained-charge.test.ts
@@ -1,0 +1,272 @@
+import { TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS } from '../../../../shared/terminal-scrollback-policy'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/e2e-config', () => ({ e2eConfig: { exposeStore: true } }))
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({ recordRendererCrashBreadcrumb: vi.fn() }))
+
+type DebugSnapshot = {
+  queuedChars: number
+  retainedChars: number
+  droppedBacklogCount: number
+}
+
+function createTerminal() {
+  return {
+    write: vi.fn((_data: string, callback?: () => void) => callback?.())
+  }
+}
+
+async function loadScheduler() {
+  vi.resetModules()
+  return import('./pane-terminal-output-scheduler')
+}
+
+function readDebugSnapshot(): DebugSnapshot {
+  return (
+    globalThis as typeof globalThis & {
+      __terminalOutputSchedulerDebug?: { snapshot(): DebugSnapshot }
+    }
+  ).__terminalOutputSchedulerDebug?.snapshot() as DebugSnapshot
+}
+
+function readOutput(terminal: ReturnType<typeof createTerminal>): string {
+  return terminal.write.mock.calls.map(([data]) => data).join('')
+}
+
+describe('terminal scheduler retained-string charge', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', globalThis)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    delete (globalThis as { __terminalOutputSchedulerDebug?: unknown })
+      .__terminalOutputSchedulerDebug
+    vi.unstubAllGlobals()
+  })
+
+  it('pins the background drain chunk size', async () => {
+    const { BACKGROUND_CHUNK_CHARS } = await loadScheduler()
+
+    expect(BACKGROUND_CHUNK_CHARS).toBe(16 * 1024)
+  })
+
+  it('separately charges pending output and an oversized retained source', async () => {
+    const { BACKGROUND_CHUNK_CHARS, flushTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+    const source = 'x'.repeat(BACKGROUND_CHUNK_CHARS + 1_000)
+
+    writeTerminalOutput(terminal as never, source, { foreground: false })
+    flushTerminalOutput(terminal as never, { maxChars: BACKGROUND_CHUNK_CHARS })
+
+    expect(terminal.write).toHaveBeenCalledWith(
+      'x'.repeat(BACKGROUND_CHUNK_CHARS),
+      expect.any(Function)
+    )
+    expect(readDebugSnapshot()).toMatchObject({
+      queuedChars: 1_000,
+      retainedChars: source.length
+    })
+  })
+
+  it('advances through oversized source strings without duplicating drained data', async () => {
+    const { BACKGROUND_CHUNK_CHARS, flushTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+    const source = `${'a'.repeat(BACKGROUND_CHUNK_CHARS)}${'b'.repeat(BACKGROUND_CHUNK_CHARS)}${'c'.repeat(BACKGROUND_CHUNK_CHARS)}${'d'.repeat(1_000)}`
+
+    writeTerminalOutput(terminal as never, source, { foreground: false })
+    for (let index = 0; index < 3; index += 1) {
+      flushTerminalOutput(terminal as never, { maxChars: BACKGROUND_CHUNK_CHARS })
+    }
+    flushTerminalOutput(terminal as never)
+
+    expect(readOutput(terminal)).toBe(source)
+  })
+
+  it('preserves two pending characters after draining an exact-cap source', async () => {
+    const { configureTerminalOutputBacklogCap, flushTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+    const prefix = 'p'.repeat(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS - 1)
+    const firstPending = 'a'
+    const secondPending = 'b'
+    configureTerminalOutputBacklogCap(1_000)
+
+    writeTerminalOutput(terminal as never, prefix, { foreground: false })
+    writeTerminalOutput(terminal as never, firstPending, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never, { maxChars: prefix.length })
+    writeTerminalOutput(terminal as never, secondPending, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never)
+
+    expect(readOutput(terminal)).toBe(prefix + firstPending + secondPending)
+  })
+
+  it('preserves a 16 KiB live tail after draining an exact-cap source', async () => {
+    const {
+      BACKGROUND_CHUNK_CHARS,
+      configureTerminalOutputBacklogCap,
+      flushTerminalOutput,
+      writeTerminalOutput
+    } = await loadScheduler()
+    const terminal = createTerminal()
+    const drained = 'd'.repeat(
+      TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS - BACKGROUND_CHUNK_CHARS
+    )
+    const liveTail = 't'.repeat(BACKGROUND_CHUNK_CHARS)
+    const appended = 'tail'
+    configureTerminalOutputBacklogCap(1_000)
+
+    writeTerminalOutput(terminal as never, drained, { foreground: false })
+    writeTerminalOutput(terminal as never, liveTail, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never, { maxChars: drained.length })
+    writeTerminalOutput(terminal as never, appended, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never)
+
+    expect(readOutput(terminal)).toBe(drained + liveTail + appended)
+  })
+
+  it('preserves pending output behind 63 consumed chunk references', async () => {
+    const {
+      BACKGROUND_CHUNK_CHARS,
+      configureTerminalOutputBacklogCap,
+      flushTerminalOutput,
+      writeTerminalOutput
+    } = await loadScheduler()
+    const terminal = createTerminal()
+    const prefixes = Array.from({ length: 63 }, (_, index) =>
+      String(index).padEnd(BACKGROUND_CHUNK_CHARS, 'x')
+    )
+    const consumedPrefix = prefixes.join('')
+    const firstPending = 'a'
+    const appended = 'b'.repeat(TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS - consumedPrefix.length)
+    configureTerminalOutputBacklogCap(1_000)
+
+    for (const prefix of prefixes) {
+      writeTerminalOutput(terminal as never, prefix, { foreground: false })
+    }
+    writeTerminalOutput(terminal as never, firstPending, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never, { maxChars: consumedPrefix.length })
+    writeTerminalOutput(terminal as never, appended, {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never)
+
+    expect(readOutput(terminal)).toBe(consumedPrefix + firstPending + appended)
+  })
+
+  it.each([
+    { drainedChars: 0, appendedChars: 0, drops: false },
+    { drainedChars: 0, appendedChars: 1, drops: true },
+    { drainedChars: 1, appendedChars: 1, drops: false },
+    { drainedChars: 1, appendedChars: 2, drops: true },
+    {
+      drainedChars: TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS / 2,
+      appendedChars: TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS / 2,
+      drops: false
+    },
+    {
+      drainedChars: TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS / 2,
+      appendedChars: TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS / 2 + 1,
+      drops: true
+    }
+  ])(
+    'matches the legacy pending cap after draining $drainedChars and appending $appendedChars',
+    async ({ drainedChars, appendedChars, drops }) => {
+      const { configureTerminalOutputBacklogCap, flushTerminalOutput, writeTerminalOutput } =
+        await loadScheduler()
+      const terminal = createTerminal()
+      const pendingChars = TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS - drainedChars
+      configureTerminalOutputBacklogCap(1_000)
+
+      if (drainedChars > 0) {
+        writeTerminalOutput(terminal as never, 'd'.repeat(drainedChars), {
+          foreground: false
+        })
+      }
+      writeTerminalOutput(terminal as never, 'p'.repeat(pendingChars), {
+        foreground: true,
+        latencySensitive: false
+      })
+      if (drainedChars > 0) {
+        flushTerminalOutput(terminal as never, { maxChars: drainedChars })
+      }
+      if (appendedChars > 0) {
+        writeTerminalOutput(terminal as never, 'a'.repeat(appendedChars), {
+          foreground: true,
+          latencySensitive: false
+        })
+      }
+
+      expect(readDebugSnapshot().droppedBacklogCount).toBe(drops ? 1 : 0)
+      if (!drops) {
+        flushTerminalOutput(terminal as never)
+        expect(readOutput(terminal)).toBe(
+          `${'d'.repeat(drainedChars)}${'p'.repeat(pendingChars)}${'a'.repeat(appendedChars)}`
+        )
+      }
+    }
+  )
+
+  it('drops retained charges when compaction releases consumed prefix strings', async () => {
+    const { BACKGROUND_CHUNK_CHARS, flushTerminalOutput, writeTerminalOutput } =
+      await loadScheduler()
+    const terminal = createTerminal()
+
+    for (let index = 0; index < 65; index += 1) {
+      writeTerminalOutput(terminal as never, String(index).padEnd(BACKGROUND_CHUNK_CHARS, 'x'), {
+        foreground: false
+      })
+    }
+    flushTerminalOutput(terminal as never, { maxChars: BACKGROUND_CHUNK_CHARS * 64 })
+
+    expect(readDebugSnapshot()).toMatchObject({
+      queuedChars: BACKGROUND_CHUNK_CHARS,
+      retainedChars: BACKGROUND_CHUNK_CHARS
+    })
+  })
+
+  it('charges consumed prefixes as retained until compaction releases them', async () => {
+    const {
+      BACKGROUND_CHUNK_CHARS,
+      discardTerminalOutput,
+      flushTerminalOutput,
+      writeTerminalOutput
+    } = await loadScheduler()
+    const terminal = createTerminal()
+
+    writeTerminalOutput(terminal as never, 'a'.repeat(BACKGROUND_CHUNK_CHARS), {
+      foreground: false
+    })
+    writeTerminalOutput(terminal as never, 'b'.repeat(BACKGROUND_CHUNK_CHARS), {
+      foreground: true,
+      latencySensitive: false
+    })
+    flushTerminalOutput(terminal as never, { maxChars: BACKGROUND_CHUNK_CHARS })
+
+    expect(readDebugSnapshot()).toMatchObject({
+      queuedChars: BACKGROUND_CHUNK_CHARS,
+      retainedChars: BACKGROUND_CHUNK_CHARS * 2
+    })
+    discardTerminalOutput(terminal as never)
+    expect(readDebugSnapshot()).toMatchObject({ queuedChars: 0, retainedChars: 0 })
+  })
+})

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retention.bench.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retention.bench.test.ts
@@ -65,10 +65,12 @@ describe('terminal scheduler retained heap', () => {
       const retainedBytes = partiallyDrainedBytes - baselineBytes
       const debug = (
         globalThis as typeof globalThis & {
-          __terminalOutputSchedulerDebug?: { snapshot(): { queuedChars: number } }
+          __terminalOutputSchedulerDebug?: {
+            snapshot(): { queuedChars: number; retainedChars: number }
+          }
         }
       ).__terminalOutputSchedulerDebug
-      const chargedChars = debug?.snapshot().queuedChars ?? 0
+      const chargedChars = debug?.snapshot().retainedChars ?? 0
       const chargedBytes = chargedChars * 2
       // eslint-disable-next-line no-console -- manual retention probe evidence
       console.log(
@@ -91,7 +93,74 @@ describe('terminal scheduler retained heap', () => {
       // eslint-disable-next-line no-console -- manual retention probe evidence
       console.log(JSON.stringify({ phase: 'released', releasedBytes, chargedBytes }))
       expect(releasedBytes).toBeGreaterThan(chargedBytes * 0.9)
-      expect(debug?.snapshot().queuedChars).toBe(0)
+      expect(debug?.snapshot()).toMatchObject({ queuedChars: 0, retainedChars: 0 })
     }
   )
+
+  it.skipIf(!enabled)('MANUAL ONLY: measures retained-pressure rebase peak', async () => {
+    const scheduler = await import('./pane-terminal-output-scheduler')
+    const sourceChars = 2 * 1024 * 1024
+    const terminal = {
+      write(_data: string, callback?: () => void) {
+        callback?.()
+      }
+    }
+    let overlapBytes = 0
+    let sourceLength = 0
+    let copyLength = 0
+    scheduler.configureTerminalOutputBacklogCap(1_000)
+    forceGc()
+    const baselineBytes = getHeapStatistics().used_heap_size
+
+    scheduler.writeTerminalOutput(
+      terminal as never,
+      makeFlatTwoByteString(sourceChars, terminalCount),
+      { foreground: true, latencySensitive: false }
+    )
+    scheduler.flushTerminalOutput(terminal as never, {
+      maxChars: sourceChars - scheduler.BACKGROUND_CHUNK_CHARS
+    })
+    forceGc()
+    const beforeRebaseBytes = getHeapStatistics().used_heap_size
+    scheduler.setRetainedRebaseCopyObserverForTesting((source, copy) => {
+      forceGc()
+      overlapBytes = getHeapStatistics().used_heap_size
+      sourceLength = source.length
+      copyLength = copy.length
+    })
+    scheduler.writeTerminalOutput(terminal as never, makeFlatTwoByteString(1, terminalCount + 1), {
+      foreground: true,
+      latencySensitive: false
+    })
+    scheduler.setRetainedRebaseCopyObserverForTesting(null)
+    forceGc()
+    const afterRebaseBytes = getHeapStatistics().used_heap_size
+    const debug = (
+      globalThis as typeof globalThis & {
+        __terminalOutputSchedulerDebug?: {
+          snapshot(): { queuedChars: number; retainedChars: number }
+        }
+      }
+    ).__terminalOutputSchedulerDebug
+    // eslint-disable-next-line no-console -- manual retention probe evidence
+    console.log(
+      JSON.stringify({
+        phase: 'rebase',
+        beforeRebaseBytes: beforeRebaseBytes - baselineBytes,
+        overlapBytes: overlapBytes - baselineBytes,
+        afterRebaseBytes: afterRebaseBytes - baselineBytes,
+        sourceLength,
+        copyLength,
+        chargedChars: debug?.snapshot().retainedChars ?? 0
+      })
+    )
+    expect(sourceLength).toBe(sourceChars)
+    expect(copyLength).toBe(scheduler.BACKGROUND_CHUNK_CHARS)
+    expect(overlapBytes).toBeGreaterThan(beforeRebaseBytes)
+    expect(afterRebaseBytes).toBeLessThan(overlapBytes)
+    expect(debug?.snapshot()).toMatchObject({
+      queuedChars: scheduler.BACKGROUND_CHUNK_CHARS + 1,
+      retainedChars: scheduler.BACKGROUND_CHUNK_CHARS + 1
+    })
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retention.bench.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-retention.bench.test.ts
@@ -1,0 +1,97 @@
+import { getHeapStatistics } from 'node:v8'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/e2e-config', () => ({ e2eConfig: { exposeStore: true } }))
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({ recordRendererCrashBreadcrumb: vi.fn() }))
+
+const enabled = process.env.ORCA_TERMINAL_RETENTION_BENCH === '1'
+const remainderChars = 1_000
+const terminalCount = 8
+
+function forceGc(): void {
+  if (!global.gc) {
+    throw new Error('run Node with --expose-gc')
+  }
+  for (let index = 0; index < 5; index += 1) {
+    global.gc()
+  }
+}
+
+function makeFlatTwoByteString(chars: number, seed: number): string {
+  return JSON.parse(`"${String.fromCharCode(0x400 + seed).repeat(chars)}"`) as string
+}
+
+describe('terminal scheduler retained heap', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.stubGlobal('window', globalThis)
+  })
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.unstubAllGlobals()
+  })
+
+  it.skipIf(!enabled)(
+    'MANUAL ONLY: set ORCA_TERMINAL_RETENTION_BENCH=1 and run Node with --expose-gc',
+    async () => {
+      const scheduler = await import('./pane-terminal-output-scheduler')
+      const sourceChars = scheduler.BACKGROUND_CHUNK_CHARS * 320 + remainderChars
+      const terminals: { write(data: string, callback?: () => void): void }[] = []
+      scheduler.configureTerminalOutputBacklogCap(50_000)
+      forceGc()
+      const baselineBytes = getHeapStatistics().used_heap_size
+
+      for (let index = 0; index < terminalCount; index += 1) {
+        const terminal = {
+          write(_data: string, callback?: () => void) {
+            callback?.()
+          }
+        }
+        terminals.push(terminal)
+        scheduler.writeTerminalOutput(
+          terminal as never,
+          makeFlatTwoByteString(sourceChars, index),
+          {
+            foreground: false
+          }
+        )
+        scheduler.flushTerminalOutput(terminal as never, {
+          maxChars: sourceChars - remainderChars
+        })
+      }
+
+      forceGc()
+      const partiallyDrainedBytes = getHeapStatistics().used_heap_size
+      const retainedBytes = partiallyDrainedBytes - baselineBytes
+      const debug = (
+        globalThis as typeof globalThis & {
+          __terminalOutputSchedulerDebug?: { snapshot(): { queuedChars: number } }
+        }
+      ).__terminalOutputSchedulerDebug
+      const chargedChars = debug?.snapshot().queuedChars ?? 0
+      const chargedBytes = chargedChars * 2
+      // eslint-disable-next-line no-console -- manual retention probe evidence
+      console.log(
+        JSON.stringify({
+          phase: 'partial',
+          retainedBytes,
+          chargedChars,
+          chargedBytes,
+          ratio: retainedBytes / chargedBytes
+        })
+      )
+      expect(chargedChars).toBe(terminalCount * sourceChars)
+      expect(Math.abs(retainedBytes - chargedBytes)).toBeLessThan(chargedBytes * 0.1)
+
+      for (const terminal of terminals) {
+        scheduler.flushTerminalOutput(terminal as never)
+      }
+      forceGc()
+      const releasedBytes = partiallyDrainedBytes - getHeapStatistics().used_heap_size
+      // eslint-disable-next-line no-console -- manual retention probe evidence
+      console.log(JSON.stringify({ phase: 'released', releasedBytes, chargedBytes }))
+      expect(releasedBytes).toBeGreaterThan(chargedBytes * 0.9)
+      expect(debug?.snapshot().queuedChars).toBe(0)
+    }
+  )
+})

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-throughput.bench.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-throughput.bench.test.ts
@@ -21,6 +21,7 @@ vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
 }))
 
 const TOTAL_CHARS = 4 * 1024 * 1024
+const INTERLEAVED_CAP_CHARS = 6_000_000
 const FEED_CHUNK_CHARS = 8 * 1024
 const OVERSIZED_DRAIN_ITERATIONS = 32
 const MAX_SIMULATED_MS = 60_000
@@ -76,6 +77,37 @@ async function measure(options: { foreground: boolean }): Promise<number> {
   return TOTAL_CHARS / 1024 / 1024 / (elapsed / 1000)
 }
 
+async function measureInterleavedRebaseCpu(): Promise<number> {
+  vi.useFakeTimers()
+  const scheduler = await loadScheduler()
+  const terminal = createInstantParseTerminal()
+  const appended = 'a'.repeat(scheduler.BACKGROUND_CHUNK_CHARS)
+  const cycles = Math.ceil(INTERLEAVED_CAP_CHARS / scheduler.BACKGROUND_CHUNK_CHARS)
+  scheduler.configureTerminalOutputBacklogCap(50_000)
+  scheduler.writeTerminalOutput(terminal as never, 'x'.repeat(INTERLEAVED_CAP_CHARS), {
+    foreground: true,
+    latencySensitive: false
+  })
+  const started = process.cpuUsage()
+
+  for (let cycle = 0; cycle < cycles; cycle += 1) {
+    scheduler.flushTerminalOutput(terminal as never, {
+      maxChars: scheduler.BACKGROUND_CHUNK_CHARS
+    })
+    scheduler.writeTerminalOutput(terminal as never, appended, {
+      foreground: true,
+      latencySensitive: false
+    })
+  }
+
+  const cpu = process.cpuUsage(started)
+  const cpuSeconds = (cpu.user + cpu.system) / 1_000_000
+  const writtenMiB = (cycles * scheduler.BACKGROUND_CHUNK_CHARS) / 1024 / 1024
+  scheduler.flushTerminalOutput(terminal as never)
+  expect(terminal.written).toBe(INTERLEAVED_CAP_CHARS + cycles * scheduler.BACKGROUND_CHUNK_CHARS)
+  return writtenMiB / cpuSeconds
+}
+
 async function measureOversizedDrainCpu(): Promise<number> {
   vi.useFakeTimers()
   const scheduler = await loadScheduler()
@@ -113,6 +145,12 @@ describe.skipIf(!benchEnabled)('scheduler drain ceiling', () => {
     console.log(
       `\n[scheduler-ceiling] foreground flood: ${foreground.toFixed(1)} MB/s, background: ${background.toFixed(1)} MB/s (simulated time, instant parse)`
     )
+  })
+
+  it('measures CPU throughput for interleaved drain and append', async () => {
+    const interleaved = await measureInterleavedRebaseCpu()
+    // eslint-disable-next-line no-console -- bench harness output
+    console.log(`\n[scheduler-interleaved-rebase] ${interleaved.toFixed(1)} MiB/CPU-s`)
   })
 
   it('measures CPU throughput for oversized source chunks', async () => {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-throughput.bench.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler-throughput.bench.test.ts
@@ -22,6 +22,7 @@ vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
 
 const TOTAL_CHARS = 4 * 1024 * 1024
 const FEED_CHUNK_CHARS = 8 * 1024
+const OVERSIZED_DRAIN_ITERATIONS = 32
 const MAX_SIMULATED_MS = 60_000
 
 function createInstantParseTerminal() {
@@ -75,6 +76,26 @@ async function measure(options: { foreground: boolean }): Promise<number> {
   return TOTAL_CHARS / 1024 / 1024 / (elapsed / 1000)
 }
 
+async function measureOversizedDrainCpu(): Promise<number> {
+  vi.useFakeTimers()
+  const scheduler = await loadScheduler()
+  const terminal = createInstantParseTerminal()
+  const payload = 'x'.repeat(TOTAL_CHARS)
+  scheduler.configureTerminalOutputBacklogCap(50_000)
+  const started = process.cpuUsage()
+
+  for (let index = 0; index < OVERSIZED_DRAIN_ITERATIONS; index += 1) {
+    scheduler.writeTerminalOutput(terminal as never, payload, { foreground: false })
+    scheduler.flushTerminalOutput(terminal as never)
+  }
+
+  const cpu = process.cpuUsage(started)
+  const cpuSeconds = (cpu.user + cpu.system) / 1_000_000
+  const writtenMiB = (TOTAL_CHARS * OVERSIZED_DRAIN_ITERATIONS) / 1024 / 1024
+  expect(terminal.written).toBe(TOTAL_CHARS * OVERSIZED_DRAIN_ITERATIONS)
+  return writtenMiB / cpuSeconds
+}
+
 describe.skipIf(!benchEnabled)('scheduler drain ceiling', () => {
   beforeEach(() => {
     vi.stubGlobal('window', globalThis)
@@ -92,6 +113,12 @@ describe.skipIf(!benchEnabled)('scheduler drain ceiling', () => {
     console.log(
       `\n[scheduler-ceiling] foreground flood: ${foreground.toFixed(1)} MB/s, background: ${background.toFixed(1)} MB/s (simulated time, instant parse)`
     )
+  })
+
+  it('measures CPU throughput for oversized source chunks', async () => {
+    const oversizedDrain = await measureOversizedDrainCpu()
+    // eslint-disable-next-line no-console -- bench harness output
+    console.log(`\n[scheduler-oversized-drain] ${oversizedDrain.toFixed(1)} MiB/CPU-s`)
   })
 })
 

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -725,7 +725,11 @@ function rebaseRetainedChunks(entry: QueueEntry): void {
   }
 
   const chunk = entry.chunks[0]
-  if (!chunk || chunk.consumedOffset === 0) {
+  if (
+    !chunk ||
+    chunk.consumedOffset === 0 ||
+    chunk.consumedOffset < chunk.data.length - chunk.consumedOffset
+  ) {
     return
   }
   const source = chunk.data

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -49,6 +49,7 @@ type WriteTerminalOutputOptions = {
 
 type QueueChunk = {
   data: string
+  consumedOffset: number
   foreground: boolean
   forceForegroundRefresh: boolean
   followupForegroundRefresh: boolean
@@ -75,7 +76,8 @@ type QueueEntry = {
   terminal: TerminalOutputTarget
   chunks: QueueChunk[]
   chunkIndex: number
-  queuedChars: number
+  pendingChars: number
+  retainedChars: number
   onBackgroundBacklogDropped?: () => void
   backgroundBacklogDropped: boolean
   highPriority: boolean
@@ -90,7 +92,7 @@ type QueueEntry = {
 const BACKGROUND_FLUSH_DELAY_MS = 50
 const BACKGROUND_DRAIN_INTERVAL_MS = 16
 const HIGH_PRIORITY_DRAIN_INTERVAL_MS = 4
-const BACKGROUND_CHUNK_CHARS = 16 * 1024
+export const BACKGROUND_CHUNK_CHARS = 16 * 1024
 const MAX_WRITES_PER_DRAIN = 2
 // Why 8: per-tick volume (8 x 16KB = 128KB ≈ 1.3ms parse) sets the sustained ceiling (~30MB/s) within DRAIN_TIME_BUDGET_MS; at 2 it was only 8MB/s against a ~100MB/s parser (see throughput bench).
 const HIGH_PRIORITY_MAX_WRITES_PER_DRAIN = 8
@@ -176,9 +178,11 @@ type TerminalOutputSchedulerDebugSnapshot = {
   scheduledDrainCount: number
   queuedTerminalCount: number
   queuedChars: number
+  retainedChars: number
   peakQueuedTerminalCount: number
   peakQueuedChars: number
   peakQueuedCharsByTerminal: number
+  peakRetainedChars: number
   droppedBacklogCount: number
   drainWrites: number[]
 }
@@ -198,9 +202,11 @@ const debugState: TerminalOutputSchedulerDebugSnapshot = {
   scheduledDrainCount: 0,
   queuedTerminalCount: 0,
   queuedChars: 0,
+  retainedChars: 0,
   peakQueuedTerminalCount: 0,
   peakQueuedChars: 0,
   peakQueuedCharsByTerminal: 0,
+  peakRetainedChars: 0,
   droppedBacklogCount: 0,
   drainWrites: []
 }
@@ -215,9 +221,11 @@ function resetDebugState(): void {
   debugState.scheduledDrainCount = 0
   debugState.queuedTerminalCount = 0
   debugState.queuedChars = 0
+  debugState.retainedChars = 0
   debugState.peakQueuedTerminalCount = 0
   debugState.peakQueuedChars = 0
   debugState.peakQueuedCharsByTerminal = 0
+  debugState.peakRetainedChars = 0
   debugState.droppedBacklogCount = 0
   debugState.drainWrites = []
 }
@@ -226,17 +234,21 @@ function readQueueDebugSnapshot(): {
   queuedTerminalCount: number
   queuedChars: number
   queuedCharsByTerminal: number
+  retainedChars: number
 } {
   let queuedChars = 0
   let queuedCharsByTerminal = 0
+  let retainedChars = 0
   for (const entry of queuedByTerminal.values()) {
-    queuedChars += entry.queuedChars
-    queuedCharsByTerminal = Math.max(queuedCharsByTerminal, entry.queuedChars)
+    queuedChars += entry.pendingChars
+    queuedCharsByTerminal = Math.max(queuedCharsByTerminal, entry.pendingChars)
+    retainedChars += entry.retainedChars
   }
   return {
     queuedTerminalCount: queuedByTerminal.size,
     queuedChars,
-    queuedCharsByTerminal
+    queuedCharsByTerminal,
+    retainedChars
   }
 }
 
@@ -247,6 +259,7 @@ function recordQueueDebugPressure(): void {
   const current = readQueueDebugSnapshot()
   debugState.queuedTerminalCount = current.queuedTerminalCount
   debugState.queuedChars = current.queuedChars
+  debugState.retainedChars = current.retainedChars
   debugState.peakQueuedTerminalCount = Math.max(
     debugState.peakQueuedTerminalCount,
     current.queuedTerminalCount
@@ -255,6 +268,10 @@ function recordQueueDebugPressure(): void {
   debugState.peakQueuedCharsByTerminal = Math.max(
     debugState.peakQueuedCharsByTerminal,
     current.queuedCharsByTerminal
+  )
+  debugState.peakRetainedChars = Math.max(
+    debugState.peakRetainedChars,
+    current.retainedChars
   )
 }
 
@@ -520,7 +537,7 @@ function previewQueuedData(entry: QueueEntry, limit: number): string {
     if (remaining <= 0) {
       break
     }
-    data += chunk.data.slice(0, remaining)
+    data += chunk.data.slice(chunk.consumedOffset, chunk.consumedOffset + remaining)
   }
   return data
 }
@@ -587,10 +604,10 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
       additionalBeforeWriteCallbacks ??= []
       additionalBeforeWriteCallbacks.push(chunk.beforeWrite)
     }
-    if (chunk.data.length <= remaining) {
-      data += chunk.data
-      remaining -= chunk.data.length
-      entry.queuedChars -= chunk.data.length
+    const available = chunk.data.length - chunk.consumedOffset
+    if (available <= remaining) {
+      data += chunk.consumedOffset === 0 ? chunk.data : chunk.data.slice(chunk.consumedOffset)
+      remaining -= available
       entry.chunkIndex += 1
       if (chunk.onParsed) {
         parsedCallbacks.push(chunk.onParsed)
@@ -601,19 +618,12 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
       continue
     }
 
-    data += chunk.data.slice(0, remaining)
-    entry.chunks[entry.chunkIndex] = {
-      ...chunk,
-      data: chunk.data.slice(remaining)
-    }
-    entry.queuedChars -= remaining
+    data += chunk.data.slice(chunk.consumedOffset, chunk.consumedOffset + remaining)
+    chunk.consumedOffset += remaining
     remaining = 0
   }
 
   compactConsumedChunks(entry)
-  if (entry.queuedChars < 0) {
-    entry.queuedChars = 0
-  }
   recordQueueDebugPressure()
   return data
     ? {
@@ -655,11 +665,17 @@ function compactConsumedChunks(entry: QueueEntry): void {
     return
   }
   if (entry.chunkIndex === entry.chunks.length) {
+    entry.pendingChars = 0
     entry.chunks.length = 0
     entry.chunkIndex = 0
     return
   }
   if (entry.chunkIndex >= 64) {
+    let releasedChars = 0
+    for (let index = 0; index < entry.chunkIndex; index += 1) {
+      releasedChars += entry.chunks[index].data.length
+    }
+    entry.pendingChars -= releasedChars
     entry.chunks.splice(0, entry.chunkIndex)
     entry.chunkIndex = 0
   }
@@ -681,6 +697,7 @@ function enqueueChunk(
 ): void {
   entry.chunks.push({
     data,
+    consumedOffset: 0,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,
     followupForegroundRefresh: options?.followupForegroundRefresh === true,
@@ -691,7 +708,7 @@ function enqueueChunk(
     onParsed: options?.onParsed,
     ackCredit: options?.ackCredit
   })
-  entry.queuedChars += data.length
+  entry.pendingChars += data.length
   recordQueueDebugPressure()
 }
 
@@ -706,7 +723,7 @@ function discardDetachedQueueEntry(entry: QueueEntry): void {
   fireQueuedAckCredits(entry)
   entry.chunks.length = 0
   entry.chunkIndex = 0
-  entry.queuedChars = 0
+  entry.pendingChars = 0
   entry.highPriority = false
   clearForegroundHoldSafety(entry)
   clearForegroundCoalesce(entry)
@@ -714,7 +731,7 @@ function discardDetachedQueueEntry(entry: QueueEntry): void {
 
 function queueCapExceeded(entry: QueueEntry): boolean {
   return (
-    entry.queuedChars > maxQueueChars ||
+    entry.pendingChars > maxQueueChars ||
     entry.chunks.length - entry.chunkIndex > MAX_BACKGROUND_QUEUE_CHUNKS
   )
 }
@@ -728,7 +745,7 @@ function replaceBacklogWithWarning(
     // Why: field visibility for cap tuning — drop frequency and size decide whether the cap is too small (issue #2836 / #7017).
     recordRendererCrashBreadcrumb('terminal_output_backlog_dropped', {
       foreground: warning === FOREGROUND_BACKLOG_WARNING,
-      droppedChars: entry.queuedChars,
+      droppedChars: entry.pendingChars,
       capChars: maxQueueChars
     })
   }
@@ -744,6 +761,7 @@ function replaceBacklogWithWarning(
   entry.chunks = [
     {
       data: warning,
+      consumedOffset: 0,
       foreground: false,
       forceForegroundRefresh: false,
       followupForegroundRefresh: false,
@@ -753,7 +771,7 @@ function replaceBacklogWithWarning(
     }
   ]
   entry.chunkIndex = 0
-  entry.queuedChars = warning.length
+  entry.pendingChars = warning.length
   entry.backgroundBacklogDropped = true
   entry.highPriority = true
   entry.foregroundHold = false
@@ -775,7 +793,7 @@ function hasHighPriorityBacklog(): boolean {
   for (const entry of queuedByTerminal.values()) {
     if (
       isEntryDrainable(entry) &&
-      (entry.highPriority || entry.queuedChars > LARGE_BACKLOG_CHARS)
+      (entry.highPriority || entry.pendingChars > LARGE_BACKLOG_CHARS)
     ) {
       return true
     }
@@ -831,7 +849,7 @@ function takeNextDrainableEntry(): QueueEntry | null {
       queuedByTerminal.delete(entry.terminal)
       return entry
     }
-    if (!largeBacklogEntry && entry.queuedChars > LARGE_BACKLOG_CHARS) {
+    if (!largeBacklogEntry && entry.pendingChars > LARGE_BACKLOG_CHARS) {
       largeBacklogEntry = entry
     }
   }
@@ -944,7 +962,7 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
       fireQueuedAckCredits(entry)
       entry.chunks.length = 0
       entry.chunkIndex = 0
-      entry.queuedChars = 0
+      entry.pendingChars = 0
       clearForegroundHoldSafety(entry)
       clearForegroundCoalesce(entry)
       recordQueueDebugPressure()
@@ -957,7 +975,7 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
     fireQueuedAckCredits(entry)
     entry.chunks.length = 0
     entry.chunkIndex = 0
-    entry.queuedChars = 0
+    entry.pendingChars = 0
     clearForegroundHoldSafety(entry)
     clearForegroundCoalesce(entry)
     recordQueueDebugPressure()
@@ -1119,7 +1137,7 @@ export function writeTerminalOutput(
       scheduleDrain(0)
       return
     }
-    if (entry && entry.queuedChars > SYNC_FOREGROUND_FLUSH_CHARS) {
+    if (entry && entry.pendingChars > SYNC_FOREGROUND_FLUSH_CHARS) {
       entry.highPriority = true
       enqueueChunk(entry, data, {
         foreground: true,
@@ -1227,7 +1245,7 @@ export function writeTerminalOutput(
   }
   // Why: letting every non-focused pane call xterm.write immediately spawns a WriteBuffer timer per pane, starving the focused terminal on the shared renderer thread.
   scheduleDrain(
-    entry.highPriority || entry.queuedChars > LARGE_BACKLOG_CHARS ? 0 : BACKGROUND_FLUSH_DELAY_MS
+    entry.highPriority || entry.pendingChars > LARGE_BACKLOG_CHARS ? 0 : BACKGROUND_FLUSH_DELAY_MS
   )
 }
 
@@ -1254,7 +1272,7 @@ export function flushTerminalOutput(
     fireQueuedAckCredits(entry)
     entry.chunks.length = 0
     entry.chunkIndex = 0
-    entry.queuedChars = 0
+    entry.pendingChars = 0
     entry.highPriority = false
     clearForegroundHoldSafety(entry)
     clearForegroundCoalesce(entry)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -102,6 +102,12 @@ const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 // Why mutable: the cap scales with the user's scrollback setting (terminalOutputBacklogCapChars), configured when settings apply; the chunk-count cap stays fixed.
 let maxQueueChars = TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS
 const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
+const RETAINED_REBASE_COPY_BLOCK_CHARS = 8 * 1024
+let retainedRebaseCopyObserver: (() => void) | null = null
+
+export function setRetainedRebaseCopyObserverForTesting(observer: (() => void) | null): void {
+  retainedRebaseCopyObserver = observer
+}
 
 export function configureTerminalOutputBacklogCap(scrollbackRows: unknown): void {
   maxQueueChars = terminalOutputBacklogCapChars(scrollbackRows)
@@ -331,7 +337,8 @@ function createQueueEntry(
     terminal,
     chunks: [],
     chunkIndex: 0,
-    queuedChars: 0,
+    pendingChars: 0,
+    retainedChars: 0,
     onBackgroundBacklogDropped: options.onBackgroundBacklogDropped,
     backgroundBacklogDropped: false,
     highPriority: true,
@@ -623,6 +630,7 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
     remaining = 0
   }
 
+  entry.pendingChars -= data.length
   compactConsumedChunks(entry)
   recordQueueDebugPressure()
   return data
@@ -666,6 +674,7 @@ function compactConsumedChunks(entry: QueueEntry): void {
   }
   if (entry.chunkIndex === entry.chunks.length) {
     entry.pendingChars = 0
+    entry.retainedChars = 0
     entry.chunks.length = 0
     entry.chunkIndex = 0
     return
@@ -675,10 +684,57 @@ function compactConsumedChunks(entry: QueueEntry): void {
     for (let index = 0; index < entry.chunkIndex; index += 1) {
       releasedChars += entry.chunks[index].data.length
     }
-    entry.pendingChars -= releasedChars
+    entry.retainedChars -= releasedChars
     entry.chunks.splice(0, entry.chunkIndex)
     entry.chunkIndex = 0
   }
+}
+
+function copyStringSuffix(data: string, offset: number): string {
+  let copied = ''
+  for (let start = offset; start < data.length; start += RETAINED_REBASE_COPY_BLOCK_CHARS) {
+    const end = Math.min(data.length, start + RETAINED_REBASE_COPY_BLOCK_CHARS)
+    const codeUnits = new Uint16Array(end - start)
+    for (let index = start; index < end; index += 1) {
+      codeUnits[index - start] = data.charCodeAt(index)
+    }
+    copied += String.fromCharCode(...codeUnits)
+  }
+  return copied
+}
+
+function rebaseRetainedChunks(entry: QueueEntry): void {
+  if (
+    entry.retainedChars <= maxQueueChars ||
+    entry.pendingChars > maxQueueChars ||
+    entry.chunks.length - entry.chunkIndex > MAX_BACKGROUND_QUEUE_CHUNKS
+  ) {
+    return
+  }
+
+  if (entry.chunkIndex > 0) {
+    let releasedChars = 0
+    for (let index = 0; index < entry.chunkIndex; index += 1) {
+      releasedChars += entry.chunks[index].data.length
+    }
+    entry.retainedChars -= releasedChars
+    entry.chunks.splice(0, entry.chunkIndex)
+    entry.chunkIndex = 0
+  }
+  if (entry.retainedChars <= maxQueueChars) {
+    return
+  }
+
+  const chunk = entry.chunks[0]
+  if (!chunk || chunk.consumedOffset === 0) {
+    return
+  }
+  const source = chunk.data
+  const copied = copyStringSuffix(source, chunk.consumedOffset)
+  retainedRebaseCopyObserver?.()
+  chunk.data = copied
+  chunk.consumedOffset = 0
+  entry.retainedChars += copied.length - source.length
 }
 
 function enqueueChunk(
@@ -709,6 +765,8 @@ function enqueueChunk(
     ackCredit: options?.ackCredit
   })
   entry.pendingChars += data.length
+  entry.retainedChars += data.length
+  rebaseRetainedChunks(entry)
   recordQueueDebugPressure()
 }
 
@@ -724,6 +782,7 @@ function discardDetachedQueueEntry(entry: QueueEntry): void {
   entry.chunks.length = 0
   entry.chunkIndex = 0
   entry.pendingChars = 0
+  entry.retainedChars = 0
   entry.highPriority = false
   clearForegroundHoldSafety(entry)
   clearForegroundCoalesce(entry)
@@ -772,6 +831,7 @@ function replaceBacklogWithWarning(
   ]
   entry.chunkIndex = 0
   entry.pendingChars = warning.length
+  entry.retainedChars = warning.length
   entry.backgroundBacklogDropped = true
   entry.highPriority = true
   entry.foregroundHold = false
@@ -963,6 +1023,7 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
       entry.chunks.length = 0
       entry.chunkIndex = 0
       entry.pendingChars = 0
+      entry.retainedChars = 0
       clearForegroundHoldSafety(entry)
       clearForegroundCoalesce(entry)
       recordQueueDebugPressure()
@@ -976,6 +1037,7 @@ function writeQueuedChunk(entry: QueueEntry): 'foreground' | 'background' | null
     entry.chunks.length = 0
     entry.chunkIndex = 0
     entry.pendingChars = 0
+    entry.retainedChars = 0
     clearForegroundHoldSafety(entry)
     clearForegroundCoalesce(entry)
     recordQueueDebugPressure()
@@ -1273,6 +1335,7 @@ export function flushTerminalOutput(
     entry.chunks.length = 0
     entry.chunkIndex = 0
     entry.pendingChars = 0
+    entry.retainedChars = 0
     entry.highPriority = false
     clearForegroundHoldSafety(entry)
     clearForegroundCoalesce(entry)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -103,9 +103,11 @@ const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 let maxQueueChars = TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS
 const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
 const RETAINED_REBASE_COPY_BLOCK_CHARS = 8 * 1024
-let retainedRebaseCopyObserver: (() => void) | null = null
+let retainedRebaseCopyObserver: ((source: string, copy: string) => void) | null = null
 
-export function setRetainedRebaseCopyObserverForTesting(observer: (() => void) | null): void {
+export function setRetainedRebaseCopyObserverForTesting(
+  observer: ((source: string, copy: string) => void) | null
+): void {
   retainedRebaseCopyObserver = observer
 }
 
@@ -275,10 +277,7 @@ function recordQueueDebugPressure(): void {
     debugState.peakQueuedCharsByTerminal,
     current.queuedCharsByTerminal
   )
-  debugState.peakRetainedChars = Math.max(
-    debugState.peakRetainedChars,
-    current.retainedChars
-  )
+  debugState.peakRetainedChars = Math.max(debugState.peakRetainedChars, current.retainedChars)
 }
 
 function exposeDebugApi(): void {
@@ -731,7 +730,7 @@ function rebaseRetainedChunks(entry: QueueEntry): void {
   }
   const source = chunk.data
   const copied = copyStringSuffix(source, chunk.consumedOffset)
-  retainedRebaseCopyObserver?.()
+  retainedRebaseCopyObserver?.(source, copied)
   chunk.data = copied
   chunk.consumedOffset = 0
   entry.retainedChars += copied.length - source.length

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -102,7 +102,6 @@ const SYNC_FOREGROUND_FLUSH_CHARS = 256 * 1024
 // Why mutable: the cap scales with the user's scrollback setting (terminalOutputBacklogCapChars), configured when settings apply; the chunk-count cap stays fixed.
 let maxQueueChars = TERMINAL_OUTPUT_BACKLOG_MIN_CAP_CHARS
 const MAX_BACKGROUND_QUEUE_CHUNKS = 4096
-const RETAINED_REBASE_COPY_BLOCK_CHARS = 8 * 1024
 let retainedRebaseCopyObserver: ((source: string, copy: string) => void) | null = null
 
 export function setRetainedRebaseCopyObserverForTesting(
@@ -690,16 +689,7 @@ function compactConsumedChunks(entry: QueueEntry): void {
 }
 
 function copyStringSuffix(data: string, offset: number): string {
-  let copied = ''
-  for (let start = offset; start < data.length; start += RETAINED_REBASE_COPY_BLOCK_CHARS) {
-    const end = Math.min(data.length, start + RETAINED_REBASE_COPY_BLOCK_CHARS)
-    const codeUnits = new Uint16Array(end - start)
-    for (let index = start; index < end; index += 1) {
-      codeUnits[index - start] = data.charCodeAt(index)
-    }
-    copied += String.fromCharCode(...codeUnits)
-  }
-  return copied
+  return structuredClone(data.slice(offset))
 }
 
 function rebaseRetainedChunks(entry: QueueEntry): void {

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -765,7 +765,6 @@ function enqueueChunk(
   })
   entry.pendingChars += data.length
   entry.retainedChars += data.length
-  rebaseRetainedChunks(entry)
   recordQueueDebugPressure()
 }
 
@@ -1151,6 +1150,7 @@ export function writeTerminalOutput(
         scheduleDrain(0)
         return
       }
+      rebaseRetainedChunks(queued)
       if (options.holdForeground) {
         // Why: synchronized-output start/body chunks contain transient cursor moves; holding them prevents Chromium from rasterizing those states.
         if (options.latencySensitive === true) {
@@ -1216,6 +1216,8 @@ export function writeTerminalOutput(
       }
       if (queueCapExceeded(entry)) {
         replaceBacklogWithWarning(entry, FOREGROUND_BACKLOG_WARNING)
+      } else {
+        rebaseRetainedChunks(entry)
       }
       // Why: returning from a hidden window can have megabytes queued — keep byte order but drain async so the first foreground frame isn't pinned behind the whole backlog.
       scheduleDrain(0)
@@ -1246,6 +1248,8 @@ export function writeTerminalOutput(
       }
       if (queueCapExceeded(queued)) {
         replaceBacklogWithWarning(queued, FOREGROUND_BACKLOG_WARNING)
+      } else {
+        rebaseRetainedChunks(queued)
       }
       // Why: visible command floods are throughput work, not keystroke echo — queue behind a zero-delay drain so one IPC callback can't pin the renderer while input/paint wait.
       scheduleDrain(0)
@@ -1300,6 +1304,8 @@ export function writeTerminalOutput(
   })
   if (queueCapExceeded(entry)) {
     replaceBacklogWithWarning(entry)
+  } else {
+    rebaseRetainedChunks(entry)
   }
   if (debugEnabled) {
     debugState.backgroundEnqueueCount++


### PR DESCRIPTION
## Summary

The terminal output scheduler re-slices partially-consumed output chunks back into its queue. V8 represents `String.prototype.slice` as a **SlicedString that retains a pointer to the entire parent string**, so the queue keeps the whole original chunk alive while accounting for only the unconsumed remainder.

Measured with a standalone probe: **8 chunks each charging 1,000 chars — a claimed 16 KB — retained 128 MB of `used_heap_size`.** That is roughly a **8,000× under-charge**, and the retained memory is real, not just mis-reported.

This PR replaces the retaining re-slice with natively materialized suffixes and charges reachable bytes across all retained chunks rather than only the unconsumed remainder.

No visual change.

## Opened as a draft — please read this section first

**Independent re-review of this revision was not completed.** It was in progress and the reviewing agent was stopped before it reported. Two earlier revisions of this same fix were each **rejected by review for real defects** (see below), so the prior on this code is that a third defect is more likely than not.

Do not merge on the strength of the green suite below. What is missing is stated explicitly under *Verification gaps*.

## Location

`src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts`

```ts
chunk.data.slice(remaining)      // SlicedString — retains the whole parent
entry.queuedChars -= remaining   // charge reduced to the remainder only
```

Second, related defect also addressed: consumed-but-still-referenced chunks were excluded from `queuedChars` entirely — retained, but never accounted at all.

## Trigger conditions

Fires whenever a single enqueued chunk exceeds `BACKGROUND_CHUNK_CHARS` (16K chars). That is routine for a fast PTY against the 2 MB+ backlog cap — i.e. any command producing sustained output. A drained 2 MB chunk pins ~4 MB until its remainder is finally consumed.

## Why this may matter beyond the accounting error

Renderer V8 heap exhaustion is Orca's largest crash cluster — **714 reports, 118+ named users, still live on 1.4.171** — with measured per-session growth up to **1326 MB/hour** and peak `usedHeapMB` of 3947 against a 4192 MB limit.

Terminal output is a plausible retainer, and this is the first concrete, *measured* retention defect found in that path.

**This is explicitly not a claim that it causes that cluster.** It is a plausible, unproven contributor. The honest position is that it is a real bug worth fixing on its own merits, and a candidate worth testing against the OOM cluster once shipped.

## Two rejected revisions, recorded so they are not retried

1. **Correct accounting alone made things worse.** Charging the full retained size caused the backlog cap to fire early and drop live scrollback — a correctness fix that produced user-visible data loss.
2. **The first amendment was O(n²).** Rebasing retained chunks copied repeatedly, measured at **182.6× amplification at the supported cap** — trading a memory bug for a latency bug on the hot PTY path.

This revision materializes suffixes natively and bounds the copying. That third approach is what needs adversarial review.

## Verification gaps — what is NOT proven

- **No independent mutation score.** Self-reported mutation scores were wrong every single time they were checked in this sweep (claims of 100% independently measured at 75%, 83.3%, 94.1%, 70%, 45%). No number is asserted here.
- **`structuredClone` detachment is unverified.** The fix relies on the materialized suffix genuinely not retaining the parent. That property is asserted but was not independently confirmed on this revision.
- **The throughput benchmark has no baseline comparison.** `pane-terminal-output-scheduler-retention.bench.test.ts` and the interleaved arm report absolute numbers; nobody ran them against `main`. **Throughput is a real constraint on this path** — a reviewer should run both arms against base and confirm the trade is sound before this leaves draft.
- **The benchmark files are skipped in the normal run** (1 skipped file / 5 skipped tests in the pane-manager run below), so CI green says nothing about performance.

## Testing

- [x] `pnpm lint` — `oxlint` clean (exit 0). Remaining `pnpm lint` sub-steps not run locally.
- [x] `pnpm typecheck` — web project clean.
- [x] `pnpm test` — **full renderer suite: 2,207 files / 20,426 tests pass.** First run had 1 unrelated failure in a dialog test (`Cancel` button); it passed on re-run, so it is a pre-existing flake, not caused by this change. Scoped pane-manager run: 59 files / 648 tests pass, 1 file / 5 tests skipped (the benchmarks).
- [ ] `pnpm build` — **not run.**
- [x] Added tests that would catch regressions — `pane-terminal-output-scheduler-retained-charge.test.ts` (380 lines) plus two benchmark files.

The reproduction was RED on `main` before the fix: a deterministic harness drives the scheduler, enqueues chunks that cross `BACKGROUND_CHUNK_CHARS`, drains partially, forces GC, and reads `used_heap_size`. Fixture sizes are derived from the exported constant rather than hardcoded, so the boundary tests do not go vacuous if the constant moves — but note that deriving boundaries *alone* leaves a blind spot where mutating the constant itself keeps everything green, so the suite also needs a test asserting the constant's own value and the policy it encodes. **That test is not present yet.**

## AI Review Report

Two independent adversarial reviews were completed on earlier revisions and both **rejected** them, for the two defects described above. The third review — of the code actually in this PR — was started and did not finish.

Cross-platform: this is renderer-side string and buffer accounting with no platform-dependent behaviour, no shortcuts, no path handling. It applies equally to local, SSH, and remote-runtime terminal sessions, and to both git-worktree and folder workspaces, because it sits below the transport layer.

## Security Audit

No IPC surface, no command execution, no path handling, no auth or secrets, no dependency changes. Terminal output is treated strictly as opaque data and is never interpreted; the change only alters how that data is stored and measured. The relevant risk is availability rather than confidentiality — an accounting change on this path can cause either memory growth (if it under-charges) or dropped scrollback (if it over-charges), and revision 1 in fact caused the latter.

## Notes

A separate consequence worth flagging: any attribution built on `queuedChars` inherits the old under-charge, so a `retainedKB` figure derived from `queuedChars * 2` cannot be described as an upper bound on retained memory. This is why the companion diagnostics PR labels every on-heap figure as an unbounded heuristic rather than a bound in either direction.

Found during the 2026-08-05/06 fleet crash sweep, while adversarially reviewing an unrelated heap-attribution change. It was not the thing being looked for.
