### PR TITLE
fix(computer-use): settle macOS permission checks

### DIFF
--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -601,7 +601,7 @@ final class Provider {
         windowIndex: Int?,
         restoreWindow: Bool
     ) throws -> Snapshot {
-        guard accessibilityTrusted() else {
+        guard accessibilityTrustedSettled() else {
             // Why: agents retry failed observations. Only the explicit setup flow
             // should open macOS privacy prompts/settings; runtime calls stay quiet.
             throw ProviderError.coded(
@@ -619,7 +619,7 @@ final class Provider {
             allowRecovery: restoreWindow
         )
         let focusedTitle = stringAttribute(focused, kAXTitleAttribute as String) ?? app.name
-        let canCaptureScreenshot = includeScreenshot && screenCaptureTrusted()
+        let canCaptureScreenshot = includeScreenshot && screenCaptureTrustedSettled()
         guard let capture = WindowCapture.resolve(
             candidates: windowCandidates,
             titleHint: focusedTitle,
@@ -1034,8 +1034,55 @@ private func accessibilityTrusted() -> Bool {
     AXIsProcessTrusted()
 }
 
+private func accessibilityTrustedSettled() -> Bool {
+    // Fresh helper processes can receive transient TCC preflight denials before the real grant settles.
+    PermissionTrustSettling.settle(probe: accessibilityTrusted).settled
+}
+
 private func screenCaptureTrusted() -> Bool {
     CGPreflightScreenCaptureAccess()
+}
+
+private func screenCaptureTrustedSettled() -> Bool {
+    PermissionTrustSettling.settleWithFallback(
+        finalTimeoutMs: 500,
+        probe: screenCaptureTrusted,
+        fallbackProbe: screenCaptureTrustedByCaptureProbe
+    )
+}
+
+private func screenCaptureTrustedByCaptureProbe() -> Bool {
+    guard let infos = CGWindowListCopyWindowInfo(
+        [.optionOnScreenOnly],
+        kCGNullWindowID
+    ) as? [[String: Any]] else {
+        return false
+    }
+    let windows = infos.compactMap { info -> ScreenCaptureProbeWindow? in
+        guard let layer = info[kCGWindowLayer as String] as? Int,
+              let ownerPid = info[kCGWindowOwnerPID as String] as? NSNumber,
+              let number = info[kCGWindowNumber as String] as? NSNumber
+        else {
+            return nil
+        }
+        return ScreenCaptureProbeWindow(
+            layer: layer,
+            ownerPid: ownerPid.int32Value,
+            windowId: number.uint32Value
+        )
+    }
+    guard let windowId = ScreenCaptureProbeWindowSelection.firstCrossProcessNormalWindow(
+        ownPid: ProcessInfo.processInfo.processIdentifier,
+        windows: windows
+    ) else {
+        return false
+    }
+    return CGWindowListCreateImage(
+        .null,
+        [.optionIncludingWindow],
+        CGWindowID(windowId),
+        [.boundsIgnoreFraming]
+    ) != nil
 }
 
 private func requestScreenCaptureAccess() -> Bool {
@@ -1065,6 +1112,38 @@ private func enableManualAccessibilityIfNeeded(_ appElement: AXUIElement, app: A
 
 private func focusedWindow(appElement: AXUIElement, app: AppDescriptor, visibleWindowCount: Int, allowRecovery: Bool) throws -> AXUIElement {
     let systemWide = AXUIElementCreateSystemWide()
+    if let window = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app) {
+        return window
+    }
+    if allowRecovery {
+        recoverWindow(app)
+        if let window = lookupUsableWindow(systemWide: systemWide, appElement: appElement, app: app) {
+            return window
+        }
+    }
+    if visibleWindowCount > 0 {
+        var settledWindow: AXUIElement?
+        let outcome = PermissionTrustSettling.settle {
+            settledWindow = lookupUsableWindow(
+                systemWide: systemWide,
+                appElement: appElement,
+                app: app
+            )
+            return settledWindow != nil
+        }
+        if let window = settledWindow, outcome.settled {
+            return window
+        }
+        throw ProviderError.coded("permission_denied", "app '\(app.name)' has visible windows but no accessibility window (AX reads stayed blocked for \(outcome.waitedMs)ms after retries). macOS Accessibility may need Orca Computer Use toggled off and on again in System Settings.")
+    }
+    throw ProviderError.coded("window_not_found", "app '\(app.name)' has no accessibility window; make sure the app has a visible window, then retry with --restore-window.")
+}
+
+private func lookupUsableWindow(
+    systemWide: AXUIElement,
+    appElement: AXUIElement,
+    app: AppDescriptor
+) -> AXUIElement? {
     if let window = focusedSystemWindow(systemWide: systemWide, app: app) {
         return window
     }
@@ -1072,31 +1151,9 @@ private func focusedWindow(appElement: AXUIElement, app: AppDescriptor, visibleW
         return window
     }
     if let windows = copyArray(appElement, kAXWindowsAttribute as String) {
-        if let window = windows.first(where: usableWindow) {
-            return window
-        }
+        return windows.first(where: usableWindow)
     }
-    if allowRecovery {
-        recoverWindow(app)
-        if let window = focusedSystemWindow(systemWide: systemWide, app: app) {
-            return window
-        }
-        if let window = copyElement(appElement, kAXFocusedWindowAttribute as String), usableWindow(window) {
-            return window
-        }
-        if let windows = copyArray(appElement, kAXWindowsAttribute as String) {
-            if let window = windows.first(where: usableWindow) {
-                return window
-            }
-        }
-    }
-    let permissionHint = visibleWindowCount > 0
-        ? " The app has visible windows, so macOS Accessibility may need Orca Computer Use toggled off and on again in System Settings."
-        : ""
-    if visibleWindowCount > 0 {
-        throw ProviderError.coded("permission_denied", "app '\(app.name)' has visible windows but no accessibility window.\(permissionHint)")
-    }
-    throw ProviderError.coded("window_not_found", "app '\(app.name)' has no accessibility window; make sure the app has a visible window, then retry with --restore-window.")
+    return nil
 }
 
 private func focusedSystemWindow(systemWide: AXUIElement, app: AppDescriptor) -> AXUIElement? {
@@ -3048,9 +3105,9 @@ private enum PermissionKind: CaseIterable {
     var isGranted: Bool {
         switch self {
         case .accessibility:
-            accessibilityTrusted()
+            accessibilityTrustedSettled()
         case .screenshots:
-            screenCaptureTrusted()
+            screenCaptureTrustedSettled()
         }
     }
 
@@ -4039,14 +4096,14 @@ private func runPermissionCheck(initialPermission: PermissionKind? = nil) {
 }
 
 private func printPermissionStatus() {
-    let accessibility = accessibilityTrusted() ? "granted" : "not-granted"
-    let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
+    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
+    let screenshots = screenCaptureTrustedSettled() ? "granted" : "not-granted"
     print(#"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#)
 }
 
 private func writePermissionStatus(to path: String) {
-    let accessibility = accessibilityTrusted() ? "granted" : "not-granted"
-    let screenshots = screenCaptureTrusted() ? "granted" : "not-granted"
+    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
+    let screenshots = screenCaptureTrustedSettled() ? "granted" : "not-granted"
     let text = #"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#
     do {
         try text.write(toFile: path, atomically: true, encoding: .utf8)

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOS/main.swift
@@ -1051,6 +1051,13 @@ private func screenCaptureTrustedSettled() -> Bool {
     )
 }
 
+private func permissionStatusSnapshotSettled() -> PermissionStatusSnapshot {
+    PermissionStatusSnapshotProbe.capture(
+        accessibilityProbe: accessibilityTrustedSettled,
+        screenshotsProbe: screenCaptureTrustedSettled
+    )
+}
+
 private func screenCaptureTrustedByCaptureProbe() -> Bool {
     guard let infos = CGWindowListCopyWindowInfo(
         [.optionOnScreenOnly],
@@ -2931,6 +2938,7 @@ private final class PermissionRuntime: NSObject, NSApplicationDelegate {
             windowController?.window?.makeKeyAndOrderFront(nil)
             NSApp.activate(ignoringOtherApps: true)
         }
+        windowController?.refreshPermissions()
     }
 
     func applicationDidBecomeActive(_ notification: Notification) {
@@ -2947,6 +2955,7 @@ private final class PermissionWindowController: NSWindowController {
     private var dragAssistantPermission: PermissionKind?
     private let initialPermission: PermissionKind?
     private let terminateWhenDragAssistantCloses: Bool
+    private var permissionStatusRefresh: PermissionStatusRefreshCoordinator?
 
     convenience init(initialPermission: PermissionKind? = nil, terminateWhenDragAssistantCloses: Bool = false) {
         let window = NSWindow(
@@ -2977,6 +2986,14 @@ private final class PermissionWindowController: NSWindowController {
         self.initialPermission = initialPermission
         self.terminateWhenDragAssistantCloses = terminateWhenDragAssistantCloses
         super.init(window: window)
+        permissionStatusRefresh = PermissionStatusRefreshCoordinator(
+            probe: permissionStatusSnapshotSettled,
+            handler: { [weak self] snapshot in
+                Task { @MainActor in
+                    self?.applyPermissionStatus(snapshot)
+                }
+            }
+        )
     }
 
     required init?(coder: NSCoder) {
@@ -3033,21 +3050,25 @@ private final class PermissionWindowController: NSWindowController {
     }
 
     func refreshPermissions() {
-        if let initialPermission, initialPermission.isGranted {
+        permissionStatusRefresh?.refresh()
+    }
+
+    private func applyPermissionStatus(_ snapshot: PermissionStatusSnapshot) {
+        if let initialPermission, initialPermission.isGranted(in: snapshot) {
             // Why: targeted permission helpers should finish once the requested
             // grant lands, even if other Computer Use permissions remain unset.
             completeDragAssistant()
             return
         }
-        if dragAssistantPermission?.isGranted == true {
+        if dragAssistantPermission?.isGranted(in: snapshot) == true {
             // Why: after one grant in full setup, the remaining missing permission
             // needs fresh guidance instead of the old assistant's instructions.
             closeDragAssistant()
         }
-        if PermissionKind.allCases.allSatisfy(\.isGranted) {
+        if PermissionKind.allCases.allSatisfy({ $0.isGranted(in: snapshot) }) {
             closeDragAssistant()
         }
-        (window?.contentView as? PermissionView)?.refreshPermissions()
+        (window?.contentView as? PermissionView)?.refreshPermissions(snapshot)
     }
 }
 
@@ -3102,12 +3123,12 @@ private enum PermissionKind: CaseIterable {
         }
     }
 
-    var isGranted: Bool {
+    func isGranted(in snapshot: PermissionStatusSnapshot) -> Bool {
         switch self {
         case .accessibility:
-            accessibilityTrustedSettled()
+            snapshot.accessibilityGranted
         case .screenshots:
-            screenCaptureTrustedSettled()
+            snapshot.screenshotsGranted
         }
     }
 
@@ -3128,6 +3149,7 @@ private final class PermissionView: NSView {
     private let close: () -> Void
     private var contentStack: NSStackView?
     private var contentConstraints: [NSLayoutConstraint] = []
+    private var permissionStatus: PermissionStatusSnapshot?
 
     init(frame frameRect: NSRect, showDragAssistant: @escaping (PermissionKind) -> Void, close: @escaping () -> Void) {
         self.showDragAssistant = showDragAssistant
@@ -3164,12 +3186,22 @@ private final class PermissionView: NSView {
             icon.heightAnchor.constraint(equalToConstant: 58)
         ])
 
-        let missingPermissions = PermissionKind.allCases.filter { !$0.isGranted }
-        let ready = missingPermissions.isEmpty
+        let missingPermissions = permissionStatus.map { snapshot in
+            PermissionKind.allCases.filter { !$0.isGranted(in: snapshot) }
+        } ?? []
+        let checking = permissionStatus == nil
+        let ready = !checking && missingPermissions.isEmpty
 
-        let title = label(ready ? "Computer Use is Ready" : "Enable Orca Computer Use", size: 22, weight: .bold)
+        let titleText = checking
+            ? "Checking Computer Use"
+            : (ready ? "Computer Use is Ready" : "Enable Orca Computer Use")
+        let title = label(titleText, size: 22, weight: .bold)
         let subtitle = label(
-            ready ? "Orca can use local apps when you ask." : "Grant permissions so Orca can use apps when you ask.",
+            checking
+                ? "Checking Accessibility and Screenshots."
+                : (ready
+                    ? "Orca can use local apps when you ask."
+                    : "Grant permissions so Orca can use apps when you ask."),
             size: 12,
             weight: .regular
         )
@@ -3186,7 +3218,16 @@ private final class PermissionView: NSView {
         header.widthAnchor.constraint(equalTo: stack.widthAnchor).isActive = true
         subtitle.widthAnchor.constraint(equalTo: stack.widthAnchor, constant: -10).isActive = true
 
-        if ready {
+        if checking {
+            let progress = NSProgressIndicator()
+            progress.style = .spinning
+            progress.controlSize = .small
+            progress.translatesAutoresizingMaskIntoConstraints = false
+            progress.startAnimation(nil)
+            stack.addArrangedSubview(progress)
+            progress.setContentHuggingPriority(.required, for: .horizontal)
+            progress.centerXAnchor.constraint(equalTo: stack.centerXAnchor).isActive = true
+        } else if ready {
             stack.addArrangedSubview(doneButton())
         } else {
             for permission in missingPermissions {
@@ -3206,8 +3247,9 @@ private final class PermissionView: NSView {
         NSLayoutConstraint.activate(contentConstraints)
     }
 
-    func refreshPermissions() {
-        // Why: TCC grants can change in System Settings while this window stays open.
+    func refreshPermissions(_ snapshot: PermissionStatusSnapshot) {
+        guard permissionStatus != snapshot else { return }
+        permissionStatus = snapshot
         build()
     }
 
@@ -4096,14 +4138,16 @@ private func runPermissionCheck(initialPermission: PermissionKind? = nil) {
 }
 
 private func printPermissionStatus() {
-    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
-    let screenshots = screenCaptureTrustedSettled() ? "granted" : "not-granted"
+    let snapshot = permissionStatusSnapshotSettled()
+    let accessibility = snapshot.accessibilityGranted ? "granted" : "not-granted"
+    let screenshots = snapshot.screenshotsGranted ? "granted" : "not-granted"
     print(#"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#)
 }
 
 private func writePermissionStatus(to path: String) {
-    let accessibility = accessibilityTrustedSettled() ? "granted" : "not-granted"
-    let screenshots = screenCaptureTrustedSettled() ? "granted" : "not-granted"
+    let snapshot = permissionStatusSnapshotSettled()
+    let accessibility = snapshot.accessibilityGranted ? "granted" : "not-granted"
+    let screenshots = snapshot.screenshotsGranted ? "granted" : "not-granted"
     let text = #"{"accessibility":"\#(accessibility)","screenshots":"\#(screenshots)"}"#
     do {
         try text.write(toFile: path, atomically: true, encoding: .utf8)

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/PermissionStatusSnapshot.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/PermissionStatusSnapshot.swift
@@ -1,0 +1,116 @@
+import Dispatch
+import Foundation
+
+public struct PermissionStatusSnapshot: Equatable, Sendable {
+    public let accessibilityGranted: Bool
+    public let screenshotsGranted: Bool
+
+    public init(accessibilityGranted: Bool, screenshotsGranted: Bool) {
+        self.accessibilityGranted = accessibilityGranted
+        self.screenshotsGranted = screenshotsGranted
+    }
+}
+
+public enum PermissionStatusSnapshotProbe {
+    public typealias Probe = @Sendable () -> Bool
+
+    private static let probeQueue = DispatchQueue(
+        label: "com.stablyai.orca.computer-use-permission-status",
+        attributes: .concurrent
+    )
+
+    public static func capture(
+        accessibilityProbe: @escaping Probe,
+        screenshotsProbe: @escaping Probe
+    ) -> PermissionStatusSnapshot {
+        let result = PermissionStatusSnapshotResult()
+        let group = DispatchGroup()
+
+        group.enter()
+        probeQueue.async {
+            result.recordAccessibility(accessibilityProbe())
+            group.leave()
+        }
+        group.enter()
+        probeQueue.async {
+            result.recordScreenshots(screenshotsProbe())
+            group.leave()
+        }
+        group.wait()
+        return result.snapshot
+    }
+}
+
+public final class PermissionStatusRefreshCoordinator: @unchecked Sendable {
+    public typealias SnapshotProbe = @Sendable () -> PermissionStatusSnapshot
+    public typealias SnapshotHandler = @Sendable (PermissionStatusSnapshot) -> Void
+
+    private let callbackQueue: DispatchQueue
+    private let handler: SnapshotHandler
+    private let probe: SnapshotProbe
+    private let stateLock = NSLock()
+    private let workerQueue: DispatchQueue
+    private var refreshInFlight = false
+
+    public init(
+        workerQueue: DispatchQueue = DispatchQueue(
+            label: "com.stablyai.orca.computer-use-permission-refresh",
+            qos: .userInitiated
+        ),
+        callbackQueue: DispatchQueue = .main,
+        probe: @escaping SnapshotProbe,
+        handler: @escaping SnapshotHandler
+    ) {
+        self.workerQueue = workerQueue
+        self.callbackQueue = callbackQueue
+        self.probe = probe
+        self.handler = handler
+    }
+
+    public func refresh() {
+        stateLock.lock()
+        guard !refreshInFlight else {
+            stateLock.unlock()
+            return
+        }
+        refreshInFlight = true
+        stateLock.unlock()
+
+        workerQueue.async { [self] in
+            let snapshot = probe()
+            callbackQueue.async { [self] in
+                stateLock.lock()
+                refreshInFlight = false
+                stateLock.unlock()
+                handler(snapshot)
+            }
+        }
+    }
+}
+
+private final class PermissionStatusSnapshotResult: @unchecked Sendable {
+    private let lock = NSLock()
+    private var accessibilityGranted = false
+    private var screenshotsGranted = false
+
+    var snapshot: PermissionStatusSnapshot {
+        lock.lock()
+        defer { lock.unlock() }
+        return PermissionStatusSnapshot(
+            accessibilityGranted: accessibilityGranted,
+            screenshotsGranted: screenshotsGranted
+        )
+    }
+
+    func recordAccessibility(_ granted: Bool) {
+        lock.lock()
+        accessibilityGranted = granted
+        lock.unlock()
+    }
+
+    func recordScreenshots(_ granted: Bool) {
+        lock.lock()
+        screenshotsGranted = granted
+        lock.unlock()
+    }
+}

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/PermissionTrustSettling.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/PermissionTrustSettling.swift
@@ -1,0 +1,73 @@
+import Foundation
+
+public enum PermissionTrustSettling {
+    public struct Outcome: Equatable {
+        public let settled: Bool
+        public let attempts: Int
+        public let waitedMs: Int
+
+        public init(settled: Bool, attempts: Int, waitedMs: Int) {
+            self.settled = settled
+            self.attempts = attempts
+            self.waitedMs = waitedMs
+        }
+    }
+
+    public static let defaultTimeoutMs = 1_500
+    public static let defaultIntervalMs = 100
+
+    public static func settle(
+        timeoutMs: Int = defaultTimeoutMs,
+        intervalMs: Int = defaultIntervalMs,
+        sleepMs: (Int) -> Void = { interval in
+            Thread.sleep(forTimeInterval: TimeInterval(interval) / 1_000)
+        },
+        probe: () -> Bool
+    ) -> Outcome {
+        precondition(timeoutMs >= 0, "timeoutMs must not be negative")
+        precondition(intervalMs > 0, "intervalMs must be positive")
+        var attempts = 0
+        var waitedMs = 0
+        while true {
+            attempts += 1
+            if probe() {
+                return Outcome(settled: true, attempts: attempts, waitedMs: waitedMs)
+            }
+            if waitedMs >= timeoutMs {
+                return Outcome(settled: false, attempts: attempts, waitedMs: waitedMs)
+            }
+            let interval = min(intervalMs, timeoutMs - waitedMs)
+            sleepMs(interval)
+            waitedMs += interval
+        }
+    }
+
+    public static func settleWithFallback(
+        initialTimeoutMs: Int = defaultTimeoutMs,
+        finalTimeoutMs: Int,
+        intervalMs: Int = defaultIntervalMs,
+        sleepMs: (Int) -> Void = { interval in
+            Thread.sleep(forTimeInterval: TimeInterval(interval) / 1_000)
+        },
+        probe: () -> Bool,
+        fallbackProbe: () -> Bool
+    ) -> Bool {
+        if settle(
+            timeoutMs: initialTimeoutMs,
+            intervalMs: intervalMs,
+            sleepMs: sleepMs,
+            probe: probe
+        ).settled {
+            return true
+        }
+        if fallbackProbe() {
+            return true
+        }
+        return settle(
+            timeoutMs: finalTimeoutMs,
+            intervalMs: intervalMs,
+            sleepMs: sleepMs,
+            probe: probe
+        ).settled
+    }
+}

--- a/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/ScreenCaptureProbeWindowSelection.swift
+++ b/native/computer-use-macos/Sources/OrcaComputerUseMacOSCore/ScreenCaptureProbeWindowSelection.swift
@@ -1,0 +1,22 @@
+public struct ScreenCaptureProbeWindow: Equatable {
+    public let layer: Int
+    public let ownerPid: Int32
+    public let windowId: UInt32
+
+    public init(layer: Int, ownerPid: Int32, windowId: UInt32) {
+        self.layer = layer
+        self.ownerPid = ownerPid
+        self.windowId = windowId
+    }
+}
+
+public enum ScreenCaptureProbeWindowSelection {
+    public static func firstCrossProcessNormalWindow(
+        ownPid: Int32,
+        windows: [ScreenCaptureProbeWindow]
+    ) -> UInt32? {
+        windows.first { window in
+            window.layer == 0 && window.ownerPid != ownPid
+        }?.windowId
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/PermissionStatusSnapshotTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/PermissionStatusSnapshotTests.swift
@@ -1,0 +1,126 @@
+import Dispatch
+@testable import OrcaComputerUseMacOSCore
+import XCTest
+
+final class PermissionStatusSnapshotTests: XCTestCase {
+    func testCapturesBothPermissionResults() {
+        let snapshot = PermissionStatusSnapshotProbe.capture(
+            accessibilityProbe: { true },
+            screenshotsProbe: { false }
+        )
+
+        XCTAssertEqual(
+            snapshot,
+            PermissionStatusSnapshot(accessibilityGranted: true, screenshotsGranted: false)
+        )
+    }
+
+    func testRunsPermissionProbesConcurrently() {
+        let accessibilityStarted = DispatchSemaphore(value: 0)
+        let screenshotsStarted = DispatchSemaphore(value: 0)
+        let releaseProbes = DispatchSemaphore(value: 0)
+        let finished = expectation(description: "permission snapshot")
+
+        DispatchQueue.global().async {
+            _ = PermissionStatusSnapshotProbe.capture(
+                accessibilityProbe: {
+                    accessibilityStarted.signal()
+                    releaseProbes.wait()
+                    return true
+                },
+                screenshotsProbe: {
+                    screenshotsStarted.signal()
+                    releaseProbes.wait()
+                    return true
+                }
+            )
+            finished.fulfill()
+        }
+
+        XCTAssertEqual(accessibilityStarted.wait(timeout: .now() + 1), .success)
+        XCTAssertEqual(screenshotsStarted.wait(timeout: .now() + 1), .success)
+        releaseProbes.signal()
+        releaseProbes.signal()
+        wait(for: [finished], timeout: 1)
+    }
+
+    func testCoalescesRefreshesWhileProbeIsRunning() {
+        let callbackQueue = DispatchQueue(label: "permission-status-test-callback")
+        let probeStarted = DispatchSemaphore(value: 0)
+        let releaseProbe = DispatchSemaphore(value: 0)
+        let handled = expectation(description: "snapshot handled")
+        let probeCount = LockedCounter()
+        let coordinator = PermissionStatusRefreshCoordinator(
+            callbackQueue: callbackQueue,
+            probe: {
+                probeCount.increment()
+                probeStarted.signal()
+                releaseProbe.wait()
+                return PermissionStatusSnapshot(
+                    accessibilityGranted: true,
+                    screenshotsGranted: true
+                )
+            },
+            handler: { _ in handled.fulfill() }
+        )
+
+        coordinator.refresh()
+        XCTAssertEqual(probeStarted.wait(timeout: .now() + 1), .success)
+        coordinator.refresh()
+        coordinator.refresh()
+        releaseProbe.signal()
+
+        wait(for: [handled], timeout: 1)
+        XCTAssertEqual(probeCount.value, 1)
+    }
+
+    func testAllowsRefreshAfterPreviousSnapshotWasHandled() {
+        let callbackQueue = DispatchQueue(label: "permission-status-test-callback")
+        let firstHandled = expectation(description: "first snapshot handled")
+        let secondHandled = expectation(description: "second snapshot handled")
+        let probeCount = LockedCounter()
+        let coordinator = PermissionStatusRefreshCoordinator(
+            callbackQueue: callbackQueue,
+            probe: {
+                let count = probeCount.increment()
+                return PermissionStatusSnapshot(
+                    accessibilityGranted: count == 2,
+                    screenshotsGranted: false
+                )
+            },
+            handler: { snapshot in
+                if snapshot.accessibilityGranted {
+                    secondHandled.fulfill()
+                } else {
+                    firstHandled.fulfill()
+                }
+            }
+        )
+
+        coordinator.refresh()
+        wait(for: [firstHandled], timeout: 1)
+        coordinator.refresh()
+
+        wait(for: [secondHandled], timeout: 1)
+        XCTAssertEqual(probeCount.value, 2)
+    }
+}
+
+private final class LockedCounter: @unchecked Sendable {
+    private let lock = NSLock()
+    private var count = 0
+
+    var value: Int {
+        lock.lock()
+        defer { lock.unlock() }
+        return count
+    }
+
+    @discardableResult
+    func increment() -> Int {
+        lock.lock()
+        defer { lock.unlock() }
+        count += 1
+        return count
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/PermissionTrustSettlingTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/PermissionTrustSettlingTests.swift
@@ -1,0 +1,59 @@
+import Testing
+@testable import OrcaComputerUseMacOSCore
+
+@Suite("PermissionTrustSettling")
+struct PermissionTrustSettlingTests {
+    @Test("already-trusted probe returns immediately")
+    func immediateSuccess() {
+        var sleeps: [Int] = []
+        let outcome = PermissionTrustSettling.settle(
+            sleepMs: { sleeps.append($0) },
+            probe: { true }
+        )
+
+        #expect(outcome == .init(settled: true, attempts: 1, waitedMs: 0))
+        #expect(sleeps.isEmpty)
+    }
+
+    @Test("transient denial settles after retries")
+    func lateGrant() {
+        var calls = 0
+        var sleeps: [Int] = []
+        let outcome = PermissionTrustSettling.settle(
+            sleepMs: { sleeps.append($0) },
+            probe: {
+                calls += 1
+                return calls >= 4
+            }
+        )
+
+        #expect(outcome == .init(settled: true, attempts: 4, waitedMs: 300))
+        #expect(sleeps == [100, 100, 100])
+    }
+
+    @Test("persistent denial stops at the timeout")
+    func neverGranted() {
+        let outcome = PermissionTrustSettling.settle(
+            timeoutMs: 1_000,
+            intervalMs: 300,
+            sleepMs: { _ in },
+            probe: { false }
+        )
+
+        #expect(outcome == .init(settled: false, attempts: 5, waitedMs: 1_000))
+    }
+
+    @Test("final interval is clamped to the timeout")
+    func clampsFinalInterval() {
+        var sleeps: [Int] = []
+        let outcome = PermissionTrustSettling.settle(
+            timeoutMs: 250,
+            intervalMs: 100,
+            sleepMs: { sleeps.append($0) },
+            probe: { false }
+        )
+
+        #expect(sleeps == [100, 100, 50])
+        #expect(outcome == .init(settled: false, attempts: 4, waitedMs: 250))
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/ScreenCapturePermissionSettlingTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/ScreenCapturePermissionSettlingTests.swift
@@ -1,0 +1,79 @@
+import Testing
+@testable import OrcaComputerUseMacOSCore
+
+@Suite("Screen Capture permission settling")
+struct ScreenCapturePermissionSettlingTests {
+    @Test("initial preflight success skips fallback")
+    func initialSuccess() {
+        var fallbackCalls = 0
+        let trusted = PermissionTrustSettling.settleWithFallback(
+            finalTimeoutMs: 500,
+            sleepMs: { _ in },
+            probe: { true },
+            fallbackProbe: {
+                fallbackCalls += 1
+                return true
+            }
+        )
+
+        #expect(trusted)
+        #expect(fallbackCalls == 0)
+    }
+
+    @Test("capture fallback can establish trust")
+    func fallbackSuccess() {
+        var fallbackCalls = 0
+        let trusted = PermissionTrustSettling.settleWithFallback(
+            initialTimeoutMs: 200,
+            finalTimeoutMs: 200,
+            intervalMs: 100,
+            sleepMs: { _ in },
+            probe: { false },
+            fallbackProbe: {
+                fallbackCalls += 1
+                return true
+            }
+        )
+
+        #expect(trusted)
+        #expect(fallbackCalls == 1)
+    }
+
+    @Test("preflight is retried after fallback failure")
+    func finalPreflightSuccess() {
+        var probeCalls = 0
+        let trusted = PermissionTrustSettling.settleWithFallback(
+            initialTimeoutMs: 100,
+            finalTimeoutMs: 200,
+            intervalMs: 100,
+            sleepMs: { _ in },
+            probe: {
+                probeCalls += 1
+                return probeCalls == 4
+            },
+            fallbackProbe: { false }
+        )
+
+        #expect(trusted)
+        #expect(probeCalls == 4)
+    }
+
+    @Test("persistent denial remains denied")
+    func persistentDenial() {
+        var fallbackCalls = 0
+        let trusted = PermissionTrustSettling.settleWithFallback(
+            initialTimeoutMs: 100,
+            finalTimeoutMs: 100,
+            intervalMs: 100,
+            sleepMs: { _ in },
+            probe: { false },
+            fallbackProbe: {
+                fallbackCalls += 1
+                return false
+            }
+        )
+
+        #expect(!trusted)
+        #expect(fallbackCalls == 1)
+    }
+}

--- a/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/ScreenCaptureProbeWindowSelectionTests.swift
+++ b/native/computer-use-macos/Tests/OrcaComputerUseMacOSTests/ScreenCaptureProbeWindowSelectionTests.swift
@@ -1,0 +1,44 @@
+import Testing
+@testable import OrcaComputerUseMacOSCore
+
+@Suite("Screen capture probe window selection")
+struct ScreenCaptureProbeWindowSelectionTests {
+    @Test("own process windows cannot prove cross-app capture permission")
+    func excludesOwnWindows() {
+        let selected = ScreenCaptureProbeWindowSelection.firstCrossProcessNormalWindow(
+            ownPid: 42,
+            windows: [
+                .init(layer: 0, ownerPid: 42, windowId: 1),
+                .init(layer: 0, ownerPid: 84, windowId: 2)
+            ]
+        )
+
+        #expect(selected == 2)
+    }
+
+    @Test("non-normal windows are skipped")
+    func excludesNonNormalWindows() {
+        let selected = ScreenCaptureProbeWindowSelection.firstCrossProcessNormalWindow(
+            ownPid: 42,
+            windows: [
+                .init(layer: 1, ownerPid: 84, windowId: 1),
+                .init(layer: 0, ownerPid: 84, windowId: 2)
+            ]
+        )
+
+        #expect(selected == 2)
+    }
+
+    @Test("no cross-process normal window returns nil")
+    func noCandidate() {
+        let selected = ScreenCaptureProbeWindowSelection.firstCrossProcessNormalWindow(
+            ownPid: 42,
+            windows: [
+                .init(layer: 0, ownerPid: 42, windowId: 1),
+                .init(layer: 1, ownerPid: 84, windowId: 2)
+            ]
+        )
+
+        #expect(selected == nil)
+    }
+}


### PR DESCRIPTION
## Summary

- Retry fresh-process Accessibility and Screen Recording trust checks while macOS TCC settles, preventing already-granted permissions from appearing denied.
- Apply settled trust to permission status, setup UI, snapshot gates, and delayed AX window availability.
- Warm Screen Recording trust with one cross-process capture probe, excluding Orca-owned windows so self-capture cannot produce a false grant.
- Probe Accessibility and Screen Recording concurrently, and coalesce setup-window refreshes on a background queue so AppKit never waits on the bounded retry loops.
- Show an immediate, honest checking state before rendering the settled permission result.

Fixes #9458.
Supersedes the combined intent of #10122 and #10373 while addressing the unresolved review findings on #10373.

## Visual proof

The helper now renders while permission probes are still settling:

![Pending permission check](https://github.com/user-attachments/assets/2b665e1d-d014-42f0-a1f6-ec899e141c28)

It then renders the settled missing-permission state:

![Settled permission result](https://github.com/user-attachments/assets/299d63df-ee0e-4fe2-9834-4c6b91b01430)

Both screenshots use a temporary ad-hoc-signed helper with a unique bundle ID, giving it a deterministic ungranted TCC identity without resetting the developer's real Orca permissions.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full repository suite not run locally; the complete native provider suite ran through `pnpm verify:computer-native`
- [ ] `pnpm build` — full application build not run; `pnpm build:computer-macos` built and signed the universal helper successfully
- [x] `pnpm verify:computer-native`
- [x] 71 XCTest cases and 11 Swift Testing cases pass
- [x] Added deterministic regression tests for immediate grants, transient denials, bounded persistent denials, Screen Recording fallback ordering, cross-process capture selection, concurrent permission snapshots, refresh coalescing, and later refreshes
- [x] Repeated the four new concurrency/coalescing tests 20 times without a failure
- [x] Earlier grant-path stress reproduction: 100 concurrent helper executions returned both permissions granted in all 100 results
- [x] Live ungranted helper status completed in 2.35 seconds, versus the previous ~3.5-second sequential ceiling
- [x] Live pending UI was accessible and captured 0.95 seconds after launch while both permission checks were still settling
- [x] A one-second process sample showed the main thread in the `NSApplication` event loop while both retry sleeps ran on the new permission-status queues

## AI Review Report

Reviewed the fresh-process TCC lifecycle, status/setup/runtime call sites, bounded wait behavior, genuine-denial path, refresh cadence, and Screen Recording fallback. The older Screen Recording PR could accept an Orca-owned window as proof of cross-app capture permission and did not test its fallback flow; this version excludes the current PID and adds direct fallback and selection tests. It also uses overflow-safe `Thread.sleep` instead of multiplying an unbounded interval for `usleep`.

The setup assistant can request a permission refresh every 350 ms while System Settings is visible. Those requests now coalesce behind one worker snapshot, preventing probe accumulation and repeated UI rebuilds. All window decisions consume the completed snapshot instead of calling TCC synchronously.

Cross-platform compatibility was checked explicitly. The implementation is confined to the macOS Swift provider and changes no shortcuts, paths, shell behavior, Electron IPC, remote wire formats, Linux behavior, or Windows behavior.

## Security Audit

No new external input, command execution, dependency, authentication, secret, path, or IPC surface is introduced. Retry loops remain bounded and the already-granted path performs no sleep. The capture fallback selects one normal window owned by another process, checks only whether CoreGraphics returns an image, and does not serialize, retain, or publish its pixels. Orca-owned windows are excluded to prevent a false-positive permission result.

Permission results cross only in-process Swift queues as a two-boolean `Sendable` snapshot. A lock protects concurrent result writes, and the UI handler returns to the main actor before touching AppKit.

## Notes

- macOS can answer a freshly launched helper with `preflight_unknown` / `do_not_cache` before the stable TCC grant becomes visible in that PID.
- A genuine denial can still add up to 1.5 seconds for Accessibility or 2 seconds for Screen Recording, but those checks now overlap. The setup window remains responsive and the CLI status ceiling is roughly 2 seconds instead of 3.5 seconds, excluding process launch overhead.
- Runtime requests that need only one permission retain their existing bounded settling behavior.
- The local helper is ad-hoc signed because this machine has no release signing identity. Universal build and signature verification passed; deterministic tests cover the transient TCC sequence independently of local signing identity.
