### PR TITLE
feat(worktree): configure creation stage timeouts

### DIFF
--- a/.github/fork-maintenance-plan.md
+++ b/.github/fork-maintenance-plan.md
@@ -110,7 +110,11 @@ The preview must pass:
 - typecheck
 - unit tests
 - desktop build
-- cross-version wire compatibility
+- cross-version wire compatibility against the latest stable tag fetched
+  read-only from the official upstream repository
+
+Unit-test jobs restore disabled workflow files from the pinned upstream target
+only as read-only fixtures; preview and production refs retain the allowlist.
 
 The first rollout must also demonstrate a no-op repeat, a clean automatic
 promotion, a source-ref lease rejection, and a conflict that leaves production

--- a/.github/fork-maintenance-plan.md
+++ b/.github/fork-maintenance-plan.md
@@ -1,0 +1,117 @@
+# Fork maintenance plan
+
+## Goal
+
+Maintain the production fork as a linear patch stack:
+
+```text
+fork = safe-upstream-anchor + fork-only commits
+safe-upstream-anchor^ = adopted upstream main SHA
+```
+
+Clean upstream updates promote automatically after validation. Conflicts, failed
+checks, or stale source refs leave the production refs unchanged.
+
+## Branches
+
+- `upstream-main` is a generated safe-anchor commit. Its single parent is the
+  exact adopted upstream commit, while its tree restores the trusted
+  maintenance files and workflow allowlist.
+- `fork` is the production source branch and contains only `upstream-main`
+  followed by fork-only commits and at most one generated maintenance-snapshot
+  commit.
+- `sync/upstream-main` is the single generated preview branch for the newest
+  attempted upstream target.
+
+The maintenance workflow must reject merge commits in
+`upstream-main..fork`. Upstream history is never merged into `fork`; fork-only
+commits are replayed in order onto a pinned upstream commit.
+
+## Synchronization
+
+1. Serialize all maintenance runs in one non-cancelling concurrency group.
+2. Fetch and pin the current `upstream-main`, `fork`, and upstream `main` SHAs.
+3. Verify that `upstream-main` is an ancestor of `fork` and that the fork patch
+   stack contains no merge commits.
+4. Create a safe anchor whose parent is the pinned upstream target and whose
+   maintenance files match production.
+5. Replay `upstream-main..fork` onto that safe anchor with baseline-compatible
+   `cherry-pick`, explicitly skipping commits that become empty.
+6. Restore all maintenance files exactly from production before publishing.
+   This prevents upstream workflow or maintenance-script changes from running
+   on maintenance refs.
+7. Publish `sync/upstream-main` with the preview SHA observed during the initial
+   fetch as its exact force-with-lease constraint. The preview is not opened as
+   a pull request because a same-repository PR is not a trust boundary.
+8. Run fork validation against the exact preview SHA without write credentials.
+9. Re-fetch all maintenance refs and promote only if every pinned source ref
+   and the preview head still match.
+10. Atomically update `fork` to the validated preview and `upstream-main` to the
+    safe anchor with exact force-with-lease constraints.
+
+The upstream repository may advance while validation runs. That does not make a
+pinned target stale; a later maintenance run adopts the newer upstream commit.
+
+## Failure handling
+
+- A replay conflict publishes the last clean replay state and records the
+  failed commit and conflicted paths in the workflow summary.
+- A validation failure leaves `fork` and `upstream-main` unchanged.
+- Any source-ref or preview-head drift rejects promotion.
+- Re-running the workflow replaces the single preview branch only when its
+  current head matches the fetched lease.
+
+Conflict resolution remains manual. Automated conflict-resolution agents are
+outside this phase.
+
+## Workflow policy
+
+Only these workflows remain enabled in the fork:
+
+- `fork-sync.yml`
+- `pr.yml`
+- `mobile.yml`
+- `e2e.yml`
+
+The maintenance workflow enforces this repository-level allowlist after every
+run. Newly inherited upstream workflows therefore default to disabled instead
+of gaining scheduled, push, release, or privileged triggers in the fork.
+The generated preview also carries the production workflow snapshot, so policy
+enforcement is defense in depth rather than a post-push security boundary.
+
+## Credentials
+
+Git ref publication uses one repository-scoped write deploy key stored as
+`FORK_MAINTENANCE_SSH_KEY`. The key is injected only into each write job's final
+push step, after all repository content has run, and cannot call GitHub APIs,
+manage Actions, or access another repository. Validation jobs never receive it.
+Workflow policy uses the per-job `GITHUB_TOKEN` with only `actions: write`.
+
+## Bootstrap order
+
+1. Commit and locally validate the maintenance implementation.
+2. Disable all workflows outside the allowlist while `main` is still the
+   default branch.
+3. Create `upstream-main` as a safe anchor over the current upstream boundary
+   and create `fork` from the maintained patch stack after restoring trusted
+   maintenance files.
+4. Install the repository-scoped write deploy key and its private-key secret.
+5. Change the default branch to `fork`.
+6. Verify the allowlist state, then dispatch one pinned maintenance run.
+7. Verify conflict preservation or clean automatic promotion before relying on
+   the hourly schedule.
+
+## Phase-one validation
+
+The preview must pass:
+
+- fork-maintenance invariant and workflow contract tests
+- lint
+- typecheck
+- unit tests
+- desktop build
+- cross-version wire compatibility
+
+The first rollout must also demonstrate a no-op repeat, a clean automatic
+promotion, a source-ref lease rejection, and a conflict that leaves production
+refs unchanged.

--- a/.github/scripts/fork-maintenance-state.mjs
+++ b/.github/scripts/fork-maintenance-state.mjs
@@ -1,0 +1,177 @@
+import { execFileSync, spawnSync } from 'node:child_process'
+import process from 'node:process'
+import { pathToFileURL } from 'node:url'
+
+const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/
+const GIT_BINARY = process.env.ORCA_FORK_MAINTENANCE_GIT_BINARY || 'git'
+const GENERATED_ANCHOR_TRAILER = 'Fork-Maintenance-Generated: upstream-anchor-v1'
+const GENERATED_SNAPSHOT_TRAILER = 'Fork-Maintenance-Generated: maintenance-snapshot-v1'
+const MAINTENANCE_PATHS = [
+  '.github/fork-maintenance-plan.md',
+  '.github/scripts/fork-maintenance-state.mjs',
+  '.github/scripts/fork-maintenance-state.test.mjs',
+  '.github/scripts/fork-maintenance-workflow.test.mjs',
+  '.github/workflows/',
+  'config/vitest.config.ts'
+]
+
+function git(args, cwd = process.cwd()) {
+  return execFileSync(GIT_BINARY, args, {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  }).trim()
+}
+
+function isAncestor(ancestor, descendant, cwd = process.cwd()) {
+  const result = spawnSync(GIT_BINARY, ['merge-base', '--is-ancestor', ancestor, descendant], {
+    cwd,
+    encoding: 'utf8',
+    stdio: ['ignore', 'pipe', 'pipe']
+  })
+  if (result.status === 0) {
+    return true
+  }
+  if (result.status === 1) {
+    return false
+  }
+  throw new Error(result.stderr.trim() || `git merge-base exited ${result.status}`)
+}
+
+function lines(value) {
+  return value ? value.split('\n').filter(Boolean) : []
+}
+
+function commitHasTrailer(commitSha, trailer, cwd) {
+  return lines(git(['log', '-1', '--format=%B', commitSha], cwd)).includes(trailer)
+}
+
+function isMaintenancePath(path) {
+  return MAINTENANCE_PATHS.some((allowedPath) =>
+    allowedPath.endsWith('/') ? path.startsWith(allowedPath) : path === allowedPath
+  )
+}
+
+function assertGeneratedMaintenanceCommit(commitSha, cwd) {
+  const changedPaths = lines(
+    git(['diff-tree', '--no-commit-id', '--name-only', '-r', `${commitSha}^`, commitSha], cwd)
+  )
+  if (changedPaths.some((path) => !isMaintenancePath(path))) {
+    throw new Error(`generated maintenance commit ${commitSha} changes a non-maintenance path`)
+  }
+}
+
+function requireGeneratedAnchor(anchorSha, cwd) {
+  if (!commitHasTrailer(anchorSha, GENERATED_ANCHOR_TRAILER, cwd)) {
+    throw new Error('upstream anchor is not a generated maintenance anchor')
+  }
+  const [commitSha, ...parents] = git(['rev-list', '--parents', '-n', '1', anchorSha], cwd).split(
+    ' '
+  )
+  if (commitSha !== anchorSha || parents.length !== 1) {
+    throw new Error('generated upstream anchor must have exactly one upstream parent')
+  }
+  assertGeneratedMaintenanceCommit(anchorSha, cwd)
+  return requireCommitSha(parents[0], 'upstreamSha')
+}
+
+function requireCommitSha(value, field) {
+  if (!COMMIT_SHA_PATTERN.test(value)) {
+    throw new Error(`${field} must be a lowercase 40-character commit SHA`)
+  }
+  return value
+}
+
+export function inspectForkPatchStack({ anchorRef, forkRef, targetRef, cwd = process.cwd() }) {
+  const anchorSha = requireCommitSha(git(['rev-parse', `${anchorRef}^{commit}`], cwd), 'anchorSha')
+  const forkSha = requireCommitSha(git(['rev-parse', `${forkRef}^{commit}`], cwd), 'forkSha')
+  const targetSha = requireCommitSha(git(['rev-parse', `${targetRef}^{commit}`], cwd), 'targetSha')
+  const upstreamSha = requireGeneratedAnchor(anchorSha, cwd)
+
+  if (!isAncestor(anchorSha, forkSha, cwd)) {
+    throw new Error(`${anchorRef} is not an ancestor of ${forkRef}`)
+  }
+  if (!isAncestor(upstreamSha, targetSha, cwd)) {
+    throw new Error(`${targetRef} is not a fast-forward of the anchored upstream commit`)
+  }
+
+  const mergeCommits = lines(git(['rev-list', '--merges', `${anchorSha}..${forkSha}`], cwd))
+  if (mergeCommits.length > 0) {
+    throw new Error(`fork patch stack contains merge commits: ${mergeCommits.join(', ')}`)
+  }
+
+  const rangeCommits = lines(git(['rev-list', '--reverse', `${anchorSha}..${forkSha}`], cwd))
+  const generatedWorkflowSnapshots = rangeCommits.filter((commitSha) =>
+    commitHasTrailer(commitSha, GENERATED_SNAPSHOT_TRAILER, cwd)
+  )
+  if (generatedWorkflowSnapshots.length > 1) {
+    throw new Error('fork patch stack contains multiple generated maintenance snapshots')
+  }
+  if (
+    generatedWorkflowSnapshots.length === 1 &&
+    generatedWorkflowSnapshots[0] !== rangeCommits.at(-1)
+  ) {
+    throw new Error('generated maintenance snapshot must be the final fork commit')
+  }
+  for (const commitSha of generatedWorkflowSnapshots) {
+    assertGeneratedMaintenanceCommit(commitSha, cwd)
+  }
+
+  const patchCommits = rangeCommits.filter(
+    (commitSha) => !generatedWorkflowSnapshots.includes(commitSha)
+  )
+  return {
+    version: 1,
+    anchorSha,
+    upstreamSha,
+    forkSha,
+    targetSha,
+    patchCommits,
+    patchCount: patchCommits.length,
+    generatedMaintenanceSnapshotSha: generatedWorkflowSnapshots[0] ?? null
+  }
+}
+
+function parseArguments(argv) {
+  const [command, ...rawOptions] = argv
+  const options = {}
+  for (const rawOption of rawOptions) {
+    const separator = rawOption.indexOf('=')
+    if (!rawOption.startsWith('--') || separator === -1) {
+      throw new Error(`invalid option: ${rawOption}`)
+    }
+    options[rawOption.slice(2, separator)] = rawOption.slice(separator + 1)
+  }
+  return { command, options }
+}
+
+function requiredOption(options, name) {
+  const value = options[name]
+  if (!value) {
+    throw new Error(`missing --${name}`)
+  }
+  return value
+}
+
+function runCli(argv) {
+  const { command, options } = parseArguments(argv)
+  if (command === 'inspect') {
+    const result = inspectForkPatchStack({
+      anchorRef: requiredOption(options, 'anchor'),
+      forkRef: requiredOption(options, 'fork'),
+      targetRef: requiredOption(options, 'target')
+    })
+    console.log(JSON.stringify(result))
+    return
+  }
+  throw new Error('usage: fork-maintenance-state.mjs inspect [options]')
+}
+
+if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+  try {
+    runCli(process.argv.slice(2))
+  } catch (error) {
+    console.error(error instanceof Error ? error.message : String(error))
+    process.exitCode = 1
+  }
+}

--- a/.github/scripts/fork-maintenance-state.mjs
+++ b/.github/scripts/fork-maintenance-state.mjs
@@ -1,6 +1,7 @@
 import { execFileSync, spawnSync } from 'node:child_process'
+import { realpathSync } from 'node:fs'
 import process from 'node:process'
-import { pathToFileURL } from 'node:url'
+import { fileURLToPath } from 'node:url'
 
 const COMMIT_SHA_PATTERN = /^[0-9a-f]{40}$/
 const GIT_BINARY = process.env.ORCA_FORK_MAINTENANCE_GIT_BINARY || 'git'
@@ -167,7 +168,14 @@ function runCli(argv) {
   throw new Error('usage: fork-maintenance-state.mjs inspect [options]')
 }
 
-if (import.meta.url === pathToFileURL(process.argv[1]).href) {
+export function isDirectExecution(moduleUrl, executablePath) {
+  return (
+    Boolean(executablePath) &&
+    realpathSync(fileURLToPath(moduleUrl)) === realpathSync(executablePath)
+  )
+}
+
+if (isDirectExecution(import.meta.url, process.argv[1])) {
   try {
     runCli(process.argv.slice(2))
   } catch (error) {

--- a/.github/scripts/fork-maintenance-state.test.mjs
+++ b/.github/scripts/fork-maintenance-state.test.mjs
@@ -1,0 +1,234 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+import { inspectForkPatchStack } from './fork-maintenance-state.mjs'
+
+function git(root, ...args) {
+  const gitBinary = process.env.ORCA_FORK_MAINTENANCE_GIT_BINARY || 'git'
+  return execFileSync(gitBinary, ['-c', 'commit.gpgsign=false', ...args], {
+    cwd: root,
+    encoding: 'utf8',
+    env: {
+      ...process.env,
+      GIT_AUTHOR_NAME: 'Fork Maintainer',
+      GIT_AUTHOR_EMAIL: 'fork@example.test',
+      GIT_COMMITTER_NAME: 'Fork Maintainer',
+      GIT_COMMITTER_EMAIL: 'fork@example.test'
+    }
+  }).trim()
+}
+
+function createRepository() {
+  const root = mkdtempSync(join(tmpdir(), 'orca-fork-maintenance-'))
+  git(root, 'init')
+  git(root, 'checkout', '-b', 'main')
+  git(root, 'config', 'core.hooksPath', join(root, 'disabled-hooks'))
+  writeFileSync(join(root, 'base.txt'), 'base\n')
+  git(root, 'add', 'base.txt')
+  git(root, 'commit', '-m', 'base')
+  git(
+    root,
+    'commit',
+    '--allow-empty',
+    '-m',
+    'generated anchor',
+    '-m',
+    'Fork-Maintenance-Generated: upstream-anchor-v1'
+  )
+  git(root, 'branch', 'anchor')
+  return root
+}
+
+function appendCommit(root, file, value, subject) {
+  mkdirSync(join(root, file, '..'), { recursive: true })
+  writeFileSync(join(root, file), value)
+  git(root, 'add', file)
+  git(root, 'commit', '-m', subject)
+  return git(root, 'rev-parse', 'HEAD')
+}
+
+describe('inspectForkPatchStack', () => {
+  it('returns an ordered linear patch stack and accepts a fast-forward target', () => {
+    const root = createRepository()
+    git(root, 'switch', '-c', 'fork')
+    const first = appendCommit(root, 'one.txt', 'one\n', 'one')
+    const second = appendCommit(root, 'two.txt', 'two\n', 'two')
+    git(root, 'switch', 'main')
+    appendCommit(root, 'upstream.txt', 'upstream\n', 'upstream')
+
+    expect(
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: root
+      })
+    ).toMatchObject({
+      version: 1,
+      patchCommits: [first, second],
+      patchCount: 2
+    })
+  })
+
+  it('excludes one generated maintenance snapshot from the replay stack', () => {
+    const root = createRepository()
+    git(root, 'switch', '-c', 'fork')
+    const patch = appendCommit(root, 'fork.txt', 'fork\n', 'fork')
+    appendCommit(
+      root,
+      '.github/workflows/fork-sync.yml',
+      'name: Fork Sync\n',
+      'chore(fork): restore maintenance snapshot\n\nFork-Maintenance-Generated: maintenance-snapshot-v1'
+    )
+
+    expect(
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: root
+      })
+    ).toMatchObject({
+      patchCommits: [patch],
+      patchCount: 1,
+      generatedMaintenanceSnapshotSha: expect.stringMatching(/^[0-9a-f]{40}$/)
+    })
+  })
+
+  it('rejects malformed or duplicate generated maintenance snapshots', () => {
+    const malformedRoot = createRepository()
+    git(malformedRoot, 'switch', '-c', 'fork')
+    writeFileSync(join(malformedRoot, 'fork.txt'), 'fork\n')
+    mkdirSync(join(malformedRoot, '.github/workflows'), { recursive: true })
+    writeFileSync(join(malformedRoot, '.github/workflows/fork-sync.yml'), 'name: Fork Sync\n')
+    git(malformedRoot, 'add', '.')
+    git(
+      malformedRoot,
+      'commit',
+      '-m',
+      'malformed snapshot',
+      '-m',
+      'Fork-Maintenance-Generated: maintenance-snapshot-v1'
+    )
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: malformedRoot
+      })
+    ).toThrow('changes a non-maintenance path')
+
+    const duplicateRoot = createRepository()
+    git(duplicateRoot, 'switch', '-c', 'fork')
+    appendCommit(
+      duplicateRoot,
+      '.github/workflows/fork-sync.yml',
+      'name: Fork Sync\n',
+      'first snapshot\n\nFork-Maintenance-Generated: maintenance-snapshot-v1'
+    )
+    appendCommit(
+      duplicateRoot,
+      '.github/workflows/pr.yml',
+      'name: PR Checks\n',
+      'second snapshot\n\nFork-Maintenance-Generated: maintenance-snapshot-v1'
+    )
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: duplicateRoot
+      })
+    ).toThrow('multiple generated maintenance snapshots')
+
+    const nonFinalRoot = createRepository()
+    git(nonFinalRoot, 'switch', '-c', 'fork')
+    appendCommit(
+      nonFinalRoot,
+      '.github/workflows/fork-sync.yml',
+      'name: Fork Sync\n',
+      'snapshot\n\nFork-Maintenance-Generated: maintenance-snapshot-v1'
+    )
+    appendCommit(nonFinalRoot, 'fork.txt', 'fork\n', 'later patch')
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: nonFinalRoot
+      })
+    ).toThrow('must be the final fork commit')
+  })
+
+  it('rejects a raw upstream commit as the anchor', () => {
+    const root = createRepository()
+    git(root, 'branch', '-f', 'anchor', 'anchor^')
+    git(root, 'switch', '-c', 'fork', 'anchor')
+    appendCommit(root, 'fork.txt', 'fork\n', 'fork')
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: root
+      })
+    ).toThrow('upstream anchor is not a generated maintenance anchor')
+  })
+
+  it('rejects an anchor that is not an ancestor of the fork', () => {
+    const root = createRepository()
+    git(root, 'switch', '--orphan', 'fork')
+    appendCommit(root, 'fork.txt', 'fork\n', 'fork')
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: root
+      })
+    ).toThrow('anchor is not an ancestor of fork')
+  })
+
+  it('rejects merge commits in the fork-only range', () => {
+    const root = createRepository()
+    git(root, 'switch', '-c', 'side', 'anchor')
+    appendCommit(root, 'side.txt', 'side\n', 'side')
+    git(root, 'switch', '-c', 'fork', 'anchor')
+    appendCommit(root, 'fork.txt', 'fork\n', 'fork')
+    git(root, 'merge', '--no-ff', 'side', '-m', 'merge side')
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'main',
+        cwd: root
+      })
+    ).toThrow('fork patch stack contains merge commits')
+  })
+
+  it('rejects a target that is not a fast-forward of the anchor', () => {
+    const root = createRepository()
+    git(root, 'switch', '-c', 'fork')
+    appendCommit(root, 'fork.txt', 'fork\n', 'fork')
+    git(root, 'switch', '--orphan', 'target')
+    appendCommit(root, 'target.txt', 'target\n', 'target')
+
+    expect(() =>
+      inspectForkPatchStack({
+        anchorRef: 'anchor',
+        forkRef: 'fork',
+        targetRef: 'target',
+        cwd: root
+      })
+    ).toThrow('target is not a fast-forward of the anchored upstream commit')
+  })
+})

--- a/.github/scripts/fork-maintenance-state.test.mjs
+++ b/.github/scripts/fork-maintenance-state.test.mjs
@@ -1,9 +1,10 @@
 import { execFileSync } from 'node:child_process'
-import { mkdirSync, mkdtempSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, symlinkSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { describe, expect, it } from 'vitest'
-import { inspectForkPatchStack } from './fork-maintenance-state.mjs'
+import { inspectForkPatchStack, isDirectExecution } from './fork-maintenance-state.mjs'
 
 function git(root, ...args) {
   const gitBinary = process.env.ORCA_FORK_MAINTENANCE_GIT_BINARY || 'git'
@@ -230,5 +231,17 @@ describe('inspectForkPatchStack', () => {
         cwd: root
       })
     ).toThrow('target is not a fast-forward of the anchored upstream commit')
+  })
+})
+
+describe('CLI entrypoint', () => {
+  it('recognizes executable paths reached through a symlink', () => {
+    const root = mkdtempSync(join(tmpdir(), 'orca-fork-maintenance-entrypoint-'))
+    const script = join(root, 'script.mjs')
+    const alias = join(root, 'script-alias.mjs')
+    writeFileSync(script, 'export {}\n')
+    symlinkSync(script, alias)
+
+    expect(isDirectExecution(pathToFileURL(script).href, alias)).toBe(true)
   })
 })

--- a/.github/scripts/fork-maintenance-workflow.test.mjs
+++ b/.github/scripts/fork-maintenance-workflow.test.mjs
@@ -3,7 +3,9 @@ import { parse } from 'yaml'
 import { describe, expect, it } from 'vitest'
 
 const workflowPath = new URL('../workflows/fork-sync.yml', import.meta.url)
+const vitestConfigPath = new URL('../../config/vitest.config.ts', import.meta.url)
 const workflowText = readFileSync(workflowPath, 'utf8')
+const vitestConfigText = readFileSync(vitestConfigPath, 'utf8')
 const workflow = parse(workflowText)
 const checkoutAction = 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803'
 
@@ -95,6 +97,10 @@ describe('fork sync workflow', () => {
     expect(fixtureStep?.run).toContain('if [ ! -e "${WORKFLOW_PATH}" ]; then')
     expect(fixtureStep?.run).toContain('git checkout FETCH_HEAD -- "${WORKFLOW_PATH}"')
     expect(JSON.stringify(testJob)).not.toContain('FORK_MAINTENANCE_SSH_KEY')
+  })
+
+  it('keeps upstream retention tests runnable in fork validation', () => {
+    expect(vitestConfigText).toContain("'--expose-gc'")
   })
 
   it('pins every checkout action to one reviewed commit', () => {

--- a/.github/scripts/fork-maintenance-workflow.test.mjs
+++ b/.github/scripts/fork-maintenance-workflow.test.mjs
@@ -1,0 +1,159 @@
+import { readFileSync } from 'node:fs'
+import { parse } from 'yaml'
+import { describe, expect, it } from 'vitest'
+
+const workflowPath = new URL('../workflows/fork-sync.yml', import.meta.url)
+const workflowText = readFileSync(workflowPath, 'utf8')
+const workflow = parse(workflowText)
+const checkoutAction = 'actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803'
+
+function job(name) {
+  const value = workflow.jobs?.[name]
+  if (!value) {
+    throw new Error(`Missing workflow job: ${name}`)
+  }
+  return value
+}
+
+describe('fork sync workflow', () => {
+  it('serializes maintenance without cancelling an in-flight promotion', () => {
+    expect(workflow.concurrency).toEqual({
+      group: 'fork-maintenance',
+      'cancel-in-progress': false
+    })
+  })
+
+  it('has no pull request or manual promotion path', () => {
+    expect(workflowText).not.toContain('pull_request')
+    expect(workflowText).not.toContain('issue_comment')
+    expect(workflowText).not.toContain('/promote-fork')
+    expect(workflowText).not.toContain('gh pr')
+    expect(workflowText).not.toContain('environment:')
+    expect(job('promote').if).toBe("needs.prepare.outputs.result == 'clean'")
+  })
+
+  it('keeps validation jobs read-only', () => {
+    for (const name of [
+      'maintenance-contract',
+      'lint',
+      'typecheck',
+      'test',
+      'build',
+      'cross-version-wire'
+    ]) {
+      expect(job(name).permissions).toEqual({ contents: 'read' })
+      expect(JSON.stringify(job(name))).not.toContain('FORK_MAINTENANCE_SSH_KEY')
+    }
+  })
+
+  it('pins validation checkouts to the generated preview SHA', () => {
+    for (const name of [
+      'maintenance-contract',
+      'lint',
+      'typecheck',
+      'test',
+      'build',
+      'cross-version-wire'
+    ]) {
+      const checkout = job(name).steps.find((step) => step.uses === checkoutAction)
+      expect(checkout?.with?.ref).toBe('${{ needs.prepare.outputs.preview_sha }}')
+      expect(checkout?.with?.['persist-credentials']).toBe(false)
+    }
+  })
+
+  it('pins every checkout action to one reviewed commit', () => {
+    expect(workflowText).not.toContain('actions/checkout@v')
+    const checkoutSteps = Object.values(workflow.jobs).flatMap((value) =>
+      (value.steps ?? []).filter((step) => step.uses?.startsWith('actions/checkout@'))
+    )
+    expect(checkoutSteps).toHaveLength(8)
+    expect(checkoutSteps.every((step) => step.uses === checkoutAction)).toBe(true)
+  })
+
+  it('uses atomic leases for preview publication and promotion', () => {
+    expect(workflowText).toContain('git push --atomic')
+    expect(workflowText).toContain('PREVIEW_LEASE_SHA: ${{ steps.refs.outputs.preview_lease_sha }}')
+    expect(workflowText).toContain(
+      '--force-with-lease="refs/heads/${FORK_BRANCH}:${SOURCE_FORK_SHA}"'
+    )
+    expect(workflowText).toContain(
+      '--force-with-lease="refs/heads/${ANCHOR_BRANCH}:${SOURCE_ANCHOR_SHA}"'
+    )
+    expect(workflowText).toContain(
+      '--force-with-lease="refs/heads/${PREVIEW_BRANCH}:${PREVIEW_SHA}"'
+    )
+  })
+
+  it('keeps replay compatible with the Git 2.25 workflow baseline', () => {
+    const prepare = job('prepare')
+      .steps.map((step) => step.run ?? '')
+      .join('\n')
+    expect(prepare).not.toContain('--empty=drop')
+    expect(prepare).toContain('git cherry-pick --skip')
+  })
+
+  it('restores the trusted maintenance snapshot before publication', () => {
+    const prepare = job('prepare')
+      .steps.map((step) => step.run ?? '')
+      .join('\n')
+    expect(prepare).toContain('git checkout "${SOURCE_FORK_SHA}" -- "${MAINTENANCE_PATHS[@]}"')
+    expect(prepare).toContain('Fork-Maintenance-Generated: upstream-anchor-v1')
+    expect(prepare).toContain('Fork-Maintenance-Generated: maintenance-snapshot-v1')
+    expect(prepare).toContain('git diff --quiet "${SOURCE_FORK_SHA}" "${PREVIEW_SHA}" --')
+  })
+
+  it('uses the repository owner identity for replay commits', () => {
+    expect(workflow.env.FORK_COMMITTER_NAME).toBe('GhostFlying')
+    expect(workflow.env.FORK_COMMITTER_EMAIL).toBe('4019569+GhostFlying@users.noreply.github.com')
+  })
+
+  it('verifies the pinned preview before promotion', () => {
+    const promote = job('promote')
+      .steps.map((step) => step.run ?? '')
+      .join('\n')
+    expect(promote).toContain('CURRENT_PREVIEW_SHA')
+    expect(promote).toContain('fork-maintenance-state.mjs inspect')
+    expect(promote).toContain('--anchor="${NEXT_ANCHOR_SHA}"')
+    expect(promote).toContain('git diff --quiet "${SOURCE_FORK_SHA}" "${PREVIEW_SHA}" --')
+  })
+
+  it('uses a repository-scoped deploy key only in the final push steps', () => {
+    expect(workflow.permissions).toEqual({})
+    expect(job('prepare').permissions).toEqual({ contents: 'read' })
+    expect(job('promote').permissions).toEqual({ contents: 'read' })
+    expect(job('conflict').permissions).toEqual({})
+    expect(workflowText).not.toContain('FORK_MAINTENANCE_TOKEN')
+    for (const name of ['prepare', 'promote']) {
+      const checkout = job(name).steps.find((step) => step.uses === checkoutAction)
+      expect(checkout?.with?.['ssh-key']).toBeUndefined()
+      expect(checkout?.with?.['persist-credentials']).toBe(false)
+      const keySteps = job(name).steps.filter((step) =>
+        JSON.stringify(step).includes('FORK_MAINTENANCE_SSH_KEY')
+      )
+      expect(keySteps).toHaveLength(1)
+      expect(keySteps[0]).toBe(job(name).steps.at(-1))
+      expect(keySteps[0].run).toContain('git push --atomic')
+    }
+  })
+
+  it('never publishes a raw upstream commit as a maintenance ref', () => {
+    expect(workflowText).toContain('${NEXT_ANCHOR_SHA}:refs/heads/${ANCHOR_BRANCH}')
+    expect(workflowText).not.toContain('${TARGET_SHA}:refs/heads/${ANCHOR_BRANCH}')
+  })
+
+  it('disables inherited workflows outside the fork allowlist', () => {
+    expect(job('workflow-policy').permissions).toEqual({ actions: 'write' })
+    const policy = job('workflow-policy')
+      .steps.map((step) => step.run ?? '')
+      .join('\n')
+    for (const path of [
+      '.github/workflows/fork-sync.yml',
+      '.github/workflows/pr.yml',
+      '.github/workflows/mobile.yml',
+      '.github/workflows/e2e.yml'
+    ]) {
+      expect(policy).toContain(path)
+    }
+    expect(policy).toContain('/disable')
+  })
+})

--- a/.github/scripts/fork-maintenance-workflow.test.mjs
+++ b/.github/scripts/fork-maintenance-workflow.test.mjs
@@ -61,6 +61,42 @@ describe('fork sync workflow', () => {
     }
   })
 
+  it('fetches cross-version baselines from official release tags', () => {
+    const crossVersionSteps = job('cross-version-wire').steps
+    const fetchIndex = crossVersionSteps.findIndex(
+      (step) => step.name === 'Fetch upstream release tags'
+    )
+    const testIndex = crossVersionSteps.findIndex((step) =>
+      step.run?.includes('cross-version-terminal-wire.unit.test.ts')
+    )
+    const crossVersionWire = crossVersionSteps.map((step) => step.run ?? '').join('\n')
+    expect(fetchIndex).toBeGreaterThan(0)
+    expect(testIndex).toBeGreaterThan(fetchIndex)
+    expect(crossVersionWire).toContain('"https://github.com/${UPSTREAM_REPOSITORY}.git"')
+    expect(crossVersionWire).toContain('"+refs/tags/v*:refs/tags/v*"')
+    expect(crossVersionWire).toContain('--no-recurse-submodules')
+    expect(crossVersionWire).not.toContain('FORK_MAINTENANCE_SSH_KEY')
+  })
+
+  it('restores disabled workflows only as pinned unit-test fixtures', () => {
+    const testJob = job('test')
+    const fixtureStep = testJob.steps.find(
+      (step) => step.name === 'Restore disabled workflow test fixtures'
+    )
+    const fixtureIndex = testJob.steps.indexOf(fixtureStep)
+    const testIndex = testJob.steps.findIndex((step) => step.name === 'Test shard')
+    expect(fixtureIndex).toBeGreaterThan(0)
+    expect(testIndex).toBeGreaterThan(fixtureIndex)
+    expect(fixtureStep?.env?.UPSTREAM_TARGET_SHA).toBe('${{ needs.prepare.outputs.target_sha }}')
+    expect(fixtureStep?.run).toContain('"${UPSTREAM_TARGET_SHA}"')
+    expect(fixtureStep?.run).toContain(
+      'test "$(git rev-parse FETCH_HEAD^{commit})" = "${UPSTREAM_TARGET_SHA}"'
+    )
+    expect(fixtureStep?.run).toContain('if [ ! -e "${WORKFLOW_PATH}" ]; then')
+    expect(fixtureStep?.run).toContain('git checkout FETCH_HEAD -- "${WORKFLOW_PATH}"')
+    expect(JSON.stringify(testJob)).not.toContain('FORK_MAINTENANCE_SSH_KEY')
+  })
+
   it('pins every checkout action to one reviewed commit', () => {
     expect(workflowText).not.toContain('actions/checkout@v')
     const checkoutSteps = Object.values(workflow.jobs).flatMap((value) =>

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -1,0 +1,545 @@
+name: Fork Sync
+
+on:
+  schedule:
+    - cron: '37 * * * *'
+  workflow_dispatch:
+    inputs:
+      upstream_sha:
+        description: Optional upstream main commit to adopt
+        required: false
+        type: string
+
+permissions: {}
+
+concurrency:
+  group: fork-maintenance
+  cancel-in-progress: false
+
+env:
+  UPSTREAM_REPOSITORY: stablyai/orca
+  ANCHOR_BRANCH: upstream-main
+  FORK_BRANCH: fork
+  PREVIEW_BRANCH: sync/upstream-main
+  FORK_COMMITTER_NAME: GhostFlying
+  FORK_COMMITTER_EMAIL: 4019569+GhostFlying@users.noreply.github.com
+
+jobs:
+  prepare:
+    if: github.repository == 'GhostFlying/orca'
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    outputs:
+      result: ${{ steps.replay.outputs.result || steps.state.outputs.result }}
+      anchor_sha: ${{ steps.state.outputs.anchor_sha }}
+      fork_sha: ${{ steps.state.outputs.fork_sha }}
+      target_sha: ${{ steps.state.outputs.target_sha }}
+      next_anchor_sha: ${{ steps.anchor.outputs.next_anchor_sha }}
+      preview_sha: ${{ steps.replay.outputs.preview_sha }}
+    steps:
+      - name: Checkout production fork
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ env.FORK_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Configure Git
+        run: |
+          git config user.name "${FORK_COMMITTER_NAME}"
+          git config user.email "${FORK_COMMITTER_EMAIL}"
+          git config commit.gpgsign false
+          cp .github/scripts/fork-maintenance-state.mjs \
+            "$RUNNER_TEMP/trusted-fork-maintenance-state.mjs"
+
+      - name: Fetch pinned maintenance refs
+        id: refs
+        env:
+          REQUESTED_UPSTREAM_SHA: ${{ inputs.upstream_sha }}
+        run: |
+          set -euo pipefail
+          git remote add upstream "https://github.com/${UPSTREAM_REPOSITORY}.git"
+          git fetch --no-tags upstream \
+            "+refs/heads/main:refs/remotes/upstream/main"
+          git fetch --no-tags origin \
+            "+refs/heads/${FORK_BRANCH}:refs/remotes/origin/${FORK_BRANCH}" \
+            "+refs/heads/${ANCHOR_BRANCH}:refs/remotes/origin/${ANCHOR_BRANCH}"
+
+          PREVIEW_LEASE_SHA="$(
+            git ls-remote origin "refs/heads/${PREVIEW_BRANCH}" | awk '{print $1}'
+          )"
+          if [ -n "${PREVIEW_LEASE_SHA}" ]; then
+            git fetch --no-tags origin \
+              "+refs/heads/${PREVIEW_BRANCH}:refs/remotes/origin/${PREVIEW_BRANCH}"
+            test "$(git rev-parse "refs/remotes/origin/${PREVIEW_BRANCH}^{commit}")" = \
+              "${PREVIEW_LEASE_SHA}"
+          fi
+          echo "preview_lease_sha=${PREVIEW_LEASE_SHA}" >> "$GITHUB_OUTPUT"
+
+          if [ -n "${REQUESTED_UPSTREAM_SHA}" ]; then
+            if ! [[ "${REQUESTED_UPSTREAM_SHA}" =~ ^[0-9a-f]{40}$ ]]; then
+              echo "::error::upstream_sha must be a lowercase 40-character commit SHA."
+              exit 1
+            fi
+            git rev-parse --verify "${REQUESTED_UPSTREAM_SHA}^{commit}" >/dev/null
+            git merge-base --is-ancestor "${REQUESTED_UPSTREAM_SHA}" refs/remotes/upstream/main
+            git update-ref refs/remotes/upstream/selected "${REQUESTED_UPSTREAM_SHA}"
+          else
+            git update-ref refs/remotes/upstream/selected refs/remotes/upstream/main
+          fi
+
+      - name: Inspect patch stack
+        id: state
+        run: |
+          set -euo pipefail
+          node "$RUNNER_TEMP/trusted-fork-maintenance-state.mjs" inspect \
+            --anchor="refs/remotes/origin/${ANCHOR_BRANCH}" \
+            --fork="refs/remotes/origin/${FORK_BRANCH}" \
+            --target=refs/remotes/upstream/selected \
+            > "$RUNNER_TEMP/fork-sync-state.json"
+
+          jq . "$RUNNER_TEMP/fork-sync-state.json"
+          jq -r '"anchor_sha=\(.anchorSha)"' "$RUNNER_TEMP/fork-sync-state.json" >> "$GITHUB_OUTPUT"
+          jq -r '"upstream_sha=\(.upstreamSha)"' "$RUNNER_TEMP/fork-sync-state.json" >> "$GITHUB_OUTPUT"
+          jq -r '"fork_sha=\(.forkSha)"' "$RUNNER_TEMP/fork-sync-state.json" >> "$GITHUB_OUTPUT"
+          jq -r '"target_sha=\(.targetSha)"' "$RUNNER_TEMP/fork-sync-state.json" >> "$GITHUB_OUTPUT"
+
+          if [ "$(jq -r .upstreamSha "$RUNNER_TEMP/fork-sync-state.json")" = \
+            "$(jq -r .targetSha "$RUNNER_TEMP/fork-sync-state.json")" ]; then
+            echo "result=noop" >> "$GITHUB_OUTPUT"
+          else
+            echo "result=pending" >> "$GITHUB_OUTPUT"
+          fi
+
+      - name: Verify production workflow snapshot
+        if: steps.state.outputs.result == 'pending'
+        env:
+          FORK_SHA: ${{ steps.state.outputs.fork_sha }}
+        run: |
+          set -euo pipefail
+          git ls-tree -r --name-only "${FORK_SHA}" .github/workflows |
+          while IFS= read -r WORKFLOW_PATH; do
+            case "${WORKFLOW_PATH}" in
+              .github/workflows/fork-sync.yml|\
+              .github/workflows/pr.yml|\
+              .github/workflows/mobile.yml|\
+              .github/workflows/e2e.yml)
+                ;;
+              *)
+                echo "::error::Production fork contains disallowed workflow ${WORKFLOW_PATH}."
+                exit 1
+                ;;
+            esac
+          done
+
+      - name: Create sanitized upstream anchor
+        if: steps.state.outputs.result == 'pending'
+        id: anchor
+        env:
+          SOURCE_FORK_SHA: ${{ steps.state.outputs.fork_sha }}
+          TARGET_SHA: ${{ steps.state.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          MAINTENANCE_PATHS=(
+            .github/fork-maintenance-plan.md
+            .github/scripts/fork-maintenance-state.mjs
+            .github/scripts/fork-maintenance-state.test.mjs
+            .github/scripts/fork-maintenance-workflow.test.mjs
+            .github/workflows
+            config/vitest.config.ts
+          )
+          git checkout -B generated-upstream-anchor "${TARGET_SHA}"
+          git rm -r --ignore-unmatch -- "${MAINTENANCE_PATHS[@]}"
+          git checkout "${SOURCE_FORK_SHA}" -- "${MAINTENANCE_PATHS[@]}"
+          git add -- "${MAINTENANCE_PATHS[@]}"
+          git commit --allow-empty \
+            -m "chore(fork): anchor upstream ${TARGET_SHA}" \
+            -m "Fork-Maintenance-Generated: upstream-anchor-v1"
+          echo "next_anchor_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
+
+      - name: Replay fork patch stack
+        if: steps.state.outputs.result == 'pending'
+        id: replay
+        env:
+          SOURCE_FORK_SHA: ${{ steps.state.outputs.fork_sha }}
+          NEXT_ANCHOR_SHA: ${{ steps.anchor.outputs.next_anchor_sha }}
+        run: |
+          set -euo pipefail
+          MAINTENANCE_PATHS=(
+            .github/fork-maintenance-plan.md
+            .github/scripts/fork-maintenance-state.mjs
+            .github/scripts/fork-maintenance-state.test.mjs
+            .github/scripts/fork-maintenance-workflow.test.mjs
+            .github/workflows
+            config/vitest.config.ts
+          )
+          STATE="$RUNNER_TEMP/fork-sync-state.json"
+          PATCH_COUNT="$(jq -r .patchCount "$STATE")"
+          APPLIED_COUNT=0
+          RESULT=clean
+          FAILED_COMMIT=""
+          : > "$RUNNER_TEMP/fork-sync-conflicts.txt"
+
+          git checkout -B "${PREVIEW_BRANCH}" "${NEXT_ANCHOR_SHA}"
+          while IFS= read -r COMMIT; do
+            [ -n "${COMMIT}" ] || continue
+            if git cherry-pick "${COMMIT}"; then
+              APPLIED_COUNT=$((APPLIED_COUNT + 1))
+              continue
+            fi
+
+            git diff --name-only --diff-filter=U > "$RUNNER_TEMP/fork-sync-conflicts.txt"
+            if [ ! -s "$RUNNER_TEMP/fork-sync-conflicts.txt" ] &&
+              git diff --cached --quiet &&
+              git diff --quiet; then
+              git cherry-pick --skip
+              APPLIED_COUNT=$((APPLIED_COUNT + 1))
+              continue
+            fi
+            if [ ! -s "$RUNNER_TEMP/fork-sync-conflicts.txt" ]; then
+              echo "::error::Cherry-pick failed without an empty change or merge conflict."
+              exit 1
+            fi
+
+            RESULT=conflict
+            FAILED_COMMIT="${COMMIT}"
+            git cherry-pick --abort || true
+            break
+          done < <(jq -r '.patchCommits[]' "$STATE")
+
+          git rm -r --ignore-unmatch -- "${MAINTENANCE_PATHS[@]}"
+          git checkout "${SOURCE_FORK_SHA}" -- "${MAINTENANCE_PATHS[@]}"
+          if ! git diff --cached --quiet || ! git diff --quiet; then
+            git add -- "${MAINTENANCE_PATHS[@]}"
+            git commit \
+              -m "chore(fork): restore maintenance snapshot" \
+              -m "Fork-Maintenance-Generated: maintenance-snapshot-v1"
+          fi
+
+          PREVIEW_SHA="$(git rev-parse HEAD)"
+          git diff --quiet "${SOURCE_FORK_SHA}" "${PREVIEW_SHA}" -- "${MAINTENANCE_PATHS[@]}"
+          echo "result=${RESULT}" >> "$GITHUB_OUTPUT"
+          echo "preview_sha=${PREVIEW_SHA}" >> "$GITHUB_OUTPUT"
+          echo "patch_count=${PATCH_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "applied_count=${APPLIED_COUNT}" >> "$GITHUB_OUTPUT"
+          echo "failed_commit=${FAILED_COMMIT}" >> "$GITHUB_OUTPUT"
+
+      - name: Report preview
+        if: steps.state.outputs.result == 'pending'
+        env:
+          RESULT: ${{ steps.replay.outputs.result }}
+          PREVIEW_SHA: ${{ steps.replay.outputs.preview_sha }}
+          PATCH_COUNT: ${{ steps.replay.outputs.patch_count }}
+          APPLIED_COUNT: ${{ steps.replay.outputs.applied_count }}
+          FAILED_COMMIT: ${{ steps.replay.outputs.failed_commit }}
+          TARGET_SHA: ${{ steps.state.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          {
+            echo "## Fork sync preview"
+            echo
+            if [ "${RESULT}" = clean ]; then
+              echo "Clean patch-stack replay onto upstream \`${TARGET_SHA}\`."
+            else
+              echo "Patch-stack replay conflicts on \`${FAILED_COMMIT}\`."
+            fi
+            echo
+            echo "- Upstream target: \`${TARGET_SHA}\`"
+            echo "- Preview head: \`${PREVIEW_SHA}\`"
+            echo "- Applied patches: \`${APPLIED_COUNT}/${PATCH_COUNT}\`"
+            if [ "${RESULT}" = conflict ]; then
+              echo "- Conflicted paths:"
+              sed 's/^/  - `/' "$RUNNER_TEMP/fork-sync-conflicts.txt" | sed 's/$/`/'
+            fi
+            echo
+            if [ "${RESULT}" = clean ]; then
+              echo "Validation and promotion continue automatically."
+            else
+              echo "Production refs remain unchanged."
+            fi
+          } >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Publish pinned preview
+        if: steps.state.outputs.result == 'pending'
+        env:
+          ANCHOR_SHA: ${{ steps.state.outputs.anchor_sha }}
+          FORK_SHA: ${{ steps.state.outputs.fork_sha }}
+          FORK_MAINTENANCE_SSH_KEY: ${{ secrets.FORK_MAINTENANCE_SSH_KEY }}
+          PREVIEW_SHA: ${{ steps.replay.outputs.preview_sha }}
+          PREVIEW_LEASE_SHA: ${{ steps.refs.outputs.preview_lease_sha }}
+        run: |
+          set -euo pipefail
+          test -n "${FORK_MAINTENANCE_SSH_KEY}"
+          KEY_PATH="$RUNNER_TEMP/fork-maintenance-key"
+          KNOWN_HOSTS_PATH="$RUNNER_TEMP/fork-maintenance-known-hosts"
+          printf '%s\n' "${FORK_MAINTENANCE_SSH_KEY}" > "${KEY_PATH}"
+          chmod 600 "${KEY_PATH}"
+          ssh-keyscan -t ed25519 github.com > "${KNOWN_HOSTS_PATH}" 2>/dev/null
+          test "$(ssh-keygen -lf "${KNOWN_HOSTS_PATH}" -E sha256 | awk '{print $2}')" = \
+            "SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU"
+
+          if [ -n "${PREVIEW_LEASE_SHA}" ]; then
+            PREVIEW_LEASE="--force-with-lease=refs/heads/${PREVIEW_BRANCH}:${PREVIEW_LEASE_SHA}"
+          else
+            PREVIEW_LEASE="--force-with-lease=refs/heads/${PREVIEW_BRANCH}:"
+          fi
+
+          git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+          GIT_SSH_COMMAND="ssh -i ${KEY_PATH} -o IdentitiesOnly=yes -o UserKnownHostsFile=${KNOWN_HOSTS_PATH}" \
+            git push --atomic \
+            --force-with-lease="refs/heads/${FORK_BRANCH}:${FORK_SHA}" \
+            --force-with-lease="refs/heads/${ANCHOR_BRANCH}:${ANCHOR_SHA}" \
+            "${PREVIEW_LEASE}" \
+            origin \
+            "${FORK_SHA}:refs/heads/${FORK_BRANCH}" \
+            "${ANCHOR_SHA}:refs/heads/${ANCHOR_BRANCH}" \
+            "${PREVIEW_SHA}:refs/heads/${PREVIEW_BRANCH}"
+
+  maintenance-contract:
+    if: needs.prepare.outputs.result == 'clean'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.prepare.outputs.preview_sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+      - run: pnpm exec vitest run --config config/vitest.config.ts .github/scripts/fork-maintenance-state.test.mjs .github/scripts/fork-maintenance-workflow.test.mjs
+      - name: Verify fork state with Git 2.25.5
+        run: |
+          archive="$RUNNER_TEMP/git-2.25.5.tar.gz"
+          source="$RUNNER_TEMP/git-2.25.5"
+          curl -fsSL https://www.kernel.org/pub/software/scm/git/git-2.25.5.tar.gz -o "$archive"
+          echo "41662c52fc16fec4963bfc41075e71f8ead6b5e386797eb6f9a1111ff95a8ddf  $archive" \
+            | sha256sum --check
+          mkdir -p "$source"
+          tar -xzf "$archive" -C "$source" --strip-components=1
+          make -C "$source" -j"$(nproc)" \
+            NO_GETTEXT=YesPlease NO_TCLTK=YesPlease NO_PYTHON=YesPlease git
+          ORCA_FORK_MAINTENANCE_GIT_BINARY="$source/git" \
+            pnpm exec vitest run --config config/vitest.config.ts \
+            .github/scripts/fork-maintenance-state.test.mjs
+
+  lint:
+    if: needs.prepare.outputs.result == 'clean'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.prepare.outputs.preview_sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+      - run: pnpm lint
+
+  typecheck:
+    if: needs.prepare.outputs.result == 'clean'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.prepare.outputs.preview_sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+      - run: pnpm typecheck
+
+  test:
+    if: needs.prepare.outputs.result == 'clean'
+    needs: prepare
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [1, 2, 3, 4, 5, 6, 7, 8]
+        shard_total: [8]
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.prepare.outputs.preview_sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+        with:
+          native-runtime: node
+      - name: Install Electron package binary for tests
+        run: node config/scripts/install-electron-package-binary.mjs
+      - name: Test shard
+        run: |
+          pnpm exec vitest run --config config/vitest.config.ts \
+            --exclude=tests/e2e/cross-version-wire/** \
+            --shard=${{ matrix.shard }}/${{ matrix.shard_total }}
+
+  build:
+    if: needs.prepare.outputs.result == 'clean'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.prepare.outputs.preview_sha }}
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+        with:
+          native-runtime: node
+      - run: pnpm build:desktop
+
+  cross-version-wire:
+    if: needs.prepare.outputs.result == 'clean'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ needs.prepare.outputs.preview_sha }}
+          fetch-depth: 0
+          persist-credentials: false
+      - uses: ./.github/actions/install-node-dependencies
+        with:
+          native-runtime: node
+      - run: pnpm exec vitest run --config config/vitest.config.ts tests/e2e/cross-version-wire/cross-version-terminal-wire.unit.test.ts
+
+  conflict:
+    if: needs.prepare.outputs.result == 'conflict'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions: {}
+    steps:
+      - run: |
+          echo "::error::Fork patch-stack replay conflicted. Production refs were not changed."
+          exit 1
+
+  workflow-policy:
+    if: always() && needs.prepare.result == 'success'
+    needs: prepare
+    runs-on: ubuntu-latest
+    permissions:
+      actions: write
+    steps:
+      - name: Enforce fork workflow allowlist
+        env:
+          GH_TOKEN: ${{ github.token }}
+        run: |
+          set -euo pipefail
+          gh api "repos/${GITHUB_REPOSITORY}/actions/workflows?per_page=100" \
+            --paginate \
+            --jq '.workflows[] | [.id, .path, .state] | @tsv' |
+          while IFS=$'\t' read -r WORKFLOW_ID WORKFLOW_PATH WORKFLOW_STATE; do
+            case "${WORKFLOW_PATH}" in
+              .github/workflows/fork-sync.yml|\
+              .github/workflows/pr.yml|\
+              .github/workflows/mobile.yml|\
+              .github/workflows/e2e.yml)
+                if [ "${WORKFLOW_STATE}" != active ]; then
+                  gh api \
+                    --method PUT \
+                    "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_ID}/enable"
+                fi
+                ;;
+              *)
+                if [ "${WORKFLOW_STATE}" = active ]; then
+                  gh api \
+                    --method PUT \
+                    "repos/${GITHUB_REPOSITORY}/actions/workflows/${WORKFLOW_ID}/disable"
+                fi
+                ;;
+            esac
+          done
+
+  promote:
+    if: needs.prepare.outputs.result == 'clean'
+    needs:
+      - prepare
+      - maintenance-contract
+      - lint
+      - typecheck
+      - test
+      - build
+      - cross-version-wire
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+    steps:
+      - name: Checkout trusted production fork
+        uses: actions/checkout@d23441a48e516b6c34aea4fa41551a30e30af803
+        with:
+          ref: ${{ env.FORK_BRANCH }}
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Verify pinned preview
+        env:
+          NEXT_ANCHOR_SHA: ${{ needs.prepare.outputs.next_anchor_sha }}
+          SOURCE_ANCHOR_SHA: ${{ needs.prepare.outputs.anchor_sha }}
+          SOURCE_FORK_SHA: ${{ needs.prepare.outputs.fork_sha }}
+          TARGET_SHA: ${{ needs.prepare.outputs.target_sha }}
+          PREVIEW_SHA: ${{ needs.prepare.outputs.preview_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --no-tags origin \
+            "+refs/heads/${FORK_BRANCH}:refs/remotes/origin/${FORK_BRANCH}" \
+            "+refs/heads/${ANCHOR_BRANCH}:refs/remotes/origin/${ANCHOR_BRANCH}" \
+            "+refs/heads/${PREVIEW_BRANCH}:refs/remotes/origin/${PREVIEW_BRANCH}"
+
+          CURRENT_FORK_SHA="$(git rev-parse "refs/remotes/origin/${FORK_BRANCH}^{commit}")"
+          CURRENT_ANCHOR_SHA="$(git rev-parse "refs/remotes/origin/${ANCHOR_BRANCH}^{commit}")"
+          CURRENT_PREVIEW_SHA="$(git rev-parse "refs/remotes/origin/${PREVIEW_BRANCH}^{commit}")"
+          test "${CURRENT_FORK_SHA}" = "${SOURCE_FORK_SHA}"
+          test "${CURRENT_ANCHOR_SHA}" = "${SOURCE_ANCHOR_SHA}"
+          test "${CURRENT_PREVIEW_SHA}" = "${PREVIEW_SHA}"
+          git diff --quiet "${SOURCE_FORK_SHA}" "${PREVIEW_SHA}" -- \
+            .github/fork-maintenance-plan.md \
+            .github/scripts/fork-maintenance-state.mjs \
+            .github/scripts/fork-maintenance-state.test.mjs \
+            .github/scripts/fork-maintenance-workflow.test.mjs \
+            .github/workflows \
+            config/vitest.config.ts
+
+          node .github/scripts/fork-maintenance-state.mjs inspect \
+            --anchor="${NEXT_ANCHOR_SHA}" \
+            --fork="refs/remotes/origin/${PREVIEW_BRANCH}" \
+            --target="${TARGET_SHA}" \
+            > "$RUNNER_TEMP/verified-preview-state.json"
+          jq . "$RUNNER_TEMP/verified-preview-state.json"
+
+      - name: Atomically promote validated fork
+        env:
+          FORK_MAINTENANCE_SSH_KEY: ${{ secrets.FORK_MAINTENANCE_SSH_KEY }}
+          NEXT_ANCHOR_SHA: ${{ needs.prepare.outputs.next_anchor_sha }}
+          SOURCE_ANCHOR_SHA: ${{ needs.prepare.outputs.anchor_sha }}
+          SOURCE_FORK_SHA: ${{ needs.prepare.outputs.fork_sha }}
+          PREVIEW_SHA: ${{ needs.prepare.outputs.preview_sha }}
+        run: |
+          set -euo pipefail
+          test -n "${FORK_MAINTENANCE_SSH_KEY}"
+          KEY_PATH="$RUNNER_TEMP/fork-maintenance-key"
+          KNOWN_HOSTS_PATH="$RUNNER_TEMP/fork-maintenance-known-hosts"
+          printf '%s\n' "${FORK_MAINTENANCE_SSH_KEY}" > "${KEY_PATH}"
+          chmod 600 "${KEY_PATH}"
+          ssh-keyscan -t ed25519 github.com > "${KNOWN_HOSTS_PATH}" 2>/dev/null
+          test "$(ssh-keygen -lf "${KNOWN_HOSTS_PATH}" -E sha256 | awk '{print $2}')" = \
+            "SHA256:+DiY3wvvV6TuJJhbpZisF/zLDA0zPMSvHdkr4UvCOqU"
+
+          git remote set-url origin "git@github.com:${GITHUB_REPOSITORY}.git"
+          GIT_SSH_COMMAND="ssh -i ${KEY_PATH} -o IdentitiesOnly=yes -o UserKnownHostsFile=${KNOWN_HOSTS_PATH}" \
+            git push --atomic \
+            --force-with-lease="refs/heads/${FORK_BRANCH}:${SOURCE_FORK_SHA}" \
+            --force-with-lease="refs/heads/${ANCHOR_BRANCH}:${SOURCE_ANCHOR_SHA}" \
+            --force-with-lease="refs/heads/${PREVIEW_BRANCH}:${PREVIEW_SHA}" \
+            origin \
+            "${PREVIEW_SHA}:refs/heads/${FORK_BRANCH}" \
+            "${NEXT_ANCHOR_SHA}:refs/heads/${ANCHOR_BRANCH}" \
+            "${PREVIEW_SHA}:refs/heads/${PREVIEW_BRANCH}"

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -375,6 +375,21 @@ jobs:
         with:
           ref: ${{ needs.prepare.outputs.preview_sha }}
           persist-credentials: false
+      - name: Restore disabled workflow test fixtures
+        env:
+          UPSTREAM_TARGET_SHA: ${{ needs.prepare.outputs.target_sha }}
+        run: |
+          set -euo pipefail
+          git fetch --quiet --no-tags --depth=1 --no-recurse-submodules \
+            "https://github.com/${UPSTREAM_REPOSITORY}.git" \
+            "${UPSTREAM_TARGET_SHA}"
+          test "$(git rev-parse FETCH_HEAD^{commit})" = "${UPSTREAM_TARGET_SHA}"
+          git ls-tree -r --name-only FETCH_HEAD -- .github/workflows |
+          while IFS= read -r WORKFLOW_PATH; do
+            if [ ! -e "${WORKFLOW_PATH}" ]; then
+              git checkout FETCH_HEAD -- "${WORKFLOW_PATH}"
+            fi
+          done
       - uses: ./.github/actions/install-node-dependencies
         with:
           native-runtime: node
@@ -414,6 +429,11 @@ jobs:
           ref: ${{ needs.prepare.outputs.preview_sha }}
           fetch-depth: 0
           persist-credentials: false
+      - name: Fetch upstream release tags
+        run: |
+          git fetch --quiet --force --no-tags --no-recurse-submodules \
+            "https://github.com/${UPSTREAM_REPOSITORY}.git" \
+            "+refs/tags/v*:refs/tags/v*"
       - uses: ./.github/actions/install-node-dependencies
         with:
           native-runtime: node

--- a/.github/workflows/fork-sync.yml
+++ b/.github/workflows/fork-sync.yml
@@ -153,7 +153,10 @@ jobs:
           git rm -r --ignore-unmatch -- "${MAINTENANCE_PATHS[@]}"
           git checkout "${SOURCE_FORK_SHA}" -- "${MAINTENANCE_PATHS[@]}"
           git add -- "${MAINTENANCE_PATHS[@]}"
-          git commit --allow-empty \
+          TARGET_COMMIT_DATE="$(git show -s --format=%cI "${TARGET_SHA}")"
+          GIT_AUTHOR_DATE="${TARGET_COMMIT_DATE}" \
+            GIT_COMMITTER_DATE="${TARGET_COMMIT_DATE}" \
+            git commit --allow-empty \
             -m "chore(fork): anchor upstream ${TARGET_SHA}" \
             -m "Fork-Maintenance-Generated: upstream-anchor-v1"
           echo "next_anchor_sha=$(git rev-parse HEAD)" >> "$GITHUB_OUTPUT"
@@ -184,7 +187,8 @@ jobs:
           git checkout -B "${PREVIEW_BRANCH}" "${NEXT_ANCHOR_SHA}"
           while IFS= read -r COMMIT; do
             [ -n "${COMMIT}" ] || continue
-            if git cherry-pick "${COMMIT}"; then
+            COMMITTER_DATE="$(git show -s --format=%cI "${COMMIT}")"
+            if GIT_COMMITTER_DATE="${COMMITTER_DATE}" git cherry-pick "${COMMIT}"; then
               APPLIED_COUNT=$((APPLIED_COUNT + 1))
               continue
             fi
@@ -212,7 +216,10 @@ jobs:
           git checkout "${SOURCE_FORK_SHA}" -- "${MAINTENANCE_PATHS[@]}"
           if ! git diff --cached --quiet || ! git diff --quiet; then
             git add -- "${MAINTENANCE_PATHS[@]}"
-            git commit \
+            SNAPSHOT_COMMIT_DATE="$(git show -s --format=%cI "${SOURCE_FORK_SHA}")"
+            GIT_AUTHOR_DATE="${SNAPSHOT_COMMIT_DATE}" \
+              GIT_COMMITTER_DATE="${SNAPSHOT_COMMIT_DATE}" \
+              git commit \
               -m "chore(fork): restore maintenance snapshot" \
               -m "Fork-Maintenance-Generated: maintenance-snapshot-v1"
           fi

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     // Why: Node 26's undefined Web Storage globals prevent Vitest from installing happy-dom's.
-    execArgv: ['--no-experimental-webstorage'],
+    // Why --expose-gc: retention tests need a deterministic collection point to measure what a queue really holds.
+    execArgv: ['--no-experimental-webstorage', '--expose-gc'],
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
     setupFiles: [resolve('config/scripts/happy-dom-mutation-observer-retention.ts')],
     include: [

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -20,6 +20,7 @@ export default defineConfig({
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
     setupFiles: [resolve('config/scripts/happy-dom-mutation-observer-retention.ts')],
     include: [
+      '.github/scripts/**/*.test.mjs',
       'src/**/*.test.ts',
       'src/**/*.test.tsx',
       'config/scripts/**/*.test.ts',

--- a/src/cli/handlers/worktree-create-timeouts.test.ts
+++ b/src/cli/handlers/worktree-create-timeouts.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { getWorktreeCreateTimeoutConfig } from './worktree-create-timeouts'
+
+const TIMEOUT_FLAGS = [
+  ['refresh-timeout-ms', 'refreshBaseRefMs'],
+  ['add-timeout-ms', 'addCheckoutMs'],
+  ['registration-timeout-ms', 'registrationMs'],
+  ['materialization-timeout-ms', 'materializationMs']
+] as const
+
+const INVALID_TIMEOUTS = ['999', '7200001', '1.5', 'NaN', 'Infinity', true]
+
+describe('worktree create timeout flags', () => {
+  it.each(TIMEOUT_FLAGS)('accepts the inclusive bounds for --%s', (flag, timeoutKey) => {
+    expect(getWorktreeCreateTimeoutConfig(new Map([[flag, '1000']])).timeouts).toEqual({
+      [timeoutKey]: 1_000
+    })
+    expect(getWorktreeCreateTimeoutConfig(new Map([[flag, '7200000']])).timeouts).toEqual({
+      [timeoutKey]: 7_200_000
+    })
+  })
+
+  it.each(
+    TIMEOUT_FLAGS.flatMap(([flag]) => INVALID_TIMEOUTS.map((value) => [flag, value] as const))
+  )('rejects invalid --%s value %s', (flag, value) => {
+    expect(() => getWorktreeCreateTimeoutConfig(new Map([[flag, value]]))).toThrow(
+      `--${flag} must be a finite integer between 1000 and 7200000`
+    )
+  })
+
+  it('omits the RPC timeout object while allowing the host maximum stage budget', () => {
+    expect(getWorktreeCreateTimeoutConfig(new Map())).toEqual({
+      transportTimeoutMs: 28_830_000
+    })
+  })
+
+  it('uses the maximum transport budget when any stage inherits from the host', () => {
+    expect(
+      getWorktreeCreateTimeoutConfig(
+        new Map([
+          ['refresh-timeout-ms', '1000'],
+          ['materialization-timeout-ms', '4000']
+        ])
+      )
+    ).toEqual({
+      timeouts: {
+        refreshBaseRefMs: 1_000,
+        materializationMs: 4_000
+      },
+      transportTimeoutMs: 28_830_000
+    })
+  })
+
+  it('keeps the maximum transport budget when every stage is explicit', () => {
+    expect(
+      getWorktreeCreateTimeoutConfig(
+        new Map([
+          ['refresh-timeout-ms', '1000'],
+          ['add-timeout-ms', '2000'],
+          ['registration-timeout-ms', '3000'],
+          ['materialization-timeout-ms', '4000']
+        ])
+      )
+    ).toEqual({
+      timeouts: {
+        refreshBaseRefMs: 1_000,
+        addCheckoutMs: 2_000,
+        registrationMs: 3_000,
+        materializationMs: 4_000
+      },
+      transportTimeoutMs: 28_830_000
+    })
+  })
+})

--- a/src/cli/handlers/worktree-create-timeouts.ts
+++ b/src/cli/handlers/worktree-create-timeouts.ts
@@ -1,0 +1,60 @@
+import { RuntimeClientError } from '../runtime-client'
+import {
+  getMaximumWorktreeCreateTransportTimeoutMs,
+  type WorktreeCreateTimeoutOverrides
+} from '../../shared/worktree-create-timeouts'
+
+const MIN_WORKTREE_CREATE_TIMEOUT_MS = 1_000
+const MAX_WORKTREE_CREATE_TIMEOUT_MS = 7_200_000
+type WorktreeCreateTimeoutConfig = {
+  timeouts?: WorktreeCreateTimeoutOverrides
+  transportTimeoutMs: number
+}
+
+function getOptionalWorktreeCreateTimeoutFlag(
+  flags: Map<string, string | boolean>,
+  name: string
+): number | undefined {
+  if (!flags.has(name)) {
+    return undefined
+  }
+  const rawValue = flags.get(name)
+  const value = typeof rawValue === 'string' ? Number(rawValue) : Number.NaN
+  if (
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < MIN_WORKTREE_CREATE_TIMEOUT_MS ||
+    value > MAX_WORKTREE_CREATE_TIMEOUT_MS
+  ) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `--${name} must be a finite integer between ${MIN_WORKTREE_CREATE_TIMEOUT_MS} and ${MAX_WORKTREE_CREATE_TIMEOUT_MS}`
+    )
+  }
+  return value
+}
+
+export function getWorktreeCreateTimeoutConfig(
+  flags: Map<string, string | boolean>
+): WorktreeCreateTimeoutConfig {
+  const refreshBaseRefMs = getOptionalWorktreeCreateTimeoutFlag(flags, 'refresh-timeout-ms')
+  const addCheckoutMs = getOptionalWorktreeCreateTimeoutFlag(flags, 'add-timeout-ms')
+  const registrationMs = getOptionalWorktreeCreateTimeoutFlag(flags, 'registration-timeout-ms')
+  const materializationMs = getOptionalWorktreeCreateTimeoutFlag(
+    flags,
+    'materialization-timeout-ms'
+  )
+  const timeouts: WorktreeCreateTimeoutOverrides = {
+    ...(refreshBaseRefMs !== undefined ? { refreshBaseRefMs } : {}),
+    ...(addCheckoutMs !== undefined ? { addCheckoutMs } : {}),
+    ...(registrationMs !== undefined ? { registrationMs } : {}),
+    ...(materializationMs !== undefined ? { materializationMs } : {})
+  }
+  return {
+    ...(Object.keys(timeouts).length > 0 ? { timeouts } : {}),
+    // Why: old hosts ignore the optional stage fields and create also performs
+    // setup outside these four budgets, so a shorter client envelope can
+    // disconnect while the host is still completing a valid workspace.
+    transportTimeoutMs: getMaximumWorktreeCreateTransportTimeoutMs()
+  }
+}

--- a/src/cli/handlers/worktree.ts
+++ b/src/cli/handlers/worktree.ts
@@ -32,6 +32,7 @@ import {
   assertCreateParentFlagsCompatible,
   resolveCreateParentSelector
 } from './worktree-create-parent-selector'
+import { getWorktreeCreateTimeoutConfig } from './worktree-create-timeouts'
 import { getOptionalLinearIssueLinkFlag } from './worktree-linear-issue-link'
 
 type HookWarningResult = {
@@ -198,6 +199,7 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
   'worktree create': async ({ flags, client, cwd, json }) => {
     assertCreateParentFlagsCompatible(flags)
     assertWorkspaceTargetFlagsCompatible(flags)
+    const timeoutConfig = getWorktreeCreateTimeoutConfig(flags)
     const callerTerminalHandle =
       typeof process.env.ORCA_TERMINAL_HANDLE === 'string' &&
       process.env.ORCA_TERMINAL_HANDLE.length > 0
@@ -229,32 +231,37 @@ export const WORKTREE_HANDLERS: Record<string, CommandHandler> = {
       }
     }
     const linearIssueLink = getOptionalLinearIssueLinkFlag(flags, 'linear-issue')
-    const result = await client.call<RuntimeWorktreeCreateResult>('worktree.create', {
-      repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
-      name: getRequiredStringFlag(flags, 'name'),
-      baseBranch: getOptionalStringFlag(flags, 'base-branch'),
-      linkedIssue: getOptionalNumberFlag(flags, 'issue'),
-      ...linearIssueLink,
-      comment: getOptionalStringFlag(flags, 'comment'),
-      runHooks: flags.get('run-hooks') === true,
-      activate: flags.get('activate') === true || flags.get('run-hooks') === true,
-      ...(setupDecision ? { setupDecision } : {}),
-      parentWorktree: explicitParentWorktree,
-      ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
-      ...(envParentWorkspace ? { envParentWorkspace } : {}),
-      ...(cwdParentWorktree ? { cwdParentWorktree } : {}),
-      noParent,
-      callerTerminalHandle,
-      // Why: marks the workspace as CLI-created so the sidebar can badge and
-      // filter it. Sent on every `worktree create` — hand-typed or agent-run.
-      cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
-      ...(startupAgent
-        ? {
-            startupAgent,
-            startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
-          }
-        : {})
-    })
+    const result = await client.call<RuntimeWorktreeCreateResult>(
+      'worktree.create',
+      {
+        repo: await getCreateRepoSelector(flags, cwdParentWorktree, client),
+        name: getRequiredStringFlag(flags, 'name'),
+        baseBranch: getOptionalStringFlag(flags, 'base-branch'),
+        linkedIssue: getOptionalNumberFlag(flags, 'issue'),
+        ...linearIssueLink,
+        comment: getOptionalStringFlag(flags, 'comment'),
+        runHooks: flags.get('run-hooks') === true,
+        activate: flags.get('activate') === true || flags.get('run-hooks') === true,
+        ...(setupDecision ? { setupDecision } : {}),
+        ...(timeoutConfig.timeouts ? { timeouts: timeoutConfig.timeouts } : {}),
+        parentWorktree: explicitParentWorktree,
+        ...(explicitParentWorkspace ? { parentWorkspace: explicitParentWorkspace } : {}),
+        ...(envParentWorkspace ? { envParentWorkspace } : {}),
+        ...(cwdParentWorktree ? { cwdParentWorktree } : {}),
+        noParent,
+        callerTerminalHandle,
+        // Why: marks the workspace as CLI-created so the sidebar can badge and
+        // filter it. Sent on every `worktree create` — hand-typed or agent-run.
+        cliProvenanceRequest: callerTerminalHandle ? { callerTerminalHandle } : {},
+        ...(startupAgent
+          ? {
+              startupAgent,
+              startupPrompt: getPresentStringFlag(flags, 'prompt', { allowEmpty: true }) ?? ''
+            }
+          : {})
+      },
+      { timeoutMs: timeoutConfig.transportTimeoutMs }
+    )
     printHookWarning(result.result, json)
     printLineageSummary(result.result, json)
     printResult(result, json, formatWorktreeShow)

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -107,6 +107,12 @@ import { RuntimeRpcFailureError } from './runtime-client'
 import { buildWorktree, okFixture, queueFixtures, worktreeListFixture } from './test-fixtures'
 import { encodePairingOffer, PAIRING_OFFER_VERSION } from '../shared/pairing'
 
+function expectWorktreeCreateCall(callIndex: number, params: unknown): void {
+  expect(callMock).toHaveBeenNthCalledWith(callIndex, 'worktree.create', params, {
+    timeoutMs: 28_830_000
+  })
+}
+
 describe('COMMAND_SPECS collision check', () => {
   it('has no duplicate command or alias paths', () => {
     // Why: first-match resolution would silently shadow duplicate aliases.
@@ -481,7 +487,12 @@ describe('orca root help', () => {
 
     await main(['worktree', 'create', '--help'], '/tmp/repo')
 
-    expect(String(logSpy.mock.calls[0][0])).toContain('--linear-issue <identifier-or-url>')
+    const createHelp = String(logSpy.mock.calls[0][0])
+    expect(createHelp).toContain('--linear-issue <identifier-or-url>')
+    expect(createHelp).toContain('--refresh-timeout-ms <ms>')
+    expect(createHelp).toContain('--add-timeout-ms <ms>')
+    expect(createHelp).toContain('--registration-timeout-ms <ms>')
+    expect(createHelp).toContain('--materialization-timeout-ms <ms>')
 
     logSpy.mockClear()
     await main(['worktree', 'set', '--help'], '/tmp/repo')
@@ -1223,7 +1234,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -1273,7 +1284,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
-    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+    expectWorktreeCreateCall(1, {
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -1398,7 +1409,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -1412,6 +1423,54 @@ describe('orca cli worktree awareness', () => {
       callerTerminalHandle: undefined,
       cliProvenanceRequest: {}
     })
+  })
+
+  it('passes worktree create stage timeouts and their resolved transport budget', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_create_timeouts', {
+        worktree: buildWorktree('/tmp/repo/feature', 'feature', 'abc', 'repo-1'),
+        lineage: null,
+        warnings: []
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+    vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await main(
+      [
+        'worktree',
+        'create',
+        '--repo',
+        'id:repo-1',
+        '--name',
+        'feature',
+        '--no-parent',
+        '--refresh-timeout-ms',
+        '1000',
+        '--add-timeout-ms',
+        '2000',
+        '--registration-timeout-ms',
+        '3000',
+        '--materialization-timeout-ms',
+        '4000',
+        '--json'
+      ],
+      '/tmp/repo'
+    )
+
+    expect(callMock).toHaveBeenCalledWith(
+      'worktree.create',
+      expect.objectContaining({
+        timeouts: {
+          refreshBaseRefMs: 1_000,
+          addCheckoutMs: 2_000,
+          registrationMs: 3_000,
+          materializationMs: 4_000
+        }
+      }),
+      { timeoutMs: 28_830_000 }
+    )
   })
 
   it('resolves project and host flags to the matching repo for worktree.create', async () => {
@@ -1470,7 +1529,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenNthCalledWith(1, 'projectHostSetup.list')
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-gpu',
       name: 'feature',
       baseBranch: undefined,
@@ -1526,11 +1585,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(
-      2,
-      'worktree.create',
-      expect.objectContaining({ repo: 'id:repo-gpu' })
-    )
+    expectWorktreeCreateCall(2, expect.objectContaining({ repo: 'id:repo-gpu' }))
   })
 
   it('rejects mixing repo and project target flags on worktree.create', async () => {
@@ -1610,7 +1665,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenCalledTimes(1)
-    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+    expectWorktreeCreateCall(1, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1656,7 +1711,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenCalledTimes(1)
-    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+    expectWorktreeCreateCall(1, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1723,7 +1778,7 @@ describe('orca cli worktree awareness', () => {
       )
 
       expect(callMock).toHaveBeenCalledTimes(1)
-      expect(callMock).toHaveBeenCalledWith('worktree.create', {
+      expectWorktreeCreateCall(1, {
         repo: 'id:repo-1',
         name: 'child',
         baseBranch: undefined,
@@ -1767,7 +1822,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1812,7 +1867,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo/parent/src'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -1873,7 +1928,7 @@ describe('orca cli worktree awareness', () => {
         '/tmp/folder/src'
       )
 
-      expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+      expectWorktreeCreateCall(2, {
         repo: 'id:repo-1',
         name: 'child',
         baseBranch: undefined,
@@ -2021,7 +2076,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     const output = String(logSpy.mock.calls[0][0])
-    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+    expectWorktreeCreateCall(1, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -2063,7 +2118,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenCalledTimes(1)
-    expect(callMock).toHaveBeenCalledWith('worktree.create', {
+    expectWorktreeCreateCall(1, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -2098,7 +2153,7 @@ describe('orca cli worktree awareness', () => {
     )
 
     expect(callMock).toHaveBeenCalledTimes(2)
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'child',
       baseBranch: undefined,
@@ -2136,7 +2191,8 @@ describe('orca cli worktree awareness', () => {
 
     expect(callMock).toHaveBeenCalledWith(
       'worktree.create',
-      expect.objectContaining({ cliProvenanceRequest: {} })
+      expect.objectContaining({ cliProvenanceRequest: {} }),
+      { timeoutMs: 28_830_000 }
     )
   })
 
@@ -2871,7 +2927,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'feature',
       baseBranch: undefined,
@@ -2918,7 +2974,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo/src'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'agent-task',
       baseBranch: undefined,
@@ -2965,7 +3021,7 @@ describe('orca cli worktree awareness', () => {
       '/tmp/repo/src'
     )
 
-    expect(callMock).toHaveBeenNthCalledWith(2, 'worktree.create', {
+    expectWorktreeCreateCall(2, {
       repo: 'id:repo-1',
       name: 'agent-task',
       baseBranch: undefined,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -86,7 +86,7 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['worktree', 'create'],
     summary: 'Create a new Orca-managed worktree',
     usage:
-      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
+      'orca worktree create --name <name> [--repo <selector>|--project <id> [--host <host-id>]|--project-host-setup <id>] [--agent <id>] [--prompt <text>] [--setup run|skip|inherit] [--base-branch <ref>] [--issue <number>] [--linear-issue <identifier-or-url>] [--comment <text>] [--refresh-timeout-ms <ms>] [--add-timeout-ms <ms>] [--registration-timeout-ms <ms>] [--materialization-timeout-ms <ms>] [--parent-worktree <selector>] [--no-parent] [--run-hooks] [--activate] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'repo',
@@ -100,6 +100,10 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'issue',
       'linear-issue',
       'comment',
+      'refresh-timeout-ms',
+      'add-timeout-ms',
+      'registration-timeout-ms',
+      'materialization-timeout-ms',
       'setup',
       'parent-worktree',
       'no-parent',

--- a/src/main/git/push-target-validation.ts
+++ b/src/main/git/push-target-validation.ts
@@ -4,6 +4,8 @@ import { gitExecFileAsync } from './runner'
 
 type GitExecOptions = {
   wslDistro?: string
+  signal?: AbortSignal
+  timeout?: number
 }
 
 export async function validateGitPushTarget(

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -41,6 +41,7 @@ import {
   moveWorktree,
   parseWorktreeList,
   removeWorktree,
+  rollbackFailedWorktreeCreate,
   WORKTREE_ADD_TIMEOUT_MS,
   WORKTREE_LIST_TIMEOUT_MS
 } from './worktree'
@@ -814,6 +815,20 @@ describe('addWorktree', () => {
     expect(WORKTREE_ADD_TIMEOUT_MS).toBeGreaterThan(0)
   })
 
+  it('uses the caller timeout for worktree add and checkout commands', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' })
+
+    await addWorktree('/repo', '/repo-feature', 'feature/test', 'feature/test', false, false, {
+      checkoutExistingBranch: true,
+      timeout: 420_000
+    })
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
+      ['worktree', 'add', '/repo-feature', 'feature/test'],
+      { cwd: '/repo', timeout: 420_000 }
+    )
+  })
+
   it('does not write branch base config when no base branch is provided', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
@@ -1027,6 +1042,53 @@ describe('addWorktree', () => {
     ])
   })
 
+  it('rolls back an exact worktree left registered after add times out', async () => {
+    resolveRemoteBase()
+    gitExecFileAsyncMock
+      .mockRejectedValueOnce(new Error('git timed out.'))
+      .mockResolvedValueOnce({
+        stdout:
+          'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-feature\nHEAD def456\nbranch refs/heads/feature/test\n'
+      })
+      .mockResolvedValueOnce({ stdout: '' }) // worktree remove
+      .mockResolvedValueOnce({ stdout: '' }) // branch -D
+
+    await expect(
+      addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', false, false, {
+        timeout: 1_000
+      })
+    ).rejects.toThrow('git timed out.')
+
+    expect(gitExecFileAsyncMock.mock.calls.slice(2).map((call) => call[0])).toEqual([
+      ['worktree', 'list', '--porcelain', '-z'],
+      ['worktree', 'remove', '--force', '/repo-feature'],
+      ['branch', '-D', '--', 'feature/test']
+    ])
+  })
+
+  it('does not roll back a different branch at the requested path', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'worktree /repo-feature\nHEAD abc123\nbranch refs/heads/someone-else\n'
+    })
+
+    await expect(
+      rollbackFailedWorktreeCreate('/repo', '/repo-feature', 'feature/test', false)
+    ).resolves.toBe(false)
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'worktree',
+      'remove',
+      '--force',
+      '/repo-feature'
+    ])
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'branch',
+      '-D',
+      '--',
+      'feature/test'
+    ])
+  })
+
   it('fast-forwards with reset --hard when localBranch is checked out in primary worktree', async () => {
     const worktreeListOutput =
       'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n\nworktree /repo-other\nHEAD def456\nbranch refs/heads/feature\n'
@@ -1159,6 +1221,74 @@ describe('addWorktree', () => {
       '--hard',
       'remote-main'
     ])
+  })
+
+  it('shares the refresh timeout across base resolution, safety checks, and update', async () => {
+    const worktreeListOutput = 'worktree /repo\nHEAD abc123\nbranch refs/heads/develop\n'
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const results = [
+      { stdout: 'abc123\n' }, // resolve creation base
+      { stdout: '0\t3\n' }, // rev-list drift
+      { stdout: 'old-main\n' }, // local oid
+      { stdout: 'remote-main\n' }, // remote oid
+      { stdout: '' }, // merge-base
+      { stdout: worktreeListOutput }, // owner inspection
+      { stdout: '' }, // update-ref
+      { stdout: '' }, // worktree add
+      { stdout: '' }, // persist branch base
+      { stdout: 'true\n' } // push.autoSetupRemote already set
+    ]
+    gitExecFileAsyncMock.mockImplementation(async () => {
+      const result = results.shift() ?? { stdout: '' }
+      now += 1_000
+      return result
+    })
+
+    try {
+      await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true, false, {
+        refreshTimeout: 10_000
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(
+      gitExecFileAsyncMock.mock.calls.slice(0, 7).map(([, options]) => options.timeout)
+    ).toEqual([10_000, 9_000, 8_000, 7_000, 6_000, 5_000, 4_000])
+  })
+
+  it('fails when a completed command has exhausted the refresh stage deadline', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    gitExecFileAsyncMock.mockImplementationOnce(async () => {
+      now = 11_000
+      return { stdout: 'abc123\n' }
+    })
+
+    try {
+      await expect(
+        addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true, false, {
+          refreshTimeout: 10_000
+        })
+      ).rejects.toThrow('Worktree base ref refresh timed out.')
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports a subprocess timeout as a refresh stage timeout', async () => {
+    gitExecFileAsyncMock.mockRejectedValueOnce(new Error('git timed out.'))
+
+    await expect(
+      addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true, false, {
+        refreshTimeout: 10_000
+      })
+    ).rejects.toThrow('Worktree base ref refresh timed out.')
+
+    expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
   it('skips local base refresh when the owner worktree becomes dirty before mutation', async () => {
@@ -1765,6 +1895,36 @@ describe('addWorktree', () => {
       '-D',
       '--',
       'feature/test'
+    ])
+  })
+
+  it('shares one timeout budget across sparse add and checkout commands', async () => {
+    const nowSpy = vi
+      .spyOn(Date, 'now')
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(1_000)
+      .mockReturnValueOnce(4_000)
+      .mockReturnValueOnce(6_000)
+      .mockReturnValueOnce(9_000)
+    gitExecFileAsyncMock.mockResolvedValue({ stdout: '' })
+
+    try {
+      await addSparseWorktree('/repo', '/repo-feature', 'feature/test', ['src'], undefined, false, {
+        checkoutExistingBranch: true,
+        timeout: 10_000
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(gitExecFileAsyncMock.mock.calls).toEqual([
+      [
+        ['worktree', 'add', '--no-checkout', '/repo-feature', 'feature/test'],
+        { cwd: '/repo', timeout: 10_000 }
+      ],
+      [['sparse-checkout', 'init', '--cone'], { cwd: '/repo-feature', timeout: 7_000 }],
+      [['sparse-checkout', 'set', '--', 'src'], { cwd: '/repo-feature', timeout: 5_000 }],
+      [['checkout', 'feature/test'], { cwd: '/repo-feature', timeout: 2_000 }]
     ])
   })
 })

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -1334,6 +1334,101 @@ describe('addWorktree', () => {
     expect(gitExecFileAsyncMock).toHaveBeenCalledTimes(1)
   })
 
+  it('preserves a Git exit failure that returns after the refresh deadline', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    gitExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: 'abc123\n' }) // resolve creation base
+      .mockImplementationOnce(async () => {
+        now = 11_000
+        throw Object.assign(new Error('fatal: bad revision'), { code: 128 })
+      })
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // persist branch base
+      .mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+
+    try {
+      await expect(
+        addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true, false, {
+          refreshTimeout: 10_000
+        })
+      ).resolves.toEqual({
+        localBaseRefRefresh: {
+          status: 'skipped_not_fast_forward',
+          baseRef: 'origin/main',
+          localBranch: 'main'
+        }
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toContainEqual([
+      'worktree',
+      'add',
+      '--no-track',
+      '-b',
+      'feature/test',
+      '/repo-feature',
+      'refs/remotes/origin/main'
+    ])
+  })
+
+  it('reports a killed subprocess as a refresh stage timeout', async () => {
+    gitExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('git was killed'), { killed: true, signal: 'SIGTERM' })
+    )
+
+    await expect(
+      addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', true, false, {
+        refreshTimeout: 10_000
+      })
+    ).rejects.toThrow('Worktree base ref refresh timed out.')
+  })
+
+  it('uses normal probes after an advisory refresh timeout', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    gitExecFileAsyncMock
+      .mockImplementationOnce(async () => {
+        now = 2_000
+        throw new Error('git timed out.')
+      })
+      .mockResolvedValueOnce({ stdout: '' }) // remote-tracking ref fallback probe
+      .mockResolvedValueOnce({ stdout: 'local-oid\n' }) // local branch fallback probe
+      .mockResolvedValueOnce({ stdout: '' }) // worktree add
+      .mockResolvedValueOnce({ stdout: '' }) // persist branch base
+      .mockResolvedValueOnce({ stdout: 'true\n' }) // push.autoSetupRemote already set
+
+    try {
+      await expect(
+        addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', false, false, {
+          refreshTimeout: 1_000,
+          suggestLocalBaseRefUpdate: true
+        })
+      ).resolves.toEqual({})
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(gitExecFileAsyncMock.mock.calls.map(([args]) => args)).toEqual([
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
+      ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
+      ['rev-parse', '--verify', '--quiet', 'refs/heads/origin/main^{commit}'],
+      [
+        'worktree',
+        'add',
+        '--no-track',
+        '-b',
+        'feature/test',
+        '/repo-feature',
+        'refs/heads/origin/main'
+      ],
+      ['config', '--local', '--replace-all', 'branch.feature/test.base', 'refs/heads/origin/main'],
+      ['config', '--get', 'push.autoSetupRemote']
+    ])
+  })
+
   it('skips local base refresh when the owner worktree becomes dirty before mutation', async () => {
     const worktreeListOutput = 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
     gitExecFileAsyncMock

--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -783,6 +783,32 @@ describe('addWorktree', () => {
     ])
   })
 
+  it('does not reuse a cancelled create signal for post-add metadata', async () => {
+    const controller = new AbortController()
+    gitExecFileAsyncMock.mockImplementation(
+      async (args: string[], options?: { signal?: AbortSignal }) => {
+        if (args[0] === 'worktree' && args[1] === 'add') {
+          controller.abort()
+          return { stdout: '' }
+        }
+        if (options?.signal?.aborted) {
+          throw Object.assign(new Error('cancelled'), { name: 'AbortError' })
+        }
+        return { stdout: args[1] === '--get' ? 'true\n' : '' }
+      }
+    )
+
+    await addWorktree('/repo', '/repo-feature', 'feature/test', 'origin/main', false, false, {
+      signal: controller.signal
+    })
+
+    const postAddCalls = gitExecFileAsyncMock.mock.calls.filter(([args]) => args[0] === 'config')
+    expect(postAddCalls).toHaveLength(2)
+    for (const [, options] of postAddCalls) {
+      expect(options.signal).toBeUndefined()
+    }
+  })
+
   it('checks out a selected existing local branch without creating a new branch', async () => {
     gitExecFileAsyncMock.mockResolvedValueOnce({ stdout: '' }) // worktree add
 
@@ -1086,6 +1112,23 @@ describe('addWorktree', () => {
       '-D',
       '--',
       'feature/test'
+    ])
+  })
+
+  it('does not roll back the same branch from a different path', async () => {
+    gitExecFileAsyncMock.mockResolvedValueOnce({
+      stdout: 'worktree /repo-other\nHEAD abc123\nbranch refs/heads/feature/test\n'
+    })
+
+    await expect(
+      rollbackFailedWorktreeCreate('/repo', '/repo-feature', 'feature/test', false)
+    ).resolves.toBe(false)
+
+    expect(gitExecFileAsyncMock.mock.calls.map((call) => call[0])).not.toContainEqual([
+      'worktree',
+      'remove',
+      '--force',
+      '/repo-other'
     ])
   })
 

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -209,7 +209,17 @@ function parseRevListDrift(output: string): { ahead: number; behind: number } | 
 }
 
 function isGitCommandTimeout(error: unknown): boolean {
-  return getErrorCode(error) === 'ETIMEDOUT' || /\btimed out\b/i.test(getErrorText(error))
+  if (typeof error !== 'object' || error === null) {
+    return false
+  }
+  const details = error as { killed?: unknown; signal?: unknown }
+  return (
+    getErrorCode(error) === 'ETIMEDOUT' ||
+    details.killed === true ||
+    details.signal === 'SIGTERM' ||
+    details.signal === 'SIGKILL' ||
+    /\btimed out\b/i.test(getErrorText(error))
+  )
 }
 
 function createWorktreeRefreshStage(options: GitWorktreeExecOptions): WorktreeCreateRefreshStage {
@@ -234,7 +244,7 @@ function createWorktreeRefreshStage(options: GitWorktreeExecOptions): WorktreeCr
     } catch (error) {
       if (
         error instanceof WorktreeCreateRefreshTimeoutError ||
-        (deadlineAt !== undefined && (isGitCommandTimeout(error) || Date.now() >= deadlineAt))
+        (deadlineAt !== undefined && isGitCommandTimeout(error))
       ) {
         throw new WorktreeCreateRefreshTimeoutError()
       }
@@ -1110,7 +1120,7 @@ async function performAddWorktree(
             if (refreshLocalBaseRef) {
               throw error
             }
-            return options.remoteTrackingBase?.ref === qualifiedRef
+            return hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
           }
           return false
         }

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -106,6 +106,13 @@ class WorktreeCreateRefreshTimeoutError extends Error {
   }
 }
 
+class WorktreeCreateAddCheckoutTimeoutError extends Error {
+  constructor() {
+    super('Worktree add and checkout timed out.')
+    this.name = 'WorktreeCreateAddCheckoutTimeoutError'
+  }
+}
+
 const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
 
 const PRUNABLE_EXISTENCE_PROBE_CONCURRENCY = 8
@@ -217,22 +224,17 @@ function createWorktreeRefreshStage(options: GitWorktreeExecOptions): WorktreeCr
       throw new WorktreeCreateRefreshTimeoutError()
     }
     try {
-      const result = await gitExecFileAsync(
+      return await gitExecFileAsync(
         args,
         gitExecOptions(cwd, {
           ...options,
           ...(remaining === undefined ? {} : { timeout: remaining })
         })
       )
-      if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
-        throw new WorktreeCreateRefreshTimeoutError()
-      }
-      return result
     } catch (error) {
       if (
         error instanceof WorktreeCreateRefreshTimeoutError ||
-        isGitCommandTimeout(error) ||
-        (deadlineAt !== undefined && Date.now() >= deadlineAt)
+        (deadlineAt !== undefined && (isGitCommandTimeout(error) || Date.now() >= deadlineAt))
       ) {
         throw new WorktreeCreateRefreshTimeoutError()
       }
@@ -875,7 +877,14 @@ function remainingStageTimeout(
   deadlineAt: number | undefined,
   fallback: number | undefined
 ): number | undefined {
-  return deadlineAt === undefined ? fallback : Math.max(1, deadlineAt - Date.now())
+  if (deadlineAt === undefined) {
+    return fallback
+  }
+  const remaining = deadlineAt - Date.now()
+  if (remaining <= 0) {
+    throw new WorktreeCreateAddCheckoutTimeoutError()
+  }
+  return remaining
 }
 
 function mayHaveCompletedWorktreeAdd(error: unknown): boolean {
@@ -1098,7 +1107,10 @@ async function performAddWorktree(
           return true
         } catch (error) {
           if (error instanceof WorktreeCreateRefreshTimeoutError) {
-            throw error
+            if (refreshLocalBaseRef) {
+              throw error
+            }
+            return options.remoteTrackingBase?.ref === qualifiedRef
           }
           return false
         }
@@ -1114,14 +1126,20 @@ async function performAddWorktree(
           refreshStage
         )
       } else if (options.suggestLocalBaseRefUpdate) {
-        localBaseRefUpdateSuggestion = await getLocalBaseRefUpdateSuggestionForWorktreeCreate(
-          repoPath,
-          baseBranch,
-          effectiveBase,
-          options.remoteTrackingBase,
-          refreshOptions,
-          refreshStage
-        )
+        try {
+          localBaseRefUpdateSuggestion = await getLocalBaseRefUpdateSuggestionForWorktreeCreate(
+            repoPath,
+            baseBranch,
+            effectiveBase,
+            options.remoteTrackingBase,
+            refreshOptions,
+            refreshStage
+          )
+        } catch (error) {
+          if (!(error instanceof WorktreeCreateRefreshTimeoutError)) {
+            throw error
+          }
+        }
       }
       args.push(effectiveBase)
     }
@@ -1151,7 +1169,7 @@ async function performAddWorktree(
         worktreePath,
         branch,
         options.checkoutExistingBranch === true,
-        options
+        options.wslDistro ? { wslDistro: options.wslDistro } : {}
       )
     } catch (cleanupError) {
       const wrapped = error instanceof Error ? error : new Error(String(error))
@@ -1170,7 +1188,11 @@ async function performAddWorktree(
   }
 
   if (effectiveBase) {
-    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, addStageOptions())
+    const remaining = addDeadlineAt === undefined ? options.timeout : addDeadlineAt - Date.now()
+    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, {
+      ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
+      timeout: remaining === undefined ? undefined : Math.max(1_000, remaining)
+    })
   }
 
   // SSH parity: relay's addWorktreeOp (src/relay/git-handler-worktree-ops.ts) mirrors this — change both in lockstep.
@@ -1183,7 +1205,10 @@ async function performAddWorktree(
     let alreadySet = false
     try {
       await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
-        ...gitExecOptions(worktreePath, addStageOptions())
+        ...gitExecOptions(worktreePath, {
+          ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
+          timeout: remainingStageTimeout(addDeadlineAt, options.timeout)
+        })
       })
       alreadySet = true
     } catch (readError) {
@@ -1195,7 +1220,10 @@ async function performAddWorktree(
     }
     if (!alreadySet) {
       await gitExecFileAsync(['config', '--local', 'push.autoSetupRemote', 'true'], {
-        ...gitExecOptions(worktreePath, addStageOptions())
+        ...gitExecOptions(worktreePath, {
+          ...(options.wslDistro ? { wslDistro: options.wslDistro } : {}),
+          timeout: remainingStageTimeout(addDeadlineAt, options.timeout)
+        })
       })
     }
   } catch (error) {

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -48,6 +48,7 @@ export type GitWorktreeExecOptions = {
   wslDistro?: string
   signal?: AbortSignal
   timeout?: number
+  detectSparseCheckout?: boolean
 }
 
 type WorktreeRemovalPreflightOptions = GitWorktreeExecOptions & {
@@ -55,6 +56,8 @@ type WorktreeRemovalPreflightOptions = GitWorktreeExecOptions & {
 }
 
 export type AddWorktreeOptions = GitWorktreeExecOptions & {
+  refreshTimeout?: number
+  addCheckoutDeadline?: { at?: number }
   checkoutExistingBranch?: boolean
   suggestLocalBaseRefUpdate?: boolean
   remoteTrackingBase?: {
@@ -69,6 +72,8 @@ export type RemoveWorktreeOptions = GitWorktreeExecOptions & {
   forceBranchDelete?: boolean
   knownRemovedWorktree?: Pick<GitWorktreeInfo, 'branch' | 'head' | 'locked' | 'lockReason'>
 }
+
+type FailedWorktreeCreateRollbackOptions = Pick<GitWorktreeExecOptions, 'wslDistro'>
 
 type LocalBaseRefRefreshability =
   | {
@@ -86,6 +91,20 @@ type LocalBaseRefRefreshability =
       refreshable: false
       result: LocalBaseRefRefreshResult
     }
+
+type WorktreeGitCommand = (args: string[], cwd: string) => ReturnType<typeof gitExecFileAsync>
+
+type WorktreeCreateRefreshStage = {
+  execute: WorktreeGitCommand
+  options: GitWorktreeExecOptions
+}
+
+class WorktreeCreateRefreshTimeoutError extends Error {
+  constructor() {
+    super('Worktree base ref refresh timed out.')
+    this.name = 'WorktreeCreateRefreshTimeoutError'
+  }
+}
 
 const SPARSE_CHECKOUT_DETECTION_CONCURRENCY = 8
 
@@ -182,14 +201,56 @@ function parseRevListDrift(output: string): { ahead: number; behind: number } | 
   return counts.status === 'ok' ? { ahead: counts.ahead, behind: counts.behind } : null
 }
 
+function isGitCommandTimeout(error: unknown): boolean {
+  return getErrorCode(error) === 'ETIMEDOUT' || /\btimed out\b/i.test(getErrorText(error))
+}
+
+function createWorktreeRefreshStage(options: GitWorktreeExecOptions): WorktreeCreateRefreshStage {
+  const timeout =
+    typeof options.timeout === 'number' && Number.isFinite(options.timeout) && options.timeout > 0
+      ? options.timeout
+      : undefined
+  const deadlineAt = timeout === undefined ? undefined : Date.now() + timeout
+  const execute: WorktreeGitCommand = async (args, cwd) => {
+    const remaining = deadlineAt === undefined ? undefined : deadlineAt - Date.now()
+    if (remaining !== undefined && remaining <= 0) {
+      throw new WorktreeCreateRefreshTimeoutError()
+    }
+    try {
+      const result = await gitExecFileAsync(
+        args,
+        gitExecOptions(cwd, {
+          ...options,
+          ...(remaining === undefined ? {} : { timeout: remaining })
+        })
+      )
+      if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
+        throw new WorktreeCreateRefreshTimeoutError()
+      }
+      return result
+    } catch (error) {
+      if (
+        error instanceof WorktreeCreateRefreshTimeoutError ||
+        isGitCommandTimeout(error) ||
+        (deadlineAt !== undefined && Date.now() >= deadlineAt)
+      ) {
+        throw new WorktreeCreateRefreshTimeoutError()
+      }
+      throw error
+    }
+  }
+  return { execute, options }
+}
+
 async function evaluateLocalBaseRefRefreshability(
   repoPath: string,
   baseBranch: string,
   remoteTrackingRef: string,
   remoteTrackingBase?: AddWorktreeOptions['remoteTrackingBase'],
-  options: GitWorktreeExecOptions = {},
+  stage: WorktreeCreateRefreshStage = createWorktreeRefreshStage({}),
   shouldInspectOwner: (behind: number) => boolean = () => true
 ): Promise<LocalBaseRefRefreshability | undefined> {
+  const { execute, options } = stage
   const parsed = parseRemoteTrackingLocalBaseRef(baseBranch, remoteTrackingRef, remoteTrackingBase)
   if (!parsed) {
     return undefined
@@ -202,9 +263,9 @@ async function evaluateLocalBaseRefRefreshability(
   let remoteOid = ''
   try {
     // Why: advisory and mutating paths must agree on "safe to fast-forward"; `rev-list A...B` proves no local-only commits and how far behind.
-    const { stdout } = await gitExecFileAsync(
+    const { stdout } = await execute(
       ['rev-list', '--left-right', '--count', `${parsed.fullRef}...${remoteTrackingRef}`],
-      gitExecOptions(repoPath, options)
+      repoPath
     )
     const parsedDrift = parseRevListDrift(stdout)
     if (!parsedDrift || parsedDrift.ahead !== 0) {
@@ -214,36 +275,36 @@ async function evaluateLocalBaseRefRefreshability(
       // Why: a current local ref yields no update suggestion, so the advisory path skips OID resolution and owner inspection.
       return undefined
     }
-    const { stdout: localOidOutput } = await gitExecFileAsync(
+    const { stdout: localOidOutput } = await execute(
       ['rev-parse', '--verify', `${parsed.fullRef}^{commit}`],
-      gitExecOptions(repoPath, options)
+      repoPath
     )
     localOid = localOidOutput.trim()
     if (!localOid) {
       return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
     }
-    const { stdout: remoteOidOutput } = await gitExecFileAsync(
+    const { stdout: remoteOidOutput } = await execute(
       ['rev-parse', '--verify', `${remoteTrackingRef}^{commit}`],
-      gitExecOptions(repoPath, options)
+      repoPath
     )
     remoteOid = remoteOidOutput.trim()
     if (!remoteOid) {
       return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
     }
-    await gitExecFileAsync(
-      ['merge-base', '--is-ancestor', localOid, remoteOid],
-      gitExecOptions(repoPath, options)
-    )
+    await execute(['merge-base', '--is-ancestor', localOid, remoteOid], repoPath)
     drift = parsedDrift
-  } catch {
+  } catch (error) {
+    if (error instanceof WorktreeCreateRefreshTimeoutError) {
+      throw error
+    }
     return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
   }
 
   try {
     // Why: if the local base branch is checked out, only update it when that owner worktree is clean.
-    const { stdout: worktreeListOutput } = await gitExecFileAsync(
+    const { stdout: worktreeListOutput } = await execute(
       ['worktree', 'list', '--porcelain'],
-      gitExecOptions(repoPath, options)
+      repoPath
     )
     const worktrees = parseWorktreeList(
       translateWslOutputPaths(worktreeListOutput, repoPath, options)
@@ -251,9 +312,9 @@ async function evaluateLocalBaseRefRefreshability(
     const ownerWorktree = worktrees.find((wt) => wt.branch === parsed.fullRef)
 
     if (ownerWorktree) {
-      const { stdout: status } = await gitExecFileAsync(
+      const { stdout: status } = await execute(
         ['status', '--porcelain', '--untracked-files=no'],
-        gitExecOptions(ownerWorktree.path, options)
+        ownerWorktree.path
       )
       if (status.trim()) {
         return {
@@ -287,7 +348,10 @@ async function evaluateLocalBaseRefRefreshability(
       remoteOid,
       behind: drift.behind
     }
-  } catch {
+  } catch (error) {
+    if (error instanceof WorktreeCreateRefreshTimeoutError) {
+      throw error
+    }
     return { refreshable: false, result: { ...resultBase, status: 'skipped_error' } }
   }
 }
@@ -297,14 +361,15 @@ async function getLocalBaseRefUpdateSuggestionForWorktreeCreate(
   baseBranch: string,
   remoteTrackingRef: string,
   remoteTrackingBase?: AddWorktreeOptions['remoteTrackingBase'],
-  options: GitWorktreeExecOptions = {}
+  options: GitWorktreeExecOptions = {},
+  stage = createWorktreeRefreshStage(options)
 ): Promise<LocalBaseRefUpdateSuggestion | undefined> {
   const evaluation = await evaluateLocalBaseRefRefreshability(
     repoPath,
     baseBranch,
     remoteTrackingRef,
     remoteTrackingBase,
-    options,
+    stage,
     (behind) => behind > 0
   )
   if (!evaluation?.refreshable || evaluation.behind <= 0) {
@@ -801,7 +866,64 @@ export async function listWorktreesStrict(
     const translatedPath = translateWorktreePath(worktree.path, repoPath, options)
     return translatedPath === worktree.path ? worktree : { ...worktree, path: translatedPath }
   })
-  return annotateSparseCheckoutStatus(worktrees)
+  return options.detectSparseCheckout === false
+    ? worktrees
+    : annotateSparseCheckoutStatus(worktrees)
+}
+
+function remainingStageTimeout(
+  deadlineAt: number | undefined,
+  fallback: number | undefined
+): number | undefined {
+  return deadlineAt === undefined ? fallback : Math.max(1, deadlineAt - Date.now())
+}
+
+function mayHaveCompletedWorktreeAdd(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const details = error as Error & {
+    code?: unknown
+    killed?: unknown
+    signal?: unknown
+  }
+  return (
+    error.name === 'AbortError' ||
+    error.message.toLowerCase().includes('timed out') ||
+    details.code === 'ETIMEDOUT' ||
+    details.killed === true ||
+    details.signal === 'SIGTERM'
+  )
+}
+
+export async function rollbackFailedWorktreeCreate(
+  repoPath: string,
+  worktreePath: string,
+  branch: string,
+  checkoutExistingBranch: boolean,
+  options: FailedWorktreeCreateRollbackOptions = {}
+): Promise<boolean> {
+  const cleanupOptions = {
+    ...options,
+    timeout: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
+    detectSparseCheckout: false
+  }
+  const created = (await listWorktreesStrict(repoPath, cleanupOptions)).find(
+    (worktree) =>
+      areWorktreePathsEqual(worktree.path, worktreePath) &&
+      normalizeLocalBranchRef(worktree.branch ?? '') === branch
+  )
+  if (!created) {
+    return false
+  }
+  await removeWorktree(repoPath, created.path, true, {
+    ...options,
+    timeout: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
+    knownRemovedWorktree: created,
+    deleteBranch: !checkoutExistingBranch,
+    forceBranchDelete: !checkoutExistingBranch
+  })
+  return true
 }
 
 async function annotateSparseCheckoutStatus(
@@ -836,14 +958,15 @@ async function refreshLocalBaseRefForWorktreeCreate(
   baseBranch: string,
   remoteTrackingRef: string,
   remoteTrackingBase?: AddWorktreeOptions['remoteTrackingBase'],
-  options: GitWorktreeExecOptions = {}
+  options: GitWorktreeExecOptions = {},
+  stage = createWorktreeRefreshStage(options)
 ): Promise<LocalBaseRefRefreshResult | undefined> {
   const evaluation = await evaluateLocalBaseRefRefreshability(
     repoPath,
     baseBranch,
     remoteTrackingRef,
     remoteTrackingBase,
-    options
+    stage
   )
   if (!evaluation) {
     return undefined
@@ -855,9 +978,9 @@ async function refreshLocalBaseRefForWorktreeCreate(
   const resultBase = { baseRef: evaluation.baseRef, localBranch: evaluation.localBranch }
   try {
     if (evaluation.ownerWorktreePath) {
-      const { stdout: worktreeListOutput } = await gitExecFileAsync(
+      const { stdout: worktreeListOutput } = await stage.execute(
         ['worktree', 'list', '--porcelain'],
-        gitExecOptions(repoPath, options)
+        repoPath
       )
       const worktrees = parseWorktreeList(
         translateWslOutputPaths(worktreeListOutput, repoPath, options)
@@ -866,9 +989,9 @@ async function refreshLocalBaseRefForWorktreeCreate(
       if (!currentOwner || currentOwner.path !== evaluation.ownerWorktreePath) {
         return { ...resultBase, status: 'skipped_error' }
       }
-      const { stdout: status } = await gitExecFileAsync(
+      const { stdout: status } = await stage.execute(
         ['status', '--porcelain', '--untracked-files=no'],
-        gitExecOptions(currentOwner.path, options)
+        currentOwner.path
       )
       if (status.trim()) {
         return {
@@ -877,20 +1000,20 @@ async function refreshLocalBaseRefForWorktreeCreate(
           ownerWorktreePath: currentOwner.path
         }
       }
-      await gitExecFileAsync(
-        ['reset', '--hard', evaluation.remoteOid],
-        gitExecOptions(currentOwner.path, options)
-      )
+      await stage.execute(['reset', '--hard', evaluation.remoteOid], currentOwner.path)
       return { ...resultBase, status: 'updated', ownerWorktreePath: currentOwner.path }
     }
 
     // Why: no owner worktree — fast-forward the bare ref; the expected-old-OID form is a no-op-safe CAS if the ref moved since evaluation.
-    await gitExecFileAsync(
+    await stage.execute(
       ['update-ref', evaluation.fullRef, evaluation.remoteOid, evaluation.localOid],
-      gitExecOptions(repoPath, options)
+      repoPath
     )
     return { ...resultBase, status: 'updated' }
-  } catch {
+  } catch (error) {
+    if (error instanceof WorktreeCreateRefreshTimeoutError) {
+      throw error
+    }
     // update-ref/reset can fail on locked refs or odd worktree states; worktree creation should still proceed.
     return { ...resultBase, status: 'skipped_error' }
   }
@@ -955,9 +1078,31 @@ async function performAddWorktree(
     // Why: --no-track avoids inheriting the base's upstream so `git status` won't misreport "behind by N" pre-publish; first push sets it (see push.autoSetupRemote below).
     args.push('--no-track', '-b', branch, worktreePath)
     if (baseBranch) {
-      effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, (qualifiedRef) =>
-        hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
-      )
+      const refreshOptions = {
+        ...options,
+        timeout: options.refreshTimeout ?? options.timeout
+      }
+      const refreshStage =
+        refreshLocalBaseRef || options.suggestLocalBaseRefUpdate
+          ? createWorktreeRefreshStage(refreshOptions)
+          : undefined
+      effectiveBase = await resolveWorktreeAddBaseRef(baseBranch, async (qualifiedRef) => {
+        if (!refreshStage) {
+          return hasWorktreeBaseCommitRef(repoPath, qualifiedRef, options)
+        }
+        try {
+          await refreshStage.execute(
+            ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+            repoPath
+          )
+          return true
+        } catch (error) {
+          if (error instanceof WorktreeCreateRefreshTimeoutError) {
+            throw error
+          }
+          return false
+        }
+      })
       // Why: resolve the creation base first to distinguish remote-tracking refs from slash-containing local branches (mutation gated behind the explicit setting).
       if (refreshLocalBaseRef) {
         localBaseRefRefresh = await refreshLocalBaseRefForWorktreeCreate(
@@ -965,7 +1110,8 @@ async function performAddWorktree(
           baseBranch,
           effectiveBase,
           options.remoteTrackingBase,
-          options
+          refreshOptions,
+          refreshStage
         )
       } else if (options.suggestLocalBaseRefUpdate) {
         localBaseRefUpdateSuggestion = await getLocalBaseRefUpdateSuggestionForWorktreeCreate(
@@ -973,24 +1119,58 @@ async function performAddWorktree(
           baseBranch,
           effectiveBase,
           options.remoteTrackingBase,
-          options
+          refreshOptions,
+          refreshStage
         )
       }
       args.push(effectiveBase)
     }
   }
-  await gitExecFileAsync(args, {
-    ...gitExecOptions(repoPath, options),
-    // Why: bound the checkout so a OneDrive cloud-placeholder stall (STA-1292) fails fast instead of hanging.
-    timeout: WORKTREE_ADD_TIMEOUT_MS
+  const addDeadlineAt = options.timeout ? Date.now() + options.timeout : undefined
+  if (options.addCheckoutDeadline) {
+    options.addCheckoutDeadline.at = addDeadlineAt
+  }
+  const addStageOptions = (): AddWorktreeOptions => ({
+    ...options,
+    timeout: remainingStageTimeout(addDeadlineAt, options.timeout)
   })
+  const worktreeAddOptions = options.addCheckoutDeadline ? addStageOptions() : options
+  try {
+    await gitExecFileAsync(args, {
+      ...gitExecOptions(repoPath, worktreeAddOptions),
+      // Why: bound the checkout so a OneDrive cloud-placeholder stall (STA-1292) fails fast instead of hanging.
+      timeout: worktreeAddOptions.timeout ?? WORKTREE_ADD_TIMEOUT_MS
+    })
+  } catch (error) {
+    if (!mayHaveCompletedWorktreeAdd(error)) {
+      throw error
+    }
+    try {
+      await rollbackFailedWorktreeCreate(
+        repoPath,
+        worktreePath,
+        branch,
+        options.checkoutExistingBranch === true,
+        options
+      )
+    } catch (cleanupError) {
+      const wrapped = error instanceof Error ? error : new Error(String(error))
+      wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
+      console.warn(
+        `[git/worktree] Failed to reconcile timed-out create at "${worktreePath}"`,
+        cleanupError
+      )
+      throw wrapped
+    }
+    throw error
+  }
 
   if (options.checkoutExistingBranch) {
     return localBaseRefRefresh ? { localBaseRefRefresh } : {}
   }
 
   if (effectiveBase) {
-    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, options)
+    await persistWorktreeCreationBase(worktreePath, branch, effectiveBase, addStageOptions())
   }
 
   // SSH parity: relay's addWorktreeOp (src/relay/git-handler-worktree-ops.ts) mirrors this — change both in lockstep.
@@ -1003,7 +1183,7 @@ async function performAddWorktree(
     let alreadySet = false
     try {
       await gitExecFileAsync(['config', '--get', 'push.autoSetupRemote'], {
-        ...gitExecOptions(worktreePath, options)
+        ...gitExecOptions(worktreePath, addStageOptions())
       })
       alreadySet = true
     } catch (readError) {
@@ -1015,7 +1195,7 @@ async function performAddWorktree(
     }
     if (!alreadySet) {
       await gitExecFileAsync(['config', '--local', 'push.autoSetupRemote', 'true'], {
-        ...gitExecOptions(worktreePath, options)
+        ...gitExecOptions(worktreePath, addStageOptions())
       })
     }
   } catch (error) {
@@ -1038,6 +1218,11 @@ export async function addSparseWorktree(
 ): Promise<AddWorktreeResult> {
   let created = false
   let addResult: AddWorktreeResult = {}
+  const addCheckoutDeadline: { at?: number } = {}
+  const stageOptions = (): AddWorktreeOptions => ({
+    ...options,
+    timeout: remainingStageTimeout(addCheckoutDeadline.at, options.timeout)
+  })
   try {
     addResult = await addWorktree(
       repoPath,
@@ -1046,18 +1231,18 @@ export async function addSparseWorktree(
       baseBranch,
       refreshLocalBaseRef,
       true,
-      options
+      { ...options, addCheckoutDeadline }
     )
     created = true
     await gitExecFileAsync(
       ['sparse-checkout', 'init', '--cone'],
-      gitExecOptions(worktreePath, options)
+      gitExecOptions(worktreePath, stageOptions())
     )
     await gitExecFileAsync(
       ['sparse-checkout', 'set', '--', ...directories],
-      gitExecOptions(worktreePath, options)
+      gitExecOptions(worktreePath, stageOptions())
     )
-    await gitExecFileAsync(['checkout', branch], gitExecOptions(worktreePath, options))
+    await gitExecFileAsync(['checkout', branch], gitExecOptions(worktreePath, stageOptions()))
     return addResult
   } catch (error) {
     const wrapped: SparseWorktreeCreateError =

--- a/src/main/ipc/repos.ts
+++ b/src/main/ipc/repos.ts
@@ -32,6 +32,7 @@ import { DEFAULT_REPO_BADGE_COLOR } from '../../shared/constants'
 import { normalizeRepoBadgeColor } from '../../shared/repo-badge-color'
 import { sanitizeRepoIcon } from '../../shared/repo-icon'
 import { normalizeRepoSourceControlAiOverrides } from '../../shared/source-control-ai'
+import { normalizeWorktreeCreateTimeoutOverrides } from '../../shared/worktree-create-timeouts'
 import {
   isRuntimePathAbsolute,
   normalizeRuntimePathForComparison,
@@ -2107,6 +2108,7 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
           >
         > & {
           sourceControlAi?: Repo['sourceControlAi'] | null
+          worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
           externalWorktreeDiscoverySuppressedAt?:
             | Repo['externalWorktreeDiscoverySuppressedAt']
             | null
@@ -2147,6 +2149,12 @@ export function registerRepoHandlers(mainWindow: BrowserWindow, store: Store): v
         } else {
           updates.worktreeBasePath = v.trim() || undefined
         }
+      }
+      if ('worktreeCreateTimeouts' in updates && updates.worktreeCreateTimeouts !== null) {
+        const worktreeCreateTimeouts = normalizeWorktreeCreateTimeoutOverrides(
+          updates.worktreeCreateTimeouts
+        )
+        updates.worktreeCreateTimeouts = worktreeCreateTimeouts
       }
       if ('repoIcon' in updates) {
         const repoIcon = sanitizeRepoIcon(updates.repoIcon)

--- a/src/main/ipc/settings.test.ts
+++ b/src/main/ipc/settings.test.ts
@@ -487,6 +487,43 @@ describe('registerSettingsHandlers', () => {
     )
   })
 
+  it('normalizes worktree create timeout settings before persistence', async () => {
+    const currentTimeouts = {
+      refreshBaseRefMs: 60_000,
+      addCheckoutMs: 180_000,
+      registrationMs: 30_000,
+      materializationMs: 300_000
+    }
+    store.getSettings.mockReturnValue({ worktreeCreateTimeouts: currentTimeouts })
+    store.updateSettings.mockReturnValue({ worktreeCreateTimeouts: currentTimeouts })
+    registerSettingsHandlers(store as never)
+
+    const handler = handleMock.mock.calls.find((call) => call[0] === 'settings:set')?.[1] as (
+      event: typeof settingsInvokeEvent,
+      args: unknown
+    ) => Promise<unknown>
+
+    await handler(settingsInvokeEvent, {
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 500,
+        addCheckoutMs: 8_000_000,
+        registrationMs: Number.NaN
+      }
+    })
+
+    expect(store.updateSettings).toHaveBeenCalledWith(
+      {
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 1_000,
+          addCheckoutMs: 7_200_000,
+          registrationMs: 30_000,
+          materializationMs: 300_000
+        }
+      },
+      { notifyListeners: true, originWebContentsId: 1 }
+    )
+  })
+
   it('normalizes terminal line height updates before persistence', async () => {
     store.getSettings.mockReturnValue({ terminalLineHeight: 1 })
     store.updateSettings.mockReturnValue({ terminalLineHeight: 1 })

--- a/src/main/ipc/settings.ts
+++ b/src/main/ipc/settings.ts
@@ -33,6 +33,10 @@ import {
   computerAwakeSettingsForMode,
   normalizeComputerAwakeMode
 } from '../../shared/computer-awake-mode'
+import {
+  WORKTREE_CREATE_TIMEOUT_DEFAULTS,
+  normalizeWorktreeCreateTimeouts
+} from '../../shared/worktree-create-timeouts'
 
 // Why: the whitelist is the source-of-truth for which keys we emit on. Casting
 // to a Set once at module load lets the IPC handler's per-key membership
@@ -179,6 +183,12 @@ export function registerSettingsHandlers(
     if ('mobilePairingCustomAddresses' in args) {
       sanitizedArgs.mobilePairingCustomAddresses = normalizeMobilePairingCustomAddresses(
         args.mobilePairingCustomAddresses
+      )
+    }
+    if ('worktreeCreateTimeouts' in args) {
+      sanitizedArgs.worktreeCreateTimeouts = normalizeWorktreeCreateTimeouts(
+        args.worktreeCreateTimeouts,
+        store.getSettings().worktreeCreateTimeouts ?? WORKTREE_CREATE_TIMEOUT_DEFAULTS
       )
     }
     if (args.theme) {

--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -132,6 +132,28 @@ describe('prepareWorktreePushTargetWithExec', () => {
     ])
   })
 
+  it('uses separate fetch and cleanup executors when provided', async () => {
+    const exec = makeRepoExec({ origin: 'git@github.com:stablyai/orca.git' })
+    const cleanupExec = vi.fn<GitRemoteExec>().mockResolvedValue({ stdout: '', stderr: '' })
+    const fetchRemoteTrackingRef = vi.fn().mockRejectedValue(new Error('fetch timed out'))
+
+    await expect(
+      prepareWorktreePushTargetWithExec(
+        exec,
+        REPO,
+        forkTarget(),
+        () => false,
+        cleanupExec,
+        fetchRemoteTrackingRef
+      )
+    ).rejects.toThrow('fetch timed out')
+
+    expect(fetchRemoteTrackingRef).toHaveBeenCalledWith('pr-contributor-orca')
+    expect(callsMatching(exec, ['fetch'])).toEqual([])
+    expect(callsMatching(exec, ['remote', 'remove'])).toEqual([])
+    expect(cleanupExec).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], REPO)
+  })
+
   it('reuses an existing remote pointing at the same fork (SSH vs HTTPS) without adding', async () => {
     const exec = makeRepoExec({
       origin: 'git@github.com:stablyai/orca.git',

--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -85,6 +85,37 @@ describe('prepareWorktreePushTargetWithExec', () => {
     firstRelease()
   })
 
+  it('removes an aborted waiter from the preparation queue', async () => {
+    const firstRelease = await acquireWorktreePushTargetPreparationLease(REPO, forkTarget())
+    const controller = new AbortController()
+    const second = acquireWorktreePushTargetPreparationLease(REPO, forkTarget(), {
+      signal: controller.signal
+    })
+
+    controller.abort()
+    await expect(second).rejects.toMatchObject({ name: 'AbortError' })
+
+    const third = acquireWorktreePushTargetPreparationLease(REPO, forkTarget())
+    firstRelease()
+    const thirdRelease = await third
+    thirdRelease()
+  })
+
+  it('uses the refresh deadline while waiting for the preparation lease', async () => {
+    const firstRelease = await acquireWorktreePushTargetPreparationLease(REPO, forkTarget())
+    const timeoutError = new Error('Worktree base ref refresh timed out after 60000ms.')
+
+    await expect(
+      acquireWorktreePushTargetPreparationLease(REPO, forkTarget(), {
+        remainingTimeoutMs: () => {
+          throw timeoutError
+        }
+      })
+    ).rejects.toBe(timeoutError)
+
+    firstRelease()
+  })
+
   it('adds a new fork remote and fetches its head when none matches', async () => {
     const exec = makeRepoExec({ origin: 'git@github.com:stablyai/orca.git' })
 
@@ -152,6 +183,38 @@ describe('prepareWorktreePushTargetWithExec', () => {
     expect(callsMatching(exec, ['fetch'])).toEqual([])
     expect(callsMatching(exec, ['remote', 'remove'])).toEqual([])
     expect(cleanupExec).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], REPO)
+  })
+
+  it('reconciles and removes a remote whose add response timed out', async () => {
+    const remotes: Record<string, string> = { origin: 'git@github.com:stablyai/orca.git' }
+    const exec = makeRepoExec(remotes)
+    const baseExec = exec.getMockImplementation()!
+    exec.mockImplementation(async (args, cwd) => {
+      if (args[0] === 'remote' && args[1] === 'add') {
+        remotes[args[2]!] = args[3]!
+        throw Object.assign(new Error('Request "git.exec" timed out after 60000ms'), {
+          code: 'SSH_MUX_REQUEST_TIMEOUT'
+        })
+      }
+      return baseExec(args, cwd)
+    })
+    const cleanupExec = makeRepoExec(remotes)
+    const baseCleanupExec = cleanupExec.getMockImplementation()!
+    cleanupExec.mockImplementation(async (args, cwd) => {
+      if (args[0] === 'remote' && args[1] === 'remove') {
+        delete remotes[args[2]!]
+        return { stdout: '', stderr: '' }
+      }
+      return baseCleanupExec(args, cwd)
+    })
+
+    await expect(
+      prepareWorktreePushTargetWithExec(exec, REPO, forkTarget(), () => false, cleanupExec)
+    ).rejects.toThrow('timed out')
+
+    expect(cleanupExec).toHaveBeenCalledWith(['remote', 'get-url', 'pr-contributor-orca'], REPO)
+    expect(cleanupExec).toHaveBeenCalledWith(['remote', 'remove', 'pr-contributor-orca'], REPO)
+    expect(remotes).toEqual({ origin: 'git@github.com:stablyai/orca.git' })
   })
 
   it('reuses an existing remote pointing at the same fork (SSH vs HTTPS) without adding', async () => {

--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -101,9 +101,9 @@ describe('prepareWorktreePushTargetWithExec', () => {
     thirdRelease()
   })
 
-  it('uses the refresh deadline while waiting for the preparation lease', async () => {
+  it('uses the caller deadline while waiting for the preparation lease', async () => {
     const firstRelease = await acquireWorktreePushTargetPreparationLease(REPO, forkTarget())
-    const timeoutError = new Error('Worktree base ref refresh timed out after 60000ms.')
+    const timeoutError = new Error('Worktree add and checkout timed out after 180000ms.')
 
     await expect(
       acquireWorktreePushTargetPreparationLease(REPO, forkTarget(), {

--- a/src/main/ipc/worktree-push-target-setup.test.ts
+++ b/src/main/ipc/worktree-push-target-setup.test.ts
@@ -2,6 +2,7 @@ import { describe, expect, it, vi, type Mock } from 'vitest'
 import type { GitPushTarget } from '../../shared/types'
 import type { GitRemoteExec } from './worktree-push-target-cleanup'
 import {
+  acquireWorktreePushTargetPreparationLease,
   configureCreatedWorktreePushTargetWithExec,
   ensureUniqueRemoteName,
   findRemoteForUrl,
@@ -52,6 +53,38 @@ function forkTarget(overrides: Partial<GitPushTarget> = {}): GitPushTarget {
 }
 
 describe('prepareWorktreePushTargetWithExec', () => {
+  it('serializes preparation for the same repository and canonical fork URL', async () => {
+    const firstRelease = await acquireWorktreePushTargetPreparationLease(REPO, forkTarget())
+    let secondAcquired = false
+    const second = acquireWorktreePushTargetPreparationLease(
+      REPO,
+      forkTarget({ remoteUrl: FORK_HTTPS })
+    ).then((release) => {
+      secondAcquired = true
+      return release
+    })
+
+    await Promise.resolve()
+    expect(secondAcquired).toBe(false)
+
+    firstRelease()
+    const secondRelease = await second
+    expect(secondAcquired).toBe(true)
+    secondRelease()
+  })
+
+  it('allows different fork URLs to prepare concurrently', async () => {
+    const firstRelease = await acquireWorktreePushTargetPreparationLease(REPO, forkTarget())
+
+    const secondRelease = await acquireWorktreePushTargetPreparationLease(
+      REPO,
+      forkTarget({ remoteUrl: 'git@github.com:other/orca.git' })
+    )
+
+    secondRelease()
+    firstRelease()
+  })
+
   it('adds a new fork remote and fetches its head when none matches', async () => {
     const exec = makeRepoExec({ origin: 'git@github.com:stablyai/orca.git' })
 
@@ -73,6 +106,30 @@ describe('prepareWorktreePushTargetWithExec', () => {
       remoteUrl: FORK_SSH,
       remoteCreated: true
     })
+  })
+
+  it('removes a newly added fork remote when its initial fetch fails', async () => {
+    const remotes: Record<string, string> = { origin: 'git@github.com:stablyai/orca.git' }
+    const exec = makeRepoExec(remotes)
+    const baseExec = exec.getMockImplementation()!
+    exec.mockImplementation(async (args, cwd) => {
+      if (args[0] === 'fetch') {
+        throw new Error('fetch failed')
+      }
+      if (args[0] === 'remote' && args[1] === 'remove') {
+        delete remotes[args[2]!]
+        return { stdout: '', stderr: '' }
+      }
+      return baseExec(args, cwd)
+    })
+
+    await expect(
+      prepareWorktreePushTargetWithExec(exec, REPO, forkTarget(), () => false)
+    ).rejects.toThrow('fetch failed')
+
+    expect(callsMatching(exec, ['remote', 'remove'])).toEqual([
+      ['remote', 'remove', 'pr-contributor-orca']
+    ])
   })
 
   it('reuses an existing remote pointing at the same fork (SSH vs HTTPS) without adding', async () => {
@@ -106,6 +163,25 @@ describe('prepareWorktreePushTargetWithExec', () => {
 
     expect(result.remoteName).toBe('fork-x')
     expect(result.remoteCreated).toBe(true)
+  })
+
+  it('does not remove a reused Orca-created remote when fetching it fails', async () => {
+    const remotes = { 'fork-x': FORK_HTTPS }
+    const exec = makeRepoExec(remotes)
+    const baseExec = exec.getMockImplementation()!
+    exec.mockImplementation(async (args, cwd) => {
+      if (args[0] === 'fetch') {
+        throw new Error('fetch failed')
+      }
+      return baseExec(args, cwd)
+    })
+
+    await expect(
+      prepareWorktreePushTargetWithExec(exec, REPO, forkTarget(), () => true)
+    ).rejects.toThrow('fetch failed')
+
+    expect(callsMatching(exec, ['remote', 'remove'])).toEqual([])
+    expect(remotes).toEqual({ 'fork-x': FORK_HTTPS })
   })
 
   it('disambiguates with a numeric suffix when the preferred remote name is taken by a different URL', async () => {

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -122,7 +122,8 @@ export async function prepareWorktreePushTargetWithExec(
   repoPath: string,
   target: GitPushTarget,
   isRemoteCreatedByKnownWorktree: (existingRemote: string) => boolean,
-  cleanupExecGit: GitRemoteExec = execGit
+  cleanupExecGit: GitRemoteExec = execGit,
+  fetchRemoteTrackingRef?: (remoteName: string) => Promise<void>
 ): Promise<GitPushTarget> {
   const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   let remoteName = target.remoteName
@@ -144,14 +145,16 @@ export async function prepareWorktreePushTargetWithExec(
   }
 
   try {
-    await execGit(
-      [
-        'fetch',
-        remoteName,
-        `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
-      ],
-      repoPath
-    )
+    await (fetchRemoteTrackingRef
+      ? fetchRemoteTrackingRef(remoteName)
+      : execGit(
+          [
+            'fetch',
+            remoteName,
+            `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
+          ],
+          repoPath
+        ))
   } catch (error) {
     if (createdThisCall) {
       try {

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -10,6 +10,11 @@ import type { GitRemoteExec } from './worktree-push-target-cleanup'
 
 const pushTargetPreparationTails = new Map<string, Promise<void>>()
 
+type WorktreePushTargetPreparationLeaseOptions = {
+  remainingTimeoutMs?: () => number
+  signal?: AbortSignal
+}
+
 function pushTargetPreparationKey(repoPath: string, target: GitPushTarget): string | null {
   if (!target.remoteUrl) {
     return null
@@ -21,9 +26,91 @@ function pushTargetPreparationKey(repoPath: string, target: GitPushTarget): stri
   return `${repoPath}\0${remoteKey}`
 }
 
+function remoteUrlsMatch(leftUrl: string, rightUrl: string): boolean {
+  const left = parseGitHubOwnerRepo(leftUrl)
+  const right = parseGitHubOwnerRepo(rightUrl)
+  return left && right
+    ? left.owner.toLowerCase() === right.owner.toLowerCase() &&
+        left.repo.toLowerCase() === right.repo.toLowerCase()
+    : leftUrl === rightUrl
+}
+
+function mayHaveCompletedRemoteAdd(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const code = (error as Error & { code?: unknown }).code
+  return (
+    error.name === 'AbortError' ||
+    error.message.toLowerCase().includes('timed out') ||
+    code === 'ETIMEDOUT' ||
+    code === 'CONNECTION_LOST' ||
+    code === 'SSH_MUX_REQUEST_TIMEOUT'
+  )
+}
+
+async function waitForPushTargetPreparationTurn(
+  previous: Promise<void>,
+  options: WorktreePushTargetPreparationLeaseOptions
+): Promise<void> {
+  const { remainingTimeoutMs, signal } = options
+  if (!remainingTimeoutMs && !signal) {
+    await previous.catch(() => {})
+    return
+  }
+  await new Promise<void>((resolve, reject) => {
+    let settled = false
+    let timer: ReturnType<typeof setTimeout> | undefined
+    const cleanup = (): void => {
+      if (timer) {
+        clearTimeout(timer)
+      }
+      signal?.removeEventListener('abort', onAbort)
+    }
+    const finish = (error?: unknown): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      if (error === undefined) {
+        resolve()
+      } else {
+        reject(error)
+      }
+    }
+    const onAbort = (): void =>
+      finish(Object.assign(new Error('Worktree creation was cancelled.'), { name: 'AbortError' }))
+    const armDeadline = (): void => {
+      if (!remainingTimeoutMs || settled) {
+        return
+      }
+      try {
+        const remaining = remainingTimeoutMs()
+        if (remaining <= 0) {
+          finish(new Error('Worktree push-target preparation timed out.'))
+          return
+        }
+        timer = setTimeout(armDeadline, remaining)
+        timer.unref?.()
+      } catch (error) {
+        finish(error)
+      }
+    }
+    if (signal?.aborted) {
+      onAbort()
+      return
+    }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    void previous.catch(() => {}).then(() => finish())
+    armDeadline()
+  })
+}
+
 export async function acquireWorktreePushTargetPreparationLease(
   repoPath: string,
-  target: GitPushTarget
+  target: GitPushTarget,
+  options: WorktreePushTargetPreparationLeaseOptions = {}
 ): Promise<() => void> {
   const key = pushTargetPreparationKey(repoPath, target)
   if (!key) {
@@ -36,10 +123,9 @@ export async function acquireWorktreePushTargetPreparationLease(
   })
   const tail = previous.catch(() => {}).then(() => slot)
   pushTargetPreparationTails.set(key, tail)
-  await previous.catch(() => {})
 
   let released = false
-  return () => {
+  const release = (): void => {
     if (released) {
       return
     }
@@ -51,6 +137,13 @@ export async function acquireWorktreePushTargetPreparationLease(
       }
     })
   }
+  try {
+    await waitForPushTargetPreparationTurn(previous, options)
+  } catch (error) {
+    release()
+    throw error
+  }
+  return release
 }
 
 export async function findRemoteForUrl(
@@ -68,16 +161,10 @@ export async function findRemoteForUrl(
       try {
         const { stdout: urlStdout } = await execGit(['remote', 'get-url', remote], repoPath)
         const candidateUrl = urlStdout.trim()
-        const candidate = parseGitHubOwnerRepo(candidateUrl)
         if (
-          target &&
-          candidate &&
-          target.owner.toLowerCase() === candidate.owner.toLowerCase() &&
-          target.repo.toLowerCase() === candidate.repo.toLowerCase()
+          (target && remoteUrlsMatch(candidateUrl, remoteUrl)) ||
+          (!target && candidateUrl === remoteUrl)
         ) {
-          return remote
-        }
-        if (candidateUrl === remoteUrl) {
           return remote
         }
       } catch {
@@ -138,7 +225,21 @@ export async function prepareWorktreePushTargetWithExec(
       remoteCreated = isRemoteCreatedByKnownWorktree(existingRemote)
     } else {
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
-      await execGit(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+      try {
+        await execGit(['remote', 'add', remoteName, target.remoteUrl], repoPath)
+      } catch (error) {
+        if (mayHaveCompletedRemoteAdd(error)) {
+          try {
+            const { stdout } = await cleanupExecGit(['remote', 'get-url', remoteName], repoPath)
+            if (remoteUrlsMatch(stdout.trim(), target.remoteUrl)) {
+              await cleanupExecGit(['remote', 'remove', remoteName], repoPath)
+            }
+          } catch {
+            // Preserve the mutation failure; retries can reconcile any surviving remote.
+          }
+        }
+        throw error
+      }
       remoteCreated = true
       createdThisCall = true
     }

--- a/src/main/ipc/worktree-push-target-setup.ts
+++ b/src/main/ipc/worktree-push-target-setup.ts
@@ -8,6 +8,51 @@ import type { GitPushTarget } from '../../shared/types'
 import { parseGitHubOwnerRepo } from '../github/gh-utils'
 import type { GitRemoteExec } from './worktree-push-target-cleanup'
 
+const pushTargetPreparationTails = new Map<string, Promise<void>>()
+
+function pushTargetPreparationKey(repoPath: string, target: GitPushTarget): string | null {
+  if (!target.remoteUrl) {
+    return null
+  }
+  const parsed = parseGitHubOwnerRepo(target.remoteUrl)
+  const remoteKey = parsed
+    ? `${parsed.owner.toLowerCase()}/${parsed.repo.toLowerCase()}`
+    : target.remoteUrl
+  return `${repoPath}\0${remoteKey}`
+}
+
+export async function acquireWorktreePushTargetPreparationLease(
+  repoPath: string,
+  target: GitPushTarget
+): Promise<() => void> {
+  const key = pushTargetPreparationKey(repoPath, target)
+  if (!key) {
+    return () => {}
+  }
+  const previous = pushTargetPreparationTails.get(key) ?? Promise.resolve()
+  let releaseSlot!: () => void
+  const slot = new Promise<void>((resolve) => {
+    releaseSlot = resolve
+  })
+  const tail = previous.catch(() => {}).then(() => slot)
+  pushTargetPreparationTails.set(key, tail)
+  await previous.catch(() => {})
+
+  let released = false
+  return () => {
+    if (released) {
+      return
+    }
+    released = true
+    releaseSlot()
+    void tail.finally(() => {
+      if (pushTargetPreparationTails.get(key) === tail) {
+        pushTargetPreparationTails.delete(key)
+      }
+    })
+  }
+}
+
 export async function findRemoteForUrl(
   execGit: GitRemoteExec,
   repoPath: string,
@@ -76,11 +121,13 @@ export async function prepareWorktreePushTargetWithExec(
   execGit: GitRemoteExec,
   repoPath: string,
   target: GitPushTarget,
-  isRemoteCreatedByKnownWorktree: (existingRemote: string) => boolean
+  isRemoteCreatedByKnownWorktree: (existingRemote: string) => boolean,
+  cleanupExecGit: GitRemoteExec = execGit
 ): Promise<GitPushTarget> {
   const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   let remoteName = target.remoteName
   let remoteCreated = false
+  let createdThisCall = false
   if (target.remoteUrl) {
     const existingRemote = await findRemoteForUrl(execGit, repoPath, target.remoteUrl)
     if (existingRemote) {
@@ -92,17 +139,29 @@ export async function prepareWorktreePushTargetWithExec(
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
       await execGit(['remote', 'add', remoteName, target.remoteUrl], repoPath)
       remoteCreated = true
+      createdThisCall = true
     }
   }
 
-  await execGit(
-    [
-      'fetch',
-      remoteName,
-      `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
-    ],
-    repoPath
-  )
+  try {
+    await execGit(
+      [
+        'fetch',
+        remoteName,
+        `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
+      ],
+      repoPath
+    )
+  } catch (error) {
+    if (createdThisCall) {
+      try {
+        await cleanupExecGit(['remote', 'remove', remoteName], repoPath)
+      } catch {
+        // Keep the fetch failure actionable; later retries can reuse or disambiguate the remote.
+      }
+    }
+    throw error
+  }
   return {
     ...sanitizedTarget,
     remoteName,

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1165,13 +1165,17 @@ export async function prepareWorktreePushTarget(
   target: GitPushTarget,
   store?: WorktreePushTargetStore,
   repoId?: string,
-  gitOptions: { wslDistro?: string; signal?: AbortSignal; timeout?: number } = {}
+  gitOptions: { wslDistro?: string; signal?: AbortSignal } = {},
+  remainingTimeoutMs: () => number = () => CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS
 ): Promise<GitPushTarget> {
-  const { timeout: fetchTimeout = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS, ...operationGitOptions } =
-    gitOptions
-  await validateGitPushTarget(repoPath, target, operationGitOptions)
+  const execGit: GitRemoteExec = (args, cwd) =>
+    gitExecFileAsync(args, { cwd, ...gitOptions, timeout: remainingTimeoutMs() })
+  await validateGitPushTarget(repoPath, target, {
+    ...gitOptions,
+    timeout: remainingTimeoutMs()
+  })
   return prepareWorktreePushTargetWithExec(
-    (args, cwd) => gitExecFileAsync(args, { cwd, ...operationGitOptions }),
+    execGit,
     repoPath,
     target,
     (existingRemote) =>
@@ -1185,6 +1189,7 @@ export async function prepareWorktreePushTarget(
     (args, cwd) =>
       gitExecFileAsync(args, {
         cwd,
+        timeout: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
         ...(gitOptions.wslDistro ? { wslDistro: gitOptions.wslDistro } : {})
       }),
     (remoteName) =>
@@ -1196,8 +1201,8 @@ export async function prepareWorktreePushTarget(
         ],
         {
           cwd: repoPath,
-          ...operationGitOptions,
-          timeout: fetchTimeout
+          ...gitOptions,
+          timeout: remainingTimeoutMs()
         }
       ).then(() => undefined)
   )
@@ -1266,11 +1271,19 @@ async function prepareWorktreePushTargetSsh(
   target: GitPushTarget,
   store?: WorktreePushTargetStore,
   repoId?: string,
-  fetchTimeoutMs = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS
+  remainingTimeoutMs: () => number = () => CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS,
+  signal?: AbortSignal
 ): Promise<GitPushTarget> {
   assertGitPushTargetShape(target)
-  const execGit: GitRemoteExec = (args, cwd) => provider.exec(args, cwd)
-  await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
+  await provider.awaitPushTargetRemoteMutations?.(repoPath, {
+    timeoutMs: remainingTimeoutMs(),
+    signal
+  })
+  const execGit: GitRemoteExec = (args, cwd) =>
+    provider.exec(args, cwd, { timeoutMs: remainingTimeoutMs(), signal })
+  const cleanupExecGit: GitRemoteExec = (args, cwd) =>
+    provider.exec(args, cwd, { timeoutMs: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS })
+  await execGit(['check-ref-format', '--branch', target.branchName], repoPath)
   return prepareWorktreePushTargetWithExec(
     execGit,
     repoPath,
@@ -1283,14 +1296,14 @@ async function prepareWorktreePushTargetSsh(
             repoId
           )
         : false,
-    execGit,
+    cleanupExecGit,
     (remoteName) =>
       provider.fetchRemoteTrackingRef(
         repoPath,
         remoteName,
         target.branchName,
         `refs/remotes/${remoteName}/${target.branchName}`,
-        { timeoutMs: fetchTimeoutMs }
+        { timeoutMs: remainingTimeoutMs(), signal }
       )
   )
 }
@@ -1945,7 +1958,10 @@ export async function createRemoteWorktree(
 
   let preparedPushTarget: GitPushTarget | undefined
   const releasePushTargetPreparation = args.pushTarget
-    ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget)
+    ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget, {
+        remainingTimeoutMs: remainingRefreshMs,
+        signal
+      })
     : undefined
   if (args.pushTarget) {
     // Why: fork-PR SSH worktrees need contributor-remote setup before create, else Push/Sync target origin.
@@ -1956,7 +1972,8 @@ export async function createRemoteWorktree(
         args.pushTarget,
         store,
         repo.id,
-        remainingRefreshMs()
+        remainingRefreshMs,
+        signal
       )
     } catch (error) {
       releasePushTargetPreparation?.()
@@ -2598,7 +2615,9 @@ export async function createLocalWorktree(
 
   let preparedPushTarget: GitPushTarget | undefined
   const releasePushTargetPreparation = args.pushTarget
-    ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget)
+    ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget, {
+        remainingTimeoutMs: remainingRefreshMs
+      })
     : undefined
   if (args.pushTarget) {
     // Why: validate/fetch the contributor remote before create so a failure doesn't leave a half-created worktree with conflicts on retry.
@@ -2608,10 +2627,8 @@ export async function createLocalWorktree(
         args.pushTarget,
         store,
         repo.id,
-        {
-          ...localWorktreeGitOptions,
-          timeout: remainingRefreshMs()
-        }
+        localWorktreeGitOptions,
+        remainingRefreshMs
       )
     } catch (error) {
       releasePushTargetPreparation?.()

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -1956,10 +1956,14 @@ export async function createRemoteWorktree(
     }
   }
 
+  const addCheckoutDeadline = createWorktreeCreateStageDeadline(
+    createTimeouts.addCheckoutMs,
+    `Worktree add and checkout timed out after ${createTimeouts.addCheckoutMs}ms.`
+  )
   let preparedPushTarget: GitPushTarget | undefined
   const releasePushTargetPreparation = args.pushTarget
     ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget, {
-        remainingTimeoutMs: remainingRefreshMs,
+        remainingTimeoutMs: addCheckoutDeadline.remainingMs,
         signal
       })
     : undefined
@@ -1972,7 +1976,7 @@ export async function createRemoteWorktree(
         args.pushTarget,
         store,
         repo.id,
-        remainingRefreshMs,
+        addCheckoutDeadline.remainingMs,
         signal
       )
     } catch (error) {
@@ -1981,16 +1985,6 @@ export async function createRemoteWorktree(
     }
   }
 
-  const addCheckoutDeadlineAt = Date.now() + createTimeouts.addCheckoutMs
-  const remainingAddCheckoutMs = (): number => {
-    const remaining = addCheckoutDeadlineAt - Date.now()
-    if (remaining <= 0) {
-      throw new Error(
-        `Worktree add and checkout timed out after ${createTimeouts.addCheckoutMs}ms.`
-      )
-    }
-    return remaining
-  }
   let created: GitWorktreeInfo
   let configuredPushTarget: GitPushTarget | undefined
   let addAttempted = false
@@ -2005,11 +1999,15 @@ export async function createRemoteWorktree(
           branchName,
           remotePath,
           checkoutExistingBranch
-            ? { checkoutExistingBranch, timeoutMs: remainingAddCheckoutMs(), signal }
+            ? {
+                checkoutExistingBranch,
+                timeoutMs: addCheckoutDeadline.remainingMs(),
+                signal
+              }
             : {
                 base: baseBranch,
                 ...(sparseDirectories.length > 0 ? { noCheckout: true } : {}),
-                timeoutMs: remainingAddCheckoutMs(),
+                timeoutMs: addCheckoutDeadline.remainingMs(),
                 signal
               }
         )
@@ -2032,15 +2030,15 @@ export async function createRemoteWorktree(
     if (sparseDirectories.length > 0) {
       // Why: SSH providers expose generic git exec, so remote sparse mirrors local addSparseWorktree without a new relay method.
       await provider.exec(['sparse-checkout', 'init', '--cone'], remotePath, {
-        timeoutMs: remainingAddCheckoutMs(),
+        timeoutMs: addCheckoutDeadline.remainingMs(),
         signal
       })
       await provider.exec(['sparse-checkout', 'set', '--', ...sparseDirectories], remotePath, {
-        timeoutMs: remainingAddCheckoutMs(),
+        timeoutMs: addCheckoutDeadline.remainingMs(),
         signal
       })
       await provider.exec(['checkout', branchName], remotePath, {
-        timeoutMs: remainingAddCheckoutMs(),
+        timeoutMs: addCheckoutDeadline.remainingMs(),
         signal
       })
     }
@@ -2270,12 +2268,21 @@ export async function createLocalWorktree(
   }
   const addRefreshTimeoutMs = (): number =>
     refreshDeadline?.remainingMs() ?? createTimeouts.refreshBaseRefMs
+  let addRefreshTimeout = createTimeouts.refreshBaseRefMs
+  let addCheckoutDeadline: ReturnType<typeof createWorktreeCreateStageDeadline> | undefined
+  const remainingAddCheckoutMs = (): number => {
+    addCheckoutDeadline ??= createWorktreeCreateStageDeadline(
+      createTimeouts.addCheckoutMs,
+      `Worktree add and checkout timed out after ${createTimeouts.addCheckoutMs}ms.`
+    )
+    return addCheckoutDeadline.remainingMs()
+  }
   const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {
     return {
       ...options,
       ...localWorktreeGitOptions,
-      refreshTimeout: addRefreshTimeoutMs(),
-      timeout: createTimeouts.addCheckoutMs
+      refreshTimeout: addRefreshTimeout,
+      timeout: remainingAddCheckoutMs()
     }
   }
 
@@ -2612,11 +2619,12 @@ export async function createLocalWorktree(
     })
   }
   emitCreateWorktreeProgress(mainWindow, 'creating', args.creationId)
+  addRefreshTimeout = addRefreshTimeoutMs()
 
   let preparedPushTarget: GitPushTarget | undefined
   const releasePushTargetPreparation = args.pushTarget
     ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget, {
-        remainingTimeoutMs: remainingRefreshMs
+        remainingTimeoutMs: remainingAddCheckoutMs
       })
     : undefined
   if (args.pushTarget) {
@@ -2628,7 +2636,7 @@ export async function createLocalWorktree(
         store,
         repo.id,
         localWorktreeGitOptions,
-        remainingRefreshMs
+        remainingAddCheckoutMs
       )
     } catch (error) {
       releasePushTargetPreparation?.()

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -111,8 +111,6 @@ import {
 import {
   acquireWorktreePushTargetPreparationLease,
   configureCreatedWorktreePushTargetWithExec,
-  ensureUniqueRemoteName,
-  findRemoteForUrl,
   prepareWorktreePushTargetWithExec
 } from './worktree-push-target-setup'
 import { isENOENT, registerWorktreeRootsForRepo } from './filesystem-auth'
@@ -651,11 +649,8 @@ async function rollbackFailedRemoteWorktreeCreate(
     : Date.now()
   let created: GitWorktreeInfo | undefined
   do {
-    const remaining = Math.max(1, reconciliationDeadlineAt - Date.now())
     const worktrees = await provider.listWorktrees(repoPath, {
-      timeoutMs: waitForLateRegistration
-        ? Math.min(WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS, remaining)
-        : WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
+      timeoutMs: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
       strict: true
     })
     created = findRemoteWorktreeCreateIdentity(provider, worktrees, worktreePath, branchName)
@@ -1170,11 +1165,13 @@ export async function prepareWorktreePushTarget(
   target: GitPushTarget,
   store?: WorktreePushTargetStore,
   repoId?: string,
-  gitOptions: { wslDistro?: string } = {}
+  gitOptions: { wslDistro?: string; signal?: AbortSignal; timeout?: number } = {}
 ): Promise<GitPushTarget> {
-  await validateGitPushTarget(repoPath, target, gitOptions)
+  const { timeout: fetchTimeout = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS, ...operationGitOptions } =
+    gitOptions
+  await validateGitPushTarget(repoPath, target, operationGitOptions)
   return prepareWorktreePushTargetWithExec(
-    (args, cwd) => gitExecFileAsync(args, { cwd, ...gitOptions }),
+    (args, cwd) => gitExecFileAsync(args, { cwd, ...operationGitOptions }),
     repoPath,
     target,
     (existingRemote) =>
@@ -1189,7 +1186,20 @@ export async function prepareWorktreePushTarget(
       gitExecFileAsync(args, {
         cwd,
         ...(gitOptions.wslDistro ? { wslDistro: gitOptions.wslDistro } : {})
-      })
+      }),
+    (remoteName) =>
+      gitExecFileAsync(
+        [
+          'fetch',
+          remoteName,
+          `+refs/heads/${target.branchName}:refs/remotes/${remoteName}/${target.branchName}`
+        ],
+        {
+          cwd: repoPath,
+          ...operationGitOptions,
+          timeout: fetchTimeout
+        }
+      ).then(() => undefined)
   )
 }
 
@@ -1255,55 +1265,34 @@ async function prepareWorktreePushTargetSsh(
   repoPath: string,
   target: GitPushTarget,
   store?: WorktreePushTargetStore,
-  repoId?: string
+  repoId?: string,
+  fetchTimeoutMs = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS
 ): Promise<GitPushTarget> {
   assertGitPushTargetShape(target)
   const execGit: GitRemoteExec = (args, cwd) => provider.exec(args, cwd)
-  const { remoteCreated: _ignoredRemoteCreated, ...sanitizedTarget } = target
   await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
-  let remoteName = target.remoteName
-  let remoteCreated = false
-  let createdThisCall = false
-  if (target.remoteUrl) {
-    const existingRemote = await findRemoteForUrl(execGit, repoPath, target.remoteUrl)
-    if (existingRemote) {
-      remoteName = existingRemote
-      remoteCreated = store
+  return prepareWorktreePushTargetWithExec(
+    execGit,
+    repoPath,
+    target,
+    (existingRemote) =>
+      store
         ? isPushTargetRemoteCreatedByKnownWorktree(
             store,
             { ...target, remoteName: existingRemote },
             repoId
           )
-        : false
-    } else {
-      remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
-      await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
-      remoteCreated = true
-      createdThisCall = true
-    }
-  }
-  try {
-    await provider.fetchRemoteTrackingRef(
-      repoPath,
-      remoteName,
-      target.branchName,
-      `refs/remotes/${remoteName}/${target.branchName}`
-    )
-  } catch (error) {
-    if (createdThisCall) {
-      try {
-        await provider.exec(['remote', 'remove', remoteName], repoPath)
-      } catch {
-        // Keep the fetch failure actionable; later retries can reuse or disambiguate the remote.
-      }
-    }
-    throw error
-  }
-  return {
-    ...sanitizedTarget,
-    remoteName,
-    ...(remoteCreated ? { remoteCreated: true } : {})
-  }
+        : false,
+    execGit,
+    (remoteName) =>
+      provider.fetchRemoteTrackingRef(
+        repoPath,
+        remoteName,
+        target.branchName,
+        `refs/remotes/${remoteName}/${target.branchName}`,
+        { timeoutMs: fetchTimeoutMs }
+      )
+  )
 }
 
 export async function cleanupUnusedWorktreePushTargetRemoteSsh(
@@ -1966,7 +1955,8 @@ export async function createRemoteWorktree(
         repo.path,
         args.pushTarget,
         store,
-        repo.id
+        repo.id,
+        remainingRefreshMs()
       )
     } catch (error) {
       releasePushTargetPreparation?.()
@@ -2618,7 +2608,10 @@ export async function createLocalWorktree(
         args.pushTarget,
         store,
         repo.id,
-        localWorktreeGitOptions
+        {
+          ...localWorktreeGitOptions,
+          timeout: remainingRefreshMs()
+        }
       )
     } catch (error) {
       releasePushTargetPreparation?.()

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -12,6 +12,7 @@ import type {
   CreateWorktreeArgs,
   CreateWorktreeResult,
   GitPushTarget,
+  GitWorktreeInfo,
   GlobalSettings,
   LocalBaseRefRefreshResult,
   LocalBaseRefUpdateSuggestion,
@@ -22,7 +23,14 @@ import type {
   WorktreeMeta
 } from '../../shared/types'
 import { getPRForBranch } from '../github/client'
-import { listWorktrees, addWorktree, addSparseWorktree } from '../git/worktree'
+import {
+  listWorktrees,
+  listWorktreesStrict,
+  addWorktree,
+  addSparseWorktree,
+  rollbackFailedWorktreeCreate,
+  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
+} from '../git/worktree'
 import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
 import {
   getBranchConflictKind,
@@ -87,6 +95,7 @@ import {
   mergeWorktree
 } from './worktree-logic'
 import { findCreatedWorktree } from './created-worktree-reconciliation'
+import { areWorktreePathsEqual } from './worktree-path-comparison'
 import type { BranchPrefixSettings } from '../../shared/branch-prefix'
 import { getRepoIdFromWorktreeId } from '../../shared/worktree-id'
 import { parseWorkspaceKey, worktreeWorkspaceKey } from '../../shared/workspace-scope'
@@ -135,6 +144,10 @@ import {
   getWorktreeCreateCandidate,
   WORKTREE_CREATE_MAX_SUFFIX_ATTEMPTS
 } from '../worktree-create-candidates'
+import {
+  createWorktreeCreateStageDeadline,
+  getEffectiveWorktreeCreateTimeouts
+} from '../worktree-create-stage-timeouts'
 
 const SSH_WORKTREE_CREATE_FETCH_FRESHNESS_MS = 30_000
 const SSH_WORKTREE_CREATE_FETCH_CACHE_MAX = 512
@@ -175,8 +188,30 @@ type RemoteLocalBaseRefRefreshability =
       result: LocalBaseRefRefreshResult
     }
 
+type RemainingWorktreeCreateStageMs = () => number
+
 function appendWorktreeCreateWarning(current: string | undefined, next: string): string {
   return current ? `${current} Also ${next[0]?.toLowerCase() ?? ''}${next.slice(1)}` : next
+}
+
+function appendFailedWorktreeCreateCleanupMessage(error: unknown, worktreePath: string): Error {
+  const wrapped = error instanceof Error ? error : new Error(String(error))
+  wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
+  return wrapped
+}
+
+function isUncertainRemoteWorktreeAddError(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const code = (error as Error & { code?: unknown }).code
+  return (
+    error.name === 'AbortError' ||
+    error.message.toLowerCase().includes('timed out') ||
+    code === 'ETIMEDOUT' ||
+    code === 'CONNECTION_LOST' ||
+    code === 'SSH_MUX_REQUEST_TIMEOUT'
+  )
 }
 
 function getSetupRunnerCommandPlatformForLaunch(
@@ -493,15 +528,19 @@ async function getOrStartSshWorktreeCreateFetch(
 async function refreshRemoteTrackingBaseForWorktreeCreate(
   provider: SshGitProvider,
   repo: Repo,
-  base: RemoteTrackingBase
+  base: RemoteTrackingBase,
+  timeoutMs = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS,
+  remainingTimeoutMs: RemainingWorktreeCreateStageMs = () => timeoutMs
 ): Promise<void> {
+  const fetchKey = `${getSshWorktreeCreateBaseFetchKey(repo, base)}::${timeoutMs}`
   return getOrStartSshWorktreeCreateFetch(
-    getSshWorktreeCreateBaseFetchKey(repo, base),
+    fetchKey,
     getSshWorktreeCreateRemoteQueueKey(repo, base.remote),
     () =>
       // Why: the exact-base refresh gates create; unrelated repo housekeeping must not extend it.
       provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref, {
-        skipAutoMaintenance: true
+        skipAutoMaintenance: true,
+        timeoutMs: remainingTimeoutMs()
       })
   )
 }
@@ -509,12 +548,18 @@ async function refreshRemoteTrackingBaseForWorktreeCreate(
 async function fetchRemoteForWorktreeCreate(
   provider: SshGitProvider,
   repo: Repo,
-  remote: string
+  remote: string,
+  timeoutMs = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS,
+  remainingTimeoutMs: RemainingWorktreeCreateStageMs = () => timeoutMs
 ): Promise<void> {
+  const fetchKey = `${getSshWorktreeCreateRemoteFetchKey(repo, remote)}::${timeoutMs}`
   return getOrStartSshWorktreeCreateFetch(
-    getSshWorktreeCreateRemoteFetchKey(repo, remote),
+    fetchKey,
     getSshWorktreeCreateRemoteQueueKey(repo, remote),
-    () => provider.exec(['fetch', remote], repo.path).then(() => undefined)
+    () =>
+      provider
+        .exec(['fetch', remote], repo.path, { timeoutMs: remainingTimeoutMs() })
+        .then(() => undefined)
   )
 }
 
@@ -538,6 +583,45 @@ async function unsetRemoteWorktreeCreationBase(
   } catch {
     // Best-effort cleanup; keep the sparse setup error as the actionable failure.
   }
+}
+
+async function rollbackFailedRemoteWorktreeCreate(
+  provider: SshGitProvider,
+  repoPath: string,
+  worktreePath: string,
+  branchName: string,
+  checkoutExistingBranch: boolean
+): Promise<boolean> {
+  const worktrees = await provider.listWorktrees(repoPath, {
+    timeoutMs: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
+    strict: true
+  })
+  const created = findRemoteWorktreeCreateIdentity(provider, worktrees, worktreePath, branchName)
+  if (!created) {
+    return false
+  }
+  if (!checkoutExistingBranch) {
+    await unsetRemoteWorktreeCreationBase(provider, created.path, branchName)
+  }
+  await provider.removeWorktree(created.path, true, {
+    deleteBranch: !checkoutExistingBranch,
+    forceBranchDelete: !checkoutExistingBranch
+  })
+  return true
+}
+
+function findRemoteWorktreeCreateIdentity(
+  provider: SshGitProvider,
+  worktrees: readonly GitWorktreeInfo[],
+  worktreePath: string,
+  branchName: string
+): GitWorktreeInfo | undefined {
+  const remotePlatform = provider.getHostPlatform?.()?.os ?? process.platform
+  return worktrees.find(
+    (worktree) =>
+      areWorktreePathsEqual(worktree.path, worktreePath, remotePlatform) &&
+      worktree.branch === `refs/heads/${branchName}`
+  )
 }
 
 async function resolveCreateBranchName(
@@ -679,18 +763,33 @@ function getLocalGitHubPrForBranch(
 function hasRemoteCommitObject(
   provider: SshGitProvider,
   repoPath: string,
-  ref: string
+  ref: string,
+  remainingTimeoutMs?: RemainingWorktreeCreateStageMs
 ): Promise<boolean> {
-  return hasCommitObjectViaGitExec((gitArgs) => provider.exec(gitArgs, repoPath), ref)
+  return hasCommitObjectViaGitExec(
+    (gitArgs) =>
+      provider.exec(
+        gitArgs,
+        repoPath,
+        remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : undefined
+      ),
+    ref
+  ).then((found) => {
+    if (!found) {
+      remainingTimeoutMs?.()
+    }
+    return found
+  })
 }
 
 async function hasRemoteWorktreeBaseRef(
   provider: SshGitProvider,
   repoPath: string,
-  baseRef: string
+  baseRef: string,
+  remainingTimeoutMs?: RemainingWorktreeCreateStageMs
 ): Promise<boolean> {
   const refExists = (qualifiedRef: string) =>
-    hasRemoteTrackingRefSsh(provider, repoPath, qualifiedRef)
+    hasRemoteTrackingRefSsh(provider, repoPath, qualifiedRef, remainingTimeoutMs)
   const resolvedBaseRef = await resolveWorktreeAddBaseRef(baseRef, refExists)
   if (resolvedBaseRef !== baseRef) {
     return true
@@ -698,22 +797,25 @@ async function hasRemoteWorktreeBaseRef(
   if (baseRef.startsWith('refs/')) {
     return refExists(baseRef)
   }
-  return hasRemoteCommitObject(provider, repoPath, baseRef)
+  return hasRemoteCommitObject(provider, repoPath, baseRef, remainingTimeoutMs)
 }
 
 // Why: hasRemoteCommitObject resolves only SHAs, not symbolic remote-tracking refs; detect those directly for the fetch-failed local fallback.
 async function hasRemoteTrackingRefSsh(
   provider: SshGitProvider,
   repoPath: string,
-  ref: string
+  ref: string,
+  remainingTimeoutMs?: RemainingWorktreeCreateStageMs
 ): Promise<boolean> {
   try {
     const { stdout } = await provider.exec(
       ['rev-parse', '--verify', '--quiet', `${ref}^{commit}`],
-      repoPath
+      repoPath,
+      remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : undefined
     )
     return stdout.trim().length > 0
   } catch {
+    remainingTimeoutMs?.()
     return false
   }
 }
@@ -1050,7 +1152,7 @@ export async function configureCreatedWorktreePushTarget(
   worktreePath: string,
   branchName: string,
   target: GitPushTarget,
-  gitOptions: { wslDistro?: string } = {}
+  gitOptions: { wslDistro?: string; timeout?: number } = {}
 ): Promise<GitPushTarget> {
   return configureCreatedWorktreePushTargetWithExec(
     (args, cwd) => gitExecFileAsync(args, { cwd, ...gitOptions }),
@@ -1304,12 +1406,15 @@ export async function prefetchRemoteWorktreeCreateBase(
 async function refreshLocalBaseRefForRemoteWorktreeCreate(
   provider: SshGitProvider,
   repoPath: string,
-  remoteTrackingBase: RemoteTrackingBase
+  remoteTrackingBase: RemoteTrackingBase,
+  remainingTimeoutMs?: RemainingWorktreeCreateStageMs
 ): Promise<LocalBaseRefRefreshResult> {
   const evaluation = await evaluateRemoteLocalBaseRefRefreshability(
     provider,
     repoPath,
-    remoteTrackingBase
+    remoteTrackingBase,
+    () => true,
+    remainingTimeoutMs
   )
   if (!evaluation.refreshable) {
     return evaluation.result
@@ -1321,7 +1426,8 @@ async function refreshLocalBaseRefForRemoteWorktreeCreate(
       repoPath,
       fullRef: evaluation.fullRef,
       remoteTrackingRef: evaluation.remoteTrackingRef,
-      ...(evaluation.ownerWorktreePath ? { ownerWorktreePath: evaluation.ownerWorktreePath } : {})
+      ...(evaluation.ownerWorktreePath ? { ownerWorktreePath: evaluation.ownerWorktreePath } : {}),
+      ...(remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : {})
     })
     return {
       ...resultBase,
@@ -1337,7 +1443,8 @@ async function evaluateRemoteLocalBaseRefRefreshability(
   provider: SshGitProvider,
   repoPath: string,
   remoteTrackingBase: RemoteTrackingBase,
-  shouldInspectOwner: (behind: number) => boolean = () => true
+  shouldInspectOwner: (behind: number) => boolean = () => true,
+  remainingTimeoutMs?: RemainingWorktreeCreateStageMs
 ): Promise<RemoteLocalBaseRefRefreshability> {
   const resultBase = {
     baseRef: remoteTrackingBase.base,
@@ -1348,10 +1455,15 @@ async function evaluateRemoteLocalBaseRefRefreshability(
   let behind = 0
   try {
     // Why: SSH generic git.exec is allowlisted — merge-base and log are permitted read-only probes; rev-list is intentionally not exposed.
-    await provider.exec(['merge-base', '--is-ancestor', fullRef, remoteTrackingBase.ref], repoPath)
+    await provider.exec(
+      ['merge-base', '--is-ancestor', fullRef, remoteTrackingBase.ref],
+      repoPath,
+      remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : undefined
+    )
     const { stdout } = await provider.exec(
       ['log', '--format=%H', `${fullRef}..${remoteTrackingBase.ref}`],
-      repoPath
+      repoPath,
+      remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : undefined
     )
     behind = countNonEmptyGitOutputLines(stdout)
     if (!shouldInspectOwner(behind)) {
@@ -1365,16 +1477,21 @@ async function evaluateRemoteLocalBaseRefRefreshability(
       }
     }
   } catch {
+    remainingTimeoutMs?.()
     return { refreshable: false, result: { ...resultBase, status: 'skipped_not_fast_forward' } }
   }
 
   try {
-    const worktrees = await provider.listWorktrees(repoPath)
+    const worktrees = await provider.listWorktrees(
+      repoPath,
+      remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : undefined
+    )
     const ownerWorktree = worktrees.find((wt) => wt.branch === fullRef)
 
     if (ownerWorktree) {
       const status = await provider.worktreeIsClean(ownerWorktree.path, {
-        includeUntracked: false
+        includeUntracked: false,
+        ...(remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : {})
       })
       if (!status.clean) {
         return {
@@ -1405,6 +1522,7 @@ async function evaluateRemoteLocalBaseRefRefreshability(
       behind
     }
   } catch {
+    remainingTimeoutMs?.()
     return { refreshable: false, result: { ...resultBase, status: 'skipped_error' } }
   }
 }
@@ -1412,13 +1530,15 @@ async function evaluateRemoteLocalBaseRefRefreshability(
 async function getRemoteLocalBaseRefUpdateSuggestionForWorktreeCreate(
   provider: SshGitProvider,
   repoPath: string,
-  remoteTrackingBase: RemoteTrackingBase
+  remoteTrackingBase: RemoteTrackingBase,
+  remainingTimeoutMs?: RemainingWorktreeCreateStageMs
 ): Promise<LocalBaseRefUpdateSuggestion | undefined> {
   const evaluation = await evaluateRemoteLocalBaseRefRefreshability(
     provider,
     repoPath,
     remoteTrackingBase,
-    (behind) => behind > 0
+    (behind) => behind > 0,
+    remainingTimeoutMs
   )
   if (!evaluation.refreshable || evaluation.behind <= 0) {
     return undefined
@@ -1429,9 +1549,11 @@ async function getRemoteLocalBaseRefUpdateSuggestionForWorktreeCreate(
       fullRef: evaluation.fullRef,
       remoteTrackingRef: evaluation.remoteTrackingRef,
       ...(evaluation.ownerWorktreePath ? { ownerWorktreePath: evaluation.ownerWorktreePath } : {}),
-      checkOnly: true
+      checkOnly: true,
+      ...(remainingTimeoutMs ? { timeoutMs: remainingTimeoutMs() } : {})
     })
   } catch {
+    remainingTimeoutMs?.()
     return undefined
   }
   return {
@@ -1492,6 +1614,7 @@ export async function createRemoteWorktree(
   const fsProvider = getSshFilesystemProvider(repo.connectionId!)
 
   const settings = store.getSettings()
+  const createTimeouts = getEffectiveWorktreeCreateTimeouts(repo, settings, args.timeouts)
   const worktreePathSettings = getWorktreePathSettings(repo, settings)
   let effectiveRequestedName = args.name
   const sanitizedName = sanitizeWorktreeName(args.name)
@@ -1649,29 +1772,59 @@ export async function createRemoteWorktree(
   // Why: addWorktree/setup probes run inside the new path; older relays need that root registered before accepting git/fs ops there.
   await registerRequiredSshWorktreeCreateRoots(repo.connectionId!, [remotePath])
 
+  const { remainingMs: remainingRefreshMs } = createWorktreeCreateStageDeadline(
+    createTimeouts.refreshBaseRefMs,
+    `Worktree base ref refresh timed out after ${createTimeouts.refreshBaseRefMs}ms.`
+  )
   if (remoteTrackingBase) {
     try {
-      await refreshRemoteTrackingBaseForWorktreeCreate(provider, repo, remoteTrackingBase)
+      await refreshRemoteTrackingBaseForWorktreeCreate(
+        provider,
+        repo,
+        remoteTrackingBase,
+        createTimeouts.refreshBaseRefMs,
+        remainingRefreshMs
+      )
     } catch {
       // Why: a refresh failure shouldn't block create if a usable (stale) local base ref exists; probe after registerRoot and hard-fail only when none does.
-      if (!(await hasRemoteTrackingRefSsh(provider, repo.path, remoteTrackingBase.ref))) {
+      if (
+        !(await hasRemoteTrackingRefSsh(
+          provider,
+          repo.path,
+          remoteTrackingBase.ref,
+          remainingRefreshMs
+        ))
+      ) {
         throw new Error(
           `Could not refresh base ref "${baseBranch}" from "${remoteTrackingBase.remote}". Check your network and try again.`
         )
       }
     }
-  } else if (!(await hasRemoteWorktreeBaseRef(provider, repo.path, baseBranch))) {
+  } else if (
+    !(await hasRemoteWorktreeBaseRef(provider, repo.path, baseBranch, remainingRefreshMs))
+  ) {
     // Why: non-remote-tracking bases keep the legacy best-effort fetch; verified PR/MR SHA bases already have the object, so a broad fetch is wasted.
     try {
-      await fetchRemoteForWorktreeCreate(provider, repo, 'origin')
+      await fetchRemoteForWorktreeCreate(
+        provider,
+        repo,
+        'origin',
+        createTimeouts.refreshBaseRefMs,
+        remainingRefreshMs
+      )
     } catch {
-      /* best-effort */
+      remainingRefreshMs()
     }
   }
 
   const localBaseRefRefresh =
     settings.refreshLocalBaseRefOnWorktreeCreate && !checkoutExistingBranch && remoteTrackingBase
-      ? await refreshLocalBaseRefForRemoteWorktreeCreate(provider, repo.path, remoteTrackingBase)
+      ? await refreshLocalBaseRefForRemoteWorktreeCreate(
+          provider,
+          repo.path,
+          remoteTrackingBase,
+          remainingRefreshMs
+        )
       : undefined
   const localBaseRefUpdateSuggestion =
     !settings.refreshLocalBaseRefOnWorktreeCreate &&
@@ -1681,7 +1834,8 @@ export async function createRemoteWorktree(
       ? await getRemoteLocalBaseRefUpdateSuggestionForWorktreeCreate(
           provider,
           repo.path,
-          remoteTrackingBase
+          remoteTrackingBase,
+          remainingRefreshMs
         )
       : undefined
 
@@ -1704,75 +1858,109 @@ export async function createRemoteWorktree(
     )
   }
 
+  const addCheckoutDeadlineAt = Date.now() + createTimeouts.addCheckoutMs
+  const remainingAddCheckoutMs = (): number => Math.max(1, addCheckoutDeadlineAt - Date.now())
+  let created: GitWorktreeInfo
+  let configuredPushTarget: GitPushTarget | undefined
+  let addCompleted = false
   try {
-    await timing.time('git_worktree_add', async () =>
-      provider.addWorktree(
-        repo.path,
-        branchName,
-        remotePath,
-        checkoutExistingBranch
-          ? { checkoutExistingBranch }
-          : { base: baseBranch, ...(sparseDirectories.length > 0 ? { noCheckout: true } : {}) }
-      )
-    )
-  } catch (err) {
-    if (
-      err instanceof Error &&
-      (err.message.includes('No workspace roots registered yet') ||
-        err.message.includes('Path outside authorized workspace'))
-    ) {
-      // Why: only OLD relays (pre-allowlist-removal) throw these; surface an upgrade message. Remove after version floor moves (docs/relay-fs-allowlist-removal.md).
-      throw new Error(
-        `Older relay reported an authorization error; please reconnect to deploy the latest relay. (${err.message})`
-      )
-    }
-    throw err
-  }
-  if (sparseDirectories.length > 0) {
     try {
-      // Why: SSH providers expose generic git exec, so remote sparse mirrors local addSparseWorktree without a new relay method.
-      await provider.exec(['sparse-checkout', 'init', '--cone'], remotePath)
-      await provider.exec(['sparse-checkout', 'set', '--', ...sparseDirectories], remotePath)
-      await provider.exec(['checkout', branchName], remotePath)
-    } catch (err) {
-      if (!checkoutExistingBranch) {
-        await unsetRemoteWorktreeCreationBase(provider, remotePath, branchName)
+      await timing.time('git_worktree_add', async () =>
+        provider.addWorktree(
+          repo.path,
+          branchName,
+          remotePath,
+          checkoutExistingBranch
+            ? { checkoutExistingBranch, timeoutMs: remainingAddCheckoutMs() }
+            : {
+                base: baseBranch,
+                ...(sparseDirectories.length > 0 ? { noCheckout: true } : {}),
+                timeoutMs: remainingAddCheckoutMs()
+              }
+        )
+      )
+      addCompleted = true
+    } catch (error) {
+      if (
+        error instanceof Error &&
+        (error.message.includes('No workspace roots registered yet') ||
+          error.message.includes('Path outside authorized workspace'))
+      ) {
+        // Why: only OLD relays (pre-allowlist-removal) throw these; surface an upgrade message. Remove after version floor moves (docs/relay-fs-allowlist-removal.md).
+        throw new Error(
+          `Older relay reported an authorization error; please reconnect to deploy the latest relay. (${error.message})`
+        )
       }
-      await provider
-        .removeWorktree(remotePath, true, {
-          deleteBranch: !checkoutExistingBranch,
-          // Why: sparse setup failed before any work happened, so rollback removes the just-created remote branch.
-          forceBranchDelete: !checkoutExistingBranch
-        })
-        .catch(() => undefined)
-      throw err
+      throw error
     }
-  }
 
-  // Re-list to get the created worktree info
-  const gitWorktrees = await timing.time('list_created_worktree', async () =>
-    provider.listWorktrees(repo.path)
-  )
-  const created = gitWorktrees.find(
-    (gw) => gw.branch?.endsWith(branchName) || gw.path.endsWith(effectiveSanitizedName)
-  )
-  if (!created) {
-    throw new Error('Worktree created but not found in listing')
+    if (sparseDirectories.length > 0) {
+      // Why: SSH providers expose generic git exec, so remote sparse mirrors local addSparseWorktree without a new relay method.
+      await provider.exec(['sparse-checkout', 'init', '--cone'], remotePath, {
+        timeoutMs: remainingAddCheckoutMs()
+      })
+      await provider.exec(['sparse-checkout', 'set', '--', ...sparseDirectories], remotePath, {
+        timeoutMs: remainingAddCheckoutMs()
+      })
+      await provider.exec(['checkout', branchName], remotePath, {
+        timeoutMs: remainingAddCheckoutMs()
+      })
+    }
+
+    const registrationDeadline = createWorktreeCreateStageDeadline(
+      createTimeouts.registrationMs,
+      `Worktree registration timed out after ${createTimeouts.registrationMs}ms.`
+    )
+    const gitWorktrees = await timing.time('list_created_worktree', async () =>
+      provider.listWorktrees(repo.path, {
+        timeoutMs: registrationDeadline.remainingMs(),
+        strict: true
+      })
+    )
+    const reconciled = findRemoteWorktreeCreateIdentity(
+      provider,
+      gitWorktrees,
+      remotePath,
+      branchName
+    )
+    if (!reconciled) {
+      throw new Error('Worktree created but not found in listing')
+    }
+    created = reconciled
+    if (preparedPushTarget) {
+      configuredPushTarget = await configureCreatedWorktreePushTargetWithExec(
+        (args, cwd) =>
+          provider.exec(args, cwd, {
+            timeoutMs: registrationDeadline.remainingMs()
+          }),
+        created.path,
+        branchName,
+        preparedPushTarget
+      )
+    }
+  } catch (error) {
+    if (!addCompleted && !isUncertainRemoteWorktreeAddError(error)) {
+      throw error
+    }
+    try {
+      await rollbackFailedRemoteWorktreeCreate(
+        provider,
+        repo.path,
+        remotePath,
+        branchName,
+        checkoutExistingBranch
+      )
+    } catch (cleanupError) {
+      console.warn(`[worktree-create] Failed to roll back remote "${remotePath}"`, cleanupError)
+      throw appendFailedWorktreeCreateCleanupMessage(error, remotePath)
+    }
+    throw error
   }
 
   const worktreeId = `${repo.id}::${created.path}`
   const now = Date.now()
   // Why: PR/MR worktrees start from a head ref/SHA but Source Control must compare against the review target branch.
   const metadataBaseRef = args.compareBaseRef ?? remoteTrackingBase?.ref ?? baseBranch
-  let configuredPushTarget: GitPushTarget | undefined
-  if (preparedPushTarget) {
-    configuredPushTarget = await configureCreatedWorktreePushTargetWithExec(
-      (args, cwd) => provider.exec(args, cwd),
-      created.path,
-      branchName,
-      preparedPushTarget
-    )
-  }
   const metaUpdates: Partial<WorktreeMeta> = {
     // Why: path-derived IDs get reused after external deletion; rotate instance identity so stale lineage can't attach to the new occupant.
     instanceId: randomUUID(),
@@ -1900,6 +2088,7 @@ export async function createLocalWorktree(
 ): Promise<CreateWorktreeResult> {
   const timing = createWorktreeCreateTimingRecorder()
   const settings = store.getSettings()
+  const createTimeouts = getEffectiveWorktreeCreateTimeouts(repo, settings, args.timeouts)
   const worktreePathSettings = getWorktreePathSettings(repo, settings)
   const localGitExecOptions = getLocalProjectGitExecOptions(store, repo)
   const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(store, repo)
@@ -1907,11 +2096,23 @@ export async function createLocalWorktree(
   const localWorktreeGitOptionArgs: [] | [{ wslDistro?: string }] = hasLocalWorktreeGitOptions
     ? [localWorktreeGitOptions]
     : []
+  let refreshDeadline: ReturnType<typeof createWorktreeCreateStageDeadline> | undefined
+  const remainingRefreshMs = (): number => {
+    refreshDeadline ??= createWorktreeCreateStageDeadline(
+      createTimeouts.refreshBaseRefMs,
+      `Worktree base ref refresh timed out after ${createTimeouts.refreshBaseRefMs}ms.`
+    )
+    return refreshDeadline.remainingMs()
+  }
+  const addRefreshTimeoutMs = (): number =>
+    refreshDeadline?.remainingMs() ?? createTimeouts.refreshBaseRefMs
   const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {
-    if (!hasLocalWorktreeGitOptions) {
-      return options
+    return {
+      ...options,
+      ...localWorktreeGitOptions,
+      refreshTimeout: addRefreshTimeoutMs(),
+      timeout: createTimeouts.addCheckoutMs
     }
-    return { ...options, ...localWorktreeGitOptions }
   }
 
   const requestedName = args.name
@@ -2013,11 +2214,10 @@ export async function createLocalWorktree(
         remoteTrackingRefresh = {
           base: remoteTrackingBase,
           hadLocalBaseRef: hasRemoteTrackingBaseRef,
-          promise: runtime.getOrStartRemoteTrackingBaseRefresh(
-            repo.path,
-            remoteTrackingBase,
-            ...localWorktreeGitOptionArgs
-          )
+          promise: runtime.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase, {
+            ...localWorktreeGitOptions,
+            timeout: remainingRefreshMs()
+          })
         }
       }
     } else if (
@@ -2025,7 +2225,10 @@ export async function createLocalWorktree(
     ) {
       // Why: non-remote-prefix bases (plain main/master/local) keep the legacy best-effort fetch; verified PR SHA bases already have the object.
       legacyFetchPromise = runtime
-        .fetchRemoteWithCache(repo.path, 'origin', ...localWorktreeGitOptionArgs)
+        .fetchRemoteWithCache(repo.path, 'origin', {
+          ...localWorktreeGitOptions,
+          timeout: remainingRefreshMs()
+        })
         .then(() => undefined)
         .catch(() => undefined)
       emitCreateWorktreeProgress(mainWindow, 'fetching', args.creationId)
@@ -2036,7 +2239,7 @@ export async function createLocalWorktree(
     ) {
       legacyFetchPromise = gitExecFileAsync(['fetch', 'origin'], {
         ...localGitExecOptions,
-        timeout: CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS
+        timeout: remainingRefreshMs()
       })
         .then(() => undefined)
         .catch(() => undefined)
@@ -2218,6 +2421,7 @@ export async function createLocalWorktree(
     await timing.time('refresh_base_ref', async () => {
       const result = await remoteTrackingRefresh.promise
       if (!result.ok && !remoteTrackingRefresh.hadLocalBaseRef) {
+        remainingRefreshMs()
         // Why: only block create when the refresh failed AND there's no local base ref; an existing (possibly stale) ref keeps worktree add viable.
         throw new Error(
           `Could not refresh base ref "${baseBranch}" from "${remoteTrackingRefresh.base.remote}". Check your network and try again.`
@@ -2225,20 +2429,22 @@ export async function createLocalWorktree(
       }
       if (
         !remoteTrackingRefresh.hadLocalBaseRef &&
-        !(await runtime?.hasRemoteTrackingRef(
-          repo.path,
-          remoteTrackingRefresh.base,
-          ...localWorktreeGitOptionArgs
-        ))
+        !(await runtime?.hasRemoteTrackingRef(repo.path, remoteTrackingRefresh.base, {
+          ...localWorktreeGitOptions,
+          timeout: remainingRefreshMs()
+        }))
       ) {
+        remainingRefreshMs()
         throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
       }
+      remainingRefreshMs()
     })
   }
 
   if (legacyFetchPromise) {
     await timing.time('refresh_base_ref', async () => {
       await legacyFetchPromise
+      remainingRefreshMs()
     })
   }
   emitCreateWorktreeProgress(mainWindow, 'creating', args.creationId)
@@ -2353,27 +2559,58 @@ export async function createLocalWorktree(
           )
     })) ?? {}
 
+  let gitWorktrees: GitWorktreeInfo[]
+  let created: GitWorktreeInfo
   let configuredPushTarget: GitPushTarget | undefined
-  if (preparedPushTarget) {
-    // Why: fork-PR review worktrees publish back to the PR author's branch; set upstream so Push/Sync use the contributor remote, not origin.
-    configuredPushTarget = await configureCreatedWorktreePushTarget(
-      worktreePath,
-      branchName,
-      preparedPushTarget,
-      localWorktreeGitOptions
+  try {
+    const registrationDeadline = createWorktreeCreateStageDeadline(
+      createTimeouts.registrationMs,
+      `Worktree registration timed out after ${createTimeouts.registrationMs}ms.`
     )
-  }
-
-  // Re-list to get the freshly created worktree info
-  const gitWorktrees = await timing.time('list_created_worktree', async () =>
-    hasLocalWorktreeGitOptions
-      ? listWorktrees(repo.path, localWorktreeGitOptions)
-      : listWorktrees(repo.path)
-  )
-  // Why: Git may canonicalize a symlinked create path; its exact branch identifies the listed row.
-  const created = findCreatedWorktree(gitWorktrees, worktreePath, branchName)
-  if (!created) {
-    throw new Error('Worktree created but not found in listing')
+    gitWorktrees = await timing.time('list_created_worktree', async () =>
+      hasLocalWorktreeGitOptions
+        ? listWorktreesStrict(repo.path, {
+            ...localWorktreeGitOptions,
+            timeout: registrationDeadline.remainingMs(),
+            detectSparseCheckout: false
+          })
+        : listWorktreesStrict(repo.path, {
+            timeout: registrationDeadline.remainingMs(),
+            detectSparseCheckout: false
+          })
+    )
+    // Why: Git may canonicalize a symlinked create path; its exact branch identifies the listed row.
+    const reconciled = findCreatedWorktree(gitWorktrees, worktreePath, branchName)
+    if (!reconciled) {
+      throw new Error('Worktree created but not found in listing')
+    }
+    created = reconciled
+    if (preparedPushTarget) {
+      // Why: fork-PR review worktrees publish back to the PR author's branch; set upstream so Push/Sync use the contributor remote, not origin.
+      configuredPushTarget = await configureCreatedWorktreePushTarget(
+        created.path,
+        branchName,
+        preparedPushTarget,
+        {
+          ...localWorktreeGitOptions,
+          timeout: registrationDeadline.remainingMs()
+        }
+      )
+    }
+  } catch (error) {
+    try {
+      await rollbackFailedWorktreeCreate(
+        repo.path,
+        worktreePath,
+        branchName,
+        checkoutExistingBranch,
+        localWorktreeGitOptions
+      )
+    } catch (cleanupError) {
+      console.warn(`[worktree-create] Failed to roll back "${worktreePath}"`, cleanupError)
+      throw appendFailedWorktreeCreateCleanupMessage(error, worktreePath)
+    }
+    throw error
   }
 
   const worktreeId = `${repo.id}::${created.path}`
@@ -2447,44 +2684,70 @@ export async function createLocalWorktree(
     repo.path,
     ...gitWorktrees.map((worktree) => worktree.path)
   ])
+  const materializationDeadlineAt = Date.now() + createTimeouts.materializationMs
+  let materializationTimedOut = false
+  const materializationOptions = {
+    deadlineAt: materializationDeadlineAt,
+    onDeadlineExceeded: () => {
+      materializationTimedOut = true
+    }
+  }
 
   // Why: link user-configured shared paths (e.g. `node_modules`, `.env`) before setup runs so setup scripts see them in place.
   const symlinkPaths = repo.symlinkPaths ?? []
   if (symlinkPaths.length > 0) {
     await timing.time('create_symlinks', async () => {
-      await createWorktreeLinkedPaths(repo.path, created.path, symlinkPaths)
+      await createWorktreeLinkedPaths(repo.path, created.path, symlinkPaths, materializationOptions)
     })
   }
 
   // Why: project-level `orca.yaml` shared directories add to (never replace) the per-user
   // setting, so a repo's shared dirs reach every teammate (issue #10451).
-  const sharedDirectories = await timing.time('resolve_shared_directories', () =>
-    resolveWorktreeSharedDirectories(repo.path, localWorktreeGitOptions)
-  )
+  const sharedDirectories =
+    Date.now() >= materializationDeadlineAt
+      ? ((materializationTimedOut = true), [])
+      : await timing.time('resolve_shared_directories', () =>
+          resolveWorktreeSharedDirectories(repo.path, localWorktreeGitOptions)
+        )
   if (sharedDirectories.length > 0) {
     await timing.time('create_shared_directories', async () => {
-      await createWorktreeSharedPaths(repo.path, created.path, sharedDirectories)
+      await createWorktreeSharedPaths(
+        repo.path,
+        created.path,
+        sharedDirectories,
+        materializationOptions
+      )
     })
   }
 
   // Why: project-level `.worktreeinclude` travels with the repo (issue #7549); copy semantics
   // (never symlink) so each worktree owns its files. Paths already linked above are skipped.
-  const includePaths = await timing.time('resolve_worktreeinclude', () =>
-    resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
-  )
+  const includePaths =
+    Date.now() >= materializationDeadlineAt
+      ? ((materializationTimedOut = true), [])
+      : await timing.time('resolve_worktreeinclude', () =>
+          resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
+        )
   let includeCopyWarning: string | undefined
   if (includePaths.length > 0) {
     await timing.time('copy_worktreeinclude', async () => {
       const skippedIncludePaths = await createWorktreeCopiedPaths(
         repo.path,
         created.path,
-        includePaths
+        includePaths,
+        materializationOptions
       )
       includeCopyWarning = formatWorktreeIncludeCopyWarning(skippedIncludePaths)
       if (includeCopyWarning) {
         console.warn(`[worktree-include] ${includeCopyWarning}`)
       }
     })
+  }
+  if (materializationTimedOut) {
+    includeCopyWarning = appendWorktreeCreateWarning(
+      includeCopyWarning,
+      `Workspace materialization stopped after ${createTimeouts.materializationMs}ms; the worktree was kept and remaining shared paths can be added manually.`
+    )
   }
 
   // Why: the worktree's base-branch `orca.yaml` is authoritative; we don't re-gate on content parity with the primary checkout since benign divergence silently disabled setup (#1280).

--- a/src/main/ipc/worktree-remote.ts
+++ b/src/main/ipc/worktree-remote.ts
@@ -80,6 +80,9 @@ type CreateWorktreeArgsWithSystemProvenance = CreateWorktreeArgs & {
   automationProvenance?: AutomationWorkspaceProvenance
   cliProvenance?: CliWorkspaceProvenance
 }
+
+const UNCERTAIN_SSH_WORKTREE_ADD_RECONCILIATION_GRACE_MS = 1_000
+const UNCERTAIN_SSH_WORKTREE_ADD_RECONCILIATION_POLL_MS = 100
 import {
   sanitizeWorktreeName,
   sanitizeWorktreeDisplayName,
@@ -106,6 +109,7 @@ import {
   type WorktreePushTargetStore
 } from './worktree-push-target-cleanup'
 import {
+  acquireWorktreePushTargetPreparationLease,
   configureCreatedWorktreePushTargetWithExec,
   ensureUniqueRemoteName,
   findRemoteForUrl,
@@ -497,31 +501,70 @@ function enqueueSshWorktreeCreateFetch(
   return promise
 }
 
+function waitForSshWorktreeCreateOperation<T>(
+  operation: Promise<T>,
+  signal?: AbortSignal
+): Promise<T> {
+  if (!signal) {
+    return operation
+  }
+  if (signal.aborted) {
+    return Promise.reject(
+      Object.assign(new Error('Worktree creation was cancelled.'), {
+        name: 'AbortError'
+      })
+    )
+  }
+  return new Promise<T>((resolve, reject) => {
+    const onAbort = (): void => {
+      reject(Object.assign(new Error('Worktree creation was cancelled.'), { name: 'AbortError' }))
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    void operation.then(
+      (result) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(result)
+      },
+      (error: unknown) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      }
+    )
+  })
+}
+
+function throwIfWorktreeCreateAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw Object.assign(new Error('Worktree creation was cancelled.'), { name: 'AbortError' })
+  }
+}
+
 async function getOrStartSshWorktreeCreateFetch(
-  key: string,
+  freshnessKey: string,
+  inflightKey: string,
   queueKey: string,
   fetch: () => Promise<void>
 ): Promise<void> {
-  if (getFreshSshWorktreeCreateFetchCompletedAt(key) !== null) {
+  if (getFreshSshWorktreeCreateFetchCompletedAt(freshnessKey) !== null) {
     return
   }
-  const existing = sshWorktreeCreateFetchInflight.get(key)
+  const existing = sshWorktreeCreateFetchInflight.get(inflightKey)
   if (existing) {
     return existing
   }
   const promise = enqueueSshWorktreeCreateFetch(queueKey, async () => {
-    if (getFreshSshWorktreeCreateFetchCompletedAt(key) !== null) {
+    if (getFreshSshWorktreeCreateFetchCompletedAt(freshnessKey) !== null) {
       return
     }
     await fetch()
     // Why: SSH creation has no OrcaRuntimeService to share; still reuse recent fetches for repeated creates on the same target.
-    rememberSshWorktreeCreateFetchCompletedAt(key)
+    rememberSshWorktreeCreateFetchCompletedAt(freshnessKey)
   }).finally(() => {
-    if (sshWorktreeCreateFetchInflight.get(key) === promise) {
-      sshWorktreeCreateFetchInflight.delete(key)
+    if (sshWorktreeCreateFetchInflight.get(inflightKey) === promise) {
+      sshWorktreeCreateFetchInflight.delete(inflightKey)
     }
   })
-  sshWorktreeCreateFetchInflight.set(key, promise)
+  sshWorktreeCreateFetchInflight.set(inflightKey, promise)
   return promise
 }
 
@@ -530,18 +573,23 @@ async function refreshRemoteTrackingBaseForWorktreeCreate(
   repo: Repo,
   base: RemoteTrackingBase,
   timeoutMs = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS,
-  remainingTimeoutMs: RemainingWorktreeCreateStageMs = () => timeoutMs
+  remainingTimeoutMs: RemainingWorktreeCreateStageMs = () => timeoutMs,
+  signal?: AbortSignal
 ): Promise<void> {
-  const fetchKey = `${getSshWorktreeCreateBaseFetchKey(repo, base)}::${timeoutMs}`
-  return getOrStartSshWorktreeCreateFetch(
-    fetchKey,
-    getSshWorktreeCreateRemoteQueueKey(repo, base.remote),
-    () =>
-      // Why: the exact-base refresh gates create; unrelated repo housekeeping must not extend it.
-      provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref, {
-        skipAutoMaintenance: true,
-        timeoutMs: remainingTimeoutMs()
-      })
+  const fetchKey = getSshWorktreeCreateBaseFetchKey(repo, base)
+  return waitForSshWorktreeCreateOperation(
+    getOrStartSshWorktreeCreateFetch(
+      fetchKey,
+      `${fetchKey}::${timeoutMs}`,
+      getSshWorktreeCreateRemoteQueueKey(repo, base.remote),
+      () =>
+        // Why: the exact-base refresh gates create; unrelated repo housekeeping must not extend it.
+        provider.fetchRemoteTrackingRef(repo.path, base.remote, base.branch, base.ref, {
+          skipAutoMaintenance: true,
+          timeoutMs: remainingTimeoutMs()
+        })
+    ),
+    signal
   )
 }
 
@@ -550,16 +598,21 @@ async function fetchRemoteForWorktreeCreate(
   repo: Repo,
   remote: string,
   timeoutMs = CREATE_BASE_FALLBACK_FETCH_TIMEOUT_MS,
-  remainingTimeoutMs: RemainingWorktreeCreateStageMs = () => timeoutMs
+  remainingTimeoutMs: RemainingWorktreeCreateStageMs = () => timeoutMs,
+  signal?: AbortSignal
 ): Promise<void> {
-  const fetchKey = `${getSshWorktreeCreateRemoteFetchKey(repo, remote)}::${timeoutMs}`
-  return getOrStartSshWorktreeCreateFetch(
-    fetchKey,
-    getSshWorktreeCreateRemoteQueueKey(repo, remote),
-    () =>
-      provider
-        .exec(['fetch', remote], repo.path, { timeoutMs: remainingTimeoutMs() })
-        .then(() => undefined)
+  const fetchKey = getSshWorktreeCreateRemoteFetchKey(repo, remote)
+  return waitForSshWorktreeCreateOperation(
+    getOrStartSshWorktreeCreateFetch(
+      fetchKey,
+      `${fetchKey}::${timeoutMs}`,
+      getSshWorktreeCreateRemoteQueueKey(repo, remote),
+      () =>
+        provider
+          .exec(['fetch', remote], repo.path, { timeoutMs: remainingTimeoutMs() })
+          .then(() => undefined)
+    ),
+    signal
   )
 }
 
@@ -590,13 +643,42 @@ async function rollbackFailedRemoteWorktreeCreate(
   repoPath: string,
   worktreePath: string,
   branchName: string,
-  checkoutExistingBranch: boolean
+  checkoutExistingBranch: boolean,
+  waitForLateRegistration = false
 ): Promise<boolean> {
-  const worktrees = await provider.listWorktrees(repoPath, {
-    timeoutMs: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
-    strict: true
-  })
-  const created = findRemoteWorktreeCreateIdentity(provider, worktrees, worktreePath, branchName)
+  const reconciliationDeadlineAt = waitForLateRegistration
+    ? Date.now() + UNCERTAIN_SSH_WORKTREE_ADD_RECONCILIATION_GRACE_MS
+    : Date.now()
+  let created: GitWorktreeInfo | undefined
+  do {
+    const remaining = Math.max(1, reconciliationDeadlineAt - Date.now())
+    const worktrees = await provider.listWorktrees(repoPath, {
+      timeoutMs: waitForLateRegistration
+        ? Math.min(WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS, remaining)
+        : WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS,
+      strict: true
+    })
+    created = findRemoteWorktreeCreateIdentity(provider, worktrees, worktreePath, branchName)
+    if (created) {
+      break
+    }
+    if (
+      !waitForLateRegistration ||
+      worktrees.some((worktree) => worktree.branch === `refs/heads/${branchName}`) ||
+      Date.now() >= reconciliationDeadlineAt
+    ) {
+      return false
+    }
+    await new Promise((resolve) =>
+      setTimeout(
+        resolve,
+        Math.min(
+          UNCERTAIN_SSH_WORKTREE_ADD_RECONCILIATION_POLL_MS,
+          reconciliationDeadlineAt - Date.now()
+        )
+      )
+    )
+  } while (Date.now() < reconciliationDeadlineAt)
   if (!created) {
     return false
   }
@@ -605,7 +687,8 @@ async function rollbackFailedRemoteWorktreeCreate(
   }
   await provider.removeWorktree(created.path, true, {
     deleteBranch: !checkoutExistingBranch,
-    forceBranchDelete: !checkoutExistingBranch
+    forceBranchDelete: !checkoutExistingBranch,
+    timeoutMs: WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS
   })
   return true
 }
@@ -1101,7 +1184,12 @@ export async function prepareWorktreePushTarget(
             { ...target, remoteName: existingRemote },
             repoId
           )
-        : false
+        : false,
+    (args, cwd) =>
+      gitExecFileAsync(args, {
+        cwd,
+        ...(gitOptions.wslDistro ? { wslDistro: gitOptions.wslDistro } : {})
+      })
   )
 }
 
@@ -1175,18 +1263,15 @@ async function prepareWorktreePushTargetSsh(
   await provider.exec(['check-ref-format', '--branch', target.branchName], repoPath)
   let remoteName = target.remoteName
   let remoteCreated = false
+  let createdThisCall = false
   if (target.remoteUrl) {
     const existingRemote = await findRemoteForUrl(execGit, repoPath, target.remoteUrl)
     if (existingRemote) {
       remoteName = existingRemote
-      // Why: a reused Orca-created fork remote must inherit ownership so deleting the final user can remove it.
       remoteCreated = store
         ? isPushTargetRemoteCreatedByKnownWorktree(
             store,
-            {
-              ...target,
-              remoteName: existingRemote
-            },
+            { ...target, remoteName: existingRemote },
             repoId
           )
         : false
@@ -1194,15 +1279,31 @@ async function prepareWorktreePushTargetSsh(
       remoteName = await ensureUniqueRemoteName(execGit, repoPath, target.remoteName)
       await provider.exec(['remote', 'add', remoteName, target.remoteUrl], repoPath)
       remoteCreated = true
+      createdThisCall = true
     }
   }
-  await provider.fetchRemoteTrackingRef(
-    repoPath,
+  try {
+    await provider.fetchRemoteTrackingRef(
+      repoPath,
+      remoteName,
+      target.branchName,
+      `refs/remotes/${remoteName}/${target.branchName}`
+    )
+  } catch (error) {
+    if (createdThisCall) {
+      try {
+        await provider.exec(['remote', 'remove', remoteName], repoPath)
+      } catch {
+        // Keep the fetch failure actionable; later retries can reuse or disambiguate the remote.
+      }
+    }
+    throw error
+  }
+  return {
+    ...sanitizedTarget,
     remoteName,
-    target.branchName,
-    `refs/remotes/${remoteName}/${target.branchName}`
-  )
-  return { ...sanitizedTarget, remoteName, ...(remoteCreated ? { remoteCreated: true } : {}) }
+    ...(remoteCreated ? { remoteCreated: true } : {})
+  }
 }
 
 export async function cleanupUnusedWorktreePushTargetRemoteSsh(
@@ -1607,8 +1708,11 @@ export async function createRemoteWorktree(
   args: CreateWorktreeArgsWithSystemProvenance,
   repo: Repo,
   store: Store,
-  mainWindow: BrowserWindow
+  mainWindow: BrowserWindow,
+  options: { signal?: AbortSignal } = {}
 ): Promise<CreateWorktreeResult> {
+  const { signal } = options
+  throwIfWorktreeCreateAborted(signal)
   const timing = createWorktreeCreateTimingRecorder()
   const provider = requireSshGitProvider(repo.connectionId!)
   const fsProvider = getSshFilesystemProvider(repo.connectionId!)
@@ -1783,9 +1887,11 @@ export async function createRemoteWorktree(
         repo,
         remoteTrackingBase,
         createTimeouts.refreshBaseRefMs,
-        remainingRefreshMs
+        remainingRefreshMs,
+        signal
       )
     } catch {
+      throwIfWorktreeCreateAborted(signal)
       // Why: a refresh failure shouldn't block create if a usable (stale) local base ref exists; probe after registerRoot and hard-fail only when none does.
       if (
         !(await hasRemoteTrackingRefSsh(
@@ -1810,9 +1916,11 @@ export async function createRemoteWorktree(
         repo,
         'origin',
         createTimeouts.refreshBaseRefMs,
-        remainingRefreshMs
+        remainingRefreshMs,
+        signal
       )
     } catch {
+      throwIfWorktreeCreateAborted(signal)
       remainingRefreshMs()
     }
   }
@@ -1847,35 +1955,55 @@ export async function createRemoteWorktree(
   }
 
   let preparedPushTarget: GitPushTarget | undefined
+  const releasePushTargetPreparation = args.pushTarget
+    ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget)
+    : undefined
   if (args.pushTarget) {
     // Why: fork-PR SSH worktrees need contributor-remote setup before create, else Push/Sync target origin.
-    preparedPushTarget = await prepareWorktreePushTargetSsh(
-      provider,
-      repo.path,
-      args.pushTarget,
-      store,
-      repo.id
-    )
+    try {
+      preparedPushTarget = await prepareWorktreePushTargetSsh(
+        provider,
+        repo.path,
+        args.pushTarget,
+        store,
+        repo.id
+      )
+    } catch (error) {
+      releasePushTargetPreparation?.()
+      throw error
+    }
   }
 
   const addCheckoutDeadlineAt = Date.now() + createTimeouts.addCheckoutMs
-  const remainingAddCheckoutMs = (): number => Math.max(1, addCheckoutDeadlineAt - Date.now())
+  const remainingAddCheckoutMs = (): number => {
+    const remaining = addCheckoutDeadlineAt - Date.now()
+    if (remaining <= 0) {
+      throw new Error(
+        `Worktree add and checkout timed out after ${createTimeouts.addCheckoutMs}ms.`
+      )
+    }
+    return remaining
+  }
   let created: GitWorktreeInfo
   let configuredPushTarget: GitPushTarget | undefined
+  let addAttempted = false
   let addCompleted = false
   try {
+    throwIfWorktreeCreateAborted(signal)
     try {
+      addAttempted = true
       await timing.time('git_worktree_add', async () =>
         provider.addWorktree(
           repo.path,
           branchName,
           remotePath,
           checkoutExistingBranch
-            ? { checkoutExistingBranch, timeoutMs: remainingAddCheckoutMs() }
+            ? { checkoutExistingBranch, timeoutMs: remainingAddCheckoutMs(), signal }
             : {
                 base: baseBranch,
                 ...(sparseDirectories.length > 0 ? { noCheckout: true } : {}),
-                timeoutMs: remainingAddCheckoutMs()
+                timeoutMs: remainingAddCheckoutMs(),
+                signal
               }
         )
       )
@@ -1897,13 +2025,16 @@ export async function createRemoteWorktree(
     if (sparseDirectories.length > 0) {
       // Why: SSH providers expose generic git exec, so remote sparse mirrors local addSparseWorktree without a new relay method.
       await provider.exec(['sparse-checkout', 'init', '--cone'], remotePath, {
-        timeoutMs: remainingAddCheckoutMs()
+        timeoutMs: remainingAddCheckoutMs(),
+        signal
       })
       await provider.exec(['sparse-checkout', 'set', '--', ...sparseDirectories], remotePath, {
-        timeoutMs: remainingAddCheckoutMs()
+        timeoutMs: remainingAddCheckoutMs(),
+        signal
       })
       await provider.exec(['checkout', branchName], remotePath, {
-        timeoutMs: remainingAddCheckoutMs()
+        timeoutMs: remainingAddCheckoutMs(),
+        signal
       })
     }
 
@@ -1914,14 +2045,15 @@ export async function createRemoteWorktree(
     const gitWorktrees = await timing.time('list_created_worktree', async () =>
       provider.listWorktrees(repo.path, {
         timeoutMs: registrationDeadline.remainingMs(),
-        strict: true
+        strict: true,
+        signal
       })
     )
-    const reconciled = findRemoteWorktreeCreateIdentity(
-      provider,
+    const reconciled = findCreatedWorktree(
       gitWorktrees,
       remotePath,
-      branchName
+      branchName,
+      provider.getHostPlatform?.()?.os ?? process.platform
     )
     if (!reconciled) {
       throw new Error('Worktree created but not found in listing')
@@ -1931,7 +2063,8 @@ export async function createRemoteWorktree(
       configuredPushTarget = await configureCreatedWorktreePushTargetWithExec(
         (args, cwd) =>
           provider.exec(args, cwd, {
-            timeoutMs: registrationDeadline.remainingMs()
+            timeoutMs: registrationDeadline.remainingMs(),
+            signal
           }),
         created.path,
         branchName,
@@ -1939,7 +2072,15 @@ export async function createRemoteWorktree(
       )
     }
   } catch (error) {
-    if (!addCompleted && !isUncertainRemoteWorktreeAddError(error)) {
+    if (!addAttempted || (!addCompleted && !isUncertainRemoteWorktreeAddError(error))) {
+      await cleanupUnusedWorktreePushTargetRemoteSsh(
+        provider,
+        repo.path,
+        `${repo.id}::${remotePath}`,
+        preparedPushTarget,
+        store
+      )
+      releasePushTargetPreparation?.()
       throw error
     }
     try {
@@ -1948,12 +2089,22 @@ export async function createRemoteWorktree(
         repo.path,
         remotePath,
         branchName,
-        checkoutExistingBranch
+        checkoutExistingBranch,
+        !addCompleted
       )
     } catch (cleanupError) {
       console.warn(`[worktree-create] Failed to roll back remote "${remotePath}"`, cleanupError)
+      releasePushTargetPreparation?.()
       throw appendFailedWorktreeCreateCleanupMessage(error, remotePath)
     }
+    await cleanupUnusedWorktreePushTargetRemoteSsh(
+      provider,
+      repo.path,
+      `${repo.id}::${remotePath}`,
+      preparedPushTarget,
+      store
+    )
+    releasePushTargetPreparation?.()
     throw error
   }
 
@@ -2017,10 +2168,16 @@ export async function createRemoteWorktree(
       : {}),
     ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
   }
-  const { worktree } = timing.timeSync('persist_metadata', () => {
-    const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
-  })
+  const { worktree } = (() => {
+    try {
+      return timing.timeSync('persist_metadata', () => {
+        const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
+        return { worktree: mergeWorktree(repo.id, created, meta) }
+      })
+    } finally {
+      releasePushTargetPreparation?.()
+    }
+  })()
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
 
   // Why: shared/symlink paths, `orca.yaml` shared directories, and `.worktreeinclude` copies are local-only; remote (SSH) support needs a new relay method + auth surface, so all are skipped here.
@@ -2450,15 +2607,23 @@ export async function createLocalWorktree(
   emitCreateWorktreeProgress(mainWindow, 'creating', args.creationId)
 
   let preparedPushTarget: GitPushTarget | undefined
+  const releasePushTargetPreparation = args.pushTarget
+    ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget)
+    : undefined
   if (args.pushTarget) {
     // Why: validate/fetch the contributor remote before create so a failure doesn't leave a half-created worktree with conflicts on retry.
-    preparedPushTarget = await prepareWorktreePushTarget(
-      repo.path,
-      args.pushTarget,
-      store,
-      repo.id,
-      localWorktreeGitOptions
-    )
+    try {
+      preparedPushTarget = await prepareWorktreePushTarget(
+        repo.path,
+        args.pushTarget,
+        store,
+        repo.id,
+        localWorktreeGitOptions
+      )
+    } catch (error) {
+      releasePushTargetPreparation?.()
+      throw error
+    }
   }
 
   const suggestLocalBaseRefUpdate =
@@ -2471,93 +2636,106 @@ export async function createLocalWorktree(
     ...remoteTrackingBaseOption,
     ...(suggestLocalBaseRefUpdate ? { suggestLocalBaseRefUpdate } : {})
   }
-  const addResult: AddWorktreeResult =
-    (await timing.time('git_worktree_add', async () => {
-      if (sparseDirectories.length > 0) {
-        if (checkoutExistingBranch) {
-          return addSparseWorktree(
-            repo.path,
-            worktreePath,
-            branchName,
-            sparseDirectories,
-            baseBranch,
-            settings.refreshLocalBaseRefOnWorktreeCreate,
-            addProjectGitOptions(existingBranchOption)
-          )
-        }
-        if (suggestLocalBaseRefUpdate) {
-          return addSparseWorktree(
-            repo.path,
-            worktreePath,
-            branchName,
-            sparseDirectories,
-            baseBranch,
-            settings.refreshLocalBaseRefOnWorktreeCreate,
-            addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
-          )
-        }
-        const sparseOptions = addProjectGitOptions(remoteTrackingBaseOption)
-        return sparseOptions
-          ? addSparseWorktree(
+  let addResult: AddWorktreeResult
+  try {
+    addResult =
+      (await timing.time('git_worktree_add', async () => {
+        if (sparseDirectories.length > 0) {
+          if (checkoutExistingBranch) {
+            return addSparseWorktree(
               repo.path,
               worktreePath,
               branchName,
               sparseDirectories,
               baseBranch,
               settings.refreshLocalBaseRefOnWorktreeCreate,
-              sparseOptions
+              addProjectGitOptions(existingBranchOption)
             )
-          : addSparseWorktree(
+          }
+          if (suggestLocalBaseRefUpdate) {
+            return addSparseWorktree(
               repo.path,
               worktreePath,
               branchName,
               sparseDirectories,
               baseBranch,
-              settings.refreshLocalBaseRefOnWorktreeCreate
+              settings.refreshLocalBaseRefOnWorktreeCreate,
+              addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
             )
-      }
+          }
+          const sparseOptions = addProjectGitOptions(remoteTrackingBaseOption)
+          return sparseOptions
+            ? addSparseWorktree(
+                repo.path,
+                worktreePath,
+                branchName,
+                sparseDirectories,
+                baseBranch,
+                settings.refreshLocalBaseRefOnWorktreeCreate,
+                sparseOptions
+              )
+            : addSparseWorktree(
+                repo.path,
+                worktreePath,
+                branchName,
+                sparseDirectories,
+                baseBranch,
+                settings.refreshLocalBaseRefOnWorktreeCreate
+              )
+        }
 
-      if (checkoutExistingBranch) {
-        return addWorktree(
-          repo.path,
-          worktreePath,
-          branchName,
-          baseBranch,
-          settings.refreshLocalBaseRefOnWorktreeCreate,
-          false,
-          addProjectGitOptions(existingBranchOption)
-        )
-      }
-      if (suggestLocalBaseRefUpdate) {
-        return addWorktree(
-          repo.path,
-          worktreePath,
-          branchName,
-          baseBranch,
-          settings.refreshLocalBaseRefOnWorktreeCreate,
-          false,
-          addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
-        )
-      }
-      const worktreeOptions = addProjectGitOptions(remoteTrackingBaseOption)
-      return worktreeOptions
-        ? addWorktree(
+        if (checkoutExistingBranch) {
+          return addWorktree(
             repo.path,
             worktreePath,
             branchName,
             baseBranch,
             settings.refreshLocalBaseRefOnWorktreeCreate,
             false,
-            worktreeOptions
+            addProjectGitOptions(existingBranchOption)
           )
-        : addWorktree(
+        }
+        if (suggestLocalBaseRefUpdate) {
+          return addWorktree(
             repo.path,
             worktreePath,
             branchName,
             baseBranch,
-            settings.refreshLocalBaseRefOnWorktreeCreate
+            settings.refreshLocalBaseRefOnWorktreeCreate,
+            false,
+            addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
           )
-    })) ?? {}
+        }
+        const worktreeOptions = addProjectGitOptions(remoteTrackingBaseOption)
+        return worktreeOptions
+          ? addWorktree(
+              repo.path,
+              worktreePath,
+              branchName,
+              baseBranch,
+              settings.refreshLocalBaseRefOnWorktreeCreate,
+              false,
+              worktreeOptions
+            )
+          : addWorktree(
+              repo.path,
+              worktreePath,
+              branchName,
+              baseBranch,
+              settings.refreshLocalBaseRefOnWorktreeCreate
+            )
+      })) ?? {}
+  } catch (error) {
+    await cleanupUnusedWorktreePushTargetRemote(
+      repo.path,
+      `${repo.id}::${worktreePath}`,
+      preparedPushTarget,
+      store,
+      localWorktreeGitOptions
+    )
+    releasePushTargetPreparation?.()
+    throw error
+  }
 
   let gitWorktrees: GitWorktreeInfo[]
   let created: GitWorktreeInfo
@@ -2608,8 +2786,17 @@ export async function createLocalWorktree(
       )
     } catch (cleanupError) {
       console.warn(`[worktree-create] Failed to roll back "${worktreePath}"`, cleanupError)
+      releasePushTargetPreparation?.()
       throw appendFailedWorktreeCreateCleanupMessage(error, worktreePath)
     }
+    await cleanupUnusedWorktreePushTargetRemote(
+      repo.path,
+      `${repo.id}::${worktreePath}`,
+      preparedPushTarget,
+      store,
+      localWorktreeGitOptions
+    )
+    releasePushTargetPreparation?.()
     throw error
   }
 
@@ -2674,10 +2861,16 @@ export async function createLocalWorktree(
       : {}),
     ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
   }
-  const { worktree } = timing.timeSync('persist_metadata', () => {
-    const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
-    return { worktree: mergeWorktree(repo.id, created, meta) }
-  })
+  const { worktree } = (() => {
+    try {
+      return timing.timeSync('persist_metadata', () => {
+        const meta = store.setWorktreeMeta(worktreeId, metaUpdates)
+        return { worktree: mergeWorktree(repo.id, created, meta) }
+      })
+    } finally {
+      releasePushTargetPreparation?.()
+    }
+  })()
   const workspaceLineage = recordWorkspaceLineageForCreatedWorktree(store, args, worktree, now)
   // Why: reuse the roots creation already paid for via `git worktree list` so later IPC doesn't lazily rescan and trip macOS privacy prompts.
   registerWorktreeRootsForRepo(store, repo.id, [

--- a/src/main/ipc/worktree-symlinks.test.ts
+++ b/src/main/ipc/worktree-symlinks.test.ts
@@ -233,6 +233,31 @@ describe('createWorktreeSymlinks', () => {
     expect(statSync(join(worktree, '.env')).isFile()).toBe(true)
   })
 
+  it('reports a deadline crossed by the final materialization operation', async () => {
+    writeFileSync(join(primary, '.env'), 'SECRET=1\n')
+    let now = 100
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const onDeadlineExceeded = vi.fn()
+    const cloneWorktreePath = vi.fn(async (_source: string, target: string) => {
+      writeFileSync(target, 'SECRET=1\n')
+      now = 201
+    })
+
+    try {
+      await createWorktreeLinkedPaths(primary, worktree, ['.env'], {
+        platform: 'darwin',
+        cloneWorktreePath,
+        deadlineAt: 200,
+        onDeadlineExceeded
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(onDeadlineExceeded).toHaveBeenCalledOnce()
+    expect(readFileSync(join(worktree, '.env'), 'utf8')).toBe('SECRET=1\n')
+  })
+
   it('does not overwrite a file target that appears before APFS clone-copy is published', async () => {
     writeFileSync(join(primary, '.env'), 'SECRET=1\n')
     const target = join(worktree, '.env')

--- a/src/main/ipc/worktree-symlinks.test.ts
+++ b/src/main/ipc/worktree-symlinks.test.ts
@@ -233,7 +233,7 @@ describe('createWorktreeSymlinks', () => {
     expect(statSync(join(worktree, '.env')).isFile()).toBe(true)
   })
 
-  it('reports a deadline crossed by the final materialization operation', async () => {
+  it('does not report a deadline when the final materialization operation completed', async () => {
     writeFileSync(join(primary, '.env'), 'SECRET=1\n')
     let now = 100
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
@@ -254,7 +254,7 @@ describe('createWorktreeSymlinks', () => {
       nowSpy.mockRestore()
     }
 
-    expect(onDeadlineExceeded).toHaveBeenCalledOnce()
+    expect(onDeadlineExceeded).not.toHaveBeenCalled()
     expect(readFileSync(join(worktree, '.env'), 'utf8')).toBe('SECRET=1\n')
   })
 

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -206,10 +206,11 @@ async function materializeWorktreePaths(
   // are refused for the same reason one `node_modules` entry is.
   const copyBudget = createWorktreeCopyBudgetTracker(options.copyBudget)
   const skipped: SkippedWorktreeCopyPath[] = []
+  let stoppedEarly = false
 
   for (const rawPath of paths) {
     if (effectiveOptions.deadlineAt !== undefined && Date.now() >= effectiveOptions.deadlineAt) {
-      effectiveOptions.onDeadlineExceeded?.()
+      stoppedEarly = true
       break
     }
     const safePath = getSafeRelativePath(rawPath)
@@ -310,7 +311,7 @@ async function materializeWorktreePaths(
       )
     }
   }
-  if (effectiveOptions.deadlineAt !== undefined && Date.now() >= effectiveOptions.deadlineAt) {
+  if (stoppedEarly) {
     effectiveOptions.onDeadlineExceeded?.()
   }
   return skipped

--- a/src/main/ipc/worktree-symlinks.ts
+++ b/src/main/ipc/worktree-symlinks.ts
@@ -23,6 +23,9 @@ type WorktreeLinkedPathOptions = {
   platform?: NodeJS.Platform
   cloneWorktreePath?: (source: string, target: string, sourceIsDirectory: boolean) => Promise<void>
   apfsCloneDeps?: ApfsCloneDeps
+  /** Stop before starting another path once this deadline has passed. */
+  deadlineAt?: number
+  onDeadlineExceeded?: () => void
   /** Copy-mode only. Overridable so tests can trip the bound without writing
    *  gigabytes to disk. */
   copyBudget?: WorktreeCopyBudget
@@ -205,6 +208,10 @@ async function materializeWorktreePaths(
   const skipped: SkippedWorktreeCopyPath[] = []
 
   for (const rawPath of paths) {
+    if (effectiveOptions.deadlineAt !== undefined && Date.now() >= effectiveOptions.deadlineAt) {
+      effectiveOptions.onDeadlineExceeded?.()
+      break
+    }
     const safePath = getSafeRelativePath(rawPath)
     if (!safePath.safe) {
       // Users can only configure paths relative to the repo root; absolute
@@ -302,6 +309,9 @@ async function materializeWorktreePaths(
         error
       )
     }
+  }
+  if (effectiveOptions.deadlineAt !== undefined && Date.now() >= effectiveOptions.deadlineAt) {
+    effectiveOptions.onDeadlineExceeded?.()
   }
   return skipped
 }

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -299,7 +299,12 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       'C:\\workspaces\\improve-dashboard',
       'improve-dashboard',
       'origin/main',
-      false
+      false,
+      false,
+      {
+        refreshTimeout: 60_000,
+        timeout: 180_000
+      }
     )
     expect(resolveLocalGitUsernameMock).not.toHaveBeenCalled()
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
@@ -346,7 +351,12 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       'C:\\workspaces\\improve-dashboard',
       'octocat/improve-dashboard',
       'origin/main',
-      false
+      false,
+      false,
+      {
+        refreshTimeout: 60_000,
+        timeout: 180_000
+      }
     )
   })
 

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -302,10 +302,15 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
       false,
       false,
       {
-        refreshTimeout: 60_000,
-        timeout: 180_000
+        refreshTimeout: expect.any(Number),
+        timeout: expect.any(Number)
       }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
+    expect(addOptions?.timeout).toBeGreaterThan(0)
+    expect(addOptions?.timeout).toBeLessThanOrEqual(180_000)
     expect(resolveLocalGitUsernameMock).not.toHaveBeenCalled()
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::C:/workspaces/improve-dashboard',

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -727,8 +727,16 @@ describe('registerWorktreeHandlers', () => {
       sha,
       false,
       false,
-      DEFAULT_LOCAL_CREATE_OPTIONS
+      {
+        refreshTimeout: expect.any(Number),
+        timeout: expect.any(Number)
+      }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
+    expect(addOptions?.timeout).toBeGreaterThan(0)
+    expect(addOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_ADD_TIMEOUT_MS)
   })
 
   it('keeps the broad remote fetch fallback when a commit SHA base is missing locally', async () => {
@@ -2188,6 +2196,14 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('configures a PR push target during local create', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'fetch' && args[1] === 'pr-prateek-orca') {
+        now += 6_000
+      }
+      return { stdout: '', stderr: '' }
+    })
     listWorktreesMock.mockResolvedValue([
       {
         path: '/workspace/improve-dashboard',
@@ -2199,15 +2215,23 @@ describe('registerWorktreeHandlers', () => {
     ])
     store.setWorktreeMeta.mockImplementation((_worktreeId, meta) => meta)
 
-    await handlers['worktrees:create'](null, {
-      repoId: 'repo-1',
-      name: 'improve-dashboard',
-      pushTarget: {
-        remoteName: 'pr-prateek-orca',
-        branchName: 'prateek/fix-sidebar-agents-toggle',
-        remoteUrl: 'git@github.com:prateek/orca.git'
-      }
-    })
+    try {
+      await handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard',
+        pushTarget: {
+          remoteName: 'pr-prateek-orca',
+          branchName: 'prateek/fix-sidebar-agents-toggle',
+          remoteUrl: 'git@github.com:prateek/orca.git'
+        },
+        timeouts: {
+          refreshBaseRefMs: 12_000,
+          addCheckoutMs: 24_000
+        }
+      })
+    } finally {
+      nowSpy.mockRestore()
+    }
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['remote', 'add', 'pr-prateek-orca', 'git@github.com:prateek/orca.git'],
@@ -2224,8 +2248,10 @@ describe('registerWorktreeHandlers', () => {
     const fetchOptions = gitExecFileAsyncMock.mock.calls.find(
       ([args]) => args[0] === 'fetch' && args[1] === 'pr-prateek-orca'
     )?.[1]
-    expect(fetchOptions?.timeout).toBeGreaterThan(0)
-    expect(fetchOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
+    expect(fetchOptions?.timeout).toBe(24_000)
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBe(12_000)
+    expect(addOptions?.timeout).toBe(18_000)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'branch',
@@ -2515,7 +2541,7 @@ describe('registerWorktreeHandlers', () => {
       ([args]) => args[0] === 'fetch' && args[1] === 'pr-contributor-orca'
     )?.[1]
     expect(fetchOptions?.timeout).toBeGreaterThan(0)
-    expect(fetchOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
+    expect(fetchOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_ADD_TIMEOUT_MS)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'pr-contributor-orca/contributor/wsl-fork', 'wsl-fork'],
       { cwd: '/workspace/wsl-fork', timeout: expect.any(Number), wslDistro: 'Ubuntu' }
@@ -5382,6 +5408,8 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('rolls back an SSH create when push-target registration fails', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
     const remoteUrl = 'git@github.com:contributor/orca.git'
     let remoteExists = false
     const repo = {
@@ -5418,7 +5446,11 @@ describe('registerWorktreeHandlers', () => {
         }
         return { stdout: '', stderr: '' }
       }),
-      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      fetchRemoteTrackingRef: vi.fn().mockImplementation(async (_repoPath, remote) => {
+        if (remote === 'contributor') {
+          now += 6_000
+        }
+      }),
       addWorktree: vi.fn().mockResolvedValue(undefined),
       listWorktrees: vi.fn().mockResolvedValue([
         {
@@ -5439,17 +5471,25 @@ describe('registerWorktreeHandlers', () => {
       notify: vi.fn()
     })
 
-    await expect(
-      handlers['worktrees:create'](null, {
-        repoId: 'repo-ssh',
-        name: 'improve-dashboard',
-        pushTarget: {
-          remoteName: 'contributor',
-          branchName: 'feature/fix',
-          remoteUrl
-        }
-      })
-    ).rejects.toThrow('upstream config failed')
+    try {
+      await expect(
+        handlers['worktrees:create'](null, {
+          repoId: 'repo-ssh',
+          name: 'improve-dashboard',
+          pushTarget: {
+            remoteName: 'contributor',
+            branchName: 'feature/fix',
+            remoteUrl
+          },
+          timeouts: {
+            refreshBaseRefMs: 12_000,
+            addCheckoutMs: 24_000
+          }
+        })
+      ).rejects.toThrow('upstream config failed')
+    } finally {
+      nowSpy.mockRestore()
+    }
 
     expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
       deleteBranch: true,
@@ -5466,8 +5506,8 @@ describe('registerWorktreeHandlers', () => {
     const pushTargetFetchOptions = provider.fetchRemoteTrackingRef.mock.calls.find(
       ([, remote]) => remote === 'contributor'
     )?.[4]
-    expect(pushTargetFetchOptions?.timeoutMs).toBeGreaterThan(0)
-    expect(pushTargetFetchOptions?.timeoutMs).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
+    expect(pushTargetFetchOptions?.timeoutMs).toBe(24_000)
+    expect(provider.addWorktree.mock.calls[0]?.[3]?.timeoutMs).toBe(18_000)
     expect(provider.exec).toHaveBeenCalledWith(['remote', 'remove', 'contributor'], '/remote/repo')
     expect(remoteExists).toBe(false)
   })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -15,7 +15,7 @@ const DEFAULT_CREATE_ADD_TIMEOUT_MS = 180_000
 const DEFAULT_CREATE_REGISTRATION_TIMEOUT_MS = 30_000
 const DEFAULT_LOCAL_CREATE_OPTIONS = {
   refreshTimeout: expect.any(Number),
-  timeout: DEFAULT_CREATE_ADD_TIMEOUT_MS
+  timeout: expect.any(Number)
 }
 const removeWorktreeLinkedPathsMock = vi.hoisted(() => vi.fn())
 const findExistingWorktreeSymlinkPathsMock = vi.hoisted(() => vi.fn())

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2211,7 +2211,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['remote', 'add', 'pr-prateek-orca', 'git@github.com:prateek/orca.git'],
-      { cwd: '/workspace/repo' }
+      { cwd: '/workspace/repo', timeout: expect.any(Number) }
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [
@@ -2493,11 +2493,11 @@ describe('registerWorktreeHandlers', () => {
 
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['check-ref-format', '--branch', 'contributor/wsl-fork'],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      { cwd: '/workspace/repo', timeout: expect.any(Number), wslDistro: 'Ubuntu' }
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['remote', 'add', 'pr-contributor-orca', 'git@github.com:contributor/orca.git'],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      { cwd: '/workspace/repo', timeout: expect.any(Number), wslDistro: 'Ubuntu' }
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [
@@ -5461,7 +5461,7 @@ describe('registerWorktreeHandlers', () => {
       'contributor',
       'feature/fix',
       'refs/remotes/contributor/feature/fix',
-      { timeoutMs: expect.any(Number) }
+      { timeoutMs: expect.any(Number), signal: undefined }
     )
     const pushTargetFetchOptions = provider.fetchRemoteTrackingRef.mock.calls.find(
       ([, remote]) => remote === 'contributor'

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1886,8 +1886,14 @@ describe('registerWorktreeHandlers', () => {
       'abc123',
       false,
       false,
-      DEFAULT_LOCAL_CREATE_OPTIONS
+      {
+        ...DEFAULT_LOCAL_CREATE_OPTIONS,
+        timeout: expect.any(Number)
+      }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.timeout).toBeGreaterThan(0)
+    expect(addOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_ADD_TIMEOUT_MS)
   })
 
   it('suffixes a matching push target branch when selected PR metadata has no PR number', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -2219,8 +2219,13 @@ describe('registerWorktreeHandlers', () => {
         'pr-prateek-orca',
         '+refs/heads/prateek/fix-sidebar-agents-toggle:refs/remotes/pr-prateek-orca/prateek/fix-sidebar-agents-toggle'
       ],
-      { cwd: '/workspace/repo' }
+      { cwd: '/workspace/repo', timeout: expect.any(Number) }
     )
+    const fetchOptions = gitExecFileAsyncMock.mock.calls.find(
+      ([args]) => args[0] === 'fetch' && args[1] === 'pr-prateek-orca'
+    )?.[1]
+    expect(fetchOptions?.timeout).toBeGreaterThan(0)
+    expect(fetchOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       [
         'branch',
@@ -2500,8 +2505,17 @@ describe('registerWorktreeHandlers', () => {
         'pr-contributor-orca',
         '+refs/heads/contributor/wsl-fork:refs/remotes/pr-contributor-orca/contributor/wsl-fork'
       ],
-      { cwd: '/workspace/repo', wslDistro: 'Ubuntu' }
+      {
+        cwd: '/workspace/repo',
+        timeout: expect.any(Number),
+        wslDistro: 'Ubuntu'
+      }
     )
+    const fetchOptions = gitExecFileAsyncMock.mock.calls.find(
+      ([args]) => args[0] === 'fetch' && args[1] === 'pr-contributor-orca'
+    )?.[1]
+    expect(fetchOptions?.timeout).toBeGreaterThan(0)
+    expect(fetchOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'pr-contributor-orca/contributor/wsl-fork', 'wsl-fork'],
       { cwd: '/workspace/wsl-fork', timeout: expect.any(Number), wslDistro: 'Ubuntu' }
@@ -5250,9 +5264,10 @@ describe('registerWorktreeHandlers', () => {
       })
     ).rejects.toThrow('add request timed out')
 
-    const reconciliationTimeoutMs = provider.listWorktrees.mock.calls[0]?.[1]?.timeoutMs
-    expect(reconciliationTimeoutMs).toBeGreaterThan(0)
-    expect(reconciliationTimeoutMs).toBeLessThanOrEqual(1_000)
+    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
+      timeoutMs: DEFAULT_CREATE_REGISTRATION_TIMEOUT_MS,
+      strict: true
+    })
     expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
       deleteBranch: true,
       forceBranchDelete: true,
@@ -5307,6 +5322,12 @@ describe('registerWorktreeHandlers', () => {
     ).rejects.toThrow('add request timed out')
 
     expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
+    for (const [, options] of provider.listWorktrees.mock.calls) {
+      expect(options).toEqual({
+        timeoutMs: DEFAULT_CREATE_REGISTRATION_TIMEOUT_MS,
+        strict: true
+      })
+    }
     expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
       deleteBranch: true,
       forceBranchDelete: true,
@@ -5435,6 +5456,18 @@ describe('registerWorktreeHandlers', () => {
       forceBranchDelete: true,
       timeoutMs: 30_000
     })
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/remote/repo',
+      'contributor',
+      'feature/fix',
+      'refs/remotes/contributor/feature/fix',
+      { timeoutMs: expect.any(Number) }
+    )
+    const pushTargetFetchOptions = provider.fetchRemoteTrackingRef.mock.calls.find(
+      ([, remote]) => remote === 'contributor'
+    )?.[4]
+    expect(pushTargetFetchOptions?.timeoutMs).toBeGreaterThan(0)
+    expect(pushTargetFetchOptions?.timeoutMs).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(provider.exec).toHaveBeenCalledWith(['remote', 'remove', 'contributor'], '/remote/repo')
     expect(remoteExists).toBe(false)
   })

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -10,6 +10,13 @@ import { LOCAL_EXECUTION_HOST_ID, toSshExecutionHostId } from '../../shared/exec
 import * as localWorktreeFilesystem from '../local-worktree-filesystem'
 
 const ORIGINAL_PLATFORM = process.platform
+const DEFAULT_CREATE_REFRESH_TIMEOUT_MS = 60_000
+const DEFAULT_CREATE_ADD_TIMEOUT_MS = 180_000
+const DEFAULT_CREATE_REGISTRATION_TIMEOUT_MS = 30_000
+const DEFAULT_LOCAL_CREATE_OPTIONS = {
+  refreshTimeout: expect.any(Number),
+  timeout: DEFAULT_CREATE_ADD_TIMEOUT_MS
+}
 const removeWorktreeLinkedPathsMock = vi.hoisted(() => vi.fn())
 const findExistingWorktreeSymlinkPathsMock = vi.hoisted(() => vi.fn())
 
@@ -28,6 +35,7 @@ const {
   assertWorktreeCleanForRemovalMock,
   addWorktreeMock,
   addSparseWorktreeMock,
+  rollbackFailedWorktreeCreateMock,
   removeWorktreeMock,
   forceDeleteLocalBranchMock,
   resolveLocalGitUsernameMock,
@@ -79,6 +87,7 @@ const {
   assertWorktreeCleanForRemovalMock: vi.fn(),
   addWorktreeMock: vi.fn(),
   addSparseWorktreeMock: vi.fn(),
+  rollbackFailedWorktreeCreateMock: vi.fn(),
   removeWorktreeMock: vi.fn(),
   forceDeleteLocalBranchMock: vi.fn(),
   resolveLocalGitUsernameMock: vi.fn(),
@@ -121,12 +130,14 @@ vi.mock('electron', () => ({
 }))
 
 vi.mock('../git/worktree', () => ({
+  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS: 30_000,
   listWorktrees: listWorktreesMock,
   listWorktreesStrict: listWorktreesMock,
   parseWorktreeList: parseWorktreeListMock,
   assertWorktreeCleanForRemoval: assertWorktreeCleanForRemovalMock,
   addWorktree: addWorktreeMock,
   addSparseWorktree: addSparseWorktreeMock,
+  rollbackFailedWorktreeCreate: rollbackFailedWorktreeCreateMock,
   removeWorktree: removeWorktreeMock,
   forceDeleteLocalBranch: forceDeleteLocalBranchMock
 }))
@@ -351,6 +362,7 @@ describe('registerWorktreeHandlers', () => {
       assertWorktreeCleanForRemovalMock,
       addWorktreeMock,
       addSparseWorktreeMock,
+      rollbackFailedWorktreeCreateMock,
       removeWorktreeMock,
       forceDeleteLocalBranchMock,
       resolveLocalGitUsernameMock,
@@ -713,7 +725,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/pr-title',
       'feature/fix',
       sha,
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -742,7 +756,9 @@ describe('registerWorktreeHandlers', () => {
       branchNameOverride: 'feature/fix'
     })
 
-    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin')
+    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin', {
+      timeout: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+    })
     expect(addWorktreeMock).toHaveBeenCalled()
   })
 
@@ -765,7 +781,9 @@ describe('registerWorktreeHandlers', () => {
       branchNameOverride: 'slash-base'
     })
 
-    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin')
+    expect(runtimeStub.fetchRemoteWithCache).toHaveBeenCalledWith('/workspace/repo', 'origin', {
+      timeout: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+    })
     expect(runtimeStub.fetchRemoteWithCache).not.toHaveBeenCalledWith('/workspace/repo', 'Jinwoo-H')
     expect(addWorktreeMock).toHaveBeenCalled()
   })
@@ -923,8 +941,16 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard-2',
       'improve-dashboard-2',
       'origin/main',
-      false
+      false,
+      false,
+      {
+        ...DEFAULT_LOCAL_CREATE_OPTIONS,
+        refreshTimeout: expect.any(Number)
+      }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(result).toMatchObject({
       worktree: expect.objectContaining({
         path: '/workspace/improve-dashboard-2',
@@ -954,7 +980,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/rocket',
       'rocket',
       'origin/main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/rocket',
@@ -996,7 +1024,9 @@ describe('registerWorktreeHandlers', () => {
       '../worktrees/feature',
       'feature',
       'origin/main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::../worktrees/feature',
@@ -1069,7 +1099,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/feature-something',
       'feature/something',
       'origin/main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(resolveLocalGitUsernameMock).not.toHaveBeenCalled()
     expect(result).toMatchObject({
@@ -1078,6 +1110,124 @@ describe('registerWorktreeHandlers', () => {
         branch: 'feature/something'
       })
     })
+  })
+
+  it('uses per-call timeout overrides for local refresh, add, and registration', async () => {
+    const remoteBase = {
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    }
+    runtimeStub.resolveRemoteTrackingBase.mockResolvedValue(remoteBase)
+    runtimeStub.hasRemoteTrackingRef.mockResolvedValue(true)
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/timeout-override',
+        head: 'abc123',
+        branch: 'refs/heads/timeout-override',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    await handlers['worktrees:create'](null, {
+      repoId: 'repo-1',
+      name: 'timeout-override',
+      timeouts: {
+        refreshBaseRefMs: 12_000,
+        addCheckoutMs: 24_000,
+        registrationMs: 36_000
+      }
+    })
+
+    expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
+      '/workspace/repo',
+      remoteBase,
+      { timeout: 12_000 }
+    )
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/timeout-override',
+      'timeout-override',
+      'origin/main',
+      false,
+      false,
+      {
+        refreshTimeout: expect.any(Number),
+        timeout: 24_000,
+        suggestLocalBaseRefUpdate: true,
+        remoteTrackingBase: remoteBase
+      }
+    )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(12_000)
+    expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo', {
+      timeout: 36_000,
+      detectSparseCheckout: false
+    })
+  })
+
+  it('rolls back a local create when registration fails after add succeeds', async () => {
+    addWorktreeMock.mockResolvedValue({})
+    listWorktreesMock.mockRejectedValue(new Error('registration timed out'))
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow('registration timed out')
+
+    expect(rollbackFailedWorktreeCreateMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/improve-dashboard',
+      'improve-dashboard',
+      false,
+      {}
+    )
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
+  it('rolls back a local create when push-target registration fails', async () => {
+    listWorktreesMock.mockResolvedValue([
+      {
+        path: '/workspace/improve-dashboard',
+        head: 'abc123',
+        branch: 'refs/heads/improve-dashboard',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+    gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
+      if (args[0] === 'remote') {
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'branch' && args.includes('--set-upstream-to')) {
+        throw new Error('upstream config failed')
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-1',
+        name: 'improve-dashboard',
+        pushTarget: {
+          remoteName: 'contributor',
+          branchName: 'feature/fix'
+        }
+      })
+    ).rejects.toThrow('upstream config failed')
+
+    expect(rollbackFailedWorktreeCreateMock).toHaveBeenCalledWith(
+      '/workspace/repo',
+      '/workspace/improve-dashboard',
+      'improve-dashboard',
+      false,
+      {}
+    )
   })
 
   it('creates an additional workspace for folder-mode repos without git worktree add', async () => {
@@ -1310,8 +1460,15 @@ describe('registerWorktreeHandlers', () => {
       'fix/bug-0',
       false,
       false,
-      { checkoutExistingBranch: true }
+      {
+        checkoutExistingBranch: true,
+        refreshTimeout: expect.any(Number),
+        timeout: DEFAULT_CREATE_ADD_TIMEOUT_MS
+      }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/fix-bug-0',
       expect.objectContaining({ preserveBranchOnDelete: true })
@@ -1368,7 +1525,7 @@ describe('registerWorktreeHandlers', () => {
       'fix/bug-0',
       false,
       false,
-      { checkoutExistingBranch: true }
+      { checkoutExistingBranch: true, ...DEFAULT_LOCAL_CREATE_OPTIONS }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/my-folder',
@@ -1423,7 +1580,7 @@ describe('registerWorktreeHandlers', () => {
       'fix/bug-0',
       false,
       false,
-      { checkoutExistingBranch: true }
+      { checkoutExistingBranch: true, ...DEFAULT_LOCAL_CREATE_OPTIONS }
     )
     expect(result).toMatchObject({
       worktree: expect.objectContaining({
@@ -1462,7 +1619,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/feature-something-2',
       'feature/something-2',
       'origin/main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -1505,7 +1664,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/fix-title',
       'feature/fix',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'origin/feature/fix', 'feature/fix'],
@@ -1598,7 +1759,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/bitbucket-title',
       'feature/bitbucket',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/bitbucket-title',
@@ -1652,7 +1815,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/bitbucket-title-2',
       'feature/bitbucket-2',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/bitbucket-title-2',
@@ -1687,7 +1852,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/fix-title-2',
       'feature/fix-2',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -1719,7 +1886,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/fix-title-2',
       'feature/fix-2',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -1761,7 +1930,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/fix-title-2',
       'feature/fix-2',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -1795,7 +1966,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/fix-title-2',
       'feature/fix-2',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -1851,7 +2024,7 @@ describe('registerWorktreeHandlers', () => {
       'abc123',
       false,
       false,
-      { checkoutExistingBranch: true }
+      { checkoutExistingBranch: true, ...DEFAULT_LOCAL_CREATE_OPTIONS }
     )
   })
 
@@ -1888,7 +2061,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/fix-title-2',
       'feature/fix-2',
       'abc123',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -2244,8 +2419,15 @@ describe('registerWorktreeHandlers', () => {
       'origin/main',
       false,
       false,
-      { wslDistro: 'Ubuntu' }
+      {
+        wslDistro: 'Ubuntu',
+        refreshTimeout: expect.any(Number),
+        timeout: DEFAULT_CREATE_ADD_TIMEOUT_MS
+      }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6] as { refreshTimeout?: number }
+    expect(addOptions.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions.refreshTimeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(resolveDefaultBaseRefWithLocalGitMock).toHaveBeenCalledWith({
       cwd: '/workspace/repo',
       wslDistro: 'Ubuntu'
@@ -2256,7 +2438,11 @@ describe('registerWorktreeHandlers', () => {
       'origin/main',
       { wslDistro: 'Ubuntu' }
     )
-    expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo', { wslDistro: 'Ubuntu' })
+    expect(listWorktreesMock).toHaveBeenCalledWith('/workspace/repo', {
+      wslDistro: 'Ubuntu',
+      timeout: DEFAULT_CREATE_REGISTRATION_TIMEOUT_MS,
+      detectSparseCheckout: false
+    })
   })
 
   it('routes fork push target setup through the selected WSL project runtime', async () => {
@@ -2350,7 +2536,7 @@ describe('registerWorktreeHandlers', () => {
       'abc123',
       false,
       false,
-      { wslDistro: 'Ubuntu' }
+      { wslDistro: 'Ubuntu', ...DEFAULT_LOCAL_CREATE_OPTIONS }
     )
   })
 
@@ -4784,14 +4970,20 @@ describe('registerWorktreeHandlers', () => {
 
     expect(provider.exec).toHaveBeenCalledWith(
       ['merge-base', '--is-ancestor', 'refs/heads/main', 'refs/remotes/origin/main'],
-      '/remote/repo'
+      '/remote/repo',
+      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['log', '--format=%H', 'refs/heads/main..refs/remotes/origin/main'],
-      '/remote/repo'
+      '/remote/repo',
+      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
+    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
+      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+    })
     expect(provider.worktreeIsClean).toHaveBeenCalledWith('/remote/repo', {
-      includeUntracked: false
+      includeUntracked: false,
+      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
     })
     expect(provider.exec).not.toHaveBeenCalledWith(
       ['reset', '--hard', 'refs/remotes/origin/main'],
@@ -4810,7 +5002,7 @@ describe('registerWorktreeHandlers', () => {
     )
   })
 
-  it('refreshes SSH local base through the narrow relay RPC when the setting is on', async () => {
+  it('uses SSH request timeout overrides for refreshability, narrow refresh, add, and registration', async () => {
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -4876,22 +5068,60 @@ describe('registerWorktreeHandlers', () => {
 
     const result = (await handlers['worktrees:create'](null, {
       repoId: 'repo-ssh',
-      name: 'improve-dashboard'
+      name: 'improve-dashboard',
+      timeouts: {
+        refreshBaseRefMs: 12_000,
+        addCheckoutMs: 24_000,
+        registrationMs: 36_000
+      }
     })) as CreateWorktreeResult
 
+    expect(provider.fetchRemoteTrackingRef).toHaveBeenCalledWith(
+      '/remote/repo',
+      'origin',
+      'main',
+      'refs/remotes/origin/main',
+      {
+        skipAutoMaintenance: true,
+        timeoutMs: 12_000
+      }
+    )
     expect(provider.exec).toHaveBeenCalledWith(
       ['merge-base', '--is-ancestor', 'refs/heads/main', 'refs/remotes/origin/main'],
-      '/remote/repo'
+      '/remote/repo',
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['log', '--format=%H', 'refs/heads/main..refs/remotes/origin/main'],
-      '/remote/repo'
+      '/remote/repo',
+      { timeoutMs: expect.any(Number) }
     )
+    expect(provider.listWorktrees).toHaveBeenNthCalledWith(1, '/remote/repo', {
+      timeoutMs: expect.any(Number)
+    })
     expect(provider.refreshLocalBaseRefForWorktreeCreate).toHaveBeenCalledWith({
       repoPath: '/remote/repo',
       fullRef: 'refs/heads/main',
       remoteTrackingRef: 'refs/remotes/origin/main',
-      ownerWorktreePath: '/remote/repo'
+      ownerWorktreePath: '/remote/repo',
+      timeoutMs: expect.any(Number)
+    })
+    const refreshStageTimeouts = [
+      provider.exec.mock.calls.find(([args]) => args[0] === 'merge-base')?.[2]?.timeoutMs,
+      provider.exec.mock.calls.find(([args]) => args[0] === 'log')?.[2]?.timeoutMs,
+      provider.listWorktrees.mock.calls[0]?.[1]?.timeoutMs,
+      provider.refreshLocalBaseRefForWorktreeCreate.mock.calls[0]?.[0]?.timeoutMs
+    ]
+    for (const timeoutMs of refreshStageTimeouts) {
+      expect(timeoutMs).toBeGreaterThan(0)
+      expect(timeoutMs).toBeLessThanOrEqual(12_000)
+    }
+    const addOptions = provider.addWorktree.mock.calls[0]?.[3] as { timeoutMs?: number } | undefined
+    expect(addOptions?.timeoutMs).toBeGreaterThan(0)
+    expect(addOptions?.timeoutMs).toBeLessThanOrEqual(24_000)
+    expect(provider.listWorktrees).toHaveBeenNthCalledWith(2, '/remote/repo', {
+      timeoutMs: 36_000,
+      strict: true
     })
     expect(provider.exec).not.toHaveBeenCalledWith(
       ['reset', '--hard', 'refs/remotes/origin/main'],
@@ -4911,6 +5141,153 @@ describe('registerWorktreeHandlers', () => {
         }
       })
     )
+  })
+
+  it('does not reconcile a definite SSH add failure', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockRejectedValue(new Error('branch conflict')),
+      listWorktrees: vi.fn(),
+      removeWorktree: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow('branch conflict')
+
+    expect(provider.listWorktrees).not.toHaveBeenCalled()
+    expect(provider.removeWorktree).not.toHaveBeenCalled()
+  })
+
+  it('reconciles an uncertain SSH add timeout before removing the exact worktree', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const timeoutError = Object.assign(new Error('add request timed out'), {
+      code: 'SSH_MUX_REQUEST_TIMEOUT'
+    })
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockRejectedValue(timeoutError),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-improve-dashboard',
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue(undefined)
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow('add request timed out')
+
+    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
+      timeoutMs: 30_000,
+      strict: true
+    })
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
+      deleteBranch: true,
+      forceBranchDelete: true
+    })
+  })
+
+  it('rolls back an SSH create when push-target registration fails', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const provider = {
+      exec: vi.fn().mockImplementation(async (args: string[]) => {
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'branch' && args.includes('--set-upstream-to')) {
+          throw new Error('upstream config failed')
+        }
+        return { stdout: '', stderr: '' }
+      }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockResolvedValue(undefined),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-improve-dashboard',
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn().mockResolvedValue(undefined)
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'improve-dashboard',
+        pushTarget: {
+          remoteName: 'contributor',
+          branchName: 'feature/fix'
+        }
+      })
+    ).rejects.toThrow('upstream config failed')
+
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
+      deleteBranch: true,
+      forceBranchDelete: true
+    })
   })
 
   it('returns SSH local base update suggestion when a full local base ref is safely behind', async () => {
@@ -4992,22 +5369,28 @@ describe('registerWorktreeHandlers', () => {
 
     expect(provider.exec).toHaveBeenCalledWith(
       ['merge-base', '--is-ancestor', 'refs/heads/main', 'refs/remotes/origin/main'],
-      '/remote/repo'
+      '/remote/repo',
+      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['log', '--format=%H', 'refs/heads/main..refs/remotes/origin/main'],
-      '/remote/repo'
+      '/remote/repo',
+      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
-    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo')
+    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
+      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+    })
     expect(provider.worktreeIsClean).toHaveBeenCalledWith('/remote/repo', {
-      includeUntracked: false
+      includeUntracked: false,
+      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
     })
     expect(provider.refreshLocalBaseRefForWorktreeCreate).toHaveBeenCalledWith({
       repoPath: '/remote/repo',
       fullRef: 'refs/heads/main',
       remoteTrackingRef: 'refs/remotes/origin/main',
       ownerWorktreePath: '/remote/repo',
-      checkOnly: true
+      checkOnly: true,
+      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
     })
     expect(provider.exec).not.toHaveBeenCalledWith(
       ['reset', '--hard', 'refs/remotes/origin/main'],
@@ -5096,7 +5479,8 @@ describe('registerWorktreeHandlers', () => {
       fullRef: 'refs/heads/main',
       remoteTrackingRef: 'refs/remotes/origin/main',
       ownerWorktreePath: '/remote/repo',
-      checkOnly: true
+      checkOnly: true,
+      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
     })
     expect(result.localBaseRefUpdateSuggestion).toBeUndefined()
   })
@@ -5225,7 +5609,7 @@ describe('registerWorktreeHandlers', () => {
       addWorktree: vi.fn().mockResolvedValue(undefined),
       listWorktrees: vi.fn().mockResolvedValue([
         {
-          path: 'C:\\remote\\improve-dashboard',
+          path: 'C:\\remote\\repo-improve-dashboard',
           head: 'abc123',
           branch: 'refs/heads/improve-dashboard',
           isBare: false,
@@ -5270,7 +5654,7 @@ describe('registerWorktreeHandlers', () => {
 
     expect(provider.exec).toHaveBeenCalledWith(
       ['rev-parse', '--git-path', 'orca/setup-runner.cmd'],
-      'C:\\remote\\improve-dashboard'
+      'C:\\remote\\repo-improve-dashboard'
     )
     expect(fsProvider.writeFile).toHaveBeenCalledWith(
       'C:\\remote\\repo\\.git\\worktrees\\improve-dashboard\\orca\\setup-runner.cmd',
@@ -5284,7 +5668,7 @@ describe('registerWorktreeHandlers', () => {
             'C:\\remote\\repo\\.git\\worktrees\\improve-dashboard\\orca\\setup-runner.cmd',
           envVars: expect.objectContaining({
             ORCA_ROOT_PATH: 'C:\\remote\\repo',
-            ORCA_WORKTREE_PATH: 'C:\\remote\\improve-dashboard'
+            ORCA_WORKTREE_PATH: 'C:\\remote\\repo-improve-dashboard'
           })
         }
       })
@@ -5355,20 +5739,31 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'sparse-dashboard',
       '/remote/repo-sparse-dashboard',
-      { base: 'origin/main', noCheckout: true }
+      {
+        base: 'origin/main',
+        noCheckout: true,
+        timeoutMs: expect.any(Number)
+      }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['sparse-checkout', 'init', '--cone'],
-      '/remote/repo-sparse-dashboard'
+      '/remote/repo-sparse-dashboard',
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['sparse-checkout', 'set', '--', 'apps/mobile', 'packages/shared'],
-      '/remote/repo-sparse-dashboard'
+      '/remote/repo-sparse-dashboard',
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['checkout', 'sparse-dashboard'],
-      '/remote/repo-sparse-dashboard'
+      '/remote/repo-sparse-dashboard',
+      { timeoutMs: expect.any(Number) }
     )
+    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
+      timeoutMs: DEFAULT_CREATE_REGISTRATION_TIMEOUT_MS,
+      strict: true
+    })
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-ssh::/remote/repo-sparse-dashboard',
       expect.objectContaining({
@@ -5476,7 +5871,10 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'feature/fix',
       '/remote/repo-fix-title-2',
-      { checkoutExistingBranch: true }
+      {
+        checkoutExistingBranch: true,
+        timeoutMs: expect.any(Number)
+      }
     )
     expect(mux.request).toHaveBeenCalledWith('session.registerRoot', {
       rootPath: '/remote/repo-fix-title-2'
@@ -5544,7 +5942,7 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'feature/something-2',
       '/remote/repo-feature-something-2',
-      { base: 'origin/main' }
+      { base: 'origin/main', timeoutMs: expect.any(Number) }
     )
   })
 
@@ -5606,7 +6004,7 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'feature/something-2',
       '/remote/repo-feature-something-2',
-      { base: 'origin/main' }
+      { base: 'origin/main', timeoutMs: expect.any(Number) }
     )
   })
 
@@ -5634,7 +6032,15 @@ describe('registerWorktreeHandlers', () => {
       fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
       addWorktree: vi.fn().mockResolvedValue(undefined),
       removeWorktree: vi.fn().mockResolvedValue(undefined),
-      listWorktrees: vi.fn()
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/repo-sparse-dashboard',
+          head: 'abc123',
+          branch: 'refs/heads/sparse-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ])
     }
     const mux = {
       request: vi.fn().mockResolvedValue(undefined),
@@ -5716,7 +6122,10 @@ describe('registerWorktreeHandlers', () => {
       'origin',
       'master',
       'refs/remotes/origin/master',
-      { skipAutoMaintenance: true }
+      {
+        skipAutoMaintenance: true,
+        timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      }
     )
   })
 
@@ -5780,14 +6189,18 @@ describe('registerWorktreeHandlers', () => {
       'origin',
       'main',
       'refs/remotes/origin/main',
-      { skipAutoMaintenance: true }
+      {
+        skipAutoMaintenance: true,
+        timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      }
     )
     expect(provider.addWorktree).toHaveBeenCalledWith(
       '/remote/repo',
       'improve-dashboard',
       '/remote/repo-improve-dashboard',
       {
-        base: 'origin/main'
+        base: 'origin/main',
+        timeoutMs: expect.any(Number)
       }
     )
   })
@@ -5859,7 +6272,8 @@ describe('registerWorktreeHandlers', () => {
       'local-branch-base',
       '/remote/repo-local-branch-base',
       {
-        base: 'develop'
+        base: 'develop',
+        timeoutMs: expect.any(Number)
       }
     )
   })
@@ -5941,7 +6355,8 @@ describe('registerWorktreeHandlers', () => {
       'slash-local-base',
       '/remote/repo-slash-local-base',
       {
-        base: 'team/feature'
+        base: 'team/feature',
+        timeoutMs: expect.any(Number)
       }
     )
     expect(result.baseFallback).toEqual({
@@ -6015,7 +6430,10 @@ describe('registerWorktreeHandlers', () => {
       'origin',
       'main',
       'refs/remotes/origin/main',
-      { skipAutoMaintenance: true }
+      {
+        skipAutoMaintenance: true,
+        timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      }
     )
     expect(provider.addWorktree).toHaveBeenCalledTimes(2)
   })
@@ -6082,7 +6500,7 @@ describe('registerWorktreeHandlers', () => {
       '/remote/repo',
       'feature/fix',
       '/remote/repo-fix-title',
-      { base: sha }
+      { base: sha, timeoutMs: expect.any(Number) }
     )
   })
 
@@ -6225,7 +6643,8 @@ describe('registerWorktreeHandlers', () => {
       'prefetched-worktree',
       '/remote/repo-prefetched-worktree',
       {
-        base: 'origin/main'
+        base: 'origin/main',
+        timeoutMs: expect.any(Number)
       }
     )
   })
@@ -6300,7 +6719,8 @@ describe('registerWorktreeHandlers', () => {
       'slash-local-base',
       '/remote/repo-slash-local-base',
       {
-        base: 'team/feature'
+        base: 'team/feature',
+        timeoutMs: expect.any(Number)
       }
     )
   })
@@ -6585,7 +7005,8 @@ describe('registerWorktreeHandlers', () => {
 
     expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
       '/workspace/repo',
-      remoteBase
+      remoteBase,
+      { timeout: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
     expect(runtimeStub.fetchRemoteWithCache).not.toHaveBeenCalled()
     resolveFetch()
@@ -6658,7 +7079,8 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
       '/workspace/repo',
-      remoteBase
+      remoteBase,
+      { timeout: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
     expect(result.worktree.id).toBe('repo-1::/workspace/improve-dashboard')
   })
@@ -6708,7 +7130,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard',
       'improve-dashboard',
       'develop',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -6769,7 +7193,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/slash-local-base',
       'slash-local-base',
       'team/feature',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -6821,7 +7247,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/offline-local-main',
       'offline-local-main',
       'main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -6888,7 +7316,8 @@ describe('registerWorktreeHandlers', () => {
 
     expect(runtimeStub.getOrStartRemoteTrackingBaseRefresh).toHaveBeenCalledWith(
       '/workspace/repo',
-      remoteBase
+      remoteBase,
+      { timeout: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
     )
     expect(result).toEqual(
       expect.objectContaining({
@@ -6943,7 +7372,8 @@ describe('registerWorktreeHandlers', () => {
           branch: 'main',
           ref: 'refs/remotes/origin/main',
           base: 'origin/main'
-        }
+        },
+        ...DEFAULT_LOCAL_CREATE_OPTIONS
       }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
@@ -7912,7 +8342,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard-3',
       'improve-dashboard-3',
       'origin/main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
     expect(result).toMatchObject({
       worktree: expect.objectContaining({
@@ -7993,7 +8425,9 @@ describe('registerWorktreeHandlers', () => {
       '/workspace/improve-dashboard',
       'improve-dashboard',
       'origin/main',
-      false
+      false,
+      false,
+      DEFAULT_LOCAL_CREATE_OPTIONS
     )
   })
 
@@ -8043,7 +8477,7 @@ describe('registerWorktreeHandlers', () => {
       'origin/main',
       false,
       false,
-      { wslDistro: 'Ubuntu' }
+      { wslDistro: 'Ubuntu', ...DEFAULT_LOCAL_CREATE_OPTIONS }
     )
   })
 
@@ -8123,8 +8557,15 @@ describe('registerWorktreeHandlers', () => {
       'improve-dashboard',
       ['packages/web', 'apps/api'],
       'origin/main',
-      false
+      false,
+      {
+        ...DEFAULT_LOCAL_CREATE_OPTIONS,
+        refreshTimeout: expect.any(Number)
+      }
     )
+    const sparseOptions = addSparseWorktreeMock.mock.calls[0]?.[6]
+    expect(sparseOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(sparseOptions?.refreshTimeout).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/improve-dashboard',
       expect.objectContaining({

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1191,6 +1191,8 @@ describe('registerWorktreeHandlers', () => {
   })
 
   it('rolls back a local create when push-target registration fails', async () => {
+    const remoteUrl = 'git@github.com:contributor/orca.git'
+    let remoteExists = false
     listWorktreesMock.mockResolvedValue([
       {
         path: '/workspace/improve-dashboard',
@@ -1201,7 +1203,18 @@ describe('registerWorktreeHandlers', () => {
       }
     ])
     gitExecFileAsyncMock.mockImplementation(async (args: string[]) => {
-      if (args[0] === 'remote') {
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: remoteExists ? 'contributor\n' : '', stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'add') {
+        remoteExists = true
+        return { stdout: '', stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return { stdout: `${remoteUrl}\n`, stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'remove') {
+        remoteExists = false
         return { stdout: '', stderr: '' }
       }
       if (args[0] === 'branch' && args.includes('--set-upstream-to')) {
@@ -1216,7 +1229,8 @@ describe('registerWorktreeHandlers', () => {
         name: 'improve-dashboard',
         pushTarget: {
           remoteName: 'contributor',
-          branchName: 'feature/fix'
+          branchName: 'feature/fix',
+          remoteUrl
         }
       })
     ).rejects.toThrow('upstream config failed')
@@ -1228,6 +1242,10 @@ describe('registerWorktreeHandlers', () => {
       false,
       {}
     )
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['remote', 'remove', 'contributor'], {
+      cwd: '/workspace/repo'
+    })
+    expect(remoteExists).toBe(false)
   })
 
   it('creates an additional workspace for folder-mode repos without git worktree add', async () => {
@@ -1670,7 +1688,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'origin/feature/fix', 'feature/fix'],
-      { cwd: '/workspace/fix-title' }
+      { cwd: '/workspace/fix-title', timeout: expect.any(Number) }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/fix-title',
@@ -2210,7 +2228,7 @@ describe('registerWorktreeHandlers', () => {
         'pr-prateek-orca/prateek/fix-sidebar-agents-toggle',
         'improve-dashboard'
       ],
-      { cwd: '/workspace/improve-dashboard' }
+      { cwd: '/workspace/improve-dashboard', timeout: expect.any(Number) }
     )
     expect(store.setWorktreeMeta).toHaveBeenCalledWith(
       'repo-1::/workspace/improve-dashboard',
@@ -2486,7 +2504,7 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'pr-contributor-orca/contributor/wsl-fork', 'wsl-fork'],
-      { cwd: '/workspace/wsl-fork', wslDistro: 'Ubuntu' }
+      { cwd: '/workspace/wsl-fork', timeout: expect.any(Number), wslDistro: 'Ubuntu' }
     )
   })
 
@@ -4971,20 +4989,30 @@ describe('registerWorktreeHandlers', () => {
     expect(provider.exec).toHaveBeenCalledWith(
       ['merge-base', '--is-ancestor', 'refs/heads/main', 'refs/remotes/origin/main'],
       '/remote/repo',
-      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['log', '--format=%H', 'refs/heads/main..refs/remotes/origin/main'],
       '/remote/repo',
-      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
-      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      timeoutMs: expect.any(Number)
     })
     expect(provider.worktreeIsClean).toHaveBeenCalledWith('/remote/repo', {
       includeUntracked: false,
-      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      timeoutMs: expect.any(Number)
     })
+    const refreshTimeouts = [
+      provider.exec.mock.calls.find(([args]) => args[0] === 'merge-base')?.[2]?.timeoutMs,
+      provider.exec.mock.calls.find(([args]) => args[0] === 'log')?.[2]?.timeoutMs,
+      provider.listWorktrees.mock.calls[0]?.[1]?.timeoutMs,
+      provider.worktreeIsClean.mock.calls[0]?.[1]?.timeoutMs
+    ]
+    for (const timeoutMs of refreshTimeouts) {
+      expect(timeoutMs).toBeGreaterThan(0)
+      expect(timeoutMs).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
+    }
     expect(provider.exec).not.toHaveBeenCalledWith(
       ['reset', '--hard', 'refs/remotes/origin/main'],
       expect.any(String)
@@ -5222,17 +5250,119 @@ describe('registerWorktreeHandlers', () => {
       })
     ).rejects.toThrow('add request timed out')
 
-    expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
-      timeoutMs: 30_000,
-      strict: true
-    })
+    const reconciliationTimeoutMs = provider.listWorktrees.mock.calls[0]?.[1]?.timeoutMs
+    expect(reconciliationTimeoutMs).toBeGreaterThan(0)
+    expect(reconciliationTimeoutMs).toBeLessThanOrEqual(1_000)
     expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
       deleteBranch: true,
-      forceBranchDelete: true
+      forceBranchDelete: true,
+      timeoutMs: 30_000
     })
   })
 
+  it('waits briefly for a cancelled SSH add to finish registering before rollback', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const timeoutError = Object.assign(new Error('add request timed out'), {
+      code: 'SSH_MUX_REQUEST_TIMEOUT'
+    })
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockRejectedValue(timeoutError),
+      listWorktrees: vi
+        .fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            path: '/remote/repo-improve-dashboard',
+            head: 'abc123',
+            branch: 'refs/heads/improve-dashboard',
+            isBare: false,
+            isMainWorktree: false
+          }
+        ]),
+      removeWorktree: vi.fn().mockResolvedValue(undefined)
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow('add request timed out')
+
+    expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
+    expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
+      deleteBranch: true,
+      forceBranchDelete: true,
+      timeoutMs: 30_000
+    })
+  })
+
+  it('does not reconcile an uncertain SSH add timeout to the same branch at another path', async () => {
+    const repo = {
+      id: 'repo-ssh',
+      path: '/remote/repo',
+      displayName: 'ssh',
+      badgeColor: '#000',
+      addedAt: 0,
+      connectionId: 'conn-1',
+      worktreeBaseRef: 'origin/main'
+    }
+    const timeoutError = Object.assign(new Error('add request timed out'), {
+      code: 'SSH_MUX_REQUEST_TIMEOUT'
+    })
+    const provider = {
+      exec: vi.fn().mockResolvedValue({ stdout: '', stderr: '' }),
+      fetchRemoteTrackingRef: vi.fn().mockResolvedValue(undefined),
+      addWorktree: vi.fn().mockRejectedValue(timeoutError),
+      listWorktrees: vi.fn().mockResolvedValue([
+        {
+          path: '/remote/concurrent-success',
+          head: 'abc123',
+          branch: 'refs/heads/improve-dashboard',
+          isBare: false,
+          isMainWorktree: false
+        }
+      ]),
+      removeWorktree: vi.fn()
+    }
+    store.getRepos.mockReturnValue([repo])
+    store.getRepo.mockReturnValue(repo)
+    getSshGitProviderMock.mockReturnValue(provider)
+    getActiveMultiplexerMock.mockReturnValue({
+      request: vi.fn().mockResolvedValue(undefined),
+      notify: vi.fn()
+    })
+
+    await expect(
+      handlers['worktrees:create'](null, {
+        repoId: 'repo-ssh',
+        name: 'improve-dashboard'
+      })
+    ).rejects.toThrow('add request timed out')
+
+    expect(provider.removeWorktree).not.toHaveBeenCalled()
+  })
+
   it('rolls back an SSH create when push-target registration fails', async () => {
+    const remoteUrl = 'git@github.com:contributor/orca.git'
+    let remoteExists = false
     const repo = {
       id: 'repo-ssh',
       path: '/remote/repo',
@@ -5244,8 +5374,23 @@ describe('registerWorktreeHandlers', () => {
     }
     const provider = {
       exec: vi.fn().mockImplementation(async (args: string[]) => {
-        if (args[0] === 'remote') {
-          return { stdout: 'origin\n', stderr: '' }
+        if (args[0] === 'remote' && args.length === 1) {
+          return { stdout: remoteExists ? 'origin\ncontributor\n' : 'origin\n', stderr: '' }
+        }
+        if (args[0] === 'remote' && args[1] === 'add') {
+          remoteExists = true
+          return { stdout: '', stderr: '' }
+        }
+        if (args[0] === 'remote' && args[1] === 'get-url') {
+          return {
+            stdout:
+              args[2] === 'contributor' ? `${remoteUrl}\n` : 'git@github.com:owner/orca.git\n',
+            stderr: ''
+          }
+        }
+        if (args[0] === 'remote' && args[1] === 'remove') {
+          remoteExists = false
+          return { stdout: '', stderr: '' }
         }
         if (args[0] === 'branch' && args.includes('--set-upstream-to')) {
           throw new Error('upstream config failed')
@@ -5279,15 +5424,19 @@ describe('registerWorktreeHandlers', () => {
         name: 'improve-dashboard',
         pushTarget: {
           remoteName: 'contributor',
-          branchName: 'feature/fix'
+          branchName: 'feature/fix',
+          remoteUrl
         }
       })
     ).rejects.toThrow('upstream config failed')
 
     expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-improve-dashboard', true, {
       deleteBranch: true,
-      forceBranchDelete: true
+      forceBranchDelete: true,
+      timeoutMs: 30_000
     })
+    expect(provider.exec).toHaveBeenCalledWith(['remote', 'remove', 'contributor'], '/remote/repo')
+    expect(remoteExists).toBe(false)
   })
 
   it('returns SSH local base update suggestion when a full local base ref is safely behind', async () => {
@@ -5370,28 +5519,41 @@ describe('registerWorktreeHandlers', () => {
     expect(provider.exec).toHaveBeenCalledWith(
       ['merge-base', '--is-ancestor', 'refs/heads/main', 'refs/remotes/origin/main'],
       '/remote/repo',
-      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.exec).toHaveBeenCalledWith(
       ['log', '--format=%H', 'refs/heads/main..refs/remotes/origin/main'],
       '/remote/repo',
-      { timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS }
+      { timeoutMs: expect.any(Number) }
     )
     expect(provider.listWorktrees).toHaveBeenCalledWith('/remote/repo', {
-      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      timeoutMs: expect.any(Number)
     })
     expect(provider.worktreeIsClean).toHaveBeenCalledWith('/remote/repo', {
       includeUntracked: false,
-      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      timeoutMs: expect.any(Number)
     })
-    expect(provider.refreshLocalBaseRefForWorktreeCreate).toHaveBeenCalledWith({
-      repoPath: '/remote/repo',
-      fullRef: 'refs/heads/main',
-      remoteTrackingRef: 'refs/remotes/origin/main',
-      ownerWorktreePath: '/remote/repo',
-      checkOnly: true,
-      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
-    })
+    expect(provider.refreshLocalBaseRefForWorktreeCreate).toHaveBeenCalledWith(
+      expect.objectContaining({
+        repoPath: '/remote/repo',
+        fullRef: 'refs/heads/main',
+        remoteTrackingRef: 'refs/remotes/origin/main',
+        ownerWorktreePath: '/remote/repo',
+        checkOnly: true,
+        timeoutMs: expect.any(Number)
+      })
+    )
+    const refreshTimeouts = [
+      provider.exec.mock.calls.find(([args]) => args[0] === 'merge-base')?.[2]?.timeoutMs,
+      provider.exec.mock.calls.find(([args]) => args[0] === 'log')?.[2]?.timeoutMs,
+      provider.listWorktrees.mock.calls[0]?.[1]?.timeoutMs,
+      provider.worktreeIsClean.mock.calls[0]?.[1]?.timeoutMs,
+      provider.refreshLocalBaseRefForWorktreeCreate.mock.calls[0]?.[0]?.timeoutMs
+    ]
+    for (const timeoutMs of refreshTimeouts) {
+      expect(timeoutMs).toBeGreaterThan(0)
+      expect(timeoutMs).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
+    }
     expect(provider.exec).not.toHaveBeenCalledWith(
       ['reset', '--hard', 'refs/remotes/origin/main'],
       expect.any(String)
@@ -5480,8 +5642,11 @@ describe('registerWorktreeHandlers', () => {
       remoteTrackingRef: 'refs/remotes/origin/main',
       ownerWorktreePath: '/remote/repo',
       checkOnly: true,
-      timeoutMs: DEFAULT_CREATE_REFRESH_TIMEOUT_MS
+      timeoutMs: expect.any(Number)
     })
+    const refreshOptions = provider.refreshLocalBaseRefForWorktreeCreate.mock.calls[0]?.[0]
+    expect(refreshOptions?.timeoutMs).toBeGreaterThan(0)
+    expect(refreshOptions?.timeoutMs).toBeLessThanOrEqual(DEFAULT_CREATE_REFRESH_TIMEOUT_MS)
     expect(result.localBaseRefUpdateSuggestion).toBeUndefined()
   })
 
@@ -6068,7 +6233,8 @@ describe('registerWorktreeHandlers', () => {
     )
     expect(provider.removeWorktree).toHaveBeenCalledWith('/remote/repo-sparse-dashboard', true, {
       deleteBranch: true,
-      forceBranchDelete: true
+      forceBranchDelete: true,
+      timeoutMs: 30_000
     })
   })
 

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -1692,8 +1692,14 @@ describe('registerWorktreeHandlers', () => {
       'abc123',
       false,
       false,
-      DEFAULT_LOCAL_CREATE_OPTIONS
+      {
+        ...DEFAULT_LOCAL_CREATE_OPTIONS,
+        timeout: expect.any(Number)
+      }
     )
+    const addOptions = addWorktreeMock.mock.calls[0]?.[6]
+    expect(addOptions?.timeout).toBeGreaterThan(0)
+    expect(addOptions?.timeout).toBeLessThanOrEqual(DEFAULT_CREATE_ADD_TIMEOUT_MS)
     expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
       ['branch', '--set-upstream-to', 'origin/feature/fix', 'feature/fix'],
       { cwd: '/workspace/fix-title', timeout: expect.any(Number) }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -3487,6 +3487,29 @@ describe('Store', () => {
     expect(fetched!.gitUsername).toBe('')
   })
 
+  it('normalizes repo worktree create timeout overrides on add', async () => {
+    const store = await createStore()
+    store.addRepo(
+      makeRepo({
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 999,
+          addCheckoutMs: -1,
+          registrationMs: 7_200_001
+        }
+      })
+    )
+
+    expect(store.getRepo('r1')?.worktreeCreateTimeouts).toEqual({
+      refreshBaseRefMs: 1_000,
+      registrationMs: 7_200_000
+    })
+    store.flush()
+    expect((readDataFile() as PersistedState).repos[0].worktreeCreateTimeouts).toEqual({
+      refreshBaseRefMs: 1_000,
+      registrationMs: 7_200_000
+    })
+  })
+
   it('setResolvedRepoGitUsername persists the enriched username for hydration', async () => {
     const store = await createStore()
     store.addRepo(makeRepo())
@@ -4683,6 +4706,31 @@ describe('Store', () => {
     expect(reloaded.getRepo('r1')!.forkSyncMode).toBe('safe-auto')
   })
 
+  it('normalizes, persists, and clears repo worktree create timeout overrides', async () => {
+    const store = await createStore()
+    store.addRepo(makeRepo())
+
+    const updated = store.updateRepo('r1', {
+      worktreeCreateTimeouts: {
+        addCheckoutMs: 250_000.4,
+        materializationMs: 8_000_000
+      }
+    })
+
+    expect(updated?.worktreeCreateTimeouts).toEqual({
+      addCheckoutMs: 250_000,
+      materializationMs: 7_200_000
+    })
+    store.flush()
+    expect((await createStore()).getRepo('r1')?.worktreeCreateTimeouts).toEqual({
+      addCheckoutMs: 250_000,
+      materializationMs: 7_200_000
+    })
+
+    store.updateRepo('r1', { worktreeCreateTimeouts: null })
+    expect(store.getRepo('r1')?.worktreeCreateTimeouts).toBeUndefined()
+  })
+
   it('updateRepo ignores invalid fork sync mode updates', async () => {
     const store = await createStore()
     store.addRepo(makeRepo({ forkSyncMode: 'ask' }))
@@ -5403,6 +5451,40 @@ describe('Store', () => {
     expect(updated.terminalFontWeight).toBe(600)
     // Other fields preserved
     expect(updated.branchPrefix).toBe('git-username')
+  })
+
+  it('normalizes worktree create timeouts on load and every settings write', async () => {
+    writeDataFile({
+      settings: {
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 500,
+          addCheckoutMs: 8_000_000,
+          registrationMs: -1
+        }
+      }
+    })
+    const store = await createStore()
+
+    expect(store.getSettings().worktreeCreateTimeouts).toEqual({
+      refreshBaseRefMs: 1_000,
+      addCheckoutMs: 7_200_000,
+      registrationMs: 30_000,
+      materializationMs: 300_000
+    })
+
+    expect(
+      store.updateSettings({
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 90_000,
+          addCheckoutMs: Number.NaN
+        } as never
+      }).worktreeCreateTimeouts
+    ).toEqual({
+      refreshBaseRefMs: 90_000,
+      addCheckoutMs: 7_200_000,
+      registrationMs: 30_000,
+      materializationMs: 300_000
+    })
   })
 
   it('normalizes bot-author overrides on load and every settings write', async () => {

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -4728,7 +4728,8 @@ describe('Store', () => {
     })
 
     store.updateRepo('r1', { worktreeCreateTimeouts: null })
-    expect(store.getRepo('r1')?.worktreeCreateTimeouts).toBeUndefined()
+    store.flush()
+    expect((await createStore()).getRepo('r1')?.worktreeCreateTimeouts).toBeUndefined()
   })
 
   it('updateRepo ignores invalid fork sync mode updates', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -261,6 +261,11 @@ import {
   normalizeFolderWorkspaces
 } from '../shared/folder-workspaces'
 import {
+  WORKTREE_CREATE_TIMEOUT_DEFAULTS,
+  normalizeWorktreeCreateTimeoutOverrides,
+  normalizeWorktreeCreateTimeouts
+} from '../shared/worktree-create-timeouts'
+import {
   folderWorkspaceKey,
   isWorkspaceKey,
   parseWorkspaceKey,
@@ -1467,7 +1472,9 @@ function sanitizeRepoUpdatesForPersistence<
       | 'projectHostSetupMethod'
       | 'forkSyncMode'
     >
-  >
+  > & {
+    worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
+  }
 >(updates: T): T {
   const sanitized = { ...updates }
   if ('badgeColor' in sanitized) {
@@ -1510,6 +1517,16 @@ function sanitizeRepoUpdatesForPersistence<
       delete sanitized.worktreeBasePath
     }
   }
+  if ('worktreeCreateTimeouts' in sanitized && sanitized.worktreeCreateTimeouts !== null) {
+    const worktreeCreateTimeouts = normalizeWorktreeCreateTimeoutOverrides(
+      sanitized.worktreeCreateTimeouts
+    )
+    if (worktreeCreateTimeouts === undefined) {
+      delete sanitized.worktreeCreateTimeouts
+    } else {
+      sanitized.worktreeCreateTimeouts = worktreeCreateTimeouts
+    }
+  }
   if ('projectHostSetupMethod' in sanitized) {
     const setupMethod = sanitizeRepoProjectHostSetupMethod(sanitized.projectHostSetupMethod)
     if (setupMethod === undefined) {
@@ -1527,6 +1544,17 @@ function sanitizeRepoUpdatesForPersistence<
     }
   }
   return sanitized
+}
+
+function normalizeRepoWorktreeCreateTimeouts(repo: Repo): Repo {
+  const worktreeCreateTimeouts = normalizeWorktreeCreateTimeoutOverrides(
+    repo.worktreeCreateTimeouts
+  )
+  if (worktreeCreateTimeouts !== undefined) {
+    return { ...repo, worktreeCreateTimeouts }
+  }
+  const { worktreeCreateTimeouts: _invalidWorktreeCreateTimeouts, ...repoWithoutTimeouts } = repo
+  return repoWithoutTimeouts
 }
 
 function expandFloatingWorkspaceHomePath(input: string, home: string): string {
@@ -3388,9 +3416,17 @@ export class Store {
         ) {
           this.loadNeedsSave = true
         }
+        const worktreeCreateTimeouts = normalizeWorktreeCreateTimeouts(
+          parsed.settings?.worktreeCreateTimeouts,
+          defaults.settings.worktreeCreateTimeouts ?? WORKTREE_CREATE_TIMEOUT_DEFAULTS
+        )
+        const normalizedRepos = (parsed.repos ?? defaults.repos).map(
+          normalizeRepoWorktreeCreateTimeouts
+        )
         result = {
           ...defaults,
           ...parsed,
+          repos: normalizedRepos,
           featureInteractionTelemetryBuckets: normalizeFeatureInteractionTelemetryBuckets(
             parsed.featureInteractionTelemetryBuckets
           ),
@@ -3410,6 +3446,7 @@ export class Store {
             ...defaults.settings,
             // Why (#7977): keep persisted experimentalNewWorktreeCardStyle:true — v1.4.130's onboarding auto-wrote it as a plain boolean, so it's indistinguishable from a real opt-in; only the default changed.
             ...stripLegacyTerminalScrollbackBytes(parsed.settings),
+            worktreeCreateTimeouts,
             prBotAuthorOverrides: normalizePRBotAuthorOverrides(
               parsed.settings?.prBotAuthorOverrides
             ),
@@ -4653,7 +4690,7 @@ export class Store {
   }
 
   addRepo(repo: Repo): void {
-    this.state.repos.push(repo)
+    this.state.repos.push(normalizeRepoWorktreeCreateTimeouts(repo))
     this.syncProjectHostSetupCompatibilityState()
     this.scheduleSave()
   }
@@ -4907,6 +4944,7 @@ export class Store {
       >
     > & {
       sourceControlAi?: Repo['sourceControlAi'] | null
+      worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
       externalWorktreeDiscoverySuppressedAt?: Repo['externalWorktreeDiscoverySuppressedAt'] | null
     },
     hostId?: ExecutionHostId
@@ -4952,6 +4990,13 @@ export class Store {
     if ('worktreeBasePath' in sanitizedUpdates && sanitizedUpdates.worktreeBasePath === undefined) {
       delete repo.worktreeBasePath
       delete sanitizedUpdates.worktreeBasePath
+    }
+    if (
+      'worktreeCreateTimeouts' in sanitizedUpdates &&
+      sanitizedUpdates.worktreeCreateTimeouts === null
+    ) {
+      delete repo.worktreeCreateTimeouts
+      delete sanitizedUpdates.worktreeCreateTimeouts
     }
     if (
       'externalWorktreeVisibility' in sanitizedUpdates &&
@@ -5082,6 +5127,7 @@ export class Store {
       upstream: rawUpstream,
       gitRemoteIdentity: rawGitRemoteIdentity,
       sourceControlAi: rawSourceControlAi,
+      worktreeCreateTimeouts: rawWorktreeCreateTimeouts,
       projectHostSetupMethod: rawProjectHostSetupMethod,
       forkSyncMode: rawForkSyncMode,
       ...repoWithoutIcon
@@ -5090,6 +5136,8 @@ export class Store {
     const upstream = sanitizeRepoUpstream(rawUpstream)
     const gitRemoteIdentity = sanitizeGitRemoteIdentity(rawGitRemoteIdentity)
     const sourceControlAi = normalizeRepoSourceControlAiOverrides(rawSourceControlAi)
+    const worktreeCreateTimeouts =
+      normalizeWorktreeCreateTimeoutOverrides(rawWorktreeCreateTimeouts)
     const projectHostSetupMethod = sanitizeRepoProjectHostSetupMethod(rawProjectHostSetupMethod)
     const forkSyncMode = sanitizeForkSyncMode(rawForkSyncMode)
     // Why: never spawn git/gh username resolution in hydration — a stuck probe froze Windows startup for minutes (issue #7225); read only cache/persisted value.
@@ -5103,6 +5151,7 @@ export class Store {
       ...(upstream !== undefined ? { upstream } : {}),
       ...(gitRemoteIdentity !== undefined ? { gitRemoteIdentity } : {}),
       ...(sourceControlAi !== undefined ? { sourceControlAi } : {}),
+      ...(worktreeCreateTimeouts !== undefined ? { worktreeCreateTimeouts } : {}),
       ...(projectHostSetupMethod !== undefined ? { projectHostSetupMethod } : {}),
       ...(forkSyncMode !== undefined ? { forkSyncMode } : {}),
       kind: isFolderRepo(repo) ? 'folder' : 'git',
@@ -5903,6 +5952,12 @@ export class Store {
     if ('mobilePairingCustomAddresses' in updates) {
       sanitizedUpdates.mobilePairingCustomAddresses = normalizeMobilePairingCustomAddresses(
         updates.mobilePairingCustomAddresses
+      )
+    }
+    if ('worktreeCreateTimeouts' in updates) {
+      sanitizedUpdates.worktreeCreateTimeouts = normalizeWorktreeCreateTimeouts(
+        updates.worktreeCreateTimeouts,
+        this.state.settings.worktreeCreateTimeouts ?? WORKTREE_CREATE_TIMEOUT_DEFAULTS
       )
     }
     if (

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -91,7 +91,7 @@ export type IGitProvider = {
   removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
+    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean; timeoutMs?: number }
   ): Promise<RemoveWorktreeResult>
   renameCurrentBranch?(worktreePath: string, newBranch: string): Promise<void>
   forceDeletePreservedBranch?(

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -72,12 +72,21 @@ export type IGitProvider = {
     worktreePath: string,
     args: { commitOid: string; parentOid?: string | null; filePath: string; oldPath?: string }
   ): Promise<GitDiffResult>
-  listWorktrees(repoPath: string, options?: { signal?: AbortSignal }): Promise<GitWorktreeInfo[]>
+  listWorktrees(
+    repoPath: string,
+    options?: { signal?: AbortSignal; timeoutMs?: number; strict?: boolean }
+  ): Promise<GitWorktreeInfo[]>
   addWorktree(
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
+    options?: {
+      base?: string
+      checkoutExistingBranch?: boolean
+      noCheckout?: boolean
+      timeoutMs?: number
+      signal?: AbortSignal
+    }
   ): Promise<void>
   removeWorktree(
     worktreePath: string,
@@ -101,6 +110,6 @@ export type IGitProvider = {
   getRemoteCommitUrl(worktreePath: string, sha: string): Promise<string | null>
   worktreeIsClean(
     worktreePath: string,
-    options?: { includeUntracked?: boolean }
+    options?: { includeUntracked?: boolean; timeoutMs?: number }
   ): Promise<{ clean: boolean; stdout?: string }>
 }

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -361,8 +361,76 @@ describe('SshGitProvider', () => {
       },
       {
         signal: controller.signal,
-        timeoutMs: 60_000
+        timeoutMs: 65_000
       }
+    )
+  })
+
+  it('exec routes push-target remote mutations through narrow relay methods', async () => {
+    const controller = new AbortController()
+
+    await provider.exec(
+      ['remote', 'add', 'fork', 'git@github.com:contributor/orca.git'],
+      '/home/user/repo',
+      { signal: controller.signal, timeoutMs: 60_000 }
+    )
+    await provider.exec(['remote', 'remove', 'fork'], '/home/user/repo', {
+      timeoutMs: 30_000
+    })
+
+    expect(mux.request).toHaveBeenNthCalledWith(
+      1,
+      'git.addPushTargetRemote',
+      {
+        repoPath: '/home/user/repo',
+        remoteName: 'fork',
+        remoteUrl: 'git@github.com:contributor/orca.git',
+        timeoutMs: 60_000
+      },
+      { signal: controller.signal, timeoutMs: 65_000 }
+    )
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.removePushTargetRemote',
+      {
+        repoPath: '/home/user/repo',
+        remoteName: 'fork',
+        timeoutMs: 30_000
+      },
+      { timeoutMs: 35_000 }
+    )
+  })
+
+  it('waits for push-target remote settlement before preserving the mutation error', async () => {
+    const mutationError = new Error('Git command timed out after 60000ms.')
+    mux.request.mockRejectedValueOnce(mutationError).mockResolvedValueOnce(undefined)
+
+    await expect(
+      provider.exec(
+        ['remote', 'add', 'fork', 'git@github.com:contributor/orca.git'],
+        '/home/user/repo',
+        { timeoutMs: 60_000 }
+      )
+    ).rejects.toBe(mutationError)
+
+    expect(mux.request).toHaveBeenNthCalledWith(
+      2,
+      'git.awaitPushTargetRemoteMutation',
+      { repoPath: '/home/user/repo' },
+      { timeoutMs: 66_000 }
+    )
+  })
+
+  it('awaitPushTargetRemoteMutations ignores old relays and propagates other errors', async () => {
+    mux.request.mockRejectedValueOnce(Object.assign(new Error('missing'), { code: -32601 }))
+    await expect(
+      provider.awaitPushTargetRemoteMutations('/home/user/repo')
+    ).resolves.toBeUndefined()
+
+    const connectionError = new Error('connection lost')
+    mux.request.mockRejectedValueOnce(connectionError)
+    await expect(provider.awaitPushTargetRemoteMutations('/home/user/repo')).rejects.toBe(
+      connectionError
     )
   })
 
@@ -988,12 +1056,13 @@ describe('SshGitProvider', () => {
   })
 
   it('fetchRemoteTrackingRef forwards the deadline to the relay and transport', async () => {
+    const controller = new AbortController()
     await provider.fetchRemoteTrackingRef(
       '/home/user/repo',
       'origin',
       'main',
       'refs/remotes/origin/main',
-      { timeoutMs: 75_000 }
+      { timeoutMs: 75_000, signal: controller.signal }
     )
 
     expect(mux.request).toHaveBeenCalledWith(
@@ -1005,7 +1074,7 @@ describe('SshGitProvider', () => {
         ref: 'refs/remotes/origin/main',
         timeoutMs: 75_000
       },
-      { timeoutMs: 75_000 }
+      { timeoutMs: 80_000, signal: controller.signal }
     )
   })
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1523,6 +1523,24 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('removeWorktree keeps the transport alive past the relay deadline', async () => {
+    await provider.removeWorktree('/home/user/feat', true, {
+      deleteBranch: true,
+      timeoutMs: 30_000
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.removeWorktree',
+      {
+        worktreePath: '/home/user/feat',
+        force: true,
+        deleteBranch: true,
+        timeoutMs: 30_000
+      },
+      { timeoutMs: 35_000 }
+    )
+  })
+
   it('worktreeIsClean sends git.worktreeIsClean request', async () => {
     const cleanResult = { clean: false, stdout: '?? scratch.txt\n' }
     mux.request.mockResolvedValue(cleanResult)

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1532,7 +1532,7 @@ describe('SshGitProvider', () => {
     expect(mux.request).toHaveBeenCalledWith(
       'git.listWorktrees',
       { repoPath: '/home/user/repo', timeoutMs: 90_000 },
-      { signal: undefined, timeoutMs: 90_000 }
+      { signal: undefined, timeoutMs: 95_000 }
     )
   })
 
@@ -1650,7 +1650,7 @@ describe('SshGitProvider', () => {
         includeUntracked: false,
         timeoutMs: 75_000
       },
-      { timeoutMs: 75_000 }
+      { timeoutMs: 80_000 }
     )
   })
 
@@ -1702,7 +1702,7 @@ describe('SshGitProvider', () => {
         remoteTrackingRef: 'refs/remotes/origin/main',
         timeoutMs: 75_000
       },
-      { timeoutMs: 75_000 }
+      { timeoutMs: 80_000 }
     )
   })
 

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -354,6 +354,7 @@ describe('SshGitProvider', () => {
       {
         args: ['clone', '--progress', '--', 'git@example.com:repo.git', 'repo'],
         cwd: '/home/user',
+        timeoutMs: 60_000,
         // Why: exec opts into response streaming so a large stdout is chunked
         // onto the bulk lane; old relays ignore the flag.
         __streamResponse: true
@@ -986,6 +987,28 @@ describe('SshGitProvider', () => {
     })
   })
 
+  it('fetchRemoteTrackingRef forwards the deadline to the relay and transport', async () => {
+    await provider.fetchRemoteTrackingRef(
+      '/home/user/repo',
+      'origin',
+      'main',
+      'refs/remotes/origin/main',
+      { timeoutMs: 75_000 }
+    )
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.fetchRemoteTrackingRef',
+      {
+        worktreePath: '/home/user/repo',
+        remote: 'origin',
+        branch: 'main',
+        ref: 'refs/remotes/origin/main',
+        timeoutMs: 75_000
+      },
+      { timeoutMs: 75_000 }
+    )
+  })
+
   it('fetchGitLabMergeRequestHead sends the durable-ref git.fetchGitLabMergeRequestHeadRef request', async () => {
     mux.request.mockResolvedValueOnce({
       localRef: 'refs/orca/merge-requests/origin-abc/42'
@@ -1432,6 +1455,18 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(worktrees)
   })
 
+  it('listWorktrees forwards the deadline to the relay and transport', async () => {
+    mux.request.mockResolvedValue([])
+
+    await provider.listWorktrees('/home/user/repo', { timeoutMs: 90_000 })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.listWorktrees',
+      { repoPath: '/home/user/repo', timeoutMs: 90_000 },
+      { signal: undefined, timeoutMs: 90_000 }
+    )
+  })
+
   it('addWorktree sends git.addWorktree request', async () => {
     await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
       base: 'main',
@@ -1444,6 +1479,40 @@ describe('SshGitProvider', () => {
       base: 'main',
       noCheckout: true
     })
+  })
+
+  it('addWorktree forwards the child deadline and adds transport headroom', async () => {
+    const controller = new AbortController()
+    await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
+      base: 'main',
+      timeoutMs: 420_000,
+      signal: controller.signal
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktree',
+      {
+        repoPath: '/home/user/repo',
+        branchName: 'feature',
+        targetDir: '/home/user/feat',
+        base: 'main',
+        timeoutMs: 420_000
+      },
+      { signal: controller.signal, timeoutMs: 425_000 }
+    )
+  })
+
+  it('addWorktree keeps the legacy transport floor for a shorter child deadline', async () => {
+    await provider.addWorktree('/home/user/repo', 'feature', '/home/user/feat', {
+      base: 'main',
+      timeoutMs: 12_000
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.addWorktree',
+      expect.objectContaining({ timeoutMs: 12_000 }),
+      { timeoutMs: 185_000 }
+    )
   })
 
   it('removeWorktree sends git.removeWorktree request', async () => {
@@ -1479,6 +1548,25 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(cleanResult)
   })
 
+  it('worktreeIsClean forwards its deadline to the relay and transport', async () => {
+    mux.request.mockResolvedValue({ clean: true })
+
+    await provider.worktreeIsClean('/home/user/feat', {
+      includeUntracked: false,
+      timeoutMs: 75_000
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.worktreeIsClean',
+      {
+        worktreePath: '/home/user/feat',
+        includeUntracked: false,
+        timeoutMs: 75_000
+      },
+      { timeoutMs: 75_000 }
+    )
+  })
+
   it('worktreeIsClean filters untracked stdout when old relays ignore the option', async () => {
     mux.request.mockResolvedValue({ clean: false, stdout: '?? scratch.txt\n' })
 
@@ -1509,6 +1597,26 @@ describe('SshGitProvider', () => {
       remoteTrackingRef: 'refs/remotes/origin/main',
       ownerWorktreePath: '/home/user/repo'
     })
+  })
+
+  it('refreshLocalBaseRefForWorktreeCreate forwards its deadline', async () => {
+    await provider.refreshLocalBaseRefForWorktreeCreate({
+      repoPath: '/home/user/repo',
+      fullRef: 'refs/heads/main',
+      remoteTrackingRef: 'refs/remotes/origin/main',
+      timeoutMs: 75_000
+    })
+
+    expect(mux.request).toHaveBeenCalledWith(
+      'git.refreshLocalBaseRefForWorktreeCreate',
+      {
+        repoPath: '/home/user/repo',
+        fullRef: 'refs/heads/main',
+        remoteTrackingRef: 'refs/remotes/origin/main',
+        timeoutMs: 75_000
+      },
+      { timeoutMs: 75_000 }
+    )
   })
 
   it('worktreeIsClean falls back to git.status for old relays', async () => {
@@ -1553,6 +1661,29 @@ describe('SshGitProvider', () => {
       expect(mux.request).toHaveBeenNthCalledWith(2, 'git.status', {
         worktreePath: '/home/user/feat'
       })
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('worktreeIsClean keeps its deadline in the old-relay status fallback', async () => {
+    const methodNotFound = Object.assign(new Error('Method not found: git.worktreeIsClean'), {
+      code: -32601
+    })
+    mux.request.mockRejectedValueOnce(methodNotFound).mockResolvedValueOnce({
+      entries: [],
+      conflictOperation: 'unknown'
+    })
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+
+    try {
+      await provider.worktreeIsClean('/home/user/feat', { timeoutMs: 75_000 })
+      expect(mux.request).toHaveBeenNthCalledWith(
+        2,
+        'git.status',
+        { worktreePath: '/home/user/feat', timeoutMs: 75_000 },
+        { signal: undefined, timeoutMs: 75_000 }
+      )
     } finally {
       warnSpy.mockRestore()
     }

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -761,15 +761,22 @@ export class SshGitProvider implements IGitProvider {
   async removeWorktree(
     worktreePath: string,
     force?: boolean,
-    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean }
+    options?: { deleteBranch?: boolean; forceBranchDelete?: boolean; timeoutMs?: number }
   ): Promise<RemoveWorktreeResult> {
+    const { timeoutMs, ...requestOptions } = options ?? {}
+    const request = {
+      worktreePath,
+      force,
+      ...requestOptions,
+      ...(timeoutMs ? { timeoutMs } : {})
+    }
     return this.runWithDiffDedupeClear(
       async () =>
-        ((await this.mux.request('git.removeWorktree', {
-          worktreePath,
-          force,
-          ...options
-        })) ?? {}) as RemoveWorktreeResult
+        ((await (timeoutMs
+          ? this.mux.request('git.removeWorktree', request, {
+              timeoutMs: timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
+            })
+          : this.mux.request('git.removeWorktree', request))) ?? {}) as RemoveWorktreeResult
     )
   }
 

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -41,6 +41,7 @@ type NonInteractiveExecQueueEntry = {
 }
 
 const NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS = 5_000
+const LEGACY_WORKTREE_ADD_TIMEOUT_MS = 180_000
 
 function isJsonRpcMethodNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
@@ -584,16 +585,22 @@ export class SshGitProvider implements IGitProvider {
     remote: string,
     branch: string,
     ref: string,
-    options?: { skipAutoMaintenance?: boolean }
+    options?: { skipAutoMaintenance?: boolean; timeoutMs?: number }
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.fetchRemoteTrackingRef', {
+      const request = {
         worktreePath,
         remote,
         branch,
         ref,
-        ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {})
-      })
+        ...(options?.skipAutoMaintenance ? { skipAutoMaintenance: true } : {}),
+        ...(options?.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
+      }
+      await (options?.timeoutMs
+        ? this.mux.request('git.fetchRemoteTrackingRef', request, {
+            timeoutMs: options.timeoutMs
+          })
+        : this.mux.request('git.fetchRemoteTrackingRef', request))
     })
   }
 
@@ -702,14 +709,16 @@ export class SshGitProvider implements IGitProvider {
 
   async listWorktrees(
     repoPath: string,
-    options?: { signal?: AbortSignal }
+    options?: { signal?: AbortSignal; timeoutMs?: number; strict?: boolean }
   ): Promise<GitWorktreeInfo[]> {
     return (await this.mux.request(
       'git.listWorktrees',
       {
-        repoPath
+        repoPath,
+        ...(options?.strict ? { strict: true } : {}),
+        ...(options?.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
       },
-      { signal: options?.signal }
+      { signal: options?.signal, timeoutMs: options?.timeoutMs }
     )) as GitWorktreeInfo[]
   }
 
@@ -717,15 +726,35 @@ export class SshGitProvider implements IGitProvider {
     repoPath: string,
     branchName: string,
     targetDir: string,
-    options?: { base?: string; checkoutExistingBranch?: boolean; noCheckout?: boolean }
+    options?: {
+      base?: string
+      checkoutExistingBranch?: boolean
+      noCheckout?: boolean
+      timeoutMs?: number
+      signal?: AbortSignal
+    }
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.addWorktree', {
+      const { signal, timeoutMs, ...requestOptions } = options ?? {}
+      const request = {
         repoPath,
         branchName,
         targetDir,
-        ...options
-      })
+        ...requestOptions,
+        ...(timeoutMs ? { timeoutMs } : {})
+      }
+      await (timeoutMs
+        ? this.mux.request('git.addWorktree', request, {
+            // Why: old relays ignore the child deadline, so keep the transport alive through
+            // the legacy create-add ceiling while new relays still receive the exact budget.
+            ...(signal ? { signal } : {}),
+            timeoutMs:
+              Math.max(timeoutMs, LEGACY_WORKTREE_ADD_TIMEOUT_MS) +
+              NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
+          })
+        : signal
+          ? this.mux.request('git.addWorktree', request, { signal })
+          : this.mux.request('git.addWorktree', request))
     })
   }
 
@@ -746,13 +775,17 @@ export class SshGitProvider implements IGitProvider {
 
   async worktreeIsClean(
     worktreePath: string,
-    options: { includeUntracked?: boolean } = {}
+    options: { includeUntracked?: boolean; timeoutMs?: number } = {}
   ): Promise<{ clean: boolean; stdout?: string }> {
     try {
-      const result = (await this.mux.request('git.worktreeIsClean', {
+      const request = {
         worktreePath,
-        ...(options.includeUntracked === false ? { includeUntracked: false } : {})
-      })) as {
+        ...(options.includeUntracked === false ? { includeUntracked: false } : {}),
+        ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
+      }
+      const result = (await (options.timeoutMs
+        ? this.mux.request('git.worktreeIsClean', request, { timeoutMs: options.timeoutMs })
+        : this.mux.request('git.worktreeIsClean', request))) as {
         clean: boolean
         stdout?: string
       }
@@ -776,7 +809,13 @@ export class SshGitProvider implements IGitProvider {
       }
       // Why: existing SSH relays may predate git.worktreeIsClean, but git.status
       // is a narrow relay RPC and avoids the generic git.exec allowlist.
-      const status = await this.getStatus(worktreePath)
+      const status = (await (options.timeoutMs
+        ? this.mux.request(
+            'git.status',
+            { worktreePath, timeoutMs: options.timeoutMs },
+            { timeoutMs: options.timeoutMs }
+          )
+        : this.mux.request('git.status', { worktreePath }))) as GitStatusResult
       const entries =
         options.includeUntracked === false
           ? status.entries.filter((entry) => entry.area !== 'untracked')
@@ -792,9 +831,14 @@ export class SshGitProvider implements IGitProvider {
     remoteTrackingRef: string
     ownerWorktreePath?: string
     checkOnly?: boolean
+    timeoutMs?: number
   }): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
-      await this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args)
+      await (args.timeoutMs
+        ? this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args, {
+            timeoutMs: args.timeoutMs
+          })
+        : this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args))
     })
   }
 
@@ -834,10 +878,15 @@ export class SshGitProvider implements IGitProvider {
     cwd: string,
     options?: { signal?: AbortSignal; timeoutMs?: number }
   ): Promise<{ stdout: string; stderr: string }> {
+    const request = {
+      args,
+      cwd,
+      ...(options?.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
+    }
     const run = () =>
       options
-        ? requestGitStreamable(this.mux, 'git.exec', { args, cwd }, options)
-        : requestGitStreamable(this.mux, 'git.exec', { args, cwd })
+        ? requestGitStreamable(this.mux, 'git.exec', request, options)
+        : requestGitStreamable(this.mux, 'git.exec', request)
     const result = gitExecMutatesRepository(args)
       ? await this.runWithDiffDedupeClear(run)
       : await run()

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -42,6 +42,9 @@ type NonInteractiveExecQueueEntry = {
 
 const NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS = 5_000
 const LEGACY_WORKTREE_ADD_TIMEOUT_MS = 180_000
+const PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS = 30_000
+const PUSH_TARGET_REMOTE_SETTLEMENT_TIMEOUT_MS =
+  PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS * 2 + 1_000 + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
 
 function isJsonRpcMethodNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
@@ -585,7 +588,7 @@ export class SshGitProvider implements IGitProvider {
     remote: string,
     branch: string,
     ref: string,
-    options?: { skipAutoMaintenance?: boolean; timeoutMs?: number }
+    options?: { skipAutoMaintenance?: boolean; timeoutMs?: number; signal?: AbortSignal }
   ): Promise<void> {
     await this.runWithDiffDedupeClear(async () => {
       const request = {
@@ -598,10 +601,36 @@ export class SshGitProvider implements IGitProvider {
       }
       await (options?.timeoutMs
         ? this.mux.request('git.fetchRemoteTrackingRef', request, {
-            timeoutMs: options.timeoutMs
+            ...(options.signal ? { signal: options.signal } : {}),
+            timeoutMs: options.timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
           })
-        : this.mux.request('git.fetchRemoteTrackingRef', request))
+        : options?.signal
+          ? this.mux.request('git.fetchRemoteTrackingRef', request, { signal: options.signal })
+          : this.mux.request('git.fetchRemoteTrackingRef', request))
     })
+  }
+
+  async awaitPushTargetRemoteMutations(
+    repoPath: string,
+    options: { signal?: AbortSignal; timeoutMs?: number } = {}
+  ): Promise<void> {
+    try {
+      await this.mux.request(
+        'git.awaitPushTargetRemoteMutation',
+        { repoPath },
+        {
+          ...(options.signal ? { signal: options.signal } : {}),
+          timeoutMs: Math.min(
+            options.timeoutMs ?? PUSH_TARGET_REMOTE_SETTLEMENT_TIMEOUT_MS,
+            PUSH_TARGET_REMOTE_SETTLEMENT_TIMEOUT_MS
+          )
+        }
+      )
+    } catch (error) {
+      if (!isJsonRpcMethodNotFoundError(error)) {
+        throw error
+      }
+    }
   }
 
   async fetchGitLabMergeRequestHead(
@@ -885,6 +914,54 @@ export class SshGitProvider implements IGitProvider {
     cwd: string,
     options?: { signal?: AbortSignal; timeoutMs?: number }
   ): Promise<{ stdout: string; stderr: string }> {
+    const pushTargetRemoteMethod =
+      args.length === 4 && args[0] === 'remote' && args[1] === 'add'
+        ? 'git.addPushTargetRemote'
+        : args.length === 3 && args[0] === 'remote' && args[1] === 'remove'
+          ? 'git.removePushTargetRemote'
+          : null
+    if (pushTargetRemoteMethod) {
+      try {
+        await this.runWithDiffDedupeClear(() =>
+          this.mux.request(
+            pushTargetRemoteMethod,
+            {
+              repoPath: cwd,
+              remoteName: args[2],
+              ...(pushTargetRemoteMethod === 'git.addPushTargetRemote'
+                ? { remoteUrl: args[3] }
+                : {}),
+              ...(options?.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
+            },
+            {
+              ...(options?.signal ? { signal: options.signal } : {}),
+              ...(options?.timeoutMs
+                ? {
+                    timeoutMs: options.timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
+                  }
+                : {})
+            }
+          )
+        )
+        return { stdout: '', stderr: '' }
+      } catch (error) {
+        try {
+          await this.mux.request(
+            'git.awaitPushTargetRemoteMutation',
+            { repoPath: cwd },
+            { timeoutMs: PUSH_TARGET_REMOTE_SETTLEMENT_TIMEOUT_MS }
+          )
+        } catch {
+          // Preserve the mutation failure; old relays do not implement the settlement barrier.
+        }
+        if (isJsonRpcMethodNotFoundError(error)) {
+          throw new Error(
+            'This SSH host is running an older Orca relay that cannot configure worktree push-target remotes. Reconnect to deploy the latest relay, then try again.'
+          )
+        }
+        throw error
+      }
+    }
     const request = {
       args,
       cwd,
@@ -892,7 +969,14 @@ export class SshGitProvider implements IGitProvider {
     }
     const run = () =>
       options
-        ? requestGitStreamable(this.mux, 'git.exec', request, options)
+        ? requestGitStreamable(this.mux, 'git.exec', request, {
+            ...options,
+            ...(options.timeoutMs
+              ? {
+                  timeoutMs: options.timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
+                }
+              : {})
+          })
         : requestGitStreamable(this.mux, 'git.exec', request)
     const result = gitExecMutatesRepository(args)
       ? await this.runWithDiffDedupeClear(run)

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -747,7 +747,12 @@ export class SshGitProvider implements IGitProvider {
         ...(options?.strict ? { strict: true } : {}),
         ...(options?.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
       },
-      { signal: options?.signal, timeoutMs: options?.timeoutMs }
+      {
+        signal: options?.signal,
+        timeoutMs: options?.timeoutMs
+          ? options.timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
+          : undefined
+      }
     )) as GitWorktreeInfo[]
   }
 
@@ -820,7 +825,9 @@ export class SshGitProvider implements IGitProvider {
         ...(options.timeoutMs ? { timeoutMs: options.timeoutMs } : {})
       }
       const result = (await (options.timeoutMs
-        ? this.mux.request('git.worktreeIsClean', request, { timeoutMs: options.timeoutMs })
+        ? this.mux.request('git.worktreeIsClean', request, {
+            timeoutMs: options.timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
+          })
         : this.mux.request('git.worktreeIsClean', request))) as {
         clean: boolean
         stdout?: string
@@ -872,7 +879,7 @@ export class SshGitProvider implements IGitProvider {
     await this.runWithDiffDedupeClear(async () => {
       await (args.timeoutMs
         ? this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args, {
-            timeoutMs: args.timeoutMs
+            timeoutMs: args.timeoutMs + NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS
           })
         : this.mux.request('git.refreshLocalBaseRefForWorktreeCreate', args))
     })

--- a/src/main/runtime/fetch-remote-cache.test.ts
+++ b/src/main/runtime/fetch-remote-cache.test.ts
@@ -37,14 +37,6 @@ function fetchCallCount(): number {
   return gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv)).length
 }
 
-function exactBaseRefreshOptions(cwd: string): {
-  cwd: string
-  timeout: number
-  useConfiguredSshCommandForNetwork: boolean
-} {
-  return { cwd, timeout: 60_000, useConfiguredSshCommandForNetwork: true }
-}
-
 function exactBaseRefreshArgs(branch = 'main'): string[] {
   return [
     '-c',
@@ -64,6 +56,11 @@ function exactBaseRefreshArgs(branch = 'main'): string[] {
 // credential-manager GUI hang can't wedge worktree creation forever.
 function fullRemoteFetchOptions(cwd: string): { cwd: string; timeout: number } {
   return { cwd, timeout: 60_000 }
+}
+
+function expectStageTimeout(options: { timeout: number }, maximum = 60_000): void {
+  expect(options.timeout).toBeGreaterThan(0)
+  expect(options.timeout).toBeLessThanOrEqual(maximum)
 }
 
 function mockFetchResults(results: (Promise<unknown> | unknown)[]): void {
@@ -211,10 +208,13 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       base: 'origin/main'
     })
 
-    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(
-      exactBaseRefreshArgs(),
-      exactBaseRefreshOptions('/repo/f')
-    )
+    const fetchCall = gitExecFileAsyncMock.mock.calls.find(([argv]) => isFetchArgs(argv))
+    expect(fetchCall?.[0]).toEqual(exactBaseRefreshArgs())
+    expect(fetchCall?.[1]).toMatchObject({
+      cwd: '/repo/f',
+      useConfiguredSshCommandForNetwork: true
+    })
+    expectStageTimeout(fetchCall?.[1] as { timeout: number })
   })
 
   it('keeps automatic maintenance enabled for ordinary full remote fetches', async () => {
@@ -334,10 +334,14 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       { ok: true }
     ])
     const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv))
-    expect(fetchCalls).toEqual([
-      [exactBaseRefreshArgs(), exactBaseRefreshOptions('/repo/h')],
-      [['fetch', 'origin'], fullRemoteFetchOptions('/repo/h')]
-    ])
+    expect(fetchCalls.map(([args]) => args)).toEqual([exactBaseRefreshArgs(), ['fetch', 'origin']])
+    expect(fetchCalls[0]?.[1]).toMatchObject({
+      cwd: '/repo/h',
+      useConfiguredSshCommandForNetwork: true
+    })
+    expectStageTimeout(fetchCalls[0]?.[1] as { timeout: number })
+    expectStageTimeout(fetchCalls[1]?.[1] as { timeout: number })
+    expect(fetchCalls[1]?.[1]).toMatchObject({ cwd: '/repo/h' })
   })
 
   it('runs a queued exact base refresh after an in-flight full remote fetch succeeds', async () => {
@@ -375,10 +379,13 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       { ok: true }
     ])
     const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv))
-    expect(fetchCalls).toEqual([
-      [['fetch', 'origin'], fullRemoteFetchOptions('/repo/i')],
-      [exactBaseRefreshArgs(), exactBaseRefreshOptions('/repo/i')]
-    ])
+    expect(fetchCalls.map(([args]) => args)).toEqual([['fetch', 'origin'], exactBaseRefreshArgs()])
+    expect(fetchCalls[0]?.[1]).toEqual(fullRemoteFetchOptions('/repo/i'))
+    expectStageTimeout(fetchCalls[1]?.[1] as { timeout: number })
+    expect(fetchCalls[1]?.[1]).toMatchObject({
+      cwd: '/repo/i',
+      useConfiguredSshCommandForNetwork: true
+    })
   })
 
   it('runs a queued exact base refresh when an in-flight full remote fetch fails', async () => {
@@ -416,9 +423,12 @@ describe('OrcaRuntimeService.fetchRemoteWithCache', () => {
       { ok: true }
     ])
     const fetchCalls = gitExecFileAsyncMock.mock.calls.filter(([argv]) => isFetchArgs(argv))
-    expect(fetchCalls).toEqual([
-      [['fetch', 'origin'], fullRemoteFetchOptions('/repo/i-fail')],
-      [exactBaseRefreshArgs(), exactBaseRefreshOptions('/repo/i-fail')]
-    ])
+    expect(fetchCalls.map(([args]) => args)).toEqual([['fetch', 'origin'], exactBaseRefreshArgs()])
+    expect(fetchCalls[0]?.[1]).toEqual(fullRemoteFetchOptions('/repo/i-fail'))
+    expectStageTimeout(fetchCalls[1]?.[1] as { timeout: number })
+    expect(fetchCalls[1]?.[1]).toMatchObject({
+      cwd: '/repo/i-fail',
+      useConfiguredSshCommandForNetwork: true
+    })
   })
 })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4113,6 +4113,133 @@ describe('OrcaRuntimeService', () => {
     expect(setWorktreeMeta).not.toHaveBeenCalled()
   })
 
+  it('removes a runtime-created push remote after registration rollback', async () => {
+    const createdPath = '/tmp/workspaces/push-remote-registration-timeout'
+    const remoteName = 'pr-contributor-orca'
+    const remoteUrl = 'git@github.com:contributor/orca.git'
+    const runtime = new OrcaRuntimeService(store)
+    computeWorktreePathMock.mockReturnValue(createdPath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdPath)
+    listWorktreesStrictMock.mockRejectedValueOnce(new Error('git timed out.'))
+    const gitSpy = vi.spyOn(gitRunner, 'gitExecFileAsync').mockImplementation(async (args) => {
+      if (args[0] === 'remote' && args.length === 1) {
+        return { stdout: 'origin\n', stderr: '' }
+      }
+      if (args[0] === 'remote' && args[1] === 'get-url') {
+        return {
+          stdout: args[2] === remoteName ? `${remoteUrl}\n` : 'git@github.com:stablyai/orca.git\n',
+          stderr: ''
+        }
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    try {
+      await expect(
+        runtime.createManagedWorktree({
+          repoSelector: 'id:repo-1',
+          name: 'push-remote-registration-timeout',
+          baseBranch: 'abc123',
+          pushTarget: {
+            remoteName,
+            branchName: 'contributor/runtime-timeout',
+            remoteUrl
+          }
+        })
+      ).rejects.toThrow('git timed out.')
+
+      expect(rollbackFailedWorktreeCreateMock).toHaveBeenCalledWith(
+        TEST_REPO_PATH,
+        createdPath,
+        'push-remote-registration-timeout',
+        false,
+        {}
+      )
+      expect(gitSpy).toHaveBeenCalledWith(['remote', 'add', remoteName, remoteUrl], {
+        cwd: TEST_REPO_PATH
+      })
+      expect(gitSpy).toHaveBeenCalledWith(['remote', 'remove', remoteName], {
+        cwd: TEST_REPO_PATH
+      })
+    } finally {
+      gitSpy.mockRestore()
+    }
+  })
+
+  it('does not reuse an aborted create signal for local rollback', async () => {
+    const createdPath = '/tmp/workspaces/cancelled-registration'
+    const controller = new AbortController()
+    const runtime = new OrcaRuntimeService(store)
+    computeWorktreePathMock.mockReturnValue(createdPath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdPath)
+    listWorktreesStrictMock.mockImplementationOnce(async (_repoPath, options) => {
+      expect((options as { signal?: AbortSignal } | undefined)?.signal).toBe(controller.signal)
+      controller.abort()
+      throw Object.assign(new Error('cancelled'), { name: 'AbortError' })
+    })
+
+    await expect(
+      runtime.createManagedWorktree({
+        repoSelector: 'id:repo-1',
+        name: 'cancelled-registration',
+        signal: controller.signal
+      })
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(addWorktreeMock).toHaveBeenCalledWith(
+      TEST_REPO_PATH,
+      createdPath,
+      'cancelled-registration',
+      expect.any(String),
+      expect.any(Boolean),
+      false,
+      expect.objectContaining({ signal: controller.signal })
+    )
+    expect(rollbackFailedWorktreeCreateMock).toHaveBeenCalledWith(
+      TEST_REPO_PATH,
+      createdPath,
+      'cancelled-registration',
+      false,
+      {}
+    )
+  })
+
+  it('does not bind a shared base refresh to one create caller signal', async () => {
+    const createdPath = '/tmp/workspaces/cancelled-refresh'
+    const controller = new AbortController()
+    const refresh = deferred<{ ok: true }>()
+    const runtime = new OrcaRuntimeService(store)
+    computeWorktreePathMock.mockReturnValue(createdPath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdPath)
+    vi.spyOn(runtime, 'resolveRemoteTrackingBase').mockResolvedValue({
+      remote: 'origin',
+      branch: 'main',
+      ref: 'refs/remotes/origin/main',
+      base: 'origin/main'
+    })
+    vi.spyOn(runtime, 'hasRemoteTrackingRef').mockResolvedValue(true)
+    const refreshSpy = vi
+      .spyOn(runtime, 'getOrStartRemoteTrackingBaseRefresh')
+      .mockReturnValue(refresh.promise)
+
+    const create = runtime.createManagedWorktree({
+      repoSelector: 'id:repo-1',
+      name: 'cancelled-refresh',
+      signal: controller.signal
+    })
+    await vi.waitFor(() => expect(refreshSpy).toHaveBeenCalledTimes(1))
+    controller.abort()
+
+    await expect(create).rejects.toMatchObject({ name: 'AbortError' })
+    expect(refreshSpy.mock.calls[0]?.[2]).toEqual({
+      timeout: expect.any(Number)
+    })
+    expect(addWorktreeMock).not.toHaveBeenCalled()
+
+    refresh.resolve({ ok: true })
+    await expect(refresh.promise).resolves.toEqual({ ok: true })
+  })
+
   it('creates additional workspace metadata for folder-mode repos through runtime create', async () => {
     const folderRepo = {
       id: 'folder-repo',

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -140,6 +140,10 @@ const ORIGINAL_PLATFORM_DESCRIPTOR = Object.getOwnPropertyDescriptor(process, 'p
 const removeWorktreeLinkedPathsMock = vi.hoisted(() => vi.fn())
 const findExistingWorktreeSymlinkPathsMock = vi.hoisted(() => vi.fn())
 const resolveLocalGitUsernameMock = vi.hoisted(() => vi.fn(async () => ''))
+const listWorktreesMock = vi.hoisted(() => vi.fn())
+const listWorktreesStrictMock = vi.hoisted(() =>
+  vi.fn((...args: unknown[]) => listWorktreesMock(...args))
+)
 
 vi.mock('../ipc/worktree-symlinks', () => ({
   createWorktreeCopiedPaths: vi.fn(),
@@ -220,6 +224,7 @@ const {
   MOCK_GIT_WORKTREES,
   addWorktreeMock,
   removeWorktreeMock,
+  rollbackFailedWorktreeCreateMock,
   forceDeleteLocalBranchMock,
   computeWorktreePathMock,
   ensurePathWithinWorkspaceMock,
@@ -315,6 +320,7 @@ const {
     ],
     addWorktreeMock: vi.fn(),
     removeWorktreeMock: vi.fn(),
+    rollbackFailedWorktreeCreateMock: vi.fn(),
     forceDeleteLocalBranchMock: vi.fn(),
     computeWorktreePathMock: vi.fn(),
     ensurePathWithinWorkspaceMock: vi.fn(),
@@ -409,11 +415,13 @@ const {
 })
 
 vi.mock('../git/worktree', () => ({
-  listWorktrees: vi.fn().mockResolvedValue(MOCK_GIT_WORKTREES),
-  listWorktreesStrict: vi.fn().mockResolvedValue(MOCK_GIT_WORKTREES),
+  listWorktrees: listWorktreesMock,
+  listWorktreesStrict: listWorktreesStrictMock,
+  WORKTREE_REMOVAL_REGISTRATION_TIMEOUT_MS: 30_000,
   assertWorktreeCleanForRemoval: vi.fn().mockResolvedValue(undefined),
   addWorktree: addWorktreeMock,
   removeWorktree: removeWorktreeMock,
+  rollbackFailedWorktreeCreate: rollbackFailedWorktreeCreateMock,
   forceDeleteLocalBranch: forceDeleteLocalBranchMock
 }))
 
@@ -659,7 +667,7 @@ function resetRuntimeTestMocks(): void {
   forgetLocalWatcherRemovalSnapshotMock.mockReset()
   forgetRemoteWatcherRemovalSnapshotMock.mockReset()
   vi.mocked(listWorktrees).mockResolvedValue(MOCK_GIT_WORKTREES)
-  vi.mocked(listWorktreesStrict).mockResolvedValue(MOCK_GIT_WORKTREES)
+  vi.mocked(listWorktreesStrict).mockImplementation((...args) => listWorktreesMock(...args))
   scanLocalRepoWorktreesForResolutionMock
     .mockReset()
     .mockImplementation(async (repoPath: string, options: { wslDistro?: string }) => {
@@ -673,6 +681,7 @@ function resetRuntimeTestMocks(): void {
       }
     })
   vi.mocked(addWorktree).mockReset()
+  rollbackFailedWorktreeCreateMock.mockReset().mockResolvedValue(true)
   vi.mocked(assertWorktreeCleanForRemoval).mockReset()
   vi.mocked(assertWorktreeCleanForRemoval).mockResolvedValue(undefined)
   vi.mocked(removeWorktree).mockReset()
@@ -962,6 +971,10 @@ async function referenceStatusFrameLines(
 const TEST_WINDOW_ID = 1
 const TEST_REPO_ID = 'repo-1'
 const TEST_REPO_PATH = '/tmp/repo'
+const TEST_WORKTREE_CREATE_GIT_OPTIONS = {
+  refreshTimeout: 60_000,
+  timeout: 180_000
+}
 const TEST_WORKTREE_PATH = '/tmp/worktree-a'
 const TEST_WORKTREE_ID = `${TEST_REPO_ID}::${TEST_WORKTREE_PATH}`
 const TEST_FOLDER_PROJECT_GROUP_ID = 'folder-project-group-1'
@@ -1788,6 +1801,43 @@ describe('OrcaRuntimeService', () => {
       minimaxGroupId: 'group-42',
       minimaxUsageModels: 'general,abab6.5'
     })
+  })
+
+  it('merges partial worktree timeout updates with the host settings', async () => {
+    let settings = {
+      ...store.getSettings(),
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 90_000,
+        addCheckoutMs: 240_000,
+        registrationMs: 45_000,
+        materializationMs: 360_000
+      }
+    }
+    const updateSettings = vi.fn((updates: Partial<typeof settings>) => {
+      settings = { ...settings, ...updates }
+      return settings
+    })
+    const runtime = new OrcaRuntimeService({
+      ...store,
+      getSettings: () => settings,
+      updateSettings
+    } as never)
+
+    await runtime.updateClientSettings({
+      worktreeCreateTimeouts: { addCheckoutMs: 420_000 }
+    })
+
+    expect(updateSettings).toHaveBeenCalledWith(
+      {
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 90_000,
+          addCheckoutMs: 420_000,
+          registrationMs: 45_000,
+          materializationMs: 360_000
+        }
+      },
+      { notifyListeners: true }
+    )
   })
 
   it('reconciles hooks only when paired-client hook settings change', async () => {
@@ -4038,6 +4088,31 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('rolls back the exact worktree when registration fails after add', async () => {
+    const createdPath = '/tmp/workspaces/registration-timeout'
+    const setWorktreeMeta = vi.fn(store.setWorktreeMeta)
+    const runtime = new OrcaRuntimeService({ ...store, setWorktreeMeta } as never)
+    computeWorktreePathMock.mockReturnValue(createdPath)
+    ensurePathWithinWorkspaceMock.mockReturnValue(createdPath)
+    listWorktreesStrictMock.mockRejectedValueOnce(new Error('git timed out.'))
+
+    await expect(
+      runtime.createManagedWorktree({
+        repoSelector: 'id:repo-1',
+        name: 'registration-timeout'
+      })
+    ).rejects.toThrow('git timed out.')
+
+    expect(rollbackFailedWorktreeCreateMock).toHaveBeenCalledWith(
+      TEST_REPO_PATH,
+      createdPath,
+      'registration-timeout',
+      false,
+      {}
+    )
+    expect(setWorktreeMeta).not.toHaveBeenCalled()
+  })
+
   it('creates additional workspace metadata for folder-mode repos through runtime create', async () => {
     const folderRepo = {
       id: 'folder-repo',
@@ -4234,6 +4309,8 @@ describe('OrcaRuntimeService', () => {
         false,
         false,
         {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number),
           suggestLocalBaseRefUpdate: true,
           remoteTrackingBase: {
             remote: 'origin',
@@ -4243,6 +4320,9 @@ describe('OrcaRuntimeService', () => {
           }
         }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls.at(-1)?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
       expect(result.worktree).toMatchObject({
         path: createdWorktree.path,
         baseRef: 'refs/remotes/origin/main'
@@ -4352,6 +4432,8 @@ describe('OrcaRuntimeService', () => {
         false,
         false,
         {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number),
           remoteTrackingBase: {
             remote: 'origin',
             branch: 'main',
@@ -4361,6 +4443,9 @@ describe('OrcaRuntimeService', () => {
           suggestLocalBaseRefUpdate: true
         }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls.at(-1)?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
       expect(getBaseRefDefault).toHaveBeenCalled()
     } finally {
       getReposSpy.mockRestore()
@@ -4411,7 +4496,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'local-branch-base',
         'develop',
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
     } finally {
       getReposSpy.mockRestore()
@@ -4465,7 +4552,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'slash-local-base',
         'team/feature',
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
       expect(gitSpy).not.toHaveBeenCalledWith(
         [
@@ -4556,7 +4645,9 @@ describe('OrcaRuntimeService', () => {
       '/tmp/workspaces/feature-something',
       'feature/something',
       'origin/feature/something',
-      false
+      false,
+      false,
+      TEST_WORKTREE_CREATE_GIT_OPTIONS
     )
     expect(resolveLocalGitUsernameMock).not.toHaveBeenCalled()
     expect(result.worktree).toMatchObject({
@@ -4621,7 +4712,7 @@ describe('OrcaRuntimeService', () => {
         'fix/bug-0',
         false,
         false,
-        { checkoutExistingBranch: true }
+        { ...TEST_WORKTREE_CREATE_GIT_OPTIONS, checkoutExistingBranch: true }
       )
       expect(result.worktree).toMatchObject({
         path: createdWorktree.path,
@@ -4676,11 +4767,19 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/fix',
         'abc123',
-        false
+        false,
+        false,
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
       expect(gitSpy).toHaveBeenCalledWith(
         ['branch', '--set-upstream-to', 'origin/feature/fix', 'feature/fix'],
-        { cwd: createdWorktree.path }
+        { cwd: createdWorktree.path, timeout: expect.any(Number) }
       )
       expect(result.worktree).toMatchObject({
         path: createdWorktree.path,
@@ -4732,7 +4831,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/fix',
         sha,
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
       expect(result.worktree).toMatchObject({
         path: createdWorktree.path,
@@ -4799,7 +4900,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/bitbucket',
         'abc123',
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
       expect(result.worktree).toMatchObject({
         path: createdWorktree.path,
@@ -4860,8 +4963,16 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/fix-2',
         'abc123',
-        false
+        false,
+        false,
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     } finally {
       gitSpy.mockRestore()
     }
@@ -4907,7 +5018,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/fix-2',
         'abc123',
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
     } finally {
       gitSpy.mockRestore()
@@ -4964,7 +5077,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/fix-2',
         'abc123',
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
     } finally {
       gitSpy.mockRestore()
@@ -5013,7 +5128,9 @@ describe('OrcaRuntimeService', () => {
         createdWorktree.path,
         'feature/fix-2',
         'abc123',
-        false
+        false,
+        false,
+        TEST_WORKTREE_CREATE_GIT_OPTIONS
       )
     } finally {
       gitSpy.mockRestore()
@@ -5069,7 +5186,7 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        { checkoutExistingBranch: true }
+        { ...TEST_WORKTREE_CREATE_GIT_OPTIONS, checkoutExistingBranch: true }
       )
     } finally {
       gitSpy.mockRestore()
@@ -5136,7 +5253,7 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        { checkoutExistingBranch: true }
+        { ...TEST_WORKTREE_CREATE_GIT_OPTIONS, checkoutExistingBranch: true }
       )
     } finally {
       gitSpy.mockRestore()
@@ -5241,7 +5358,7 @@ describe('OrcaRuntimeService', () => {
       '/remote/repo',
       'mobile-feature',
       '/remote/repo-mobile-feature',
-      { base: 'origin/main' }
+      { base: 'origin/main', timeoutMs: 180_000 }
     )
     expect(result.worktree).toMatchObject({
       id: `${TEST_REPO_ID}::${created.path}`,
@@ -5282,7 +5399,7 @@ describe('OrcaRuntimeService', () => {
       isMainWorktree: false
     }
     const created = {
-      path: '/remote/child-feature',
+      path: '/remote/repo-child-feature',
       head: 'def',
       branch: 'refs/heads/child-feature',
       isBare: false,
@@ -5406,8 +5523,16 @@ describe('OrcaRuntimeService', () => {
       created.path,
       'folder-child',
       'origin/main',
-      false
+      false,
+      false,
+      {
+        ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+        refreshTimeout: expect.any(Number)
+      }
     )
+    const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     expect(result.lineage).toBeNull()
     expect(result.workspaceLineage).toMatchObject({
       childWorkspaceKey: `worktree:${childId}`,
@@ -5430,7 +5555,7 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(addWorktree).mockClear()
     const created = {
-      path: '/remote/agent-feature',
+      path: '/remote/repo-agent-feature',
       head: 'def',
       branch: 'refs/heads/agent-feature',
       isBare: false,
@@ -5527,7 +5652,7 @@ describe('OrcaRuntimeService', () => {
 
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
-          cwd: '/remote/agent-feature',
+          cwd: '/remote/repo-agent-feature',
           command: "codex '--dangerously-bypass-approvals-and-sandbox' 'hi'",
           worktreeId: result.worktree.id
         })
@@ -5550,7 +5675,7 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(addWorktree).mockClear()
     const created = {
-      path: 'C:/remote/agent-feature',
+      path: 'C:/remote/repo-agent-feature',
       head: 'def',
       branch: 'refs/heads/agent-feature',
       isBare: false,
@@ -5638,7 +5763,7 @@ describe('OrcaRuntimeService', () => {
 
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
-          cwd: 'C:/remote/agent-feature',
+          cwd: 'C:/remote/repo-agent-feature',
           command: "codex '--dangerously-bypass-approvals-and-sandbox' 'fix Bob''s branch'"
         })
       )
@@ -5653,7 +5778,7 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(addWorktree).mockClear()
     const created = {
-      path: '/remote/mobile-setup',
+      path: '/remote/repo-mobile-setup',
       head: 'def',
       branch: 'refs/heads/mobile-setup',
       isBare: false,
@@ -5775,7 +5900,7 @@ describe('OrcaRuntimeService', () => {
       expect(spawn).toHaveBeenNthCalledWith(
         1,
         expect.objectContaining({
-          cwd: '/remote/mobile-setup',
+          cwd: '/remote/repo-mobile-setup',
           env: expect.objectContaining({
             [SETUP_AGENT_SEQUENCE_STARTUP_SCRIPT_ENV]: expect.stringContaining('exec claude')
           }),
@@ -5785,7 +5910,7 @@ describe('OrcaRuntimeService', () => {
       expect(spawn).toHaveBeenNthCalledWith(
         2,
         expect.objectContaining({
-          cwd: '/remote/mobile-setup',
+          cwd: '/remote/repo-mobile-setup',
           command: expect.stringContaining(
             'bash /remote/repo/.git/worktrees/mobile-setup/orca/setup-runner.sh'
           ),
@@ -5825,7 +5950,7 @@ describe('OrcaRuntimeService', () => {
     vi.mocked(listWorktrees).mockClear()
     vi.mocked(addWorktree).mockClear()
     const created = {
-      path: '/remote/mobile-setup-split',
+      path: '/remote/repo-mobile-setup-split',
       head: 'def',
       branch: 'refs/heads/mobile-setup-split',
       isBare: false,
@@ -41143,8 +41268,16 @@ describe('OrcaRuntimeService', () => {
       '/tmp/workspaces/runtime-hook-test',
       'runtime-hook-test',
       'origin/main',
-      false
+      false,
+      false,
+      {
+        ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+        refreshTimeout: expect.any(Number)
+      }
     )
+    const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+    expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+    expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     expect(result).toEqual({
       worktree: expect.objectContaining({
         repoId: 'repo-1',
@@ -43310,7 +43443,7 @@ describe('OrcaRuntimeService', () => {
   it('detects agents on the SSH host before launching remote startup drafts', async () => {
     detectRemoteAgentsMock.mockResolvedValue(['claude'])
     const created = {
-      path: '/remote/mobile-startup-draft',
+      path: '/remote/repo-mobile-startup-draft',
       head: 'def',
       branch: 'refs/heads/mobile-startup-draft',
       isBare: false,
@@ -43393,7 +43526,7 @@ describe('OrcaRuntimeService', () => {
     expect(detectInstalledAgentsWithShellPathHydrationMock).not.toHaveBeenCalled()
     expect(spawn).toHaveBeenCalledWith(
       expect.objectContaining({
-        cwd: '/remote/mobile-startup-draft',
+        cwd: '/remote/repo-mobile-startup-draft',
         command: `claude '--dangerously-skip-permissions' --prefill '${draftUrl}'`,
         connectionId: 'ssh-1',
         worktreeId: result.worktree.id
@@ -43406,7 +43539,7 @@ describe('OrcaRuntimeService', () => {
     detectRemoteAgentsMock.mockResolvedValue(['codex'])
     muxRequestMock.mockResolvedValue({ resolvedPath: '/home/dev' })
     const created = {
-      path: '/remote/mobile-codex-draft',
+      path: '/remote/repo-mobile-codex-draft',
       head: 'def',
       branch: 'refs/heads/mobile-codex-draft',
       isBare: false,
@@ -43468,7 +43601,7 @@ describe('OrcaRuntimeService', () => {
       listWorktrees: vi.fn().mockResolvedValue([created])
     }
     const fsProvider = {
-      realpath: vi.fn().mockResolvedValue('/remote/mobile-codex-draft'),
+      realpath: vi.fn().mockResolvedValue('/remote/repo-mobile-codex-draft'),
       readFile: vi.fn().mockRejectedValue(new Error('missing config')),
       createDir: vi.fn().mockResolvedValue(undefined),
       writeFile: vi.fn().mockResolvedValue(undefined)
@@ -43496,7 +43629,7 @@ describe('OrcaRuntimeService', () => {
       expect(fsProvider.createDir).toHaveBeenCalledWith('/home/dev/.codex')
       expect(fsProvider.writeFile).toHaveBeenCalledWith(
         '/home/dev/.codex/config.toml',
-        expect.stringContaining('[projects."/remote/mobile-codex-draft"]')
+        expect.stringContaining('[projects."/remote/repo-mobile-codex-draft"]')
       )
       expect(fsProvider.writeFile).toHaveBeenCalledWith(
         '/home/dev/.codex/config.toml',
@@ -43504,7 +43637,7 @@ describe('OrcaRuntimeService', () => {
       )
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
-          cwd: '/remote/mobile-codex-draft',
+          cwd: '/remote/repo-mobile-codex-draft',
           command: "codex '--dangerously-bypass-approvals-and-sandbox'",
           connectionId: 'ssh-1',
           worktreeId: result.worktree.id
@@ -43523,7 +43656,7 @@ describe('OrcaRuntimeService', () => {
   it('pre-marks remote Codex workspaces trusted before explicit startup commands', async () => {
     muxRequestMock.mockResolvedValue({ resolvedPath: '/home/dev' })
     const created = {
-      path: '/remote/mobile-codex-command',
+      path: '/remote/repo-mobile-codex-command',
       head: 'def',
       branch: 'refs/heads/mobile-codex-command',
       isBare: false,
@@ -43581,7 +43714,7 @@ describe('OrcaRuntimeService', () => {
       listWorktrees: vi.fn().mockResolvedValue([created])
     }
     const fsProvider = {
-      realpath: vi.fn().mockResolvedValue('/remote/mobile-codex-command'),
+      realpath: vi.fn().mockResolvedValue('/remote/repo-mobile-codex-command'),
       readFile: vi.fn().mockRejectedValue(new Error('missing config')),
       createDir: vi.fn().mockResolvedValue(undefined),
       writeFile: vi.fn().mockResolvedValue(undefined)
@@ -43609,7 +43742,7 @@ describe('OrcaRuntimeService', () => {
       expect(muxRequestMock).toHaveBeenCalledWith('session.resolveHome', { path: '~' })
       expect(fsProvider.writeFile).toHaveBeenCalledWith(
         '/home/dev/.codex/config.toml',
-        expect.stringContaining('[projects."/remote/mobile-codex-command"]')
+        expect.stringContaining('[projects."/remote/repo-mobile-codex-command"]')
       )
       expect(fsProvider.writeFile).toHaveBeenCalledWith(
         '/home/dev/.codex/config.toml',
@@ -43617,7 +43750,7 @@ describe('OrcaRuntimeService', () => {
       )
       expect(spawn).toHaveBeenCalledWith(
         expect.objectContaining({
-          cwd: '/remote/mobile-codex-command',
+          cwd: '/remote/repo-mobile-codex-command',
           command: 'codex',
           connectionId: 'ssh-1',
           worktreeId: result.worktree.id
@@ -45417,6 +45550,8 @@ describe('OrcaRuntimeService', () => {
         false,
         false,
         {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number),
           remoteTrackingBase: {
             base: 'origin/main',
             branch: 'main',
@@ -45427,6 +45562,9 @@ describe('OrcaRuntimeService', () => {
           wslDistro: 'Ubuntu'
         }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
       expect(gitSpy).toHaveBeenCalledWith(
         ['check-ref-format', '--branch', 'contributor/runtime-wsl'],
         { cwd: TEST_REPO_PATH, wslDistro: 'Ubuntu' }
@@ -45446,9 +45584,13 @@ describe('OrcaRuntimeService', () => {
           'pr-contributor-orca/contributor/runtime-wsl',
           'runtime-wsl'
         ],
-        { cwd: createdWorktree.path, wslDistro: 'Ubuntu' }
+        { cwd: createdWorktree.path, timeout: expect.any(Number), wslDistro: 'Ubuntu' }
       )
-      expect(listWorktrees).toHaveBeenCalledWith(TEST_REPO_PATH, { wslDistro: 'Ubuntu' })
+      expect(listWorktrees).toHaveBeenCalledWith(TEST_REPO_PATH, {
+        wslDistro: 'Ubuntu',
+        timeout: 30_000,
+        detectSparseCheckout: false
+      })
     } finally {
       gitSpy.mockRestore()
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5409,8 +5409,15 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        { ...TEST_WORKTREE_CREATE_GIT_OPTIONS, checkoutExistingBranch: true }
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          checkoutExistingBranch: true,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     } finally {
       gitSpy.mockRestore()
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4439,6 +4439,7 @@ describe('OrcaRuntimeService', () => {
         {
           ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
           refreshTimeout: expect.any(Number),
+          timeout: expect.any(Number),
           suggestLocalBaseRefUpdate: true,
           remoteTrackingBase: {
             remote: 'origin',
@@ -4451,6 +4452,8 @@ describe('OrcaRuntimeService', () => {
       const addOptions = vi.mocked(addWorktree).mock.calls.at(-1)?.[6]
       expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
       expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
+      expect(addOptions?.timeout).toBeGreaterThan(0)
+      expect(addOptions?.timeout).toBeLessThanOrEqual(180_000)
       expect(result.worktree).toMatchObject({
         path: createdWorktree.path,
         baseRef: 'refs/remotes/origin/main'
@@ -5326,8 +5329,15 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        { ...TEST_WORKTREE_CREATE_GIT_OPTIONS, checkoutExistingBranch: true }
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          checkoutExistingBranch: true,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     } finally {
       gitSpy.mockRestore()
     }
@@ -5498,8 +5508,11 @@ describe('OrcaRuntimeService', () => {
       '/remote/repo',
       'mobile-feature',
       '/remote/repo-mobile-feature',
-      { base: 'origin/main', timeoutMs: 180_000 }
+      { base: 'origin/main', signal: undefined, timeoutMs: expect.any(Number) }
     )
+    const addOptions = provider.addWorktree.mock.calls[0]?.[3]
+    expect(addOptions?.timeoutMs).toBeGreaterThan(0)
+    expect(addOptions?.timeoutMs).toBeLessThanOrEqual(180_000)
     expect(result.worktree).toMatchObject({
       id: `${TEST_REPO_ID}::${created.path}`,
       path: created.path,
@@ -45597,6 +45610,8 @@ describe('OrcaRuntimeService', () => {
 
   it('routes runtime worktree creation through the selected WSL project runtime', async () => {
     setPlatform('win32')
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
     const runtimeStore = {
       ...store,
       getProjects: () => [
@@ -45612,7 +45627,13 @@ describe('OrcaRuntimeService', () => {
       ],
       getSettings: () => ({
         ...store.getSettings(),
-        localWindowsRuntimeDefault: { kind: 'windows-host' }
+        localWindowsRuntimeDefault: { kind: 'windows-host' },
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 12_000,
+          addCheckoutMs: 24_000,
+          registrationMs: 30_000,
+          materializationMs: 300_000
+        }
       })
     }
     const runtime = new OrcaRuntimeService(runtimeStore as never)
@@ -45644,6 +45665,9 @@ describe('OrcaRuntimeService', () => {
       }
       if (args[0] === 'remote' && args[1] === 'get-url') {
         return { stdout: 'git@github.com:stablyai/orca.git\n', stderr: '' }
+      }
+      if (args[0] === 'fetch' && args[1] === 'pr-contributor-orca') {
+        now += 6_000
       }
       return { stdout: '', stderr: '' }
     })
@@ -45691,7 +45715,8 @@ describe('OrcaRuntimeService', () => {
         false,
         {
           ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
-          refreshTimeout: expect.any(Number),
+          refreshTimeout: 12_000,
+          timeout: 18_000,
           remoteTrackingBase: {
             base: 'origin/main',
             branch: 'main',
@@ -45703,8 +45728,8 @@ describe('OrcaRuntimeService', () => {
         }
       )
       const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
-      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
-      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
+      expect(addOptions?.refreshTimeout).toBe(12_000)
+      expect(addOptions?.timeout).toBe(18_000)
       expect(gitSpy).toHaveBeenCalledWith(
         ['check-ref-format', '--branch', 'contributor/runtime-wsl'],
         { cwd: TEST_REPO_PATH, timeout: expect.any(Number), wslDistro: 'Ubuntu' }
@@ -45720,8 +45745,7 @@ describe('OrcaRuntimeService', () => {
       const pushTargetFetchOptions = gitSpy.mock.calls.find(
         ([args]) => args[0] === 'fetch' && args[1] === 'pr-contributor-orca'
       )?.[1]
-      expect(pushTargetFetchOptions?.timeout).toBeGreaterThan(0)
-      expect(pushTargetFetchOptions?.timeout).toBeLessThanOrEqual(60_000)
+      expect(pushTargetFetchOptions?.timeout).toBe(24_000)
       expect(gitSpy).toHaveBeenCalledWith(
         [
           'branch',
@@ -45738,6 +45762,7 @@ describe('OrcaRuntimeService', () => {
       })
     } finally {
       gitSpy.mockRestore()
+      nowSpy.mockRestore()
     }
   })
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -5273,8 +5273,14 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        TEST_WORKTREE_CREATE_GIT_OPTIONS
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     } finally {
       gitSpy.mockRestore()
     }

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -4156,7 +4156,8 @@ describe('OrcaRuntimeService', () => {
         {}
       )
       expect(gitSpy).toHaveBeenCalledWith(['remote', 'add', remoteName, remoteUrl], {
-        cwd: TEST_REPO_PATH
+        cwd: TEST_REPO_PATH,
+        timeout: expect.any(Number)
       })
       expect(gitSpy).toHaveBeenCalledWith(['remote', 'remove', remoteName], {
         cwd: TEST_REPO_PATH
@@ -5147,8 +5148,14 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        TEST_WORKTREE_CREATE_GIT_OPTIONS
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     } finally {
       gitSpy.mockRestore()
     }
@@ -5206,8 +5213,14 @@ describe('OrcaRuntimeService', () => {
         'abc123',
         false,
         false,
-        TEST_WORKTREE_CREATE_GIT_OPTIONS
+        {
+          ...TEST_WORKTREE_CREATE_GIT_OPTIONS,
+          refreshTimeout: expect.any(Number)
+        }
       )
+      const addOptions = vi.mocked(addWorktree).mock.calls[0]?.[6]
+      expect(addOptions?.refreshTimeout).toBeGreaterThan(0)
+      expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
     } finally {
       gitSpy.mockRestore()
     }
@@ -45694,7 +45707,7 @@ describe('OrcaRuntimeService', () => {
       expect(addOptions?.refreshTimeout).toBeLessThanOrEqual(60_000)
       expect(gitSpy).toHaveBeenCalledWith(
         ['check-ref-format', '--branch', 'contributor/runtime-wsl'],
-        { cwd: TEST_REPO_PATH, wslDistro: 'Ubuntu' }
+        { cwd: TEST_REPO_PATH, timeout: expect.any(Number), wslDistro: 'Ubuntu' }
       )
       expect(gitSpy).toHaveBeenCalledWith(
         [

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -45702,8 +45702,13 @@ describe('OrcaRuntimeService', () => {
           'pr-contributor-orca',
           '+refs/heads/contributor/runtime-wsl:refs/remotes/pr-contributor-orca/contributor/runtime-wsl'
         ],
-        { cwd: TEST_REPO_PATH, wslDistro: 'Ubuntu' }
+        { cwd: TEST_REPO_PATH, timeout: expect.any(Number), wslDistro: 'Ubuntu' }
       )
+      const pushTargetFetchOptions = gitSpy.mock.calls.find(
+        ([args]) => args[0] === 'fetch' && args[1] === 'pr-contributor-orca'
+      )?.[1]
+      expect(pushTargetFetchOptions?.timeout).toBeGreaterThan(0)
+      expect(pushTargetFetchOptions?.timeout).toBeLessThanOrEqual(60_000)
       expect(gitSpy).toHaveBeenCalledWith(
         [
           'branch',

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -22179,7 +22179,10 @@ export class OrcaRuntimeService {
           args.pushTarget,
           this.store,
           repo.id,
-          localWorktreeGitOptions
+          {
+            ...localWorktreeGitOptions,
+            timeout: remainingRefreshMs()
+          }
         )
       } catch (error) {
         releasePushTargetPreparation?.()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -21896,12 +21896,21 @@ export class OrcaRuntimeService {
     }
     const addRefreshTimeoutMs = (): number =>
       refreshDeadline?.remainingMs() ?? createTimeouts.refreshBaseRefMs
+    let addRefreshTimeout = createTimeouts.refreshBaseRefMs
+    let addCheckoutDeadline: ReturnType<typeof createWorktreeCreateStageDeadline> | undefined
+    const remainingAddCheckoutMs = (): number => {
+      addCheckoutDeadline ??= createWorktreeCreateStageDeadline(
+        createTimeouts.addCheckoutMs,
+        `Worktree add and checkout timed out after ${createTimeouts.addCheckoutMs}ms.`
+      )
+      return addCheckoutDeadline.remainingMs()
+    }
     const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {
       return {
         ...options,
         ...localWorktreeGitOptions,
-        refreshTimeout: addRefreshTimeoutMs(),
-        timeout: createTimeouts.addCheckoutMs
+        refreshTimeout: addRefreshTimeout,
+        timeout: remainingAddCheckoutMs()
       }
     }
     const hostedReviewExecutionContext = this.getHostedReviewExecutionOptions(repo)
@@ -22164,11 +22173,12 @@ export class OrcaRuntimeService {
     if (args.sparseCheckout && sparseDirectories.length === 0) {
       throw new Error('Sparse checkout requires at least one repo-relative directory.')
     }
+    addRefreshTimeout = addRefreshTimeoutMs()
 
     let preparedPushTarget: GitPushTarget | undefined
     const releasePushTargetPreparation = args.pushTarget
       ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget, {
-          remainingTimeoutMs: remainingRefreshMs,
+          remainingTimeoutMs: remainingAddCheckoutMs,
           signal: args.signal
         })
       : undefined
@@ -22183,7 +22193,7 @@ export class OrcaRuntimeService {
           this.store,
           repo.id,
           localWorktreeGitOptions,
-          remainingRefreshMs
+          remainingAddCheckoutMs
         )
       } catch (error) {
         releasePushTargetPreparation?.()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -913,6 +913,7 @@ import {
   configureCreatedWorktreePushTarget,
   prepareWorktreePushTarget
 } from '../ipc/worktree-remote'
+import { acquireWorktreePushTargetPreparationLease } from '../ipc/worktree-push-target-setup'
 import {
   getBranchNameOverrideCandidate,
   getWorktreeCreateCandidate,
@@ -21577,6 +21578,7 @@ export class OrcaRuntimeService {
   async createManagedWorktree(args: {
     repoSelector: string
     name: string
+    signal?: AbortSignal
     timeouts?: WorktreeCreateTimeoutOverrides
     baseBranch?: string
     compareBaseRef?: string
@@ -21844,8 +21846,43 @@ export class OrcaRuntimeService {
     const settings = createSettings
     const worktreePathSettings = getWorktreePathSettings(repo, settings)
     const localGitExecOptions = getLocalProjectGitExecOptions(this.requireStore(), repo)
-    const localWorktreeGitOptions = getLocalProjectWorktreeGitOptions(this.requireStore(), repo)
-    const hasLocalWorktreeGitOptions = hasLocalGitOptions(localWorktreeGitOptions)
+    const localWorktreeCleanupGitOptions = getLocalProjectWorktreeGitOptions(
+      this.requireStore(),
+      repo
+    )
+    const localWorktreeGitOptions = {
+      ...localWorktreeCleanupGitOptions,
+      ...(args.signal ? { signal: args.signal } : {})
+    }
+    const waitForSharedFetch = <T>(operation: Promise<T>): Promise<T> => {
+      if (!args.signal) {
+        return operation
+      }
+      if (args.signal.aborted) {
+        return Promise.reject(
+          Object.assign(new Error('Worktree creation was cancelled.'), { name: 'AbortError' })
+        )
+      }
+      return new Promise<T>((resolve, reject) => {
+        const onAbort = (): void => {
+          reject(
+            Object.assign(new Error('Worktree creation was cancelled.'), { name: 'AbortError' })
+          )
+        }
+        args.signal?.addEventListener('abort', onAbort, { once: true })
+        void operation.then(
+          (result) => {
+            args.signal?.removeEventListener('abort', onAbort)
+            resolve(result)
+          },
+          (error: unknown) => {
+            args.signal?.removeEventListener('abort', onAbort)
+            reject(error)
+          }
+        )
+      })
+    }
+    const hasLocalWorktreeGitOptions = hasLocalGitOptions(localWorktreeCleanupGitOptions)
     const localWorktreeGitOptionArgs: [] | [{ wslDistro?: string }] = hasLocalWorktreeGitOptions
       ? [localWorktreeGitOptions]
       : []
@@ -22064,13 +22101,11 @@ export class OrcaRuntimeService {
       if (!hadRemoteTrackingBaseRef && hasLocalBaseRef) {
         remoteTrackingBase = null
       } else {
-        const refreshResult = await this.getOrStartRemoteTrackingBaseRefresh(
-          repo.path,
-          remoteTrackingBase,
-          {
-            ...localWorktreeGitOptions,
+        const refreshResult = await waitForSharedFetch(
+          this.getOrStartRemoteTrackingBaseRefresh(repo.path, remoteTrackingBase, {
+            ...localWorktreeCleanupGitOptions,
             timeout: remainingRefreshMs()
-          }
+          })
         )
         if (!refreshResult.ok && !hadRemoteTrackingBaseRef) {
           remainingRefreshMs()
@@ -22106,12 +22141,17 @@ export class OrcaRuntimeService {
       // Why: local bases keep legacy best-effort fetch behavior. Verified PR
       // SHA bases already have the commit object needed by `git worktree add`.
       try {
-        await this.fetchRemoteWithCache(repo.path, 'origin', {
-          ...localWorktreeGitOptions,
-          timeout: remainingRefreshMs()
-        })
+        await waitForSharedFetch(
+          this.fetchRemoteWithCache(repo.path, 'origin', {
+            ...localWorktreeCleanupGitOptions,
+            timeout: remainingRefreshMs()
+          })
+        )
         remainingRefreshMs()
-      } catch {
+      } catch (error) {
+        if (args.signal?.aborted) {
+          throw error
+        }
         // Why: belt-and-suspenders. fetchRemoteWithCache already logs and does
         // not throw; the outer try/catch guarantees create-path tolerance even
         // if future refactors change that contract.
@@ -22126,17 +22166,25 @@ export class OrcaRuntimeService {
     }
 
     let preparedPushTarget: GitPushTarget | undefined
+    const releasePushTargetPreparation = args.pushTarget
+      ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget)
+      : undefined
     if (args.pushTarget) {
       // Why: fork-PR worktrees created through a remote runtime need the same
       // upstream target setup as local desktop creates, or Push would publish
       // to the wrong remote after the client/server split.
-      preparedPushTarget = await prepareWorktreePushTarget(
-        repo.path,
-        args.pushTarget,
-        this.store,
-        repo.id,
-        localWorktreeGitOptions
-      )
+      try {
+        preparedPushTarget = await prepareWorktreePushTarget(
+          repo.path,
+          args.pushTarget,
+          this.store,
+          repo.id,
+          localWorktreeGitOptions
+        )
+      } catch (error) {
+        releasePushTargetPreparation?.()
+        throw error
+      }
     }
 
     const suggestLocalBaseRefUpdate =
@@ -22150,19 +22198,11 @@ export class OrcaRuntimeService {
       ...(suggestLocalBaseRefUpdate ? { suggestLocalBaseRefUpdate } : {})
     }
     const defaultAddWorktreeOption = addProjectGitOptions()
-    const addResult: AddWorktreeResult =
-      (await (sparseDirectories.length > 0
-        ? checkoutExistingBranch
-          ? addSparseWorktree(
-              repo.path,
-              worktreePath,
-              branchName,
-              sparseDirectories,
-              baseBranch,
-              settings.refreshLocalBaseRefOnWorktreeCreate,
-              addProjectGitOptions(existingBranchOption)
-            )
-          : suggestLocalBaseRefUpdate
+    let addResult: AddWorktreeResult
+    try {
+      addResult =
+        (await (sparseDirectories.length > 0
+          ? checkoutExistingBranch
             ? addSparseWorktree(
                 repo.path,
                 worktreePath,
@@ -22170,9 +22210,9 @@ export class OrcaRuntimeService {
                 sparseDirectories,
                 baseBranch,
                 settings.refreshLocalBaseRefOnWorktreeCreate,
-                addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
+                addProjectGitOptions(existingBranchOption)
               )
-            : remoteTrackingBaseOption
+            : suggestLocalBaseRefUpdate
               ? addSparseWorktree(
                   repo.path,
                   worktreePath,
@@ -22180,9 +22220,9 @@ export class OrcaRuntimeService {
                   sparseDirectories,
                   baseBranch,
                   settings.refreshLocalBaseRefOnWorktreeCreate,
-                  addProjectGitOptions(remoteTrackingBaseOption)
+                  addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
                 )
-              : defaultAddWorktreeOption
+              : remoteTrackingBaseOption
                 ? addSparseWorktree(
                     repo.path,
                     worktreePath,
@@ -22190,27 +22230,27 @@ export class OrcaRuntimeService {
                     sparseDirectories,
                     baseBranch,
                     settings.refreshLocalBaseRefOnWorktreeCreate,
-                    defaultAddWorktreeOption
+                    addProjectGitOptions(remoteTrackingBaseOption)
                   )
-                : addSparseWorktree(
-                    repo.path,
-                    worktreePath,
-                    branchName,
-                    sparseDirectories,
-                    baseBranch,
-                    settings.refreshLocalBaseRefOnWorktreeCreate
-                  )
-        : checkoutExistingBranch
-          ? addWorktree(
-              repo.path,
-              worktreePath,
-              branchName,
-              baseBranch,
-              settings.refreshLocalBaseRefOnWorktreeCreate,
-              false,
-              addProjectGitOptions(existingBranchOption)
-            )
-          : suggestLocalBaseRefUpdate
+                : defaultAddWorktreeOption
+                  ? addSparseWorktree(
+                      repo.path,
+                      worktreePath,
+                      branchName,
+                      sparseDirectories,
+                      baseBranch,
+                      settings.refreshLocalBaseRefOnWorktreeCreate,
+                      defaultAddWorktreeOption
+                    )
+                  : addSparseWorktree(
+                      repo.path,
+                      worktreePath,
+                      branchName,
+                      sparseDirectories,
+                      baseBranch,
+                      settings.refreshLocalBaseRefOnWorktreeCreate
+                    )
+          : checkoutExistingBranch
             ? addWorktree(
                 repo.path,
                 worktreePath,
@@ -22218,9 +22258,9 @@ export class OrcaRuntimeService {
                 baseBranch,
                 settings.refreshLocalBaseRefOnWorktreeCreate,
                 false,
-                addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
+                addProjectGitOptions(existingBranchOption)
               )
-            : remoteTrackingBaseOption
+            : suggestLocalBaseRefUpdate
               ? addWorktree(
                   repo.path,
                   worktreePath,
@@ -22228,9 +22268,9 @@ export class OrcaRuntimeService {
                   baseBranch,
                   settings.refreshLocalBaseRefOnWorktreeCreate,
                   false,
-                  addProjectGitOptions(remoteTrackingBaseOption)
+                  addProjectGitOptions({ ...remoteTrackingBaseOption, suggestLocalBaseRefUpdate })
                 )
-              : defaultAddWorktreeOption
+              : remoteTrackingBaseOption
                 ? addWorktree(
                     repo.path,
                     worktreePath,
@@ -22238,15 +22278,36 @@ export class OrcaRuntimeService {
                     baseBranch,
                     settings.refreshLocalBaseRefOnWorktreeCreate,
                     false,
-                    defaultAddWorktreeOption
+                    addProjectGitOptions(remoteTrackingBaseOption)
                   )
-                : addWorktree(
-                    repo.path,
-                    worktreePath,
-                    branchName,
-                    baseBranch,
-                    settings.refreshLocalBaseRefOnWorktreeCreate
-                  ))) ?? {}
+                : defaultAddWorktreeOption
+                  ? addWorktree(
+                      repo.path,
+                      worktreePath,
+                      branchName,
+                      baseBranch,
+                      settings.refreshLocalBaseRefOnWorktreeCreate,
+                      false,
+                      defaultAddWorktreeOption
+                    )
+                  : addWorktree(
+                      repo.path,
+                      worktreePath,
+                      branchName,
+                      baseBranch,
+                      settings.refreshLocalBaseRefOnWorktreeCreate
+                    ))) ?? {}
+    } catch (error) {
+      await cleanupUnusedWorktreePushTargetRemote(
+        repo.path,
+        `${repo.id}::${worktreePath}`,
+        preparedPushTarget,
+        this.store,
+        localWorktreeCleanupGitOptions
+      )
+      releasePushTargetPreparation?.()
+      throw error
+    }
 
     let configuredPushTarget: GitPushTarget | undefined
     let gitWorktrees: GitWorktreeInfo[]
@@ -22256,18 +22317,6 @@ export class OrcaRuntimeService {
         createTimeouts.registrationMs,
         `Worktree registration timed out after ${createTimeouts.registrationMs}ms.`
       )
-      if (preparedPushTarget) {
-        configuredPushTarget = await configureCreatedWorktreePushTarget(
-          worktreePath,
-          branchName,
-          preparedPushTarget,
-          {
-            ...localWorktreeGitOptions,
-            timeout: registrationDeadline.remainingMs()
-          }
-        )
-      }
-
       gitWorktrees = hasLocalWorktreeGitOptions
         ? await listWorktreesStrict(repo.path, {
             ...localWorktreeGitOptions,
@@ -22275,6 +22324,7 @@ export class OrcaRuntimeService {
             detectSparseCheckout: false
           })
         : await listWorktreesStrict(repo.path, {
+            ...(args.signal ? { signal: args.signal } : {}),
             timeout: registrationDeadline.remainingMs(),
             detectSparseCheckout: false
           })
@@ -22284,6 +22334,17 @@ export class OrcaRuntimeService {
         throw new Error('Worktree created but not found in listing')
       }
       created = reconciled
+      if (preparedPushTarget) {
+        configuredPushTarget = await configureCreatedWorktreePushTarget(
+          created.path,
+          branchName,
+          preparedPushTarget,
+          {
+            ...localWorktreeGitOptions,
+            timeout: registrationDeadline.remainingMs()
+          }
+        )
+      }
     } catch (error) {
       try {
         await rollbackFailedWorktreeCreate(
@@ -22291,14 +22352,23 @@ export class OrcaRuntimeService {
           worktreePath,
           branchName,
           checkoutExistingBranch,
-          localWorktreeGitOptions
+          localWorktreeCleanupGitOptions
         )
       } catch (cleanupError) {
         const wrapped = error instanceof Error ? error : new Error(String(error))
         wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
         console.warn(`[worktree-create] Failed to roll back "${worktreePath}"`, cleanupError)
+        releasePushTargetPreparation?.()
         throw wrapped
       }
+      await cleanupUnusedWorktreePushTargetRemote(
+        repo.path,
+        `${repo.id}::${worktreePath}`,
+        preparedPushTarget,
+        this.store,
+        localWorktreeCleanupGitOptions
+      )
+      releasePushTargetPreparation?.()
       throw error
     }
 
@@ -22312,7 +22382,7 @@ export class OrcaRuntimeService {
       : shouldSetDisplayName(effectiveRequestedName, branchName, effectiveSanitizedName)
         ? { displayName: effectiveRequestedName }
         : {}
-    const meta = this.store.setWorktreeMeta(worktreeId, {
+    const metaUpdates: Partial<WorktreeMeta> = {
       // Why: worktree IDs are path-derived. If a path is deleted outside Orca
       // and later recreated, creation must mint a fresh instance identity so
       // stale lineage records tied to the old occupant fail validation.
@@ -22373,7 +22443,13 @@ export class OrcaRuntimeService {
       ...(args.comment !== undefined ? { comment: args.comment } : {}),
       ...(args.manualOrder !== undefined ? { manualOrder: args.manualOrder } : {}),
       ...(args.workspaceStatus !== undefined ? { workspaceStatus: args.workspaceStatus } : {})
-    })
+    }
+    let meta: WorktreeMeta
+    try {
+      meta = this.store.setWorktreeMeta(worktreeId, metaUpdates)
+    } finally {
+      releasePushTargetPreparation?.()
+    }
     const worktree = {
       ...mergeWorktree(repo.id, created, meta),
       hostId: meta.hostId ?? getRepoExecutionHostId(repo)
@@ -22769,6 +22845,7 @@ export class OrcaRuntimeService {
     repo: Repo,
     args: {
       name: string
+      signal?: AbortSignal
       timeouts?: WorktreeCreateTimeoutOverrides
       baseBranch?: string
       compareBaseRef?: string
@@ -22861,7 +22938,8 @@ export class OrcaRuntimeService {
       },
       repo,
       this.store as unknown as Store,
-      headlessWindow
+      headlessWindow,
+      { signal: args.signal }
     )
 
     if (args.comment !== undefined) {
@@ -23196,6 +23274,9 @@ export class OrcaRuntimeService {
     }
 
     const promise = this.enqueueRemoteFetch(key, () => {
+      if (this.getFreshFetchCompletedAt(key) !== null) {
+        return Promise.resolve({ ok: true })
+      }
       const remaining = deadlineAt - Date.now()
       if (remaining <= 0) {
         return Promise.resolve({ ok: false, errorKind: 'git_error' })

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -22167,7 +22167,10 @@ export class OrcaRuntimeService {
 
     let preparedPushTarget: GitPushTarget | undefined
     const releasePushTargetPreparation = args.pushTarget
-      ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget)
+      ? await acquireWorktreePushTargetPreparationLease(repo.path, args.pushTarget, {
+          remainingTimeoutMs: remainingRefreshMs,
+          signal: args.signal
+        })
       : undefined
     if (args.pushTarget) {
       // Why: fork-PR worktrees created through a remote runtime need the same
@@ -22179,10 +22182,8 @@ export class OrcaRuntimeService {
           args.pushTarget,
           this.store,
           repo.id,
-          {
-            ...localWorktreeGitOptions,
-            timeout: remainingRefreshMs()
-          }
+          localWorktreeGitOptions,
+          remainingRefreshMs
         )
       } catch (error) {
         releasePushTargetPreparation?.()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -240,6 +240,14 @@ import type {
   CodexRateLimitAccountsState
 } from '../../shared/types'
 import type { TaskSourceContext } from '../../shared/task-source-context'
+import {
+  normalizeWorktreeCreateTimeouts,
+  type WorktreeCreateTimeoutOverrides
+} from '../../shared/worktree-create-timeouts'
+import {
+  createWorktreeCreateStageDeadline,
+  getEffectiveWorktreeCreateTimeouts
+} from '../worktree-create-stage-timeouts'
 import { assertWorktreeUnlockedForRemoval } from '../../shared/worktree-removal'
 import {
   LOCAL_EXECUTION_HOST_ID,
@@ -857,7 +865,8 @@ import {
   addSparseWorktree,
   assertWorktreeCleanForRemoval,
   forceDeleteLocalBranch,
-  removeWorktree
+  removeWorktree,
+  rollbackFailedWorktreeCreate
 } from '../git/worktree'
 import type { AddWorktreeOptions, AddWorktreeResult } from '../git/worktree'
 import { isENOENT, invalidateAuthorizedRootsCache } from '../ipc/filesystem-auth'
@@ -1154,6 +1163,7 @@ type RuntimeStore = {
     githubProjects?: GlobalSettings['githubProjects']
     experimentalNewWorktreeCardStyle?: GlobalSettings['experimentalNewWorktreeCardStyle']
     compactWorktreeCards?: GlobalSettings['compactWorktreeCards']
+    worktreeCreateTimeouts?: GlobalSettings['worktreeCreateTimeouts']
     minimaxGroupId?: GlobalSettings['minimaxGroupId']
     minimaxUsageModels?: GlobalSettings['minimaxUsageModels']
     prBotAuthorOverrides?: GlobalSettings['prBotAuthorOverrides']
@@ -3427,6 +3437,7 @@ export class OrcaRuntimeService {
     | 'githubProjects'
     | 'experimentalNewWorktreeCardStyle'
     | 'compactWorktreeCards'
+    | 'worktreeCreateTimeouts'
     | 'minimaxGroupId'
     | 'minimaxUsageModels'
     | 'prBotAuthorOverrides'
@@ -3453,6 +3464,7 @@ export class OrcaRuntimeService {
       githubProjects: settings.githubProjects,
       experimentalNewWorktreeCardStyle: settings.experimentalNewWorktreeCardStyle === true,
       compactWorktreeCards: settings.compactWorktreeCards === true,
+      worktreeCreateTimeouts: normalizeWorktreeCreateTimeouts(settings.worktreeCreateTimeouts),
       minimaxGroupId: settings.minimaxGroupId ?? '',
       minimaxUsageModels: settings.minimaxUsageModels ?? 'general',
       prBotAuthorOverrides: settings.prBotAuthorOverrides ?? [],
@@ -3488,25 +3500,29 @@ export class OrcaRuntimeService {
   }
 
   async updateClientSettings(
-    updates: Pick<
-      Partial<GlobalSettings>,
-      | 'agentStatusHooksEnabled'
-      | 'defaultTuiAgent'
-      | 'disabledTuiAgents'
-      | 'agentDefaultArgs'
-      | 'agentDefaultEnv'
-      | 'defaultTaskSource'
-      | 'defaultTaskViewPreset'
-      | 'visibleTaskProviders'
-      | 'defaultRepoSelection'
-      | 'defaultLinearTeamSelection'
-      | 'githubProjects'
-      | 'experimentalNewWorktreeCardStyle'
-      | 'compactWorktreeCards'
-      | 'minimaxGroupId'
-      | 'minimaxUsageModels'
-      | 'prBotAuthorOverrides'
-    >
+    updates: Omit<
+      Pick<
+        Partial<GlobalSettings>,
+        | 'agentStatusHooksEnabled'
+        | 'defaultTuiAgent'
+        | 'disabledTuiAgents'
+        | 'agentDefaultArgs'
+        | 'agentDefaultEnv'
+        | 'defaultTaskSource'
+        | 'defaultTaskViewPreset'
+        | 'visibleTaskProviders'
+        | 'defaultRepoSelection'
+        | 'defaultLinearTeamSelection'
+        | 'githubProjects'
+        | 'experimentalNewWorktreeCardStyle'
+        | 'compactWorktreeCards'
+        | 'worktreeCreateTimeouts'
+        | 'minimaxGroupId'
+        | 'minimaxUsageModels'
+        | 'prBotAuthorOverrides'
+      >,
+      'worktreeCreateTimeouts'
+    > & { worktreeCreateTimeouts?: WorktreeCreateTimeoutOverrides }
   ): Promise<
     Pick<
       GlobalSettings,
@@ -3524,6 +3540,7 @@ export class OrcaRuntimeService {
       | 'githubProjects'
       | 'experimentalNewWorktreeCardStyle'
       | 'compactWorktreeCards'
+      | 'worktreeCreateTimeouts'
       | 'minimaxGroupId'
       | 'minimaxUsageModels'
       | 'prBotAuthorOverrides'
@@ -3534,7 +3551,18 @@ export class OrcaRuntimeService {
     }
     const beforeSettings = this.store.getSettings()
     const before = beforeSettings.agentStatusHooksEnabled !== false
-    this.store.updateSettings(updates, { notifyListeners: true })
+    const { worktreeCreateTimeouts, ...otherUpdates } = updates
+    const normalizedUpdates: Partial<GlobalSettings> =
+      worktreeCreateTimeouts === undefined
+        ? otherUpdates
+        : {
+            ...otherUpdates,
+            worktreeCreateTimeouts: normalizeWorktreeCreateTimeouts(
+              worktreeCreateTimeouts,
+              normalizeWorktreeCreateTimeouts(beforeSettings.worktreeCreateTimeouts)
+            )
+          }
+    this.store.updateSettings(normalizedUpdates, { notifyListeners: true })
     const settings = this.store.getSettings()
     if (
       (typeof updates.agentStatusHooksEnabled === 'boolean' &&
@@ -21549,6 +21577,7 @@ export class OrcaRuntimeService {
   async createManagedWorktree(args: {
     repoSelector: string
     name: string
+    timeouts?: WorktreeCreateTimeoutOverrides
     baseBranch?: string
     compareBaseRef?: string
     branchNameOverride?: string
@@ -21594,6 +21623,13 @@ export class OrcaRuntimeService {
 
     const repo = await this.resolveRepoSelector(args.repoSelector)
     const createSettings = this.store.getSettings()
+    const createTimeouts = getEffectiveWorktreeCreateTimeouts(
+      repo,
+      {
+        worktreeCreateTimeouts: (createSettings as Partial<GlobalSettings>).worktreeCreateTimeouts
+      },
+      args.timeouts
+    )
     const requestedAgent = args.startupAgent ?? args.createdWithAgent
     const requestedAgentEnabled =
       requestedAgent !== undefined
@@ -21773,6 +21809,7 @@ export class OrcaRuntimeService {
     if (repo.connectionId) {
       const result = await this.createManagedRemoteWorktree(repo, {
         ...args,
+        timeouts: args.timeouts,
         activate: args.activate,
         ...(effectiveStartup ? { startup: effectiveStartup } : {}),
         ...(effectiveStartupFollowup ? { startupFollowup: effectiveStartupFollowup } : {}),
@@ -21812,11 +21849,23 @@ export class OrcaRuntimeService {
     const localWorktreeGitOptionArgs: [] | [{ wslDistro?: string }] = hasLocalWorktreeGitOptions
       ? [localWorktreeGitOptions]
       : []
+    let refreshDeadline: ReturnType<typeof createWorktreeCreateStageDeadline> | undefined
+    const remainingRefreshMs = (): number => {
+      refreshDeadline ??= createWorktreeCreateStageDeadline(
+        createTimeouts.refreshBaseRefMs,
+        `Worktree base ref refresh timed out after ${createTimeouts.refreshBaseRefMs}ms.`
+      )
+      return refreshDeadline.remainingMs()
+    }
+    const addRefreshTimeoutMs = (): number =>
+      refreshDeadline?.remainingMs() ?? createTimeouts.refreshBaseRefMs
     const addProjectGitOptions = (options?: AddWorktreeOptions): AddWorktreeOptions | undefined => {
-      if (!hasLocalWorktreeGitOptions) {
-        return options
+      return {
+        ...options,
+        ...localWorktreeGitOptions,
+        refreshTimeout: addRefreshTimeoutMs(),
+        timeout: createTimeouts.addCheckoutMs
       }
-      return { ...options, ...localWorktreeGitOptions }
     }
     const hostedReviewExecutionContext = this.getHostedReviewExecutionOptions(repo)
     let effectiveRequestedName = args.name
@@ -22018,9 +22067,13 @@ export class OrcaRuntimeService {
         const refreshResult = await this.getOrStartRemoteTrackingBaseRefresh(
           repo.path,
           remoteTrackingBase,
-          ...localWorktreeGitOptionArgs
+          {
+            ...localWorktreeGitOptions,
+            timeout: remainingRefreshMs()
+          }
         )
         if (!refreshResult.ok && !hadRemoteTrackingBaseRef) {
+          remainingRefreshMs()
           // Why: only block creation when the refresh failed AND there is no
           // usable local base ref to fall back on. If a local remote-tracking ref
           // already exists, `git worktree add` can create from it — a possibly
@@ -22033,14 +22086,15 @@ export class OrcaRuntimeService {
         }
         if (
           !hadRemoteTrackingBaseRef &&
-          !(await this.hasRemoteTrackingRef(
-            repo.path,
-            remoteTrackingBase,
-            ...localWorktreeGitOptionArgs
-          ))
+          !(await this.hasRemoteTrackingRef(repo.path, remoteTrackingBase, {
+            ...localWorktreeGitOptions,
+            timeout: remainingRefreshMs()
+          }))
         ) {
+          remainingRefreshMs()
           throw new Error(`Base ref "${baseBranch}" was not found after fetching.`)
         }
+        remainingRefreshMs()
       }
     } else if (
       !(await hasLocalWorktreeBaseRef(
@@ -22052,7 +22106,11 @@ export class OrcaRuntimeService {
       // Why: local bases keep legacy best-effort fetch behavior. Verified PR
       // SHA bases already have the commit object needed by `git worktree add`.
       try {
-        await this.fetchRemoteWithCache(repo.path, 'origin', ...localWorktreeGitOptionArgs)
+        await this.fetchRemoteWithCache(repo.path, 'origin', {
+          ...localWorktreeGitOptions,
+          timeout: remainingRefreshMs()
+        })
+        remainingRefreshMs()
       } catch {
         // Why: belt-and-suspenders. fetchRemoteWithCache already logs and does
         // not throw; the outer try/catch guarantees create-path tolerance even
@@ -22191,22 +22249,57 @@ export class OrcaRuntimeService {
                   ))) ?? {}
 
     let configuredPushTarget: GitPushTarget | undefined
-    if (preparedPushTarget) {
-      configuredPushTarget = await configureCreatedWorktreePushTarget(
-        worktreePath,
-        branchName,
-        preparedPushTarget,
-        localWorktreeGitOptions
+    let gitWorktrees: GitWorktreeInfo[]
+    let created: GitWorktreeInfo
+    try {
+      const registrationDeadline = createWorktreeCreateStageDeadline(
+        createTimeouts.registrationMs,
+        `Worktree registration timed out after ${createTimeouts.registrationMs}ms.`
       )
-    }
+      if (preparedPushTarget) {
+        configuredPushTarget = await configureCreatedWorktreePushTarget(
+          worktreePath,
+          branchName,
+          preparedPushTarget,
+          {
+            ...localWorktreeGitOptions,
+            timeout: registrationDeadline.remainingMs()
+          }
+        )
+      }
 
-    const gitWorktrees = hasLocalWorktreeGitOptions
-      ? await listWorktrees(repo.path, localWorktreeGitOptions)
-      : await listWorktrees(repo.path)
-    // Why: Git may canonicalize a symlinked create path; its exact branch identifies the listed row.
-    const created = findCreatedWorktree(gitWorktrees, worktreePath, branchName)
-    if (!created) {
-      throw new Error('Worktree created but not found in listing')
+      gitWorktrees = hasLocalWorktreeGitOptions
+        ? await listWorktreesStrict(repo.path, {
+            ...localWorktreeGitOptions,
+            timeout: registrationDeadline.remainingMs(),
+            detectSparseCheckout: false
+          })
+        : await listWorktreesStrict(repo.path, {
+            timeout: registrationDeadline.remainingMs(),
+            detectSparseCheckout: false
+          })
+      // Why: Git may canonicalize a symlinked create path; its exact branch identifies the listed row.
+      const reconciled = findCreatedWorktree(gitWorktrees, worktreePath, branchName)
+      if (!reconciled) {
+        throw new Error('Worktree created but not found in listing')
+      }
+      created = reconciled
+    } catch (error) {
+      try {
+        await rollbackFailedWorktreeCreate(
+          repo.path,
+          worktreePath,
+          branchName,
+          checkoutExistingBranch,
+          localWorktreeGitOptions
+        )
+      } catch (cleanupError) {
+        const wrapped = error instanceof Error ? error : new Error(String(error))
+        wrapped.message = `${wrapped.message} (cleanup also failed — the partially created worktree at "${worktreePath}" may need manual removal)`
+        console.warn(`[worktree-create] Failed to roll back "${worktreePath}"`, cleanupError)
+        throw wrapped
+      }
+      throw error
     }
 
     const worktreeId = `${repo.id}::${created.path}`
@@ -22290,39 +22383,59 @@ export class OrcaRuntimeService {
       workspaceLineage,
       warnings: lineageWarnings
     } = this.recordCreatedWorktreeLineage(worktree, lineageResolution)
+    const materializationDeadlineAt = Date.now() + createTimeouts.materializationMs
+    let materializationTimedOut = false
+    const materializationOptions = {
+      deadlineAt: materializationDeadlineAt,
+      onDeadlineExceeded: () => {
+        materializationTimedOut = true
+      }
+    }
 
     const symlinkPaths = repo.symlinkPaths ?? []
     if (symlinkPaths.length > 0) {
-      await createWorktreeLinkedPaths(repo.path, created.path, symlinkPaths)
+      await createWorktreeLinkedPaths(repo.path, created.path, symlinkPaths, materializationOptions)
     }
 
     // Why: project-level `orca.yaml` shared directories add to (never replace) the
     // per-user setting, so a repo's shared dirs reach every teammate (issue #10451).
-    const sharedDirectories = await resolveWorktreeSharedDirectories(
-      repo.path,
-      localWorktreeGitOptions
-    )
+    const sharedDirectories =
+      Date.now() >= materializationDeadlineAt
+        ? ((materializationTimedOut = true), [])
+        : await resolveWorktreeSharedDirectories(repo.path, localWorktreeGitOptions)
     if (sharedDirectories.length > 0) {
-      await createWorktreeSharedPaths(repo.path, created.path, sharedDirectories)
+      await createWorktreeSharedPaths(
+        repo.path,
+        created.path,
+        sharedDirectories,
+        materializationOptions
+      )
     }
 
     // Why: project-level `.worktreeinclude` travels with the repo (issue #7549); copy semantics
     // (never symlink) so each worktree owns its files. Paths already linked above are skipped.
-    const worktreeIncludePaths = await resolveWorktreeIncludePaths(
-      repo.path,
-      localWorktreeGitOptions
-    )
+    const worktreeIncludePaths =
+      Date.now() >= materializationDeadlineAt
+        ? ((materializationTimedOut = true), [])
+        : await resolveWorktreeIncludePaths(repo.path, localWorktreeGitOptions)
     let includeCopyWarning: string | undefined
     if (worktreeIncludePaths.length > 0) {
       const skippedIncludePaths = await createWorktreeCopiedPaths(
         repo.path,
         created.path,
-        worktreeIncludePaths
+        worktreeIncludePaths,
+        materializationOptions
       )
       includeCopyWarning = formatWorktreeIncludeCopyWarning(skippedIncludePaths)
       if (includeCopyWarning) {
         console.warn(`[worktree-include] ${includeCopyWarning}`)
       }
+    }
+    if (materializationTimedOut) {
+      const timeoutWarning = `Workspace materialization stopped after ${createTimeouts.materializationMs}ms; the worktree was kept and remaining shared paths can be added manually.`
+      includeCopyWarning = includeCopyWarning
+        ? `${includeCopyWarning} Also ${timeoutWarning[0]?.toLowerCase() ?? ''}${timeoutWarning.slice(1)}`
+        : timeoutWarning
     }
 
     let setup: CreateWorktreeResult['setup']
@@ -22656,6 +22769,7 @@ export class OrcaRuntimeService {
     repo: Repo,
     args: {
       name: string
+      timeouts?: WorktreeCreateTimeoutOverrides
       baseBranch?: string
       compareBaseRef?: string
       branchNameOverride?: string
@@ -22707,6 +22821,7 @@ export class OrcaRuntimeService {
       {
         repoId: repo.id,
         name: args.name,
+        ...(args.timeouts ? { timeouts: args.timeouts } : {}),
         ...(args.displayName ? { displayName: args.displayName } : {}),
         ...(args.baseBranch ? { baseBranch: args.baseBranch } : {}),
         ...(args.compareBaseRef ? { compareBaseRef: args.compareBaseRef } : {}),
@@ -23060,7 +23175,7 @@ export class OrcaRuntimeService {
   async getOrStartRemoteFetch(
     repoPath: string,
     remote: string,
-    gitOptions: { wslDistro?: string } = {}
+    gitOptions: { wslDistro?: string; timeout?: number } = {}
   ): Promise<RemoteFetchResult> {
     const key = await this.getCanonicalFetchKey(repoPath, remote, gitOptions)
     if (this.getFreshFetchCompletedAt(key) !== null) {
@@ -23070,20 +23185,27 @@ export class OrcaRuntimeService {
       return { ok: true }
     }
 
-    const existing = this.fetchInflight.get(key)
+    const timeout = gitOptions.timeout ?? REMOTE_FETCH_TIMEOUT_MS
+    const deadlineAt = Date.now() + timeout
+    const inflightKey = `${key}\0${timeout}`
+    const existing = this.fetchInflight.get(inflightKey)
     if (existing) {
       // Why: genuine serialization (not check-then-set). Two callers racing
       // on the same repo+remote share the single underlying `git fetch`.
       return existing
     }
 
-    const promise = this.enqueueRemoteFetch(key, () =>
-      gitExecFileAsync(['fetch', remote], {
+    const promise = this.enqueueRemoteFetch(key, () => {
+      const remaining = deadlineAt - Date.now()
+      if (remaining <= 0) {
+        return Promise.resolve({ ok: false, errorKind: 'git_error' })
+      }
+      return gitExecFileAsync(['fetch', remote], {
         cwd: repoPath,
         ...gitOptions,
         // Why: cap the create-path base-ref fetch so a stuck first-auth on
         // Windows (GCM prompt) fails fast instead of hanging creation (STA-1292).
-        timeout: REMOTE_FETCH_TIMEOUT_MS
+        timeout: remaining
       })
         .then((): RemoteFetchResult => {
           // Why (§3.3 Lifecycle): timestamp on success ONLY. Writing on rejection
@@ -23098,21 +23220,21 @@ export class OrcaRuntimeService {
           console.warn(`[fetchRemoteWithCache] ${remote} fetch failed for ${repoPath}:`, err)
           return { ok: false, errorKind: 'git_error' }
         })
-    ).finally(() => {
+    }).finally(() => {
       // Why (§3.3 Lifecycle): evict on BOTH success and rejection. A
       // rejected entry that survived in the Map would wedge every future
       // create on this repo until Orca restarted (the F2 bug §3.3 pins).
-      this.fetchInflight.delete(key)
+      this.fetchInflight.delete(inflightKey)
     })
 
-    this.fetchInflight.set(key, promise)
+    this.fetchInflight.set(inflightKey, promise)
     return promise
   }
 
   async getOrStartRemoteTrackingBaseRefresh(
     repoPath: string,
     base: RemoteTrackingBase,
-    gitOptions: { wslDistro?: string } = {}
+    gitOptions: { wslDistro?: string; timeout?: number } = {}
   ): Promise<RemoteFetchResult> {
     const remoteKey = await this.getCanonicalFetchKey(repoPath, base.remote, gitOptions)
     const key = await this.getCanonicalFetchKey(
@@ -23126,7 +23248,10 @@ export class OrcaRuntimeService {
       return { ok: true }
     }
 
-    const existing = this.fetchInflight.get(key)
+    const timeout = gitOptions.timeout ?? REMOTE_FETCH_TIMEOUT_MS
+    const deadlineAt = Date.now() + timeout
+    const inflightKey = `${key}\0${timeout}`
+    const existing = this.fetchInflight.get(inflightKey)
     if (existing) {
       return existing
     }
@@ -23134,6 +23259,10 @@ export class OrcaRuntimeService {
     const promise = this.enqueueRemoteFetch(remoteKey, async () => {
       if (this.getFreshFetchCompletedAt(key) !== null) {
         return { ok: true }
+      }
+      const remaining = deadlineAt - Date.now()
+      if (remaining <= 0) {
+        return { ok: false, errorKind: 'git_error' }
       }
       // Why: this exact refresh gates worktree create; ordinary fetches still own maintenance.
       return gitExecFileAsync(
@@ -23150,7 +23279,7 @@ export class OrcaRuntimeService {
           // Why: exact remote-base refresh is the network gate for worktree
           // creation, so honor repo SSH routing and bound custom wrappers.
           useConfiguredSshCommandForNetwork: true,
-          timeout: REMOTE_FETCH_TIMEOUT_MS
+          timeout: remaining
         }
       )
         .then((): RemoteFetchResult => {
@@ -23165,17 +23294,17 @@ export class OrcaRuntimeService {
           return { ok: false, errorKind: 'git_error' }
         })
     }).finally(() => {
-      this.fetchInflight.delete(key)
+      this.fetchInflight.delete(inflightKey)
     })
 
-    this.fetchInflight.set(key, promise)
+    this.fetchInflight.set(inflightKey, promise)
     return promise
   }
 
   async fetchRemoteWithCache(
     repoPath: string,
     remote: string,
-    gitOptions: { wslDistro?: string } = {}
+    gitOptions: { wslDistro?: string; timeout?: number } = {}
   ): Promise<void> {
     await this.getOrStartRemoteFetch(repoPath, remote, gitOptions)
   }
@@ -23221,7 +23350,7 @@ export class OrcaRuntimeService {
   async hasRemoteTrackingRef(
     repoPath: string,
     base: RemoteTrackingBase,
-    gitOptions: { wslDistro?: string } = {}
+    gitOptions: { wslDistro?: string; timeout?: number } = {}
   ): Promise<boolean> {
     try {
       await gitExecFileAsync(['rev-parse', '--verify', `${base.ref}^{commit}`], {

--- a/src/main/runtime/rpc/methods/client-settings-update-schema.ts
+++ b/src/main/runtime/rpc/methods/client-settings-update-schema.ts
@@ -1,0 +1,82 @@
+import { z } from 'zod'
+import {
+  normalizeTuiAgentArgsRecord,
+  normalizeTuiAgentEnvRecord
+} from '../../../../shared/tui-agent-launch-defaults'
+import { isTuiAgent } from '../../../../shared/tui-agent-config'
+import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
+import { normalizePRBotAuthorOverrides } from '../../../../shared/pr-bot-author-overrides'
+import { normalizeWorktreeCreateTimeoutOverrides } from '../../../../shared/worktree-create-timeouts'
+import { isTaskProvider } from '../../../../shared/task-providers'
+import type { TaskProvider } from '../../../../shared/types'
+
+const TaskProviderParam = z.custom<TaskProvider>(isTaskProvider, {
+  message: 'Unknown task provider'
+})
+const GitHubProjectRef = z
+  .object({
+    owner: z.string(),
+    ownerType: z.enum(['organization', 'user']),
+    number: z.number().int(),
+    host: z.string().optional()
+  })
+  .strict()
+const GitHubProjectSettings = z
+  .object({
+    pinned: z.array(GitHubProjectRef),
+    recent: z.array(
+      GitHubProjectRef.extend({
+        lastOpenedAt: z.string()
+      }).strict()
+    ),
+    lastViewByProject: z.record(z.string(), z.object({ viewId: z.string() }).strict()),
+    activeProject: GitHubProjectRef.nullable()
+  })
+  .strict()
+
+export const SettingsUpdate = z
+  .object({
+    defaultTuiAgent: z
+      .unknown()
+      .transform((value) =>
+        value === null || value === 'blank' || isTuiAgent(value) ? value : undefined
+      )
+      .optional(),
+    disabledTuiAgents: z
+      .unknown()
+      .transform((value) => normalizeDisabledTuiAgents(value))
+      .optional(),
+    agentDefaultArgs: z
+      .unknown()
+      .transform((value) => normalizeTuiAgentArgsRecord(value))
+      .optional(),
+    agentDefaultEnv: z
+      .unknown()
+      .transform((value) => normalizeTuiAgentEnvRecord(value))
+      .optional(),
+    defaultTaskSource: TaskProviderParam.optional(),
+    visibleTaskProviders: z.array(TaskProviderParam).optional(),
+    defaultTaskViewPreset: z
+      .enum(['issues', 'my-issues', 'prs', 'my-prs', 'review', 'all'])
+      .optional(),
+    experimentalNewWorktreeCardStyle: z.boolean().optional(),
+    agentStatusHooksEnabled: z.boolean().optional(),
+    defaultRepoSelection: z.array(z.string()).nullable().optional(),
+    defaultLinearTeamSelection: z.array(z.string()).nullable().optional(),
+    compactWorktreeCards: z.boolean().optional(),
+    worktreeCreateTimeouts: z
+      .unknown()
+      .transform((value) =>
+        value === undefined ? undefined : normalizeWorktreeCreateTimeoutOverrides(value)
+      )
+      .optional(),
+    minimaxGroupId: z.string().optional(),
+    minimaxUsageModels: z.string().optional(),
+    githubProjects: GitHubProjectSettings.optional(),
+    prBotAuthorOverrides: z
+      .unknown()
+      .transform((value) => normalizePRBotAuthorOverrides(value))
+      .optional()
+  })
+  .strict()
+  .default({})

--- a/src/main/runtime/rpc/methods/client-ui-schemas.ts
+++ b/src/main/runtime/rpc/methods/client-ui-schemas.ts
@@ -4,29 +4,18 @@ import {
   type FeatureInteractionId
 } from '../../../../shared/feature-interactions'
 import { isFeatureTipId } from '../../../../shared/feature-tips'
-import {
-  normalizeTuiAgentArgsRecord,
-  normalizeTuiAgentEnvRecord
-} from '../../../../shared/tui-agent-launch-defaults'
-import { isTuiAgent } from '../../../../shared/tui-agent-config'
-import { isTaskProvider } from '../../../../shared/task-providers'
 import { isReleaseChannel, type ReleaseChannel } from '../../../../shared/release-channel'
-import { normalizeDisabledTuiAgents } from '../../../../shared/tui-agent-selection'
-import { normalizePRBotAuthorOverrides } from '../../../../shared/pr-bot-author-overrides'
 import {
   normalizeWorktreeCardProperties,
   WORKTREE_CARD_PROPERTIES
 } from '../../../../shared/worktree-card-properties'
 import { isPluginPanelTabKey } from '../../../../shared/plugins/plugin-manifest'
-import type { TaskProvider } from '../../../../shared/types'
+export { SettingsUpdate } from './client-settings-update-schema'
 import { TaskResumeState } from './task-resume-state-schema'
 import { omitUndefinedValues, tolerateUnknownValues } from './ui-update-value-tolerance'
 
 const NullableString = z.string().nullable()
 const StringArray = z.array(z.string())
-const TaskProviderParam = z.custom<TaskProvider>(isTaskProvider, {
-  message: 'Unknown task provider'
-})
 const FeatureTipIds = z.array(z.custom(isFeatureTipId, { message: 'Unknown feature tip id' }))
 const UnknownRecord = z.record(z.string(), z.unknown())
 const UnknownRecordArray = z.array(UnknownRecord)
@@ -114,68 +103,6 @@ export const FeatureInteractionIdParam = z.custom<FeatureInteractionId>(isFeatur
 export const PRBotAuthorOverrideUpdate = z
   .object({ author: z.string(), isBot: z.boolean() })
   .strict()
-const GitHubProjectRef = z
-  .object({
-    owner: z.string(),
-    ownerType: z.enum(['organization', 'user']),
-    number: z.number().int(),
-    host: z.string().optional()
-  })
-  .strict()
-const GitHubProjectSettings = z
-  .object({
-    pinned: z.array(GitHubProjectRef),
-    recent: z.array(
-      GitHubProjectRef.extend({
-        lastOpenedAt: z.string()
-      }).strict()
-    ),
-    lastViewByProject: z.record(z.string(), z.object({ viewId: z.string() }).strict()),
-    activeProject: GitHubProjectRef.nullable()
-  })
-  .strict()
-
-export const SettingsUpdate = z
-  .object({
-    defaultTuiAgent: z
-      .unknown()
-      .transform((value) =>
-        value === null || value === 'blank' || isTuiAgent(value) ? value : undefined
-      )
-      .optional(),
-    disabledTuiAgents: z
-      .unknown()
-      .transform((value) => normalizeDisabledTuiAgents(value))
-      .optional(),
-    agentDefaultArgs: z
-      .unknown()
-      .transform((value) => normalizeTuiAgentArgsRecord(value))
-      .optional(),
-    agentDefaultEnv: z
-      .unknown()
-      .transform((value) => normalizeTuiAgentEnvRecord(value))
-      .optional(),
-    defaultTaskSource: TaskProviderParam.optional(),
-    visibleTaskProviders: z.array(TaskProviderParam).optional(),
-    defaultTaskViewPreset: z
-      .enum(['issues', 'my-issues', 'prs', 'my-prs', 'review', 'all'])
-      .optional(),
-    experimentalNewWorktreeCardStyle: z.boolean().optional(),
-    agentStatusHooksEnabled: z.boolean().optional(),
-    defaultRepoSelection: z.array(z.string()).nullable().optional(),
-    defaultLinearTeamSelection: z.array(z.string()).nullable().optional(),
-    compactWorktreeCards: z.boolean().optional(),
-    minimaxGroupId: z.string().optional(),
-    minimaxUsageModels: z.string().optional(),
-    githubProjects: GitHubProjectSettings.optional(),
-    prBotAuthorOverrides: z
-      .unknown()
-      .transform((value) => normalizePRBotAuthorOverrides(value))
-      .optional()
-  })
-  .strict()
-  .default({})
-
 const TopLevelViewSchema = z.enum([
   'terminal',
   'settings',

--- a/src/main/runtime/rpc/methods/client-ui.test.ts
+++ b/src/main/runtime/rpc/methods/client-ui.test.ts
@@ -30,6 +30,12 @@ describe('client UI RPC methods', () => {
       defaultRepoSelection: ['repo-1'],
       defaultLinearTeamSelection: ['team-1'],
       compactWorktreeCards: true,
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 60_000,
+        addCheckoutMs: 180_000,
+        registrationMs: 30_000,
+        materializationMs: 300_000
+      },
       minimaxGroupId: 'group-42',
       minimaxUsageModels: 'general,abab6.5',
       githubProjects: {
@@ -70,6 +76,12 @@ describe('client UI RPC methods', () => {
       defaultLinearTeamSelection: ['team-1', 'team-2'],
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 60_000,
+        addCheckoutMs: 180_000,
+        registrationMs: 30_000,
+        materializationMs: 300_000
+      },
       githubProjects: {
         pinned: [],
         recent: [],
@@ -99,6 +111,10 @@ describe('client UI RPC methods', () => {
         defaultTaskViewPreset: 'my-prs',
         experimentalNewWorktreeCardStyle: true,
         compactWorktreeCards: true,
+        worktreeCreateTimeouts: {
+          refreshBaseRefMs: 500,
+          addCheckoutMs: 8_000_000
+        },
         minimaxGroupId: 'group-42',
         minimaxUsageModels: 'general,abab6.5',
         defaultRepoSelection: settings.defaultRepoSelection,
@@ -115,6 +131,10 @@ describe('client UI RPC methods', () => {
       defaultTaskViewPreset: 'my-prs',
       experimentalNewWorktreeCardStyle: true,
       compactWorktreeCards: true,
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 1_000,
+        addCheckoutMs: 7_200_000
+      },
       minimaxGroupId: 'group-42',
       minimaxUsageModels: 'general,abab6.5',
       defaultRepoSelection: settings.defaultRepoSelection,

--- a/src/main/runtime/rpc/methods/repo-update-schema.ts
+++ b/src/main/runtime/rpc/methods/repo-update-schema.ts
@@ -3,6 +3,7 @@ import { OptionalFiniteNumber, OptionalString } from '../schemas'
 import { sanitizeRepoIcon } from '../../../../shared/repo-icon'
 import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
 import { normalizeRepoSourceControlAiOverrides } from '../../../../shared/source-control-ai'
+import { normalizeWorktreeCreateTimeoutOverrides } from '../../../../shared/worktree-create-timeouts'
 
 export const RepoSourceControlAiOverrides = z
   .unknown()
@@ -30,6 +31,17 @@ const RepoUpstream = z
   .nullable()
   .optional()
 
+const WorktreeCreateTimeoutOverrides = z
+  .unknown()
+  .optional()
+  .transform((value) =>
+    value === undefined
+      ? undefined
+      : value === null
+        ? null
+        : normalizeWorktreeCreateTimeoutOverrides(value)
+  )
+
 export function createRepoUpdateSchema<T extends z.ZodRawShape>(
   selectorShape: T
 ): z.ZodObject<T & { updates: z.ZodObject<z.ZodRawShape> }> {
@@ -46,6 +58,7 @@ export function createRepoUpdateSchema<T extends z.ZodRawShape>(
       hookSettings: z.unknown().optional(),
       worktreeBaseRef: OptionalString,
       worktreeBasePath: OptionalString,
+      worktreeCreateTimeouts: WorktreeCreateTimeoutOverrides,
       kind: z.enum(['git', 'folder']).optional(),
       symlinkPaths: z.array(z.string()).optional(),
       issueSourcePreference: z.enum(['auto', 'upstream', 'origin']).optional(),

--- a/src/main/runtime/rpc/methods/repo.test.ts
+++ b/src/main/runtime/rpc/methods/repo.test.ts
@@ -303,6 +303,47 @@ describe('repo RPC methods', () => {
     })
   })
 
+  it('normalizes worktree create timeout overrides and preserves clear requests', async () => {
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      updateRepo: vi.fn().mockResolvedValue({
+        id: 'repo-1',
+        path: '/srv/repo',
+        worktreeCreateTimeouts: { addCheckoutMs: 7_200_000 }
+      })
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: REPO_METHODS })
+
+    await dispatcher.dispatch(
+      makeRequest('repo.update', {
+        repo: 'repo-1',
+        updates: {
+          worktreeCreateTimeouts: {
+            refreshBaseRefMs: 500,
+            addCheckoutMs: 8_000_000,
+            registrationMs: -1
+          }
+        }
+      })
+    )
+    await dispatcher.dispatch(
+      makeRequest('repo.update', {
+        repo: 'repo-1',
+        updates: { worktreeCreateTimeouts: null }
+      })
+    )
+
+    expect(runtime.updateRepo).toHaveBeenNthCalledWith(1, 'repo-1', {
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 1_000,
+        addCheckoutMs: 7_200_000
+      }
+    })
+    expect(runtime.updateRepo).toHaveBeenNthCalledWith(2, 'repo-1', {
+      worktreeCreateTimeouts: null
+    })
+  })
+
   it('persists resolved GitHub upstream metadata updates', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',

--- a/src/main/runtime/rpc/methods/worktree-schemas.ts
+++ b/src/main/runtime/rpc/methods/worktree-schemas.ts
@@ -14,6 +14,7 @@ import {
 import { TaskSourceContextSchema } from '../../../../shared/task-source-context-schema'
 import { WorkspaceLinkedItemSchema } from '../../../../shared/workspace-linked-item-schema'
 import { isWorkspaceLinkedItemSourceContextMatch } from '../../../../shared/workspace-linked-item-source-context'
+import { normalizeWorktreeCreateTimeoutOverrides } from '../../../../shared/worktree-create-timeouts'
 
 const OptionalTuiAgent = z
   .unknown()
@@ -38,6 +39,11 @@ const AutomationWorkspaceProvenanceRequest = z.object({
 const CliWorkspaceProvenanceRequest = z.object({
   callerTerminalHandle: OptionalString
 })
+
+const WorktreeCreateTimeoutOverrides = z
+  .unknown()
+  .optional()
+  .transform((value) => normalizeWorktreeCreateTimeoutOverrides(value))
 
 export const WorktreeListParams = z.object({
   repo: OptionalString,
@@ -104,6 +110,7 @@ export const WorktreeCreate = z
       .transform((v) => (typeof v === 'string' ? v : ''))
       .pipe(z.string().min(1, 'Missing repo selector')),
     name: OptionalString,
+    timeouts: WorktreeCreateTimeoutOverrides,
     baseBranch: OptionalString,
     compareBaseRef: OptionalString,
     branchNameOverride: OptionalString,

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -176,9 +176,8 @@ describe('worktree RPC methods', () => {
       }),
       { signal }
     )
-    expect(runtime.createManagedWorktree).toHaveBeenLastCalledWith(
-      expect.not.objectContaining({ signal: expect.anything() })
-    )
+    const lastCreateOptions = vi.mocked(runtime.createManagedWorktree).mock.lastCall?.[0]
+    expect(lastCreateOptions).not.toHaveProperty('signal')
   })
 
   it('mints automation provenance from a valid dispatch request on worktree creation', async () => {

--- a/src/main/runtime/rpc/methods/worktree.test.ts
+++ b/src/main/runtime/rpc/methods/worktree.test.ts
@@ -105,6 +105,7 @@ describe('worktree RPC methods', () => {
       createManagedWorktree: vi.fn().mockResolvedValue({ worktree: { id: 'wt-1' } })
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: WORKTREE_METHODS })
+    const signal = new AbortController().signal
 
     await dispatcher.dispatch(
       makeRequest('worktree.create', {
@@ -125,12 +126,14 @@ describe('worktree RPC methods', () => {
         sparseCheckout: { directories: ['src'], presetId: 'preset-1' },
         pushTarget: { remoteName: 'fork', branchName: 'feature' },
         parentWorktree: 'id:parent'
-      })
+      }),
+      { signal }
     )
 
     expect(runtime.createManagedWorktree).toHaveBeenCalledWith({
       repoSelector: 'repo-1',
       name: 'feature',
+      signal,
       branchNameOverride: 'feature/something',
       baseBranch: 'origin/main',
       linkedIssue: 123,
@@ -164,6 +167,18 @@ describe('worktree RPC methods', () => {
         orchestrationContext: undefined
       }
     })
+
+    await dispatcher.dispatch(
+      makeRequest('worktree.create', {
+        repo: 'repo-1',
+        name: 'mobile-create',
+        clientMutationId: 'mutation-1'
+      }),
+      { signal }
+    )
+    expect(runtime.createManagedWorktree).toHaveBeenLastCalledWith(
+      expect.not.objectContaining({ signal: expect.anything() })
+    )
   })
 
   it('mints automation provenance from a valid dispatch request on worktree creation', async () => {

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -96,7 +96,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
   defineMethod({
     name: 'worktree.create',
     params: WorktreeCreate,
-    handler: async (params, { runtime }) =>
+    handler: async (params, { runtime, signal }) =>
       // Why: a mobile create interrupted by a connection migration is retried with
       // the same clientMutationId; dedupe so the host returns the in-flight/created
       // worktree instead of spawning a duplicate. No key (desktop/CLI) runs plainly.
@@ -114,6 +114,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
           const result = await runtime.createManagedWorktree({
             repoSelector: params.repo,
             name: params.name ?? '',
+            ...(!params.clientMutationId && signal ? { signal } : {}),
             timeouts: params.timeouts,
             baseBranch: params.baseBranch,
             compareBaseRef: params.compareBaseRef,

--- a/src/main/runtime/rpc/methods/worktree.ts
+++ b/src/main/runtime/rpc/methods/worktree.ts
@@ -114,6 +114,7 @@ export const WORKTREE_METHODS: RpcMethod[] = [
           const result = await runtime.createManagedWorktree({
             repoSelector: params.repo,
             name: params.name ?? '',
+            timeouts: params.timeouts,
             baseBranch: params.baseBranch,
             compareBaseRef: params.compareBaseRef,
             branchNameOverride: params.branchNameOverride,

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -5463,6 +5463,56 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('aborts an unkeyed worktree.create when its Unix socket disconnects', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      let createSignal: AbortSignal | undefined
+      vi.spyOn(runtime, 'dedupeWorktreeCreate').mockImplementation(
+        async (_repoSelector, _clientMutationId, create) => create()
+      )
+      vi.spyOn(runtime, 'showRepo').mockResolvedValue({
+        id: 'repo-1',
+        path: '/tmp/repo',
+        displayName: 'Repo',
+        badgeColor: '#000000',
+        addedAt: 1
+      })
+      vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(
+        (args) =>
+          new Promise((_resolve, reject) => {
+            createSignal = args.signal
+            args.signal?.addEventListener(
+              'abort',
+              () => reject(Object.assign(new Error('cancelled'), { name: 'AbortError' })),
+              { once: true }
+            )
+          })
+      )
+      const server = new OrcaRuntimeRpcServer({ runtime, userDataPath })
+      await server.start()
+
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const session = openFramedSession(metadata!.transports[0]!.endpoint, {
+          id: 'req_create_abort',
+          authToken: metadata!.authToken,
+          method: 'worktree.create',
+          params: { repo: 'repo-1', name: 'feature' }
+        })
+        await waitFor(() => createSignal !== undefined)
+        expect(server['activeLongPolls']).toBe(0)
+
+        session.socket.destroy()
+        await session.done
+        await waitFor(() => createSignal?.aborted === true)
+
+        expect(createSignal?.aborted).toBe(true)
+        expect(server['activeLongPolls']).toBe(0)
+      } finally {
+        await server.stop()
+      }
+    })
+
     it('does not emit keepalive frames for short RPCs', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -5421,6 +5421,48 @@ describe('OrcaRuntimeRpcServer', () => {
       }
     })
 
+    it('emits keepalive frames while worktree.create blocks without taking a long-poll slot', async () => {
+      const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
+      const runtime = new OrcaRuntimeService()
+      vi.spyOn(runtime, 'dedupeWorktreeCreate').mockImplementation(
+        async (_repoSelector, _clientMutationId, create) => create()
+      )
+      vi.spyOn(runtime, 'showRepo').mockResolvedValue({
+        id: 'repo-1',
+        path: '/tmp/repo',
+        displayName: 'Repo',
+        badgeColor: '#000000',
+        addedAt: 1
+      })
+      vi.spyOn(runtime, 'createManagedWorktree').mockImplementation(
+        () => new Promise((resolve) => setTimeout(() => resolve({} as never), 180))
+      )
+      const server = new OrcaRuntimeRpcServer({
+        runtime,
+        userDataPath,
+        keepaliveIntervalMs: 30
+      })
+      await server.start()
+
+      try {
+        const metadata = readRuntimeMetadata(userDataPath)
+        const session = openFramedSession(metadata!.transports[0]!.endpoint, {
+          id: 'req_create',
+          authToken: metadata!.authToken,
+          method: 'worktree.create',
+          params: { repo: 'repo-1', name: 'feature' }
+        })
+        await waitFor(() => session.frames.some((frame) => frame._keepalive === true))
+        expect(server['activeLongPolls']).toBe(0)
+        await session.done
+        expect(session.frames.filter((frame) => frame._keepalive === true).length).toBeGreaterThan(
+          0
+        )
+      } finally {
+        await server.stop()
+      }
+    })
+
     it('does not emit keepalive frames for short RPCs', async () => {
       const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-rpc-'))
       const runtime = new OrcaRuntimeService()

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -461,6 +461,10 @@ function longPollClassOf(request: RpcRequest): LongPollClass | null {
   return null
 }
 
+function requestNeedsKeepalive(request: RpcRequest, longPoll: LongPollClass | null): boolean {
+  return longPoll !== null || request.method === 'worktree.create'
+}
+
 // Why: status.get has no per-connection context in the dispatcher, so stamp the scope here at the transport boundary.
 function injectDeviceScope(response: string, scope: DeviceScope): string {
   try {
@@ -1534,8 +1538,9 @@ export class OrcaRuntimeRpcServer {
     if (rejection) {
       return this.buildError(request.id, 'runtime_busy', rejection)
     }
-    if (longPoll) {
-      // Why: arm keepalive only for long-polls; short RPCs never create the setInterval. See §3.1.
+    if (requestNeedsKeepalive(request, longPoll)) {
+      // Why: creates can legitimately run for minutes, but unlike waiters they
+      // do not consume long-poll admission capacity.
       context?.startKeepalive()
     }
 

--- a/src/main/runtime/runtime-rpc.ts
+++ b/src/main/runtime/runtime-rpc.ts
@@ -1546,7 +1546,7 @@ export class OrcaRuntimeRpcServer {
 
     try {
       return await this.dispatcher.dispatch(request, {
-        signal: longPoll ? context?.signal : undefined
+        signal: longPoll || request.method === 'worktree.create' ? context?.signal : undefined
       })
     } finally {
       this.releaseLongPoll(longPoll)

--- a/src/main/worktree-create-stage-timeouts.ts
+++ b/src/main/worktree-create-stage-timeouts.ts
@@ -1,0 +1,38 @@
+import type { GlobalSettings, Repo } from '../shared/types'
+import type {
+  WorktreeCreateTimeoutOverrides,
+  WorktreeCreateTimeouts
+} from '../shared/worktree-create-timeouts'
+import { resolveWorktreeCreateTimeouts } from '../shared/worktree-create-timeouts'
+
+export type WorktreeCreateStageDeadline = {
+  remainingMs: () => number
+}
+
+export function createWorktreeCreateStageDeadline(
+  timeoutMs: number,
+  timeoutMessage: string
+): WorktreeCreateStageDeadline {
+  const deadlineAt = Date.now() + timeoutMs
+  return {
+    remainingMs: () => {
+      const remaining = deadlineAt - Date.now()
+      if (remaining <= 0) {
+        throw new Error(timeoutMessage)
+      }
+      return remaining
+    }
+  }
+}
+
+export function getEffectiveWorktreeCreateTimeouts(
+  repo: Pick<Repo, 'worktreeCreateTimeouts'>,
+  settings: Pick<GlobalSettings, 'worktreeCreateTimeouts'>,
+  request?: WorktreeCreateTimeoutOverrides
+): WorktreeCreateTimeouts {
+  return resolveWorktreeCreateTimeouts({
+    global: settings.worktreeCreateTimeouts,
+    repo: repo.worktreeCreateTimeouts,
+    request
+  })
+}

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1273,6 +1273,7 @@ export type PreloadApi = {
         >
       > & {
         sourceControlAi?: Repo['sourceControlAi'] | null
+        worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
         externalWorktreeDiscoverySuppressedAt?: Repo['externalWorktreeDiscoverySuppressedAt'] | null
       }
     }) => Promise<Repo>

--- a/src/relay/git-handler-local-base-ref-refresh.test.ts
+++ b/src/relay/git-handler-local-base-ref-refresh.test.ts
@@ -43,7 +43,7 @@ describe('refreshLocalBaseRefForWorktreeCreateOp timeout', () => {
     ])
   })
 
-  it('fails when a completed subprocess has exhausted the refresh stage', async () => {
+  it('keeps a completed subprocess result and fails before the next command', async () => {
     let now = 1_000
     const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
     const git = vi.fn<GitExec>().mockImplementationOnce(async () => {
@@ -71,4 +71,33 @@ describe('refreshLocalBaseRefForWorktreeCreateOp timeout', () => {
       refreshLocalBaseRefForWorktreeCreateOp(git, params, new GitCapabilityCache())
     ).rejects.toThrow('Worktree base ref refresh timed out.')
   })
+
+  it('preserves timeout-shaped Git errors when no refresh deadline was requested', async () => {
+    const error = Object.assign(new Error('proxy timed out.'), { code: 'ETIMEDOUT' })
+    const git = vi.fn<GitExec>().mockRejectedValue(error)
+
+    await expect(
+      refreshLocalBaseRefForWorktreeCreateOp(
+        git,
+        { ...params, timeoutMs: undefined },
+        new GitCapabilityCache()
+      )
+    ).rejects.toBe(error)
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, 7_200_001])(
+    'rejects an invalid local base ref refresh timeout: %s',
+    async (timeoutMs) => {
+      const git = vi.fn<GitExec>()
+
+      await expect(
+        refreshLocalBaseRefForWorktreeCreateOp(
+          git,
+          { ...params, timeoutMs },
+          new GitCapabilityCache()
+        )
+      ).rejects.toThrow('Invalid local base ref refresh timeout.')
+      expect(git).not.toHaveBeenCalled()
+    }
+  )
 })

--- a/src/relay/git-handler-local-base-ref-refresh.test.ts
+++ b/src/relay/git-handler-local-base-ref-refresh.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it, vi } from 'vitest'
+import { GitCapabilityCache } from '../shared/git-capability-cache'
+import type { GitExec } from './git-handler-ops'
+import { refreshLocalBaseRefForWorktreeCreateOp } from './git-handler-local-base-ref-refresh'
+
+const params = {
+  repoPath: '/repo',
+  fullRef: 'refs/heads/main',
+  remoteTrackingRef: 'refs/remotes/origin/main',
+  timeoutMs: 10_000
+}
+
+function commandResult(stdout = ''): { stdout: string; stderr: string } {
+  return { stdout, stderr: '' }
+}
+
+describe('refreshLocalBaseRefForWorktreeCreateOp timeout', () => {
+  it('passes each subprocess the remaining refresh stage time', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const git = vi.fn<GitExec>(async (args) => {
+      now += 1_000
+      if (args[0] === 'rev-parse' && args[2] === 'refs/heads/main^{commit}') {
+        return commandResult('local-oid\n')
+      }
+      if (args[0] === 'rev-parse') {
+        return commandResult('remote-oid\n')
+      }
+      if (args[0] === 'worktree') {
+        return commandResult('worktree /repo\nHEAD local-oid\nbranch refs/heads/develop\n')
+      }
+      return commandResult()
+    })
+
+    try {
+      await refreshLocalBaseRefForWorktreeCreateOp(git, params, new GitCapabilityCache())
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(git.mock.calls.map(([, , options]) => options?.timeout)).toEqual([
+      10_000, 9_000, 8_000, 7_000, 6_000, 5_000, 4_000
+    ])
+  })
+
+  it('fails when a completed subprocess has exhausted the refresh stage', async () => {
+    let now = 1_000
+    const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => now)
+    const git = vi.fn<GitExec>().mockImplementationOnce(async () => {
+      now = 11_000
+      return commandResult()
+    })
+
+    try {
+      await expect(
+        refreshLocalBaseRefForWorktreeCreateOp(git, params, new GitCapabilityCache())
+      ).rejects.toThrow('Worktree base ref refresh timed out.')
+    } finally {
+      nowSpy.mockRestore()
+    }
+
+    expect(git).toHaveBeenCalledTimes(1)
+  })
+
+  it('preserves an explicit timeout when the current subprocess times out', async () => {
+    const git = vi
+      .fn<GitExec>()
+      .mockRejectedValue(Object.assign(new Error('git timed out.'), { code: 'ETIMEDOUT' }))
+
+    await expect(
+      refreshLocalBaseRefForWorktreeCreateOp(git, params, new GitCapabilityCache())
+    ).rejects.toThrow('Worktree base ref refresh timed out.')
+  })
+})

--- a/src/relay/git-handler-local-base-ref-refresh.ts
+++ b/src/relay/git-handler-local-base-ref-refresh.ts
@@ -2,6 +2,30 @@ import type { GitExec } from './git-handler-ops'
 import { areRelayWorktreePathsEqual, readRelayWorktreeList } from './git-handler-worktree-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
 
+class RelayWorktreeCreateRefreshTimeoutError extends Error {
+  constructor() {
+    super('Worktree base ref refresh timed out.')
+    this.name = 'RelayWorktreeCreateRefreshTimeoutError'
+  }
+}
+
+function getErrorText(error: unknown): string {
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return String((error as { message?: unknown }).message ?? '')
+  }
+  return String(error)
+}
+
+function isGitCommandTimeout(error: unknown): boolean {
+  return (
+    (typeof error === 'object' &&
+      error !== null &&
+      'code' in error &&
+      String((error as { code?: unknown }).code) === 'ETIMEDOUT') ||
+    /\btimed out\b/i.test(getErrorText(error))
+  )
+}
+
 export async function refreshLocalBaseRefForWorktreeCreateOp(
   git: GitExec,
   params: Record<string, unknown>,
@@ -12,6 +36,41 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
   const remoteTrackingRef = params.remoteTrackingRef as string
   const ownerWorktreePath = params.ownerWorktreePath as string | undefined
   const checkOnly = params.checkOnly === true
+  const timeout =
+    typeof params.timeoutMs === 'number' &&
+    Number.isFinite(params.timeoutMs) &&
+    params.timeoutMs > 0
+      ? params.timeoutMs
+      : undefined
+  const deadlineAt = timeout === undefined ? undefined : Date.now() + timeout
+  const execute: GitExec = async (args, cwd, options) => {
+    const remaining = deadlineAt === undefined ? undefined : deadlineAt - Date.now()
+    if (remaining !== undefined && remaining <= 0) {
+      throw new RelayWorktreeCreateRefreshTimeoutError()
+    }
+    try {
+      if (remaining === undefined && options === undefined) {
+        return await git(args, cwd)
+      }
+      const result = await git(args, cwd, {
+        ...options,
+        ...(remaining === undefined ? {} : { timeout: remaining })
+      })
+      if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
+        throw new RelayWorktreeCreateRefreshTimeoutError()
+      }
+      return result
+    } catch (error) {
+      if (
+        error instanceof RelayWorktreeCreateRefreshTimeoutError ||
+        isGitCommandTimeout(error) ||
+        (deadlineAt !== undefined && Date.now() >= deadlineAt)
+      ) {
+        throw new RelayWorktreeCreateRefreshTimeoutError()
+      }
+      throw error
+    }
+  }
 
   if (
     typeof repoPath !== 'string' ||
@@ -25,12 +84,12 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
     throw new Error('Invalid local base ref refresh refs.')
   }
 
-  await git(['check-ref-format', fullRef], repoPath)
-  await git(['check-ref-format', remoteTrackingRef], repoPath)
+  await execute(['check-ref-format', fullRef], repoPath)
+  await execute(['check-ref-format', remoteTrackingRef], repoPath)
 
-  const localOid = await revParseCommit(git, repoPath, fullRef, 'Local base ref is missing.')
+  const localOid = await revParseCommit(execute, repoPath, fullRef, 'Local base ref is missing.')
   const remoteOid = await revParseCommit(
-    git,
+    execute,
     repoPath,
     remoteTrackingRef,
     'Remote-tracking base ref is missing.'
@@ -39,18 +98,21 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
   // Why: this RPC mutates refs/worktrees, so the relay repeats main-process
   // safety checks at mutation time to close stale-preflight and direct-call gaps.
   try {
-    await git(['merge-base', '--is-ancestor', localOid, remoteOid], repoPath)
-  } catch {
+    await execute(['merge-base', '--is-ancestor', localOid, remoteOid], repoPath)
+  } catch (error) {
+    if (error instanceof RelayWorktreeCreateRefreshTimeoutError) {
+      throw error
+    }
     throw new Error('Local base ref is not a fast-forward update.')
   }
 
-  const worktrees = await readRelayWorktreeList(git, repoPath, capabilities)
+  const worktrees = await readRelayWorktreeList(execute, repoPath, capabilities)
   const ownerWorktree = worktrees.find((worktree) => worktree.branch === fullRef)
   if (ownerWorktree) {
     if (ownerWorktreePath && !areRelayWorktreePathsEqual(ownerWorktree.path, ownerWorktreePath)) {
       throw new Error('Local base ref is checked out in a different worktree.')
     }
-    const { stdout } = await git(
+    const { stdout } = await execute(
       ['status', '--porcelain', '--untracked-files=no'],
       ownerWorktree.path
     )
@@ -60,7 +122,7 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
     if (checkOnly) {
       return
     }
-    await git(['reset', '--hard', remoteOid], ownerWorktree.path)
+    await execute(['reset', '--hard', remoteOid], ownerWorktree.path)
     return
   }
 
@@ -70,7 +132,7 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
   if (checkOnly) {
     return
   }
-  await git(['update-ref', fullRef, remoteOid, localOid], repoPath)
+  await execute(['update-ref', fullRef, remoteOid, localOid], repoPath)
 }
 
 async function revParseCommit(

--- a/src/relay/git-handler-local-base-ref-refresh.ts
+++ b/src/relay/git-handler-local-base-ref-refresh.ts
@@ -1,6 +1,7 @@
 import type { GitExec } from './git-handler-ops'
 import { areRelayWorktreePathsEqual, readRelayWorktreeList } from './git-handler-worktree-ops'
 import type { GitCapabilityCache } from '../shared/git-capability-cache'
+import { WORKTREE_CREATE_TIMEOUT_MAX_MS } from '../shared/worktree-create-timeouts'
 
 class RelayWorktreeCreateRefreshTimeoutError extends Error {
   constructor() {
@@ -36,12 +37,17 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
   const remoteTrackingRef = params.remoteTrackingRef as string
   const ownerWorktreePath = params.ownerWorktreePath as string | undefined
   const checkOnly = params.checkOnly === true
-  const timeout =
-    typeof params.timeoutMs === 'number' &&
-    Number.isFinite(params.timeoutMs) &&
-    params.timeoutMs > 0
-      ? params.timeoutMs
-      : undefined
+  const timeoutValue = params.timeoutMs
+  if (
+    timeoutValue !== undefined &&
+    (typeof timeoutValue !== 'number' ||
+      !Number.isFinite(timeoutValue) ||
+      timeoutValue <= 0 ||
+      timeoutValue > WORKTREE_CREATE_TIMEOUT_MAX_MS)
+  ) {
+    throw new Error('Invalid local base ref refresh timeout.')
+  }
+  const timeout = timeoutValue as number | undefined
   const deadlineAt = timeout === undefined ? undefined : Date.now() + timeout
   const execute: GitExec = async (args, cwd, options) => {
     const remaining = deadlineAt === undefined ? undefined : deadlineAt - Date.now()
@@ -52,19 +58,14 @@ export async function refreshLocalBaseRefForWorktreeCreateOp(
       if (remaining === undefined && options === undefined) {
         return await git(args, cwd)
       }
-      const result = await git(args, cwd, {
+      return await git(args, cwd, {
         ...options,
         ...(remaining === undefined ? {} : { timeout: remaining })
       })
-      if (deadlineAt !== undefined && Date.now() >= deadlineAt) {
-        throw new RelayWorktreeCreateRefreshTimeoutError()
-      }
-      return result
     } catch (error) {
       if (
         error instanceof RelayWorktreeCreateRefreshTimeoutError ||
-        isGitCommandTimeout(error) ||
-        (deadlineAt !== undefined && Date.now() >= deadlineAt)
+        (deadlineAt !== undefined && (isGitCommandTimeout(error) || Date.now() >= deadlineAt))
       ) {
         throw new RelayWorktreeCreateRefreshTimeoutError()
       }

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -111,7 +111,39 @@ describe('addWorktreeOp', () => {
     )
   })
 
-  it.each([Number.NaN, Number.POSITIVE_INFINITY, 999, 7_200_001])(
+  it('does not reuse a cancelled request signal for post-add metadata', async () => {
+    const controller = new AbortController()
+    const git = vi.fn<GitExec>(async (args, _cwd, options) => {
+      if (args[0] === 'worktree' && args[1] === 'add') {
+        controller.abort()
+        return { stdout: '', stderr: '' }
+      }
+      if (options?.signal?.aborted) {
+        throw Object.assign(new Error('cancelled'), { name: 'AbortError' })
+      }
+      return { stdout: args[1] === '--get' ? 'true\n' : '', stderr: '' }
+    })
+
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: '/repo',
+        branchName: 'feature/test',
+        targetDir: '/repo-feature',
+        base: 'origin/main',
+        timeoutMs: 420_000
+      },
+      { signal: controller.signal }
+    )
+
+    const postAddCalls = git.mock.calls.filter(([args]) => args[0] === 'config')
+    expect(postAddCalls).toHaveLength(2)
+    for (const [, , options] of postAddCalls) {
+      expect(options?.signal).toBeUndefined()
+    }
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 0, 7_200_001])(
     'rejects an invalid worktree add timeout: %s',
     async (timeoutMs) => {
       const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -2,7 +2,7 @@ import { describe, expect, it, vi } from 'vitest'
 import * as path from 'node:path'
 import { GitCapabilityCache } from '../shared/git-capability-cache'
 import type { GitExec } from './git-handler-ops'
-import { addWorktreeOp, removeWorktreeOp } from './git-handler-worktree-ops'
+import { addWorktreeOp, removeWorktreeOp, worktreeIsCleanOp } from './git-handler-worktree-ops'
 
 function removeWorktreeWithCapabilityCache(
   git: GitExec,
@@ -88,6 +88,70 @@ describe('addWorktreeOp', () => {
     ])
   })
 
+  it('applies the requested timeout to git worktree add', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+    const controller = new AbortController()
+
+    await addWorktreeOp(
+      git,
+      {
+        repoPath: '/repo',
+        branchName: 'feature/test',
+        targetDir: '/repo-feature',
+        checkoutExistingBranch: true,
+        timeoutMs: 420_000
+      },
+      { signal: controller.signal }
+    )
+
+    expect(git).toHaveBeenCalledWith(
+      ['worktree', 'add', '/repo-feature', 'feature/test'],
+      '/repo',
+      { signal: controller.signal, timeout: 420_000 }
+    )
+  })
+
+  it.each([Number.NaN, Number.POSITIVE_INFINITY, 999, 7_200_001])(
+    'rejects an invalid worktree add timeout: %s',
+    async (timeoutMs) => {
+      const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+      await expect(
+        addWorktreeOp(git, {
+          repoPath: '/repo',
+          branchName: 'feature/test',
+          targetDir: '/repo-feature',
+          checkoutExistingBranch: true,
+          timeoutMs
+        })
+      ).rejects.toThrow('Invalid worktree add timeout.')
+      expect(git).not.toHaveBeenCalled()
+    }
+  )
+
+  it('does not swallow a cancelled base-ref probe', async () => {
+    const controller = new AbortController()
+    const error = Object.assign(new Error('cancelled'), { name: 'AbortError' })
+    const git = vi.fn<GitExec>(async () => {
+      controller.abort()
+      throw error
+    })
+
+    await expect(
+      addWorktreeOp(
+        git,
+        {
+          repoPath: '/repo',
+          branchName: 'feature/test',
+          targetDir: '/repo-feature',
+          base: 'origin/main'
+        },
+        { signal: controller.signal }
+      )
+    ).rejects.toBe(error)
+    expect(git).toHaveBeenCalledTimes(1)
+  })
+
   it('does not write branch base config when SSH creation has no base', async () => {
     const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
 
@@ -132,6 +196,24 @@ describe('addWorktreeOp', () => {
       'branch.feature/test.base'
     ])
     warnSpy.mockRestore()
+  })
+})
+
+describe('worktreeIsCleanOp', () => {
+  it('applies the requested timeout to the status child process', async () => {
+    const git = vi.fn<GitExec>(async () => ({ stdout: '', stderr: '' }))
+
+    await worktreeIsCleanOp(git, {
+      worktreePath: '/repo-feature',
+      includeUntracked: false,
+      timeoutMs: 75_000
+    })
+
+    expect(git).toHaveBeenCalledWith(
+      ['status', '--porcelain', '--untracked-files=no'],
+      '/repo-feature',
+      { timeout: 75_000 }
+    )
   })
 })
 

--- a/src/relay/git-handler-worktree-ops.test.ts
+++ b/src/relay/git-handler-worktree-ops.test.ts
@@ -457,6 +457,117 @@ describe('removeWorktreeOp', () => {
     expect(git).not.toHaveBeenCalledWith(['branch', '-D', '--', 'feature/test'], expect.any(String))
   })
 
+  it('propagates a branch deletion child-process timeout', async () => {
+    const interruption = Object.assign(new Error('git timed out.'), {
+      killed: true,
+      signal: 'SIGTERM'
+    })
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'branch' && args[1] === '-d') {
+        throw interruption
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeWithCapabilityCache(git, { worktreePath: '/repo-feature' })
+    ).rejects.toBe(interruption)
+    expect(git).toHaveBeenCalledWith(['branch', '-d', '--', 'feature/test'], expect.any(String))
+  })
+
+  it('propagates branch deletion AbortSignal cancellation', async () => {
+    const controller = new AbortController()
+    const interruption = Object.assign(new Error('cancelled'), { name: 'AbortError' })
+    const git = vi.fn<GitExec>(async (args, _cwd, options) => {
+      if (args[0] === 'rev-parse') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'branch' && args[1] === '-d') {
+        expect(options?.signal).toBe(controller.signal)
+        controller.abort(interruption)
+        throw interruption
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeOp(git, { worktreePath: '/repo-feature' }, new GitCapabilityCache(), {
+        signal: controller.signal
+      })
+    ).rejects.toBe(interruption)
+    expect(git).not.toHaveBeenCalledWith(
+      ['config', '--get', 'branch.feature/test.base'],
+      expect.any(String)
+    )
+  })
+
+  it('propagates cancellation from the already-merged branch deletion fallback', async () => {
+    const controller = new AbortController()
+    const interruption = Object.assign(new Error('cancelled'), { name: 'AbortError' })
+    const git = vi.fn<GitExec>(async (args, _cwd, options) => {
+      if (args[0] === 'rev-parse' && args[1] === '--git-common-dir') {
+        return { stdout: '/repo/.git\n', stderr: '' }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list' && args.includes('-z')) {
+        return {
+          stdout: worktreeList(
+            { path: '/repo', branch: 'main' },
+            { path: '/repo-feature', branch: 'feature/test' }
+          ),
+          stderr: ''
+        }
+      }
+      if (args[0] === 'worktree' && args[1] === 'list') {
+        return { stdout: worktreeList({ path: '/repo', branch: 'main' }), stderr: '' }
+      }
+      if (args[0] === 'branch' && args[1] === '-d') {
+        throw new Error('error: the branch feature/test is not fully merged')
+      }
+      if (args[0] === 'rev-parse' && args.includes('HEAD^{commit}')) {
+        return { stdout: 'base123\n', stderr: '' }
+      }
+      if (args[0] === 'merge-tree') {
+        return { stdout: 'tree123\n', stderr: '' }
+      }
+      if (args[0] === 'rev-parse' && args.includes('base123^{tree}')) {
+        return { stdout: 'tree123\n', stderr: '' }
+      }
+      if (args[0] === 'update-ref' && args[1] === '-d') {
+        expect(options?.signal).toBe(controller.signal)
+        controller.abort(interruption)
+        throw interruption
+      }
+      return { stdout: '', stderr: '' }
+    })
+
+    await expect(
+      removeWorktreeOp(git, { worktreePath: '/repo-feature' }, new GitCapabilityCache(), {
+        signal: controller.signal
+      })
+    ).rejects.toBe(interruption)
+  })
+
   it('force-deletes the just-created branch during failed sparse setup rollback', async () => {
     let listCount = 0
     const git = vi.fn<GitExec>(async (args) => {

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,15 +1,19 @@
 import * as path from 'node:path'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
-import {
-  WORKTREE_CREATE_TIMEOUT_MAX_MS,
-  WORKTREE_CREATE_TIMEOUT_MIN_MS
-} from '../shared/worktree-create-timeouts'
+import { WORKTREE_CREATE_TIMEOUT_MAX_MS } from '../shared/worktree-create-timeouts'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
 
 function remainingTimeout(deadlineAt: number | undefined, fallback: number | undefined) {
-  return deadlineAt === undefined ? fallback : Math.max(1, deadlineAt - Date.now())
+  if (deadlineAt === undefined) {
+    return fallback
+  }
+  const remaining = deadlineAt - Date.now()
+  if (remaining <= 0) {
+    throw new Error('Worktree add and checkout timed out.')
+  }
+  return remaining
 }
 
 function rethrowIfRequestAborted(signal: AbortSignal | undefined, error: unknown): void {
@@ -61,7 +65,7 @@ export async function addWorktreeOp(
     timeoutValue !== undefined &&
     (typeof timeoutValue !== 'number' ||
       !Number.isFinite(timeoutValue) ||
-      timeoutValue < WORKTREE_CREATE_TIMEOUT_MIN_MS ||
+      timeoutValue <= 0 ||
       timeoutValue > WORKTREE_CREATE_TIMEOUT_MAX_MS)
   ) {
     throw new Error('Invalid worktree add timeout.')
@@ -134,7 +138,16 @@ export async function addWorktreeOp(
   }
 
   if (effectiveBase) {
-    await persistRelayWorktreeCreationBase(stageGit, targetDir, branchName, effectiveBase, signal)
+    const metadataGit: GitExec = (args, cwd, childOptions) => {
+      if (deadlineAt === undefined && childOptions === undefined) {
+        return git(args, cwd)
+      }
+      return git(args, cwd, {
+        ...childOptions,
+        ...(deadlineAt === undefined ? {} : { timeout: Math.max(1_000, deadlineAt - Date.now()) })
+      })
+    }
+    await persistRelayWorktreeCreationBase(metadataGit, targetDir, branchName, effectiveBase)
   }
 
   // Why: best-effort write so a deliberate user value (any scope) is
@@ -146,10 +159,13 @@ export async function addWorktreeOp(
   try {
     let alreadySet = false
     try {
-      await stageGit(['config', '--get', 'push.autoSetupRemote'], targetDir)
+      await git(
+        ['config', '--get', 'push.autoSetupRemote'],
+        targetDir,
+        deadlineAt === undefined ? undefined : { timeout: Math.max(1_000, deadlineAt - Date.now()) }
+      )
       alreadySet = true
     } catch (readError) {
-      rethrowIfRequestAborted(signal, readError)
       // Why: `git config --get` exits 1 only when the key is unset at every
       // scope. Any other code is a real read failure (corrupt config,
       // locked file) — surface it via the outer catch instead of falling
@@ -160,10 +176,13 @@ export async function addWorktreeOp(
       }
     }
     if (!alreadySet) {
-      await stageGit(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
+      await git(
+        ['config', '--local', 'push.autoSetupRemote', 'true'],
+        targetDir,
+        deadlineAt === undefined ? undefined : { timeout: Math.max(1_000, deadlineAt - Date.now()) }
+      )
     }
   } catch (error) {
-    rethrowIfRequestAborted(signal, error)
     console.warn(`relay addWorktree: failed to set push.autoSetupRemote for ${targetDir}`, error)
   }
 }

--- a/src/relay/git-handler-worktree-ops.ts
+++ b/src/relay/git-handler-worktree-ops.ts
@@ -1,25 +1,42 @@
 import * as path from 'node:path'
 import { resolveWorktreeAddBaseRef } from '../shared/worktree-base-ref'
+import {
+  WORKTREE_CREATE_TIMEOUT_MAX_MS,
+  WORKTREE_CREATE_TIMEOUT_MIN_MS
+} from '../shared/worktree-create-timeouts'
 import type { GitExec } from './git-handler-ops'
 export { removeWorktreeOp } from './git-handler-worktree-remove'
 export { readRelayWorktreeList } from './git-handler-worktree-list'
+
+function remainingTimeout(deadlineAt: number | undefined, fallback: number | undefined) {
+  return deadlineAt === undefined ? fallback : Math.max(1, deadlineAt - Date.now())
+}
+
+function rethrowIfRequestAborted(signal: AbortSignal | undefined, error: unknown): void {
+  if (signal?.aborted) {
+    throw error
+  }
+}
 
 async function persistRelayWorktreeCreationBase(
   git: GitExec,
   targetDir: string,
   branchName: string,
-  effectiveBase: string
+  effectiveBase: string,
+  signal?: AbortSignal
 ): Promise<void> {
   const configKey = `branch.${branchName}.base`
   try {
     await git(['config', '--local', '--replace-all', configKey, effectiveBase], targetDir)
   } catch (error) {
+    rethrowIfRequestAborted(signal, error)
     console.warn(`relay addWorktree: failed to set ${configKey} for ${targetDir}`, error)
     try {
       // Why: SSH worktree creation shares branch config by name; clear stale
       // metadata if replacing an old same-name base fails.
       await git(['config', '--local', '--unset-all', configKey], targetDir)
     } catch (unsetError) {
+      rethrowIfRequestAborted(signal, unsetError)
       console.warn(
         `relay addWorktree: failed to unset stale ${configKey} for ${targetDir}`,
         unsetError
@@ -28,13 +45,47 @@ async function persistRelayWorktreeCreationBase(
   }
 }
 
-export async function addWorktreeOp(git: GitExec, params: Record<string, unknown>): Promise<void> {
+export async function addWorktreeOp(
+  git: GitExec,
+  params: Record<string, unknown>,
+  options: { signal?: AbortSignal } = {}
+): Promise<void> {
   const repoPath = params.repoPath as string
   const branchName = params.branchName as string
   const targetDir = params.targetDir as string
   const base = params.base as string | undefined
   const checkoutExistingBranch = params.checkoutExistingBranch === true
   const noCheckout = params.noCheckout === true
+  const timeoutValue = params.timeoutMs
+  if (
+    timeoutValue !== undefined &&
+    (typeof timeoutValue !== 'number' ||
+      !Number.isFinite(timeoutValue) ||
+      timeoutValue < WORKTREE_CREATE_TIMEOUT_MIN_MS ||
+      timeoutValue > WORKTREE_CREATE_TIMEOUT_MAX_MS)
+  ) {
+    throw new Error('Invalid worktree add timeout.')
+  }
+  const timeout = timeoutValue as number | undefined
+  const deadlineAt = timeout ? Date.now() + timeout : undefined
+  const signal = options.signal
+  const stageGit: GitExec = (args, cwd, childOptions) => {
+    const effectiveSignal = childOptions?.signal ?? signal
+    if (!timeout && !childOptions && !effectiveSignal) {
+      return git(args, cwd)
+    }
+    const gitOptions = {
+      ...childOptions,
+      ...(effectiveSignal ? { signal: effectiveSignal } : {})
+    }
+    if (!timeout) {
+      return git(args, cwd, gitOptions)
+    }
+    return git(args, cwd, {
+      ...gitOptions,
+      timeout: remainingTimeout(deadlineAt, timeout)
+    })
+  }
 
   // Why: a branchName starting with '-' would be interpreted as a git flag,
   // potentially changing the command's semantics (e.g. "--detach").
@@ -54,9 +105,13 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     base && !checkoutExistingBranch
       ? await resolveWorktreeAddBaseRef(base, async (qualifiedRef) => {
           try {
-            await git(['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`], repoPath)
+            await stageGit(
+              ['rev-parse', '--verify', '--quiet', `${qualifiedRef}^{commit}`],
+              repoPath
+            )
             return true
-          } catch {
+          } catch (error) {
+            rethrowIfRequestAborted(signal, error)
             return false
           }
         })
@@ -72,14 +127,14 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
     args.push(effectiveBase)
   }
 
-  await git(args, repoPath)
+  await stageGit(args, repoPath)
 
   if (checkoutExistingBranch) {
     return
   }
 
   if (effectiveBase) {
-    await persistRelayWorktreeCreationBase(git, targetDir, branchName, effectiveBase)
+    await persistRelayWorktreeCreationBase(stageGit, targetDir, branchName, effectiveBase, signal)
   }
 
   // Why: best-effort write so a deliberate user value (any scope) is
@@ -91,9 +146,10 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
   try {
     let alreadySet = false
     try {
-      await git(['config', '--get', 'push.autoSetupRemote'], targetDir)
+      await stageGit(['config', '--get', 'push.autoSetupRemote'], targetDir)
       alreadySet = true
     } catch (readError) {
+      rethrowIfRequestAborted(signal, readError)
       // Why: `git config --get` exits 1 only when the key is unset at every
       // scope. Any other code is a real read failure (corrupt config,
       // locked file) — surface it via the outer catch instead of falling
@@ -104,9 +160,10 @@ export async function addWorktreeOp(git: GitExec, params: Record<string, unknown
       }
     }
     if (!alreadySet) {
-      await git(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
+      await stageGit(['config', '--local', 'push.autoSetupRemote', 'true'], targetDir)
     }
   } catch (error) {
+    rethrowIfRequestAborted(signal, error)
     console.warn(`relay addWorktree: failed to set push.autoSetupRemote for ${targetDir}`, error)
   }
 }
@@ -142,10 +199,18 @@ export async function worktreeIsCleanOp(
 ): Promise<{ clean: boolean; stdout?: string }> {
   const worktreePath = params.worktreePath as string
   const includeUntracked = params.includeUntracked !== false
-  const { stdout } = await git(
-    ['status', '--porcelain', includeUntracked ? '--untracked-files=all' : '--untracked-files=no'],
-    worktreePath
-  )
+  const timeout =
+    typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs)
+      ? params.timeoutMs
+      : undefined
+  const args = [
+    'status',
+    '--porcelain',
+    includeUntracked ? '--untracked-files=all' : '--untracked-files=no'
+  ]
+  const { stdout } = timeout
+    ? await git(args, worktreePath, { timeout })
+    : await git(args, worktreePath)
   const clean = !stdout.trim()
   return { clean, stdout: clean ? undefined : stdout }
 }

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -30,6 +30,35 @@ function isBranchCheckedOutInWorktreeError(error: unknown): boolean {
   )
 }
 
+function isWorktreeRemovalInterruption(error: unknown): boolean {
+  if (!error || typeof error !== 'object') {
+    return false
+  }
+  const details = error as {
+    name?: unknown
+    code?: unknown
+    killed?: unknown
+    signal?: unknown
+  }
+  return (
+    details.name === 'AbortError' ||
+    details.code === 'ABORT_ERR' ||
+    details.code === 'ETIMEDOUT' ||
+    details.killed === true ||
+    (typeof details.signal === 'string' && details.signal.length > 0) ||
+    /\btimed out\b/i.test(getErrorText(error))
+  )
+}
+
+function createWorktreeRemovalAbortError(signal: AbortSignal): Error {
+  if (signal.reason instanceof Error) {
+    return signal.reason
+  }
+  const error = new Error('Worktree removal aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
 function normalizeLocalBranchRef(branch: string): string {
   return branch.replace(/^refs\/heads\//, '')
 }
@@ -140,19 +169,39 @@ export async function removeWorktreeOp(
     throw new Error('Invalid worktree removal timeout.')
   }
   const deadlineAt = timeoutValue === undefined ? undefined : Date.now() + timeoutValue
-  const stageGit: GitExec = (args, cwd, childOptions) => {
+  let interruptionError: unknown
+  const stageGit: GitExec = async (args, cwd, childOptions) => {
     const remaining = deadlineAt === undefined ? undefined : deadlineAt - Date.now()
     if (remaining !== undefined && remaining <= 0) {
-      throw new Error('Worktree removal timed out.')
+      interruptionError = new Error('Worktree removal timed out.')
+      throw interruptionError
     }
     const signal = childOptions?.signal ?? options.signal
-    return remaining === undefined && !signal && childOptions === undefined
-      ? git(args, cwd)
-      : git(args, cwd, {
-          ...childOptions,
-          ...(signal ? { signal } : {}),
-          ...(remaining === undefined ? {} : { timeout: remaining })
-        })
+    try {
+      return await (remaining === undefined && !signal && childOptions === undefined
+        ? git(args, cwd)
+        : git(args, cwd, {
+            ...childOptions,
+            ...(signal ? { signal } : {}),
+            ...(remaining === undefined ? {} : { timeout: remaining })
+          }))
+    } catch (error) {
+      if (isWorktreeRemovalInterruption(error)) {
+        interruptionError = error
+      }
+      throw error
+    }
+  }
+  const throwIfInterrupted = (error?: unknown): void => {
+    if (isWorktreeRemovalInterruption(error)) {
+      throw error
+    }
+    if (interruptionError !== undefined) {
+      throw interruptionError
+    }
+    if (options.signal?.aborted) {
+      throw createWorktreeRemovalAbortError(options.signal)
+    }
   }
 
   let repoPath = worktreePath
@@ -162,7 +211,8 @@ export async function removeWorktreeOp(
     if (commonDir && commonDir !== '.git') {
       repoPath = resolveRelayRepoPath(worktreePath, commonDir)
     }
-  } catch {
+  } catch (error) {
+    throwIfInterrupted(error)
     // fall through with worktreePath as repo
   }
 
@@ -171,6 +221,7 @@ export async function removeWorktreeOp(
     repoPath,
     capabilities
   )
+  throwIfInterrupted()
   const removedWorktree = worktreesBeforeRemoval.find((worktree) =>
     areRelayWorktreePathsEqual(worktree.path, worktreePath)
   )
@@ -223,11 +274,13 @@ export async function removeWorktreeOp(
       branchName,
       forceBranchDelete
     )
+    throwIfInterrupted()
     if (branchDeleteResult === 'checked-out') {
       return {}
     }
     return {}
   } catch (error) {
+    throwIfInterrupted(error)
     if (!forceBranchDelete && branchHead) {
       try {
         if (
@@ -239,9 +292,11 @@ export async function removeWorktreeOp(
             capabilities
           )
         ) {
+          throwIfInterrupted()
           return {}
         }
       } catch (alreadyMergedDeleteError) {
+        throwIfInterrupted(alreadyMergedDeleteError)
         // Why: worktree is gone; preserve branch recovery on cleanup races.
         console.warn(
           `relay removeWorktree: failed to delete already-merged local branch "${branchName}" after removing worktree`,
@@ -249,6 +304,7 @@ export async function removeWorktreeOp(
         )
       }
     }
+    throwIfInterrupted()
     // Expected when the branch still has unmerged/unpublished commits: keep it.
     console.warn(
       `relay removeWorktree: preserved local branch "${branchName}" after removing worktree (not fully merged)`,

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -125,16 +125,39 @@ async function deleteRelayBranchAfterWorktreeRemoval(
 export async function removeWorktreeOp(
   git: GitExec,
   params: Record<string, unknown>,
-  capabilities: GitCapabilityCache
+  capabilities: GitCapabilityCache,
+  options: { signal?: AbortSignal } = {}
 ): Promise<RemoveWorktreeResult> {
   const worktreePath = params.worktreePath as string
   const force = params.force as boolean | undefined
   const deleteBranch = params.deleteBranch !== false
   const forceBranchDelete = params.forceBranchDelete === true
+  const timeoutValue = params.timeoutMs
+  if (
+    timeoutValue !== undefined &&
+    (typeof timeoutValue !== 'number' || !Number.isFinite(timeoutValue) || timeoutValue <= 0)
+  ) {
+    throw new Error('Invalid worktree removal timeout.')
+  }
+  const deadlineAt = timeoutValue === undefined ? undefined : Date.now() + timeoutValue
+  const stageGit: GitExec = (args, cwd, childOptions) => {
+    const remaining = deadlineAt === undefined ? undefined : deadlineAt - Date.now()
+    if (remaining !== undefined && remaining <= 0) {
+      throw new Error('Worktree removal timed out.')
+    }
+    const signal = childOptions?.signal ?? options.signal
+    return remaining === undefined && !signal && childOptions === undefined
+      ? git(args, cwd)
+      : git(args, cwd, {
+          ...childOptions,
+          ...(signal ? { signal } : {}),
+          ...(remaining === undefined ? {} : { timeout: remaining })
+        })
+  }
 
   let repoPath = worktreePath
   try {
-    const { stdout } = await git(['rev-parse', '--git-common-dir'], worktreePath)
+    const { stdout } = await stageGit(['rev-parse', '--git-common-dir'], worktreePath)
     const commonDir = stdout.trim()
     if (commonDir && commonDir !== '.git') {
       repoPath = resolveRelayRepoPath(worktreePath, commonDir)
@@ -143,7 +166,11 @@ export async function removeWorktreeOp(
     // fall through with worktreePath as repo
   }
 
-  const worktreesBeforeRemoval = await listRelayWorktreesForRemoval(git, repoPath, capabilities)
+  const worktreesBeforeRemoval = await listRelayWorktreesForRemoval(
+    stageGit,
+    repoPath,
+    capabilities
+  )
   const removedWorktree = worktreesBeforeRemoval.find((worktree) =>
     areRelayWorktreePathsEqual(worktree.path, worktreePath)
   )
@@ -158,7 +185,7 @@ export async function removeWorktreeOp(
   }
   args.push(worktreePath)
   try {
-    await git(args, repoPath)
+    await stageGit(args, repoPath)
   } catch (error) {
     if (force || !isSubmoduleWorktreeRemovalRefusal(error)) {
       throw error
@@ -166,13 +193,16 @@ export async function removeWorktreeOp(
     // Why: Git refuses non-force removal of any worktree with an initialised
     // submodule even when everything is clean. Re-prove cleanliness (parent
     // status reports dirty submodule content as ` M <sub>`), then --force.
-    const { stdout } = await git(['status', '--porcelain', '--untracked-files=all'], worktreePath)
+    const { stdout } = await stageGit(
+      ['status', '--porcelain', '--untracked-files=all'],
+      worktreePath
+    )
     if (stdout.trim()) {
       const dirtyError = new Error('Worktree has uncommitted or untracked changes.')
       ;(dirtyError as Error & { stdout?: string }).stdout = stdout
       throw dirtyError
     }
-    await git(['worktree', 'remove', '--force', worktreePath], repoPath)
+    await stageGit(['worktree', 'remove', '--force', worktreePath], repoPath)
   }
 
   if (!branchName) {
@@ -188,7 +218,7 @@ export async function removeWorktreeOp(
   try {
     // Why: use `-d` (not `-D`) to mirror the local removeWorktree fix.
     const branchDeleteResult = await deleteRelayBranchAfterWorktreeRemoval(
-      git,
+      stageGit,
       repoPath,
       branchName,
       forceBranchDelete
@@ -202,7 +232,7 @@ export async function removeWorktreeOp(
       try {
         if (
           await deleteAlreadyMergedRelayBranchAfterSafeDeleteFailure(
-            git,
+            stageGit,
             repoPath,
             branchName,
             branchHead,

--- a/src/relay/git-handler-worktree-remove.ts
+++ b/src/relay/git-handler-worktree-remove.ts
@@ -46,7 +46,9 @@ function isWorktreeRemovalInterruption(error: unknown): boolean {
     details.code === 'ETIMEDOUT' ||
     details.killed === true ||
     (typeof details.signal === 'string' && details.signal.length > 0) ||
-    /\btimed out\b/i.test(getErrorText(error))
+    ('message' in error &&
+      typeof error.message === 'string' &&
+      /\btimed out\b/i.test(error.message))
   )
 }
 

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -25,7 +25,7 @@ type GitSpyTarget = {
   git(
     args: string[],
     cwd: string,
-    opts?: { signal?: AbortSignal }
+    opts?: { signal?: AbortSignal; timeout?: number }
   ): Promise<{ stdout: string; stderr: string }>
 }
 
@@ -119,6 +119,9 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.fetch')
     expect(methods).toContain('git.forkSync')
     expect(methods).toContain('git.fetchRemoteTrackingRef')
+    expect(methods).toContain('git.addPushTargetRemote')
+    expect(methods).toContain('git.removePushTargetRemote')
+    expect(methods).toContain('git.awaitPushTargetRemoteMutation')
     expect(methods).toContain('git.fetchGitHubPullRequestHead')
     expect(methods).toContain('git.fetchGitLabMergeRequestHead')
     expect(methods).toContain('git.fetchGitLabMergeRequestHeadRef')
@@ -137,6 +140,114 @@ describe('GitHandler', () => {
     expect(methods).toContain('git.exec')
     expect(methods).toContain('git.clone')
     expect(methods).toContain('git.isGitRepo')
+  })
+
+  it('forwards remote-tracking fetch cancellation to every Git command', async () => {
+    const controller = new AbortController()
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitSpyTarget, 'git')
+      .mockImplementation(async (args, _cwd, options) => {
+        expect(options?.signal).toBe(controller.signal)
+        if (args[0] === 'remote') {
+          return { stdout: 'origin\n', stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      })
+
+    await dispatcher.callRequest(
+      'git.fetchRemoteTrackingRef',
+      {
+        worktreePath: tmpDir,
+        remote: 'origin',
+        branch: 'main',
+        ref: 'refs/remotes/origin/main',
+        timeoutMs: 75_000
+      },
+      { isStale: () => false, signal: controller.signal }
+    )
+
+    expect(gitSpy).toHaveBeenLastCalledWith(
+      ['fetch', '--no-tags', 'origin', '+refs/heads/main:refs/remotes/origin/main'],
+      tmpDir,
+      { signal: controller.signal, timeout: 75_000 }
+    )
+  })
+
+  it('normalizes timed-out push-target remote additions for client reconciliation', async () => {
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitSpyTarget, 'git')
+      .mockRejectedValueOnce(
+        Object.assign(new Error('Command failed: git remote add fork url'), {
+          code: null,
+          killed: true,
+          signal: 'SIGTERM'
+        })
+      )
+      .mockResolvedValueOnce({
+        stdout: 'git@github.com:contributor/orca.git\n',
+        stderr: ''
+      })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await expect(
+      dispatcher.callRequest('git.addPushTargetRemote', {
+        repoPath: tmpDir,
+        remoteName: 'fork',
+        remoteUrl: 'git@github.com:contributor/orca.git',
+        timeoutMs: 75_000
+      })
+    ).rejects.toThrow('Git command timed out after 75000ms.')
+
+    expect(gitSpy).toHaveBeenCalledWith(
+      ['remote', 'add', 'fork', 'git@github.com:contributor/orca.git'],
+      tmpDir,
+      { signal: undefined, timeout: 75_000 }
+    )
+    expect(gitSpy).toHaveBeenCalledWith(['config', '--get', 'remote.fork.url'], tmpDir, {
+      timeout: 30_000
+    })
+    expect(gitSpy).toHaveBeenCalledWith(['remote', 'remove', 'fork'], tmpDir, {
+      timeout: 30_000
+    })
+  })
+
+  it('removes an added push-target remote when its response is not delivered', async () => {
+    let responseSettled: ((result: { ok: boolean; error?: Error }) => void) | undefined
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitSpyTarget, 'git')
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({
+        stdout: 'git@github.com:contributor/orca.git\n',
+        stderr: ''
+      })
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+
+    await dispatcher.callRequest(
+      'git.addPushTargetRemote',
+      {
+        repoPath: tmpDir,
+        remoteName: 'fork',
+        remoteUrl: 'git@github.com:contributor/orca.git',
+        timeoutMs: 75_000
+      },
+      {
+        isStale: () => false,
+        onResponseSettled: (callback) => {
+          responseSettled = callback
+        }
+      } as never
+    )
+
+    responseSettled?.({ ok: false, error: new Error('connection lost') })
+    await dispatcher.callRequest('git.awaitPushTargetRemoteMutation', {
+      repoPath: tmpDir
+    })
+    expect(gitSpy).toHaveBeenCalledWith(['remote', 'remove', 'fork'], tmpDir, {
+      timeout: 30_000
+    })
+    expect(gitSpy).toHaveBeenCalledWith(['config', '--get', 'remote.fork.url'], tmpDir, {
+      timeout: 30_000
+    })
   })
 
   it('runs remote worktree deletion inside the relay watcher fence', async () => {
@@ -2548,7 +2659,10 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls[2]?.[1]).toBe('/relay/wt')
       expect(gitMock.mock.calls[3]?.[1]).toBe('/relay/wt')
       expect(gitMock.mock.calls[4]?.[1]).toBe('/relay/wt')
-      expect(gitMock.mock.calls.every((call) => call[2]?.signal === controller.signal)).toBe(true)
+      expect(
+        gitMock.mock.calls.slice(0, 2).every((call) => call[2]?.signal === controller.signal)
+      ).toBe(true)
+      expect(gitMock.mock.calls.slice(2).every((call) => call[2]?.signal === undefined)).toBe(true)
     })
 
     it('checks out a selected existing local branch without creating a new branch', async () => {

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -2163,7 +2163,7 @@ describe('GitHandler', () => {
           (
             args: string[],
             cwd: string,
-            opts?: { maxBuffer?: number }
+            opts?: { maxBuffer?: number; signal?: AbortSignal }
           ) => Promise<{ stdout: string; stderr: string }>
         >()
       ;(localHandler as unknown as { git: typeof gitMock }).git = gitMock
@@ -2494,7 +2494,7 @@ describe('GitHandler', () => {
           (
             args: string[],
             cwd: string,
-            opts?: { maxBuffer?: number }
+            opts?: { maxBuffer?: number; signal?: AbortSignal }
           ) => Promise<{ stdout: string; stderr: string }>
         >()
       ;(handler as unknown as { git: typeof gitMock }).git = gitMock
@@ -2503,18 +2503,23 @@ describe('GitHandler', () => {
 
     it('passes --no-track and writes push.autoSetupRemote when unset', async () => {
       const { localDispatcher, gitMock } = setupMockedHandler(['/relay/repo', '/relay/wt'])
+      const controller = new AbortController()
       gitMock.mockResolvedValueOnce({ stdout: 'abc123\n', stderr: '' }) // rev-parse refs/remotes/origin/main^{commit}
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // worktree add
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // config --local --replace-all branch.<branch>.base
       gitMock.mockRejectedValueOnce(Object.assign(new Error('key unset'), { code: 1 })) // --get
       gitMock.mockResolvedValueOnce({ stdout: '', stderr: '' }) // --local set
 
-      await localDispatcher.callRequest('git.addWorktree', {
-        repoPath: '/relay/repo',
-        branchName: 'feature/test',
-        targetDir: '/relay/wt',
-        base: 'origin/main'
-      })
+      await localDispatcher.callRequest(
+        'git.addWorktree',
+        {
+          repoPath: '/relay/repo',
+          branchName: 'feature/test',
+          targetDir: '/relay/wt',
+          base: 'origin/main'
+        },
+        { isStale: () => false, signal: controller.signal }
+      )
 
       expect(gitMock.mock.calls.map((c) => c[0])).toEqual([
         ['rev-parse', '--verify', '--quiet', 'refs/remotes/origin/main^{commit}'],
@@ -2543,6 +2548,7 @@ describe('GitHandler', () => {
       expect(gitMock.mock.calls[2]?.[1]).toBe('/relay/wt')
       expect(gitMock.mock.calls[3]?.[1]).toBe('/relay/wt')
       expect(gitMock.mock.calls[4]?.[1]).toBe('/relay/wt')
+      expect(gitMock.mock.calls.every((call) => call[2]?.signal === controller.signal)).toBe(true)
     })
 
     it('checks out a selected existing local branch without creating a new branch', async () => {

--- a/src/relay/git-handler.test.ts
+++ b/src/relay/git-handler.test.ts
@@ -146,8 +146,7 @@ describe('GitHandler', () => {
     const controller = new AbortController()
     const gitSpy = vi
       .spyOn(handler as unknown as GitSpyTarget, 'git')
-      .mockImplementation(async (args, _cwd, options) => {
-        expect(options?.signal).toBe(controller.signal)
+      .mockImplementation(async (args) => {
         if (args[0] === 'remote') {
           return { stdout: 'origin\n', stderr: '' }
         }
@@ -171,6 +170,9 @@ describe('GitHandler', () => {
       tmpDir,
       { signal: controller.signal, timeout: 75_000 }
     )
+    for (const [, , options] of gitSpy.mock.calls) {
+      expect(options?.signal).toBe(controller.signal)
+    }
   })
 
   it('normalizes timed-out push-target remote additions for client reconciliation', async () => {
@@ -248,6 +250,104 @@ describe('GitHandler', () => {
     expect(gitSpy).toHaveBeenCalledWith(['config', '--get', 'remote.fork.url'], tmpDir, {
       timeout: 30_000
     })
+  })
+
+  it('holds the push-target mutation until failed-response cleanup finishes', async () => {
+    let responseSettled: ((result: { ok: boolean; error?: Error }) => void) | undefined
+    let finishCleanup!: () => void
+    const cleanupBlocked = new Promise<void>((resolve) => {
+      finishCleanup = resolve
+    })
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitSpyTarget, 'git')
+      .mockResolvedValueOnce({ stdout: '', stderr: '' })
+      .mockResolvedValueOnce({
+        stdout: 'git@github.com:contributor/orca.git\n',
+        stderr: ''
+      })
+      .mockImplementationOnce(async () => {
+        await cleanupBlocked
+        return { stdout: '', stderr: '' }
+      })
+
+    await dispatcher.callRequest(
+      'git.addPushTargetRemote',
+      {
+        repoPath: tmpDir,
+        remoteName: 'fork',
+        remoteUrl: 'git@github.com:contributor/orca.git',
+        timeoutMs: 75_000
+      },
+      {
+        isStale: () => false,
+        onResponseSettled: (callback) => {
+          responseSettled = callback
+        }
+      } as never
+    )
+    responseSettled?.({ ok: false, error: new Error('connection lost') })
+    await waitForSpyCalls(gitSpy, 3)
+
+    const barrier = dispatcher.callRequest('git.awaitPushTargetRemoteMutation', {
+      repoPath: tmpDir
+    })
+    let barrierSettled = false
+    void barrier.then(() => {
+      barrierSettled = true
+    })
+    await new Promise<void>((resolve) => setTimeout(resolve, 0))
+    expect(barrierSettled).toBe(false)
+
+    finishCleanup()
+    await barrier
+    expect(barrierSettled).toBe(true)
+  })
+
+  it('releases a push-target mutation when response settlement never fires', async () => {
+    vi.useFakeTimers()
+    try {
+      let responseSettled: ((result: { ok: boolean; error?: Error }) => void) | undefined
+      const gitSpy = vi
+        .spyOn(handler as unknown as GitSpyTarget, 'git')
+        .mockResolvedValue({ stdout: '', stderr: '' })
+
+      await dispatcher.callRequest(
+        'git.addPushTargetRemote',
+        {
+          repoPath: tmpDir,
+          remoteName: 'fork',
+          remoteUrl: 'git@github.com:contributor/orca.git',
+          timeoutMs: 75_000
+        },
+        {
+          isStale: () => false,
+          onResponseSettled: (callback) => {
+            responseSettled = callback
+          }
+        } as never
+      )
+      const barrier = dispatcher.callRequest('git.awaitPushTargetRemoteMutation', {
+        repoPath: tmpDir
+      })
+      let barrierSettled = false
+      void barrier.then(() => {
+        barrierSettled = true
+      })
+
+      await vi.advanceTimersByTimeAsync(60_999)
+      expect(barrierSettled).toBe(false)
+      await vi.advanceTimersByTimeAsync(1)
+      await barrier
+      expect(barrierSettled).toBe(true)
+
+      responseSettled?.({ ok: false, error: new Error('late connection loss') })
+      await vi.runAllTimersAsync()
+      expect(gitSpy).not.toHaveBeenCalledWith(['remote', 'remove', 'fork'], tmpDir, {
+        timeout: 30_000
+      })
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('runs remote worktree deletion inside the relay watcher fence', async () => {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -248,7 +248,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
     this.dispatcher.onRequest('git.addWorktree', (p, context) => this.addWorktree(p, context))
-    this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
+    this.dispatcher.onRequest('git.removeWorktree', (p, context) => this.removeWorktree(p, context))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>
       this.refreshLocalBaseRefForWorktreeCreate(p)
@@ -910,7 +910,9 @@ export class GitHandler {
     const ref = params.ref
     const skipAutoMaintenance = params.skipAutoMaintenance
     const timeout =
-      typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs)
+      typeof params.timeoutMs === 'number' &&
+      Number.isFinite(params.timeoutMs) &&
+      params.timeoutMs > 0
         ? params.timeoutMs
         : undefined
     try {
@@ -1204,7 +1206,9 @@ export class GitHandler {
     const args = params.args as string[]
     const cwd = params.cwd as string
     const timeout =
-      typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs)
+      typeof params.timeoutMs === 'number' &&
+      Number.isFinite(params.timeoutMs) &&
+      params.timeoutMs > 0
         ? params.timeoutMs
         : undefined
 
@@ -1408,7 +1412,12 @@ export class GitHandler {
   private async listWorktrees(params: Record<string, unknown>, context?: RequestContext) {
     const repoPath = params.repoPath as string
     const strict = params.strict === true
-    const timeout = typeof params.timeoutMs === 'number' ? params.timeoutMs : undefined
+    const timeout =
+      typeof params.timeoutMs === 'number' &&
+      Number.isFinite(params.timeoutMs) &&
+      params.timeoutMs > 0
+        ? params.timeoutMs
+        : undefined
     const scan = this.gitCapabilities.runWithFallback(
       'worktree-list-z',
       async () => {
@@ -1452,10 +1461,12 @@ export class GitHandler {
     )
   }
 
-  private async removeWorktree(params: Record<string, unknown>) {
+  private async removeWorktree(params: Record<string, unknown>, context?: RequestContext) {
     const remove = () =>
       this.runWithGitReadCacheClear(() =>
-        removeWorktreeOp(this.git.bind(this), params, this.gitCapabilities)
+        removeWorktreeOp(this.git.bind(this), params, this.gitCapabilities, {
+          signal: context?.signal
+        })
       )
     const worktreePath = params.worktreePath
     return this.watcherRegistry && typeof worktreePath === 'string'

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -247,7 +247,7 @@ export class GitHandler {
     this.dispatcher.onRequest('git.branchDiff', (p, context) => this.branchDiff(p, context))
     this.dispatcher.onRequest('git.commitDiff', (p, context) => this.commitDiff(p, context))
     this.dispatcher.onRequest('git.listWorktrees', (p, context) => this.listWorktrees(p, context))
-    this.dispatcher.onRequest('git.addWorktree', (p) => this.addWorktree(p))
+    this.dispatcher.onRequest('git.addWorktree', (p, context) => this.addWorktree(p, context))
     this.dispatcher.onRequest('git.removeWorktree', (p) => this.removeWorktree(p))
     this.dispatcher.onRequest('git.worktreeIsClean', (p) => this.worktreeIsClean(p))
     this.dispatcher.onRequest('git.refreshLocalBaseRefForWorktreeCreate', (p) =>
@@ -909,6 +909,10 @@ export class GitHandler {
     const branch = params.branch
     const ref = params.ref
     const skipAutoMaintenance = params.skipAutoMaintenance
+    const timeout =
+      typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs)
+        ? params.timeoutMs
+        : undefined
     try {
       if (typeof remote !== 'string' || typeof branch !== 'string' || typeof ref !== 'string') {
         throw new Error('Invalid remote-tracking fetch request.')
@@ -934,16 +938,16 @@ export class GitHandler {
         }
         await this.git(['check-ref-format', `refs/heads/${branch}`], worktreePath)
         await this.git(['check-ref-format', ref], worktreePath)
-        await this.git(
-          [
-            ...(skipAutoMaintenance ? GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS : []),
-            'fetch',
-            '--no-tags',
-            remote,
-            `+refs/heads/${branch}:${ref}`
-          ],
-          worktreePath
-        )
+        const fetchArgs = [
+          ...(skipAutoMaintenance ? GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS : []),
+          'fetch',
+          '--no-tags',
+          remote,
+          `+refs/heads/${branch}:${ref}`
+        ]
+        await (timeout === undefined
+          ? this.git(fetchArgs, worktreePath)
+          : this.git(fetchArgs, worktreePath, { timeout }))
       } catch (error) {
         // Why: create-worktree needs a write-capable fetch that generic git.exec rejects; narrow RPC keeps the allowlist tight.
         throw new Error(normalizeGitErrorMessage(error, 'fetch'))
@@ -1199,9 +1203,13 @@ export class GitHandler {
   private async exec(params: Record<string, unknown>, context?: RequestContext) {
     const args = params.args as string[]
     const cwd = params.cwd as string
+    const timeout =
+      typeof params.timeoutMs === 'number' && Number.isFinite(params.timeoutMs)
+        ? params.timeoutMs
+        : undefined
 
     validateGitExecArgs(args)
-    const run = () => this.git(args, cwd, { signal: context?.signal })
+    const run = () => this.git(args, cwd, { signal: context?.signal, timeout })
     const { stdout, stderr } = gitExecMutatesRepository(args)
       ? await this.runWithGitReadCacheClear(run)
       : await run()
@@ -1399,41 +1407,49 @@ export class GitHandler {
 
   private async listWorktrees(params: Record<string, unknown>, context?: RequestContext) {
     const repoPath = params.repoPath as string
-    return this.gitCapabilities
-      .runWithFallback(
-        'worktree-list-z',
-        async () => {
-          const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath, {
-            signal: context?.signal
+    const strict = params.strict === true
+    const timeout = typeof params.timeoutMs === 'number' ? params.timeoutMs : undefined
+    const scan = this.gitCapabilities.runWithFallback(
+      'worktree-list-z',
+      async () => {
+        const { stdout } = await this.git(['worktree', 'list', '--porcelain', '-z'], repoPath, {
+          signal: context?.signal,
+          timeout
+        })
+        return this.normalizeMainWorktreePath(
+          repoPath,
+          parseWorktreeList(stdout, { nulDelimited: true })
+        )
+      },
+      async () => {
+        // Why: Git <2.36 lacks worktree-list `-z`, so fall back to the newline-block parser (loses newline-in-path safety).
+        try {
+          const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath, {
+            signal: context?.signal,
+            timeout
           })
-          return this.normalizeMainWorktreePath(
+          const normalized = await this.normalizeMainWorktreePath(
             repoPath,
-            parseWorktreeList(stdout, { nulDelimited: true })
+            parseWorktreeList(stdout)
           )
-        },
-        async () => {
-          // Why: Git <2.36 lacks worktree-list `-z`, so fall back to the newline-block parser (loses newline-in-path safety).
-          try {
-            const { stdout } = await this.git(['worktree', 'list', '--porcelain'], repoPath, {
-              signal: context?.signal
-            })
-            const normalized = await this.normalizeMainWorktreePath(
-              repoPath,
-              parseWorktreeList(stdout)
-            )
-            // Why: Git <2.31 emits no `prunable` annotation, so probe each linked worktree's existence instead of trusting stale registrations (issue #8389).
-            return annotatePrunableWorktreesByExistence(normalized)
-          } catch {
-            return []
+          // Why: Git <2.31 emits no `prunable` annotation, so probe each linked worktree's existence instead of trusting stale registrations (issue #8389).
+          return annotatePrunableWorktreesByExistence(normalized)
+        } catch (error) {
+          if (strict) {
+            throw error
           }
-        },
-        isUnsupportedWorktreeListZError
-      )
-      .catch(() => [])
+          return []
+        }
+      },
+      isUnsupportedWorktreeListZError
+    )
+    return strict ? scan : scan.catch(() => [])
   }
 
-  private async addWorktree(params: Record<string, unknown>) {
-    return this.runWithGitReadCacheClear(() => addWorktreeOp(this.git.bind(this), params))
+  private async addWorktree(params: Record<string, unknown>, context: RequestContext) {
+    return this.runWithGitReadCacheClear(() =>
+      addWorktreeOp(this.git.bind(this), params, { signal: context.signal })
+    )
   }
 
   private async removeWorktree(params: Record<string, unknown>) {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -95,6 +95,40 @@ import { streamRelayGitStdout } from './git-stdout-stream'
 const execFileAsync = promisify(execFile)
 const MAX_GIT_BUFFER = 10 * 1024 * 1024
 const BULK_CHUNK_SIZE = 100
+const PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS = 30_000
+const PUSH_TARGET_REMOTE_RECONCILIATION_GRACE_MS = 1_000
+const PUSH_TARGET_REMOTE_RECONCILIATION_POLL_MS = 100
+
+function normalizeRelayGitTimeout(error: unknown, timeout: number | undefined): never {
+  const details = error as Error & { code?: unknown; killed?: unknown; signal?: unknown }
+  if (
+    timeout !== undefined &&
+    error instanceof Error &&
+    error.name !== 'AbortError' &&
+    (details.code === 'ETIMEDOUT' ||
+      details.killed === true ||
+      details.signal === 'SIGTERM' ||
+      details.signal === 'SIGKILL')
+  ) {
+    throw new Error(`Git command timed out after ${timeout}ms.`)
+  }
+  throw error
+}
+
+function mayHaveCompletedRelayGitMutation(error: unknown): boolean {
+  if (!(error instanceof Error)) {
+    return false
+  }
+  const details = error as Error & { code?: unknown; killed?: unknown; signal?: unknown }
+  return (
+    error.name === 'AbortError' ||
+    error.message.toLowerCase().includes('timed out') ||
+    details.code === 'ETIMEDOUT' ||
+    details.killed === true ||
+    details.signal === 'SIGTERM' ||
+    details.signal === 'SIGKILL'
+  )
+}
 
 function resolveSubmoduleStatusArea(
   params: Record<string, unknown>
@@ -176,6 +210,7 @@ function execFileWithStdin(
 export class GitHandler {
   private dispatcher: RelayDispatcher
   private readonly gitDiffReadDedupe = new InFlightPromiseDedupe<unknown>()
+  private readonly pushTargetRemoteMutationTails = new Map<string, Promise<void>>()
   private readonly gitCapabilities = new GitCapabilityCache()
   // Why: use the bulk lane so large responses do not block interactive PTY echo.
   private readonly responseStreams = new GitResponseStreamRegistry()
@@ -225,7 +260,18 @@ export class GitHandler {
     this.dispatcher.onRequest('git.upstreamStatus', (p) => this.upstreamStatus(p))
     this.dispatcher.onRequest('git.fetch', (p) => this.fetch(p))
     this.dispatcher.onRequest('git.forkSync', (p, context) => this.forkSync(p, context))
-    this.dispatcher.onRequest('git.fetchRemoteTrackingRef', (p) => this.fetchRemoteTrackingRef(p))
+    this.dispatcher.onRequest('git.fetchRemoteTrackingRef', (p, context) =>
+      this.fetchRemoteTrackingRef(p, context)
+    )
+    this.dispatcher.onRequest('git.addPushTargetRemote', (p, context) =>
+      this.addPushTargetRemote(p, context)
+    )
+    this.dispatcher.onRequest('git.removePushTargetRemote', (p, context) =>
+      this.removePushTargetRemote(p, context)
+    )
+    this.dispatcher.onRequest('git.awaitPushTargetRemoteMutation', (p) =>
+      this.awaitPushTargetRemoteMutation(p)
+    )
     this.dispatcher.onRequest('git.fetchGitHubPullRequestHead', (p) =>
       this.fetchGitHubPullRequestHead(p)
     )
@@ -311,6 +357,30 @@ export class GitHandler {
       return await run()
     } finally {
       this.clearGitMutationReadCaches()
+    }
+  }
+
+  private async acquirePushTargetRemoteMutation(repoPath: string): Promise<() => void> {
+    const previous = this.pushTargetRemoteMutationTails.get(repoPath) ?? Promise.resolve()
+    let releaseSlot!: () => void
+    const slot = new Promise<void>((resolve) => {
+      releaseSlot = resolve
+    })
+    const tail = previous.catch(() => {}).then(() => slot)
+    this.pushTargetRemoteMutationTails.set(repoPath, tail)
+    await previous.catch(() => {})
+    let released = false
+    return () => {
+      if (released) {
+        return
+      }
+      released = true
+      releaseSlot()
+      void tail.finally(() => {
+        if (this.pushTargetRemoteMutationTails.get(repoPath) === tail) {
+          this.pushTargetRemoteMutationTails.delete(repoPath)
+        }
+      })
     }
   }
 
@@ -902,7 +972,7 @@ export class GitHandler {
     })
   }
 
-  private async fetchRemoteTrackingRef(params: Record<string, unknown>) {
+  private async fetchRemoteTrackingRef(params: Record<string, unknown>, context?: RequestContext) {
     this.clearGitMutationReadCaches()
     const worktreePath = params.worktreePath as string
     const remote = params.remote
@@ -930,7 +1000,16 @@ export class GitHandler {
       }
 
       try {
-        const { stdout } = await this.git(['remote'], worktreePath)
+        const requestGit = (args: string[], options?: { timeout?: number }) => {
+          if (!options && !context?.signal) {
+            return this.git(args, worktreePath)
+          }
+          return this.git(args, worktreePath, {
+            ...options,
+            ...(context?.signal ? { signal: context.signal } : {})
+          })
+        }
+        const { stdout } = await requestGit(['remote'])
         const remotes = stdout
           .split(/\r?\n/)
           .map((line) => line.trim())
@@ -938,8 +1017,8 @@ export class GitHandler {
         if (!remotes.includes(remote)) {
           throw new Error(`Remote "${remote}" is not configured.`)
         }
-        await this.git(['check-ref-format', `refs/heads/${branch}`], worktreePath)
-        await this.git(['check-ref-format', ref], worktreePath)
+        await requestGit(['check-ref-format', `refs/heads/${branch}`])
+        await requestGit(['check-ref-format', ref])
         const fetchArgs = [
           ...(skipAutoMaintenance ? GIT_FETCH_SKIP_AUTO_MAINTENANCE_CONFIG_ARGS : []),
           'fetch',
@@ -947,9 +1026,7 @@ export class GitHandler {
           remote,
           `+refs/heads/${branch}:${ref}`
         ]
-        await (timeout === undefined
-          ? this.git(fetchArgs, worktreePath)
-          : this.git(fetchArgs, worktreePath, { timeout }))
+        await requestGit(fetchArgs, timeout === undefined ? undefined : { timeout })
       } catch (error) {
         // Why: create-worktree needs a write-capable fetch that generic git.exec rejects; narrow RPC keeps the allowlist tight.
         throw new Error(normalizeGitErrorMessage(error, 'fetch'))
@@ -1017,6 +1094,127 @@ export class GitHandler {
     } finally {
       this.clearGitMutationReadCaches()
     }
+  }
+
+  private async addPushTargetRemote(params: Record<string, unknown>, context?: RequestContext) {
+    const repoPath = params.repoPath
+    const remoteName = params.remoteName
+    const remoteUrl = params.remoteUrl
+    const timeout =
+      typeof params.timeoutMs === 'number' &&
+      Number.isFinite(params.timeoutMs) &&
+      params.timeoutMs > 0
+        ? params.timeoutMs
+        : undefined
+    assertGitPushTargetShape({
+      remoteName,
+      branchName: 'push-target-validation',
+      remoteUrl
+    })
+    if (typeof repoPath !== 'string' || repoPath.length === 0) {
+      throw new Error('Invalid push-target repository path.')
+    }
+    const releaseMutation = await this.acquirePushTargetRemoteMutation(repoPath)
+    let releaseOnResponseSettlement = false
+    const cleanupAddedRemote = async (): Promise<void> => {
+      const deadlineAt = Date.now() + PUSH_TARGET_REMOTE_RECONCILIATION_GRACE_MS
+      do {
+        try {
+          const { stdout } = await this.git(
+            ['config', '--get', `remote.${remoteName as string}.url`],
+            repoPath,
+            { timeout: PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS }
+          )
+          if (stdout.trim() === remoteUrl) {
+            await this.runWithGitReadCacheClear(() =>
+              this.git(['remote', 'remove', remoteName as string], repoPath, {
+                timeout: PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS
+              })
+            )
+          }
+          return
+        } catch {
+          // The canceled add may still be settling; retry briefly before client reconciliation takes over.
+        }
+        await new Promise((resolve) =>
+          setTimeout(
+            resolve,
+            Math.min(PUSH_TARGET_REMOTE_RECONCILIATION_POLL_MS, deadlineAt - Date.now())
+          )
+        )
+      } while (Date.now() < deadlineAt)
+    }
+    try {
+      await this.runWithGitReadCacheClear(() =>
+        this.git(['remote', 'add', remoteName as string, remoteUrl as string], repoPath, {
+          signal: context?.signal,
+          timeout
+        })
+      )
+      if (context?.onResponseSettled) {
+        context.onResponseSettled((result) => {
+          void (async () => {
+            try {
+              if (!result.ok) {
+                await cleanupAddedRemote()
+              }
+            } finally {
+              releaseMutation()
+            }
+          })()
+        })
+        releaseOnResponseSettlement = true
+      }
+    } catch (error) {
+      if (mayHaveCompletedRelayGitMutation(error)) {
+        await cleanupAddedRemote()
+      }
+      normalizeRelayGitTimeout(error, timeout)
+    } finally {
+      if (!releaseOnResponseSettlement) {
+        releaseMutation()
+      }
+    }
+  }
+
+  private async removePushTargetRemote(params: Record<string, unknown>, context?: RequestContext) {
+    const repoPath = params.repoPath
+    const remoteName = params.remoteName
+    const timeout =
+      typeof params.timeoutMs === 'number' &&
+      Number.isFinite(params.timeoutMs) &&
+      params.timeoutMs > 0
+        ? params.timeoutMs
+        : undefined
+    assertGitPushTargetShape({
+      remoteName,
+      branchName: 'push-target-validation'
+    })
+    if (typeof repoPath !== 'string' || repoPath.length === 0) {
+      throw new Error('Invalid push-target repository path.')
+    }
+    const releaseMutation = await this.acquirePushTargetRemoteMutation(repoPath)
+    try {
+      await this.runWithGitReadCacheClear(() =>
+        this.git(['remote', 'remove', remoteName as string], repoPath, {
+          signal: context?.signal,
+          timeout
+        })
+      )
+    } catch (error) {
+      normalizeRelayGitTimeout(error, timeout)
+    } finally {
+      releaseMutation()
+    }
+  }
+
+  private async awaitPushTargetRemoteMutation(params: Record<string, unknown>): Promise<void> {
+    const repoPath = params.repoPath
+    if (typeof repoPath !== 'string' || repoPath.length === 0) {
+      throw new Error('Invalid push-target repository path.')
+    }
+    const releaseMutation = await this.acquirePushTargetRemoteMutation(repoPath)
+    releaseMutation()
   }
 
   private async fetchGitHubPullRequestHead(params: Record<string, unknown>) {

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -98,6 +98,8 @@ const BULK_CHUNK_SIZE = 100
 const PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS = 30_000
 const PUSH_TARGET_REMOTE_RECONCILIATION_GRACE_MS = 1_000
 const PUSH_TARGET_REMOTE_RECONCILIATION_POLL_MS = 100
+const PUSH_TARGET_REMOTE_SETTLEMENT_TIMEOUT_MS =
+  PUSH_TARGET_REMOTE_CLEANUP_TIMEOUT_MS * 2 + PUSH_TARGET_REMOTE_RECONCILIATION_GRACE_MS
 
 function normalizeRelayGitTimeout(error: unknown, timeout: number | undefined): never {
   const details = error as Error & { code?: unknown; killed?: unknown; signal?: unknown }
@@ -1152,7 +1154,17 @@ export class GitHandler {
         })
       )
       if (context?.onResponseSettled) {
+        let settlementExpired = false
+        const settlementGuard = setTimeout(() => {
+          settlementExpired = true
+          releaseMutation()
+        }, PUSH_TARGET_REMOTE_SETTLEMENT_TIMEOUT_MS)
+        settlementGuard.unref?.()
         context.onResponseSettled((result) => {
+          clearTimeout(settlementGuard)
+          if (settlementExpired) {
+            return
+          }
           void (async () => {
             try {
               if (!result.ok) {

--- a/src/renderer/src/components/settings/GitPane.tsx
+++ b/src/renderer/src/components/settings/GitPane.tsx
@@ -19,6 +19,7 @@ import {
   KEEP_LOCAL_MAIN_UP_TO_DATE_SECTION_ID,
   getKeepLocalMainUpToDateTitle
 } from './keep-local-main-up-to-date-setting'
+import { WorktreeCreateTimeoutSettings } from './WorktreeCreateTimeoutSettings'
 import { translate } from '@/i18n/i18n'
 import { SettingsRow, SettingsSegmentedControl } from './SettingsFormControls'
 
@@ -321,6 +322,12 @@ export function GitPane({
         updateSettings={updateSettings}
       />
     ) : null,
+    <WorktreeCreateTimeoutSettings
+      key="worktree-create-timeouts"
+      settings={settings}
+      updateSettings={updateSettings}
+      searchQuery={searchQuery}
+    />,
     shouldShowAutoRenameBranchSetting(searchQuery, hasUnsavedBranchPromptChanges) ? (
       <AutoRenameBranchFromWorkSetting
         key="auto-rename-branch-from-work"

--- a/src/renderer/src/components/settings/RepositoryPane.test.ts
+++ b/src/renderer/src/components/settings/RepositoryPane.test.ts
@@ -102,6 +102,8 @@ describe('RepositoryPane search entries', () => {
     expect(matchesSettingsSearch('local settings scripts', entries)).toBe(true)
     expect(matchesSettingsSearch('../worktrees', entries)).toBe(true)
     expect(matchesSettingsSearch('worktree path', entries)).toBe(true)
+    expect(matchesSettingsSearch('git worktree add', entries)).toBe(true)
+    expect(matchesSettingsSearch('materialization', entries)).toBe(true)
   })
 
   it('includes each project search section once', () => {

--- a/src/renderer/src/components/settings/RepositoryPane.tsx
+++ b/src/renderer/src/components/settings/RepositoryPane.tsx
@@ -36,8 +36,12 @@ import { getProjectRuntimeSessionSummary } from './repository-runtime-session-su
 export { getRepositoryPaneSearchEntries }
 export { matchesRepositoryIdentitySearch } from './repository-identity-search'
 
-type RepositoryPaneRepoUpdate = Omit<Partial<Repo>, 'sourceControlAi'> & {
+type RepositoryPaneRepoUpdate = Omit<
+  Partial<Repo>,
+  'sourceControlAi' | 'worktreeCreateTimeouts'
+> & {
   sourceControlAi?: Repo['sourceControlAi'] | null
+  worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
 }
 
 const EMPTY_WSL_DISTROS: string[] = []
@@ -170,6 +174,10 @@ export function RepositoryPane({
     ),
     translate('auto.components.settings.repository.search.094adbe930', 'Default Worktree Base'),
     translate('auto.components.settings.repository.search.443d127b5a', 'Worktree Location'),
+    translate(
+      'auto.components.settings.repository.search.worktreeCreationTimeouts',
+      'Worktree Creation Timeouts'
+    ),
     translate('auto.components.settings.repository.search.projectRuntime', 'Project Runtime'),
     translate('auto.components.settings.repository.search.c5266c2c9d', 'Remove Project')
   ])

--- a/src/renderer/src/components/settings/RepositoryWorktreeCreateTimeoutSettings.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeCreateTimeoutSettings.tsx
@@ -1,0 +1,295 @@
+import { useEffect, useRef } from 'react'
+import type { GlobalSettings, Repo } from '../../../../shared/types'
+import {
+  WORKTREE_CREATE_TIMEOUT_DEFAULTS,
+  type WorktreeCreateTimeoutOverrides,
+  type WorktreeCreateTimeouts
+} from '../../../../shared/worktree-create-timeouts'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import { translate } from '@/i18n/i18n'
+import { Button } from '../ui/button'
+import { SettingsRow } from './SettingsFormControls'
+import { RepoSettingsDraftInput } from './RepositorySettingsDraftInput'
+import { SearchableSetting } from './SearchableSetting'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+const MIN_TIMEOUT_SECONDS = 1
+const MAX_TIMEOUT_SECONDS = 7200
+const EMPTY_TIMEOUT_OVERRIDES: WorktreeCreateTimeoutOverrides = {}
+
+type TimeoutField = {
+  key: keyof WorktreeCreateTimeouts
+}
+
+const TIMEOUT_FIELDS: readonly TimeoutField[] = [
+  { key: 'refreshBaseRefMs' },
+  { key: 'addCheckoutMs' },
+  { key: 'registrationMs' },
+  { key: 'materializationMs' }
+]
+
+function getTimeoutFieldCopy(key: keyof WorktreeCreateTimeouts): {
+  label: string
+  description: string
+} {
+  switch (key) {
+    case 'refreshBaseRefMs':
+      return {
+        label: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.refreshBaseRefMs.label',
+          'Refresh base reference'
+        ),
+        description: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.refreshBaseRefMs.description',
+          'Fetching the remote base branch before creating the checkout.'
+        )
+      }
+    case 'addCheckoutMs':
+      return {
+        label: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.addCheckoutMs.label',
+          'Add checkout'
+        ),
+        description: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.addCheckoutMs.description',
+          'Running git worktree add and creating the checkout.'
+        )
+      }
+    case 'registrationMs':
+      return {
+        label: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.registrationMs.label',
+          'Workspace registration'
+        ),
+        description: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.registrationMs.description',
+          'Waiting for the new workspace to appear in Orca.'
+        )
+      }
+    case 'materializationMs':
+      return {
+        label: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.materializationMs.label',
+          'Workspace materialization'
+        ),
+        description: translate(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.materializationMs.description',
+          'Waiting for checkout files and workspace metadata to become ready.'
+        )
+      }
+  }
+}
+
+type RepositoryWorktreeCreateTimeoutSettingsProps = {
+  repo: Repo
+  settings: Pick<GlobalSettings, 'worktreeCreateTimeouts'> | null
+  updateTimeouts: (worktreeCreateTimeouts: WorktreeCreateTimeoutOverrides | null) => void
+  forceVisible: boolean
+}
+
+function withoutTimeout(
+  timeouts: WorktreeCreateTimeoutOverrides,
+  key: keyof WorktreeCreateTimeouts
+): WorktreeCreateTimeoutOverrides {
+  const next = { ...timeouts }
+  delete next[key]
+  return next
+}
+
+function timeoutOverridesMatch(
+  left: WorktreeCreateTimeoutOverrides,
+  right: WorktreeCreateTimeoutOverrides
+): boolean {
+  return TIMEOUT_FIELDS.every((field) => left[field.key] === right[field.key])
+}
+
+function formatTimeoutSeconds(timeoutMs: number | undefined): string {
+  return timeoutMs === undefined ? '' : String(timeoutMs / 1000)
+}
+
+export function RepositoryWorktreeCreateTimeoutSettings({
+  repo,
+  settings,
+  updateTimeouts,
+  forceVisible
+}: RepositoryWorktreeCreateTimeoutSettingsProps): React.JSX.Element {
+  const configuredTimeouts = repo.worktreeCreateTimeouts ?? EMPTY_TIMEOUT_OVERRIDES
+  const inheritedTimeouts = settings?.worktreeCreateTimeouts ?? WORKTREE_CREATE_TIMEOUT_DEFAULTS
+  const canShowInheritedValue = !getRepoExecutionHostId(repo).startsWith('runtime:')
+  const latestTimeoutsRef = useRef<WorktreeCreateTimeoutOverrides>({ ...configuredTimeouts })
+  const observedTimeoutsRef = useRef<WorktreeCreateTimeoutOverrides>({ ...configuredTimeouts })
+  const pendingTimeoutsRef = useRef<WorktreeCreateTimeoutOverrides[]>([])
+  const observedRepoIdRef = useRef(repo.id)
+
+  useEffect(() => {
+    if (observedRepoIdRef.current !== repo.id) {
+      observedRepoIdRef.current = repo.id
+      latestTimeoutsRef.current = configuredTimeouts
+      observedTimeoutsRef.current = configuredTimeouts
+      pendingTimeoutsRef.current = []
+      return
+    }
+    if (timeoutOverridesMatch(configuredTimeouts, observedTimeoutsRef.current)) {
+      return
+    }
+    observedTimeoutsRef.current = configuredTimeouts
+    const pendingIndex = pendingTimeoutsRef.current.findIndex((pendingTimeouts) =>
+      timeoutOverridesMatch(pendingTimeouts, configuredTimeouts)
+    )
+    if (pendingIndex >= 0) {
+      pendingTimeoutsRef.current.splice(0, pendingIndex + 1)
+      if (pendingTimeoutsRef.current.length === 0) {
+        latestTimeoutsRef.current = configuredTimeouts
+      }
+      return
+    }
+    pendingTimeoutsRef.current = []
+    latestTimeoutsRef.current = configuredTimeouts
+  }, [configuredTimeouts, repo.id])
+
+  const updateTimeout = (key: keyof WorktreeCreateTimeouts, text: string): void => {
+    const latestTimeouts = latestTimeoutsRef.current
+    const trimmed = text.trim()
+    if (trimmed === '') {
+      if (latestTimeouts[key] === undefined) {
+        return
+      }
+      const nextTimeouts = withoutTimeout(latestTimeouts, key)
+      latestTimeoutsRef.current = nextTimeouts
+      pendingTimeoutsRef.current.push(nextTimeouts)
+      updateTimeouts(Object.keys(nextTimeouts).length > 0 ? nextTimeouts : null)
+      return
+    }
+    const seconds = Number(trimmed)
+    if (!Number.isFinite(seconds)) {
+      return
+    }
+    const timeoutMs = Math.round(
+      Math.min(MAX_TIMEOUT_SECONDS, Math.max(MIN_TIMEOUT_SECONDS, seconds)) * 1000
+    )
+    if (latestTimeouts[key] === timeoutMs) {
+      return
+    }
+    const nextTimeouts = { ...latestTimeouts, [key]: timeoutMs }
+    latestTimeoutsRef.current = nextTimeouts
+    pendingTimeoutsRef.current.push(nextTimeouts)
+    updateTimeouts(nextTimeouts)
+  }
+
+  return (
+    <SearchableSetting
+      title={translate(
+        'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.title',
+        'Worktree Creation Timeouts'
+      )}
+      description={translate(
+        'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.description',
+        'Override worktree creation stage timeouts for this project.'
+      )}
+      keywords={[
+        repo.displayName,
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.advanced',
+          'advanced'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.timeout',
+          'timeout'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.seconds',
+          'seconds'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.slowNetwork',
+          'slow network'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.gitWorktreeAdd',
+          'git worktree add'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.registration',
+          'registration'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.keyword.materialization',
+          'materialization'
+        )
+      ]}
+      forceVisible={forceVisible}
+    >
+      <div className="rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+        <div className="flex items-start justify-between gap-3 pb-1">
+          <p className="text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.inheritance',
+              'Leave a field empty to inherit the global setting on the execution host.'
+            )}
+          </p>
+          {repo.worktreeCreateTimeouts ? (
+            <Button
+              type="button"
+              variant="ghost"
+              size="sm"
+              onClick={() => {
+                latestTimeoutsRef.current = {}
+                pendingTimeoutsRef.current.push({})
+                updateTimeouts(null)
+              }}
+            >
+              {translate(
+                'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.useGlobal',
+                'Use Global'
+              )}
+            </Button>
+          ) : null}
+        </div>
+        <div className="divide-y divide-border/50">
+          {TIMEOUT_FIELDS.map((field) => {
+            const copy = getTimeoutFieldCopy(field.key)
+            return (
+              <SettingsRow
+                key={field.key}
+                label={copy.label}
+                description={copy.description}
+                control={
+                  <div className="flex items-center gap-2">
+                    <RepoSettingsDraftInput
+                      repoId={`${repo.id}:${field.key}`}
+                      storeValue={formatTimeoutSeconds(configuredTimeouts[field.key])}
+                      type="number"
+                      min={MIN_TIMEOUT_SECONDS}
+                      max={MAX_TIMEOUT_SECONDS}
+                      step={1}
+                      placeholder={
+                        canShowInheritedValue
+                          ? String(
+                              (inheritedTimeouts[field.key] ??
+                                WORKTREE_CREATE_TIMEOUT_DEFAULTS[field.key]) / 1000
+                            )
+                          : translate(
+                              'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.hostDefault',
+                              'Host default'
+                            )
+                      }
+                      onTextChange={() => {}}
+                      onBlur={(event) => updateTimeout(field.key, event.currentTarget.value)}
+                      className="number-input-clean w-24 tabular-nums"
+                    />
+                    <span className="shrink-0 text-xs text-muted-foreground">
+                      {translate(
+                        'auto.components.settings.RepositoryWorktreeCreateTimeoutSettings.seconds',
+                        'seconds'
+                      )}
+                    </span>
+                  </div>
+                }
+              />
+            )
+          })}
+        </div>
+      </div>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.test.tsx
@@ -3,7 +3,7 @@
 import React, { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type { Repo } from '../../../../shared/types'
+import type { GlobalSettings, Repo } from '../../../../shared/types'
 import { RepositoryWorktreeDefaultsSection } from './RepositoryWorktreeDefaultsSection'
 
 vi.mock('../../store', () => ({
@@ -39,12 +39,16 @@ afterEach(() => {
   container.remove()
 })
 
-function render(repo: Repo, updateRepo: (repoId: string, updates: object) => void): void {
+function render(
+  repo: Repo,
+  updateRepo: (repoId: string, updates: object) => void,
+  settings: Pick<GlobalSettings, 'workspaceDir' | 'worktreeCreateTimeouts'> | null = null
+): void {
   act(() => {
     root.render(
       React.createElement(RepositoryWorktreeDefaultsSection, {
         repo,
-        settings: null,
+        settings,
         updateRepo,
         forceVisible: true
       })
@@ -80,6 +84,10 @@ function blurInput(input: HTMLInputElement): void {
   act(() => {
     input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
   })
+}
+
+function getTimeoutInputs(): HTMLInputElement[] {
+  return Array.from(container.querySelectorAll<HTMLInputElement>('input[type="number"]'))
 }
 
 describe('RepositoryWorktreeDefaultsSection — worktree path', () => {
@@ -139,5 +147,109 @@ describe('RepositoryWorktreeDefaultsSection — worktree path', () => {
     blurInput(input)
 
     expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeBasePath: undefined })
+  })
+})
+
+describe('RepositoryWorktreeDefaultsSection — creation timeouts', () => {
+  it('shows the execution host global values as inherited placeholders', () => {
+    render(BASE_REPO, vi.fn(), {
+      workspaceDir: '/tmp',
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 11_000,
+        addCheckoutMs: 22_000,
+        registrationMs: 33_000,
+        materializationMs: 44_000
+      }
+    })
+
+    expect(getTimeoutInputs().map((input) => input.placeholder)).toEqual(['11', '22', '33', '44'])
+  })
+
+  it('converts seconds to milliseconds and preserves rapid field edits', () => {
+    const updateRepo = vi.fn()
+    render(BASE_REPO, updateRepo)
+    const [refreshInput, addInput] = getTimeoutInputs()
+
+    typeText(refreshInput, '12')
+    blurInput(refreshInput)
+    typeText(addInput, '34')
+    blurInput(addInput)
+
+    expect(updateRepo).toHaveBeenNthCalledWith(1, 'repo-1', {
+      worktreeCreateTimeouts: { refreshBaseRefMs: 12_000 }
+    })
+    expect(updateRepo).toHaveBeenNthCalledWith(2, 'repo-1', {
+      worktreeCreateTimeouts: { refreshBaseRefMs: 12_000, addCheckoutMs: 34_000 }
+    })
+  })
+
+  it('clamps an override to the supported range', () => {
+    const updateRepo = vi.fn()
+    render(BASE_REPO, updateRepo)
+    const [refreshInput] = getTimeoutInputs()
+
+    typeText(refreshInput, '9999')
+    blurInput(refreshInput)
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', {
+      worktreeCreateTimeouts: { refreshBaseRefMs: 7_200_000 }
+    })
+  })
+
+  it('clears the final field back to global inheritance', () => {
+    const updateRepo = vi.fn()
+    render(
+      {
+        ...BASE_REPO,
+        worktreeCreateTimeouts: { registrationMs: 45_000 }
+      },
+      updateRepo
+    )
+    const registrationInput = getTimeoutInputs()[2]
+
+    typeText(registrationInput, '')
+    blurInput(registrationInput)
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeCreateTimeouts: null })
+  })
+
+  it('clears every project override from Use Global', () => {
+    const updateRepo = vi.fn()
+    render(
+      {
+        ...BASE_REPO,
+        worktreeCreateTimeouts: { registrationMs: 45_000 }
+      },
+      updateRepo
+    )
+
+    const useGlobalButton = Array.from(container.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Use Global'
+    )
+    expect(useGlobalButton).toBeDefined()
+    act(() => {
+      useGlobalButton?.click()
+    })
+
+    expect(updateRepo).toHaveBeenCalledWith('repo-1', { worktreeCreateTimeouts: null })
+  })
+
+  it('does not claim a desktop global value for a runtime-owned project', () => {
+    render({ ...BASE_REPO, executionHostId: 'runtime:builder' }, vi.fn(), {
+      workspaceDir: '/tmp',
+      worktreeCreateTimeouts: {
+        refreshBaseRefMs: 11_000,
+        addCheckoutMs: 22_000,
+        registrationMs: 33_000,
+        materializationMs: 44_000
+      }
+    })
+
+    expect(getTimeoutInputs().map((input) => input.placeholder)).toEqual([
+      'Host default',
+      'Host default',
+      'Host default',
+      'Host default'
+    ])
   })
 })

--- a/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryWorktreeDefaultsSection.tsx
@@ -3,15 +3,18 @@ import { Button } from '../ui/button'
 import { Label } from '../ui/label'
 import { BaseRefPicker } from './BaseRefPicker'
 import { RepoSettingsDraftInput } from './RepositorySettingsDraftInput'
+import { RepositoryWorktreeCreateTimeoutSettings } from './RepositoryWorktreeCreateTimeoutSettings'
 import { SearchableSetting } from './SearchableSetting'
 import { translate } from '@/i18n/i18n'
 import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 
-type RepositoryWorktreeDefaultsUpdate = Pick<Repo, 'worktreeBasePath' | 'worktreeBaseRef'>
+type RepositoryWorktreeDefaultsUpdate = Pick<Repo, 'worktreeBasePath' | 'worktreeBaseRef'> & {
+  worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
+}
 
 type RepositoryWorktreeDefaultsSectionProps = {
   repo: Repo
-  settings: Pick<GlobalSettings, 'workspaceDir'> | null
+  settings: Pick<GlobalSettings, 'workspaceDir' | 'worktreeCreateTimeouts'> | null
   updateRepo: (repoId: string, updates: Partial<RepositoryWorktreeDefaultsUpdate>) => void
   forceVisible: boolean
 }
@@ -104,6 +107,13 @@ export function RepositoryWorktreeDefaultsSection({
           )}
         </p>
       </SearchableSetting>
+
+      <RepositoryWorktreeCreateTimeoutSettings
+        repo={repo}
+        settings={settings}
+        updateTimeouts={(worktreeCreateTimeouts) => updateRepo(repo.id, { worktreeCreateTimeouts })}
+        forceVisible={forceVisible}
+      />
     </>
   )
 }

--- a/src/renderer/src/components/settings/WorktreeCreateTimeoutSettings.test.tsx
+++ b/src/renderer/src/components/settings/WorktreeCreateTimeoutSettings.test.tsx
@@ -1,0 +1,186 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../../../shared/types'
+import type { WorktreeCreateTimeouts } from '../../../../shared/worktree-create-timeouts'
+import { WorktreeCreateTimeoutSettings } from './WorktreeCreateTimeoutSettings'
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, defaultValue: string) => defaultValue
+}))
+
+const INITIAL_TIMEOUTS: WorktreeCreateTimeouts = {
+  refreshBaseRefMs: 30_000,
+  addCheckoutMs: 120_000,
+  registrationMs: 45_000,
+  materializationMs: 90_000
+}
+
+describe('WorktreeCreateTimeoutSettings', () => {
+  let container: HTMLDivElement
+  let root: Root
+
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(() => {
+    act(() => root.unmount())
+    document.body.replaceChildren()
+  })
+
+  function renderSettings(
+    updateSettings = vi.fn<(updates: Partial<GlobalSettings>) => void>(),
+    searchQuery = '',
+    worktreeCreateTimeouts = INITIAL_TIMEOUTS
+  ): typeof updateSettings {
+    act(() => {
+      root.render(
+        <WorktreeCreateTimeoutSettings
+          settings={{ worktreeCreateTimeouts } as GlobalSettings}
+          updateSettings={updateSettings}
+          searchQuery={searchQuery}
+        />
+      )
+    })
+    return updateSettings
+  }
+
+  function getDisclosure(): HTMLButtonElement {
+    const button = container.querySelector<HTMLButtonElement>('button')
+    if (!button) {
+      throw new Error('worktree timeout disclosure was not rendered')
+    }
+    return button
+  }
+
+  function getInputs(): HTMLInputElement[] {
+    return Array.from(container.querySelectorAll<HTMLInputElement>('input[type="number"]'))
+  }
+
+  function setInputValue(input: HTMLInputElement, value: string): void {
+    act(() => {
+      const setValue = Object.getOwnPropertyDescriptor(HTMLInputElement.prototype, 'value')?.set
+      setValue?.call(input, value)
+      input.dispatchEvent(new Event('input', { bubbles: true }))
+    })
+  }
+
+  function pressEnter(input: HTMLInputElement): void {
+    act(() => {
+      input.dispatchEvent(new KeyboardEvent('keydown', { key: 'Enter', bubbles: true }))
+    })
+  }
+
+  function blurInput(input: HTMLInputElement): void {
+    act(() => {
+      input.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+  }
+
+  it('keeps the advanced timeout fields collapsed until opened', () => {
+    renderSettings()
+
+    expect(getDisclosure().getAttribute('aria-expanded')).toBe('false')
+    expect(getInputs()).toHaveLength(0)
+
+    act(() => getDisclosure().click())
+
+    expect(getDisclosure().getAttribute('aria-expanded')).toBe('true')
+    expect(getInputs().map((input) => input.value)).toEqual(['30', '120', '45', '90'])
+  })
+
+  it('forces the disclosure open when timeout search matches', () => {
+    renderSettings(vi.fn(), 'materialization')
+
+    expect(getDisclosure().getAttribute('aria-expanded')).toBe('true')
+    expect(getDisclosure().disabled).toBe(true)
+    expect(getInputs()).toHaveLength(4)
+  })
+
+  it('converts seconds to milliseconds and preserves the full nested object', () => {
+    const updateSettings = renderSettings()
+    act(() => getDisclosure().click())
+    const inputs = getInputs()
+
+    setInputValue(inputs[0], '12')
+    pressEnter(inputs[0])
+    setInputValue(inputs[1], '34')
+    blurInput(inputs[1])
+
+    expect(updateSettings).toHaveBeenNthCalledWith(1, {
+      worktreeCreateTimeouts: {
+        ...INITIAL_TIMEOUTS,
+        refreshBaseRefMs: 12_000
+      }
+    })
+    expect(updateSettings).toHaveBeenNthCalledWith(2, {
+      worktreeCreateTimeouts: {
+        ...INITIAL_TIMEOUTS,
+        refreshBaseRefMs: 12_000,
+        addCheckoutMs: 34_000
+      }
+    })
+  })
+
+  it('clamps timeout drafts to 1 through 7200 seconds', () => {
+    const updateSettings = renderSettings()
+    act(() => getDisclosure().click())
+    const inputs = getInputs()
+
+    setInputValue(inputs[2], '0')
+    blurInput(inputs[2])
+    setInputValue(inputs[3], '9000')
+    pressEnter(inputs[3])
+
+    expect(inputs[2].value).toBe('1')
+    expect(inputs[3].value).toBe('7200')
+    expect(updateSettings).toHaveBeenNthCalledWith(1, {
+      worktreeCreateTimeouts: {
+        ...INITIAL_TIMEOUTS,
+        registrationMs: 1_000
+      }
+    })
+    expect(updateSettings).toHaveBeenNthCalledWith(2, {
+      worktreeCreateTimeouts: {
+        ...INITIAL_TIMEOUTS,
+        registrationMs: 1_000,
+        materializationMs: 7_200_000
+      }
+    })
+  })
+
+  it('keeps newer nested edits when an older persistence echo arrives', () => {
+    const updateSettings = renderSettings()
+    act(() => getDisclosure().click())
+    let inputs = getInputs()
+
+    setInputValue(inputs[0], '12')
+    pressEnter(inputs[0])
+    setInputValue(inputs[1], '34')
+    pressEnter(inputs[1])
+
+    renderSettings(updateSettings, '', {
+      ...INITIAL_TIMEOUTS,
+      refreshBaseRefMs: 12_000
+    })
+    inputs = getInputs()
+    setInputValue(inputs[2], '56')
+    pressEnter(inputs[2])
+
+    expect(updateSettings).toHaveBeenLastCalledWith({
+      worktreeCreateTimeouts: {
+        ...INITIAL_TIMEOUTS,
+        refreshBaseRefMs: 12_000,
+        addCheckoutMs: 34_000,
+        registrationMs: 56_000
+      }
+    })
+  })
+})

--- a/src/renderer/src/components/settings/WorktreeCreateTimeoutSettings.tsx
+++ b/src/renderer/src/components/settings/WorktreeCreateTimeoutSettings.tsx
@@ -1,0 +1,261 @@
+import { useEffect, useRef, useState } from 'react'
+import { ChevronRight } from 'lucide-react'
+import type { GlobalSettings } from '../../../../shared/types'
+import {
+  WORKTREE_CREATE_TIMEOUT_DEFAULTS,
+  type WorktreeCreateTimeouts
+} from '../../../../shared/worktree-create-timeouts'
+import { translate } from '@/i18n/i18n'
+import { cn } from '@/lib/utils'
+import { Button } from '../ui/button'
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible'
+import { NumberField, SettingsBadge } from './SettingsFormControls'
+import { SearchableSetting } from './SearchableSetting'
+import {
+  matchesSettingsSearch,
+  normalizeSettingsSearchQuery,
+  type SettingsSearchEntry
+} from './settings-search'
+import { translateSearchKeyword } from './settings-search-keywords'
+
+const MIN_TIMEOUT_SECONDS = 1
+const MAX_TIMEOUT_SECONDS = 7200
+
+type TimeoutField = {
+  key: keyof WorktreeCreateTimeouts
+  label: string
+  description: string
+}
+
+function timeoutValuesMatch(left: WorktreeCreateTimeouts, right: WorktreeCreateTimeouts): boolean {
+  return (
+    left.refreshBaseRefMs === right.refreshBaseRefMs &&
+    left.addCheckoutMs === right.addCheckoutMs &&
+    left.registrationMs === right.registrationMs &&
+    left.materializationMs === right.materializationMs
+  )
+}
+
+function getTimeoutFields(): readonly TimeoutField[] {
+  return [
+    {
+      key: 'refreshBaseRefMs',
+      label: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.refreshBaseRefMs.label',
+        'Refresh base reference'
+      ),
+      description: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.refreshBaseRefMs.description',
+        'Fetching the remote base branch before creating the checkout.'
+      )
+    },
+    {
+      key: 'addCheckoutMs',
+      label: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.addCheckoutMs.label',
+        'Add checkout'
+      ),
+      description: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.addCheckoutMs.description',
+        'Running git worktree add and creating the checkout.'
+      )
+    },
+    {
+      key: 'registrationMs',
+      label: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.registrationMs.label',
+        'Workspace registration'
+      ),
+      description: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.registrationMs.description',
+        'Waiting for the new workspace to appear in Orca.'
+      )
+    },
+    {
+      key: 'materializationMs',
+      label: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.materializationMs.label',
+        'Workspace materialization'
+      ),
+      description: translate(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.materializationMs.description',
+        'Waiting for checkout files and workspace metadata to become ready.'
+      )
+    }
+  ]
+}
+
+export function getWorktreeCreateTimeoutSearchEntry(): SettingsSearchEntry {
+  return {
+    title: translate(
+      'auto.components.settings.WorktreeCreateTimeoutSettings.title',
+      'Worktree Creation Timeouts'
+    ),
+    description: translate(
+      'auto.components.settings.WorktreeCreateTimeoutSettings.description',
+      'Set how long Orca waits for each worktree creation stage before reporting a timeout.'
+    ),
+    keywords: [
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.advanced',
+        'advanced'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.timeout',
+        'timeout'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.seconds',
+        'seconds'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.slowNetwork',
+        'slow network'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.remoteHost',
+        'remote host'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.refreshBase',
+        'refresh base'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.gitWorktreeAdd',
+        'git worktree add'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.registration',
+        'registration'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.WorktreeCreateTimeoutSettings.keyword.materialization',
+        'materialization'
+      )
+    ]
+  }
+}
+
+export function shouldOpenWorktreeCreateTimeouts(searchQuery: string): boolean {
+  return (
+    normalizeSettingsSearchQuery(searchQuery) !== '' &&
+    matchesSettingsSearch(searchQuery, getWorktreeCreateTimeoutSearchEntry())
+  )
+}
+
+type WorktreeCreateTimeoutSettingsProps = {
+  settings: GlobalSettings
+  updateSettings: (updates: Partial<GlobalSettings>) => void | Promise<void>
+  searchQuery: string
+}
+
+export function WorktreeCreateTimeoutSettings({
+  settings,
+  updateSettings,
+  searchQuery
+}: WorktreeCreateTimeoutSettingsProps): React.JSX.Element | null {
+  const searchEntry = getWorktreeCreateTimeoutSearchEntry()
+  const matchesSearch = matchesSettingsSearch(searchQuery, searchEntry)
+  const forcedOpen = shouldOpenWorktreeCreateTimeouts(searchQuery)
+  const [open, setOpen] = useState(false)
+  const configuredTimeouts = settings.worktreeCreateTimeouts ?? WORKTREE_CREATE_TIMEOUT_DEFAULTS
+  const latestTimeoutsRef = useRef<WorktreeCreateTimeouts>({ ...configuredTimeouts })
+  const observedTimeoutsRef = useRef<WorktreeCreateTimeouts>({ ...configuredTimeouts })
+  const pendingTimeoutsRef = useRef<WorktreeCreateTimeouts[]>([])
+
+  useEffect(() => {
+    const incomingTimeouts = settings.worktreeCreateTimeouts ?? WORKTREE_CREATE_TIMEOUT_DEFAULTS
+    if (timeoutValuesMatch(incomingTimeouts, observedTimeoutsRef.current)) {
+      return
+    }
+    observedTimeoutsRef.current = incomingTimeouts
+    const pendingIndex = pendingTimeoutsRef.current.findIndex((pendingTimeouts) =>
+      timeoutValuesMatch(pendingTimeouts, incomingTimeouts)
+    )
+    if (pendingIndex >= 0) {
+      pendingTimeoutsRef.current.splice(0, pendingIndex + 1)
+      if (pendingTimeoutsRef.current.length === 0) {
+        latestTimeoutsRef.current = incomingTimeouts
+      }
+      return
+    }
+    pendingTimeoutsRef.current = []
+    latestTimeoutsRef.current = incomingTimeouts
+  }, [settings.worktreeCreateTimeouts])
+
+  if (!matchesSearch) {
+    return null
+  }
+
+  const expanded = open || forcedOpen
+  const updateTimeout = (field: keyof WorktreeCreateTimeouts, seconds: number): void => {
+    const nextTimeouts = {
+      ...latestTimeoutsRef.current,
+      [field]: Math.round(seconds * 1000)
+    }
+    latestTimeoutsRef.current = nextTimeouts
+    pendingTimeoutsRef.current.push(nextTimeouts)
+    void updateSettings({ worktreeCreateTimeouts: nextTimeouts })
+  }
+
+  return (
+    <SearchableSetting {...searchEntry} forceVisible>
+      <Collapsible
+        open={expanded}
+        onOpenChange={(nextOpen) => {
+          if (!forcedOpen) {
+            setOpen(nextOpen)
+          }
+        }}
+        className="border-t border-border/50 pt-2"
+      >
+        <CollapsibleTrigger asChild>
+          <Button
+            type="button"
+            variant="ghost"
+            size="sm"
+            disabled={forcedOpen}
+            className="-ml-2 h-8 px-2 text-sm font-semibold disabled:cursor-default disabled:opacity-100"
+          >
+            <ChevronRight
+              className={cn(
+                'size-3.5 text-muted-foreground transition-transform',
+                expanded && 'rotate-90'
+              )}
+            />
+            {searchEntry.title}
+            <SettingsBadge tone="muted">
+              {translate(
+                'auto.components.settings.WorktreeCreateTimeoutSettings.advanced',
+                'Advanced'
+              )}
+            </SettingsBadge>
+          </Button>
+        </CollapsibleTrigger>
+        <CollapsibleContent>
+          <div className="mt-2 rounded-md border border-border/60 bg-muted/20 px-3 py-3">
+            <p className="pb-1 text-xs text-muted-foreground">{searchEntry.description}</p>
+            <div className="divide-y divide-border/50">
+              {getTimeoutFields().map((field) => (
+                <NumberField
+                  key={field.key}
+                  label={field.label}
+                  description={field.description}
+                  value={configuredTimeouts[field.key] / 1000}
+                  min={MIN_TIMEOUT_SECONDS}
+                  max={MAX_TIMEOUT_SECONDS}
+                  step={1}
+                  suffix={translate(
+                    'auto.components.settings.WorktreeCreateTimeoutSettings.seconds',
+                    'seconds'
+                  )}
+                  onChange={(seconds) => updateTimeout(field.key, seconds)}
+                />
+              ))}
+            </div>
+          </div>
+        </CollapsibleContent>
+      </Collapsible>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/repository-git-worktree-search-entries.ts
+++ b/src/renderer/src/components/settings/repository-git-worktree-search-entries.ts
@@ -58,6 +58,36 @@ export function getRepositoryGitWorktreeSearchEntries(repo: Repo): SettingsSearc
     },
     {
       title: translate(
+        'auto.components.settings.repository.search.worktreeCreationTimeouts',
+        'Worktree Creation Timeouts'
+      ),
+      description: translate(
+        'auto.components.settings.repository.search.worktreeCreationTimeoutsDescription',
+        'Override worktree creation stage timeouts for this project.'
+      ),
+      keywords: [
+        repo.displayName,
+        ...translateSearchKeyword('auto.components.settings.repository.search.timeout', 'timeout'),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.slowNetwork',
+          'slow network'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.gitWorktreeAdd',
+          'git worktree add'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.registration',
+          'registration'
+        ),
+        ...translateSearchKeyword(
+          'auto.components.settings.repository.search.materialization',
+          'materialization'
+        )
+      ]
+    },
+    {
+      title: translate(
         'auto.components.settings.repository.search.1f0f20bbb6',
         'Sparse Checkout Presets'
       ),

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6380,6 +6380,7 @@
             "timeout": "timeout",
             "seconds": "seconds",
             "slowNetwork": "slow network",
+            "refreshBase": "refresh base",
             "gitWorktreeAdd": "git worktree add",
             "registration": "registration",
             "materialization": "materialization"
@@ -9111,6 +9112,7 @@
             "worktreeCreationTimeoutsDescription": "Override worktree creation stage timeouts for this project.",
             "timeout": "timeout",
             "slowNetwork": "slow network",
+            "refreshBase": "refresh base",
             "gitWorktreeAdd": "git worktree add",
             "registration": "registration",
             "materialization": "materialization",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6319,6 +6319,72 @@
           "compareBaseRepositoryDefault": "Repository default",
           "compareBaseBranchUpstream": "Branch upstream"
         },
+        "WorktreeCreateTimeoutSettings": {
+          "refreshBaseRefMs": {
+            "label": "Refresh base reference",
+            "description": "Fetching the remote base branch before creating the checkout."
+          },
+          "addCheckoutMs": {
+            "label": "Add checkout",
+            "description": "Running git worktree add and creating the checkout."
+          },
+          "registrationMs": {
+            "label": "Workspace registration",
+            "description": "Waiting for the new workspace to appear in Orca."
+          },
+          "materializationMs": {
+            "label": "Workspace materialization",
+            "description": "Waiting for checkout files and workspace metadata to become ready."
+          },
+          "title": "Worktree Creation Timeouts",
+          "description": "Set how long Orca waits for each worktree creation stage before reporting a timeout.",
+          "advanced": "Advanced",
+          "seconds": "seconds",
+          "keyword": {
+            "advanced": "advanced",
+            "timeout": "timeout",
+            "seconds": "seconds",
+            "slowNetwork": "slow network",
+            "remoteHost": "remote host",
+            "refreshBase": "refresh base",
+            "gitWorktreeAdd": "git worktree add",
+            "registration": "registration",
+            "materialization": "materialization"
+          }
+        },
+        "RepositoryWorktreeCreateTimeoutSettings": {
+          "refreshBaseRefMs": {
+            "label": "Refresh base reference",
+            "description": "Fetching the remote base branch before creating the checkout."
+          },
+          "addCheckoutMs": {
+            "label": "Add checkout",
+            "description": "Running git worktree add and creating the checkout."
+          },
+          "registrationMs": {
+            "label": "Workspace registration",
+            "description": "Waiting for the new workspace to appear in Orca."
+          },
+          "materializationMs": {
+            "label": "Workspace materialization",
+            "description": "Waiting for checkout files and workspace metadata to become ready."
+          },
+          "title": "Worktree Creation Timeouts",
+          "description": "Override worktree creation stage timeouts for this project.",
+          "inheritance": "Leave a field empty to inherit the global setting on the execution host.",
+          "useGlobal": "Use Global",
+          "hostDefault": "Host default",
+          "seconds": "seconds",
+          "keyword": {
+            "advanced": "advanced",
+            "timeout": "timeout",
+            "seconds": "seconds",
+            "slowNetwork": "slow network",
+            "gitWorktreeAdd": "git worktree add",
+            "registration": "registration",
+            "materialization": "materialization"
+          }
+        },
         "HiddenExperimentalGroup": {
           "d0f914a528": "Placeholder toggle",
           "1014ddbfaf": "Does nothing today. Reserved as the first slot for hidden experimental options.",
@@ -9041,6 +9107,13 @@
             "f41cef5083": "base ref",
             "f571081ec4": "Default base branch or ref when creating worktrees.",
             "094adbe930": "Default Worktree Base",
+            "worktreeCreationTimeouts": "Worktree Creation Timeouts",
+            "worktreeCreationTimeoutsDescription": "Override worktree creation stage timeouts for this project.",
+            "timeout": "timeout",
+            "slowNetwork": "slow network",
+            "gitWorktreeAdd": "git worktree add",
+            "registration": "registration",
+            "materialization": "materialization",
             "27733eb6c1": "favicon",
             "1e73e840ff": "emoji",
             "cb4b4de666": "avatar",

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -42,6 +42,7 @@ import {
 import { isGitRepoKind } from '../../../../shared/repo-kind'
 import { sanitizeRepoIcon } from '../../../../shared/repo-icon'
 import { normalizeRepoBadgeColor } from '../../../../shared/repo-badge-color'
+import { normalizeWorktreeCreateTimeoutOverrides } from '../../../../shared/worktree-create-timeouts'
 import { applyManualRepoOrder, getManualRepoOrder } from '../../../../shared/manual-repo-order'
 import { getProjectGroupSubtreeIds } from '../../../../shared/project-groups'
 import { isPathInsideOrEqual } from '../../../../shared/cross-platform-path'
@@ -136,6 +137,7 @@ export type RepoUpdate = Partial<
   >
 > & {
   sourceControlAi?: Repo['sourceControlAi'] | null
+  worktreeCreateTimeouts?: Repo['worktreeCreateTimeouts'] | null
   externalWorktreeDiscoverySuppressedAt?: Repo['externalWorktreeDiscoverySuppressedAt'] | null
 }
 
@@ -259,6 +261,12 @@ function sanitizeRepoUpdate(updates: RepoUpdate): RepoUpdate {
   }
   if ('worktreeBasePath' in sanitized && sanitized.worktreeBasePath !== undefined) {
     sanitized.worktreeBasePath = sanitized.worktreeBasePath.trim() || undefined
+  }
+  if ('worktreeCreateTimeouts' in sanitized && sanitized.worktreeCreateTimeouts !== null) {
+    const worktreeCreateTimeouts = normalizeWorktreeCreateTimeoutOverrides(
+      sanitized.worktreeCreateTimeouts
+    )
+    sanitized.worktreeCreateTimeouts = worktreeCreateTimeouts
   }
   if (
     'forkSyncMode' in sanitized &&
@@ -3571,6 +3579,7 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
             let mergedRepo: Repo = r
             const {
               sourceControlAi,
+              worktreeCreateTimeouts,
               externalWorktreeDiscoverySuppressedAt,
               ...updatesWithoutClearSentinels
             } = sanitizedUpdates
@@ -3581,6 +3590,15 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
               mergedRepo = repoWithoutSourceControlAi
             } else if (sourceControlAi !== undefined) {
               mergedRepo = { ...mergedRepo, sourceControlAi }
+            }
+            if (worktreeCreateTimeouts === null) {
+              const {
+                worktreeCreateTimeouts: _worktreeCreateTimeouts,
+                ...repoWithoutWorktreeCreateTimeouts
+              } = mergedRepo
+              mergedRepo = repoWithoutWorktreeCreateTimeouts
+            } else if (worktreeCreateTimeouts !== undefined) {
+              mergedRepo = { ...mergedRepo, worktreeCreateTimeouts }
             }
             if (externalWorktreeDiscoverySuppressedAt === null) {
               const {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -34,6 +34,7 @@ import {
   hasDismissedHugeRepoWarning,
   markHugeRepoWarningDismissed
 } from '@/lib/source-control-huge-repo-warning-dismissals'
+import { getMaximumWorktreeCreateTransportTimeoutMs } from '../../../../shared/worktree-create-timeouts'
 
 const requestWorktreeBaseFallbackNotice = vi.hoisted(() => vi.fn())
 
@@ -5740,6 +5741,7 @@ describe('worktree remote runtime mutations', () => {
     expect(result).toEqual({ worktree: wt })
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
+      expectedEnvironmentPairingRevision: undefined,
       method: 'worktree.create',
       params: {
         repo: 'repo1',
@@ -5753,7 +5755,7 @@ describe('worktree remote runtime mutations', () => {
         linkedPR: 456,
         pushTarget: { remoteName: 'fork', branchName: 'feature' }
       },
-      timeoutMs: 10 * 60_000
+      timeoutMs: getMaximumWorktreeCreateTransportTimeoutMs()
     })
     expect(mockApi.worktrees.create).not.toHaveBeenCalled()
     expect(store.getState().worktreesByRepo.repo1).toEqual([wt])

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -88,6 +88,7 @@ import {
   type ExecutionHostId
 } from '../../../../shared/execution-host'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import { getMaximumWorktreeCreateTransportTimeoutMs } from '../../../../shared/worktree-create-timeouts'
 import {
   resolveWorktreeOperationRoute,
   resolveWorktreeOperationRouteResult,
@@ -4112,7 +4113,7 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
                         }
                       : {})
                   },
-                  { timeoutMs: 10 * 60_000 }
+                  { timeoutMs: getMaximumWorktreeCreateTransportTimeoutMs() }
                 )
           // Why: worktrees.onChanged can add this worktree before this callback runs; appending blindly would duplicate it (React key clash).
           set((s) => {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -6,6 +6,7 @@ import type { FeatureInteractionState } from '../../../shared/feature-interactio
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import type { TaskSourceContext } from '../../../shared/task-source-context'
 import { MIN_COMPATIBLE_RUNTIME_SERVER_VERSION } from '../../../shared/protocol-version'
+import { getMaximumWorktreeCreateTransportTimeoutMs } from '../../../shared/worktree-create-timeouts'
 
 const TEST_COMMIT_OID = '0123456789abcdef0123456789abcdef01234567'
 
@@ -37,11 +38,13 @@ class MemoryStorage implements Storage {
   }
 }
 
-function installBrowserGlobals(userAgent = 'Linux'): {
+function installBrowserGlobals(
+  userAgent = 'Linux',
+  storage = new MemoryStorage()
+): {
   window: Window & typeof globalThis
   storage: MemoryStorage
 } {
-  const storage = new MemoryStorage()
   const windowStub = {
     localStorage: storage,
     location: {
@@ -1028,6 +1031,48 @@ describe('web settings preload API', () => {
     expect(settings.autoRenameBranchFromWorkDefaultedOn).toBe(true)
     expect(stored.autoRenameBranchFromWork).toBe(false)
     expect(stored.autoRenameBranchFromWorkDefaultedOn).toBe(true)
+  })
+
+  it('persists worktree creation timeouts without an active runtime environment', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    const timeouts = {
+      refreshBaseRefMs: 90_000,
+      addCheckoutMs: 240_000,
+      registrationMs: 45_000,
+      materializationMs: 360_000
+    }
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          throw new Error('Unexpected runtime call')
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(
+      globals.window.api.settings.set({ worktreeCreateTimeouts: timeouts })
+    ).resolves.toMatchObject({ worktreeCreateTimeouts: timeouts })
+    expect(
+      JSON.parse(globals.storage.getItem('orca.web.settings.v1.runtime:browser-local') ?? '{}')
+    ).toMatchObject({ worktreeCreateTimeouts: timeouts })
+    expect(JSON.parse(globals.storage.getItem('orca.web.settings.v1') ?? '{}')).not.toHaveProperty(
+      'worktreeCreateTimeouts'
+    )
+
+    vi.resetModules()
+    const reloadedGlobals = installBrowserGlobals('Linux', globals.storage)
+    const { installWebPreloadApi: installReloadedWebPreloadApi } = await import('./web-preload-api')
+    installReloadedWebPreloadApi()
+
+    expect(reloadedGlobals.window.api.settings.getSync()?.worktreeCreateTimeouts).toEqual(timeouts)
+    expect(runtimeCalls).toEqual([])
   })
 
   it('hydrates compact worktree cards from paired runtime settings', async () => {
@@ -3577,12 +3622,12 @@ describe('web worktree preload API', () => {
       {
         method: 'worktree.create',
         params: expect.objectContaining({ repo: 'repo-1', name: 'new-host', timeouts }),
-        options: { timeoutMs: 28_830_000 }
+        options: { timeoutMs: getMaximumWorktreeCreateTransportTimeoutMs() }
       },
       {
         method: 'worktree.create',
         params: expect.not.objectContaining({ timeouts: expect.anything() }),
-        options: { timeoutMs: 28_830_000 }
+        options: { timeoutMs: getMaximumWorktreeCreateTransportTimeoutMs() }
       }
     ])
   })

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -1103,6 +1103,128 @@ describe('web settings preload API', () => {
     expect(runtimeCalls).toEqual([{ method: 'settings.get', params: undefined }])
   })
 
+  it('hydrates worktree creation timeouts from a paired runtime', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    const timeouts = {
+      refreshBaseRefMs: 90_000,
+      addCheckoutMs: 240_000,
+      registrationMs: 45_000,
+      materializationMs: 360_000
+    }
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: { settings: { worktreeCreateTimeouts: timeouts } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const settings = await globals.window.api.settings.get()
+
+    expect(settings.worktreeCreateTimeouts).toEqual(timeouts)
+    expect(runtimeCalls).toEqual([{ method: 'settings.get', params: undefined }])
+  })
+
+  it('isolates worktree creation timeouts across paired runtimes', async () => {
+    const runtimeCalls: { host: string; method: string; params: unknown }[] = []
+    const hostATimeouts = {
+      refreshBaseRefMs: 90_000,
+      addCheckoutMs: 240_000,
+      registrationMs: 45_000,
+      materializationMs: 360_000
+    }
+    const hostBTimeouts = {
+      refreshBaseRefMs: 120_000,
+      addCheckoutMs: 300_000,
+      registrationMs: 60_000,
+      materializationMs: 420_000
+    }
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        private readonly host: string
+
+        constructor(offer: { publicKeyB64: string }) {
+          this.host = offer.publicKeyB64
+        }
+
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ host: this.host, method, params })
+          const currentTimeouts = this.host === 'public-key' ? hostATimeouts : hostBTimeouts
+          const requestedTimeouts =
+            method === 'settings.update'
+              ? ((params as { worktreeCreateTimeouts?: Partial<typeof hostBTimeouts> })
+                  .worktreeCreateTimeouts ?? {})
+              : {}
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: {
+              settings: {
+                worktreeCreateTimeouts: { ...currentTimeouts, ...requestedTimeouts }
+              }
+            },
+            _meta: { runtimeId: `runtime-${this.host}` }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'host-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    await expect(globals.window.api.settings.get()).resolves.toMatchObject({
+      worktreeCreateTimeouts: hostATimeouts
+    })
+    const paired = await globals.window.api.runtimeEnvironments.addFromPairingCode({
+      name: 'Host B',
+      pairingCode: encodePairingCode({ publicKeyB64: 'server-b-key' })
+    })
+    await expect(globals.window.api.settings.get()).resolves.toMatchObject({
+      worktreeCreateTimeouts: hostBTimeouts
+    })
+    await globals.window.api.settings.set({
+      worktreeCreateTimeouts: { ...hostBTimeouts, addCheckoutMs: 480_000 }
+    })
+
+    expect(runtimeCalls.at(-1)).toEqual({
+      host: 'server-b-key',
+      method: 'settings.update',
+      params: {
+        worktreeCreateTimeouts: { ...hostBTimeouts, addCheckoutMs: 480_000 }
+      }
+    })
+    expect(
+      JSON.parse(globals.storage.getItem('orca.web.settings.v1.runtime:host-a') ?? '{}')
+    ).toMatchObject({ worktreeCreateTimeouts: hostATimeouts })
+    expect(
+      JSON.parse(
+        globals.storage.getItem(`orca.web.settings.v1.runtime:${paired.environment.id}`) ?? '{}'
+      )
+    ).toMatchObject({
+      worktreeCreateTimeouts: { ...hostBTimeouts, addCheckoutMs: 480_000 }
+    })
+    expect(JSON.parse(globals.storage.getItem('orca.web.settings.v1') ?? '{}')).not.toHaveProperty(
+      'worktreeCreateTimeouts'
+    )
+  })
+
   it('hydrates MiniMax usage settings from a paired runtime', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
     vi.doMock('./web-runtime-client', () => ({
@@ -1247,6 +1369,96 @@ describe('web settings preload API', () => {
     expect(runtimeCalls).toEqual([
       { method: 'settings.update', params: { experimentalNewWorktreeCardStyle: true } }
     ])
+  })
+
+  it('forwards worktree creation timeout updates to a paired runtime', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    const timeouts = {
+      refreshBaseRefMs: 90_000,
+      addCheckoutMs: 240_000,
+      registrationMs: 45_000,
+      materializationMs: 360_000
+    }
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: { settings: { worktreeCreateTimeouts: timeouts } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const settings = await globals.window.api.settings.set({
+      worktreeCreateTimeouts: timeouts
+    })
+
+    expect(settings.worktreeCreateTimeouts).toEqual(timeouts)
+    expect(runtimeCalls).toEqual([
+      { method: 'settings.update', params: { worktreeCreateTimeouts: timeouts } }
+    ])
+  })
+
+  it('rolls back the host timeout shadow when a strict runtime rejects the update', async () => {
+    const originalTimeouts = {
+      refreshBaseRefMs: 90_000,
+      addCheckoutMs: 240_000,
+      registrationMs: 45_000,
+      materializationMs: 360_000
+    }
+    const rejectedTimeouts = { ...originalTimeouts, addCheckoutMs: 480_000 }
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          if (method === 'settings.update') {
+            return Promise.resolve({
+              id: 'settings-update',
+              ok: false,
+              error: {
+                code: 'invalid_params',
+                message: 'Unrecognized key: worktreeCreateTimeouts'
+              },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          return Promise.resolve({
+            id: 'settings-get',
+            ok: true,
+            result: { settings: { worktreeCreateTimeouts: originalTimeouts } },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    await globals.window.api.settings.get()
+
+    const settings = await globals.window.api.settings.set({
+      worktreeCreateTimeouts: rejectedTimeouts
+    })
+
+    expect(settings.worktreeCreateTimeouts).toEqual(originalTimeouts)
+    expect(globals.window.api.settings.getSync()?.worktreeCreateTimeouts).toEqual(originalTimeouts)
+    expect(
+      JSON.parse(globals.storage.getItem('orca.web.settings.v1.runtime:web-env-1') ?? '{}')
+    ).toMatchObject({ worktreeCreateTimeouts: originalTimeouts })
   })
 
   it('forwards MiniMax usage setting updates to a paired runtime', async () => {
@@ -3308,6 +3520,69 @@ describe('web worktree preload API', () => {
           targetBranch: 'release',
           isCrossRepository: false
         }
+      }
+    ])
+  })
+
+  it('uses the maximum compatible transport budget for new and legacy create requests', async () => {
+    const runtimeCalls: {
+      method: string
+      params: unknown
+      options: { timeoutMs?: number } | undefined
+    }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(
+          method: string,
+          params?: unknown,
+          options?: { timeoutMs?: number }
+        ): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params, options })
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result: {
+              worktree: { id: 'repo-1::/workspace/review', path: '/workspace/review' }
+            },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    const timeouts = {
+      refreshBaseRefMs: 1_000,
+      addCheckoutMs: 2_000,
+      registrationMs: 3_000,
+      materializationMs: 4_000
+    }
+
+    await globals.window.api.worktrees.create({
+      repoId: 'repo-1',
+      name: 'new-host',
+      timeouts
+    })
+    await globals.window.api.worktrees.create({
+      repoId: 'repo-1',
+      name: 'legacy-host'
+    })
+
+    expect(runtimeCalls).toEqual([
+      {
+        method: 'worktree.create',
+        params: expect.objectContaining({ repo: 'repo-1', name: 'new-host', timeouts }),
+        options: { timeoutMs: 28_830_000 }
+      },
+      {
+        method: 'worktree.create',
+        params: expect.not.objectContaining({ timeouts: expect.anything() }),
+        options: { timeoutMs: 28_830_000 }
       }
     ])
   })

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -162,6 +162,7 @@ import {
 import { createWebFileMutationMethods } from './web-file-mutation-methods'
 
 const SETTINGS_STORAGE_KEY = 'orca.web.settings.v1'
+const BROWSER_LOCAL_RUNTIME_SETTINGS_STORAGE_KEY = `${SETTINGS_STORAGE_KEY}.runtime:browser-local`
 const UI_STORAGE_KEY = 'orca.web.ui.v1'
 const SESSION_STORAGE_KEY = 'orca.web.workspaceSession.v1'
 const ONBOARDING_STORAGE_KEY = 'orca.web.onboarding.v1'
@@ -731,8 +732,8 @@ function createWebPreloadApi(): Partial<PreloadApi> {
             ? captureStoredWorktreeCreateTimeoutShadow(environment.id)
             : undefined
         writeStoredSettings(next)
-        if (environment && sanitizedUpdates.worktreeCreateTimeouts !== undefined) {
-          writeStoredWorktreeCreateTimeouts(environment.id, next.worktreeCreateTimeouts)
+        if (sanitizedUpdates.worktreeCreateTimeouts !== undefined) {
+          writeStoredWorktreeCreateTimeouts(environment?.id ?? null, next.worktreeCreateTimeouts)
         }
         return syncRuntimeBackedSettings(sanitizedUpdates, next, timeoutShadowSnapshot)
       },
@@ -3774,9 +3775,7 @@ function getStoredSettings(): GlobalSettings {
       // Keep readJson's invalid-JSON fallback non-destructive.
     }
   }
-  const runtimeStored = activeEnvironment
-    ? readStoredWorktreeCreateTimeouts(activeEnvironment.id)
-    : undefined
+  const runtimeStored = readStoredWorktreeCreateTimeouts(activeEnvironment?.id ?? null)
   return mergeSettings(
     {
       ...defaults,
@@ -3815,18 +3814,24 @@ function runtimeSettingsStorageKey(environmentId: string): string {
 }
 
 function readStoredWorktreeCreateTimeouts(
-  environmentId: string
+  environmentId: string | null
 ): GlobalSettings['worktreeCreateTimeouts'] | undefined {
-  const stored = readJson<Partial<GlobalSettings>>(runtimeSettingsStorageKey(environmentId), {})
+  const storageKey = environmentId
+    ? runtimeSettingsStorageKey(environmentId)
+    : BROWSER_LOCAL_RUNTIME_SETTINGS_STORAGE_KEY
+  const stored = readJson<Partial<GlobalSettings>>(storageKey, {})
   const normalized = normalizeWorktreeCreateTimeoutOverrides(stored.worktreeCreateTimeouts)
   return normalized ? normalizeWorktreeCreateTimeouts(normalized) : undefined
 }
 
 function writeStoredWorktreeCreateTimeouts(
-  environmentId: string,
+  environmentId: string | null,
   timeouts: GlobalSettings['worktreeCreateTimeouts']
 ): void {
-  writeJson(runtimeSettingsStorageKey(environmentId), {
+  const storageKey = environmentId
+    ? runtimeSettingsStorageKey(environmentId)
+    : BROWSER_LOCAL_RUNTIME_SETTINGS_STORAGE_KEY
+  writeJson(storageKey, {
     worktreeCreateTimeouts: normalizeWorktreeCreateTimeouts(timeouts)
   })
 }

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -96,6 +96,12 @@ import {
   computerAwakeSettingsForMode,
   normalizeComputerAwakeMode
 } from '../../../shared/computer-awake-mode'
+import {
+  getMaximumWorktreeCreateTransportTimeoutMs,
+  normalizeWorktreeCreateTimeoutOverrides,
+  normalizeWorktreeCreateTimeouts,
+  type WorktreeCreateTimeoutOverrides
+} from '../../../shared/worktree-create-timeouts'
 import type { RateLimitState } from '../../../shared/rate-limit-types'
 import type { RuntimeStatus, RuntimeSyncWindowGraph } from '../../../shared/runtime-types'
 import { assertFileMutationOwnershipCapability } from '../../../shared/file-mutation-ownership'
@@ -705,11 +711,30 @@ function createWebPreloadApi(): Partial<PreloadApi> {
         if ('autoRenameBranchFromWorkDefaultedOn' in sanitizedUpdates) {
           sanitizedUpdates.autoRenameBranchFromWorkDefaultedOn = true
         }
-        const next = mergeSettings(getStoredSettings(), sanitizedUpdates, {
+        const current = getStoredSettings()
+        const localUpdates =
+          sanitizedUpdates.worktreeCreateTimeouts === undefined
+            ? sanitizedUpdates
+            : {
+                ...sanitizedUpdates,
+                worktreeCreateTimeouts: normalizeWorktreeCreateTimeouts(
+                  sanitizedUpdates.worktreeCreateTimeouts,
+                  current.worktreeCreateTimeouts
+                )
+              }
+        const next = mergeSettings(current, localUpdates, {
           preserveAutoRenameBranchFromWorkUpdate: 'autoRenameBranchFromWork' in sanitizedUpdates
         })
+        const environment = requireActiveEnvironmentOrNull()
+        const timeoutShadowSnapshot =
+          environment && sanitizedUpdates.worktreeCreateTimeouts !== undefined
+            ? captureStoredWorktreeCreateTimeoutShadow(environment.id)
+            : undefined
         writeStoredSettings(next)
-        return syncRuntimeBackedSettings(sanitizedUpdates, next)
+        if (environment && sanitizedUpdates.worktreeCreateTimeouts !== undefined) {
+          writeStoredWorktreeCreateTimeouts(environment.id, next.worktreeCreateTimeouts)
+        }
+        return syncRuntimeBackedSettings(sanitizedUpdates, next, timeoutShadowSnapshot)
       },
       setActiveRuntimeEnvironmentPreference: async ({ environmentId }) => {
         const requestedEnvironmentId = environmentId?.trim() || null
@@ -1762,46 +1787,52 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
     listAll: () => listAllRuntimeWorktrees(),
     create: async (args) => {
       invalidateRuntimeWorktreeCaches()
-      const owned = await callRuntimeResultWithOwner<{ worktree: Worktree }>('worktree.create', {
-        repo: args.repoId,
-        name: args.name,
-        baseBranch: args.baseBranch,
-        compareBaseRef: args.compareBaseRef,
-        branchNameOverride: args.branchNameOverride,
-        linkedIssue: args.linkedIssue,
-        linkedPR: args.linkedPR,
-        linkedLinearIssue: args.linkedLinearIssue,
-        linkedLinearIssueWorkspaceId: args.linkedLinearIssueWorkspaceId,
-        linkedLinearIssueOrganizationUrlKey: args.linkedLinearIssueOrganizationUrlKey,
-        linkedGitLabIssue: args.linkedGitLabIssue,
-        linkedGitLabMR: args.linkedGitLabMR,
-        linkedBitbucketPR: args.linkedBitbucketPR,
-        linkedAzureDevOpsPR: args.linkedAzureDevOpsPR,
-        linkedGiteaPR: args.linkedGiteaPR,
-        displayName: args.displayName,
-        sparseCheckout: args.sparseCheckout,
-        pushTarget: args.pushTarget,
-        setupDecision: args.setupDecision,
-        createdWithAgent: args.createdWithAgent,
-        pendingFirstAgentMessageRename: args.pendingFirstAgentMessageRename,
-        ...(args.startup
-          ? {
-              startupCommand: args.startup.command,
-              ...(args.startup.env ? { startupEnv: args.startup.env } : {}),
-              ...(args.startup.launchConfig
-                ? { startupLaunchConfig: args.startup.launchConfig }
-                : {}),
-              ...(args.startup.startupCommandDelivery
-                ? { startupCommandDelivery: args.startup.startupCommandDelivery }
-                : {}),
-              activate: true
-            }
-          : {}),
-        parentWorkspace: args.parentWorkspace,
-        workspaceStatus: args.workspaceStatus,
-        manualOrder: args.manualOrder,
-        automationProvenanceRequest: args.automationProvenanceRequest
-      })
+      const timeouts = normalizeWorktreeCreateTimeoutOverrides(args.timeouts)
+      const owned = await callRuntimeResultWithOwner<{ worktree: Worktree }>(
+        'worktree.create',
+        {
+          repo: args.repoId,
+          name: args.name,
+          ...(timeouts ? { timeouts } : {}),
+          baseBranch: args.baseBranch,
+          compareBaseRef: args.compareBaseRef,
+          branchNameOverride: args.branchNameOverride,
+          linkedIssue: args.linkedIssue,
+          linkedPR: args.linkedPR,
+          linkedLinearIssue: args.linkedLinearIssue,
+          linkedLinearIssueWorkspaceId: args.linkedLinearIssueWorkspaceId,
+          linkedLinearIssueOrganizationUrlKey: args.linkedLinearIssueOrganizationUrlKey,
+          linkedGitLabIssue: args.linkedGitLabIssue,
+          linkedGitLabMR: args.linkedGitLabMR,
+          linkedBitbucketPR: args.linkedBitbucketPR,
+          linkedAzureDevOpsPR: args.linkedAzureDevOpsPR,
+          linkedGiteaPR: args.linkedGiteaPR,
+          displayName: args.displayName,
+          sparseCheckout: args.sparseCheckout,
+          pushTarget: args.pushTarget,
+          setupDecision: args.setupDecision,
+          createdWithAgent: args.createdWithAgent,
+          pendingFirstAgentMessageRename: args.pendingFirstAgentMessageRename,
+          ...(args.startup
+            ? {
+                startupCommand: args.startup.command,
+                ...(args.startup.env ? { startupEnv: args.startup.env } : {}),
+                ...(args.startup.launchConfig
+                  ? { startupLaunchConfig: args.startup.launchConfig }
+                  : {}),
+                ...(args.startup.startupCommandDelivery
+                  ? { startupCommandDelivery: args.startup.startupCommandDelivery }
+                  : {}),
+                activate: true
+              }
+            : {}),
+          parentWorkspace: args.parentWorkspace,
+          workspaceStatus: args.workspaceStatus,
+          manualOrder: args.manualOrder,
+          automationProvenanceRequest: args.automationProvenanceRequest
+        },
+        getMaximumWorktreeCreateTransportTimeoutMs()
+      )
       return {
         ...owned.result,
         worktree: withRuntimeWorktreeOwner(owned.result.worktree, owned.hostId)
@@ -3700,17 +3731,19 @@ function getStoredSettings(): GlobalSettings {
   const defaults = getDefaultSettings('~')
   const rawStoredSettings = window.localStorage.getItem(SETTINGS_STORAGE_KEY)
   const stored = readJson<Partial<GlobalSettings>>(SETTINGS_STORAGE_KEY, {})
+  const { worktreeCreateTimeouts: _runtimeWorktreeCreateTimeouts, ...browserStored } = stored
   const migratedStored = {
-    ...stored,
-    ...normalizeAutoRenameBranchFromWorkDefaultOn(stored),
-    ...normalizeTerminalCursorStyleDefault(stored),
-    ...normalizeOsc52ClipboardDefaultOn(stored),
-    terminalCustomThemes: normalizeTerminalCustomThemes(stored.terminalCustomThemes),
-    uiLanguage: normalizeUiLanguage(stored.uiLanguage)
+    ...browserStored,
+    ...normalizeAutoRenameBranchFromWorkDefaultOn(browserStored),
+    ...normalizeTerminalCursorStyleDefault(browserStored),
+    ...normalizeOsc52ClipboardDefaultOn(browserStored),
+    terminalCustomThemes: normalizeTerminalCustomThemes(browserStored.terminalCustomThemes),
+    uiLanguage: normalizeUiLanguage(browserStored.uiLanguage)
   }
   if (
     rawStoredSettings &&
-    (stored.autoRenameBranchFromWork !== migratedStored.autoRenameBranchFromWork ||
+    (stored.worktreeCreateTimeouts !== undefined ||
+      stored.autoRenameBranchFromWork !== migratedStored.autoRenameBranchFromWork ||
       stored.autoRenameBranchFromWorkDefaultedOn !==
         migratedStored.autoRenameBranchFromWorkDefaultedOn ||
       stored.terminalCursorStyle !== migratedStored.terminalCursorStyle ||
@@ -3741,6 +3774,9 @@ function getStoredSettings(): GlobalSettings {
       // Keep readJson's invalid-JSON fallback non-destructive.
     }
   }
+  const runtimeStored = activeEnvironment
+    ? readStoredWorktreeCreateTimeouts(activeEnvironment.id)
+    : undefined
   return mergeSettings(
     {
       ...defaults,
@@ -3748,7 +3784,10 @@ function getStoredSettings(): GlobalSettings {
       rightSidebarOpenByDefault: false,
       activeRuntimeEnvironmentId: null
     },
-    migratedStored
+    {
+      ...migratedStored,
+      ...(runtimeStored ? { worktreeCreateTimeouts: runtimeStored } : {})
+    }
   )
 }
 
@@ -3757,6 +3796,7 @@ function writeStoredSettings(
   explicitActiveRuntimeEnvironmentId?: string | null
 ): void {
   const durable = { ...settings }
+  delete durable.worktreeCreateTimeouts
   if (explicitActiveRuntimeEnvironmentId !== undefined) {
     durable.activeRuntimeEnvironmentId = explicitActiveRuntimeEnvironmentId
   } else {
@@ -3770,9 +3810,56 @@ function writeStoredSettings(
   writeJson(SETTINGS_STORAGE_KEY, durable)
 }
 
+function runtimeSettingsStorageKey(environmentId: string): string {
+  return `${SETTINGS_STORAGE_KEY}.runtime:${environmentId}`
+}
+
+function readStoredWorktreeCreateTimeouts(
+  environmentId: string
+): GlobalSettings['worktreeCreateTimeouts'] | undefined {
+  const stored = readJson<Partial<GlobalSettings>>(runtimeSettingsStorageKey(environmentId), {})
+  const normalized = normalizeWorktreeCreateTimeoutOverrides(stored.worktreeCreateTimeouts)
+  return normalized ? normalizeWorktreeCreateTimeouts(normalized) : undefined
+}
+
+function writeStoredWorktreeCreateTimeouts(
+  environmentId: string,
+  timeouts: GlobalSettings['worktreeCreateTimeouts']
+): void {
+  writeJson(runtimeSettingsStorageKey(environmentId), {
+    worktreeCreateTimeouts: normalizeWorktreeCreateTimeouts(timeouts)
+  })
+}
+
+type StoredWorktreeCreateTimeoutShadow = {
+  environmentId: string
+  rawValue: string | null
+}
+
+function captureStoredWorktreeCreateTimeoutShadow(
+  environmentId: string
+): StoredWorktreeCreateTimeoutShadow {
+  return {
+    environmentId,
+    rawValue: window.localStorage.getItem(runtimeSettingsStorageKey(environmentId))
+  }
+}
+
+function restoreStoredWorktreeCreateTimeoutShadow(
+  snapshot: StoredWorktreeCreateTimeoutShadow
+): void {
+  const storageKey = runtimeSettingsStorageKey(snapshot.environmentId)
+  if (snapshot.rawValue === null) {
+    window.localStorage.removeItem(storageKey)
+    return
+  }
+  window.localStorage.setItem(storageKey, snapshot.rawValue)
+}
+
 async function getRuntimeBackedStoredSettings(): Promise<GlobalSettings> {
   const local = getStoredSettings()
-  if (!requireActiveEnvironmentOrNull()) {
+  const environment = requireActiveEnvironmentOrNull()
+  if (!environment) {
     return local
   }
   try {
@@ -3788,6 +3875,11 @@ async function getRuntimeBackedStoredSettings(): Promise<GlobalSettings> {
     }
     if (typeof result.settings.compactWorktreeCards === 'boolean') {
       runtimeSettings.compactWorktreeCards = result.settings.compactWorktreeCards
+    }
+    if (result.settings.worktreeCreateTimeouts !== undefined) {
+      runtimeSettings.worktreeCreateTimeouts = normalizeWorktreeCreateTimeouts(
+        result.settings.worktreeCreateTimeouts
+      )
     }
     if (typeof result.settings.minimaxGroupId === 'string') {
       runtimeSettings.minimaxGroupId = result.settings.minimaxGroupId
@@ -3805,28 +3897,46 @@ async function getRuntimeBackedStoredSettings(): Promise<GlobalSettings> {
     if (typeof result.settings.artifactSharingEnabled === 'boolean') {
       runtimeSettings.artifactSharingEnabled = result.settings.artifactSharingEnabled
     }
+    assertActiveEnvironment(environment.id)
     const next = mergeSettings(local, runtimeSettings)
     writeStoredSettings(next)
+    if (runtimeSettings.worktreeCreateTimeouts) {
+      writeStoredWorktreeCreateTimeouts(environment.id, runtimeSettings.worktreeCreateTimeouts)
+    }
     return next
   } catch {
     // Why: unpaired/offline web clients keep a local settings fallback.
-    return local
+    return getStoredSettings()
   }
 }
 
 async function syncRuntimeBackedSettings(
-  updates: Partial<GlobalSettings>,
-  localNext: GlobalSettings
+  updates: Omit<Partial<GlobalSettings>, 'worktreeCreateTimeouts'> & {
+    worktreeCreateTimeouts?: WorktreeCreateTimeoutOverrides
+  },
+  localNext: GlobalSettings,
+  timeoutShadowSnapshot?: StoredWorktreeCreateTimeoutShadow
 ): Promise<GlobalSettings> {
-  if (!requireActiveEnvironmentOrNull()) {
+  const environment = requireActiveEnvironmentOrNull()
+  if (!environment) {
     return localNext
   }
-  const runtimeUpdates: Partial<GlobalSettings> = {}
+  const runtimeUpdates: Omit<Partial<GlobalSettings>, 'worktreeCreateTimeouts'> & {
+    worktreeCreateTimeouts?: WorktreeCreateTimeoutOverrides
+  } = {}
   if (typeof updates.experimentalNewWorktreeCardStyle === 'boolean') {
     runtimeUpdates.experimentalNewWorktreeCardStyle = updates.experimentalNewWorktreeCardStyle
   }
   if (typeof updates.compactWorktreeCards === 'boolean') {
     runtimeUpdates.compactWorktreeCards = updates.compactWorktreeCards
+  }
+  if (updates.worktreeCreateTimeouts !== undefined) {
+    const normalizedTimeouts = normalizeWorktreeCreateTimeoutOverrides(
+      updates.worktreeCreateTimeouts
+    )
+    if (normalizedTimeouts) {
+      runtimeUpdates.worktreeCreateTimeouts = normalizedTimeouts
+    }
   }
   if (typeof updates.minimaxGroupId === 'string') {
     runtimeUpdates.minimaxGroupId = updates.minimaxGroupId
@@ -3850,12 +3960,32 @@ async function syncRuntimeBackedSettings(
     )
     const runtimeSettings = { ...result.settings }
     delete runtimeSettings.activeRuntimeEnvironmentId
-    const next = mergeSettings(localNext, runtimeSettings)
+    if (runtimeSettings.worktreeCreateTimeouts !== undefined) {
+      runtimeSettings.worktreeCreateTimeouts = normalizeWorktreeCreateTimeouts(
+        runtimeSettings.worktreeCreateTimeouts,
+        localNext.worktreeCreateTimeouts
+      )
+    } else if (timeoutShadowSnapshot) {
+      restoreStoredWorktreeCreateTimeoutShadow(timeoutShadowSnapshot)
+    }
+    assertActiveEnvironment(environment.id)
+    const next = mergeSettings(
+      timeoutShadowSnapshot && runtimeSettings.worktreeCreateTimeouts === undefined
+        ? getStoredSettings()
+        : localNext,
+      runtimeSettings
+    )
     writeStoredSettings(next)
+    if (runtimeSettings.worktreeCreateTimeouts) {
+      writeStoredWorktreeCreateTimeouts(environment.id, runtimeSettings.worktreeCreateTimeouts)
+    }
     return next
   } catch {
+    if (timeoutShadowSnapshot) {
+      restoreStoredWorktreeCreateTimeoutShadow(timeoutShadowSnapshot)
+    }
     // Why: unpaired/offline web clients still need local settings persistence.
-    return localNext
+    return getStoredSettings()
   }
 }
 

--- a/src/shared/constants.test.ts
+++ b/src/shared/constants.test.ts
@@ -6,6 +6,7 @@ import {
   getDefaultTerminalRightClickToPaste,
   getDefaultSettings
 } from './constants'
+import { WORKTREE_CREATE_TIMEOUT_DEFAULTS } from './worktree-create-timeouts'
 
 describe('getDefaultSettings', () => {
   it('uses platform-consistent separators for the default workspace directory', () => {
@@ -35,6 +36,12 @@ describe('getDefaultSettings', () => {
   it('keeps first-work branch auto-renaming on by default for new settings', () => {
     expect(getDefaultSettings('/tmp').autoRenameBranchFromWork).toBe(true)
     expect(getDefaultSettings('/tmp').autoRenameBranchFromWorkDefaultedOn).toBe(true)
+  })
+
+  it('uses the built-in worktree create timeouts', () => {
+    expect(getDefaultSettings('/tmp').worktreeCreateTimeouts).toEqual(
+      WORKTREE_CREATE_TIMEOUT_DEFAULTS
+    )
   })
 
   it('uses a block terminal cursor by default for new settings', () => {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -34,6 +34,7 @@ import { DEFAULT_SETUP_AGENT_STARTUP_POLICY } from './setup-agent-startup-policy
 import { DESKTOP_TERMINAL_SCROLLBACK_ROWS_DEFAULT } from './terminal-scrollback-policy'
 import { DEFAULT_USAGE_PERCENTAGE_DISPLAY } from './usage-percentage-display'
 import { DEFAULT_STATUS_BAR_USAGE_MODE } from './status-bar-usage-mode'
+import { WORKTREE_CREATE_TIMEOUT_DEFAULTS } from './worktree-create-timeouts'
 
 export { DEFAULT_STATUS_BAR_ITEMS } from './status-bar-defaults'
 export {
@@ -177,6 +178,7 @@ export function getDefaultSettings(homedir: string): GlobalSettings {
     nestWorkspaces: true,
     workspaceDirHistory: [],
     refreshLocalBaseRefOnWorktreeCreate: false,
+    worktreeCreateTimeouts: { ...WORKTREE_CREATE_TIMEOUT_DEFAULTS },
     localBaseRefSuggestionDismissed: false,
     autoRenameBranchFromWork: true,
     autoRenameBranchFromWorkDefaultedOn: true,

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -54,6 +54,10 @@ import type { TaskSourceContext } from './task-source-context'
 import type { SetupRunnerShell } from './setup-runner-command'
 import type { AiVaultSessionTitle } from './ai-vault-session-title'
 import type { ComputerAwakeMode } from './computer-awake-mode'
+import type {
+  WorktreeCreateTimeoutOverrides,
+  WorktreeCreateTimeouts
+} from './worktree-create-timeouts'
 
 // Re-exported for backward compat with renderer call sites that import
 // `WorkspaceCreateTelemetrySource` from '../../../shared/types'.
@@ -260,6 +264,8 @@ export type Repo = {
   kind?: RepoKind
   gitUsername?: string
   worktreeBaseRef?: string
+  /** Repo-specific worktree-create timeout overrides. Missing fields inherit global settings. */
+  worktreeCreateTimeouts?: WorktreeCreateTimeoutOverrides
   /** Optional repo-scoped workspace root override. Relative paths resolve from `path`. */
   worktreeBasePath?: string
   hookSettings?: RepoHookSettings
@@ -2243,6 +2249,8 @@ export type SparsePreset = {
 export type CreateWorktreeArgs = {
   repoId: string
   name: string
+  /** Per-create timeout overrides. Missing fields inherit repo/global defaults. */
+  timeouts?: WorktreeCreateTimeoutOverrides
   /** Optional user-facing label to persist separately from the git-safe
    *  branch/path seed. Used when a workspace is created from a GitHub or
    *  Linear artifact whose title should remain readable in the sidebar. */
@@ -2744,6 +2752,7 @@ export type GlobalSettings = {
   nestWorkspaces: boolean
   workspaceDirHistory?: OrcaWorkspaceLayout[]
   refreshLocalBaseRefOnWorktreeCreate: boolean
+  worktreeCreateTimeouts?: WorktreeCreateTimeouts
   /** Set once the user dismisses the "local main is behind" suggestion toast, so
    *  the nudge to enable refreshLocalBaseRefOnWorktreeCreate never shows again. */
   localBaseRefSuggestionDismissed: boolean

--- a/src/shared/worktree-create-timeouts.test.ts
+++ b/src/shared/worktree-create-timeouts.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import {
+  WORKTREE_CREATE_TIMEOUT_DEFAULTS,
+  normalizeWorktreeCreateTimeoutOverrides,
+  normalizeWorktreeCreateTimeouts,
+  resolveWorktreeCreateTimeouts
+} from './worktree-create-timeouts'
+
+describe('worktree create timeouts', () => {
+  it('exports the built-in defaults', () => {
+    expect(WORKTREE_CREATE_TIMEOUT_DEFAULTS).toEqual({
+      refreshBaseRefMs: 60_000,
+      addCheckoutMs: 180_000,
+      registrationMs: 30_000,
+      materializationMs: 300_000
+    })
+  })
+
+  it('normalizes complete values against a fieldwise fallback', () => {
+    expect(
+      normalizeWorktreeCreateTimeouts(
+        {
+          refreshBaseRefMs: 999,
+          addCheckoutMs: 7_200_001,
+          registrationMs: 2_500.4,
+          materializationMs: Number.NaN
+        },
+        {
+          refreshBaseRefMs: 10_000,
+          addCheckoutMs: 20_000,
+          registrationMs: 30_000,
+          materializationMs: 40_000
+        }
+      )
+    ).toEqual({
+      refreshBaseRefMs: 1_000,
+      addCheckoutMs: 7_200_000,
+      registrationMs: 2_500,
+      materializationMs: 40_000
+    })
+  })
+
+  it('keeps repo and request overrides sparse', () => {
+    expect(
+      normalizeWorktreeCreateTimeoutOverrides({
+        refreshBaseRefMs: 999,
+        addCheckoutMs: -1,
+        registrationMs: 2_500.6,
+        materializationMs: Number.POSITIVE_INFINITY,
+        unknownMs: 45_000
+      })
+    ).toEqual({
+      refreshBaseRefMs: 1_000,
+      registrationMs: 2_501
+    })
+    expect(normalizeWorktreeCreateTimeoutOverrides({ addCheckoutMs: 0 })).toBeUndefined()
+    expect(normalizeWorktreeCreateTimeoutOverrides(null)).toBeUndefined()
+  })
+
+  it('resolves request, repo, global, and defaults fieldwise', () => {
+    expect(
+      resolveWorktreeCreateTimeouts({
+        global: {
+          refreshBaseRefMs: 70_000,
+          addCheckoutMs: 200_000
+        },
+        repo: {
+          addCheckoutMs: 210_000,
+          registrationMs: 35_000
+        },
+        request: {
+          registrationMs: 40_000,
+          materializationMs: 600_000
+        }
+      })
+    ).toEqual({
+      refreshBaseRefMs: 70_000,
+      addCheckoutMs: 210_000,
+      registrationMs: 40_000,
+      materializationMs: 600_000
+    })
+  })
+})

--- a/src/shared/worktree-create-timeouts.test.ts
+++ b/src/shared/worktree-create-timeouts.test.ts
@@ -1,6 +1,8 @@
 import { describe, expect, it } from 'vitest'
 import {
   WORKTREE_CREATE_TIMEOUT_DEFAULTS,
+  getMaximumWorktreeCreateTransportTimeoutMs,
+  getWorktreeCreateTransportTimeoutMs,
   normalizeWorktreeCreateTimeoutOverrides,
   normalizeWorktreeCreateTimeouts,
   resolveWorktreeCreateTimeouts
@@ -79,5 +81,10 @@ describe('worktree create timeouts', () => {
       registrationMs: 40_000,
       materializationMs: 600_000
     })
+  })
+
+  it('adds transport headroom to resolved and maximum stage budgets', () => {
+    expect(getWorktreeCreateTransportTimeoutMs(WORKTREE_CREATE_TIMEOUT_DEFAULTS)).toBe(600_000)
+    expect(getMaximumWorktreeCreateTransportTimeoutMs()).toBe(28_830_000)
   })
 })

--- a/src/shared/worktree-create-timeouts.ts
+++ b/src/shared/worktree-create-timeouts.ts
@@ -1,0 +1,105 @@
+export type WorktreeCreateTimeouts = {
+  refreshBaseRefMs: number
+  addCheckoutMs: number
+  registrationMs: number
+  materializationMs: number
+}
+
+export type WorktreeCreateTimeoutOverrides = Partial<WorktreeCreateTimeouts>
+
+export const WORKTREE_CREATE_TIMEOUT_DEFAULTS: Readonly<WorktreeCreateTimeouts> = {
+  refreshBaseRefMs: 60_000,
+  addCheckoutMs: 180_000,
+  registrationMs: 30_000,
+  materializationMs: 300_000
+}
+
+export const WORKTREE_CREATE_TIMEOUT_MIN_MS = 1_000
+export const WORKTREE_CREATE_TIMEOUT_MAX_MS = 2 * 60 * 60 * 1_000
+export const WORKTREE_CREATE_TRANSPORT_HEADROOM_MS = 30_000
+const WORKTREE_CREATE_TIMEOUT_KEYS = [
+  'refreshBaseRefMs',
+  'addCheckoutMs',
+  'registrationMs',
+  'materializationMs'
+] as const satisfies readonly (keyof WorktreeCreateTimeouts)[]
+
+function normalizeTimeout(value: unknown, fallback: number): number {
+  if (typeof value !== 'number' || !Number.isFinite(value) || value <= 0) {
+    return fallback
+  }
+  return Math.min(
+    WORKTREE_CREATE_TIMEOUT_MAX_MS,
+    Math.max(WORKTREE_CREATE_TIMEOUT_MIN_MS, Math.round(value))
+  )
+}
+
+export function normalizeWorktreeCreateTimeoutOverrides(
+  value: unknown
+): WorktreeCreateTimeoutOverrides | undefined {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return undefined
+  }
+  const candidate = value as Record<string, unknown>
+  const normalized: WorktreeCreateTimeoutOverrides = {}
+  for (const key of WORKTREE_CREATE_TIMEOUT_KEYS) {
+    const rawValue = candidate[key]
+    if (typeof rawValue === 'number' && Number.isFinite(rawValue) && rawValue > 0) {
+      normalized[key] = normalizeTimeout(rawValue, WORKTREE_CREATE_TIMEOUT_DEFAULTS[key])
+    }
+  }
+  return Object.keys(normalized).length > 0 ? normalized : undefined
+}
+
+export function normalizeWorktreeCreateTimeouts(
+  value: unknown,
+  fallback: WorktreeCreateTimeouts = { ...WORKTREE_CREATE_TIMEOUT_DEFAULTS }
+): WorktreeCreateTimeouts {
+  const normalizedFallback = Object.fromEntries(
+    WORKTREE_CREATE_TIMEOUT_KEYS.map((key) => [
+      key,
+      normalizeTimeout(fallback[key], WORKTREE_CREATE_TIMEOUT_DEFAULTS[key])
+    ])
+  ) as WorktreeCreateTimeouts
+  const candidate =
+    value && typeof value === 'object' && !Array.isArray(value)
+      ? (value as Record<string, unknown>)
+      : {}
+  return Object.fromEntries(
+    WORKTREE_CREATE_TIMEOUT_KEYS.map((key) => [
+      key,
+      normalizeTimeout(candidate[key], normalizedFallback[key])
+    ])
+  ) as WorktreeCreateTimeouts
+}
+
+export function resolveWorktreeCreateTimeouts({
+  global,
+  repo,
+  request
+}: {
+  global?: WorktreeCreateTimeoutOverrides | null
+  repo?: WorktreeCreateTimeoutOverrides | null
+  request?: WorktreeCreateTimeoutOverrides | null
+}): WorktreeCreateTimeouts {
+  const globalTimeouts = normalizeWorktreeCreateTimeouts(global)
+  const repoTimeouts = normalizeWorktreeCreateTimeouts(repo, globalTimeouts)
+  return normalizeWorktreeCreateTimeouts(request, repoTimeouts)
+}
+
+export function getWorktreeCreateTransportTimeoutMs(timeouts: WorktreeCreateTimeouts): number {
+  return (
+    timeouts.refreshBaseRefMs +
+    timeouts.addCheckoutMs +
+    timeouts.registrationMs +
+    timeouts.materializationMs +
+    WORKTREE_CREATE_TRANSPORT_HEADROOM_MS
+  )
+}
+
+export function getMaximumWorktreeCreateTransportTimeoutMs(): number {
+  return (
+    WORKTREE_CREATE_TIMEOUT_MAX_MS * WORKTREE_CREATE_TIMEOUT_KEYS.length +
+    WORKTREE_CREATE_TRANSPORT_HEADROOM_MS
+  )
+}


### PR DESCRIPTION
## Summary

Large repositories can spend significantly longer than the fixed defaults in base-ref refresh, checkout, registration, or post-create file materialization. This caused otherwise healthy worktree creation to be reported as timed out, especially over SSH or on slower hosts, while the underlying Git operation could still be running.

- Add configurable timeouts for the four worktree creation stages: base-ref refresh, add/checkout, registration, and post-create materialization.
- Support host-global defaults, per-repository overrides, and per-call CLI/RPC overrides with the precedence `request > repository > execution-host global > built-in defaults`.
- Apply stage deadlines across local, WSL, direct SSH/relay, paired runtime, CLI, and web flows, including cancellation propagation and rollback after a failed create.
- Add advanced Git and repository settings controls plus CLI flags, validation, persistence, mixed-version-safe optional wire fields, and focused regression coverage.

Closes #9865.

This supersedes and extends #9903. It includes the SSH child-process cancellation fix from that PR while covering all creation stages and execution paths.

## Screenshots

- No screenshot attached. The visual change is limited to new advanced timeout controls in **Settings > Git** and the repository worktree defaults section.

## Testing

- [x] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Validation details:

- Before the final upstream rebase, `pnpm typecheck` and `pnpm run build:desktop` passed, including relay builds for Linux/macOS/Windows x64/arm64, CLI, Electron renderer/main, and projected web client.
- After rebasing onto current `main` (`419151dddd54891e863206b1a01ea35ed6f8017b`), typecheck and desktop build are blocked before reaching this feature by `TS2307: Cannot find module 'psl'` in `src/main/browser/browser-cookie-import-policy.ts`. Both the `psl` dependency and that import are already present on upstream `main`; `pnpm install --frozen-lockfile` installs a Node-resolvable `psl@1.15.0`, but its exports do not expose the bundled declaration to the repository's TypeScript bundler resolution.
- Focused suites passed for shared normalization and precedence, settings persistence/RPC schemas, CLI flags and transport budgets, local/WSL create and rollback, direct SSH cancellation/deadlines, runtime registration/refresh deadlines, paired web host isolation, and global/repository settings UI.
- Final pre-rebase targeted runs included 115 relay/provider tests, 21 settings UI tests, 20 focused relay-handler tests, and 6 focused runtime tests. After rebasing onto current `main`, a consolidated 171-test timeout/settings/relay/provider suite also passed.
- A full `pnpm test` run reached 46,413 passing tests. It also exposed scoped assertion mismatches that were fixed and revalidated; the remaining failures were unrelated environment/flaky cases such as missing release tags and local shell/FIFO/submodule timeouts.
- Before the final upstream rebase, `pnpm build` completed the full desktop build, then failed in the native-only step because this machine's pnpm macOS binary was parsed as JavaScript by `build-native-for-platform.mjs`.

## AI Review Report

The AI review traced worktree creation through local, WSL, direct SSH/relay, paired runtime, CLI, and web clients. It explicitly checked macOS, Linux, and Windows compatibility, including native/WSL/SSH path handling, Git 2.25-compatible commands, Electron/runtime transport behavior, and the absence of platform-specific shortcut, label, or shell changes.

The review flagged:

- SSH cancellation was not initially propagated from the request through the provider and relay to every Git child process. The final implementation forwards `AbortSignal` without serializing it into the RPC payload.
- Runtime refresh queue time did not initially consume the configured absolute deadline. Queue wait and execution now share one deadline.
- Registration originally bounded only the final worktree list. Push-target configuration and discovery now share the registration-stage deadline.
- Sparse checkout initially applied a full timeout per Git subprocess. Local and relay flows now use a stage deadline and pass only the remaining budget.
- Web settings could leak between paired execution hosts, and runtime partial updates could reset omitted fields. Settings are now host-isolated and partial updates preserve existing values.
- Relay timeout input needed a strict boundary check. It now rejects non-finite and out-of-range values before running Git.

## Security Audit

- Validated all timeout inputs at UI, CLI, persistence, IPC/RPC, provider, and relay boundaries; accepted values are finite numbers from 1,000 to 7,200,000 ms.
- New RPC fields are optional and do not include credentials or arbitrary command input. Cancellation signals remain transport-only and are not serialized.
- Existing branch/ref validation, command construction, path canonicalization, exact-worktree rollback, and Git capability fallbacks remain in place.
- No dependencies, authentication flows, secret handling, or executable shell interpolation were added.
- Materialization checks deadlines at safe filesystem-operation boundaries; an individual filesystem operation is not forcibly interrupted mid-copy/link.

## Notes

- Optional wire fields are mixed-version safe. Older peers continue using legacy defaults; an older relay may ignore the child deadline, while the client transport retains a compatibility floor.
- Client transport uses a compatibility upper envelope (up to 8h 30s) because the effective global/repository settings are owned by the execution host; it is not presented as the sum of the user's selected stage budgets.
- Folder workspaces are unaffected.
- Thanks to @OnlyYu1996 for the focused SSH timeout/cancellation work in #9903.
