### PR TITLE
Prevent empty agent-launch fallback on automation dispatch

### DIFF
--- a/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.test.ts
@@ -293,6 +293,19 @@ describe('useAutomationDispatchEvents setup launch', () => {
     expect(mockLaunchAgentBackgroundSession).toHaveBeenCalled()
   })
 
+  it('does not stamp the created workspace with an empty agent-launch fallback', async () => {
+    await registerAndDispatch()
+
+    expect(mockCreateWorktree.mock.calls[0][10]).toBeUndefined()
+    expect(mockLaunchAgentBackgroundSession).toHaveBeenCalledWith(
+      expect.objectContaining({
+        agent: 'claude',
+        prompt: 'run this',
+        worktreeId: 'wt-created'
+      })
+    )
+  })
+
   it('keeps launching the agent when background setup terminal launch fails', async () => {
     const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => undefined)
     mockLaunchWorktreeBackgroundTerminals.mockRejectedValue(new Error('tab launch failed'))

--- a/src/renderer/src/hooks/useAutomationDispatchEvents.ts
+++ b/src/renderer/src/hooks/useAutomationDispatchEvents.ts
@@ -220,43 +220,43 @@ export function useAutomationDispatchEvents(): void {
           const automationWorkspaceCreateRequestId = createBrowserUuid()
           const createResult =
             automation.workspaceMode === 'new_per_run'
-              ? await useAppStore
-                  .getState()
-                  .createWorktree(
-                    runRepoId,
-                    buildAutomationWorkspaceName(run.title, run.scheduledFor),
-                    automation.baseBranch ?? undefined,
-                    automation.setupDecision ?? 'skip',
-                    undefined,
-                    'unknown',
-                    run.title,
-                    undefined,
-                    undefined,
-                    undefined,
-                    automation.agentId,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    undefined,
-                    {
-                      automationProvenanceRequest: {
-                        automationId: automation.id,
-                        automationRunId: run.id,
-                        dispatchToken,
-                        createRequestId: automationWorkspaceCreateRequestId
-                      }
+              ? await useAppStore.getState().createWorktree(
+                  runRepoId,
+                  buildAutomationWorkspaceName(run.title, run.scheduledFor),
+                  automation.baseBranch ?? undefined,
+                  automation.setupDecision ?? 'skip',
+                  undefined,
+                  'unknown',
+                  run.title,
+                  undefined,
+                  undefined,
+                  undefined,
+                  // Why: the automation session below owns the prompt-bearing
+                  // agent tab; createdWithAgent would reopen an empty fallback.
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  undefined,
+                  {
+                    automationProvenanceRequest: {
+                      automationId: automation.id,
+                      automationRunId: run.id,
+                      dispatchToken,
+                      createRequestId: automationWorkspaceCreateRequestId
                     }
-                  )
+                  }
+                )
               : null
           const worktree = createResult
             ? createResult.worktree


### PR DESCRIPTION
## Problem
When an automation is set to **new workspace every run**, creating that workspace was also labeled as “created with agent X.” That label could open an **extra blank agent tab** (agent open, no prompt / no task) next to the real automation agent that already carries the job prompt.

## Solution
When automation creates the new workspace, pass no “created with agent” label. The automation session still launches the real agent **with the prompt**; only the empty side-effect tab is avoided.

## Related
No dedicated GitHub issue was found for this exact automation empty-tab path. Closest lineage:

- **Earlier fix (activation):** #10647 — *Stop relaunching creation-time agents on workspace activation*
- **Issue that motivated that fix:** #10578 — *Let workspaces opt out of relaunching the agent they were created with* (closed by #10647)

This PR is a follow-up on the **automation create** path: stop stamping `createdWithAgent` when the job already owns the prompt-bearing agent, so we don’t invite the same empty-agent pattern at create time.

## Summary
- Automation `new_per_run` workspace create: do not set `createdWithAgent`
- Still launch the automation agent with the real prompt
- Regression test: create arg is undefined; background launch still gets agent + prompt

## Screenshots
No UI redesign. User-visible effect only: fewer empty agent tabs when “new workspace every run” automations fire.

## Testing
- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added test: `does not stamp the created workspace with an empty agent-launch fallback` verifies the create parameter is undefined and the agent launch is called with correct parameters.

## Notes
- Affects renderer automation dispatch (`useAutomationDispatchEvents`) only.
- Headless create that stamps + starts with prompt in one step is out of scope.
- Manual “create workspace with agent” is unchanged.