### PR TITLE
fix(antigravity): allow PreToolUse status hooks

### DIFF
--- a/src/main/agent-hooks/remote-hook-service-installers.test.ts
+++ b/src/main/agent-hooks/remote-hook-service-installers.test.ts
@@ -342,8 +342,7 @@ describe('remote hook service installers', () => {
       expect(command).toContain('/home/dev/.orca/agent-hooks/antigravity-hook.sh')
       expect(command).toContain(`ORCA_ANTIGRAVITY_EVENT='${eventName}'`)
     }
-    expect(antigravityConfig['orca-status'].PreToolUse).toBeUndefined()
-    for (const eventName of ['PostToolUse']) {
+    for (const eventName of ['PreToolUse', 'PostToolUse']) {
       const definition = antigravityConfig['orca-status'][eventName]?.[0]
       const command = definition?.hooks?.[0]?.command
       expect(definition?.matcher).toBe('*')
@@ -522,7 +521,7 @@ describe('remote hook service installers', () => {
     }
   })
 
-  it('removes stale remote Antigravity PreToolUse hooks while installing SSH hooks', async () => {
+  it('replaces stale remote Antigravity PreToolUse hooks while installing SSH hooks', async () => {
     const { sftp, fs } = createFakeSftp()
     fs.files.set(
       '/home/dev/.gemini/config/hooks.json',
@@ -563,7 +562,13 @@ describe('remote hook service installers', () => {
     const config = JSON.parse(fs.files.get('/home/dev/.gemini/config/hooks.json')!) as {
       'orca-status': Record<string, { hooks?: { command: string }[] }[]>
     }
-    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    const preToolCommands = config['orca-status'].PreToolUse.flatMap((definition) =>
+      (definition.hooks ?? []).map((hook) => hook.command)
+    )
+    expect(preToolCommands).toEqual(
+      expect.arrayContaining([expect.stringContaining('antigravity-hook.sh')])
+    )
+    expect(preToolCommands).not.toContain('/tmp/old/agent-hooks/antigravity-hook.sh')
     const postToolCommands = config['orca-status'].PostToolUse.flatMap((definition) =>
       (definition.hooks ?? []).map((hook) => hook.command)
     )

--- a/src/main/antigravity/hook-service.test.ts
+++ b/src/main/antigravity/hook-service.test.ts
@@ -1,4 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
@@ -25,6 +26,8 @@ const ANTIGRAVITY_PRE_INVOCATION_COMMAND =
   process.platform === 'win32' ? 'antigravity-pre-invocation.cmd' : 'antigravity-hook.sh'
 const ANTIGRAVITY_POST_TOOL_USE_COMMAND =
   process.platform === 'win32' ? 'antigravity-post-tool-use.cmd' : 'antigravity-hook.sh'
+const ANTIGRAVITY_PRE_TOOL_USE_COMMAND =
+  process.platform === 'win32' ? 'antigravity-pre-tool-use.cmd' : 'antigravity-hook.sh'
 
 function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
   const originalPlatform = Object.getOwnPropertyDescriptor(process, 'platform')
@@ -67,10 +70,12 @@ describe('AntigravityHookService', () => {
       >
     }
     expect(Object.keys(config['orca-status']).sort()).toEqual(
-      ['PostInvocation', 'PostToolUse', 'PreInvocation', 'Stop'].sort()
+      ['PostInvocation', 'PostToolUse', 'PreInvocation', 'PreToolUse', 'Stop'].sort()
     )
-    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    expect(config['orca-status'].PreToolUse[0].matcher).toBe('*')
     expect(config['orca-status'].PostToolUse[0].matcher).toBe('*')
+    const preToolCommand = config['orca-status'].PreToolUse[0].hooks?.[0]?.command
+    expect(preToolCommand).toContain(ANTIGRAVITY_PRE_TOOL_USE_COMMAND)
     expect(config['orca-status'].PreInvocation[0].command).toContain(
       ANTIGRAVITY_PRE_INVOCATION_COMMAND
     )
@@ -105,9 +110,31 @@ describe('AntigravityHookService', () => {
       expect(script).not.toContain('--data-urlencode "payload=${payload}"')
     }
     expect(script).toContain('{"decision":""}')
+    expect(script).toContain('{"decision":"allow"}')
+    expect(script).not.toContain('{"decision":"deny"}')
+    expect(script).not.toContain('{"decision":"ask"}')
+
+    if (process.platform !== 'win32') {
+      const preTool = spawnSync(
+        '/bin/sh',
+        [join(homeDir, '.orca', 'agent-hooks', 'antigravity-hook.sh')],
+        {
+          env: {
+            ...process.env,
+            ORCA_ANTIGRAVITY_EVENT: 'PreToolUse',
+            ORCA_AGENT_HOOK_ENDPOINT: '',
+            ORCA_AGENT_HOOK_PORT: ''
+          },
+          input: '{"tool_name":"Read"}',
+          encoding: 'utf8'
+        }
+      )
+      expect(preTool.status).toBe(0)
+      expect(preTool.stdout).toBe('{"decision":"allow"}\n')
+    }
   })
 
-  it('installs Windows event wrappers without nested cmd quoting and removes stale PreToolUse hooks', () => {
+  it('installs Windows event wrappers without nested cmd quoting and replaces stale PreToolUse hooks', () => {
     withPlatform('win32', () => {
       const configPath = join(homeDir, '.gemini', 'config', 'hooks.json')
       const staleScriptPath = join(
@@ -155,18 +182,20 @@ describe('AntigravityHookService', () => {
           { matcher?: string; command?: string; hooks?: { command: string }[] }[]
         >
       }
-      expect(config['orca-status'].PreToolUse).toBeUndefined()
+      expect(config['orca-status'].PreToolUse).toHaveLength(1)
 
       const expectedWrappers = {
         PreInvocation: 'antigravity-pre-invocation.cmd',
         PostInvocation: 'antigravity-post-invocation.cmd',
+        PreToolUse: 'antigravity-pre-tool-use.cmd',
         Stop: 'antigravity-stop.cmd',
         PostToolUse: 'antigravity-post-tool-use.cmd'
       }
       for (const [eventName, wrapperFileName] of Object.entries(expectedWrappers)) {
         const definition = config['orca-status'][eventName][0]
-        const command =
-          eventName === 'PostToolUse' ? definition.hooks?.[0]?.command : definition.command
+        const command = ['PreToolUse', 'PostToolUse'].includes(eventName)
+          ? definition.hooks?.[0]?.command
+          : definition.command
         expect(createManagedCommandMatcher(wrapperFileName)(command)).toBe(true)
         expect(command).not.toContain('cmd /d /s /c')
         expect(command).not.toContain('ORCA_ANTIGRAVITY_EVENT')
@@ -174,6 +203,10 @@ describe('AntigravityHookService', () => {
         const wrapper = readFileSync(join(homeDir, '.orca', 'agent-hooks', wrapperFileName), 'utf8')
         expect(wrapper).toContain(`set "ORCA_ANTIGRAVITY_EVENT=${eventName}"`)
         expect(wrapper).toContain('call "%ORCA_ANTIGRAVITY_CORE%"')
+        if (eventName === 'PreToolUse') {
+          expect(wrapper).toContain('echo {"decision":"allow"}')
+          expect(wrapper).not.toContain('echo {"decision":"deny"}')
+        }
       }
 
       const script = readFileSync(
@@ -254,7 +287,13 @@ describe('AntigravityHookService', () => {
       'orca-status': Record<string, { command?: string; hooks?: { command: string }[] }[]>
     }
     expect(config['orca-status'].OldEvent).toBeUndefined()
-    expect(config['orca-status'].PreToolUse).toBeUndefined()
+    const preToolCommands = config['orca-status'].PreToolUse.flatMap((definition) =>
+      (definition.hooks ?? []).map((hook) => hook.command)
+    )
+    expect(preToolCommands).toHaveLength(1)
+    expect(preToolCommands[0]).toContain(
+      join(homeDir, '.orca', 'agent-hooks', ANTIGRAVITY_PRE_TOOL_USE_COMMAND)
+    )
     const commands = config['orca-status'].PostToolUse.flatMap((definition) =>
       (definition.hooks ?? []).map((hook) => hook.command)
     )

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -46,8 +46,11 @@ const ANTIGRAVITY_EVENTS = [
     windowsWrapperFileName: 'antigravity-post-invocation.cmd'
   },
   { eventName: 'Stop', schema: 'direct', windowsWrapperFileName: 'antigravity-stop.cmd' },
-  // Why: Antigravity requires PreToolUse hooks to make permission decisions.
-  // Orca's hook is observational, so installing there can block user tools.
+  {
+    eventName: 'PreToolUse',
+    schema: 'tool',
+    windowsWrapperFileName: 'antigravity-pre-tool-use.cmd'
+  },
   {
     eventName: 'PostToolUse',
     schema: 'tool',
@@ -95,6 +98,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       'setlocal',
       'if /I "%ORCA_ANTIGRAVITY_EVENT%"=="Stop" (',
       '  echo {"decision":""}',
+      ') else if /I "%ORCA_ANTIGRAVITY_EVENT%"=="PreToolUse" (',
+      '  echo {"decision":"allow"}',
       ') else (',
       '  echo {}',
       ')',
@@ -113,10 +118,12 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
     '  Stop)',
     '    printf \'{"decision":""}\\n\'',
     '    ;;',
+    '  PreToolUse)',
+    '    printf \'{"decision":"allow"}\\n\'',
+    '    ;;',
     '  *)',
     // Why: Antigravity accepts an empty JSON object for passive status hooks;
-    // returning allow/ask/deny from PreToolUse would change the user's tool
-    // permission policy.
+    // PreToolUse is the only passive status hook with a required allow response.
     '    printf "{}\\n"',
     '    ;;',
     'esac',
@@ -162,6 +169,8 @@ function getWindowsWrapperScript(eventName: string): string {
     ')',
     'if /I "%ORCA_ANTIGRAVITY_EVENT%"=="Stop" (',
     '  echo {"decision":""}',
+    ') else if /I "%ORCA_ANTIGRAVITY_EVENT%"=="PreToolUse" (',
+    '  echo {"decision":"allow"}',
     ') else (',
     '  echo {}',
     ')',


### PR DESCRIPTION
## Description

Restore Antigravity `PreToolUse` status events with the schema-required allow response.

## Focused fix

- In scope: install the observational `PreToolUse` hook with a fixed `decision: allow` response and cover local, Windows, and SSH installers.
- Out of scope: changing Antigravity tool-event consumers or other hook decisions.

## Preserves

- The hook remains observational and explicitly allows the tool call, preserving Antigravity's required response schema instead of sending the invalid empty response.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/antigravity/hook-service.test.ts src/main/agent-hooks/remote-hook-service-installers.test.ts`
- Post-rebase result: 2 files, 27 tests passed.
- Changed-file oxfmt and oxlint passed.

## User-regression-tradeoffs

- Antigravity panes receive live tool-name status while retaining the existing invocation and completion lifecycle.

Fixes #12898
