### PR TITLE
fix(mobile): warm GitHub project repositories before filtering

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -85,6 +85,7 @@ import {
   type GitHubRepoSlugCacheEntry
 } from '../../../src/tasks/github-project-repo-match'
 import { warmGitHubProjectModeRepos } from '../../../src/tasks/github-project-mode-repo-warmup'
+import { commitGitHubProjectModeRepos } from '../../../src/tasks/github-project-mode-commit-repos'
 import {
   parseGitHubProjectInput as parseProjectInput,
   type GitHubProjectOwnerType,
@@ -3036,32 +3037,31 @@ export default function MobileTasksScreen() {
     setProvider(resolveVisibleTaskProvider(provider, visibleProviders))
   }, [provider, visibleProviders])
 
-  const loadRepos = useCallback(async (): Promise<RepoSummary[]> => {
-    if (!client || connState !== 'connected') {
-      return []
-    }
-    const response = await client.sendRequest('repo.list')
-    if (!isSuccess(response)) {
-      throw new Error(response.error.message)
-    }
-    const result = response.result as { repos: RepoSummary[] }
-    reposRef.current = result.repos
-    setRepos(result.repos)
-    if (!repoSelectionHydratedRef.current) {
-      repoSelectionHydratedRef.current = true
-      setSelectedRepoIds(reconcileRepoSelection(result.repos, defaultRepoSelectionRef.current))
-    } else {
-      setSelectedRepoIds((current) => {
-        if (current.size === 0) {
-          return current
-        }
-        const availableIds = new Set(result.repos.filter(isHostedTaskRepo).map((repo) => repo.id))
-        const next = new Set([...current].filter((id) => availableIds.has(id)))
-        return next.size === current.size ? current : next
+  const loadRepos = useCallback(
+    async (isCurrent?: () => boolean): Promise<RepoSummary[]> => {
+      if (!client || connState !== 'connected') {
+        return []
+      }
+      const response = await client.sendRequest('repo.list')
+      if (!isSuccess(response)) {
+        throw new Error(response.error.message)
+      }
+      const result = response.result as { repos: RepoSummary[] }
+      commitGitHubProjectModeRepos({
+        repos: result.repos,
+        isCurrent,
+        setRepos,
+        reposRef,
+        repoSelectionHydratedRef,
+        defaultRepoSelectionRef,
+        setSelectedRepoIds,
+        reconcileRepoSelection,
+        isHostedTaskRepo
       })
-    }
-    return result.repos
-  }, [client, connState])
+      return result.repos
+    },
+    [client, connState]
+  )
 
   const loadLinearContext = useCallback(async (): Promise<void> => {
     if (!client || connState !== 'connected' || !tasksSupported) {

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -84,6 +84,7 @@ import {
   findRepoForGitHubProjectRepository,
   type GitHubRepoSlugCacheEntry
 } from '../../../src/tasks/github-project-repo-match'
+import { warmGitHubProjectModeRepos } from '../../../src/tasks/github-project-mode-repo-warmup'
 import {
   parseGitHubProjectInput as parseProjectInput,
   type GitHubProjectOwnerType,
@@ -3258,7 +3259,7 @@ export default function MobileTasksScreen() {
           setGithubSourceFallbacks([])
         }
         if (provider === 'github' && githubMode === 'project') {
-          setItems([])
+          await warmGitHubProjectModeRepos(reposRef.current.length, loadRepos, isCurrent, setItems)
           return
         }
         if (provider === 'linear' && !linearConnected) {

--- a/mobile/src/tasks/github-project-mode-commit-repos.ts
+++ b/mobile/src/tasks/github-project-mode-commit-repos.ts
@@ -1,0 +1,33 @@
+/** Apply repo.list results only when the caller still owns the load (#12991). */
+export function commitGitHubProjectModeRepos<T extends { id: string }>(args: {
+  repos: T[]
+  isCurrent?: () => boolean
+  setRepos: (repos: T[]) => void
+  reposRef: { current: T[] }
+  repoSelectionHydratedRef: { current: boolean }
+  defaultRepoSelectionRef: { current: string[] | null }
+  setSelectedRepoIds: (value: Set<string> | ((current: Set<string>) => Set<string>)) => void
+  reconcileRepoSelection: (repos: T[], defaults: string[] | null) => Set<string>
+  isHostedTaskRepo: (repo: T) => boolean
+}): void {
+  if (args.isCurrent?.() === false) {
+    return
+  }
+  args.reposRef.current = args.repos
+  args.setRepos(args.repos)
+  if (!args.repoSelectionHydratedRef.current) {
+    args.repoSelectionHydratedRef.current = true
+    args.setSelectedRepoIds(
+      args.reconcileRepoSelection(args.repos, args.defaultRepoSelectionRef.current)
+    )
+    return
+  }
+  args.setSelectedRepoIds((current) => {
+    if (current.size === 0) {
+      return current
+    }
+    const availableIds = new Set(args.repos.filter(args.isHostedTaskRepo).map((repo) => repo.id))
+    const next = new Set([...current].filter((id) => availableIds.has(id)))
+    return next.size === current.size ? current : next
+  })
+}

--- a/mobile/src/tasks/github-project-mode-repo-warmup.test.ts
+++ b/mobile/src/tasks/github-project-mode-repo-warmup.test.ts
@@ -10,6 +10,7 @@ describe('GitHub project mode repo warmup', () => {
     await warmGitHubProjectModeRepos(0, loadRepos, isCurrent, setItems)
 
     expect(loadRepos).toHaveBeenCalledTimes(1)
+    expect(loadRepos).toHaveBeenCalledWith(isCurrent)
     expect(setItems).toHaveBeenCalledWith([])
   })
 
@@ -36,5 +37,15 @@ describe('GitHub project mode repo warmup', () => {
     )
 
     expect(setItems).not.toHaveBeenCalled()
+  })
+
+  it('passes the current-load guard into loadRepos for stale-host protection', async () => {
+    const isCurrent = vi.fn(() => true)
+    const loadRepos = vi.fn(async (guard: () => boolean) => {
+      expect(guard).toBe(isCurrent)
+      return [{ id: 'repo-1' }]
+    })
+    await warmGitHubProjectModeRepos(0, loadRepos, isCurrent, vi.fn())
+    expect(loadRepos).toHaveBeenCalledWith(isCurrent)
   })
 })

--- a/mobile/src/tasks/github-project-mode-repo-warmup.test.ts
+++ b/mobile/src/tasks/github-project-mode-repo-warmup.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+import { warmGitHubProjectModeRepos } from './github-project-mode-repo-warmup'
+
+describe('GitHub project mode repo warmup', () => {
+  it('loads repos when Mobile lands directly in GitHub project mode with an empty repo cache', async () => {
+    const loadRepos = vi.fn(async () => [{ id: 'repo-1' }])
+    const isCurrent = vi.fn(() => true)
+    const setItems = vi.fn()
+
+    await warmGitHubProjectModeRepos(0, loadRepos, isCurrent, setItems)
+
+    expect(loadRepos).toHaveBeenCalledTimes(1)
+    expect(setItems).toHaveBeenCalledWith([])
+  })
+
+  it('reuses cached repos before filtering project rows', async () => {
+    const loadRepos = vi.fn(async () => [{ id: 'repo-1' }])
+    const isCurrent = vi.fn(() => true)
+    const setItems = vi.fn()
+
+    await warmGitHubProjectModeRepos(1, loadRepos, isCurrent, setItems)
+
+    expect(loadRepos).not.toHaveBeenCalled()
+    expect(setItems).toHaveBeenCalledWith([])
+  })
+
+  it('does not update items after a newer task load starts', async () => {
+    const isCurrent = vi.fn(() => false)
+    const setItems = vi.fn()
+
+    await warmGitHubProjectModeRepos(
+      0,
+      vi.fn(async () => []),
+      isCurrent,
+      setItems
+    )
+
+    expect(setItems).not.toHaveBeenCalled()
+  })
+})

--- a/mobile/src/tasks/github-project-mode-repo-warmup.ts
+++ b/mobile/src/tasks/github-project-mode-repo-warmup.ts
@@ -1,11 +1,12 @@
 export async function warmGitHubProjectModeRepos(
   cachedRepoCount: number,
-  loadRepos: () => Promise<unknown>,
+  // Why: pass isCurrent so loadRepos can refuse stale host writes (#12991 CR).
+  loadRepos: (isCurrent: () => boolean) => Promise<unknown>,
   isCurrent: () => boolean,
   setItems: (items: never[]) => void
 ): Promise<void> {
   if (cachedRepoCount === 0) {
-    await loadRepos()
+    await loadRepos(isCurrent)
   }
   if (isCurrent()) {
     setItems([])

--- a/mobile/src/tasks/github-project-mode-repo-warmup.ts
+++ b/mobile/src/tasks/github-project-mode-repo-warmup.ts
@@ -1,0 +1,13 @@
+export async function warmGitHubProjectModeRepos(
+  cachedRepoCount: number,
+  loadRepos: () => Promise<unknown>,
+  isCurrent: () => boolean,
+  setItems: (items: never[]) => void
+): Promise<void> {
+  if (cachedRepoCount === 0) {
+    await loadRepos()
+  }
+  if (isCurrent()) {
+    setItems([])
+  }
+}


### PR DESCRIPTION
## Description

Warm the GitHub repository list before filtering Project rows in Orca Mobile.

## Focused fix

- In scope: load the repository cache before the project-mode row filter runs.
- Out of scope: changing the project-row filtering contract or desktop behavior.

## Preserves

- The existing repository-aware filtering and the upstream project-row behavior remain unchanged once the repository list is available.

## Evidence

- Test: `pnpm exec vitest run src/tasks/github-project-mode-repo-warmup.test.ts`
- Post-rebase result: 1 file, 3 tests passed.
- Changed-file oxfmt and oxlint passed.

## User-regression-tradeoffs

- A direct landing in GitHub Projects now loads the same repository context that an Issues-first navigation already populated.

Fixes #12966
