### PR TITLE
fix(terminal): explain a dead terminal host instead of leaking a socket error

### DIFF
--- a/src/main/daemon/daemon-errors.test.ts
+++ b/src/main/daemon/daemon-errors.test.ts
@@ -3,8 +3,10 @@ import {
   DaemonProtocolError,
   decodeDaemonResponseError,
   isDaemonEndpointGoneError,
-  SessionNotFoundError
+  SessionNotFoundError,
+  TerminalHostGoneError
 } from './daemon-errors'
+import { mapRuntimeError } from '../runtime/rpc/errors'
 
 function socketError(code: string, syscall: string): Error & { code: string; syscall: string } {
   return Object.assign(new Error(`${syscall} ${code}`), { code, syscall })
@@ -24,10 +26,6 @@ describe('decodeDaemonResponseError', () => {
   })
 })
 
-/**
- * On Windows a named pipe vanishes with its server process, so `connect ENOENT
- * \\?\pipe\orca-terminal-host-vNN-…` is proof the owning daemon died — it used to reach the user raw.
- */
 describe('isDaemonEndpointGoneError', () => {
   it('recognizes a missing Windows named pipe', () => {
     const err = Object.assign(
@@ -42,7 +40,6 @@ describe('isDaemonEndpointGoneError', () => {
   })
 
   it('ignores a missing token file, which does not prove the endpoint is gone', () => {
-    // Why: ENOENT on open is the token path, and an initially missing token can still hide a live daemon.
     expect(isDaemonEndpointGoneError(socketError('ENOENT', 'open'))).toBe(false)
   })
 
@@ -57,5 +54,15 @@ describe('isDaemonEndpointGoneError', () => {
     expect(isDaemonEndpointGoneError('connect ENOENT')).toBe(false)
     expect(isDaemonEndpointGoneError(null)).toBe(false)
     expect(isDaemonEndpointGoneError(undefined)).toBe(false)
+  })
+
+  it('keeps the host-gone marker across runtime RPC error mapping', () => {
+    const response = mapRuntimeError(
+      'req-1',
+      { runtimeId: 'runtime-1' },
+      new TerminalHostGoneError()
+    )
+
+    expect(response.error).toEqual({ code: 'runtime_error', message: 'terminal_host_gone' })
   })
 })

--- a/src/main/daemon/daemon-errors.test.ts
+++ b/src/main/daemon/daemon-errors.test.ts
@@ -2,8 +2,13 @@ import { describe, expect, it } from 'vitest'
 import {
   DaemonProtocolError,
   decodeDaemonResponseError,
+  isDaemonEndpointGoneError,
   SessionNotFoundError
 } from './daemon-errors'
+
+function socketError(code: string, syscall: string): Error & { code: string; syscall: string } {
+  return Object.assign(new Error(`${syscall} ${code}`), { code, syscall })
+}
 
 describe('decodeDaemonResponseError', () => {
   it('types the exact legacy session-absence response', () => {
@@ -16,5 +21,41 @@ describe('decodeDaemonResponseError', () => {
     expect(decodeDaemonResponseError('proxy failed: Session not found: pty-1')).toBeInstanceOf(
       DaemonProtocolError
     )
+  })
+})
+
+/**
+ * On Windows a named pipe vanishes with its server process, so `connect ENOENT
+ * \\?\pipe\orca-terminal-host-vNN-…` is proof the owning daemon died — it used to reach the user raw.
+ */
+describe('isDaemonEndpointGoneError', () => {
+  it('recognizes a missing Windows named pipe', () => {
+    const err = Object.assign(
+      new Error('connect ENOENT \\\\?\\pipe\\orca-terminal-host-v30-14cb7f94b511'),
+      { code: 'ENOENT', syscall: 'connect' }
+    )
+    expect(isDaemonEndpointGoneError(err)).toBe(true)
+  })
+
+  it('recognizes a refused socket', () => {
+    expect(isDaemonEndpointGoneError(socketError('ECONNREFUSED', 'connect'))).toBe(true)
+  })
+
+  it('ignores a missing token file, which does not prove the endpoint is gone', () => {
+    // Why: ENOENT on open is the token path, and an initially missing token can still hide a live daemon.
+    expect(isDaemonEndpointGoneError(socketError('ENOENT', 'open'))).toBe(false)
+  })
+
+  it('ignores connect failures that are not proof of absence', () => {
+    for (const code of ['ETIMEDOUT', 'ECONNRESET', 'EPIPE', 'EACCES']) {
+      expect(isDaemonEndpointGoneError(socketError(code, 'connect'))).toBe(false)
+    }
+  })
+
+  it('ignores non-socket errors and non-objects', () => {
+    expect(isDaemonEndpointGoneError(new Error('Connection lost'))).toBe(false)
+    expect(isDaemonEndpointGoneError('connect ENOENT')).toBe(false)
+    expect(isDaemonEndpointGoneError(null)).toBe(false)
+    expect(isDaemonEndpointGoneError(undefined)).toBe(false)
   })
 })

--- a/src/main/daemon/daemon-errors.ts
+++ b/src/main/daemon/daemon-errors.ts
@@ -28,6 +28,28 @@ export class TerminalSessionOwnerUnverifiedError extends Error {
   }
 }
 
+export class TerminalHostGoneError extends Error {
+  constructor(sessionId: string) {
+    super(`Terminal host that owned session ${sessionId} is gone`)
+    this.name = 'TerminalHostGoneError'
+  }
+}
+
+/**
+ * A connect-time ENOENT/ECONNREFUSED proves the endpoint is absent rather than busy — on Windows a
+ * named pipe disappears with its server process — so the daemon that owned the session is gone. Reaching
+ * a caller at all means respawn-and-retry already failed or was unavailable (legacy adapters never respawn).
+ */
+export function isDaemonEndpointGoneError(err: unknown): boolean {
+  const candidate = err as { code?: unknown; syscall?: unknown } | null
+  return (
+    typeof candidate === 'object' &&
+    candidate !== null &&
+    candidate.syscall === 'connect' &&
+    (candidate.code === 'ENOENT' || candidate.code === 'ECONNREFUSED')
+  )
+}
+
 export function decodeDaemonResponseError(message: string): Error {
   const prefix = 'Session not found: '
   return message.startsWith(prefix)

--- a/src/main/daemon/daemon-errors.ts
+++ b/src/main/daemon/daemon-errors.ts
@@ -29,17 +29,13 @@ export class TerminalSessionOwnerUnverifiedError extends Error {
 }
 
 export class TerminalHostGoneError extends Error {
-  constructor(sessionId: string) {
-    super(`Terminal host that owned session ${sessionId} is gone`)
+  constructor() {
+    super('terminal_host_gone')
     this.name = 'TerminalHostGoneError'
   }
 }
 
-/**
- * A connect-time ENOENT/ECONNREFUSED proves the endpoint is absent rather than busy — on Windows a
- * named pipe disappears with its server process — so the daemon that owned the session is gone. Reaching
- * a caller at all means respawn-and-retry already failed or was unavailable (legacy adapters never respawn).
- */
+// Connect ENOENT/ECONNREFUSED proves the endpoint is absent; open ENOENT can be a missing token file.
 export function isDaemonEndpointGoneError(err: unknown): boolean {
   const candidate = err as { code?: unknown; syscall?: unknown } | null
   return (

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -95,6 +95,7 @@ import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import { recordDaemonStreamBacklogEvent } from '../daemon/daemon-stream-backlog-probe'
 import {
   isDaemonEndpointGoneError,
+  TerminalHostGoneError,
   TerminalSessionOwnerUnverifiedError
 } from '../daemon/daemon-errors'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
@@ -818,10 +819,9 @@ async function attachStablePaneOwner(
     if (error instanceof TerminalSessionOwnerUnverifiedError) {
       throw new Error('terminal_pane_owner_unverified')
     }
-    // Why: a raw `connect ENOENT \\?\pipe\orca-terminal-host-vNN-…` is unactionable in a toast, and the
-    // session it names is unrecoverable — translate it before it can reach the renderer.
+    // Why: translate before paired-runtime RPC strips the socket error's code and syscall.
     if (isDaemonEndpointGoneError(error)) {
-      throw new Error('terminal_host_gone')
+      throw new TerminalHostGoneError()
     }
     if (!isPtyAlreadyGoneError(error)) {
       throw error

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -93,7 +93,10 @@ import {
 import { resolveWslSessionContext } from '../daemon/wsl-session-context'
 import { addNodePtyRecoveryHint } from '../daemon/node-pty-error-hints'
 import { recordDaemonStreamBacklogEvent } from '../daemon/daemon-stream-backlog-probe'
-import { TerminalSessionOwnerUnverifiedError } from '../daemon/daemon-errors'
+import {
+  isDaemonEndpointGoneError,
+  TerminalSessionOwnerUnverifiedError
+} from '../daemon/daemon-errors'
 import type { ClaudeRuntimeAuthPreparation } from '../claude-accounts/runtime-auth-service'
 import type { ClaudeAccountSelectionTarget } from '../claude-accounts/runtime-selection'
 import { CLAUDE_AUTH_ENV_VARS, hasClaudeAuthEnvConflict } from '../claude-accounts/environment'
@@ -814,6 +817,11 @@ async function attachStablePaneOwner(
   } catch (error) {
     if (error instanceof TerminalSessionOwnerUnverifiedError) {
       throw new Error('terminal_pane_owner_unverified')
+    }
+    // Why: a raw `connect ENOENT \\?\pipe\orca-terminal-host-vNN-…` is unactionable in a toast, and the
+    // session it names is unrecoverable — translate it before it can reach the renderer.
+    if (isDaemonEndpointGoneError(error)) {
+      throw new Error('terminal_host_gone')
     }
     if (!isPtyAlreadyGoneError(error)) {
       throw error

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -114,9 +114,9 @@ describe('isExplainedTerminalError', () => {
     expect(isExplainedTerminalError('node-pty: open_slave failed: EMFILE')).toBe(false)
     expect(isExplainedTerminalError('terminal_gone')).toBe(false)
     expect(isExplainedTerminalError('terminal_host_gone_extra')).toBe(false)
-    expect(isExplainedTerminalError('aterminal_host_gonea')).toBe(false)
-    expect(isExplainedTerminalError('0terminal_host_gone0')).toBe(false)
-    expect(isExplainedTerminalError('_terminal_host_gone_')).toBe(false)
+    expect(isExplainedTerminalError('aterminal_host_gone.')).toBe(false)
+    expect(isExplainedTerminalError('0terminal_host_gone.')).toBe(false)
+    expect(isExplainedTerminalError('_terminal_host_gone.')).toBe(false)
     expect(isExplainedTerminalError('open ENOENT \\\\?\\pipe\\orca-terminal-host-v30-dead')).toBe(
       false
     )

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -64,8 +64,11 @@ describe('humanizeTerminalError', () => {
   })
 
   it('humanizes an IPC-wrapped terminal-host-gone error', () => {
-    const wrapped = "Error invoking remote method 'pty:spawn': Error: terminal_host_gone"
-    expect(humanizeTerminalError(wrapped)).not.toContain('terminal_host_gone')
+    const prefix = "Error invoking remote method 'pty:spawn': Error: ("
+    const humanized = humanizeTerminalError(`${prefix}terminal_host_gone).`)
+    expect(humanized).not.toContain('terminal_host_gone')
+    expect(humanized).toContain(`${prefix}The terminal daemon`)
+    expect(humanized).toMatch(/\)\.$/)
   })
 
   it('humanizes a legacy host raw named-pipe error', () => {
@@ -111,6 +114,9 @@ describe('isExplainedTerminalError', () => {
     expect(isExplainedTerminalError('node-pty: open_slave failed: EMFILE')).toBe(false)
     expect(isExplainedTerminalError('terminal_gone')).toBe(false)
     expect(isExplainedTerminalError('terminal_host_gone_extra')).toBe(false)
+    expect(isExplainedTerminalError('aterminal_host_gonea')).toBe(false)
+    expect(isExplainedTerminalError('0terminal_host_gone0')).toBe(false)
+    expect(isExplainedTerminalError('_terminal_host_gone_')).toBe(false)
     expect(isExplainedTerminalError('open ENOENT \\\\?\\pipe\\orca-terminal-host-v30-dead')).toBe(
       false
     )

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -74,6 +74,22 @@ describe('humanizeTerminalError', () => {
     expect(humanized).not.toContain('orca-terminal-host-v30')
     expect(humanized).toContain('Open a new terminal to continue')
   })
+
+  it('only replaces exact host-gone markers in aggregated errors', () => {
+    const humanized = humanizeTerminalError('terminal_host_gone\nterminal_host_gone_extra')
+    expect(humanized).toContain('Open a new terminal to continue')
+    expect(humanized).toContain('\nterminal_host_gone_extra')
+  })
+
+  it.each(['ENOENT', 'ECONNREFUSED'])(
+    'does not combine a %s connection failure with a host endpoint on another line',
+    (code) => {
+      const aggregated =
+        `connect ${code} \\\\?\\pipe\\unrelated\n` + 'orca-terminal-host-v30-14cb7f94b511'
+      expect(isExplainedTerminalError(aggregated)).toBe(false)
+      expect(humanizeTerminalError(aggregated)).toBe(aggregated)
+    }
+  )
 })
 
 describe('isExplainedTerminalError', () => {

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -12,6 +12,8 @@ const SSH_FAILURE =
 // Relay loss reaches reportError already IPC-wrapped, so the marker is mid-string.
 const RELAY_LOST =
   "Error invoking remote method 'pty:attach': Error: SSH connection lost, reconnecting..."
+const LEGACY_HOST_GONE =
+  "Error invoking remote method 'pty:spawn': Error: connect ENOENT \\\\?\\pipe\\orca-terminal-host-v30-14cb7f94b511"
 
 describe('isSshReconnectOwnedTerminalError', () => {
   it('matches raw ssh:connect failures and inactive-host messages', () => {
@@ -65,6 +67,13 @@ describe('humanizeTerminalError', () => {
     const wrapped = "Error invoking remote method 'pty:spawn': Error: terminal_host_gone"
     expect(humanizeTerminalError(wrapped)).not.toContain('terminal_host_gone')
   })
+
+  it('humanizes a legacy host raw named-pipe error', () => {
+    const humanized = humanizeTerminalError(LEGACY_HOST_GONE)
+    expect(humanized).not.toContain('connect ENOENT')
+    expect(humanized).not.toContain('orca-terminal-host-v30')
+    expect(humanized).toContain('Open a new terminal to continue')
+  })
 })
 
 describe('isExplainedTerminalError', () => {
@@ -75,11 +84,24 @@ describe('isExplainedTerminalError', () => {
         "Error invoking remote method 'pty:spawn': Error: terminal_host_gone"
       )
     ).toBe(true)
+    expect(isExplainedTerminalError(LEGACY_HOST_GONE)).toBe(true)
+    expect(
+      isExplainedTerminalError('connect ECONNREFUSED /tmp/orca-terminal-host-v30-14cb7f94b511.sock')
+    ).toBe(true)
   })
 
   it('keeps the issue link for errors Orca cannot explain', () => {
     expect(isExplainedTerminalError('Paste failed.')).toBe(false)
     expect(isExplainedTerminalError('node-pty: open_slave failed: EMFILE')).toBe(false)
+    expect(isExplainedTerminalError('terminal_gone')).toBe(false)
+    expect(isExplainedTerminalError('terminal_host_gone_extra')).toBe(false)
+    expect(isExplainedTerminalError('open ENOENT \\\\?\\pipe\\orca-terminal-host-v30-dead')).toBe(
+      false
+    )
+    expect(
+      isExplainedTerminalError('connect ETIMEDOUT \\\\?\\pipe\\orca-terminal-host-v30-dead')
+    ).toBe(false)
+    expect(isExplainedTerminalError('connect ENOENT \\\\?\\pipe\\unrelated')).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.test.ts
@@ -1,6 +1,7 @@
 import { describe, expect, it } from 'vitest'
 import {
   humanizeTerminalError,
+  isExplainedTerminalError,
   isSshReconnectOwnedTerminalError,
   shouldOfferDaemonRestart,
   stripSshReconnectOwnedErrorLines
@@ -52,6 +53,33 @@ describe('humanizeTerminalError', () => {
 
   it('leaves other errors untouched', () => {
     expect(humanizeTerminalError('Paste failed.')).toBe('Paste failed.')
+  })
+
+  it('replaces the terminal-host-gone code with copy that explains the loss', () => {
+    const humanized = humanizeTerminalError('terminal_host_gone')
+    expect(humanized).not.toContain('terminal_host_gone')
+    expect(humanized).toContain('Open a new terminal to continue')
+  })
+
+  it('humanizes an IPC-wrapped terminal-host-gone error', () => {
+    const wrapped = "Error invoking remote method 'pty:spawn': Error: terminal_host_gone"
+    expect(humanizeTerminalError(wrapped)).not.toContain('terminal_host_gone')
+  })
+})
+
+describe('isExplainedTerminalError', () => {
+  it('suppresses the issue link for a provably dead terminal host', () => {
+    expect(isExplainedTerminalError('terminal_host_gone')).toBe(true)
+    expect(
+      isExplainedTerminalError(
+        "Error invoking remote method 'pty:spawn': Error: terminal_host_gone"
+      )
+    ).toBe(true)
+  })
+
+  it('keeps the issue link for errors Orca cannot explain', () => {
+    expect(isExplainedTerminalError('Paste failed.')).toBe(false)
+    expect(isExplainedTerminalError('node-pty: open_slave failed: EMFILE')).toBe(false)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -14,6 +14,8 @@ const STALE_DAEMON_CWD_MARKERS = [
 ]
 // Thrown by ipc/pty.ts when a persisted pane owner can't be proven alive or dead (STA-3536).
 const PANE_OWNER_UNVERIFIED_MARKER = 'terminal_pane_owner_unverified'
+// Thrown by ipc/pty.ts when the daemon that owned this session is provably gone (its endpoint is absent).
+const TERMINAL_HOST_GONE_MARKER = 'terminal_host_gone'
 
 function isSshError(error: string): boolean {
   return error.startsWith(SSH_PREFIX) || error.includes(SSH_RELAY_LOST_MARKER)
@@ -44,18 +46,33 @@ export function shouldOfferDaemonRestart(error: string): boolean {
   )
 }
 
-/** Swaps the raw pane-owner-unverified code for copy a user can act on. */
+/** A condition the copy already fully explains — an issue link would just add noise. */
+export function isExplainedTerminalError(error: string): boolean {
+  return error.includes(TERMINAL_HOST_GONE_MARKER)
+}
+
+/** Swaps raw daemon-boundary codes for copy a user can act on. */
 export function humanizeTerminalError(error: string): string {
-  if (!error.includes(PANE_OWNER_UNVERIFIED_MARKER)) {
-    return error
-  }
-  return error.replace(
-    PANE_OWNER_UNVERIFIED_MARKER,
-    translate(
-      'auto.components.terminal.pane.TerminalErrorToast.7ee11bc0db',
-      "Orca couldn't confirm whether this terminal's previous session is still running, so it left the session untouched. Reopen this pane to retry."
+  let humanized = error
+  if (humanized.includes(PANE_OWNER_UNVERIFIED_MARKER)) {
+    humanized = humanized.replace(
+      PANE_OWNER_UNVERIFIED_MARKER,
+      translate(
+        'auto.components.terminal.pane.TerminalErrorToast.7ee11bc0db',
+        "Orca couldn't confirm whether this terminal's previous session is still running, so it left the session untouched. Reopen this pane to retry."
+      )
     )
-  )
+  }
+  if (humanized.includes(TERMINAL_HOST_GONE_MARKER)) {
+    humanized = humanized.replace(
+      TERMINAL_HOST_GONE_MARKER,
+      translate(
+        'auto.components.terminal.pane.TerminalErrorToast.e16012e31e',
+        'The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.'
+      )
+    )
+  }
+  return humanized
 }
 
 export function TerminalErrorToast({
@@ -69,6 +86,8 @@ export function TerminalErrorToast({
 }): React.JSX.Element {
   const ssh = isSshError(error)
   const showDaemonRestart = !ssh && onRestartDaemon && shouldOfferDaemonRestart(error)
+  // Why: restarting the daemon cannot recover a session whose owner already exited, so the copy stands alone.
+  const showIssueLink = !ssh && !showDaemonRestart && !isExplainedTerminalError(error)
   const displayError = humanizeTerminalError(error)
 
   return (
@@ -101,7 +120,7 @@ export function TerminalErrorToast({
                 'Restart the terminal daemon from here to clear stale daemon state.'
               )}
             </>
-          ) : !ssh ? (
+          ) : showIssueLink ? (
             <>
               {'\n'}
               {translate(

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -14,8 +14,10 @@ const STALE_DAEMON_CWD_MARKERS = [
 ]
 // Thrown by ipc/pty.ts when a persisted pane owner can't be proven alive or dead (STA-3536).
 const PANE_OWNER_UNVERIFIED_MARKER = 'terminal_pane_owner_unverified'
-// Thrown by ipc/pty.ts when the daemon that owned this session is provably gone (its endpoint is absent).
 const TERMINAL_HOST_GONE_MARKER = 'terminal_host_gone'
+const TERMINAL_HOST_GONE_PATTERN = /(?:^|[^a-z0-9_])terminal_host_gone(?:$|[^a-z0-9_])/
+const LEGACY_TERMINAL_HOST_ENDPOINT_MARKER = 'orca-terminal-host-v'
+const LEGACY_TERMINAL_HOST_GONE_PATTERN = /connect (?:ENOENT|ECONNREFUSED) [^\n]*/
 
 function isSshError(error: string): boolean {
   return error.startsWith(SSH_PREFIX) || error.includes(SSH_RELAY_LOST_MARKER)
@@ -46,9 +48,12 @@ export function shouldOfferDaemonRestart(error: string): boolean {
   )
 }
 
-/** A condition the copy already fully explains — an issue link would just add noise. */
 export function isExplainedTerminalError(error: string): boolean {
-  return error.includes(TERMINAL_HOST_GONE_MARKER)
+  return (
+    TERMINAL_HOST_GONE_PATTERN.test(error) ||
+    (error.includes(LEGACY_TERMINAL_HOST_ENDPOINT_MARKER) &&
+      LEGACY_TERMINAL_HOST_GONE_PATTERN.test(error))
+  )
 }
 
 /** Swaps raw daemon-boundary codes for copy a user can act on. */
@@ -63,14 +68,18 @@ export function humanizeTerminalError(error: string): string {
       )
     )
   }
-  if (humanized.includes(TERMINAL_HOST_GONE_MARKER)) {
-    humanized = humanized.replace(
-      TERMINAL_HOST_GONE_MARKER,
-      translate(
-        'auto.components.terminal.pane.TerminalErrorToast.e16012e31e',
-        'The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.'
-      )
+  if (isExplainedTerminalError(humanized)) {
+    const explanation = translate(
+      'auto.components.terminal.pane.TerminalErrorToast.e16012e31e',
+      'The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.'
     )
+    humanized = humanized.replaceAll(TERMINAL_HOST_GONE_MARKER, explanation)
+    if (humanized.includes(LEGACY_TERMINAL_HOST_ENDPOINT_MARKER)) {
+      humanized = humanized
+        .split('\n')
+        .map((line) => line.replace(LEGACY_TERMINAL_HOST_GONE_PATTERN, explanation))
+        .join('\n')
+    }
   }
   return humanized
 }
@@ -86,7 +95,7 @@ export function TerminalErrorToast({
 }): React.JSX.Element {
   const ssh = isSshError(error)
   const showDaemonRestart = !ssh && onRestartDaemon && shouldOfferDaemonRestart(error)
-  // Why: restarting the daemon cannot recover a session whose owner already exited, so the copy stands alone.
+  // Restart cannot recover a session after its owning daemon exits.
   const showIssueLink = !ssh && !showDaemonRestart && !isExplainedTerminalError(error)
   const displayError = humanizeTerminalError(error)
 

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -14,10 +14,10 @@ const STALE_DAEMON_CWD_MARKERS = [
 ]
 // Thrown by ipc/pty.ts when a persisted pane owner can't be proven alive or dead (STA-3536).
 const PANE_OWNER_UNVERIFIED_MARKER = 'terminal_pane_owner_unverified'
-const TERMINAL_HOST_GONE_MARKER = 'terminal_host_gone'
 const TERMINAL_HOST_GONE_PATTERN = /(?:^|[^a-z0-9_])terminal_host_gone(?:$|[^a-z0-9_])/
-const LEGACY_TERMINAL_HOST_ENDPOINT_MARKER = 'orca-terminal-host-v'
-const LEGACY_TERMINAL_HOST_GONE_PATTERN = /connect (?:ENOENT|ECONNREFUSED) [^\n]*/
+const TERMINAL_HOST_GONE_REPLACE_PATTERN = /(^|[^a-z0-9_])terminal_host_gone(?=$|[^a-z0-9_])/g
+const LEGACY_TERMINAL_HOST_GONE_PATTERN =
+  /(^|[^a-z])connect (?:ENOENT|ECONNREFUSED) [^\r\n]*orca-terminal-host-v[^\r\n]*/i
 
 function isSshError(error: string): boolean {
   return error.startsWith(SSH_PREFIX) || error.includes(SSH_RELAY_LOST_MARKER)
@@ -49,11 +49,12 @@ export function shouldOfferDaemonRestart(error: string): boolean {
 }
 
 export function isExplainedTerminalError(error: string): boolean {
-  return (
-    TERMINAL_HOST_GONE_PATTERN.test(error) ||
-    (error.includes(LEGACY_TERMINAL_HOST_ENDPOINT_MARKER) &&
-      LEGACY_TERMINAL_HOST_GONE_PATTERN.test(error))
-  )
+  return error
+    .split('\n')
+    .some(
+      (line) =>
+        TERMINAL_HOST_GONE_PATTERN.test(line) || LEGACY_TERMINAL_HOST_GONE_PATTERN.test(line)
+    )
 }
 
 /** Swaps raw daemon-boundary codes for copy a user can act on. */
@@ -68,20 +69,25 @@ export function humanizeTerminalError(error: string): string {
       )
     )
   }
-  if (isExplainedTerminalError(humanized)) {
-    const explanation = translate(
-      'auto.components.terminal.pane.TerminalErrorToast.e16012e31e',
-      'The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.'
-    )
-    humanized = humanized.replaceAll(TERMINAL_HOST_GONE_MARKER, explanation)
-    if (humanized.includes(LEGACY_TERMINAL_HOST_ENDPOINT_MARKER)) {
-      humanized = humanized
-        .split('\n')
-        .map((line) => line.replace(LEGACY_TERMINAL_HOST_GONE_PATTERN, explanation))
-        .join('\n')
-    }
+  if (!isExplainedTerminalError(humanized)) {
+    return humanized
   }
+  const explanation = translate(
+    'auto.components.terminal.pane.TerminalErrorToast.e16012e31e',
+    'The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.'
+  )
   return humanized
+    .split('\n')
+    .map((line) =>
+      line
+        .replace(TERMINAL_HOST_GONE_REPLACE_PATTERN, (_match, prefix: string) =>
+          prefix.concat(explanation)
+        )
+        .replace(LEGACY_TERMINAL_HOST_GONE_PATTERN, (_match, prefix: string) =>
+          prefix.concat(explanation)
+        )
+    )
+    .join('\n')
 }
 
 export function TerminalErrorToast({

--- a/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalErrorToast.tsx
@@ -14,8 +14,11 @@ const STALE_DAEMON_CWD_MARKERS = [
 ]
 // Thrown by ipc/pty.ts when a persisted pane owner can't be proven alive or dead (STA-3536).
 const PANE_OWNER_UNVERIFIED_MARKER = 'terminal_pane_owner_unverified'
-const TERMINAL_HOST_GONE_PATTERN = /(?:^|[^a-z0-9_])terminal_host_gone(?:$|[^a-z0-9_])/
-const TERMINAL_HOST_GONE_REPLACE_PATTERN = /(^|[^a-z0-9_])terminal_host_gone(?=$|[^a-z0-9_])/g
+// Why one source: the test and replace forms must match the same token, and a lone /g regex carries
+// lastIndex state across .test() calls. Capture the leading boundary so replacement can restore it.
+const TERMINAL_HOST_GONE_SOURCE = '(^|[^a-z0-9_])terminal_host_gone(?=$|[^a-z0-9_])'
+const TERMINAL_HOST_GONE_PATTERN = new RegExp(TERMINAL_HOST_GONE_SOURCE)
+const TERMINAL_HOST_GONE_REPLACE_PATTERN = new RegExp(TERMINAL_HOST_GONE_SOURCE, 'g')
 const LEGACY_TERMINAL_HOST_GONE_PATTERN =
   /(^|[^a-z])connect (?:ENOENT|ECONNREFUSED) [^\r\n]*orca-terminal-host-v[^\r\n]*/i
 

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -2806,7 +2806,8 @@
             "a7e2fd2699": "file an issue",
             "5c8ce20be6": "If this persists, please",
             "cc6d997c65": "Restart the terminal daemon from here to clear stale daemon state.",
-            "7ee11bc0db": "Orca couldn't confirm whether this terminal's previous session is still running, so it left the session untouched. Reopen this pane to retry."
+            "7ee11bc0db": "Orca couldn't confirm whether this terminal's previous session is still running, so it left the session untouched. Reopen this pane to retry.",
+            "e16012e31e": "The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue."
           },
           "TerminalPane": {
             "ac112e9036": "Remove title",


### PR DESCRIPTION
## Summary

When the daemon that owned a terminal session has exited, resuming that terminal surfaced the raw socket error for its endpoint in a red toast that ended in "If this persists, please file an issue". On Windows that reads as:

```
connect ENOENT \\?\pipe\orca-terminal-host-v30-<hash>
```

Two problems: the text is unactionable, and the suggested remedy is wrong — the session is unrecoverable, so there is nothing to file and nothing to retry.

The condition is already precisely known internally: a connect-time `ENOENT`/`ECONNREFUSED` proves the endpoint is absent rather than busy (on Windows a named pipe disappears with its server process), and the daemon audit path already classifies this as `state: 'gone'`. It was simply rethrown raw.

This translates it at the daemon boundary into a `terminal_host_gone` code and humanizes it in the toast, following the existing `terminal_pane_owner_unverified` path exactly (typed predicate → code at the IPC boundary → marker + humanize in the renderer → tests at both ends). The issue link is suppressed for a condition Orca can fully explain.

**Remote hosts are covered.** The conversion sits in `attachStablePaneOwner`, which a paired client's resume reaches via `adoptStablePane`. I verified this is the first catch before `mapRuntimeError` serializes the error onto the wire — without that placement the fix would have sat on a path the remote case never touches. Note that `error.code`/`syscall` do not survive RPC serialization, only `message`, which is why the marker travels in the message and the toast matches on substring.

## Screenshots

No screenshot captured, but this changes user-facing copy, so the before/after verbatim:

- **Before:** `connect ENOENT \\?\pipe\orca-terminal-host-v30-<hash>` followed by `If this persists, please file an issue.`
- **After:** `The terminal daemon that owned this session exited, so the session and its scrollback could not be recovered. Open a new terminal to continue.` with no issue link.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — ran `daemon-errors` and the full renderer `terminal-pane` suite (3164 passed). `src/main/ipc/pty.test.ts` has 9 failures locally, but they reproduce identically on clean `main` (verified by stashing and re-running) and are environment-dependent, unrelated to this change. Full-repo run not executed locally.
- [ ] `pnpm build` — not run.
- [x] Added or updated high-quality tests

New tests cover the predicate (missing named pipe, refused socket, and the negative cases: a missing *token* file is `ENOENT` on `open` and must NOT be treated as a dead endpoint, since an initially missing token can still hide a live daemon; transient connect failures; non-objects) plus humanization of both the bare and IPC-wrapped forms, and that the issue link is suppressed only for explained errors.

## AI Review Report

Reviewed for: whether the predicate is too broad (it is deliberately narrower than the internal `isDaemonGoneError`, excluding `'Connection lost'`/`'Daemon temporarily unavailable'` which are transient and do get respawned — only connect-time absence is treated as proof of death); whether converting the error breaks internal recovery (it does not — the conversion is at the IPC boundary, so respawn-and-retry has already run or was unavailable by the time it fires); and whether the new marker could collide with the existing `terminal_gone` remote classification (it cannot — `'terminal_gone'` is not a substring of `'terminal_host_gone'`, verified against `isRemoteTerminalGoneMessage`).

Cross-platform: the named-pipe framing is Windows-specific but the predicate is not platform-branched — `ECONNREFUSED`/`ENOENT` on `connect` is the equivalent proof for a Unix socket on macOS and Linux, and both are covered by tests. No shortcuts, labels, shell behavior, or Electron-specific APIs are touched. The user-facing string says "terminal daemon", matching the existing wording used by the adjacent restart affordance on all platforms.

## Security Audit

No command execution, path construction, auth, or secrets handling changes. The change *reduces* information disclosure: an internal endpoint path (which embeds a hash of the user-data directory) is no longer surfaced in user-visible text or logs from this path. The new error code carries no session or path data. No new dependencies or IPC channels; one new error string crosses an existing channel.

## Notes

Mixed client/host versions: the host now publishes `terminal_host_gone` where it previously published the raw connect string, so an older client without the humanizer will show the bare token. This matches the precedent already set by `terminal_pane_owner_unverified`, which publishes a bare token for the same reason, so it is consistent rather than a new pattern. For that same consistency I did not add the code to `RUNTIME_PASSTHROUGH_CODES` — the sibling code is not there either — though doing so later would give code-based clients a stable machine token.

The English catalog entry is added; the other four locales fall back to English until the translation pipeline runs, consistent with the ~310 entries already pending in each.