### PR TITLE
fix(preflight): avoid WSL agent detection timeouts

### DIFF
--- a/src/main/ipc/preflight-wsl-agent-detection.test.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.test.ts
@@ -37,16 +37,15 @@ describe('detectWslCommandsOnPath', () => {
     vi.restoreAllMocks()
   })
 
-  it('builds a probe script with no `fi done` (zsh parse error) sequence', async () => {
+  it('runs parallel probes through a noninteractive shell', async () => {
     execFileAsyncMock.mockResolvedValue({ stdout: '', stderr: '' })
 
     await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude'])
 
     const payload = lastShCommandPayload()
-    // Why: zsh aborts on `fi done` — the loop body and `done` must be separated
-    // by a newline. Regression guard for issue #5325.
     expect(payload).not.toContain('fi done')
-    expect(payload).toContain('fi\ndone')
+    expect(payload).toContain('exec /bin/sh -c')
+    expect(payload).toContain(') &\ndone\nwait')
   })
 
   it('uses the shared alias- and function-neutral PATH lookup', async () => {
@@ -59,7 +58,10 @@ describe('detectWslCommandsOnPath', () => {
       kind: 'shell-variable',
       name: 'cmd'
     })
-    expect(payload).toContain(escapeWslShCommandForWindows(lookupScript))
+    expect(payload).toContain('command -v')
+    expect(payload).toContain(
+      escapeWslShCommandForWindows(lookupScript.split('\n').find((line) => line.includes('PATH-'))!)
+    )
     expect(payload).not.toContain('type -P')
   })
 
@@ -68,6 +70,20 @@ describe('detectWslCommandsOnPath', () => {
       stdout:
         '__ORCA_AGENT_PATH__claude\t/usr/bin/claude\n' +
         '__ORCA_AGENT_PATH__codex\t/home/user/.local/bin/codex\n',
+      stderr: ''
+    })
+
+    const found = await detectWslCommandsOnPath({ distro: 'Ubuntu' }, ['claude', 'codex'])
+
+    expect(found).toEqual(new Set(['claude', 'codex']))
+  })
+
+  it('parses a first record preceded by shell OSC output', async () => {
+    execFileAsyncMock.mockResolvedValue({
+      stdout:
+        '\u001B]633;P;HasRichCommandDetection=True\u0007' +
+        '__ORCA_AGENT_PATH__claude\t/home/user/.local/bin/claude\n' +
+        '__ORCA_AGENT_PATH__codex\t/usr/local/bin/codex\n',
       stderr: ''
     })
 

--- a/src/main/ipc/preflight-wsl-agent-detection.ts
+++ b/src/main/ipc/preflight-wsl-agent-detection.ts
@@ -25,24 +25,26 @@ export async function detectWslCommandsOnPath(
   }
 
   const commandList = uniqueCommands.map(shellQuote).join(' ')
-  const lookupScript = buildPosixCommandPathLookupScript({
+  const fallbackLookupScript = buildPosixCommandPathLookupScript({
     kind: 'shell-variable',
     name: 'cmd'
   })
-  // Newlines keep the loop valid in zsh and every POSIX shell used here.
+  const lookupScript = buildWslAgentPathLookupScript(fallbackLookupScript)
+  // Parallel lookups avoid serial drvfs scans across inherited Windows PATH entries.
   const script = [
     `for cmd in ${commandList}; do`,
+    '(',
     lookupScript,
     'if [ -n "$resolved" ]; then',
     `printf '${WSL_AGENT_DETECTION_PREFIX}%s\\t%s\\n' "$cmd" "$resolved";`,
     'fi',
-    'done'
+    ') &',
+    'done',
+    'wait'
   ].join('\n')
 
   try {
-    // Why: WSL cold-start plus many parallel wsl.exe probes can timeout and
-    // cache an empty result. One probe through the distro user's login shell
-    // matches zsh/bash PATH customizations from their normal terminals.
+    // One login-shell probe captures the user's PATH without repeated WSL cold starts.
     const { stdout } = await execWslAgentDetectionCommand(wslTarget, script)
     return parseWslDetectedCommands(stdout)
   } catch {
@@ -54,11 +56,31 @@ function shellQuote(value: string): string {
   return `'${value.replace(/'/g, "'\\''")}'`
 }
 
+function buildWslAgentPathLookupScript(fallbackLookupScript: string): string {
+  return [
+    '_orca_fast_resolved=$(command -v "$cmd" 2>/dev/null || true)',
+    'case "$_orca_fast_resolved" in',
+    '  /*)',
+    '    if [ -x "$_orca_fast_resolved" ] && [ ! -d "$_orca_fast_resolved" ]; then',
+    '      resolved=$_orca_fast_resolved',
+    '    else',
+    '      resolved=',
+    '    fi',
+    '    ;;',
+    '  "") resolved= ;;',
+    '  *)',
+    ...fallbackLookupScript.split('\n').map((line) => `    ${line}`),
+    '    ;;',
+    'esac'
+  ].join('\n')
+}
+
 async function execWslAgentDetectionCommand(
   target: WslPreflightTarget,
   command: string
 ): Promise<{ stdout: string; stderr: string }> {
   const distroArgs = target.distro ? ['-d', target.distro] : []
+  const loginShellCommand = `exec /bin/sh -c ${shellQuote(command)}`
   const commandPromise = execFileAsync(
     'wsl.exe',
     [
@@ -66,7 +88,7 @@ async function execWslAgentDetectionCommand(
       '--',
       'sh',
       '-c',
-      escapeWslShCommandForWindows(buildWslLoginShellCommand(command))
+      escapeWslShCommandForWindows(buildWslLoginShellCommand(loginShellCommand))
     ],
     {
       encoding: 'utf-8',
@@ -104,10 +126,11 @@ function parseWslDetectedCommands(stdout: string): Set<string> {
   const found = new Set<string>()
   for (const rawLine of stdout.split(/\r?\n/)) {
     const line = rawLine.trim()
-    if (!line.startsWith(WSL_AGENT_DETECTION_PREFIX)) {
+    const prefixIndex = line.indexOf(WSL_AGENT_DETECTION_PREFIX)
+    if (prefixIndex < 0) {
       continue
     }
-    const payload = line.slice(WSL_AGENT_DETECTION_PREFIX.length)
+    const payload = line.slice(prefixIndex + WSL_AGENT_DETECTION_PREFIX.length)
     const separatorIndex = payload.indexOf('\t')
     if (separatorIndex <= 0) {
       continue


### PR DESCRIPTION
## Summary

- Run WSL agent PATH lookups concurrently inside one login-shell probe instead of serially scanning inherited Windows PATH entries.
- Use `command -v` as the fast path while retaining the existing alias/function-neutral fallback for non-file results.
- Accept result records preceded by shell OSC output so login-shell initialization cannot hide the first detected agent.

This prevents installed WSL agents from being reported missing when slow drvfs PATH entries consume the preflight timeout.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - tracked lint, code-quality, reliability, max-lines, and bundled-guide checks pass; current `origin/main` fails `verify:skill-bundle-manifest` because its generated skill manifests are stale.
- [ ] `pnpm typecheck` - current `origin/main` fails resolving the existing `psl` import in `browser-cookie-import-policy.ts`.
- [ ] `pnpm test` - the full same-base suite exceeded the 20-minute local command limit; no Vitest workers remained afterward.
- [ ] `pnpm build` - stops at the same existing `psl` typecheck failure.
- [x] Added regression coverage for parallel/noninteractive probing and OSC-prefixed output.

Additional passing checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/ipc/preflight-wsl-agent-detection.test.ts` (7 tests)
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`

## AI Review Report

Reviewed shell quoting, process lifetime, timeout behavior, output parsing, and regression coverage. The command names remain shell-quoted, lookups stay inside the selected WSL distro, and the existing absolute-path validation remains in place. macOS, native Linux, native Windows, SSH, folder workspaces, Git providers, and non-WSL agent detection are unchanged. The main performance risk checked was process multiplication: the change keeps one `wsl.exe` process and parallelizes only the small in-guest lookup set. There is no UI change.

## Security Audit

No credentials, secrets, IPC surface, dependencies, filesystem writes, or network requests are added. Agent command names continue through the existing shell quoting, and only POSIX-absolute executable paths are accepted from guest output. The OSC-tolerant parser still requires Orca's private record prefix before accepting a result.

## Notes

- Windows/WSL-specific behavior only; runtime guards and existing WSL routing are unchanged.
- SSH and remote execution paths are unaffected.
- X handle: not provided.