### PR TITLE
feat(diff): HTML preview actions in View all combined diffs

### DIFF
--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -13,6 +13,8 @@ import { getVirtualizedScrollAnchorForOffset } from '@/hooks/virtualized-scroll-
 import { createProgrammaticScrollMarks } from '@/hooks/programmatic-scroll-marks'
 import { joinPath } from '@/lib/path'
 import { detectLanguage } from '@/lib/language-detect'
+import { openFilePreviewToSide } from '@/lib/file-preview'
+import { canOpenDiffSectionPreviewToSide } from './diff-section-preview'
 import { setWithLRU } from '@/lib/scroll-cache'
 import { getCombinedDiffSectionConnectionId } from './combined-diff-section-connection'
 import { findWorktreeById } from '@/store/slices/worktree-helpers'
@@ -1284,6 +1286,29 @@ export default function CombinedDiffViewer({
     ]
   )
 
+  // Why: match single-file HTML diffs — preview the on-disk working tree file
+  // beside the combined view when the section is still present on disk.
+  const openSectionPreview = useCallback(
+    (section: DiffSection) => {
+      if (
+        !canOpenDiffSectionPreviewToSide({
+          path: section.path,
+          status: section.status,
+          isCommitSurface: isCommitMode
+        })
+      ) {
+        return
+      }
+      openFilePreviewToSide({
+        language: detectLanguage(section.path),
+        filePath: joinPath(file.filePath, section.path),
+        worktreeId: file.worktreeId,
+        sourceGroupId: activeGroupId ?? null
+      })
+    },
+    [activeGroupId, file.filePath, file.worktreeId, isCommitMode]
+  )
+
   const handleSectionSave = useCallback(
     async (index: number) => {
       const section = sections[index]
@@ -2023,6 +2048,15 @@ export default function CombinedDiffViewer({
                         openSection={openSection}
                         openSectionTitle={
                           isAllMode || isBranchMode || isCommitMode ? 'Open diff' : 'Open in editor'
+                        }
+                        onOpenPreview={
+                          canOpenDiffSectionPreviewToSide({
+                            path: section.path,
+                            status: section.status,
+                            isCommitSurface: isCommitMode
+                          })
+                            ? (previewSection) => openSectionPreview(previewSection)
+                            : undefined
                         }
                         setSectionHeights={setSectionHeights}
                         setSections={setSections}

--- a/src/renderer/src/components/editor/CombinedDiffViewer.tsx
+++ b/src/renderer/src/components/editor/CombinedDiffViewer.tsx
@@ -1299,14 +1299,24 @@ export default function CombinedDiffViewer({
       ) {
         return
       }
+      // Why: use this combined-diff tab's group, not worktree activeGroupId —
+      // in a multi-pane layout the active group may be a different split.
+      const state = useAppStore.getState()
+      const sourceGroupId =
+        (state.unifiedTabsByWorktree[file.worktreeId] ?? []).find(
+          (tab) =>
+            tab.entityId === file.id && (tab.contentType === 'diff' || tab.contentType === 'editor')
+        )?.groupId ??
+        activeGroupId ??
+        null
       openFilePreviewToSide({
         language: detectLanguage(section.path),
         filePath: joinPath(file.filePath, section.path),
         worktreeId: file.worktreeId,
-        sourceGroupId: activeGroupId ?? null
+        sourceGroupId
       })
     },
-    [activeGroupId, file.filePath, file.worktreeId, isCommitMode]
+    [activeGroupId, file.filePath, file.id, file.worktreeId, isCommitMode]
   )
 
   const handleSectionSave = useCallback(
@@ -2055,7 +2065,7 @@ export default function CombinedDiffViewer({
                             status: section.status,
                             isCommitSurface: isCommitMode
                           })
-                            ? (previewSection) => openSectionPreview(previewSection)
+                            ? openSectionPreview
                             : undefined
                         }
                         setSectionHeights={setSectionHeights}

--- a/src/renderer/src/components/editor/DiffSectionHeader.tsx
+++ b/src/renderer/src/components/editor/DiffSectionHeader.tsx
@@ -76,10 +76,14 @@ export function DiffSectionHeader({
         {onOpenPreview != null && (
           <button
             type="button"
-            // Why: always visible (unlike other hover-reveal section actions) so
-            // HTML preview matches the single-file editor header affordance.
+            // Why: always visible (not hover-reveal) so HTML preview matches the
+            // single-file editor header and stays usable without hover (touch).
             className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
-            onClick={onOpenPreview}
+            onClick={(event) => {
+              // Why: header owns stopPropagation so callers cannot forget and toggle the section.
+              event.stopPropagation()
+              onOpenPreview(event)
+            }}
             title={translate(
               'auto.components.editor.EditorPanelHeader.fb8331694e',
               'Open Preview to the Side'
@@ -96,8 +100,12 @@ export function DiffSectionHeader({
           // Why: always visible so open-file matches Eye preview and works without hover (touch).
           type="button"
           className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
-          onClick={onOpenSection}
+          onClick={(event) => {
+            event.stopPropagation()
+            onOpenSection(event)
+          }}
           title={openSectionTitle}
+          aria-label={openSectionTitle}
         >
           <ExternalLink className="size-3.5" />
         </button>

--- a/src/renderer/src/components/editor/DiffSectionHeader.tsx
+++ b/src/renderer/src/components/editor/DiffSectionHeader.tsx
@@ -1,4 +1,4 @@
-import { ChevronDown, ChevronRight, ExternalLink } from 'lucide-react'
+import { ChevronDown, ChevronRight, ExternalLink, Eye } from 'lucide-react'
 import type { MouseEvent, ReactElement, ReactNode } from 'react'
 import { translate } from '@/i18n/i18n'
 
@@ -11,6 +11,7 @@ export function DiffSectionHeader({
   onToggle,
   onOpenSection,
   openSectionTitle,
+  onOpenPreview,
   trailingContent
 }: {
   path: string
@@ -21,6 +22,7 @@ export function DiffSectionHeader({
   onToggle: () => void
   onOpenSection: (event: MouseEvent) => void
   openSectionTitle: string
+  onOpenPreview?: (event: MouseEvent) => void
   trailingContent?: ReactNode
 }): ReactElement {
   return (
@@ -71,8 +73,29 @@ export function DiffSectionHeader({
       </span>
       <div className="flex items-center gap-1 shrink-0 ml-2">
         {trailingContent}
+        {onOpenPreview != null && (
+          <button
+            type="button"
+            // Why: always visible (unlike other hover-reveal section actions) so
+            // HTML preview matches the single-file editor header affordance.
+            className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
+            onClick={onOpenPreview}
+            title={translate(
+              'auto.components.editor.EditorPanelHeader.fb8331694e',
+              'Open Preview to the Side'
+            )}
+            aria-label={translate(
+              'auto.components.editor.EditorPanelHeader.fb8331694e',
+              'Open Preview to the Side'
+            )}
+          >
+            <Eye className="size-3.5" />
+          </button>
+        )}
         <button
-          className="p-0.5 rounded text-muted-foreground hover:text-foreground can-hover:opacity-0 group-hover:opacity-100 transition-opacity"
+          // Why: always visible so open-file matches Eye preview and works without hover (touch).
+          type="button"
+          className="p-0.5 rounded text-muted-foreground hover:text-foreground transition-colors"
           onClick={onOpenSection}
           title={openSectionTitle}
         >

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -346,8 +346,7 @@ export function DiffSectionItem({
         openSectionTitle={openSectionTitle}
         onOpenPreview={
           onOpenPreview
-            ? (event) => {
-                event.stopPropagation()
+            ? () => {
                 onOpenPreview(section, index)
               }
             : undefined

--- a/src/renderer/src/components/editor/DiffSectionItem.tsx
+++ b/src/renderer/src/components/editor/DiffSectionItem.tsx
@@ -1,12 +1,4 @@
-import {
-  useCallback,
-  useEffect,
-  useMemo,
-  useRef,
-  useState,
-  type MutableRefObject,
-  type ReactNode
-} from 'react'
+import { useEffect, useMemo, useRef, useState } from 'react'
 import type { DiffOnMount } from '@monaco-editor/react'
 import type { editor as monacoEditor } from 'monaco-editor'
 import { monaco } from '@/lib/monaco-setup'
@@ -14,26 +6,23 @@ import { detectLanguage } from '@/lib/language-detect'
 import { useAppStore } from '@/store'
 import { computeDiffEditorFontSize, resolveEditorFontFamily } from '@/lib/editor-font-zoom'
 import { selectWorktreeDiffComments } from '@/store/worktree-diff-comments-selector'
-import {
-  useDiffCommentDecorator,
-  type DecoratedDiffComment
-} from '../diff-comments/useDiffCommentDecorator'
+import { useDiffCommentDecorator } from '../diff-comments/useDiffCommentDecorator'
 import {
   getDiffCommentPopoverLeft,
   getDiffCommentPopoverTop
 } from '../diff-comments/diff-comment-popover-position'
 import { applyDiffEditorLineNumberOptions } from './diff-editor-line-number-options'
 import { DiffSectionHeader } from './DiffSectionHeader'
-import type { DiffSection } from './diff-section-types'
 import type { DiffComment } from '../../../../shared/types'
 import { isDiffComment } from '@/lib/diff-comment-compat'
 import { installEditorSaveShortcut, installMonacoEditorFindShortcut } from './editor-shortcuts'
 import { DiffSectionBody } from './DiffSectionBody'
 import { useDiffSectionLayoutMetrics } from './useDiffSectionLayoutMetrics'
-import { disposeUnattachedMonacoModelPaths } from './diff-monaco-model-disposal'
 import { getLiveDiffSectionRenderLimit } from './diff-section-live-render-limit'
 import { useDiffSectionFallbackCleanup } from './useDiffSectionFallbackCleanup'
 import { submitDiffSectionComment } from './diff-section-comment-submit'
+import type { DiffSectionItemProps } from './diff-section-item-props'
+import { useDiffSectionModelLifecycle } from './use-diff-section-model-lifecycle'
 
 export function DiffSectionItem({
   section,
@@ -49,6 +38,7 @@ export function DiffSectionItem({
   toggleSection,
   openSection,
   openSectionTitle,
+  onOpenPreview,
   renderHeaderTrailingContent,
   onAddLineComment,
   addLineCommentLabel,
@@ -59,42 +49,7 @@ export function DiffSectionItem({
   setSections,
   modifiedEditorsRef,
   handleSectionSaveRef
-}: {
-  section: DiffSection
-  index: number
-  isBranchMode: boolean
-  sideBySide: boolean
-  isDark: boolean
-  settings: {
-    terminalFontSize?: number
-    terminalFontFamily?: string
-    diffWordWrap?: boolean
-  } | null
-  sectionHeight: number | undefined
-  worktreeId?: string
-  loadSection: (index: number) => void
-  retrySection: (index: number) => void
-  toggleSection: (index: number) => void
-  openSection: (index: number) => void
-  openSectionTitle: string
-  renderHeaderTrailingContent?: (section: DiffSection, index: number) => ReactNode
-  onAddLineComment?: (
-    section: DiffSection,
-    args: {
-      lineNumber: number
-      startLine?: number
-      body: string
-    }
-  ) => Promise<boolean>
-  addLineCommentLabel?: string
-  addLineCommentPlaceholder?: string
-  inlineComments?: readonly DecoratedDiffComment[]
-  getCommentableLineNumbers?: (section: DiffSection) => readonly number[] | undefined
-  setSectionHeights: React.Dispatch<React.SetStateAction<Record<number, number>>>
-  setSections: React.Dispatch<React.SetStateAction<DiffSection[]>>
-  modifiedEditorsRef: MutableRefObject<Map<number, monacoEditor.IStandaloneCodeEditor>>
-  handleSectionSaveRef: MutableRefObject<(index: number) => Promise<void>>
-}): React.JSX.Element {
+}: DiffSectionItemProps): React.JSX.Element {
   const editorFontZoomLevel = useAppStore((s) => s.editorFontZoomLevel)
   const addDiffComment = useAppStore((s) => s.addDiffComment)
   const deleteDiffComment = useAppStore((s) => s.deleteDiffComment)
@@ -137,31 +92,10 @@ export function DiffSectionItem({
   } | null>(null)
   const hasLineCommentAction = Boolean(worktreeId || onAddLineComment)
 
-  const disposeDiffModels = useCallback(() => {
-    window.setTimeout(() => {
-      disposeUnattachedMonacoModelPaths(monaco, [
-        `${modelPathBase}:original`,
-        `${modelPathBase}:modified`
-      ])
-    }, 0)
-  }, [modelPathBase])
-  const disposeDiffModelsRef = useRef(disposeDiffModels)
-  disposeDiffModelsRef.current = disposeDiffModels
-
-  const setSectionRootNode = useCallback((node: HTMLDivElement | null): void => {
-    if (node) {
-      return
-    }
-    // Why: virtualized diff rows remount as their keyed section/collapse state
-    // changes; the row root is the owner of the detached Monaco models.
-    disposeDiffModelsRef.current()
-  }, [])
-
-  useEffect(() => {
-    if (section.collapsed) {
-      disposeDiffModels()
-    }
-  }, [disposeDiffModels, section.collapsed])
+  const { disposeDiffModels, setSectionRootNode } = useDiffSectionModelLifecycle({
+    modelPathBase,
+    collapsed: section.collapsed
+  })
 
   // Why: only forward the pending scroll id when it matches a comment in this
   // section so unrelated sections don't keep re-rendering their decorator
@@ -410,6 +344,14 @@ export function DiffSectionItem({
           openSection(index)
         }}
         openSectionTitle={openSectionTitle}
+        onOpenPreview={
+          onOpenPreview
+            ? (event) => {
+                event.stopPropagation()
+                onOpenPreview(section, index)
+              }
+            : undefined
+        }
         trailingContent={renderHeaderTrailingContent?.(section, index)}
       />
 
@@ -435,9 +377,7 @@ export function DiffSectionItem({
           onCancelComment={() => setPopover(null)}
           onSubmitComment={handleSubmitComment}
           onRetrySection={retrySection}
-          onSaveLimitedDiff={() => {
-            void handleSectionSaveRef.current(index)
-          }}
+          onSaveLimitedDiff={() => void handleSectionSaveRef.current(index)}
           onMount={handleMount}
         />
       )}

--- a/src/renderer/src/components/editor/diff-section-item-props.ts
+++ b/src/renderer/src/components/editor/diff-section-item-props.ts
@@ -1,0 +1,38 @@
+import type { Dispatch, MutableRefObject, ReactNode, SetStateAction } from 'react'
+import type { editor as monacoEditor } from 'monaco-editor'
+import type { DecoratedDiffComment } from '../diff-comments/useDiffCommentDecorator'
+import type { DiffSection } from './diff-section-types'
+
+export type DiffSectionItemProps = {
+  section: DiffSection
+  index: number
+  isBranchMode: boolean
+  sideBySide: boolean
+  isDark: boolean
+  settings: {
+    terminalFontSize?: number
+    terminalFontFamily?: string
+    diffWordWrap?: boolean
+  } | null
+  sectionHeight: number | undefined
+  worktreeId?: string
+  loadSection: (index: number) => void
+  retrySection: (index: number) => void
+  toggleSection: (index: number) => void
+  openSection: (index: number) => void
+  openSectionTitle: string
+  onOpenPreview?: (section: DiffSection, index: number) => void
+  renderHeaderTrailingContent?: (section: DiffSection, index: number) => ReactNode
+  onAddLineComment?: (
+    section: DiffSection,
+    args: { lineNumber: number; startLine?: number; body: string }
+  ) => Promise<boolean>
+  addLineCommentLabel?: string
+  addLineCommentPlaceholder?: string
+  inlineComments?: readonly DecoratedDiffComment[]
+  getCommentableLineNumbers?: (section: DiffSection) => readonly number[] | undefined
+  setSectionHeights: Dispatch<SetStateAction<Record<number, number>>>
+  setSections: Dispatch<SetStateAction<DiffSection[]>>
+  modifiedEditorsRef: MutableRefObject<Map<number, monacoEditor.IStandaloneCodeEditor>>
+  handleSectionSaveRef: MutableRefObject<(index: number) => Promise<void>>
+}

--- a/src/renderer/src/components/editor/diff-section-preview.test.ts
+++ b/src/renderer/src/components/editor/diff-section-preview.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { canOpenDiffSectionPreviewToSide } from './diff-section-preview'
+
+describe('canOpenDiffSectionPreviewToSide', () => {
+  it('enables HTML working-tree sections that still exist on disk', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'docs/demo.html',
+        status: 'modified',
+        isCommitSurface: false
+      })
+    ).toBe(true)
+  })
+
+  it('enables .htm paths', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'index.htm',
+        status: 'added',
+        isCommitSurface: false
+      })
+    ).toBe(true)
+  })
+
+  it('disables deleted HTML files', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'gone.html',
+        status: 'deleted',
+        isCommitSurface: false
+      })
+    ).toBe(false)
+  })
+
+  it('disables commit surfaces whose content may not match disk', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'docs/demo.html',
+        status: 'modified',
+        isCommitSurface: true
+      })
+    ).toBe(false)
+  })
+
+  it('disables non-previewable languages', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'src/app.ts',
+        status: 'modified',
+        isCommitSurface: false
+      })
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/editor/diff-section-preview.test.ts
+++ b/src/renderer/src/components/editor/diff-section-preview.test.ts
@@ -22,6 +22,33 @@ describe('canOpenDiffSectionPreviewToSide', () => {
     ).toBe(true)
   })
 
+  it('enables untracked and renamed HTML files still present on disk', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'scratch.html',
+        status: 'untracked',
+        isCommitSurface: false
+      })
+    ).toBe(true)
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'renamed.html',
+        status: 'renamed',
+        isCommitSurface: false
+      })
+    ).toBe(true)
+  })
+
+  it('enables uppercase HTML extensions', () => {
+    expect(
+      canOpenDiffSectionPreviewToSide({
+        path: 'Docs/DEMO.HTML',
+        status: 'modified',
+        isCommitSurface: false
+      })
+    ).toBe(true)
+  })
+
   it('disables deleted HTML files', () => {
     expect(
       canOpenDiffSectionPreviewToSide({

--- a/src/renderer/src/components/editor/diff-section-preview.ts
+++ b/src/renderer/src/components/editor/diff-section-preview.ts
@@ -1,0 +1,19 @@
+import { detectLanguage } from '@/lib/language-detect'
+import { canPreviewLanguage } from '@/lib/file-preview'
+
+// Why: HTML preview renders the on-disk working-tree file, so combined-diff
+// sections only get the affordance when that file still exists and the surface
+// is not a historical commit snapshot whose content may not match disk.
+export function canOpenDiffSectionPreviewToSide(params: {
+  path: string
+  status: string
+  isCommitSurface: boolean
+}): boolean {
+  if (params.isCommitSurface) {
+    return false
+  }
+  if (params.status === 'deleted') {
+    return false
+  }
+  return canPreviewLanguage(detectLanguage(params.path))
+}

--- a/src/renderer/src/components/editor/use-diff-section-model-lifecycle.ts
+++ b/src/renderer/src/components/editor/use-diff-section-model-lifecycle.ts
@@ -20,7 +20,10 @@ export function useDiffSectionModelLifecycle(params: {
     }, 0)
   }, [params.modelPathBase])
   const disposeDiffModelsRef = useRef(disposeDiffModels)
-  disposeDiffModelsRef.current = disposeDiffModels
+  // Keep callback-ref dispose path on the latest disposer without render-time mutation.
+  useEffect(() => {
+    disposeDiffModelsRef.current = disposeDiffModels
+  }, [disposeDiffModels])
 
   const setSectionRootNode = useCallback((node: HTMLDivElement | null): void => {
     if (node) {

--- a/src/renderer/src/components/editor/use-diff-section-model-lifecycle.ts
+++ b/src/renderer/src/components/editor/use-diff-section-model-lifecycle.ts
@@ -1,0 +1,39 @@
+import { useCallback, useEffect, useRef } from 'react'
+import { monaco } from '@/lib/monaco-setup'
+import { disposeUnattachedMonacoModelPaths } from './diff-monaco-model-disposal'
+
+// Why: virtualized section rows own Monaco model paths for their lifetime;
+// dispose on unmount/collapse so remounts do not leak detached models.
+export function useDiffSectionModelLifecycle(params: {
+  modelPathBase: string
+  collapsed: boolean
+}): {
+  disposeDiffModels: () => void
+  setSectionRootNode: (node: HTMLDivElement | null) => void
+} {
+  const disposeDiffModels = useCallback(() => {
+    window.setTimeout(() => {
+      disposeUnattachedMonacoModelPaths(monaco, [
+        `${params.modelPathBase}:original`,
+        `${params.modelPathBase}:modified`
+      ])
+    }, 0)
+  }, [params.modelPathBase])
+  const disposeDiffModelsRef = useRef(disposeDiffModels)
+  disposeDiffModelsRef.current = disposeDiffModels
+
+  const setSectionRootNode = useCallback((node: HTMLDivElement | null): void => {
+    if (node) {
+      return
+    }
+    disposeDiffModelsRef.current()
+  }, [])
+
+  useEffect(() => {
+    if (params.collapsed) {
+      disposeDiffModels()
+    }
+  }, [disposeDiffModels, params.collapsed])
+
+  return { disposeDiffModels, setSectionRootNode }
+}


### PR DESCRIPTION
## Summary

- Show **Open Preview to the Side** (Eye) on HTML sections in **View all** / combined diffs when the working-tree file still exists (not deleted, not commit-only surfaces).
- Keep the **open-file external-link** icon always visible (no hover-only reveal), matching single-file diff affordances.
- Extract DiffSectionItem props + Monaco model lifecycle helpers so the section file stays under the max-lines limit.

## Test plan

- [x] Open Source Control → View all with an unstaged HTML change
- [x] Confirm Eye + external-link are visible without hovering the section header
- [x] Click Eye → HTML opens in a side browser split with working-tree content
- [x] Unit tests for `canOpenDiffSectionPreviewToSide`
- [ ] Smoke non-HTML combined sections (no Eye), deleted HTML (no Eye), commit combined surface (no Eye)

## Visual proof

(Screenshot attached in follow-up comment — not committed to the repo.)