### PR TITLE
feat(settings): allow hiding the terminal command button

### DIFF
--- a/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
+++ b/src/renderer/src/components/settings/TerminalAppearanceSection.tsx
@@ -9,6 +9,7 @@ import {
 import { useAppStore } from '../../store'
 import {
   getTerminalAdvancedTypographySearchEntries,
+  getTerminalChromeSearchEntries,
   getTerminalCursorSearchEntries,
   getTerminalDarkThemeSearchEntries,
   getTerminalGhosttyImportSearchEntries,
@@ -21,7 +22,12 @@ import {
   getTerminalWindowSearchEntries
 } from './terminal-search'
 import { Button } from '../ui/button'
-import { SettingsRow, SettingsSubsectionHeader, FontAutocomplete } from './SettingsFormControls'
+import {
+  SettingsRow,
+  SettingsSubsectionHeader,
+  FontAutocomplete,
+  SettingsSwitchRow
+} from './SettingsFormControls'
 import { SearchableSetting } from './SearchableSetting'
 import { TerminalFontSizeSetting } from './TerminalFontSizeSetting'
 import { TerminalAdvancedTypographyControls } from './TerminalAdvancedTypographyControls'
@@ -87,6 +93,7 @@ export function TerminalAppearanceSection({
   const darkThemeSearchEntries = getTerminalDarkThemeSearchEntries()
   const lightThemeSearchEntries = getTerminalLightThemeSearchEntries()
   const terminalTypographyEntries = getTerminalTypographySearchEntries()
+  const terminalChromeEntries = getTerminalChromeSearchEntries()
   const ghosttyImportEntries = getTerminalGhosttyImportSearchEntries()
   const themeCatalogSearchEntries = [
     ...getTerminalThemeTargetSearchEntries(),
@@ -117,6 +124,7 @@ export function TerminalAppearanceSection({
     terminalTypographyEntries.slice(0, 2)
   )
   const ghosttyImportMatches = matchesSettingsSearch(searchQuery, ghosttyImportEntries)
+  const chromeMatches = matchesSettingsSearch(searchQuery, terminalChromeEntries)
   const showPrimaryTypography =
     !isSearching ||
     forceVisiblePrimary ||
@@ -125,6 +133,7 @@ export function TerminalAppearanceSection({
     ghosttyImportMatches
   const showGhosttyImport = !isSearching || forceVisiblePrimary || ghosttyImportMatches
   const showTypographyAdvancedDisclosure = !isSearching || typographyMatches
+  const showTerminalChrome = !isSearching || forceVisiblePrimary || chromeMatches
 
   const advancedGroups = [
     cursorMatches
@@ -245,6 +254,45 @@ export function TerminalAppearanceSection({
               </AppearanceAdvancedDisclosure>
             </div>
           ) : null}
+        </section>
+      ) : null}
+
+      {showTerminalChrome ? (
+        <section className="space-y-3">
+          <SettingsSubsectionHeader
+            title={translate(
+              'auto.components.settings.TerminalAppearanceSection.terminalChromeTitle',
+              'Terminal Toolbar'
+            )}
+          />
+          <div className="ml-4 divide-y divide-border/40 border-y border-border/40">
+            <SearchableSetting
+              title={terminalChromeEntries[0]?.title ?? 'Command Button'}
+              description={terminalChromeEntries[0]?.description}
+              keywords={terminalChromeEntries[0]?.keywords ?? ['terminal', 'command']}
+              forceVisible={forceVisiblePrimary}
+            >
+              <SettingsSwitchRow
+                label={translate(
+                  'auto.components.settings.TerminalAppearanceSection.commandButtonLabel',
+                  'Command Button'
+                )}
+                description={terminalChromeEntries[0]?.description}
+                checked={settings.showTerminalQuickCommandsButton !== false}
+                onChange={() =>
+                  updateSettings({
+                    showTerminalQuickCommandsButton: !(
+                      settings.showTerminalQuickCommandsButton !== false
+                    )
+                  })
+                }
+                ariaLabel={translate(
+                  'auto.components.settings.TerminalAppearanceSection.commandButtonLabel',
+                  'Command Button'
+                )}
+              />
+            </SearchableSetting>
+          </div>
         </section>
       ) : null}
 

--- a/src/renderer/src/components/settings/terminal-search.ts
+++ b/src/renderer/src/components/settings/terminal-search.ts
@@ -20,6 +20,7 @@ import {
 import {
   getTerminalCursorSearchEntries,
   getTerminalRenderingSearchEntries,
+  getTerminalChromeSearchEntries,
   getTerminalTypographySearchEntries
 } from './terminal-typography-search'
 import {
@@ -38,6 +39,7 @@ export {
   getTerminalAdvancedTypographySearchEntries,
   getTerminalTypographySearchEntries,
   getTerminalRenderingSearchEntries,
+  getTerminalChromeSearchEntries,
   getTerminalCursorSearchEntries
 } from './terminal-typography-search'
 export {
@@ -71,6 +73,7 @@ type TerminalAppearanceSearchOptions = {
 const getTerminalAppearanceSearchEntriesWithoutWarp = createLocalizedCatalog(
   (): SettingsSearchEntry[] => [
     ...getTerminalTypographySearchEntries(),
+    ...getTerminalChromeSearchEntries(),
     ...getTerminalCursorSearchEntries(),
     ...getTerminalPaneAppearanceSearchEntries(),
     ...getTerminalThemeTargetSearchEntries(),

--- a/src/renderer/src/components/settings/terminal-typography-search.ts
+++ b/src/renderer/src/components/settings/terminal-typography-search.ts
@@ -131,6 +131,31 @@ export const getTerminalRenderingSearchEntries = createLocalizedCatalog(() => [
   }
 ])
 
+export const getTerminalChromeSearchEntries = createLocalizedCatalog(() => [
+  {
+    title: translate(
+      'auto.components.settings.terminal.search.commandButtonTitle',
+      'Command Button'
+    ),
+    description: translate(
+      'auto.components.settings.terminal.search.commandButtonDescription',
+      'Show the quick-command button in focused terminal toolbars.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.terminal.search.f66a7cf715', 'terminal'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.commandKeyword',
+        'command'
+      ),
+      ...translateSearchKeyword('auto.components.settings.terminal.search.quickKeyword', 'quick'),
+      ...translateSearchKeyword(
+        'auto.components.settings.terminal.search.toolbarKeyword',
+        'toolbar'
+      )
+    ]
+  }
+])
+
 export const getTerminalCursorSearchEntries = createLocalizedCatalog(() => [
   {
     title: translate('auto.components.settings.terminal.search.97bcfff662', 'Cursor Shape'),

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.tsx
@@ -33,6 +33,9 @@ export function TabBarQuickCommandsButton({
   worktreeId,
   groupId
 }: TabBarQuickCommandsButtonProps): React.JSX.Element | null {
+  const showQuickCommandsButton = useAppStore(
+    (s) => s.settings?.showTerminalQuickCommandsButton !== false
+  )
   const recentByGroup = useAppStore((s) => s.recentQuickCommandIdByGroup)
   const repos = useAppStore((s) => s.repos)
   const { executionHostId, hosts, refreshRemoteHost, remoteHostLoadFailed, remoteHostPending } =
@@ -98,6 +101,10 @@ export function TabBarQuickCommandsButton({
   const defaultHostId = hosts.some((host) => host.hostId === executionHostId)
     ? executionHostId
     : hosts[0].hostId
+
+  if (!showQuickCommandsButton) {
+    return null
+  }
 
   const addRepoCommand = (hostId: ExecutionHostId): void => {
     setEditor({

--- a/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.visibility.test.tsx
+++ b/src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.visibility.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ReactNode } from 'react'
+
+const appStoreMock = vi.hoisted(() => ({
+  state: {
+    settings: {
+      showTerminalQuickCommandsButton: undefined as boolean | undefined,
+      terminalQuickCommands: []
+    },
+    recentQuickCommandIdByGroup: {},
+    repos: [{ id: 'repo-1' }],
+    updateSettings: vi.fn()
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: typeof appStoreMock.state) => unknown) =>
+    selector(appStoreMock.state)
+}))
+
+vi.mock('@/components/confirmation-dialog-context', () => ({
+  useConfirmationDialog: () => vi.fn()
+}))
+
+vi.mock('@/components/terminal-quick-commands/TerminalQuickCommandDialog', () => ({
+  createTerminalQuickCommandDraft: () => ({
+    id: 'draft',
+    label: '',
+    action: 'terminal-command',
+    command: '',
+    appendEnter: true,
+    scope: { type: 'repo', repoId: 'repo-1' }
+  }),
+  TerminalQuickCommandDialog: () => null
+}))
+
+vi.mock('./TabBarQuickCommandsMenu', () => ({
+  TabBarQuickCommandsMenu: () => <div data-testid="quick-commands-menu" />
+}))
+
+vi.mock('@/hooks/use-terminal-quick-command-hosts', () => ({
+  flattenTerminalQuickCommandHosts: () => [],
+  useTerminalQuickCommandHosts: () => ({
+    executionHostId: 'local',
+    hosts: [{ commands: [], hostId: 'local', label: 'This computer' }],
+    refreshRemoteHost: vi.fn(),
+    remoteHostLoadFailed: false,
+    remoteHostPending: false
+  })
+}))
+
+vi.mock('@/lib/run-quick-command-in-new-tab', () => ({
+  runQuickCommandInNewTab: vi.fn()
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: ReactNode }) => children,
+  TooltipContent: () => null,
+  TooltipTrigger: ({ children }: { children: ReactNode }) => children
+}))
+
+vi.mock('lucide-react', () => ({
+  Play: () => null
+}))
+
+describe('TabBarQuickCommandsButton visibility', () => {
+  afterEach(() => {
+    cleanup()
+  })
+
+  beforeEach(() => {
+    appStoreMock.state.settings.showTerminalQuickCommandsButton = undefined
+  })
+
+  it('keeps the button visible when the setting is missing for legacy settings', async () => {
+    const { TabBarQuickCommandsButton } = await import('./TabBarQuickCommandsButton')
+
+    render(<TabBarQuickCommandsButton worktreeId="repo-1::/repo" groupId="group-1" />)
+
+    expect(screen.getByRole('button', { name: 'Add quick command' })).toBeTruthy()
+  })
+
+  it('hides the button when the persisted setting is disabled', async () => {
+    appStoreMock.state.settings.showTerminalQuickCommandsButton = false
+    const { TabBarQuickCommandsButton } = await import('./TabBarQuickCommandsButton')
+
+    const view = render(<TabBarQuickCommandsButton worktreeId="repo-1::/repo" groupId="group-1" />)
+
+    expect(view.container.childElementCount).toBe(0)
+  })
+})

--- a/src/renderer/src/store/slices/settings.ts
+++ b/src/renderer/src/store/slices/settings.ts
@@ -66,6 +66,10 @@ function normalizeSettingsUpdates(
       updates.terminalQuickCommands
     )
   }
+  if ('showTerminalQuickCommandsButton' in updates) {
+    sanitizedUpdates.showTerminalQuickCommandsButton =
+      updates.showTerminalQuickCommandsButton !== false
+  }
   if ('terminalCustomThemes' in updates) {
     sanitizedUpdates.terminalCustomThemes = normalizeTerminalCustomThemes(
       updates.terminalCustomThemes

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -143,6 +143,10 @@ describe('getDefaultSettings', () => {
     })
     expect(settings.agentYoloDefaultsMigrated).toBe(true)
   })
+
+  it('shows terminal quick commands by default', () => {
+    expect(getDefaultSettings('/tmp').showTerminalQuickCommandsButton).toBe(true)
+  })
 })
 
 describe('getDefaultPrimarySelectionMiddleClickPaste', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -240,6 +240,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     // Why: prefer modern PowerShell when installed, falling back to inbox Windows PowerShell.
     terminalWindowsPowerShellImplementation: 'auto',
     terminalMouseHideWhileTyping: false,
+    showTerminalQuickCommandsButton: true,
     terminalQuickCommands: getDefaultTerminalQuickCommands(),
     // Why: opt-in only, matching Ghostty's default (upgrades never enable it unexpectedly).
     terminalFocusFollowsMouse: false,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2826,6 +2826,8 @@ export type GlobalSettings = {
   terminalMouseHideWhileTyping?: boolean
   terminalWordSeparator?: string
   terminalCursorOpacity?: number
+  /** Shows the terminal toolbar quick-command button; missing legacy values stay visible. */
+  showTerminalQuickCommandsButton?: boolean
   terminalQuickCommands?: TerminalQuickCommand[]
   windowBackgroundBlur?: boolean
   /** Windows-only: close (X) hides to tray instead of quitting; the tray icon is always present regardless. */


### PR DESCRIPTION
## Description

Add a persisted setting to hide the terminal toolbar Command button.

## Focused fix

- In scope: a default-on boolean setting, an Appearance > Terminal Toolbar toggle, and the render gate.
- Out of scope: quick-command storage, execution, keyboard behavior, and menu behavior.

## Preserves

- Existing users keep the button visible.
- Quick commands remain stored and executable when the button is shown again.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/tab-bar/TabBarQuickCommandsButton.visibility.test.tsx src/shared/constants.test.ts src/renderer/src/store/slices/settings.test.ts`
- Typecheck: `pnpm run typecheck`
- Changed-code quality: `pnpm run check:code-quality:changed -- upstream/main`
- Result: 46 tests passed; 0 new quality findings.

## User-regression-tradeoffs

- The new default-on setting adds no behavior change until explicitly disabled; the hidden button can be restored from Settings.

Fixes #12949
