### PR TITLE
fix(agent-status): suppress replayed completion notifications

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -8101,6 +8101,32 @@ describe('AgentHookServer ingestRemote', () => {
     )
   })
 
+  it('preserves remote replay provenance in renderer IPC payload snapshots', () => {
+    const server = new AgentHookServer()
+    const payload = parseAgentStatusPayload(
+      JSON.stringify({ state: 'done', prompt: 'cached task', agentType: 'claude' })
+    )
+    if (!payload) {
+      throw new Error('parseAgentStatusPayload returned null for a known-good fixture')
+    }
+    const listener = vi.fn()
+    server.setListener(listener)
+    server.ingestRemote(
+      { paneKey: PANE, tabId: 'tab-1', worktreeId: 'wt-1', payload, isReplay: true },
+      'conn-1'
+    )
+
+    expect(listener).toHaveBeenCalledWith(expect.objectContaining({ isReplay: true }))
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE,
+        state: 'done',
+        prompt: 'cached task',
+        isReplay: true
+      })
+    ])
+  })
+
   it('preserves active pane identity when a nested remote hook reports another agent', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -394,6 +394,7 @@ function toAgentStatusIpcPayload(entry: EnrichedAgentHookEventPayload): AgentSta
     connectionId: entry.connectionId,
     receivedAt: entry.receivedAt,
     stateStartedAt: entry.stateStartedAt,
+    ...(entry.isReplay ? { isReplay: true } : {}),
     ...(entry.providerSession ? { providerSession: entry.providerSession } : {}),
     ...(entry.providerSessionOnly ? { providerSessionOnly: true } : {}),
     ...(entry.promptInteractionKey ? { promptInteractionKey: entry.promptInteractionKey } : {}),

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1446,6 +1446,7 @@ function openMainWindow(): BrowserWindow {
           connectionId,
           receivedAt,
           stateStartedAt,
+          ...(isReplay ? { isReplay: true } : {}),
           ...(providerSession ? { providerSession } : {}),
           providerSessionOnly: true
         })
@@ -1473,6 +1474,7 @@ function openMainWindow(): BrowserWindow {
         connectionId,
         receivedAt,
         stateStartedAt,
+        ...(isReplay ? { isReplay: true } : {}),
         ...(providerSession ? { providerSession } : {}),
         ...(promptInteractionKey ? { promptInteractionKey } : {}),
         ...(restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4970,6 +4970,7 @@ describe('useIpcEvents agent status snapshot integration', () => {
     connectionId?: string | null
     receivedAt: number
     stateStartedAt: number
+    isReplay?: boolean
   }
   type StoreLike = Record<string, unknown>
   type StoreSubscribeListener = (state: StoreLike, previousState: StoreLike) => void
@@ -6850,6 +6851,91 @@ describe('useIpcEvents agent status snapshot integration', () => {
         payload: expect.objectContaining({ state: 'done', agentType: 'codex' })
       })
     )
+  })
+
+  it('applies replayed done statuses without observing completion notifications', async () => {
+    const setAgentStatus = vi.fn()
+    const observeAgentHookCompletionForNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: true, agentTaskComplete: true } },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Claude' }]
+      },
+      terminalLayoutsByTabId: {
+        'tab-future': {
+          root: { type: 'leaf', leafId: FUTURE_LEAF_ID },
+          activeLeafId: FUTURE_LEAF_ID,
+          expandedLeafId: null
+        }
+      }
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    vi.doMock('./agent-hook-completion-notifications', () => ({
+      observeAgentHookCompletionForNotification,
+      resetAgentHookCompletionNotificationCoordinators: vi.fn(),
+      syncAgentHookCompletionNotificationsForStoreUpdate: vi.fn()
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      tabId: 'tab-future',
+      worktreeId: 'wt-1',
+      state: 'done',
+      prompt: 'cached task',
+      agentType: 'claude',
+      lastAssistantMessage: 'Already finished.',
+      receivedAt: 1_700_000_000_600,
+      stateStartedAt: 1_699_999_999_600,
+      isReplay: true
+    })
+
+    expect(setAgentStatus).toHaveBeenCalledTimes(1)
+    expect(setAgentStatus).toHaveBeenCalledWith(
+      FUTURE_PANE_KEY,
+      expect.objectContaining({
+        state: 'done',
+        prompt: 'cached task',
+        agentType: 'claude',
+        lastAssistantMessage: 'Already finished.'
+      }),
+      'Claude',
+      { updatedAt: 1_700_000_000_600, stateStartedAt: 1_699_999_999_600 },
+      expectWorktreeRouting('wt-1'),
+      undefined
+    )
+    expect(observeAgentHookCompletionForNotification).not.toHaveBeenCalled()
   })
 
   it('drops late push events for a recently closed terminal tab', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3278,7 +3278,7 @@ export function useIpcEvents(): void {
           : undefined
       )
       applyResolvedAgentTerminalTitleToTab(store, paneKey, title, terminalTitle)
-      if (options?.replay !== true && statusWorktreeId) {
+      if (options?.replay !== true && data.isReplay !== true && statusWorktreeId) {
         // Why: local Codex/Claude hooks arrive via this main-process IPC path, not the PTY OSC fallback, so task-complete notifications must observe accepted hook state here too.
         const notificationPayload =
           typeof data.stateStartedAt === 'number'

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -231,6 +231,8 @@ export type AgentStatusIpcPayload = ParsedAgentStatusPayload & {
   receivedAt: number
   /** Timestamp (ms) when the current state first appeared for this pane. */
   stateStartedAt: number
+  /** True when this status is a reconnect/listener replay, not a newly observed live transition. */
+  isReplay?: boolean
   orchestration?: AgentStatusOrchestrationContext
   providerSession?: AgentProviderSessionMetadata
   /** Resume identity update only; the status-shaped fields are transport placeholders. */


### PR DESCRIPTION
## Description
Prevent reconnect-replayed agent statuses from firing duplicate task-complete notifications.

## Focused fix
- In scope: preserve replay provenance through the agent-status IPC payload and suppress completion observation for replayed live-set events.
- Out of scope: status rendering, replay snapshot application, live completion notifications, and agent-hook state transitions.

## Preserves
- Replayed statuses still update the renderer's visible agent state, while a newly observed live completion remains eligible for its notification.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/agent-hooks/server.test.ts src/renderer/src/hooks/useIpcEvents.test.ts --reporter=dot`
- Changed-code quality: `pnpm run check:code-quality:changed -- upstream/main`
- Regression coverage passed: 369 tests, including replay provenance and notification suppression.

## User-regression-tradeoffs
- Reconnects no longer repeat completion notifications for work that already finished; live status updates and first-time completion notifications remain unchanged.

Fixes #12747
