### PR TITLE
feat(workspace): add assignable board toggle shortcut

### DIFF
--- a/src/main/browser/browser-guest-ui.ts
+++ b/src/main/browser/browser-guest-ui.ts
@@ -437,6 +437,8 @@ export function setupGuestShortcutForwarding(args: {
       renderer.send('ui:openNewWorkspace')
     } else if (action?.type === 'openWorkspaceBoard') {
       renderer.send('ui:openWorkspaceBoard')
+    } else if (action?.type === 'toggleWorkspaceBoard') {
+      renderer.send('ui:toggleWorkspaceBoard')
     } else if (action?.type === 'openTasks') {
       renderer.send('ui:openTasks')
     } else if (action?.type === 'openSettings') {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -1435,6 +1435,70 @@ describe('createMainWindow', () => {
     expect(webContents.send).not.toHaveBeenCalled()
   })
 
+  it('suppresses auto-repeat for workspace board toggle', () => {
+    const windowHandlers: Record<string, (...args: any[]) => void> = {}
+    const webContents = {
+      on: vi.fn((event, handler) => {
+        windowHandlers[event] = handler
+      }),
+      setZoomLevel: vi.fn(),
+      setBackgroundThrottling: vi.fn(),
+      invalidate: vi.fn(),
+      setWindowOpenHandler: vi.fn(),
+      send: vi.fn(),
+      isDevToolsOpened: vi.fn(),
+      openDevTools: vi.fn(),
+      closeDevTools: vi.fn()
+    }
+    const browserWindowInstance = {
+      webContents,
+      on: vi.fn(),
+      isDestroyed: vi.fn(() => false),
+      isMaximized: vi.fn(() => true),
+      isFullScreen: vi.fn(() => false),
+      getSize: vi.fn(() => [1200, 800]),
+      setSize: vi.fn(),
+      maximize: vi.fn(),
+      show: vi.fn(),
+      loadFile: vi.fn(),
+      loadURL: vi.fn()
+    }
+    browserWindowMock.mockImplementation(function () {
+      return browserWindowInstance
+    })
+
+    createMainWindow(null, {
+      getKeybindings: () => ({
+        'workspace.toggleBoard': ['Mod+Alt+T']
+      })
+    })
+
+    const isDarwin = process.platform === 'darwin'
+    const input = {
+      type: 'keyDown',
+      code: 'KeyT',
+      key: 't',
+      meta: isDarwin,
+      control: !isDarwin,
+      alt: true,
+      shift: false
+    }
+    const firstPreventDefault = vi.fn()
+    windowHandlers['before-input-event']({ preventDefault: firstPreventDefault } as never, input)
+    expect(firstPreventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.send).toHaveBeenCalledWith('ui:toggleWorkspaceBoard')
+
+    webContents.send.mockClear()
+    const repeatPreventDefault = vi.fn()
+    windowHandlers['before-input-event']({ preventDefault: repeatPreventDefault } as never, {
+      ...input,
+      isAutoRepeat: true
+    })
+
+    expect(repeatPreventDefault).toHaveBeenCalledTimes(1)
+    expect(webContents.send).not.toHaveBeenCalled()
+  })
+
   it('lets Terminal-first pass risky app shortcuts through when terminal input is focused', () => {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -707,6 +707,9 @@ export function createMainWindow(
       case 'openWorkspaceBoard':
         mainWindow.webContents.send('ui:openWorkspaceBoard')
         return
+      case 'toggleWorkspaceBoard':
+        mainWindow.webContents.send('ui:toggleWorkspaceBoard')
+        return
       case 'openTasks':
         mainWindow.webContents.send('ui:openTasks')
         return

--- a/src/main/window/createMainWindow.ts
+++ b/src/main/window/createMainWindow.ts
@@ -788,7 +788,11 @@ export function createMainWindow(
       return true
     }
 
-    if (action.type === 'toggleQuickCommandsMenu' && isAutoRepeat) {
+    if (
+      (action.type === 'toggleQuickCommandsMenu' || action.type === 'toggleWorkspaceBoard') &&
+      isAutoRepeat
+    ) {
+      // Why: held keys fire keyDown auto-repeat; toggles must flip once (#12992 CR).
       event.preventDefault()
       return true
     }

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3167,6 +3167,7 @@ export type PreloadApi = {
     onOpenNewWorkspace: (callback: () => void) => () => void
     onDeleteCurrentWorkspace: (callback: () => void) => () => void
     onOpenWorkspaceBoard: (callback: () => void) => () => void
+    onToggleWorkspaceBoard: (callback: () => void) => () => void
     onOpenTasks: (callback: () => void) => () => void
     onJumpToWorktreeIndex: (callback: (index: number) => void) => () => void
     onJumpToTabIndex: (callback: (index: number) => void) => () => void

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3547,6 +3547,11 @@ const api = {
       ipcRenderer.on('ui:openWorkspaceBoard', listener)
       return () => ipcRenderer.removeListener('ui:openWorkspaceBoard', listener)
     },
+    onToggleWorkspaceBoard: (callback: () => void): (() => void) => {
+      const listener = (_event: Electron.IpcRendererEvent) => callback()
+      ipcRenderer.on('ui:toggleWorkspaceBoard', listener)
+      return () => ipcRenderer.removeListener('ui:toggleWorkspaceBoard', listener)
+    },
     onOpenTasks: (callback: () => void): (() => void) => {
       const listener = (_event: Electron.IpcRendererEvent) => callback()
       ipcRenderer.on('ui:openTasks', listener)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -82,7 +82,10 @@ import {
 } from '@/lib/floating-workspace-terminal-actions'
 import { createFloatingWorkspaceTourInteractionSnapshot } from '@/lib/floating-workspace-tour-interaction-snapshot'
 import { requestScrollToCurrentWorkspaceRevealAndRename } from '@/lib/scroll-to-current-workspace-status'
-import { OPEN_WORKSPACE_BOARD_EVENT } from './components/sidebar/useWorkspaceBoardPanel'
+import {
+  OPEN_WORKSPACE_BOARD_EVENT,
+  TOGGLE_WORKSPACE_BOARD_EVENT
+} from './components/sidebar/useWorkspaceBoardPanel'
 import { WorkspacePortScanner } from './components/ports/WorkspacePortScanner'
 import { CrashReportDialog } from './components/crash-report/CrashReportDialog'
 import NewWorkspaceComposerModal from './components/NewWorkspaceComposerModal'
@@ -1689,6 +1692,17 @@ function App(): React.JSX.Element {
             return claim('workspace.openBoard', () => {
               useAppStore.getState().setSidebarOpen(true)
               window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
+            })
+          }
+        ],
+        [
+          'workspace.toggleBoard',
+          () => {
+            if (activeView === 'settings') {
+              return false
+            }
+            return claim('workspace.toggleBoard', () => {
+              window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
             })
           }
         ],

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
@@ -5,6 +5,7 @@ import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   OPEN_WORKSPACE_BOARD_EVENT,
+  TOGGLE_WORKSPACE_BOARD_EVENT,
   useWorkspaceBoardPanel,
   type WorkspaceBoardPanelState
 } from './useWorkspaceBoardPanel'
@@ -108,6 +109,21 @@ describe('useWorkspaceBoardPanel', () => {
 
     expect(panelState().workspaceBoardOpen).toBe(true)
     expect(panelState().workspaceBoardRenderedOpen).toBe(true)
+    expect(mocks.recordFeatureInteraction).toHaveBeenCalledExactlyOnceWith('workspace-board')
+  })
+
+  it('toggles the board from the shortcut bridge event', async () => {
+    await renderHookProbe()
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
+    })
+    expect(panelState().workspaceBoardOpen).toBe(true)
+
+    await act(async () => {
+      window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
+    })
+    expect(panelState().workspaceBoardOpen).toBe(false)
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledExactlyOnceWith('workspace-board')
   })
 

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx
@@ -11,13 +11,15 @@ import {
 } from './useWorkspaceBoardPanel'
 
 const mocks = vi.hoisted(() => ({
-  recordFeatureInteraction: vi.fn()
+  recordFeatureInteraction: vi.fn(),
+  setSidebarOpen: vi.fn()
 }))
 
 vi.mock('@/store', () => ({
   useAppStore: {
     getState: () => ({
-      recordFeatureInteraction: mocks.recordFeatureInteraction
+      recordFeatureInteraction: mocks.recordFeatureInteraction,
+      setSidebarOpen: mocks.setSidebarOpen
     })
   }
 }))
@@ -74,6 +76,7 @@ describe('useWorkspaceBoardPanel', () => {
   beforeEach(() => {
     latestState = null
     mocks.recordFeatureInteraction.mockReset()
+    mocks.setSidebarOpen.mockReset()
   })
 
   afterEach(() => {
@@ -92,12 +95,15 @@ describe('useWorkspaceBoardPanel', () => {
     expect(panelState().workspaceBoardRenderedOpen).toBe(true)
     expect(panelState().workspaceBoardDragPreviewOpen).toBe(false)
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledExactlyOnceWith('workspace-board')
+    expect(mocks.setSidebarOpen).toHaveBeenCalledExactlyOnceWith(true)
 
     await updatePanel((state) => state.toggleWorkspaceBoard())
 
     expect(panelState().workspaceBoardOpen).toBe(false)
     expect(panelState().workspaceBoardRenderedOpen).toBe(false)
     expect(mocks.recordFeatureInteraction).toHaveBeenCalledOnce()
+    // Why: closing must not re-open/toggle the sidebar.
+    expect(mocks.setSidebarOpen).toHaveBeenCalledOnce()
   })
 
   it('opens the board from the shortcut bridge event', async () => {

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
@@ -65,7 +65,11 @@ export function useWorkspaceBoardPanel(): WorkspaceBoardPanelState {
     workspaceBoardDragPreviewOpenRef.current = false
     // Why: opening the board is the user action; recording here avoids a
     // post-render bookkeeping Effect in the drawer.
-    useAppStore.getState().recordFeatureInteraction('workspace-board')
+    const store = useAppStore.getState()
+    store.recordFeatureInteraction('workspace-board')
+    // Why: board lives in the left sidebar — reveal it when opening so a
+    // keyboard toggle is not a no-op while the sidebar is collapsed (#12992 CR).
+    store.setSidebarOpen(true)
     setWorkspaceBoardOpen(true)
     setWorkspaceBoardDragPreviewOpen(false)
   }, [])
@@ -113,12 +117,9 @@ export function useWorkspaceBoardPanel(): WorkspaceBoardPanelState {
       }
       return
     }
-    workspaceBoardOpenRef.current = true
-    workspaceBoardDragPreviewOpenRef.current = false
-    useAppStore.getState().recordFeatureInteraction('workspace-board')
-    setWorkspaceBoardOpen(true)
-    setWorkspaceBoardDragPreviewOpen(false)
-  }, [])
+    // Why: share openWorkspaceBoard so drag solidify also reveals the sidebar.
+    openWorkspaceBoard()
+  }, [openWorkspaceBoard])
 
   const cancelWorkspaceBoardDragPreview = useCallback(() => {
     if (!workspaceBoardDragPreviewOpenRef.current) {

--- a/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
+++ b/src/renderer/src/components/sidebar/useWorkspaceBoardPanel.ts
@@ -27,6 +27,7 @@ const WORKSPACE_BOARD_ESCAPE_BLOCKING_OVERLAY_SELECTOR = [
 ].join(', ')
 
 export const OPEN_WORKSPACE_BOARD_EVENT = 'orca:open-workspace-board'
+export const TOGGLE_WORKSPACE_BOARD_EVENT = 'orca:toggle-workspace-board'
 
 export type WorkspaceBoardPanelState = {
   workspaceBoardOpen: boolean
@@ -161,6 +162,11 @@ export function useWorkspaceBoardPanel(): WorkspaceBoardPanelState {
     window.addEventListener(OPEN_WORKSPACE_BOARD_EVENT, openWorkspaceBoard)
     return () => window.removeEventListener(OPEN_WORKSPACE_BOARD_EVENT, openWorkspaceBoard)
   }, [openWorkspaceBoard])
+
+  useEffect(() => {
+    window.addEventListener(TOGGLE_WORKSPACE_BOARD_EVENT, toggleWorkspaceBoard)
+    return () => window.removeEventListener(TOGGLE_WORKSPACE_BOARD_EVENT, toggleWorkspaceBoard)
+  }, [toggleWorkspaceBoard])
 
   return {
     workspaceBoardOpen,

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -11,7 +11,10 @@ import { buildLinearIssueLinkedWorkItem } from '@/lib/linear-linked-work-item'
 import { runWorktreeDelete } from '@/components/sidebar/delete-worktree-flow'
 import { runSleepWorktree } from '@/components/sidebar/sleep-worktree-flow'
 import { createBackgroundSleepingAgentWakeDispatcher } from '@/lib/wake-sleeping-agents-in-background'
-import { OPEN_WORKSPACE_BOARD_EVENT } from '@/components/sidebar/useWorkspaceBoardPanel'
+import {
+  OPEN_WORKSPACE_BOARD_EVENT,
+  TOGGLE_WORKSPACE_BOARD_EVENT
+} from '@/components/sidebar/useWorkspaceBoardPanel'
 import { SPLIT_TERMINAL_PANE_EVENT, CLOSE_TERMINAL_PANE_EVENT } from '@/constants/terminal'
 import { requestBackgroundTerminalWorktreeMount } from '@/components/terminal/background-terminal-worktree-mount'
 import { planMobileTerminalTabMount } from '@/lib/mobile-terminal-tab-mount'
@@ -1332,6 +1335,18 @@ export function useIpcEvents(): void {
           }
           store.setSidebarOpen(true)
           window.dispatchEvent(new CustomEvent(OPEN_WORKSPACE_BOARD_EVENT))
+        })
+      )
+    }
+
+    if (window.api.ui.onToggleWorkspaceBoard) {
+      unsubs.push(
+        window.api.ui.onToggleWorkspaceBoard(() => {
+          const store = useAppStore.getState()
+          if (store.activeView === 'settings') {
+            return
+          }
+          window.dispatchEvent(new CustomEvent(TOGGLE_WORKSPACE_BOARD_EVENT))
         })
       )
     }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -2696,6 +2696,7 @@ function createWebUiApi(): NonNullable<Partial<PreloadApi>['ui']> {
     onOpenNewWorkspace: () => noopUnsubscribe,
     onDeleteCurrentWorkspace: () => noopUnsubscribe,
     onOpenWorkspaceBoard: () => noopUnsubscribe,
+    onToggleWorkspaceBoard: () => noopUnsubscribe,
     onJumpToWorktreeIndex: () => noopUnsubscribe,
     onJumpToTabIndex: () => noopUnsubscribe,
     onWorktreeHistoryNavigate: () => noopUnsubscribe,

--- a/src/shared/keybindings.test.ts
+++ b/src/shared/keybindings.test.ts
@@ -781,6 +781,31 @@ describe('keybindings', () => {
     )
   })
 
+  it('keeps the workspace board toggle unassigned until users customize it', () => {
+    const binding = {
+      key: 'b',
+      code: 'KeyB',
+      control: true,
+      meta: false,
+      alt: true,
+      shift: true
+    }
+
+    expect(getEffectiveKeybindingsForAction('workspace.toggleBoard', 'linux')).toEqual([])
+    expect(keybindingMatchesAction('workspace.toggleBoard', binding, 'linux')).toBe(false)
+    expect(
+      keybindingMatchesAction('workspace.toggleBoard', binding, 'linux', {
+        'workspace.toggleBoard': ['Mod+Alt+Shift+B']
+      })
+    ).toBe(true)
+
+    const definition = getKeybindingDefinition('workspace.toggleBoard')
+    expect(definition?.title).toBe('Toggle Workspace Board')
+    expect(definition?.searchKeywords).toEqual(
+      expect.arrayContaining(['workspace', 'board', 'kanban'])
+    )
+  })
+
   it('keeps the quick commands menu toggle unassigned until users customize it', () => {
     const platforms: readonly KeybindingPlatform[] = ['darwin', 'linux', 'win32']
 

--- a/src/shared/keybindings.ts
+++ b/src/shared/keybindings.ts
@@ -37,6 +37,7 @@ export type KeybindingActionId =
   | 'workspace.rename'
   | 'workspace.delete'
   | 'workspace.openBoard'
+  | 'workspace.toggleBoard'
   | 'workspace.selectByIndex'
   | 'voice.dictation'
   | 'view.tasks'
@@ -298,6 +299,16 @@ export const KEYBINDING_DEFINITIONS: readonly KeybindingDefinition[] = [
   {
     id: 'workspace.openBoard',
     title: 'Open Workspace Board',
+    group: 'Global',
+    scope: 'global',
+    searchKeywords: ['shortcut', 'global', 'workspace', 'board', 'kanban', 'worktree'],
+    // Why: configurable but unbound by default, to not take a global chord from terminal/browser/editor users.
+    defaultBindings: platformBindings([]),
+    allowInTerminal: true
+  },
+  {
+    id: 'workspace.toggleBoard',
+    title: 'Toggle Workspace Board',
     group: 'Global',
     scope: 'global',
     searchKeywords: ['shortcut', 'global', 'workspace', 'board', 'kanban', 'worktree'],

--- a/src/shared/plugins/plugin-command-actions.ts
+++ b/src/shared/plugins/plugin-command-actions.ts
@@ -11,6 +11,7 @@ export const PLUGIN_COMMAND_ALIAS_ACTION_IDS = [
   'tab.rename',
   'workspace.rename',
   'workspace.openBoard',
+  'workspace.toggleBoard',
   'view.tasks',
   'sidebar.right.toggle',
   'sidebar.explorer.toggle',

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -344,6 +344,7 @@ describe('resolveWindowShortcutAction', () => {
     const overrides: KeybindingOverrides = {
       'worktree.quickOpen': ['Mod+Shift+O'],
       'workspace.openBoard': ['Mod+Alt+B'],
+      'workspace.toggleBoard': ['Mod+Alt+T'],
       'view.tasks': ['Mod+Alt+K']
     }
 
@@ -368,6 +369,13 @@ describe('resolveWindowShortcutAction', () => {
         overrides
       )
     ).toEqual({ type: 'openWorkspaceBoard' })
+    expect(
+      resolveWindowShortcutAction(
+        { code: 'KeyT', key: 't', meta: false, control: true, alt: true, shift: false },
+        'linux',
+        overrides
+      )
+    ).toEqual({ type: 'toggleWorkspaceBoard' })
     expect(
       resolveWindowShortcutAction(
         { code: 'KeyK', key: 'k', meta: false, control: true, alt: true, shift: false },

--- a/src/shared/window-shortcut-policy.test.ts
+++ b/src/shared/window-shortcut-policy.test.ts
@@ -341,6 +341,17 @@ describe('resolveWindowShortcutAction', () => {
   })
 
   it('applies custom keybinding overrides to main-process shortcuts', () => {
+    const linuxCtrlAltT = {
+      code: 'KeyT',
+      key: 't',
+      meta: false,
+      control: true,
+      alt: true,
+      shift: false
+    }
+    // Why: workspace.toggleBoard ships without a default binding (#12992 CR).
+    expect(resolveWindowShortcutAction(linuxCtrlAltT, 'linux')).toBeNull()
+
     const overrides: KeybindingOverrides = {
       'worktree.quickOpen': ['Mod+Shift+O'],
       'workspace.openBoard': ['Mod+Alt+B'],
@@ -369,13 +380,9 @@ describe('resolveWindowShortcutAction', () => {
         overrides
       )
     ).toEqual({ type: 'openWorkspaceBoard' })
-    expect(
-      resolveWindowShortcutAction(
-        { code: 'KeyT', key: 't', meta: false, control: true, alt: true, shift: false },
-        'linux',
-        overrides
-      )
-    ).toEqual({ type: 'toggleWorkspaceBoard' })
+    expect(resolveWindowShortcutAction(linuxCtrlAltT, 'linux', overrides)).toEqual({
+      type: 'toggleWorkspaceBoard'
+    })
     expect(
       resolveWindowShortcutAction(
         { code: 'KeyK', key: 'k', meta: false, control: true, alt: true, shift: false },

--- a/src/shared/window-shortcut-policy.ts
+++ b/src/shared/window-shortcut-policy.ts
@@ -40,6 +40,7 @@ export type WindowShortcutAction =
   | { type: 'openNewWorkspace' }
   | { type: 'deleteCurrentWorkspace' }
   | { type: 'openWorkspaceBoard' }
+  | { type: 'toggleWorkspaceBoard' }
   | { type: 'openTasks' }
   | { type: 'switchRecentTab' }
   | { type: 'jumpToWorktreeIndex'; index: number }
@@ -243,6 +244,10 @@ export function resolveWindowShortcutAction(
     return { type: 'openWorkspaceBoard' }
   }
 
+  if (actionMatches('workspace.toggleBoard', input, platform, keybindings, options)) {
+    return { type: 'toggleWorkspaceBoard' }
+  }
+
   if (actionMatches('voice.dictation', input, platform, keybindings, options)) {
     return { type: 'dictationKeyDown' }
   }
@@ -322,6 +327,8 @@ export function getWindowShortcutActionId(action: WindowShortcutAction): Keybind
       return 'workspace.delete'
     case 'openWorkspaceBoard':
       return 'workspace.openBoard'
+    case 'toggleWorkspaceBoard':
+      return 'workspace.toggleBoard'
     case 'openTasks':
       return 'view.tasks'
     case 'switchRecentTab':


### PR DESCRIPTION
## Description

Expose the existing Workspace Board toggle as an assignable keyboard action.

## Focused fix

- In scope: route `workspace.toggleBoard` through the existing keybinding, preload, and renderer paths.
- Out of scope: changing the open-only `workspace.openBoard` action or broadening Escape handling.

## Preserves

- `workspace.openBoard` keeps its open-only semantics, while the new action uses the existing board toggle implementation and platform shortcut policy.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/shared/keybindings.test.ts src/shared/window-shortcut-policy.test.ts src/renderer/src/components/sidebar/useWorkspaceBoardPanel.test.tsx`
- Post-rebase result: 3 files, 120 tests passed.
- Changed-file oxfmt and oxlint passed.

## User-regression-tradeoffs

- Users can bind one shortcut to open and close the board without changing sidebar-wide shortcuts or relying on Escape.

Fixes #12969
