### PR TITLE
fix(terminal): skip a too-wide alt frame on snapshot replay

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1321,6 +1321,18 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         source: 'headless'
       })
     })
+
+    it('exposes live state separately from the visible frame', async () => {
+      const { id } = await adapter.spawn({ cols: 80, rows: 24 })
+      lastSubprocess._simulateData('\x1b[?1049h\x1b[?1004h\x1b[?25lframe')
+
+      const snapshot = await adapter.getBufferSnapshot(id)
+
+      expect(snapshot?.frameRestoreAnsi).toContain('\x1b[?1004h')
+      expect(snapshot?.frameRestoreAnsi).toContain('\x1b[?25l')
+      expect(snapshot?.frameRestoreAnsi).not.toContain('frame')
+      expect(snapshot?.data).toContain('frame')
+    })
   })
 
   describe('shutdown', () => {
@@ -1504,6 +1516,21 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.isReattach).toBe(true)
       expect(result.snapshot).toContain('\x1b[?2004h')
       expect(result.snapshot).toContain('prompt$')
+    })
+
+    it('marks the alt-frame boundary without duplicating the snapshot payload', async () => {
+      const sessionId = 'alt-frame-boundary'
+      await adapter.spawn({ cols: 80, rows: 24, sessionId })
+      lastSubprocess._simulateData('\x1b[?1049h\x1b[HSTATIC-ALT-FRAME')
+      await new Promise((r) => setTimeout(r, 50))
+
+      const result = await adapter.spawn({ cols: 80, rows: 24, sessionId })
+      const frameStart = result.snapshotFrameStart
+
+      expect(typeof frameStart).toBe('number')
+      expect(result.snapshot?.slice(0, frameStart)).toContain('\x1b[?1049h')
+      expect(result.snapshot?.slice(frameStart)).toContain('STATIC-ALT-FRAME')
+      expect(result.snapshotFrameRestoreAnsi).not.toContain('STATIC-ALT-FRAME')
     })
 
     it('returns the preserved sequence from attach-only adoption', async () => {

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1518,18 +1518,16 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.snapshot).toContain('prompt$')
     })
 
-    it('marks the alt-frame boundary without duplicating the snapshot payload', async () => {
+    it('publishes the alt-frame payload as explicit strings', async () => {
       const sessionId = 'alt-frame-boundary'
       await adapter.spawn({ cols: 80, rows: 24, sessionId })
       lastSubprocess._simulateData('\x1b[?1049h\x1b[HSTATIC-ALT-FRAME')
       await new Promise((r) => setTimeout(r, 50))
 
       const result = await adapter.spawn({ cols: 80, rows: 24, sessionId })
-      const frameStart = result.snapshotFrameStart
-
-      expect(typeof frameStart).toBe('number')
-      expect(result.snapshot?.slice(0, frameStart)).toContain('\x1b[?1049h')
-      expect(result.snapshot?.slice(frameStart)).toContain('STATIC-ALT-FRAME')
+      expect(result.snapshotPrefixAnsi).toContain('\x1b[?1049h')
+      expect(result.snapshotFrameAnsi).toContain('STATIC-ALT-FRAME')
+      expect(result.snapshot).toBe([result.snapshotPrefixAnsi, result.snapshotFrameAnsi].join(''))
       expect(result.snapshotFrameRestoreAnsi).not.toContain('STATIC-ALT-FRAME')
     })
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -831,10 +831,13 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const isAltScreen = result.snapshot.modes.alternateScreen
-    const snapshotPayload =
-      result.snapshot.scrollbackAnsi +
-      result.snapshot.rehydrateSequences +
-      result.snapshot.snapshotAnsi
+    // Why split out: an alt-screen frame is absolutely positioned, so it only
+    // renders at its capture width. The renderer pins to the snapshot grid, paints,
+    // then fits to its container — and a narrower container makes xterm split every
+    // frame row. Carrying the prefix separately lets the renderer drop just the
+    // frame and let the app repaint. Optional: older renderers read `snapshot`.
+    const snapshotPrefix = result.snapshot.scrollbackAnsi + result.snapshot.rehydrateSequences
+    const snapshotPayload = snapshotPrefix + result.snapshot.snapshotAnsi
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).
     const kittyKeyboardFlags = result.snapshot.modes.kittyKeyboardFlags
     return {
@@ -847,6 +850,14 @@ export class DaemonPtyAdapter implements IPtyProvider {
       snapshot: snapshotPayload,
       snapshotCols: result.snapshot.cols,
       snapshotRows: result.snapshot.rows,
+      // Why only for an alt frame: the normal buffer is soft-wrapped and reflows
+      // correctly, so splitting it would buy nothing.
+      ...(isAltScreen && result.snapshot.snapshotAnsi
+        ? {
+            snapshotPrefixAnsi: snapshotPrefix,
+            snapshotFrameAnsi: result.snapshot.snapshotAnsi
+          }
+        : {}),
       ...(providerSequence ? { providerSequence } : {}),
       ...(typeof kittyKeyboardFlags === 'number' && kittyKeyboardFlags > 0
         ? { snapshotKittyKeyboardFlags: kittyKeyboardFlags }

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -831,9 +831,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const isAltScreen = result.snapshot.modes.alternateScreen
-    // The optional boundary lets newer renderers omit a stale fixed-grid frame without duplicating the payload.
     const snapshotPrefix = result.snapshot.scrollbackAnsi + result.snapshot.rehydrateSequences
-    const snapshotPayload = snapshotPrefix + result.snapshot.snapshotAnsi
+    const snapshotFrame = result.snapshot.snapshotAnsi
+    const snapshotPayload = snapshotPrefix + snapshotFrame
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).
     const kittyKeyboardFlags = result.snapshot.modes.kittyKeyboardFlags
     return {
@@ -846,11 +846,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       snapshot: snapshotPayload,
       snapshotCols: result.snapshot.cols,
       snapshotRows: result.snapshot.rows,
-      // Why only for an alt frame: the normal buffer is soft-wrapped and reflows
-      // correctly, so marking a boundary would buy nothing.
-      ...(isAltScreen && result.snapshot.snapshotAnsi && result.snapshot.frameRestoreAnsi
+      // Why only for an alt frame: normal history remains safe to replay at its capture grid.
+      ...(isAltScreen && snapshotFrame && result.snapshot.frameRestoreAnsi
         ? {
-            snapshotFrameStart: snapshotPrefix.length,
+            snapshotPrefixAnsi: snapshotPrefix,
+            snapshotFrameAnsi: snapshotFrame,
             snapshotFrameRestoreAnsi: result.snapshot.frameRestoreAnsi
           }
         : {}),

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -831,11 +831,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const isAltScreen = result.snapshot.modes.alternateScreen
-    // Why split out: an alt-screen frame is absolutely positioned, so it only
+    // Why mark the boundary: an alt-screen frame is absolutely positioned, so it only
     // renders at its capture width. The renderer pins to the snapshot grid, paints,
     // then fits to its container — and a narrower container makes xterm split every
-    // frame row. Carrying the prefix separately lets the renderer drop just the
-    // frame and let the app repaint. Optional: older renderers read `snapshot`.
+    // frame row. The marker lets the renderer drop just the frame without sending
+    // the payload twice. Optional: older renderers still read the merged `snapshot`.
     const snapshotPrefix = result.snapshot.scrollbackAnsi + result.snapshot.rehydrateSequences
     const snapshotPayload = snapshotPrefix + result.snapshot.snapshotAnsi
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).
@@ -851,11 +851,11 @@ export class DaemonPtyAdapter implements IPtyProvider {
       snapshotCols: result.snapshot.cols,
       snapshotRows: result.snapshot.rows,
       // Why only for an alt frame: the normal buffer is soft-wrapped and reflows
-      // correctly, so splitting it would buy nothing.
-      ...(isAltScreen && result.snapshot.snapshotAnsi
+      // correctly, so marking a boundary would buy nothing.
+      ...(isAltScreen && result.snapshot.snapshotAnsi && result.snapshot.frameRestoreAnsi
         ? {
-            snapshotPrefixAnsi: snapshotPrefix,
-            snapshotFrameAnsi: result.snapshot.snapshotAnsi
+            snapshotFrameStart: snapshotPrefix.length,
+            snapshotFrameRestoreAnsi: result.snapshot.frameRestoreAnsi
           }
         : {}),
       ...(providerSequence ? { providerSequence } : {}),
@@ -1227,6 +1227,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       }
       return {
         data: snapshot.rehydrateSequences + snapshot.snapshotAnsi,
+        frameRestoreAnsi: snapshot.frameRestoreAnsi,
         scrollbackAnsi: snapshot.scrollbackAnsi,
         cols: snapshot.cols,
         rows: snapshot.rows,

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -831,11 +831,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const isAltScreen = result.snapshot.modes.alternateScreen
-    // Why mark the boundary: an alt-screen frame is absolutely positioned, so it only
-    // renders at its capture width. The renderer pins to the snapshot grid, paints,
-    // then fits to its container — and a narrower container makes xterm split every
-    // frame row. The marker lets the renderer drop just the frame without sending
-    // the payload twice. Optional: older renderers still read the merged `snapshot`.
+    // The optional boundary lets newer renderers omit a stale fixed-grid frame without duplicating the payload.
     const snapshotPrefix = result.snapshot.scrollbackAnsi + result.snapshot.rehydrateSequences
     const snapshotPayload = snapshotPrefix + result.snapshot.snapshotAnsi
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).

--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -575,6 +575,25 @@ describe('HeadlessEmulator', () => {
   })
 
   describe('rehydration sequences', () => {
+    it('separates complete live state from an alternate-screen frame', async () => {
+      emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
+      await emulator.write('\x1b[?1049h\x1b[?1004h\x1b[?25l\x1b[5;10H\x1b7\x1b[31;44;1mframe')
+
+      const snapshot = emulator.getSnapshot()
+
+      expect(snapshot.frameRestoreAnsi).toContain('\x1b[?1004h')
+      expect(snapshot.frameRestoreAnsi).toContain('\x1b[?25l')
+      expect(snapshot.frameRestoreAnsi).toContain('\x1b7')
+      expect(snapshot.frameRestoreAnsi).toContain('\x1b[31;44;1m')
+      expect(snapshot.frameRestoreAnsi).not.toContain('frame')
+
+      const restored = new HeadlessEmulator({ cols: 80, rows: 24 })
+      await restored.write(snapshot.frameRestoreAnsi ?? '')
+      await restored.write('X')
+      expect(restored.getSnapshot().snapshotAnsi).toContain('\x1b[31;44;1mX')
+      restored.dispose()
+    })
+
     it('generates rehydration for non-default modes', async () => {
       emulator = new HeadlessEmulator({ cols: 80, rows: 24 })
       await emulator.write('\x1b[?2004h')

--- a/src/main/daemon/headless-emulator.test.ts
+++ b/src/main/daemon/headless-emulator.test.ts
@@ -581,6 +581,7 @@ describe('HeadlessEmulator', () => {
 
       const snapshot = emulator.getSnapshot()
 
+      expect(snapshot.frameRestoreAnsi).toContain('\x1b[?1049h')
       expect(snapshot.frameRestoreAnsi).toContain('\x1b[?1004h')
       expect(snapshot.frameRestoreAnsi).toContain('\x1b[?25l')
       expect(snapshot.frameRestoreAnsi).toContain('\x1b7')
@@ -589,8 +590,37 @@ describe('HeadlessEmulator', () => {
 
       const restored = new HeadlessEmulator({ cols: 80, rows: 24 })
       await restored.write(snapshot.frameRestoreAnsi ?? '')
+      expect(restored.isAlternateScreen).toBe(true)
       await restored.write('X')
       expect(restored.getSnapshot().snapshotAnsi).toContain('\x1b[31;44;1mX')
+      restored.dispose()
+    })
+
+    it('restores current and saved cursor rows relative to origin-mode margins', async () => {
+      emulator = new HeadlessEmulator({ cols: 20, rows: 10 })
+      await emulator.write('\x1b[?1049h\x1b[3;8r\x1b[?6h\x1b[2;7H\x1b7\x1b[4;5H')
+
+      const snapshot = emulator.getSnapshot()
+      const restored = new HeadlessEmulator({ cols: 20, rows: 10 })
+      await restored.write(snapshot.frameRestoreAnsi ?? '')
+      await restored.write('C\x1b8S')
+
+      expect(restored.getVisibleLines()[5]?.[4]).toBe('C')
+      expect(restored.getVisibleLines()[3]?.[6]).toBe('S')
+      restored.dispose()
+    })
+
+    it('restores a saved cursor from before the current origin-mode margins', async () => {
+      emulator = new HeadlessEmulator({ cols: 20, rows: 10 })
+      await emulator.write('\x1b[?1049h\x1b[1;3H\x1b7\x1b[3;8r\x1b[?6h\x1b[4;5H')
+
+      const snapshot = emulator.getSnapshot()
+      const restored = new HeadlessEmulator({ cols: 20, rows: 10 })
+      await restored.write(snapshot.frameRestoreAnsi ?? '')
+      await restored.write('C\x1b8S')
+
+      expect(restored.getVisibleLines()[5]?.[4]).toBe('C')
+      expect(restored.getVisibleLines()[0]?.[2]).toBe('S')
       restored.dispose()
     })
 

--- a/src/main/daemon/headless-emulator.ts
+++ b/src/main/daemon/headless-emulator.ts
@@ -13,6 +13,7 @@ import { collectHeadlessOscLinkRanges } from './headless-osc-link-ranges'
 import { buildRehydrateSequences } from './terminal-mode-rehydrate-sequences'
 import { TerminalMouseModeMirror } from './terminal-mouse-mode-mirror'
 import { TerminalOscCwdTitleScanner } from './terminal-osc-cwd-title-scanner'
+import { buildFrameRestoreSnapshotFields } from './terminal-frame-restore-sequences'
 import { splitTerminalSnapshotAnsi } from './terminal-snapshot-ansi-buffers'
 import {
   installTerminalViewAttributeResponder,
@@ -255,6 +256,7 @@ export class HeadlessEmulator {
         this.restoredOscLinks
       ),
       rehydrateSequences: buildRehydrateSequences(modes),
+      ...buildFrameRestoreSnapshotFields(this.serializer, this.terminal, modes),
       cwd: this.oscText.cwd,
       modes,
       cols: this.terminal.cols,
@@ -265,10 +267,6 @@ export class HeadlessEmulator {
       ...(this.partialEscapeTail.length > 0
         ? { pendingEscapeTailAnsi: this.partialEscapeTail }
         : {})
-    }
-    if (this.partialEscapeTail.length > 0) {
-      // Why a separate field: consumers write their own reset sequences after the body, and any ESC after a dangling partial would abort it.
-      snapshot.pendingEscapeTailAnsi = this.partialEscapeTail
     }
     return snapshot
   }

--- a/src/main/daemon/terminal-frame-restore-sequences.ts
+++ b/src/main/daemon/terminal-frame-restore-sequences.ts
@@ -7,10 +7,6 @@ import {
 import type { SavedCursorRegister } from '../../shared/terminal-serialize-absolute-cursor'
 import type { TerminalModes } from './types'
 
-type TerminalWithScrollRegion = Terminal & {
-  _core?: { buffer?: { scrollTop?: number; scrollBottom?: number } }
-}
-
 export function buildFrameRestoreSnapshotFields(
   serializer: SerializeAddon,
   terminal: Terminal,
@@ -49,9 +45,6 @@ function buildTerminalFrameRestoreSequences(
   if (terminalModes.insertMode) {
     seqs.push('\x1b[4h')
   }
-  if (terminalModes.originMode) {
-    seqs.push('\x1b[?6h')
-  }
   if (terminalModes.reverseWraparoundMode) {
     seqs.push('\x1b[?45h')
   }
@@ -85,15 +78,11 @@ function buildTerminalFrameRestoreSequences(
   if (!terminalModes.showCursor) {
     seqs.push('\x1b[?25l')
   }
-  const buffer = (terminal as TerminalWithScrollRegion)._core?.buffer
-  if (
-    typeof buffer?.scrollTop === 'number' &&
-    typeof buffer.scrollBottom === 'number' &&
-    (buffer.scrollTop !== 0 || buffer.scrollBottom !== terminal.rows - 1)
-  ) {
-    seqs.push(`\x1b[${buffer.scrollTop + 1};${buffer.scrollBottom + 1}r`)
-  }
-  seqs.push(buildAbsoluteCursorRestoreSequence(terminal, savedCursor))
+  seqs.push(
+    buildAbsoluteCursorRestoreSequence(terminal, savedCursor, {
+      restoreModesWithoutCursor: true
+    })
+  )
   return seqs.join('')
 }
 

--- a/src/main/daemon/terminal-frame-restore-sequences.ts
+++ b/src/main/daemon/terminal-frame-restore-sequences.ts
@@ -87,7 +87,7 @@ function buildTerminalFrameRestoreSequences(
 }
 
 function serializeCurrentSgrState(serializer: SerializeAddon, terminal: Terminal): string {
-  // An out-of-range row emits no cells; SerializeAddon still appends its authoritative pen-state diff.
+  // Unsupported addon behavior under our vendored patch: an out-of-range row emits only its authoritative pen-state diff.
   const emptyRow = terminal.buffer.normal.length
   return serializer.serialize({
     range: { start: emptyRow, end: emptyRow },

--- a/src/main/daemon/terminal-frame-restore-sequences.ts
+++ b/src/main/daemon/terminal-frame-restore-sequences.ts
@@ -1,0 +1,108 @@
+import type { Terminal } from '@xterm/headless'
+import type { SerializeAddon } from '@xterm/addon-serialize'
+import {
+  buildAbsoluteCursorRestoreSequence,
+  readSavedCursorRegister
+} from '../../shared/terminal-serialize-absolute-cursor'
+import type { SavedCursorRegister } from '../../shared/terminal-serialize-absolute-cursor'
+import type { TerminalModes } from './types'
+
+type TerminalWithScrollRegion = Terminal & {
+  _core?: { buffer?: { scrollTop?: number; scrollBottom?: number } }
+}
+
+export function buildFrameRestoreSnapshotFields(
+  serializer: SerializeAddon,
+  terminal: Terminal,
+  modes: TerminalModes
+): { frameRestoreAnsi?: string } {
+  return modes.alternateScreen
+    ? {
+        frameRestoreAnsi: buildTerminalFrameRestoreSequences(
+          serializer,
+          terminal,
+          modes,
+          readSavedCursorRegister(terminal)
+        )
+      }
+    : {}
+}
+
+/** Restores live terminal state without replaying an alternate-screen frame. */
+function buildTerminalFrameRestoreSequences(
+  serializer: SerializeAddon,
+  terminal: Terminal,
+  modes: TerminalModes,
+  savedCursor: SavedCursorRegister | null
+): string {
+  const terminalModes = terminal.modes
+  const seqs: string[] = ['\x1b[0m\x1b[?1049h', serializeCurrentSgrState(serializer, terminal)]
+  if (terminalModes.applicationCursorKeysMode) {
+    seqs.push('\x1b[?1h')
+  }
+  if (terminalModes.applicationKeypadMode) {
+    seqs.push('\x1b[?66h')
+  }
+  if (terminalModes.bracketedPasteMode) {
+    seqs.push('\x1b[?2004h')
+  }
+  if (terminalModes.insertMode) {
+    seqs.push('\x1b[4h')
+  }
+  if (terminalModes.originMode) {
+    seqs.push('\x1b[?6h')
+  }
+  if (terminalModes.reverseWraparoundMode) {
+    seqs.push('\x1b[?45h')
+  }
+  if (terminalModes.sendFocusMode) {
+    seqs.push('\x1b[?1004h')
+  }
+  if (!terminalModes.wraparoundMode) {
+    seqs.push('\x1b[?7l')
+  }
+  switch (modes.mouseTracking ? (modes.mouseTrackingMode ?? 'vt200') : 'none') {
+    case 'x10':
+      seqs.push('\x1b[?9h')
+      break
+    case 'vt200':
+      seqs.push('\x1b[?1000h')
+      break
+    case 'drag':
+      seqs.push('\x1b[?1002h')
+      break
+    case 'any':
+      seqs.push('\x1b[?1003h')
+      break
+    case 'none':
+      break
+  }
+  if (modes.sgrMousePixelsMode) {
+    seqs.push('\x1b[?1016h')
+  } else if (modes.sgrMouseMode) {
+    seqs.push('\x1b[?1006h')
+  }
+  if (!terminalModes.showCursor) {
+    seqs.push('\x1b[?25l')
+  }
+  const buffer = (terminal as TerminalWithScrollRegion)._core?.buffer
+  if (
+    typeof buffer?.scrollTop === 'number' &&
+    typeof buffer.scrollBottom === 'number' &&
+    (buffer.scrollTop !== 0 || buffer.scrollBottom !== terminal.rows - 1)
+  ) {
+    seqs.push(`\x1b[${buffer.scrollTop + 1};${buffer.scrollBottom + 1}r`)
+  }
+  seqs.push(buildAbsoluteCursorRestoreSequence(terminal, savedCursor))
+  return seqs.join('')
+}
+
+function serializeCurrentSgrState(serializer: SerializeAddon, terminal: Terminal): string {
+  // An out-of-range row emits no cells; SerializeAddon still appends its authoritative pen-state diff.
+  const emptyRow = terminal.buffer.normal.length
+  return serializer.serialize({
+    range: { start: emptyRow, end: emptyRow },
+    excludeAltBuffer: true,
+    excludeModes: true
+  })
+}

--- a/src/main/daemon/terminal-snapshot-serialize-roundtrip.test.ts
+++ b/src/main/daemon/terminal-snapshot-serialize-roundtrip.test.ts
@@ -70,6 +70,24 @@ async function roundTripStyles(source: string): Promise<Terminal> {
   return replay(addon.serialize())
 }
 
+describe('out-of-range SGR state serialization', () => {
+  it('emits only the live pen state for a row beyond the normal buffer', async () => {
+    const { terminal, addon } = createTerminal()
+    await write(terminal, '\x1b[31;44;1m')
+
+    // This deliberately pins unsupported SerializeAddon behavior used by
+    // terminal-frame-restore-sequences under Orca's vendored addon patch.
+    const outOfRangeRow = terminal.buffer.normal.length
+    expect(
+      addon.serialize({
+        range: { start: outOfRangeRow, end: outOfRangeRow },
+        excludeAltBuffer: true,
+        excludeModes: true
+      })
+    ).toBe('\x1b[31;44;1m')
+  })
+})
+
 describe('SGR intensity round-trip (BUG B, addon patch)', () => {
   it('restores bold set immediately after dim is cleared (minimized repro)', async () => {
     const restored = await roundTripStyles('\x1b[2mA\x1b[22m\x1b[1mB')

--- a/src/main/daemon/terminal-snapshot.ts
+++ b/src/main/daemon/terminal-snapshot.ts
@@ -9,6 +9,8 @@ export type TerminalSnapshot = {
   scrollbackAnsi: string
   oscLinks?: TerminalOscLinkRange[]
   rehydrateSequences: string
+  /** Live modes and cursor state that can be restored without the alt frame. */
+  frameRestoreAnsi?: string
   cwd: string | null
   modes: TerminalModes
   cols: number

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5672,6 +5672,7 @@ export function registerPtyHandlers(
       args: { id?: unknown; opts?: { scrollbackRows?: unknown } }
     ): Promise<{
       data: string
+      frameRestoreAnsi?: string
       cols: number
       rows: number
       cwd?: string | null

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -19,6 +19,8 @@ export type {
 
 export type PtyProviderBufferSnapshot = {
   data: string
+  /** Live state that can be restored without an alternate-screen frame. */
+  frameRestoreAnsi?: string
   /** Authoritative normal buffer captured beside an alternate-screen frame. */
   scrollbackAnsi?: string
   cols: number

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -32,13 +32,12 @@ export type PtySpawnResult = {
    *  writing the snapshot so ANSI cursor positions land correctly. */
   snapshotCols?: number
   snapshotRows?: number
-  /** Optional split of `snapshot` for alt-screen reattaches: everything before the
-   *  frame, and the frame itself. Present only when the snapshot is an alt-screen
-   *  capture. A reader that ignores these still has the merged `snapshot`, so an
-   *  older client is unaffected; a newer one can drop a frame whose capture width
-   *  no longer matches the pane instead of letting xterm reflow-split it. */
-  snapshotPrefixAnsi?: string
-  snapshotFrameAnsi?: string
+  /** UTF-16 index where the alt frame begins in `snapshot`. Optional so older
+   *  clients keep reading the merged snapshot and newer clients can omit only
+   *  a mismatched frame without duplicating the payload over IPC. */
+  snapshotFrameStart?: number
+  /** Live state to append when omitting the alt frame at `snapshotFrameStart`. */
+  snapshotFrameRestoreAnsi?: string
   /** Provider sequence at the attach boundary. `reset` starts a new provider
    *  generation; `continued` resumes the existing absolute domain. */
   providerSequence?: {

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -32,11 +32,11 @@ export type PtySpawnResult = {
    *  writing the snapshot so ANSI cursor positions land correctly. */
   snapshotCols?: number
   snapshotRows?: number
-  /** UTF-16 index where the alt frame begins in `snapshot`. Optional so older
-   *  clients keep reading the merged snapshot and newer clients can omit only
-   *  a mismatched frame without duplicating the payload over IPC. */
-  snapshotFrameStart?: number
-  /** Live state to append when omitting the alt frame at `snapshotFrameStart`. */
+  /** Normal-buffer history and mode preamble before an alternate-screen frame. */
+  snapshotPrefixAnsi?: string
+  /** Visual alternate-screen frame, separate so newer clients can omit it safely. */
+  snapshotFrameAnsi?: string
+  /** Live state to append when omitting `snapshotFrameAnsi`. */
   snapshotFrameRestoreAnsi?: string
   /** Provider sequence at the attach boundary. `reset` starts a new provider
    *  generation; `continued` resumes the existing absolute domain. */

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -32,6 +32,13 @@ export type PtySpawnResult = {
    *  writing the snapshot so ANSI cursor positions land correctly. */
   snapshotCols?: number
   snapshotRows?: number
+  /** Optional split of `snapshot` for alt-screen reattaches: everything before the
+   *  frame, and the frame itself. Present only when the snapshot is an alt-screen
+   *  capture. A reader that ignores these still has the merged `snapshot`, so an
+   *  older client is unaffected; a newer one can drop a frame whose capture width
+   *  no longer matches the pane instead of letting xterm reflow-split it. */
+  snapshotPrefixAnsi?: string
+  snapshotFrameAnsi?: string
   /** Provider sequence at the attach boundary. `reset` starts a new provider
    *  generation; `continued` resumes the existing absolute domain. */
   providerSequence?: {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11053,6 +11053,7 @@ describe('OrcaRuntimeService', () => {
     expect(snapshot?.frameRestoreAnsi).toContain('\x1b[?1004h')
     expect(snapshot?.frameRestoreAnsi).toContain('\x1b[?25l')
     expect(snapshot?.frameRestoreAnsi).not.toContain('STATIC-FRAME')
+    expect(snapshot?.data).toContain('STATIC-FRAME')
   })
 
   it('keeps Windows SSH OSC7 cwd as a drive path when the desktop runtime is POSIX', () => {

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -11043,6 +11043,18 @@ describe('OrcaRuntimeService', () => {
     expect(snapshot?.cwd).toBe('/home/me/repo/src')
   })
 
+  it('projects frame-independent live state through main buffer snapshots', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    runtime.registerPty('pty-frame-state', TEST_WORKTREE_ID)
+    runtime.onPtyData('pty-frame-state', '\x1b[?1049h\x1b[?1004h\x1b[?25lSTATIC-FRAME', 123)
+
+    const snapshot = await runtime.serializeMainTerminalBuffer('pty-frame-state')
+
+    expect(snapshot?.frameRestoreAnsi).toContain('\x1b[?1004h')
+    expect(snapshot?.frameRestoreAnsi).toContain('\x1b[?25l')
+    expect(snapshot?.frameRestoreAnsi).not.toContain('STATIC-FRAME')
+  })
+
   it('keeps Windows SSH OSC7 cwd as a drive path when the desktop runtime is POSIX', () => {
     setPlatform('darwin')
     const runtime = new OrcaRuntimeService(store)

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1595,6 +1595,8 @@ type ProviderBufferAcquisition = {
 
 type RuntimeTerminalBufferSnapshot = {
   data: string
+  /** Live state that can be restored without an alternate-screen frame. */
+  frameRestoreAnsi?: string
   cols: number
   rows: number
   seq?: number
@@ -11080,6 +11082,7 @@ export class OrcaRuntimeService {
     opts: { scrollbackRows?: number } = {}
   ): Promise<{
     data: string
+    frameRestoreAnsi?: string
     cols: number
     rows: number
     seq?: number
@@ -11098,6 +11101,7 @@ export class OrcaRuntimeService {
     opts: { scrollbackRows?: number } = {}
   ): Promise<{
     data: string
+    frameRestoreAnsi?: string
     cols: number
     rows: number
     cwd?: string | null
@@ -11548,6 +11552,7 @@ export class OrcaRuntimeService {
     opts: { scrollbackRows?: number } = {}
   ): Promise<{
     data: string
+    frameRestoreAnsi?: string
     cols: number
     rows: number
     cwd?: string | null
@@ -11598,6 +11603,7 @@ export class OrcaRuntimeService {
     opts: { scrollbackRows?: number } = {}
   ): Promise<{
     data: string
+    frameRestoreAnsi?: string
     cols: number
     rows: number
     seq?: number
@@ -12018,6 +12024,7 @@ export class OrcaRuntimeService {
     return data.length > 0 || opts.includeEmpty === true
       ? this.preferTrackedLastTitle(ptyId, {
           data,
+          frameRestoreAnsi: snapshot.frameRestoreAnsi,
           cols: snapshot.cols,
           rows: snapshot.rows,
           cwd: snapshot.cwd ?? this.terminalCwdByPtyId.get(ptyId),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1566,8 +1566,8 @@ export type PreloadApi = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
-      snapshotPrefixAnsi?: string
-      snapshotFrameAnsi?: string
+      snapshotFrameStart?: number
+      snapshotFrameRestoreAnsi?: string
       isReattach?: boolean
       isAlternateScreen?: boolean
       replay?: string
@@ -1634,6 +1634,7 @@ export type PreloadApi = {
       opts?: { scrollbackRows?: number }
     ) => Promise<{
       data: string
+      frameRestoreAnsi?: string
       cols: number
       rows: number
       cwd?: string | null

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1566,7 +1566,8 @@ export type PreloadApi = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
-      snapshotFrameStart?: number
+      snapshotPrefixAnsi?: string
+      snapshotFrameAnsi?: string
       snapshotFrameRestoreAnsi?: string
       isReattach?: boolean
       isAlternateScreen?: boolean

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1566,6 +1566,8 @@ export type PreloadApi = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
+      snapshotPrefixAnsi?: string
+      snapshotFrameAnsi?: string
       isReattach?: boolean
       isAlternateScreen?: boolean
       replay?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -963,6 +963,8 @@ const api = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
+      snapshotPrefixAnsi?: string
+      snapshotFrameAnsi?: string
       isReattach?: boolean
       isAlternateScreen?: boolean
       replay?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -963,8 +963,8 @@ const api = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
-      snapshotPrefixAnsi?: string
-      snapshotFrameAnsi?: string
+      snapshotFrameStart?: number
+      snapshotFrameRestoreAnsi?: string
       isReattach?: boolean
       isAlternateScreen?: boolean
       replay?: string
@@ -1075,6 +1075,7 @@ const api = {
       opts?: { scrollbackRows?: number }
     ): Promise<{
       data: string
+      frameRestoreAnsi?: string
       cols: number
       rows: number
       cwd?: string | null

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -963,7 +963,8 @@ const api = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
-      snapshotFrameStart?: number
+      snapshotPrefixAnsi?: string
+      snapshotFrameAnsi?: string
       snapshotFrameRestoreAnsi?: string
       isReattach?: boolean
       isAlternateScreen?: boolean

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -21085,7 +21085,7 @@ describe('connectPanePty', () => {
     expect(api.pty.signal).toHaveBeenCalledWith('leaf-session', 'SIGWINCH')
   })
 
-  it('paints a parked SSH model before the remote connection settles', async () => {
+  it('keeps a too-wide parked SSH alt frame while no live process can repaint it', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const sshPtyId = toAppSshPtyId('conn-1', 'relay-pty-1')
     const sshConnect = createDeferred<SshConnectionState | null>()
@@ -21094,10 +21094,12 @@ describe('connectPanePty', () => {
     vi.mocked(window.api.ssh.connect).mockReturnValue(sshConnect.promise)
     vi.mocked(window.api.pty.getMainBufferSnapshot).mockResolvedValue({
       data: 'PARKED-SSH-PAINTED-WITHOUT-NETWORK\r\n',
-      cols: 101,
+      cols: 140,
       rows: 31,
       seq: 123,
-      source: 'headless'
+      source: 'headless',
+      alternateScreen: true,
+      scrollbackAnsi: 'PARKED-SSH-SCROLLBACK\r\n'
     })
     await parkTabForReveal('tab-1', sshPtyId)
     mockStoreState = {
@@ -21111,6 +21113,7 @@ describe('connectPanePty', () => {
     }
 
     const pane = createPane(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 80, rows: 24 }))
     const { writes } = captureCallbackTerminalWrites(pane)
     const binding = connectPanePty(
       pane as never,
@@ -21124,6 +21127,7 @@ describe('connectPanePty', () => {
 
     expect(window.api.ssh.connect).toHaveBeenCalledWith({ targetId: 'conn-1' })
     expect(window.api.pty.getMainBufferSnapshot).toHaveBeenCalledOnce()
+    // No live SSH process can repaint this preconnect frame after a SIGWINCH.
     expect(writes.join('')).toContain('PARKED-SSH-PAINTED-WITHOUT-NETWORK')
     expect(transport.connect).not.toHaveBeenCalled()
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8694,6 +8694,127 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('drops a too-wide daemon alt frame and keeps the scrollback prefix', async () => {
+    // Why: the frame is absolutely positioned, so the narrower post-replay fit would
+    // make xterm split every row longer than the new width. Scrollback still replays.
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return {
+          id: sessionId,
+          snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
+          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+          snapshotFrameAnsi: 'ALT-FRAME-BODY',
+          snapshotCols: 200,
+          snapshotRows: 50,
+          isAlternateScreen: true
+        }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }] }
+    } as StoreState
+
+    const pane = createPane(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 }))
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+
+    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
+    expect(writes).toContain('PREFIX-SCROLLBACK')
+    expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
+  })
+
+  it('keeps a daemon alt frame when the pane is not narrower than the capture', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return {
+          id: sessionId,
+          snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
+          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+          snapshotFrameAnsi: 'ALT-FRAME-BODY',
+          snapshotCols: 120,
+          snapshotRows: 40,
+          isAlternateScreen: true
+        }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }] }
+    } as StoreState
+
+    const pane = createPane(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 }))
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+
+    expect(
+      (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]).join('')
+    ).toContain('ALT-FRAME-BODY')
+  })
+
+  it('keeps a too-wide daemon alt frame on a cold restore, whose owner cannot repaint', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+      if (sessionId) {
+        return {
+          id: sessionId,
+          snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
+          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+          snapshotFrameAnsi: 'ALT-FRAME-BODY',
+          snapshotCols: 200,
+          snapshotRows: 50,
+          isAlternateScreen: true,
+          coldRestore: { scrollback: 'x', cwd: '/tmp' }
+        }
+      }
+      return null
+    })
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }] }
+    } as StoreState
+
+    const pane = createPane(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 }))
+    const manager = createManager(1)
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, manager as never, deps as never)
+    await flushAsyncTicks(20)
+
+    // Nothing would repaint, so a stale frame beats a blank pane.
+    expect(
+      (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]).join('')
+    ).toContain('ALT-FRAME-BODY')
+  })
+
   it('resizes the pane to the snapshot grid before replaying daemon snapshot bytes (bug #7279)', async () => {
     // Why: the daemon serializes soft-wrapped lines flat, so reattach must resize xterm to the snapshot grid before writing, or rows rewrap wrong.
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8704,8 +8704,8 @@ describe('connectPanePty', () => {
         return {
           id: sessionId,
           snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
-          snapshotFrameAnsi: 'ALT-FRAME-BODY',
+          snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+          snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
           snapshotCols: 200,
           snapshotRows: 50,
           isAlternateScreen: true
@@ -8731,7 +8731,48 @@ describe('connectPanePty', () => {
     await flushAsyncTicks(20)
 
     const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
-    expect(writes).toContain('PREFIX-SCROLLBACK')
+    expect(writes.join('')).toContain('PREFIX-SCROLLBACK')
+    expect(writes.join('')).toContain('RESTORE-LIVE-STATE')
+    expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
+  })
+
+  it('drops a live daemon alt frame until a hidden pane has a final grid', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) =>
+      sessionId
+        ? {
+            id: sessionId,
+            snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
+            snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+            snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
+            snapshotCols: 120,
+            snapshotRows: 40,
+            isAlternateScreen: true
+          }
+        : null
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }] }
+    } as StoreState
+
+    const pane = createPane(1)
+    pane.container.getBoundingClientRect = vi.fn(() => createRect(0, 0))
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 1, rows: 1 }))
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      }) as never
+    )
+    await flushAsyncTicks(20)
+
+    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
+    expect(writes.join('')).toContain('PREFIX-SCROLLBACK')
     expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
   })
 
@@ -8743,8 +8784,8 @@ describe('connectPanePty', () => {
         return {
           id: sessionId,
           snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
-          snapshotFrameAnsi: 'ALT-FRAME-BODY',
+          snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+          snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
           snapshotCols: 120,
           snapshotRows: 40,
           isAlternateScreen: true
@@ -8782,8 +8823,8 @@ describe('connectPanePty', () => {
         return {
           id: sessionId,
           snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
-          snapshotFrameAnsi: 'ALT-FRAME-BODY',
+          snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+          snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
           snapshotCols: 200,
           snapshotRows: 50,
           isAlternateScreen: true,
@@ -15326,6 +15367,55 @@ describe('connectPanePty', () => {
     )
     expect(pane.terminal.write).toHaveBeenCalledWith('altscreen-snapshot\r\n', expect.any(Function))
     disposable.dispose()
+  })
+
+  it('repaints a skipped hidden alt frame at the active fit override grid', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { setFitOverride } = await import('@/lib/pane-manager/mobile-fit-overrides')
+    const transport = createMockTransport('pty-id')
+    let onData: ConnectCallbacks['onData']
+    transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
+      onData = callbacks.onData
+      return 'pty-id'
+    })
+    transportFactoryQueue.push(transport)
+    const getMainBufferSnapshot = window.api.pty.getMainBufferSnapshot as unknown as ReturnType<
+      typeof vi.fn
+    >
+    const hidden = 'x'.repeat(2 * 1024 * 1024 + 1)
+    getMainBufferSnapshot.mockResolvedValue({
+      data: 'TOO-WIDE-ALT-FRAME',
+      frameRestoreAnsi: '\x1b[?1004h\x1b[?25l',
+      cols: 100,
+      rows: 30,
+      seq: hidden.length + 1,
+      alternateScreen: true,
+      scrollbackAnsi: 'preserved history'
+    })
+    const pane = createPane(1)
+    const deps = createDeps({ isVisibleRef: { current: false } })
+    const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
+    setFitOverride('pty-id', 'mobile-fit', 40, 20)
+
+    try {
+      const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+      await flushAsyncTicks(6)
+      onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+      ;(deps.isVisibleRef as { current: boolean }).current = true
+      onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
+      await flushAsyncTicks(20)
+
+      const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
+        (call) => call[0]
+      )
+      expect(writes.join('')).not.toContain('TOO-WIDE-ALT-FRAME')
+      expect(writes.join('')).toContain('\x1b[?1004h\x1b[?25l')
+      expect(pane.terminal.resize).toHaveBeenLastCalledWith(40, 20)
+      expect(signalPty).toHaveBeenCalledWith('pty-id', 'SIGWINCH')
+      disposable.dispose()
+    } finally {
+      setFitOverride('pty-id', 'desktop-fit', 0, 0)
+    }
   })
 
   it('drains foreground output after a renderer-sourced hidden-backlog snapshot without seq', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8695,8 +8695,7 @@ describe('connectPanePty', () => {
   })
 
   it('drops a too-wide daemon alt frame and keeps the scrollback prefix', async () => {
-    // Why: the frame is absolutely positioned, so the narrower post-replay fit would
-    // make xterm split every row longer than the new width. Scrollback still replays.
+    // Why: fixed-grid alt rows clip at a narrower viewport until the owner repaints.
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -8704,7 +8703,8 @@ describe('connectPanePty', () => {
         return {
           id: sessionId,
           snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-          snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+          snapshotFrameAnsi: 'ALT-FRAME-BODY',
           snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
           snapshotCols: 200,
           snapshotRows: 50,
@@ -8744,7 +8744,8 @@ describe('connectPanePty', () => {
         ? {
             id: sessionId,
             snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-            snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+            snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+            snapshotFrameAnsi: 'ALT-FRAME-BODY',
             snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
             snapshotCols: 120,
             snapshotRows: 40,
@@ -8776,6 +8777,45 @@ describe('connectPanePty', () => {
     expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
   })
 
+  it('falls back to the merged daemon snapshot when split metadata is incomplete', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) =>
+      sessionId
+        ? {
+            id: sessionId,
+            snapshot: 'LEGACY-MERGED-SNAPSHOT',
+            snapshotPrefixAnsi: 'INCOMPLETE-PREFIX',
+            snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
+            snapshotCols: 200,
+            snapshotRows: 50,
+            isAlternateScreen: true
+          }
+        : null
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }] }
+    } as StoreState
+
+    const pane = createPane(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 }))
+    connectPanePty(
+      pane as never,
+      createManager(1) as never,
+      createDeps({
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+      }) as never
+    )
+    await flushAsyncTicks(20)
+
+    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
+    expect(writes.join('')).toContain('LEGACY-MERGED-SNAPSHOT')
+    expect(writes.join('')).not.toContain('INCOMPLETE-PREFIX')
+  })
+
   it('keeps a daemon alt frame when the pane is not narrower than the capture', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
@@ -8784,7 +8824,8 @@ describe('connectPanePty', () => {
         return {
           id: sessionId,
           snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-          snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+          snapshotFrameAnsi: 'ALT-FRAME-BODY',
           snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
           snapshotCols: 120,
           snapshotRows: 40,
@@ -8815,7 +8856,7 @@ describe('connectPanePty', () => {
     ).toContain('ALT-FRAME-BODY')
   })
 
-  it('keeps a too-wide daemon alt frame on a cold restore, whose owner cannot repaint', async () => {
+  it('drops a too-wide daemon alt frame on cold restore and keeps its history', async () => {
     const { connectPanePty } = await import('./pty-connection')
     const transport = createMockTransport('tab-pty')
     transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
@@ -8823,7 +8864,8 @@ describe('connectPanePty', () => {
         return {
           id: sessionId,
           snapshot: 'PREFIX-SCROLLBACK' + 'ALT-FRAME-BODY',
-          snapshotFrameStart: 'PREFIX-SCROLLBACK'.length,
+          snapshotPrefixAnsi: 'PREFIX-SCROLLBACK',
+          snapshotFrameAnsi: 'ALT-FRAME-BODY',
           snapshotFrameRestoreAnsi: 'RESTORE-LIVE-STATE',
           snapshotCols: 200,
           snapshotRows: 50,
@@ -8850,10 +8892,11 @@ describe('connectPanePty', () => {
     connectPanePty(pane as never, manager as never, deps as never)
     await flushAsyncTicks(20)
 
-    // Nothing would repaint, so a stale frame beats a blank pane.
-    expect(
-      (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0]).join('')
-    ).toContain('ALT-FRAME-BODY')
+    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map((c) => c[0])
+    expect(writes.join('')).toContain('PREFIX-SCROLLBACK')
+    expect(writes.join('')).toContain('RESTORE-LIVE-STATE')
+    expect(writes.join('')).not.toContain('ALT-FRAME-BODY')
+    expect(writes).toContain(POST_REPLAY_MODE_RESET)
   })
 
   it('resizes the pane to the snapshot grid before replaying daemon snapshot bytes (bug #7279)', async () => {
@@ -15369,9 +15412,9 @@ describe('connectPanePty', () => {
     disposable.dispose()
   })
 
-  it('repaints a skipped hidden alt frame at the active fit override grid', async () => {
+  it('pulses a skipped hidden alt frame when reveal keeps the snapshot grid', async () => {
     const { connectPanePty } = await import('./pty-connection')
-    const { setFitOverride } = await import('@/lib/pane-manager/mobile-fit-overrides')
+    const { safeFit } = await import('@/lib/pane-manager/pane-tree-ops')
     const transport = createMockTransport('pty-id')
     let onData: ConnectCallbacks['onData']
     transport.connect.mockImplementation(async ({ callbacks }: { callbacks: ConnectCallbacks }) => {
@@ -15386,36 +15429,48 @@ describe('connectPanePty', () => {
     getMainBufferSnapshot.mockResolvedValue({
       data: 'TOO-WIDE-ALT-FRAME',
       frameRestoreAnsi: '\x1b[?1004h\x1b[?25l',
-      cols: 100,
-      rows: 30,
+      cols: 120,
+      rows: 40,
       seq: hidden.length + 1,
       alternateScreen: true,
       scrollbackAnsi: 'preserved history'
     })
     const pane = createPane(1)
+    let paneRect = createRect(0, 0)
+    pane.container.getBoundingClientRect = vi.fn(() => paneRect)
+    let xtermContainerDisplay = 'none'
+    const xtermContainer = new EventTarget() as HTMLElement
+    Object.defineProperty(xtermContainer, 'parentElement', { value: null })
+    Object.defineProperty(xtermContainer, 'ownerDocument', {
+      value: { defaultView: { getComputedStyle: () => ({ display: xtermContainerDisplay }) } }
+    })
+    ;(pane as { xtermContainer?: HTMLElement }).xtermContainer = xtermContainer
     const deps = createDeps({ isVisibleRef: { current: false } })
-    const signalPty = window.api.pty.signal as unknown as ReturnType<typeof vi.fn>
-    setFitOverride('pty-id', 'mobile-fit', 40, 20)
+    const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(6)
+    onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
+    ;(deps.isVisibleRef as { current: boolean }).current = true
+    onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
+    await flushAsyncTicks(20)
 
-    try {
-      const disposable = connectPanePty(pane as never, createManager(1) as never, deps as never)
-      await flushAsyncTicks(6)
-      onData?.(hidden, { seq: hidden.length, rawLength: hidden.length })
-      ;(deps.isVisibleRef as { current: boolean }).current = true
-      onData?.('x', { seq: hidden.length + 1, rawLength: 1 })
-      await flushAsyncTicks(20)
+    const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
+      (call) => call[0]
+    )
+    expect(writes.join('')).not.toContain('TOO-WIDE-ALT-FRAME')
+    expect(writes.join('')).toContain('\x1b[?1004h\x1b[?25l')
+    expect(transport.resize).not.toHaveBeenCalled()
 
-      const writes = (pane.terminal.write as ReturnType<typeof vi.fn>).mock.calls.map(
-        (call) => call[0]
-      )
-      expect(writes.join('')).not.toContain('TOO-WIDE-ALT-FRAME')
-      expect(writes.join('')).toContain('\x1b[?1004h\x1b[?25l')
-      expect(pane.terminal.resize).toHaveBeenLastCalledWith(40, 20)
-      expect(signalPty).toHaveBeenCalledWith('pty-id', 'SIGWINCH')
-      disposable.dispose()
-    } finally {
-      setFitOverride('pty-id', 'desktop-fit', 0, 0)
-    }
+    xtermContainerDisplay = 'block'
+    paneRect = createRect(800, 600)
+    safeFit(pane as never)
+    await flushAsyncTicks(12)
+
+    const pulseStart = transport.resize.mock.calls.findIndex(
+      ([cols, rows]) => cols === 119 && rows === 40
+    )
+    expect(pulseStart).toBeGreaterThanOrEqual(0)
+    expect(transport.resize.mock.calls[pulseStart + 1]).toEqual([120, 40])
+    disposable.dispose()
   })
 
   it('drains foreground output after a renderer-sourced hidden-backlog snapshot without seq', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -8206,7 +8206,26 @@ export function connectPanePty(
           writeReplayData('\x1b[2J\x1b[3J\x1b[H')
           // Why: re-arm the kitty keyboard mirror from the snapshot preamble so Option chords keep their encoding after a window reload.
           kittyKeyboardModes.scanReplay(connectResult.snapshot)
-          writeReplayData(connectResult.snapshot)
+          // Why the split when the host offers it: replay pins the terminal to the
+          // snapshot grid (#7279), then the post-replay fit sizes the pane back to
+          // its container. A narrower container makes xterm split every alt-frame
+          // row longer than the new width. The frame only renders at its capture
+          // width, so drop it and let the SIGWINCH below repaint it.
+          // Why not on a cold restore: its owner is gone, so nothing would repaint —
+          // a stale frame beats a blank pane.
+          const daemonAltFrameSkippable =
+            typeof connectResult.snapshotPrefixAnsi === 'string' &&
+            typeof connectResult.snapshotFrameAnsi === 'string' &&
+            !connectResult.coldRestore &&
+            shouldSkipAltFrameForWidthMismatch(
+              connectResult.snapshotCols,
+              readProposedTerminalCols(pane)
+            )
+          writeReplayData(
+            daemonAltFrameSkippable
+              ? (connectResult.snapshotPrefixAnsi ?? '')
+              : connectResult.snapshot
+          )
           // Snapshot reattach keeps a live session, so drop only renderer-owned state instead of the broader mode reset — unless this is a cold restore, whose owner is gone.
           writeReplayData(
             reattachReplayResetSequence(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -8224,11 +8224,7 @@ export function connectPanePty(
           writeReplayData('\x1b[2J\x1b[3J\x1b[H')
           // Why: re-arm the kitty keyboard mirror from the snapshot preamble so Option chords keep their encoding after a window reload.
           kittyKeyboardModes.scanReplay(connectResult.snapshot)
-          // Why the split when the host offers it: replay pins the terminal to the
-          // snapshot grid (#7279), then the post-replay fit sizes the pane back to
-          // its container. A narrower container makes xterm split every alt-frame
-          // row longer than the new width. The frame only renders at its capture
-          // width, so drop it and let the SIGWINCH below repaint it.
+          // A narrower fit clips the fixed-grid alt frame; drop it and let SIGWINCH repaint.
           // Why not on a cold restore: its owner is gone, so nothing would repaint —
           // a stale frame beats a blank pane.
           const snapshotFrameStart = connectResult.snapshotFrameStart

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7200,6 +7200,7 @@ export function connectPanePty(
 
     async function applyMainBufferSnapshot(snapshot: {
       data: string
+      frameRestoreAnsi?: string
       cols: number
       rows: number
       seq?: number
@@ -7223,6 +7224,7 @@ export function connectPanePty(
       const colsBeforeReplay = pane.terminal.cols
       const rowsBeforeReplay = pane.terminal.rows
       const hasSnapshotDimensions = hasPositiveTerminalDimensions(snapshot.cols, snapshot.rows)
+      let skippedAltFrame = false
       try {
         await structuralReplayCoordinator.run(
           async () => {
@@ -7259,11 +7261,14 @@ export function connectPanePty(
             // Why shared: the SSH reattach model paint inlines the same
             // choreography (coordinator nesting would deadlock there); one
             // builder keeps the alt-screen branches from drifting.
+            skippedAltFrame =
+              snapshot.alternateScreen === true &&
+              snapshot.frameRestoreAnsi !== undefined &&
+              shouldSkipAltFrameForWidthMismatch(snapshot.cols, readProposedTerminalCols(pane), {
+                skipIfTargetUnknown: true
+              })
             for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
-              skipAltFrame: shouldSkipAltFrameForWidthMismatch(
-                snapshot.cols,
-                readProposedTerminalCols(pane)
-              )
+              skipAltFrame: skippedAltFrame
             })) {
               writeReplayData(replayChunk)
             }
@@ -7298,7 +7303,14 @@ export function connectPanePty(
                 return
               }
               const currentPtyId = transport.getPtyId()
-              if (!currentPtyId || getFitOverrideForPty(currentPtyId)) {
+              if (!currentPtyId) {
+                return
+              }
+              if (getFitOverrideForPty(currentPtyId)) {
+                safeFit(pane)
+                if (skippedAltFrame && !isRemoteRuntimePtyId(currentPtyId)) {
+                  window.api.pty.signal(currentPtyId, 'SIGWINCH')
+                }
                 return
               }
               const fit = safeFitAndThen(
@@ -7320,7 +7332,13 @@ export function connectPanePty(
                     }
                   }
                 },
-                { shouldContinue: isCurrentRestore, retryIfUnmeasurable: true }
+                {
+                  shouldContinue: isCurrentRestore,
+                  retryIfUnmeasurable: true,
+                  // A skipped frame is blank until this fit pushes the final
+                  // grid/SIGWINCH, so carry the continuation through reveal.
+                  deferIfHidden: true
+                }
               )
               pendingHiddenSnapshotFit = fit
               try {
@@ -8213,17 +8231,23 @@ export function connectPanePty(
           // width, so drop it and let the SIGWINCH below repaint it.
           // Why not on a cold restore: its owner is gone, so nothing would repaint —
           // a stale frame beats a blank pane.
+          const snapshotFrameStart = connectResult.snapshotFrameStart
+          const snapshotFrameRestoreAnsi = connectResult.snapshotFrameRestoreAnsi
           const daemonAltFrameSkippable =
-            typeof connectResult.snapshotPrefixAnsi === 'string' &&
-            typeof connectResult.snapshotFrameAnsi === 'string' &&
+            typeof snapshotFrameStart === 'number' &&
+            typeof snapshotFrameRestoreAnsi === 'string' &&
+            Number.isInteger(snapshotFrameStart) &&
+            snapshotFrameStart >= 0 &&
+            snapshotFrameStart <= connectResult.snapshot.length &&
             !connectResult.coldRestore &&
             shouldSkipAltFrameForWidthMismatch(
               connectResult.snapshotCols,
-              readProposedTerminalCols(pane)
+              readProposedTerminalCols(pane),
+              { skipIfTargetUnknown: true }
             )
           writeReplayData(
             daemonAltFrameSkippable
-              ? (connectResult.snapshotPrefixAnsi ?? '')
+              ? connectResult.snapshot.slice(0, snapshotFrameStart) + snapshotFrameRestoreAnsi
               : connectResult.snapshot
           )
           // Snapshot reattach keeps a live session, so drop only renderer-owned state instead of the broader mode reset — unless this is a cold restore, whose owner is gone.
@@ -8284,10 +8308,11 @@ export function connectPanePty(
             // the ?1049h marker when splitting scrollbackAnsi) — inlined here
             // because nesting structuralReplayCoordinator would deadlock.
             for (const replayChunk of buildMainModelSnapshotReplayWrites(modelSnapshot, {
-              skipAltFrame: shouldSkipAltFrameForWidthMismatch(
-                modelCols,
-                readProposedTerminalCols(pane)
-              )
+              skipAltFrame:
+                !connectResult?.coldRestore &&
+                shouldSkipAltFrameForWidthMismatch(modelCols, readProposedTerminalCols(pane), {
+                  skipIfTargetUnknown: true
+                })
             })) {
               writeReplayData(replayChunk)
             }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -259,7 +259,9 @@ import { resolveHiddenRestoreScrollbackRows } from './terminal-hidden-restore-sc
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
-  resolvePositiveTerminalDimensions
+  readProposedTerminalCols,
+  resolvePositiveTerminalDimensions,
+  shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
 import {
   decideSshReattachPaintSource,
@@ -7257,7 +7259,12 @@ export function connectPanePty(
             // Why shared: the SSH reattach model paint inlines the same
             // choreography (coordinator nesting would deadlock there); one
             // builder keeps the alt-screen branches from drifting.
-            for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot)) {
+            for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
+              skipAltFrame: shouldSkipAltFrameForWidthMismatch(
+                snapshot.cols,
+                readProposedTerminalCols(pane)
+              )
+            })) {
               writeReplayData(replayChunk)
             }
             // Why: live agents own ?25l/?1004h; a forced ?1004l here would silence focus events until restart (agents enable focus reporting only at startup).
@@ -7989,7 +7996,12 @@ export function connectPanePty(
                 }
               }
               kittyKeyboardModes.scanReplay(modelData)
-              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot)) {
+              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
+                skipAltFrame: shouldSkipAltFrameForWidthMismatch(
+                  snapshot.cols,
+                  readProposedTerminalCols(pane)
+                )
+              })) {
                 writeReplayData(replayChunk)
               }
               writeReplayData(reattachReplayResetSequence(modelData))
@@ -8256,7 +8268,12 @@ export function connectPanePty(
             // ?1049l/?1049h rebuild as applyMainBufferSnapshot (main strips
             // the ?1049h marker when splitting scrollbackAnsi) — inlined here
             // because nesting structuralReplayCoordinator would deadlock.
-            for (const replayChunk of buildMainModelSnapshotReplayWrites(modelSnapshot)) {
+            for (const replayChunk of buildMainModelSnapshotReplayWrites(modelSnapshot, {
+              skipAltFrame: shouldSkipAltFrameForWidthMismatch(
+                modelCols,
+                readProposedTerminalCols(pane)
+              )
+            })) {
               writeReplayData(replayChunk)
             }
             writeReplayData(

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7996,12 +7996,8 @@ export function connectPanePty(
                 }
               }
               kittyKeyboardModes.scanReplay(modelData)
-              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot, {
-                skipAltFrame: shouldSkipAltFrameForWidthMismatch(
-                  snapshot.cols,
-                  readProposedTerminalCols(pane)
-                )
-              })) {
+              // Why keep a too-wide frame: preconnect SSH has no live repaint owner or post-restore fit.
+              for (const replayChunk of buildMainModelSnapshotReplayWrites(snapshot)) {
                 writeReplayData(replayChunk)
               }
               writeReplayData(reattachReplayResetSequence(modelData))

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -7324,6 +7324,10 @@ export function connectPanePty(
                     ? pane.terminal.cols !== snapshot.cols || pane.terminal.rows !== snapshot.rows
                     : pane.terminal.cols !== colsBeforeReplay ||
                       pane.terminal.rows !== rowsBeforeReplay
+                  if (skippedAltFrame) {
+                    pulseVisibleLocalPtySizeForTuiRepaint(currentPtyId)
+                    return
+                  }
                   if (replayChangedDimensions && isRendererPtyResizeAuthoritative()) {
                     transport.resize(pane.terminal.cols, pane.terminal.rows)
                     if (!isRemoteRuntimePtyId(currentPtyId)) {
@@ -8203,7 +8207,18 @@ export function connectPanePty(
           return
         }
         if (connectResult?.snapshot) {
-          rememberReattachPayloadAgentSignal(connectResult.snapshot, { fullScreenReplay: true })
+          const snapshotPrefixAnsi = connectResult.snapshotPrefixAnsi
+          const snapshotFrameAnsi = connectResult.snapshotFrameAnsi
+          const snapshotFrameRestoreAnsi = connectResult.snapshotFrameRestoreAnsi
+          const hasSplitDaemonAltFrame =
+            typeof snapshotPrefixAnsi === 'string' &&
+            snapshotPrefixAnsi.length > 0 &&
+            typeof snapshotFrameAnsi === 'string' &&
+            snapshotFrameAnsi.length > 0
+          const daemonSnapshotReplay = hasSplitDaemonAltFrame
+            ? snapshotPrefixAnsi + snapshotFrameAnsi
+            : connectResult.snapshot
+          rememberReattachPayloadAgentSignal(daemonSnapshotReplay, { fullScreenReplay: true })
           // Why: replay at the snapshot's own dimensions to avoid rewrapping soft-wrapped rows at a different column count (#7279); suppress the PTY forward so this layout-only resize doesn't SIGWINCH the remote TUI.
           const snapshotDimensions = resolvePositiveTerminalDimensions(
             connectResult.snapshotCols,
@@ -8223,19 +8238,13 @@ export function connectPanePty(
           }
           writeReplayData('\x1b[2J\x1b[3J\x1b[H')
           // Why: re-arm the kitty keyboard mirror from the snapshot preamble so Option chords keep their encoding after a window reload.
-          kittyKeyboardModes.scanReplay(connectResult.snapshot)
+          kittyKeyboardModes.scanReplay(daemonSnapshotReplay)
           // A narrower fit clips the fixed-grid alt frame; drop it and let SIGWINCH repaint.
-          // Why not on a cold restore: its owner is gone, so nothing would repaint —
-          // a stale frame beats a blank pane.
-          const snapshotFrameStart = connectResult.snapshotFrameStart
-          const snapshotFrameRestoreAnsi = connectResult.snapshotFrameRestoreAnsi
+          // A dead-owner restore keeps history plus its restored-session treatment;
+          // a frozen foreign-width frame would look live when no owner remains.
           const daemonAltFrameSkippable =
-            typeof snapshotFrameStart === 'number' &&
+            hasSplitDaemonAltFrame &&
             typeof snapshotFrameRestoreAnsi === 'string' &&
-            Number.isInteger(snapshotFrameStart) &&
-            snapshotFrameStart >= 0 &&
-            snapshotFrameStart <= connectResult.snapshot.length &&
-            !connectResult.coldRestore &&
             shouldSkipAltFrameForWidthMismatch(
               connectResult.snapshotCols,
               readProposedTerminalCols(pane),
@@ -8243,13 +8252,12 @@ export function connectPanePty(
             )
           writeReplayData(
             daemonAltFrameSkippable
-              ? connectResult.snapshot.slice(0, snapshotFrameStart) + snapshotFrameRestoreAnsi
-              : connectResult.snapshot
+              ? snapshotPrefixAnsi + snapshotFrameRestoreAnsi
+              : daemonSnapshotReplay
           )
-          // Snapshot reattach keeps a live session, so drop only renderer-owned state instead of the broader mode reset — unless this is a cold restore, whose owner is gone.
           writeReplayData(
             reattachReplayResetSequence(
-              connectResult.snapshot,
+              daemonSnapshotReplay,
               Boolean(connectResult.coldRestore),
               connectResult.isAlternateScreen
             )
@@ -8304,11 +8312,13 @@ export function connectPanePty(
             // the ?1049h marker when splitting scrollbackAnsi) — inlined here
             // because nesting structuralReplayCoordinator would deadlock.
             for (const replayChunk of buildMainModelSnapshotReplayWrites(modelSnapshot, {
-              skipAltFrame:
-                !connectResult?.coldRestore &&
-                shouldSkipAltFrameForWidthMismatch(modelCols, readProposedTerminalCols(pane), {
+              skipAltFrame: shouldSkipAltFrameForWidthMismatch(
+                modelCols,
+                readProposedTerminalCols(pane),
+                {
                   skipIfTargetUnknown: true
-                })
+                }
+              )
             })) {
               writeReplayData(replayChunk)
             }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -18,6 +18,8 @@ import type { RemoteRuntimeSnapshotOutcome } from '../../runtime/remote-runtime-
 
 export type PtyBufferSnapshot = {
   data: string
+  /** Live state that can be restored without an alternate-screen frame. */
+  frameRestoreAnsi?: string
   cols: number
   rows: number
   seq?: number
@@ -59,11 +61,11 @@ export type PtyConnectResult = {
   snapshot?: string
   snapshotCols?: number
   snapshotRows?: number
-  /** Optional split of `snapshot` for an alt-screen reattach: everything before
-   *  the frame, and the frame itself. Absent from older hosts, so every reader
-   *  must fall back to the merged `snapshot`. */
-  snapshotPrefixAnsi?: string
-  snapshotFrameAnsi?: string
+  /** UTF-16 index where the alt frame begins in `snapshot`. Absent from older
+   *  hosts, so readers must fall back to the merged snapshot. */
+  snapshotFrameStart?: number
+  /** Live state to append when omitting the alt frame at `snapshotFrameStart`. */
+  snapshotFrameRestoreAnsi?: string
   isAlternateScreen?: boolean
   sessionExpired?: boolean
   coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -59,6 +59,11 @@ export type PtyConnectResult = {
   snapshot?: string
   snapshotCols?: number
   snapshotRows?: number
+  /** Optional split of `snapshot` for an alt-screen reattach: everything before
+   *  the frame, and the frame itself. Absent from older hosts, so every reader
+   *  must fall back to the merged `snapshot`. */
+  snapshotPrefixAnsi?: string
+  snapshotFrameAnsi?: string
   isAlternateScreen?: boolean
   sessionExpired?: boolean
   coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -61,10 +61,11 @@ export type PtyConnectResult = {
   snapshot?: string
   snapshotCols?: number
   snapshotRows?: number
-  /** UTF-16 index where the alt frame begins in `snapshot`. Absent from older
-   *  hosts, so readers must fall back to the merged snapshot. */
-  snapshotFrameStart?: number
-  /** Live state to append when omitting the alt frame at `snapshotFrameStart`. */
+  /** Normal-buffer history and mode preamble before an alternate-screen frame. */
+  snapshotPrefixAnsi?: string
+  /** Visual alternate-screen frame. Both fields are absent on older hosts. */
+  snapshotFrameAnsi?: string
+  /** Live state to append when omitting `snapshotFrameAnsi`. */
   snapshotFrameRestoreAnsi?: string
   isAlternateScreen?: boolean
   sessionExpired?: boolean

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1763,7 +1763,7 @@ describe('createIpcPtyTransport', () => {
     expect(writeMock).not.toHaveBeenCalled()
   })
 
-  it('preserves snapshot dimensions and split alt-frame payload when reattaching', async () => {
+  it('preserves snapshot dimensions and the alt-frame boundary when reattaching', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawnMock = vi.fn().mockResolvedValue({
       id: 'pty-reattach',
@@ -1772,8 +1772,8 @@ describe('createIpcPtyTransport', () => {
       snapshot: 'snapshot data',
       snapshotCols: 132,
       snapshotRows: 43,
-      snapshotPrefixAnsi: 'scrollback and modes',
-      snapshotFrameAnsi: 'alt frame'
+      snapshotFrameStart: 20,
+      snapshotFrameRestoreAnsi: 'live state'
     })
 
     ;(globalThis as { window: typeof window }).window = {
@@ -1813,8 +1813,8 @@ describe('createIpcPtyTransport', () => {
       snapshot: 'snapshot data',
       snapshotCols: 132,
       snapshotRows: 43,
-      snapshotPrefixAnsi: 'scrollback and modes',
-      snapshotFrameAnsi: 'alt frame',
+      snapshotFrameStart: 20,
+      snapshotFrameRestoreAnsi: 'live state',
       isAlternateScreen: undefined,
       coldRestore: undefined,
       replay: undefined,

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1763,7 +1763,7 @@ describe('createIpcPtyTransport', () => {
     expect(writeMock).not.toHaveBeenCalled()
   })
 
-  it('preserves snapshot dimensions when reattaching', async () => {
+  it('preserves snapshot dimensions and split alt-frame payload when reattaching', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawnMock = vi.fn().mockResolvedValue({
       id: 'pty-reattach',
@@ -1771,7 +1771,9 @@ describe('createIpcPtyTransport', () => {
       launchAgent: 'droid',
       snapshot: 'snapshot data',
       snapshotCols: 132,
-      snapshotRows: 43
+      snapshotRows: 43,
+      snapshotPrefixAnsi: 'scrollback and modes',
+      snapshotFrameAnsi: 'alt frame'
     })
 
     ;(globalThis as { window: typeof window }).window = {
@@ -1811,6 +1813,8 @@ describe('createIpcPtyTransport', () => {
       snapshot: 'snapshot data',
       snapshotCols: 132,
       snapshotRows: 43,
+      snapshotPrefixAnsi: 'scrollback and modes',
+      snapshotFrameAnsi: 'alt frame',
       isAlternateScreen: undefined,
       coldRestore: undefined,
       replay: undefined,

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1763,7 +1763,7 @@ describe('createIpcPtyTransport', () => {
     expect(writeMock).not.toHaveBeenCalled()
   })
 
-  it('preserves snapshot dimensions and the alt-frame boundary when reattaching', async () => {
+  it('preserves snapshot dimensions and split alt-frame strings when reattaching', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawnMock = vi.fn().mockResolvedValue({
       id: 'pty-reattach',
@@ -1772,7 +1772,8 @@ describe('createIpcPtyTransport', () => {
       snapshot: 'snapshot data',
       snapshotCols: 132,
       snapshotRows: 43,
-      snapshotFrameStart: 20,
+      snapshotPrefixAnsi: 'history and modes',
+      snapshotFrameAnsi: 'visual frame',
       snapshotFrameRestoreAnsi: 'live state'
     })
 
@@ -1813,7 +1814,8 @@ describe('createIpcPtyTransport', () => {
       snapshot: 'snapshot data',
       snapshotCols: 132,
       snapshotRows: 43,
-      snapshotFrameStart: 20,
+      snapshotPrefixAnsi: 'history and modes',
+      snapshotFrameAnsi: 'visual frame',
       snapshotFrameRestoreAnsi: 'live state',
       isAlternateScreen: undefined,
       coldRestore: undefined,

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -893,11 +893,11 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             snapshot: spawnResult.snapshot,
             snapshotCols: spawnResult.snapshotCols,
             snapshotRows: spawnResult.snapshotRows,
-            ...(spawnResult.snapshotPrefixAnsi !== undefined
-              ? { snapshotPrefixAnsi: spawnResult.snapshotPrefixAnsi }
+            ...(spawnResult.snapshotFrameStart !== undefined
+              ? { snapshotFrameStart: spawnResult.snapshotFrameStart }
               : {}),
-            ...(spawnResult.snapshotFrameAnsi !== undefined
-              ? { snapshotFrameAnsi: spawnResult.snapshotFrameAnsi }
+            ...(spawnResult.snapshotFrameRestoreAnsi !== undefined
+              ? { snapshotFrameRestoreAnsi: spawnResult.snapshotFrameRestoreAnsi }
               : {}),
             isAlternateScreen: spawnResult.isAlternateScreen,
             sessionExpired: spawnResult.sessionExpired,

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -893,6 +893,12 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             snapshot: spawnResult.snapshot,
             snapshotCols: spawnResult.snapshotCols,
             snapshotRows: spawnResult.snapshotRows,
+            ...(spawnResult.snapshotPrefixAnsi !== undefined
+              ? { snapshotPrefixAnsi: spawnResult.snapshotPrefixAnsi }
+              : {}),
+            ...(spawnResult.snapshotFrameAnsi !== undefined
+              ? { snapshotFrameAnsi: spawnResult.snapshotFrameAnsi }
+              : {}),
             isAlternateScreen: spawnResult.isAlternateScreen,
             sessionExpired: spawnResult.sessionExpired,
             coldRestore: spawnResult.coldRestore,

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -893,8 +893,11 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             snapshot: spawnResult.snapshot,
             snapshotCols: spawnResult.snapshotCols,
             snapshotRows: spawnResult.snapshotRows,
-            ...(spawnResult.snapshotFrameStart !== undefined
-              ? { snapshotFrameStart: spawnResult.snapshotFrameStart }
+            ...(spawnResult.snapshotPrefixAnsi !== undefined
+              ? { snapshotPrefixAnsi: spawnResult.snapshotPrefixAnsi }
+              : {}),
+            ...(spawnResult.snapshotFrameAnsi !== undefined
+              ? { snapshotFrameAnsi: spawnResult.snapshotFrameAnsi }
               : {}),
             ...(spawnResult.snapshotFrameRestoreAnsi !== undefined
               ? { snapshotFrameRestoreAnsi: spawnResult.snapshotFrameRestoreAnsi }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -1,10 +1,15 @@
 import { describe, expect, it } from 'vitest'
+import { Terminal } from '@xterm/headless'
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
   resolvePositiveTerminalDimensions,
   shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
+
+function writeTerminal(terminal: Terminal, data: string): Promise<void> {
+  return new Promise((resolve) => terminal.write(data, resolve))
+}
 
 describe('hasPositiveTerminalDimensions', () => {
   it('accepts only finite positive numeric pairs', () => {
@@ -71,11 +76,8 @@ describe('buildMainModelSnapshotReplayWrites', () => {
 describe('shouldSkipAltFrameForWidthMismatch', () => {
   it('skips only when the snapshot is WIDER than the target', () => {
     expect(shouldSkipAltFrameForWidthMismatch(135, 128)).toBe(true)
-    // One column is enough: _reflowSmaller splits every row longer than the new width.
     expect(shouldSkipAltFrameForWidthMismatch(129, 128)).toBe(true)
     expect(shouldSkipAltFrameForWidthMismatch(128, 128)).toBe(false)
-    // Widening only joins soft-wrapped lines, so an unwrapped frame row survives
-    // intact — keep it rather than blanking the pane.
     expect(shouldSkipAltFrameForWidthMismatch(100, 120)).toBe(false)
   })
 
@@ -99,6 +101,29 @@ describe('shouldSkipAltFrameForWidthMismatch', () => {
 })
 
 describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
+  it('keeps normal history and a clean alt grid through the real resize path', async () => {
+    const terminal = new Terminal({ cols: 12, rows: 5, scrollback: 20 })
+    const snapshot = {
+      data: '\x1b[1;1HWIDE-FRAME',
+      frameRestoreAnsi: '\x1b[?25l',
+      alternateScreen: true,
+      scrollbackAnsi: 'log'
+    }
+
+    try {
+      for (const chunk of buildMainModelSnapshotReplayWrites(snapshot, { skipAltFrame: true })) {
+        await writeTerminal(terminal, chunk)
+      }
+      terminal.resize(4, 5)
+
+      expect(terminal.buffer.active.type).toBe('alternate')
+      expect(terminal.buffer.active.getLine(0)?.translateToString(true)).toBe('')
+      expect(terminal.buffer.normal.getLine(0)?.translateToString(true)).toBe('log')
+    } finally {
+      terminal.dispose()
+    }
+  })
+
   it('drops only the frame paint, keeping scrollback and the alt-buffer choreography', () => {
     expect(
       buildMainModelSnapshotReplayWrites(

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -2,7 +2,8 @@ import { describe, expect, it } from 'vitest'
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
-  resolvePositiveTerminalDimensions
+  resolvePositiveTerminalDimensions,
+  shouldSkipAltFrameForWidthMismatch
 } from './terminal-snapshot-replay-paint'
 
 describe('hasPositiveTerminalDimensions', () => {
@@ -64,5 +65,58 @@ describe('buildMainModelSnapshotReplayWrites', () => {
     expect(
       buildMainModelSnapshotReplayWrites({ data: 'alt-frame', alternateScreen: true })
     ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'alt-frame'])
+  })
+})
+
+describe('shouldSkipAltFrameForWidthMismatch', () => {
+  it('skips only when the snapshot is WIDER than the target', () => {
+    expect(shouldSkipAltFrameForWidthMismatch(135, 128)).toBe(true)
+    // One column is enough: _reflowSmaller splits every row longer than the new width.
+    expect(shouldSkipAltFrameForWidthMismatch(129, 128)).toBe(true)
+    expect(shouldSkipAltFrameForWidthMismatch(128, 128)).toBe(false)
+    // Widening only joins soft-wrapped lines, so an unwrapped frame row survives
+    // intact — keep it rather than blanking the pane.
+    expect(shouldSkipAltFrameForWidthMismatch(100, 120)).toBe(false)
+  })
+
+  it('never skips when a width is missing or nonsensical', () => {
+    // Why: an unknown width must not cost the user their restored frame.
+    expect(shouldSkipAltFrameForWidthMismatch(undefined, 128)).toBe(false)
+    expect(shouldSkipAltFrameForWidthMismatch(135, undefined)).toBe(false)
+    expect(shouldSkipAltFrameForWidthMismatch(0, 128)).toBe(false)
+    expect(shouldSkipAltFrameForWidthMismatch(Number.NaN, 128)).toBe(false)
+    expect(shouldSkipAltFrameForWidthMismatch(Number.POSITIVE_INFINITY, 128)).toBe(false)
+  })
+})
+
+describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
+  it('drops only the frame paint, keeping scrollback and the alt-buffer choreography', () => {
+    expect(
+      buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true, scrollbackAnsi: 'normal-history' },
+        { skipAltFrame: true }
+      )
+    ).toEqual([
+      '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
+      'normal-history',
+      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H'
+    ])
+  })
+
+  it('still enters a cleared alt screen when skipping without split scrollback', () => {
+    // Why the clear still runs: the caller's SIGWINCH must land on a clean
+    // screen the application repaints, not the stale pre-park frame.
+    expect(
+      buildMainModelSnapshotReplayWrites(
+        { data: 'alt-frame', alternateScreen: true },
+        { skipAltFrame: true }
+      )
+    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H'])
+  })
+
+  it('never drops a normal-buffer snapshot, whose rows reflow correctly', () => {
+    expect(
+      buildMainModelSnapshotReplayWrites({ data: 'shell-output' }, { skipAltFrame: true })
+    ).toEqual(['\x1b[2J\x1b[3J\x1b[H', 'shell-output'])
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -87,19 +87,34 @@ describe('shouldSkipAltFrameForWidthMismatch', () => {
     expect(shouldSkipAltFrameForWidthMismatch(Number.NaN, 128)).toBe(false)
     expect(shouldSkipAltFrameForWidthMismatch(Number.POSITIVE_INFINITY, 128)).toBe(false)
   })
+
+  it('can conservatively skip a live frame until a hidden pane has a final grid', () => {
+    expect(shouldSkipAltFrameForWidthMismatch(135, undefined, { skipIfTargetUnknown: true })).toBe(
+      true
+    )
+    expect(
+      shouldSkipAltFrameForWidthMismatch(undefined, undefined, { skipIfTargetUnknown: true })
+    ).toBe(false)
+  })
 })
 
 describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
   it('drops only the frame paint, keeping scrollback and the alt-buffer choreography', () => {
     expect(
       buildMainModelSnapshotReplayWrites(
-        { data: 'alt-frame', alternateScreen: true, scrollbackAnsi: 'normal-history' },
+        {
+          data: 'mode-prefixalt-frame',
+          frameRestoreAnsi: 'complete-live-state',
+          alternateScreen: true,
+          scrollbackAnsi: 'normal-history'
+        },
         { skipAltFrame: true }
       )
     ).toEqual([
       '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       'normal-history',
-      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H'
+      '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
+      'complete-live-state'
     ])
   })
 
@@ -108,10 +123,23 @@ describe('buildMainModelSnapshotReplayWrites alt-frame skip', () => {
     // screen the application repaints, not the stale pre-park frame.
     expect(
       buildMainModelSnapshotReplayWrites(
-        { data: 'alt-frame', alternateScreen: true },
+        {
+          data: 'mode-prefixalt-frame',
+          frameRestoreAnsi: 'complete-live-state',
+          alternateScreen: true
+        },
         { skipAltFrame: true }
       )
-    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H'])
+    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'complete-live-state'])
+  })
+
+  it('keeps composed data when an older producer omits the mode boundary', () => {
+    expect(
+      buildMainModelSnapshotReplayWrites(
+        { data: 'legacy-modes-and-frame', alternateScreen: true },
+        { skipAltFrame: true }
+      )
+    ).toEqual(['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', 'legacy-modes-and-frame'])
   })
 
   it('never drops a normal-buffer snapshot, whose rows reflow correctly', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -32,18 +32,6 @@ export function resolvePositiveTerminalDimensions(
 }
 
 /**
- * Why width-gated: an alt-screen frame is absolutely positioned. Replay pins
- * the terminal to the snapshot's grid (#7279) and the post-replay fit sizes the
- * pane back to its container, so a narrower target makes xterm's _reflowSmaller
- * split every frame row longer than the new width into a stray remainder row —
- * the garbled-on-reopen shape.
- *
- * Why only narrowing: _reflowLarger merely joins soft-wrapped lines, and a frame
- * row is not wrapped, so a wider target leaves it intact (just short of the
- * edge) — worth keeping over a blank screen. Scrollback is never dropped either
- * way: those rows are soft-wrapped, which is what reflow re-wraps correctly.
- */
-/**
  * The column count the post-replay fit will land on. Why not terminal.cols: a
  * pane that has not been fitted yet still reads xterm's 80-column default, so
  * comparing against it would drop frames whose width actually matches the
@@ -59,24 +47,15 @@ export function shouldSkipAltFrameForWidthMismatch(
   targetCols: number | undefined,
   options: { skipIfTargetUnknown?: boolean } = {}
 ): boolean {
-  const hasSnapshotWidth =
-    typeof snapshotCols === 'number' && Number.isFinite(snapshotCols) && snapshotCols > 0
-  if (!hasSnapshotWidth) {
+  if (typeof snapshotCols !== 'number' || !Number.isFinite(snapshotCols) || snapshotCols <= 0) {
     return false
   }
-  const hasTargetWidth =
-    typeof targetCols === 'number' && Number.isFinite(targetCols) && targetCols > 0
-  if (!hasTargetWidth) {
-    // A hidden pane has no final grid yet. A live app can repaint a cleared
-    // screen after its deferred fit; painting first risks destructive reflow.
+  if (typeof targetCols !== 'number' || !Number.isFinite(targetCols) || targetCols <= 0) {
+    // A hidden pane has no final grid; its live app can repaint after the deferred fit.
     return options.skipIfTargetUnknown === true
   }
-  return (
-    typeof snapshotCols === 'number' &&
-    typeof targetCols === 'number' &&
-    targetCols > 0 &&
-    snapshotCols > targetCols
-  )
+  // Fixed-grid alt rows clip at narrower columns; normal history remains reflowable.
+  return snapshotCols > targetCols
 }
 
 /**

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -35,8 +35,8 @@ export function resolvePositiveTerminalDimensions(
  * The column count the post-replay fit will land on. Why not terminal.cols: a
  * pane that has not been fitted yet still reads xterm's 80-column default, so
  * comparing against it would drop frames whose width actually matches the
- * container. Returns undefined when the pane cannot be measured; live callers
- * can clear and defer repaint, while cold/offline callers keep their frame.
+ * container. Returns undefined when the pane cannot be measured; callers with
+ * a repaint owner can clear and defer, while offline preconnect paint cannot.
  */
 export function readProposedTerminalCols(pane: ManagedPane): number | undefined {
   return readProposedPaneFitDimensions(pane)?.cols

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -29,22 +29,74 @@ export function resolvePositiveTerminalDimensions(
 }
 
 /**
+ * Why width-gated: an alt-screen frame is absolutely positioned. Replay pins
+ * the terminal to the snapshot's grid (#7279) and the post-replay fit sizes the
+ * pane back to its container, so a narrower target makes xterm's _reflowSmaller
+ * split every frame row longer than the new width into a stray remainder row —
+ * the garbled-on-reopen shape.
+ *
+ * Why only narrowing: _reflowLarger merely joins soft-wrapped lines, and a frame
+ * row is not wrapped, so a wider target leaves it intact (just short of the
+ * edge) — worth keeping over a blank screen. Scrollback is never dropped either
+ * way: those rows are soft-wrapped, which is what reflow re-wraps correctly.
+ */
+/**
+ * The column count the post-replay fit will land on. Why not terminal.cols: a
+ * pane that has not been fitted yet still reads xterm's 80-column default, so
+ * comparing against it would drop frames whose width actually matches the
+ * container. Returns undefined when the pane cannot be measured, which the
+ * caller must treat as "do not skip".
+ */
+export function readProposedTerminalCols(pane: {
+  fitAddon?: { proposeDimensions?: () => { cols: number; rows: number } | undefined }
+}): number | undefined {
+  try {
+    return pane.fitAddon?.proposeDimensions?.()?.cols
+  } catch {
+    return undefined
+  }
+}
+
+export function shouldSkipAltFrameForWidthMismatch(
+  snapshotCols: number | undefined,
+  targetCols: number | undefined
+): boolean {
+  return (
+    typeof snapshotCols === 'number' &&
+    typeof targetCols === 'number' &&
+    Number.isFinite(snapshotCols) &&
+    Number.isFinite(targetCols) &&
+    snapshotCols > 0 &&
+    targetCols > 0 &&
+    snapshotCols > targetCols
+  )
+}
+
+/**
  * Ordered replay writes for a main-model snapshot, including the alt-screen
  * choreography: main strips the `?1049h` marker when splitting scrollbackAnsi
  * from an alt frame, so the restorer owns the transition — rebuild the normal
  * buffer while on it, then paint the alt frame clean. Callers write these
  * before their post-replay reset/escape-tail sequences.
+ *
+ * `skipAltFrame` drops only the frame paint, never the buffer choreography or
+ * scrollback: the alt buffer is still entered and cleared so the caller's
+ * SIGWINCH lands on a clean screen the application repaints itself.
  */
-export function buildMainModelSnapshotReplayWrites(snapshot: {
-  data: string
-  alternateScreen?: boolean
-  scrollbackAnsi?: string
-}): string[] {
+export function buildMainModelSnapshotReplayWrites(
+  snapshot: {
+    data: string
+    alternateScreen?: boolean
+    scrollbackAnsi?: string
+  },
+  options: { skipAltFrame?: boolean } = {}
+): string[] {
   if (!snapshot.alternateScreen) {
     // Why: \x1b[3J wipes xterm scrollback; safe here because a normal-buffer
     // snapshot carries its own history in data (mirrors pty-transport.ts).
     return ['\x1b[2J\x1b[3J\x1b[H', snapshot.data]
   }
+  const altFrame = options.skipAltFrame ? [] : [snapshot.data]
   if (snapshot.scrollbackAnsi !== undefined) {
     // Why: main serializes normal + alt buffers separately; rebuild normal
     // while active, then return to a clean alt frame.
@@ -52,11 +104,11 @@ export function buildMainModelSnapshotReplayWrites(snapshot: {
       '\x1b[?1049l\x1b[2J\x1b[3J\x1b[H',
       snapshot.scrollbackAnsi,
       '\x1b[0m\x1b[?1049h\x1b[2J\x1b[H',
-      snapshot.data
+      ...altFrame
     ]
   }
   // Why: the snapshot's ?1049h no-ops when already on alt screen and skips
   // blank cells; clear the alt buffer so the pre-hide frame can't bleed
   // through blank cells (spares normal-buffer scrollback).
-  return ['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', snapshot.data]
+  return ['\x1b[0m\x1b[?1049h\x1b[2J\x1b[H', ...altFrame]
 }

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -1,3 +1,6 @@
+import type { ManagedPane } from '@/lib/pane-manager/pane-manager-types'
+import { readProposedPaneFitDimensions } from '@/lib/pane-manager/pane-fit'
+
 /**
  * Shared guards and write choreography for painting a main-model snapshot into
  * a (possibly fresh) xterm. One source for the reattach/hidden-restore paint
@@ -44,29 +47,33 @@ export function resolvePositiveTerminalDimensions(
  * The column count the post-replay fit will land on. Why not terminal.cols: a
  * pane that has not been fitted yet still reads xterm's 80-column default, so
  * comparing against it would drop frames whose width actually matches the
- * container. Returns undefined when the pane cannot be measured, which the
- * caller must treat as "do not skip".
+ * container. Returns undefined when the pane cannot be measured; live callers
+ * can clear and defer repaint, while cold/offline callers keep their frame.
  */
-export function readProposedTerminalCols(pane: {
-  fitAddon?: { proposeDimensions?: () => { cols: number; rows: number } | undefined }
-}): number | undefined {
-  try {
-    return pane.fitAddon?.proposeDimensions?.()?.cols
-  } catch {
-    return undefined
-  }
+export function readProposedTerminalCols(pane: ManagedPane): number | undefined {
+  return readProposedPaneFitDimensions(pane)?.cols
 }
 
 export function shouldSkipAltFrameForWidthMismatch(
   snapshotCols: number | undefined,
-  targetCols: number | undefined
+  targetCols: number | undefined,
+  options: { skipIfTargetUnknown?: boolean } = {}
 ): boolean {
+  const hasSnapshotWidth =
+    typeof snapshotCols === 'number' && Number.isFinite(snapshotCols) && snapshotCols > 0
+  if (!hasSnapshotWidth) {
+    return false
+  }
+  const hasTargetWidth =
+    typeof targetCols === 'number' && Number.isFinite(targetCols) && targetCols > 0
+  if (!hasTargetWidth) {
+    // A hidden pane has no final grid yet. A live app can repaint a cleared
+    // screen after its deferred fit; painting first risks destructive reflow.
+    return options.skipIfTargetUnknown === true
+  }
   return (
     typeof snapshotCols === 'number' &&
     typeof targetCols === 'number' &&
-    Number.isFinite(snapshotCols) &&
-    Number.isFinite(targetCols) &&
-    snapshotCols > 0 &&
     targetCols > 0 &&
     snapshotCols > targetCols
   )
@@ -80,12 +87,14 @@ export function shouldSkipAltFrameForWidthMismatch(
  * before their post-replay reset/escape-tail sequences.
  *
  * `skipAltFrame` drops only the frame paint, never the buffer choreography or
- * scrollback: the alt buffer is still entered and cleared so the caller's
- * SIGWINCH lands on a clean screen the application repaints itself.
+ * scrollback or mode rehydration: the alt buffer is still entered and cleared
+ * so the caller's SIGWINCH lands on a clean screen the application repaints.
  */
 export function buildMainModelSnapshotReplayWrites(
   snapshot: {
     data: string
+    /** Live state that can be restored without an alternate-screen frame. */
+    frameRestoreAnsi?: string
     alternateScreen?: boolean
     scrollbackAnsi?: string
   },
@@ -96,7 +105,12 @@ export function buildMainModelSnapshotReplayWrites(
     // snapshot carries its own history in data (mirrors pty-transport.ts).
     return ['\x1b[2J\x1b[3J\x1b[H', snapshot.data]
   }
-  const altFrame = options.skipAltFrame ? [] : [snapshot.data]
+  // Older snapshot producers do not expose the mode/frame boundary. Keep their
+  // composed data rather than dropping terminal modes together with the frame.
+  const altFrame =
+    options.skipAltFrame && snapshot.frameRestoreAnsi !== undefined
+      ? [snapshot.frameRestoreAnsi]
+      : [snapshot.data]
   if (snapshot.scrollbackAnsi !== undefined) {
     // Why: main serializes normal + alt buffers separately; rebuild normal
     // while active, then return to a clean alt frame.

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -1,9 +1,10 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import type { ManagedPane, ManagedPaneInternal, ScrollState } from './pane-manager-types'
-import { safeFit, safeFitAndThen } from './pane-fit'
+import { readProposedPaneFitDimensions, safeFit, safeFitAndThen } from './pane-fit'
 import { applyOrDeferPaneMetricOptions } from './pane-metric-options-deferral'
 import { paneFitClientSizeChanged } from './pane-reveal-fit'
+import { setFitOverride } from './mobile-fit-overrides'
 
 vi.mock('@/lib/crash-breadcrumb-recorder', () => ({
   recordRendererCrashBreadcrumb: vi.fn()
@@ -501,5 +502,62 @@ describe('deferred metric flush inside safeFit', () => {
     expect(safeFit(pane)).toBe(true)
     expect(pane.terminal.options.fontSize).toBe(12)
     expect(pane.fitAddon.fit).toHaveBeenCalled()
+  })
+
+  it('reports the post-metric grid used by the next safe fit', () => {
+    const terminal = { cols: 80, rows: 24, options: {} as Record<string, unknown> }
+    const pane = {
+      id: 12,
+      terminal,
+      container: {
+        dataset: {},
+        getBoundingClientRect: () => ({ width: 500, height: 300 })
+      },
+      fitAddon: {
+        fit: vi.fn(),
+        proposeDimensions: vi.fn(() =>
+          Number(terminal.options.fontSize ?? 10) >= 18
+            ? { cols: 20, rows: 10 }
+            : { cols: 40, rows: 20 }
+        )
+      }
+    } as unknown as ManagedPane
+    applyOrDeferPaneMetricOptions(pane, { fontSize: 18 }, false)
+
+    expect(readProposedPaneFitDimensions(pane)).toEqual({ cols: 20, rows: 10 })
+    expect(pane.terminal.options.fontSize).toBe(18)
+  })
+
+  it('reports an owner override even while the pane is unmeasurable', () => {
+    const pane = {
+      terminal: { cols: 80, rows: 24, options: {} },
+      container: {
+        dataset: { ptyId: 'pty-override' },
+        getBoundingClientRect: () => ({ width: 0, height: 0 })
+      },
+      fitAddon: { proposeDimensions: vi.fn() }
+    } as unknown as ManagedPane
+    setFitOverride('pty-override', 'mobile-fit', 49, 20)
+
+    try {
+      expect(readProposedPaneFitDimensions(pane)).toEqual({ cols: 49, rows: 20 })
+      expect(pane.fitAddon.proposeDimensions).not.toHaveBeenCalled()
+    } finally {
+      setFitOverride('pty-override', 'desktop-fit', 0, 0)
+    }
+  })
+
+  it('flushes deferred metrics before reporting a measurable owner override', () => {
+    const pane = createMetricPane()
+    pane.container.dataset.ptyId = 'pty-metric-override'
+    applyOrDeferPaneMetricOptions(pane, { fontSize: 12 }, false)
+    setFitOverride('pty-metric-override', 'mobile-fit', 49, 20)
+
+    try {
+      expect(readProposedPaneFitDimensions(pane)).toEqual({ cols: 49, rows: 20 })
+      expect(pane.terminal.options.fontSize).toBe(12)
+    } finally {
+      setFitOverride('pty-metric-override', 'desktop-fit', 0, 0)
+    }
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -529,8 +529,9 @@ describe('deferred metric flush inside safeFit', () => {
   })
 
   it('reports an owner override even while the pane is unmeasurable', () => {
+    const resize = vi.fn()
     const pane = {
-      terminal: { cols: 80, rows: 24, options: {} },
+      terminal: { cols: 80, rows: 24, options: {}, resize },
       container: {
         dataset: { ptyId: 'pty-override' },
         getBoundingClientRect: () => ({ width: 0, height: 0 })
@@ -542,6 +543,8 @@ describe('deferred metric flush inside safeFit', () => {
     try {
       expect(readProposedPaneFitDimensions(pane)).toEqual({ cols: 49, rows: 20 })
       expect(pane.fitAddon.proposeDimensions).not.toHaveBeenCalled()
+      expect(safeFit(pane)).toBe(false)
+      expect(resize).not.toHaveBeenCalled()
     } finally {
       setFitOverride('pty-override', 'desktop-fit', 0, 0)
     }

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -88,10 +88,12 @@ function performSafeFit(pane: ManagedPane): boolean {
   if (deferTerminalGeometryMutationDuringRebuild(pane.terminal, 'safe-fit', () => safeFit(pane))) {
     return false
   }
-  // Why here: replay width gates share this helper, so they compare against the
-  // same post-metric grid that fit will actually apply.
-  const proposedDimensions = readProposedPaneFitDimensions(pane)
-  if (!proposedDimensions) {
+  if (!canMeasurePaneForFit(pane)) {
+    return false
+  }
+  // Why here: metric options deferred while the pane was unmeasurable must land
+  // before this fit reads dimensions, then the fit floor must be checked again.
+  if (flushDeferredPaneMetricOptions(pane) && !canMeasurePaneForFit(pane)) {
     return false
   }
   let scrollIntent = null as ReturnType<typeof captureTerminalStructuralScrollIntent>
@@ -121,7 +123,7 @@ function performSafeFit(pane: ManagedPane): boolean {
       return true
     }
 
-    const dims = proposedDimensions
+    const dims = getProposedPaneDimensions(pane)
     if (dims && dims.cols === pane.terminal.cols && dims.rows === pane.terminal.rows) {
       // Why: divider drags often stay within one cell; avoid needless clear/refresh churn.
       resumePendingFitScrollRestoreAfterFit(pane.terminal)

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -55,6 +55,28 @@ export type SafeFitContinuationHandle = {
 
 export { readFitClientSize } from './pane-fit-client-size'
 
+/** Returns the exact dimensions the next safe fit will use after any applicable
+ * deferred metrics. An owner override remains measurable while its pane is hidden. */
+export function readProposedPaneFitDimensions(
+  pane: ManagedPane
+): { cols: number; rows: number } | null {
+  const ptyId = pane.container?.dataset?.ptyId
+  const override = ptyId ? getFitOverrideForPty(ptyId) : null
+  const measurable = canMeasurePaneForFit(pane)
+  if (!measurable && !override) {
+    return null
+  }
+  // Re-check after the metric flush: larger cells can push a narrow pane below
+  // the fit floor even though it was measurable with the old metrics.
+  if (measurable && flushDeferredPaneMetricOptions(pane) && !canMeasurePaneForFit(pane)) {
+    return null
+  }
+  if (override) {
+    return { cols: override.cols, rows: override.rows }
+  }
+  return getProposedPaneDimensions(pane)
+}
+
 function canPreserveScrollIntentForFit(pane: ManagedPane): boolean {
   // Why: split reparent has its own delayed restore; restoring here can fight that timer.
   return !(
@@ -66,15 +88,10 @@ function performSafeFit(pane: ManagedPane): boolean {
   if (deferTerminalGeometryMutationDuringRebuild(pane.terminal, 'safe-fit', () => safeFit(pane))) {
     return false
   }
-  if (!canMeasurePaneForFit(pane)) {
-    return false
-  }
-  // Why here: metric options deferred while the pane was unmeasurable must land
-  // before this fit reads dimensions, or the fit pins cols/rows to stale metrics.
-  // Why re-check: the gate above measured with the old cell size — a large font
-  // jump on a narrow pane can drop it under the floor, and fit() would then pin
-  // the PTY at the tiny grid that floor exists to prevent.
-  if (flushDeferredPaneMetricOptions(pane) && !canMeasurePaneForFit(pane)) {
+  // Why here: replay width gates share this helper, so they compare against the
+  // same post-metric grid that fit will actually apply.
+  const proposedDimensions = readProposedPaneFitDimensions(pane)
+  if (!proposedDimensions) {
     return false
   }
   let scrollIntent = null as ReturnType<typeof captureTerminalStructuralScrollIntent>
@@ -104,7 +121,7 @@ function performSafeFit(pane: ManagedPane): boolean {
       return true
     }
 
-    const dims = getProposedPaneDimensions(pane)
+    const dims = proposedDimensions
     if (dims && dims.cols === pane.terminal.cols && dims.rows === pane.terminal.rows) {
       // Why: divider drags often stay within one cell; avoid needless clear/refresh churn.
       resumePendingFitScrollRestoreAfterFit(pane.terminal)

--- a/src/shared/terminal-serialize-absolute-cursor.ts
+++ b/src/shared/terminal-serialize-absolute-cursor.ts
@@ -19,7 +19,7 @@ type BufferSerializer<TOpts> = {
 }
 
 /** VT100 DECSC saved-cursor register (0-based, viewport-relative row). */
-export type SavedCursorRegister = { x: number; y: number }
+export type SavedCursorRegister = { x: number; y: number; originMode: boolean }
 
 // xterm keeps the DECSC register on each Buffer (savedY is absolute:
 // ybase-included). It is not exposed through the public API, so snapshot
@@ -27,7 +27,17 @@ export type SavedCursorRegister = { x: number; y: number }
 // buffer, so an alt-screen TUI yields the alternate screen's own register,
 // matching the one a post-restore DECRC would consult.
 type TerminalWithSavedCursorCore = SerializeCursorTerminal & {
-  _core?: { buffer?: { savedX?: number; savedY?: number; ybase?: number } }
+  modes?: { originMode?: boolean }
+  _core?: {
+    buffer?: {
+      savedX?: number
+      savedY?: number
+      savedOriginMode?: boolean
+      ybase?: number
+      scrollTop?: number
+      scrollBottom?: number
+    }
+  }
 }
 
 /** Reads the source terminal's active-buffer DECSC register, or null when it
@@ -48,13 +58,14 @@ export function readSavedCursorRegister(
   // cols (DECSC during wrap-pending); CUP cannot re-create pending, so clamp.
   const y = Math.min(Math.max(core.savedY - core.ybase, 0), terminal.rows - 1)
   const x = Math.min(Math.max(core.savedX, 0), terminal.cols - 1)
-  if (x === 0 && y === 0) {
+  const originMode = core.savedOriginMode === true
+  if (x === 0 && y === 0 && !originMode) {
     // Home is xterm's never-saved default: a fresh restore terminal already
     // sends DECRC to home, and skipping the injection avoids overwriting the
     // fresh terminal's default saved SGR/charset when nothing was ever saved.
     return null
   }
-  return { x, y }
+  return { x, y, originMode }
 }
 
 export function serializeWithAbsoluteCursor<TOpts>(
@@ -76,16 +87,23 @@ export function serializeWithAbsoluteCursor<TOpts>(
 /** Cursor state appended after serialized modes; safe to replay without the frame body. */
 export function buildAbsoluteCursorRestoreSequence(
   terminal: SerializeCursorTerminal,
-  savedCursor?: SavedCursorRegister | null
+  savedCursor?: SavedCursorRegister | null,
+  options: { restoreModesWithoutCursor?: boolean } = {}
 ): string {
   const { cursorX, cursorY } = terminal.buffer.active
+  const terminalWithCore = terminal as TerminalWithSavedCursorCore
+  const buffer = terminalWithCore._core?.buffer
+  const scrollTop = buffer?.scrollTop ?? 0
+  const scrollBottom = buffer?.scrollBottom ?? terminal.rows - 1
+  const originMode = terminalWithCore.modes?.originMode === true
+  const cupCursorY = cursorY - (originMode ? scrollTop : 0)
   // Why skip wrap-pending sources (cursorX == cols): plain replay already
   // reproduces that state exactly, while CUP would clamp to the last column
   // and clear the pending-wrap flag, changing how the next byte renders.
   // The remaining bounds checks are defensive: never emit a clamping CUP.
-  // The saved-cursor injection is skipped with it — it moves the cursor, so
-  // it may only ride along when the absolute CUP restores the position after.
-  if (cursorX < 0 || cursorX >= terminal.cols || cursorY < 0 || cursorY >= terminal.rows) {
+  const canRestoreCurrentCursor =
+    cursorX >= 0 && cursorX < terminal.cols && cupCursorY >= 0 && cupCursorY < terminal.rows
+  if (!canRestoreCurrentCursor && options.restoreModesWithoutCursor !== true) {
     return ''
   }
   // Why the DECSC injection: the serialized screen cannot carry the VT100
@@ -95,9 +113,20 @@ export function buildAbsoluteCursorRestoreSequence(
   // the source's saved position, then CUP back to the real cursor. Saved SGR/
   // charset are not carried — the synthetic ESC 7 saves the serializer's
   // final pen, a deliberate position-only fidelity trade.
-  const savedRestore = savedCursor ? `\x1b[${savedCursor.y + 1};${savedCursor.x + 1}H\x1b7` : ''
-  // cursorY is viewport-relative (0 at the buffer's base row), which is the
-  // same coordinate space CUP addresses after replay; scrollback length
-  // differences between source and destination do not shift it.
-  return `${savedRestore}\x1b[${cursorY + 1};${cursorX + 1}H`
+  // Install the saved register against a full region so its absolute row is
+  // representable even when it predates the current DECSTBM/DECOM state.
+  const savedRestore = savedCursor
+    ? `\x1b[r\x1b[?6${savedCursor.originMode ? 'h' : 'l'}\x1b[${savedCursor.y + 1};${savedCursor.x + 1}H\x1b7`
+    : ''
+  const scrollRegionRestore =
+    scrollTop !== 0 || scrollBottom !== terminal.rows - 1
+      ? `\x1b[${scrollTop + 1};${scrollBottom + 1}r`
+      : ''
+  const originModeRestore = `\x1b[?6${originMode ? 'h' : 'l'}`
+  // CUP rows become margin-relative under DECOM; ordinary snapshots keep the
+  // zero offset because scrollback length does not shift viewport coordinates.
+  const currentCursorRestore = canRestoreCurrentCursor
+    ? `\x1b[${cupCursorY + 1};${cursorX + 1}H`
+    : ''
+  return `${savedRestore}${scrollRegionRestore}${originModeRestore}${currentCursorRestore}`
 }

--- a/src/shared/terminal-serialize-absolute-cursor.ts
+++ b/src/shared/terminal-serialize-absolute-cursor.ts
@@ -118,11 +118,12 @@ export function buildAbsoluteCursorRestoreSequence(
   const savedRestore = savedCursor
     ? `\x1b[r\x1b[?6${savedCursor.originMode ? 'h' : 'l'}\x1b[${savedCursor.y + 1};${savedCursor.x + 1}H\x1b7`
     : ''
+  const mustRestoreModes = savedCursor != null || options.restoreModesWithoutCursor === true
   const scrollRegionRestore =
-    scrollTop !== 0 || scrollBottom !== terminal.rows - 1
+    mustRestoreModes && (scrollTop !== 0 || scrollBottom !== terminal.rows - 1)
       ? `\x1b[${scrollTop + 1};${scrollBottom + 1}r`
       : ''
-  const originModeRestore = `\x1b[?6${originMode ? 'h' : 'l'}`
+  const originModeRestore = mustRestoreModes ? `\x1b[?6${originMode ? 'h' : 'l'}` : ''
   // CUP rows become margin-relative under DECOM; ordinary snapshots keep the
   // zero offset because scrollback length does not shift viewport coordinates.
   const currentCursorRestore = canRestoreCurrentCursor

--- a/src/shared/terminal-serialize-absolute-cursor.ts
+++ b/src/shared/terminal-serialize-absolute-cursor.ts
@@ -70,6 +70,14 @@ export function serializeWithAbsoluteCursor<TOpts>(
   if (serialized.length === 0) {
     return serialized
   }
+  return `${serialized}${buildAbsoluteCursorRestoreSequence(terminal, savedCursor)}`
+}
+
+/** Cursor state appended after serialized modes; safe to replay without the frame body. */
+export function buildAbsoluteCursorRestoreSequence(
+  terminal: SerializeCursorTerminal,
+  savedCursor?: SavedCursorRegister | null
+): string {
   const { cursorX, cursorY } = terminal.buffer.active
   // Why skip wrap-pending sources (cursorX == cols): plain replay already
   // reproduces that state exactly, while CUP would clamp to the last column
@@ -78,7 +86,7 @@ export function serializeWithAbsoluteCursor<TOpts>(
   // The saved-cursor injection is skipped with it — it moves the cursor, so
   // it may only ride along when the absolute CUP restores the position after.
   if (cursorX < 0 || cursorX >= terminal.cols || cursorY < 0 || cursorY >= terminal.rows) {
-    return serialized
+    return ''
   }
   // Why the DECSC injection: the serialized screen cannot carry the VT100
   // saved-cursor register, so a hidden DECSC followed by a post-reveal DECRC
@@ -91,5 +99,5 @@ export function serializeWithAbsoluteCursor<TOpts>(
   // cursorY is viewport-relative (0 at the buffer's base row), which is the
   // same coordinate space CUP addresses after replay; scrollback length
   // differences between source and destination do not shift it.
-  return `${serialized}${savedRestore}\x1b[${cursorY + 1};${cursorX + 1}H`
+  return `${savedRestore}\x1b[${cursorY + 1};${cursorX + 1}H`
 }


### PR DESCRIPTION
## Summary

Reopening a parked worktree could replay a full-screen TUI snapshot at its captured width and then fit xterm to a narrower pane. The alternate buffer does not reflow in our pinned xterm; instead, the fixed-grid frame stayed full-width and was clipped at the narrower viewport until the live application repainted, producing the filmed row fragments and mid-word cuts.

This change omits only a live alternate-screen frame when its captured grid is wider than the pending fit, or when a hidden pane has no trustworthy target grid yet. Normal-buffer scrollback, alternate-buffer activation/clearing, and frame-independent terminal state are restored, then the attached PTY owner receives repaint activity on the final grid.

## Root cause and implementation

The first renderer-only gate did not cover the filmed path. Instrumentation showed the parked reveal painted through `daemon-connectResult-snapshot`, where the daemon's composed snapshot bypassed the model-snapshot call sites.

The daemon now exposes additive optional strings for the normal-buffer/mode prefix and visual alt frame:

- `snapshotPrefixAnsi`
- `snapshotFrameAnsi`

The renderer preserves those fields through the transport projection. On a narrowing live restore it writes the prefix plus compact frame-independent restore state instead of the stale visual frame. Missing, empty, or partial split metadata falls back to the original merged snapshot, preserving compatibility without an escape-sequence boundary index that could drift.

The restore state covers alternate-buffer entry, SGR pen state, cursor/keypad/paste/insert/origin/wrap/focus/cursor/mouse modes, scroll region, and saved/current cursor positions. The unsupported SerializeAddon out-of-range-row SGR capture is documented and pinned by a direct test under our vendored xterm patch.

The width decision uses the same proposed pane-fit dimensions consumed by `safeFit`, including active fit overrides. Hidden or unmeasurable live restores conservatively omit the frame and carry the fit continuation through reveal. If the final reveal grid equals the snapshot grid, a one-column PTY size pulse still produces `SIGWINCH`; this prevents a skipped frame from leaving a permanently blank TUI when same-size resize calls would otherwise be ignored.

Equal-width and wider measurable restores keep their captured frame. The scope does not change `performSafeFit` behavior for unmeasurable override panes, preserving #12944's terminal-keyed metric deferral, settled gate, font-zoom folding, and retry invariants.

## Compatibility and deliberate boundaries

The split fields are additive and optional across local IPC/runtime contracts. Existing consumers ignore them, and producers without a complete split fall back to the merged snapshot.

- A cold restore with the owner gone drops a mismatched frame while retaining normal-buffer history and the existing restored-session/reset treatment. This polarity is unit-covered. The separate owner-death Electron lifecycle was not live-tested in the park/remount matrix.
- Offline/preconnect SSH retains its parked frame because no attached SSH process can repaint it yet.
- Paired remote-runtime snapshot recovery does not yet transport the optional split metadata and remains out of scope. Changing that independently updated mixed-version wire path would expand this defect fix; it continues to use the backward-compatible merged fallback.

The static TUI used for narrowing QA deliberately ignores `SIGWINCH`. It is a worst-case probe, not typical application behavior: a blank cleared alt screen proves the stale frame was omitted instead of being masked by a quick repaint.

## Verification

- Two final same-model review rounds returned CLEAN at exact post-rebase head `6ace57fd73`.
- Focused Vitest: 7 files, 949 passed; reviewer rerun: 7 files, 897 passed.
- `pnpm run typecheck`.
- `pnpm run audit:code-quality:native`.
- `pnpm run audit:code-quality:type-aware`.
- `git diff --check`.
- Exact-head GitHub CI: 50 checks completed with no failures or pending jobs; `verify`, Windows packaging, cross-version wire compatibility, and native smoke checks passed.
- Rebased onto `origin/main` at `2ee43bfc0d`; later main commits touch only README/ripgrep filesystem files, with no terminal/PTY/snapshot/pane-fit overlap.

### Electron/CDP matrix

All UI automation used `agent-browser` over Electron CDP with isolated profiles.

| Scenario | Result |
|---|---|
| Narrow daemon remount, 135 to 9 cols | PASS: clean cleared alt screen from t0 through t5; no clipped stale-frame debris |
| Same-width daemon remount, 135 to 135 cols | PASS: complete captured frame remains intact |
| Wider daemon remount, narrow capture to 135 cols | PASS: captured frame remains intact at the left of the wider grid |
| Scrollback across all daemon cases | PASS: `SCROLLBACK-LINE` remains in the target main-buffer snapshot |
| Hidden same-grid reveal, 135×59 to 135×59 | PASS: skipped stale frame receives a two-step `SIGWINCH` repaint and shows `TOP_AFTER_SIGWINCH count=2` on the same PTY |

## Security audit

No new input, command execution, path, auth, secret, or dependency surface. The change adds optional terminal-snapshot metadata and replay choreography only.
