### PR TITLE
Prepare mobile 0.0.42 and fix TestFlight CI hang

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -30,6 +30,9 @@ jobs:
     # (@MainActor isolation). Xcode 16.x (macos-15) can't even parse it
     # ("unknown attribute 'MainActor'"), so we need Xcode 26.x → macos-26.
     runs-on: macos-26
+    # Archive + upload is ~30–40m when healthy; 90m leaves margin without
+    # sitting multi-hour on ASC processing polls (see Fastfile pilot wait).
+    timeout-minutes: 90
 
     defaults:
       run:

--- a/mobile/app.json
+++ b/mobile/app.json
@@ -2,7 +2,7 @@
   "expo": {
     "name": "Orca",
     "slug": "orca-mobile",
-    "version": "0.0.41",
+    "version": "0.0.42",
     "orientation": "default",
     "icon": "./assets/icon.png",
     "userInterfaceStyle": "automatic",

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -221,14 +221,13 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      # Why: fastlane can only assign external TestFlight groups after Apple
-      # finishes processing the uploaded build.
-      skip_waiting_for_build_processing: false,
-      distribute_external: true,
-      groups: TESTFLIGHT_GROUPS,
-      notify_external_testers: true,
-      # Why: fastlane requires release notes when distributing to external
-      # TestFlight testers, even for CI-triggered smoke releases.
+      # Why: waiting for ASC processing has hung for hours (0.0.42 builds 1–2)
+      # with no email and no Ready build in the UI. Exit after upload so CI is
+      # green when the binary is accepted; distribute externally from ASC once
+      # the build is Ready (or a follow-up lane).
+      skip_waiting_for_build_processing: true,
+      distribute_external: false,
+      # Changelog is still useful if someone later distributes this build.
       changelog: testflight_changelog,
     )
   end

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -28,8 +28,6 @@ WORKSPACE = File.join(MOBILE_ROOT, "ios", "Orca.xcworkspace")
 BUILD_OUTPUT_DIRECTORY = File.join(MOBILE_ROOT, "build")
 SCHEME = "Orca"
 BUNDLE_ID = "com.stably.orca.mobile"
-TESTFLIGHT_GROUPS = ["peeps"].freeze
-DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
 
 # App Store version states in which the version "train" is terminally closed to
 # new TestFlight build uploads (altool rejects with 90186 "train ... is
@@ -112,11 +110,6 @@ rescue StandardError => error
   nil
 end
 
-def testflight_changelog
-  changelog = ENV.fetch("TESTFLIGHT_CHANGELOG", "").strip
-  changelog.empty? ? DEFAULT_TESTFLIGHT_CHANGELOG : changelog
-end
-
 platform :ios do
   desc "Resolve the iOS release version and next TestFlight build number"
   lane :prepare_release_version do |options|
@@ -178,7 +171,7 @@ platform :ios do
     UI.message("Prepared Orca Mobile iOS #{version} (#{build_number})")
   end
 
-  desc "Build, sign, upload, and share Orca Mobile on TestFlight"
+  desc "Build, sign, and upload Orca Mobile to App Store Connect / TestFlight"
   lane :release do
     api_key = app_store_connect_api_key_from_env
 
@@ -221,14 +214,13 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      # Why: waiting for ASC processing has hung for hours (0.0.42 builds 1–2)
-      # with no email and no Ready build in the UI. Exit after upload so CI is
-      # green when the binary is accepted; distribute externally from ASC once
-      # the build is Ready (or a follow-up lane).
+      # Why: ASC processing wait hung for hours (0.0.42 builds 1–2) with no Ready
+      # build and no email. Exit after upload acceptance. Do not pass changelog —
+      # Pilot only fully skips waiting when changelog is nil (otherwise it still
+      # polls until the build appears). External distribute (e.g. peeps) from ASC
+      # or a follow-up lane once Ready.
       skip_waiting_for_build_processing: true,
       distribute_external: false,
-      # Changelog is still useful if someone later distributes this build.
-      changelog: testflight_changelog,
     )
   end
 end


### PR DESCRIPTION
## Summary
- Bump `mobile/app.json` `expo.version` to **0.0.42** after shipping App Store **0.0.41** (leave `ios.buildNumber` / `android.versionCode` to CI).
- Stop Mobile iOS Release from hanging multi-hour on App Store Connect after a successful upload:
  - Fastlane Pilot: `skip_waiting_for_build_processing: true`, `distribute_external: false`, **no `changelog`** (Pilot only fully skips wait when changelog is nil)
  - Workflow: `timeout-minutes: 90` on the iOS job
  - Removed unused `TESTFLIGHT_GROUPS` / default changelog helpers from this lane

## Why
Two CI runs for **0.0.42** (builds 1 and 2) archived and uploaded successfully, then sat for hours on Pilot’s processing wait. No Ready build appeared in TestFlight and no Apple processing emails arrived.

After this change, a green Mobile iOS Release means **upload accepted**. External TestFlight distribute (e.g. group `peeps`) is done from App Store Connect once the build is Ready—or a follow-up lane later.

## Files
- `mobile/app.json` — marketing version 0.0.42
- `mobile/fastlane/Fastfile` — pilot wait / external distribute / no post-upload changelog poll
- `.github/workflows/mobile-ios-release.yml` — job timeout

## Review
Single-pass review applied: drop `changelog` so Pilot truly exits after upload (with `skip_waiting` alone, a non-nil changelog still polls until the build is listable).

## Verification
- [ ] PR CI green
- [ ] Dispatch **Mobile iOS Release** with `release_version: 0.0.42` after merge
- [ ] Job finishes after upload (no multi-hour ASC poll)
- [ ] Build appears under TestFlight when ASC finishes processing; distribute externally from ASC if needed