### PR TITLE
fix(remote-workspace): stop snapshot applies from erasing worktrees outside the hydration validity set

### DIFF
--- a/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-apply.ts
@@ -125,11 +125,19 @@ export async function applyDirectSshRemoteWorkspaceSnapshot({
   try {
     const currentStore = store.getState()
     const replaceWorkspaceKeys = [...worktreeIds]
+    // Why additionalValidWorkspaceKeys: the hydrators re-derive validity from the
+    // loaded-worktree catalog only, but the replace scope legitimately includes
+    // detection-only worktrees — without declaring them valid, every apply erases
+    // their freshly hydrated tabs.
     currentStore.hydrateWorkspaceSession(merged, {
       directSshAuthority: authority,
-      replaceWorkspaceKeys
+      replaceWorkspaceKeys,
+      additionalValidWorkspaceKeys: replaceWorkspaceKeys
     })
-    currentStore.hydrateTabsSession(merged, { replaceWorkspaceKeys })
+    currentStore.hydrateTabsSession(merged, {
+      replaceWorkspaceKeys,
+      additionalValidWorkspaceKeys: replaceWorkspaceKeys
+    })
     // Why: direct SSH snapshots project terminal state only; global editor/browser hydration would reset unrelated hosts.
     currentStore.markRemoteWorkspaceHydrated(authority.targetId)
     currentStore.setRemoteWorkspaceSyncStatus(authority.targetId, {

--- a/src/renderer/src/hooks/remote-workspace-snapshot-detected-worktree-hydration.test.ts
+++ b/src/renderer/src/hooks/remote-workspace-snapshot-detected-worktree-hydration.test.ts
@@ -1,0 +1,138 @@
+/**
+ * The snapshot apply's replace scope comes from the direct-SSH target scope,
+ * which includes detected worktrees; the hydrators re-derive validity from the
+ * loaded-worktree catalog only. A worktree known solely through detection sits
+ * in the gap: it is in the replace scope, so its current state is replaced, but
+ * outside the validity set, so nothing hydrated survives the filter — every
+ * sync erases its tabs instead of restoring them. These tests pin the apply to
+ * declaring its replace scope valid.
+ */
+import { describe, expect, it, vi } from 'vitest'
+import type * as AgentStatusModule from '@/lib/agent-status'
+import type { RemoteWorkspaceSnapshot } from '../../../shared/remote-workspace-types'
+import type { DirectSshAuthority, SshProviderEpoch } from '../../../shared/ssh-types'
+import { createTestStore, makeWorktree } from '../store/slices/store-test-helpers'
+import { applyDirectSshRemoteWorkspaceSnapshot } from './remote-workspace-snapshot-apply'
+import type { DirectSshSnapshotApplyToken } from './direct-ssh-reconnect-coordinator-types'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const actual = await importOriginal<typeof AgentStatusModule>()
+  return { ...actual, detectAgentStatusFromTitle: vi.fn().mockReturnValue(null) }
+})
+
+const TARGET_ID = 'ssh-target-1'
+const DETECTED_PATH = '/srv/proj/wt-detected'
+const DETECTED_ID = `repoA::${DETECTED_PATH}`
+
+const authority: DirectSshAuthority = {
+  targetId: TARGET_ID,
+  providerEpoch: 'provider-epoch-1' as SshProviderEpoch,
+  connectionGeneration: 1
+}
+
+function token(snapshotRevision: number): DirectSshSnapshotApplyToken {
+  return {
+    authority,
+    catalogRevision: 0,
+    repoFingerprint: 'fp',
+    authorityRequirement: 'required',
+    snapshotRevision,
+    outcome: 'complete'
+  }
+}
+
+function snapshot(revision: number, tabIds: readonly string[]): RemoteWorkspaceSnapshot {
+  return {
+    namespace: 'workspace',
+    revision,
+    updatedAt: revision,
+    schemaVersion: 1,
+    session: {
+      activeWorktreePath: null,
+      activeTabId: null,
+      tabsByWorktreePath: {
+        [DETECTED_PATH]: tabIds.map((tabId, index) => ({
+          id: tabId,
+          worktreePath: DETECTED_PATH,
+          ptyId: `pty-${tabId}`,
+          title: `Terminal ${index + 1}`,
+          customTitle: null,
+          color: null,
+          sortOrder: index,
+          createdAt: index + 1
+        }))
+      },
+      terminalLayoutsByTabId: {},
+      activeWorktreePathsOnShutdown: [],
+      activeTabIdByWorktreePath: {},
+      remoteSessionIdsByTabId: Object.fromEntries(tabIds.map((id) => [id, `pty-${id}`])),
+      lastVisitedAtByWorktreePath: {},
+      defaultTerminalTabsAppliedByWorktreePath: {}
+    }
+  } satisfies RemoteWorkspaceSnapshot
+}
+
+type TestStore = ReturnType<typeof createTestStore>
+
+async function applySnapshot(store: TestStore, snap: RemoteWorkspaceSnapshot): Promise<void> {
+  await applyDirectSshRemoteWorkspaceSnapshot({
+    store,
+    snapshot: snap,
+    token: token(snap.revision),
+    arrival: 1,
+    isArrivalCurrent: () => true,
+    isPreparationTokenCurrent: () => true,
+    waitForWorkspaceSessionReady: async () => true,
+    finalizeHydratedTerminals: () => 0
+  })
+}
+
+function seedDetectedOnlyCatalog(store: TestStore): void {
+  store.setState({
+    // Why: the worktree is known to detection (authoritative git scan) but not
+    // loaded — the exact split between the target scope and hydration validity.
+    worktreesByRepo: {},
+    detectedWorktreesByRepo: {
+      repoA: {
+        repoId: 'repoA',
+        authoritative: true,
+        source: 'git',
+        worktrees: [
+          makeWorktree({
+            id: DETECTED_ID,
+            repoId: 'repoA',
+            path: DETECTED_PATH,
+            hostId: `ssh:${TARGET_ID}`
+          } as never)
+        ]
+      } as never
+    }
+  })
+}
+
+function tabIds(store: TestStore, worktreeId: string): string[] {
+  return (store.getState().tabsByWorktree[worktreeId] ?? []).map((tab) => tab.id)
+}
+
+describe('direct-SSH snapshot apply, detected-only worktree hydration', () => {
+  it('hydrates snapshot tabs for a worktree known only through detection', async () => {
+    const store = createTestStore()
+    seedDetectedOnlyCatalog(store)
+
+    await applySnapshot(store, snapshot(1, ['tab-r1']))
+
+    expect(tabIds(store, DETECTED_ID)).toEqual(['tab-r1'])
+  })
+
+  it('does not erase existing tabs of a detected-only worktree on re-apply', async () => {
+    const store = createTestStore()
+    seedDetectedOnlyCatalog(store)
+    await applySnapshot(store, snapshot(1, ['tab-r1']))
+    expect(tabIds(store, DETECTED_ID)).toEqual(['tab-r1'])
+
+    await applySnapshot(store, snapshot(2, ['tab-r1']))
+
+    expect(tabIds(store, DETECTED_ID)).toEqual(['tab-r1'])
+  })
+})

--- a/src/renderer/src/lib/workspace-session-hydration-keys.ts
+++ b/src/renderer/src/lib/workspace-session-hydration-keys.ts
@@ -6,7 +6,10 @@ import { parseWorkspaceKey } from '../../../shared/workspace-scope'
 import { getRepoIdFromWorktreeId } from '../../../shared/worktree/id'
 
 export type WorkspaceSessionHydrationOptions = {
-  additionalValidWorkspaceKeys?: readonly WorkspaceKey[]
+  // Why plain strings: entries land in the hydrators' validity sets, which hold the raw
+  // keys of session.tabsByWorktree — bare worktree ids for worktrees, WorkspaceKey
+  // strings for folder workspaces. Plain strings match what the sets compare.
+  additionalValidWorkspaceKeys?: readonly string[]
   replaceWorkspaceKeys?: readonly string[]
 }
 


### PR DESCRIPTION
## Problem

`applyDirectSshRemoteWorkspaceSnapshot` hydrates the merged session with `replaceWorkspaceKeys` derived from `resolveDirectSshTargetScope`, whose scope includes `detectedWorktreesByRepo`. The hydrators independently re-derive a validity set via `buildValidWorktreeIdsForSessionHydration`, which accepts ids from `worktreesByRepo` only. The replace step removes every replace-scope key from current state and re-adds only entries that survived the validity filter — so a worktree in the scope-minus-validity gap is erased rather than replaced on every sync: its current tabs are dropped and its merged tabs are filtered out.

A remote worktree the catalog knows only through detection (e.g. while catalog sources are still filling in after connect, or a worktree classified as non-visible) hits this on every snapshot apply. Observed effect: the remote store holds the worktree's terminal session across restarts while the UI shows an empty worktree, auto-creates junk terminals into it, and treats the running agent session's tab as gone.

## Change

The apply passes its replace scope as `additionalValidWorkspaceKeys` to both hydrators — replacing a worktree's session implies accepting that worktree's session. The keys are locally derived (never from snapshot content), and a genuinely deleted worktree cannot appear in the target scope, so this cannot resurrect deleted worktrees or widen what remote content may inject; per-tab validation is unchanged.

`WorkspaceSessionHydrationOptions.additionalValidWorkspaceKeys` widens from `readonly WorkspaceKey[]` to `readonly string[]`: the hydrators' validity sets hold the raw keys of `session.tabsByWorktree` — bare worktree ids for worktrees, `WorkspaceKey` strings for folder workspaces — which the template-literal type cannot express for the worktree case. The option's only consumer adds entries to a `Set<string>`.

## Testing

New `remote-workspace-snapshot-detected-worktree-hydration.test.ts` (real-store harness): snapshot tabs for a detected-only worktree hydrate into `tabsByWorktree`, and a re-apply does not erase them. Both fail without the fix with the exact erasure symptom (`expected [] to deeply equal ['tab-r1']`). The pinned-options assertion in `remote-workspace-target-sync.test.ts` reflects the new call shape. `typecheck:web` clean; renderer hooks+lib suites pass (4090 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)