### PR TITLE
fix(tab-group): remove 4px lip above the active terminal tab when not split

### DIFF
--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -206,8 +206,9 @@ export default function TabGroupPanel({
     >
       {/* Why: each split group needs its own tab row because multiple groups can show at once but the titlebar has only one shared center slot. */}
       {/* Why: macOS hiddenInset titleBarStyle makes -webkit-app-region: drag the only way to move the window from this tab row. */}
+      {/* Why height is split-conditional: the top band totals 36px. When split, a 4px drag strip above the split layout carries the shared seam and each tab row is 32px (4+32). When NOT split that strip collapses to 0, so this lone tab row takes the full 36px and the active tab sits flush against the window top — no 4px lip above it. */}
       <div
-        className="h-[32px] shrink-0 border-b border-border bg-card"
+        className={`${hasSplitGroups ? 'h-[32px]' : 'h-[36px]'} shrink-0 border-b border-border bg-card`}
         data-tab-group-strip-id={groupId}
         data-terminal-focus-release-surface="true"
         data-worktree-id={worktreeId}

--- a/src/renderer/src/components/tab-group/TabGroupPanel.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupPanel.tsx
@@ -206,7 +206,7 @@ export default function TabGroupPanel({
     >
       {/* Why: each split group needs its own tab row because multiple groups can show at once but the titlebar has only one shared center slot. */}
       {/* Why: macOS hiddenInset titleBarStyle makes -webkit-app-region: drag the only way to move the window from this tab row. */}
-      {/* Why height is split-conditional: the top band totals 36px. When split, a 4px drag strip above the split layout carries the shared seam and each tab row is 32px (4+32). When NOT split that strip collapses to 0, so this lone tab row takes the full 36px and the active tab sits flush against the window top — no 4px lip above it. */}
+      {/* Why split-conditional: top band totals 36px. Split → 32px row under a 4px strip; unsplit → strip collapses so the lone row is full 36px and the active tab sits flush against the window top. */}
       <div
         className={`${hasSplitGroups ? 'h-[32px]' : 'h-[36px]'} shrink-0 border-b border-border bg-card`}
         data-tab-group-strip-id={groupId}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.test.ts
@@ -107,6 +107,12 @@ describe('TabGroupSplitLayout', () => {
     }
   }
 
+  function getTopDragStripClassName(element: ReturnType<typeof TabGroupSplitLayout>) {
+    const wrapper = asElement(getLayoutWrapper(element))
+    const strip = React.Children.toArray(wrapper.props.children as React.ReactNode)[0]
+    return asElement(strip).props.className as string
+  }
+
   it('does not mark an offscreen worktree group as focused', () => {
     expect(getLeafPanelProps(false)).toEqual(
       expect.objectContaining({
@@ -205,5 +211,40 @@ describe('TabGroupSplitLayout', () => {
     ;(resizeHandle.props.onResizeStart as () => void)()
 
     expect(recordFeatureInteractionMock).toHaveBeenCalledWith('terminal-panes')
+  })
+
+  it('collapses the top drag strip to 0 for an unsplit layout', () => {
+    const className = getTopDragStripClassName(
+      TabGroupSplitLayout({
+        layout: { type: 'leaf', groupId: 'group-1' },
+        worktreeId: 'wt-1',
+        focusedGroupId: 'group-1',
+        isWorktreeActive: true
+      })
+    )
+
+    expect(className).toContain('h-0')
+    expect(className).toContain('bg-worktree-sidebar')
+    expect(className).not.toContain('h-[4px]')
+  })
+
+  it('keeps a 4px top drag strip for a split layout', () => {
+    const className = getTopDragStripClassName(
+      TabGroupSplitLayout({
+        layout: {
+          type: 'split',
+          direction: 'horizontal',
+          ratio: 0.5,
+          first: { type: 'leaf', groupId: 'left-group' },
+          second: { type: 'leaf', groupId: 'right-group' }
+        },
+        worktreeId: 'wt-1',
+        focusedGroupId: 'right-group',
+        isWorktreeActive: true
+      })
+    )
+
+    expect(className).toContain('h-[4px]')
+    expect(className).toContain('bg-worktree-sidebar')
   })
 })

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -295,17 +295,24 @@ export default function TabGroupSplitLayout({
         // so disabling it is the simplest fix.
         autoScroll={false}
       >
-        {/* Why: the 10px drag strip sits ABOVE the split layout — lifted out of
+        {/* Why: this drag strip sits ABOVE the split layout — lifted out of
           each pane — so vertical split resize handles don't extend into the
           window-drag region at the top. Only the split layout's own panes
           own the resize handles, while this strip keeps the whole top of the
           center column draggable regardless of how the splits are arranged.
-          Why 4px specifically: pairs with the 32px tab row below so the
-          total top-band is 36px, matching the sibling `titlebar-left` above
-          the sidebar. Keep this small — it's just enough drag surface above
-          the tabs without opening a visible gap between the window top and
-          the tab chrome. Without this, the tab row's bottom border falls short
-          of the sidebar header's and the seam between columns reads as off.
+          Why height is split-conditional: the top band must total 36px to
+          match the sibling `titlebar-left` above the sidebar. When split, the
+          strip is 4px and each pane's tab row is 32px (4+32=36); the strip is
+          the shared drag/seam surface spanning both panes. When NOT split
+          there is only one pane and no cross-pane seam to bridge, so the strip
+          collapses to 0 and the single tab row grows to the full 36px — this
+          lets the active tab sit flush against the window top instead of
+          floating under a 4px lip. Either way the tab row's bottom border
+          lands at 36px, aligned with the sidebar header.
+          Why `bg-worktree-sidebar` not `bg-card`: while visible (split only)
+          the strip shares the top band with `titlebar-left`, which paints
+          `--worktree-sidebar`; matching that tint keeps the band one
+          continuous surface rather than a bright lip above the tabs.
           Why `border-l` on the wrapper: paint the single full-height divider
           between the left sidebar and the terminal area, regardless of split
           state. The leftmost pane suppresses its own `border-l` via
@@ -315,7 +322,10 @@ export default function TabGroupSplitLayout({
           ref={dragSplit.setDragRootNode}
           className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border"
         >
-          <div className="h-[4px] shrink-0 bg-card" data-terminal-focus-release-surface="true" />
+          <div
+            className={`${hasSplits ? 'h-[4px]' : 'h-0'} shrink-0 bg-worktree-sidebar`}
+            data-terminal-focus-release-surface="true"
+          />
           <div className="flex flex-1 min-w-0 min-h-0 overflow-hidden">
             <SplitNode
               node={layout}

--- a/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
+++ b/src/renderer/src/components/tab-group/TabGroupSplitLayout.tsx
@@ -295,29 +295,17 @@ export default function TabGroupSplitLayout({
         // so disabling it is the simplest fix.
         autoScroll={false}
       >
-        {/* Why: this drag strip sits ABOVE the split layout — lifted out of
-          each pane — so vertical split resize handles don't extend into the
-          window-drag region at the top. Only the split layout's own panes
-          own the resize handles, while this strip keeps the whole top of the
-          center column draggable regardless of how the splits are arranged.
-          Why height is split-conditional: the top band must total 36px to
-          match the sibling `titlebar-left` above the sidebar. When split, the
-          strip is 4px and each pane's tab row is 32px (4+32=36); the strip is
-          the shared drag/seam surface spanning both panes. When NOT split
-          there is only one pane and no cross-pane seam to bridge, so the strip
-          collapses to 0 and the single tab row grows to the full 36px — this
-          lets the active tab sit flush against the window top instead of
-          floating under a 4px lip. Either way the tab row's bottom border
-          lands at 36px, aligned with the sidebar header.
-          Why `bg-worktree-sidebar` not `bg-card`: while visible (split only)
-          the strip shares the top band with `titlebar-left`, which paints
-          `--worktree-sidebar`; matching that tint keeps the band one
-          continuous surface rather than a bright lip above the tabs.
-          Why `border-l` on the wrapper: paint the single full-height divider
-          between the left sidebar and the terminal area, regardless of split
-          state. The leftmost pane suppresses its own `border-l` via
-          `touchesLeftEdge`, so the seam is always exactly 1px — previously
-          both painted and stacked into a 2px bar below the drag strip. */}
+        {/* Why: this drag strip is lifted ABOVE the split layout so vertical
+          split-resize handles can't extend into the window-drag region; it
+          keeps the whole top draggable regardless of split arrangement.
+          Why split-conditional height: top band totals 36px. Split → 4px strip
+          + 32px rows carries the shared cross-pane seam; unsplit → collapses to
+          0 so the single row is full 36px (no lip above the active tab).
+          Why `bg-worktree-sidebar`: match the sibling `titlebar-left` tint so
+          the visible (split-only) strip reads as one continuous band.
+          Why `border-l` here: paint the single 1px sidebar/terminal divider
+          regardless of split state — the leftmost pane suppresses its own
+          `border-l`, avoiding the previous 2px double seam. */}
         <div
           ref={dragSplit.setDragRootNode}
           className="flex flex-col flex-1 min-w-0 min-h-0 overflow-hidden border-l border-border"


### PR DESCRIPTION
## Problem

With a single (unsplit) terminal, the **active** tab looks clipped — a bright 4px lip sits between the tab and the window top, so the tab floats instead of sitting flush against the top edge (aligned with the sidebar header on the left).

**Overview** — the active tab (here `Claude …`) and its top edge:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/adaex/orca/pr-assets-tab-strip/tab-strip-wide-before.png" width="460"> | <img src="https://raw.githubusercontent.com/adaex/orca/pr-assets-tab-strip/tab-strip-wide-after.png" width="460"> |

**8× zoom** on the active tab's top edge — the white lip vs. flush:

| Before | After |
| --- | --- |
| <img src="https://raw.githubusercontent.com/adaex/orca/pr-assets-tab-strip/tab-strip-before.png" width="460"> | <img src="https://raw.githubusercontent.com/adaex/orca/pr-assets-tab-strip/tab-strip-after.png" width="460"> |

## Root cause

The tab row sits below a 4px drag strip that `TabGroupSplitLayout` lifts out of the split layout. That strip:

- always reserves **4px**, and
- paints **`bg-card`** (white).

The active tab's own surface is the muted `color-mix(foreground 6%, card)` grey, so above it the white 4px strip reads as a lip. It isn't visible above *inactive* tabs only because those are `bg-card` too (white-on-white).

The strip exists to serve the **split** case: there it spans both panes as the shared drag/seam surface above the vertical resize handles, and 4px + 32px tab row = the 36px top band that matches `.titlebar-left` above the sidebar. With **no split** there is no cross-pane seam to bridge, yet the 4px was still reserved.

## Fix

- **Not split:** collapse the strip to `h-0` and grow the lone tab row from `h-[32px]` to `h-[36px]`. The active tab now sits flush against the window top; the band still totals 36px.
- **Split:** keep the 4px strip (functionally required), but paint it `bg-worktree-sidebar` — the same token `.titlebar-left` already uses (`background: var(--worktree-sidebar)`) — instead of white, so the top band reads as one continuous surface.

Split layout keeps the exact 4px + 32px geometry it had before; only the unsplit case changes height, and only the strip's color changes when split.

## Testing

- `tab-group` + `tab-bar` suites: **342 passed**
- `pnpm typecheck`: clean
- Verified live via CDP: unsplit → strip `h=0`, tab row `h=36` at `y=0`, active tab flush at `y=0`; split → strip restored to `h=4`, tab rows `h=32`.
