### PR TITLE
fix(gitlab): keep authenticated hosts on partial auth failure

### DIFF
--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -164,6 +164,7 @@ async function probeGlabKnownHosts(
   }
 }
 
+/** Merge discovered hosts into the cache for one execution context. */
 function cacheGlabKnownHosts(key: string, hosts: readonly string[]): readonly string[] {
   const remembered = knownHostsCacheByExecutionContext.get(key) ?? []
   const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...remembered, ...hosts]))
@@ -171,6 +172,7 @@ function cacheGlabKnownHosts(key: string, hosts: readonly string[]): readonly st
   return merged
 }
 
+/** Collect auth-status output retained on a failed glab process result. */
 function getGlabAuthStatusOutput(error: unknown): string {
   if (!error || typeof error !== 'object') {
     return String(error)

--- a/src/main/gitlab/gitlab-known-host-probe.ts
+++ b/src/main/gitlab/gitlab-known-host-probe.ts
@@ -152,15 +152,33 @@ async function probeGlabKnownHosts(
         ? { wslDistro: localGitOptions.wslDistro }
         : {})
     })
-    const hosts = parseGlabAuthStatusHosts(`${stdout}\n${stderr}`)
-    const remembered = knownHostsCacheByExecutionContext.get(key) ?? []
-    const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...remembered, ...hosts]))
-    knownHostsCacheByExecutionContext.set(key, merged)
-    return merged
-  } catch {
+    return cacheGlabKnownHosts(key, parseGlabAuthStatusHosts(`${stdout}\n${stderr}`))
+  } catch (error) {
+    const hosts = parseGlabAuthStatusHosts(getGlabAuthStatusOutput(error))
+    if (hosts.length > 0) {
+      // glab exits nonzero when any configured host is unauthenticated.
+      return cacheGlabKnownHosts(key, hosts)
+    }
     // Keep failures uncached so auth or tunnel recovery is discovered later.
     return knownHostsCacheByExecutionContext.get(key) ?? [...DEFAULT_GITLAB_HOSTS]
   }
+}
+
+function cacheGlabKnownHosts(key: string, hosts: readonly string[]): readonly string[] {
+  const remembered = knownHostsCacheByExecutionContext.get(key) ?? []
+  const merged = Array.from(new Set([...DEFAULT_GITLAB_HOSTS, ...remembered, ...hosts]))
+  knownHostsCacheByExecutionContext.set(key, merged)
+  return merged
+}
+
+function getGlabAuthStatusOutput(error: unknown): string {
+  if (!error || typeof error !== 'object') {
+    return String(error)
+  }
+  const result = error as { stdout?: unknown; stderr?: unknown; message?: unknown }
+  return [result.stdout, result.stderr, result.message]
+    .filter((value): value is string => typeof value === 'string' && value.length > 0)
+    .join('\n')
 }
 
 export function parseGlabAuthStatusHosts(output: string): string[] {

--- a/src/main/gitlab/gl-utils.test.ts
+++ b/src/main/gitlab/gl-utils.test.ts
@@ -574,6 +574,17 @@ describe('getGlabKnownHosts', () => {
     await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.com'])
   })
 
+  it('keeps authenticated hosts when another glab host makes auth status fail', async () => {
+    glabExecFileAsyncMock.mockRejectedValueOnce(
+      Object.assign(new Error('glab auth status exited with code 1'), {
+        stdout: 'gitlab.example.com\n  Logged in to gitlab.example.com as user\n',
+        stderr: 'gitlab.com\n  ! No token found\n'
+      })
+    )
+
+    await expect(getGlabKnownHosts()).resolves.toEqual(['gitlab.com', 'gitlab.example.com'])
+  })
+
   it('caches the result across calls', async () => {
     glabExecFileAsyncMock.mockResolvedValueOnce({
       stdout: '✓ Logged in to gitlab.com as user\n',


### PR DESCRIPTION
## Summary

- Parse `glab auth status` output even when `glab` exits nonzero because one configured host is unauthenticated.
- Preserve and cache hosts successfully reported by the same command instead of falling back to `gitlab.com` only.
- Keep genuine command failures uncached so later auth or tunnel recovery is still detected.

This keeps authenticated self-hosted GitLab instances available when another stale host entry makes `glab auth status` return exit code 1.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` - tracked lint, code-quality, reliability, max-lines, and bundled-guide checks pass; current `origin/main` fails `verify:skill-bundle-manifest` because its generated skill manifests are stale.
- [ ] `pnpm typecheck` - current `origin/main` fails resolving the existing `psl` import in `browser-cookie-import-policy.ts`.
- [ ] `pnpm test` - the full suite exceeded the 20-minute local command limit; no Vitest workers remained afterward.
- [ ] `pnpm build` - stops at the same existing `psl` typecheck failure.
- [x] Added regression coverage for mixed authenticated and unauthenticated `glab` hosts.

Additional passing checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/gitlab/gl-utils.test.ts` (58 tests)
- Targeted `oxlint`, `oxfmt --check`, and `git diff --check`
- Localization catalog, extraction, and coverage verification

## AI Review Report

Reviewed success and error paths, cache identity, retries, parsing behavior, and regression coverage. Native, WSL-distro, SSH/relay generation, and folder-workspace cache scopes remain unchanged. The change is GitLab-specific and does not alter GitHub or other provider behavior. It adds no subprocesses and only parses output already returned by the existing probe, so performance risk is negligible. There is no UI change.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This PR adds no keyboard shortcuts or shortcut labels, changes no path handling or Electron-specific behavior, and does not alter shell command construction. Native execution, WSL distro routing, SSH/relay execution, folder workspaces, and GitLab-specific provider boundaries retain their existing behavior.

## Security Audit

No command construction, credentials, token persistence, logging, IPC, dependencies, or network endpoints are added. The code reads only the existing `stdout`, `stderr`, and error message from `glab auth status`; it stores normalized host names through the existing bounded cache and does not retain auth output or secrets.

## Notes

- Applies equally to native, WSL, and SSH execution contexts without sharing cache entries between them.
- Genuine failures with no parseable host remain uncached and retryable.
- X handle: not provided.
