### PR TITLE
fix(copy): stop soft-wrapping code blocks so copied commands stay on one line

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -101,6 +101,7 @@ docs/**
 !docs/reference/linux-glibc-compatibility.md
 !docs/reference/relay-grace-time-reconfiguration.md
 !docs/reference/remote-wire-compatibility.md
+!docs/reference/soft-wrap-selection-copy.md
 !docs/reference/windows-setup-shell.md
 
 # Stably CLI (only docs/ are tracked)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -44,6 +44,10 @@ All changes must consider folder workspaces as well as git worktrees. Don't assu
 
 Clients and remote Orca servers update independently, so mixed versions are the normal state. Before changing anything a paired client and host exchange — RPC params, stream frames, or the content either side publishes over them — follow [`docs/reference/remote-wire-compatibility.md`](./docs/reference/remote-wire-compatibility.md). A new optional field is safe; a new stream opcode must be capability-negotiated because decoders drop unknown opcodes silently; and changing what the host publishes reaches old clients even with no wire change.
 
+## DOM Copy Compatibility
+
+Chromium (Electron's engine) turns soft-wrapped `white-space: pre-wrap` text into real newlines on copy, so a visually wrapped command pastes into a shell as two commands. Code/command-shaped DOM content must therefore render with `white-space: pre` and horizontal scroll — never `pre-wrap`; prose containers (comment bodies, error notices) may keep `pre-wrap`. xterm terminal selections are unaffected. See [`docs/reference/soft-wrap-selection-copy.md`](./docs/reference/soft-wrap-selection-copy.md).
+
 ## Git Binary Compatibility
 
 Orca runs the user's Git binary on native, WSL, and SSH hosts, which may all have different versions. Treat Git 2.25 as the core-workflow baseline and follow [`docs/reference/git-compatibility.md`](./docs/reference/git-compatibility.md).

--- a/docs/reference/soft-wrap-selection-copy.md
+++ b/docs/reference/soft-wrap-selection-copy.md
@@ -1,0 +1,117 @@
+# Soft-Wrap Selection Copy: "copied command splits into two lines" — Findings & Fix
+
+Date: 2026-08-07
+Status: PR-ready
+
+## Reported symptom
+
+Copying an AI-generated command (e.g. `npx skills add … --agent claude-code … -y`)
+from a chat/markdown surface and pasting it into a terminal produces a **broken
+command**: the wrapped visual line comes out as two real lines, so zsh runs the
+second fragment as a separate command and fails with e.g.
+`zsh: command not found: code` (the `claude-` / `code` split).
+
+The source text contains **no newline** — the command is one continuous line. The
+break is introduced by copy, not by the source.
+
+## Root cause
+
+Copy-paste of soft-wrapped text is **UA-defined** (see `commonmark/commonmark-spec`
+issue #744): browsers disagree on whether a visual soft-wrap position becomes a
+newline in the copied text.
+
+| Engine | `white-space: pre-wrap` soft wrap | `white-space: normal` (incl. `overflow-wrap`) |
+|---|---|---|
+| Chromium (Chrome / Edge / Electron / Cursor) | **inserts `\n`** at the wrap point | does not insert `\n` |
+| Firefox / Safari (WebKit) | does not insert `\n` | does not insert `\n` |
+
+Orca ships on Chromium (Electron), so any text rendered with
+`white-space: pre-wrap` **soft-wraps and copies back with a real `\n`** on the
+primary platform. Pasting into a shell then treats the `\n` as a command
+separator.
+
+This is **distinct from the terminal-internal path**: `@xterm/xterm` generates
+selection text itself (it joins rows by `isWrapped`, only inserting `\r\n`/`\n`
+for hard line breaks), so selecting wrapped output inside an Orca terminal does
+**not** insert newlines. The bug is confined to DOM-rendered surfaces.
+
+## Affected surfaces in Orca
+
+Any DOM surface that renders command/code-shaped text with `pre-wrap` semantics:
+
+- `src/renderer/src/assets/main.css` — `.orca-diff-comment-body`
+  (`white-space: pre-wrap; word-break: break-word`), used by
+  `DiffCommentCard.tsx` for AI review comment bodies.
+- `src/renderer/src/components/dashboard/DashboardAgentRow.tsx` — agent status
+  text (`whitespace-pre-wrap break-words`).
+- Command/preview `<pre>` blocks that explicitly opt into
+  `whitespace-pre-wrap` (settings/dialogs): `RepositoryHooksSection.tsx`,
+  `GitLabItemDialog.tsx`, `NewWorkspaceComposerCard.tsx`,
+  `OrcaYamlTrustDialog.tsx`, `AutoRenameFailedDialog.tsx`,
+  `AutoRenameBranchFromWorkSetting.tsx`, `PluginVmRecipeConsentPreview.tsx`,
+  `PullRequestPage.tsx`.
+
+Markdown code blocks (`CommentMarkdown` compact/document variants,
+`.markdown-body pre`) currently render with the UA default
+`white-space: pre` (no soft wrap) — **but only by relying on UA defaults**:
+neither the components nor `markdown-preview.css` declare `white-space`
+explicitly, so any preflight/reset change silently reintroduces the bug.
+
+## Fix
+
+Principle: **code/command-shaped content must never soft-wrap.** It wraps
+horizontally (`overflow-x: auto`) instead, matching GitHub/ChatGPT code-block
+behavior, so copy never gains synthetic newlines.
+
+1. `src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx`
+   — declare `whitespace-pre` explicitly on the compact `pre` and the
+   document `pre` (currently implicit via UA default). This covers agent
+   replies in native chat (`CommentMarkdown`).
+2. `src/renderer/src/assets/markdown-preview.css` and
+   `src/renderer/src/assets/rich-markdown-editor.css` — declare
+   `white-space: pre` on `.markdown-body pre` / `.rich-markdown-editor pre`
+   (already `overflow-x: auto`).
+3. Agent tool output and diffs in native chat —
+   `NativeChatToolRun.tsx` (tool stdout/command output) and
+   `NativeChatDiffView.tsx` (diff lines; the container switched from
+   `overflow-hidden` to `overflow-x-auto overflow-y-hidden`, lines get
+   `min-w-max` so add/del backgrounds cover unwrapped text).
+4. Command/preview/log `<pre>` blocks elsewhere — drop `whitespace-pre-wrap`
+   in favor of `whitespace-pre` (each already has horizontal scroll):
+   `RepositoryHooksSection.tsx`, `GitLabItemDialog.tsx`,
+   `GitHubItemDialog.tsx` / `PullRequestPage.tsx` / `checks-panel-content.tsx`
+   (annotation raw details), `NewWorkspaceComposerCard.tsx`,
+   `OrcaYamlTrustDialog.tsx`, `PluginVmRecipeConsentPreview.tsx`,
+   `AutoRenameFailedDialog.tsx`, `SkillFreshnessUpdateDialog.tsx`,
+   `WorktreeCreationPanel.tsx`, `CheckRunAnnotations.tsx`,
+   `check-job-log-tail.tsx`, `source-control-recovery-notice.tsx`,
+   `CrashReportDialogSurface.tsx`, `EditorContent.tsx`, `MarkdownPreview.tsx`,
+   `IpynbViewer.tsx`.
+5. Prose surfaces (`.orca-diff-comment-body`, `DashboardAgentRow`,
+   `AutoRenameBranchFromWorkSetting` prompt preview, error notices) keep
+   `pre-wrap` — their real newlines are meaningful prose formatting and cannot
+   be collapsed without changing semantics; copy of their soft wraps is a
+   known Chromium limitation (mitigate via the copy buttons Orca already
+   provides, which copy source text directly). `DashboardAgentRowToolStep`
+   also stays `pre-wrap` because its `overflow-hidden` is required for the
+   row-collapse animation.
+
+## Testing
+
+- Unit: assert the compact/document `pre` renderers emit `whitespace-pre`
+  (`comment-markdown-element-renderers.test.tsx`).
+- Manual (Chromium/Electron): render a long command in a markdown code block,
+  mouse-select across its width, copy, paste — the command must remain one
+  line; repeat on a `pre-wrap` command preview to confirm it now scrolls
+  horizontally instead of wrapping.
+- Manual: verify real multi-line code blocks still copy their hard newlines
+  (i.e. only soft wraps are eliminated, hard content is untouched).
+
+## Residual risk
+
+- Prose `pre-wrap` surfaces still split soft wraps on copy under Chromium.
+  Fixing them requires either per-surface copy handlers (can't distinguish
+  soft vs hard newlines from the clipboard text) or accepting horizontal
+  scrolling for prose (rejected: breaks multi-line prose semantics).
+- External chat UIs (ChatGPT/Claude/Cursor web) are outside Orca's control;
+  the "copy button" path is the reliable workaround there.

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -640,6 +640,9 @@
   border-radius: 8px;
   overflow-x: auto;
   line-height: 1.55;
+  /* Why: explicit `white-space: pre` — Chromium copies soft-wrapped code with
+     synthetic newlines (see docs/reference/soft-wrap-selection-copy.md). */
+  white-space: pre;
 }
 
 .markdown-dark .markdown-body pre {

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -1005,6 +1005,9 @@
   overflow-x: auto;
   line-height: 1.55;
   background: transparent;
+  /* Why: explicit `white-space: pre` — Chromium copies soft-wrapped code with
+     synthetic newlines (see docs/reference/soft-wrap-selection-copy.md). */
+  white-space: pre;
 }
 
 .rich-markdown-editor pre code {

--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -3194,6 +3194,7 @@ function CommentReplyForm({
   )
 }
 
+/** Renders CI check annotations with raw detail blocks. */
 function ChecksTab({
   item,
   repoPath,
@@ -3807,7 +3808,7 @@ function ChecksTab({
                         {annotation.message}
                       </div>
                       {annotation.rawDetails && (
-                        <pre className="mt-1 whitespace-pre-wrap rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
+                        <pre className="mt-1 overflow-x-auto whitespace-pre rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
                           {annotation.rawDetails}
                         </pre>
                       )}

--- a/src/renderer/src/components/GitLabItemDialog.tsx
+++ b/src/renderer/src/components/GitLabItemDialog.tsx
@@ -232,6 +232,7 @@ function CommentCard({
   )
 }
 
+/** One CI job row, including its trace log. */
 function PipelineJobRow({
   job,
   expanded,
@@ -319,7 +320,7 @@ function PipelineJobRow({
           ) : traceState?.error ? (
             <div className="px-2.5 py-3 text-xs text-destructive">{traceState.error}</div>
           ) : (
-            <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words px-2.5 py-2 font-mono text-[11px] leading-4 text-foreground scrollbar-sleek">
+            <pre className="max-h-64 overflow-auto whitespace-pre break-words px-2.5 py-2 font-mono text-[11px] leading-4 text-foreground scrollbar-sleek">
               {traceState?.trace?.trim()
                 ? traceState.trace
                 : translate('auto.components.GitLabItemDialog.32f8bef818', 'No log output.')}
@@ -331,6 +332,7 @@ function PipelineJobRow({
   )
 }
 
+/** GitLab merge-request dialog with trace and diff details. */
 export default function GitLabItemDialog({
   item,
   repoPath,
@@ -1563,7 +1565,7 @@ export default function GitLabItemDialog({
                                 </div>
                               </div>
                               {file.diff ? (
-                                <pre className="max-h-80 overflow-auto whitespace-pre-wrap break-words px-3 py-2 font-mono text-[11px] leading-4 text-foreground scrollbar-sleek">
+                                <pre className="max-h-80 overflow-auto whitespace-pre break-words px-3 py-2 font-mono text-[11px] leading-4 text-foreground scrollbar-sleek">
                                   {file.diff}
                                 </pre>
                               ) : (

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -212,6 +212,7 @@ function getSshStatusLabel(status: SshConnectionStatus): string {
   return SSH_STATUS_LABELS[status] ?? status
 }
 
+/** Preview of the setup command, un-wrapped with horizontal scroll. */
 function SetupCommandPreview({ setupConfig }: { setupConfig: SetupConfig }): React.JSX.Element {
   // Why: just the script in a quiet monochrome card — the source label (orca.yaml / local) and
   // the run-setup toggle live in the section header above, so the card carries no chrome of its
@@ -219,7 +220,7 @@ function SetupCommandPreview({ setupConfig }: { setupConfig: SetupConfig }): Rea
   // growing the dialog past the viewport.
   return (
     <div className="rounded-md border border-border/60 bg-muted/40 shadow-inner">
-      <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-words px-4 py-3 font-mono text-[12px] leading-5 text-foreground/90 scrollbar-sleek">
+      <pre className="max-h-48 overflow-auto whitespace-pre break-words px-4 py-3 font-mono text-[12px] leading-5 text-foreground/90 scrollbar-sleek">
         {setupConfig.command}
       </pre>
     </div>

--- a/src/renderer/src/components/PullRequestPage.tsx
+++ b/src/renderer/src/components/PullRequestPage.tsx
@@ -3189,6 +3189,7 @@ function CommentReplyForm({
   )
 }
 
+/** Renders CI check annotations with raw detail blocks. */
 function ChecksTab({
   item,
   repoPath,
@@ -3891,7 +3892,7 @@ function ChecksTab({
                         {annotation.message}
                       </div>
                       {annotation.rawDetails && (
-                        <pre className="mt-1 whitespace-pre-wrap rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
+                        <pre className="mt-1 overflow-x-auto whitespace-pre rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
                           {annotation.rawDetails}
                         </pre>
                       )}

--- a/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
+++ b/src/renderer/src/components/crash-report/CrashReportDialogSurface.tsx
@@ -74,6 +74,7 @@ type CrashReportDialogSurfaceProps = {
   onReportChange: (report: CrashReportRecord | null) => void
 }
 
+/** Crash report dialog surface showing the report body. */
 export function CrashReportDialogSurface({
   open,
   report,
@@ -259,7 +260,7 @@ export function CrashReportDialogSurface({
                     'Diagnostic text'
                   )}
                 </div>
-                <pre className="max-h-44 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/20 p-3 font-mono text-[11px] leading-5 text-muted-foreground scrollbar-sleek">
+                <pre className="max-h-44 overflow-auto whitespace-pre break-words rounded-md border border-border bg-muted/20 p-3 font-mono text-[11px] leading-5 text-muted-foreground scrollbar-sleek">
                   {diagnosticText}
                 </pre>
               </div>

--- a/src/renderer/src/components/editor/CheckRunAnnotations.tsx
+++ b/src/renderer/src/components/editor/CheckRunAnnotations.tsx
@@ -8,6 +8,7 @@ import {
   openAnnotationLocation
 } from './check-annotation-open'
 
+/** Renders annotations for a check run. */
 export function CheckRunAnnotations({
   annotations,
   worktreeId
@@ -78,7 +79,7 @@ export function CheckRunAnnotations({
               )}
               <div className="mt-2 break-words text-sm text-foreground">{annotation.message}</div>
               {annotation.rawDetails && (
-                <pre className="mt-2 max-h-60 overflow-auto whitespace-pre-wrap rounded bg-muted/40 p-3 font-mono text-xs text-muted-foreground scrollbar-sleek">
+                <pre className="mt-2 max-h-60 overflow-auto whitespace-pre rounded bg-muted/40 p-3 font-mono text-xs text-muted-foreground scrollbar-sleek">
                   {annotation.rawDetails}
                 </pre>
               )}

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -971,6 +971,7 @@ export function EditorContent({
 }
 
 // Why: no collapsible state — layout shifts would interfere with ProseMirror's scroll management.
+/** Banner for markdown front matter, mono with horizontal scroll. */
 function FrontMatterBanner({ raw }: { raw: string }): React.JSX.Element {
   // Strip the opening/closing delimiters to show only the YAML/TOML content.
   const inner = raw
@@ -986,7 +987,7 @@ function FrontMatterBanner({ raw }: { raw: string }): React.JSX.Element {
           {translate('auto.components.editor.EditorContent.56dba34e1a', '(edit in source mode)')}
         </span>
       </div>
-      <pre className="max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor">
+      <pre className="max-h-32 overflow-auto whitespace-pre text-xs text-muted-foreground font-mono scrollbar-editor">
         {inner}
       </pre>
     </div>

--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -454,6 +454,7 @@ function EditableTextCell({
   )
 }
 
+/** Notebook cell preformatted output. */
 function PreformattedOutput({
   text,
   error = false
@@ -464,7 +465,7 @@ function PreformattedOutput({
   return (
     <pre
       className={cn(
-        'max-h-[420px] overflow-auto whitespace-pre-wrap px-3 py-2 font-mono text-xs leading-5 scrollbar-editor',
+        'max-h-[420px] overflow-auto whitespace-pre px-3 py-2 font-mono text-xs leading-5 scrollbar-editor',
         error ? 'text-destructive' : 'text-foreground'
       )}
     >

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -507,6 +507,7 @@ export function getMarkdownPreviewSourceRelativePath(
   return relativePathInsideRoot(sourceWorktreePath, filePath)
 }
 
+/** Markdown preview surface with error/output display. */
 export default function MarkdownPreview({
   content,
   filePath,
@@ -1993,7 +1994,7 @@ export default function MarkdownPreview({
               <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                 {translate('auto.components.editor.MarkdownPreview.2b2b31382c', 'Front Matter')}
               </div>
-              <pre className="max-h-48 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor">
+              <pre className="max-h-48 overflow-auto whitespace-pre text-xs text-muted-foreground font-mono scrollbar-editor">
                 {frontMatterInner}
               </pre>
             </div>

--- a/src/renderer/src/components/native-chat/NativeChatDiffView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatDiffView.tsx
@@ -6,12 +6,12 @@ import type { DiffLine } from './native-chat-diff'
  *  matching the terminal's diff palette (no invented colors). */
 export function NativeChatDiffView({ lines }: { lines: DiffLine[] }): React.JSX.Element {
   return (
-    <div className="overflow-hidden rounded bg-accent py-1 font-mono text-[11px] leading-relaxed">
+    <div className="overflow-x-auto overflow-y-hidden rounded bg-accent py-1 font-mono text-[11px] leading-relaxed">
       {lines.map((line, i) => (
         <div
           key={i}
           className={cn(
-            'whitespace-pre-wrap break-words px-2',
+            'whitespace-pre px-2 min-w-max',
             line.kind === 'add' && 'bg-emerald-500/10 text-[var(--git-decoration-added)]',
             line.kind === 'del' && 'bg-rose-500/10 text-[var(--git-decoration-deleted)]',
             line.kind === 'meta' && 'text-muted-foreground',

--- a/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatToolRun.tsx
@@ -87,7 +87,7 @@ function ToolLine({ block }: { block: NativeChatBlock }): React.JSX.Element | nu
           {!diff && body ? (
             <pre
               className={cn(
-                'max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-accent p-2 font-mono text-[11px] scrollbar-sleek',
+                'max-h-64 overflow-auto whitespace-pre break-words rounded bg-accent p-2 font-mono text-[11px] scrollbar-sleek',
                 body.isError ? 'text-destructive' : 'text-foreground/80'
               )}
             >
@@ -95,7 +95,7 @@ function ToolLine({ block }: { block: NativeChatBlock }): React.JSX.Element | nu
             </pre>
           ) : null}
           {!diff && !body && detail ? (
-            <pre className="max-h-64 overflow-auto whitespace-pre-wrap break-words rounded bg-accent p-2 font-mono text-[11px] text-foreground/80 scrollbar-sleek">
+            <pre className="max-h-64 overflow-auto whitespace-pre break-words rounded bg-accent p-2 font-mono text-[11px] text-foreground/80 scrollbar-sleek">
               {detail}
             </pre>
           ) : null}

--- a/src/renderer/src/components/right-sidebar/check-job-log-tail.tsx
+++ b/src/renderer/src/components/right-sidebar/check-job-log-tail.tsx
@@ -85,6 +85,7 @@ function CopyButton({
   )
 }
 
+/** Tails a check job's log output. */
 export function CheckJobLogTail({
   logTail,
   expanded = false
@@ -124,7 +125,7 @@ export function CheckJobLogTail({
       <pre
         ref={logPreRef}
         className={cn(
-          'overflow-auto whitespace-pre-wrap rounded bg-muted/40 p-3 font-mono text-xs text-muted-foreground scrollbar-sleek',
+          'overflow-auto whitespace-pre rounded bg-muted/40 p-3 font-mono text-xs text-muted-foreground scrollbar-sleek',
           expanded ? 'min-h-48 max-h-[min(50vh,32rem)]' : 'max-h-72'
         )}
       >

--- a/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
+++ b/src/renderer/src/components/right-sidebar/checks-panel-content.tsx
@@ -239,6 +239,7 @@ export function MergeConflictNotice({
   )
 }
 
+/** Shows the mergeability recalculation command. */
 function MergeabilityRecalculationCommandBox({
   commands
 }: {
@@ -313,7 +314,7 @@ function MergeabilityRecalculationCommandBox({
               )}
         </Button>
       </div>
-      <pre className="scrollbar-sleek mt-2 max-h-28 overflow-auto whitespace-pre-wrap break-all rounded-md border border-border bg-background px-2 py-1.5 font-mono text-[10px] leading-4 text-foreground">
+      <pre className="scrollbar-sleek mt-2 max-h-28 overflow-auto whitespace-pre break-all rounded-md border border-border bg-background px-2 py-1.5 font-mono text-[10px] leading-4 text-foreground">
         {commands}
       </pre>
     </div>
@@ -665,6 +666,7 @@ function ViewFullCheckDetailsButton({
   )
 }
 
+/** Details of a single check run, incl. annotation raw details. */
 function CheckRunDetails({
   check,
   state,
@@ -862,7 +864,7 @@ function CheckRunDetails({
                       {annotation.message}
                     </div>
                     {annotation.rawDetails && (
-                      <pre className="mt-1 whitespace-pre-wrap rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
+                      <pre className="mt-1 overflow-x-auto whitespace-pre rounded bg-muted/40 p-2 font-mono text-[11px] text-muted-foreground">
                         {annotation.rawDetails}
                       </pre>
                     )}

--- a/src/renderer/src/components/right-sidebar/source-control-recovery-notice.tsx
+++ b/src/renderer/src/components/right-sidebar/source-control-recovery-notice.tsx
@@ -174,6 +174,7 @@ function useRecoveryCopy(recoveryKind: SourceControlRecoveryKind): {
   }, [recoveryKind])
 }
 
+/** Notice with source-control recovery output. */
 export function SourceControlRecoveryNotice({
   id,
   recoveryKind,
@@ -316,7 +317,7 @@ export function SourceControlRecoveryNotice({
               <DialogTitle>{detailsTitle}</DialogTitle>
               <DialogDescription>{summary}</DialogDescription>
             </DialogHeader>
-            <pre className="max-h-[60vh] overflow-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs whitespace-pre-wrap text-foreground scrollbar-sleek">
+            <pre className="max-h-[60vh] overflow-auto rounded-md border border-border bg-muted/40 p-3 font-mono text-xs whitespace-pre text-foreground scrollbar-sleek">
               {detailText}
             </pre>
             <DialogFooter>

--- a/src/renderer/src/components/settings/PluginVmRecipeConsentPreview.tsx
+++ b/src/renderer/src/components/settings/PluginVmRecipeConsentPreview.tsx
@@ -16,6 +16,7 @@ function lifecycleLabel(phase: VmRecipePreview['commands'][number]['phase']): st
   }
 }
 
+/** Preview of the plugin VM recipe command before consent. */
 export function PluginVmRecipeConsentPreview({
   recipes
 }: {
@@ -57,7 +58,7 @@ export function PluginVmRecipeConsentPreview({
                         '{{value0}} · {{value1}} command',
                         { value0: recipe.name, value1: phaseLabel }
                       )}
-                      className="max-h-40 overflow-auto scrollbar-sleek whitespace-pre-wrap break-all rounded-md bg-muted px-2.5 py-2 font-mono text-xs leading-5 text-foreground"
+                      className="max-h-40 overflow-auto scrollbar-sleek whitespace-pre break-all rounded-md bg-muted px-2.5 py-2 font-mono text-xs leading-5 text-foreground"
                     >
                       {command}
                     </pre>

--- a/src/renderer/src/components/settings/RepositoryHooksSection.tsx
+++ b/src/renderer/src/components/settings/RepositoryHooksSection.tsx
@@ -431,6 +431,7 @@ function SegmentedPolicyToggle<P extends string>({
   )
 }
 
+/** Card showing the example hook template. */
 function ExampleTemplateCard({
   copiedTemplate,
   onCopyTemplate
@@ -461,7 +462,7 @@ function ExampleTemplateCard({
             ? translate('auto.components.settings.RepositoryHooksSection.3149964b66', 'Copied')
             : translate('auto.components.settings.RepositoryHooksSection.da37d6f10e', 'Copy')}
         </Button>
-        <pre className="overflow-x-auto whitespace-pre-wrap break-words p-3 pr-16 font-mono text-[11px] leading-5 text-muted-foreground">
+        <pre className="overflow-x-auto whitespace-pre break-words p-3 pr-16 font-mono text-[11px] leading-5 text-muted-foreground">
           {EXAMPLE_TEMPLATE}
         </pre>
       </div>
@@ -469,9 +470,10 @@ function ExampleTemplateCard({
   )
 }
 
+/** Renders YAML content un-wrapped with horizontal scroll. */
 function YamlScriptBlock({ content }: { content: string }): React.JSX.Element {
   return (
-    <pre className="overflow-x-auto whitespace-pre-wrap break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-[11.5px] leading-5 text-foreground">
+    <pre className="overflow-x-auto whitespace-pre break-words rounded-lg border border-border/50 bg-muted/30 p-3 font-mono text-[11.5px] leading-5 text-foreground">
       {content}
     </pre>
   )

--- a/src/renderer/src/components/sidebar/AutoRenameFailedDialog.tsx
+++ b/src/renderer/src/components/sidebar/AutoRenameFailedDialog.tsx
@@ -115,7 +115,7 @@ export function AutoRenameFailedDialog({
           )}
         </p>
         {/* Why: agent-CLI output is literal and often multi-line, so render it
-            verbatim (mono, wrapped) inside a height-capped scroll region. */}
+            verbatim (mono, un-wrapped) inside a height-capped scroll region. */}
         <div className="space-y-1.5">
           <p className="text-xs font-medium text-foreground">
             {translate(
@@ -143,7 +143,7 @@ export function AutoRenameFailedDialog({
             >
               {copied ? <Check className="size-3.5" /> : <Copy className="size-3.5" />}
             </Button>
-            <pre className="scrollbar-sleek max-h-[40vh] overflow-auto rounded-md border border-border/60 bg-muted/40 py-3 pl-3 pr-9 font-mono text-[11px] leading-4 whitespace-pre-wrap break-words text-foreground">
+            <pre className="scrollbar-sleek max-h-[40vh] overflow-auto rounded-md border border-border/60 bg-muted/40 py-3 pl-3 pr-9 font-mono text-[11px] leading-4 whitespace-pre break-words text-foreground">
               {detailText}
             </pre>
           </div>

--- a/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.test.tsx
@@ -2,6 +2,7 @@ import { renderToStaticMarkup } from 'react-dom/server'
 import { describe, expect, it } from 'vitest'
 import CommentMarkdown, { remarkGitHubReferences } from './CommentMarkdown'
 
+/** Test suite for CommentMarkdown rendering. */
 describe('CommentMarkdown', () => {
   it('marks compact headings so a parent can opt into block flow', () => {
     const markup = renderToStaticMarkup(
@@ -233,6 +234,31 @@ describe('CommentMarkdown', () => {
     expect(markup).toContain('max-h-32')
     expect(markup).toContain('overflow-x-auto')
     expect(markup).not.toContain('mermaid-block')
+  })
+
+  /** Chromium turns soft-wrapped `pre-wrap` text into real newlines on copy,
+   *  breaking pasted commands (see docs/reference/soft-wrap-selection-copy.md). */
+  it('declares whitespace-pre on compact code blocks so copy never gains newlines', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown content={'```sh\nnpx skills add --agent claude-code -y\n```'} />
+    )
+
+    expect(markup).toContain('<pre class="my-1 max-h-32 max-w-full overflow-x-auto whitespace-pre ')
+    expect(markup).not.toContain('whitespace-pre-wrap')
+  })
+
+  /** Document-variant code blocks must also render un-wrapped (see above). */
+  it('declares whitespace-pre on document-variant code blocks', () => {
+    const markup = renderToStaticMarkup(
+      <CommentMarkdown
+        variant="document"
+        content={'```sh\nnpx skills add --agent claude-code -y\n```'}
+      />
+    )
+
+    expect(markup).toContain('whitespace-pre')
+    expect(markup).toContain('overflow-x-auto')
+    expect(markup).not.toContain('whitespace-pre-wrap')
   })
 
   it('renders headings as block elements with hierarchy in the document variant', () => {

--- a/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
+++ b/src/renderer/src/components/sidebar/OrcaYamlTrustDialog.tsx
@@ -28,6 +28,7 @@ const SCRIPT_KIND_TRIGGER: Record<ScriptKind, string> = {
   vmRecipe: 'before provisioning a VM'
 }
 
+/** Trust confirmation for an Orca YAML file. */
 const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
   const activeModal = useAppStore((s) => s.activeModal)
   const modalData = useAppStore((s) => s.modalData)
@@ -170,7 +171,7 @@ const OrcaYamlTrustDialog = React.memo(function OrcaYamlTrustDialog() {
                     { value0: scriptKind }
                   )}
             </div>
-            <pre className="max-h-48 overflow-auto whitespace-pre-wrap break-all font-mono text-xs text-foreground scrollbar-sleek">
+            <pre className="max-h-48 overflow-auto whitespace-pre break-all font-mono text-xs text-foreground scrollbar-sleek">
               {scriptContent}
             </pre>
           </div>

--- a/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
+++ b/src/renderer/src/components/sidebar/comment-markdown-element-renderers.tsx
@@ -50,6 +50,7 @@ function handleMarkdownImageClick(
   onLinkClick(event, src)
 }
 
+/** Builds compact markdown renderers for chat/comment surfaces. */
 export function createCompactCommentMarkdownComponents(
   onLinkClick?: CommentMarkdownLinkClickHandler,
   expandImages = false
@@ -83,9 +84,13 @@ export function createCompactCommentMarkdownComponents(
         {children}
       </code>
     ),
-    // Compact pre blocks — no syntax highlighting needed for short comments.
+    /**
+     * Compact pre-block renderer — no syntax highlighting for short comments.
+     * Why: explicit whitespace-pre (not the UA default) — soft-wrapped code copies
+     * back with synthetic newlines on Chromium (see docs/reference/soft-wrap-selection-copy.md).
+     */
     pre: ({ children }) => (
-      <pre className="my-1 max-h-32 max-w-full overflow-x-auto rounded bg-accent p-1.5 text-[10px] font-mono">
+      <pre className="my-1 max-h-32 max-w-full overflow-x-auto whitespace-pre rounded bg-accent p-1.5 text-[10px] font-mono">
         {children}
       </pre>
     ),
@@ -204,6 +209,7 @@ export function createCompactCommentMarkdownComponents(
   }
 }
 
+/** Builds document-variant markdown renderers. */
 export function createDocumentCommentMarkdownComponents(
   onLinkClick?: CommentMarkdownLinkClickHandler
 ): Components {
@@ -237,11 +243,12 @@ export function createDocumentCommentMarkdownComponents(
         </code>
       ),
     // Mermaid fences render a <div>, which is invalid inside <pre>, so unwrap them.
+    /** Document-variant pre renderer — mermaid fences unwrap to a div (invalid inside pre). */
     pre: ({ children }) =>
       isMermaidPre(children) ? (
         <>{children}</>
       ) : (
-        <pre className="my-3 max-h-80 max-w-full overflow-x-auto rounded-md bg-accent p-3 font-mono text-[12px]">
+        <pre className="my-3 max-h-80 max-w-full overflow-x-auto whitespace-pre rounded-md bg-accent p-3 font-mono text-[12px]">
           {children}
         </pre>
       ),

--- a/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.tsx
+++ b/src/renderer/src/components/skills/SkillFreshnessUpdateDialog.tsx
@@ -36,6 +36,7 @@ import {
   subscribeSkillFreshnessUpdateDialog
 } from './skill-freshness-update-dialog'
 
+/** Scrollable log of a skill update run. */
 function RunLog({ output }: { output: string }): React.JSX.Element | null {
   if (!output.trim()) {
     return null
@@ -55,7 +56,7 @@ function RunLog({ output }: { output: string }): React.JSX.Element | null {
       </CollapsibleTrigger>
       <CollapsibleContent className="mt-1">
         {/* Displayed verbatim, never parsed — `skills update` has no --json. */}
-        <pre className="scrollbar-sleek max-h-40 overflow-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted px-3 py-2.5 font-mono text-[11px] leading-relaxed text-muted-foreground">
+        <pre className="scrollbar-sleek max-h-40 overflow-auto whitespace-pre break-words rounded-md border border-border bg-muted px-3 py-2.5 font-mono text-[11px] leading-relaxed text-muted-foreground">
           {output.trim()}
         </pre>
       </CollapsibleContent>

--- a/src/renderer/src/components/worktree-creation/WorktreeCreationPanel.tsx
+++ b/src/renderer/src/components/worktree-creation/WorktreeCreationPanel.tsx
@@ -266,6 +266,7 @@ function VmProvisioningStatus({
 // Why: the recipe's stderr is the only thing that explains a failure or a slow
 // provision, so it gets the same fixed-height log surface whether provisioning is
 // in progress or has failed.
+/** Output log of a workspace recipe run. */
 function RecipeOutputLog({
   log,
   emptyLabel
@@ -294,7 +295,7 @@ function RecipeOutputLog({
     <pre
       ref={ref}
       onScroll={handleScroll}
-      className="scrollbar-sleek h-72 overflow-auto whitespace-pre-wrap rounded-md bg-muted/40 p-3 font-mono text-[11px] leading-4 text-muted-foreground"
+      className="scrollbar-sleek h-72 overflow-auto whitespace-pre rounded-md bg-muted/40 p-3 font-mono text-[11px] leading-4 text-muted-foreground"
     >
       {log || <span className="text-muted-foreground/60">{emptyLabel}</span>}
     </pre>


### PR DESCRIPTION
## Summary

Copying an AI-generated command (or any long code line) from chat, diff, settings-preview or log surfaces produced a broken command: Chromium (Electron) turns soft-wrapped `pre-wrap` text into real newlines on copy, so a visually wrapped command pasted into a shell split into two commands (`claude-` / `code` → `zsh: command not found: code`).

Code/command-shaped DOM content now renders with `white-space: pre` and horizontal scroll (explicit, not UA-default) across markdown code blocks, agent tool output, native-chat diffs, command previews and log panels. Prose containers (comment bodies, error notices, collapse-animated rows) keep `pre-wrap`. xterm terminal selections were already unaffected.

## Screenshots

No screenshots available from the reporter; behavior is a CSS change (long lines scroll horizontally instead of wrapping, matching GitHub/ChatGPT code blocks).

## Testing

- [x] `pnpm lint` — oxlint 0 warnings / 0 errors (changed files)
- [x] `pnpm typecheck` — full `tsc --noEmit` (node / cli / web) passes
- [x] `pnpm test` — 67 tests across 7 affected component files pass (incl. 2 new `whitespace-pre` assertions in CommentMarkdown.test.tsx)
- [x] `pnpm build` — electron-vite renderer/main bundle passes

## AI Review Report

Reviewed the full diff with an AI review agent; blocking findings were addressed (one prose surface reverted to `pre-wrap`, diff-line highlight coverage fixed via `min-w-max`). Cross-platform check: pure className/CSS change with no platform branches; Electron is Chromium on all three OSes, so macOS/Linux/Windows all benefit; keyboard shortcuts, labels, paths and shell behavior untouched.

## Security Audit

No input handling, command execution, auth, secrets, dependency or IPC code touched — className and CSS rules only.

## Notes

- Residual: prose `pre-wrap` surfaces still copy soft wraps with newlines on Chromium (documented in `docs/reference/soft-wrap-selection-copy.md`); no CSS solution exists without changing prose semantics.
- `DashboardAgentRowToolStep` tool input intentionally stays `pre-wrap` (`overflow-hidden` is required for its collapse animation).