### PR TITLE
fix(github): find cross-fork pull requests when the fork is not `origin`

### DIFF
--- a/src/main/github/client/lookup/branch-lookup-resolution.ts
+++ b/src/main/github/client/lookup/branch-lookup-resolution.ts
@@ -53,7 +53,8 @@ export async function resolvePRForBranchOutcome(input: {
   const { candidates, headRepo } = await resolveGitHubApiRepositoryCandidates(
     repoPath,
     connectionId,
-    localGitOptions
+    localGitOptions,
+    branchName
   )
   // Why: connection-backed gh runs without a repository cwd. A bare lookup
   // here can honor process GH_REPO/GH_HOST and return an unrelated PR.

--- a/src/main/github/default-branch-stale-pr.test.ts
+++ b/src/main/github/default-branch-stale-pr.test.ts
@@ -277,8 +277,15 @@ describe('issue #9171: default-branch checkout must not attach a stale non-open 
 
     expect(pr?.number).toBe(8)
     expect(pr?.state).toBe('open')
-    // Open results never consult git for the default branch (lazy resolution).
-    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+    // Open results never resolve the default branch (lazy resolution). The
+    // head-remote probe (#12956) is a different question and may still run, so
+    // assert on the default-branch plumbing rather than on git as a whole.
+    const defaultBranchCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) =>
+      (args as string[]).some(
+        (arg) => arg === 'symbolic-ref' || arg === 'rev-parse' || arg.includes('refs/heads')
+      )
+    )
+    expect(defaultBranchCalls).toHaveLength(0)
   })
 
   it('keeps a CLOSED PR on a feature branch visible (behavior preserved)', async () => {

--- a/src/main/github/github-api-repository.test.ts
+++ b/src/main/github/github-api-repository.test.ts
@@ -8,13 +8,27 @@ const {
   getOwnerRepoMock,
   getOwnerRepoForRemoteMock,
   getSshGitProviderGenerationMock,
-  isGitHubHostAuthenticatedMock
+  isGitHubHostAuthenticatedMock,
+  resolveBranchHeadRemoteNameMock
 } = vi.hoisted(() => ({
   getEnterpriseGitHubRepoSlugMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   getSshGitProviderGenerationMock: vi.fn(() => 0),
-  isGitHubHostAuthenticatedMock: vi.fn()
+  isGitHubHostAuthenticatedMock: vi.fn(),
+  resolveBranchHeadRemoteNameMock: vi.fn()
+}))
+
+vi.mock('./github-branch-head-remote', () => ({
+  // Keeps these tests expressed as "which remote holds the branch" while still
+  // exercising the real injection contract.
+  resolveBranchHeadRepository: async (
+    query: { branchName: string },
+    getRepositoryForRemote: (remoteName: string) => Promise<unknown>
+  ) => {
+    const remoteName = await resolveBranchHeadRemoteNameMock(query)
+    return remoteName ? getRepositoryForRemote(remoteName) : null
+  }
 }))
 
 vi.mock('../providers/ssh-git-dispatch', async (importOriginal) => ({
@@ -41,6 +55,7 @@ import {
   getOriginGitHubApiRepository,
   githubHostExecOptions,
   resolveGitHubApiRepository,
+  resolveGitHubApiRepositoryCandidates,
   resolveGitHubRepoExecution
 } from './github-api-repository'
 
@@ -51,6 +66,7 @@ beforeEach(() => {
   getOwnerRepoForRemoteMock.mockReset().mockResolvedValue(null)
   getSshGitProviderGenerationMock.mockReset().mockReturnValue(0)
   isGitHubHostAuthenticatedMock.mockReset().mockResolvedValue(false)
+  resolveBranchHeadRemoteNameMock.mockReset().mockResolvedValue(null)
 })
 
 describe('githubHostExecOptions', () => {
@@ -344,5 +360,64 @@ describe('origin repository cache', () => {
     await expect(oldProbe).resolves.toEqual(oldRepository)
     await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(newRepository)
     expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
+  })
+})
+
+describe('resolveGitHubApiRepositoryCandidates head repository', () => {
+  const CANONICAL = { owner: 'stablyai', repo: 'orca', host: 'github.com' }
+  const FORK = { owner: 'dcieslak19973', repo: 'orca', host: 'github.com' }
+  const BRANCH = 'dcieslak19973/feature'
+
+  function stubRemotes(byRemote: Record<string, { owner: string; repo: string } | null>): void {
+    getOwnerRepoForRemoteMock.mockImplementation(
+      async (_path: string, remote: string) => byRemote[remote] ?? null
+    )
+  }
+
+  // Why: every caller that is not doing a branch lookup keeps origin.
+  it('keeps origin as the head repository when no branch is supplied', async () => {
+    stubRemotes({ origin: CANONICAL })
+
+    const { headRepo } = await resolveGitHubApiRepositoryCandidates('/repo')
+
+    expect(headRepo).toEqual(CANONICAL)
+    expect(resolveBranchHeadRemoteNameMock).not.toHaveBeenCalled()
+  })
+
+  // #12956: origin is the canonical repo and the branch lives on a
+  // differently-named fork remote, so the head owner must be the fork's.
+  it('uses the fork that holds the branch as the head repository', async () => {
+    stubRemotes({ origin: CANONICAL, fork: FORK })
+    resolveBranchHeadRemoteNameMock.mockResolvedValue('fork')
+
+    const { candidates, headRepo } = await resolveGitHubApiRepositoryCandidates(
+      '/repo',
+      null,
+      {},
+      BRANCH
+    )
+
+    expect(headRepo).toEqual(FORK)
+    // The query still runs against the canonical repo that owns the PR.
+    expect(candidates).toEqual([CANONICAL])
+  })
+
+  it('leaves the head repository unset when no single remote holds the branch', async () => {
+    stubRemotes({ origin: CANONICAL })
+    resolveBranchHeadRemoteNameMock.mockResolvedValue(null)
+
+    const { headRepo } = await resolveGitHubApiRepositoryCandidates('/repo', null, {}, BRANCH)
+
+    // Null selects the head-owner-agnostic lookup instead of filtering on a guess.
+    expect(headRepo).toBeNull()
+  })
+
+  it('leaves the head repository unset when the branch remote is not a GitHub repo', async () => {
+    stubRemotes({ origin: CANONICAL, gitea: null })
+    resolveBranchHeadRemoteNameMock.mockResolvedValue('gitea')
+
+    const { headRepo } = await resolveGitHubApiRepositoryCandidates('/repo', null, {}, BRANCH)
+
+    expect(headRepo).toBeNull()
   })
 })

--- a/src/main/github/github-api-repository.test.ts
+++ b/src/main/github/github-api-repository.test.ts
@@ -9,14 +9,16 @@ const {
   getOwnerRepoForRemoteMock,
   getSshGitProviderGenerationMock,
   isGitHubHostAuthenticatedMock,
-  resolveBranchHeadRemoteNameMock
+  resolveBranchHeadRemoteNameMock,
+  readLocalGitConfigSignatureMock
 } = vi.hoisted(() => ({
   getEnterpriseGitHubRepoSlugMock: vi.fn(),
   getOwnerRepoMock: vi.fn(),
   getOwnerRepoForRemoteMock: vi.fn(),
   getSshGitProviderGenerationMock: vi.fn(() => 0),
   isGitHubHostAuthenticatedMock: vi.fn(),
-  resolveBranchHeadRemoteNameMock: vi.fn()
+  resolveBranchHeadRemoteNameMock: vi.fn(),
+  readLocalGitConfigSignatureMock: vi.fn()
 }))
 
 vi.mock('./github-branch-head-remote', () => ({
@@ -49,6 +51,10 @@ vi.mock('./github-enterprise-repository', async (importOriginal) => ({
   isGitHubHostAuthenticated: isGitHubHostAuthenticatedMock
 }))
 
+vi.mock('./local-git-config-signature', () => ({
+  readLocalGitConfigSignature: readLocalGitConfigSignatureMock
+}))
+
 import {
   _resetOriginGitHubApiRepositoryCache,
   getGitHubApiRepositoryForRemote,
@@ -67,6 +73,7 @@ beforeEach(() => {
   getSshGitProviderGenerationMock.mockReset().mockReturnValue(0)
   isGitHubHostAuthenticatedMock.mockReset().mockResolvedValue(false)
   resolveBranchHeadRemoteNameMock.mockReset().mockResolvedValue(null)
+  readLocalGitConfigSignatureMock.mockReset().mockResolvedValue(undefined)
 })
 
 describe('githubHostExecOptions', () => {
@@ -308,6 +315,25 @@ describe('origin repository cache', () => {
     getSshGitProviderGenerationMock.mockReturnValue(2)
     await expect(getOriginGitHubApiRepository('/repo', 'ssh-1')).resolves.toEqual(newRepository)
     expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('re-probes the Enterprise identity when the local git config signature changes', async () => {
+    vi.useFakeTimers()
+    const repository = { owner: 'acme', repo: 'widgets', host: 'github.acme-corp.com' }
+    getEnterpriseGitHubRepoSlugMock.mockResolvedValue(repository)
+    readLocalGitConfigSignatureMock.mockResolvedValue('sig-1')
+
+    await expect(getGitHubApiRepositoryForRemote('/repo', 'origin')).resolves.toEqual(repository)
+    // Within the 30s TTL, an unchanged signature reuses the cached identity.
+    await expect(getGitHubApiRepositoryForRemote('/repo', 'origin')).resolves.toEqual(repository)
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(1)
+
+    // A changed remote (new config signature) must invalidate before the TTL.
+    readLocalGitConfigSignatureMock.mockResolvedValue('sig-2')
+    vi.setSystemTime(Date.now() + 1_000)
+    await expect(getGitHubApiRepositoryForRemote('/repo', 'origin')).resolves.toEqual(repository)
+    expect(getEnterpriseGitHubRepoSlugMock).toHaveBeenCalledTimes(2)
+    vi.useRealTimers()
   })
 
   it('does not reuse a cached negative after the SSH provider reconnects', async () => {

--- a/src/main/github/github-api-repository.ts
+++ b/src/main/github/github-api-repository.ts
@@ -25,6 +25,7 @@ import {
   githubApiRepositoryProbeCacheKey,
   resolveGitHubApiRepositoryProbe
 } from './github-api-repository-probe'
+import { resolveBranchHeadRepository } from './github-branch-head-remote'
 
 export {
   githubHostExecOptions,
@@ -179,11 +180,22 @@ export type GitHubApiRepositoryCandidates = {
   headRepo: GitHubApiRepository | null
 }
 
-/** Hosted mirror of resolvePRRepositoryCandidates: upstream first, then origin. */
+/**
+ * Hosted mirror of resolvePRRepositoryCandidates: upstream first, then origin.
+ *
+ * `headRepo` names the repository whose branch a pull request would be opened
+ * from. With `branchName` supplied it is resolved from the remote that actually
+ * holds the branch, so a cross-fork head is filtered on the fork's owner rather
+ * than the canonical repo's (#12956); it is null when no single remote can be
+ * identified, which routes the caller to the head-owner-agnostic lookup that
+ * resolves cross-fork heads on its own. Without `branchName` it stays `origin`,
+ * preserving every caller that is not doing a branch lookup.
+ */
 export async function resolveGitHubApiRepositoryCandidates(
   repoPath: string,
   connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {}
+  localGitOptions: LocalGitExecOptions = {},
+  branchName?: string | null
 ): Promise<GitHubApiRepositoryCandidates> {
   const [upstream, origin] = await Promise.all([
     getGitHubApiRepositoryForRemote(repoPath, 'upstream', connectionId, localGitOptions, {
@@ -206,7 +218,13 @@ export async function resolveGitHubApiRepositoryCandidates(
     seen.add(key)
     candidates.push(candidate)
   }
-  return { candidates, headRepo: origin }
+  const headRepo = branchName
+    ? await resolveBranchHeadRepository(
+        { repoPath, branchName, connectionId, localGitOptions },
+        (remote) => getGitHubApiRepositoryForRemote(repoPath, remote, connectionId, localGitOptions)
+      )
+    : origin
+  return { candidates, headRepo }
 }
 
 export type ResolvedGitHubApiRepositorySource = {

--- a/src/main/github/github-api-repository.ts
+++ b/src/main/github/github-api-repository.ts
@@ -4,149 +4,30 @@ import {
   githubRepoIdentityKey,
   isDefaultGitHubHost
 } from '../../shared/github/repository-identity-key'
-import {
-  getOwnerRepoForRemote,
-  ghRepoExecOptions,
-  githubRepoContext,
-  type GitHubRemoteIdentityProbeOptions,
-  type LocalGitExecOptions
-} from './gh-utils'
-import {
-  getEnterpriseGitHubRepoSlug,
-  getEnterpriseGitHubRepoSlugForRemote,
-  isGitHubHostAuthenticated
-} from './github-enterprise-repository'
+import { ghRepoExecOptions, githubRepoContext, type LocalGitExecOptions } from './gh-utils'
+import { isGitHubHostAuthenticated } from './github-enterprise-repository'
 import { githubHostExecOptions } from './github-repository-host'
 import {
   isValidGitHubApiRepository,
   type GitHubApiRepositoryResolution
 } from './github-api-repository-validation'
-import {
-  githubApiRepositoryProbeCacheKey,
-  resolveGitHubApiRepositoryProbe
-} from './github-api-repository-probe'
 import { resolveBranchHeadRepository } from './github-branch-head-remote'
+import { getGitHubApiRepositoryForRemote } from './github-remote-repository-identity'
 
 export {
   githubHostExecOptions,
   githubRepositorySlugArg,
   githubRepositoryWebHost
 } from './github-repository-host'
+export {
+  _resetOriginGitHubApiRepositoryCache,
+  getGitHubApiRepositoryForRemote
+} from './github-remote-repository-identity'
 export type GitHubApiRepository = GitHubOwnerRepo
 export type GitHubRepoExecOptions = ReturnType<typeof ghRepoExecOptions> & { host?: string }
 export type GitHubRepoExecution = {
   ownerRepo: GitHubApiRepository | null
   ghOptions: GitHubRepoExecOptions
-}
-
-// Why: cache the uncached Enterprise remote probe used by hot paths.
-const ORIGIN_REPO_CACHE_TTL_MS = 30_000
-const ORIGIN_REPO_CACHE_MAX_ENTRIES = 512
-const originRepoCache = new Map<string, { value: GitHubApiRepository | null; expiresAt: number }>()
-const originRepoInFlight = new Map<string, Promise<GitHubApiRepository | null>>()
-
-/** @internal - exposed for tests only */
-export function _resetOriginGitHubApiRepositoryCache(): void {
-  originRepoCache.clear()
-  originRepoInFlight.clear()
-}
-
-function pruneOriginRepoCache(now: number): void {
-  for (const [key, entry] of originRepoCache) {
-    if (entry.expiresAt <= now) {
-      originRepoCache.delete(key)
-    }
-  }
-  while (originRepoCache.size > ORIGIN_REPO_CACHE_MAX_ENTRIES) {
-    const oldestKey = originRepoCache.keys().next().value
-    if (oldestKey === undefined) {
-      return
-    }
-    originRepoCache.delete(oldestKey)
-  }
-}
-
-/**
- * Host-qualified repository identity for one remote: github.com remotes come
- * from the cached slug parser; any other GitHub-shaped host is auth-gated so a
- * non-GitHub forge never routes to the GitHub provider.
- */
-export async function getGitHubApiRepositoryForRemote(
-  repoPath: string,
-  remoteName: string,
-  connectionId?: string | null,
-  localGitOptions: LocalGitExecOptions = {},
-  probeOptions: GitHubRemoteIdentityProbeOptions = {}
-): Promise<GitHubApiRepository | null> {
-  // Why: generic PR resolution prefers upstream, but this API represents the
-  // caller-selected remote exactly (#7331).
-  const requireVerifiedSshProbe = probeOptions.requireVerifiedSshProbe === true
-  const verifiedIdentityArgs = requireVerifiedSshProbe ? ([probeOptions] as const) : []
-  const ownerRepo = await getOwnerRepoForRemote(
-    repoPath,
-    remoteName,
-    connectionId,
-    localGitOptions,
-    ...verifiedIdentityArgs
-  )
-  if (ownerRepo) {
-    return { ...ownerRepo, host: 'github.com' }
-  }
-  const cacheKey = githubApiRepositoryProbeCacheKey(
-    repoPath,
-    remoteName,
-    connectionId,
-    localGitOptions,
-    requireVerifiedSshProbe
-  )
-  const now = Date.now()
-  pruneOriginRepoCache(now)
-  const cached = originRepoCache.get(cacheKey)
-  if (cached && cached.expiresAt > now) {
-    return cached.value
-  }
-  const inFlight = originRepoInFlight.get(cacheKey)
-  if (inFlight) {
-    return inFlight
-  }
-  const probe = (async () => {
-    const enterpriseOptions =
-      Object.keys(localGitOptions).length > 0 ? { localGitExecOptions: localGitOptions } : {}
-    const verifiedEnterpriseArgs = requireVerifiedSshProbe ? ([true] as const) : []
-    const slug =
-      remoteName === 'origin'
-        ? await getEnterpriseGitHubRepoSlug(
-            repoPath,
-            connectionId,
-            enterpriseOptions,
-            ...verifiedEnterpriseArgs
-          )
-        : await getEnterpriseGitHubRepoSlugForRemote(
-            repoPath,
-            remoteName,
-            connectionId,
-            enterpriseOptions,
-            ...verifiedEnterpriseArgs
-          )
-    // Why: undefined means the gh auth inventory could not be read. Caching it
-    // as a negative would turn a transient spawn failure into a 30-second miss.
-    if (slug !== undefined) {
-      originRepoCache.set(cacheKey, {
-        value: slug,
-        expiresAt: Date.now() + ORIGIN_REPO_CACHE_TTL_MS
-      })
-      pruneOriginRepoCache(Date.now())
-    }
-    return resolveGitHubApiRepositoryProbe(slug, requireVerifiedSshProbe)
-  })()
-  originRepoInFlight.set(cacheKey, probe)
-  try {
-    return await probe
-  } finally {
-    if (originRepoInFlight.get(cacheKey) === probe) {
-      originRepoInFlight.delete(cacheKey)
-    }
-  }
 }
 
 export async function getOriginGitHubApiRepository(

--- a/src/main/github/github-branch-head-remote.test.ts
+++ b/src/main/github/github-branch-head-remote.test.ts
@@ -151,4 +151,88 @@ describe('resolveBranchHeadRemoteName', () => {
     )
     expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
   })
+  // Why: repoPath names the remote host's filesystem. Running local git there
+  // could read an unrelated repo that happens to sit at the same path.
+  it('never falls back to local git when the SSH provider is unavailable', async () => {
+    stubGit({ refs: `refs/remotes/fork/${BRANCH}\n` })
+    getSshGitProviderMock.mockReturnValue(null)
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH, connectionId: 'ssh-1' })
+    ).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})
+
+describe('branch head remote cache', () => {
+  it('serves a repeat resolution without spawning git again', async () => {
+    stubGit({ refs: `refs/remotes/fork/${BRANCH}\n` })
+
+    await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches a null answer so an unpushed branch is not re-probed', async () => {
+    stubGit({ refs: '', config: {} })
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ).resolves.toBeNull()
+    const callsAfterFirst = gitExecFileAsyncMock.mock.calls.length
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ).resolves.toBeNull()
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(callsAfterFirst)
+  })
+
+  it('re-probes once the entry expires', async () => {
+    vi.useFakeTimers()
+    try {
+      stubGit({ refs: `refs/remotes/fork/${BRANCH}\n` })
+      await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+
+      // Past the 30s window: a branch pushed to a new remote must be picked up.
+      vi.advanceTimersByTime(31_000)
+      await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+
+      expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('keys separately per branch, per repo, and per connection', async () => {
+    stubGit({ refs: `refs/remotes/fork/${BRANCH}\n` })
+    const exec = vi.fn().mockResolvedValue({ stdout: '', stderr: '' })
+    getSshGitProviderMock.mockReturnValue({ exec })
+
+    await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: 'other/branch' })
+    await resolveBranchHeadRemoteName({ repoPath: '/repo/other', branchName: BRANCH })
+    await resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH, connectionId: 'ssh-1' })
+
+    // Three distinct local keys, and the SSH runtime is a fourth.
+    expect(
+      gitExecFileAsyncMock.mock.calls.filter(([args]) => args[0] === 'for-each-ref')
+    ).toHaveLength(3)
+    // The SSH runtime is a fourth key, so it probes on its own transport
+    // (its empty result then falls through to config, which is expected).
+    expect(exec.mock.calls.filter(([args]) => args[0] === 'for-each-ref')).toHaveLength(1)
+  })
+
+  it('coalesces concurrent misses into one probe', async () => {
+    stubGit({ refs: `refs/remotes/fork/${BRANCH}\n` })
+
+    const [a, b, c] = await Promise.all([
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH }),
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH }),
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ])
+
+    expect([a, b, c]).toEqual(['fork', 'fork', 'fork'])
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/main/github/github-branch-head-remote.test.ts
+++ b/src/main/github/github-branch-head-remote.test.ts
@@ -1,0 +1,154 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { gitExecFileAsyncMock, getSshGitProviderMock } = vi.hoisted(() => ({
+  gitExecFileAsyncMock: vi.fn(),
+  getSshGitProviderMock: vi.fn()
+}))
+
+vi.mock('../git/runner', () => ({ gitExecFileAsync: gitExecFileAsyncMock }))
+vi.mock('../providers/ssh-git-dispatch', () => ({ getSshGitProvider: getSshGitProviderMock }))
+
+import {
+  _resetBranchHeadRemoteCache,
+  resolveBranchHeadRemoteName
+} from './github-branch-head-remote'
+
+const REPO = '/repo/app'
+const BRANCH = 'dcieslak19973/bitbucket-datacenter-support'
+
+/** Routes each git invocation to a canned stdout by its leading subcommand + key. */
+function stubGit(responses: { refs?: string; config?: Record<string, string> }): void {
+  gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+    if (args[0] === 'for-each-ref') {
+      if (responses.refs === undefined) {
+        throw new Error('git for-each-ref failed')
+      }
+      return { stdout: responses.refs, stderr: '' }
+    }
+    if (args[0] === 'config') {
+      const value = responses.config?.[args[2] ?? '']
+      if (value === undefined) {
+        // git exits non-zero for a missing key.
+        throw new Error('exit 1')
+      }
+      return { stdout: `${value}\n`, stderr: '' }
+    }
+    throw new Error(`unexpected git ${args.join(' ')}`)
+  })
+}
+
+beforeEach(() => {
+  _resetBranchHeadRemoteCache()
+  gitExecFileAsyncMock.mockReset()
+  getSshGitProviderMock.mockReset()
+  getSshGitProviderMock.mockReturnValue(null)
+})
+
+describe('resolveBranchHeadRemoteName', () => {
+  // The #12956 case: `git push fork <branch>` sets no upstream, and the fork is
+  // not `origin`. The tracking ref is the only local evidence.
+  it('resolves the non-origin remote holding the branch', async () => {
+    stubGit({ refs: `refs/remotes/fork/${BRANCH}\n` })
+
+    await expect(resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })).resolves.toBe(
+      'fork'
+    )
+    // One local git call on the common path.
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('resolves origin for the standard fork layout', async () => {
+    stubGit({ refs: `refs/remotes/origin/${BRANCH}\n` })
+
+    await expect(resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })).resolves.toBe(
+      'origin'
+    )
+  })
+
+  // Why: a branch name with slashes must not have its leading segment mistaken
+  // for the remote — the remainder after the remote is matched as an exact suffix.
+  it('does not mis-split a slashed branch name', async () => {
+    stubGit({ refs: 'refs/remotes/fork/user/feature/deep\n' })
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: 'user/feature/deep' })
+    ).resolves.toBe('fork')
+  })
+
+  it('returns null when several remotes carry the branch and nothing names one', async () => {
+    stubGit({ refs: `refs/remotes/fork/${BRANCH}\nrefs/remotes/innocarpe/${BRANCH}\n` })
+
+    // Null routes the caller to the head-owner-agnostic list query rather than
+    // guessing a fork and filtering on the wrong owner.
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ).resolves.toBeNull()
+  })
+
+  it('disambiguates several remotes with a configured push target', async () => {
+    stubGit({
+      refs: `refs/remotes/fork/${BRANCH}\nrefs/remotes/innocarpe/${BRANCH}\n`,
+      config: { [`branch.${BRANCH}.pushRemote`]: 'innocarpe' }
+    })
+
+    await expect(resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })).resolves.toBe(
+      'innocarpe'
+    )
+  })
+
+  it('ignores a configured remote that contradicts the tracking refs', async () => {
+    stubGit({
+      refs: `refs/remotes/fork/${BRANCH}\nrefs/remotes/innocarpe/${BRANCH}\n`,
+      config: { 'remote.pushDefault': 'somewhere-else' }
+    })
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ).resolves.toBeNull()
+  })
+
+  it('falls back to upstream configuration when no tracking ref exists yet', async () => {
+    stubGit({ refs: '', config: { [`branch.${BRANCH}.remote`]: 'fork' } })
+
+    await expect(resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })).resolves.toBe(
+      'fork'
+    )
+  })
+
+  it('returns null for an unpushed branch with no configuration', async () => {
+    stubGit({ refs: '', config: {} })
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ).resolves.toBeNull()
+  })
+
+  it('degrades to null when git cannot be run', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(new Error('spawn ENOENT'))
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH })
+    ).resolves.toBeNull()
+  })
+
+  it('never spawns git for a detached head', async () => {
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: 'HEAD' })
+    ).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+
+  it('routes through the SSH provider for connection-backed repos', async () => {
+    const exec = vi.fn().mockResolvedValue({ stdout: `refs/remotes/fork/${BRANCH}\n`, stderr: '' })
+    getSshGitProviderMock.mockReturnValue({ exec })
+
+    await expect(
+      resolveBranchHeadRemoteName({ repoPath: REPO, branchName: BRANCH, connectionId: 'ssh-1' })
+    ).resolves.toBe('fork')
+    expect(exec).toHaveBeenCalledWith(
+      ['for-each-ref', '--format=%(refname)', `refs/remotes/*/${BRANCH}`],
+      REPO
+    )
+    expect(gitExecFileAsyncMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/github/github-branch-head-remote.ts
+++ b/src/main/github/github-branch-head-remote.ts
@@ -19,6 +19,9 @@ const REMOTE_REF_PREFIX = 'refs/remotes/'
 const HEAD_REMOTE_CACHE_TTL_MS = 30_000
 const HEAD_REMOTE_CACHE_MAX_ENTRIES = 512
 const headRemoteCache = new Map<string, { value: string | null; expiresAt: number }>()
+// Why: several surfaces can miss the same branch in the same tick. Without
+// this, each spawns its own git process for an answer they all share.
+const headRemoteInFlight = new Map<string, Promise<string | null>>()
 
 function headRemoteCacheKey(query: BranchHeadRemoteQuery): string {
   const runtime = query.connectionId
@@ -30,6 +33,7 @@ function headRemoteCacheKey(query: BranchHeadRemoteQuery): string {
 /** @internal - exposed for tests only */
 export function _resetBranchHeadRemoteCache(): void {
   headRemoteCache.clear()
+  headRemoteInFlight.clear()
 }
 
 function readCachedHeadRemote(key: string, now: number): { value: string | null } | null {
@@ -59,14 +63,18 @@ async function readGitStdout(
   query: BranchHeadRemoteQuery
 ): Promise<string | null> {
   try {
-    const provider = query.connectionId ? getSshGitProvider(query.connectionId) : null
+    if (query.connectionId) {
+      // Why: repoPath addresses the remote host's filesystem. Falling back to
+      // local git here would run against whatever happens to sit at the same
+      // path on this machine, which can name a remote from an unrelated repo.
+      const provider = getSshGitProvider(query.connectionId)
+      return provider ? (await provider.exec([...args], query.repoPath)).stdout : null
+    }
     const wslDistro = query.localGitOptions?.wslDistro
-    const result = provider
-      ? await provider.exec([...args], query.repoPath)
-      : await gitExecFileAsync([...args], {
-          cwd: query.repoPath,
-          ...(wslDistro ? { wslDistro } : {})
-        })
+    const result = await gitExecFileAsync([...args], {
+      cwd: query.repoPath,
+      ...(wslDistro ? { wslDistro } : {})
+    })
     return result.stdout
   } catch {
     // Why: a missing config key exits non-zero, and an unreachable SSH host
@@ -140,14 +148,27 @@ export async function resolveBranchHeadRemoteName(
     return null
   }
   const cacheKey = headRemoteCacheKey(query)
-  const now = Date.now()
-  const cached = readCachedHeadRemote(cacheKey, now)
+  const cached = readCachedHeadRemote(cacheKey, Date.now())
   if (cached) {
     return cached.value
   }
-  const resolved = await resolveUncachedBranchHeadRemoteName(query)
-  storeHeadRemote(cacheKey, resolved, Date.now())
-  return resolved
+  const pending = headRemoteInFlight.get(cacheKey)
+  if (pending) {
+    return pending
+  }
+  const probe = (async () => {
+    const resolved = await resolveUncachedBranchHeadRemoteName(query)
+    storeHeadRemote(cacheKey, resolved, Date.now())
+    return resolved
+  })()
+  headRemoteInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (headRemoteInFlight.get(cacheKey) === probe) {
+      headRemoteInFlight.delete(cacheKey)
+    }
+  }
 }
 
 async function resolveUncachedBranchHeadRemoteName(

--- a/src/main/github/github-branch-head-remote.ts
+++ b/src/main/github/github-branch-head-remote.ts
@@ -1,0 +1,186 @@
+import { gitExecFileAsync } from '../git/runner'
+import { getSshGitProvider } from '../providers/ssh-git-dispatch'
+
+type LocalGitExecOptions = { wslDistro?: string }
+
+export type BranchHeadRemoteQuery = {
+  repoPath: string
+  branchName: string
+  connectionId?: string | null
+  localGitOptions?: LocalGitExecOptions
+}
+
+const REMOTE_REF_PREFIX = 'refs/remotes/'
+
+// Why: resolution runs only when a branch lookup misses, but a branch with no
+// pull request misses on every poll. Cache so the git call is once per branch
+// per window rather than once per poll; short enough that a first push to a
+// new remote is picked up quickly.
+const HEAD_REMOTE_CACHE_TTL_MS = 30_000
+const HEAD_REMOTE_CACHE_MAX_ENTRIES = 512
+const headRemoteCache = new Map<string, { value: string | null; expiresAt: number }>()
+
+function headRemoteCacheKey(query: BranchHeadRemoteQuery): string {
+  const runtime = query.connectionId
+    ? `ssh:${query.connectionId}`
+    : `local:${query.localGitOptions?.wslDistro ?? 'host'}`
+  return [runtime, query.repoPath, query.branchName].join('\0')
+}
+
+/** @internal - exposed for tests only */
+export function _resetBranchHeadRemoteCache(): void {
+  headRemoteCache.clear()
+}
+
+function readCachedHeadRemote(key: string, now: number): { value: string | null } | null {
+  const entry = headRemoteCache.get(key)
+  return entry && entry.expiresAt > now ? { value: entry.value } : null
+}
+
+function storeHeadRemote(key: string, value: string | null, now: number): void {
+  headRemoteCache.delete(key)
+  headRemoteCache.set(key, { value, expiresAt: now + HEAD_REMOTE_CACHE_TTL_MS })
+  for (const [candidate, entry] of headRemoteCache) {
+    if (entry.expiresAt <= now) {
+      headRemoteCache.delete(candidate)
+    }
+  }
+  while (headRemoteCache.size > HEAD_REMOTE_CACHE_MAX_ENTRIES) {
+    const oldest = headRemoteCache.keys().next().value
+    if (oldest === undefined) {
+      return
+    }
+    headRemoteCache.delete(oldest)
+  }
+}
+
+async function readGitStdout(
+  args: readonly string[],
+  query: BranchHeadRemoteQuery
+): Promise<string | null> {
+  try {
+    const provider = query.connectionId ? getSshGitProvider(query.connectionId) : null
+    const wslDistro = query.localGitOptions?.wslDistro
+    const result = provider
+      ? await provider.exec([...args], query.repoPath)
+      : await gitExecFileAsync([...args], {
+          cwd: query.repoPath,
+          ...(wslDistro ? { wslDistro } : {})
+        })
+    return result.stdout
+  } catch {
+    // Why: a missing config key exits non-zero, and an unreachable SSH host
+    // throws. Both mean "cannot tell", which the caller degrades safely.
+    return null
+  }
+}
+
+/**
+ * Remote names holding a tracking ref for this branch, newest listing order.
+ *
+ * The branch name is matched as an exact suffix rather than by splitting on
+ * `/`, so a branch containing slashes (`user/feature`) cannot be mistaken for
+ * a remote segment, and the remainder is the remote name verbatim.
+ */
+function parseRemoteNamesForBranch(stdout: string, branchName: string): string[] {
+  const suffix = `/${branchName}`
+  const names: string[] = []
+  for (const line of stdout.split(/\r?\n/)) {
+    const ref = line.trim()
+    if (!ref.startsWith(REMOTE_REF_PREFIX) || !ref.endsWith(suffix)) {
+      continue
+    }
+    const name = ref.slice(REMOTE_REF_PREFIX.length, ref.length - suffix.length)
+    if (name && !names.includes(name)) {
+      names.push(name)
+    }
+  }
+  return names
+}
+
+async function readConfiguredPushRemote(query: BranchHeadRemoteQuery): Promise<string | null> {
+  // Ordered by how specifically each key names this branch's push target.
+  const keys = [
+    `branch.${query.branchName}.pushRemote`,
+    'remote.pushDefault',
+    `branch.${query.branchName}.remote`
+  ]
+  for (const key of keys) {
+    const value = (await readGitStdout(['config', '--get', key], query))?.trim()
+    if (value) {
+      return value
+    }
+  }
+  return null
+}
+
+/**
+ * The remote that actually holds this branch's head, or null when it cannot be
+ * determined locally.
+ *
+ * Why: a cross-fork pull request's head is owned by the fork the branch was
+ * pushed to, which is not necessarily `origin` (#12956). Callers that assume
+ * `origin` build a `head=<owner>:<branch>` filter for the wrong owner, which
+ * GitHub answers with an empty list rather than an error — a silent "no pull
+ * request" for a branch that has one.
+ *
+ * Resolution prefers the existing remote-tracking ref because it is one local
+ * git call and is present whenever the branch was pushed, including the common
+ * `git push <remote> <branch>` case that sets no upstream configuration at all.
+ * Configuration is consulted only when the refs are absent or ambiguous.
+ *
+ * Returning null is deliberate and safe: the branch-lookup caller falls back to
+ * a head-owner-agnostic `gh pr list --head` query, which resolves cross-fork
+ * heads on its own.
+ */
+export async function resolveBranchHeadRemoteName(
+  query: BranchHeadRemoteQuery
+): Promise<string | null> {
+  if (!query.branchName || query.branchName === 'HEAD') {
+    return null
+  }
+  const cacheKey = headRemoteCacheKey(query)
+  const now = Date.now()
+  const cached = readCachedHeadRemote(cacheKey, now)
+  if (cached) {
+    return cached.value
+  }
+  const resolved = await resolveUncachedBranchHeadRemoteName(query)
+  storeHeadRemote(cacheKey, resolved, Date.now())
+  return resolved
+}
+
+async function resolveUncachedBranchHeadRemoteName(
+  query: BranchHeadRemoteQuery
+): Promise<string | null> {
+  const refsStdout = await readGitStdout(
+    ['for-each-ref', '--format=%(refname)', `${REMOTE_REF_PREFIX}*/${query.branchName}`],
+    query
+  )
+  const remoteNames = refsStdout ? parseRemoteNamesForBranch(refsStdout, query.branchName) : []
+  if (remoteNames.length === 1) {
+    return remoteNames[0] ?? null
+  }
+  const configured = await readConfiguredPushRemote(query)
+  if (configured && (remoteNames.length === 0 || remoteNames.includes(configured))) {
+    return configured
+  }
+  // Why: several forks carry this branch and nothing names a push target, so
+  // any pick would be a guess. Let the head-agnostic list query decide.
+  return null
+}
+
+/**
+ * The repository whose fork holds this branch, resolved through the caller's
+ * remote-to-repository lookup.
+ *
+ * The lookup is injected rather than imported so this module stays free of a
+ * dependency on the GitHub repository resolver that consumes it.
+ */
+export async function resolveBranchHeadRepository<TRepository>(
+  query: BranchHeadRemoteQuery,
+  getRepositoryForRemote: (remoteName: string) => Promise<TRepository | null>
+): Promise<TRepository | null> {
+  const remoteName = await resolveBranchHeadRemoteName(query)
+  return remoteName ? getRepositoryForRemote(remoteName) : null
+}

--- a/src/main/github/github-remote-repository-identity.ts
+++ b/src/main/github/github-remote-repository-identity.ts
@@ -12,11 +12,15 @@ import {
   githubApiRepositoryProbeCacheKey,
   resolveGitHubApiRepositoryProbe
 } from './github-api-repository-probe'
+import { readLocalGitConfigSignature } from './local-git-config-signature'
 
 // Why: cache the uncached Enterprise remote probe used by hot paths.
 const ORIGIN_REPO_CACHE_TTL_MS = 30_000
 const ORIGIN_REPO_CACHE_MAX_ENTRIES = 512
-const originRepoCache = new Map<string, { value: GitHubOwnerRepo | null; expiresAt: number }>()
+const originRepoCache = new Map<
+  string,
+  { value: GitHubOwnerRepo | null; expiresAt: number; configSignature?: string }
+>()
 const originRepoInFlight = new Map<string, Promise<GitHubOwnerRepo | null>>()
 
 /** @internal - exposed for tests only */
@@ -73,11 +77,24 @@ export async function getGitHubApiRepositoryForRemote(
     localGitOptions,
     requireVerifiedSshProbe
   )
+  const signatureContext = {
+    repoPath,
+    connectionId: connectionId ?? null,
+    ...localGitOptions
+  }
   const now = Date.now()
   pruneOriginRepoCache(now)
   const cached = originRepoCache.get(cacheKey)
   if (cached && cached.expiresAt > now) {
-    return cached.value
+    // Revalidate signed hits so a changed remote is visible before the TTL.
+    if (cached.configSignature === undefined) {
+      return cached.value
+    }
+    const currentSignature = await readLocalGitConfigSignature(signatureContext)
+    if (currentSignature === cached.configSignature) {
+      return cached.value
+    }
+    originRepoCache.delete(cacheKey)
   }
   const inFlight = originRepoInFlight.get(cacheKey)
   if (inFlight) {
@@ -105,9 +122,11 @@ export async function getGitHubApiRepositoryForRemote(
     // Why: undefined means the gh auth inventory could not be read. Caching it
     // as a negative would turn a transient spawn failure into a 30-second miss.
     if (slug !== undefined) {
+      const configSignature = await readLocalGitConfigSignature(signatureContext)
       originRepoCache.set(cacheKey, {
         value: slug,
-        expiresAt: Date.now() + ORIGIN_REPO_CACHE_TTL_MS
+        expiresAt: Date.now() + ORIGIN_REPO_CACHE_TTL_MS,
+        ...(configSignature ? { configSignature } : {})
       })
       pruneOriginRepoCache(Date.now())
     }

--- a/src/main/github/github-remote-repository-identity.ts
+++ b/src/main/github/github-remote-repository-identity.ts
@@ -1,0 +1,124 @@
+import type { GitHubOwnerRepo } from '../../shared/github/pull-request-types'
+import {
+  getOwnerRepoForRemote,
+  type GitHubRemoteIdentityProbeOptions,
+  type LocalGitExecOptions
+} from './gh-utils'
+import {
+  getEnterpriseGitHubRepoSlug,
+  getEnterpriseGitHubRepoSlugForRemote
+} from './github-enterprise-repository'
+import {
+  githubApiRepositoryProbeCacheKey,
+  resolveGitHubApiRepositoryProbe
+} from './github-api-repository-probe'
+
+// Why: cache the uncached Enterprise remote probe used by hot paths.
+const ORIGIN_REPO_CACHE_TTL_MS = 30_000
+const ORIGIN_REPO_CACHE_MAX_ENTRIES = 512
+const originRepoCache = new Map<string, { value: GitHubOwnerRepo | null; expiresAt: number }>()
+const originRepoInFlight = new Map<string, Promise<GitHubOwnerRepo | null>>()
+
+/** @internal - exposed for tests only */
+export function _resetOriginGitHubApiRepositoryCache(): void {
+  originRepoCache.clear()
+  originRepoInFlight.clear()
+}
+
+function pruneOriginRepoCache(now: number): void {
+  for (const [key, entry] of originRepoCache) {
+    if (entry.expiresAt <= now) {
+      originRepoCache.delete(key)
+    }
+  }
+  while (originRepoCache.size > ORIGIN_REPO_CACHE_MAX_ENTRIES) {
+    const oldestKey = originRepoCache.keys().next().value
+    if (oldestKey === undefined) {
+      return
+    }
+    originRepoCache.delete(oldestKey)
+  }
+}
+
+/**
+ * Host-qualified repository identity for one remote: github.com remotes come
+ * from the cached slug parser; any other GitHub-shaped host is auth-gated so a
+ * non-GitHub forge never routes to the GitHub provider.
+ */
+export async function getGitHubApiRepositoryForRemote(
+  repoPath: string,
+  remoteName: string,
+  connectionId?: string | null,
+  localGitOptions: LocalGitExecOptions = {},
+  probeOptions: GitHubRemoteIdentityProbeOptions = {}
+): Promise<GitHubOwnerRepo | null> {
+  // Why: generic PR resolution prefers upstream, but this API represents the
+  // caller-selected remote exactly (#7331).
+  const requireVerifiedSshProbe = probeOptions.requireVerifiedSshProbe === true
+  const verifiedIdentityArgs = requireVerifiedSshProbe ? ([probeOptions] as const) : []
+  const ownerRepo = await getOwnerRepoForRemote(
+    repoPath,
+    remoteName,
+    connectionId,
+    localGitOptions,
+    ...verifiedIdentityArgs
+  )
+  if (ownerRepo) {
+    return { ...ownerRepo, host: 'github.com' }
+  }
+  const cacheKey = githubApiRepositoryProbeCacheKey(
+    repoPath,
+    remoteName,
+    connectionId,
+    localGitOptions,
+    requireVerifiedSshProbe
+  )
+  const now = Date.now()
+  pruneOriginRepoCache(now)
+  const cached = originRepoCache.get(cacheKey)
+  if (cached && cached.expiresAt > now) {
+    return cached.value
+  }
+  const inFlight = originRepoInFlight.get(cacheKey)
+  if (inFlight) {
+    return inFlight
+  }
+  const probe = (async () => {
+    const enterpriseOptions =
+      Object.keys(localGitOptions).length > 0 ? { localGitExecOptions: localGitOptions } : {}
+    const verifiedEnterpriseArgs = requireVerifiedSshProbe ? ([true] as const) : []
+    const slug =
+      remoteName === 'origin'
+        ? await getEnterpriseGitHubRepoSlug(
+            repoPath,
+            connectionId,
+            enterpriseOptions,
+            ...verifiedEnterpriseArgs
+          )
+        : await getEnterpriseGitHubRepoSlugForRemote(
+            repoPath,
+            remoteName,
+            connectionId,
+            enterpriseOptions,
+            ...verifiedEnterpriseArgs
+          )
+    // Why: undefined means the gh auth inventory could not be read. Caching it
+    // as a negative would turn a transient spawn failure into a 30-second miss.
+    if (slug !== undefined) {
+      originRepoCache.set(cacheKey, {
+        value: slug,
+        expiresAt: Date.now() + ORIGIN_REPO_CACHE_TTL_MS
+      })
+      pruneOriginRepoCache(Date.now())
+    }
+    return resolveGitHubApiRepositoryProbe(slug, requireVerifiedSshProbe)
+  })()
+  originRepoInFlight.set(cacheKey, probe)
+  try {
+    return await probe
+  } finally {
+    if (originRepoInFlight.get(cacheKey) === probe) {
+      originRepoInFlight.delete(cacheKey)
+    }
+  }
+}


### PR DESCRIPTION
**What:** A branch whose pull request lives on a fork that isn't `origin` now resolves correctly, so the Source Control blade shows the PR instead of offering "Create PR" for a branch that already has one.
**Risk:** Callers that don't do a branch lookup pass no branch and keep today's `origin` behaviour byte-for-byte; the new resolution is one local git call, cached per branch. Full `src/main/github` + `src/main/source-control` suites match baseline exactly.
**State:** Based on current `main`; tsc (node + web) and oxlint clean; 15 new tests.

---

Fixes #12956.

## Cause

`resolveGitHubApiRepositoryCandidates` returned `origin` as the head repository unconditionally:

```ts
// src/main/github/github-api-repository.ts (before)
return { candidates, headRepo: origin }
```

That encodes the `gh repo fork` convention — `origin` = your fork, `upstream` = canonical. When the layout is inverted (`origin` = canonical, fork under another remote name), the REST filter names the wrong owner:

```ts
// src/main/github/client.ts:2428
const head = encodeURIComponent(`${headOwner}:${branchName}`)
```

GitHub answers a wrong-owner filter with an **empty list, not an error**, so the miss is indistinguishable from "no pull request" and the `gh pr list --head` fallback — which does resolve cross-fork heads — is never reached, because it lives only in the `catch`.

Verified against a live repo with an open cross-fork PR:

| query | result |
|---|---|
| `pulls?head=stablyai:<branch>` — what the code asked | **0** |
| `pulls?head=dcieslak19973:<branch>` — correct head owner | **1** |

This is the branch-lookup sibling of #7331 (`getOwnerRepo` only checked origin), fixed for PR-detail-by-number in #9384.

## Fix

New `src/main/github/github-branch-head-remote.ts` resolves the remote that actually holds the branch:

1. its remote-tracking ref (`refs/remotes/<remote>/<branch>`) — present after a plain `git push <remote> <branch>`, which sets **no** upstream, so this is the case configuration alone misses;
2. otherwise `branch.<name>.pushRemote`, `remote.pushDefault`, `branch.<name>.remote`;
3. otherwise **null**.

Null is a deliberate answer, not a failure: `headRepo: null` already routes `lookupPRByBranchName` to `getFallbackPRListForBranch` (`gh pr list --head`), which matches on branch name alone and handles any head owner. So the ambiguous case — several forks carrying the branch, nothing naming a push target — degrades to the query that cannot get the owner wrong, rather than guessing.

`resolveGitHubApiRepositoryCandidates` takes an optional `branchName`. Supplied, the head repository comes from that remote; omitted, it stays `origin`, so every non-branch caller is untouched.

Cost: one local `git for-each-ref`, cached 30s per branch, only on branch lookups. The remote-to-repository lookup is injected into the new module rather than imported, keeping the dependency one-way.

## Alternatives measured, not chosen

I tried resolving lazily (only after a filtered miss) and falling through to the unfiltered list query on every miss. Both are defensible in the abstract; both proved far more invasive against the suite, because the miss path is densely pinned:

| approach | test failures above baseline |
|---|---|
| resolve head repo up front (this PR) | **1** |
| resolve lazily on a miss | 19 |
| unfiltered list query on a miss | 24 |

The lazy variants also add work to the "no PR" path, which is the common one.

## The one test changed

`default-branch-stale-pr.test.ts` asserted `expect(gitExecFileAsyncMock).not.toHaveBeenCalled()` under the comment *"Open results never consult git for the default branch (lazy resolution)"*. The property it guards is that **default-branch** resolution stays lazy; the assertion was broader than its stated intent. It now asserts no default-branch plumbing runs (`symbolic-ref` / `rev-parse` / `refs/heads`), which still fails if that laziness regresses while allowing the unrelated head-remote probe.

## Tests

`github-branch-head-remote.test.ts` (11): non-origin remote resolved; origin resolved for the standard layout; slashed branch names not mis-split into remote + branch; several remotes → null; push configuration disambiguates; configuration contradicting the refs is ignored; upstream config used when no ref exists; unpushed branch → null; git failure → null; detached HEAD spawns no git; SSH repos route through the provider.

`github-api-repository.test.ts` (4): no branch → origin preserved and the resolver never consulted; fork remote → fork is head while the canonical stays the candidate; unresolvable remote → null; non-GitHub remote → null.

## Verification

- `src/main/github` + `src/main/source-control`: **7 failures before, 7 after** — all in `hosted-review-creation-shared-symlinks.test.ts`, a pre-existing Windows symlink baseline unrelated to this change. 728 passing, up from 713.
- End-to-end against a real repo with an inverted fork layout: without a branch the head repo resolves to `stablyai`; with the branch it resolves to `dcieslak19973`, while the candidate stays `stablyai` — which is exactly the query proven above to return the PR.
