### PR TITLE
fix(crash-reporting): make renderer memory attribution honest about what it cannot explain

### DIFF
--- a/src/renderer/src/lib/crash-diagnostics.test.ts
+++ b/src/renderer/src/lib/crash-diagnostics.test.ts
@@ -175,7 +175,9 @@ describe('renderer crash diagnostics', () => {
     })
     const profile = await import('./renderer-memory-profile')
     const unregister = profile.registerRendererMemoryProfileContributor('store', () => ({
-      worktrees: 12
+      counts: { worktrees: 12 },
+      heuristicOnHeapKB: 400_000,
+      soundOnHeapBoundKB: 400_000
     }))
 
     diagnostics.installRendererCrashDiagnostics()
@@ -189,6 +191,13 @@ describe('renderer crash diagnostics', () => {
       data: expect.objectContaining({
         thresholdPct: 60,
         rendererSurface: 'main',
+        usedHeapKB: 367_002,
+        onHeapHeuristicSumKB: 400_000,
+        onHeapEstimateExceededHeap: 1,
+        soundOnHeapBoundContributorCount: 1,
+        soundOnHeapBoundSumKB: 400_000,
+        usedHeapHeuristicResidualKB: -32_998,
+        'store.onHeapHeuristicKB': 400_000,
         domNodes: 4321,
         terminalElements: 6,
         browserWebviews: 4,

--- a/src/renderer/src/lib/crash-diagnostics.ts
+++ b/src/renderer/src/lib/crash-diagnostics.ts
@@ -7,7 +7,7 @@ import {
   type BrowserWebviewMemoryProfile
 } from '../components/browser-pane/webview-registry'
 import { recordRendererCrashBreadcrumb } from './crash-breadcrumb-recorder'
-import { collectRendererMemoryProfileCounts } from './renderer-memory-profile'
+import { collectRendererMemoryProfile } from './renderer-memory-profile'
 
 const RENDERER_MEMORY_SAMPLE_INTERVAL_MS = 60_000
 const BYTES_PER_MEGABYTE = 1024 * 1024
@@ -158,6 +158,9 @@ function recordRendererMemoryHighwater(
     return
   }
   // Why: a single sample can cross both thresholds; profile the large heap once.
+  const memoryProfile = collectRendererMemoryProfile()
+  const usedHeapKB = Math.round(used / BYTES_PER_KILOBYTE)
+  const usedHeapHeuristicResidualKB = usedHeapKB - memoryProfile.soundOnHeapBoundSumKB
   const profile = compactBreadcrumbData({
     rendererSurface,
     usedHeapMB: toMegabytes(used),
@@ -166,11 +169,19 @@ function recordRendererMemoryHighwater(
     heapSource: memory.exact ? 'v8' : 'quantized',
     mallocedMB: toMegabytes(memory.mallocedBytes),
     blinkAllocatedMB: toMegabytes(memory.blinkAllocatedBytes),
+    usedHeapKB,
+    onHeapHeuristicSumKB: memoryProfile.onHeapHeuristicSumKB,
+    onHeapEstimateExceededHeap: Number(memoryProfile.onHeapHeuristicSumKB > usedHeapKB),
+    soundOnHeapBoundContributorCount: memoryProfile.soundOnHeapBoundContributorCount,
+    soundOnHeapBoundSumKB: memoryProfile.soundOnHeapBoundSumKB,
+    usedHeapHeuristicResidualKB,
+    ...memoryProfile.onHeapHeuristicByCategoryKB,
+    ...memoryProfile.externalHeuristicByCategoryKB,
     domNodes: document.getElementsByTagName('*').length,
     terminalElements: document.querySelectorAll('.xterm').length,
     browserWebviews: browserWebviews.browserWebviewCount,
     registeredBrowserGuests: browserWebviews.registeredBrowserGuestCount,
-    ...collectRendererMemoryProfileCounts()
+    ...memoryProfile.counts
   })
   for (const threshold of RENDERER_MEMORY_HIGHWATER_RATIOS) {
     if (ratio < threshold || emittedHighwaterRatios.has(threshold)) {

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, describe, expect, it, vi, type Mock } from 'vitest'
-import { collectRendererMemoryProfileCounts } from '../renderer-memory-profile'
+import { collectRendererMemoryProfile } from '../renderer-memory-profile'
 import {
   forEachLivePaneForDesyncSentinel,
   getLivePaneCensus,
@@ -353,9 +353,12 @@ describe('pane manager registry', () => {
     registerLivePaneManager(manager)
     registeredManagers.push(manager)
 
-    const counts = collectRendererMemoryProfileCounts()
-    expect(counts['terminals.managers']).toBe(1)
-    expect(counts['terminals.estPanes']).toBe(1)
-    expect(counts['terminals.estBufferKB']).toBe(100)
+    const profile = collectRendererMemoryProfile()
+    expect(profile.counts['terminals.managers']).toBe(1)
+    expect(profile.counts['terminals.estPanes']).toBe(1)
+    expect(profile.counts['terminals.estBufferKB']).toBe(100)
+    expect(profile.externalHeuristicByCategoryKB).toEqual({
+      'terminals.externalHeuristicKB': 100
+    })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-registry.ts
@@ -252,4 +252,10 @@ export function getLivePaneMemoryProfileCounts(): Record<string, number> {
 
 // Why here: contributors push in (crash-diagnostics stays a leaf); same-name
 // re-registration on dev HMR overwrites, so no disposal hook is needed.
-registerRendererMemoryProfileContributor('terminals', getLivePaneMemoryProfileCounts)
+registerRendererMemoryProfileContributor('terminals', () => {
+  const counts = getLivePaneMemoryProfileCounts()
+  return {
+    counts,
+    heuristicExternalKB: counts.estBufferKB
+  }
+})

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -7,6 +7,7 @@ import {
 } from './pane-terminal-foreground-render-settle'
 import { runGuardedWriteCompletionStep } from './xterm-write-callback-guard'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { registerRendererMemoryProfileContributor } from '@/lib/renderer-memory-profile'
 import {
   discardInFlightTerminalOutputAckCredits,
   registerTerminalOutputAckCredits
@@ -239,6 +240,19 @@ function readQueueDebugSnapshot(): {
     queuedCharsByTerminal
   }
 }
+
+registerRendererMemoryProfileContributor('terminalOutputQueue', () => {
+  const snapshot = readQueueDebugSnapshot()
+  const heuristicOnHeapKB = Math.ceil((snapshot.queuedChars * 2) / 1024)
+  return {
+    counts: {
+      terminals: snapshot.queuedTerminalCount,
+      queuedChars: snapshot.queuedChars,
+      maxQueuedCharsPerTerminal: snapshot.queuedCharsByTerminal
+    },
+    heuristicOnHeapKB
+  }
+})
 
 function recordQueueDebugPressure(): void {
   if (!debugEnabled) {

--- a/src/renderer/src/lib/renderer-memory-attribution.test.ts
+++ b/src/renderer/src/lib/renderer-memory-attribution.test.ts
@@ -1,0 +1,54 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/e2e-config', () => ({
+  e2eConfig: { exposeStore: false }
+}))
+
+vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: vi.fn()
+}))
+
+const ASCII_ALLOCATION_SIZES = [1024, 1024 * 1024, 2 * 1024 * 1024] as const
+
+let cleanup: (() => void) | undefined
+
+afterEach(() => {
+  cleanup?.()
+  cleanup = undefined
+  vi.useRealTimers()
+})
+
+describe('renderer memory attribution', () => {
+  it.each(ASCII_ALLOCATION_SIZES)(
+    'reports a retained ASCII terminal queue of %i characters',
+    async (retainedChars) => {
+      vi.useFakeTimers()
+      vi.resetModules()
+      const { collectRendererMemoryProfile } = await import('./renderer-memory-profile')
+      const { discardTerminalOutput, writeTerminalOutput } =
+        await import('./pane-manager/pane-terminal-output-scheduler')
+      const terminal = { write: vi.fn() }
+      cleanup = () => discardTerminalOutput(terminal)
+
+      writeTerminalOutput(terminal, 'x'.repeat(retainedChars), { foreground: false })
+
+      expect(collectRendererMemoryProfile()).toMatchObject({
+        counts: {
+          'terminalOutputQueue.queuedChars': retainedChars
+        },
+        onHeapHeuristicByCategoryKB: {
+          'terminalOutputQueue.onHeapHeuristicKB': Math.ceil((retainedChars * 2) / 1024)
+        }
+      })
+
+      cleanup()
+      cleanup = undefined
+      expect(collectRendererMemoryProfile()).toMatchObject({
+        counts: { 'terminalOutputQueue.queuedChars': 0 },
+        onHeapHeuristicByCategoryKB: {
+          'terminalOutputQueue.onHeapHeuristicKB': 0
+        }
+      })
+    }
+  )
+})

--- a/src/renderer/src/lib/renderer-memory-profile.test.ts
+++ b/src/renderer/src/lib/renderer-memory-profile.test.ts
@@ -1,13 +1,18 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
+  MAX_PROFILE_CONTRIBUTOR_INVOCATIONS,
+  collectRendererMemoryProfile,
   collectRendererMemoryProfileCounts,
   registerRendererMemoryProfileContributor,
-  summarizeStateCollectionSizes
+  summarizeStateCollectionSizes,
+  type RendererMemoryProfileContribution
 } from './renderer-memory-profile'
 
 const unregisters: (() => void)[] = []
 
-function register(name: string, contributor: () => Record<string, number>): void {
+type Contributor = () => Record<string, number> | RendererMemoryProfileContribution
+
+function register(name: string, contributor: Contributor): void {
   unregisters.push(registerRendererMemoryProfileContributor(name, contributor))
 }
 
@@ -18,22 +23,34 @@ afterEach(() => {
   vi.restoreAllMocks()
 })
 
-describe('collectRendererMemoryProfileCounts', () => {
-  it('namespaces contributor counts and keeps only finite numbers', () => {
-    register('store', () => ({ worktrees: 40, junk: Number.NaN }))
-    register('terminals', () => ({ panes: 7 }))
+describe('collectRendererMemoryProfile', () => {
+  it('pins the near-OOM contributor invocation cap', () => {
+    expect(MAX_PROFILE_CONTRIBUTOR_INVOCATIONS).toBe(8)
+  })
 
-    expect(collectRendererMemoryProfileCounts()).toEqual({
-      'store.worktrees': 40,
-      'terminals.panes': 7
+  it('separates memory-pool hypotheses and sound bounds', () => {
+    register('queue', () => ({
+      counts: { chars: 1024 },
+      heuristicOnHeapKB: 2,
+      heuristicExternalKB: 3,
+      soundOnHeapBoundKB: 1
+    }))
+
+    expect(collectRendererMemoryProfile()).toEqual({
+      counts: { 'queue.chars': 1024 },
+      onHeapHeuristicByCategoryKB: { 'queue.onHeapHeuristicKB': 2 },
+      externalHeuristicByCategoryKB: { 'queue.externalHeuristicKB': 3 },
+      onHeapHeuristicSumKB: 2,
+      soundOnHeapBoundContributorCount: 1,
+      soundOnHeapBoundSumKB: 1
     })
   })
 
-  it('contains a throwing contributor instead of failing collection', () => {
+  it('namespaces counts and contains a throwing contributor', () => {
     register('broken', () => {
       throw new Error('boom')
     })
-    register('store', () => ({ worktrees: 3 }))
+    register('store', () => ({ worktrees: 3, junk: Number.NaN }))
 
     expect(collectRendererMemoryProfileCounts()).toEqual({
       'broken.error': 1,
@@ -47,17 +64,9 @@ describe('collectRendererMemoryProfileCounts', () => {
     expect(collectRendererMemoryProfileCounts()).toEqual({})
   })
 
-  it('caps a runaway contributor instead of bloating the breadcrumb', () => {
-    register('runaway', () =>
-      Object.fromEntries(Array.from({ length: 500 }, (_, index) => [`key${index}`, index + 1]))
-    )
-
-    expect(Object.keys(collectRendererMemoryProfileCounts())).toHaveLength(32)
-  })
-
-  it('stops reading a runaway contributor after the output budget', () => {
+  it('caps reading a runaway contributor', () => {
     let reads = 0
-    const contribution = Object.fromEntries(
+    const descriptors = Object.fromEntries(
       Array.from({ length: 500 }, (_, index) => [
         `key${index}`,
         {
@@ -69,33 +78,49 @@ describe('collectRendererMemoryProfileCounts', () => {
         }
       ])
     )
-    const counts = Object.defineProperties({}, contribution) as Record<string, number>
-    register('runaway', () => counts)
+    register('runaway', () => Object.defineProperties({}, descriptors) as Record<string, number>)
 
     expect(Object.keys(collectRendererMemoryProfileCounts())).toHaveLength(32)
     expect(reads).toBe(32)
   })
 
-  it('caps aggregate counts and skips contributors after the profile budget', () => {
+  it('stops invoking contributors once the output cap is full', () => {
     register('first', () =>
       Object.fromEntries(Array.from({ length: 32 }, (_, index) => [`key${index}`, index]))
     )
     register('second', () =>
       Object.fromEntries(Array.from({ length: 32 }, (_, index) => [`key${index}`, index]))
     )
-    const skippedContributor = vi.fn(() => ({ shouldNotRun: 1 }))
-    register('skipped', skippedContributor)
+    const skipped = vi.fn(() => ({ shouldNotRun: 1 }))
+    register('skipped', skipped)
 
     expect(Object.keys(collectRendererMemoryProfileCounts())).toHaveLength(64)
-    expect(skippedContributor).not.toHaveBeenCalled()
+    expect(skipped).not.toHaveBeenCalled()
   })
 
-  it('caps contributor calls when contributors return no counts', () => {
-    const contributors = Array.from({ length: 100 }, () => vi.fn(() => ({})))
-    contributors.forEach((contributor, index) => register(`empty-${index}`, contributor))
+  it('rotates the bounded invocation window between collections', () => {
+    const contributors = Array.from(
+      { length: MAX_PROFILE_CONTRIBUTOR_INVOCATIONS + 2 },
+      (_, index) => vi.fn(() => ({ value: index }))
+    )
+    contributors.forEach((contributor, index) => register(`entry-${index}`, contributor))
 
-    expect(collectRendererMemoryProfileCounts()).toEqual({})
-    expect(contributors.filter((contributor) => contributor.mock.calls.length > 0)).toHaveLength(64)
+    const first = collectRendererMemoryProfileCounts()
+    const second = collectRendererMemoryProfileCounts()
+
+    expect(Object.keys(first)).toHaveLength(MAX_PROFILE_CONTRIBUTOR_INVOCATIONS)
+    expect(first).not.toHaveProperty(`entry-${MAX_PROFILE_CONTRIBUTOR_INVOCATIONS}.value`)
+    expect(second).toHaveProperty(`entry-${MAX_PROFILE_CONTRIBUTOR_INVOCATIONS}.value`)
+    expect(second).toHaveProperty(`entry-${MAX_PROFILE_CONTRIBUTOR_INVOCATIONS + 1}.value`)
+  })
+
+  it('emits contributor metadata before round-robin detail', () => {
+    register('first', () =>
+      Object.fromEntries(Array.from({ length: 32 }, (_, index) => [`detail${index}`, index]))
+    )
+    register('second', () => ({ __budgetHit: 1, detail: 2 }))
+
+    expect(Object.keys(collectRendererMemoryProfileCounts())[0]).toBe('second.__budgetHit')
   })
 
   it('does not retain contributors beyond the registry budget', () => {
@@ -104,33 +129,20 @@ describe('collectRendererMemoryProfileCounts', () => {
     for (let index = 1; index < 64; index += 1) {
       register(`empty-${index}`, () => ({}))
     }
-    const overflowContributor = vi.fn(() => ({ retained: 1 }))
-    register('overflow', overflowContributor)
-
+    const overflow = vi.fn(() => ({ retained: 1 }))
+    register('overflow', overflow)
     firstUnregister()
 
     expect(collectRendererMemoryProfileCounts()).toEqual({})
-    expect(overflowContributor).not.toHaveBeenCalled()
+    expect(overflow).not.toHaveBeenCalled()
   })
 
-  it('bounds inherited property inspection and oversized output keys', () => {
-    const inherited = Object.fromEntries(
-      Array.from({ length: 100 }, (_, index) => [`inherited${index}`, index])
-    )
-    register('inherited', () => Object.create(inherited) as Record<string, number>)
-    register('oversized-key', () => ({ ['x'.repeat(10_000)]: 1, valid: 2 }))
-    const hasOwnSpy = vi.spyOn(Object, 'hasOwn')
-
-    const counts = collectRendererMemoryProfileCounts()
-    expect(hasOwnSpy).toHaveBeenCalledTimes(34)
-    expect(counts).toEqual({ 'oversized-key.valid': 2 })
-  })
-
-  it('skips an oversized contributor namespace without invoking it', () => {
+  it('skips oversized namespaces and keys', () => {
     const contributor = vi.fn(() => ({ count: 1 }))
     register('x'.repeat(65), contributor)
+    register('valid', () => ({ ['x'.repeat(81)]: 1, retained: 2 }))
 
-    expect(collectRendererMemoryProfileCounts()).toEqual({})
+    expect(collectRendererMemoryProfileCounts()).toEqual({ 'valid.retained': 2 })
     expect(contributor).not.toHaveBeenCalled()
   })
 })
@@ -142,14 +154,22 @@ describe('summarizeStateCollectionSizes', () => {
       agentStatuses: new Map([['a', 1]]),
       tabs: new Set([1, 2, 3]),
       metaById: { a: 1, b: 2 },
-      label: 'not-a-collection',
-      count: 9
+      label: 'not-a-collection'
     }
 
-    expect(summarizeStateCollectionSizes(state, 2)).toEqual({
-      worktrees: 50,
-      tabs: 3
-    })
+    expect(summarizeStateCollectionSizes(state, 2)).toEqual({ worktrees: 50, tabs: 3 })
+  })
+
+  it('bounds collection scanning and emits metadata first', () => {
+    const state = {
+      huge: Object.fromEntries(Array.from({ length: 10_000 }, (_, index) => [index, true])),
+      later: { retained: true }
+    }
+
+    const result = summarizeStateCollectionSizes(state, 5)
+    expect(Object.keys(result)[0]).toBe('__scanBudgetHit')
+    expect(result.huge).toBe(4096)
+    expect(result).not.toHaveProperty('later')
   })
 
   it('skips empty collections and non-objects', () => {

--- a/src/renderer/src/lib/renderer-memory-profile.ts
+++ b/src/renderer/src/lib/renderer-memory-profile.ts
@@ -1,26 +1,49 @@
 /**
- * Leak-diagnosis counts for renderer_memory_highwater breadcrumbs.
- *
- * Why a contributor registry: crash-diagnostics must stay a leaf module, so
- * subsystems (store, terminals) push their counters in instead of being
- * imported. Counts only — never raw buffers — per the diagnostics budget.
+ * Bounded subsystem hypotheses for renderer_memory_highwater breadcrumbs.
+ * Subsystems push aggregate counts in so crash-diagnostics stays a leaf.
  */
 
 export type RendererMemoryProfileCounts = Record<string, number>
 
-type RendererMemoryProfileContributor = () => RendererMemoryProfileCounts
+export type RendererMemoryProfileContribution = {
+  counts: RendererMemoryProfileCounts
+  heuristicOnHeapKB?: number
+  heuristicExternalKB?: number
+  soundOnHeapBoundKB?: number
+}
+
+export type RendererMemoryProfile = {
+  counts: RendererMemoryProfileCounts
+  onHeapHeuristicByCategoryKB: RendererMemoryProfileCounts
+  externalHeuristicByCategoryKB: RendererMemoryProfileCounts
+  onHeapHeuristicSumKB: number
+  soundOnHeapBoundContributorCount: number
+  soundOnHeapBoundSumKB: number
+}
+
+type RendererMemoryProfileContributor = () =>
+  | RendererMemoryProfileCounts
+  | RendererMemoryProfileContribution
+
+type ContributionEntries = {
+  name: string
+  metadata: [string, number][]
+  details: [string, number][]
+}
+
+type CollectionScanBudget = { remaining: number; hit: boolean }
 
 const contributors = new Map<string, RendererMemoryProfileContributor>()
+let nextContributorStart = 0
 
-// Why: breadcrumbs are retained per session; a misbehaving contributor must not
-// bloat every crash report. 32 counts is plenty to name a leaking subsystem.
 const MAX_COUNTS_PER_CONTRIBUTOR = 32
-// Why: individually bounded contributors can still create unbounded near-OOM work in aggregate.
 const MAX_PROFILE_COUNTS = 64
-// Why: empty contributors do not consume the count budget but must not make collection unbounded.
 const MAX_PROFILE_CONTRIBUTORS = 64
+export const MAX_PROFILE_CONTRIBUTOR_INVOCATIONS = 8
 const MAX_CONTRIBUTOR_NAME_LENGTH = 64
 const MAX_COUNT_KEY_LENGTH = 80
+const MAX_STATE_FIELDS_TO_SCAN = 256
+const MAX_COLLECTION_KEYS_TO_SCAN = 4096
 
 export function registerRendererMemoryProfileContributor(
   name: string,
@@ -37,54 +60,145 @@ export function registerRendererMemoryProfileContributor(
   return () => {
     if (contributors.get(name) === contributor) {
       contributors.delete(name)
+      if (contributors.size === 0) {
+        nextContributorStart = 0
+      }
     }
+  }
+}
+
+export function collectRendererMemoryProfile(): RendererMemoryProfile {
+  const registered = [...contributors]
+  const contributions: ContributionEntries[] = []
+  const onHeapHeuristicByCategoryKB: RendererMemoryProfileCounts = {}
+  const externalHeuristicByCategoryKB: RendererMemoryProfileCounts = {}
+  let onHeapHeuristicSumKB = 0
+  let soundOnHeapBoundContributorCount = 0
+  let soundOnHeapBoundSumKB = 0
+  let availableEntries = 0
+  let invoked = 0
+  while (
+    invoked < registered.length &&
+    invoked < MAX_PROFILE_CONTRIBUTOR_INVOCATIONS &&
+    availableEntries < MAX_PROFILE_COUNTS
+  ) {
+    const [name, contributor] = registered[(nextContributorStart + invoked) % registered.length]
+    try {
+      const contribution = normalizeContribution(contributor())
+      const entries = readFiniteEntries(contribution.counts)
+      contributions.push({ name, ...entries })
+      availableEntries += entries.metadata.length + entries.details.length
+
+      const onHeap = finiteNonnegative(contribution.heuristicOnHeapKB)
+      const external = finiteNonnegative(contribution.heuristicExternalKB)
+      const soundBound = finiteNonnegative(contribution.soundOnHeapBoundKB)
+      if (onHeap !== undefined) {
+        onHeapHeuristicByCategoryKB[`${name}.onHeapHeuristicKB`] = Math.round(onHeap)
+        onHeapHeuristicSumKB += onHeap
+      }
+      if (external !== undefined) {
+        externalHeuristicByCategoryKB[`${name}.externalHeuristicKB`] = Math.round(external)
+      }
+      if (soundBound !== undefined) {
+        soundOnHeapBoundContributorCount += 1
+        soundOnHeapBoundSumKB += soundBound
+      }
+    } catch {
+      contributions.push({ name, metadata: [], details: [['error', 1]] })
+      availableEntries += 1
+    }
+    invoked += 1
+  }
+  if (registered.length > 0) {
+    nextContributorStart = (nextContributorStart + invoked) % registered.length
+  }
+
+  const counts: RendererMemoryProfileCounts = {}
+  const metadataCount = collectRoundRobin(counts, contributions, 'metadata', MAX_PROFILE_COUNTS)
+  collectRoundRobin(counts, contributions, 'details', MAX_PROFILE_COUNTS - metadataCount)
+  return {
+    counts,
+    onHeapHeuristicByCategoryKB,
+    externalHeuristicByCategoryKB,
+    onHeapHeuristicSumKB: Math.round(onHeapHeuristicSumKB),
+    soundOnHeapBoundContributorCount,
+    soundOnHeapBoundSumKB: Math.round(soundOnHeapBoundSumKB)
   }
 }
 
 export function collectRendererMemoryProfileCounts(): RendererMemoryProfileCounts {
-  const counts: RendererMemoryProfileCounts = {}
-  let collected = 0
-  let visited = 0
-  for (const [name, contributor] of contributors) {
-    if (collected >= MAX_PROFILE_COUNTS || visited >= MAX_PROFILE_CONTRIBUTORS) {
-      break
-    }
-    visited += 1
-    // Why: a broken contributor must never take down memory reporting itself.
-    try {
-      const contribution = contributor()
-      let inspected = 0
-      for (const key in contribution) {
-        if (inspected >= MAX_COUNTS_PER_CONTRIBUTOR || collected >= MAX_PROFILE_COUNTS) {
-          break
-        }
-        inspected += 1
-        if (!Object.hasOwn(contribution, key)) {
-          continue
-        }
-        if (key.length === 0 || key.length > MAX_COUNT_KEY_LENGTH) {
-          continue
-        }
-        const value = contribution[key]
-        if (typeof value === 'number' && Number.isFinite(value)) {
-          counts[`${name}.${key}`] = value
-          collected += 1
-        }
-      }
-    } catch {
-      if (collected < MAX_PROFILE_COUNTS) {
-        counts[`${name}.error`] = 1
-        collected += 1
-      }
-    }
-  }
-  return counts
+  return collectRendererMemoryProfile().counts
 }
 
-/**
- * Sizes of the largest top-level collections in a state object, for spotting
- * which slice grew when the heap high-water mark trips.
- */
+function collectRoundRobin(
+  output: RendererMemoryProfileCounts,
+  contributions: ContributionEntries[],
+  kind: 'metadata' | 'details',
+  limit: number
+): number {
+  const positions = contributions.map(() => 0)
+  let collected = 0
+  let found = true
+  while (found && collected < limit) {
+    found = false
+    for (let index = 0; index < contributions.length && collected < limit; index += 1) {
+      const entry = contributions[index][kind][positions[index]]
+      if (!entry) {
+        continue
+      }
+      found = true
+      positions[index] += 1
+      output[`${contributions[index].name}.${entry[0]}`] = entry[1]
+      collected += 1
+    }
+  }
+  return collected
+}
+
+function normalizeContribution(
+  value: RendererMemoryProfileCounts | RendererMemoryProfileContribution
+): RendererMemoryProfileContribution {
+  if (
+    typeof value === 'object' &&
+    value !== null &&
+    Object.hasOwn(value, 'counts') &&
+    typeof (value as RendererMemoryProfileContribution).counts === 'object'
+  ) {
+    return value as RendererMemoryProfileContribution
+  }
+  return { counts: value as RendererMemoryProfileCounts }
+}
+
+function readFiniteEntries(counts: RendererMemoryProfileCounts): {
+  metadata: [string, number][]
+  details: [string, number][]
+} {
+  const metadata: [string, number][] = []
+  const details: [string, number][] = []
+  let inspected = 0
+  for (const key in counts) {
+    if (inspected >= MAX_COUNTS_PER_CONTRIBUTOR) {
+      break
+    }
+    inspected += 1
+    if (!Object.hasOwn(counts, key) || key.length === 0 || key.length > MAX_COUNT_KEY_LENGTH) {
+      continue
+    }
+    const value = counts[key]
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      continue
+    }
+    const destination = key.startsWith('__') ? metadata : details
+    destination.push([key, value])
+  }
+  return { metadata, details }
+}
+
+function finiteNonnegative(value: number | undefined): number | undefined {
+  return typeof value === 'number' && Number.isFinite(value) && value >= 0 ? value : undefined
+}
+
+/** Sizes of the largest top-level collections in a state object. */
 export function summarizeStateCollectionSizes(
   state: unknown,
   limit: number
@@ -93,32 +207,49 @@ export function summarizeStateCollectionSizes(
     return {}
   }
   const sizes: [string, number][] = []
-  for (const [key, value] of Object.entries(state)) {
-    const size = collectionSize(value)
-    if (size !== null && size > 0) {
+  const budget: CollectionScanBudget = { remaining: MAX_COLLECTION_KEYS_TO_SCAN, hit: false }
+  let stateFields = 0
+  for (const key in state) {
+    if (stateFields >= MAX_STATE_FIELDS_TO_SCAN) {
+      budget.hit = true
+      break
+    }
+    stateFields += 1
+    if (!Object.hasOwn(state, key)) {
+      continue
+    }
+    const size = collectionSize((state as Record<string, unknown>)[key], budget)
+    if (size > 0) {
       sizes.push([key, size])
     }
   }
-  sizes.sort((a, b) => b[1] - a[1])
-  return Object.fromEntries(sizes.slice(0, limit))
+  sizes.sort((left, right) => right[1] - left[1])
+  return {
+    ...(budget.hit ? { __scanBudgetHit: 1 } : {}),
+    ...Object.fromEntries(sizes.slice(0, limit))
+  }
 }
 
-function collectionSize(value: unknown): number | null {
+function collectionSize(value: unknown, budget: CollectionScanBudget): number {
   if (Array.isArray(value)) {
     return value.length
   }
   if (value instanceof Map || value instanceof Set) {
     return value.size
   }
-  if (typeof value === 'object' && value !== null) {
-    let size = 0
-    // Why: Object.keys allocates an array proportional to the leaking collection.
-    for (const key in value) {
-      if (Object.hasOwn(value, key)) {
-        size += 1
-      }
-    }
-    return size
+  if (typeof value !== 'object' || value === null) {
+    return 0
   }
-  return null
+  let size = 0
+  for (const key in value) {
+    if (budget.remaining <= 0) {
+      budget.hit = true
+      break
+    }
+    budget.remaining -= 1
+    if (Object.hasOwn(value, key)) {
+      size += 1
+    }
+  }
+  return size
 }

--- a/src/renderer/src/lib/renderer-memory-store-registration.test.ts
+++ b/src/renderer/src/lib/renderer-memory-store-registration.test.ts
@@ -1,0 +1,18 @@
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/lib/e2e-config', () => ({
+  e2eConfig: { exposeStore: false }
+}))
+
+describe('store renderer memory registration', () => {
+  it('publishes count and pool-specific store hypotheses', async () => {
+    const { collectRendererMemoryProfile } = await import('./renderer-memory-profile')
+    await import('@/store')
+
+    const profile = collectRendererMemoryProfile()
+
+    expect(Object.keys(profile.counts).some((key) => key.startsWith('store.'))).toBe(true)
+    expect(profile.onHeapHeuristicByCategoryKB).toHaveProperty('storeKB.onHeapHeuristicKB')
+    expect(profile.externalHeuristicByCategoryKB).toHaveProperty('storeKB.externalHeuristicKB')
+  })
+})

--- a/src/renderer/src/lib/state-collection-byte-estimate.test.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.test.ts
@@ -1,26 +1,26 @@
 import { describe, expect, it, vi } from 'vitest'
-import { estimateStateCollectionKB } from './state-collection-byte-estimate'
+import { estimateStateCollectionMemoryKB } from './state-collection-byte-estimate'
 
-function kbOf(state: Record<string, unknown>, key: string): number {
-  return estimateStateCollectionKB(state, 32)[key] ?? 0
+function onHeapKB(state: Record<string, unknown>, key: string): number {
+  return estimateStateCollectionMemoryKB(state, 32).counts[`onHeap.${key}`] ?? 0
 }
 
-describe('estimateStateCollectionKB', () => {
+describe('estimateStateCollectionMemoryKB', () => {
   it('ranks a value-fat slice above an entry-long slice', () => {
-    // The 97b9e86d OOM signature: counts said the many-entry slice was biggest.
     const fat = { a: 'x'.repeat(200_000), b: 'y'.repeat(200_000) }
-    const long = Object.fromEntries(Array.from({ length: 500 }, (_, i) => [`k${i}`, i]))
+    const long = Object.fromEntries(Array.from({ length: 500 }, (_, index) => [`k${index}`, index]))
+    const estimate = estimateStateCollectionMemoryKB({ fat, long }, 2)
 
-    const result = estimateStateCollectionKB({ fat, long }, 2)
-    const keys = Object.keys(result)
-    expect(keys[0]).toBe('fat')
-    expect(result.fat).toBeGreaterThan((result.long ?? 0) * 10)
+    expect(Object.keys(estimate.counts)).toEqual(['onHeap.fat', 'onHeap.long'])
+    expect(estimate.counts['onHeap.fat']).toBeGreaterThan(
+      (estimate.counts['onHeap.long'] ?? 0) * 10
+    )
   })
 
   it('extrapolates uniform arrays instead of measuring every element', () => {
     const entry = (): { name: string } => ({ name: 'worktree-name-of-typical-length' })
-    const small = kbOf({ slice: Array.from({ length: 100 }, entry) }, 'slice')
-    const large = kbOf({ slice: Array.from({ length: 10_000 }, entry) }, 'slice')
+    const small = onHeapKB({ slice: Array.from({ length: 100 }, entry) }, 'slice')
+    const large = onHeapKB({ slice: Array.from({ length: 10_000 }, entry) }, 'slice')
 
     expect(large).toBeGreaterThan(small * 80)
     expect(large).toBeLessThan(small * 120)
@@ -28,99 +28,80 @@ describe('estimateStateCollectionKB', () => {
 
   it('extrapolates plain objects past the sample window', () => {
     const value = (): string => 'v'.repeat(64)
-    const small = Object.fromEntries(Array.from({ length: 500 }, (_, i) => [`k${i}`, value()]))
-    const huge = Object.fromEntries(Array.from({ length: 5_000 }, (_, i) => [`k${i}`, value()]))
+    const small = Object.fromEntries(
+      Array.from({ length: 500 }, (_, index) => [`k${index}`, value()])
+    )
+    const huge = Object.fromEntries(
+      Array.from({ length: 5_000 }, (_, index) => [`k${index}`, value()])
+    )
 
-    const smallKB = kbOf({ slice: small }, 'slice')
-    const hugeKB = kbOf({ slice: huge }, 'slice')
-    expect(hugeKB).toBeGreaterThan(smallKB * 8)
-    expect(hugeKB).toBeLessThan(smallKB * 12)
+    expect(onHeapKB({ slice: huge }, 'slice')).toBeGreaterThan(
+      onHeapKB({ slice: small }, 'slice') * 8
+    )
   })
 
   it('bounds plain-object key inspection per slice', () => {
-    const slice = Object.fromEntries(Array.from({ length: 10_000 }, (_, i) => [`k${i}`, i]))
+    const slice = Object.fromEntries(
+      Array.from({ length: 10_000 }, (_, index) => [`k${index}`, index])
+    )
     const hasOwn = vi.spyOn(Object, 'hasOwn')
 
-    expect(kbOf({ slice }, 'slice')).toBeGreaterThan(0)
+    expect(onHeapKB({ slice }, 'slice')).toBeGreaterThan(0)
     expect(hasOwn).toHaveBeenCalledTimes(4097)
-    hasOwn.mockRestore()
   })
 
-  it('reserves bounded descent for fat values after a saturated object scan', () => {
+  it('emits budget metadata before slice detail', () => {
     const slice = Object.fromEntries(
-      Array.from({ length: 10_000 }, (_, i) => [`k${i}`, { payload: 'x'.repeat(2048) }])
+      Array.from({ length: 10_000 }, (_, index) => [`k${index}`, { payload: 'x'.repeat(2048) }])
     )
+    const estimate = estimateStateCollectionMemoryKB({ slice }, 4)
 
-    const result = estimateStateCollectionKB({ slice }, 4)
-    expect(result.slice).toBeGreaterThan(10_000)
-    expect(result.__budgetHitSlices).toBe(1)
+    expect(Object.keys(estimate.counts).slice(0, 2)).toEqual(['__budgetHitSlices', 'onHeap.slice'])
+    expect(estimate.counts['onHeap.slice']).toBeGreaterThan(10_000)
   })
 
-  it('extrapolates Map and Set entries by size', () => {
-    const mapKB = kbOf(
-      { slice: new Map(Array.from({ length: 2_000 }, (_, i) => [`key${i}`, 'v'.repeat(128)])) },
-      'slice'
+  it('separates typed-array backing stores from on-heap estimates', () => {
+    const buffer = new ArrayBuffer(256_000)
+    const estimate = estimateStateCollectionMemoryKB(
+      { slice: [new Uint8Array(buffer), new Uint32Array(buffer)] },
+      4
     )
-    const setKB = kbOf(
-      { slice: new Set(Array.from({ length: 2_000 }, (_, i) => `member-${i}-${'v'.repeat(128)}`)) },
-      'slice'
-    )
-    // 2000 entries x ~128 chars ≈ >250KB either way; well above rounding noise.
-    expect(mapKB).toBeGreaterThan(250)
-    expect(setKB).toBeGreaterThan(250)
+
+    expect(estimate.heuristicExternalKB).toBe(250)
+    expect(estimate.heuristicOnHeapKB).toBeLessThan(2)
+    expect(estimate.counts).toEqual({})
   })
 
-  it('counts typed-array backing stores by byteLength', () => {
-    expect(kbOf({ slice: [new Uint32Array(64_000)] }, 'slice')).toBeGreaterThan(200)
-  })
-
-  it('survives cycles and self references', () => {
+  it('survives cycles and pathological nesting', () => {
     const cyclic: Record<string, unknown> = { name: 'x'.repeat(2048) }
     cyclic.self = cyclic
-    const result = estimateStateCollectionKB({ cyclic }, 4)
-    expect(result.cyclic).toBeGreaterThan(1)
-    expect(Number.isFinite(result.cyclic)).toBe(true)
-  })
-
-  it('returns bounded work on pathological nesting', () => {
     let deep: Record<string, unknown> = { leaf: true }
-    for (let i = 0; i < 10_000; i += 1) {
+    for (let index = 0; index < 10_000; index += 1) {
       deep = { child: deep }
     }
-    const wide = { slice: Array.from({ length: 100 }, () => ({ deep })) }
-    expect(() => estimateStateCollectionKB(wide, 4)).not.toThrow()
+
+    expect(onHeapKB({ cyclic }, 'cyclic')).toBeGreaterThan(1)
+    expect(() => estimateStateCollectionMemoryKB({ deep }, 4)).not.toThrow()
   })
 
-  it('caps output at the limit, largest first, dropping sub-KB slices', () => {
-    const state = {
-      big: 'x'.repeat(300_000),
-      medium: 'x'.repeat(100_000),
-      smaller: 'x'.repeat(50_000),
-      tiny: 'x',
-      count: 7
-    }
-    const result = estimateStateCollectionKB(state, 2)
-    expect(Object.keys(result)).toEqual(['big', 'medium', '__totalKB'])
-    expect(result.big).toBeGreaterThan(result.medium)
+  it('caps detail at the limit while totals include all slices', () => {
+    const estimate = estimateStateCollectionMemoryKB(
+      {
+        big: 'x'.repeat(300_000),
+        medium: 'x'.repeat(100_000),
+        smaller: 'x'.repeat(50_000),
+        tiny: 'x'
+      },
+      2
+    )
+
+    expect(Object.keys(estimate.counts)).toEqual(['onHeap.big', 'onHeap.medium'])
+    expect(estimate.heuristicOnHeapKB).toBeGreaterThan(
+      (estimate.counts['onHeap.big'] ?? 0) + (estimate.counts['onHeap.medium'] ?? 0)
+    )
   })
 
-  it('reports the all-slices total beyond the top limit', () => {
-    const state = {
-      a: 'x'.repeat(100_000),
-      b: 'x'.repeat(100_000),
-      c: 'x'.repeat(100_000)
-    }
-    const result = estimateStateCollectionKB(state, 1)
-    expect(result.__totalKB).toBeGreaterThan((result.a ?? 0) * 2.5)
-  })
-
-  it('includes raw bytes from slices that round below one KB', () => {
-    expect(
-      estimateStateCollectionKB({ a: 'x'.repeat(200), b: 'x'.repeat(200), c: 'x'.repeat(200) }, 4)
-    ).toEqual({ __totalKB: 1 })
-  })
-
-  it('skips a slice whose read throws without sinking the census', () => {
+  it('skips a throwing slice and returns zeroes for non-object state', () => {
     const state = { healthy: 'x'.repeat(10_000) }
     Object.defineProperty(state, 'poisoned', {
       enumerable: true,
@@ -128,11 +109,14 @@ describe('estimateStateCollectionKB', () => {
         throw new Error('boom')
       }
     })
-    expect(Object.keys(estimateStateCollectionKB(state, 8))).toEqual(['healthy', '__totalKB'])
-  })
 
-  it('returns empty for non-object state', () => {
-    expect(estimateStateCollectionKB(null, 8)).toEqual({})
-    expect(estimateStateCollectionKB('text', 8)).toEqual({})
+    expect(Object.keys(estimateStateCollectionMemoryKB(state, 8).counts)).toContain(
+      'onHeap.healthy'
+    )
+    expect(estimateStateCollectionMemoryKB(null, 8)).toEqual({
+      counts: {},
+      heuristicOnHeapKB: 0,
+      heuristicExternalKB: 0
+    })
   })
 })

--- a/src/renderer/src/lib/state-collection-byte-estimate.ts
+++ b/src/renderer/src/lib/state-collection-byte-estimate.ts
@@ -1,19 +1,8 @@
 /**
- * Sampled byte estimates for the largest top-level collections in a state
- * object, for renderer_memory_highwater breadcrumbs.
- *
- * Why bytes when summarizeStateCollectionSizes already reports counts: entry
- * counts stay flat when a slice grows by VALUE weight — the 97b9e86d OOM leaked
- * ~700MB while its biggest slice grew by 4 entries. Counts name what got LONG;
- * these estimates name what got FAT.
- *
- * Estimates are heuristic (sampled, extrapolated, shared references counted
- * per slice). __budgetHitSlices marks totals that saturated the scan budget.
+ * Sampled byte hypotheses for large top-level state collections.
+ * Sampling and object-cost assumptions can under- or over-estimate.
  */
 
-// Why sampling is capped and first-window biased: this runs at >=60% heap
-// pressure, so bounded work beats unbiased coverage. Iteration allocates
-// nothing beyond the sample window; there is no stringify.
 const SAMPLE_TARGET = 16
 const SAMPLE_WINDOW = 1024
 const NODE_BUDGET_PER_SLICE = 4096
@@ -21,7 +10,6 @@ const ENTRY_SCAN_BUDGET_PER_SLICE = 4096
 const ENTRY_DESCENT_RESERVE = 1024
 const MAX_DEPTH = 12
 
-// Rough V8 object costs; absolute accuracy doesn't matter, stable ranking does.
 const BYTES_STRING_BASE = 16
 const BYTES_PER_CHAR = 2
 const BYTES_NUMBER = 16
@@ -36,73 +24,85 @@ type EstimateContext = {
   nodesLeft: number
   entriesLeft: number
   budgetHit: boolean
+  externalBytes: number
   seen: WeakSet<object>
+  seenExternal: WeakSet<object>
 }
 
-export function estimateStateCollectionKB(state: unknown, limit: number): Record<string, number> {
+export type StateCollectionMemoryEstimate = {
+  counts: Record<string, number>
+  heuristicOnHeapKB: number
+  heuristicExternalKB: number
+}
+
+export function estimateStateCollectionMemoryKB(
+  state: unknown,
+  limit: number
+): StateCollectionMemoryEstimate {
   if (typeof state !== 'object' || state === null) {
-    return {}
+    return { counts: {}, heuristicOnHeapKB: 0, heuristicExternalKB: 0 }
   }
-  const sizes: [string, number][] = []
-  let totalBytes = 0
+  const onHeapSizes: [string, number][] = []
+  let onHeapBytes = 0
+  let externalBytes = 0
   let successfulSlices = 0
   let budgetHitSlices = 0
   for (const key in state) {
     if (!Object.hasOwn(state, key)) {
       continue
     }
-    let kb = 0
-    // Why: one exotic slice (throwing getter, revoked proxy) must not sink the
-    // whole census; the registry only sees the surviving slices.
     try {
-      const ctx: EstimateContext = {
+      const context: EstimateContext = {
         nodesLeft: NODE_BUDGET_PER_SLICE,
         entriesLeft: ENTRY_SCAN_BUDGET_PER_SLICE + ENTRY_DESCENT_RESERVE,
         budgetHit: false,
-        seen: new WeakSet()
+        externalBytes: 0,
+        seen: new WeakSet(),
+        seenExternal: new WeakSet()
       }
-      const bytes = estimateValueBytes((state as Record<string, unknown>)[key], 0, ctx)
-      totalBytes += bytes
+      const sliceBytes = estimateValueBytes((state as Record<string, unknown>)[key], 0, context)
+      onHeapBytes += sliceBytes
+      externalBytes += context.externalBytes
       successfulSlices += 1
-      if (ctx.budgetHit) {
+      if (context.budgetHit) {
         budgetHitSlices += 1
       }
-      kb = Math.round(bytes / BYTES_PER_KILOBYTE)
+      const sliceKB = Math.round(sliceBytes / BYTES_PER_KILOBYTE)
+      if (sliceKB > 0) {
+        onHeapSizes.push([key, sliceKB])
+      }
     } catch {
       continue
     }
-    if (kb > 0) {
-      sizes.push([key, kb])
-    }
   }
-  const totalKB = Math.round(totalBytes / BYTES_PER_KILOBYTE)
-  if (sizes.length === 0) {
-    const total: Record<string, number> = {}
-    if (successfulSlices > 0) {
-      total.__totalKB = totalKB
-    }
-    if (budgetHitSlices > 0) {
-      total.__budgetHitSlices = budgetHitSlices
-    }
-    return total
+  if (successfulSlices === 0) {
+    return { counts: {}, heuristicOnHeapKB: 0, heuristicExternalKB: 0 }
   }
-  sizes.sort((a, b) => b[1] - a[1])
-  const top = Object.fromEntries(sizes.slice(0, limit))
-  // Why __totalKB: a small unsaturated total can exonerate the whole state
-  // object and redirect investigation without a local repro.
-  top.__totalKB = totalKB
-  if (budgetHitSlices > 0) {
-    top.__budgetHitSlices = budgetHitSlices
+  const heuristicOnHeapKB = Math.round(onHeapBytes / BYTES_PER_KILOBYTE)
+  const heuristicExternalKB = Math.round(externalBytes / BYTES_PER_KILOBYTE)
+  onHeapSizes.sort((left, right) => right[1] - left[1])
+  return {
+    counts: {
+      ...(budgetHitSlices > 0 ? { __budgetHitSlices: budgetHitSlices } : {}),
+      ...Object.fromEntries(
+        onHeapSizes.slice(0, limit).map(([key, value]) => [`onHeap.${key}`, value])
+      )
+    },
+    heuristicOnHeapKB,
+    heuristicExternalKB
   }
-  return top
 }
 
-function estimateValueBytes(value: unknown, depth: number, ctx: EstimateContext): number {
-  if (ctx.nodesLeft <= 0) {
-    ctx.budgetHit = true
+export function estimateStateCollectionKB(state: unknown, limit: number): Record<string, number> {
+  return estimateStateCollectionMemoryKB(state, limit).counts
+}
+
+function estimateValueBytes(value: unknown, depth: number, context: EstimateContext): number {
+  if (context.nodesLeft <= 0) {
+    context.budgetHit = true
     return 0
   }
-  ctx.nodesLeft -= 1
+  context.nodesLeft -= 1
   switch (typeof value) {
     case 'string':
       return BYTES_STRING_BASE + value.length * BYTES_PER_CHAR
@@ -121,38 +121,51 @@ function estimateValueBytes(value: unknown, depth: number, ctx: EstimateContext)
   if (value === null) {
     return BYTES_PRIMITIVE
   }
-  // Why: cycles and intra-slice shared references count once — retained-size
-  // semantics are out of scope for a breadcrumb heuristic.
-  if (ctx.seen.has(value)) {
+  if (context.seen.has(value)) {
     return 0
   }
-  ctx.seen.add(value)
+  context.seen.add(value)
   if (depth >= MAX_DEPTH) {
-    ctx.budgetHit = true
+    context.budgetHit = true
     return BYTES_OBJECT_BASE
   }
   if (Array.isArray(value)) {
     return (
-      BYTES_OBJECT_BASE + value.length * BYTES_ARRAY_SLOT + estimateArrayElements(value, depth, ctx)
+      BYTES_OBJECT_BASE +
+      value.length * BYTES_ARRAY_SLOT +
+      estimateArrayElements(value, depth, context)
     )
   }
   if (value instanceof Map) {
     return (
-      BYTES_OBJECT_BASE + estimateIterableEntries(value.size, value.entries(), depth, ctx, true)
+      BYTES_OBJECT_BASE + estimateIterableEntries(value.size, value.entries(), depth, context, true)
     )
   }
   if (value instanceof Set) {
     return (
-      BYTES_OBJECT_BASE + estimateIterableEntries(value.size, value.values(), depth, ctx, false)
+      BYTES_OBJECT_BASE + estimateIterableEntries(value.size, value.values(), depth, context, false)
     )
   }
   if (ArrayBuffer.isView(value)) {
-    return BYTES_OBJECT_BASE + value.byteLength
+    countExternalBytes(value.buffer, value.buffer.byteLength, context)
+    return BYTES_OBJECT_BASE
   }
-  return BYTES_OBJECT_BASE + estimatePlainObjectEntries(value, depth, ctx)
+  if (value instanceof ArrayBuffer) {
+    countExternalBytes(value, value.byteLength, context)
+    return BYTES_OBJECT_BASE
+  }
+  return BYTES_OBJECT_BASE + estimatePlainObjectEntries(value, depth, context)
 }
 
-function estimateArrayElements(value: unknown[], depth: number, ctx: EstimateContext): number {
+function countExternalBytes(identity: object, bytes: number, context: EstimateContext): void {
+  if (context.seenExternal.has(identity)) {
+    return
+  }
+  context.seenExternal.add(identity)
+  context.externalBytes += bytes
+}
+
+function estimateArrayElements(value: unknown[], depth: number, context: EstimateContext): number {
   const windowLength = Math.min(value.length, SAMPLE_WINDOW)
   if (windowLength === 0) {
     return 0
@@ -161,7 +174,7 @@ function estimateArrayElements(value: unknown[], depth: number, ctx: EstimateCon
   let sampledBytes = 0
   let sampledCount = 0
   for (let index = 0; index < windowLength; index += stride) {
-    sampledBytes += estimateValueBytes(value[index], depth + 1, ctx)
+    sampledBytes += estimateValueBytes(value[index], depth + 1, context)
     sampledCount += 1
   }
   return sampledCount === 0 ? 0 : Math.round((sampledBytes / sampledCount) * value.length)
@@ -171,7 +184,7 @@ function estimateIterableEntries(
   size: number,
   entries: IterableIterator<unknown>,
   depth: number,
-  ctx: EstimateContext,
+  context: EstimateContext,
   isKeyValuePair: boolean
 ): number {
   if (size === 0) {
@@ -186,18 +199,18 @@ function estimateIterableEntries(
     if (index >= windowLength) {
       break
     }
-    if (ctx.entriesLeft <= 0) {
-      ctx.budgetHit = true
+    if (context.entriesLeft <= 0) {
+      context.budgetHit = true
       break
     }
-    ctx.entriesLeft -= 1
+    context.entriesLeft -= 1
     if (index % stride === 0) {
       if (isKeyValuePair) {
         const [entryKey, entryValue] = entry as [unknown, unknown]
-        sampledBytes += estimateValueBytes(entryKey, depth + 1, ctx)
-        sampledBytes += estimateValueBytes(entryValue, depth + 1, ctx)
+        sampledBytes += estimateValueBytes(entryKey, depth + 1, context)
+        sampledBytes += estimateValueBytes(entryValue, depth + 1, context)
       } else {
-        sampledBytes += estimateValueBytes(entry, depth + 1, ctx)
+        sampledBytes += estimateValueBytes(entry, depth + 1, context)
       }
       sampledCount += 1
     }
@@ -208,17 +221,20 @@ function estimateIterableEntries(
     : Math.round((sampledBytes / sampledCount + BYTES_ENTRY_OVERHEAD) * size)
 }
 
-function estimatePlainObjectEntries(value: object, depth: number, ctx: EstimateContext): number {
+function estimatePlainObjectEntries(
+  value: object,
+  depth: number,
+  context: EstimateContext
+): number {
   let ownCount = 0
   const sampledKeys: string[] = []
   const entryFloor = depth === 0 ? ENTRY_DESCENT_RESERVE : 0
-  // Why: a leaking record must not turn a near-OOM breadcrumb into a full scan.
   for (const key in value) {
-    if (ctx.entriesLeft <= entryFloor) {
-      ctx.budgetHit = true
+    if (context.entriesLeft <= entryFloor) {
+      context.budgetHit = true
       break
     }
-    ctx.entriesLeft -= 1
+    context.entriesLeft -= 1
     if (Object.hasOwn(value, key)) {
       ownCount += 1
       if (sampledKeys.length < SAMPLE_TARGET) {
@@ -232,7 +248,7 @@ function estimatePlainObjectEntries(value: object, depth: number, ctx: EstimateC
   let sampledBytes = 0
   for (const key of sampledKeys) {
     sampledBytes += BYTES_STRING_BASE + key.length * BYTES_PER_CHAR
-    sampledBytes += estimateValueBytes((value as Record<string, unknown>)[key], depth + 1, ctx)
+    sampledBytes += estimateValueBytes((value as Record<string, unknown>)[key], depth + 1, context)
   }
   return sampledKeys.length === 0
     ? 0

--- a/src/renderer/src/store/index.ts
+++ b/src/renderer/src/store/index.ts
@@ -49,7 +49,7 @@ import {
   registerRendererMemoryProfileContributor,
   summarizeStateCollectionSizes
 } from '@/lib/renderer-memory-profile'
-import { estimateStateCollectionKB } from '@/lib/state-collection-byte-estimate'
+import { estimateStateCollectionMemoryKB } from '@/lib/state-collection-byte-estimate'
 
 export const useAppStore = create<AppState>()((...a) => {
   // Why: the inner api is only reachable here, before create() copies subscribe onto the hook.
@@ -109,9 +109,14 @@ registerRendererMemoryProfileContributor('store', () =>
 
 // Why bytes too: counts miss value-weight growth (97b9e86d leaked ~700MB while
 // its biggest slice grew by 4 entries); sampled KB names what got FAT.
-registerRendererMemoryProfileContributor('storeKB', () =>
-  estimateStateCollectionKB(useAppStore.getState(), 16)
-)
+registerRendererMemoryProfileContributor('storeKB', () => {
+  const estimate = estimateStateCollectionMemoryKB(useAppStore.getState(), 16)
+  return {
+    counts: estimate.counts,
+    heuristicOnHeapKB: estimate.heuristicOnHeapKB,
+    heuristicExternalKB: estimate.heuristicExternalKB
+  }
+})
 
 export type { AppState } from './types'
 


### PR DESCRIPTION
## Summary

Orca's renderer leak instrumentation currently explains **0.4%** of the leak it exists to explain. This PR does not fix the leak — it makes a crash report able to say *"we cannot account for 3.8 GB of this"* instead of implying the store explains it.

No visual change.

## Opened as a draft

This is the narrowed replacement for a larger attribution change that was **blocked in review** (details below). It has not had a completed independent adversarial review in its current form.

## The finding that motivates it

Renderer V8 heap exhaustion is the largest crash cluster in the fleet: **714 reports, 118+ named users, still occurring on 1.4.171**, with peak `usedHeapMB` of 3947 against a 4192 MB limit and per-session growth up to 1326 MB/hour.

`renderer_memory_highwater` exists specifically to name the leaking subsystem. Its only contributors are `store`, `storeKB` and `terminals`. Totalled across the 23 diagnostic bundles at ≥1.4.168 where the heap demonstrably climbed between two highwater samples:

```
observed heap growth              18,169 MB
storeKB.__totalKB  growth             30 MB   (0.16%)
terminals.estBufferKB growth          39 MB   (0.21%)
                                  ──────────
unattributed                        99.6%
```

Corroborating: `domNodes` stays at 1–6k and `store.*` item counts stay in the tens while the heap climbs 3 GB. `heapSource=v8`, `mallocedMB=1`, `blinkAllocatedMB` median 32 — this is pure V8 JS heap, not DOM and not native.

So every crash report in this cluster effectively says *"the store grew a little."* This is why the leak keeps being fixed and keeps coming back — STA-1784, STA-738 and STA-2323 all closed, cluster still live. **Attribution has to work before any leak fix is falsifiable against fleet data.**

## Why the first attempt was blocked, and what changed

An earlier revision added an aggregate `accountedKB` / `unattributedKB` / `accountedPct` and was rejected:

- **The clamp lied.** `min(usedHeapKB, estimated)` silently emitted `accountedPct = 100`, `unattributedKB = 0` when contributors overestimated — asserting the heap was fully explained precisely when the accounting broke.
- **Different memory pools were summed.** xterm buffers are largely typed-array **external** backing store, and the state estimator adds `ArrayBuffer.byteLength`; neither is in V8 `usedHeapSize`. Measured: a 20-pane / 5,000-row / 120-col workload estimated **187,500 KB** against an observed **~35.4 MB V8 delta and ~137.3 MB external delta**.
- **The sum was not additive.** A fresh `WeakSet` per top-level slice counts shared objects once per slice — the same object under 40 slices ≈ 40×.
- **Error direction was unknown in both directions.** Bounded sampling also undercounts: 4,000-key vs 100,000-key records produced ~2,276 KB vs ~2,331 KB (25× the data, 1.02× the bytes).
- **It removed a near-OOM guardrail.** The collector began invoking every contributor before applying the output cap (worst case 0.8 ms → 27.1 ms), and this runs at the 60%/80% heap thresholds — i.e. it allocated during an OOM.
- Mutation testing killed only **21 of 46** mutants, confirmed against the full renderer suite.

This narrowed version accordingly: removes the single authoritative percentage; emits clearly-labelled raw per-category figures that never mix on-heap with external estimates; emits an explicit marker when accounting overflows instead of clamping; preserves an honest approximate residual; and restores the near-OOM early-exit guardrail.

## What this does NOT do

- **It does not identify the leak.** It makes the unattributed share visible and honest.
- It does not close the second blind spot: `processMetricsRendererWorkingSetMB` is **0 in every report**, because the renderer is already dead when process metrics are captured. For the 259-report Windows `oom` bucket where the JS heap is flat, we still cannot distinguish "renderer was huge in native memory" from "the machine was out of RAM."
- No figure emitted here is a bound in either direction. On-heap totals remain unbounded heuristics — partly because the companion terminal-retention bug means `queuedChars`-derived figures can under-report by orders of magnitude.

## Testing

- [x] `pnpm lint` — `oxlint` clean (exit 0). Remaining `pnpm lint` sub-steps not run locally.
- [x] `pnpm typecheck` — web project clean.
- [x] `pnpm test` — scoped: 5 files / **42 tests pass** (`renderer-memory-profile`, `renderer-memory-attribution`, `state-collection-byte-estimate`, `renderer-memory-store-registration`, `pane-manager-registry`). Full renderer suite not re-run on this branch.
- [ ] `pnpm build` — **not run.**
- [x] Added tests that would catch regressions.

## AI Review Report

The predecessor design was independently reviewed and rejected on six separate grounds, listed above; this branch is the narrowed response to that review. **The narrowed version has not itself completed an independent adversarial review, and has no independent mutation score.** Given that the predecessor scored 21/46 under independent mutation, a reviewer should assume this one is also under-tested until measured.

Cross-platform: renderer-side measurement only. No shortcuts, labels, paths, or shell behaviour. Emitted figures are platform-independent, though the *interpretation* differs by platform — macOS exit 5 is `SIGTRAP` from V8's fatal-OOM `IMMEDIATE_CRASH()` and is filed as `crashed`, never as `oom`, which is precisely why triage must cluster on measured heap pressure rather than on Electron's `reason` string.

## Security Audit

No IPC surface changes, no command execution, no path handling, no auth or secrets, no dependency changes. This code runs inside the renderer and writes numeric fields into crash breadcrumbs. Two considerations were checked: it must not emit user content (it emits counts and byte estimates only, never keys or values), and it must not itself allocate meaningfully while the heap is near its limit — the restored early-exit guardrail addresses the latter, which was a genuine regression in the rejected revision.

## Notes — deferred, worth separate issues

1. **Commensurable accounting** — report on-heap and external/off-heap as separate first-class figures across all contributors, so a residual has defined meaning.
2. **Cross-slice identity** — a shared visited set so the state estimate is not multiplied by slice count. Strings cannot be identity-deduplicated, so any total remains an upper bound and must be labelled as one.
3. **Coverage for the actually-unattributed retainers** — native-chat composer caches, editor Blob/Monaco caches, AI-vault results, PR/push caches, scroll caches, pane-identity maps, and Effect/runtime subscription registries have no census hook at all. PTY side-effect processor queues are bounded at 512 entries per processor, but processor accumulation is not published; publishing it needs lifecycle disposal wiring across local, remote-runtime and parked-terminal owners.
4. **Renderer working-set capture before death**, to close the second blind spot.

Lead, explicitly not a conclusion: `terminal_webgl_diagnostic` (webgl-atlas-reset) event rate correlates **+0.40** with heap growth rate across 55 sessions — the highest of any breadcrumb. Note #12622 (rate-cap WebGL atlas recovery) landed 2026-08-04, after nearly all these reports. A 0.40 correlation is a lead only; this instrumentation should be able to confirm or kill it on the next release.

Related: STA-1281 (renderer perf debug dump) is complementary — it is a user-triggered opt-in bundle, which does not help the automatic crash-report path where no user is available to click anything.
