### PR TITLE
fix(terminal): wait for shell-ready before every SSH startup command

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -6365,7 +6365,7 @@ describe('connectPanePty', () => {
     expect(transport.sendInput).not.toHaveBeenCalled()
   })
 
-  it('sends fast startup commands via sendInput for SSH connections', async () => {
+  it('waits for shell-ready before unhinted SSH startup commands', async () => {
     // Capture the setTimeout callback directly so we can fire it without vi.useFakeTimers() (which would also replace beforeEach's rAF mock).
     const pendingTimeouts: (() => void)[] = []
     const originalSetTimeout = globalThis.setTimeout
@@ -6389,7 +6389,7 @@ describe('connectPanePty', () => {
       )
       transportFactoryQueue.push(transport)
 
-      // SSH connection: connectionId set; relay gets command metadata for spawn context but the renderer owns fast command delivery.
+      // SSH connection: the relay gets command metadata while the renderer owns delivery.
       mockStoreState = {
         ...mockStoreState,
         tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: null }] },
@@ -6405,14 +6405,17 @@ describe('connectPanePty', () => {
       connectPanePty(pane as never, manager as never, deps as never)
       expect(capturedDataCallback.current).not.toBeNull()
 
-      // Simulate shell prompt arriving — queues the debounce timer
       capturedDataCallback.current?.('user@remote $ ')
+      expect(transport.sendInput).not.toHaveBeenCalled()
 
-      // Fire all queued setTimeout callbacks (the debounce)
-      for (const fn of pendingTimeouts) {
+      capturedDataCallback.current?.('\x1b]777;orca-shell-ready\x07user@remote $ ')
+      for (const fn of pendingTimeouts.splice(0)) {
         fn()
       }
 
+      expect(createdTransportOptions[0]).toEqual(
+        expect.objectContaining({ startupCommandDelivery: 'shell-ready' })
+      )
       expect(transport.sendInput).toHaveBeenCalledWith("claude 'say test'\r")
     } finally {
       globalThis.setTimeout = originalSetTimeout
@@ -8209,7 +8212,10 @@ describe('connectPanePty', () => {
       connectPanePty(pane as never, manager as never, deps as never)
       await flushAsyncTicks(20)
       capturedDataCallback.current?.('user@remote $ ')
-      for (const fn of pendingTimeouts) {
+      expect(transport.sendInput).not.toHaveBeenCalled()
+
+      capturedDataCallback.current?.('\x1b]777;orca-shell-ready\x07user@remote $ ')
+      for (const fn of pendingTimeouts.splice(0)) {
         fn()
       }
 
@@ -8218,6 +8224,7 @@ describe('connectPanePty', () => {
         2,
         expect.objectContaining({
           command: "codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'",
+          startupCommandDelivery: 'shell-ready',
           env: expect.objectContaining({
             ORCA_PANE_KEY: paneKey,
             ORCA_TAB_ID: 'tab-1',

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3770,7 +3770,9 @@ export function connectPanePty(
     command: shouldDeliverStartupViaTerminalPaste ? undefined : paneStartup?.command,
     startupCommandDelivery: shouldDeliverStartupViaTerminalPaste
       ? undefined
-      : paneStartup?.startupCommandDelivery,
+      : connectionId && paneStartup?.command
+        ? 'shell-ready'
+        : paneStartup?.startupCommandDelivery,
     connectionId,
     executionHostId,
     worktreeId: deps.worktreeId,
@@ -4750,18 +4752,27 @@ export function connectPanePty(
           ? { command: paneStartup.command }
           : null
         : null
-    // Why every startup command and not a per-agent list: a shell that has not reached its
-    // prompt drops whatever is written to it, whichever agent the command names. The relay
-    // already gates its own delivery on the marker it armed; this mirrors that for the
-    // renderer-delivered path, bounded by the existing fallback timer.
+    // Why: every renderer-delivered SSH command needs the relay's readiness marker;
+    // the existing fallback preserves shells that cannot emit it.
     const shouldWaitForSshShellReady =
       Boolean(connectionId) &&
       Boolean(pendingStartupCommand) &&
       !shouldDeliverStartupViaTerminalPaste
-    const sshShellReadyMarkerScan = shouldWaitForSshShellReady
+    let sshShellReadyMarkerScan = shouldWaitForSshShellReady
       ? createShellReadyMarkerScanState()
       : null
     let sshStartupShellReady = !shouldWaitForSshShellReady
+    const armSshStartupShellReady = (): void => {
+      if (!connectionId || !pendingStartupCommand || shouldDeliverStartupViaTerminalPaste) {
+        return
+      }
+      if (sshShellReadyFallbackTimer !== null) {
+        clearTimeout(sshShellReadyFallbackTimer)
+        sshShellReadyFallbackTimer = null
+      }
+      sshShellReadyMarkerScan = createShellReadyMarkerScanState()
+      sshStartupShellReady = false
+    }
     const markSshStartupShellReady = (): void => {
       if (sshStartupShellReady) {
         return
@@ -5076,7 +5087,8 @@ export function connectPanePty(
       return transport.sendInput('\r')
     }
     const schedulePendingStartupCommandDelivery = (): void => {
-      if (!pendingStartupCommand) {
+      const startup = pendingStartupCommand
+      if (!startup) {
         return
       }
       if (!sshStartupShellReady) {
@@ -5097,8 +5109,7 @@ export function connectPanePty(
       startupInjectTimer = setTimeout(() => {
         startupInjectTimer = null
         void (async () => {
-          const startup = pendingStartupCommand
-          if (!startup || disposed) {
+          if (pendingStartupCommand !== startup || disposed) {
             return
           }
           if (shouldDeliverStartupViaTerminalPaste) {
@@ -5197,6 +5208,7 @@ export function connectPanePty(
         // must still submit the resume command to the fresh remote shell.
         pendingStartupCommand = { command: startupOverride.command }
       }
+      armSshStartupShellReady()
       const coldRestoreOverride =
         startupOverride && 'launchConfig' in startupOverride
           ? (startupOverride as ColdRestoreAgentResumeStartup)
@@ -5219,6 +5231,9 @@ export function connectPanePty(
         cols,
         rows,
         ...(startupOverride?.command ? { command: startupOverride.command } : {}),
+        ...(connectionId && startupOverride?.command
+          ? { startupCommandDelivery: 'shell-ready' as const }
+          : {}),
         ...(startupOverride?.env
           ? { env: mergeStartupEnvWithPaneIdentity(startupOverride.env) }
           : {}),

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -4766,6 +4766,10 @@ export function connectPanePty(
       if (!connectionId || !pendingStartupCommand || shouldDeliverStartupViaTerminalPaste) {
         return
       }
+      if (startupInjectTimer !== null) {
+        clearTimeout(startupInjectTimer)
+        startupInjectTimer = null
+      }
       if (sshShellReadyFallbackTimer !== null) {
         clearTimeout(sshShellReadyFallbackTimer)
         sshShellReadyFallbackTimer = null

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -128,8 +128,6 @@ import {
 } from '../../../../shared/terminal-mode-reset-profiles'
 import { buildFreshShellViewportBlankingSequence } from './terminal-restored-viewport'
 import { createShellReadyMarkerScanState, scanForShellReadyMarker } from './shell-ready-marker-scan'
-import { shouldUseShellReadyStartupDelivery } from '../../../../shared/codex-startup-delivery'
-import { resolveSetupAgentSequenceLaunchCommand } from '../../../../shared/setup-agent-sequencing'
 import { getSystemPrefersDark } from '@/lib/terminal-theme'
 import {
   INITIAL_MODE_2031_REPLY_SCAN_STATE,
@@ -4752,16 +4750,13 @@ export function connectPanePty(
           ? { command: paneStartup.command }
           : null
         : null
-    const startupShellReadyCommandHint = resolveSetupAgentSequenceLaunchCommand(
-      paneStartup?.env ?? {},
-      paneStartup?.command
-    )
+    // Why every startup command and not a per-agent list: a shell that has not reached its
+    // prompt drops whatever is written to it, whichever agent the command names. The relay
+    // already gates its own delivery on the marker it armed; this mirrors that for the
+    // renderer-delivered path, bounded by the existing fallback timer.
     const shouldWaitForSshShellReady =
       Boolean(connectionId) &&
-      shouldUseShellReadyStartupDelivery({
-        command: startupShellReadyCommandHint,
-        startupCommandDelivery: paneStartup?.startupCommandDelivery
-      }) &&
+      Boolean(pendingStartupCommand) &&
       !shouldDeliverStartupViaTerminalPaste
     const sshShellReadyMarkerScan = shouldWaitForSshShellReady
       ? createShellReadyMarkerScanState()


### PR DESCRIPTION
## Summary

Split out of #12840 (STA-3417). **This change does not fix STA-3417** and #12840 does not depend on it — the two are scoped differently and their file sets are disjoint, so either can merge first.

Renderer-delivered SSH launches wrote the startup command after a flat 50 ms, so a remote shell that had not yet reached its prompt could drop it. Only Codex plans opted into waiting for the remote shell-ready marker.

The gate now keys on whether a startup command exists at all, rather than on which agent the command happens to name:

```ts
const shouldWaitForSshShellReady =
  Boolean(connectionId) &&
  Boolean(pendingStartupCommand) &&
  !shouldDeliverStartupViaTerminalPaste
```

An unready shell drops whatever is written to it regardless of which binary the command invokes, so agent identity was the wrong axis. The relay already gates its own delivery on the marker it armed (`pty-handler.ts` — `waitForShellReady: shellLaunch.env.ORCA_SHELL_READY_MARKER === '1'`); this mirrors that decision for the renderer-delivered path instead of duplicating it with a hand-maintained list.

An earlier revision of this PR added a `startupCommandDelivery: 'shell-ready'` allowlist of four agents. That has been removed — it covered 4 of ~30 agents (omitting `claude`, which carries both an argv prompt and `--prefill`), had to be extended by hand for every new agent with no type or test to catch an omission, and did nothing on the local or daemon paths, which already wrap every non-Codex command unconditionally. Deleting it takes `codex-startup-delivery.ts` and `tui-agent-startup.ts` back to their `main` state.

Net effect: **5 insertions, 10 deletions, one file.**

Behaviour notes:

- Bare Codex now also waits on the SSH path. On a bash/zsh remote the marker arrives promptly, so there is no measurable cost; the deliberate markerless fast path it keeps locally is unaffected.
- Worst case is bounded by the existing `SSH_SHELL_READY_STARTUP_FALLBACK_MS` (1.5 s) — strictly safer than today's 50 ms blind send.
- Fish remotes are unchanged: the relay wraps only bash and zsh, so no marker is armed and delivery falls through the same fallback timer. That gap is tracked separately.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — oxlint + oxfmt clean on the changed file
- [x] `pnpm typecheck` — all three projects (node, cli, web) clean against current `main`
- [x] `pnpm test` — `pty-connection`, `codex-session-restart`, `codex-startup-delivery`: 591 passed
- [ ] `pnpm build` — not run locally; no dependency, bundler, or asset changes
- [x] Added or updated high-quality tests that would catch regressions

On that last box, in the interest of being straight about it: this revision **removes** tests rather than adding them, because it removes the machinery they covered. The behaviour it changes is a timing decision on the SSH transport, which the existing `pty-connection` suite exercises but does not assert an SSH-specific wait for.

**Not covered: no QA against a live SSH remote.** That is the only transport this change affects, so a bash/zsh remote launch should be exercised before merge.

## AI Review Report

- **Cross-platform (macOS/Linux/Windows):** the change is a single boolean in renderer transport setup, with no platform branch, no path handling, no shortcut or accelerator changes, and no Electron-surface differences. The gate is already behind `Boolean(connectionId)`, so only SSH-connected panes are affected on any platform.
- **Remote wire compatibility:** no wire change. `startupCommandDelivery` is a pre-existing optional field that remains in the schema and is still honoured by the relay and by the local/daemon Codex fast paths; this PR simply stops consulting it for the renderer's SSH wait. Old and new relays are unaffected because nothing new is sent.
- **SSH:** the affected path. Behaviour moves from "write after 50 ms" to "write on the marker, or after 1.5 s" — a strict superset of the previous safety, with the fallback already in place and unchanged.
- **Regression risk:** the local and daemon paths are untouched (both already call `getShellReadyLaunchConfig` for every non-Codex command). Codex's markerless local fast path is unchanged. Two imports became unused and were removed; `shouldUseShellReadyStartupDelivery` itself is retained and still used by the relay, the local provider, and background launches.
- **Folder workspaces / worktrees:** unaffected — this is transport-level delivery timing.

## Security Audit

- **Command execution:** no change to command construction, quoting, or content. This only delays an already-authorized write.
- **Input handling:** no new parsing of untrusted data; the marker scanner is reused unchanged.
- **Secrets / auth / IPC / paths:** none added or altered. No new dependencies.
- No follow-up security work needed.

## Notes

- Originated in STA-3417 but does not close it; #12840 does. May warrant its own Linear ticket.
- Follow-up: the relay has no fish wrapper, so remote marker support for fish remains open.
