### PR TITLE
fix(right-sidebar): use createBrowserUuid for cross-platform UUID generation

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
@@ -556,3 +556,31 @@ describe('useAiVaultSessionRefresh in-app agent session behavior', () => {
     expect(listSessionsMock).toHaveBeenCalledTimes(3)
   })
 })
+
+describe('useAiVaultSessionRefresh non-secure browser context', () => {
+  // Reproduces the LAN web-client crash: served over plain HTTP, the browser
+  // hides crypto.randomUUID (secure-context-only), and the old direct call
+  // threw "crypto.randomUUID is not a function" inside the AiVaultPanel render.
+  const realCrypto = globalThis.crypto
+
+  beforeEach(() => {
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) }
+    })
+  })
+
+  afterEach(() => {
+    Object.defineProperty(globalThis, 'crypto', { configurable: true, value: realCrypto })
+  })
+
+  it('renders and scans without crypto.randomUUID', async () => {
+    expect((globalThis.crypto as Crypto).randomUUID).toBeUndefined()
+
+    await renderHook(['/repo'], 'ssh:dev-box')
+    await flushMicrotasks()
+
+    expect(listSessionsMock).toHaveBeenCalledTimes(1)
+    expect(lastCallArgs()).toMatchObject({ executionHostScope: 'ssh:dev-box' })
+  })
+})

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -6,6 +6,7 @@ import {
 } from '../../../../shared/ai-vault-types'
 import type { ExecutionHostScope } from '../../../../shared/execution-host'
 import { useAppStore } from '@/store'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 import {
   aiVaultSessionResultCacheKey,
@@ -45,7 +46,7 @@ export function useAiVaultSessionRefresh(
   const [scanResult, setScanResult] = useState<AiVaultListResult | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const requestTokenRef = useRef(crypto.randomUUID())
+  const requestTokenRef = useRef(createBrowserUuid())
   const refreshIdRef = useRef(0)
   const refreshInFlightRef = useRef(false)
   const pendingRefreshRef = useRef(false)


### PR DESCRIPTION
## Summary

- Fixes a renderer crash in the AiVault panel when connecting to a remote Orca backend through a web browser served over plain HTTP (non-secure context). `crypto.randomUUID` is a [secure-context-only](https://developer.mozilla.org/en-US/docs/Web/API/Crypto/randomUUID) API — browsers hide it on LAN web clients over plain HTTP, so the direct call threw `TypeError: crypto.randomUUID is not a function` inside the `AiVaultPanel` render, caught by the error boundary.
- Replaced the direct `crypto.randomUUID()` call in `useAiVaultSessionRefresh` with the existing `createBrowserUuid()` helper (`src/renderer/src/lib/browser-uuid.ts`)
- Added a regression test that stubs `globalThis.crypto` to match a non-secure browser context (no `randomUUID`, only `getRandomValues`) and renders the hook — this reproduces the exact crash and now passes.

## Screenshots

No visual change — this is a crash fix only.

## Testing

- [ X ] `pnpm lint`
- [ X ] `pnpm typecheck`
- [ X ] `pnpm test`
- [ X ] `pnpm build`
- [ X ] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

## AI Review Report

- **Cross-platform compatibility**: The fix uses `createBrowserUuid()`, which is already the canonical cross-runtime UUID helper used by `worktree-creation-flow.ts` and `feedback-image-attachments.ts`. It works across Electron (has `crypto.randomUUID`), secure browsers (has `crypto.randomUUID`), and non-secure browsers (falls back to `getRandomValues` → `Math.random`). No platform-specific behavior introduced.
- **SSH/remote/local compatibility**: Directly fixes the remote web-client case (LAN over plain HTTP). The `requestToken` is a local UI correlation id passed to `window.api.aiVault.listSessions` — its format is not validated by the host, so a v4 UUID from the fallback path is equivalent to one from `crypto.randomUUID`.
- **Agent/integration compatibility**: No agent or integration-specific behavior touched. The AiVault panel lists agent sessions from any provider (Codex, Claude, etc.) and the token is provider-agnostic.
- **Performance risk**: None. `createBrowserUuid` runs once per hook mount (in `useRef` initializer), same as before. The fallback path is a single `getRandomValues` call.
- **UI quality**: No UI change. The panel that was crashing now renders.

## Security Audit

- **Security risk**: None. The `requestToken` is a local UI correlation id used to cancel superseded scans — not a credential or auth token. `Math.random` fallback is acceptable for this purpose (matches the existing `createBrowserUuid` contract and the comment in `browser-uuid.ts`).

## Notes

X (Twitter): [@kku1993](https://x.com/kku1993)

Generated with [Devin](https://devin.ai)