### PR TITLE
fix(ssh): keep orchestration check help side-effect free

### DIFF
--- a/src/main/ssh/ssh-remote-orca-cli.test.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.test.ts
@@ -84,6 +84,7 @@ describe('runRemoteOrcaCli', () => {
       getCurrentRunForPane: vi.fn(() => undefined),
       findActiveRemoteAttachmentForPane: vi.fn(() => undefined)
     }
+    const getOrchestrationDb = vi.fn(() => db)
     const runtime = {
       getRuntimeId: () => 'runtime-test',
       getStatus: () => ({
@@ -94,7 +95,7 @@ describe('runRemoteOrcaCli', () => {
         liveTabCount: 1,
         liveLeafCount: 1
       }),
-      getOrchestrationDb: () => db,
+      getOrchestrationDb,
       getTerminalPaneKey: () => null,
       deliverPendingMessagesForHandle: vi.fn(),
       notifyMessageArrived: vi.fn(),
@@ -136,7 +137,7 @@ describe('runRemoteOrcaCli', () => {
         meta: { query: 'auth bug', limit: 5, returned: 0, limitReached: false }
       }))
     } as unknown as OrcaRuntimeService
-    return { runtime, db }
+    return { runtime, db, getOrchestrationDb }
   }
 
   it.each([
@@ -176,7 +177,7 @@ describe('runRemoteOrcaCli', () => {
   )
 
   it('prints orchestration check help through the SSH legacy fallback without dispatching RPC', async () => {
-    const { runtime, db } = createRuntime()
+    const { runtime, db, getOrchestrationDb } = createRuntime()
 
     const result = await runRemoteOrcaCli(
       runtime,
@@ -212,13 +213,13 @@ describe('runRemoteOrcaCli', () => {
         --pairing-code
         --environment
         --terminal <handle>  Runtime-issued terminal handle
-        --run
-        --ack
+        --run <run_id>
+        --ack <delivery_id>
         --unread
         --peek
         --all
-        --types
-        --format <png|jpeg>    Screenshot image format
+        --types <type,...>
+        --format               Render returned rows as local text
         --wait
         --timeout-ms <ms>     Maximum wait time before timing out
         --retry-request
@@ -232,6 +233,7 @@ describe('runRemoteOrcaCli', () => {
     expect(db.getCurrentRunForPane).not.toHaveBeenCalled()
     expect(db.getUnreadMessages).not.toHaveBeenCalled()
     expect(db.markAsRead).not.toHaveBeenCalled()
+    expect(getOrchestrationDb).not.toHaveBeenCalled()
   })
 
   it('uses the remote ORCA_TERMINAL_HANDLE as orchestration sender identity', async () => {

--- a/src/main/ssh/ssh-remote-orca-cli.test.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.test.ts
@@ -175,6 +175,65 @@ describe('runRemoteOrcaCli', () => {
     }
   )
 
+  it('prints orchestration check help through the SSH legacy fallback without dispatching RPC', async () => {
+    const { runtime, db } = createRuntime()
+
+    const result = await runRemoteOrcaCli(
+      runtime,
+      {
+        argv: ['orchestration', 'check', '--help'],
+        cwd: '/home/alice/repo',
+        env: { ORCA_TERMINAL_HANDLE: 'term_ssh' }
+      },
+      LEGACY_FALLBACK_OPTIONS
+    )
+
+    expect(result.stderr).toBe('')
+    expect(result.exitCode).toBe(0)
+    expect(result.stdout).toMatchInlineSnapshot(`
+      "orca orchestration check
+
+      Usage: orca orchestration check [--terminal <handle>] [--run <run_id>] [--ack <delivery_id>] [--unread | --peek | --all] [--types <type,...>] [--format] [--wait] [--timeout-ms <n>] [--json]
+        default: return the bound Run's oldest unacknowledged FIFO batch.
+        --ack: acknowledge the prior whole batch before checking/waiting.
+        --peek: return only unread messages without marking them read.
+        --all: return every message for the handle; does not mark read.
+        --wait: block until a matching message arrives or --timeout-ms expires.
+                Emits JSON keepalive lines to stderr every 15s so the caller can
+                tell the process is alive. \`_keepalive\` is unrelated to heartbeat
+                messages; \`_heartbeat\` remains as a deprecated compatibility alias.
+                Filter with \`jq "select(._keepalive|not)"\` when merging streams.
+
+      Check messages for a terminal
+
+      Options:
+        --help                 Show this help message
+        --json                 Emit machine-readable JSON
+        --pairing-code
+        --environment
+        --terminal <handle>  Runtime-issued terminal handle
+        --run
+        --ack
+        --unread
+        --peek
+        --all
+        --types
+        --format <png|jpeg>    Screenshot image format
+        --wait
+        --timeout-ms <ms>     Maximum wait time before timing out
+        --retry-request
+
+      Notes:
+        On Windows PowerShell, quote comma-separated type filters, e.g. --types "worker_done,escalation".
+        --format renders the returned rows as local text only; it never writes to another terminal.
+        A bound Run replays the same Delivery until --ack; process every message before acknowledging.
+      "
+    `)
+    expect(db.getCurrentRunForPane).not.toHaveBeenCalled()
+    expect(db.getUnreadMessages).not.toHaveBeenCalled()
+    expect(db.markAsRead).not.toHaveBeenCalled()
+  })
+
   it('uses the remote ORCA_TERMINAL_HANDLE as orchestration sender identity', async () => {
     const { runtime, db } = createRuntime()
 

--- a/src/main/ssh/ssh-remote-orca-cli.ts
+++ b/src/main/ssh/ssh-remote-orca-cli.ts
@@ -27,6 +27,7 @@ import {
   getRemoteOrchestrationPayload,
   resolveRemoteOrchestrationSender
 } from './ssh-remote-orchestration-send'
+import { getRemoteOrchestrationHelp } from './ssh-remote-orchestration-help'
 import { formatInProcessRemoteCliResult } from './ssh-remote-cli-in-process-result'
 
 export type { RemoteOrcaCliRequest, RemoteOrcaCliResult } from './ssh-remote-cli-host-passthrough'
@@ -101,6 +102,10 @@ async function runLegacyRemoteOrcaCli(
   passthroughFailure: HostCliUnavailableError
 ): Promise<RemoteOrcaCliResult> {
   const dispatcher = new RpcDispatcher({ runtime })
+  const orchestrationHelp = getRemoteOrchestrationHelp(parsed)
+  if (orchestrationHelp) {
+    return { stdout: `${orchestrationHelp}\n`, stderr: '', exitCode: 0 }
+  }
   const help = getRemoteLinearHelp(parsed)
   if (help) {
     return { stdout: `${help}\n`, stderr: '', exitCode: 0 }

--- a/src/main/ssh/ssh-remote-orchestration-help.ts
+++ b/src/main/ssh/ssh-remote-orchestration-help.ts
@@ -21,13 +21,13 @@ Options:
   --pairing-code
   --environment
   --terminal <handle>  Runtime-issued terminal handle
-  --run
-  --ack
+  --run <run_id>
+  --ack <delivery_id>
   --unread
   --peek
   --all
-  --types
-  --format <png|jpeg>    Screenshot image format
+  --types <type,...>
+  --format               Render returned rows as local text
   --wait
   --timeout-ms <ms>     Maximum wait time before timing out
   --retry-request

--- a/src/main/ssh/ssh-remote-orchestration-help.ts
+++ b/src/main/ssh/ssh-remote-orchestration-help.ts
@@ -1,0 +1,45 @@
+import type { ParsedRemoteCli } from './ssh-remote-cli-argument-error'
+
+const ORCHESTRATION_CHECK_HELP = `orca orchestration check
+
+Usage: orca orchestration check [--terminal <handle>] [--run <run_id>] [--ack <delivery_id>] [--unread | --peek | --all] [--types <type,...>] [--format] [--wait] [--timeout-ms <n>] [--json]
+  default: return the bound Run's oldest unacknowledged FIFO batch.
+  --ack: acknowledge the prior whole batch before checking/waiting.
+  --peek: return only unread messages without marking them read.
+  --all: return every message for the handle; does not mark read.
+  --wait: block until a matching message arrives or --timeout-ms expires.
+          Emits JSON keepalive lines to stderr every 15s so the caller can
+          tell the process is alive. \`_keepalive\` is unrelated to heartbeat
+          messages; \`_heartbeat\` remains as a deprecated compatibility alias.
+          Filter with \`jq "select(._keepalive|not)"\` when merging streams.
+
+Check messages for a terminal
+
+Options:
+  --help                 Show this help message
+  --json                 Emit machine-readable JSON
+  --pairing-code
+  --environment
+  --terminal <handle>  Runtime-issued terminal handle
+  --run
+  --ack
+  --unread
+  --peek
+  --all
+  --types
+  --format <png|jpeg>    Screenshot image format
+  --wait
+  --timeout-ms <ms>     Maximum wait time before timing out
+  --retry-request
+
+Notes:
+  On Windows PowerShell, quote comma-separated type filters, e.g. --types "worker_done,escalation".
+  --format renders the returned rows as local text only; it never writes to another terminal.
+  A bound Run replays the same Delivery until --ack; process every message before acknowledging.`
+
+export function getRemoteOrchestrationHelp(parsed: ParsedRemoteCli): string | null {
+  if (!parsed.flags.has('help') || parsed.commandPath.join(' ') !== 'orchestration check') {
+    return null
+  }
+  return ORCHESTRATION_CHECK_HELP
+}


### PR DESCRIPTION
## Description
Prevent the SSH legacy fallback from executing `orchestration check` when a user only asks for help.

## Focused fix
- In scope: return the existing command usage before legacy RPC dispatch for `orca orchestration check --help`.
- Out of scope: normal local CLI help, passthrough-capable hosts, and non-help orchestration commands.

## Preserves
- Mailbox reads, acknowledgements, and other orchestration side effects remain unchanged for commands that actually execute.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-orca-cli.test.ts`
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/ssh/ssh-remote-orca-cli.test.ts src/main/ssh/ssh-remote-cli-host-passthrough.test.ts`
- Typecheck: `pnpm run typecheck:node`
- Changed-code quality: `pnpm run check:code-quality:changed -- upstream/main`
- Regression coverage asserts help succeeds without calling the orchestration database paths.

## User-regression-tradeoffs
- Legacy SSH hosts now match the local CLI's side-effect-free help contract; the fallback owns only the existing `check` help text and does not change command execution.

Fixes #12985
