### PR TITLE
fix(terminal): preserve Cmd+C scroll with Korean input

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -263,6 +263,33 @@ describe('AgentTerminalPreview', () => {
     expect(imeHarness.inputSourceTrackerRequests).toBe(1)
   })
 
+  it('bubbles physical Cmd+C from a Korean input source without leaking its keyup', async () => {
+    platformState.value = 'darwin'
+    render(<AgentTerminalPreview ptyId="pty-1" />)
+    await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))
+    const terminal = terminalHarness.instances[0]!
+    await waitFor(() => expect(terminal.customKeyHandler).not.toBeNull())
+
+    const keydown = new KeyboardEvent('keydown', {
+      key: 'ㅊ',
+      code: 'KeyC',
+      metaKey: true,
+      cancelable: true
+    })
+    const keyup = new KeyboardEvent('keyup', {
+      key: 'ㅊ',
+      code: 'KeyC',
+      metaKey: true,
+      cancelable: true
+    })
+
+    expect(terminal.customKeyHandler!(keydown)).toBe(false)
+    expect(terminal.customKeyHandler!(keyup)).toBe(false)
+    expect(keydown.defaultPrevented).toBe(false)
+    expect(keyup.defaultPrevented).toBe(false)
+    expect(writeTerminalClipboardText).not.toHaveBeenCalled()
+  })
+
   it('does not install the IME native-text forwarder off macOS', async () => {
     render(<AgentTerminalPreview ptyId="pty-1" />)
     await waitFor(() => expect(terminalHarness.instances).toHaveLength(1))

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-key-handler.ts
@@ -4,6 +4,7 @@ import { keybindingMatchesAction } from '../../../../shared/keybindings'
 import { useAppStore } from '@/store'
 import { prefetchLayoutBaseCharacters } from '@/lib/keyboard-layout/layout-base-character'
 import { createTerminalNativeOnlyShortcutTracker } from '@/components/terminal-pane/terminal-native-only-shortcut'
+import { isMacNonLatinPhysicalCopyChord } from '@/components/terminal-pane/xterm-bypass-policy'
 import {
   resolvePreviewShortcutAction,
   type PreviewShortcutContext
@@ -88,6 +89,9 @@ export function installPreviewTerminalKeyHandler(args: {
   terminal.attachCustomKeyEventHandler((event) => {
     if (args.claimImeKeyEvent(event)) {
       // Why: bypass xterm's kitty encoder for native-text keydowns so the committed glyph survives via the input event.
+      return false
+    }
+    if (platform === 'darwin' && isMacNonLatinPhysicalCopyChord(event)) {
       return false
     }
     if (event.type !== 'keydown') {

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.test.ts
@@ -40,6 +40,30 @@ describe('shouldBypassXtermKeyboardEvent — macOS', () => {
     ).toBe(false)
   })
 
+  it('bubbles Cmd+C keydown and keyup when the Korean input source reports physical C as ㅊ', () => {
+    for (const type of ['keydown', 'keyup']) {
+      expect(
+        shouldBypassXtermKeyboardEvent(
+          event({ type, key: 'ㅊ', code: 'KeyC', metaKey: true }),
+          opts
+        )
+      ).toBe(true)
+    }
+  })
+
+  it.each([
+    ['Shift', { shiftKey: true }],
+    ['Control', { ctrlKey: true }],
+    ['Option', { altKey: true }]
+  ])('does not treat Cmd+%s+ㅊ as physical Cmd+C', (_modifier, modifiers) => {
+    expect(
+      shouldBypassXtermKeyboardEvent(
+        event({ key: 'ㅊ', code: 'KeyC', metaKey: true, ...modifiers }),
+        opts
+      )
+    ).toBe(false)
+  })
+
   it('does NOT bubble other Cmd chords — Orca window handlers intercept them before xterm', () => {
     // Why: this policy is narrowly scoped to clipboard chords. Cmd+F, Cmd+D,
     // Cmd+K, Cmd+W, Cmd+Arrow, Cmd+Backspace are handled in keyboard-handlers.ts

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -174,6 +174,17 @@ function matchesClipboardBinding(
   return keybindingMatchesInput(binding, event, platform)
 }
 
+export function isMacNonLatinPhysicalCopyChord(event: XtermBypassEvent): boolean {
+  return (
+    event.metaKey &&
+    !event.ctrlKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    event.code === 'KeyC' &&
+    isSingleNonAsciiPrintableText(event.key)
+  )
+}
+
 /**
  * Decide whether plain Ctrl+C should bypass xterm's kitty CSI-u encoder and
  * be sent as ETX through Terminal.input() instead.
@@ -251,6 +262,8 @@ export function shouldBypassXtermKeyboardEvent(
     // Chromium's native paste event instead of xterm's Kitty encoder.
     return (
       matchesClipboardBinding('Mod+C', event, 'darwin') ||
+      // Why: macOS Korean and other non-Latin sources report physical Cmd+C as a translated glyph; xterm would encode it as PTY input and snap scrollback to the bottom.
+      isMacNonLatinPhysicalCopyChord(event) ||
       matchesClipboardBinding('Mod+V', event, 'darwin')
     )
   }


### PR DESCRIPTION
## Summary

- Preserve terminal scrollback when macOS reports physical Cmd+C as a translated non-Latin glyph, such as Korean `ㅊ` with `code: "KeyC"`.
- Share the physical-copy classifier with the dashboard pop-out terminal so the shortcut bypasses xterm in both terminal paths.
- Keep the handling macOS-specific and require Meta without Shift, Control, or Option, leaving Windows and Linux behavior unchanged.

Fixes #13033

## Screenshots

No visual changes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 4,425 files and 47,407 tests passed; 14 files and 87 tests skipped
- [x] `pnpm build:desktop` — Electron renderer, runtime closure verification, and projected web client passed
- [x] Focused terminal policy and dashboard pop-out suites — 90 tests passed
- [x] Local xterm reproduction — before the fix, physical Cmd+C under Korean input emitted `ESC[12618;9u` and moved the viewport from line 30 to 109; after the bypass, no PTY data was emitted and the viewport remained at line 30
- [ ] `pnpm build` — the desktop phase passed, but the native Swift package phase is blocked on this machine by a mismatched Apple Command Line Tools installation whose `PackageDescription` interface and dylib expose incompatible manifest initializers; `swift package describe` reproduces the failure independently of this patch

## AI Review Report

An independent review found that the dashboard pop-out terminal has a separate xterm key handler. The patch now uses the same physical-copy classifier in both paths and adds keydown, keyup, and Shift/Control/Option negative coverage. The follow-up review found no critical, important, or minor issues and confirmed that Windows/Linux behavior and local/SSH/remote PTY routing remain unchanged.

## Security Audit

This change does not add dependencies or alter commands, paths, authentication, IPC, persistence, or network behavior. The new predicate only classifies a narrow macOS keyboard event before xterm input encoding.

## Notes

- The native-build failure appears local to the installed Apple Command Line Tools: the Swift manifest compiler expects the deprecated `SwiftVersion` initializer while the linked `libPackageDescription.dylib` only exports the `SwiftLanguageMode` overload.
- X/Twitter handle: none; GitHub credit as `@siyeonson-quantit` is fine.
