### PR TITLE
feat(composer): open project select with Cmd/Ctrl+.

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerModal.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerModal.tsx
@@ -25,7 +25,11 @@ import type { WorkspaceSource as WorkspaceCreateTelemetrySource } from '../../..
 import type { WorkspaceStatus } from '../../../shared/worktree/types'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { translate } from '@/i18n/i18n'
-import { getWorkspaceComposerInitialFocusTarget } from '@/lib/workspace-composer-initial-focus'
+import {
+  getWorkspaceComposerInitialFocusTarget,
+  isComposerProjectSelectShortcut,
+  openWorkspaceComposerProjectSelect
+} from '@/lib/workspace-composer-initial-focus'
 import { getFolderWorkspacePrimaryActionLabel } from '@/components/sidebar/folder-workspace-composer-helpers'
 
 // Why: match App-level AddRepoDialog loading — the add flow is off the hot
@@ -235,12 +239,13 @@ function QuickTabBody({
       ? translate('auto.components.NewWorkspaceComposerModal.createWorktree', 'Create worktree')
       : translate('auto.components.NewWorkspaceComposerModal.createWorkspace', 'Create workspace')
 
-  // Cmd/Ctrl+Enter submits. Escape belongs to the dialog's dismissable layer:
-  // the page-style "blur the focused field first" rule assumes the user chose
-  // that field, but this dialog auto-focuses the name input on open, so handling
-  // Escape here swallowed every first press and left the composer stuck open.
-  // Radix also closes only the topmost layer, so nested popovers/selects/dialogs
-  // keep their own Escape without needing a guard here.
+  // Cmd/Ctrl+Enter submits, Cmd/Ctrl+. opens the project select. Escape belongs
+  // to the dialog's dismissable layer: the page-style "blur the focused field
+  // first" rule assumes the user chose that field, but this dialog auto-focuses
+  // the name input on open, so handling Escape here swallowed every first press
+  // and left the composer stuck open. Radix also closes only the topmost layer,
+  // so nested popovers/selects/dialogs keep their own Escape without needing a
+  // guard here.
   const nestedDialogOpen = agentSettingsOpen || addProjectOpen || setLocationOpen
   useEffect(() => {
     if (!active || nestedDialogOpen) {
@@ -249,6 +254,15 @@ function QuickTabBody({
       return
     }
     const onKeyDown = (event: KeyboardEvent): void => {
+      if (isComposerProjectSelectShortcut(event)) {
+        const root = composerRef.current
+        if (!root || !openWorkspaceComposerProjectSelect(root)) {
+          return
+        }
+        event.preventDefault()
+        return
+      }
+
       // Why: workspace creation is screen-local submit behavior, not a
       // user-configurable app command.
       if (!isScreenSubmitShortcut(event)) {

--- a/src/renderer/src/lib/workspace-composer-initial-focus.test.ts
+++ b/src/renderer/src/lib/workspace-composer-initial-focus.test.ts
@@ -1,7 +1,15 @@
 // @vitest-environment happy-dom
 
-import { describe, expect, it } from 'vitest'
-import { getWorkspaceComposerInitialFocusTarget } from './workspace-composer-initial-focus'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  getWorkspaceComposerInitialFocusTarget,
+  isComposerProjectSelectShortcut,
+  openWorkspaceComposerProjectSelect
+} from './workspace-composer-initial-focus'
+
+function setUserAgent(userAgent: string): void {
+  vi.stubGlobal('navigator', { userAgent })
+}
 
 describe('getWorkspaceComposerInitialFocusTarget', () => {
   it('focuses the workspace name input used by the current composer', () => {
@@ -77,5 +85,57 @@ describe('getWorkspaceComposerInitialFocusTarget', () => {
     root.append(repoTrigger)
 
     expect(getWorkspaceComposerInitialFocusTarget(root)).toBe(repoTrigger)
+  })
+})
+
+describe('isComposerProjectSelectShortcut', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses Cmd+. on macOS and Ctrl+. elsewhere', () => {
+    setUserAgent('Macintosh')
+    expect(isComposerProjectSelectShortcut({ key: '.', metaKey: true })).toBe(true)
+    expect(isComposerProjectSelectShortcut({ key: '。', code: 'Period', metaKey: true })).toBe(
+      true
+    )
+    expect(isComposerProjectSelectShortcut({ key: '.', ctrlKey: true })).toBe(false)
+
+    setUserAgent('Linux')
+    expect(isComposerProjectSelectShortcut({ key: '.', ctrlKey: true })).toBe(true)
+    expect(isComposerProjectSelectShortcut({ key: '.', metaKey: true })).toBe(false)
+  })
+
+  it('ignores extra modifiers, non-period keys, and composing events', () => {
+    setUserAgent('Macintosh')
+    expect(isComposerProjectSelectShortcut({ key: '.', metaKey: true, shiftKey: true })).toBe(
+      false
+    )
+    expect(isComposerProjectSelectShortcut({ key: '.', metaKey: true, altKey: true })).toBe(false)
+    expect(isComposerProjectSelectShortcut({ key: '.', metaKey: true, ctrlKey: true })).toBe(false)
+
+    setUserAgent('Linux')
+    expect(isComposerProjectSelectShortcut({ key: 'Enter', ctrlKey: true })).toBe(false)
+    expect(isComposerProjectSelectShortcut({ key: '.', ctrlKey: true, isComposing: true })).toBe(
+      false
+    )
+  })
+})
+
+describe('openWorkspaceComposerProjectSelect', () => {
+  it('clicks the project combobox shell to open it', () => {
+    const root = document.createElement('div')
+    const shell = document.createElement('div')
+    shell.setAttribute('data-project-combobox-root', 'true')
+    const click = vi.fn()
+    shell.addEventListener('click', click)
+    root.append(shell)
+
+    expect(openWorkspaceComposerProjectSelect(root)).toBe(true)
+    expect(click).toHaveBeenCalledTimes(1)
+  })
+
+  it('returns false when no project picker exists', () => {
+    expect(openWorkspaceComposerProjectSelect(document.createElement('div'))).toBe(false)
   })
 })

--- a/src/renderer/src/lib/workspace-composer-initial-focus.ts
+++ b/src/renderer/src/lib/workspace-composer-initial-focus.ts
@@ -1,7 +1,23 @@
+import { getShortcutPlatform } from './shortcut-platform'
+
 const WORKSPACE_NAME_INPUT_SELECTOR = '[data-workspace-name-input="true"]'
 const WORKSPACE_SOURCE_PILL_SELECTOR = '[data-workspace-source-pill="true"]'
+const PROJECT_COMBOBOX_SHELL_SELECTOR = 'div[data-project-combobox-root="true"]'
 const PROJECT_COMBOBOX_TRIGGER_SELECTOR = '[data-project-combobox-root="true"][role="combobox"]'
 const LEGACY_REPO_COMBOBOX_TRIGGER_SELECTOR = '[data-repo-combobox-root="true"][role="combobox"]'
+
+type ComposerProjectSelectShortcutEvent = {
+  key: string
+  code?: string
+  altKey?: boolean
+  ctrlKey?: boolean
+  metaKey?: boolean
+  shiftKey?: boolean
+  isComposing?: boolean
+  nativeEvent?: {
+    isComposing?: boolean
+  }
+}
 
 export function getWorkspaceComposerInitialFocusTarget(root: ParentNode): HTMLElement | null {
   // Why: most opens already have a project selected; land on the name/source
@@ -14,4 +30,37 @@ export function getWorkspaceComposerInitialFocusTarget(root: ParentNode): HTMLEl
     root.querySelector<HTMLElement>(PROJECT_COMBOBOX_TRIGGER_SELECTOR) ??
     root.querySelector<HTMLElement>(LEGACY_REPO_COMBOBOX_TRIGGER_SELECTOR)
   )
+}
+
+/** Cmd/Ctrl+. — composer-local, not a remappable app command. */
+export function isComposerProjectSelectShortcut(
+  event: ComposerProjectSelectShortcutEvent
+): boolean {
+  if (event.isComposing || event.nativeEvent?.isComposing) {
+    return false
+  }
+  if (event.altKey || event.shiftKey) {
+    return false
+  }
+  // Why: macOS composition can rewrite event.key for punctuation; prefer code,
+  // and keep key === '.' for environments that omit code.
+  if (event.code !== 'Period' && event.key !== '.') {
+    return false
+  }
+  const platform = getShortcutPlatform()
+  return platform === 'darwin'
+    ? Boolean(event.metaKey) && !event.ctrlKey
+    : Boolean(event.ctrlKey) && !event.metaKey
+}
+
+/** Opens (and focuses) the project picker — Cmd/Ctrl+. from the create modal. */
+export function openWorkspaceComposerProjectSelect(root: ParentNode): boolean {
+  // Why: shell click always opens even when the field already has focus;
+  // bare focus() would no-op and leave a closed list.
+  const shell = root.querySelector<HTMLElement>(PROJECT_COMBOBOX_SHELL_SELECTOR)
+  if (!shell) {
+    return false
+  }
+  shell.click()
+  return true
 }


### PR DESCRIPTION
## Summary
- In the create-worktree / create-workspace composer modal, `⌘.` (macOS) / `Ctrl+.` (Linux/Windows) focuses and opens the project picker — the same habit as common IDEs.
- Wired beside the existing screen-local submit shortcut; nested dialogs (Add Project / Agent settings) still suppress the handler.
- Shell `click()` is used so the list reopens even when the project field already has focus.

## Screenshots
No visual change (keyboard affordance only). Verified manually in `pnpm dev`: from the workspace-name field, `⌘.` expands the project combobox list.

## Testing
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/lib/workspace-composer-initial-focus.test.ts src/renderer/src/components/new-workspace/ProjectCombobox.test.tsx` (29 passed)
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added unit coverage for platform matching, composing/extra modifiers, and shell-open behavior
- [x] Manual: open composer → focus name → `⌘.` opens project list; close and repeat

## AI Review Report
Reviewed for over-engineering (ponytail-style): removed unused label helper, legacy repo-combobox open path, and a one-call-site shortcut module; matcher lives next to the open helper. Cross-platform: macOS uses `metaKey`, Linux/Windows use `ctrlKey`; period matching prefers `code === 'Period'` for composition-rewritten `event.key`. SSH/remote/local: composer-modal only, no host path/shell assumptions. Performance: capture-phase keydown early-returns unless the chord matches. UI: no layout/token changes.

## Security Audit
No new IPC, command execution, auth, secrets, or path handling. Shortcut only focuses/clicks an existing in-modal combobox shell; nested dialogs keep the handler disabled so Escape/submit are not stolen underneath.

## Notes
- Platform-specific: `⌘.` vs `Ctrl+.`; same posture as `isScreenSubmitShortcut`.
- X: [@flowoodzx](https://x.com/flowoodzx)