### PR TITLE
fix(activity): foreground the worktree hosting an in-app browser tab

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -51,6 +51,7 @@ import {
   setActivityTerminalPortals,
   type ActivityTerminalPortalTarget
 } from './activity-terminal-portal'
+import { createActivityThreadLinkClick } from './activity-thread-link-click'
 import {
   reconcileActivityPortalThreads,
   resolveActivityPortalSwap
@@ -1233,6 +1234,12 @@ function ThreadRow({
   const renderedResponsePreview = activityThreadResponseRenderPreview({
     responsePreview: thread.responsePreview
   })
+  // Why: keep handler identity stable across re-renders so CommentMarkdown's
+  // memoized components don't rebuild on every row hover/selection change.
+  const threadLinkClick = useCallback(
+    () => createActivityThreadLinkClick({ worktreeId: thread.worktree.id, tabId: thread.tab.id }),
+    [thread.worktree.id, thread.tab.id]
+  )
   const workspaceTitle = getActivityThreadWorkspaceTitle(thread.worktree)
   const taskTitle = thread.paneTitle
   const agentLabel = formatAgentTypeLabel(thread.agentType)
@@ -1304,6 +1311,7 @@ function ThreadRow({
               {showStatusPreview ? (
                 <CommentMarkdown
                   content={renderedResponsePreview}
+                  onLinkClick={threadLinkClick}
                   className={cn(
                     'h-[1lh] min-w-0 overflow-hidden truncate whitespace-nowrap text-[11px] font-normal leading-snug text-muted-foreground/80',
                     '[&_*]:inline [&_*]:!m-0 [&_*]:!p-0 [&_*]:!whitespace-nowrap [&_br]:hidden [&_ol]:list-none [&_ul]:list-none'

--- a/src/renderer/src/components/activity/activity-thread-link-click.test.ts
+++ b/src/renderer/src/components/activity/activity-thread-link-click.test.ts
@@ -1,0 +1,144 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { registerHttpLinkStoreAccessor } from '@/lib/http-link-routing'
+import type { CommentMarkdownLinkClickHandler } from '@/components/sidebar/CommentMarkdown'
+import { createActivityThreadLinkClick } from './activity-thread-link-click'
+
+const { resolveNativeChatFileLinkContextMock, resolveNativeChatFileLinkMock } = vi.hoisted(() => ({
+  resolveNativeChatFileLinkContextMock: vi.fn(),
+  resolveNativeChatFileLinkMock: vi.fn()
+}))
+
+vi.mock('@/components/native-chat/native-chat-file-link', () => ({
+  resolveNativeChatFileLink: resolveNativeChatFileLinkMock,
+  resolveNativeChatFileLinkContext: resolveNativeChatFileLinkContextMock
+}))
+
+const { openDetectedFilePathMock } = vi.hoisted(() => ({
+  openDetectedFilePathMock: vi.fn()
+}))
+
+vi.mock('@/components/terminal-pane/terminal-file-open-routing', () => ({
+  openDetectedFilePath: openDetectedFilePathMock
+}))
+
+const openUrlMock = vi.fn()
+const setActiveWorktreeMock = vi.fn()
+const createBrowserTabMock = vi.fn()
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resolveNativeChatFileLinkContextMock.mockReset()
+  resolveNativeChatFileLinkMock.mockReset()
+  openDetectedFilePathMock.mockReset()
+  registerHttpLinkStoreAccessor(() => ({
+    settings: { openLinksInApp: true },
+    setActiveWorktree: setActiveWorktreeMock,
+    createBrowserTab: createBrowserTabMock,
+    repos: [],
+    projects: [],
+    worktreesByRepo: {},
+    allWorktrees: vi.fn(() => []),
+    workspacePortScan: null,
+    workspacePortScansByKey: {}
+  }))
+  vi.stubGlobal('window', { api: { shell: { openUrl: openUrlMock } } })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+function makeEvent(shiftKey = false): {
+  preventDefault: ReturnType<typeof vi.fn>
+  stopPropagation: ReturnType<typeof vi.fn>
+  shiftKey: boolean
+} {
+  return {
+    preventDefault: vi.fn(),
+    stopPropagation: vi.fn(),
+    shiftKey
+  }
+}
+
+function invoke(
+  handler: CommentMarkdownLinkClickHandler,
+  event: ReturnType<typeof makeEvent>,
+  href: string | undefined
+): void {
+  handler(event as unknown as Parameters<CommentMarkdownLinkClickHandler>[0], href)
+}
+
+describe('createActivityThreadLinkClick', () => {
+  it('routes http links through openHttpLink so the hosting worktree is foregrounded', () => {
+    const handler = createActivityThreadLinkClick({ worktreeId: 'wt-1', tabId: 'tab-1' })
+    const event = makeEvent()
+
+    invoke(handler, event, 'https://example.com/')
+
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(openDetectedFilePathMock).not.toHaveBeenCalled()
+  })
+
+  it('keeps http links out of Orca when openLinksInApp is off', () => {
+    registerHttpLinkStoreAccessor(() => ({
+      settings: { openLinksInApp: false },
+      setActiveWorktree: setActiveWorktreeMock,
+      createBrowserTab: createBrowserTabMock,
+      repos: [],
+      projects: [],
+      worktreesByRepo: {},
+      allWorktrees: vi.fn(() => []),
+      workspacePortScan: null,
+      workspacePortScansByKey: {}
+    }))
+    const handler = createActivityThreadLinkClick({ worktreeId: 'wt-1', tabId: 'tab-1' })
+
+    invoke(handler, makeEvent(), 'https://example.com/')
+
+    expect(openUrlMock).toHaveBeenCalledWith('https://example.com/')
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('opens file links in their worktree like native chat does', () => {
+    resolveNativeChatFileLinkContextMock.mockReturnValue({
+      worktreeId: 'wt-1',
+      worktreePath: '/repo/wt-1',
+      runtimeEnvironmentId: null
+    })
+    resolveNativeChatFileLinkMock.mockReturnValue({
+      absolutePath: '/repo/wt-1/src/main.ts',
+      line: 10,
+      column: null
+    })
+    const handler = createActivityThreadLinkClick({ worktreeId: 'wt-1', tabId: 'tab-1' })
+    const event = makeEvent()
+
+    invoke(handler, event, 'file:///repo/wt-1/src/main.ts')
+
+    expect(openDetectedFilePathMock).toHaveBeenCalledWith(
+      '/repo/wt-1/src/main.ts',
+      10,
+      null,
+      expect.objectContaining({ worktreeId: 'wt-1', worktreePath: '/repo/wt-1' })
+    )
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(event.stopPropagation).toHaveBeenCalled()
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-file, non-http links without consuming the click', () => {
+    const handler = createActivityThreadLinkClick({ worktreeId: 'wt-1', tabId: 'tab-1' })
+    const event = makeEvent()
+
+    invoke(handler, event, 'mailto:someone@example.com')
+
+    expect(event.preventDefault).not.toHaveBeenCalled()
+    expect(event.stopPropagation).not.toHaveBeenCalled()
+    expect(openDetectedFilePathMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/activity/activity-thread-link-click.ts
+++ b/src/renderer/src/components/activity/activity-thread-link-click.ts
@@ -1,0 +1,46 @@
+import type { CommentMarkdownLinkClickHandler } from '@/components/sidebar/CommentMarkdown'
+import {
+  resolveNativeChatFileLink,
+  resolveNativeChatFileLinkContext
+} from '@/components/native-chat/native-chat-file-link'
+import { openDetectedFilePath } from '@/components/terminal-pane/terminal-file-open-routing'
+import { openHttpLink } from '@/lib/http-link-routing'
+import { useAppStore } from '@/store'
+
+export type ActivityThreadLinkClickContext = {
+  worktreeId: string
+  tabId: string
+}
+
+// Why: the Activity thread preview mirrors terminal/native-chat link handling —
+// file links switch to their worktree and open there, http links honor
+// openLinksInApp and foreground the worktree hosting the browser tab.
+export function createActivityThreadLinkClick(
+  context: ActivityThreadLinkClickContext
+): CommentMarkdownLinkClickHandler {
+  return (event, href) => {
+    const state = useAppStore.getState()
+    const fileContext = resolveNativeChatFileLinkContext(state, context.tabId)
+    const fileTarget = fileContext ? resolveNativeChatFileLink(href, fileContext) : null
+    if (fileTarget && fileContext) {
+      event.preventDefault()
+      event.stopPropagation()
+      openDetectedFilePath(fileTarget.absolutePath, fileTarget.line, fileTarget.column, {
+        worktreeId: fileContext.worktreeId,
+        worktreePath: fileContext.worktreePath,
+        runtimeEnvironmentId: fileContext.runtimeEnvironmentId,
+        openWithSystemDefault: event.shiftKey
+      })
+      return
+    }
+    const normalized = href?.trim().toLowerCase() ?? ''
+    if (href && (normalized.startsWith('http:') || normalized.startsWith('https:'))) {
+      event.preventDefault()
+      event.stopPropagation()
+      openHttpLink(href, {
+        worktreeId: context.worktreeId,
+        modifierHeld: event.shiftKey
+      })
+    }
+  }
+}

--- a/src/renderer/src/lib/http-link-routing.test.ts
+++ b/src/renderer/src/lib/http-link-routing.test.ts
@@ -4,6 +4,7 @@ import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
 import {
   openHttpLink,
   registerHttpLinkStoreAccessor,
+  registerHttpLinkWorktreeActivator,
   resolveLocalhostHttpLinkDisplayUrl
 } from './http-link-routing'
 
@@ -42,6 +43,7 @@ beforeEach(() => {
   storeState.settings = undefined
   storeState.workspacePortScansByKey = {}
   registerHttpLinkStoreAccessor(() => storeState)
+  registerHttpLinkWorktreeActivator(null)
   vi.stubGlobal('window', {
     api: {
       shell: {
@@ -69,6 +71,49 @@ describe('openHttpLink', () => {
       activate: true
     })
     expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('foregrounds the hosting worktree before opening an in-app browser tab', () => {
+    storeState.settings = { openLinksInApp: true }
+    const worktreeActivatorMock = vi.fn(() => true)
+    registerHttpLinkWorktreeActivator(worktreeActivatorMock)
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(worktreeActivatorMock).toHaveBeenCalledWith('wt-1')
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('falls back to setActiveWorktree when the activator cannot reveal the worktree', () => {
+    storeState.settings = { openLinksInApp: true }
+    registerHttpLinkWorktreeActivator(() => false)
+
+    openHttpLink('https://example.com/', { worktreeId: 'wt-1' })
+
+    expect(setActiveWorktreeMock).toHaveBeenCalledWith('wt-1')
+    expect(createBrowserTabMock).toHaveBeenCalledWith('wt-1', 'https://example.com/', {
+      activate: true
+    })
+  })
+
+  it('does not foreground the floating workspace for in-app browser tabs', () => {
+    storeState.settings = { openLinksInApp: true }
+    const worktreeActivatorMock = vi.fn(() => true)
+    registerHttpLinkWorktreeActivator(worktreeActivatorMock)
+
+    openHttpLink('https://example.com/', { worktreeId: FLOATING_TERMINAL_WORKTREE_ID })
+
+    expect(worktreeActivatorMock).not.toHaveBeenCalled()
+    expect(setActiveWorktreeMock).not.toHaveBeenCalled()
+    expect(createBrowserTabMock).toHaveBeenCalledWith(
+      FLOATING_TERMINAL_WORKTREE_ID,
+      'https://example.com/',
+      { activate: true }
+    )
   })
 
   it('defaults to the system browser when settings have not hydrated', () => {

--- a/src/renderer/src/lib/http-link-routing.ts
+++ b/src/renderer/src/lib/http-link-routing.ts
@@ -15,6 +15,9 @@ export type OpenHttpLinkOptions = {
   sourceOwner?: HttpLinkSourceOwner
 }
 
+/** Foregrounds the worktree that will host an in-app browser tab; true when revealed. */
+export type HttpLinkWorktreeActivator = (worktreeId: string) => boolean
+
 export type HttpLinkSourceOwner =
   | { kind: 'local' }
   | { kind: 'runtime'; runtimeEnvironmentId: string }
@@ -62,6 +65,15 @@ let storeAccessor: StoreAccessor | null = null
 
 export function registerHttpLinkStoreAccessor(fn: StoreAccessor): void {
   storeAccessor = fn
+}
+
+// Why: injected like setWorktreeNavActivator to avoid an import cycle — the
+// real activator (activateAndRevealWorktree) imports the store, which pulls in
+// this module through the editor slice.
+let worktreeActivator: HttpLinkWorktreeActivator | null = null
+
+export function registerHttpLinkWorktreeActivator(fn: HttpLinkWorktreeActivator | null): void {
+  worktreeActivator = fn
 }
 
 // Scope: http(s) URLs only. file: URIs and in-worktree markdown targets are
@@ -112,14 +124,19 @@ export function openHttpLink(url: string, opts: OpenHttpLinkOptions = {}): void 
     (openLinksInApp || modifier.wantsOrca)
 
   if (routeToOrca && worktreeId && state) {
-    // Why: http clicks from inside a worktree should not push a worktree-switch
-    // history entry — the user isn't changing worktrees, they're opening a tab
-    // in the one they're already in. activateAndRevealWorktree is reserved for
-    // file-link jumps that genuinely switch worktrees.
+    // Why: an in-app browser tab is scoped to the worktree it opens in, so the
+    // worktree must be foregrounded first or the tab opens invisibly from a page
+    // view like Activity (file-link jumps already do this). The registered
+    // revealer skips a history entry when that worktree is already active;
+    // setActiveWorktree remains the fallback so unknown worktrees and test
+    // stores keep working.
+    // Why: the floating workspace uses a synthetic worktree id; promoting it to
+    // the global activeWorktreeId would deselect the real repo workspace.
     if (worktreeId !== FLOATING_TERMINAL_WORKTREE_ID) {
-      // Why: the floating workspace uses a synthetic worktree id. Promoting it
-      // to the global activeWorktreeId deselects the real repo workspace.
-      state.setActiveWorktree(worktreeId)
+      const activated = worktreeActivator ? worktreeActivator(worktreeId) : false
+      if (!activated) {
+        state.setActiveWorktree(worktreeId)
+      }
     }
     const localhostRoute = localhostLabelRouteForHttpLink(url, state, sourceOwner)
     if (!localhostRoute) {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -21,6 +21,7 @@ import { getSetupRunnerCommandPlatformForPath } from '../../../shared/setup-runn
 import { agentKindToTuiAgent } from '../../../shared/agent-kind'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
+import { registerHttpLinkWorktreeActivator } from '@/lib/http-link-routing'
 import type { PendingSidebarWorktreeReveal } from '@/store/slices/ui'
 import { tabHasLivePty } from '@/lib/tab-has-live-pty'
 import {
@@ -737,6 +738,10 @@ export function activateAndRevealWorkspace(workspaceId: string): ActivateAndReve
 
 // Why: break the import cycle — nav-history slice (under @/store) can't import activation directly, so register the activator here.
 setWorktreeNavActivator(activateAndRevealWorkspace)
+
+// Why: http links routed into Orca's browser must foreground the worktree owning
+// the tab, or they'd open invisibly from page views like Activity.
+registerHttpLinkWorktreeActivator((worktreeId) => activateAndRevealWorktree(worktreeId) !== false)
 
 // Why: page entries replay via setActiveView (not open*Page) so back/forward doesn't mutate previousViewBefore* or duplicate history (see navigateToIndex).
 setWorktreeNavViewActivator((entry) => {


### PR DESCRIPTION
## Problem

In the Agents tab (Activity page), clicking a **file** link switches to that file's workspace and opens the file there, but clicking an **HTTPS** link (with "open links in the in-app browser" enabled) opened a browser tab **without switching to the workspace that hosts it** — so the tab opened invisibly.

Root cause: file links route through `openDetectedFilePath` → `activateAndRevealWorktree` (switches the view), while HTTP links route through `openHttpLink`, which only called `setActiveWorktree` and never changed `activeView` away from the Activity page.

## Fix

- **`http-link-routing.ts`**: when a link routes into Orca's in-app browser, foreground the hosting worktree first via an injected `HttpLinkWorktreeActivator`, falling back to `setActiveWorktree` when no activator is registered or the worktree is unknown. The floating-terminal worktree stays excluded.
- **`worktree-activation.ts`**: registers `activateAndRevealWorktree` as that activator (same injection pattern as `setWorktreeNavActivator`, avoiding the store import cycle). It skips a history entry when the worktree is already active, so in-worktree HTTP clicks don't push spurious history, while page-view clicks (e.g. Activity) now switch to the workspace.
- **Activity thread preview**: the thread `CommentMarkdown` now gets an `onLinkClick` (`activity-thread-link-click.ts`) that mirrors the terminal/native-chat behavior — file links resolve + switch + open, HTTP links honor `openLinksInApp` and foreground the hosting worktree.

## Preserved behavior

- File links still switch + open the file (unchanged).
- External-browser links (`openLinksInApp` off, remote/SSH sources, Shift escape hatch) never touch the worktree.
- Floating-terminal links unchanged.

## Verification

- Full renderer unit suite: 2256 files / 20,834 tests pass.
- `oxlint` (native + type-aware, `--deny-warnings`), web typecheck, and `check:max-lines-ratchet` pass.