### PR TITLE
fix(ai-vault): tolerate unknown session agents

### DIFF
--- a/src/main/ai-vault/session-list-result-validation.test.ts
+++ b/src/main/ai-vault/session-list-result-validation.test.ts
@@ -46,6 +46,32 @@ describe('parseAiVaultListResult', () => {
     expect(parsed.issues).toEqual([])
   })
 
+  it('keeps known scan issues while silently dropping unknown-agent issues', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [],
+      issues: [validScanIssue(), validScanIssue('future-agent')],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.issues).toEqual([validScanIssue()])
+  })
+
+  it('does not throw when malformed rows are mixed with well-formed unknown sessions', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [{ id: 42 }, { ...validSession('session-new'), agent: 'future-agent' }],
+      issues: [],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.sessions).toEqual([])
+    expect(parsed.issues).toContainEqual(
+      expect.objectContaining({
+        path: 'aiVault.listSessions',
+        message: expect.stringContaining('Skipped 1 invalid')
+      })
+    )
+  })
+
   it('preserves the optional session fields the panel renders', () => {
     const parsed = parseAiVaultListResult({
       sessions: [
@@ -105,5 +131,13 @@ function validSession(sessionId = 'session-1'): Record<string, unknown> {
     subagentTranscriptCount: 0,
     resumeCommand: `codex resume ${sessionId}`,
     subagent: null
+  }
+}
+
+function validScanIssue(agent = 'codex'): Record<string, unknown> {
+  return {
+    agent,
+    path: '/tmp/sessions',
+    message: 'permission denied'
   }
 }

--- a/src/main/ai-vault/session-list-result-validation.test.ts
+++ b/src/main/ai-vault/session-list-result-validation.test.ts
@@ -19,6 +19,33 @@ describe('parseAiVaultListResult', () => {
     )
   })
 
+  it('keeps known-agent sessions while silently dropping unknown-agent rows', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [validSession(), { ...validSession('session-new'), agent: 'future-agent' }],
+      issues: [],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.sessions).toHaveLength(1)
+    expect(parsed.sessions[0]?.agent).toBe('codex')
+    expect(parsed.sessions[0]?.sessionId).toBe('session-1')
+    expect(parsed.issues).toEqual([])
+  })
+
+  it('accepts an all-unknown-agent response as an empty supported session list', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [
+        { ...validSession('future-1'), agent: 'future-agent' },
+        { ...validSession('future-2'), agent: 'newer-agent' }
+      ],
+      issues: [],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.sessions).toEqual([])
+    expect(parsed.issues).toEqual([])
+  })
+
   it('preserves the optional session fields the panel renders', () => {
     const parsed = parseAiVaultListResult({
       sessions: [
@@ -55,18 +82,18 @@ describe('parseAiVaultListResult', () => {
   })
 })
 
-function validSession(): Record<string, unknown> {
+function validSession(sessionId = 'session-1'): Record<string, unknown> {
   return {
-    id: 'local:codex:session-1:/tmp/session-1.jsonl',
+    id: `local:codex:${sessionId}:/tmp/${sessionId}.jsonl`,
     executionHostId: 'local',
     executionHostPlatform: 'linux',
     agent: 'codex',
-    sessionId: 'session-1',
+    sessionId,
     title: 'Session one',
     cwd: '/repo',
     branch: null,
     model: null,
-    filePath: '/tmp/session-1.jsonl',
+    filePath: `/tmp/${sessionId}.jsonl`,
     codexHome: null,
     createdAt: null,
     updatedAt: null,
@@ -76,7 +103,7 @@ function validSession(): Record<string, unknown> {
     previewMessages: [],
     queuedMessageCount: 0,
     subagentTranscriptCount: 0,
-    resumeCommand: 'codex resume session-1',
+    resumeCommand: `codex resume ${sessionId}`,
     subagent: null
   }
 }

--- a/src/main/ai-vault/session-list-result-validation.test.ts
+++ b/src/main/ai-vault/session-list-result-validation.test.ts
@@ -56,9 +56,28 @@ describe('parseAiVaultListResult', () => {
     expect(parsed.issues).toEqual([validScanIssue()])
   })
 
+  it('reports malformed scan issues without counting unknown-agent issues as invalid', () => {
+    const parsed = parseAiVaultListResult({
+      sessions: [],
+      issues: [validScanIssue(), { agent: 'future-agent' }, validScanIssue('newer-agent')],
+      scannedAt: '2026-07-27T00:00:00.000Z'
+    })
+
+    expect(parsed.issues).toEqual([
+      validScanIssue(),
+      expect.objectContaining({
+        path: 'aiVault.listSessions',
+        message: expect.stringContaining('Skipped 1 invalid')
+      })
+    ])
+  })
+
   it('does not throw when malformed rows are mixed with well-formed unknown sessions', () => {
     const parsed = parseAiVaultListResult({
-      sessions: [{ id: 42 }, { ...validSession('session-new'), agent: 'future-agent' }],
+      sessions: [
+        { ...validSession('malformed-future'), agent: 'future-agent', messageCount: 'invalid' },
+        { ...validSession('valid-future'), agent: 'newer-agent' }
+      ],
       issues: [],
       scannedAt: '2026-07-27T00:00:00.000Z'
     })

--- a/src/main/ai-vault/session-list-result-validation.ts
+++ b/src/main/ai-vault/session-list-result-validation.ts
@@ -3,6 +3,7 @@ import {
   AI_VAULT_AGENTS,
   type AiVaultAgent,
   type AiVaultListResult,
+  type AiVaultScanIssue,
   type AiVaultSession
 } from '../../shared/ai-vault-types'
 import { normalizeExecutionHostId } from '../../shared/execution-host'
@@ -78,7 +79,7 @@ const aiVaultSessionSchema = z.object({
 
 const aiVaultScanIssueSchema = z.object({
   executionHostId: executionHostIdSchema.optional(),
-  agent: z.enum(AI_VAULT_AGENTS),
+  agent: z.string().min(1),
   kind: z.enum(['host', 'scope', 'notice']).optional(),
   path: z.string(),
   message: z.string()
@@ -97,25 +98,40 @@ export function parseAiVaultListResult(value: unknown): AiVaultListResult {
   }
   const sessions: AiVaultSession[] = []
   let malformedSessionCount = 0
+  let wellFormedSessionCount = 0
   for (const session of envelope.data.sessions) {
     const parsed = aiVaultSessionSchema.safeParse(session)
     if (!parsed.success) {
       malformedSessionCount += 1
       continue
     }
+    wellFormedSessionCount += 1
     if (!isAiVaultAgent(parsed.data.agent)) {
       continue
     }
     sessions.push({ ...parsed.data, agent: parsed.data.agent })
   }
-  if (envelope.data.sessions.length > 0 && malformedSessionCount > 0 && sessions.length === 0) {
+  if (
+    envelope.data.sessions.length > 0 &&
+    malformedSessionCount > 0 &&
+    wellFormedSessionCount === 0
+  ) {
     throw new Error('all supplied Agent Session History sessions were invalid')
   }
-  const issues = envelope.data.issues.flatMap((issue) => {
+  const issues: AiVaultScanIssue[] = []
+  let malformedIssueCount = 0
+  for (const issue of envelope.data.issues) {
     const parsed = aiVaultScanIssueSchema.safeParse(issue)
-    return parsed.success ? [parsed.data] : []
-  })
-  const invalidCount = malformedSessionCount + (envelope.data.issues.length - issues.length)
+    if (!parsed.success) {
+      malformedIssueCount += 1
+      continue
+    }
+    if (!isAiVaultAgent(parsed.data.agent)) {
+      continue
+    }
+    issues.push({ ...parsed.data, agent: parsed.data.agent })
+  }
+  const invalidCount = malformedSessionCount + malformedIssueCount
   if (invalidCount > 0) {
     issues.push({
       agent: 'codex',

--- a/src/main/ai-vault/session-list-result-validation.ts
+++ b/src/main/ai-vault/session-list-result-validation.ts
@@ -1,6 +1,17 @@
 import { z } from 'zod'
-import { AI_VAULT_AGENTS, type AiVaultListResult } from '../../shared/ai-vault-types'
+import {
+  AI_VAULT_AGENTS,
+  type AiVaultAgent,
+  type AiVaultListResult,
+  type AiVaultSession
+} from '../../shared/ai-vault-types'
 import { normalizeExecutionHostId } from '../../shared/execution-host'
+
+const aiVaultAgentSet = new Set<string>(AI_VAULT_AGENTS)
+
+function isAiVaultAgent(agent: string): agent is AiVaultAgent {
+  return aiVaultAgentSet.has(agent)
+}
 
 const nodePlatformSchema = z.enum([
   'aix',
@@ -35,7 +46,7 @@ const aiVaultSessionSchema = z.object({
   id: z.string(),
   executionHostId: executionHostIdSchema,
   executionHostPlatform: nodePlatformSchema.nullable().optional(),
-  agent: z.enum(AI_VAULT_AGENTS),
+  agent: z.string().min(1),
   sessionId: z.string(),
   title: z.string(),
   cwd: z.string().nullable(),
@@ -84,19 +95,27 @@ export function parseAiVaultListResult(value: unknown): AiVaultListResult {
   if (!envelope.success) {
     throw new Error(envelope.error.issues[0]?.message ?? 'unexpected result shape')
   }
-  const sessions = envelope.data.sessions.flatMap((session) => {
+  const sessions: AiVaultSession[] = []
+  let malformedSessionCount = 0
+  for (const session of envelope.data.sessions) {
     const parsed = aiVaultSessionSchema.safeParse(session)
-    return parsed.success ? [parsed.data] : []
-  })
-  if (envelope.data.sessions.length > 0 && sessions.length === 0) {
+    if (!parsed.success) {
+      malformedSessionCount += 1
+      continue
+    }
+    if (!isAiVaultAgent(parsed.data.agent)) {
+      continue
+    }
+    sessions.push({ ...parsed.data, agent: parsed.data.agent })
+  }
+  if (envelope.data.sessions.length > 0 && malformedSessionCount > 0 && sessions.length === 0) {
     throw new Error('all supplied Agent Session History sessions were invalid')
   }
   const issues = envelope.data.issues.flatMap((issue) => {
     const parsed = aiVaultScanIssueSchema.safeParse(issue)
     return parsed.success ? [parsed.data] : []
   })
-  const invalidCount =
-    envelope.data.sessions.length - sessions.length + (envelope.data.issues.length - issues.length)
+  const invalidCount = malformedSessionCount + (envelope.data.issues.length - issues.length)
   if (invalidCount > 0) {
     issues.push({
       agent: 'codex',


### PR DESCRIPTION
## Description
Keep remote AI Vault session scans usable when a newer host publishes sessions for an agent this client does not know yet.

## Focused fix
- In scope: accept non-empty agent strings at the wire boundary, fully validate session and issue rows, and omit well-formed rows for agents this client does not support.
- Out of scope: inventing an agent label or resume command for an unsupported agent, changing host merge semantics, or relaxing malformed-payload validation.

## Preserves
- Known-agent sessions and issues retain their typed behavior; malformed rows are still reported, and all-malformed session payloads still fail closed.

## Evidence
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/ai-vault/session-list-result-validation.test.ts --pool=forks --maxWorkers=1`
- Typecheck: `pnpm exec tsc --noEmit -p config/tsconfig.node.json --pretty false`
- Changed-file Oxlint and React Doctor checks pass with no warnings.
- Regression coverage covers mixed known/unknown rows, all-unknown rows, unknown scan issues, malformed unknown-agent rows, and all-malformed payloads.

## User-regression-tradeoffs
- A client that predates a new agent no longer misattributes the unsupported row to Codex or falls into the SSH crawl; it simply omits that row until the client supports the agent.

Fixes #12958
