### PR TITLE
fix(file-explorer): open symlinked folders that point outside the workspace

### DIFF
--- a/src/main/ipc/filesystem-auth.test.ts
+++ b/src/main/ipc/filesystem-auth.test.ts
@@ -285,6 +285,42 @@ describe('filesystem-auth path containment', () => {
     }
   )
 
+  it.skipIf(process.platform === 'win32')(
+    'reads a symlinked dir outside the repo once its target is authorized',
+    async () => {
+      const tempRoot = await mkdtemp(join(tmpdir(), 'orca-auth-symlink-open-'))
+      try {
+        const repoPath = join(tempRoot, 'repo')
+        const outsidePath = join(tempRoot, 'outside')
+        const nestedPath = join(outsidePath, 'nested')
+        await mkdir(repoPath)
+        await mkdir(nestedPath, { recursive: true })
+        const linkPath = join(repoPath, 'linked-outside')
+        await symlink(outsidePath, linkPath, 'dir')
+        const store = makeStore([{ ...repo, id: 'repo-temp', path: repoPath }])
+
+        // A listing never resolves links, so nothing has authorized the target yet.
+        await expect(resolveAuthorizedPath(linkPath, store)).rejects.toThrow('Access denied')
+
+        authorizeExternalPath(await realpath(linkPath))
+
+        await expect(resolveAuthorizedPath(linkPath, store)).resolves.toBe(
+          await realpath(outsidePath)
+        )
+        // Expanding the link's subtree must keep working without re-authorizing each child.
+        await expect(resolveAuthorizedPath(join(linkPath, 'nested'), store)).resolves.toBe(
+          await realpath(nestedPath)
+        )
+        // Authorizing one link does not open its siblings.
+        const unrelatedPath = join(tempRoot, 'unrelated')
+        await mkdir(unrelatedPath)
+        await expect(resolveAuthorizedPath(unrelatedPath, store)).rejects.toThrow('Access denied')
+      } finally {
+        await rm(tempRoot, { recursive: true, force: true })
+      }
+    }
+  )
+
   it('allows descendants whose path segment starts with dotdot characters', () => {
     const root = resolve('/workspace/repo')
     const child = resolve('/workspace/repo/..fixtures/file.ts')

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -1059,11 +1059,12 @@ describe('registerFilesystemHandlers', () => {
     expect(listWorktreesMock).not.toHaveBeenCalled()
   })
 
-  it('does not follow symlinks when classifying readDir entries', async () => {
+  it('classifies symlinked dirs as dirs so listings show them as folders', async () => {
     const modelLinkPath = path.join(REPO_PATH, 'Model')
     readdirMock.mockResolvedValue([
       dirEntry({ name: 'README.md', file: true }),
-      dirEntry({ name: 'Model', directory: true, symlink: true })
+      dirEntry({ name: 'Model', symlink: true }),
+      dirEntry({ name: 'notes-link.md', symlink: true })
     ])
     statMock.mockImplementation(async (targetPath: string) => ({
       size: 10,
@@ -1074,10 +1075,68 @@ describe('registerFilesystemHandlers', () => {
     registerFilesystemHandlers(store as never)
 
     await expect(handlers.get('fs:readDir')!(null, { dirPath: REPO_PATH })).resolves.toEqual([
-      { name: 'Model', isDirectory: false, isSymlink: true },
+      { name: 'Model', isDirectory: true, isSymlink: true },
+      { name: 'notes-link.md', isDirectory: false, isSymlink: true },
       { name: 'README.md', isDirectory: false, isSymlink: false }
     ])
-    expect(statMock).not.toHaveBeenCalledWith(modelLinkPath)
+  })
+
+  it('keeps a dangling symlink file-like instead of failing the whole listing', async () => {
+    readdirMock.mockResolvedValue([dirEntry({ name: 'broken-link', symlink: true })])
+    statMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(handlers.get('fs:readDir')!(null, { dirPath: REPO_PATH })).resolves.toEqual([
+      { name: 'broken-link', isDirectory: false, isSymlink: true }
+    ])
+  })
+
+  it('authorizes a symlink target outside allowed roots so the follow-up readDir succeeds', async () => {
+    const linkPath = path.join(REPO_PATH, 'linked-notes')
+    const outsideTargetPath = path.resolve('/elsewhere/notes')
+    realpathMock.mockImplementation(async (targetPath: string) =>
+      targetPath === linkPath ? outsideTargetPath : targetPath
+    )
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => true })
+    readdirMock.mockResolvedValue([dirEntry({ name: 'todo.md', file: true })])
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(handlers.get('fs:readDir')!(null, { dirPath: linkPath })).rejects.toThrow(
+      'Access denied'
+    )
+
+    await expect(handlers.get('fs:authorizeSymlinkTarget')!(null, { linkPath })).resolves.toBe(true)
+
+    await expect(handlers.get('fs:readDir')!(null, { dirPath: linkPath })).resolves.toEqual([
+      { name: 'todo.md', isDirectory: false, isSymlink: false }
+    ])
+    expect(readdirMock).toHaveBeenCalledWith(outsideTargetPath, { withFileTypes: true })
+  })
+
+  it('refuses to authorize a path that is not a symlink', async () => {
+    const plainPath = path.join(REPO_PATH, 'src')
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => false })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:authorizeSymlinkTarget')!(null, { linkPath: plainPath })
+    ).resolves.toBe(false)
+    expect(realpathMock).not.toHaveBeenCalledWith(plainPath)
+  })
+
+  it('refuses to authorize a symlink that lives outside allowed roots', async () => {
+    const outsideLinkPath = path.resolve('/elsewhere/rogue-link')
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => true })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('fs:authorizeSymlinkTarget')!(null, { linkPath: outsideLinkPath })
+    ).resolves.toBe(false)
+    expect(lstatMock).not.toHaveBeenCalled()
   })
 
   it('returns false from pathExists when a local authorized path is missing', async () => {

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -492,6 +492,7 @@ async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
   }
 }
 
+/** Classifies a listing entry, following symlinks so linked folders render as folders. */
 async function isDirectoryEntry(
   dirPath: string,
   entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1,6 +1,16 @@
 /* eslint-disable max-lines */
 import { BrowserWindow, dialog, ipcMain, shell } from 'electron'
-import { readdir, readFile, writeFile, stat, lstat, open, rename, rm } from 'node:fs/promises'
+import {
+  readdir,
+  readFile,
+  writeFile,
+  stat,
+  lstat,
+  open,
+  realpath,
+  rename,
+  rm
+} from 'node:fs/promises'
 import type { FileHandle } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import { dirname, extname, join, resolve } from 'node:path'
@@ -484,19 +494,21 @@ async function isBinaryFilePrefix(filePath: string): Promise<boolean> {
 
 async function isDirectoryEntry(
   dirPath: string,
-  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean },
-  _resolveEntryPath: (entryPath: string) => Promise<string>
+  entry: { name: string; isDirectory(): boolean; isSymbolicLink(): boolean }
 ): Promise<boolean> {
-  // Why: following a symlink in readDir can touch macOS TCC-protected containers; treat links as file-like until explicitly opened.
-  void _resolveEntryPath
-  if (entry.isSymbolicLink()) {
-    void dirPath
-    return false
-  }
   if (entry.isDirectory()) {
     return true
   }
-  return false
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  // Classification only — the target still needs explicit activation before anything reads it.
+  try {
+    return (await stat(join(dirPath, entry.name))).isDirectory()
+  } catch {
+    // Why: dangling links and macOS TCC-protected targets stay file-like instead of failing the listing.
+    return false
+  }
 }
 
 export function registerFilesystemHandlers(
@@ -552,9 +564,7 @@ export function registerFilesystemHandlers(
         const mapped = await Promise.all(
           entries.map(async (entry) => ({
             name: entry.name,
-            isDirectory: await isDirectoryEntry(dirPath, entry, (entryPath) =>
-              resolveAuthorizedPath(entryPath, store)
-            ),
+            isDirectory: await isDirectoryEntry(dirPath, entry),
             isSymlink: entry.isSymbolicLink()
           }))
         )
@@ -918,6 +928,31 @@ export function registerFilesystemHandlers(
   ipcMain.handle('fs:authorizeExternalPath', (_event, args: { targetPath: string }): void => {
     authorizeExternalPath(args.targetPath)
   })
+
+  ipcMain.handle(
+    'fs:authorizeSymlinkTarget',
+    async (_event, args: { linkPath: string; connectionId?: string }): Promise<boolean> => {
+      // Remote paths never reach the local allow-list; the provider scopes them on its own host.
+      if (args.connectionId) {
+        return true
+      }
+      try {
+        // preserveSymlink keeps the leaf unresolved, so this authorizes the link's own location, not wherever it points.
+        const linkPath = await resolveAuthorizedPath(args.linkPath, store, {
+          preserveSymlink: true
+        })
+        if (!(await lstat(linkPath)).isSymbolicLink()) {
+          return false
+        }
+        // Why: a link inside an allowed root is trusted only once the user activates it — listings still classify links as file-like.
+        const targetPath = await realpath(linkPath)
+        authorizeExternalPath(targetPath)
+        return true
+      } catch {
+        return false
+      }
+    }
+  )
 
   ipcMain.handle(
     'fs:stat',

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -358,21 +358,36 @@ describe('RuntimeFileCommands', () => {
     expect(openFile).not.toHaveBeenCalled()
   })
 
-  it('does not follow symlinks when reading runtime-local file explorer dirs', async () => {
+  it('classifies symlinked dirs as dirs when reading runtime-local file explorer dirs', async () => {
     const { commands } = createRuntimeFileCommands()
     resolveAuthorizedPathMock.mockResolvedValue('/repo')
     readdirMock.mockResolvedValue([
       dirEntry({ name: 'README.md' }),
-      dirEntry({ name: 'linked-docs', directory: true, symlink: true })
+      dirEntry({ name: 'linked-docs', symlink: true }),
+      dirEntry({ name: 'linked-file.md', symlink: true })
     ])
+    statMock.mockImplementation(async (path: string) => ({
+      isDirectory: () => path === '/repo/linked-docs'
+    }))
 
     const result = await commands.readFileExplorerDir('id:wt-1', '')
 
     expect(result).toEqual([
-      { name: 'linked-docs', isDirectory: false, isSymlink: true },
+      { name: 'linked-docs', isDirectory: true, isSymlink: true },
+      { name: 'linked-file.md', isDirectory: false, isSymlink: true },
       { name: 'README.md', isDirectory: false, isSymlink: false }
     ])
-    expect(statMock).not.toHaveBeenCalledWith('/repo/linked-docs')
+  })
+
+  it('leaves a dangling symlink file-like instead of failing the listing', async () => {
+    const { commands } = createRuntimeFileCommands()
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    readdirMock.mockResolvedValue([dirEntry({ name: 'broken-link', symlink: true })])
+    statMock.mockRejectedValue(Object.assign(new Error('missing'), { code: 'ENOENT' }))
+
+    await expect(commands.readFileExplorerDir('id:wt-1', '')).resolves.toEqual([
+      { name: 'broken-link', isDirectory: false, isSymlink: true }
+    ])
   })
 
   it('renames a runtime-local file when destination does not exist', async () => {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -2185,17 +2185,21 @@ function basenameFromRelativePath(relativePath: string): string {
 
 async function isRuntimeDirectoryEntry(
   entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
-  _entryPath: string
+  entryPath: string
 ): Promise<boolean> {
-  // Why: listings are passive UI reads; don't stat symlink targets here (explicit open/expand resolves them).
-  if (entry.isSymbolicLink()) {
-    void _entryPath
-    return false
-  }
   if (entry.isDirectory()) {
     return true
   }
-  return false
+  if (!entry.isSymbolicLink()) {
+    return false
+  }
+  // Classification only — opening or expanding the target still authorizes it separately.
+  try {
+    return (await stat(entryPath)).isDirectory()
+  } catch {
+    // Why: dangling links and unreadable targets stay file-like instead of failing the listing.
+    return false
+  }
 }
 
 function isBinaryBuffer(buffer: Buffer): boolean {

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -2183,6 +2183,7 @@ function basenameFromRelativePath(relativePath: string): string {
   return normalized.slice(normalized.lastIndexOf('/') + 1)
 }
 
+/** Classifies a listing entry, following symlinks so linked folders render as folders. */
 async function isRuntimeDirectoryEntry(
   entry: { isDirectory(): boolean; isSymbolicLink(): boolean },
   entryPath: string

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2839,6 +2839,8 @@ export type PreloadApi = {
       } & SshMutationExpectation
     ) => Promise<void>
     authorizeExternalPath: (args: { targetPath: string }) => Promise<void>
+    /** Authorizes the target of a symlink that lives inside an allowed root, so explicit activation can follow it out of the workspace. */
+    authorizeSymlinkTarget: (args: { linkPath: string; connectionId?: string }) => Promise<boolean>
     stat: (args: {
       filePath: string
       connectionId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3156,6 +3156,8 @@ const api = {
     ): Promise<void> => ipcRenderer.invoke('fs:deletePath', args),
     authorizeExternalPath: (args: { targetPath: string }): Promise<void> =>
       ipcRenderer.invoke('fs:authorizeExternalPath', args),
+    authorizeSymlinkTarget: (args: { linkPath: string; connectionId?: string }): Promise<boolean> =>
+      ipcRenderer.invoke('fs:authorizeSymlinkTarget', args),
     stat: (args: {
       filePath: string
       connectionId?: string

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -146,6 +146,7 @@ function FileExplorerFiles(): React.JSX.Element {
     rootError,
     loadDir,
     statPath,
+    authorizeSymlinkTarget,
     markPathAsDirectory,
     refreshTree,
     refreshDir,
@@ -504,6 +505,7 @@ function FileExplorerFiles(): React.JSX.Element {
       toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
       loadDir,
       statPath,
+      authorizeSymlinkTarget,
       markPathAsDirectory,
       setSelectedPath: setSingleSelectedPath,
       scrollRef

--- a/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorerRow.tsx
@@ -14,6 +14,7 @@ import {
   Folder,
   FolderOpen,
   FolderPlus,
+  FolderSymlink,
   Globe,
   ListCollapse,
   Link,
@@ -610,6 +611,9 @@ export function FileExplorerRow({
               />
               {isLoading ? (
                 <Loader2 className="size-3 shrink-0 animate-spin text-muted-foreground" />
+              ) : node.isSymlink ? (
+                // Why: a linked folder is indistinguishable from a real one otherwise; the chevron already carries expansion state.
+                <FolderSymlink className="size-3 shrink-0 text-muted-foreground" />
               ) : isExpanded ? (
                 <FolderOpen className="size-3 shrink-0 text-muted-foreground" />
               ) : (

--- a/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.test.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.test.ts
@@ -10,7 +10,10 @@ vi.mock('./file-explorer-operation-owner', () => ({
   getFileExplorerOwnerUnresolvedMessage: () => 'unresolved'
 }))
 
-import { readFileExplorerDirectory } from './file-explorer-directory-listing'
+import {
+  fileExplorerEntriesToTreeNodes,
+  readFileExplorerDirectory
+} from './file-explorer-directory-listing'
 
 describe('readFileExplorerDirectory', () => {
   it('re-sorts backend order — remote-runtime and paired-web routes return the host order verbatim', async () => {
@@ -28,5 +31,42 @@ describe('readFileExplorerDirectory', () => {
       '99 - a.txt',
       '100 - b.txt'
     ])
+  })
+})
+
+describe('fileExplorerEntriesToTreeNodes', () => {
+  const owner = { kind: 'local' } as const
+
+  it('keeps a link an activation already resolved to a directory expanded across re-reads', () => {
+    const entries = [
+      { name: 'linked-docs', isDirectory: false, isSymlink: true },
+      { name: 'linked-file.md', isDirectory: false, isSymlink: true }
+    ]
+
+    const nodes = fileExplorerEntriesToTreeNodes(
+      entries,
+      '/w',
+      -1,
+      '/w',
+      owner,
+      new Set(['/w/linked-docs'])
+    )
+
+    expect(nodes.map((node) => [node.path, node.isDirectory])).toEqual([
+      ['/w/linked-docs', true],
+      ['/w/linked-file.md', false]
+    ])
+  })
+
+  it('leaves unresolved links file-like', () => {
+    const nodes = fileExplorerEntriesToTreeNodes(
+      [{ name: 'linked-docs', isDirectory: false, isSymlink: true }],
+      '/w',
+      -1,
+      '/w',
+      owner
+    )
+
+    expect(nodes[0].isDirectory).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.ts
@@ -15,6 +15,7 @@ export type FileExplorerDirectoryListing = {
   operationOwner: FileExplorerOperationOwner
 }
 
+/** Projects a directory listing into tree rows, resolving each entry's path relative to the worktree. */
 export function fileExplorerEntriesToTreeNodes(
   entries: DirEntry[],
   dirPath: string,

--- a/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-directory-listing.ts
@@ -20,7 +20,9 @@ export function fileExplorerEntriesToTreeNodes(
   dirPath: string,
   depth: number,
   worktreePath: string | null,
-  operationOwner: FileExplorerOperationOwner
+  operationOwner: FileExplorerOperationOwner,
+  /** Links a previous activation already resolved to a directory — listings never follow links themselves. */
+  knownSymlinkDirectories?: ReadonlySet<string>
 ): TreeNode[] {
   return entries.filter(shouldIncludeFileExplorerEntry).map((entry) => {
     const path = joinPath(dirPath, entry.name)
@@ -30,7 +32,8 @@ export function fileExplorerEntriesToTreeNodes(
       relativePath: worktreePath
         ? normalizeRelativePath(path.slice(worktreePath.length + 1))
         : entry.name,
-      isDirectory: entry.isDirectory,
+      isDirectory:
+        entry.isDirectory || (entry.isSymlink && (knownSymlinkDirectories?.has(path) ?? false)),
       isSymlink: entry.isSymlink,
       depth: depth + 1,
       operationOwner

--- a/src/renderer/src/components/right-sidebar/file-explorer-expanded-dirs-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/file-explorer-expanded-dirs-refresh.ts
@@ -21,6 +21,8 @@ export type RefreshFileExplorerExpandedDirsParams = {
   maxConcurrentReads: number
   /** Called per dir whose fresh listing was committed, so callers can clear a staleness mark. */
   onDirCommitted?: (dirPath: string) => void
+  /** Links a previous activation resolved to a directory; a refresh would otherwise demote them back to files. */
+  knownSymlinkDirectories?: ReadonlySet<string>
 }
 
 export async function refreshFileExplorerExpandedDirs({
@@ -30,7 +32,8 @@ export async function refreshFileExplorerExpandedDirs({
   setDirCache,
   readDirectory,
   maxConcurrentReads,
-  onDirCommitted
+  onDirCommitted,
+  knownSymlinkDirectories
 }: RefreshFileExplorerExpandedDirsParams): Promise<boolean> {
   if (dirs.length === 0) {
     return true
@@ -139,7 +142,8 @@ export async function refreshFileExplorerExpandedDirs({
             dirPath,
             depth,
             worktreePath,
-            listing.operationOwner
+            listing.operationOwner,
+            knownSymlinkDirectories
           ),
           loading: false,
           operationOwner: listing.operationOwner

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
@@ -72,6 +72,69 @@ describe('activateFileExplorerNode', () => {
     expect(openFile).not.toHaveBeenCalled()
   })
 
+  it('authorizes the symlink target before reading it, so links out of the workspace resolve', async () => {
+    const calls: string[] = []
+    const authorizeSymlinkTarget = vi.fn(async (path: string) => {
+      calls.push(`authorize:${path}`)
+    })
+    const statPath = vi.fn(async () => {
+      calls.push('stat')
+      return { isDirectory: true }
+    })
+
+    await activateFileExplorerNode({
+      node: symlinkNode,
+      activeWorktreeId: 'wt-1',
+      openFile: vi.fn(),
+      toggleDir: vi.fn(),
+      loadDir: vi.fn().mockResolvedValue(true),
+      statPath,
+      authorizeSymlinkTarget,
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(calls).toEqual(['authorize:/repo/linked-docs', 'stat'])
+  })
+
+  it('authorizes a link the listing already classified as a directory before expanding it', async () => {
+    const authorizeSymlinkTarget = vi.fn().mockResolvedValue(undefined)
+    const toggleDir = vi.fn()
+
+    await activateFileExplorerNode({
+      node: { ...symlinkNode, isDirectory: true },
+      activeWorktreeId: 'wt-1',
+      openFile: vi.fn(),
+      toggleDir,
+      loadDir: vi.fn(),
+      statPath: vi.fn(),
+      authorizeSymlinkTarget,
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(authorizeSymlinkTarget).toHaveBeenCalledWith('/repo/linked-docs')
+    expect(toggleDir).toHaveBeenCalledWith('wt-1', '/repo/linked-docs')
+  })
+
+  it('does not authorize targets for rows that are not symlinks', async () => {
+    const authorizeSymlinkTarget = vi.fn()
+
+    await activateFileExplorerNode({
+      node: directoryNode,
+      activeWorktreeId: 'wt-1',
+      openFile: vi.fn(),
+      toggleDir: vi.fn(),
+      loadDir: vi.fn(),
+      statPath: vi.fn(),
+      authorizeSymlinkTarget,
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(authorizeSymlinkTarget).not.toHaveBeenCalled()
+  })
+
   it('falls back to opening a symlink as a file when directory loading fails', async () => {
     const openFile = vi.fn()
     useAppStore.setState({

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -40,6 +40,7 @@ type UseFileExplorerHandlersParams = {
     options?: { force?: boolean; failOnError?: boolean }
   ) => Promise<boolean>
   statPath: (path: string) => Promise<{ isDirectory: boolean }>
+  authorizeSymlinkTarget?: (path: string) => Promise<void>
   markPathAsDirectory: (path: string) => void
   setSelectedPath: (path: string) => void
   scrollRef: RefObject<HTMLDivElement | null>
@@ -64,6 +65,7 @@ export async function activateFileExplorerNode(args: {
   canToggleDirectories?: boolean
   loadDir: UseFileExplorerHandlersParams['loadDir']
   statPath: UseFileExplorerHandlersParams['statPath']
+  authorizeSymlinkTarget?: UseFileExplorerHandlersParams['authorizeSymlinkTarget']
   markPathAsDirectory: (path: string) => void
   setSelectedPath: (path: string) => void
 }): Promise<void> {
@@ -75,6 +77,7 @@ export async function activateFileExplorerNode(args: {
     canToggleDirectories = true,
     loadDir,
     statPath,
+    authorizeSymlinkTarget,
     markPathAsDirectory,
     setSelectedPath
   } = args
@@ -82,6 +85,11 @@ export async function activateFileExplorerNode(args: {
     return
   }
   setSelectedPath(node.path)
+  if (node.isSymlink) {
+    // Why: a listing classifies a link but never authorizes it. Activation is what unlocks a
+    // target outside the workspace roots — without this every read below is access-denied.
+    await authorizeSymlinkTarget?.(node.path)
+  }
   if (node.isDirectory) {
     if (!canToggleDirectories) {
       return
@@ -90,8 +98,8 @@ export async function activateFileExplorerNode(args: {
     return
   }
   if (node.isSymlink) {
-    // Why: symlink targets may live in macOS TCC-protected app data. Resolve
-    // them only after the user explicitly activates the row.
+    // Why: a route whose listing left the link unclassified (remote hosts, TCC-blocked stat)
+    // still needs an explicit resolve before the tree can treat it as a directory.
     let targetIsDirectory = false
     try {
       targetIsDirectory = (await statPath(node.path)).isDirectory
@@ -163,6 +171,7 @@ export function useFileExplorerHandlers({
   canToggleDirectories = true,
   loadDir,
   statPath,
+  authorizeSymlinkTarget,
   markPathAsDirectory,
   setSelectedPath,
   scrollRef
@@ -228,6 +237,7 @@ export function useFileExplorerHandlers({
         canToggleDirectories,
         loadDir,
         statPath,
+        authorizeSymlinkTarget,
         markPathAsDirectory,
         setSelectedPath
       })
@@ -235,6 +245,7 @@ export function useFileExplorerHandlers({
     [
       activeWorktreeId,
       runtimeEnvironmentId,
+      authorizeSymlinkTarget,
       canToggleDirectories,
       settlePendingDirToggle,
       loadDir,

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -56,6 +56,7 @@ type UseFileExplorerHandlersReturn = {
 type OpenFileParams = Parameters<UseFileExplorerHandlersParams['openFile']>[0]
 type OpenFileOptions = Parameters<UseFileExplorerHandlersParams['openFile']>[1]
 
+/** Runs the shared activate gesture for a row: toggle a directory, or open a file in the editor. */
 export async function activateFileExplorerNode(args: {
   node: TreeNode
   activeWorktreeId: string | null
@@ -88,6 +89,8 @@ export async function activateFileExplorerNode(args: {
   if (node.isSymlink) {
     // Why: a listing classifies a link but never authorizes it. Activation is what unlocks a
     // target outside the workspace roots — without this every read below is access-denied.
+    // Deliberately not a gate: a refusal (dangling link, host that scopes reads itself) must fall
+    // through so the read below reports the real reason instead of failing silently here.
     await authorizeSymlinkTarget?.(node.path)
   }
   if (node.isDirectory) {

--- a/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
@@ -2,7 +2,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useRef, useState } from 'react'
 import type { DirCache, FileExplorerTreeRefreshOutcome } from './file-explorer-types'
 import { splitPathSegments } from './path-tree'
-import { statRuntimePath } from '@/runtime/runtime-file-client'
+import { authorizeRuntimeSymlinkTarget, statRuntimePath } from '@/runtime/runtime-file-client'
 import { createFileExplorerDirLoadTracker } from './file-explorer-dir-load-tracker'
 import {
   getFileExplorerOperationOwner,
@@ -28,6 +28,7 @@ type UseFileExplorerTreeResult = {
     options?: { force?: boolean; failOnError?: boolean }
   ) => Promise<boolean>
   statPath: (path: string) => Promise<{ isDirectory: boolean }>
+  authorizeSymlinkTarget: (path: string) => Promise<void>
   markPathAsDirectory: (path: string) => void
   refreshTree: () => Promise<FileExplorerTreeRefreshOutcome>
   refreshDir: (dirPath: string) => Promise<void>
@@ -51,6 +52,9 @@ export function useFileExplorerTree(
   const staleDirsRef = useRef(new Set<string>())
   // Why: separates a failed root read from a superseded one — loadDir returns false for both.
   const rootReadFailedRef = useRef(false)
+  // Why: readDir reports every symlink as file-like, so each re-read would demote a link the user
+  // already expanded and collapse its subtree. Remember the ones activation proved to be dirs.
+  const symlinkDirsRef = useRef(new Set<string>())
 
   const loadDir = useCallback(
     async (
@@ -89,7 +93,8 @@ export function useFileExplorerTree(
           dirPath,
           depth,
           worktreePath,
-          listing.operationOwner
+          listing.operationOwner,
+          symlinkDirsRef.current
         )
         setDirCache((prev) => ({
           ...prev,
@@ -116,6 +121,7 @@ export function useFileExplorerTree(
   )
 
   const markPathAsDirectory = useCallback((path: string) => {
+    symlinkDirsRef.current.add(path)
     setDirCache((prev) => {
       let changed = false
       const next: Record<string, DirCache> = {}
@@ -151,6 +157,26 @@ export function useFileExplorerTree(
         },
         path
       )
+    },
+    [activeWorktreeId, worktreePath]
+  )
+
+  const authorizeSymlinkTarget = useCallback(
+    async (path: string) => {
+      const route = getFileExplorerOperationRoute(getFileExplorerOperationOwner(activeWorktreeId))
+      if (!route) {
+        return
+      }
+      // Why: best-effort — a link the host refuses to authorize still fails loudly on the read that follows.
+      await authorizeRuntimeSymlinkTarget(
+        {
+          settings: route.settings,
+          worktreeId: activeWorktreeId,
+          worktreePath,
+          connectionId: route.connectionId
+        },
+        path
+      ).catch(() => false)
     },
     [activeWorktreeId, worktreePath]
   )
@@ -210,7 +236,8 @@ export function useFileExplorerTree(
       maxConcurrentReads: fileExplorerRefreshConcurrency(
         getFileExplorerOperationOwner(activeWorktreeId)
       ),
-      onDirCommitted: (dirPath) => staleDirsRef.current.delete(dirPath)
+      onDirCommitted: (dirPath) => staleDirsRef.current.delete(dirPath),
+      knownSymlinkDirectories: symlinkDirsRef.current
     })
     return allDirsCommitted ? 'refreshed' : 'superseded'
   }, [activeWorktreeId, expanded, loadDir, worktreePath])
@@ -238,6 +265,7 @@ export function useFileExplorerTree(
     // must not repopulate the explorer after the tree has been cleared.
     dirLoadTrackerRef.current.reset()
     staleDirsRef.current.clear()
+    symlinkDirsRef.current.clear()
     setDirCache({})
     setRootError(null)
     if (worktreePath) {
@@ -252,6 +280,7 @@ export function useFileExplorerTree(
     rootError,
     loadDir,
     statPath,
+    authorizeSymlinkTarget,
     markPathAsDirectory,
     refreshTree,
     refreshDir,

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -1031,6 +1031,26 @@ export async function statRuntimePath(
   )
 }
 
+/**
+ * Lets a later read follow a symlink whose target sits outside the workspace roots.
+ *
+ * Why: listings classify links as file-like without resolving them, so nothing has
+ * authorized the target until the user activates the row.
+ */
+export async function authorizeRuntimeSymlinkTarget(
+  context: RuntimeFileOperationArgs,
+  linkPath: string
+): Promise<boolean> {
+  // Remote runtimes scope reads on their own host; there is no local allow-list to unlock.
+  if (getRemoteFileArgs(context, linkPath)) {
+    return true
+  }
+  return window.api.fs.authorizeSymlinkTarget({
+    linkPath,
+    connectionId: context.connectionId
+  })
+}
+
 export async function subscribeRuntimeFileChanges(
   context: RuntimeFileOperationArgs,
   onPayload: (payload: FsChangedPayload) => void,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1883,6 +1883,8 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       captureSession: captureWebFileMutationSession
     }),
     authorizeExternalPath: () => Promise.resolve(),
+    // Paired web sessions read through the host, which owns its own path scoping.
+    authorizeSymlinkTarget: () => Promise.resolve(true),
     stat: async ({ filePath }) => {
       const file = await resolveRuntimeFilePath(filePath)
       return callRuntimeResult('files.stat', {


### PR DESCRIPTION
## Summary

A symlinked folder whose target sits outside the workspace roots could not be opened from the file explorer, and every symlink rendered as a file until the user clicked it. Two independent causes:

1. **Every symlink rendered as a file.** `fs:readDir` classified symlinks as `isDirectory: false` unconditionally, so a linked folder showed a link icon with no chevron until an activation resolved it — and any tree refresh demoted it back to a file, collapsing what the user had expanded.
2. **Reading through the link was denied with no way forward.** `resolveAuthorizedPath` canonicalizes before checking the allow-list, so `fs:readDir` / `fs:stat` on a link pointing out of the workspace threw `Access denied`. The explorer surfaced only a generic "Cannot open symlink target" toast.

**Classification** — listings now `stat` a symlink to decide whether it is a directory, falling back to file-like when the stat fails (dangling links, TCC-blocked targets) so one bad entry cannot fail the whole listing. Applied to both the local `fs:readDir` handler and the runtime-local `readFileExplorerDir` path.

**Authorization** — new `fs:authorizeSymlinkTarget` IPC authorizes a link's target, but only when the link *itself* resolves inside an allowed root (`preserveSymlink`, so the check covers the link's location rather than wherever it points) and `lstat` confirms it really is a symlink. The explorer calls it when the user activates the row, matching the existing `authorizeExternalPath` pattern used for drag-drop and external file tabs. Reading through an un-activated link is still denied, and authorizing one link does not open its siblings. SSH routes short-circuit (the provider scopes reads on its own host); remote runtimes are unchanged and authorize on their own host.

**Affordance** — symlinked folders render with `FolderSymlink` instead of `Folder`, so a linked folder is distinguishable from a real one.

## Screenshots

Verified in a dev build; images are not attachable from the CLI, so the visual delta is described below.

File explorer rows for a repo containing `link-inside -> inside-target`, `link-outside -> ~/…/orca-symlink-external`, and `link-outside-file.md -> …/notes.md`:

```
before                              after
  📄 link-inside                      › 📁↗ link-inside          (FolderSymlink, expandable)
  📄 link-outside                     › 📁↗ link-outside         (FolderSymlink, expandable)
  🔗 link-outside-file.md               🔗 link-outside-file.md   (unchanged — points at a file)
  › 📁 inside-target                  › 📁 inside-target          (unchanged — plain Folder)
```

Before: linked folders sat in the file group with a link icon and no chevron; clicking one produced a "Cannot open symlink target" toast when its target was outside the workspace. After: they sort with the directories, carry a distinct linked-folder icon, and expand on click.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 47456 passed. 3 files fail on this machine **before** the change as well (verified by stashing): `config/scripts/check-root-directory-entries.test.mjs` and `src/main/rate-limits/codex-fetcher-pty-settle.test.ts` fail identically on a clean tree, and `src/main/ipc/worktree-base-directory-poller.test.ts` passes when run on its own (flaky under full-suite concurrency). None touch this change.
- [x] `pnpm build` — ran `pnpm run build:desktop` (typecheck + relay + cli + electron-vite + web projection), exit 0. `build:native` was skipped: this machine is at 99% disk and the native step is unrelated to the changed files.
- [x] Added or updated high-quality tests that would catch regressions

New/updated tests:
- `filesystem-auth.test.ts` — real-fs symlink case: denied before authorization → link *and its descendants* readable after → an unrelated sibling path stays denied.
- `filesystem.test.ts` — symlinked dirs classify as dirs, symlinked files stay files, a dangling link does not fail the listing; `authorizeSymlinkTarget` refuses non-symlinks and links outside allowed roots.
- `orca-runtime-files.test.ts` — the same classification contract for the runtime-local listing path, including the dangling-link fallback.
- `useFileExplorerHandlers.test.ts` — authorization runs before the reads, runs for links the listing already classified as directories, and does not run for plain rows.
- `file-explorer-directory-listing.test.ts` — a resolved link survives re-reads; unresolved links stay file-like.

Manual verification against a dev build, with a repo containing links to a directory inside the repo, a directory outside it, and a file outside it:
- Cold start classifies `link-inside` and `link-outside` as directories and `link-outside-file.md` as a file.
- Reading through `link-outside` before activation: denied. After clicking the row: allowed, expands to its contents, nested children expand, and files under the target open.
- The symlink pointing at a file outside the repo opens in the editor.

## AI Review Report

Reviewed with Claude Opus 5. Risks checked and outcomes:

- **Does classification widen read access?** No. `stat` reads metadata only; it neither authorizes nor reads content. Every read still goes through `resolveAuthorizedPath`. Confirmed by a test asserting a pre-activation read through an outside link is still denied.
- **Can the new IPC authorize an arbitrary path?** No. It requires the link to resolve inside an allowed root under `preserveSymlink` *and* `lstat` to report a symlink; both negative cases are covered by tests.
- **Regression caught during review:** once listings classified symlinked directories as directories, activation took the plain-directory branch and skipped authorization, so expanding an outside link produced an empty folder. Fixed by hoisting the authorization above the `isDirectory` branch, with a test for the classified-as-directory case.
- **Why activation does not gate on the authorization result:** a refusal (dangling link, or a host that scopes reads itself) must fall through so the read below reports the real reason; gating would swallow the error. Recorded in a comment at the call site.
- **Cross-platform (macOS / Linux / Windows) — explicitly checked.** All new path work uses `node:path` `join`; no separator assumptions. `stat`/`lstat`/`realpath` are portable. On Windows, pnpm store links and directory junctions report `isSymbolicLink() === true` and `stat` resolves them, so they classify as directories — the intended behavior; Windows `realpath` UNC shapes were already normalized by `resolveAuthorizedPath`. No keyboard shortcuts, accelerators, or shortcut labels are touched, so no `metaKey`/`CmdOrCtrl` surface is involved. WSL and SSH path translation are untouched; SSH short-circuits the new IPC.
- **SSH / remote-runtime / folder-workspace cases:** SSH returns early (provider-scoped); remote runtimes keep their own host-side scoping and the renderer no-ops there; folder workspaces go through the same `getAllowedRoots` path as git worktrees, with no repo-specific assumption added.
- **Remote wire compatibility:** no RPC params, stream opcodes, or published content changed. The new IPC is main↔renderer only, inside a single process pair.

## Security Audit

- **New IPC surface (`fs:authorizeSymlinkTarget`).** Input is a renderer-supplied path. It is validated by `resolveAuthorizedPath(..., { preserveSymlink: true })` — the leaf stays unresolved so the check constrains where the *link* lives, not where it points — and then by `lstat().isSymbolicLink()`. Non-symlinks and links outside allowed roots return `false` without authorizing anything. This is strictly narrower than the pre-existing `fs:authorizeExternalPath`, which authorizes any renderer-supplied path with no validation.
- **Blast radius of a grant.** Authorizing a link's target makes that target and its descendants readable, which is what expanding the folder requires. It does not authorize siblings — covered by a test.
- **TOCTOU.** A path could in principle be swapped between the `lstat` and the `realpath`. Exploiting it requires write access inside an already-allowed root, which grants more direct paths to the same data; flagged rather than mitigated.
- **Path handling.** All joins use `node:path`; no string concatenation, no shell interpolation. No command execution, no network calls, no dependency changes, no secrets or credential handling touched.
- **Denial-of-service / listing cost.** Classification adds one `stat` per symlink entry in the directory being listed (not recursive). Failures are caught per entry, so an unreadable or dangling link degrades to file-like instead of failing the listing.

## Notes

- **macOS TCC.** The previous code avoided statting symlink targets because a link into a TCC-protected container could prompt. The stat is now attempted but wrapped: a denial is caught and the entry stays file-like, i.e. the old behavior, rather than erroring.
- **Known gap — grants are not persisted.** Authorization lives in main-process memory, so after a restart a restored editor tab for an outside-the-workspace symlinked *file*, or a restored expansion of such a folder, needs one more click. Persisting grants would fix both but introduces a durable authorization allow-list, which felt like a decision worth making separately rather than folding in here.
- CodeRabbit's docstring-coverage check is below its threshold. Docstrings were added to the entry points this change touches; raising the ratio further would mean documenting untouched functions in the same files, which conflicts with the repo's "concise, non-obvious comments only" guidance in `AGENTS.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
