### PR TITLE
fix(opencode): preserve run subcommand before launch flags

### DIFF
--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -94,6 +94,36 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
+  it('places OpenCode launch flags after the run subcommand', () => {
+    const result = planCommitMessageGeneration(
+      {
+        agentId: 'opencode',
+        model: 'opencode/gpt-5.4-mini',
+        agentCommandOverride: 'opencode --auto'
+      },
+      'PROMPT'
+    )
+
+    expect(result).toEqual({
+      ok: true,
+      plan: {
+        binary: 'opencode',
+        args: [
+          'run',
+          '--auto',
+          '--model',
+          'opencode/gpt-5.4-mini',
+          '--agent',
+          'build',
+          '--format',
+          'default'
+        ],
+        stdinPayload: 'PROMPT',
+        label: 'OpenCode'
+      }
+    })
+  })
+
   it('plans Amp execute generation without the removed archive flag', () => {
     const result = planCommitMessageGeneration(
       {

--- a/src/shared/commit-message-plan.test.ts
+++ b/src/shared/commit-message-plan.test.ts
@@ -94,35 +94,38 @@ describe('planCommitMessageGeneration', () => {
     })
   })
 
-  it('places OpenCode launch flags after the run subcommand', () => {
-    const result = planCommitMessageGeneration(
-      {
-        agentId: 'opencode',
-        model: 'opencode/gpt-5.4-mini',
-        agentCommandOverride: 'opencode --auto'
-      },
-      'PROMPT'
-    )
+  it.each(['opencode', 'opencode.cmd', 'opencode.exe'])(
+    'places OpenCode launch flags after the run subcommand for %s',
+    (agentCommandOverride) => {
+      const result = planCommitMessageGeneration(
+        {
+          agentId: 'opencode',
+          model: 'opencode/gpt-5.4-mini',
+          agentCommandOverride: `${agentCommandOverride} --auto`
+        },
+        'PROMPT'
+      )
 
-    expect(result).toEqual({
-      ok: true,
-      plan: {
-        binary: 'opencode',
-        args: [
-          'run',
-          '--auto',
-          '--model',
-          'opencode/gpt-5.4-mini',
-          '--agent',
-          'build',
-          '--format',
-          'default'
-        ],
-        stdinPayload: 'PROMPT',
-        label: 'OpenCode'
-      }
-    })
-  })
+      expect(result).toEqual({
+        ok: true,
+        plan: {
+          binary: agentCommandOverride,
+          args: [
+            'run',
+            '--auto',
+            '--model',
+            'opencode/gpt-5.4-mini',
+            '--agent',
+            'build',
+            '--format',
+            'default'
+          ],
+          stdinPayload: 'PROMPT',
+          label: 'OpenCode'
+        }
+      })
+    }
+  )
 
   it('plans Amp execute generation without the removed archive flag', () => {
     const result = planCommitMessageGeneration(

--- a/src/shared/commit-message-plan.ts
+++ b/src/shared/commit-message-plan.ts
@@ -156,6 +156,26 @@ function insertAdditionalAgentArgs(args: {
   return [...args.baseArgs, ...args.agentArgs]
 }
 
+function mergePresetAgentCommandArgs(
+  agentId: TuiAgent,
+  binary: string,
+  prefixArgs: string[],
+  generatedArgs: string[]
+): string[] {
+  if (agentId !== 'opencode' || !/(?:^|[\\/])opencode(?:\.(?:cmd|exe))?$/i.test(binary)) {
+    return [...prefixArgs, ...generatedArgs]
+  }
+  const runIndex = generatedArgs.indexOf('run')
+  if (runIndex === -1) {
+    return [...prefixArgs, ...generatedArgs]
+  }
+  return [
+    ...generatedArgs.slice(0, runIndex + 1),
+    ...prefixArgs,
+    ...generatedArgs.slice(runIndex + 1)
+  ]
+}
+
 export function planCommitMessageGeneration(
   input: CommitMessagePlanInput,
   prompt: string
@@ -251,7 +271,7 @@ export function planCommitMessageGeneration(
     ok: true,
     plan: {
       binary: command.binary,
-      args: [...command.prefixArgs, ...args],
+      args: mergePresetAgentCommandArgs(input.agentId, command.binary, command.prefixArgs, args),
       stdinPayload: spec.promptDelivery === 'stdin' ? prompt : null,
       label: spec.label
     }


### PR DESCRIPTION
## Summary

Fixes OpenCode AI commit-message generation when an `agentCmdOverrides` value includes launch flags, for example `opencode --auto`. Orca now produces `opencode run --auto ...` instead of `opencode --auto run ...`, which caused OpenCode to print global help and exit with code 1.

- Limits the reordering to direct OpenCode binaries: `opencode`, `opencode.cmd`, and `opencode.exe`.
- Leaves wrapper commands such as `npx opencode` unchanged.
- Adds regression coverage for POSIX and Windows executable names.

X: @coelhoxyz

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [ ] `pnpm typecheck` (fails before the changed files are analyzed: TypeScript 7 reports the unchanged root `tsconfig.json` `baseUrl` setting as deprecated.)
- [ ] `pnpm test` (8 existing failures outside this change; the targeted test passes.)
- [ ] `pnpm build` (desktop build completed; native macOS universal-binary packaging cannot find expected arm64/x86_64 artifacts and `lipo` exits 1.)
- [x] Added regression tests covering the direct POSIX, `.cmd`, and `.exe` OpenCode commands.

Additional validation:

- `pnpm vitest run src/shared/commit-message-plan.test.ts` (22 tests passed).
- `opencode run --auto --model opencode/gpt-5.4-mini --agent build --format default --help` (validated that the resulting command is parsed by `opencode run`).

## AI Review Report

Reviewed the focused diff for CLI token ordering and wrapper-command behavior, then checked cross-platform compatibility for macOS, Linux, and Windows. The review covered executable suffixes, path separators, and shell behavior. This remains a pure shared planner used by local, remote, and SSH generation paths; it adds no platform-specific I/O.

The review also checked supported-agent behavior, Electron/UI impact, and performance. Only the explicit `opencode` path changes; there are no renderer, shortcut, label, or Electron API changes. The added regex runs only while building a generation plan. No defects were found after adding Windows executable coverage.

## Security Audit

The change only reorders existing tokenized argv values. It introduces no shell execution, input interpolation, path resolution, auth, IPC, secret, or dependency changes. Existing command-override tokenization and validation remain in place. No follow-up is needed.

## Notes

- The direct OpenCode command was exercised on macOS. Windows behavior is covered at planner level for `.cmd` and `.exe`; no Windows runtime is available in this environment.
- X: @coelhoxyz