### PR TITLE
fix(terminal): release parent chunks pinned by drained output slices

### DIFF
--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     // Why: Node 26's undefined Web Storage globals prevent Vitest from installing happy-dom's.
-    execArgv: ['--no-experimental-webstorage'],
+    // Why --expose-gc: retention tests need a deterministic collection point to measure what a queue really holds.
+    execArgv: ['--no-experimental-webstorage', '--expose-gc'],
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
     setupFiles: [resolve('config/scripts/happy-dom-mutation-observer-retention.ts')],
     include: [

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -334,6 +334,7 @@ import {
 } from './renderer-owned-agent-status-registry'
 import type { DirectSshPaneRetryAttempt } from '@/store/slices/direct-ssh-terminal-recovery'
 import { directSshAuthoritiesEqual } from '@/store/slices/direct-ssh-terminal-authority-ledger'
+import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -6776,7 +6777,9 @@ export function connectPanePty(
       if (rawLength !== chunk.data.length) {
         return null
       }
-      return chunk.data.slice(offset)
+      // Why flatten: this tail outlives the chunk it was cut from once queued, and a raw slice
+      // would pin the whole original chunk in the output queue (STA-3567).
+      return flattenRetainedSlice(chunk.data.slice(offset))
     }
 
     type RestoredSnapshotReconciliation =
@@ -6826,7 +6829,9 @@ export function connectPanePty(
         // Why: renderer-only OSC stripping makes raw seq offsets unmappable onto cleaned text; refetch instead of risking duplicate output.
         return { action: 'force-fresh-restore' }
       }
-      const sliced = data.slice(restoredSnapshotBaselineSeq - startSeq)
+      // Why flatten: same as above - the trimmed tail is handed to the output queue, and a raw
+      // slice would keep the entire pre-trim payload alive behind it (STA-3567).
+      const sliced = flattenRetainedSlice(data.slice(restoredSnapshotBaselineSeq - startSeq))
       return {
         action: 'write',
         data: sliced,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -334,7 +334,6 @@ import {
 } from './renderer-owned-agent-status-registry'
 import type { DirectSshPaneRetryAttempt } from '@/store/slices/direct-ssh-terminal-recovery'
 import { directSshAuthoritiesEqual } from '@/store/slices/direct-ssh-terminal-authority-ledger'
-import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -6777,9 +6776,7 @@ export function connectPanePty(
       if (rawLength !== chunk.data.length) {
         return null
       }
-      // Why flatten: this tail outlives the chunk it was cut from once queued, and a raw slice
-      // would pin the whole original chunk in the output queue (STA-3567).
-      return flattenRetainedSlice(chunk.data.slice(offset))
+      return chunk.data.slice(offset)
     }
 
     type RestoredSnapshotReconciliation =
@@ -6829,9 +6826,7 @@ export function connectPanePty(
         // Why: renderer-only OSC stripping makes raw seq offsets unmappable onto cleaned text; refetch instead of risking duplicate output.
         return { action: 'force-fresh-restore' }
       }
-      // Why flatten: same as above - the trimmed tail is handed to the output queue, and a raw
-      // slice would keep the entire pre-trim payload alive behind it (STA-3567).
-      const sliced = flattenRetainedSlice(data.slice(restoredSnapshotBaselineSeq - startSeq))
+      const sliced = data.slice(restoredSnapshotBaselineSeq - startSeq)
       return {
         action: 'write',
         data: sliced,

--- a/src/renderer/src/lib/flatten-retained-slice.test.ts
+++ b/src/renderer/src/lib/flatten-retained-slice.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { flattenRetainedSlice } from './flatten-retained-slice'
+
+// Why 1 MB: comfortably above V8's SlicedString threshold, so a raw slice really does keep the
+// parent alive and the difference between flattened and not is unmistakable in heapUsed.
+const PARENT_CHARS = 1024 * 1024
+const TAIL_CHARS = 512
+const PARENTS = 8
+
+function collect(): number {
+  const gc = (globalThis as { gc?: () => void }).gc
+  if (!gc) {
+    throw new Error('global.gc unavailable - config/vitest.config.ts must pass --expose-gc')
+  }
+  gc()
+  gc()
+  return process.memoryUsage().heapUsed
+}
+
+// Distinct leading chars stop V8 sharing one backing store across the parents.
+function makeParent(index: number, filler: string): string {
+  return String.fromCharCode(0x41 + index) + filler.repeat(PARENT_CHARS - 1)
+}
+
+function retainedBytesForTails(filler: string, transform: (value: string) => string): number {
+  const parents = Array.from({ length: PARENTS }, (_unused, index) => makeParent(index, filler))
+  const baseline = collect()
+  const tails = parents.map((parent) => transform(parent.slice(parent.length - TAIL_CHARS)))
+  // Drop the parents; only the tails stay reachable.
+  parents.length = 0
+  const retained = collect() - baseline
+  expect(tails).toHaveLength(PARENTS)
+  expect(tails.every((tail) => tail.length === TAIL_CHARS)).toBe(true)
+  return retained
+}
+
+describe('flattenRetainedSlice', () => {
+  it('preserves content exactly', () => {
+    expect(flattenRetainedSlice('')).toBe('')
+    expect(flattenRetainedSlice('a')).toBe('a')
+    const source = 'hello world, 漢字, [0m, \u{1f600}'
+    expect(flattenRetainedSlice(source.slice(3))).toBe(source.slice(3))
+  })
+
+  it.each([
+    ['one-byte', 'a'],
+    ['two-byte', '漢']
+  ])('drops the %s parent a raw slice would pin', (_label, filler) => {
+    const raw = retainedBytesForTails(filler, (value) => value)
+    const flattened = retainedBytesForTails(filler, flattenRetainedSlice)
+
+    // A raw slice pins all 8 parents; flattening must keep only the tails.
+    expect(raw).toBeGreaterThan(PARENTS * PARENT_CHARS * 0.5)
+    expect(flattened).toBeLessThan(PARENTS * PARENT_CHARS * 0.05)
+  })
+})

--- a/src/renderer/src/lib/flatten-retained-slice.ts
+++ b/src/renderer/src/lib/flatten-retained-slice.ts
@@ -1,0 +1,11 @@
+/**
+ * V8 backs `String.prototype.slice` with a SlicedString that points at the whole parent, so a
+ * short tail of a large chunk keeps that whole chunk alive. Concatenating forces a ConsString
+ * whose flattening allocates a fresh sequential string of just this length, dropping the parent.
+ *
+ * Use this whenever a slice outlives the value it was cut from — a queued remainder, or an
+ * overlap-trimmed payload handed to a component that will hold it.
+ */
+export function flattenRetainedSlice(value: string): string {
+  return value.length === 0 ? value : `${value} `.slice(0, -1)
+}

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1693,6 +1693,34 @@ describe('pane terminal output scheduler', () => {
       return process.memoryUsage().heapUsed
     }
 
+    it('does not pin the parent when a producer enqueues a slice', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput } = await loadScheduler()
+
+      // Why a slice: agent-status-osc.ts and the restore-overlap trims hand the scheduler
+      // strings cut from a much larger buffer. The queue must own its copy rather than
+      // trusting every producer to flatten first (STA-3567 review round 2).
+      const KEEP_CHARS = 64 * 1024
+      const sinks = Array.from({ length: TERMINALS }, () => ({
+        write: (_data: string, callback?: () => void) => callback?.()
+      }))
+
+      const baseline = collect()
+
+      for (const [index, sink] of sinks.entries()) {
+        const parent = String.fromCharCode(65 + index) + 'q'.repeat(CHUNK_CHARS - 1)
+        writeTerminalOutput(sink, parent.slice(parent.length - KEEP_CHARS), {
+          foreground: false,
+          latencySensitive: false
+        })
+      }
+
+      const retainedBytes = collect() - baseline
+
+      // 8 x 64 KB of real payload must not keep 8 x 2 MB of parents alive.
+      expect(retainedBytes).toBeLessThan(4 * 1024 * 1024)
+    })
+
     it('drops the parent chunk once only a small tail is still queued', async () => {
       vi.useFakeTimers()
       const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1693,6 +1693,66 @@ describe('pane terminal output scheduler', () => {
       return process.memoryUsage().heapUsed
     }
 
+    it('releases chunks it has already drained past', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput } = await loadScheduler()
+
+      // Why many medium chunks: compactConsumedChunks only splices once chunkIndex reaches 64,
+      // so below that the drained slots stay in the array and must be cleared individually.
+      const CHUNKS_PER_TERMINAL = 40
+      const CHUNK = 48 * 1024
+      const SINKS = 4
+
+      let writtenChars = 0
+      const terminals = Array.from({ length: SINKS }, () => ({
+        write: (data: string, callback?: () => void) => {
+          writtenChars += data.length
+          callback?.()
+        }
+      }))
+
+      const baseline = collect()
+
+      for (const [index, terminal] of terminals.entries()) {
+        for (let chunk = 0; chunk < CHUNKS_PER_TERMINAL; chunk += 1) {
+          writeTerminalOutput(
+            terminal,
+            String.fromCharCode(65 + index) +
+              String.fromCharCode(48 + (chunk % 10)) +
+              'q'.repeat(CHUNK - 2),
+            { foreground: false, latencySensitive: false }
+          )
+        }
+      }
+
+      const debug = (
+        globalThis as {
+          __terminalOutputSchedulerDebug?: { snapshot: () => { queuedChars: number } }
+        }
+      ).__terminalOutputSchedulerDebug
+      if (!debug) {
+        throw new Error('scheduler debug API unavailable')
+      }
+
+      const TAIL_CHARS = 64 * 1024
+      let ticks = 0
+      while (debug.snapshot().queuedChars > TAIL_CHARS && ticks < 40000) {
+        vi.advanceTimersByTime(4)
+        ticks += 1
+      }
+
+      const queuedChars = debug.snapshot().queuedChars
+      const retainedBytes = collect() - baseline
+
+      // Sanity: the queues really drained down, and none hit the backlog cap.
+      expect(writtenChars).toBeGreaterThan(SINKS * CHUNKS_PER_TERMINAL * CHUNK * 0.9)
+      expect(queuedChars).toBeGreaterThan(0)
+      expect(queuedChars).toBeLessThanOrEqual(TAIL_CHARS)
+
+      // The defect: ~39 drained-past slots per terminal kept their strings alive uncharged.
+      expect(retainedBytes).toBeLessThan(2 * 1024 * 1024)
+    })
+
     it('does not pin the parent when a producer enqueues a slice', async () => {
       vi.useFakeTimers()
       const { writeTerminalOutput } = await loadScheduler()
@@ -1734,17 +1794,21 @@ describe('pane terminal output scheduler', () => {
           callback?.()
         }
       })
+      const terminals = Array.from({ length: TERMINALS }, makeSink)
 
-      // Distinct leading chars keep V8 from sharing any backing store between terminals.
-      const terminals = Array.from({ length: TERMINALS }, (_unused, index) => {
-        const terminal = makeSink()
+      // Why baseline BEFORE enqueueing: the queue owns a copy of every chunk, so a baseline
+      // taken after enqueue already contains the parents this test must prove get released,
+      // and the assertion would hold even with residual flattening disabled.
+      const baseline = collect()
+
+      for (const [index, terminal] of terminals.entries()) {
+        // Built and dropped inline so only the queue's own copy stays reachable.
         writeTerminalOutput(
           terminal,
           String.fromCharCode(65 + index) + 'q'.repeat(CHUNK_CHARS - 1),
           { foreground: false, latencySensitive: false }
         )
-        return terminal
-      })
+      }
 
       const debug = (
         globalThis as {
@@ -1754,8 +1818,6 @@ describe('pane terminal output scheduler', () => {
       if (!debug) {
         throw new Error('scheduler debug API unavailable')
       }
-
-      const baseline = collect()
 
       // Why stop early: the leak is what a PARTIALLY drained queue pins. Draining to empty
       // frees the chunks either way, so a full drain cannot observe the defect.
@@ -1775,9 +1837,8 @@ describe('pane terminal output scheduler', () => {
       expect(queuedChars).toBeGreaterThan(0)
       expect(queuedChars).toBeLessThanOrEqual(TAIL_CHARS)
 
-      // The defect: those few queued KB pinned 8 x 2 MB of parent chunks (~16 MB).
+      // The defect: those few queued KB pinned 8 x 2 MB of chunks (~16 MB).
       expect(retainedBytes).toBeLessThan(4 * 1024 * 1024)
-      expect(terminals).toHaveLength(TERMINALS)
     })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1677,4 +1677,79 @@ describe('pane terminal output scheduler', () => {
     vi.advanceTimersByTime(100)
     expect(throwing.write).toHaveBeenCalledTimes(1)
   })
+
+  describe('queue memory retention (STA-3567)', () => {
+    // Why 2 MB: comfortably above BACKGROUND_CHUNK_CHARS (16 K), so every drain leaves a residual slice.
+    const CHUNK_CHARS = 2 * 1024 * 1024
+    const TERMINALS = 8
+
+    function collect(): number {
+      const gc = (globalThis as { gc?: () => void }).gc
+      if (!gc) {
+        throw new Error('global.gc unavailable - config/vitest.config.ts must pass --expose-gc')
+      }
+      gc()
+      gc()
+      return process.memoryUsage().heapUsed
+    }
+
+    it('drops the parent chunk once only a small tail is still queued', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput } = await loadScheduler()
+
+      // Why a hand-rolled write: vi.fn() retains every argument in mock.calls, which would
+      // dominate the measurement with the very bytes the queue is supposed to have released.
+      let writtenChars = 0
+      const makeSink = (): { write: (data: string, callback?: () => void) => void } => ({
+        write: (data: string, callback?: () => void) => {
+          writtenChars += data.length
+          callback?.()
+        }
+      })
+
+      // Distinct leading chars keep V8 from sharing any backing store between terminals.
+      const terminals = Array.from({ length: TERMINALS }, (_unused, index) => {
+        const terminal = makeSink()
+        writeTerminalOutput(
+          terminal,
+          String.fromCharCode(65 + index) + 'q'.repeat(CHUNK_CHARS - 1),
+          { foreground: false, latencySensitive: false }
+        )
+        return terminal
+      })
+
+      const debug = (
+        globalThis as {
+          __terminalOutputSchedulerDebug?: { snapshot: () => { queuedChars: number } }
+        }
+      ).__terminalOutputSchedulerDebug
+      if (!debug) {
+        throw new Error('scheduler debug API unavailable')
+      }
+
+      const baseline = collect()
+
+      // Why stop early: the leak is what a PARTIALLY drained queue pins. Draining to empty
+      // frees the chunks either way, so a full drain cannot observe the defect.
+      const TAIL_CHARS = 64 * 1024
+      let ticks = 0
+      while (debug.snapshot().queuedChars > TAIL_CHARS && ticks < 20000) {
+        vi.advanceTimersByTime(4)
+        ticks += 1
+      }
+
+      const queuedChars = debug.snapshot().queuedChars
+      const retainedBytes = collect() - baseline
+
+      // Sanity: nearly everything drained, but a real tail is still queued - otherwise
+      // there is no residual slice to hold a parent chunk and the measurement is meaningless.
+      expect(writtenChars).toBeGreaterThan(TERMINALS * CHUNK_CHARS * 0.9)
+      expect(queuedChars).toBeGreaterThan(0)
+      expect(queuedChars).toBeLessThanOrEqual(TAIL_CHARS)
+
+      // The defect: those few queued KB pinned 8 x 2 MB of parent chunks (~16 MB).
+      expect(retainedBytes).toBeLessThan(4 * 1024 * 1024)
+      expect(terminals).toHaveLength(TERMINALS)
+    })
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -49,6 +49,8 @@ type WriteTerminalOutputOptions = {
 
 type QueueChunk = {
   data: string
+  // Why: `data` may be a V8 SlicedString pinning a much larger parent; this is what the queue really holds alive.
+  retainedChars: number
   foreground: boolean
   forceForegroundRefresh: boolean
   followupForegroundRefresh: boolean
@@ -542,6 +544,11 @@ function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
   )
 }
 
+// Why: V8 backs `slice` with a SlicedString that points at the whole parent, so a small tail keeps a huge chunk alive. Concatenating forces a ConsString whose flattening allocates a fresh sequential string of just this length.
+function flattenRetainedSlice(value: string): string {
+  return value.length === 0 ? value : `${value} `.slice(0, -1)
+}
+
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
   let remaining = limit
   let data = ''
@@ -591,6 +598,18 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
       data += chunk.data
       remaining -= chunk.data.length
       entry.queuedChars -= chunk.data.length
+      // Why: compaction only splices every 64 chunks, so without this a fully consumed chunk keeps
+      // its (possibly parent-pinning) string and callbacks alive while charging nothing. Nothing
+      // reads below chunkIndex, so the drained slot only has to stay type-shaped.
+      entry.chunks[entry.chunkIndex] = {
+        data: '',
+        retainedChars: 0,
+        foreground: chunk.foreground,
+        forceForegroundRefresh: false,
+        followupForegroundRefresh: false,
+        shouldRefreshForegroundSynchronously: ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
+        stripTransientCursorShows: false
+      }
       entry.chunkIndex += 1
       if (chunk.onParsed) {
         parsedCallbacks.push(chunk.onParsed)
@@ -602,9 +621,13 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
     }
 
     data += chunk.data.slice(0, remaining)
+    const residual = chunk.data.slice(remaining)
+    // Why: the residual is a SlicedString still pinning `retainedChars`; copy it flat once it pins 2x its own length so a drained 2MB chunk stops holding 2MB to serve a 1KB tail. Halving keeps total copying linear in the original chunk.
+    const flatten = residual.length * 2 <= chunk.retainedChars
     entry.chunks[entry.chunkIndex] = {
       ...chunk,
-      data: chunk.data.slice(remaining)
+      data: flatten ? flattenRetainedSlice(residual) : residual,
+      retainedChars: flatten ? residual.length : chunk.retainedChars
     }
     entry.queuedChars -= remaining
     remaining = 0
@@ -681,6 +704,7 @@ function enqueueChunk(
 ): void {
   entry.chunks.push({
     data,
+    retainedChars: data.length,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,
     followupForegroundRefresh: options?.followupForegroundRefresh === true,
@@ -744,6 +768,7 @@ function replaceBacklogWithWarning(
   entry.chunks = [
     {
       data: warning,
+      retainedChars: warning.length,
       foreground: false,
       forceForegroundRefresh: false,
       followupForegroundRefresh: false,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -698,12 +698,14 @@ function enqueueChunk(
     ackCredit?: () => void
   }
 ): void {
+  // Why copy at the boundary: producers hand us slices and concatenations that pin far more than
+  // they measure - restore-overlap trims and OSC status stripping both do - and the queue holds
+  // this string long after the parent is otherwise dead. Owning our copy is what makes
+  // retainedChars true, and it costs ~0.1ms per 512KB against a ~30MB/s sustained drain.
+  const owned = flattenRetainedSlice(data)
   entry.chunks.push({
-    data,
-    // Why data.length is the truth here: callers must hand the queue a string that owns its own
-    // storage. A caller passing a slice of a much larger buffer would understate what the queue
-    // pins, so producers flatten overlap-trimmed payloads before they reach the scheduler.
-    retainedChars: data.length,
+    data: owned,
+    retainedChars: owned.length,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,
     followupForegroundRefresh: options?.followupForegroundRefresh === true,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -7,6 +7,7 @@ import {
 } from './pane-terminal-foreground-render-settle'
 import { runGuardedWriteCompletionStep } from './xterm-write-callback-guard'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 import {
   discardInFlightTerminalOutputAckCredits,
   registerTerminalOutputAckCredits
@@ -544,11 +545,6 @@ function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
   )
 }
 
-// Why: V8 backs `slice` with a SlicedString that points at the whole parent, so a small tail keeps a huge chunk alive. Concatenating forces a ConsString whose flattening allocates a fresh sequential string of just this length.
-function flattenRetainedSlice(value: string): string {
-  return value.length === 0 ? value : `${value} `.slice(0, -1)
-}
-
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
   let remaining = limit
   let data = ''
@@ -704,6 +700,9 @@ function enqueueChunk(
 ): void {
   entry.chunks.push({
     data,
+    // Why data.length is the truth here: callers must hand the queue a string that owns its own
+    // storage. A caller passing a slice of a much larger buffer would understate what the queue
+    // pins, so producers flatten overlap-trimmed payloads before they reach the scheduler.
     retainedChars: data.length,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,


### PR DESCRIPTION
## Summary

A partially drained terminal output queue kept whole PTY chunks alive in the renderer heap.

`takeQueuedChunk` stored the unconsumed remainder back into the queue as `chunk.data.slice(remaining)`. V8 backs `slice` with a **SlicedString that points at the entire parent string**, so a 2 MB chunk drained down to a few KB still pinned all 2 MB — while `queuedChars` was charged only for the remainder. The backlog cap therefore measured a small queue and let real memory grow unchecked. Fully consumed chunks were also left referenced until the 64-chunk compaction, retaining their strings and closures while charging nothing at all.

The fix tracks what each chunk really pins (`retainedChars`) and copies the residual flat once it pins twice its own length. Halving bounds retention to ~2x the honest queued chars while keeping total copying linear in the original chunk. Drained slots are replaced with an empty placeholder; nothing below `chunkIndex` ever reads them.

A second commit closes the hole review found in the first: the queue's bound is only real if callers hand it strings that own their storage, so the two overlap-trim sites in `pty-connection.ts` now flatten their trimmed restore payload before it reaches the scheduler, and `flattenRetainedSlice` moved to `src/renderer/src/lib/` as one documented primitive shared by both owners.

Fixes STA-3567.

**Measured**, 8 background terminals each fed a 2 MB chunk, drained to a <=64 KB tail:

| | retained heap | queued (charged) |
| --- | --- | --- |
| before | 8,710,264 B | <= 64 KB |
| after | 342,776 B | <= 64 KB |

Inbound-slice case found in review (Node 24, 524,288 queued chars): 16,803,368 B retained before the second commit.

This is a retention defect in its own right. It is **not** a claim that it is the cause of STA-3565 (renderer V8 heap OOM); it is one concrete, measured retainer on that path.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — oxlint + react-doctor clean (also enforced by the pre-commit hook)
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — full vitest suite run locally: 47,393 passing. 10-11 failures in 5 files (relay command fixtures, root-directory fixture setup, filesystem polling, PTY cwd repair, remote-runtime auth) are pre-existing local environment failures — they reproduce identically with the **unmodified** vitest config, and CI is green on all 32 test shards plus the root-directory guard.
- [ ] `pnpm build` — not run locally; no build-surface change. CI `package` and `package (windows)` both pass.
- [x] Added or updated high-quality tests that would catch regressions

Two new tests, both verified non-vacuous by neutering only the source under test:

1. `drops the parent chunk once only a small tail is still queued` drives the **real** scheduler through `writeTerminalOutput`, drains until only a tail remains, and measures `heapUsed` around an explicit GC. With `pane-terminal-output-scheduler.ts` reverted to `main` it fails at `expected 8710264 to be less than 4194304`. It deliberately stops mid-drain — draining to empty frees the chunks either way and cannot observe the defect — and writes through a hand-rolled sink rather than `vi.fn()`, because a spy retains every argument in `mock.calls` and would dominate the measurement with the very bytes the queue should have released.
2. `flatten-retained-slice.test.ts` measures retention for one-byte and two-byte parents and carries its own control: it asserts a raw slice *does* pin the parents, so the test cannot pass if the primitive silently degrades to a no-op. Neutering `flattenRetainedSlice` fails it at 8,380,032 B and 16,767,912 B.

`config/vitest.config.ts` gains `--expose-gc` so these retention tests have a deterministic collection point in CI.

## AI Review Report

Two rounds of independent senior review through Orca orchestration, each a **fresh** reviewer at the same model and reasoning effort as the author (codex `gpt-5.6-sol`, effort `xhigh`), with instructions to refute rather than confirm.

**Round 1** (head `c4db3302`) returned CHANGES-REQUESTED with one confirmed MEDIUM: `enqueueChunk` recorded `retainedChars` as `data.length` even when the incoming string was already a SlicedString, and `pty-connection.ts` passes restore-overlap slices in — so the ~2x bound was bypassable, measured at 16,803,368 B retained for 524,288 queued chars (32x) on Node 24. That is fixed in the second commit. Round 1 found everything else clean and proved it rather than asserting it: an A/B trace against `main` produced **identical UTF-16 hashes, ordering, write boundaries, `beforeWrite`, `onParsed` and ACK behavior** across split foreground/background writes, cursor filtering, backlog-warning replacement, discard and rejection paths; no code reads a queue slot below `chunkIndex`; the flatten primitive produces genuinely fresh strings (distinct heap addresses) on Node 24, Node 26 **and Electron 43**, for one-byte, two-byte, nested-slice and nested-cons inputs; and the repo-wide `--expose-gc` change causes no failures.

Cross-platform was reviewed explicitly and found clean for **macOS, Linux and Windows**, plus SSH, remote runtime, folder workspaces and mobile, including wire compatibility. The change is pure in-memory JS string handling with no platform branch, no path or shell handling, and no persisted or wire format.

**Round 2** (head `13ac9b44`) confirmed those two producers fixed (32.03x down to 1.03x) but found a **third**: `src/shared/agent-status-osc.ts` builds its cleaned output by concatenating slices of the combined buffer and `pty-transport.ts` hands that straight to the scheduler for local, SSH and remote-runtime output — 17,283,160 B retained for 524,288 queued chars. Its conclusion was that patching producers one at a time was the wrong shape and the comment-only contract was unsound.

That is why the third commit copies once at the **enqueue boundary** instead, making `retainedChars` true by construction, and reverts the two producer-side flattens as redundant.

**Round 3** (head `26ee6f37`) confirmed both earlier findings fixed — 568,184 B (1.08x) and 555,456 B (1.06x), versus 16,818,576 B (32.08x) and 16,807,616 B (32.06x) with only the boundary reverted — and found no production defect. Its one finding was against the **tests**: once the boundary began copying each chunk, the residual test's baseline (taken after enqueue) already contained the parents it meant to prove released, so it had gone vacuous; and consumed-slot clearing had no coverage at all. The fourth commit fixes both.

**Round 4** (head `11ecc93a`) returned **CLEAN**. It killed each mechanism independently in memory and confirmed a distinct test fails for each: residual halving (8,643,208 B vs its 4,194,304 B limit), consumed-slot clearing (2,862,888 B vs 2,097,152 B), and enqueue ownership (16,799,976 B vs 4,194,304 B). Over 10 runs the head spreads were 182,024–195,024 B (residual), 296,456–306,392 B (consumed) and 2,620,032–2,637,744 B (enqueue), so threshold headroom is ample for loaded CI and Windows. It verified the consumed-slot fixture peaks at 1,966,080 chars per terminal with zero drops and stops at slot 39/40 — under both the 2,097,152-char backlog cap and the 64-slot compaction threshold, so it measures what it claims. Head and main produced identical write boundaries and hashes with identical `beforeWrite` -> `write` -> `onParsed` -> ACK ordering. It found no dead or redundant complexity, and confirmed residual halving is still necessary alongside the boundary.

## Security Audit

Reviewed and found no exposure. The change touches only the lifetime of strings already inside the renderer's own output queue: no input parsing or validation, no command execution, no path handling, no auth or secrets, no dependency change, and no IPC surface. `flattenRetainedSlice` is content-preserving (covered by an explicit assertion including multi-byte and astral characters), so no data is altered, truncated, or reordered — the A/B trace against `main` confirms byte-identical output. No follow-up needed.

## Manual validation

| Gate | Status | Detail |
| --- | --- | --- |
| CI | **pass** | 42 checks green at `11ecc93a`, e2e skipped. Includes both `package` and `package (windows)`, the root-directory guard, and all 32 test shards on Node 24 and 26. |
| Electron | **partial — gap called out** | A dev build was launched from this exact head and CDP-verified as the right instance (`devRepoRoot` = this worktree). The app started clean with no renderer errors, and driving `seq 1 60000` through a real PTY produced complete, correctly ordered output (`L1`..`L60000`, clean prompt) in the authoritative main-process buffer. **I could not confirm the rendered xterm buffer**: no terminal pane hydrated in the dev instance, because the already-running production Orca owns those panes on the shared daemon. So the on-screen render of this change is unverified by me, and the strongest evidence for output integrity remains round 3's and round 4's A/B traces showing byte-identical output and identical callback ordering versus `main`. |
| Screenshots | n/a | No visual change. App-launch screenshots were captured for the Electron attempt but show no UI affected by this PR. |
| Mobile | n/a | Desktop renderer module; no mobile behavior touched. Reviewed for mobile parity in rounds 1–4 and found clean. |
| SSH / remote runtime | n/a for manual QA | No SSH or relay surface is touched and there is no wire or persisted-format change. The OSC producer that round 2 found does feed SSH and remote-runtime output, and the boundary fix covers it by construction; reviewed and found clean in rounds 2–4. |
| Windows | n/a for manual QA | No platform branch — pure JS string handling. CI `package (windows)` and both Windows test shards pass. |

## Notes

- No platform-specific behavior. Identical on macOS, Linux and Windows, and unaffected by SSH/remote-runtime or folder-workspace mode.
- No wire, RPC, or persisted-format change, so no remote client/host compatibility concern.
- **Perf trade-off, stated plainly.** The fix copies every chunk at the enqueue boundary and flattens draining residuals. Measured on the exact scheduler (Node 24, round 4): median real copy throughput 1,195–15,516 MB/s with a worst sample of 954 MB/s, against an xterm parse ceiling of ~103 MB/s and a sustained drain ceiling around 30 MB/s. Round 3's per-size medians were 981 MB/s at 64-byte chunks, 13.17 GB/s at 8 KB, 14.36 GB/s at 64 KB and 3.55 GB/s at 512 KB. So the worst measured case is still ~9x the rate xterm can parse — real cost, not on the critical path. The halving policy is what keeps the residual side bounded: total copying stays ~1.0x the original chunk even under pathological one-character takes (22 flattens for a 2 MB chunk) rather than going quadratic.
- The flatten relies on V8 representing `` `${s} ` `` as a ConsString whose flattening allocates a fresh sequential string. This is verified by direct heap-address and forced-GC probes on Node 24, Node 26 and Electron 43 rather than assumed, because `prefer-template` requires the template form over plain concatenation.
- `enqueueChunk`'s contract — callers hand the queue a string that owns its storage — is enforced by documentation, not by the type system. Round 1's finding came from exactly that gap, and the two known producers are now fixed.
