### PR TITLE
fix(skills): preserve WSL discovery command as one bash argument

### DIFF
--- a/src/main/skills/skill-discovery-wsl-plugins.test.ts
+++ b/src/main/skills/skill-discovery-wsl-plugins.test.ts
@@ -63,8 +63,20 @@ describe('WSL Claude plugin skill discovery', () => {
     const result = await discoverSkillsInWsl({ distro: 'Ubuntu', homeDir, cwd })
 
     expect(execFileMock).toHaveBeenCalledTimes(2)
+    const metadataArgs = execFileMock.mock.calls[0]?.[1] as string[]
+    expect(metadataArgs.slice(0, 5)).toEqual(['-d', 'Ubuntu', '--', 'bash', '-c'])
+    expect(metadataArgs[5]).toContain('set -o pipefail; printf %s')
     const scanArgs = execFileMock.mock.calls[1]?.[1] as string[]
-    const encoded = /printf %s '([^']+)'/.exec(scanArgs[5] ?? '')?.[1]
+    expect(scanArgs.slice(0, 7)).toEqual([
+      '-d',
+      'Ubuntu',
+      '--',
+      'bash',
+      '-c',
+      'eval "\\$1"',
+      'orca-skill-discovery'
+    ])
+    const encoded = /printf %s '([^']+)'/.exec(scanArgs[7] ?? '')?.[1]
     const scanScript = Buffer.from(encoded ?? '', 'base64').toString('utf8')
     expect(scanScript).toContain(`${installPath}/skills`)
     expect(result.skills).toEqual([

--- a/src/main/skills/skill-discovery-wsl.test.ts
+++ b/src/main/skills/skill-discovery-wsl.test.ts
@@ -1,6 +1,10 @@
 import { describe, expect, it } from 'vitest'
 import type { SkillScanRoot } from './skill-discovery-sources'
-import { buildWslSkillDiscoveryCommand, parseWslSkillDiscoveryOutput } from './skill-discovery-wsl'
+import {
+  buildWslSkillDiscoveryArgs,
+  buildWslSkillDiscoveryCommand,
+  parseWslSkillDiscoveryOutput
+} from './skill-discovery-wsl'
 
 const homeRoot: SkillScanRoot = {
   id: 'home-codex',
@@ -86,6 +90,27 @@ describe('WSL skill discovery', () => {
     expect(script).toContain('realpath -- "$skill_file"')
     expect(script).toContain('head -c 262144 -- "$skill_file"')
     expect(script).toContain(`'/work/alice'\\''s project/.agents/skills'`)
+  })
+
+  it('keeps the semicolon-delimited scan payload outside the bash -c argument', () => {
+    const command = buildWslSkillDiscoveryCommand([repoRoot])
+    const args = buildWslSkillDiscoveryArgs('Ubuntu', command)
+    const commandIndex = args.indexOf('-c') + 1
+
+    expect(args.slice(0, commandIndex + 1)).toEqual([
+      '-d',
+      'Ubuntu',
+      '--',
+      'bash',
+      '-c',
+      'eval "\\$1"'
+    ])
+    expect(args[commandIndex]).not.toContain(';')
+    expect(args[commandIndex]).not.toContain('base64 -d | bash')
+    expect(args[commandIndex + 1]).toBe('orca-skill-discovery')
+    expect(args[commandIndex + 2]).toBe(command)
+    expect(args[commandIndex + 2]).toContain('set -o pipefail; printf %s')
+    expect(args[commandIndex + 2]).toContain('base64 -d | bash')
   })
 
   it('rejects malformed host responses instead of reporting an empty scan', () => {

--- a/src/main/skills/skill-discovery-wsl.ts
+++ b/src/main/skills/skill-discovery-wsl.ts
@@ -6,6 +6,7 @@ import type {
   SkillDiscoveryResult,
   SkillDiscoverySource
 } from '../../shared/skills'
+import { escapeWslShCommandForWindows } from '../../shared/wsl-login-shell-command'
 import { buildEncodedWslBashCommand, quoteBashString } from '../wsl-bash-command'
 import {
   buildSkillDiscoverySources,
@@ -21,6 +22,8 @@ const MAX_MARKDOWN_BYTES = 256 * 1024
 const MAX_PACKAGE_FILES = 200
 const WSL_SCAN_TIMEOUT_MS = 10_000
 const WSL_SCAN_MAX_BUFFER_BYTES = 128 * 1024 * 1024
+const WSL_SKILL_DISCOVERY_ARG0 = 'orca-skill-discovery'
+const WSL_SKILL_DISCOVERY_EVAL = escapeWslShCommandForWindows('eval "$1"')
 
 export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): string {
   const lines = [
@@ -58,11 +61,24 @@ export function buildWslSkillDiscoveryCommand(roots: readonly SkillScanRoot[]): 
   return buildEncodedWslBashCommand(lines.join('\n'))
 }
 
+export function buildWslSkillDiscoveryArgs(distro: string, command: string): string[] {
+  return [
+    '-d',
+    distro,
+    '--',
+    'bash',
+    '-c',
+    WSL_SKILL_DISCOVERY_EVAL,
+    WSL_SKILL_DISCOVERY_ARG0,
+    command
+  ]
+}
+
 function executeWslSkillDiscovery(distro: string, command: string): Promise<string> {
   return new Promise((resolve, reject) => {
     execFile(
       'wsl.exe',
-      ['-d', distro, '--', 'bash', '-c', command],
+      buildWslSkillDiscoveryArgs(distro, command),
       {
         encoding: 'utf8',
         maxBuffer: WSL_SCAN_MAX_BUFFER_BYTES,


### PR DESCRIPTION
## Description

On Windows, WSL skill discovery passed a multi-command scan payload directly as bash's `-c` argument. Windows argument handling could split the payload before bash received it, leaving the Settings skill check stuck on Not installed.

## Focused fix

- In scope: invoke bash with a fixed `eval "$1"` script and pass the discovery payload as a positional argument.
- In scope: preserve the existing WSL distro selection and discovery payload.
- Out of scope: skill scan content, skill installation, shell preference, and non-WSL discovery.

## Preserves

- Metadata discovery and scan output parsing are unchanged.
- The existing command payload remains the only script evaluated inside WSL.

## Evidence

- Targeted Vitest: 2 files, 5 tests passed.
- Regression coverage verifies that the semicolon-delimited scan script is outside bash's `-c` argument and is passed unchanged as `$1`.
- oxfmt, oxlint, and git diff checks passed after rebasing onto current upstream/main.

## User-regression-tradeoffs

- The command adds one fixed bash evaluation layer so Windows/WSL argument boundaries remain stable.
- Linux and macOS discovery paths are unchanged.

Fixes #12964
