### PR TITLE
feat(cli): expose terminal agent status

### DIFF
--- a/src/cli/format.ts
+++ b/src/cli/format.ts
@@ -31,6 +31,7 @@ export {
   formatProjectList
 } from './project-format'
 export {
+  formatTerminalAgentStatus,
   formatTerminalClose,
   formatTerminalCreate,
   formatTerminalFocus,

--- a/src/cli/handler-group-manifest.ts
+++ b/src/cli/handler-group-manifest.ts
@@ -76,6 +76,7 @@ export const HANDLER_GROUPS: readonly HandlerGroup[] = [
     keys: [
       'terminal list',
       'terminal show',
+      'terminal agent-status',
       'terminal read',
       'terminal send',
       'terminal wait',

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -1,5 +1,6 @@
 import type {
   RuntimeTerminalClose,
+  RuntimeTerminalAgentStatus,
   RuntimeTerminalCreate,
   RuntimeTerminalFocus,
   RuntimeTerminalListResult,
@@ -13,6 +14,7 @@ import type {
 import type { CommandHandler } from '../dispatch'
 import { shouldUseRendererBackedInteractiveTerminal } from '../codex-command-classification'
 import {
+  formatTerminalAgentStatus,
   formatTerminalClose,
   formatTerminalCreate,
   formatTerminalFocus,
@@ -66,6 +68,15 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       terminal: await getTerminalHandle(flags, cwd, client)
     })
     printResult(result, json, formatTerminalShow)
+  },
+  'terminal agent-status': async ({ flags, client, cwd, json }) => {
+    const result = await client.call<{ agentStatus: RuntimeTerminalAgentStatus }>(
+      'terminal.agentStatus',
+      {
+        terminal: await getTerminalHandle(flags, cwd, client)
+      }
+    )
+    printResult(result, json, formatTerminalAgentStatus)
   },
   'terminal read': async ({ flags, client, cwd, json }) => {
     const cursorFlag = getOptionalStringFlag(flags, 'cursor')

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -3159,6 +3159,80 @@ describe('orca cli worktree awareness', () => {
     ])
   })
 
+  it.each(['working', 'permission', 'idle'] as const)(
+    'prints terminal agent status JSON for %s',
+    async (status) => {
+      queueFixtures(
+        callMock,
+        okFixture('req_terminal_agent_status', {
+          agentStatus: {
+            handle: 'term_worker',
+            isRunningAgent: true,
+            status
+          }
+        })
+      )
+      const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+      await main(['terminal', 'agent-status', '--terminal', 'term_worker', '--json'], '/tmp/repo')
+
+      expect(callMock).toHaveBeenCalledWith('terminal.agentStatus', {
+        terminal: 'term_worker'
+      })
+      const printed = JSON.parse(String(logSpy.mock.calls[0]?.[0]))
+      expect(printed.result.agentStatus).toEqual({
+        handle: 'term_worker',
+        isRunningAgent: true,
+        status
+      })
+    }
+  )
+
+  it('prints terminal agent status in human-readable mode', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_terminal_agent_status', {
+        agentStatus: {
+          handle: 'term_worker',
+          isRunningAgent: true,
+          status: 'permission'
+        }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'agent-status', '--terminal', 'term_worker'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith('terminal.agentStatus', {
+      terminal: 'term_worker'
+    })
+    expect(logSpy.mock.calls.flat().join('\n')).toBe(
+      ['handle: term_worker', 'isRunningAgent: true', 'status: permission'].join('\n')
+    )
+  })
+
+  it('prints terminal agent status null for non-agent terminals', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_terminal_agent_status', {
+        agentStatus: {
+          handle: 'term_shell',
+          isRunningAgent: false,
+          status: null
+        }
+      })
+    )
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['terminal', 'agent-status', '--terminal', 'term_shell'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith('terminal.agentStatus', {
+      terminal: 'term_shell'
+    })
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('isRunningAgent: false')
+    expect(logSpy.mock.calls.flat().join('\n')).toContain('status: null')
+  })
+
   it('keeps interactive Codex startup commands backgrounded unless focus is explicit', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -194,6 +194,17 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'terminal']
   },
   {
+    path: ['terminal', 'agent-status'],
+    summary: 'Show the detected agent state for a terminal',
+    usage: 'orca terminal agent-status [--terminal <handle>] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'terminal'],
+    notes: ['Reports terminal.agentStatus state: working, permission, idle, or null.'],
+    examples: [
+      'orca terminal agent-status --terminal term_abc123',
+      'orca terminal agent-status --terminal term_abc123 --json'
+    ]
+  },
+  {
     path: ['terminal', 'read'],
     summary: 'Read bounded terminal output',
     usage: 'orca terminal read [--terminal <handle>] [--cursor <n>] [--limit <n>] [--json]',

--- a/src/cli/terminal-format.ts
+++ b/src/cli/terminal-format.ts
@@ -1,5 +1,6 @@
 import type {
   RuntimeTerminalClose,
+  RuntimeTerminalAgentStatus,
   RuntimeTerminalCreate,
   RuntimeTerminalFocus,
   RuntimeTerminalListResult,
@@ -98,6 +99,17 @@ export function formatTerminalShow(result: { terminal: RuntimeTerminalShow }): s
     `connected: ${terminal.connected}`,
     `writable: ${terminal.writable}`,
     `preview: ${terminal.preview || '<empty>'}`
+  ].join('\n')
+}
+
+export function formatTerminalAgentStatus(result: {
+  agentStatus: RuntimeTerminalAgentStatus
+}): string {
+  const agentStatus = result.agentStatus
+  return [
+    `handle: ${agentStatus.handle}`,
+    `isRunningAgent: ${agentStatus.isRunningAgent}`,
+    `status: ${agentStatus.status ?? 'null'}`
   ].join('\n')
 }
 


### PR DESCRIPTION
## Description

Expose the existing terminal agent-status RPC through a public non-blocking CLI command.

## Focused fix

- In scope: add `orca terminal agent-status`, its human-readable and JSON formatters, and focused CLI coverage.
- Out of scope: introducing new runtime states or changing terminal wait/show output.

## Preserves

- The command reports the existing `working | permission | idle | null` vocabulary and keeps `isRunningAgent: false` distinct from a null status.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/cli/index.test.ts`
- Post-rebase result: 1 file, 163 tests passed.
- Changed-file oxfmt and oxlint passed.

## User-regression-tradeoffs

- Supervisors can poll the runtime classification without blocking on `terminal wait` or screen-scraping provider-specific output.

Fixes #12844
