### PR TITLE
fix(remote): treat an absent worktree and an empty tab list as different answers

### DIFF
--- a/src/renderer/src/hooks/remote-workspace-session-merge.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-merge.ts
@@ -14,13 +14,47 @@ function preserveNewerLocalTerminalFields(remote: TerminalTab, local: TerminalTa
     : preserved
 }
 
+// Why key presence and not tab count: the host says "no tabs here" in two shapes that demand
+// opposite handling, and collapsing them is the entire bug class in this file.
+//
+//   present, empty array -> the user closed the last tab. Authoritative. Honor it, or a close
+//                           performed on one client is silently undone by the next pull.
+//   key absent           -> the host has no record for this worktree at all: its export scope
+//                           disagreed with ours, or importRemoteWorkspaceSession dropped the entry
+//                           because the worktree path did not resolve to exactly one local id.
+//                           That is UNKNOWN, not empty — and deleting on it destroys terminals the
+//                           user can see, unrecoverably.
+//
+// Deciding on tab count instead treats both as "delete" (losing data) or both as "keep" (resurrecting
+// closed tabs). The distinction is carried intact by exportRemoteWorkspaceSession, JSON, and
+// importRemoteWorkspaceSession, so this reads a real signal from the host rather than guessing.
+export function narrowDirectSshReplaceWorktreeIds(
+  requestedReplaceWorktreeIds: ReadonlySet<string>,
+  remote: WorkspaceSessionState
+): ReadonlySet<string> {
+  return new Set(
+    [...requestedReplaceWorktreeIds].filter((worktreeId) =>
+      Object.hasOwn(remote.tabsByWorktree, worktreeId)
+    )
+  )
+}
+
 export function mergeDirectSshRemoteWorkspaceSession(
   current: WorkspaceSessionState,
   remote: WorkspaceSessionState,
-  replaceWorktreeIds: ReadonlySet<string>,
+  requestedReplaceWorktreeIds: ReadonlySet<string>,
   liveTabsByWorktree: AppState['tabsByWorktree'],
   preserveLocalTerminalTabIds: ReadonlySet<string>
 ): WorkspaceSessionState {
+  // Why narrowed here rather than trusted from the caller: this is the boundary that turns a remote
+  // report into a local delete, so it must hold on its own. Idempotent, so a caller that already
+  // narrowed pays nothing.
+  const replaceWorktreeIds = narrowDirectSshReplaceWorktreeIds(requestedReplaceWorktreeIds, remote)
+  const inReplaceScope = (worktreeId: string): boolean => replaceWorktreeIds.has(worktreeId)
+  // Why remote records are scoped: the snapshot can carry per-worktree entries for worktrees the
+  // narrowing protected, and spreading those over current would delete the state it just protected.
+  const scopedRemoteRecord = <T>(record: Record<string, T> | undefined): [string, T][] =>
+    Object.entries(record ?? {}).filter(([worktreeId]) => inReplaceScope(worktreeId))
   const currentTabsById = new Map(
     [...replaceWorktreeIds]
       .flatMap((worktreeId) => liveTabsByWorktree[worktreeId] ?? [])
@@ -28,7 +62,7 @@ export function mergeDirectSshRemoteWorkspaceSession(
   )
   const locallyPreservedTabIds = new Set<string>()
   const tabsByWorktree = Object.fromEntries(
-    Object.entries(remote.tabsByWorktree).map(([worktreeId, tabs]) => [
+    scopedRemoteRecord(remote.tabsByWorktree).map(([worktreeId, tabs]) => [
       worktreeId,
       tabs.map((tab) => {
         const local = currentTabsById.get(tab.id)
@@ -89,11 +123,11 @@ export function mergeDirectSshRemoteWorkspaceSession(
     terminalLayoutsByTabId,
     activeWorktreeIdsOnShutdown: [
       ...(current.activeWorktreeIdsOnShutdown ?? []).filter((id) => !replaceWorktreeIds.has(id)),
-      ...(remote.activeWorktreeIdsOnShutdown ?? [])
+      ...(remote.activeWorktreeIdsOnShutdown ?? []).filter(inReplaceScope)
     ],
     activeTabIdByWorktree: {
       ...omitTargetWorktrees(current.activeTabIdByWorktree),
-      ...remote.activeTabIdByWorktree
+      ...Object.fromEntries(scopedRemoteRecord(remote.activeTabIdByWorktree))
     },
     remoteSessionIdsByTabId: {
       ...Object.fromEntries(
@@ -109,11 +143,11 @@ export function mergeDirectSshRemoteWorkspaceSession(
     },
     lastVisitedAtByWorktreeId: {
       ...omitTargetWorktrees(current.lastVisitedAtByWorktreeId),
-      ...remote.lastVisitedAtByWorktreeId
+      ...Object.fromEntries(scopedRemoteRecord(remote.lastVisitedAtByWorktreeId))
     },
     defaultTerminalTabsAppliedByWorktreeId: {
       ...omitTargetWorktrees(current.defaultTerminalTabsAppliedByWorktreeId),
-      ...remote.defaultTerminalTabsAppliedByWorktreeId
+      ...Object.fromEntries(scopedRemoteRecord(remote.defaultTerminalTabsAppliedByWorktreeId))
     }
   }
 }

--- a/src/renderer/src/hooks/remote-workspace-session-tab-authority.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-session-tab-authority.test.ts
@@ -1,0 +1,155 @@
+import { describe, expect, it } from 'vitest'
+import { getDefaultWorkspaceSession } from '../../../shared/constants'
+import {
+  exportRemoteWorkspaceSession,
+  importRemoteWorkspaceSession
+} from '../../../shared/remote-workspace-session-projection'
+import type {
+  TerminalLayoutSnapshot,
+  TerminalTab,
+  WorkspaceSessionState
+} from '../../../shared/types'
+import {
+  mergeDirectSshRemoteWorkspaceSession,
+  uniqueWorktreeIdByPath
+} from './remote-workspace-session-merge'
+
+// Why this file exists: the host answers "this worktree has no tabs" two different ways — an
+// explicit empty list (the user closed the last tab) and an absent key (the host never knew about
+// this worktree). Those demand opposite handling, and every bug in this area comes from collapsing
+// them. These tests pin both directions so neither fix can be traded for the other.
+
+const REPO = 'repo-1'
+const WT_A = `${REPO}::/srv/wt-a`
+const WT_B = `${REPO}::/srv/wt-b`
+
+function tab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    ptyId: `pty-${id}`,
+    worktreeId,
+    title: id,
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+function layout(leafId: string): TerminalLayoutSnapshot {
+  return {
+    root: { type: 'leaf', leafId },
+    ptyIdsByLeafId: {},
+    activeLeafId: leafId,
+    expandedLeafId: null
+  }
+}
+
+function sessionWith(tabsByWorktree: Record<string, TerminalTab[]>): WorkspaceSessionState {
+  return { ...getDefaultWorkspaceSession(), tabsByWorktree }
+}
+
+/** Drives the real wire path so the empty-vs-absent distinction is proven end to end, not assumed. */
+function pullFromHost(
+  hostSession: WorkspaceSessionState,
+  clientSession: WorkspaceSessionState,
+  replaceWorktreeIds: ReadonlySet<string>
+): WorkspaceSessionState {
+  const wire = JSON.parse(
+    JSON.stringify(
+      exportRemoteWorkspaceSession(hostSession, {
+        isTargetWorktree: () => true
+      })
+    )
+  ) as ReturnType<typeof exportRemoteWorkspaceSession>
+  const remote = importRemoteWorkspaceSession(wire, {
+    resolveWorktreeId: uniqueWorktreeIdByPath(replaceWorktreeIds)
+  })
+  return mergeDirectSshRemoteWorkspaceSession(
+    clientSession,
+    remote,
+    replaceWorktreeIds,
+    clientSession.tabsByWorktree,
+    new Set()
+  )
+}
+
+describe('direct SSH snapshot tab authority', () => {
+  it('keeps an empty tab list distinct from an absent worktree across the wire', () => {
+    const wire = JSON.parse(
+      JSON.stringify(
+        exportRemoteWorkspaceSession(sessionWith({ [WT_A]: [], [WT_B]: [tab('t1', WT_B)] }), {
+          isTargetWorktree: () => true
+        })
+      )
+    ) as ReturnType<typeof exportRemoteWorkspaceSession>
+    // The whole design rests on this surviving JSON: '/srv/wt-a' present-but-empty, '/srv/wt-c' absent.
+    expect(wire.tabsByWorktreePath['/srv/wt-a']).toEqual([])
+    expect(Object.hasOwn(wire.tabsByWorktreePath, '/srv/wt-a')).toBe(true)
+    expect(Object.hasOwn(wire.tabsByWorktreePath, '/srv/wt-c')).toBe(false)
+
+    const remote = importRemoteWorkspaceSession(wire, {
+      resolveWorktreeId: uniqueWorktreeIdByPath(new Set([WT_A, WT_B]))
+    })
+    expect(Object.hasOwn(remote.tabsByWorktree, WT_A)).toBe(true)
+    expect(remote.tabsByWorktree[WT_A]).toEqual([])
+  })
+
+  // The reported P0: the host has no record of this worktree, and the client's visible tabs vanish.
+  it('preserves local tabs when the host snapshot omits the worktree entirely', () => {
+    const merged = pullFromHost(
+      sessionWith({ [WT_A]: [tab('a1', WT_A)] }),
+      sessionWith({ [WT_A]: [tab('a1', WT_A)], [WT_B]: [tab('b1', WT_B)] }),
+      new Set([WT_A, WT_B])
+    )
+    expect(merged.tabsByWorktree[WT_B]?.map((t) => t.id)).toEqual(['b1'])
+  })
+
+  // The regression a "protect whenever local has tabs" heuristic introduces: closing the last tab
+  // on one client must not be undone by the next pull on another.
+  it('honors an explicit empty tab list so a closed tab does not come back', () => {
+    const merged = pullFromHost(
+      sessionWith({ [WT_A]: [tab('a1', WT_A)], [WT_B]: [] }),
+      sessionWith({ [WT_A]: [tab('a1', WT_A)], [WT_B]: [tab('b1', WT_B)] }),
+      new Set([WT_A, WT_B])
+    )
+    expect(merged.tabsByWorktree[WT_B] ?? []).toEqual([])
+  })
+
+  it('honors an empty list even when it empties every worktree in scope', () => {
+    const merged = pullFromHost(
+      sessionWith({ [WT_A]: [], [WT_B]: [] }),
+      sessionWith({ [WT_A]: [tab('a1', WT_A)], [WT_B]: [tab('b1', WT_B)] }),
+      new Set([WT_A, WT_B])
+    )
+    expect(merged.tabsByWorktree[WT_A] ?? []).toEqual([])
+    expect(merged.tabsByWorktree[WT_B] ?? []).toEqual([])
+  })
+
+  it('drops layout and remote-session records only for worktrees the host actually emptied', () => {
+    const client: WorkspaceSessionState = {
+      ...sessionWith({ [WT_A]: [tab('a1', WT_A)], [WT_B]: [tab('b1', WT_B)] }),
+      terminalLayoutsByTabId: {
+        a1: layout('l-a1'),
+        b1: layout('l-b1')
+      },
+      remoteSessionIdsByTabId: { a1: 'rs-a1', b1: 'rs-b1' }
+    }
+    // Host emptied A (explicit) and never knew B (absent).
+    const merged = pullFromHost(sessionWith({ [WT_A]: [] }), client, new Set([WT_A, WT_B]))
+    expect(merged.terminalLayoutsByTabId.a1).toBeUndefined()
+    expect(merged.remoteSessionIdsByTabId?.a1).toBeUndefined()
+    expect(merged.terminalLayoutsByTabId.b1).toBeDefined()
+    expect(merged.remoteSessionIdsByTabId?.b1).toBe('rs-b1')
+  })
+
+  it('leaves worktrees outside the replace scope untouched in both shapes', () => {
+    const merged = pullFromHost(
+      sessionWith({ [WT_A]: [] }),
+      sessionWith({ [WT_A]: [tab('a1', WT_A)], [WT_B]: [tab('b1', WT_B)] }),
+      new Set([WT_A])
+    )
+    expect(merged.tabsByWorktree[WT_A] ?? []).toEqual([])
+    expect(merged.tabsByWorktree[WT_B]?.map((t) => t.id)).toEqual(['b1'])
+  })
+})


### PR DESCRIPTION
## Problem

The direct-SSH workspace snapshot merge deleted a worktree's local tabs whenever the imported remote session reported no tabs for it. Two very different situations reach that point:

- **present, empty array** — the user closed their last tab on another client. Authoritative.
- **key absent** — the host has no record for this worktree: its export scope disagreed with ours, or the worktree path did not resolve to exactly one local id and the entry was dropped on import. Unknown, not empty.

Honoring both as "delete" loses terminals the user can still see. Protecting both — deciding on tab *count*, which is what a local-tabs-present guard does — resurrects tabs the user deliberately closed.

## Fix

The distinction is already carried intact by the exporter, by JSON, and by the importer. The merge now reads it with `Object.hasOwn` instead of inferring it from tab count, so an absent key is treated as unknown and an explicit empty array is honored.

## Tests

Six tests drive the real `export -> JSON -> import -> merge` path rather than constructing merge input by hand, so the discriminator has to survive serialization.

Both failure directions are pinned so neither can be traded for the other, and both were mutation-verified on this base:

- swapping key-presence for tab-count (the resurrection behavior) fails 4 named tests
- removing the narrowing entirely (the tab-loss behavior) fails 2 named tests

## Relationship to #12751

#12751 fixes the same underlying bug and I do not want to duplicate that work. The difference is the discriminator: guarding on whether local tabs exist protects the unknown case, but it also protects the authoritative empty case, so a tab closed on one client reappears on the next pull. This PR keys on whether the host sent a record for the worktree at all, which separates the two.

Happy for either to land — flagging it so a maintainer can pick, rather than proposing this over the top of a contributor's PR.

## Verification

- 6 targeted tests pass; full renderer suite green (2 unrelated failures reproduce on `main` on this machine: a guard script needing bash 4 on a bash 3.2 host, and a relay test asserting against the developer's shell env)
- `tsc` and `oxlint` clean
- Applies cleanly to current `main`