### PR TITLE
fix(mobile): never auto-advertise virtual bridge addresses for pairing

### DIFF
--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -190,7 +190,10 @@ describe('registerMobileHandlers', () => {
 
     await expect(handlers.get('mobile:getPairingQR')?.(null, {})).resolves.toMatchObject({
       available: true,
-      connectionMode: 'automatic'
+      connectionMode: 'automatic',
+      // Why: the offer's loopback fallback points at the scanning phone, not this host — reporting it
+      // would print a direct endpoint under the QR that nothing can dial.
+      endpoint: null
     })
     expect(createMobilePairingOffer).toHaveBeenCalledWith(
       expect.objectContaining({ address: null })

--- a/src/main/ipc/mobile.test.ts
+++ b/src/main/ipc/mobile.test.ts
@@ -171,6 +171,84 @@ describe('registerMobileHandlers', () => {
     })
   })
 
+  it('never auto-advertises a bridge: a bridge-only host pairs over Relay with no address', async () => {
+    // Why: a bridge address the phone provably cannot reach must not become the default, and Relay
+    // needs no local address — so the QR ships without a direct path instead of an unreachable one.
+    networkInterfacesMock.mockReturnValue({
+      docker0: [{ family: 'IPv4', internal: false, address: '172.17.0.1' }],
+      'vEthernet (WSL)': [{ family: 'IPv4', internal: false, address: '172.28.80.1' }]
+    })
+    const createMobilePairingOffer = vi.fn().mockResolvedValue({
+      available: true,
+      pairingUrl: 'orca://pair#relay',
+      endpoint: 'ws://127.0.0.1:6768',
+      deviceId: 'mobile-bridge-only',
+      connectionMode: 'automatic'
+    })
+
+    registerMobileHandlers({ createMobilePairingOffer } as never)
+
+    await expect(handlers.get('mobile:getPairingQR')?.(null, {})).resolves.toMatchObject({
+      available: true,
+      connectionMode: 'automatic'
+    })
+    expect(createMobilePairingOffer).toHaveBeenCalledWith(
+      expect.objectContaining({ address: null })
+    )
+    // The bridges stay pickable, just never automatically.
+    expect(handlers.get('mobile:listNetworkInterfaces')?.()).toEqual({
+      interfaces: [
+        { name: 'docker0', address: '172.17.0.1' },
+        { name: 'vEthernet (WSL)', address: '172.28.80.1' }
+      ]
+    })
+  })
+
+  it('refuses a LAN-only QR on a bridge-only host instead of advertising the bridge', async () => {
+    // Why: LAN has no Relay to fall back on, so a dead direct endpoint is worse than saying so —
+    // the guidance points at the picker, where the bridge is still selectable on purpose.
+    networkInterfacesMock.mockReturnValue({
+      docker0: [{ family: 'IPv4', internal: false, address: '172.17.0.1' }]
+    })
+    const createMobilePairingOffer = vi.fn()
+
+    registerMobileHandlers({ createMobilePairingOffer } as never)
+
+    await expect(
+      handlers.get('mobile:getPairingQR')?.(null, { connectionMode: 'local-only' })
+    ).resolves.toMatchObject({
+      available: false,
+      reason: 'invalid_advertised_endpoint'
+    })
+    expect(createMobilePairingOffer).not.toHaveBeenCalled()
+  })
+
+  it('honors an explicitly picked bridge address', async () => {
+    // Why: exclusion is about the automatic default only — a user who knows their bridge is routable
+    // (a VM guest pairing with the host) must still be able to advertise it.
+    networkInterfacesMock.mockReturnValue({
+      docker0: [{ family: 'IPv4', internal: false, address: '172.17.0.1' }],
+      en0: [{ family: 'IPv4', internal: false, address: '192.168.1.24' }]
+    })
+    const createMobilePairingOffer = vi.fn().mockResolvedValue({
+      available: true,
+      pairingUrl: 'orca://pair#bridge',
+      endpoint: 'ws://172.17.0.1:6768',
+      deviceId: 'mobile-bridge-pick',
+      connectionMode: 'local-only'
+    })
+
+    registerMobileHandlers({ createMobilePairingOffer } as never)
+    await handlers.get('mobile:getPairingQR')?.(null, {
+      address: '172.17.0.1',
+      connectionMode: 'local-only'
+    })
+
+    expect(createMobilePairingOffer).toHaveBeenCalledWith(
+      expect.objectContaining({ address: '172.17.0.1' })
+    )
+  })
+
   it('returns an IPv6 interface on an IPv6-only host (regression: was empty, breaking mobile pairing)', () => {
     networkInterfacesMock.mockReturnValue({
       eth0: [
@@ -386,6 +464,23 @@ describe('registerMobileHandlers', () => {
       deviceId: 'runtime-local'
     }),
     ensureNetworkExposure: vi.fn().mockResolvedValue(undefined)
+  })
+
+  it('reports runtime pairing unavailable rather than advertising a bridge', async () => {
+    // Why: runtime clients have no Relay fallback, so a bridge-only host has nothing reachable to
+    // advertise — and no widen should happen for a link that would be dead anyway.
+    networkInterfacesMock.mockReturnValue({
+      docker0: [{ family: 'IPv4', internal: false, address: '172.17.0.1' }]
+    })
+    const rpcServer = stubRuntimePairingServer('172.17.0.1:6768')
+
+    registerMobileHandlers(rpcServer as never)
+
+    await expect(handlers.get('mobile:getRuntimePairingUrl')?.(null, {})).resolves.toEqual({
+      available: false
+    })
+    expect(rpcServer.createPairingOffer).not.toHaveBeenCalled()
+    expect(rpcServer.ensureNetworkExposure).not.toHaveBeenCalled()
   })
 
   // Why: every loopback form the address field accepts must behave identically once the user declared

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -2,6 +2,10 @@ import { app, ipcMain, shell, type IpcMainInvokeEvent } from 'electron'
 import { networkInterfaces } from 'node:os'
 import type { RuntimeAccessGrant } from '../../shared/runtime-access-grants'
 import type { MobilePairingConnectionMode } from '../../shared/mobile-pairing-connection-mode'
+import {
+  isVirtualBridgeInterface,
+  selectAutoAdvertisedPairingAddress
+} from '../../shared/pairing-address-auto-selection'
 import { classifyRemotePairingHostname } from '../../shared/remote-pairing-address'
 import type { RuntimePairingReach } from '../../shared/runtime-pairing-reach'
 import { isTailnetIPv4Address } from '../../shared/tailnet-address'
@@ -35,19 +39,6 @@ function isProxyFakeIpIPv4Address(address: string): boolean {
   return /^198\.(?:18|19)\./.test(address)
 }
 
-// Why: container/VM bridges are host-local — a phone can never reach docker0 or
-// vmnet8 — but they enumerate as ordinary non-internal IPv4, so advertising one
-// makes the direct path silently lose the pairing race and every session relay.
-// Keyed on interface name, not subnet: Docker's 172.16/12 pool overlaps real
-// corporate LANs, so an address test would demote genuine addresses. These stay
-// pickable in the UI; they are only ranked below a real LAN address.
-const VIRTUAL_BRIDGE_INTERFACE_PATTERN =
-  /^(?:docker|br-|virbr|vmnet|vboxnet|veth|lxcbr|cni|flannel|cali|bridge)|^vEthernet |VMware Network Adapter|VirtualBox Host-Only/i
-
-function isVirtualBridgeInterface(name: string): boolean {
-  return VIRTUAL_BRIDGE_INTERFACE_PATTERN.test(name)
-}
-
 // Why: the WebSocket transport advertises 0.0.0.0 as its endpoint, which isn't
 // connectable from a mobile device. We enumerate all non-internal IPv4 and
 // (non-link-local) IPv6 addresses so the user can choose which one to advertise
@@ -78,7 +69,8 @@ function getNetworkInterfaces(): NetworkInterface[] {
   }
   // Why: prefer tailnet IPv4 first (most portable across networks), then other
   // IPv4, then IPv6 as a fallback for IPv6-only environments. Virtual bridges
-  // sort below both so they are never the auto-advertised default.
+  // sort below all of them and stay in the list so they remain explicitly
+  // pickable; the automatic default skips them entirely.
   return result.sort((a, b) => rankInterface(a) - rankInterface(b))
 }
 
@@ -90,9 +82,10 @@ function rankInterface({ name, address }: NetworkInterface): number {
   return (address.includes(':') ? 2 : 1) + bridgePenalty
 }
 
+// Why: null when every enumerated interface is a host-local bridge, so a docker0-only host
+// advertises no direct address instead of one the phone provably cannot reach.
 function getDefaultPairingAddress(): string | null {
-  const ifaces = getNetworkInterfaces()
-  return ifaces.length > 0 ? ifaces[0]!.address : null
+  return selectAutoAdvertisedPairingAddress(getNetworkInterfaces()) ?? null
 }
 
 // Why: only an explicit "This computer only" pick skips the one-way widen, and only when the address it
@@ -156,7 +149,10 @@ export function registerMobileHandlers(
       // embed in the QR code. This supports overlay networks (Tailscale,
       // ZeroTier) where the default LAN IP isn't reachable from the phone.
       const ip = args?.address ?? getDefaultPairingAddress()
-      if (!ip) {
+      // Why: the local address is optional under Relay — the QR carries the relay invite, so a host
+      // with nothing auto-advertisable (only container bridges, or no interface at all) still pairs,
+      // just without a direct path to race. LAN-only has nothing to fall back on, so it fails closed.
+      if (!ip && args?.connectionMode === 'local-only') {
         return {
           available: false as const,
           reason: 'invalid_advertised_endpoint',

--- a/src/main/ipc/mobile.ts
+++ b/src/main/ipc/mobile.ts
@@ -150,8 +150,9 @@ export function registerMobileHandlers(
       // ZeroTier) where the default LAN IP isn't reachable from the phone.
       const ip = args?.address ?? getDefaultPairingAddress()
       // Why: the local address is optional under Relay — the QR carries the relay invite, so a host
-      // with nothing auto-advertisable (only container bridges, or no interface at all) still pairs,
-      // just without a direct path to race. LAN-only has nothing to fall back on, so it fails closed.
+      // with nothing auto-advertisable (only container bridges, or no interface at all) still pairs.
+      // The offer's endpoint then falls back to loopback, which is the phone's own device: the direct
+      // candidate loses the race by construction. LAN-only has no relay to fall back on, so it fails closed.
       if (!ip && args?.connectionMode === 'local-only') {
         return {
           available: false as const,
@@ -192,7 +193,10 @@ export function registerMobileHandlers(
         qrDataUrl: qr.ok ? qr.qrDataUrl : null,
         ...(!qr.ok ? { qrError: qr.reason } : {}),
         pairingUrl: offer.pairingUrl,
-        endpoint: offer.endpoint,
+        // Why: with nothing advertised the offer's endpoint is the loopback fallback, which points at
+        // whichever device scans the QR — never this host. Report no endpoint so the UI omits it
+        // instead of printing an address the phone can't reach.
+        endpoint: ip ? offer.endpoint : null,
         deviceId: offer.deviceId,
         connectionMode: offer.connectionMode
       }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3678,7 +3678,8 @@ export type PreloadApi = {
           qrDataUrl: string | null
           qrError?: 'encoding_failed'
           pairingUrl: string
-          endpoint: string
+          /** Null when no direct address was advertised — the QR pairs over Relay alone. */
+          endpoint: string | null
           deviceId: string
           /** Mode the QR actually encodes. */
           connectionMode: MobilePairingConnectionMode

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4690,7 +4690,8 @@ const api = {
           qrDataUrl: string | null
           qrError?: 'encoding_failed'
           pairingUrl: string
-          endpoint: string
+          /** Null when no direct address was advertised — the QR pairs over Relay alone. */
+          endpoint: string | null
           deviceId: string
           connectionMode: MobilePairingConnectionMode
         }

--- a/src/renderer/src/components/mobile/NetworkInterfacePicker.test.tsx
+++ b/src/renderer/src/components/mobile/NetworkInterfacePicker.test.tsx
@@ -1,0 +1,52 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { NetworkInterfacePicker } from './NetworkInterfacePicker'
+
+afterEach(cleanup)
+
+const noop = vi.fn()
+
+function renderPicker(props: {
+  networkInterfaces?: { name: string; address: string }[]
+  customAddresses?: string[]
+  selectedAddress?: string
+}): void {
+  render(
+    <NetworkInterfacePicker
+      networkInterfaces={props.networkInterfaces ?? []}
+      customAddresses={props.customAddresses ?? []}
+      selectedAddress={props.selectedAddress}
+      selectedAddressIsCustom={false}
+      onSelectedAddressChange={noop}
+      onCustomAddressSelect={noop}
+      onCustomAddressRemove={noop}
+    />
+  )
+}
+
+describe('NetworkInterfacePicker', () => {
+  // Why: a bridge-only host auto-advertises nothing, so the trigger has no selection to show while the
+  // bridge is still listed inside. Claiming "No interfaces found" there contradicts the list itself.
+  it('does not claim there are no interfaces when unselected options exist', () => {
+    renderPicker({ networkInterfaces: [{ name: 'docker0', address: '172.17.0.1' }] })
+
+    expect(screen.getByRole('combobox').textContent).toContain('No address selected')
+  })
+
+  it('reports an empty interface list when there is genuinely nothing to pick', () => {
+    renderPicker({})
+
+    expect(screen.getByRole('combobox').textContent).toContain('No interfaces found')
+  })
+
+  it('shows the selected interface instead of any placeholder', () => {
+    renderPicker({
+      networkInterfaces: [{ name: 'en0', address: '192.168.1.24' }],
+      selectedAddress: '192.168.1.24'
+    })
+
+    expect(screen.getByRole('combobox').textContent).toContain('192.168.1.24 (en0)')
+  })
+})

--- a/src/renderer/src/components/mobile/NetworkInterfacePicker.tsx
+++ b/src/renderer/src/components/mobile/NetworkInterfacePicker.tsx
@@ -55,6 +55,18 @@ export function NetworkInterfacePicker({
       })),
     [customAddresses]
   )
+  // Why: a host whose only interfaces are container bridges advertises no address by default, but the
+  // bridges are still listed here — "No interfaces found" would contradict the options right below it.
+  const placeholder =
+    options.length > 0 || customOptions.length > 0
+      ? translate(
+          'auto.components.mobile.NetworkInterfacePicker.no-address-selected',
+          'No address selected'
+        )
+      : translate(
+          'auto.components.settings.MobileNetworkInterfaceSection.b2c384cfd6',
+          'No interfaces found'
+        )
 
   return (
     <AddressPicker
@@ -85,10 +97,7 @@ export function NetworkInterfacePicker({
         'auto.components.mobile.NetworkInterfacePicker.add-custom',
         'Add custom address…'
       )}
-      placeholder={translate(
-        'auto.components.settings.MobileNetworkInterfaceSection.b2c384cfd6',
-        'No interfaces found'
-      )}
+      placeholder={placeholder}
       triggerAriaLabel={translate(
         'auto.components.mobile.NetworkInterfacePicker.trigger-label',
         'Network address to advertise'

--- a/src/renderer/src/components/settings/mobile-network-interface-selection.test.ts
+++ b/src/renderer/src/components/settings/mobile-network-interface-selection.test.ts
@@ -6,6 +6,7 @@ import {
 
 const LAN: MobileNetworkInterface = { name: 'en0', address: '192.168.1.24' }
 const TAILNET: MobileNetworkInterface = { name: 'tailscale0', address: '100.64.1.20' }
+const BRIDGE: MobileNetworkInterface = { name: 'docker0', address: '172.17.0.1' }
 
 describe('selectRefreshedNetworkAddress', () => {
   // Why: regression for the manual-address branch the PR adds — a
@@ -37,5 +38,19 @@ describe('selectRefreshedNetworkAddress', () => {
 
   it('clears the selection when no interfaces are available', () => {
     expect(selectRefreshedNetworkAddress(LAN.address, [])).toBeUndefined()
+  })
+
+  it('skips a container bridge in favor of a reachable address', () => {
+    expect(selectRefreshedNetworkAddress(undefined, [BRIDGE, LAN])).toBe(LAN.address)
+  })
+
+  // Why: matches main's default — advertising nothing beats advertising docker0, and Relay
+  // pairs without a direct address. A divergence here would show an address the QR never carried.
+  it('selects no address when every interface is a container bridge', () => {
+    expect(selectRefreshedNetworkAddress(undefined, [BRIDGE])).toBeUndefined()
+  })
+
+  it('keeps a bridge the user picked explicitly', () => {
+    expect(selectRefreshedNetworkAddress(BRIDGE.address, [BRIDGE, LAN])).toBe(BRIDGE.address)
   })
 })

--- a/src/renderer/src/components/settings/mobile-network-interface-selection.ts
+++ b/src/renderer/src/components/settings/mobile-network-interface-selection.ts
@@ -1,4 +1,4 @@
-import { isTailnetIPv4Address } from '../../../../shared/tailnet-address'
+import { selectAutoAdvertisedPairingAddress } from '../../../../shared/pairing-address-auto-selection'
 
 export type MobileNetworkInterface = {
   name: string
@@ -25,8 +25,7 @@ export function selectRefreshedNetworkAddress(
   ) {
     return currentAddress
   }
-  return (
-    interfaces.find((iface) => isTailnetIPv4Address(iface.address))?.address ??
-    interfaces[0]!.address
-  )
+  // Why: shared with main so the picker never shows a default the QR didn't advertise. Undefined on
+  // a bridge-only host: Relay pairs without a direct address rather than offering an unreachable one.
+  return selectAutoAdvertisedPairingAddress(interfaces)
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -12190,6 +12190,7 @@
           "confirmationError": "This address could not produce a scannable pairing code. Check the address and try again."
         },
         "NetworkInterfacePicker": {
+          "no-address-selected": "No address selected",
           "trigger-label": "Network address to advertise",
           "custom-option": "{{address}} (custom)",
           "add-custom": "Add custom address…",

--- a/src/shared/pairing-address-auto-selection.ts
+++ b/src/shared/pairing-address-auto-selection.ts
@@ -1,0 +1,32 @@
+import { isTailnetIPv4Address } from './tailnet-address'
+
+export type PairingNetworkInterface = {
+  name: string
+  address: string
+}
+
+// Why: container/VM bridges are host-local — a phone can never reach docker0 or
+// vmnet8 — but they enumerate as ordinary non-internal IPv4, so advertising one
+// makes the direct path silently lose the pairing race and every session relay.
+// Keyed on interface name, not subnet: Docker's 172.16/12 pool overlaps real
+// corporate LANs, so an address test would demote genuine addresses.
+const VIRTUAL_BRIDGE_INTERFACE_PATTERN =
+  /^(?:docker|br-|virbr|vmnet|vboxnet|veth|lxcbr|cni|flannel|cali|bridge)|^vEthernet |VMware Network Adapter|VirtualBox Host-Only/i
+
+export function isVirtualBridgeInterface(name: string): boolean {
+  return VIRTUAL_BRIDGE_INTERFACE_PATTERN.test(name)
+}
+
+// Why: main mints the QR from this and the renderer's picker shows its result, so both sides must
+// agree — a divergence would display one address while the QR advertises another. Bridges stay
+// pickable for an explicit choice but are never chosen here; `undefined` means "advertise no direct
+// address", which Relay tolerates (it carries its own invite) and the LAN-only path refuses.
+export function selectAutoAdvertisedPairingAddress(
+  interfaces: readonly PairingNetworkInterface[]
+): string | undefined {
+  const advertisable = interfaces.filter((iface) => !isVirtualBridgeInterface(iface.name))
+  return (
+    advertisable.find((iface) => isTailnetIPv4Address(iface.address))?.address ??
+    advertisable[0]?.address
+  )
+}


### PR DESCRIPTION
## Summary

Virtual container/VM bridges (`docker0`, `vEthernet (WSL)`, `vmnet*`, etc.) enumerate as ordinary non-internal IPv4, so automatic pairing could advertise an address a phone can never reach. That made the direct path lose the pairing race and forced sessions onto Relay even when a real LAN/tailnet address existed.

This change:

- Centralizes auto-selection in `selectAutoAdvertisedPairingAddress` (shared by main and the settings picker) so the QR and UI never disagree.
- Skips virtual bridges for the **automatic** default only; they remain explicitly pickable for cases like a VM guest pairing with the host.
- On bridge-only (or no-interface) hosts: **Relay** still pairs with no direct address; **LAN-only** and **runtime** pairing fail closed instead of advertising a dead endpoint.

## Test plan

- [x] Unit coverage for bridge-only auto path, LAN-only refusal, explicit bridge pick, runtime unavailability, and renderer default selection
- [ ] Pairing QR on a machine with both LAN and docker0 advertises LAN (or tailnet), not the bridge
- [ ] Bridge-only host + automatic/Relay: QR available without a local address
- [ ] Bridge-only host + LAN-only: pairing unavailable with guidance toward the picker
- [ ] Explicitly selecting a bridge in the address picker still embeds that address in the QR
