### PR TITLE
perf: isolate remote clipboard staging cleanup

### DIFF
--- a/src/main/window/clipboard-dashboard-popout-access.test.ts
+++ b/src/main/window/clipboard-dashboard-popout-access.test.ts
@@ -39,6 +39,7 @@ vi.mock('electron', () => ({
 vi.mock('./dashboard-popout-window', () => ({ isDashboardPopoutRenderer }))
 vi.mock('./clipboard-remote-file-copy', () => ({
   cleanupExpiredRemoteClipboardFiles: vi.fn(async () => undefined),
+  scheduleLegacyRemoteClipboardFileMigration: vi.fn(),
   writeRemoteFileToClipboard: vi.fn()
 }))
 

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -200,10 +200,10 @@ describe('registerClipboardHandlers', () => {
     handleMock.mockReset()
     spawnMock.mockClear()
     childStdinEndMock.mockClear()
-    resolveAuthorizedPathMock.mockReset()
-    resolveAuthorizedPathMock.mockImplementation(async (path: string) => path)
+    resolveAuthorizedPathMock.mockReset().mockImplementation(async (path: string) => path)
     fsAccessMock.mockReset().mockResolvedValue(undefined)
     fsLstatMock.mockReset().mockResolvedValue({
+      mode: 0o700,
       uid: typeof process.getuid === 'function' ? process.getuid() : 0,
       isDirectory: () => true,
       isSymbolicLink: () => false
@@ -215,12 +215,10 @@ describe('registerClipboardHandlers', () => {
       async *[Symbol.asyncIterator]() {},
       close: vi.fn().mockResolvedValue(undefined)
     }))
-    fsRmMock.mockReset()
-    fsRmMock.mockResolvedValue(undefined)
+    fsRmMock.mockReset().mockResolvedValue(undefined)
     fsWriteFileMock.mockReset()
     fsOpenMock.mockReset()
-    fsStatMock.mockReset()
-    fsStatMock.mockResolvedValue({})
+    fsStatMock.mockReset().mockResolvedValue({})
     clipboardReadTextMock.mockReset()
     clipboardReadBufferMock.mockReset()
     clipboardReadBufferMock.mockReturnValue(Buffer.alloc(0))

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -202,16 +202,13 @@ describe('registerClipboardHandlers', () => {
     childStdinEndMock.mockClear()
     resolveAuthorizedPathMock.mockReset()
     resolveAuthorizedPathMock.mockImplementation(async (path: string) => path)
-    fsAccessMock.mockReset()
-    fsAccessMock.mockResolvedValue(undefined)
-    fsLstatMock.mockReset()
-    fsLstatMock.mockResolvedValue({
+    fsAccessMock.mockReset().mockResolvedValue(undefined)
+    fsLstatMock.mockReset().mockResolvedValue({
       uid: typeof process.getuid === 'function' ? process.getuid() : 0,
       isDirectory: () => true,
       isSymbolicLink: () => false
     })
-    fsMkdirMock.mockReset()
-    fsMkdirMock.mockResolvedValue(undefined)
+    fsMkdirMock.mockReset().mockResolvedValue(undefined)
     fsOpendirMock.mockReset()
     // Why: handler registration kicks off the expired-staging sweep; an empty temp root keeps it inert.
     fsOpendirMock.mockImplementation(async () => ({

--- a/src/main/window/clipboard-ipc-handlers.test.ts
+++ b/src/main/window/clipboard-ipc-handlers.test.ts
@@ -12,6 +12,8 @@ const {
   spawnMock,
   childStdinEndMock,
   resolveAuthorizedPathMock,
+  fsAccessMock,
+  fsLstatMock,
   fsMkdirMock,
   fsOpendirMock,
   fsRmMock,
@@ -45,6 +47,8 @@ const {
     return child
   }),
   resolveAuthorizedPathMock: vi.fn(),
+  fsAccessMock: vi.fn(),
+  fsLstatMock: vi.fn(),
   fsMkdirMock: vi.fn(),
   fsOpendirMock: vi.fn(),
   fsRmMock: vi.fn(),
@@ -68,11 +72,14 @@ vi.mock('node:child_process', () => ({
 }))
 
 vi.mock('node:fs/promises', () => ({
+  access: fsAccessMock,
+  lstat: fsLstatMock,
   mkdir: fsMkdirMock,
   opendir: fsOpendirMock,
   rm: fsRmMock,
   open: fsOpenMock,
   stat: fsStatMock,
+  writeFile: fsWriteFileMock,
   default: {
     writeFile: fsWriteFileMock
   }
@@ -134,6 +141,14 @@ import {
   setTrustedClipboardRendererWebContentsId
 } from './clipboard-ipc-handlers'
 
+const REMOTE_CLIPBOARD_UID_SUFFIX =
+  typeof process.getuid === 'function' ? `-${process.getuid()}` : ''
+const REMOTE_CLIPBOARD_STAGING_ROOT = join(
+  '/tmp',
+  `orca-clipboard-files${REMOTE_CLIPBOARD_UID_SUFFIX}`
+)
+const REMOTE_CLIPBOARD_ROOT_OPTIONS = { recursive: true, mode: 0o700 }
+
 function getRegisteredHandlers(): Map<string, (...args: unknown[]) => unknown> {
   const handlers = new Map<string, (...args: unknown[]) => unknown>()
   for (const [channel, handler] of handleMock.mock.calls as [
@@ -187,6 +202,14 @@ describe('registerClipboardHandlers', () => {
     childStdinEndMock.mockClear()
     resolveAuthorizedPathMock.mockReset()
     resolveAuthorizedPathMock.mockImplementation(async (path: string) => path)
+    fsAccessMock.mockReset()
+    fsAccessMock.mockResolvedValue(undefined)
+    fsLstatMock.mockReset()
+    fsLstatMock.mockResolvedValue({
+      uid: typeof process.getuid === 'function' ? process.getuid() : 0,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
     fsMkdirMock.mockReset()
     fsMkdirMock.mockResolvedValue(undefined)
     fsOpendirMock.mockReset()
@@ -316,8 +339,8 @@ describe('registerClipboardHandlers', () => {
 
     const handlers = getRegisteredHandlers()
     const tempDir = join(
-      '/tmp',
-      'orca-clipboard-file-1760000000000-00000000-0000-4000-8000-000000000000'
+      REMOTE_CLIPBOARD_STAGING_ROOT,
+      '1760000000000-00000000-0000-4000-8000-000000000000'
     )
     const tempPath = join(tempDir, 'report.pdf')
 
@@ -329,6 +352,10 @@ describe('registerClipboardHandlers', () => {
     ).resolves.toEqual({ ok: true })
 
     expect(provider.stat).toHaveBeenCalledWith('/remote/report.pdf')
+    expect(fsMkdirMock).toHaveBeenCalledWith(
+      REMOTE_CLIPBOARD_STAGING_ROOT,
+      REMOTE_CLIPBOARD_ROOT_OPTIONS
+    )
     expect(fsMkdirMock).toHaveBeenCalledWith(tempDir, { mode: 0o700 })
     expect(provider.downloadFile).toHaveBeenCalledWith('/remote/report.pdf', tempPath)
     expect(fsStatMock).toHaveBeenCalledWith(tempPath)
@@ -353,7 +380,11 @@ describe('registerClipboardHandlers', () => {
     ).resolves.toEqual({ ok: false, reason: 'is-directory' })
 
     expect(provider.downloadFile).not.toHaveBeenCalled()
-    expect(fsMkdirMock).not.toHaveBeenCalled()
+    expect(fsMkdirMock).toHaveBeenCalledOnce()
+    expect(fsMkdirMock).toHaveBeenCalledWith(
+      REMOTE_CLIPBOARD_STAGING_ROOT,
+      REMOTE_CLIPBOARD_ROOT_OPTIONS
+    )
     expect(clipboardWriteBufferMock).not.toHaveBeenCalled()
   })
 
@@ -367,8 +398,8 @@ describe('registerClipboardHandlers', () => {
 
     const handlers = getRegisteredHandlers()
     const tempDir = join(
-      '/tmp',
-      'orca-clipboard-file-1760000000000-00000000-0000-4000-8000-000000000000'
+      REMOTE_CLIPBOARD_STAGING_ROOT,
+      '1760000000000-00000000-0000-4000-8000-000000000000'
     )
     const tempPath = join(tempDir, 'report.pdf')
 

--- a/src/main/window/clipboard-ipc-handlers.ts
+++ b/src/main/window/clipboard-ipc-handlers.ts
@@ -31,6 +31,7 @@ import {
 } from './clipboard-file-copy'
 import {
   cleanupExpiredRemoteClipboardFiles,
+  scheduleLegacyRemoteClipboardFileMigration,
   writeRemoteFileToClipboard
 } from './clipboard-remote-file-copy'
 import { saveClipboardImageBufferInRuntime } from './clipboard-runtime-image-upload'
@@ -85,6 +86,7 @@ export function registerClipboardHandlers(store: Store): void {
   ipcMain.removeHandler('clipboard:saveImageAsTempFile')
 
   void cleanupExpiredRemoteClipboardFiles()
+  scheduleLegacyRemoteClipboardFileMigration()
 
   ipcMain.handle('clipboard:readText', async (event, options?: ReadClipboardTextOptions) => {
     assertTrustedClipboardTextSender(event)

--- a/src/main/window/clipboard-remote-file-cleanup.test.ts
+++ b/src/main/window/clipboard-remote-file-cleanup.test.ts
@@ -74,6 +74,7 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
     vi.clearAllMocks()
     accessMock.mockResolvedValue(undefined)
     lstatMock.mockResolvedValue({
+      mode: 0o700,
       uid: typeof process.getuid === 'function' ? process.getuid() : 0,
       isDirectory: () => true,
       isSymbolicLink: () => false
@@ -92,6 +93,7 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.unstubAllGlobals()
   })
 
   it('scans only the owned staging root after legacy migration', async () => {
@@ -161,6 +163,7 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
 
   it('rejects an unsafe staging-root symlink before scanning it', async () => {
     lstatMock.mockResolvedValue({
+      mode: 0o700,
       uid: typeof process.getuid === 'function' ? process.getuid() : 0,
       isDirectory: () => false,
       isSymbolicLink: () => true
@@ -177,7 +180,25 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
       return
     }
     lstatMock.mockResolvedValue({
+      mode: 0o700,
       uid: process.getuid() + 1,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
+
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(opendirMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a POSIX staging root with insecure permissions', async () => {
+    const processWithUid = Object.assign(Object.create(process) as NodeJS.Process, {
+      getuid: () => 1000
+    })
+    vi.stubGlobal('process', processWithUid)
+    lstatMock.mockResolvedValue({
+      mode: 0o755,
+      uid: 1000,
       isDirectory: () => true,
       isSymbolicLink: () => false
     })

--- a/src/main/window/clipboard-remote-file-cleanup.test.ts
+++ b/src/main/window/clipboard-remote-file-cleanup.test.ts
@@ -1,17 +1,25 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { join } from 'node:path'
 
-const { opendirMock, rmMock, statMock } = vi.hoisted(() => ({
-  opendirMock: vi.fn(),
-  rmMock: vi.fn(),
-  statMock: vi.fn()
-}))
+const { accessMock, lstatMock, mkdirMock, opendirMock, rmMock, statMock, writeFileMock } =
+  vi.hoisted(() => ({
+    accessMock: vi.fn(),
+    lstatMock: vi.fn(),
+    mkdirMock: vi.fn(),
+    opendirMock: vi.fn(),
+    rmMock: vi.fn(),
+    statMock: vi.fn(),
+    writeFileMock: vi.fn()
+  }))
 
 vi.mock('node:fs/promises', () => ({
-  mkdir: vi.fn(),
+  access: accessMock,
+  lstat: lstatMock,
+  mkdir: mkdirMock,
   opendir: opendirMock,
   rm: rmMock,
-  stat: statMock
+  stat: statMock,
+  writeFile: writeFileMock
 }))
 vi.mock('electron', () => ({ app: { getPath: () => '/tmp' } }))
 vi.mock('../providers/ssh-filesystem-dispatch', () => ({
@@ -19,44 +27,83 @@ vi.mock('../providers/ssh-filesystem-dispatch', () => ({
 }))
 vi.mock('./clipboard-file-copy', () => ({ writeFileToClipboard: vi.fn() }))
 
-import { cleanupExpiredRemoteClipboardFiles } from './clipboard-remote-file-copy'
+import {
+  cleanupExpiredRemoteClipboardFiles,
+  migrateLegacyRemoteClipboardFiles,
+  scheduleLegacyRemoteClipboardFileMigration
+} from './clipboard-remote-file-copy'
 
 const TTL_MS = 60 * 60 * 1000
 const NOW_MS = 1_760_000_000_000
+const UID_SUFFIX = typeof process.getuid === 'function' ? `-${process.getuid()}` : ''
+const STAGING_ROOT = join('/tmp', `orca-clipboard-files${UID_SUFFIX}`)
+const MIGRATION_MARKER = join(STAGING_ROOT, '.legacy-cleanup-complete')
 
-function mockTempRoot(entries: Iterable<{ name: string; isDirectory: () => boolean }>): void {
-  opendirMock.mockResolvedValue({
+type MockDirent = { name: string; isDirectory: () => boolean }
+
+function directoryEntry(name: string, isDirectory = true): MockDirent {
+  return { name, isDirectory: () => isDirectory }
+}
+
+function openedDirectory(entries: Iterable<MockDirent>): {
+  [Symbol.asyncIterator]: () => AsyncGenerator<MockDirent>
+  close: ReturnType<typeof vi.fn>
+} {
+  return {
     async *[Symbol.asyncIterator]() {
       yield* entries
     },
     close: vi.fn().mockResolvedValue(undefined)
-  })
-}
-
-function* orcaStagingDirs(count: number): Generator<{ name: string; isDirectory: () => boolean }> {
-  for (let index = 0; index < count; index += 1) {
-    yield { name: `orca-clipboard-file-expired-${index}`, isDirectory: () => true }
   }
 }
 
-function* unrelatedTempEntries(
-  count: number
-): Generator<{ name: string; isDirectory: () => boolean }> {
+function* stagingDirectories(count: number): Generator<MockDirent> {
   for (let index = 0; index < count; index += 1) {
-    // Mirrors a real temp root: mostly foreign entries, both files and directories.
-    yield { name: `unrelated-${index}`, isDirectory: () => index % 2 === 0 }
+    yield directoryEntry(`expired-${index}`)
+  }
+}
+
+function* foreignTempEntries(count: number): Generator<MockDirent> {
+  for (let index = 0; index < count; index += 1) {
+    yield directoryEntry(`unrelated-${index}`, index % 2 === 0)
   }
 }
 
 describe('cleanupExpiredRemoteClipboardFiles', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    accessMock.mockResolvedValue(undefined)
+    lstatMock.mockResolvedValue({
+      uid: typeof process.getuid === 'function' ? process.getuid() : 0,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
+    mkdirMock.mockResolvedValue(undefined)
+    opendirMock.mockImplementation(async (targetPath: string) => {
+      if (targetPath !== STAGING_ROOT) {
+        throw new Error(`unexpected directory scan: ${targetPath}`)
+      }
+      return openedDirectory([])
+    })
     rmMock.mockResolvedValue(undefined)
     statMock.mockResolvedValue({ mtimeMs: NOW_MS - TTL_MS - 1 })
+    writeFileMock.mockResolvedValue(undefined)
   })
 
-  it('streams all entries with at most eight cleanups in flight', async () => {
-    mockTempRoot(orcaStagingDirs(257))
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('scans only the owned staging root after legacy migration', async () => {
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(opendirMock).toHaveBeenCalledOnce()
+    expect(opendirMock).toHaveBeenCalledWith(STAGING_ROOT)
+    expect(opendirMock).not.toHaveBeenCalledWith('/tmp')
+  })
+
+  it('keeps cleanup concurrency at eight inside the staging root', async () => {
+    opendirMock.mockResolvedValue(openedDirectory(stagingDirectories(257)))
     let active = 0
     let peak = 0
     statMock.mockImplementation(async () => {
@@ -73,45 +120,15 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
     expect(peak).toBe(8)
   })
 
-  it('does no per-entry work for foreign temp-root entries', async () => {
-    mockTempRoot(unrelatedTempEntries(200_000))
-
-    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
-
-    expect(statMock).not.toHaveBeenCalled()
-    expect(rmMock).not.toHaveBeenCalled()
-  })
-
-  it('acts on owned directories while the temp root is still being enumerated', async () => {
-    // Regression: the sweep materialized the whole temp root and built one promise
-    // per entry before doing any work, so a %TEMP% with ~1.2M unrelated entries
-    // froze the main process at startup (#12835). Streaming means an owned
-    // directory is swept before enumeration reaches the end.
-    let sweptDuringEnumeration = false
-    function* enumeration(): Generator<{ name: string; isDirectory: () => boolean }> {
-      yield { name: 'orca-clipboard-file-expired', isDirectory: () => true }
-      for (const entry of unrelatedTempEntries(1_000)) {
-        sweptDuringEnumeration ||= rmMock.mock.calls.length > 0
-        yield entry
-      }
-    }
-    mockTempRoot(enumeration())
-
-    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
-
-    expect(sweptDuringEnumeration).toBe(true)
-    expect(rmMock).toHaveBeenCalledTimes(1)
-  })
-
-  it('removes only expired staging directories it owns', async () => {
-    function* interleaved(): Generator<{ name: string; isDirectory: () => boolean }> {
-      yield* unrelatedTempEntries(50_000)
-      yield { name: 'orca-clipboard-file-expired', isDirectory: () => true }
-      yield* unrelatedTempEntries(50_000)
-      yield { name: 'orca-clipboard-file-fresh', isDirectory: () => true }
-      yield { name: 'orca-clipboard-file-plain-file', isDirectory: () => false }
-    }
-    mockTempRoot(interleaved())
+  it('removes only expired directories inside the owned root', async () => {
+    opendirMock.mockResolvedValue(
+      openedDirectory([
+        directoryEntry('expired'),
+        directoryEntry('fresh'),
+        directoryEntry('plain-file', false),
+        directoryEntry('.legacy-cleanup-complete', false)
+      ])
+    )
     statMock.mockImplementation(async (targetPath: string) => ({
       mtimeMs: targetPath.endsWith('expired') ? NOW_MS - TTL_MS - 1 : NOW_MS - 1000
     }))
@@ -119,18 +136,18 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
     await cleanupExpiredRemoteClipboardFiles(NOW_MS)
 
     expect(statMock).toHaveBeenCalledTimes(2)
-    expect(rmMock).toHaveBeenCalledTimes(1)
-    expect(rmMock).toHaveBeenCalledWith(join('/tmp', 'orca-clipboard-file-expired'), {
+    expect(rmMock).toHaveBeenCalledOnce()
+    expect(rmMock).toHaveBeenCalledWith(join(STAGING_ROOT, 'expired'), {
       recursive: true,
       force: true
     })
   })
 
-  it('closes the temp-root handle and still sweeps when enumeration fails midway', async () => {
+  it('finishes pending cleanup when owned-root enumeration fails', async () => {
     const close = vi.fn().mockResolvedValue(undefined)
     opendirMock.mockResolvedValue({
       async *[Symbol.asyncIterator]() {
-        yield { name: 'orca-clipboard-file-expired', isDirectory: () => true }
+        yield directoryEntry('expired')
         throw new Error('EIO')
       },
       close
@@ -138,16 +155,139 @@ describe('cleanupExpiredRemoteClipboardFiles', () => {
 
     await expect(cleanupExpiredRemoteClipboardFiles(NOW_MS)).resolves.toBeUndefined()
 
-    expect(rmMock).toHaveBeenCalledTimes(1)
-    expect(close).toHaveBeenCalledTimes(1)
+    expect(rmMock).toHaveBeenCalledOnce()
+    expect(close).toHaveBeenCalledOnce()
   })
 
-  it('returns quietly when the temp root cannot be opened', async () => {
-    opendirMock.mockRejectedValue(new Error('EACCES'))
+  it('rejects an unsafe staging-root symlink before scanning it', async () => {
+    lstatMock.mockResolvedValue({
+      uid: typeof process.getuid === 'function' ? process.getuid() : 0,
+      isDirectory: () => false,
+      isSymbolicLink: () => true
+    })
 
     await expect(cleanupExpiredRemoteClipboardFiles(NOW_MS)).resolves.toBeUndefined()
 
-    expect(statMock).not.toHaveBeenCalled()
+    expect(opendirMock).not.toHaveBeenCalled()
+    expect(rmMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a POSIX staging root owned by another user', async () => {
+    if (typeof process.getuid !== 'function') {
+      return
+    }
+    lstatMock.mockResolvedValue({
+      uid: process.getuid() + 1,
+      isDirectory: () => true,
+      isSymbolicLink: () => false
+    })
+
+    await cleanupExpiredRemoteClipboardFiles(NOW_MS)
+
+    expect(opendirMock).not.toHaveBeenCalled()
+  })
+
+  it('migrates legacy directories once and records completion', async () => {
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    opendirMock.mockImplementation(async (targetPath: string) => {
+      if (targetPath === '/tmp') {
+        return openedDirectory(
+          (function* (): Generator<MockDirent> {
+            yield* foreignTempEntries(200_000)
+            yield directoryEntry('orca-clipboard-file-expired')
+          })()
+        )
+      }
+      throw new Error(`unexpected directory scan: ${targetPath}`)
+    })
+
+    await migrateLegacyRemoteClipboardFiles(NOW_MS)
+
+    expect(statMock).toHaveBeenCalledOnce()
+    expect(rmMock).toHaveBeenCalledWith(join('/tmp', 'orca-clipboard-file-expired'), {
+      recursive: true,
+      force: true
+    })
+    expect(writeFileMock).toHaveBeenCalledWith(MIGRATION_MARKER, '', { flag: 'wx' })
+  })
+
+  it('skips the shared temp root once migration is marked complete', async () => {
+    await migrateLegacyRemoteClipboardFiles(NOW_MS)
+
+    expect(accessMock).toHaveBeenCalledWith(MIGRATION_MARKER)
+    expect(opendirMock).not.toHaveBeenCalled()
+  })
+
+  it('delays the legacy scan until after startup', async () => {
+    vi.useFakeTimers()
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    opendirMock.mockResolvedValue(openedDirectory([]))
+
+    scheduleLegacyRemoteClipboardFileMigration()
+    scheduleLegacyRemoteClipboardFileMigration()
+    await vi.advanceTimersByTimeAsync(29_999)
+
+    expect(opendirMock).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(1)
+
+    expect(opendirMock).toHaveBeenCalledOnce()
+    expect(opendirMock).toHaveBeenCalledWith('/tmp')
+  })
+
+  it('retries migration until fresh legacy directories can expire', async () => {
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    opendirMock.mockImplementation(async () =>
+      openedDirectory([directoryEntry('orca-clipboard-file-recent')])
+    )
+    statMock.mockResolvedValueOnce({ mtimeMs: NOW_MS - 1000 })
+
+    await migrateLegacyRemoteClipboardFiles(NOW_MS)
+
+    expect(writeFileMock).not.toHaveBeenCalled()
+    expect(rmMock).not.toHaveBeenCalled()
+
+    statMock.mockResolvedValue({ mtimeMs: NOW_MS - TTL_MS - 1 })
+    await migrateLegacyRemoteClipboardFiles(NOW_MS)
+
+    expect(rmMock).toHaveBeenCalledOnce()
+    expect(writeFileMock).toHaveBeenCalledWith(MIGRATION_MARKER, '', { flag: 'wx' })
+  })
+
+  it('does not mark migration complete after a partial legacy scan', async () => {
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    opendirMock.mockResolvedValue({
+      async *[Symbol.asyncIterator]() {
+        yield directoryEntry('orca-clipboard-file-expired')
+        throw new Error('EIO')
+      },
+      close: vi.fn().mockResolvedValue(undefined)
+    })
+
+    await migrateLegacyRemoteClipboardFiles(NOW_MS)
+
+    expect(rmMock).toHaveBeenCalledOnce()
+    expect(writeFileMock).not.toHaveBeenCalled()
+  })
+
+  it('does not mark migration complete when a legacy entry cannot be inspected', async () => {
+    accessMock.mockRejectedValue(new Error('ENOENT'))
+    opendirMock.mockResolvedValue(
+      openedDirectory([directoryEntry('orca-clipboard-file-unreadable')])
+    )
+    statMock.mockRejectedValue(new Error('EACCES'))
+
+    await migrateLegacyRemoteClipboardFiles(NOW_MS)
+
+    expect(writeFileMock).not.toHaveBeenCalled()
+  })
+
+  it('returns quietly when the owned root cannot be prepared', async () => {
+    mkdirMock.mockRejectedValue(new Error('EACCES'))
+
+    await expect(cleanupExpiredRemoteClipboardFiles(NOW_MS)).resolves.toBeUndefined()
+
+    expect(opendirMock).not.toHaveBeenCalled()
     expect(rmMock).not.toHaveBeenCalled()
   })
 })

--- a/src/main/window/clipboard-remote-file-copy.ts
+++ b/src/main/window/clipboard-remote-file-copy.ts
@@ -99,7 +99,8 @@ async function ensureRemoteClipboardStagingRoot(): Promise<string> {
   await mkdir(stagingRoot, { recursive: true, mode: 0o700 })
   const rootStats = await lstat(stagingRoot)
   const wrongOwner = typeof process.getuid === 'function' && rootStats.uid !== process.getuid()
-  if (!rootStats.isDirectory() || rootStats.isSymbolicLink() || wrongOwner) {
+  const wrongMode = typeof process.getuid === 'function' && (rootStats.mode & 0o777) !== 0o700
+  if (!rootStats.isDirectory() || rootStats.isSymbolicLink() || wrongOwner || wrongMode) {
     throw new Error('Remote clipboard staging root is unsafe')
   }
   return stagingRoot

--- a/src/main/window/clipboard-remote-file-copy.ts
+++ b/src/main/window/clipboard-remote-file-copy.ts
@@ -1,6 +1,6 @@
 import { randomUUID } from 'node:crypto'
 import type { Dir } from 'node:fs'
-import { mkdir, opendir, rm, stat } from 'node:fs/promises'
+import { access, lstat, mkdir, opendir, rm, stat, writeFile } from 'node:fs/promises'
 import { join } from 'node:path'
 
 import { app } from 'electron'
@@ -16,10 +16,14 @@ import {
 type RemoteClipboardFileDeps = Omit<ClipboardFileDeps, 'resolveFilePath'>
 
 const REMOTE_CLIPBOARD_FILE_TTL_MS = 60 * 60 * 1000
-const REMOTE_CLIPBOARD_FILE_PREFIX = 'orca-clipboard-file-'
+const REMOTE_CLIPBOARD_STAGING_ROOT_NAME = 'orca-clipboard-files'
+const REMOTE_CLIPBOARD_LEGACY_PREFIX = 'orca-clipboard-file-'
+const REMOTE_CLIPBOARD_LEGACY_MIGRATION_MARKER = '.legacy-cleanup-complete'
+const REMOTE_CLIPBOARD_LEGACY_MIGRATION_DELAY_MS = 30_000
 const REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY = 8
 const WINDOWS_RESERVED_LOCAL_BASENAME = /^(?:con|prn|aux|nul|com[1-9]|lpt[1-9])(?:\..*)?$/i
 const LOCAL_FILENAME_REPLACEMENT_CHARS = new Set(['<', '>', ':', '"', '/', '\\', '|', '?', '*'])
+let legacyMigrationScheduled = false
 
 export async function writeRemoteFileToClipboard({
   remotePath,
@@ -39,10 +43,8 @@ export async function writeRemoteFileToClipboard({
     throw new Error('Remote file download is unavailable. Reconnect the SSH target and retry.')
   }
 
-  const tempDir = join(
-    app.getPath('temp'),
-    `${REMOTE_CLIPBOARD_FILE_PREFIX}${Date.now()}-${randomUUID()}`
-  )
+  const stagingRoot = await ensureRemoteClipboardStagingRoot()
+  const tempDir = join(stagingRoot, `${Date.now()}-${randomUUID()}`)
   await mkdir(tempDir, { mode: 0o700 })
   const localPath = join(
     tempDir,
@@ -80,25 +82,93 @@ export async function writeRemoteFileToClipboard({
   }
 }
 
-// Why: the OS temp root is shared with every other program and routinely holds
-// millions of unrelated entries on long-lived machines, so this startup sweep
-// streams it and only ever retains work for entries it actually owns.
 export async function cleanupExpiredRemoteClipboardFiles(nowMs = Date.now()): Promise<void> {
-  const tempRoot = app.getPath('temp')
-  let tempRootDir: Dir
+  let stagingRoot: string
   try {
-    tempRootDir = await opendir(tempRoot)
+    stagingRoot = await ensureRemoteClipboardStagingRoot()
   } catch {
     return
   }
 
+  await sweepRemoteClipboardDirectories(stagingRoot, nowMs, () => true)
+}
+
+async function ensureRemoteClipboardStagingRoot(): Promise<string> {
+  const uidSuffix = typeof process.getuid === 'function' ? `-${process.getuid()}` : ''
+  const stagingRoot = join(app.getPath('temp'), `${REMOTE_CLIPBOARD_STAGING_ROOT_NAME}${uidSuffix}`)
+  await mkdir(stagingRoot, { recursive: true, mode: 0o700 })
+  const rootStats = await lstat(stagingRoot)
+  const wrongOwner = typeof process.getuid === 'function' && rootStats.uid !== process.getuid()
+  if (!rootStats.isDirectory() || rootStats.isSymbolicLink() || wrongOwner) {
+    throw new Error('Remote clipboard staging root is unsafe')
+  }
+  return stagingRoot
+}
+
+export async function migrateLegacyRemoteClipboardFiles(nowMs = Date.now()): Promise<void> {
+  let stagingRoot: string
+  try {
+    stagingRoot = await ensureRemoteClipboardStagingRoot()
+  } catch {
+    return
+  }
+
+  const markerPath = join(stagingRoot, REMOTE_CLIPBOARD_LEGACY_MIGRATION_MARKER)
+  const migrationComplete = await access(markerPath).then(
+    () => true,
+    () => false
+  )
+  if (migrationComplete) {
+    return
+  }
+
+  const result = await sweepRemoteClipboardDirectories(app.getPath('temp'), nowMs, (name) =>
+    name.startsWith(REMOTE_CLIPBOARD_LEGACY_PREFIX)
+  )
+  if (result.complete && !result.hasFreshDirectories) {
+    await writeFile(markerPath, '', { flag: 'wx' }).catch(() => undefined)
+  }
+}
+
+export function scheduleLegacyRemoteClipboardFileMigration(): void {
+  if (legacyMigrationScheduled) {
+    return
+  }
+  legacyMigrationScheduled = true
+  const timer = setTimeout(() => {
+    void migrateLegacyRemoteClipboardFiles()
+  }, REMOTE_CLIPBOARD_LEGACY_MIGRATION_DELAY_MS)
+  if (typeof timer === 'object' && 'unref' in timer) {
+    timer.unref()
+  }
+}
+
+async function sweepRemoteClipboardDirectories(
+  root: string,
+  nowMs: number,
+  ownsEntry: (name: string) => boolean
+): Promise<{ complete: boolean; hasFreshDirectories: boolean }> {
+  let rootDir: Dir
+  try {
+    rootDir = await opendir(root)
+  } catch {
+    return { complete: false, hasFreshDirectories: false }
+  }
+
+  let complete = true
+  let hasFreshDirectories = false
   const pending = new Set<Promise<void>>()
   try {
-    for await (const entry of tempRootDir) {
-      if (!entry.isDirectory() || !entry.name.startsWith(REMOTE_CLIPBOARD_FILE_PREFIX)) {
+    for await (const entry of rootDir) {
+      if (!entry.isDirectory() || !ownsEntry(entry.name)) {
         continue
       }
-      const cleanup = cleanupExpiredRemoteClipboardDirectory(join(tempRoot, entry.name), nowMs)
+      const cleanup = cleanupExpiredRemoteClipboardDirectory(join(root, entry.name), nowMs).then(
+        (result) => {
+          hasFreshDirectories ||= result === 'fresh'
+          complete &&= result !== 'failed'
+        }
+      )
       pending.add(cleanup)
       void cleanup.finally(() => pending.delete(cleanup))
       if (pending.size >= REMOTE_CLIPBOARD_CLEANUP_CONCURRENCY) {
@@ -106,25 +176,28 @@ export async function cleanupExpiredRemoteClipboardFiles(nowMs = Date.now()): Pr
       }
     }
   } catch {
-    // Why: a partial best-effort sweep beats failing startup on a temp-root read error.
+    complete = false
   } finally {
-    // Why: exhausting the iterator already closes the handle; closing again is harmless.
-    await tempRootDir.close().catch(() => undefined)
+    await rootDir.close().catch(() => undefined)
   }
   await Promise.all(pending)
+  return { complete, hasFreshDirectories }
 }
 
 async function cleanupExpiredRemoteClipboardDirectory(
   tempDir: string,
   nowMs: number
-): Promise<void> {
+): Promise<'failed' | 'fresh' | 'removed'> {
   try {
     const tempStats = await stat(tempDir)
-    if (nowMs - tempStats.mtimeMs >= REMOTE_CLIPBOARD_FILE_TTL_MS) {
-      await rm(tempDir, { recursive: true, force: true })
+    if (nowMs - tempStats.mtimeMs < REMOTE_CLIPBOARD_FILE_TTL_MS) {
+      return 'fresh'
     }
+    await rm(tempDir, { recursive: true, force: true })
+    return 'removed'
   } catch {
     // Why: stale staged SSH files should not make startup cleanup noisy.
+    return 'failed'
   }
 }
 


### PR DESCRIPTION
## Summary

- Move staged SSH clipboard files into a single Orca-owned temp root, scoped by UID on POSIX.
- Make normal startup cleanup enumerate only that root instead of the shared system temp directory.
- Delay the old-layout scan by 30 seconds and run it only until a completion marker can be safely written. Partial scans, fresh entries, and per-entry failures retry on a later launch.
- Preserve streaming cleanup with an eight-operation concurrency cap and reject symlinked, non-directory, or wrong-owner POSIX roots.

This is the ownership-boundary follow-up to #12917. That PR bounded the shared-root scan; this PR removes it from steady-state startup entirely.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — Oxlint, native/type-aware audits, reliability gates, max-lines, and bundled guides pass; the command then stops on pre-existing generated skill-manifest drift in `resources/skills/{current-manifest,snapshot-registry,release-mapping}.json`.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused suite run instead: 42/42 tests passed across the three affected test files.
- [ ] `pnpm build` — Electron main, preload, and renderer development builds completed during live validation; the full packaging build was not run.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional deterministic validation on Windows:

- Seeded the temp root with 100,000 unrelated files, one expired owned entry, and one expired legacy entry.
- First launch removed the owned entry immediately, left the legacy entry before 30 seconds, then removed it and wrote the marker after the delay. All 100,000 unrelated files remained.
- Second launch removed a new owned entry immediately but preserved a new legacy sentinel past 30 seconds, proving the marker prevents future shared-root scans. All unrelated files remained.
- The renderer reached a complete, visible, responsive Orca UI on both launches with no captured renderer errors.
- `verify:localization-catalog`, `verify:localization-extraction`, and `verify:localization-coverage` pass.

## AI Review Report

Reviewed the ownership boundary, cleanup concurrency, migration-marker lifecycle, incomplete enumeration, per-entry failures, and startup scheduling. The review found that a failed legacy `stat`/remove could still allow the marker to be written; the implementation now treats any per-entry failure as an incomplete migration, with a regression test.

Cross-platform behavior was explicitly checked: Windows uses its user temp directory without a UID suffix; macOS/Linux use a UID-suffixed root, validate POSIX ownership, and use `path.join` throughout. Electron timer and temp-path behavior are platform-neutral. No shortcuts, labels, shell invocation, remote wire format, or Git behavior changed. SSH clipboard materialization and failure cleanup remain covered by the existing IPC tests.

## Security Audit

The owned root is created with mode `0700` and validated with `lstat` before use. Symlinks, non-directories, and roots owned by another POSIX UID are rejected. Child directories use unpredictable UUID names and mode `0700`; remote basenames continue through the existing Windows-safe sanitizer. Cleanup operates only on direct child directories, executes no commands, changes no authentication or secrets behavior, and leaves trusted-renderer IPC checks intact.

## Notes

The delayed legacy scan is intentionally one-time and best-effort. It writes its marker only after a complete scan with no fresh or failed legacy entries, so interrupted or blocked migrations retry on a later app launch.