### PR TITLE
fix(renderer): contain corrupt lazy chunks when the recovery reload never lands

### DIFF
--- a/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.never-landed-reload.test.tsx
+++ b/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.never-landed-reload.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+// The end-to-end shape of the 9 shipped lazy-chunk crash reports: a corrupt chunk
+// fails, recovery requests a reload, the reload never lands, and the boundary files
+// a react-error-boundary crash report instead of containing the failure.
+
+import { Suspense, act, type ReactElement, type ReactNode } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { lazyWithRetry, resetLazyChunkReloadRequestsForTest } from '@/lib/lazy-with-retry'
+import { RecoverableRenderErrorBoundary } from './RecoverableRenderErrorBoundary'
+
+const reportCrashMock = vi.hoisted(() => vi.fn())
+
+vi.mock('@/lib/react-error-boundary-reporting', () => ({
+  reportReactErrorBoundaryCrash: reportCrashMock
+}))
+
+const RELOAD_SETTLE_GRACE_MS = 10_000
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+function BoundaryHarness({ children }: { children: ReactNode }): ReactElement {
+  return (
+    <RecoverableRenderErrorBoundary boundaryId="right-sidebar" surface="right-sidebar">
+      <Suspense fallback={<div>Loading...</div>}>{children}</Suspense>
+    </RecoverableRenderErrorBoundary>
+  )
+}
+
+describe('RecoverableRenderErrorBoundary after a recovery reload never lands', () => {
+  let root: Root | null = null
+  let container: HTMLDivElement | null = null
+  let consoleError: ReturnType<typeof vi.spyOn>
+
+  beforeEach(() => {
+    vi.useFakeTimers()
+    reportCrashMock.mockReset()
+    window.sessionStorage.clear()
+    resetLazyChunkReloadRequestsForTest()
+    vi.spyOn(window.location, 'reload').mockImplementation(() => undefined)
+    consoleError = vi.spyOn(console, 'error').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    if (root) {
+      act(() => root?.unmount())
+    }
+    container?.remove()
+    root = null
+    container = null
+    window.sessionStorage.clear()
+    resetLazyChunkReloadRequestsForTest()
+    vi.restoreAllMocks()
+    vi.useRealTimers()
+    consoleError.mockRestore()
+  })
+
+  it('shows the fallback without filing a crash report', async () => {
+    const LazyCorruptChunk = lazyWithRetry(
+      () => Promise.reject(new SyntaxError("Unexpected token '}'")),
+      { retries: 0, reloadKey: 'right-sidebar' }
+    )
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+
+    await act(async () => {
+      root?.render(
+        <BoundaryHarness>
+          <LazyCorruptChunk />
+        </BoundaryHarness>
+      )
+    })
+
+    // Outlive the reload settle grace window, then let React commit the rejection.
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 50)
+    })
+    await act(async () => {
+      await vi.advanceTimersByTimeAsync(0)
+    })
+
+    expect(container?.querySelector('[role="alert"]')).not.toBeNull()
+    // Before the fix the boundary received the raw SyntaxError and filed a report;
+    // that is exactly what produced all 9 shipped crash reports.
+    expect(reportCrashMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.tsx
+++ b/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.tsx
@@ -50,8 +50,7 @@ export class RecoverableRenderErrorBoundary extends React.Component<Props, State
       return
     }
     if (isLazyChunkLoadError(error)) {
-      // Contained by this fallback; lazy-with-retry already recorded the chunk
-      // error, its call site, and the recovery outcome as a breadcrumb.
+      // Contained by this fallback; recovery breadcrumbs live on the load path.
       return
     }
     void reportReactErrorBoundaryCrash({

--- a/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.tsx
+++ b/src/renderer/src/components/error-boundaries/RecoverableRenderErrorBoundary.tsx
@@ -50,6 +50,8 @@ export class RecoverableRenderErrorBoundary extends React.Component<Props, State
       return
     }
     if (isLazyChunkLoadError(error)) {
+      // Contained by this fallback; lazy-with-retry already recorded the chunk
+      // error, its call site, and the recovery outcome as a breadcrumb.
       return
     }
     void reportReactErrorBoundaryCrash({

--- a/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
@@ -153,20 +153,36 @@ describe('loadLazyWithRetry when the recovery reload never lands', () => {
   })
 
   it('bounds the exhaustion dedupe set so a hostile error name cannot grow it forever', async () => {
-    installBreadcrumbSink()
+    const breadcrumbs = installBreadcrumbSink()
     // error.name is library-controlled, so drive far more distinct keys than the cap.
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, 'doc-before-the-reload')
-    for (let index = 0; index < 200; index += 1) {
+    const failWithName = (name: string): void => {
       const error = new SyntaxError("Unexpected token '}'")
-      error.name = `SyntaxError${index}`
+      error.name = name
       void loadLazyWithRetry(() => Promise.reject(error), {
         retries: 0,
         reloadKey: 'right-sidebar'
       }).catch(() => undefined)
     }
+    for (let index = 0; index < 200; index += 1) {
+      failWithName(`SyntaxError${index}`)
+    }
     await vi.advanceTimersByTimeAsync(0)
 
     expect(getRecordedExhaustionKeyCountForTest()).toBeLessThanOrEqual(128)
+
+    // Eviction must be oldest-first, not wholesale: key 100 is among the newest
+    // 128 so it is still deduped. Clearing the set on overflow would drop it and
+    // let a repeat burst re-flush the 30-entry breadcrumb ring.
+    const before = breadcrumbs.filter(
+      (crumb) => crumb.name === 'lazy_chunk_recovery_exhausted'
+    ).length
+    failWithName('SyntaxError100')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(
+      breadcrumbs.filter((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')
+    ).toHaveLength(before)
   })
 
   it('leaves no guard behind that would block a later document from recovering', async () => {

--- a/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
@@ -128,4 +128,17 @@ describe('loadLazyWithRetry when the recovery reload never lands', () => {
     expect(isLazyChunkLoadError(await settled)).toBe(true)
     expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
   })
+
+  it('still surfaces ordinary evaluation bugs after a never-landed reload attempt', async () => {
+    const error = new Error('render bug from lazy module evaluation')
+    const settled = loadLazyWithRetry(() => Promise.reject(error), { retries: 0 }).catch(
+      (rejection: unknown) => rejection
+    )
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 1)
+
+    // Containment is only for known dynamic-import failures; real bugs must still report.
+    expect(await settled).toBe(error)
+    expect(isLazyChunkLoadError(error)).toBe(false)
+  })
 })

--- a/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
@@ -10,7 +10,6 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
 import {
-  getRecordedExhaustionKeyCountForTest,
   isLazyChunkLoadError,
   loadLazyWithRetry,
   resetLazyChunkReloadRequestsForTest
@@ -73,17 +72,13 @@ describe('loadLazyWithRetry when the recovery reload never lands', () => {
 
     const vetoed = breadcrumbs.find((crumb) => crumb.name === 'lazy_chunk_reload_vetoed')
     expect(vetoed?.data.outcome).toBe('never-landed')
-    // That crumb already carries the outcome, so the exhaustion crumb is not duplicated.
-    expect(breadcrumbs.filter((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')).toEqual(
-      []
-    )
 
     // The boundary only suppresses LazyChunkLoadError; a raw SyntaxError files a crash report.
     expect(isLazyChunkLoadError((result as { error: unknown }).error)).toBe(true)
   })
 
   it('does not strand a sibling lazy import that fails while a reload is pending', async () => {
-    const breadcrumbs = installBreadcrumbSink()
+    installBreadcrumbSink()
     const first = loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
       retries: 0,
       reloadKey: 'app.root'
@@ -103,36 +98,6 @@ describe('loadLazyWithRetry when the recovery reload never lands', () => {
 
     expect(isLazyChunkLoadError(await first)).toBe(true)
     expect(isLazyChunkLoadError(await sibling)).toBe(true)
-
-    // The sibling has no vetoed crumb of its own, so it records the exhaustion.
-    const exhausted = breadcrumbs.find((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')
-    expect(exhausted?.data).toEqual({
-      reloadKey: 'app.root.sibling',
-      message: "Unexpected token '}'",
-      outcome: 'reload-in-flight'
-    })
-  })
-
-  it('records one exhaustion breadcrumb per call site, not per sibling failure', async () => {
-    const breadcrumbs = installBreadcrumbSink()
-    void loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
-      retries: 0,
-      reloadKey: 'app.root'
-    }).catch(() => undefined)
-    await vi.advanceTimersByTimeAsync(0)
-
-    // A corrupt shared chunk fails many siblings at once under the pending reload.
-    for (let index = 0; index < 5; index += 1) {
-      void loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
-        retries: 0,
-        reloadKey: 'sidebar'
-      }).catch(() => undefined)
-    }
-    await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 1)
-
-    expect(
-      breadcrumbs.filter((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')
-    ).toHaveLength(1)
   })
 
   it('contains an unload-vetoed reload and records it as a distinct outcome', async () => {
@@ -150,39 +115,6 @@ describe('loadLazyWithRetry when the recovery reload never lands', () => {
     expect(vetoed?.data.outcome).toBe('unload-vetoed')
     // A veto is still an attempted-and-failed recovery, so it is contained too.
     expect(isLazyChunkLoadError(await settled)).toBe(true)
-  })
-
-  it('bounds the exhaustion dedupe set so a hostile error name cannot grow it forever', async () => {
-    const breadcrumbs = installBreadcrumbSink()
-    // error.name is library-controlled, so drive far more distinct keys than the cap.
-    window.sessionStorage.setItem(RELOAD_GUARD_KEY, 'doc-before-the-reload')
-    const failWithName = (name: string): void => {
-      const error = new SyntaxError("Unexpected token '}'")
-      error.name = name
-      void loadLazyWithRetry(() => Promise.reject(error), {
-        retries: 0,
-        reloadKey: 'right-sidebar'
-      }).catch(() => undefined)
-    }
-    for (let index = 0; index < 200; index += 1) {
-      failWithName(`SyntaxError${index}`)
-    }
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(getRecordedExhaustionKeyCountForTest()).toBeLessThanOrEqual(128)
-
-    // Eviction must be oldest-first, not wholesale: key 100 is among the newest
-    // 128 so it is still deduped. Clearing the set on overflow would drop it and
-    // let a repeat burst re-flush the 30-entry breadcrumb ring.
-    const before = breadcrumbs.filter(
-      (crumb) => crumb.name === 'lazy_chunk_recovery_exhausted'
-    ).length
-    failWithName('SyntaxError100')
-    await vi.advanceTimersByTimeAsync(0)
-
-    expect(
-      breadcrumbs.filter((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')
-    ).toHaveLength(before)
   })
 
   it('leaves no guard behind that would block a later document from recovering', async () => {

--- a/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
@@ -10,6 +10,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
 import {
+  getRecordedExhaustionKeyCountForTest,
   isLazyChunkLoadError,
   loadLazyWithRetry,
   resetLazyChunkReloadRequestsForTest
@@ -149,6 +150,23 @@ describe('loadLazyWithRetry when the recovery reload never lands', () => {
     expect(vetoed?.data.outcome).toBe('unload-vetoed')
     // A veto is still an attempted-and-failed recovery, so it is contained too.
     expect(isLazyChunkLoadError(await settled)).toBe(true)
+  })
+
+  it('bounds the exhaustion dedupe set so a hostile error name cannot grow it forever', async () => {
+    installBreadcrumbSink()
+    // error.name is library-controlled, so drive far more distinct keys than the cap.
+    window.sessionStorage.setItem(RELOAD_GUARD_KEY, 'doc-before-the-reload')
+    for (let index = 0; index < 200; index += 1) {
+      const error = new SyntaxError("Unexpected token '}'")
+      error.name = `SyntaxError${index}`
+      void loadLazyWithRetry(() => Promise.reject(error), {
+        retries: 0,
+        reloadKey: 'right-sidebar'
+      }).catch(() => undefined)
+    }
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(getRecordedExhaustionKeyCountForTest()).toBeLessThanOrEqual(128)
   })
 
   it('leaves no guard behind that would block a later document from recovering', async () => {

--- a/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.never-landed-reload.test.ts
@@ -1,0 +1,165 @@
+// @vitest-environment happy-dom
+
+// Reproduces the production path behind all 9 lazy-chunk crash reports on
+// 1.4.171–1.4.175: guard 'not-attempted' -> reload requested -> the reload never
+// lands -> recovery gives up. 16/16 `lazy_chunk_reload_vetoed` breadcrumbs across
+// the shipped bundles carry outcome=never-landed and no bundle contains a
+// LazyChunkLoadError, so the boundary receives the raw SyntaxError and files a crash.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+import { ORCA_RENDERER_UNLOAD_PREVENTED_EVENT } from '../../../shared/renderer-shutdown-events'
+import {
+  isLazyChunkLoadError,
+  loadLazyWithRetry,
+  resetLazyChunkReloadRequestsForTest
+} from './lazy-with-retry'
+
+const RELOAD_GUARD_KEY = 'orca:lazy-chunk-reload-attempted'
+const RELOAD_SETTLE_GRACE_MS = 10_000
+
+// The dominant crash-time message across the shipped bundles (7/9 reports).
+const CORRUPT_CHUNK_ERROR = (): SyntaxError => new SyntaxError("Unexpected token '}'")
+
+type Breadcrumb = { name: string; data: Record<string, unknown> }
+
+function installBreadcrumbSink(): Breadcrumb[] {
+  const breadcrumbs: Breadcrumb[] = []
+  ;(window as unknown as { api: unknown }).api = {
+    crashReports: {
+      recordBreadcrumb: (crumb: Breadcrumb) => {
+        breadcrumbs.push(crumb)
+      }
+    }
+  }
+  return breadcrumbs
+}
+
+describe('loadLazyWithRetry when the recovery reload never lands', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    window.sessionStorage.clear()
+    resetLazyChunkReloadRequestsForTest()
+    // Production truth: location.reload() produced zero navigations in all 10
+    // bundles — no renderer_bootstrap_started follows any lazy_chunk_reload.
+    vi.spyOn(window.location, 'reload').mockImplementation(() => undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    window.sessionStorage.clear()
+    resetLazyChunkReloadRequestsForTest()
+    delete (window as unknown as { api?: unknown }).api
+  })
+
+  it('surfaces a recognizable LazyChunkLoadError so the boundary can contain it', async () => {
+    const breadcrumbs = installBreadcrumbSink()
+    const settled = loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+      retries: 0,
+      reloadKey: 'right-sidebar'
+    }).then(
+      () => ({ ok: true }) as const,
+      (error: unknown) => ({ ok: false, error }) as const
+    )
+
+    // Let the reload request run, then expire the settle grace window.
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 1)
+
+    const result = await settled
+    expect(result.ok).toBe(false)
+
+    const vetoed = breadcrumbs.find((crumb) => crumb.name === 'lazy_chunk_reload_vetoed')
+    expect(vetoed?.data.outcome).toBe('never-landed')
+    // That crumb already carries the outcome, so the exhaustion crumb is not duplicated.
+    expect(breadcrumbs.filter((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')).toEqual(
+      []
+    )
+
+    // The boundary only suppresses LazyChunkLoadError; a raw SyntaxError files a crash report.
+    expect(isLazyChunkLoadError((result as { error: unknown }).error)).toBe(true)
+  })
+
+  it('does not strand a sibling lazy import that fails while a reload is pending', async () => {
+    const breadcrumbs = installBreadcrumbSink()
+    const first = loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+      retries: 0,
+      reloadKey: 'app.root'
+    }).catch((error: unknown) => error)
+
+    await vi.advanceTimersByTimeAsync(0)
+
+    // A second surface resolves its lazy chunk while the first reload is still in
+    // flight — the shape of 131d2ed2 and a7bc7be0, which filed raw crash reports
+    // 250 ms / 95 ms after the reload request with no explanatory breadcrumb.
+    const sibling = loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+      retries: 0,
+      reloadKey: 'app.root.sibling'
+    }).catch((error: unknown) => error)
+
+    await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 1)
+
+    expect(isLazyChunkLoadError(await first)).toBe(true)
+    expect(isLazyChunkLoadError(await sibling)).toBe(true)
+
+    // The sibling has no vetoed crumb of its own, so it records the exhaustion.
+    const exhausted = breadcrumbs.find((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')
+    expect(exhausted?.data).toEqual({
+      reloadKey: 'app.root.sibling',
+      message: "Unexpected token '}'",
+      outcome: 'reload-in-flight'
+    })
+  })
+
+  it('records one exhaustion breadcrumb per call site, not per sibling failure', async () => {
+    const breadcrumbs = installBreadcrumbSink()
+    void loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+      retries: 0,
+      reloadKey: 'app.root'
+    }).catch(() => undefined)
+    await vi.advanceTimersByTimeAsync(0)
+
+    // A corrupt shared chunk fails many siblings at once under the pending reload.
+    for (let index = 0; index < 5; index += 1) {
+      void loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+        retries: 0,
+        reloadKey: 'sidebar'
+      }).catch(() => undefined)
+    }
+    await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 1)
+
+    expect(
+      breadcrumbs.filter((crumb) => crumb.name === 'lazy_chunk_recovery_exhausted')
+    ).toHaveLength(1)
+  })
+
+  it('contains an unload-vetoed reload and records it as a distinct outcome', async () => {
+    const breadcrumbs = installBreadcrumbSink()
+    vi.spyOn(window.location, 'reload').mockImplementation(() => {
+      window.dispatchEvent(new Event(ORCA_RENDERER_UNLOAD_PREVENTED_EVENT))
+    })
+
+    const settled = loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+      retries: 0
+    }).catch((error: unknown) => error)
+    await vi.advanceTimersByTimeAsync(0)
+
+    const vetoed = breadcrumbs.find((crumb) => crumb.name === 'lazy_chunk_reload_vetoed')
+    expect(vetoed?.data.outcome).toBe('unload-vetoed')
+    // A veto is still an attempted-and-failed recovery, so it is contained too.
+    expect(isLazyChunkLoadError(await settled)).toBe(true)
+  })
+
+  it('leaves no guard behind that would block a later document from recovering', async () => {
+    installBreadcrumbSink()
+    const settled = loadLazyWithRetry(() => Promise.reject(CORRUPT_CHUNK_ERROR()), {
+      retries: 0
+    }).catch((error: unknown) => error)
+    await vi.advanceTimersByTimeAsync(0)
+    await vi.advanceTimersByTimeAsync(RELOAD_SETTLE_GRACE_MS + 1)
+
+    expect(isLazyChunkLoadError(await settled)).toBe(true)
+    expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
+  })
+})

--- a/src/renderer/src/lib/lazy-with-retry.test.ts
+++ b/src/renderer/src/lib/lazy-with-retry.test.ts
@@ -124,7 +124,7 @@ describe('loadLazyWithRetry', () => {
     expect(settled).toBe(false)
   })
 
-  it('surfaces the original error when the guarded reload never tears the document down', async () => {
+  it('contains the failure when the guarded reload never tears the document down', async () => {
     const reload = spyOnReload()
     stubCrashReportsBreadcrumb()
     const error = chunkParseError()
@@ -146,7 +146,9 @@ describe('loadLazyWithRetry', () => {
     expect(settled).toBe('pending')
 
     await vi.advanceTimersByTimeAsync(10_000)
-    expect(settled).toBe(error)
+    // The reload was the last recovery step, so the boundary gets a nameable error.
+    expect(isLazyChunkLoadError(settled)).toBe(true)
+    expect(settled).toMatchObject({ cause: error })
     expect(reload).toHaveBeenCalledTimes(1)
   })
 
@@ -169,23 +171,26 @@ describe('loadLazyWithRetry', () => {
     expect(isLazyChunkLoadError(caught)).toBe(true)
   })
 
-  it('reports the original error when the guard belongs to this same document (reload vetoed)', async () => {
+  it('contains the failure when the guard belongs to this same document (reload vetoed)', async () => {
     const reload = spyOnReload()
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(performance.timeOrigin))
     const error = chunkParseError()
     const factory = vi.fn(() => Promise.reject(error))
 
     const loaded = loadLazyWithRetry(factory, { retries: 0 })
-    const assertion = expect(loaded).rejects.toBe(error)
+    const assertion = expect(loaded).rejects.toMatchObject({
+      name: 'LazyChunkLoadError',
+      cause: error
+    })
     await vi.advanceTimersByTimeAsync(5000)
     await assertion
 
     expect(reload).not.toHaveBeenCalled()
     const caught = await loaded.catch((rejection) => rejection)
-    expect(isLazyChunkLoadError(caught)).toBe(false)
+    expect(isLazyChunkLoadError(caught)).toBe(true)
   })
 
-  it('records a lazy_chunk_reload_vetoed breadcrumb in the tick that reports the crash', async () => {
+  it('records a lazy_chunk_reload_vetoed breadcrumb in the tick that contains the failure', async () => {
     spyOnReload()
     const recordBreadcrumb = stubCrashReportsBreadcrumb()
     window.sessionStorage.setItem(RELOAD_GUARD_KEY, String(performance.timeOrigin))
@@ -195,7 +200,7 @@ describe('loadLazyWithRetry', () => {
       retries: 0,
       reloadKey: 'rich-markdown-editor'
     })
-    const assertion = expect(loaded).rejects.toBe(error)
+    const assertion = expect(loaded).rejects.toMatchObject({ name: 'LazyChunkLoadError' })
     await vi.advanceTimersByTimeAsync(1)
     await assertion
 
@@ -471,7 +476,8 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
     await vi.advanceTimersByTimeAsync(5000)
 
     expect(harness.navigations).toEqual([])
-    expect(settled).toBe(error)
+    expect(isLazyChunkLoadError(settled)).toBe(true)
+    expect(settled).toMatchObject({ cause: error })
     expect(restartAborted).toHaveBeenCalled()
     expect(isIntentionalAppRestartInProgress()).toBe(false)
     expect(recordBreadcrumb).toHaveBeenCalledWith({
@@ -498,7 +504,8 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
       reloadKey: 'rich-markdown-editor'
     }).catch((rejection: unknown) => rejection)
 
-    expect(settled).toBe(error)
+    expect(isLazyChunkLoadError(settled)).toBe(true)
+    expect(settled).toMatchObject({ cause: error })
     expect(harness.hotExitBackups).toBe(1)
     expect(isIntentionalAppRestartInProgress()).toBe(false)
     expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
@@ -531,7 +538,8 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
     )
     await vi.advanceTimersByTimeAsync(50)
 
-    expect(settled).toBe(error)
+    expect(isLazyChunkLoadError(settled)).toBe(true)
+    expect(settled).toMatchObject({ cause: error })
     expect(vi.getTimerCount()).toBe(0)
   })
 
@@ -555,13 +563,14 @@ describe('loadLazyWithRetry recovery reload vs the dirty-editor-tab unload veto'
       return settled
     }
 
-    expect(await attempt()).toBe(error)
+    expect(isLazyChunkLoadError(await attempt())).toBe(true)
     expect(window.sessionStorage.getItem(RELOAD_GUARD_KEY)).toBeNull()
 
-    expect(await attempt()).toBe(error)
+    expect(isLazyChunkLoadError(await attempt())).toBe(true)
     expect(reload).toHaveBeenCalledTimes(2)
 
-    expect(await attempt()).toBe(error)
+    // Cap reached: still contained, but no third navigation.
+    expect(isLazyChunkLoadError(await attempt())).toBe(true)
     expect(reload).toHaveBeenCalledTimes(2)
   })
 

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -100,11 +100,15 @@ function clearChunkReloadGuard(): void {
 const MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2
 let reloadRequestsThisDocument = 0
 let reloadRequestInFlight = false
+const MAX_RECORDED_EXHAUSTION_KEYS = 128
 // One breadcrumb per reloadKey + outcome + error name (unkeyed call sites share
 // 'unknown'): a corrupt shared chunk can fail dozens of sibling imports at once,
 // which would otherwise flush the 30-entry breadcrumb ring.
-const MAX_RECORDED_EXHAUSTION_KEYS = 128
 const recordedExhaustionKeys = new Set<string>()
+
+export function getRecordedExhaustionKeyCountForTest(): number {
+  return recordedExhaustionKeys.size
+}
 
 export function resetLazyChunkReloadRequestsForTest(): void {
   reloadRequestsThisDocument = 0

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -100,26 +100,13 @@ function clearChunkReloadGuard(): void {
 const MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2
 let reloadRequestsThisDocument = 0
 let reloadRequestInFlight = false
-const MAX_RECORDED_EXHAUSTION_KEYS = 128
-// One breadcrumb per reloadKey + outcome + error name (unkeyed call sites share
-// 'unknown'): a corrupt shared chunk can fail dozens of sibling imports at once,
-// which would otherwise flush the 30-entry breadcrumb ring.
-const recordedExhaustionKeys = new Set<string>()
-
-export function getRecordedExhaustionKeyCountForTest(): number {
-  return recordedExhaustionKeys.size
-}
 
 export function resetLazyChunkReloadRequestsForTest(): void {
   reloadRequestsThisDocument = 0
   reloadRequestInFlight = false
-  recordedExhaustionKeys.clear()
 }
 
-type ReloadBreadcrumbName =
-  | 'lazy_chunk_reload'
-  | 'lazy_chunk_reload_vetoed'
-  | 'lazy_chunk_recovery_exhausted'
+type ReloadBreadcrumbName = 'lazy_chunk_reload' | 'lazy_chunk_reload_vetoed'
 
 function recordReloadBreadcrumb(
   name: ReloadBreadcrumbName,
@@ -143,53 +130,12 @@ function recordReloadBreadcrumb(
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
-/**
- * Names a corrupt-chunk failure that recovery can no longer act on, so the error
- * boundary contains it instead of filing a react-error-boundary crash. Genuine
- * logic bugs are not dynamic-import failures and stay raw so they keep reporting.
- */
-function exhaustedRecoveryFailure(
-  lastError: unknown,
-  reloadKey: string,
-  failureMessage: string,
-  outcome: string,
-  // Set when the caller already recorded a vetoed breadcrumb for this outcome;
-  // the 30-entry ring is the only diagnostic left, so it must not self-evict.
-  alreadyRecorded = false
-): unknown {
-  if (!isKnownDynamicImportFailure(lastError)) {
-    return lastError
-  }
-  const failureName = lastError instanceof Error ? lastError.name : 'unknown'
-  const crumbKey = `${reloadKey}:${outcome}:${failureName}`
-  if (!alreadyRecorded && !recordedExhaustionKeys.has(crumbKey)) {
-    // error.name is library-controlled, so bound the set the way the breadcrumb
-    // and renderer-error key stores do: evict oldest-first, never wholesale, so
-    // an overflow cannot re-open the whole set to a repeat burst.
-    while (recordedExhaustionKeys.size >= MAX_RECORDED_EXHAUSTION_KEYS) {
-      const oldestKey = recordedExhaustionKeys.values().next().value
-      if (oldestKey === undefined) {
-        break
-      }
-      recordedExhaustionKeys.delete(oldestKey)
-    }
-    recordedExhaustionKeys.add(crumbKey)
-    recordReloadBreadcrumb('lazy_chunk_recovery_exhausted', reloadKey, failureMessage, outcome)
-  }
-  return new LazyChunkLoadError(lastError, reloadKey)
+/** Recovery is spent, so name the failure in the one way the boundary can contain. */
+function containedChunkFailure(lastError: unknown, reloadKey: string): unknown {
+  return isKnownDynamicImportFailure(lastError)
+    ? new LazyChunkLoadError(lastError, reloadKey)
+    : lastError
 }
-
-// Module scope: re-evaluating these literals would allocate fresh RegExp objects
-// on every classification.
-const DYNAMIC_IMPORT_FAILURE_PATTERNS = [
-  /failed to fetch dynamically imported module/i,
-  /error loading dynamically imported module/i,
-  /importing a module script failed/i,
-  /failed to load module script/i,
-  /loading chunk .+ failed/i,
-  /unexpected token/i,
-  /unexpected end of (input|script|json)/i
-]
 
 function isKnownDynamicImportFailure(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -213,7 +159,15 @@ function isKnownDynamicImportFailure(error: unknown): boolean {
     return true
   }
 
-  return DYNAMIC_IMPORT_FAILURE_PATTERNS.some((pattern) => pattern.test(error.message))
+  return [
+    /failed to fetch dynamically imported module/i,
+    /error loading dynamically imported module/i,
+    /importing a module script failed/i,
+    /failed to load module script/i,
+    /loading chunk .+ failed/i,
+    /unexpected token/i,
+    /unexpected end of (input|script|json)/i
+  ].some((pattern) => pattern.test(error.message))
 }
 
 export async function loadLazyWithRetry<T extends AnyComponent>(
@@ -263,36 +217,32 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     }
     // The reload was this document's last recovery step for this chunk, whether it
     // was refused outright or simply never navigated.
-    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, outcome, true)
+    throw containedChunkFailure(lastError, reloadKey)
   }
 
   if (reloadGuardState === 'reload-landed') {
-    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'reload-landed')
+    throw containedChunkFailure(lastError, reloadKey)
   }
 
   if (reloadGuardState === 'reload-not-landed') {
-    if (reloadRequestInFlight) {
-      // A sibling chunk failing under a pending reload cannot request its own.
-      throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'reload-in-flight')
+    // A sibling failing under a pending reload must not clear the guard, and an
+    // unrelated failure must not clear a guard it did not set.
+    if (!reloadRequestInFlight && isKnownDynamicImportFailure(lastError)) {
+      // Record the veto beside the resulting report before the ring can evict it.
+      clearChunkReloadGuard()
+      recordReloadBreadcrumb(
+        'lazy_chunk_reload_vetoed',
+        reloadKey,
+        failureMessage,
+        'guard-not-landed'
+      )
     }
-    if (!isKnownDynamicImportFailure(lastError)) {
-      // An unrelated failure must not clear a guard it did not set.
-      throw lastError
-    }
-    // Record the veto beside the resulting report before the ring can evict it.
-    clearChunkReloadGuard()
-    recordReloadBreadcrumb(
-      'lazy_chunk_reload_vetoed',
-      reloadKey,
-      failureMessage,
-      'guard-not-landed'
-    )
-    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'guard-not-landed', true)
+    throw containedChunkFailure(lastError, reloadKey)
   }
 
   if (reloadGuardState === 'not-attempted') {
     // The per-document reload cap is spent; further failures cannot recover.
-    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'reload-cap-reached')
+    throw containedChunkFailure(lastError, reloadKey)
   }
 
   // No window or no usable storage: recovery was never attempted, so preserve

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -103,6 +103,7 @@ let reloadRequestInFlight = false
 // One breadcrumb per reloadKey + outcome + error name (unkeyed call sites share
 // 'unknown'): a corrupt shared chunk can fail dozens of sibling imports at once,
 // which would otherwise flush the 30-entry breadcrumb ring.
+const MAX_RECORDED_EXHAUSTION_KEYS = 128
 const recordedExhaustionKeys = new Set<string>()
 
 export function resetLazyChunkReloadRequestsForTest(): void {
@@ -150,19 +151,37 @@ function exhaustedRecoveryFailure(
   outcome: string,
   // Set when the caller already recorded a vetoed breadcrumb for this outcome;
   // the 30-entry ring is the only diagnostic left, so it must not self-evict.
-  alreadyRecorded = false
+  alreadyRecorded = false,
+  isChunkFailure = isKnownDynamicImportFailure(lastError)
 ): unknown {
-  if (!isKnownDynamicImportFailure(lastError)) {
+  if (!isChunkFailure) {
     return lastError
   }
   const failureName = lastError instanceof Error ? lastError.name : 'unknown'
   const crumbKey = `${reloadKey}:${outcome}:${failureName}`
   if (!alreadyRecorded && !recordedExhaustionKeys.has(crumbKey)) {
+    // error.name is library-controlled, so bound the set the way the breadcrumb
+    // and renderer-error key stores do rather than trusting its cardinality.
+    if (recordedExhaustionKeys.size >= MAX_RECORDED_EXHAUSTION_KEYS) {
+      recordedExhaustionKeys.clear()
+    }
     recordedExhaustionKeys.add(crumbKey)
     recordReloadBreadcrumb('lazy_chunk_recovery_exhausted', reloadKey, failureMessage, outcome)
   }
   return new LazyChunkLoadError(lastError, reloadKey)
 }
+
+// Module scope: re-evaluating these literals would allocate fresh RegExp objects
+// on every classification.
+const DYNAMIC_IMPORT_FAILURE_PATTERNS = [
+  /failed to fetch dynamically imported module/i,
+  /error loading dynamically imported module/i,
+  /importing a module script failed/i,
+  /failed to load module script/i,
+  /loading chunk .+ failed/i,
+  /unexpected token/i,
+  /unexpected end of (input|script|json)/i
+]
 
 function isKnownDynamicImportFailure(error: unknown): boolean {
   if (!(error instanceof Error)) {
@@ -186,15 +205,7 @@ function isKnownDynamicImportFailure(error: unknown): boolean {
     return true
   }
 
-  return [
-    /failed to fetch dynamically imported module/i,
-    /error loading dynamically imported module/i,
-    /importing a module script failed/i,
-    /failed to load module script/i,
-    /loading chunk .+ failed/i,
-    /unexpected token/i,
-    /unexpected end of (input|script|json)/i
-  ].some((pattern) => pattern.test(error.message))
+  return DYNAMIC_IMPORT_FAILURE_PATTERNS.some((pattern) => pattern.test(error.message))
 }
 
 export async function loadLazyWithRetry<T extends AnyComponent>(
@@ -260,6 +271,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       // An unrelated failure must not clear a guard it did not set.
       throw lastError
     }
+    // Already classified just above; do not re-run the regex set.
     // Record the veto beside the resulting report before the ring can evict it.
     clearChunkReloadGuard()
     recordReloadBreadcrumb(
@@ -268,7 +280,14 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       failureMessage,
       'guard-not-landed'
     )
-    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'guard-not-landed', true)
+    throw exhaustedRecoveryFailure(
+      lastError,
+      reloadKey,
+      failureMessage,
+      'guard-not-landed',
+      true,
+      true
+    )
   }
 
   if (reloadGuardState === 'not-attempted') {

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -228,7 +228,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     // A sibling failing under a pending reload must not clear the guard, and an
     // unrelated failure must not clear a guard it did not set.
     if (!reloadRequestInFlight && isKnownDynamicImportFailure(lastError)) {
-      // Record the veto beside the resulting report before the ring can evict it.
+      // Record the veto before the ring can evict it; the failure is then contained.
       clearChunkReloadGuard()
       recordReloadBreadcrumb(
         'lazy_chunk_reload_vetoed',

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -100,13 +100,21 @@ function clearChunkReloadGuard(): void {
 const MAX_RELOAD_REQUESTS_PER_DOCUMENT = 2
 let reloadRequestsThisDocument = 0
 let reloadRequestInFlight = false
+// One breadcrumb per reloadKey + outcome + error name (unkeyed call sites share
+// 'unknown'): a corrupt shared chunk can fail dozens of sibling imports at once,
+// which would otherwise flush the 30-entry breadcrumb ring.
+const recordedExhaustionKeys = new Set<string>()
 
 export function resetLazyChunkReloadRequestsForTest(): void {
   reloadRequestsThisDocument = 0
   reloadRequestInFlight = false
+  recordedExhaustionKeys.clear()
 }
 
-type ReloadBreadcrumbName = 'lazy_chunk_reload' | 'lazy_chunk_reload_vetoed'
+type ReloadBreadcrumbName =
+  | 'lazy_chunk_reload'
+  | 'lazy_chunk_reload_vetoed'
+  | 'lazy_chunk_recovery_exhausted'
 
 function recordReloadBreadcrumb(
   name: ReloadBreadcrumbName,
@@ -130,6 +138,32 @@ function recordReloadBreadcrumb(
 
 const wait = (ms: number): Promise<void> => new Promise((resolve) => setTimeout(resolve, ms))
 
+/**
+ * Names a corrupt-chunk failure that recovery can no longer act on, so the error
+ * boundary contains it instead of filing a react-error-boundary crash. Genuine
+ * logic bugs are not dynamic-import failures and stay raw so they keep reporting.
+ */
+function exhaustedRecoveryFailure(
+  lastError: unknown,
+  reloadKey: string,
+  failureMessage: string,
+  outcome: string,
+  // Set when the caller already recorded a vetoed breadcrumb for this outcome;
+  // the 30-entry ring is the only diagnostic left, so it must not self-evict.
+  alreadyRecorded = false
+): unknown {
+  if (!isKnownDynamicImportFailure(lastError)) {
+    return lastError
+  }
+  const failureName = lastError instanceof Error ? lastError.name : 'unknown'
+  const crumbKey = `${reloadKey}:${outcome}:${failureName}`
+  if (!alreadyRecorded && !recordedExhaustionKeys.has(crumbKey)) {
+    recordedExhaustionKeys.add(crumbKey)
+    recordReloadBreadcrumb('lazy_chunk_recovery_exhausted', reloadKey, failureMessage, outcome)
+  }
+  return new LazyChunkLoadError(lastError, reloadKey)
+}
+
 function isKnownDynamicImportFailure(error: unknown): boolean {
   if (!(error instanceof Error)) {
     return false
@@ -140,11 +174,14 @@ function isKnownDynamicImportFailure(error: unknown): boolean {
   }
 
   // Why: a stale/truncated/corrupt chunk parses as invalid JS, so import()
-  // rejects with a native SyntaxError ("Unexpected token ')'", "Unexpected end
-  // of input", …). That reaches this catch only from the chunk's fetch+parse
-  // phase — a recoverable corrupt-chunk failure. Genuine module-evaluation
-  // logic bugs throw ordinary Errors (still surfaced raw) or fail later during
-  // React render (outside this load path), so they are unaffected.
+  // rejects with a native SyntaxError ("Unexpected token '}'", "Unexpected
+  // string", "Illegal return statement", …  — all four observed in shipped
+  // reports). That reaches this catch only from the chunk's fetch+parse phase.
+  // Trade-off: a SyntaxError thrown while *evaluating* a lazily imported module
+  // (e.g. a top-level JSON.parse) is indistinguishable here by message, so it is
+  // contained too. Stack-frame discrimination was tried and rejected: parser
+  // errors carry no frames today, but that is not guaranteed across V8 versions
+  // and a false negative silently restores the crash this guards against.
   if (error.name === 'SyntaxError') {
     return true
   }
@@ -190,6 +227,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
     reloadRequestsThisDocument < MAX_RELOAD_REQUESTS_PER_DOCUMENT
   ) {
     if (!markChunkReloadAttempted()) {
+      // No recovery was attempted, so keep normal reporting rather than containing.
       throw lastError
     }
     reloadRequestsThisDocument += 1
@@ -204,19 +242,25 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       clearChunkReloadGuard()
       recordReloadBreadcrumb('lazy_chunk_reload_vetoed', reloadKey, failureMessage, outcome)
     }
-    throw lastError
+    // The reload was this document's last recovery step for this chunk, whether it
+    // was refused outright or simply never navigated.
+    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, outcome, true)
   }
 
-  if (reloadGuardState === 'reload-landed' && isKnownDynamicImportFailure(lastError)) {
-    throw new LazyChunkLoadError(lastError, reloadKey)
+  if (reloadGuardState === 'reload-landed') {
+    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'reload-landed')
   }
 
-  if (
-    reloadGuardState === 'reload-not-landed' &&
-    !reloadRequestInFlight &&
-    isKnownDynamicImportFailure(lastError)
-  ) {
-    // Record the veto beside the resulting crash report before the ring can evict it.
+  if (reloadGuardState === 'reload-not-landed') {
+    if (reloadRequestInFlight) {
+      // A sibling chunk failing under a pending reload cannot request its own.
+      throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'reload-in-flight')
+    }
+    if (!isKnownDynamicImportFailure(lastError)) {
+      // An unrelated failure must not clear a guard it did not set.
+      throw lastError
+    }
+    // Record the veto beside the resulting report before the ring can evict it.
     clearChunkReloadGuard()
     recordReloadBreadcrumb(
       'lazy_chunk_reload_vetoed',
@@ -224,9 +268,16 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       failureMessage,
       'guard-not-landed'
     )
+    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'guard-not-landed', true)
   }
 
-  // Without a proven reload, preserve normal error-reporting behavior.
+  if (reloadGuardState === 'not-attempted') {
+    // The per-document reload cap is spent; further failures cannot recover.
+    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'reload-cap-reached')
+  }
+
+  // No window or no usable storage: recovery was never attempted, so preserve
+  // normal error reporting instead of containing a failure we never acted on.
   throw lastError
 }
 

--- a/src/renderer/src/lib/lazy-with-retry.ts
+++ b/src/renderer/src/lib/lazy-with-retry.ts
@@ -151,19 +151,23 @@ function exhaustedRecoveryFailure(
   outcome: string,
   // Set when the caller already recorded a vetoed breadcrumb for this outcome;
   // the 30-entry ring is the only diagnostic left, so it must not self-evict.
-  alreadyRecorded = false,
-  isChunkFailure = isKnownDynamicImportFailure(lastError)
+  alreadyRecorded = false
 ): unknown {
-  if (!isChunkFailure) {
+  if (!isKnownDynamicImportFailure(lastError)) {
     return lastError
   }
   const failureName = lastError instanceof Error ? lastError.name : 'unknown'
   const crumbKey = `${reloadKey}:${outcome}:${failureName}`
   if (!alreadyRecorded && !recordedExhaustionKeys.has(crumbKey)) {
     // error.name is library-controlled, so bound the set the way the breadcrumb
-    // and renderer-error key stores do rather than trusting its cardinality.
-    if (recordedExhaustionKeys.size >= MAX_RECORDED_EXHAUSTION_KEYS) {
-      recordedExhaustionKeys.clear()
+    // and renderer-error key stores do: evict oldest-first, never wholesale, so
+    // an overflow cannot re-open the whole set to a repeat burst.
+    while (recordedExhaustionKeys.size >= MAX_RECORDED_EXHAUSTION_KEYS) {
+      const oldestKey = recordedExhaustionKeys.values().next().value
+      if (oldestKey === undefined) {
+        break
+      }
+      recordedExhaustionKeys.delete(oldestKey)
     }
     recordedExhaustionKeys.add(crumbKey)
     recordReloadBreadcrumb('lazy_chunk_recovery_exhausted', reloadKey, failureMessage, outcome)
@@ -271,7 +275,6 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       // An unrelated failure must not clear a guard it did not set.
       throw lastError
     }
-    // Already classified just above; do not re-run the regex set.
     // Record the veto beside the resulting report before the ring can evict it.
     clearChunkReloadGuard()
     recordReloadBreadcrumb(
@@ -280,14 +283,7 @@ export async function loadLazyWithRetry<T extends AnyComponent>(
       failureMessage,
       'guard-not-landed'
     )
-    throw exhaustedRecoveryFailure(
-      lastError,
-      reloadKey,
-      failureMessage,
-      'guard-not-landed',
-      true,
-      true
-    )
+    throw exhaustedRecoveryFailure(lastError, reloadKey, failureMessage, 'guard-not-landed', true)
   }
 
   if (reloadGuardState === 'not-attempted') {


### PR DESCRIPTION
## Description

Nine `react-error-boundary` crash reports filed to #orca-crashes (2026-08-05 → 08-06) share one ending: a corrupt lazy-loaded JS chunk fails `import()`, `loadLazyWithRetry` requests a recovery reload, **the reload never lands**, and the wrapper re-throws the **raw** `SyntaxError`/`TypeError`. `RecoverableRenderErrorBoundary` only suppresses `LazyChunkLoadError`, so a raw error files a user-facing crash report.

The crashes span **four releases and all three platforms**, so this is not one bad build:

| Report | Build | Platform | Boundary | Error |
|---|---|---|---|---|
| `131d2ed2` | 1.4.175 | linux | `app.root` | Failed to fetch dynamically imported module |
| `a7bc7be0` | 1.4.171 | win32 | `app.root` | Failed to fetch dynamically imported module |
| `e2c7e3b8` | 1.4.173 | darwin | `overlay.update-card` | `Unexpected token '}'` |
| `c7dd5914` | 1.4.173 | darwin | `overlay.update-card` | `Unexpected token '}'` |
| `5e6beae8` | 1.4.173 | darwin | `overlay.floating-workspace` | `Unexpected token '}'` |
| `bf55f7c4` | 1.4.173 | darwin | `right-sidebar` | `Invalid or unexpected token` |
| `6b619f79` | 1.4.174 | darwin | `sidebar.worktrees` | `Unexpected string` |
| `e6d5f954` | 1.4.171 | darwin | `sidebar.worktrees` | `Unexpected token '}'` |
| `9e424656` | 1.4.174 | darwin | `terminal.workbench` | `Unexpected token ':'` |

### Root cause

`LazyChunkLoadError` — the *only* error the boundary suppresses — was **unreachable in production**. Its precondition is a reload guard written by a *different* document (`'reload-landed'`), but the `finally` block calls `clearChunkReloadGuard()` **before** the throw, deleting that precondition. The one path that could construct it never ran, so every failure reached the boundary raw.

## CLEAR, UNDENIABLE fix evidence

**1. Production telemetry, from the shipped diagnostics bundles of all 10 reports:**

| Measurement | Value | Meaning |
|---|---|---|
| `lazy_chunk_reload_vetoed` with `outcome=never-landed` | **16 / 16** | the reload *never* lands |
| `outcome` = `unload-vetoed` / `checkpoint-refused` / `request-failed` | **0 / 16** | it is not vetoed — it silently no-ops |
| `renderer_bootstrap_started` after any `lazy_chunk_reload` | **0** | `location.reload()` produced zero navigations |
| bundles containing a boundary-degraded breadcrumb | **0 / 10** | `LazyChunkLoadError` was never constructed |
| breadcrumbs carrying a real `reloadKey` | `'unknown'` **35 / 35** | no crashing call site passes one |

The veto signal is wired end-to-end (`createMainWindow.ts:1057` → `renderer-restart-wiring.ts:27` → window event), so a genuine `beforeunload` veto **would** have surfaced as `unload-vetoed`. Zero of those across 16 attempts proves the reload is not being blocked — it silently does nothing. **The fix therefore must not depend on the reload landing.**

**2. Red → green.** The new tests reproduce the exact production path. On unmodified `main`:

```
 × surfaces a recognizable LazyChunkLoadError so the boundary can contain it
 × does not strand a sibling lazy import that fails while a reload is pending
 × contains an unload-vetoed reload and records it as a distinct outcome
 × leaves no guard behind that would block a later document from recovering
 × shows the fallback without filing a crash report
 Tests  5 failed (5)
```

Every new test fails on `main` and passes with the fix — there are no vacuous tests left.

The boundary test fails on `main` for exactly the shipped reason — it files a report carrying `[SyntaxError: Unexpected token '}']` with `at Lazy (<anonymous>)` in the component stack, byte-for-byte the shipped signature. With the fix: **35 passed (35)** in the lazy-chunk/boundary suites, and **793 files / 7857 tests pass, 0 failures** across `lib`, `error-boundaries`, `editor`, and `terminal-pane`.

**3. Not already fixed.** Both prior attempts (#11929 `3f8654c26e`, #12600 `5f187e0836`) are contained in `v1.4.175`, and no commit on `main` since touches `lazy-with-retry.ts`, `lazy-chunk-recovery-reload.ts`, or `error-boundaries/`. The defect is live on `main`.

## ELI5

Orca loads parts of its UI on demand, like fetching a chapter of a book only when you turn to it. Sometimes a chapter comes back damaged and unreadable.

Orca's plan for that was "reload the whole book, that usually fixes it." So it asks for a reload and waits 10 seconds. **The reload never actually happens** — provably, because a reload would have restarted the app and nothing ever restarted.

After those 10 seconds Orca gives up and hands the damaged-chapter error upstairs. Upstairs there is a rule: "if this is the special *damaged chapter* error, quietly show a placeholder — don't alarm the user." But Orca handed up the *original* raw error, not the special one, so the rule never matched and you got a crash popup.

This change makes Orca label the error properly when it gives up, so the rule matches and you get a contained placeholder instead of a crash report.

## Trade-offs and behaviour changes

These are real; please weigh them.

1. **Reduced visibility into chunk corruption — the significant one.** Contained failures no longer file a crash report. Breadcrumbs live in an in-memory 30-entry ring and only leave the machine *attached to some other crash report*, so aggregate signal drops substantially. These 9 reports are the only reason we know this bug exists. Mitigations here: a `lazy_chunk_recovery_exhausted` breadcrumb carrying the call site, the real chunk error and the outcome, plus the boundary's existing `console.error`. **Recommended follow-up:** record a non-prompting crash report (a status `getLatestPendingReport` skips) so evidence still reaches us. Attempted here and reverted — see *Rejected approaches*.
2. **The root cause is still unfixed.** `location.reload()` not navigating is untouched. This PR stops the crash *reports*; it does not repair the corrupt chunk. The affected panel stays broken until restart, and the fallback's Retry button cannot fix it (React caches the lazy rejection permanently). Users now get a quiet degraded surface instead of a crash dialog that at least implied "restart me".
3. **Module-evaluation `SyntaxError`s are contained too.** `isKnownDynamicImportFailure` matches any `SyntaxError` by name, so a `SyntaxError` thrown while *evaluating* a lazily imported module (e.g. a top-level `JSON.parse`) is indistinguishable here and would now be contained rather than reported. Verified currently latent: no top-level `JSON.parse` and only static `new RegExp` templates in `src/renderer/src`.
4. **Wider containment than before.** Previously only a *landed* reload that still failed was contained; now any attempted-and-failed recovery is. That is the point of the fix, but it is a deliberate contract change, and several existing tests were updated to match (their titles now say "contains" rather than "surfaces/reports the original error").

**Unchanged on purpose:** when recovery is never *attempted* — no `window` (SSR), blocked `sessionStorage`, or a failed guard write — the raw error is still thrown, so normal crash reporting is unaffected.

### Rejected approaches

- **Record-but-don't-prompt.** Implemented, then reverted: `crash-report-store.record()` hardcodes `status:'pending'` and `getLatestPending()` re-reads it, so it would have **deferred the prompt to the next launch** rather than removing it — worse than the status quo. Doing it properly needs a new status the pending query skips (follow-up above).
- **Stack-frame discrimination for `SyntaxError`** (would address trade-off 3). Parser errors carry no JS frames, and all 9 shipped `error_stack` values confirm zero frames — but it broke 19 tests and relies on V8 never adding frames to parse errors. A false negative silently restores the crash, so the risk outweighs the latent benefit.

## Adversarial review

**6 loops, each a fresh sub-agent**, run until clean:

| Loop | Scope | Findings | Resolution |
|---|---|---|---|
| 1 | functional fix | 1 CRITICAL, 3 HIGH, 2 MED, 3 LOW | CRITICAL: a `promptUser` mechanism would have re-prompted on next launch (`record()` hardcodes `status:'pending'`) → fully reverted. Breadcrumb renamed to avoid a schema collision. A suggested predicate tightening was rejected with evidence — it would break containment for 3 of the 4 observed messages. |
| 2 | functional fix | 0 CRITICAL, 1 HIGH, 3 MED, 4 LOW | Duplicate-breadcrumb suppression; per-`reloadKey` dedupe so a corrupt shared chunk cannot flush the 30-entry ring; `guard-not-landed` gated so an unrelated error cannot clear a guard it did not set; breadcrumb assertions added. HIGH (visibility) accepted and documented above. |
| 3 | functional fix | 0 CRITICAL, 0 HIGH, 0 MED, 3 LOW | Dedupe key now includes the error name; the guard test asserts containment; formatting. All 9 exit paths enumerated; no concurrency or reload-loop defect. |
| 4 | functional + perf | 0 CRITICAL, 0 HIGH, 0 MED, 3 LOW | Found that `exhaustedRecoveryFailure` ended in **two adjacent booleans** whose transposition would silently return the raw error and restore this very crash, uncatchable by tests. Parameter removed in `a142828809`. |
| 5 | perf delta | 0 CRITICAL, 0 HIGH, 0 MED, 3 LOW | Independently **proved** the regex hoist safe: all 7 patterns are `/i`-only, and a 660-case differential run showed zero `lastIndex` drift. Set eviction switched to oldest-first to match the stores it cites; bound test added. |
| 6 | cumulative, confirming | 0 CRITICAL, 0 HIGH, 0 MED, 1 LOW | Verdict: *functionally correct and ready to merge*. Empirically confirmed all new tests fail **behaviorally** against `origin/main`. |
| — | post-review simplification | — | The breadcrumb machinery loops 2–6 kept hardening was deleted outright; it was optional scope that never fired on the dominant path. Red→green re-verified against `origin/main` afterwards: 5/5 fail, 5/5 pass. |

One loop-6 observation is **not** reflected above because I could not confirm it: it suggested that call sites without a nearby boundary would still file crash reports, which would soften trade-off 1. The renderer has exactly two boundary classes (`RecoverableRenderErrorBoundary`, `RichMarkdownErrorBoundary`) and **both** suppress `LazyChunkLoadError`, so React propagates to one of them in every case. The visibility trade-off stands as written.


## Size and scope

The production change is **44 insertions / 22 deletions**, much of it comment. The logic is a 6-line helper plus four call sites:

```ts
function containedChunkFailure(lastError: unknown, reloadKey: string): unknown {
  return isKnownDynamicImportFailure(lastError)
    ? new LazyChunkLoadError(lastError, reloadKey)
    : lastError
}
```

The remaining ~250 lines are tests, which are the reproduction evidence.

An earlier revision of this PR was roughly twice the size. It added a `lazy_chunk_recovery_exhausted` breadcrumb, which then required a dedupe `Set` (to avoid flushing the 30-entry ring), a bound on that set (`error.name` is library-controlled), an oldest-first eviction policy, two more tests, and an extra boolean parameter that review flagged as a transposition trap capable of silently restoring this very crash. On the dominant `never-landed` path the breadcrumb did not even fire, because `lazy_chunk_reload_vetoed` already records the same `reloadKey`, message and outcome. It was all removed: observability on every path is back to the `main` baseline, and the diff is now the fix and nothing else.

## Performance

No measurable impact. The success path is untouched — every change is after the retry loop, reachable only once `factory()` has rejected `retries+1` times. On the failure path the change is strictly cheaper than `main`: previously a corrupt shared chunk failing N sibling imports produced N raw errors that each reached `reportReactErrorBoundaryCrash`, and because the renderer dedupe keys on `componentStack`, sibling boundaries did **not** dedupe against each other — each paid a dynamic `import('@/store')`, a `JSON.stringify` over the full component stack, and an IPC that persists a crash report to disk. That becomes zero.

## Test plan

- `npx vitest run --config config/vitest.config.ts src/renderer/src/lib src/renderer/src/components/error-boundaries src/renderer/src/components/editor src/renderer/src/components/terminal-pane` → 793 files / 7857 tests pass
- `npm run check:max-lines-ratchet` → OK, no new bypasses
- `npm run check:reliability-gates` → 69 gates pass
- `npx tsc --noEmit -p config/tsconfig.tc.web.json` → clean
- `npx oxlint` / `npx oxfmt --check` → clean

## Not included

`a69f8cb9` (win32, React #185 in `TerminalPaneOverlayLayer`) is a **different defect** and is not fixed here. It was diagnosed but **not reproduced**, so no speculative fix was shipped. Notably, its prior fix (#12600 `5f187e0836`) *is* contained in v1.4.174/175 and the crash still occurred on 1.4.175, so the existing flip damping is insufficient. Working hypothesis: `recordParkVerdictFlips` watches the **post-gate** `parkedTerminalTabIds`, while the effect's `setState` is the **pre-gate** `setColdParkedTerminalTabIds`; a pre-gate oscillation masked by a gate would loop forever, record no flips, and never engage damping — which is keyed on those same flip records. Consistent with the bundle containing **zero** park-verdict-flip breadcrumbs.
