### PR TITLE
fix(editor): highlight the whole .env.* family as ini

### DIFF
--- a/mobile/src/session/mobile-file-language.ts
+++ b/mobile/src/session/mobile-file-language.ts
@@ -54,6 +54,9 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.ini': 'ini',
   '.cfg': 'ini',
   '.conf': 'ini',
+  // Why: covers bare .env (extname yields the whole dotfile name) and
+  // compose-style `env_file` names like dev.env.
+  '.env': 'ini',
   '.sql': 'sql',
   '.graphql': 'graphql',
   '.gql': 'graphql',
@@ -69,13 +72,10 @@ const FILENAME_TO_LANGUAGE: Record<string, string> = {
   'CMakeLists.txt': 'cmake',
   '.gitignore': 'ini',
   '.gitattributes': 'ini',
-  '.editorconfig': 'ini',
-  '.env': 'ini',
-  '.env.local': 'ini',
-  '.env.development': 'ini',
-  '.env.production': 'ini'
+  '.editorconfig': 'ini'
 }
 
+/** Resolve a highlight language id from a file path, honoring a caller-preferred language. */
 export function detectMobileFileLanguage(filePath: string, preferredLanguage?: string): string {
   const normalizedPreferred = preferredLanguage?.trim().toLowerCase()
   if (normalizedPreferred && normalizedPreferred !== 'plaintext') {
@@ -89,5 +89,11 @@ export function detectMobileFileLanguage(filePath: string, preferredLanguage?: s
     return exact
   }
 
-  return EXT_TO_LANGUAGE[extname(filename).toLowerCase()] ?? 'plaintext'
+  // Why: open-ended dotenv names (.env.local, .env.functions.local, ...) fall
+  // back to ini only after the extension miss, so .env.sh / .env.json keep
+  // their own language.
+  return (
+    EXT_TO_LANGUAGE[extname(filename).toLowerCase()] ??
+    (filename.toLowerCase().startsWith('.env.') ? 'ini' : 'plaintext')
+  )
 }

--- a/mobile/src/session/mobile-file-syntax.test.ts
+++ b/mobile/src/session/mobile-file-syntax.test.ts
@@ -20,6 +20,17 @@ describe('mobile file syntax highlighting', () => {
     expect(resolveMobileSyntaxLanguage('Dockerfile')).toBe('plaintext')
   })
 
+  it('detects the whole dotenv family as ini and resolves a registered grammar', () => {
+    expect(detectMobileFileLanguage('.env')).toBe('ini')
+    expect(detectMobileFileLanguage('apps/api/.env.local')).toBe('ini')
+    expect(detectMobileFileLanguage('.env.functions.local')).toBe('ini')
+    expect(detectMobileFileLanguage('.ENV.STAGING')).toBe('ini')
+    expect(detectMobileFileLanguage('deploy/dev.env')).toBe('ini')
+    expect(detectMobileFileLanguage('scripts/.env.sh')).toBe('shell')
+    expect(detectMobileFileLanguage('.envrc')).toBe('plaintext')
+    expect(resolveMobileSyntaxLanguage('.env.functions.local')).toBe('ini')
+  })
+
   it('emits semantic syntax segments for highlighted code', () => {
     const result = highlightMobileCode('const label: string = "Orca"', 'typescript')
 

--- a/src/renderer/src/lib/language-detect.test.ts
+++ b/src/renderer/src/lib/language-detect.test.ts
@@ -69,4 +69,29 @@ describe('detectLanguage', () => {
     expect(detectLanguage('config/tsconfig.jsonc')).toBe('json')
     expect(detectLanguage('notes/scratch.unknownext')).toBe('plaintext')
   })
+
+  it('maps the whole dotenv family to the ini language id (case-insensitive)', () => {
+    expect(detectLanguage('.env')).toBe('ini')
+    expect(detectLanguage('apps/api/.env.local')).toBe('ini')
+    expect(detectLanguage('.env.functions.local')).toBe('ini')
+    expect(detectLanguage('.env.staging.example')).toBe('ini')
+    expect(detectLanguage('C:\\repo\\.env.production')).toBe('ini')
+    expect(detectLanguage('.ENV')).toBe('ini')
+    expect(detectLanguage('.ENV.STAGING')).toBe('ini')
+  })
+
+  it('maps compose-style env_file names to the ini language id', () => {
+    expect(detectLanguage('deploy/dev.env')).toBe('ini')
+    expect(detectLanguage('C:\\repo\\docker.env')).toBe('ini')
+  })
+
+  it('keeps extension mapping ahead of the dotenv fallback', () => {
+    expect(detectLanguage('scripts/.env.sh')).toBe('shell')
+    expect(detectLanguage('config/.env.json')).toBe('json')
+  })
+
+  it('does not treat non-dotenv dotfiles as dotenv', () => {
+    expect(detectLanguage('.envrc')).toBe('plaintext')
+    expect(detectLanguage('.environment')).toBe('plaintext')
+  })
 })

--- a/src/renderer/src/lib/language-detect.ts
+++ b/src/renderer/src/lib/language-detect.ts
@@ -67,6 +67,9 @@ const EXT_TO_LANGUAGE: Record<string, string> = {
   '.ini': 'ini',
   '.cfg': 'ini',
   '.conf': 'ini',
+  // Why: covers bare .env (extname yields the whole dotfile name) and
+  // compose-style `env_file` names like dev.env.
+  '.env': 'ini',
   '.sql': 'sql',
   '.graphql': 'graphql',
   '.gql': 'graphql',
@@ -105,13 +108,10 @@ const FILENAME_TO_LANGUAGE: Record<string, string> = {
   'CMakeLists.txt': 'cmake',
   '.gitignore': 'ini',
   '.gitattributes': 'ini',
-  '.editorconfig': 'ini',
-  '.env': 'ini',
-  '.env.local': 'ini',
-  '.env.development': 'ini',
-  '.env.production': 'ini'
+  '.editorconfig': 'ini'
 }
 
+/** Resolve a Monaco language id from a file path; falls back to plaintext. */
 export function detectLanguage(filePath: string): string {
   // Check exact filename first
   const parts = filePath.split(/[\\/]/)
@@ -122,5 +122,8 @@ export function detectLanguage(filePath: string): string {
 
   // Check extension
   const ext = extname(filename).toLowerCase()
-  return EXT_TO_LANGUAGE[ext] ?? 'plaintext'
+  // Why: open-ended dotenv names (.env.local, .env.functions.local, ...) fall
+  // back to ini only after the extension miss, so .env.sh / .env.json keep
+  // their own language.
+  return EXT_TO_LANGUAGE[ext] ?? (filename.toLowerCase().startsWith('.env.') ? 'ini' : 'plaintext')
 }


### PR DESCRIPTION
## Summary

Fixes #13028

`.env.functions.local`, `.env.staging`, and other non-standard dotenv names rendered as plaintext because language detection only exact-matched four names (`.env`, `.env.local`, `.env.development`, `.env.production`).

Change, on both detection paths (`src/renderer/src/lib/language-detect.ts` desktop, `mobile/src/session/mobile-file-language.ts` mobile — `ini` is registered in the bundled lowlight `common` set, so highlighting is effective there, not a silent plaintext fallback):

- `'.env': 'ini'` added to `EXT_TO_LANGUAGE`. Because `extname()` returns the whole name for dotfiles, this one entry covers bare `.env`, uppercase `.ENV` (extension lookup already lowercases), and compose-style `env_file` names like `dev.env` / `docker.env`.
- After the exact-filename and extension lookups both miss, any filename matching `.env.*` (case-insensitive) resolves to `ini`.

The four exact `.env*` entries in `FILENAME_TO_LANGUAGE` are removed as redundant — the new lookups produce identical results for them. No new helper functions; the fallback is a single inlined check.

Deliberate ordering: the dotenv check runs *after* extension lookup, so a dotenv-prefixed name with a real extension (`.env.sh`, `.env.json`) keeps its own language. `.envrc` (direnv, bash syntax) does not match and is unchanged.

## Screenshots

**Before** (v1.4.175, `.env.functions.local` as plaintext):

<img width="1914" height="307" alt="Screenshot 2026-08-07 at 12 17 48" src="https://github.com/user-attachments/assets/3d6aac3e-66dc-4748-a189-d0986705bc94" />


**After** (this branch, same file as ini):

<img width="1898" height="490" alt="Screenshot 2026-08-07 at 12 21 05" src="https://github.com/user-attachments/assets/bc892e99-b033-4d6b-b0f9-c4954ef9ef96" />


## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Regression cases in `src/renderer/src/lib/language-detect.test.ts` and `mobile/src/session/mobile-file-syntax.test.ts`: family match (including `.env.functions.local`, `.env.staging.example`, uppercase `.ENV` / `.ENV.STAGING`), compose-style `dev.env` / `docker.env`, extension precedence (`.env.sh` → shell, `.env.json` → json), Windows paths, `.envrc`/`.environment` non-match, and mobile grammar resolution (`resolveMobileSyntaxLanguage` returns a lowlight-registered language, not a silent fallback).

Full-suite note: on my machine (macOS) 5 pre-existing failures reproduce identically with and without this change — 3 in `check-root-directory-entries.test.mjs` (the guard script uses `declare -A`, bash 4+, while macOS system bash is 3.2) and 2 in `agent-exec-handler.test.ts` (the test snapshots `process.env`, which my terminal pollutes with `GIT_CONFIG_*` vars). Both pass in a clean Linux environment.

## AI Review Report

Reviewed with Claude Code. Checks and outcomes:

- **Cross-platform (macOS/Linux/Windows):** pure string logic on the basename; the existing `split(/[\\/]/)` handles both separator styles, and Windows-path cases are covered in tests. Case-insensitive matching also covers case-preserving-but-insensitive filesystems (Windows, default macOS). No shortcuts, labels, shell behavior, or Electron platform APIs touched.
- **Remote/SSH/local:** detection operates on file paths already delivered to the renderer/mobile client; no assumption about where the file lives. No process, credential, or network-path assumptions added.
- **Agent/integration neutrality:** not integration-specific; applies to any file opened in the editor/diff views.
- **Performance:** two O(1) map lookups plus one `startsWith` on the basename, only on the miss path that previously returned `plaintext`. No hot-path impact.
- **Behavior-compat check:** the removed `FILENAME_TO_LANGUAGE` entries are provably equivalent under the new lookups (bare `.env` hits the new extension entry; `.local`, `.development`, `.production` fall through to the `.env.*` check). The only intentional behavior change beyond the dotenv family is `*.env` files moving from plaintext to ini.

## Security Audit

No input handling, command execution, IPC, auth, secret, or dependency changes. The change maps filenames to a syntax-highlighting language id; env-file *contents* are not parsed or transmitted differently. One consideration reviewed: env files often contain secrets, but highlighting them as ini does not alter storage, logging, or rendering scope — the file was already displayed in full as plaintext.

## Notes

No platform-specific behavior. Mobile needed no grammar registration — `ini` is already in the lowlight `common` bundle (same resolution path #11256 relied on).

Overlaps with #13239 (opened after this PR, same issue). Differences here: bare uppercase `.ENV` and compose-style `*.env` files are also covered, the now-redundant exact-name entries are removed, and the fallback stays inline with no new helper.
