### PR TITLE
fix(updater): start Squirrel.Mac staging for macOS serve downloads

### DIFF
--- a/src/main/updater.headless-serve-install.test.ts
+++ b/src/main/updater.headless-serve-install.test.ts
@@ -1,4 +1,4 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const {
   appMock,
@@ -242,7 +242,6 @@ describe('headless serve update install handoff', () => {
     downloadUpdate()
     downloadUpdate()
 
-    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false)
     expect(autoUpdaterMock.downloadUpdate).not.toHaveBeenCalled()
     expect(
       recordUpdaterLifecycleMock.mock.calls.filter(
@@ -306,7 +305,6 @@ describe('headless serve update install handoff', () => {
     quitAndInstall()
 
     expect(requestServeUpdateHandoffMock).toHaveBeenCalledWith('1.0.61')
-    expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false)
     expect(autoUpdaterMock.autoRunAppAfterInstall).toBe(false)
     expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledOnce()
     expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledWith(true, false)
@@ -519,5 +517,122 @@ describe('headless serve update install handoff', () => {
       reason: 'manual-service-update-required'
     })
     expect(() => checkForRemoteServerUpdate('runtime-1')).toThrow('remote_update_manual_required')
+  })
+})
+
+/**
+ * Squirrel.Mac staging is gated by `autoInstallOnAppQuit`, so these assert the
+ * macOS contract on every runner instead of `runIf(darwin)` — PR CI is Linux
+ * only, which is how the staging deadlock reached users unnoticed.
+ */
+describe('headless serve updates on macOS', () => {
+  const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'darwin' })
+    autoUpdaterMock.checkForUpdates.mockReset().mockImplementation(() => {
+      autoUpdaterMock.emit('checking-for-update')
+      queueMicrotask(() => autoUpdaterMock.emit('update-available', { version: '1.0.61' }))
+      return Promise.resolve(null)
+    })
+    autoUpdaterMock.downloadUpdate.mockReset().mockResolvedValue([])
+    autoUpdaterMock.quitAndInstall.mockReset()
+    autoUpdaterMock.setFeedURL.mockReset()
+    autoUpdaterMock.on.mockClear()
+    autoUpdaterMock.autoInstallOnAppQuit = false
+    autoUpdaterMock.autoRunAppAfterInstall = true
+    nativeUpdaterMock.on.mockReset()
+    appMock.on.mockClear()
+    appMock.quit.mockReset()
+    killAllPtyMock.mockReset()
+    recordUpdaterLifecycleMock.mockReset()
+    requestServeUpdateHandoffMock.mockReset().mockReturnValue(true)
+    resetHandlers()
+  })
+
+  afterEach(() => {
+    Object.defineProperty(process, 'platform', originalPlatform)
+  })
+
+  /**
+   * Mirrors MacUpdater.doDownloadUpdate: electron-updater dispatches its own
+   * 'update-downloaded' as soon as the zip lands, but only asks Squirrel.Mac to
+   * stage it — the native 'update-downloaded' — when autoInstallOnAppQuit is set.
+   */
+  const completeMacDownload = (version: string): void => {
+    autoUpdaterMock.emit('update-downloaded', { version })
+    if (!autoUpdaterMock.autoInstallOnAppQuit) {
+      return
+    }
+    const nativeReady = nativeUpdaterMock.on.mock.calls.find(
+      ([event]) => event === 'update-downloaded'
+    )?.[1] as (() => void) | undefined
+    nativeReady?.()
+  }
+
+  const lastStatus = (send: ReturnType<typeof vi.fn>): Record<string, unknown> | undefined =>
+    send.mock.calls.findLast(([channel]) => channel === 'updater:status')?.[1]
+
+  it.each(['supervised-headless-serve', 'unsupported-headless-serve'] as const)(
+    'starts Squirrel.Mac staging in %s mode',
+    async (installMode) => {
+      const { setupAutoUpdater } = await import('./updater')
+
+      setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
+        getLastUpdateCheckAt: () => Date.now(),
+        installMode
+      })
+
+      expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true)
+      // The supervisor, not Squirrel, still owns the serve relaunch.
+      expect(autoUpdaterMock.autoRunAppAfterInstall).toBe(false)
+    }
+  )
+
+  it('settles a supervised serve download on downloaded instead of stalling at 100%', async () => {
+    const send = vi.fn()
+    const { checkForUpdatesFromMenu, downloadUpdate, setupAutoUpdater } = await import('./updater')
+    setupAutoUpdater({ webContents: { send } } as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      installMode: 'supervised-headless-serve'
+    })
+    checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+
+    downloadUpdate()
+    completeMacDownload('1.0.61')
+    await vi.advanceTimersByTimeAsync(0)
+
+    expect(autoUpdaterMock.downloadUpdate).toHaveBeenCalledOnce()
+    expect(recordUpdaterLifecycleMock).toHaveBeenCalledWith(
+      'macos_installer_ready',
+      expect.anything()
+    )
+    expect(lastStatus(send)).toEqual(
+      expect.objectContaining({ state: 'downloaded', version: '1.0.61' })
+    )
+  })
+
+  it('keeps the serve download reinstallable across a restart once staged', async () => {
+    const send = vi.fn()
+    const { checkForUpdatesFromMenu, downloadUpdate, quitAndInstall, setupAutoUpdater } =
+      await import('./updater')
+    setupAutoUpdater({ webContents: { send } } as never, {
+      getLastUpdateCheckAt: () => Date.now(),
+      installMode: 'supervised-headless-serve'
+    })
+    checkForUpdatesFromMenu()
+    await vi.advanceTimersByTimeAsync(0)
+    downloadUpdate()
+    completeMacDownload('1.0.61')
+    await vi.advanceTimersByTimeAsync(0)
+
+    quitAndInstall()
+    await vi.advanceTimersByTimeAsync(100)
+
+    expect(requestServeUpdateHandoffMock).toHaveBeenCalledWith('1.0.61')
+    expect(autoUpdaterMock.quitAndInstall).toHaveBeenCalledWith(true, false)
   })
 })

--- a/src/main/updater.test.ts
+++ b/src/main/updater.test.ts
@@ -3968,18 +3968,24 @@ describe('updater', () => {
     }
 
     it('disables install-on-quit for deb and rpm root packages', async () => {
-      for (const packageType of ['deb', 'rpm'] as const) {
-        vi.resetModules()
-        autoUpdaterMock.autoInstallOnAppQuit = true
-        getLinuxRootPackageTypeMock.mockReturnValue(packageType)
-        const { setupAutoUpdater } = await import('./updater')
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      try {
+        for (const packageType of ['deb', 'rpm'] as const) {
+          vi.resetModules()
+          autoUpdaterMock.autoInstallOnAppQuit = true
+          getLinuxRootPackageTypeMock.mockReturnValue(packageType)
+          const { setupAutoUpdater } = await import('./updater')
 
-        setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
-          getLastUpdateCheckAt: () => Date.now(),
-          installMode: 'interactive'
-        })
+          setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
+            getLastUpdateCheckAt: () => Date.now(),
+            installMode: 'interactive'
+          })
 
-        expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false)
+          expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false)
+        }
+      } finally {
+        Object.defineProperty(process, 'platform', originalPlatform)
       }
     })
 
@@ -3995,21 +4001,28 @@ describe('updater', () => {
       expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(true)
     })
 
-    it('leaves headless serve installs supervisor-controlled', async () => {
-      for (const installMode of [
-        'supervised-headless-serve',
-        'unsupported-headless-serve'
-      ] as const) {
-        vi.resetModules()
-        autoUpdaterMock.autoInstallOnAppQuit = true
-        const { setupAutoUpdater } = await import('./updater')
+    // Why: pinned off the host platform so the non-macOS contract is asserted on every CI runner.
+    it('leaves headless serve installs supervisor-controlled off macOS', async () => {
+      const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')!
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'linux' })
+      try {
+        for (const installMode of [
+          'supervised-headless-serve',
+          'unsupported-headless-serve'
+        ] as const) {
+          vi.resetModules()
+          autoUpdaterMock.autoInstallOnAppQuit = true
+          const { setupAutoUpdater } = await import('./updater')
 
-        setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
-          getLastUpdateCheckAt: () => Date.now(),
-          installMode
-        })
+          setupAutoUpdater({ webContents: { send: vi.fn() } } as never, {
+            getLastUpdateCheckAt: () => Date.now(),
+            installMode
+          })
 
-        expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false)
+          expect(autoUpdaterMock.autoInstallOnAppQuit).toBe(false)
+        }
+      } finally {
+        Object.defineProperty(process, 'platform', originalPlatform)
       }
     })
 

--- a/src/main/updater.ts
+++ b/src/main/updater.ts
@@ -2187,8 +2187,12 @@ export function setupAutoUpdater(
   }
   // Why: supervised serve installs require an explicit handoff; ordinary service quits must never install implicitly.
   // Root Linux packages also opt out: an implicit quit-time escalation would fail after the UI is gone, leaving no recovery surface.
+  // Why (darwin): MacUpdater extends AppUpdater, not BaseUpdater, so it never registers a quit handler and this flag cannot
+  // install on quit. Its only Squirrel.Mac effect is gating whether staging starts after download, so forcing it false in
+  // serve mode strands the update at 100% with no path to 'downloaded' — and no path to the install that would unstick it.
   autoUpdater.autoInstallOnAppQuit =
-    updateInstallMode === 'interactive' && getLinuxRootPackageType() === null
+    process.platform === 'darwin' ||
+    (updateInstallMode === 'interactive' && getLinuxRootPackageType() === null)
   // Why: MacUpdater ignores quitAndInstall arguments; the surviving CLI supervisor must be the only serve relaunch owner.
   autoUpdater.autoRunAppAfterInstall = updateInstallMode === 'interactive'
 


### PR DESCRIPTION
## Summary

On macOS, auto-update in any `--serve` mode downloads to 100% and then stops forever. No error, no "Restart to install". Restarting re-downloads the same ~200MB and stalls again. `~/Library/Caches/<bundle-id>.ShipIt/` is never touched, so ShipIt never runs.

The cause is a closed loop between Orca and `electron-updater`:

1. `resolveUpdateInstallMode()` never returns `interactive` for serve mode, so `autoInstallOnAppQuit` was forced `false`.
2. `MacUpdater.doDownloadUpdate()` only asks Squirrel.Mac to stage the download — `nativeUpdater.checkForUpdates()` — **when `autoInstallOnAppQuit` is set**. False means native Squirrel never even requests the localhost proxy.
3. Orca holds the UI at `downloading/100%` until Squirrel reports ready (`updater-events.ts`), so the status never becomes `downloaded`.
4. The install action only exists in the `downloaded` state, so `performQuitAndInstall()` is never called — and `MacUpdater.quitAndInstall()` is exactly where `electron-updater` compensates for a `false` flag by kicking off `checkForUpdates()` late.

Staging waits for an install the user can never trigger, because the install only appears once staging completes.

**The flag cannot install on quit on macOS at all.** `MacUpdater extends AppUpdater`, not `BaseUpdater`, and `addQuitHandler()`/`install()` live only on `BaseUpdater` — `MacUpdater` defines neither. electron-builder documents `autoInstallOnAppQuit` as Windows/Linux-only, yet `MacUpdater` reads it. So on macOS its only effect is gating staging.

This exempts darwin from the serve opt-out. Linux and Windows keep the existing expression unchanged, including the deb/rpm root-package opt-out. The original comment's intent — "ordinary service quits must never install implicitly" — is still enforced on macOS by `autoRunAppAfterInstall = false`, the `deferHeadlessServeInstall()` guard, and the serve handoff; none of those are touched.

```ts
autoUpdater.autoInstallOnAppQuit =
  process.platform === 'darwin' ||
  (updateInstallMode === 'interactive' && getLinuxRootPackageType() === null)
```

Only `supervised-headless-serve` actually reached the stall. `unsupported-headless-serve` blocks the download earlier in `deferHeadlessServeInstall('download', …)`, which is an intended guard, not a bug — so this only bit users who wired up the CLI supervisor correctly.

### Why CI missed it

PR unit tests run on `ubuntu-latest` only, so every `it.runIf(process.platform === 'darwin')` case is skipped in CI. The existing supervised-serve test also fired the native `update-downloaded` event by hand, simulating the staging that production never starts — so it passed against deadlocked code.

The new assertions stub `process.platform` instead of using `runIf`, so the macOS contract is verified on every runner. Two existing tests that read the host platform are now pinned to `linux` for the same reason.

## Screenshots

No visual change. The renderer already implements the `downloaded` state; it was simply unreachable in serve mode on macOS.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

All 4 new tests were confirmed to **fail against the unfixed code** and pass with the fix:

```
× starts Squirrel.Mac staging in supervised-headless-serve mode
× starts Squirrel.Mac staging in unsupported-headless-serve mode
× settles a supervised serve download on downloaded instead of stalling at 100%
× keeps the serve download reinstallable across a restart once staged
```

`settles a supervised serve download on downloaded instead of stalling at 100%` reproduces the reported symptom directly: its `completeMacDownload()` helper mirrors `MacUpdater.doDownloadUpdate()` by emitting the native ready event **only when `autoInstallOnAppQuit` is set**, then asserts the final status is `downloaded`.

`pnpm test`: 47190 passed, 5 pre-existing failures in `src/relay/agent-exec-handler.test.ts` and `config/scripts/check-root-directory-entries.test.mjs`. Both reproduce on a clean `origin/main` with these changes stashed and are unrelated (the root-directory guard one is macOS-local and already addressed by #12879).

Also verified the new tests still run and pass with `process.platform` stubbed to `linux` at module load, simulating a Linux CI host — 10 passed, 3 skipped (the pre-existing `runIf(darwin)` cases).

## AI Review Report

- **Cross-platform**: The only behavioral delta is on darwin. On Linux and Windows `process.platform === 'darwin'` short-circuits to `false` and the original expression is evaluated unchanged, so the deb/rpm root-package opt-out and the serve opt-out both survive — covered by a test pinned to `linux`. On darwin, `interactive` was already `true` (the Linux root-package term is inert there), so only serve modes change. No shortcuts, labels, or path handling involved.
- **SSH/remote/local**: `getRemoteServerUpdateSupport()` and `checkForRemoteServerUpdate()` are untouched — `unsupported-headless-serve` still reports `manual-service-update-required` and still throws `remote_update_manual_required`, so paired clients see identical policy. The change affects only whether the host stages its own download locally.
- **Agents / integrations / git providers**: No agent, integration, or provider surface touched.
- **Performance**: Squirrel.Mac now performs the staging work it was always meant to on macOS serve hosts. Net cost is lower, not higher — the previous behavior re-downloaded ~200MB on every restart and discarded it. No hot path affected.
- **UI**: No new UI. `autoRunAppAfterInstall` is deliberately left alone so the CLI supervisor remains the only serve relaunch owner.
- **Verification method**: Claims about `MacUpdater` were checked against the vendored `node_modules/electron-updater@6.8.9` source (`doDownloadUpdate`, `quitAndInstall`, `handleUpdateDownloaded`, the `class MacUpdater extends AppUpdater` declaration, and the absence of `addQuitHandler`/`install`), not from memory.

## Security Audit

- No change to input handling, command execution, path construction, IPC, auth, secrets, or dependencies. One boolean gains a platform term.
- `verifyUpdateCodeSignature` is untouched; the in-file warning against overriding it still stands.
- Feed URL, provider, download path, and the sha512 check on the downloaded artifact are unchanged.
- Enabling staging **adds** a verification step relative to the broken state: the artifact now passes through Squirrel.Mac's own code-signature validation before any bundle swap, where previously nothing was staged at all.
- `autoDownload` remains `false`, so nothing stages without an explicit `downloadUpdate()`. For `unsupported-headless-serve` the download is still refused before it starts, so the flag has no reachable effect there.
- The resulting macOS serve behavior is the same staging path already shipping for `interactive` macOS users.

## Notes

**macOS-specific.** Linux and Windows are unaffected by design.

**Known follow-up, deliberately out of scope.** This fixes the staging deadlock so serve-mode updates reach `downloaded` and become installable. The step *after* `quitAndInstall()` is a separate question worth its own change: with `autoRunAppAfterInstall = false`, `MacUpdater.handleUpdateDownloaded()` calls `app.quit()` rather than `nativeUpdater.quitAndInstall()`. Electron documents a staged update as applied on next start, but that timing interacts with `waitForMacBundleVersion()` in `serve-update-supervisor.ts`, which waits for the bundle version to change *before* respawning. electron-builder documents `autoRunAppAfterInstall` as not applicable on macOS, so the relaunch-ownership design there deserves a look. I did not touch it, because choosing between "let Squirrel relaunch and risk a duplicate GUI instance alongside the supervisor's serve child" and the current behavior needs a real end-to-end release cycle on a macOS serve host to settle, which I could not run here. Flagging rather than guessing.

Adjacent open PRs, no functional overlap: #9094 touches `updater.ts` and the same two test files (racing app instances killing macOS installs) and may need a trivial merge; #12818 touches serve-mode argv detection.

X: I don't have one to share — happy to be credited as @YulHeon on GitHub.
