### PR TITLE
fix(terminal): per-pane WebGL attach latch and fit-anchored reattach

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-fit-client-size.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-client-size.ts
@@ -1,0 +1,21 @@
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
+
+// Why: measure the element FitAddon fits (the xterm host), not the outer .pane —
+// a title/banner can shrink the inner fittable area while the outer stays put.
+// Round to whole pixels so sub-pixel jitter never reads as a resize.
+export function readFitClientSize(pane: ManagedPane): { width: number; height: number } | null {
+  const element = (pane as ManagedPaneInternal).xtermContainer ?? pane.container
+  const measure = element?.getBoundingClientRect
+  if (typeof measure !== 'function') {
+    return null
+  }
+  const rect = measure.call(element)
+  return { width: Math.round(rect.width), height: Math.round(rect.height) }
+}
+
+export function recordPaneFitClientSize(pane: ManagedPane): void {
+  const size = readFitClientSize(pane)
+  if (size && size.width > 0 && size.height > 0) {
+    ;(pane as ManagedPaneInternal).lastFitClientSize = size
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-fit-webgl-attach-signal.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-webgl-attach-signal.ts
@@ -1,0 +1,23 @@
+import type { ManagedPane, ManagedPaneInternal } from './pane-manager-types'
+
+/**
+ * Why an indirection: the fit path must offer a WebGL reattach opportunity on
+ * every successful fit (event-anchored recovery — a resize or late mount is the
+ * moment a DOM-stuck pane can heal), but pane-webgl-renderer already imports
+ * pane-fit, so pane-fit cannot import it back. The renderer registers here.
+ */
+type PaneFitWebglAttachHook = (pane: ManagedPaneInternal) => void
+
+let hook: PaneFitWebglAttachHook | null = null
+
+export function setPaneFitWebglAttachHook(next: PaneFitWebglAttachHook | null): void {
+  hook = next
+}
+
+export function notifyPaneFitSucceeded(pane: ManagedPane): void {
+  try {
+    hook?.(pane as ManagedPaneInternal)
+  } catch {
+    /* ignore — a reattach failure must not fail the fit that triggered it */
+  }
+}

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -21,6 +21,8 @@ import {
   deferTerminalGeometryMutationDuringRebuild,
   isTerminalScrollIntentRebuildInFlight
 } from './terminal-scroll-intent-rebuild'
+import { notifyPaneFitSucceeded } from './pane-fit-webgl-attach-signal'
+import { recordPaneFitClientSize } from './pane-fit-client-size'
 
 const MIN_PANE_FIT_WIDTH_PX = 48
 const MIN_PANE_FIT_HEIGHT_PX = 24
@@ -51,25 +53,7 @@ function getProposedDimensions(pane: ManagedPane): { cols: number; rows: number 
   }
 }
 
-// Why: measure the element FitAddon fits (the xterm host), not the outer .pane —
-// a title/banner can shrink the inner fittable area while the outer stays put.
-// Round to whole pixels so sub-pixel jitter never reads as a resize.
-export function readFitClientSize(pane: ManagedPane): { width: number; height: number } | null {
-  const element = (pane as ManagedPaneInternal).xtermContainer ?? pane.container
-  const measure = element?.getBoundingClientRect
-  if (typeof measure !== 'function') {
-    return null
-  }
-  const rect = measure.call(element)
-  return { width: Math.round(rect.width), height: Math.round(rect.height) }
-}
-
-function recordPaneFitClientSize(pane: ManagedPane): void {
-  const size = readFitClientSize(pane)
-  if (size && size.width > 0 && size.height > 0) {
-    ;(pane as ManagedPaneInternal).lastFitClientSize = size
-  }
-}
+export { readFitClientSize } from './pane-fit-client-size'
 
 export function canMeasurePaneForFit(pane: ManagedPane): boolean {
   const measure = pane.container?.getBoundingClientRect
@@ -215,6 +199,8 @@ export function flushPendingSafeFitContinuations(pane: ManagedPane): void {
 export function safeFit(pane: ManagedPane): boolean {
   const completed = performSafeFit(pane)
   if (completed) {
+    // A completed fit proves measurability — the reattach moment for a DOM-stuck pane.
+    notifyPaneFitSucceeded(pane)
     // Why: baseline for the reveal fit to tell a real resize from a metric wobble.
     recordPaneFitClientSize(pane)
     // Why: replay transactions may be waiting for renderer dimensions; any

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -114,6 +114,7 @@ export type PaneRenderingDiagnostics = {
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
+  webglAttachFailedSinceRecovery: boolean
   hasComplexScriptOutput: boolean
   terminalWebglAutoDecision: TerminalWebglAutoDecision
   hasWebgl: boolean
@@ -141,6 +142,10 @@ export type ManagedPaneInternal = {
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
+  // Why per-pane: one pane's failed WebGL attach must not strand every other
+  // pane on the DOM renderer until the next recovery boundary. Optional so
+  // absent means "never failed"; only the attach failure path sets it.
+  webglAttachFailedSinceRecovery?: boolean
   // Why: expose complex-output diagnostics without changing renderer choice;
   // auto renderer fallback is reserved for platform or WebGL failures.
   hasComplexScriptOutput: boolean

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -280,6 +280,7 @@ export class PaneManager {
       gpuRenderingEnabled: pane.gpuRenderingEnabled,
       webglAttachmentDeferred: pane.webglAttachmentDeferred,
       webglDisabledAfterContextLoss: pane.webglDisabledAfterContextLoss,
+      webglAttachFailedSinceRecovery: pane.webglAttachFailedSinceRecovery === true,
       hasComplexScriptOutput: pane.hasComplexScriptOutput,
       terminalWebglAutoDecision: getTerminalWebglAutoDecision(),
       hasWebgl: Boolean(pane.webglAddon)

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -50,11 +50,11 @@ export function suspendPaneRendering(panes: Iterable<ManagedPaneInternal>): void
 }
 
 export function resumePaneRendering(panes: Iterable<ManagedPaneInternal>): void {
-  // Why: resume (worktree foreground, window wake) is the WebGL retry
-  // boundary — Chromium may have restored the GPU process since a context
-  // loss, and bounding retries to resume events cannot loop on live loss.
-  clearTerminalWebglAttachBackoff()
   for (const pane of panes) {
+    // Why: resume (worktree foreground, window wake) is the WebGL retry
+    // boundary — Chromium may have restored the GPU process since a context
+    // loss, and bounding retries to resume events cannot loop on live loss.
+    clearTerminalWebglAttachBackoff(pane)
     pane.webglAttachmentDeferred = false
     pane.webglDisabledAfterContextLoss = false
     reattachWebglIfNeeded(pane)

--- a/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-gpu-acceleration.ts
@@ -23,8 +23,10 @@ export function applyTerminalGpuAcceleration(
     pane.terminalGpuAcceleration = nextMode
     if (modeChanged) {
       // Why: an explicit setting change is user intent to re-evaluate the
-      // renderer; context-loss latches from the old mode should not pin DOM.
+      // renderer; context-loss and attach-failure latches from the old mode
+      // should not pin DOM.
       pane.webglDisabledAfterContextLoss = false
+      pane.webglAttachFailedSinceRecovery = false
     }
     if (!shouldUseTerminalWebgl(pane)) {
       disposeWebgl(pane, { refreshDimensions: true })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
@@ -14,6 +14,6 @@ export function rebuildAttachedWebgl(pane: ManagedPaneInternal): void {
   disposeWebgl(pane)
   // Why: the live addon just proved context creation works, so a stale attach
   // backoff from an earlier failure must not downgrade this pane to DOM.
-  clearTerminalWebglAttachBackoff()
+  clearTerminalWebglAttachBackoff(pane)
   attachWebgl(pane)
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -3,9 +3,11 @@ import { WebglAddon } from '@xterm/addon-webgl'
 import type { ManagedPaneInternal } from './pane-manager-types'
 import {
   attachWebgl,
+  clearTerminalWebglAttachBackoff,
   resetTerminalWebglSuggestion,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
+import { notifyPaneFitSucceeded } from './pane-fit-webgl-attach-signal'
 
 function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneInternal {
   const leafId = '22222222-2222-4222-8222-222222222222' as never
@@ -122,5 +124,109 @@ describe('terminal WebGL addon lifecycle', () => {
     resetWebglTextureAtlas(pane)
 
     expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
+
+  it('keeps attaching to healthy panes after another pane fails to attach', () => {
+    // Regression: the attach-failure latch was module-global, so one pane's
+    // failed context creation stranded every later pane on the DOM renderer
+    // (bold/wider text) until the next recovery boundary.
+    const failing = createPane({
+      loadAddon: () => {
+        throw new Error('WebGL2 not supported null')
+      }
+    })
+    attachWebgl(failing)
+    expect(failing.webglAddon).toBeNull()
+    expect(failing.webglAttachFailedSinceRecovery).toBe(true)
+
+    const healthy = createPane()
+    attachWebgl(healthy)
+
+    expect(healthy.webglAddon).not.toBeNull()
+    expect(healthy.webglAttachFailedSinceRecovery).not.toBe(true)
+  })
+
+  it('honors the per-pane failure latch until it is cleared', () => {
+    const loadAddon = vi.fn(() => {
+      throw new Error('WebGL2 not supported null')
+    })
+    const pane = createPane({ loadAddon })
+
+    attachWebgl(pane)
+    attachWebgl(pane)
+
+    // Second attempt must not burn another canvas/getContext while latched.
+    expect(loadAddon).toHaveBeenCalledTimes(1)
+
+    clearTerminalWebglAttachBackoff(pane)
+    attachWebgl(pane)
+
+    expect(loadAddon).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('fit-anchored WebGL reattach', () => {
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('attaches WebGL to an eligible addon-less pane when a fit succeeds', () => {
+    // The event-anchored heal: a user resize (or late mount) proves the pane
+    // measurable, which is the moment a DOM-stuck pane can regain WebGL.
+    const pane = createPane()
+    expect(pane.webglAddon).toBeNull()
+
+    notifyPaneFitSucceeded(pane)
+
+    expect(pane.webglAddon).not.toBeNull()
+  })
+
+  it('does not retry a pane whose attach already failed since recovery', () => {
+    const loadAddon = vi.fn(() => {
+      throw new Error('WebGL2 not supported null')
+    })
+    const pane = createPane({ loadAddon })
+    attachWebgl(pane)
+    expect(loadAddon).toHaveBeenCalledTimes(1)
+
+    notifyPaneFitSucceeded(pane)
+
+    // Failed attaches retry only at recovery boundaries, never on every fit.
+    expect(loadAddon).toHaveBeenCalledTimes(1)
+    expect(pane.webglAddon).toBeNull()
+  })
+
+  it('leaves suspended and context-loss panes alone on fit', () => {
+    const deferred = createPane()
+    deferred.webglAttachmentDeferred = true
+    notifyPaneFitSucceeded(deferred)
+    expect(deferred.webglAddon).toBeNull()
+
+    const lost = createPane()
+    lost.webglDisabledAfterContextLoss = true
+    notifyPaneFitSucceeded(lost)
+    expect(lost.webglAddon).toBeNull()
+  })
+
+  it('does not disturb a pane that already has a live addon', () => {
+    const pane = createPane()
+    attachWebgl(pane)
+    const liveAddon = pane.webglAddon
+    expect(liveAddon).not.toBeNull()
+
+    notifyPaneFitSucceeded(pane)
+
+    expect(pane.webglAddon).toBe(liveAddon)
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -8,6 +8,7 @@ import {
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
 import { notifyPaneFitSucceeded } from './pane-fit-webgl-attach-signal'
+import { safeFit } from './pane-fit'
 
 function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneInternal {
   const leafId = '22222222-2222-4222-8222-222222222222' as never
@@ -228,5 +229,72 @@ describe('fit-anchored WebGL reattach', () => {
     notifyPaneFitSucceeded(pane)
 
     expect(pane.webglAddon).toBe(liveAddon)
+  })
+})
+
+// Why a separate suite: the tests above drive the signal directly, so they stay
+// green even if safeFit stops calling it. These go through the real fit path so
+// the wiring — and the import-time hook registration — is what is under test.
+describe('safeFit drives the fit-anchored WebGL reattach', () => {
+  function createFittablePane(): ManagedPaneInternal {
+    const pane = createPane()
+    const rect = { width: 800, height: 400 }
+    pane.container = { dataset: {}, getBoundingClientRect: () => rect } as never
+    pane.xtermContainer = { getBoundingClientRect: () => rect } as never
+    // Why: WebGL floors the device cell width, so the same box proposes a wider
+    // grid once the addon is live — the divergence the reattach has to settle.
+    pane.fitAddon.proposeDimensions = vi.fn(() =>
+      pane.webglAddon ? { cols: 84, rows: 24 } : { cols: 80, rows: 24 }
+    ) as never
+    return pane
+  }
+
+  beforeEach(() => {
+    resetTerminalWebglSuggestion()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      callback(16)
+      return 1
+    })
+    vi.stubGlobal('cancelAnimationFrame', vi.fn())
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('attaches WebGL when a real safeFit completes', () => {
+    const pane = createFittablePane()
+
+    expect(safeFit(pane)).toBe(true)
+
+    expect(pane.webglAddon).not.toBeNull()
+  })
+
+  it('refits the pane onto the WebGL cell metrics after attaching', () => {
+    // Without the follow-up fit the healed pane keeps the DOM-derived column
+    // count, leaving an unpainted gutter and a PTY narrower than the pane.
+    const pane = createFittablePane()
+    const hadAddonPerFit: boolean[] = []
+    pane.fitAddon.fit = vi.fn(() => {
+      hadAddonPerFit.push(pane.webglAddon != null)
+    }) as never
+
+    safeFit(pane)
+
+    expect(hadAddonPerFit).toEqual([true])
+  })
+
+  it('does not fit when the pane is unmeasurable', () => {
+    const pane = createFittablePane()
+    pane.container = {
+      dataset: {},
+      getBoundingClientRect: () => ({ width: 0, height: 0 })
+    } as never
+
+    expect(safeFit(pane)).toBe(false)
+
+    expect(pane.webglAddon).toBeNull()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.test.ts
@@ -9,6 +9,7 @@ import {
 } from './pane-webgl-renderer'
 import { notifyPaneFitSucceeded } from './pane-fit-webgl-attach-signal'
 import { safeFit } from './pane-fit'
+import { disposePane } from './pane-lifecycle'
 
 function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneInternal {
   const leafId = '22222222-2222-4222-8222-222222222222' as never
@@ -47,6 +48,19 @@ function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneIntern
     pendingSplitScrollState: null,
     debugLabel: null
   }
+}
+
+function createFittablePane(): ManagedPaneInternal {
+  const pane = createPane()
+  const rect = { width: 800, height: 400 }
+  pane.container = { dataset: {}, getBoundingClientRect: () => rect } as never
+  pane.xtermContainer = { getBoundingClientRect: () => rect } as never
+  // Why: WebGL floors the device cell width, so the same box proposes a wider
+  // grid once the addon is live — the divergence the reattach has to settle.
+  pane.fitAddon.proposeDimensions = vi.fn(() =>
+    pane.webglAddon ? { cols: 84, rows: 24 } : { cols: 80, rows: 24 }
+  ) as never
+  return pane
 }
 
 describe('terminal WebGL addon lifecycle', () => {
@@ -236,19 +250,6 @@ describe('fit-anchored WebGL reattach', () => {
 // green even if safeFit stops calling it. These go through the real fit path so
 // the wiring — and the import-time hook registration — is what is under test.
 describe('safeFit drives the fit-anchored WebGL reattach', () => {
-  function createFittablePane(): ManagedPaneInternal {
-    const pane = createPane()
-    const rect = { width: 800, height: 400 }
-    pane.container = { dataset: {}, getBoundingClientRect: () => rect } as never
-    pane.xtermContainer = { getBoundingClientRect: () => rect } as never
-    // Why: WebGL floors the device cell width, so the same box proposes a wider
-    // grid once the addon is live — the divergence the reattach has to settle.
-    pane.fitAddon.proposeDimensions = vi.fn(() =>
-      pane.webglAddon ? { cols: 84, rows: 24 } : { cols: 80, rows: 24 }
-    ) as never
-    return pane
-  }
-
   beforeEach(() => {
     resetTerminalWebglSuggestion()
     vi.spyOn(console, 'warn').mockImplementation(() => {})
@@ -296,5 +297,62 @@ describe('safeFit drives the fit-anchored WebGL reattach', () => {
     expect(safeFit(pane)).toBe(false)
 
     expect(pane.webglAddon).toBeNull()
+  })
+})
+
+// Why a deferred stub: the suites above run rAF synchronously, so the window in
+// which the refit handle is live never exists there — and that window is exactly
+// where teardown and re-entry have to hold.
+describe('the deferred fit-anchored refit frame', () => {
+  const frames: (FrameRequestCallback | null)[] = []
+  const cancelledFrameIds: number[] = []
+
+  beforeEach(() => {
+    frames.length = 0
+    cancelledFrameIds.length = 0
+    resetTerminalWebglSuggestion()
+    vi.spyOn(console, 'warn').mockImplementation(() => {})
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) =>
+      frames.push(callback)
+    )
+    vi.stubGlobal('cancelAnimationFrame', (id: number) => {
+      cancelledFrameIds.push(id)
+      frames[id - 1] = null
+    })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.restoreAllMocks()
+  })
+
+  it('cancels the refit when the pane is disposed before the frame runs', () => {
+    // An uncancelled handle refits — and forwards a PTY resize for — a pane
+    // whose terminal is already disposed.
+    const pane = createFittablePane()
+    safeFit(pane)
+    const refitFrameId = pane.pendingWebglRefreshRafId
+    expect(refitFrameId).not.toBeNull()
+
+    disposePane(pane, new Map([[pane.id, pane]]))
+
+    expect(cancelledFrameIds).toContain(refitFrameId)
+    expect(pane.pendingWebglRefreshRafId).toBeNull()
+    expect(pane.fitAddon.fit).not.toHaveBeenCalled()
+  })
+
+  it('settles after one refit instead of cycling fit -> attach -> fit', () => {
+    const pane = createFittablePane()
+
+    safeFit(pane)
+    // Bounded drain: a cycle would keep queueing frames past the cap.
+    for (let index = 0; index < frames.length && index < 8; index += 1) {
+      const frame = frames[index]
+      frames[index] = null
+      frame?.(16)
+    }
+
+    expect(frames.length).toBe(1)
+    expect(pane.pendingWebglRefreshRafId).toBeNull()
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -7,7 +7,7 @@ import {
   getTerminalWebglAutoDecision,
   resetTerminalWebglAutoDecision
 } from './terminal-webgl-auto-policy'
-import { safeFitAndThen } from './pane-fit'
+import { safeFit, safeFitAndThen } from './pane-fit'
 import { setPaneFitWebglAttachHook } from './pane-fit-webgl-attach-signal'
 
 export const ENABLE_WEBGL_RENDERER = true
@@ -150,6 +150,25 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
   }
 }
 
+function refitAfterFitAnchoredWebglAttach(pane: ManagedPaneInternal): void {
+  // Why: the fit that triggered this attach measured DOM cell metrics, but WebGL
+  // floors the device cell width — keeping that grid leaves an unpainted right
+  // gutter and a PTY narrower than the pane. Refit on the next frame (mirroring
+  // the dispose-side refreshDimensions) so xterm has re-measured against the new
+  // renderer, and so the running fit is never re-entered.
+  if (typeof globalThis.requestAnimationFrame !== 'function') {
+    return
+  }
+  pane.pendingWebglRefreshRafId = globalThis.requestAnimationFrame(() => {
+    pane.pendingWebglRefreshRafId = null
+    try {
+      safeFit(pane)
+    } catch {
+      /* ignore — pane may have been disposed in the meantime */
+    }
+  })
+}
+
 export function attachWebglAfterFitIfMissing(pane: ManagedPaneInternal): void {
   // Why: a successful fit is the event-anchored moment a WebGL-eligible pane
   // that is stuck on the DOM renderer can heal — a late mount that missed the
@@ -168,6 +187,7 @@ export function attachWebglAfterFitIfMissing(pane: ManagedPaneInternal): void {
     attachWebgl(pane)
     if (pane.webglAddon) {
       recordTerminalWebglDiagnostic('webgl-fit-attach', { paneId: pane.id })
+      refitAfterFitAnchoredWebglAttach(pane)
     }
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -8,15 +8,17 @@ import {
   resetTerminalWebglAutoDecision
 } from './terminal-webgl-auto-policy'
 import { safeFitAndThen } from './pane-fit'
+import { setPaneFitWebglAttachHook } from './pane-fit-webgl-attach-signal'
 
 export const ENABLE_WEBGL_RENDERER = true
 let suggestedRendererType: 'dom' | undefined
-// Why: while Chromium refuses WebGL context creation (GPU process crashed or
-// WebGL blocked after repeated resets), every attach attempt burns a canvas +
-// failed getContext and logs a full-stack warning — and title changes retrigger
-// attach constantly in "on" mode. Latch the first failure and skip attempts
-// until the next recovery boundary (rendering resume or GPU-setting change).
-let webglAttachFailedSinceRecovery = false
+// Attach-failure latching is per-pane (pane.webglAttachFailedSinceRecovery):
+// while Chromium refuses WebGL context creation, every attach attempt burns a
+// canvas + failed getContext and logs a full-stack warning — and title changes
+// retrigger attach constantly in "on" mode. Each pane latches its own failure
+// and retries at the next recovery boundary (rendering resume or GPU-setting
+// change). A module-global latch here previously let ONE pane's failure strand
+// every other pane on the DOM renderer until the next boundary.
 
 type ReleasableWebglContext = {
   getExtension(name: 'WEBGL_lose_context'): WEBGL_lose_context | null
@@ -31,14 +33,14 @@ type XtermWebglAddonInternals = {
 
 export function resetTerminalWebglSuggestion(): void {
   // Why: toggling GPU settings should let "auto" retry WebGL after an earlier
-  // attach failure suggested DOM rendering for this app session.
+  // attach failure suggested DOM rendering for this app session. Per-pane
+  // failure latches are cleared by the callers that iterate panes.
   suggestedRendererType = undefined
-  webglAttachFailedSinceRecovery = false
   resetTerminalWebglAutoDecision()
 }
 
-export function clearTerminalWebglAttachBackoff(): void {
-  webglAttachFailedSinceRecovery = false
+export function clearTerminalWebglAttachBackoff(pane: ManagedPaneInternal): void {
+  pane.webglAttachFailedSinceRecovery = false
 }
 
 export function shouldUseTerminalWebgl(pane: ManagedPaneInternal): boolean {
@@ -148,6 +150,30 @@ export function resetWebglTextureAtlas(pane: ManagedPaneInternal): void {
   }
 }
 
+export function attachWebglAfterFitIfMissing(pane: ManagedPaneInternal): void {
+  // Why: a successful fit is the event-anchored moment a WebGL-eligible pane
+  // that is stuck on the DOM renderer can heal — a late mount that missed the
+  // coalesced reveal repaint, or a fallback whose cause has passed. A user
+  // resize then repairs the bold/wider DOM-rendered pane instead of leaving it.
+  // The per-pane failure latch stays honored: genuinely failed attaches retry
+  // only at recovery boundaries.
+  if (
+    !pane.webglAddon &&
+    pane.gpuRenderingEnabled &&
+    !pane.webglAttachmentDeferred &&
+    !pane.webglDisabledAfterContextLoss &&
+    !pane.webglAttachFailedSinceRecovery &&
+    shouldUseTerminalWebgl(pane)
+  ) {
+    attachWebgl(pane)
+    if (pane.webglAddon) {
+      recordTerminalWebglDiagnostic('webgl-fit-attach', { paneId: pane.id })
+    }
+  }
+}
+
+setPaneFitWebglAttachHook(attachWebglAfterFitIfMissing)
+
 export function attachWebgl(pane: ManagedPaneInternal): void {
   if (
     !ENABLE_WEBGL_RENDERER ||
@@ -155,7 +181,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
     !shouldUseTerminalWebgl(pane) ||
     pane.webglAttachmentDeferred ||
     pane.webglDisabledAfterContextLoss ||
-    webglAttachFailedSinceRecovery
+    pane.webglAttachFailedSinceRecovery
   ) {
     // Why: nulling the reference here used to leak a still-loaded addon that
     // kept painting stale frames while every recovery path (atlas reset,
@@ -204,7 +230,7 @@ export function attachWebgl(pane: ManagedPaneInternal): void {
       // enough signal to keep new auto panes on DOM until the setting changes.
       suggestedRendererType = 'dom'
     }
-    webglAttachFailedSinceRecovery = true
+    pane.webglAttachFailedSinceRecovery = true
     // WebGL not available — default DOM renderer is fine, but log it for debugging
     console.warn('[terminal] WebGL unavailable for pane', pane.id, '— using DOM renderer:', err)
     try {


### PR DESCRIPTION
## Summary

Fixes the other route into the P0 "terminal stuck on bold/blurry font until resize" reports (Slack, Aug 5): a pane left on the DOM renderer when it should be on WebGL. The two renderers differ visibly by design — WebGL floors the device cell width (`floor(8.4287 × 2) = 16` device px at SF Mono 14 / dpr 2, i.e. 8.0 css px vs the DOM renderer's 8.43) and rasterizes through the glyph atlas rather than browser AA — so a DOM-stuck pane reads as bolder, ~5% wider text at the same wrap column.

Two changes:

1. **Per-pane attach-failure latch.** `webglAttachFailedSinceRecovery` was module-global: one pane's failed WebGL context creation stranded every other pane on the DOM renderer until the next recovery boundary. It is now per-pane (`ManagedPaneInternal.webglAttachFailedSinceRecovery`), cleared per-pane at the existing boundaries (rendering resume, GPU-setting change, live-addon rebuild).

2. **Fit-anchored reattach.** A successful `safeFit` now offers a reattach to a pane that is WebGL-eligible but addon-less (a late mount that missed the coalesced reveal repaint, or a stale fallback). This makes recovery event-anchored — the fit proves the pane is measurable — instead of relying on wall-clock reveal bursts, and it means a user resize genuinely heals a DOM-stuck pane. The per-pane failure latch is honored: genuinely failed attaches still retry only at recovery boundaries, never per-fit. Wired through a small signal module (`pane-fit-webgl-attach-signal.ts`) because `pane-webgl-renderer` already imports `pane-fit`.

A `webgl-fit-attach` diagnostic records each late attach, and pane rendering diagnostics now include the per-pane latch — the stuck state finally shows up in telemetry.

Client-size fit helpers moved from `pane-fit.ts` to `pane-fit-client-size.ts` to stay under the max-lines cap (no behavior change in the move).

## Screenshots

No visual change in the normal path; the fix removes a wrong-renderer state. The bold/wider DOM-fallback signature was verified in a CDP rig by forcing `suspendRendering()` on a live pane and measuring the text extent shift (74 device px / 5.3% at SF Mono 14, dpr 2).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — targeted suites run locally: all of `src/renderer/src/lib/pane-manager/` (640 tests) and all of `src/renderer/src/components/terminal-pane/` (245 files / 3154 tests); full suite left to CI
- [ ] `pnpm build` — left to CI
- [x] Added or updated high-quality tests that would catch regressions: per-pane latch isolation (healthy pane attaches after another pane's failure — fails under the old global latch), latch honored until cleared (no repeat canvas burn), fit-anchored reattach (attaches eligible addon-less pane; skips latched/suspended/context-loss panes; leaves a live addon untouched)

## AI Review Report

Reviewed by the implementing agent with the repo's WebGL-recovery history in context (#7064 introduced the global latch, #11864's coalesced reveal repaint created the late-mount gap). Main risks checked: (1) attach storms on a broken GPU — bounded: each pane attempts once per recovery boundary (previously one pane attempted; the delta is at most one failed `getContext` per pane per boundary), and the fit pump never retries a latched pane; (2) import cycle `pane-fit ↔ pane-webgl-renderer` — broken via the registration signal module; hook exceptions are swallowed so a reattach failure cannot fail the fit that triggered it; (3) recovery-boundary semantics preserved — `resumePaneRendering`, `applyTerminalGpuAcceleration` (mode change), and `rebuildAttachedWebgl` all clear the per-pane latch exactly where the global was cleared before; (4) `attachWebgl`'s ineligible-path `disposeWebgl` is a no-op for addon-less panes, so the fit pump adds no churn. Cross-platform: explicitly considered Windows ANGLE → D3D11 context creation cost (100–500 ms/pane) — the fit pump attaches only when the addon is missing and unlatched, a rare one-shot heal, not a per-fit cost; macOS/Linux identical logic; no shortcuts, labels, paths, or shell behavior touched.

## Security Audit

Renderer-internal state only. No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. Diagnostics carry only numeric pane ids and booleans through the existing `terminal_webgl_diagnostic` sink.

## Notes

- Companion PR (deferred metric-option writes for hidden panes) fixes the other route into the same reports; independent, either order. Both touch the `pane-fit.ts` import block, so whichever lands second needs a trivial rebase.
- Windows note: with the per-pane latch, a machine whose GPU process is genuinely down pays up to one failed attach per pane per recovery boundary instead of one globally; each is a canvas + failed `getContext`, bounded by pane count.
- Follow-ups deliberately out of scope: reducing reveal-time atlas resets, and the parking/unmount architecture discussion (keeping WebGL alive for hot-retained panes).
