### PR TITLE
Cap AI Vault history depth to 250 for performance

### DIFF
--- a/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultPanel.tsx
@@ -49,6 +49,7 @@ import {
 import { usePersistedAiVaultViewOptions } from './use-persisted-ai-vault-view-options'
 import { AgentSessionContinuationDialog } from '@/components/agent-session-continuation/AgentSessionContinuationDialog'
 import { AiVaultScanIssueBanners } from './AiVaultScanIssueBanners'
+import { AiVaultSessionLimitNotice } from './AiVaultSessionLimitNotice'
 
 export default function AiVaultPanel(): React.JSX.Element {
   const activeWorktreeId = useActiveWorktreeId()
@@ -79,12 +80,14 @@ export default function AiVaultPanel(): React.JSX.Element {
     group,
     hideEmptySessions,
     sessionLimit,
+    sessionLimitNoticePending,
     setSort,
     setGroup,
     setHideEmptySessions,
     setSessionLimit,
     setAgentEnabled,
     setAllAgentsEnabled,
+    acknowledgeSessionLimitNotice,
     resetViewOptions
   } = usePersistedAiVaultViewOptions()
   const [collapsedGroups, setCollapsedGroups] = useState<Set<string>>(() => new Set())
@@ -335,6 +338,10 @@ export default function AiVaultPanel(): React.JSX.Element {
         onReset={resetViewOptions}
         onRefresh={() => void refresh({ force: true })}
       />
+
+      {sessionLimitNoticePending ? (
+        <AiVaultSessionLimitNotice onAcknowledge={acknowledgeSessionLimitNotice} />
+      ) : null}
 
       {error ? (
         <div className="border-b border-sidebar-border px-3 py-2 text-xs text-destructive">

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionLimitNotice.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionLimitNotice.test.tsx
@@ -1,0 +1,34 @@
+// @vitest-environment happy-dom
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AiVaultSessionLimitNotice } from './AiVaultSessionLimitNotice'
+
+afterEach(() => {
+  cleanup()
+})
+
+describe('AiVaultSessionLimitNotice', () => {
+  it('explains the performance reset and acknowledges on Got it', async () => {
+    const onAcknowledge = vi.fn()
+    render(<AiVaultSessionLimitNotice onAcknowledge={onAcknowledge} />)
+
+    const notice = screen.getByRole('status')
+    expect(notice.textContent).toContain('History depth is now 250')
+    expect(notice.textContent).toContain('for performance')
+
+    await userEvent.click(screen.getByRole('button', { name: 'Got it' }))
+    expect(onAcknowledge).toHaveBeenCalledTimes(1)
+  })
+
+  it('reflows the panel instead of floating over it', () => {
+    // Why: a floating card cannot clear this ~350px panel, so the notice must stay in
+    // flow — no portal, no fixed/absolute positioning that would cover the controls.
+    const { container } = render(<AiVaultSessionLimitNotice onAcknowledge={vi.fn()} />)
+
+    const notice = screen.getByRole('status')
+    expect(container.contains(notice)).toBe(true)
+    expect(notice.className).not.toMatch(/\b(fixed|absolute)\b/)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionLimitNotice.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionLimitNotice.tsx
@@ -1,0 +1,57 @@
+import { Gauge } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import { translate } from '@/i18n/i18n'
+import { DEFAULT_AI_VAULT_SESSION_LIMIT } from './ai-vault-session-limit'
+
+/**
+ * One-time banner for the forced history-depth reset, shown the first time the panel
+ * mounts after the update and pinned until acknowledged.
+ *
+ * Why inline instead of a popover on the view-options button: this panel is ~350px
+ * wide, so any floating card anchored inside it blankets the scope switch and search
+ * field no matter which side it takes. A banner reflows the panel instead of covering it.
+ */
+export function AiVaultSessionLimitNotice({
+  onAcknowledge
+}: {
+  onAcknowledge: () => void
+}): React.JSX.Element {
+  return (
+    <div
+      role="status"
+      className="shrink-0 border-b border-sidebar-border bg-sidebar-accent/40 px-3 py-2.5"
+    >
+      <div className="flex items-center gap-2">
+        <span
+          className="flex size-5 shrink-0 items-center justify-center rounded-full border border-border bg-secondary text-foreground"
+          aria-hidden="true"
+        >
+          <Gauge className="size-3" />
+        </span>
+        <div className="min-w-0 text-xs font-semibold leading-snug text-foreground">
+          {translate(
+            'auto.components.right.sidebar.AiVaultSessionLimitNotice.title',
+            'History depth is now {{value0}}',
+            { value0: String(DEFAULT_AI_VAULT_SESSION_LIMIT) }
+          )}
+        </div>
+      </div>
+      <p className="mt-1.5 text-[11px] leading-4 text-muted-foreground">
+        {translate(
+          'auto.components.right.sidebar.AiVaultSessionLimitNotice.body',
+          'We lowered your Agent Session History depth for performance — deeper histories slow the whole app, especially on remote hosts. Change it any time under View options → History depth.'
+        )}
+      </p>
+      <div className="mt-2 flex justify-end">
+        <Button
+          variant="secondary"
+          size="sm"
+          className="h-6 px-2 text-[11px]"
+          onClick={onAcknowledge}
+        >
+          {translate('auto.components.right.sidebar.AiVaultSessionLimitNotice.gotIt', 'Got it')}
+        </Button>
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-limit-reset.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-limit-reset.test.ts
@@ -1,0 +1,75 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+  createAppliedAiVaultSessionLimitReset,
+  hasCurrentAiVaultSessionLimitReset,
+  resolveAiVaultSessionLimitReset
+} from './ai-vault-session-limit-reset'
+
+describe('AI Vault session limit reset', () => {
+  it('pulls an upgraded profile back to the performance default and queues the notice', () => {
+    for (const sessionLimit of [500, 1000, 'unlimited'] as const) {
+      expect(resolveAiVaultSessionLimitReset({ sessionLimit })).toEqual({
+        sessionLimit: 250,
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+        sessionLimitNoticeAcknowledged: false
+      })
+    }
+  })
+
+  it('stays quiet for profiles already at the default', () => {
+    expect(resolveAiVaultSessionLimitReset({ sessionLimit: 250 })).toEqual({
+      sessionLimit: 250,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
+    })
+  })
+
+  it('keeps a deeper history the user re-picked after the reset already ran', () => {
+    expect(
+      resolveAiVaultSessionLimitReset({
+        sessionLimit: 1000,
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+        sessionLimitNoticeAcknowledged: true
+      })
+    ).toEqual({
+      sessionLimit: 1000,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
+    })
+  })
+
+  it('keeps the notice pending across reads until it is acknowledged', () => {
+    expect(
+      resolveAiVaultSessionLimitReset({
+        sessionLimit: 250,
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+        sessionLimitNoticeAcknowledged: false
+      }).sessionLimitNoticeAcknowledged
+    ).toBe(false)
+  })
+
+  it('treats malformed revisions and depths as never reset', () => {
+    expect(hasCurrentAiVaultSessionLimitReset({ sessionLimitResetRevision: 'yes' })).toBe(false)
+    expect(hasCurrentAiVaultSessionLimitReset({ sessionLimitResetRevision: 0 })).toBe(false)
+    expect(hasCurrentAiVaultSessionLimitReset(null)).toBe(false)
+    expect(
+      hasCurrentAiVaultSessionLimitReset({
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION + 1
+      })
+    ).toBe(true)
+    expect(resolveAiVaultSessionLimitReset({ sessionLimit: 42 })).toEqual({
+      sessionLimit: 250,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
+    })
+  })
+
+  it('marks fresh profiles as already reset so they see no notice', () => {
+    expect(createAppliedAiVaultSessionLimitReset()).toEqual({
+      sessionLimit: 250,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
+    })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-limit-reset.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-limit-reset.ts
@@ -1,0 +1,70 @@
+import {
+  AI_VAULT_SESSION_LIMITS,
+  DEFAULT_AI_VAULT_SESSION_LIMIT,
+  normalizeAiVaultSessionLimit,
+  type AiVaultSessionLimit
+} from './ai-vault-session-limit'
+
+// Bump when a new forced history-depth reset ships: every stored profile below this
+// revision is pulled back to the performance default once and told why.
+export const AI_VAULT_SESSION_LIMIT_RESET_REVISION = 1
+
+export type AiVaultSessionLimitResetState = {
+  sessionLimit: AiVaultSessionLimit
+  sessionLimitResetRevision: number
+  sessionLimitNoticeAcknowledged: boolean
+}
+
+type AiVaultSessionLimitResetRecord = {
+  sessionLimit?: unknown
+  sessionLimitResetRevision?: unknown
+  sessionLimitNoticeAcknowledged?: unknown
+}
+
+function appliedResetRevision(value: unknown): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? Math.floor(value) : 0
+}
+
+// Ordering lives in the option list, so a default change cannot desync this comparison.
+function exceedsPerformanceDefault(limit: AiVaultSessionLimit): boolean {
+  return (
+    AI_VAULT_SESSION_LIMITS.indexOf(limit) >
+    AI_VAULT_SESSION_LIMITS.indexOf(DEFAULT_AI_VAULT_SESSION_LIMIT)
+  )
+}
+
+export function hasCurrentAiVaultSessionLimitReset(value: unknown): boolean {
+  const record = value && typeof value === 'object' ? (value as AiVaultSessionLimitResetRecord) : {}
+  return (
+    appliedResetRevision(record.sessionLimitResetRevision) >= AI_VAULT_SESSION_LIMIT_RESET_REVISION
+  )
+}
+
+export function createAppliedAiVaultSessionLimitReset(): AiVaultSessionLimitResetState {
+  // Profiles that never stored a depth start at the default, so there is nothing to announce.
+  return {
+    sessionLimit: DEFAULT_AI_VAULT_SESSION_LIMIT,
+    sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+    sessionLimitNoticeAcknowledged: true
+  }
+}
+
+export function resolveAiVaultSessionLimitReset(
+  record: AiVaultSessionLimitResetRecord
+): AiVaultSessionLimitResetState {
+  const storedLimit = normalizeAiVaultSessionLimit(record.sessionLimit)
+  if (hasCurrentAiVaultSessionLimitReset(record)) {
+    return {
+      sessionLimit: storedLimit,
+      sessionLimitResetRevision: appliedResetRevision(record.sessionLimitResetRevision),
+      sessionLimitNoticeAcknowledged: record.sessionLimitNoticeAcknowledged === true
+    }
+  }
+  const reset = exceedsPerformanceDefault(storedLimit)
+  return {
+    sessionLimit: reset ? DEFAULT_AI_VAULT_SESSION_LIMIT : storedLimit,
+    sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+    // Why: nothing moved for profiles already at or below the default, so stay quiet.
+    sessionLimitNoticeAcknowledged: !reset
+  }
+}

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.test.ts
@@ -8,6 +8,7 @@ import {
   readAiVaultViewOptions,
   writeAiVaultViewOptions
 } from './ai-vault-view-options-persistence'
+import { AI_VAULT_SESSION_LIMIT_RESET_REVISION } from './ai-vault-session-limit-reset'
 
 afterEach(() => {
   vi.unstubAllGlobals()
@@ -34,7 +35,9 @@ describe('AI Vault view option persistence', () => {
       sort: 'updated',
       group: 'agent',
       hideEmptySessions: false,
-      sessionLimit: 250
+      sessionLimit: 250,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
     })
   })
 
@@ -52,7 +55,9 @@ describe('AI Vault view option persistence', () => {
       sort: 'updated',
       group: 'project',
       hideEmptySessions: false,
-      sessionLimit: 250
+      sessionLimit: 250,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
     })
     expect(
       normalizeAiVaultViewOptions({
@@ -60,19 +65,55 @@ describe('AI Vault view option persistence', () => {
         sort: 'created',
         group: 'folder',
         hideEmptySessions: true,
-        sessionLimit: 1000
+        sessionLimit: 1000,
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+        sessionLimitNoticeAcknowledged: true
       })
     ).toEqual({
       disabledAgents: [],
       sort: 'created',
       group: 'folder',
       hideEmptySessions: true,
-      sessionLimit: 1000
+      sessionLimit: 1000,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
     })
     expect(normalizeAiVaultViewOptions({ group: 'agent' }).group).toBe('agent')
-    expect(normalizeAiVaultViewOptions({ sessionLimit: 'unlimited' }).sessionLimit).toBe(
-      'unlimited'
+    expect(
+      normalizeAiVaultViewOptions({
+        sessionLimit: 'unlimited',
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+        sessionLimitNoticeAcknowledged: true
+      }).sessionLimit
+    ).toBe('unlimited')
+  })
+
+  it('resets a stored history depth above the default once and flags the notice', () => {
+    const stored = JSON.stringify({ sort: 'created', sessionLimit: 'unlimited' })
+    const storage = { getItem: vi.fn(() => stored), setItem: vi.fn() }
+
+    const options = readAiVaultViewOptions(storage)
+
+    expect(options.sessionLimit).toBe(250)
+    expect(options.sessionLimitNoticeAcknowledged).toBe(false)
+    expect(options.sort).toBe('created')
+    // The reset must land in storage immediately, or a later opt-back-up is clamped again.
+    expect(storage.setItem).toHaveBeenCalledWith(
+      AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify(options)
     )
+  })
+
+  it('leaves an already-reset profile untouched on read', () => {
+    const stored = JSON.stringify({
+      sessionLimit: 1000,
+      sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+      sessionLimitNoticeAcknowledged: true
+    })
+    const storage = { getItem: vi.fn(() => stored), setItem: vi.fn() }
+
+    expect(readAiVaultViewOptions(storage).sessionLimit).toBe(1000)
+    expect(storage.setItem).not.toHaveBeenCalled()
   })
 
   it('preserves a fully cleared agent selection', () => {
@@ -124,7 +165,9 @@ describe('AI Vault view option persistence', () => {
           sort: 'created',
           group: 'folder',
           hideEmptySessions: true,
-          sessionLimit: 500
+          sessionLimit: 500,
+          sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+          sessionLimitNoticeAcknowledged: true
         },
         storage
       )
@@ -136,7 +179,9 @@ describe('AI Vault view option persistence', () => {
         sort: 'created',
         group: 'folder',
         hideEmptySessions: true,
-        sessionLimit: 500
+        sessionLimit: 500,
+        sessionLimitResetRevision: AI_VAULT_SESSION_LIMIT_RESET_REVISION,
+        sessionLimitNoticeAcknowledged: true
       })
     )
   })

--- a/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-view-options-persistence.ts
@@ -9,11 +9,12 @@ import {
   DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
   DEFAULT_AI_VAULT_SORT
 } from './ai-vault-view-defaults'
+import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 import {
-  DEFAULT_AI_VAULT_SESSION_LIMIT,
-  normalizeAiVaultSessionLimit,
-  type AiVaultSessionLimit
-} from './ai-vault-session-limit'
+  createAppliedAiVaultSessionLimitReset,
+  hasCurrentAiVaultSessionLimitReset,
+  resolveAiVaultSessionLimitReset
+} from './ai-vault-session-limit-reset'
 
 export const AI_VAULT_VIEW_OPTIONS_STORAGE_KEY = 'orca.aiVault.viewOptions.v1'
 
@@ -23,6 +24,8 @@ export type AiVaultViewOptions = {
   group: AiVaultGroup
   hideEmptySessions: boolean
   sessionLimit: AiVaultSessionLimit
+  sessionLimitResetRevision: number
+  sessionLimitNoticeAcknowledged: boolean
 }
 
 type AiVaultViewOptionsStorage = {
@@ -36,7 +39,7 @@ export function createDefaultAiVaultViewOptions(): AiVaultViewOptions {
     sort: DEFAULT_AI_VAULT_SORT,
     group: DEFAULT_AI_VAULT_GROUP,
     hideEmptySessions: DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
-    sessionLimit: DEFAULT_AI_VAULT_SESSION_LIMIT
+    ...createAppliedAiVaultSessionLimitReset()
   }
 }
 
@@ -71,7 +74,7 @@ export function normalizeAiVaultViewOptions(value: unknown): AiVaultViewOptions 
       typeof record.hideEmptySessions === 'boolean'
         ? record.hideEmptySessions
         : DEFAULT_AI_VAULT_HIDE_EMPTY_SESSIONS,
-    sessionLimit: normalizeAiVaultSessionLimit(record.sessionLimit)
+    ...resolveAiVaultSessionLimitReset(record)
   }
 }
 
@@ -94,7 +97,17 @@ export function readAiVaultViewOptions(
   }
   try {
     const raw = storage.getItem(AI_VAULT_VIEW_OPTIONS_STORAGE_KEY)
-    return raw ? normalizeAiVaultViewOptions(JSON.parse(raw)) : createDefaultAiVaultViewOptions()
+    if (!raw) {
+      return createDefaultAiVaultViewOptions()
+    }
+    const stored: unknown = JSON.parse(raw)
+    const options = normalizeAiVaultViewOptions(stored)
+    // Why: persist the one-time reset on first read, otherwise a user who opts back
+    // up to a deeper history would be pulled down to the default again next launch.
+    if (!hasCurrentAiVaultSessionLimitReset(stored)) {
+      writeAiVaultViewOptions(options, storage)
+    }
+    return options
   } catch {
     return createDefaultAiVaultViewOptions()
   }

--- a/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.test.tsx
+++ b/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.test.tsx
@@ -74,6 +74,8 @@ describe('usePersistedAiVaultViewOptions', () => {
 
     expect(setItem).toHaveBeenCalled()
     expect(hook.result.current.sort).toBe('created')
+    // happy-dom proxies localStorage, so restoreAllMocks cannot unwind this spy.
+    setItem.mockRestore()
   })
 
   it('resets every persisted option to its default', () => {
@@ -100,5 +102,60 @@ describe('usePersistedAiVaultViewOptions', () => {
     expect(restored.result.current.group).toBe('project')
     expect(restored.result.current.hideEmptySessions).toBe(false)
     expect(restored.result.current.sessionLimit).toBe(250)
+  })
+
+  it('resets a pre-update history depth on first open and keeps the notice until acknowledged', () => {
+    window.localStorage.setItem(
+      AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify({ sort: 'created', sessionLimit: 'unlimited' })
+    )
+
+    const first = renderHook(() => usePersistedAiVaultViewOptions())
+    expect(first.result.current.sessionLimit).toBe(250)
+    expect(first.result.current.sessionLimitNoticePending).toBe(true)
+    first.unmount()
+
+    // Reopening the panel before acknowledging must re-show the notice, not swallow it.
+    const second = renderHook(() => usePersistedAiVaultViewOptions())
+    expect(second.result.current.sessionLimitNoticePending).toBe(true)
+    act(() => second.result.current.acknowledgeSessionLimitNotice())
+    expect(second.result.current.sessionLimitNoticePending).toBe(false)
+    second.unmount()
+
+    const third = renderHook(() => usePersistedAiVaultViewOptions())
+    expect(third.result.current.sessionLimitNoticePending).toBe(false)
+  })
+
+  it('keeps a deeper depth chosen after the reset instead of clamping it again', () => {
+    window.localStorage.setItem(
+      AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify({ sessionLimit: 1000 })
+    )
+
+    const first = renderHook(() => usePersistedAiVaultViewOptions())
+    act(() => {
+      first.result.current.acknowledgeSessionLimitNotice()
+      first.result.current.setSessionLimit(1000)
+    })
+    first.unmount()
+
+    const restored = renderHook(() => usePersistedAiVaultViewOptions())
+    expect(restored.result.current.sessionLimit).toBe(1000)
+    expect(restored.result.current.sessionLimitNoticePending).toBe(false)
+  })
+
+  it('does not re-open the notice when the view is reset', () => {
+    window.localStorage.setItem(
+      AI_VAULT_VIEW_OPTIONS_STORAGE_KEY,
+      JSON.stringify({ sessionLimit: 500 })
+    )
+
+    const hook = renderHook(() => usePersistedAiVaultViewOptions())
+    act(() => {
+      hook.result.current.acknowledgeSessionLimitNotice()
+      hook.result.current.resetViewOptions()
+    })
+
+    expect(hook.result.current.sessionLimitNoticePending).toBe(false)
   })
 })

--- a/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.ts
+++ b/src/renderer/src/components/right-sidebar/use-persisted-ai-vault-view-options.ts
@@ -22,12 +22,14 @@ export function usePersistedAiVaultViewOptions(): {
   group: AiVaultGroup
   hideEmptySessions: boolean
   sessionLimit: AiVaultSessionLimit
+  sessionLimitNoticePending: boolean
   setSort: (sort: AiVaultSort) => void
   setGroup: (group: AiVaultGroup) => void
   setHideEmptySessions: (hide: boolean) => void
   setSessionLimit: (limit: AiVaultSessionLimit) => void
   setAgentEnabled: (agent: AiVaultAgent, enabled: boolean) => void
   setAllAgentsEnabled: (enabled: boolean) => void
+  acknowledgeSessionLimitNotice: () => void
   resetViewOptions: () => void
 } {
   const [options, setOptions] = useState<AiVaultViewOptions>(() => readAiVaultViewOptions())
@@ -106,8 +108,24 @@ export function usePersistedAiVaultViewOptions(): {
     },
     [updateOptions]
   )
+  const acknowledgeSessionLimitNotice = useCallback(
+    () =>
+      updateOptions((current) =>
+        current.sessionLimitNoticeAcknowledged
+          ? current
+          : { ...current, sessionLimitNoticeAcknowledged: true }
+      ),
+    [updateOptions]
+  )
   const resetViewOptions = useCallback(
-    () => updateOptions(() => createDefaultAiVaultViewOptions()),
+    () =>
+      // Why: Reset view restores view preferences only — it must not replay the
+      // one-time depth reset or re-open a notice the user already acknowledged.
+      updateOptions((current) => ({
+        ...createDefaultAiVaultViewOptions(),
+        sessionLimitResetRevision: current.sessionLimitResetRevision,
+        sessionLimitNoticeAcknowledged: current.sessionLimitNoticeAcknowledged
+      })),
     [updateOptions]
   )
 
@@ -121,12 +139,14 @@ export function usePersistedAiVaultViewOptions(): {
     group: options.group,
     hideEmptySessions: options.hideEmptySessions,
     sessionLimit: options.sessionLimit,
+    sessionLimitNoticePending: !options.sessionLimitNoticeAcknowledged,
     setSort,
     setGroup,
     setHideEmptySessions,
     setSessionLimit,
     setAgentEnabled,
     setAllAgentsEnabled,
+    acknowledgeSessionLimitNotice,
     resetViewOptions
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11693,6 +11693,11 @@
             "mayBeSlower": "May be slower",
             "slowest": "Slowest",
             "unlimited": "Unlimited"
+          },
+          "AiVaultSessionLimitNotice": {
+            "title": "History depth is now {{value0}}",
+            "body": "We lowered your Agent Session History depth for performance — deeper histories slow the whole app, especially on remote hosts. Change it any time under View options → History depth.",
+            "gotIt": "Got it"
           }
         }
       },


### PR DESCRIPTION
## Problem

Deeper AI Vault histories slow the whole app, especially on remote hosts. Profiles that upgraded their history depth to 500, 1000, or unlimited can severely impact performance. We need to reset existing high-depth profiles back to a reasonable default while explaining the reason to users.

## Solution

Implement a one-time history depth reset:
- Cap default history depth at 250 for new installs
- Reset existing profiles with depth above 250 to 250 on first read
- Show an inline notice explaining the change, dismissible with "Got it"
- Users can freely choose a deeper history after acknowledging the notice
- Once acknowledged, the notice never reappears—even if the app restarts
- Resetting view options preserves the acknowledgment state to avoid replaying the notice

The notice renders inline in the panel (not floating) to avoid covering the scope and search controls.

## Screenshots

Added an inline banner in the AI Vault panel with a gauge icon, explaining the reset and offering a "Got it" button.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Tests cover:
- One-time reset logic and revision tracking
- Notice display and dismissal
- Behavior when users opt back up to deeper history after reset
- Persistence across app restarts
- Preservation of acknowledgment state during view reset

## AI Review Report

TODO

## Security Audit

TODO

## Notes

This is a one-time migration with a gating mechanism (`AI_VAULT_SESSION_LIMIT_RESET_REVISION`) to allow future resets if needed. The reset is applied during view-options read and persisted immediately.