### PR TITLE
test: adopt robust Settings AUMID polling for UWP e2e test

### DIFF
--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -50,6 +50,7 @@ on:
       - 'tests/e2e/computer-mac-safari.e2e.ts'
       - 'tests/e2e/computer-windows.e2e.ts'
       - 'tests/e2e/computer-windows-store.e2e.ts'
+      - 'tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1'
       - 'tests/e2e/helpers/computer-cli-driver.ts'
       - 'tests/e2e/helpers/computer-driver.ts'
       - 'tests/e2e/vitest.config.ts'

--- a/.github/workflows/computer-e2e.yml
+++ b/.github/workflows/computer-e2e.yml
@@ -51,6 +51,8 @@ on:
       - 'tests/e2e/computer-windows.e2e.ts'
       - 'tests/e2e/computer-windows-store.e2e.ts'
       - 'tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1'
+      - 'tests/e2e/helpers/windows-settings-frame.ts'
+      - 'tests/e2e/helpers/windows-settings-frame.unit.test.ts'
       - 'tests/e2e/helpers/computer-cli-driver.ts'
       - 'tests/e2e/helpers/computer-driver.ts'
       - 'tests/e2e/vitest.config.ts'
@@ -103,6 +105,7 @@ jobs:
           config/scripts/computer-use-modifier-safety.test.mjs
           config/scripts/computer-use-skill-guidance.test.mjs
           config/scripts/computer-use-smoke.test.mjs
+          tests/e2e/helpers/windows-settings-frame.unit.test.ts
           src/main/computer/computer-provider-lifecycle.test.ts
           src/main/computer/computer-provider-unavailable-message.test.ts
           src/main/computer/sidecar-client.test.ts

--- a/.gitignore
+++ b/.gitignore
@@ -158,3 +158,5 @@ tests/e2e/.cross-version-checkouts/
 # IS committed). Also keeps oxfmt/oxlint, which honor this file, from walking
 # vendored gems.
 /mobile/vendor/
+# PowerShell module analysis cache dumped in local dir
+/Microsoft/

--- a/.gitignore
+++ b/.gitignore
@@ -159,4 +159,4 @@ tests/e2e/.cross-version-checkouts/
 # vendored gems.
 /mobile/vendor/
 # PowerShell module analysis cache dumped in local dir
-/Microsoft/
+/Microsoft/Windows/PowerShell/

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -18,11 +18,6 @@ describe('computer-use e2e workflow', () => {
       join(projectDir, 'tests/e2e/helpers/computer-cli-driver.ts'),
       'utf8'
     )
-    const windowsStoreE2e = readFileSync(
-      join(projectDir, 'tests/e2e/computer-windows-store.e2e.ts'),
-      'utf8'
-    )
-
     expect(driver).not.toContain('await delay(3500)')
     expect(driver).toContain("await waitForComputerWindowTitle('gedit', fileName, 15000)")
     expect(cliDriver).toContain('ORCA_DEV_USER_DATA_PATH')
@@ -30,7 +25,6 @@ describe('computer-use e2e workflow', () => {
     expect(cliDriver).toContain('retryMissingRuntimeMetadata')
     expect(cliDriver).toContain('Could not read Orca runtime metadata')
     expect(cliDriver).toContain("'serve', '--no-pairing', '--json'")
-
   })
 
   it('triggers on computer-use shared contracts, scripts, and agent skill changes', () => {
@@ -98,6 +92,7 @@ describe('computer-use e2e workflow', () => {
       'config/scripts/computer-use-modifier-safety.test.mjs',
       'config/scripts/computer-use-skill-guidance.test.mjs',
       'config/scripts/computer-use-smoke.test.mjs',
+      'tests/e2e/helpers/windows-settings-frame.unit.test.ts',
       'src/main/computer/computer-provider-lifecycle.test.ts',
       'src/main/computer/computer-provider-unavailable-message.test.ts',
       'src/main/computer/sidecar-client.test.ts',

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -31,14 +31,6 @@ describe('computer-use e2e workflow', () => {
     expect(cliDriver).toContain('Could not read Orca runtime metadata')
     expect(cliDriver).toContain("'serve', '--no-pairing', '--json'")
 
-    expect(windowsStoreE2e).toMatch(
-      /'--window-id',\s*BigInt\(targetHwnd\)\.toString\(10\)/
-    )
-    expect(windowsStoreE2e).toContain("'-FramePid'")
-    expect(windowsStoreE2e).toContain("'-AppPid'")
-
-    expect(windowsStoreE2e).not.toContain('findRoleIndex')
-    expect(windowsStoreE2e).not.toContain("'One', 'Plus', 'Two', 'Equals'")
   })
 
   it('triggers on computer-use shared contracts, scripts, and agent skill changes', () => {
@@ -65,6 +57,27 @@ describe('computer-use e2e workflow', () => {
       ])
     )
     expect(triggerPaths).not.toContain('src/shared/runtime-types.ts')
+  })
+
+  it('triggers when the Windows Store E2E test or its launcher changes', () => {
+    const workflow = parse(
+      readFileSync(join(projectDir, '.github/workflows/computer-e2e.yml'), 'utf8')
+    )
+
+    expect(workflow.on.pull_request.paths).toEqual(
+      expect.arrayContaining([
+        'tests/e2e/computer-windows-store.e2e.ts',
+        'tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1'
+      ])
+    )
+
+    const windowsRuns = workflow.jobs.windows.steps
+      .map((step) => step.run)
+      .filter((run) => typeof run === 'string')
+
+    expect(windowsRuns).toContain(
+      'pnpm test:e2e:computer --reporter=verbose tests/e2e/computer-windows.e2e.ts tests/e2e/computer-windows-store.e2e.ts'
+    )
   })
 
   it('runs focused computer-use regression tests in the PR native-smoke job', () => {

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -32,10 +32,13 @@ describe('computer-use e2e workflow', () => {
     expect(cliDriver).toContain("'serve', '--no-pairing', '--json'")
 
     expect(windowsStoreE2e).toMatch(
-      /for \(const buttonName of \['One', 'Plus', 'Two', 'Equals'\]\) \{[\s\S]*findRoleIndex\(state\.result\.snapshot\.treeText, `button \$\{buttonName\}`\)[\s\S]*state = parseJsonOutput/
+      /'--window-id',\s*BigInt\(targetHwnd\)\.toString\(10\)/
     )
-    expect(windowsStoreE2e).not.toMatch(/const one = findRoleIndex/)
-    expect(windowsStoreE2e).not.toMatch(/for \(const index of \[one, plus, two, equals\]\)/)
+    expect(windowsStoreE2e).toContain("'-FramePid'")
+    expect(windowsStoreE2e).toContain("'-AppPid'")
+
+    expect(windowsStoreE2e).not.toContain('findRoleIndex')
+    expect(windowsStoreE2e).not.toContain("'One', 'Plus', 'Two', 'Equals'")
   })
 
   it('triggers on computer-use shared contracts, scripts, and agent skill changes', () => {

--- a/config/scripts/computer-e2e-workflow.test.mjs
+++ b/config/scripts/computer-e2e-workflow.test.mjs
@@ -61,14 +61,15 @@ describe('computer-use e2e workflow', () => {
     expect(workflow.on.pull_request.paths).toEqual(
       expect.arrayContaining([
         'tests/e2e/computer-windows-store.e2e.ts',
-        'tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1'
+        'tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1',
+        'tests/e2e/helpers/windows-settings-frame.ts',
+        'tests/e2e/helpers/windows-settings-frame.unit.test.ts'
       ])
     )
 
     const windowsRuns = workflow.jobs.windows.steps
       .map((step) => step.run)
       .filter((run) => typeof run === 'string')
-
     expect(windowsRuns).toContain(
       'pnpm test:e2e:computer --reporter=verbose tests/e2e/computer-windows.e2e.ts tests/e2e/computer-windows-store.e2e.ts'
     )

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -1,5 +1,9 @@
 import { describe, expect, test } from 'vitest'
-import type { ComputerListAppsResult, ComputerSnapshotResult } from '../../src/shared/runtime-types'
+import type {
+  ComputerActionResult,
+  ComputerListAppsResult,
+  ComputerSnapshotResult
+} from '../../src/shared/runtime-types'
 import { execFile } from 'node:child_process'
 import { join } from 'node:path'
 import { promisify } from 'node:util'
@@ -12,8 +16,12 @@ import {
 import {
   buildCloseSettingsArgs,
   buildGetSettingsStateArgs,
+  findSettingsSearchEchoLines,
+  parseElementLineIndex,
   parseSettingsCloseOutput,
   parseSettingsLaunchOutput,
+  requireUniqueSettingsSearchBoxIndex,
+  selectSettingsSearchBoxLine,
   type SettingsFrame
 } from './helpers/windows-settings-frame'
 
@@ -22,65 +30,83 @@ const execFileAsync = promisify(execFile)
 const isWindows = process.platform === 'win32'
 const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
 
+// Nonsense query that cannot match any Settings entry on any locale.
+const SEARCH_PROBE = 'zzqq7391'
+const SEARCH_POLL_INTERVAL_MS = 500
+const SEARCH_POLL_DEADLINE_MS = 15_000
+
 // Settings is single-instance UWP. This file assumes an isolated CI session:
 // do not run in parallel with other UWP e2e, and expect teardown to close
 // any pre-existing Settings window in the same session.
 describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)', () => {
-  test('Store app windows are discoverable and attachable by pid', { timeout: 120_000 }, async () => {
-    let frame: SettingsFrame | undefined
-    let primaryError: unknown
-    let hasPrimaryError = false
+  test(
+    'Store app windows are discoverable and attachable by pid',
+    { timeout: 120_000 },
+    async () => {
+      await withSettingsFrame(async (frame) => {
+        const apps = parseJsonOutput<{ result: ComputerListAppsResult }>(
+          (await runOrcaCli(['computer', 'list-apps', '--json'])).stdout
+        )
+        expect(apps.result.apps).toEqual(
+          expect.arrayContaining([
+            expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: frame.FramePid })
+          ])
+        )
+        const state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
+          (await runOrcaCli(buildGetSettingsStateArgs(frame))).stdout
+        )
+        // Ensure the snapshot returned belongs to our targeted app
+        expect(state.result.snapshot.app.pid).toBe(frame.FramePid)
+        expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
+      })
+    }
+  )
 
-    try {
-      await ensureOrcaRuntimeLaunched()
-
-      frame = await launchSettingsApp()
-
-      const apps = parseJsonOutput<{ result: ComputerListAppsResult }>(
-        (await runOrcaCli(['computer', 'list-apps', '--json'])).stdout
-      )
-      expect(apps.result.apps).toEqual(
-        expect.arrayContaining([
-          expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: frame.FramePid })
-        ])
-      )
-      const state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
+  test('Store app elements are clickable and accept typed text', { timeout: 120_000 }, async () => {
+    await withSettingsFrame(async (frame) => {
+      const app = `pid:${frame.FramePid}`
+      const before = parseJsonOutput<{ result: ComputerSnapshotResult }>(
         (await runOrcaCli(buildGetSettingsStateArgs(frame))).stdout
+      ).result.snapshot.treeText
+      const searchIndex = requireUniqueSettingsSearchBoxIndex(before)
+
+      const clicked = parseJsonOutput<{ result: ComputerActionResult }>(
+        (
+          await runOrcaCli([
+            'computer',
+            'click',
+            '--app',
+            app,
+            '--element-index',
+            String(searchIndex),
+            '--restore-window',
+            '--no-screenshot',
+            '--json'
+          ])
+        ).stdout
       )
-      // Ensure the snapshot returned belongs to our targeted app
-      expect(state.result.snapshot.app.pid).toBe(frame.FramePid)
-      expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
-    } catch (error) {
-      hasPrimaryError = true
-      primaryError = error
-    }
+      // Pin the ACT path: synthetic input, not an accessibility call.
+      expect(clicked.result.action?.path).toBe('synthetic')
 
-    const cleanupErrors: unknown[] = []
+      const typed = parseJsonOutput<{ result: ComputerActionResult }>(
+        (
+          await runOrcaCli([
+            'computer',
+            'type-text',
+            '--app',
+            app,
+            '--text',
+            SEARCH_PROBE,
+            '--restore-window',
+            '--no-screenshot',
+            '--json'
+          ])
+        ).stdout
+      )
+      expect(typed.result.action?.path).toBe('synthetic')
 
-    if (frame) {
-      try {
-        await closeSettingsFrame(frame)
-      } catch (error) {
-        cleanupErrors.push(error)
-      }
-    }
-
-    try {
-      await stopOrcaRuntime()
-    } catch (error) {
-      cleanupErrors.push(error)
-    }
-
-    if (hasPrimaryError) {
-      if (cleanupErrors.length > 0) {
-        throw new AggregateError([primaryError, ...cleanupErrors], 'The E2E test and its cleanup both failed')
-      }
-      throw primaryError
-    }
-
-    if (cleanupErrors.length > 0) {
-      throw new AggregateError(cleanupErrors, 'E2E cleanup failed')
-    }
+      await pollForSearchEchoes(frame)
+    })
   })
 })
 
@@ -124,5 +150,87 @@ async function closeSettingsFrame(frame: SettingsFrame): Promise<void> {
     throw new Error(
       `Settings frame ${frame.FrameHwnd} teardown returned status "${result.Status}" (identity mismatch or failure).`
     )
+  }
+}
+
+// Shared lifecycle: identity-checked teardown aggregates its failures instead
+// of masking the primary assertion error.
+async function withSettingsFrame(body: (frame: SettingsFrame) => Promise<void>): Promise<void> {
+  let frame: SettingsFrame | undefined
+  let primaryError: unknown
+  let hasPrimaryError = false
+
+  try {
+    await ensureOrcaRuntimeLaunched()
+    frame = await launchSettingsApp()
+    await body(frame)
+  } catch (error) {
+    hasPrimaryError = true
+    primaryError = error
+  }
+
+  const cleanupErrors: unknown[] = []
+
+  if (frame) {
+    try {
+      await closeSettingsFrame(frame)
+    } catch (error) {
+      cleanupErrors.push(error)
+    }
+  }
+
+  try {
+    await stopOrcaRuntime()
+  } catch (error) {
+    cleanupErrors.push(error)
+  }
+
+  if (hasPrimaryError) {
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(
+        [primaryError, ...cleanupErrors],
+        'The E2E test and its cleanup both failed'
+      )
+    }
+    throw primaryError
+  }
+
+  if (cleanupErrors.length > 0) {
+    throw new AggregateError(cleanupErrors, 'E2E cleanup failed')
+  }
+}
+
+async function pollForSearchEchoes(frame: SettingsFrame): Promise<void> {
+  const deadline = Date.now() + SEARCH_POLL_DEADLINE_MS
+  let lastDiagnostics = '(no snapshot taken)'
+
+  for (;;) {
+    const treeText = parseJsonOutput<{ result: ComputerSnapshotResult }>(
+      (await runOrcaCli(buildGetSettingsStateArgs(frame))).stdout
+    ).result.snapshot.treeText
+    // Re-select per snapshot: element indexes are reassigned after re-renders.
+    const fieldLine = selectSettingsSearchBoxLine(treeText)
+    const fieldIndex = fieldLine ? parseElementLineIndex(fieldLine) : -1
+    const resultLines = fieldLine
+      ? findSettingsSearchEchoLines(treeText, SEARCH_PROBE, fieldIndex)
+      : []
+    lastDiagnostics = `searchBox=${fieldLine ? 'unique' : 'absent-or-ambiguous'}, probe lines:\n${treeText
+      .split('\n')
+      .filter((line) => line.includes(SEARCH_PROBE))
+      .join('\n')}`
+
+    if (fieldLine && fieldLine.includes(SEARCH_PROBE) && resultLines.length > 0) {
+      return
+    }
+
+    if (Date.now() >= deadline) {
+      throw new Error(
+        `Settings search did not echo "${SEARCH_PROBE}" in ${SEARCH_POLL_DEADLINE_MS}ms.\n${lastDiagnostics}`
+      )
+    }
+
+    const { promise: ticked, resolve: onTicked } = Promise.withResolvers<void>()
+    setTimeout(onTicked, SEARCH_POLL_INTERVAL_MS)
+    await ticked
   }
 }

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -10,6 +10,7 @@ import {
   runOrcaCli,
   stopOrcaRuntime
 } from './helpers/computer-driver'
+const execFileAsync = promisify(execFile)
 
 const isWindows = process.platform === 'win32'
 const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
@@ -52,16 +53,15 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
         await killSettingsApp(targetHwnd, targetPid)
       } else {
         // Fallback cleanup if launch timed out and leaked a frame
-        await import('node:child_process').then(({ execFile }) => {
-          execFile('powershell.exe', ['-Command', 'Stop-Process -Name ApplicationFrameHost -ErrorAction SilentlyContinue'])
-        })
+        await execFileAsync('powershell.exe', [
+          '-Command',
+          'Stop-Process -Name ApplicationFrameHost -ErrorAction SilentlyContinue'
+        ]).catch(() => undefined)
       }
       await stopOrcaRuntime()
     }
   })
 })
-const execFileAsync = promisify(execFile)
-
 const settingsFrameScript = join(__dirname, 'helpers', 'Invoke-SettingsApplicationFrame.ps1')
 
 async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): Promise<string> {

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -5,7 +5,6 @@ import { join } from 'node:path'
 import { promisify } from 'node:util'
 import {
   ensureOrcaRuntimeLaunched,
-  findRoleIndex,
   parseJsonOutput,
   runOrcaCli,
   stopOrcaRuntime
@@ -15,6 +14,9 @@ const execFileAsync = promisify(execFile)
 const isWindows = process.platform === 'win32'
 const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
 
+// Settings is single-instance UWP. This file assumes an isolated CI session:
+// do not run in parallel with other UWP e2e, and expect teardown to close
+// any pre-existing Settings window in the same session.
 describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)', () => {
   test('Store app windows are discoverable and attachable by pid', async () => {
     await ensureOrcaRuntimeLaunched()
@@ -42,6 +44,8 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
             'get-app-state',
             '--app',
             `pid:${targetPid}`,
+            '--window-id',
+            BigInt(targetHwnd).toString(10),
             '--no-screenshot',
             '--json'
           ])
@@ -103,10 +107,16 @@ async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: strin
 }
 
 async function killSettingsApp(hwnd: string, framePid: number, appPid: number): Promise<void> {
-  await runSettingsFrameScript(
-    ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-AppPid', String(appPid), '-TimeoutMilliseconds', '5000'],
-    10000
-  ).catch((error: unknown) => {
+  try {
+    const stdout = await runSettingsFrameScript(
+      ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-AppPid', String(appPid), '-TimeoutMilliseconds', '5000'],
+      10000
+    )
+    const result = JSON.parse(stdout.trim()) as Record<string, unknown>
+    if (result.Closed !== true) {
+      console.warn(`Settings frame ${hwnd} identity mismatch or close failed. Cleanup aborted to preserve isolation.`)
+    }
+  } catch (error) {
     console.warn(`Failed to close Settings frame ${hwnd}:`, error)
-  })
+  }
 }

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -16,13 +16,15 @@ const isWindows = process.platform === 'win32'
 const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
 
 describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)', () => {
-  test('Store app windows are discoverable by title and clickable', async () => {
+  test('Store app windows are discoverable and attachable by pid', async () => {
     await ensureOrcaRuntimeLaunched()
     let targetHwnd: string | undefined
     let targetPid: number | undefined
+    let targetAppPid: number | undefined
     try {
       const frame = await launchSettingsApp()
       targetPid = frame.FramePid
+      targetAppPid = frame.AppPid
       targetHwnd = frame.FrameHwnd
 
       const apps = parseJsonOutput<{ result: ComputerListAppsResult }>(
@@ -49,8 +51,8 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
       expect(state.result.snapshot.app.pid).toBe(targetPid)
       expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
     } finally {
-      if (targetHwnd && targetPid !== undefined) {
-        await killSettingsApp(targetHwnd, targetPid)
+      if (targetHwnd && targetPid !== undefined && targetAppPid !== undefined) {
+        await killSettingsApp(targetHwnd, targetPid, targetAppPid)
       } else {
         // Fallback cleanup skipped: terminating by name breaks CI isolation and user environments.
         console.warn('Launch timed out or failed, skipping teardown to avoid killing unrelated UWP apps.')
@@ -84,21 +86,25 @@ async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): 
   return stdout
 }
 
-async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: string }> {
+async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: string; AppPid: number }> {
   const stdout = await runSettingsFrameScript(
     ['-Action', 'Launch', '-TimeoutMilliseconds', '15000'],
     20000
   )
   try {
-    return JSON.parse(stdout.trim())
+    const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
+    if (typeof parsed.FramePid !== 'number' || typeof parsed.FrameHwnd !== 'string' || typeof parsed.AppPid !== 'number') {
+      throw new Error(`Invalid SettingsFrameLauncher payload: ${stdout}`)
+    }
+    return parsed as { FramePid: number; FrameHwnd: string; AppPid: number }
   } catch (error) {
     throw new Error(`Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${error instanceof Error ? error.message : String(error)}`)
   }
 }
 
-async function killSettingsApp(hwnd: string, framePid: number): Promise<void> {
+async function killSettingsApp(hwnd: string, framePid: number, appPid: number): Promise<void> {
   await runSettingsFrameScript(
-    ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-TimeoutMilliseconds', '5000'],
+    ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-AppPid', String(appPid), '-TimeoutMilliseconds', '5000'],
     10000
   ).catch((error: unknown) => {
     console.warn(`Failed to close Settings frame ${hwnd}:`, error)

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -56,7 +56,7 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
       expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
     } finally {
       if (targetHwnd && targetPid !== undefined && targetAppPid !== undefined) {
-        await killSettingsApp(targetHwnd, targetPid, targetAppPid)
+        await closeSettingsFrame(targetHwnd, targetPid, targetAppPid)
       } else {
         // Fallback cleanup skipped: terminating by name breaks CI isolation and user environments.
         console.warn('Launch timed out or failed, skipping teardown to avoid killing unrelated UWP apps.')
@@ -89,24 +89,32 @@ async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): 
   )
   return stdout
 }
-
 async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: string; AppPid: number }> {
   const stdout = await runSettingsFrameScript(
     ['-Action', 'Launch', '-TimeoutMilliseconds', '15000'],
-    20000
+    45000
   )
+  let parsed: Record<string, unknown>
   try {
-    const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
-    if (typeof parsed.FramePid !== 'number' || typeof parsed.FrameHwnd !== 'string' || typeof parsed.AppPid !== 'number') {
-      throw new Error(`Invalid SettingsFrameLauncher payload: ${stdout}`)
-    }
-    return parsed as { FramePid: number; FrameHwnd: string; AppPid: number }
-  } catch (error) {
-    throw new Error(`Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${error instanceof Error ? error.message : String(error)}`)
+    parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
+  } catch (parseError) {
+    throw new Error(`Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${parseError instanceof Error ? parseError.message : String(parseError)}`)
   }
+
+  if (
+    !Number.isSafeInteger(parsed.FramePid) ||
+    (parsed.FramePid as number) <= 0 ||
+    !Number.isSafeInteger(parsed.AppPid) ||
+    (parsed.AppPid as number) <= 0 ||
+    typeof parsed.FrameHwnd !== 'string' ||
+    !/^0x[0-9a-f]+$/i.test(parsed.FrameHwnd)
+  ) {
+    throw new Error(`Invalid SettingsFrameLauncher payload shape: ${stdout}`)
+  }
+  return parsed as { FramePid: number; FrameHwnd: string; AppPid: number }
 }
 
-async function killSettingsApp(hwnd: string, framePid: number, appPid: number): Promise<void> {
+async function closeSettingsFrame(hwnd: string, framePid: number, appPid: number): Promise<void> {
   try {
     const stdout = await runSettingsFrameScript(
       ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-AppPid', String(appPid), '-TimeoutMilliseconds', '5000'],
@@ -114,9 +122,9 @@ async function killSettingsApp(hwnd: string, framePid: number, appPid: number): 
     )
     const result = JSON.parse(stdout.trim()) as Record<string, unknown>
     if (result.Closed !== true) {
-      console.warn(`Settings frame ${hwnd} identity mismatch or close failed. Cleanup aborted to preserve isolation.`)
+      throw new Error(`Settings frame ${hwnd} identity mismatch or close failed. Cleanup aborted to preserve isolation.`)
     }
   } catch (error) {
-    console.warn(`Failed to close Settings frame ${hwnd}:`, error)
+    throw new Error(`Failed to close Settings frame ${hwnd}: ${error instanceof Error ? error.message : String(error)}`)
   }
 }

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -18,12 +18,16 @@ const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
 // do not run in parallel with other UWP e2e, and expect teardown to close
 // any pre-existing Settings window in the same session.
 describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)', () => {
-  test('Store app windows are discoverable and attachable by pid', async () => {
-    await ensureOrcaRuntimeLaunched()
+  test('Store app windows are discoverable and attachable by pid', { timeout: 120_000 }, async () => {
     let targetHwnd: string | undefined
     let targetPid: number | undefined
     let targetAppPid: number | undefined
+    let primaryError: unknown
+    let hasPrimaryError = false
+
     try {
+      await ensureOrcaRuntimeLaunched()
+
       const frame = await launchSettingsApp()
       targetPid = frame.FramePid
       targetAppPid = frame.AppPid
@@ -37,7 +41,7 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
           expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: targetPid })
         ])
       )
-      let state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
+      const state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
         (
           await runOrcaCli([
             'computer',
@@ -54,14 +58,36 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
       // Ensure the snapshot returned belongs to our targeted app
       expect(state.result.snapshot.app.pid).toBe(targetPid)
       expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
-    } finally {
-      if (targetHwnd && targetPid !== undefined && targetAppPid !== undefined) {
+    } catch (error) {
+      hasPrimaryError = true
+      primaryError = error
+    }
+
+    const cleanupErrors: unknown[] = []
+
+    if (targetHwnd && targetPid !== undefined && targetAppPid !== undefined) {
+      try {
         await closeSettingsFrame(targetHwnd, targetPid, targetAppPid)
-      } else {
-        // Fallback cleanup skipped: terminating by name breaks CI isolation and user environments.
-        console.warn('Launch timed out or failed, skipping teardown to avoid killing unrelated UWP apps.')
+      } catch (error) {
+        cleanupErrors.push(error)
       }
+    }
+
+    try {
       await stopOrcaRuntime()
+    } catch (error) {
+      cleanupErrors.push(error)
+    }
+
+    if (hasPrimaryError) {
+      if (cleanupErrors.length > 0) {
+        throw new AggregateError([primaryError, ...cleanupErrors], 'The E2E test and its cleanup both failed')
+      }
+      throw primaryError
+    }
+
+    if (cleanupErrors.length > 0) {
+      throw new AggregateError(cleanupErrors, 'E2E cleanup failed')
     }
   })
 })
@@ -121,8 +147,8 @@ async function closeSettingsFrame(hwnd: string, framePid: number, appPid: number
       10000
     )
     const result = JSON.parse(stdout.trim()) as Record<string, unknown>
-    if (result.Closed !== true) {
-      throw new Error(`Settings frame ${hwnd} identity mismatch or close failed. Cleanup aborted to preserve isolation.`)
+    if (result.Status !== 'Closed' && result.Status !== 'AlreadyGone') {
+      throw new Error(`Settings frame ${hwnd} teardown returned status "${result.Status}" (identity mismatch or failure).`)
     }
   } catch (error) {
     throw new Error(`Failed to close Settings frame ${hwnd}: ${error instanceof Error ? error.message : String(error)}`)

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -52,11 +52,8 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
       if (targetHwnd && targetPid !== undefined) {
         await killSettingsApp(targetHwnd, targetPid)
       } else {
-        // Fallback cleanup if launch timed out and leaked a frame
-        await execFileAsync('powershell.exe', [
-          '-Command',
-          'Stop-Process -Name ApplicationFrameHost -ErrorAction SilentlyContinue'
-        ]).catch(() => undefined)
+        // Fallback cleanup skipped: terminating by name breaks CI isolation and user environments.
+        console.warn('Launch timed out or failed, skipping teardown to avoid killing unrelated UWP apps.')
       }
       await stopOrcaRuntime()
     }

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -1,5 +1,8 @@
 import { describe, expect, test } from 'vitest'
 import type { ComputerListAppsResult, ComputerSnapshotResult } from '../../src/shared/runtime-types'
+import { execFile } from 'node:child_process'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
 import {
   ensureOrcaRuntimeLaunched,
   findRoleIndex,
@@ -14,97 +17,99 @@ const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
 describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)', () => {
   test('Store app windows are discoverable by title and clickable', async () => {
     await ensureOrcaRuntimeLaunched()
-    await launchCalculator()
+    let targetHwnd: string | undefined
     try {
+      const frame = await launchSettingsApp()
+      const targetPid = String(frame.FramePid)
+      targetHwnd = frame.FrameHwnd
+
       const apps = parseJsonOutput<{ result: ComputerListAppsResult }>(
         (await runOrcaCli(['computer', 'list-apps', '--json'])).stdout
       )
       expect(apps.result.apps).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ name: 'Calculator', bundleId: 'ApplicationFrameHost' })
+          expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: Number.parseInt(targetPid, 10) })
         ])
       )
-
       let state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
         (
           await runOrcaCli([
             'computer',
             'get-app-state',
             '--app',
-            'Calculator',
+            `pid:${targetPid}`,
             '--no-screenshot',
             '--json'
           ])
         ).stdout
       )
-      for (const buttonName of ['One', 'Plus', 'Two', 'Equals']) {
-        const index = findRoleIndex(state.result.snapshot.treeText, `button ${buttonName}`)
-        expect(index).toBeGreaterThanOrEqual(0)
-        state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
-          (
-            await runOrcaCli([
-              'computer',
-              'click',
-              '--app',
-              'Calculator',
-              '--element-index',
-              String(index),
-              '--no-screenshot',
-              '--json'
-            ])
-          ).stdout
-        )
-      }
-      expect(state.result.snapshot.treeText).toMatch(/Display is 3\b/)
+      // Find the first valid element index in the tree. We avoid role names to prevent localization issues.
+      const index = findRoleIndex(state.result.snapshot.treeText, /^\s*(\d+)\s+[^\n]+/m)
+      expect(index).toBeGreaterThanOrEqual(0)
+      state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
+        (
+          await runOrcaCli([
+            'computer',
+            'click',
+            '--app',
+            `pid:${targetPid}`,
+            '--element-index',
+            String(index),
+            '--no-screenshot',
+            '--json'
+          ])
+        ).stdout
+      )
+      // Ensure the snapshot returned after the click still belongs to our targeted app
+      expect(state.result.snapshot.app.pid).toBe(Number.parseInt(targetPid, 10))
+      expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
     } finally {
-      await killCalculator()
+      if (targetHwnd) {
+        await killSettingsApp(targetHwnd)
+      }
       await stopOrcaRuntime()
     }
   })
 })
+const execFileAsync = promisify(execFile)
 
-async function launchCalculator(): Promise<void> {
-  await runPowerShell('Start-Process calc.exe')
-  await runPowerShell(
+const settingsFrameScript = join(__dirname, 'helpers', 'Invoke-SettingsApplicationFrame.ps1')
+
+async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): Promise<string> {
+  const { stdout } = await execFileAsync(
+    'powershell.exe',
     [
-      '$deadline = (Get-Date).AddSeconds(15)',
-      '$target = $null',
-      'while ((Get-Date) -lt $deadline -and $null -eq $target) {',
-      '  Start-Sleep -Milliseconds 250',
-      '  $target = Get-Process |',
-      '    Where-Object { $_.MainWindowHandle -ne 0 -and $_.MainWindowTitle -eq "Calculator" } |',
-      '    Select-Object -First 1',
-      '}',
-      'if ($null -eq $target) { throw "No visible Calculator window found" }'
-    ].join('\n')
+      '-NoLogo',
+      '-NoProfile',
+      '-NonInteractive',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      settingsFrameScript,
+      ...scriptArgs
+    ],
+    {
+      windowsHide: true,
+      encoding: 'utf8',
+      timeout: timeoutMs
+    }
   )
+  return stdout
 }
 
-async function killCalculator(): Promise<void> {
-  // Why: teardown is best-effort so cleanup noise cannot mask assertion signal.
-  await runPowerShell(
-    [
-      '$processes = @()',
-      '$processes += Get-Process -Name CalculatorApp -ErrorAction SilentlyContinue',
-      '$processes += Get-Process -Name ApplicationFrameHost -ErrorAction SilentlyContinue |',
-      '  Where-Object { $_.MainWindowTitle -eq "Calculator" }',
-      'foreach ($process in $processes) {',
-      '  try { Stop-Process -Id $process.Id -Force -ErrorAction Stop } catch { }',
-      '}',
-      'exit 0'
-    ].join('\n')
-  ).catch(() => undefined)
+async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: string }> {
+  const stdout = await runSettingsFrameScript(
+    ['-Action', 'Launch', '-TimeoutMilliseconds', '15000'],
+    20000
+  )
+  return JSON.parse(stdout.trim())
 }
 
-async function runPowerShell(script: string): Promise<void> {
-  const { execFile } = await import('node:child_process')
-  await new Promise<void>((resolve, reject) => {
-    execFile('powershell.exe', ['-NoProfile', '-NonInteractive', '-Command', script], (error) => {
-      if (error) {
-        reject(error)
-        return
-      }
-      resolve()
-    })
+async function killSettingsApp(hwnd: string): Promise<void> {
+  await runSettingsFrameScript(
+    ['-Action', 'Close', '-Hwnd', hwnd, '-TimeoutMilliseconds', '5000'],
+    10000
+  ).catch((error: unknown) => {
+    console.warn(`Failed to close Settings frame ${hwnd}:`, error)
   })
 }

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -118,7 +118,7 @@ async function launchSettingsApp(): Promise<SettingsFrame> {
 }
 
 async function closeSettingsFrame(frame: SettingsFrame): Promise<void> {
-  const stdout = await runSettingsFrameScript(buildCloseSettingsArgs(frame), 10000)
+  const stdout = await runSettingsFrameScript(buildCloseSettingsArgs(frame), 30000)
   const result = parseSettingsCloseOutput(stdout)
   if (result.Status !== 'Closed' && result.Status !== 'AlreadyGone') {
     throw new Error(

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -68,6 +68,7 @@ async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): 
       '-NoLogo',
       '-NoProfile',
       '-NonInteractive',
+      '-Sta',
       '-ExecutionPolicy',
       'Bypass',
       '-File',

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -18,9 +18,10 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
   test('Store app windows are discoverable by title and clickable', async () => {
     await ensureOrcaRuntimeLaunched()
     let targetHwnd: string | undefined
+    let targetPid: number | undefined
     try {
       const frame = await launchSettingsApp()
-      const targetPid = String(frame.FramePid)
+      targetPid = frame.FramePid
       targetHwnd = frame.FrameHwnd
 
       const apps = parseJsonOutput<{ result: ComputerListAppsResult }>(
@@ -28,7 +29,7 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
       )
       expect(apps.result.apps).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: Number.parseInt(targetPid, 10) })
+          expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: targetPid })
         ])
       )
       let state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
@@ -43,29 +44,17 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
           ])
         ).stdout
       )
-      // Find the first valid element index in the tree. We avoid role names to prevent localization issues.
-      const index = findRoleIndex(state.result.snapshot.treeText, /^\s*(\d+)\s+[^\n]+/m)
-      expect(index).toBeGreaterThanOrEqual(0)
-      state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
-        (
-          await runOrcaCli([
-            'computer',
-            'click',
-            '--app',
-            `pid:${targetPid}`,
-            '--element-index',
-            String(index),
-            '--no-screenshot',
-            '--json'
-          ])
-        ).stdout
-      )
-      // Ensure the snapshot returned after the click still belongs to our targeted app
-      expect(state.result.snapshot.app.pid).toBe(Number.parseInt(targetPid, 10))
+      // Ensure the snapshot returned belongs to our targeted app
+      expect(state.result.snapshot.app.pid).toBe(targetPid)
       expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
     } finally {
-      if (targetHwnd) {
-        await killSettingsApp(targetHwnd)
+      if (targetHwnd && targetPid !== undefined) {
+        await killSettingsApp(targetHwnd, targetPid)
+      } else {
+        // Fallback cleanup if launch timed out and leaked a frame
+        await import('node:child_process').then(({ execFile }) => {
+          execFile('powershell.exe', ['-Command', 'Stop-Process -Name ApplicationFrameHost -ErrorAction SilentlyContinue'])
+        })
       }
       await stopOrcaRuntime()
     }
@@ -102,12 +91,16 @@ async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: strin
     ['-Action', 'Launch', '-TimeoutMilliseconds', '15000'],
     20000
   )
-  return JSON.parse(stdout.trim())
+  try {
+    return JSON.parse(stdout.trim())
+  } catch (error) {
+    throw new Error(`Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${error instanceof Error ? error.message : String(error)}`)
+  }
 }
 
-async function killSettingsApp(hwnd: string): Promise<void> {
+async function killSettingsApp(hwnd: string, framePid: number): Promise<void> {
   await runSettingsFrameScript(
-    ['-Action', 'Close', '-Hwnd', hwnd, '-TimeoutMilliseconds', '5000'],
+    ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-TimeoutMilliseconds', '5000'],
     10000
   ).catch((error: unknown) => {
     console.warn(`Failed to close Settings frame ${hwnd}:`, error)

--- a/tests/e2e/computer-windows-store.e2e.ts
+++ b/tests/e2e/computer-windows-store.e2e.ts
@@ -9,6 +9,14 @@ import {
   runOrcaCli,
   stopOrcaRuntime
 } from './helpers/computer-driver'
+import {
+  buildCloseSettingsArgs,
+  buildGetSettingsStateArgs,
+  parseSettingsCloseOutput,
+  parseSettingsLaunchOutput,
+  type SettingsFrame
+} from './helpers/windows-settings-frame'
+
 const execFileAsync = promisify(execFile)
 
 const isWindows = process.platform === 'win32'
@@ -19,44 +27,28 @@ const e2eOptIn = process.env.ORCA_COMPUTER_E2E === '1'
 // any pre-existing Settings window in the same session.
 describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)', () => {
   test('Store app windows are discoverable and attachable by pid', { timeout: 120_000 }, async () => {
-    let targetHwnd: string | undefined
-    let targetPid: number | undefined
-    let targetAppPid: number | undefined
+    let frame: SettingsFrame | undefined
     let primaryError: unknown
     let hasPrimaryError = false
 
     try {
       await ensureOrcaRuntimeLaunched()
 
-      const frame = await launchSettingsApp()
-      targetPid = frame.FramePid
-      targetAppPid = frame.AppPid
-      targetHwnd = frame.FrameHwnd
+      frame = await launchSettingsApp()
 
       const apps = parseJsonOutput<{ result: ComputerListAppsResult }>(
         (await runOrcaCli(['computer', 'list-apps', '--json'])).stdout
       )
       expect(apps.result.apps).toEqual(
         expect.arrayContaining([
-          expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: targetPid })
+          expect.objectContaining({ bundleId: 'ApplicationFrameHost', pid: frame.FramePid })
         ])
       )
       const state = parseJsonOutput<{ result: ComputerSnapshotResult }>(
-        (
-          await runOrcaCli([
-            'computer',
-            'get-app-state',
-            '--app',
-            `pid:${targetPid}`,
-            '--window-id',
-            BigInt(targetHwnd).toString(10),
-            '--no-screenshot',
-            '--json'
-          ])
-        ).stdout
+        (await runOrcaCli(buildGetSettingsStateArgs(frame))).stdout
       )
       // Ensure the snapshot returned belongs to our targeted app
-      expect(state.result.snapshot.app.pid).toBe(targetPid)
+      expect(state.result.snapshot.app.pid).toBe(frame.FramePid)
       expect(state.result.snapshot.treeText.length).toBeGreaterThan(0)
     } catch (error) {
       hasPrimaryError = true
@@ -65,9 +57,9 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
 
     const cleanupErrors: unknown[] = []
 
-    if (targetHwnd && targetPid !== undefined && targetAppPid !== undefined) {
+    if (frame) {
       try {
-        await closeSettingsFrame(targetHwnd, targetPid, targetAppPid)
+        await closeSettingsFrame(frame)
       } catch (error) {
         cleanupErrors.push(error)
       }
@@ -91,6 +83,7 @@ describe.skipIf(!isWindows || !e2eOptIn)('computer-use Windows e2e (Store apps)'
     }
   })
 })
+
 const settingsFrameScript = join(__dirname, 'helpers', 'Invoke-SettingsApplicationFrame.ps1')
 
 async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): Promise<string> {
@@ -115,42 +108,21 @@ async function runSettingsFrameScript(scriptArgs: string[], timeoutMs: number): 
   )
   return stdout
 }
-async function launchSettingsApp(): Promise<{ FramePid: number; FrameHwnd: string; AppPid: number }> {
+
+async function launchSettingsApp(): Promise<SettingsFrame> {
   const stdout = await runSettingsFrameScript(
     ['-Action', 'Launch', '-TimeoutMilliseconds', '15000'],
     45000
   )
-  let parsed: Record<string, unknown>
-  try {
-    parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
-  } catch (parseError) {
-    throw new Error(`Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${parseError instanceof Error ? parseError.message : String(parseError)}`)
-  }
-
-  if (
-    !Number.isSafeInteger(parsed.FramePid) ||
-    (parsed.FramePid as number) <= 0 ||
-    !Number.isSafeInteger(parsed.AppPid) ||
-    (parsed.AppPid as number) <= 0 ||
-    typeof parsed.FrameHwnd !== 'string' ||
-    !/^0x[0-9a-f]+$/i.test(parsed.FrameHwnd)
-  ) {
-    throw new Error(`Invalid SettingsFrameLauncher payload shape: ${stdout}`)
-  }
-  return parsed as { FramePid: number; FrameHwnd: string; AppPid: number }
+  return parseSettingsLaunchOutput(stdout)
 }
 
-async function closeSettingsFrame(hwnd: string, framePid: number, appPid: number): Promise<void> {
-  try {
-    const stdout = await runSettingsFrameScript(
-      ['-Action', 'Close', '-Hwnd', hwnd, '-FramePid', String(framePid), '-AppPid', String(appPid), '-TimeoutMilliseconds', '5000'],
-      10000
+async function closeSettingsFrame(frame: SettingsFrame): Promise<void> {
+  const stdout = await runSettingsFrameScript(buildCloseSettingsArgs(frame), 10000)
+  const result = parseSettingsCloseOutput(stdout)
+  if (result.Status !== 'Closed' && result.Status !== 'AlreadyGone') {
+    throw new Error(
+      `Settings frame ${frame.FrameHwnd} teardown returned status "${result.Status}" (identity mismatch or failure).`
     )
-    const result = JSON.parse(stdout.trim()) as Record<string, unknown>
-    if (result.Status !== 'Closed' && result.Status !== 'AlreadyGone') {
-      throw new Error(`Settings frame ${hwnd} teardown returned status "${result.Status}" (identity mismatch or failure).`)
-    }
-  } catch (error) {
-    throw new Error(`Failed to close Settings frame ${hwnd}: ${error instanceof Error ? error.message : String(error)}`)
   }
 }

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -1,0 +1,368 @@
+[CmdletBinding()]
+param(
+    [ValidateSet('Launch', 'Close')]
+    [string]$Action = 'Launch',
+
+    [string]$Hwnd,
+
+    [ValidateRange(1, 120000)]
+    [int]$TimeoutMilliseconds = 15000
+)
+
+$ErrorActionPreference = 'Stop'
+if (-not ('SettingsFrameLauncher' -as [type])) {
+Add-Type -TypeDefinition @'
+using System;
+using System.Collections.Generic;
+using System.ComponentModel;
+using System.Diagnostics;
+using System.Globalization;
+using System.Runtime.InteropServices;
+using System.Text;
+using System.Threading;
+
+public sealed class SettingsFrameInfo
+{
+    public uint AppPid { get; internal set; }
+    public uint FramePid { get; internal set; }
+    public long FrameHwndValue { get; internal set; }
+    public string FrameHwndHex
+    {
+        get { return "0x" + unchecked((ulong)FrameHwndValue).ToString("X"); }
+    }
+    public string FrameClass { get; internal set; }
+    public string FrameTitle { get; internal set; }
+}
+
+public static class SettingsFrameLauncher
+{
+    private const string SettingsAumid =
+        "windows.immersivecontrolpanel_cw5n1h2txyewy!microsoft.windows.immersivecontrolpanel";
+
+    private const uint CLSCTX_LOCAL_SERVER = 0x4;
+    private const uint AO_NOERRORUI = 0x2;
+    private const uint WM_CLOSE = 0x0010;
+    private const int RPC_E_CHANGED_MODE = unchecked((int)0x80010106);
+
+    private static readonly Guid ActivationManagerClsid =
+        new Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C");
+    private static readonly Guid ActivationManagerIid =
+        new Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D");
+
+    [ComImport]
+    [Guid("2E941141-7F97-4756-BA1D-9DECDE894A3D")]
+    [InterfaceType(ComInterfaceType.InterfaceIsIUnknown)]
+    private interface IApplicationActivationManager
+    {
+        [PreserveSig]
+        int ActivateApplication(
+            [MarshalAs(UnmanagedType.LPWStr)] string appUserModelId,
+            [MarshalAs(UnmanagedType.LPWStr)] string arguments,
+            uint options,
+            out uint processId);
+    }
+
+    private delegate bool EnumWindowsProc(IntPtr hwnd, IntPtr lParam);
+
+    [DllImport("ole32.dll", ExactSpelling = true)]
+    private static extern int CoInitializeEx(IntPtr reserved, uint coInit);
+
+    [DllImport("ole32.dll", ExactSpelling = true)]
+    private static extern void CoUninitialize();
+
+    [DllImport("ole32.dll", ExactSpelling = true)]
+    private static extern int CoCreateInstance(
+        ref Guid clsid,
+        IntPtr outer,
+        uint clsContext,
+        ref Guid iid,
+        out IntPtr instance);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool EnumChildWindows(
+        IntPtr parent,
+        EnumWindowsProc callback,
+        IntPtr lParam);
+
+    [DllImport("user32.dll")]
+    private static extern uint GetWindowThreadProcessId(IntPtr hwnd, out uint processId);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindow(IntPtr hwnd);
+
+    [DllImport("user32.dll")]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool IsWindowVisible(IntPtr hwnd);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetClassName(IntPtr hwnd, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowText(IntPtr hwnd, StringBuilder text, int maxCount);
+
+    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
+    private static extern int GetWindowTextLength(IntPtr hwnd);
+
+    [DllImport("user32.dll", SetLastError = true)]
+    [return: MarshalAs(UnmanagedType.Bool)]
+    private static extern bool PostMessage(IntPtr hwnd, uint message, IntPtr wParam, IntPtr lParam);
+
+    public static SettingsFrameInfo Launch(int timeoutMilliseconds)
+    {
+        if (timeoutMilliseconds <= 0)
+            throw new ArgumentOutOfRangeException("timeoutMilliseconds");
+
+        int initHr = CoInitializeEx(IntPtr.Zero, 0); // COINIT_MULTITHREADED
+        bool uninitialize = initHr >= 0;
+        if (initHr < 0 && initHr != RPC_E_CHANGED_MODE)
+            ThrowForHr(initHr, "CoInitializeEx");
+
+        IntPtr rawManager = IntPtr.Zero;
+        IApplicationActivationManager manager = null;
+
+        try
+        {
+            Guid clsid = ActivationManagerClsid;
+            Guid iid = ActivationManagerIid;
+            int hr = CoCreateInstance(
+                ref clsid,
+                IntPtr.Zero,
+                CLSCTX_LOCAL_SERVER,
+                ref iid,
+                out rawManager);
+            ThrowForHr(hr, "CoCreateInstance(CLSID_ApplicationActivationManager)");
+
+            manager = (IApplicationActivationManager)Marshal.GetObjectForIUnknown(rawManager);
+            Marshal.Release(rawManager);
+            rawManager = IntPtr.Zero;
+
+            uint appPid;
+            hr = manager.ActivateApplication(
+                SettingsAumid,
+                null,
+                AO_NOERRORUI,
+                out appPid);
+            ThrowForHr(hr, "IApplicationActivationManager.ActivateApplication");
+
+            Stopwatch timer = Stopwatch.StartNew();
+            List<SettingsFrameInfo> last = new List<SettingsFrameInfo>();
+
+            while (timer.ElapsedMilliseconds < timeoutMilliseconds)
+            {
+                last = FindFrames(appPid);
+                if (last.Count == 1 && IsStillTheSameFrame(last[0]))
+                    return last[0];
+
+                if (!ProcessExists(appPid))
+                    throw new InvalidOperationException(
+                        "The Settings process returned by activation exited before its frame was found. PID=" + appPid);
+
+                Thread.Sleep(50);
+            }
+
+            if (last.Count > 1)
+                throw new InvalidOperationException(
+                    "Activation returned Settings PID " + appPid +
+                    ", but more than one visible ApplicationFrameHost window contains an HWND owned by that PID. " +
+                    "The activation cannot be correlated to one window without an app-level token.");
+
+            throw new TimeoutException(
+                "Activation returned Settings PID " + appPid +
+                ", but no visible ApplicationFrameHost top-level window containing an HWND owned by that PID appeared within " +
+                timeoutMilliseconds + " ms.");
+        }
+        finally
+        {
+            if (manager != null && Marshal.IsComObject(manager))
+                Marshal.FinalReleaseComObject(manager);
+            if (rawManager != IntPtr.Zero)
+                Marshal.Release(rawManager);
+            if (uninitialize)
+                CoUninitialize();
+        }
+    }
+
+    public static void CloseFrameHex(string frameHwndHex, int timeoutMilliseconds)
+    {
+        if (string.IsNullOrWhiteSpace(frameHwndHex))
+            throw new ArgumentException("A window handle is required.", "frameHwndHex");
+
+        string value = frameHwndHex.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
+            ? frameHwndHex.Substring(2)
+            : frameHwndHex;
+
+        ulong raw = ulong.Parse(value, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
+        CloseFrame(unchecked((long)raw), timeoutMilliseconds);
+    }
+
+    public static void CloseFrame(long frameHwndValue, int timeoutMilliseconds)
+    {
+        IntPtr hwnd = new IntPtr(frameHwndValue);
+        if (!IsWindow(hwnd))
+            return;
+
+        uint ownerPid;
+        if (GetWindowThreadProcessId(hwnd, out ownerPid) == 0 ||
+            !ProcessNameEquals(ownerPid, "ApplicationFrameHost"))
+            return;
+
+        if (!PostMessage(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero))
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "PostMessage(WM_CLOSE) failed");
+
+        Stopwatch timer = Stopwatch.StartNew();
+        while (IsWindow(hwnd) && timer.ElapsedMilliseconds < timeoutMilliseconds)
+            Thread.Sleep(50);
+
+        if (IsWindow(hwnd))
+            throw new TimeoutException("The Settings frame did not close in time: " + frameHwndValue);
+    }
+
+    private static List<SettingsFrameInfo> FindFrames(uint appPid)
+    {
+        List<SettingsFrameInfo> result = new List<SettingsFrameInfo>();
+
+        EnumWindowsProc topCallback = delegate(IntPtr top, IntPtr ignored)
+        {
+            if (!IsWindowVisible(top))
+                return true;
+
+            uint framePid;
+            if (GetWindowThreadProcessId(top, out framePid) == 0 || framePid == 0 || framePid == appPid)
+                return true;
+
+            if (!ProcessNameEquals(framePid, "ApplicationFrameHost"))
+                return true;
+
+            if (!HasDescendantOwnedBy(top, appPid))
+                return true;
+
+            SettingsFrameInfo info = new SettingsFrameInfo();
+            info.AppPid = appPid;
+            info.FramePid = framePid;
+            info.FrameHwndValue = top.ToInt64();
+            info.FrameClass = ReadClassName(top);
+            info.FrameTitle = ReadWindowText(top);
+            result.Add(info);
+            return true;
+        };
+
+        EnumWindows(topCallback, IntPtr.Zero);
+        GC.KeepAlive(topCallback);
+        return result;
+    }
+
+    private static bool HasDescendantOwnedBy(IntPtr parent, uint appPid)
+    {
+        bool found = false;
+
+        EnumWindowsProc childCallback = delegate(IntPtr child, IntPtr ignored)
+        {
+            uint childPid;
+            if (GetWindowThreadProcessId(child, out childPid) != 0 && childPid == appPid)
+            {
+                found = true;
+                return false;
+            }
+            return true;
+        };
+
+        EnumChildWindows(parent, childCallback, IntPtr.Zero);
+        GC.KeepAlive(childCallback);
+        return found;
+    }
+
+    private static bool IsStillTheSameFrame(SettingsFrameInfo info)
+    {
+        IntPtr hwnd = new IntPtr(info.FrameHwndValue);
+        if (!IsWindow(hwnd))
+            return false;
+
+        uint currentPid;
+        if (GetWindowThreadProcessId(hwnd, out currentPid) == 0 || currentPid != info.FramePid)
+            return false;
+
+        return ProcessNameEquals(currentPid, "ApplicationFrameHost") &&
+               HasDescendantOwnedBy(hwnd, info.AppPid);
+    }
+
+    private static bool ProcessNameEquals(uint pid, string expected)
+    {
+        try
+        {
+            using (Process process = Process.GetProcessById((int)pid))
+                return string.Equals(process.ProcessName, expected, StringComparison.OrdinalIgnoreCase);
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static bool ProcessExists(uint pid)
+    {
+        try
+        {
+            using (Process process = Process.GetProcessById((int)pid))
+                return !process.HasExited;
+        }
+        catch
+        {
+            return false;
+        }
+    }
+
+    private static string ReadClassName(IntPtr hwnd)
+    {
+        StringBuilder text = new StringBuilder(256);
+        return GetClassName(hwnd, text, text.Capacity) > 0 ? text.ToString() : string.Empty;
+    }
+
+    private static string ReadWindowText(IntPtr hwnd)
+    {
+        int length = GetWindowTextLength(hwnd);
+        StringBuilder text = new StringBuilder(Math.Max(length + 1, 2));
+        GetWindowText(hwnd, text, text.Capacity);
+        return text.ToString();
+    }
+
+    private static void ThrowForHr(int hr, string operation)
+    {
+        if (hr >= 0)
+            return;
+
+        Exception inner = Marshal.GetExceptionForHR(hr);
+        string detail = inner == null ? "HRESULT 0x" + hr.ToString("X8") : inner.Message;
+        throw new COMException(operation + " failed: " + detail, hr);
+    }
+}
+'@
+}
+
+
+switch ($Action) {
+    'Launch' {
+        $frame = [SettingsFrameLauncher]::Launch($TimeoutMilliseconds)
+        [pscustomobject]@{
+            AppPid      = $frame.AppPid
+            FramePid    = $frame.FramePid
+            FrameHwnd   = $frame.FrameHwndHex
+            FrameClass  = $frame.FrameClass
+            FrameTitle  = $frame.FrameTitle
+        } | ConvertTo-Json -Compress
+    }
+
+    'Close' {
+        if ([string]::IsNullOrWhiteSpace($Hwnd)) {
+            throw '-Hwnd is required for -Action Close.'
+        }
+        [SettingsFrameLauncher]::CloseFrameHex($Hwnd, $TimeoutMilliseconds)
+        [pscustomobject]@{ Closed = $true; FrameHwnd = $Hwnd } |
+            ConvertTo-Json -Compress
+    }
+}

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -48,7 +48,6 @@ public static class SettingsFrameLauncher
     private const uint CLSCTX_LOCAL_SERVER = 0x4;
     private const uint AO_NOERRORUI = 0x2;
     private const uint WM_CLOSE = 0x0010;
-    private const int RPC_E_CHANGED_MODE = unchecked((int)0x80010106);
     private const uint COINIT_APARTMENTTHREADED = 0x2;
 
     private static readonly Guid ActivationManagerClsid =
@@ -85,7 +84,7 @@ public static class SettingsFrameLauncher
         ref Guid iid,
         out IntPtr instance);
 
-    [DllImport("user32.dll")]
+    [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool EnumWindows(EnumWindowsProc callback, IntPtr lParam);
 
@@ -335,15 +334,6 @@ public static class SettingsFrameLauncher
                HasDescendantOwnedBy(hwnd, info.AppPid);
     }
 
-    private static bool IsWindowOwnedByProcess(IntPtr hwnd, uint expectedPid)
-    {
-        if (!IsWindow(hwnd))
-            return false;
-
-        uint ownerPid;
-        return GetWindowThreadProcessId(hwnd, out ownerPid) != 0 &&
-               ownerPid == expectedPid;
-    }
 
     private static bool ProcessNameEquals(uint pid, string expected)
     {

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -127,7 +127,7 @@ public static class SettingsFrameLauncher
 
         int initHr = CoInitializeEx(IntPtr.Zero, COINIT_APARTMENTTHREADED);
         bool uninitialize = initHr >= 0;
-        if (initHr < 0 && initHr != RPC_E_CHANGED_MODE)
+        if (initHr < 0)
             ThrowForHr(initHr, "CoInitializeEx");
 
         IntPtr rawManager = IntPtr.Zero;
@@ -195,7 +195,7 @@ public static class SettingsFrameLauncher
         }
     }
 
-    public static bool CloseFrameHex(
+    public static string CloseFrameHex(
         string frameHwndHex,
         uint expectedFramePid,
         uint expectedAppPid,
@@ -214,13 +214,43 @@ public static class SettingsFrameLauncher
         return CloseFrame(unchecked((long)raw), expectedFramePid, expectedAppPid, timeoutMilliseconds);
     }
 
-    public static bool CloseFrame(
+    public static string CloseFrame(
         long frameHwndValue,
         uint expectedFramePid,
         uint expectedAppPid,
         int timeoutMilliseconds)
     {
         IntPtr hwnd = new IntPtr(frameHwndValue);
+        if (!IsWindow(hwnd))
+            return "AlreadyGone";
+
+        if (!IsExpectedFrame(hwnd, expectedFramePid, expectedAppPid))
+            return "IdentityMismatch";
+
+        if (!PostMessage(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero))
+        {
+            // The target may have closed between identity check and PostMessage.
+            if (!IsExpectedFrame(hwnd, expectedFramePid, expectedAppPid))
+                return "AlreadyGone";
+
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "PostMessage(WM_CLOSE) failed");
+        }
+
+        Stopwatch timer = Stopwatch.StartNew();
+        while (IsExpectedFrame(hwnd, expectedFramePid, expectedAppPid) &&
+               timer.ElapsedMilliseconds < timeoutMilliseconds)
+            Thread.Sleep(50);
+
+        if (IsExpectedFrame(hwnd, expectedFramePid, expectedAppPid))
+            throw new TimeoutException(
+                "The Settings frame did not close in time: HWND=" + frameHwndValue +
+                ", PID=" + expectedFramePid);
+
+        return "Closed";
+    }
+
+    private static bool IsExpectedFrame(IntPtr hwnd, uint expectedFramePid, uint expectedAppPid)
+    {
         if (!IsWindow(hwnd))
             return false;
 
@@ -232,25 +262,6 @@ public static class SettingsFrameLauncher
 
         if (expectedAppPid != 0 && !HasDescendantOwnedBy(hwnd, expectedAppPid))
             return false;
-
-        if (!PostMessage(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero))
-        {
-            // The target may have closed between PID verification and PostMessage.
-            if (!IsWindowOwnedByProcess(hwnd, expectedFramePid))
-                return false;
-
-            throw new Win32Exception(Marshal.GetLastWin32Error(), "PostMessage(WM_CLOSE) failed");
-        }
-
-        Stopwatch timer = Stopwatch.StartNew();
-        while (IsWindowOwnedByProcess(hwnd, expectedFramePid) &&
-               timer.ElapsedMilliseconds < timeoutMilliseconds)
-            Thread.Sleep(50);
-
-        if (IsWindowOwnedByProcess(hwnd, expectedFramePid))
-            throw new TimeoutException(
-                "The Settings frame did not close in time: HWND=" + frameHwndValue +
-                ", PID=" + expectedFramePid);
 
         return true;
     }
@@ -284,7 +295,8 @@ public static class SettingsFrameLauncher
             return true;
         };
 
-        EnumWindows(topCallback, IntPtr.Zero);
+        if (!EnumWindows(topCallback, IntPtr.Zero))
+            throw new Win32Exception(Marshal.GetLastWin32Error(), "EnumWindows failed");
         GC.KeepAlive(topCallback);
         return result;
     }
@@ -410,14 +422,14 @@ switch ($Action) {
             throw '-AppPid is required for -Action Close.'
         }
 
-        $closed = [SettingsFrameLauncher]::CloseFrameHex(
+        $status = [SettingsFrameLauncher]::CloseFrameHex(
             $Hwnd,
             $FramePid,
             $AppPid,
             $TimeoutMilliseconds
         )
         [pscustomobject]@{
-            Closed    = $closed
+            Status    = $status
             FramePid  = $FramePid
             AppPid    = $AppPid
             FrameHwnd = $Hwnd

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -5,11 +5,15 @@ param(
 
     [string]$Hwnd,
 
+    [uint32]$FramePid,
+
     [ValidateRange(1, 120000)]
     [int]$TimeoutMilliseconds = 15000
 )
 
 $ErrorActionPreference = 'Stop'
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
+
 if (-not ('SettingsFrameLauncher' -as [type])) {
 Add-Type -TypeDefinition @'
 using System;
@@ -188,39 +192,59 @@ public static class SettingsFrameLauncher
         }
     }
 
-    public static void CloseFrameHex(string frameHwndHex, int timeoutMilliseconds)
+    public static bool CloseFrameHex(
+        string frameHwndHex,
+        uint expectedFramePid,
+        int timeoutMilliseconds)
     {
         if (string.IsNullOrWhiteSpace(frameHwndHex))
             throw new ArgumentException("A window handle is required.", "frameHwndHex");
+        if (expectedFramePid == 0)
+            throw new ArgumentOutOfRangeException("expectedFramePid");
 
         string value = frameHwndHex.StartsWith("0x", StringComparison.OrdinalIgnoreCase)
             ? frameHwndHex.Substring(2)
             : frameHwndHex;
 
         ulong raw = ulong.Parse(value, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
-        CloseFrame(unchecked((long)raw), timeoutMilliseconds);
+        return CloseFrame(unchecked((long)raw), expectedFramePid, timeoutMilliseconds);
     }
 
-    public static void CloseFrame(long frameHwndValue, int timeoutMilliseconds)
+    public static bool CloseFrame(
+        long frameHwndValue,
+        uint expectedFramePid,
+        int timeoutMilliseconds)
     {
         IntPtr hwnd = new IntPtr(frameHwndValue);
         if (!IsWindow(hwnd))
-            return;
+            return false;
 
         uint ownerPid;
         if (GetWindowThreadProcessId(hwnd, out ownerPid) == 0 ||
+            ownerPid != expectedFramePid ||
             !ProcessNameEquals(ownerPid, "ApplicationFrameHost"))
-            return;
+            return false;
 
         if (!PostMessage(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero))
+        {
+            // The target may have closed between PID verification and PostMessage.
+            if (!IsWindowOwnedByProcess(hwnd, expectedFramePid))
+                return false;
+
             throw new Win32Exception(Marshal.GetLastWin32Error(), "PostMessage(WM_CLOSE) failed");
+        }
 
         Stopwatch timer = Stopwatch.StartNew();
-        while (IsWindow(hwnd) && timer.ElapsedMilliseconds < timeoutMilliseconds)
+        while (IsWindowOwnedByProcess(hwnd, expectedFramePid) &&
+               timer.ElapsedMilliseconds < timeoutMilliseconds)
             Thread.Sleep(50);
 
-        if (IsWindow(hwnd))
-            throw new TimeoutException("The Settings frame did not close in time: " + frameHwndValue);
+        if (IsWindowOwnedByProcess(hwnd, expectedFramePid))
+            throw new TimeoutException(
+                "The Settings frame did not close in time: HWND=" + frameHwndValue +
+                ", PID=" + expectedFramePid);
+
+        return true;
     }
 
     private static List<SettingsFrameInfo> FindFrames(uint appPid)
@@ -291,6 +315,16 @@ public static class SettingsFrameLauncher
                HasDescendantOwnedBy(hwnd, info.AppPid);
     }
 
+    private static bool IsWindowOwnedByProcess(IntPtr hwnd, uint expectedPid)
+    {
+        if (!IsWindow(hwnd))
+            return false;
+
+        uint ownerPid;
+        return GetWindowThreadProcessId(hwnd, out ownerPid) != 0 &&
+               ownerPid == expectedPid;
+    }
+
     private static bool ProcessNameEquals(uint pid, string expected)
     {
         try
@@ -344,7 +378,6 @@ public static class SettingsFrameLauncher
 '@
 }
 
-[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 switch ($Action) {
     'Launch' {
@@ -362,8 +395,19 @@ switch ($Action) {
         if ([string]::IsNullOrWhiteSpace($Hwnd)) {
             throw '-Hwnd is required for -Action Close.'
         }
-        [SettingsFrameLauncher]::CloseFrameHex($Hwnd, $TimeoutMilliseconds)
-        [pscustomobject]@{ Closed = $true; FrameHwnd = $Hwnd } |
-            ConvertTo-Json -Compress
+        if ($FramePid -eq 0) {
+            throw '-FramePid is required for -Action Close.'
+        }
+
+        $closed = [SettingsFrameLauncher]::CloseFrameHex(
+            $Hwnd,
+            $FramePid,
+            $TimeoutMilliseconds
+        )
+        [pscustomobject]@{
+            Closed    = $closed
+            FramePid  = $FramePid
+            FrameHwnd = $Hwnd
+        } | ConvertTo-Json -Compress
     }
 }

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -344,6 +344,7 @@ public static class SettingsFrameLauncher
 '@
 }
 
+[Console]::OutputEncoding = [System.Text.Encoding]::UTF8
 
 switch ($Action) {
     'Launch' {

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -24,7 +24,6 @@ using System.ComponentModel;
 using System.Diagnostics;
 using System.Globalization;
 using System.Runtime.InteropServices;
-using System.Text;
 using System.Threading;
 
 public sealed class SettingsFrameInfo
@@ -36,8 +35,6 @@ public sealed class SettingsFrameInfo
     {
         get { return "0x" + unchecked((ulong)FrameHwndValue).ToString("X"); }
     }
-    public string FrameClass { get; internal set; }
-    public string FrameTitle { get; internal set; }
 }
 
 public static class SettingsFrameLauncher
@@ -106,14 +103,6 @@ public static class SettingsFrameLauncher
     [return: MarshalAs(UnmanagedType.Bool)]
     private static extern bool IsWindowVisible(IntPtr hwnd);
 
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    private static extern int GetClassName(IntPtr hwnd, StringBuilder text, int maxCount);
-
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    private static extern int GetWindowText(IntPtr hwnd, StringBuilder text, int maxCount);
-
-    [DllImport("user32.dll", CharSet = CharSet.Unicode)]
-    private static extern int GetWindowTextLength(IntPtr hwnd);
 
     [DllImport("user32.dll", SetLastError = true)]
     [return: MarshalAs(UnmanagedType.Bool)]
@@ -288,8 +277,6 @@ public static class SettingsFrameLauncher
             info.AppPid = appPid;
             info.FramePid = framePid;
             info.FrameHwndValue = top.ToInt64();
-            info.FrameClass = ReadClassName(top);
-            info.FrameTitle = ReadWindowText(top);
             result.Add(info);
             return true;
         };
@@ -361,20 +348,6 @@ public static class SettingsFrameLauncher
         }
     }
 
-    private static string ReadClassName(IntPtr hwnd)
-    {
-        StringBuilder text = new StringBuilder(256);
-        return GetClassName(hwnd, text, text.Capacity) > 0 ? text.ToString() : string.Empty;
-    }
-
-    private static string ReadWindowText(IntPtr hwnd)
-    {
-        int length = GetWindowTextLength(hwnd);
-        StringBuilder text = new StringBuilder(Math.Max(length + 1, 2));
-        GetWindowText(hwnd, text, text.Capacity);
-        return text.ToString();
-    }
-
     private static void ThrowForHr(int hr, string operation)
     {
         if (hr >= 0)
@@ -396,8 +369,6 @@ switch ($Action) {
             AppPid      = $frame.AppPid
             FramePid    = $frame.FramePid
             FrameHwnd   = $frame.FrameHwndHex
-            FrameClass  = $frame.FrameClass
-            FrameTitle  = $frame.FrameTitle
         } | ConvertTo-Json -Compress
     }
 

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -49,6 +49,7 @@ public static class SettingsFrameLauncher
     private const uint AO_NOERRORUI = 0x2;
     private const uint WM_CLOSE = 0x0010;
     private const int RPC_E_CHANGED_MODE = unchecked((int)0x80010106);
+    private const uint COINIT_APARTMENTTHREADED = 0x2;
 
     private static readonly Guid ActivationManagerClsid =
         new Guid("45BA127D-10A8-46EA-8AB7-56EA9078943C");
@@ -124,7 +125,7 @@ public static class SettingsFrameLauncher
         if (timeoutMilliseconds <= 0)
             throw new ArgumentOutOfRangeException("timeoutMilliseconds");
 
-        int initHr = CoInitializeEx(IntPtr.Zero, 0); // COINIT_MULTITHREADED
+        int initHr = CoInitializeEx(IntPtr.Zero, COINIT_APARTMENTTHREADED);
         bool uninitialize = initHr >= 0;
         if (initHr < 0 && initHr != RPC_E_CHANGED_MODE)
             ThrowForHr(initHr, "CoInitializeEx");

--- a/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
+++ b/tests/e2e/helpers/Invoke-SettingsApplicationFrame.ps1
@@ -7,6 +7,8 @@ param(
 
     [uint32]$FramePid,
 
+    [uint32]$AppPid,
+
     [ValidateRange(1, 120000)]
     [int]$TimeoutMilliseconds = 15000
 )
@@ -195,6 +197,7 @@ public static class SettingsFrameLauncher
     public static bool CloseFrameHex(
         string frameHwndHex,
         uint expectedFramePid,
+        uint expectedAppPid,
         int timeoutMilliseconds)
     {
         if (string.IsNullOrWhiteSpace(frameHwndHex))
@@ -207,12 +210,13 @@ public static class SettingsFrameLauncher
             : frameHwndHex;
 
         ulong raw = ulong.Parse(value, NumberStyles.AllowHexSpecifier, CultureInfo.InvariantCulture);
-        return CloseFrame(unchecked((long)raw), expectedFramePid, timeoutMilliseconds);
+        return CloseFrame(unchecked((long)raw), expectedFramePid, expectedAppPid, timeoutMilliseconds);
     }
 
     public static bool CloseFrame(
         long frameHwndValue,
         uint expectedFramePid,
+        uint expectedAppPid,
         int timeoutMilliseconds)
     {
         IntPtr hwnd = new IntPtr(frameHwndValue);
@@ -223,6 +227,9 @@ public static class SettingsFrameLauncher
         if (GetWindowThreadProcessId(hwnd, out ownerPid) == 0 ||
             ownerPid != expectedFramePid ||
             !ProcessNameEquals(ownerPid, "ApplicationFrameHost"))
+            return false;
+
+        if (expectedAppPid != 0 && !HasDescendantOwnedBy(hwnd, expectedAppPid))
             return false;
 
         if (!PostMessage(hwnd, WM_CLOSE, IntPtr.Zero, IntPtr.Zero))
@@ -398,15 +405,20 @@ switch ($Action) {
         if ($FramePid -eq 0) {
             throw '-FramePid is required for -Action Close.'
         }
+        if ($AppPid -eq 0) {
+            throw '-AppPid is required for -Action Close.'
+        }
 
         $closed = [SettingsFrameLauncher]::CloseFrameHex(
             $Hwnd,
             $FramePid,
+            $AppPid,
             $TimeoutMilliseconds
         )
         [pscustomobject]@{
             Closed    = $closed
             FramePid  = $FramePid
+            AppPid    = $AppPid
             FrameHwnd = $Hwnd
         } | ConvertTo-Json -Compress
     }

--- a/tests/e2e/helpers/windows-settings-frame.test.ts
+++ b/tests/e2e/helpers/windows-settings-frame.test.ts
@@ -1,0 +1,118 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCloseSettingsArgs,
+  buildGetSettingsStateArgs,
+  parseSettingsCloseOutput,
+  parseSettingsLaunchOutput
+} from './windows-settings-frame'
+
+describe('windows-settings-frame helpers', () => {
+  describe('buildGetSettingsStateArgs', () => {
+    it('targets the exact ApplicationFrameHost frame returned by the launcher', () => {
+      const frame = { FramePid: 123, AppPid: 456, FrameHwnd: '0x1234' }
+
+      expect(buildGetSettingsStateArgs(frame)).toEqual([
+        'computer',
+        'get-app-state',
+        '--app',
+        'pid:123',
+        '--window-id',
+        '4660',
+        '--no-screenshot',
+        '--json'
+      ])
+    })
+
+    it('converts large 64-bit HWND to decimal without precision loss', () => {
+      const frame = { FramePid: 1, AppPid: 2, FrameHwnd: '0x1FFFFFFFF' }
+      const args = buildGetSettingsStateArgs(frame)
+      const windowIdIndex = args.indexOf('--window-id')
+      expect(args[windowIdIndex + 1]).toBe('8589934591')
+    })
+  })
+
+  describe('buildCloseSettingsArgs', () => {
+    it('passes FramePid and AppPid without mixing them up', () => {
+      const frame = { FramePid: 123, AppPid: 456, FrameHwnd: '0x1234' }
+
+      expect(buildCloseSettingsArgs(frame)).toEqual([
+        '-Action',
+        'Close',
+        '-Hwnd',
+        '0x1234',
+        '-FramePid',
+        '123',
+        '-AppPid',
+        '456',
+        '-TimeoutMilliseconds',
+        '5000'
+      ])
+    })
+  })
+
+  describe('parseSettingsLaunchOutput', () => {
+    it('parses valid JSON with all required fields', () => {
+      const stdout = '{"AppPid":456,"FramePid":123,"FrameHwnd":"0x1234"}'
+      const result = parseSettingsLaunchOutput(stdout)
+
+      expect(result).toEqual({ AppPid: 456, FramePid: 123, FrameHwnd: '0x1234' })
+    })
+
+    it('throws on malformed JSON with descriptive error', () => {
+      expect(() => parseSettingsLaunchOutput('not json')).toThrow(
+        /Failed to parse SettingsFrameLauncher output as JSON/
+      )
+    })
+
+    it('throws on valid JSON with invalid payload shape', () => {
+      expect(() => parseSettingsLaunchOutput('{"foo":"bar"}')).toThrow(
+        /Invalid SettingsFrameLauncher payload shape/
+      )
+    })
+
+    it('throws on zero or negative PID', () => {
+      expect(() =>
+        parseSettingsLaunchOutput('{"AppPid":0,"FramePid":123,"FrameHwnd":"0x1"}')
+      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+      expect(() =>
+        parseSettingsLaunchOutput('{"AppPid":-1,"FramePid":123,"FrameHwnd":"0x1"}')
+      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+    })
+
+    it('throws on non-hex HWND', () => {
+      expect(() =>
+        parseSettingsLaunchOutput('{"AppPid":1,"FramePid":2,"FrameHwnd":"1234"}')
+      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+    })
+
+    it('throws on fractional PID', () => {
+      expect(() =>
+        parseSettingsLaunchOutput('{"AppPid":1.5,"FramePid":2,"FrameHwnd":"0x1"}')
+      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+    })
+  })
+
+  describe('parseSettingsCloseOutput', () => {
+    it('parses Closed status', () => {
+      expect(parseSettingsCloseOutput('{"Status":"Closed"}')).toEqual({ Status: 'Closed' })
+    })
+
+    it('parses AlreadyGone status', () => {
+      expect(parseSettingsCloseOutput('{"Status":"AlreadyGone"}')).toEqual({
+        Status: 'AlreadyGone'
+      })
+    })
+
+    it('parses IdentityMismatch status', () => {
+      expect(parseSettingsCloseOutput('{"Status":"IdentityMismatch"}')).toEqual({
+        Status: 'IdentityMismatch'
+      })
+    })
+
+    it('throws on missing Status field', () => {
+      expect(() => parseSettingsCloseOutput('{"foo":"bar"}')).toThrow(
+        /Invalid SettingsFrameLauncher close payload/
+      )
+    })
+  })
+})

--- a/tests/e2e/helpers/windows-settings-frame.ts
+++ b/tests/e2e/helpers/windows-settings-frame.ts
@@ -1,0 +1,69 @@
+export interface SettingsFrame {
+  FramePid: number
+  AppPid: number
+  FrameHwnd: string
+}
+
+export interface SettingsCloseResult {
+  Status: string
+}
+
+export function parseSettingsLaunchOutput(stdout: string): SettingsFrame {
+  let parsed: Record<string, unknown>
+  try {
+    parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
+  } catch (parseError) {
+    throw new Error(
+      `Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${parseError instanceof Error ? parseError.message : String(parseError)}`
+    )
+  }
+
+  if (
+    !Number.isSafeInteger(parsed.FramePid) ||
+    (parsed.FramePid as number) <= 0 ||
+    !Number.isSafeInteger(parsed.AppPid) ||
+    (parsed.AppPid as number) <= 0 ||
+    typeof parsed.FrameHwnd !== 'string' ||
+    !/^0x[0-9a-f]+$/i.test(parsed.FrameHwnd)
+  ) {
+    throw new Error(`Invalid SettingsFrameLauncher payload shape: ${stdout}`)
+  }
+
+  return parsed as unknown as SettingsFrame
+}
+
+export function parseSettingsCloseOutput(stdout: string): SettingsCloseResult {
+  const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
+  if (typeof parsed.Status !== 'string') {
+    throw new Error(`Invalid SettingsFrameLauncher close payload: ${stdout}`)
+  }
+  return parsed as unknown as SettingsCloseResult
+}
+
+export function buildGetSettingsStateArgs(frame: SettingsFrame): string[] {
+  return [
+    'computer',
+    'get-app-state',
+    '--app',
+    `pid:${frame.FramePid}`,
+    '--window-id',
+    BigInt(frame.FrameHwnd).toString(10),
+    '--no-screenshot',
+    '--json'
+  ]
+}
+
+export function buildCloseSettingsArgs(frame: SettingsFrame): string[] {
+  return [
+    '-Action',
+    'Close',
+    '-Hwnd',
+    frame.FrameHwnd,
+    '-FramePid',
+    String(frame.FramePid),
+    '-AppPid',
+    String(frame.AppPid),
+    '-TimeoutMilliseconds',
+    '5000'
+  ]
+}

--- a/tests/e2e/helpers/windows-settings-frame.ts
+++ b/tests/e2e/helpers/windows-settings-frame.ts
@@ -31,7 +31,8 @@ export function parseSettingsLaunchOutput(stdout: string): SettingsFrame {
     !Number.isSafeInteger((parsed as Record<string, unknown>).AppPid) ||
     ((parsed as Record<string, unknown>).AppPid as number) <= 0 ||
     typeof (parsed as Record<string, unknown>).FrameHwnd !== 'string' ||
-    !/^0x[0-9a-f]+$/i.test((parsed as Record<string, unknown>).FrameHwnd as string)
+    !/^0x[0-9a-f]+$/i.test((parsed as Record<string, unknown>).FrameHwnd as string) ||
+    BigInt((parsed as Record<string, unknown>).FrameHwnd as string) === BigInt(0)
   ) {
     throw new Error(`Invalid SettingsFrameLauncher payload shape: ${stdout}`)
   }

--- a/tests/e2e/helpers/windows-settings-frame.ts
+++ b/tests/e2e/helpers/windows-settings-frame.ts
@@ -1,17 +1,21 @@
-export interface SettingsFrame {
+export type SettingsFrame = {
   FramePid: number
   AppPid: number
   FrameHwnd: string
 }
 
-export interface SettingsCloseResult {
-  Status: string
+export type SettingsCloseStatus = 'Closed' | 'AlreadyGone' | 'IdentityMismatch'
+
+export type SettingsCloseResult = {
+  Status: SettingsCloseStatus
 }
 
+const CLOSE_STATUSES = ['Closed', 'AlreadyGone', 'IdentityMismatch'] as const
+
 export function parseSettingsLaunchOutput(stdout: string): SettingsFrame {
-  let parsed: Record<string, unknown>
+  let parsed: unknown
   try {
-    parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
+    parsed = JSON.parse(stdout.trim())
   } catch (parseError) {
     throw new Error(
       `Failed to parse SettingsFrameLauncher output as JSON.\nStdout: ${stdout}\nError: ${parseError instanceof Error ? parseError.message : String(parseError)}`
@@ -19,25 +23,40 @@ export function parseSettingsLaunchOutput(stdout: string): SettingsFrame {
   }
 
   if (
-    !Number.isSafeInteger(parsed.FramePid) ||
-    (parsed.FramePid as number) <= 0 ||
-    !Number.isSafeInteger(parsed.AppPid) ||
-    (parsed.AppPid as number) <= 0 ||
-    typeof parsed.FrameHwnd !== 'string' ||
-    !/^0x[0-9a-f]+$/i.test(parsed.FrameHwnd)
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    Array.isArray(parsed) ||
+    !Number.isSafeInteger((parsed as Record<string, unknown>).FramePid) ||
+    ((parsed as Record<string, unknown>).FramePid as number) <= 0 ||
+    !Number.isSafeInteger((parsed as Record<string, unknown>).AppPid) ||
+    ((parsed as Record<string, unknown>).AppPid as number) <= 0 ||
+    typeof (parsed as Record<string, unknown>).FrameHwnd !== 'string' ||
+    !/^0x[0-9a-f]+$/i.test((parsed as Record<string, unknown>).FrameHwnd as string)
   ) {
     throw new Error(`Invalid SettingsFrameLauncher payload shape: ${stdout}`)
   }
 
-  return parsed as unknown as SettingsFrame
+  return parsed as SettingsFrame
 }
 
 export function parseSettingsCloseOutput(stdout: string): SettingsCloseResult {
-  const parsed = JSON.parse(stdout.trim()) as Record<string, unknown>
-  if (typeof parsed.Status !== 'string') {
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(stdout.trim())
+  } catch {
+    throw new Error(`Failed to parse SettingsFrameLauncher close output as JSON: ${stdout}`)
+  }
+
+  if (
+    typeof parsed !== 'object' ||
+    parsed === null ||
+    typeof (parsed as Record<string, unknown>).Status !== 'string' ||
+    !CLOSE_STATUSES.includes((parsed as Record<string, unknown>).Status as SettingsCloseStatus)
+  ) {
     throw new Error(`Invalid SettingsFrameLauncher close payload: ${stdout}`)
   }
-  return parsed as unknown as SettingsCloseResult
+
+  return parsed as SettingsCloseResult
 }
 
 export function buildGetSettingsStateArgs(frame: SettingsFrame): string[] {

--- a/tests/e2e/helpers/windows-settings-frame.ts
+++ b/tests/e2e/helpers/windows-settings-frame.ts
@@ -87,3 +87,52 @@ export function buildCloseSettingsArgs(frame: SettingsFrame): string[] {
     '5000'
   ]
 }
+
+// Secondary-action metadata is Orca-generated (English on any OS locale), so
+// targeting survives localized roles/names; raw ControlType.* lines are window chrome.
+export function findSettingsSearchBoxCandidates(treeText: string): string[] {
+  return treeText
+    .split('\n')
+    .filter((line) => !/ControlType\./.test(line) && line.endsWith('Secondary Actions: SetValue'))
+}
+
+// Returns the search box line iff exactly one candidate exists; null otherwise,
+// so callers can choose strict failure or transient retry.
+export function selectSettingsSearchBoxLine(treeText: string): string | null {
+  const candidates = findSettingsSearchBoxCandidates(treeText)
+  return candidates.length === 1 ? (candidates.at(0) ?? null) : null
+}
+
+// Locale-free targeting: fail loudly when the Settings home layout drifts.
+export function requireUniqueSettingsSearchBoxIndex(treeText: string): number {
+  const line = selectSettingsSearchBoxLine(treeText)
+  if (line === null) {
+    const candidates = findSettingsSearchBoxCandidates(treeText)
+    throw new Error(
+      `Expected exactly one Settings search box candidate (Secondary Actions: SetValue, non-chrome), got ${candidates.length}:\n${candidates.join('\n')}`
+    )
+  }
+  return parseElementLineIndex(line)
+}
+
+// The result echo must come from a different indexed element, never a header/summary line.
+export function findSettingsSearchEchoLines(
+  treeText: string,
+  probe: string,
+  fieldIndex: number
+): string[] {
+  return treeText
+    .split('\n')
+    .filter(
+      (line) =>
+        /^\s*\d+\s/.test(line) && line.includes(probe) && parseElementLineIndex(line) !== fieldIndex
+    )
+}
+
+export function parseElementLineIndex(line: string): number {
+  const index = Number.parseInt(line.match(/^\s*(\d+)/)?.[1] ?? '', 10)
+  if (!Number.isInteger(index) || index < 0) {
+    throw new Error(`Not an indexed element line: ${JSON.stringify(line)}`)
+  }
+  return index
+}

--- a/tests/e2e/helpers/windows-settings-frame.unit.test.ts
+++ b/tests/e2e/helpers/windows-settings-frame.unit.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest'
 import {
   buildCloseSettingsArgs,
   buildGetSettingsStateArgs,
+  findSettingsSearchBoxCandidates,
+  findSettingsSearchEchoLines,
+  parseElementLineIndex,
   parseSettingsCloseOutput,
-  parseSettingsLaunchOutput
+  parseSettingsLaunchOutput,
+  requireUniqueSettingsSearchBoxIndex,
+  selectSettingsSearchBoxLine
 } from './windows-settings-frame'
 
 describe('windows-settings-frame helpers', () => {
@@ -153,5 +158,122 @@ describe('windows-settings-frame helpers', () => {
         /Failed to parse SettingsFrameLauncher close output as JSON/
       )
     })
+  })
+})
+
+describe('findSettingsSearchBoxCandidates', () => {
+  const enLine = '\t\t9 edit Find a setting, search settings, Secondary Actions: SetValue'
+  const ruLine =
+    '\t\t9 правка Поле поиска, поиск настроек, Value: zzqq7391, Secondary Actions: SetValue'
+
+  it('finds the single search box by invariant metadata regardless of locale', () => {
+    const tree = [
+      'App=ApplicationFrameHost (pid 6300)',
+      '\t1 ControlType.Window Параметры, Secondary Actions: SetValue',
+      enLine,
+      '\t\t\t78 кнопка Резервная копия, Secondary Actions: SetValue, Select',
+      '\t\t\t88 переключатель Bluetooth, Secondary Actions: Toggle'
+    ].join('\n')
+
+    expect(findSettingsSearchBoxCandidates(tree)).toEqual([enLine])
+  })
+
+  it('keeps matching after typing when a localized role renders Value as a labeled segment', () => {
+    expect(findSettingsSearchBoxCandidates(ruLine)).toEqual([ruLine])
+  })
+
+  it('keeps matching after typing when the English role renders the value bare', () => {
+    const bare = '\t\t9 edit Find a setting zzqq7391, Secondary Actions: SetValue'
+    expect(findSettingsSearchBoxCandidates(bare)).toEqual([bare])
+  })
+
+  it('returns every match so callers can fail loudly on ambiguity', () => {
+    const tree = [enLine, ruLine.replace(/^\t\t9/, '\t\t10')].join('\n')
+    expect(findSettingsSearchBoxCandidates(tree)).toHaveLength(2)
+  })
+
+  it('returns nothing when no element advertises SetValue as its only action', () => {
+    expect(
+      findSettingsSearchBoxCandidates('0 window Параметры\n\t1 текст Нет результатов')
+    ).toEqual([])
+  })
+})
+
+describe('parseElementLineIndex', () => {
+  it('extracts the index from an indented localized element line', () => {
+    expect(parseElementLineIndex('\t\t9 правка Поле поиска, поиск настроек')).toBe(9)
+  })
+
+  it('rejects non-element header lines', () => {
+    expect(() => parseElementLineIndex('App=ApplicationFrameHost (pid 6300)')).toThrow(
+      /Not an indexed element line/
+    )
+  })
+})
+
+describe('findSettingsSearchEchoLines', () => {
+  it('returns only other indexed element lines containing the probe', () => {
+    const tree = [
+      '\t\t9 правка Поле поиска, поиск настроек, Value: zzqq7391, Secondary Actions: SetValue',
+      '\t\t\t11 текст Нет результатов для zzqq7391'
+    ].join('\n')
+
+    expect(findSettingsSearchEchoLines(tree, 'zzqq7391', 9)).toEqual([
+      '\t\t\t11 текст Нет результатов для zzqq7391'
+    ])
+  })
+
+  it('ignores unindexed lines that contain the probe', () => {
+    const tree = [
+      'App=ApplicationFrameHost (pid 6300)',
+      'Window: "zzqq7391", App: Параметры.',
+      '\t\t9 правка Поле поиска, поиск настроек, Value: zzqq7391, Secondary Actions: SetValue'
+    ].join('\n')
+
+    expect(findSettingsSearchEchoLines(tree, 'zzqq7391', 9)).toEqual([])
+  })
+
+  it('excludes the field element even when its line text differs between snapshots', () => {
+    const tree = '\t\t9 edit Find a setting zzqq7391, Secondary Actions: SetValue'
+
+    expect(findSettingsSearchEchoLines(tree, 'zzqq7391', 9)).toEqual([])
+  })
+})
+
+describe('selectSettingsSearchBoxLine', () => {
+  const enLine = '\t\t9 edit Find a setting, search settings, Secondary Actions: SetValue'
+
+  it('returns the line when exactly one candidate exists', () => {
+    expect(selectSettingsSearchBoxLine(`0 window Settings\n${enLine}`)).toBe(enLine)
+  })
+
+  it('returns null when no candidate exists', () => {
+    expect(selectSettingsSearchBoxLine('0 window Settings\n\t1 text Home')).toBeNull()
+  })
+
+  it('returns null when multiple candidates exist', () => {
+    const tree = [enLine, '\t\t10 edit Other, Secondary Actions: SetValue'].join('\n')
+    expect(selectSettingsSearchBoxLine(tree)).toBeNull()
+  })
+})
+
+describe('requireUniqueSettingsSearchBoxIndex', () => {
+  it('returns the element index for a single candidate', () => {
+    expect(
+      requireUniqueSettingsSearchBoxIndex('\t\t9 edit Find a setting, Secondary Actions: SetValue')
+    ).toBe(9)
+  })
+
+  it('fails loudly listing candidates when none exist', () => {
+    expect(() => requireUniqueSettingsSearchBoxIndex('0 window Settings')).toThrow(/got 0:/)
+  })
+
+  it('fails loudly listing candidates when several exist', () => {
+    const tree = [
+      '\t\t9 edit Find a setting, Secondary Actions: SetValue',
+      '\t\t10 edit Other, Secondary Actions: SetValue'
+    ].join('\n')
+    expect(() => requireUniqueSettingsSearchBoxIndex(tree)).toThrow(/got 2:/)
+    expect(() => requireUniqueSettingsSearchBoxIndex(tree)).toThrow(/Find a setting/)
   })
 })

--- a/tests/e2e/helpers/windows-settings-frame.unit.test.ts
+++ b/tests/e2e/helpers/windows-settings-frame.unit.test.ts
@@ -23,11 +23,12 @@ describe('windows-settings-frame helpers', () => {
       ])
     })
 
-    it('converts large 64-bit HWND to decimal without precision loss', () => {
-      const frame = { FramePid: 1, AppPid: 2, FrameHwnd: '0x1FFFFFFFF' }
+    it('converts HWND above Number.MAX_SAFE_INTEGER without precision loss', () => {
+      // Why: 0x20000000000001 = 9007199254740993 > 2^53. Using Number() would round to 9007199254740992.
+      const frame = { FramePid: 1, AppPid: 2, FrameHwnd: '0x20000000000001' }
       const args = buildGetSettingsStateArgs(frame)
       const windowIdIndex = args.indexOf('--window-id')
-      expect(args[windowIdIndex + 1]).toBe('8589934591')
+      expect(args[windowIdIndex + 1]).toBe('9007199254740993')
     })
   })
 
@@ -64,30 +65,41 @@ describe('windows-settings-frame helpers', () => {
       )
     })
 
+    it('throws on null JSON', () => {
+      expect(() => parseSettingsLaunchOutput('null')).toThrow(
+        /Invalid SettingsFrameLauncher payload shape/
+      )
+    })
+
     it('throws on valid JSON with invalid payload shape', () => {
       expect(() => parseSettingsLaunchOutput('{"foo":"bar"}')).toThrow(
         /Invalid SettingsFrameLauncher payload shape/
       )
     })
 
-    it('throws on zero or negative PID', () => {
-      expect(() =>
-        parseSettingsLaunchOutput('{"AppPid":0,"FramePid":123,"FrameHwnd":"0x1"}')
-      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
-      expect(() =>
-        parseSettingsLaunchOutput('{"AppPid":-1,"FramePid":123,"FrameHwnd":"0x1"}')
-      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+    it.each([
+      ['AppPid', 0],
+      ['AppPid', -1],
+      ['AppPid', 1.5],
+      ['FramePid', 0],
+      ['FramePid', -1],
+      ['FramePid', 1.5]
+    ] as const)('rejects invalid %s=%s', (field, value) => {
+      const payload = {
+        AppPid: 1,
+        FramePid: 2,
+        FrameHwnd: '0x1',
+        [field]: value
+      }
+
+      expect(() => parseSettingsLaunchOutput(JSON.stringify(payload))).toThrow(
+        /Invalid SettingsFrameLauncher payload shape/
+      )
     })
 
     it('throws on non-hex HWND', () => {
       expect(() =>
         parseSettingsLaunchOutput('{"AppPid":1,"FramePid":2,"FrameHwnd":"1234"}')
-      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
-    })
-
-    it('throws on fractional PID', () => {
-      expect(() =>
-        parseSettingsLaunchOutput('{"AppPid":1.5,"FramePid":2,"FrameHwnd":"0x1"}')
       ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
     })
   })
@@ -112,6 +124,24 @@ describe('windows-settings-frame helpers', () => {
     it('throws on missing Status field', () => {
       expect(() => parseSettingsCloseOutput('{"foo":"bar"}')).toThrow(
         /Invalid SettingsFrameLauncher close payload/
+      )
+    })
+
+    it('throws on unknown Status value', () => {
+      expect(() => parseSettingsCloseOutput('{"Status":"Unknown"}')).toThrow(
+        /Invalid SettingsFrameLauncher close payload/
+      )
+    })
+
+    it('throws on null JSON', () => {
+      expect(() => parseSettingsCloseOutput('null')).toThrow(
+        /Invalid SettingsFrameLauncher close payload/
+      )
+    })
+
+    it('throws on malformed JSON', () => {
+      expect(() => parseSettingsCloseOutput('not json')).toThrow(
+        /Failed to parse SettingsFrameLauncher close output as JSON/
       )
     })
   })

--- a/tests/e2e/helpers/windows-settings-frame.unit.test.ts
+++ b/tests/e2e/helpers/windows-settings-frame.unit.test.ts
@@ -102,6 +102,15 @@ describe('windows-settings-frame helpers', () => {
         parseSettingsLaunchOutput('{"AppPid":1,"FramePid":2,"FrameHwnd":"1234"}')
       ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
     })
+
+    it('throws on a zero HWND', () => {
+      expect(() =>
+        parseSettingsLaunchOutput('{"AppPid":1,"FramePid":2,"FrameHwnd":"0x0"}')
+      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+      expect(() =>
+        parseSettingsLaunchOutput('{"AppPid":1,"FramePid":2,"FrameHwnd":"0x0000"}')
+      ).toThrow(/Invalid SettingsFrameLauncher payload shape/)
+    })
   })
 
   describe('parseSettingsCloseOutput', () => {


### PR DESCRIPTION
## Summary

Fixes the UWP `computer-windows-store.e2e.ts` test failing on Windows Server 2025 runners.

Fixes #14894.

*Note: This PR is a clean, consolidated re-submission that replaces #13046 and #13038.*

The original test used `calc.exe` to test UWP app interaction, but Windows Server 2025 now launches `calc.exe` as a standard Win32 app (`win32calc.exe`) instead of an `ApplicationFrameHost` wrapper. To guarantee we're testing UWP container handling (`ApplicationFrameHost`) across all supported Windows versions, this PR replaces `calc.exe` with the Windows Settings app, activated via its full AUMID through `IApplicationActivationManager.ActivateApplication`.

To prevent process leakage and race conditions inherent in single-instance UWP apps, it integrates `Invoke-SettingsApplicationFrame.ps1` to reliably discover the exact `ApplicationFrameHost` PID using the Settings AUMID (`ActivateApplication`) and cleanly manages window teardown via HWND.

The test suite now covers both halves of the computer-use loop on UWP: discovery/attach (by pid), and interaction — a second test clicks the Settings search box (locale-free targeting via invariant `Secondary Actions` metadata), types a nonsense query through the synthetic input path (asserted via `action.path`), and verifies the effect through the query echo in the field and in the results element.

## Screenshots

`No visual change` (Internal testing logic update only).

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed (Updated existing E2E test + extracted unit tests)

## AI Review Report

The AI agent reviewed the fix to ensure cross-platform test reliability.
- **Cross-platform check:** The fix correctly scopes the changes to Windows-only E2E tests (`isWindows` guard) and uses PowerShell commands appropriately without affecting macOS or Linux test logic. 
- **Robust AUMID Polling:** Instead of error-prone process diffing, the script uses `ActivateApplication` to get the App PID, then enumerates visible top-level windows owned by an `ApplicationFrameHost` process that contain a descendant HWND owned by that PID, requiring exactly one match — no title or window-class matching involved.
- **Safe Teardown:** Instead of blindly terminating `SystemSettings` or `ApplicationFrameHost` by name (which can kill other user apps or parallel tests), it validates the HWND owner and sends a targeted `WM_CLOSE`.
- **Resilience:** Implemented outer Node.js level execution timeouts to prevent Vitest hangs, and strict `ErrorActionPreference` in PowerShell to reliably fail fast if window interactions fault.

## Security Audit

- **Execution Risks:** The script uses `ActivateApplication` and Win32 API calls cleanly. No user input is passed to the shell, mitigating injection risks.
- **Resource Cleanup:** The helper performs identity-validated, best-effort teardown of the discovered Settings frame. Isolation relies on a clean, ephemeral CI user session: in a session where Settings is already open, activation cannot be correlated to a single frame, so launch fails loudly instead of attaching to the pre-existing instance.

## Notes

- **⚠️ CI Environment Assumption:** Because Windows Settings is a strictly single-instance application, this E2E test asserts an architectural invariant: **it must run in a clean, isolated CI runner session**. If run in a session where Settings is already open, launch fails loudly (the activation cannot be correlated to one frame) rather than guessing, and parallel Vitest workers would fight over the single instance.
- Windows Server 2025 compatibility: Resolves CI failures on the new GitHub Actions `windows-latest` image (see #14894 — the nightly `windows` job has been red in all 91 scheduled runs).
- **Replaces #13046 and #13038**: history is kept as reviewable commits on top of current `main`; the repo's squash-merge will land it as a single commit. All CodeRabbit feedback is addressed — see the point-by-point comment, the follow-up for the latest review round, and the interaction-coverage comment.
- **Validated end-to-end on `windows-latest` (Windows Server 2025)** via `workflow_dispatch` runs on my fork, including the current head (`599ae8e`) — Windows job ✅: https://github.com/Zuz666/orca/actions/runs/31999148805/job/95296107362
Earlier heads also green:
https://github.com/Zuz666/orca/actions/runs/31954211489/job/95182224498, https://github.com/Zuz666/orca/actions/runs/31971437490/job/95224406989, https://github.com/Zuz666/orca/actions/runs/31971898775/job/95225521727.
Also validated locally on a ru-RU machine — the interaction test is locale-independent by construction.
The overall runs are red only because the `mac` job hits its own pre-existing intermittent failure, which occurs on `main` as well and is unrelated to this PR.
- X handle: @Zuz666

