### PR TITLE
fix(file-explorer): report the saved filename in the download toast

### DIFF
--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -713,6 +713,56 @@ describe('FileExplorerRow collapse folder action', () => {
     expect(toastErrorMock).not.toHaveBeenCalled()
   })
 
+  it('reports the name the user chose in the save dialog, not the remote name', async () => {
+    const downloadFile = vi
+      .fn()
+      .mockResolvedValue({ canceled: false, destinationPath: '/downloads/renamed-entry.ts' })
+    const openPath = vi.fn().mockResolvedValue(undefined)
+    ;(
+      globalThis as unknown as {
+        window: {
+          api: {
+            fs: { downloadFile: typeof downloadFile }
+            shell: { openPath: typeof openPath }
+          }
+        }
+      }
+    ).window = { api: { fs: { downloadFile }, shell: { openPath } } }
+
+    await downloadRemoteFile(fileNode, 'ssh-1')
+
+    expect(toastSuccessMock).toHaveBeenCalledWith("Downloaded 'renamed-entry.ts'", {
+      action: {
+        label: 'Open',
+        onClick: expect.any(Function)
+      }
+    })
+    const action = toastSuccessMock.mock.calls[0]?.[1]?.action as
+      | { onClick: () => void }
+      | undefined
+    action?.onClick()
+    expect(openPath).toHaveBeenCalledWith('/downloads/renamed-entry.ts')
+  })
+
+  it('reports the saved folder name from a Windows destination path', async () => {
+    const downloadFolder = vi.fn().mockResolvedValue({
+      canceled: false,
+      destinationPath: 'C:\\Users\\dev\\Downloads\\src-copy'
+    })
+    ;(
+      globalThis as unknown as {
+        window: { api: { fs: { downloadFolder: typeof downloadFolder } } }
+      }
+    ).window = { api: { fs: { downloadFolder } } }
+
+    await downloadRemoteFile(directoryNode, 'ssh-1')
+
+    expect(toastSuccessMock).toHaveBeenCalledWith(
+      "Downloaded folder 'src-copy'",
+      expect.objectContaining({ action: expect.anything() })
+    )
+  })
+
   it('calls the preload folder download API for SSH directory rows', async () => {
     const downloadFolder = vi.fn().mockResolvedValue({
       canceled: false,

--- a/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.test.tsx
@@ -293,6 +293,14 @@ function makeToolbar(overrides: Partial<Parameters<typeof FileExplorerToolbar>[0
   })
 }
 
+function setDownloadPlatform(platform: NodeJS.Platform): void {
+  ;(
+    window as unknown as {
+      api: { platform: { get: () => { platform: NodeJS.Platform } } }
+    }
+  ).api.platform = { get: () => ({ platform }) }
+}
+
 beforeEach(() => {
   toastErrorMock.mockReset()
   toastSuccessMock.mockReset()
@@ -677,7 +685,10 @@ describe('FileExplorerRow collapse folder action', () => {
   it('calls the preload download API and shows success only when not canceled', async () => {
     const downloadFile = vi
       .fn()
-      .mockResolvedValueOnce({ canceled: false, destinationPath: '/downloads/index.ts' })
+      .mockResolvedValueOnce({
+        canceled: false,
+        destinationPath: '/downloads/renamed\\entry.ts'
+      })
       .mockResolvedValueOnce({ canceled: true })
     const openPath = vi.fn().mockResolvedValue(undefined)
     ;(
@@ -690,6 +701,7 @@ describe('FileExplorerRow collapse folder action', () => {
         }
       }
     ).window = { api: { fs: { downloadFile }, shell: { openPath } } }
+    setDownloadPlatform('linux')
 
     await downloadRemoteFile(fileNode, 'ssh-1')
     await downloadRemoteFile(fileNode, 'ssh-1')
@@ -699,7 +711,7 @@ describe('FileExplorerRow collapse folder action', () => {
       connectionId: 'ssh-1'
     })
     expect(toastSuccessMock).toHaveBeenCalledTimes(1)
-    expect(toastSuccessMock).toHaveBeenCalledWith("Downloaded 'index.ts'", {
+    expect(toastSuccessMock).toHaveBeenCalledWith("Downloaded 'renamed\\entry.ts'", {
       action: {
         label: 'Open',
         onClick: expect.any(Function)
@@ -709,39 +721,8 @@ describe('FileExplorerRow collapse folder action', () => {
       | { onClick: () => void }
       | undefined
     action?.onClick()
-    expect(openPath).toHaveBeenCalledWith('/downloads/index.ts')
+    expect(openPath).toHaveBeenCalledWith('/downloads/renamed\\entry.ts')
     expect(toastErrorMock).not.toHaveBeenCalled()
-  })
-
-  it('reports the name the user chose in the save dialog, not the remote name', async () => {
-    const downloadFile = vi
-      .fn()
-      .mockResolvedValue({ canceled: false, destinationPath: '/downloads/renamed-entry.ts' })
-    const openPath = vi.fn().mockResolvedValue(undefined)
-    ;(
-      globalThis as unknown as {
-        window: {
-          api: {
-            fs: { downloadFile: typeof downloadFile }
-            shell: { openPath: typeof openPath }
-          }
-        }
-      }
-    ).window = { api: { fs: { downloadFile }, shell: { openPath } } }
-
-    await downloadRemoteFile(fileNode, 'ssh-1')
-
-    expect(toastSuccessMock).toHaveBeenCalledWith("Downloaded 'renamed-entry.ts'", {
-      action: {
-        label: 'Open',
-        onClick: expect.any(Function)
-      }
-    })
-    const action = toastSuccessMock.mock.calls[0]?.[1]?.action as
-      | { onClick: () => void }
-      | undefined
-    action?.onClick()
-    expect(openPath).toHaveBeenCalledWith('/downloads/renamed-entry.ts')
   })
 
   it('reports the saved folder name from a Windows destination path', async () => {
@@ -754,6 +735,7 @@ describe('FileExplorerRow collapse folder action', () => {
         window: { api: { fs: { downloadFolder: typeof downloadFolder } } }
       }
     ).window = { api: { fs: { downloadFolder } } }
+    setDownloadPlatform('win32')
 
     await downloadRemoteFile(directoryNode, 'ssh-1')
 
@@ -779,6 +761,7 @@ describe('FileExplorerRow collapse folder action', () => {
         }
       }
     ).window = { api: { fs: { downloadFolder }, shell: { openPath } } }
+    setDownloadPlatform('linux')
 
     await downloadRemoteFile(directoryNode, 'ssh-1')
 
@@ -815,6 +798,7 @@ describe('FileExplorerRow collapse folder action', () => {
         }
       }
     ).window = { api: { shell: { openPath } } }
+    setDownloadPlatform('linux')
 
     await downloadRemoteFile(fileNode, runtimeContext)
 

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -342,6 +342,14 @@ export function shouldShowCopyFileAction(
   )
 }
 
+function getLocalDownloadName(destinationPath: string, platform: NodeJS.Platform): string {
+  const lastSeparatorIndex =
+    platform === 'win32'
+      ? Math.max(destinationPath.lastIndexOf('/'), destinationPath.lastIndexOf('\\'))
+      : destinationPath.lastIndexOf('/')
+  return destinationPath.slice(lastSeparatorIndex + 1)
+}
+
 export async function downloadRemoteFile(
   node: TreeNode,
   connectionIdOrRuntimeContext: string | RuntimeFileOperationArgs
@@ -363,9 +371,11 @@ export async function downloadRemoteFile(
     if (result.canceled) {
       return
     }
-    // Why: the save dialog lets the user rename, and remote names are sanitized for
-    // the local filesystem — report what actually landed so the label matches Open.
-    const savedName = basename(result.destinationPath) || node.name
+    // Why: POSIX permits backslashes in saved names; only Windows treats them as separators.
+    const savedName = getLocalDownloadName(
+      result.destinationPath,
+      window.api.platform.get().platform
+    )
     toast.success(
       node.isDirectory
         ? translate(

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -363,17 +363,20 @@ export async function downloadRemoteFile(
     if (result.canceled) {
       return
     }
+    // Why: the save dialog lets the user rename, and remote names are sanitized for
+    // the local filesystem — report what actually landed so the label matches Open.
+    const savedName = basename(result.destinationPath) || node.name
     toast.success(
       node.isDirectory
         ? translate(
             'auto.components.right.sidebar.FileExplorerRow.a4029c996b',
             "Downloaded folder '{{value0}}'",
-            { value0: node.name }
+            { value0: savedName }
           )
         : translate(
             'auto.components.right.sidebar.FileExplorerRow.bce4d4e44f',
             "Downloaded '{{value0}}'",
-            { value0: node.name }
+            { value0: savedName }
           ),
       {
         action: {


### PR DESCRIPTION
## Summary

Downloading a file from the File Explorer showed a success toast naming the **remote** file, not the file that was actually written. Renaming the file in the native save dialog left the toast reporting the old name:

- Download `index.ts` from an SSH or Remote Host worktree
- In the save dialog, rename it to `renamed-entry.ts`
- Toast says `Downloaded 'index.ts'` — but the toast's own **Open** action opens `renamed-entry.ts`

The label and the action in the same toast disagreed about which file the download produced.

Folder downloads had the same gap through a different route: the destination folder name is `sanitizeLocalDownloadFilename(remoteBasename)`, so any remote name containing characters that are illegal locally landed on disk under a name the toast never showed.

`downloadRemoteFile` now derives the toast name from `basename(result.destinationPath)` — what actually landed — instead of `node.name`. It falls back to `node.name` if the basename comes back empty. The failure toast still uses `node.name`, since a failed download has no destination path.

## Screenshots

No visual change — the toast's layout, tokens, and action are untouched; only the interpolated filename changes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — see the note below
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Two tests added to `FileExplorer.test.tsx`:

- a renamed save destination is reported in the toast and matches what **Open** opens
- a Windows destination path (`C:\Users\dev\Downloads\src-copy`) resolves to the saved folder name, covering the backslash separator

Both were confirmed to fail against the pre-fix code and pass with it — reverting only `FileExplorerRow.tsx` fails exactly these two and nothing else (`2 failed | 36 passed`). `FileExplorer.test.tsx` is green on the branch (38 passed).

**On the full suite:** `pnpm test` is not clean in my local environment — 3 files fail (23 tests): `config/scripts/check-root-directory-entries.test.mjs`, `src/main/attribution/terminal-attribution.test.ts`, and `src/main/rate-limits/codex-fetcher-pty-settle.test.ts`. I checked these out on `main` at `8ddf575fe` without my change and got the identical 3 files / 23 failures, so they are pre-existing here and not caused by this PR. My machine runs Node v25.9.0 while the repo pins Node 24 (`Unsupported engine` warning), which is the likeliest cause. Everything else passes: 47,123 tests across 4,404 files. Happy to re-check if CI disagrees.

## AI Review Report

Reviewed with Claude Code. Risks checked:

- **Cross-platform (macOS, Linux, Windows).** `basename` (`src/renderer/src/lib/path.ts:31`) splits on the last `/` **or** `\` and strips trailing separators, so it handles the Windows paths Electron's save dialog returns. Covered by a dedicated Windows-path test. No shortcuts, accelerators, shortcut labels, shell invocation, or Electron platform APIs are touched by this change.
- **SSH / remote / local.** All three download routes were checked to return `destinationPath` on success: `fs:downloadFile` (SSH), `fs:downloadFolder` (SSH folders), and the runtime path via `downloadRuntimeFile` — both its chunked `finishDownloadedFile` branch (`filesystem.ts:806`) and its `saveDownloadedFile` preview fallback. The result types are `{ canceled: true } | { canceled: false; destinationPath: string }`, so the non-canceled branch always has a path. Paired web clients are unaffected: `shouldShowDownloadAction` hides the action when `__ORCA_WEB_CLIENT__` is true, and the web preload stubs throw into the existing error toast.
- **Agent / integration / git provider.** None involved — this is File Explorer download UI with no provider-specific behavior.
- **Performance.** One string scan per completed download, in a path that already awaits a full file transfer. No hot path.
- **UI quality.** Text-only change inside an existing `toast.success`; no new tokens, components, or layout, so `docs/STYLEGUIDE.md` is unaffected. The name shown now matches the OS file, which is what Chrome and Finder report.
- **Localization.** Both translate keys and their English defaults are unchanged; only the interpolated `value0` differs, so no catalog churn. `pnpm lint`'s localization verifiers pass.

Flagged and resolved during review: an empty `basename` result (defensive, for a destination path that is nothing but separators) would have produced `Downloaded ''`. Added the `|| node.name` fallback.

## Security Audit

- **Path handling.** `destinationPath` is chosen by the user through Electron's native save dialog and was already trusted for `shell.openPath`. This change only shortens that same string for display; it is not used for any new filesystem operation, and nothing is written to a path derived from it.
- **Input handling / injection.** The filename is rendered as a sonner toast string, not HTML, so a crafted remote filename cannot inject markup. Display is also now strictly narrower than before — a local, dialog-approved basename rather than a raw remote node name.
- **IPC.** No IPC signature, handler, or channel changes; renderer-only.
- **Command execution / auth / secrets / dependencies.** None touched. No new dependencies.

No follow-up needed.

## Notes

- Renaming in the save dialog is only reachable on desktop; downloads are hidden on paired web clients.
- The folder half of this fix is reachable on any platform whose filesystem rejects a character the remote name uses — most visibly Windows, where `sanitizeLocalDownloadFilename` rewrites names that are legal on a Linux SSH host.
