### PR TITLE
Remove idle agent toggle from global settings

### DIFF
--- a/src/renderer/src/components/settings/AgentDashboardExperimentalSetting.tsx
+++ b/src/renderer/src/components/settings/AgentDashboardExperimentalSetting.tsx
@@ -16,7 +16,6 @@ export function AgentDashboardExperimentalSetting({
 }: AgentDashboardExperimentalSettingProps): React.JSX.Element {
   const enabled = settings.experimentalAgentDashboardPopout === true
   const mode = settings.experimentalAgentDashboardMode ?? 'in-window'
-  const showIdle = settings.experimentalAgentDashboardShowIdle === true
 
   return (
     <SearchableSetting
@@ -97,22 +96,6 @@ export function AgentDashboardExperimentalSetting({
                   )
                 }
               ]}
-            />
-          </div>
-          <div className="flex items-start justify-between gap-4">
-            <div className="min-w-0 shrink space-y-0.5">
-              <Label>{translate('dashboardPopout.settings.showIdle', 'Show idle agents')}</Label>
-              <p className="text-xs text-muted-foreground">
-                {translate(
-                  'dashboardPopout.settings.showIdleCopy',
-                  'Include agents that have gone quiet for 30 minutes without reporting completion. Hidden by default.'
-                )}
-              </p>
-            </div>
-            <SettingsSwitch
-              checked={showIdle}
-              onChange={() => updateSettings({ experimentalAgentDashboardShowIdle: !showIdle })}
-              ariaLabel={translate('dashboardPopout.settings.showIdle', 'Show idle agents')}
             />
           </div>
         </div>

--- a/src/renderer/src/components/settings/ExperimentalPane.test.tsx
+++ b/src/renderer/src/components/settings/ExperimentalPane.test.tsx
@@ -164,29 +164,15 @@ describe('ExperimentalPane', () => {
     root.unmount()
   })
 
-  it('exposes idle-agent visibility for pop-out dashboards', async () => {
-    const updateSettings = vi.fn()
-    const settings = {
-      ...getDefaultSettings('/tmp'),
-      experimentalAgentDashboardPopout: true
-    }
-    const { root, container } = await renderExperimentalPane({
-      settings,
-      updateSettings
-    })
-    const idleSwitch = container.querySelector<HTMLButtonElement>(
-      '#experimental-agent-dashboard button[role="switch"][aria-label="Show idle agents"]'
+  it('keeps idle-agent visibility out of global settings', () => {
+    const markup = renderToStaticMarkup(
+      <ExperimentalPane
+        settings={{ ...getDefaultSettings('/tmp'), experimentalAgentDashboardPopout: true }}
+        updateSettings={vi.fn()}
+      />
     )
-    if (!idleSwitch) {
-      throw new Error('Idle-agent visibility switch was not rendered')
-    }
 
-    await act(async () => {
-      idleSwitch.dispatchEvent(new MouseEvent('click', { bubbles: true }))
-    })
-
-    expect(updateSettings).toHaveBeenCalledWith({ experimentalAgentDashboardShowIdle: true })
-    root.unmount()
+    expect(markup).not.toContain('Show idle agents')
   })
 
   it('renders Cloud VM as an off-by-default experimental subsection', () => {


### PR DESCRIPTION
## Summary

Remove the Show idle agents toggle from global Experimental Settings. The setting remains available in the in-window Agent Dashboard settings popover, keeping the control scoped to the surface it affects.

## Screenshots

Global Experimental Settings with the duplicate toggle removed:

![Experimental Settings](https://github.com/user-attachments/assets/38715852-f3a9-45b7-ad96-41e499f0281f)

In-window Agent Dashboard popover retaining the toggle:

![Agent Dashboard settings](https://github.com/user-attachments/assets/4bd6e777-cb86-4bfd-8582-549c445b9a96)

## Testing

- [ ] pnpm lint — targeted oxlint passed for the changed settings and dashboard files
- [ ] pnpm typecheck — pnpm run typecheck:web passed
- [ ] pnpm test — targeted Vitest suite passed: 2 files, 14 tests
- [ ] pnpm build — not run; Electron dev build and launch succeeded for UI validation
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Electron CDP validation confirmed the toggle is absent from global Experimental Settings and present in the in-window dashboard popover.

## AI Review Report

Reviewed the ownership boundary between global settings and AgentDashboardSettingsMenu, confirmed the persisted setting and dashboard filtering behavior remain unchanged, and verified the existing popover test still covers setting updates. No issues were flagged after targeted lint, formatting, tests, typecheck, and Electron UI inspection.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This change removes renderer markup only and does not touch shortcuts, labels, paths, shell behavior, native APIs, or Electron platform branches.

## Security Audit

No security-sensitive behavior changed. The diff does not add or alter input handling, command execution, path handling, authentication, secrets, dependencies, IPC, RPC, or remote wire data.

## Notes

No platform-specific behavior or follow-up work identified.