### PR TITLE
fix(dashboard): scale preview terminal font instead of CSS transform

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.test.tsx
@@ -92,7 +92,11 @@ vi.mock('@xterm/xterm', () => ({
       return { dispose: vi.fn() }
     })
 
-    constructor() {
+    // Real xterm exposes the live options bag (fontSize etc.); the fit path reads and writes it.
+    options: Record<string, unknown> = {}
+
+    constructor(options?: Record<string, unknown>) {
+      this.options = options ?? {}
       terminalHarness.instances.push(this)
     }
   }

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -22,6 +22,7 @@ import { cn } from '@/lib/utils'
 import { useAppStore } from '@/store'
 import { installPreviewTerminalKeyHandler } from './preview-terminal-key-handler'
 import { createPreviewGridClaim } from './preview-grid-claim'
+import { createPreviewFitScheduler } from './preview-terminal-fit'
 import type { TerminalPreviewDataPayload } from '../../../../shared/terminal-preview'
 
 const PREVIEW_SCROLLBACK_ROWS = 24
@@ -59,6 +60,9 @@ export function AgentTerminalPreview({
 }): React.JSX.Element {
   const containerRef = useRef<HTMLDivElement>(null)
   const terminalRef = useRef<Terminal | null>(null)
+  // Why: the appearance effect rewrites options.fontSize from settings, which
+  // clobbers the fit-scaled font; it re-runs the fit through this ref.
+  const scheduleFitRef = useRef<(() => void) | null>(null)
   const settings = useAppStore((state) => state.settings)
   const systemPrefersDark = useSystemPrefersDark()
   const macOptionAsAlt = useEffectiveMacOptionAsAlt(settings?.terminalMacOptionAsAlt)
@@ -113,36 +117,14 @@ export function AgentTerminalPreview({
     let retryTimer: ReturnType<typeof setTimeout> | null = null
     const pendingLivePayloads: Extract<TerminalPreviewDataPayload, { type: 'data' }>[] = []
 
-    const fitToBox = (): void => {
-      const screen = container.querySelector<HTMLElement>('.xterm-screen')
-      const box = container.parentElement
-      if (!screen || !box || !terminal) {
-        return
-      }
-      const scale = Math.min(1, box.clientWidth / Math.max(1, screen.offsetWidth))
-      container.style.transform = scale < 1 ? `scale(${scale})` : ''
-      // Anchor whichever end keeps the CURSOR row in view when the terminal is
-      // taller than the box: a fresh shell prompts at the TOP of its screen
-      // (blind bottom-anchoring clipped it away), while a busy TUI keeps its
-      // action at the bottom.
-      const cellHeight = screen.offsetHeight / Math.max(1, terminal.rows)
-      const cursorBottom = (terminal.buffer.active.cursorY + 1) * cellHeight * scale
-      const anchorTop = cursorBottom <= box.clientHeight
-      box.style.alignItems = anchorTop ? 'flex-start' : 'flex-end'
-      container.style.transformOrigin = anchorTop ? 'top left' : 'bottom left'
-    }
-    // Re-fit after every parsed write (cursor may move ends); rAF coalesces.
-    let fitScheduled = false
-    const scheduleFit = (): void => {
-      if (fitScheduled) {
-        return
-      }
-      fitScheduled = true
-      requestAnimationFrame(() => {
-        fitScheduled = false
-        fitToBox()
-      })
-    }
+    // Why font-scaling (see createPreviewFitScheduler): CSS-downscaling the
+    // rendered terminal resamples glyph bitmaps into visible smear.
+    const { scheduleFit } = createPreviewFitScheduler({
+      container,
+      getTerminal: () => terminal,
+      getBaseFontSize: () => settingsRef.current?.terminalFontSize ?? 14
+    })
+    scheduleFitRef.current = scheduleFit
 
     const gridClaim = createPreviewGridClaim({
       ptyId,
@@ -408,6 +390,7 @@ export function AgentTerminalPreview({
 
     return () => {
       disposed = true
+      scheduleFitRef.current = null
       if (retryTimer) {
         clearTimeout(retryTimer)
       }
@@ -438,6 +421,8 @@ export function AgentTerminalPreview({
       buildPreviewAppearanceOptions(settings, macOptionAsAlt === 'true')
     )
     syncPreviewTerminalLigatures(terminal, settings)
+    // The assign above restored the settings font size; re-shrink if the box needs it.
+    scheduleFitRef.current?.()
   }, [settings, macOptionAsAlt])
 
   return (

--- a/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentTerminalPreview.tsx
@@ -129,7 +129,8 @@ export function AgentTerminalPreview({
     const gridClaim = createPreviewGridClaim({
       ptyId,
       container,
-      getTerminal: () => terminal
+      getTerminal: () => terminal,
+      getBaseFontSize: () => settingsRef.current?.terminalFontSize ?? 14
     })
     // Box growth/shrink (window resize) changes the reachable grid.
     const boxResizeObserver =

--- a/src/renderer/src/components/dashboard-popout/preview-grid-claim.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-grid-claim.test.ts
@@ -30,7 +30,8 @@ describe('createPreviewGridClaim', () => {
     const claim = createPreviewGridClaim({
       ptyId: 'pty-1',
       container,
-      getTerminal: () => ({ cols: 80, rows: 24 }) as never
+      getTerminal: () => ({ cols: 80, rows: 24, options: { fontSize: 14 } }) as never,
+      getBaseFontSize: () => 14
     })
 
     claim.schedule()
@@ -63,7 +64,8 @@ describe('createPreviewGridClaim', () => {
     const claim = createPreviewGridClaim({
       ptyId: 'pty-1',
       container,
-      getTerminal: () => ({ cols: 80, rows: 24 }) as never
+      getTerminal: () => ({ cols: 80, rows: 24, options: { fontSize: 14 } }) as never,
+      getBaseFontSize: () => 14
     })
 
     claim.schedule()
@@ -76,6 +78,35 @@ describe('createPreviewGridClaim', () => {
     expect(fit).not.toHaveBeenCalled()
     await vi.advanceTimersByTimeAsync(200)
     expect(fit).toHaveBeenCalledTimes(1)
+    expect(fit).toHaveBeenCalledWith('pty-1', 100, 30)
+    claim.dispose()
+  })
+
+  it('claims from base metrics after fallback fitting shrinks the preview font', async () => {
+    vi.useFakeTimers()
+    const fit = vi.fn(async (_ptyId: string, cols: number, rows: number) => ({ cols, rows }))
+    Object.assign(window, { api: { terminalPreview: { fit } } })
+    const box = document.createElement('div')
+    const container = document.createElement('div')
+    const screen = document.createElement('div')
+    screen.className = 'xterm-screen'
+    box.appendChild(container)
+    container.appendChild(screen)
+    dimension(box, 'clientWidth', 800)
+    dimension(box, 'clientHeight', 480)
+    // The 200x24 source grid was 1600x384 at 14px, then fitted to 800x192 at 7px.
+    dimension(screen, 'offsetWidth', 800)
+    dimension(screen, 'offsetHeight', 192)
+    const claim = createPreviewGridClaim({
+      ptyId: 'pty-1',
+      container,
+      getTerminal: () => ({ cols: 200, rows: 24, options: { fontSize: 7 } }) as never,
+      getBaseFontSize: () => 14
+    })
+
+    claim.schedule()
+    await vi.advanceTimersByTimeAsync(200)
+
     expect(fit).toHaveBeenCalledWith('pty-1', 100, 30)
     claim.dispose()
   })

--- a/src/renderer/src/components/dashboard-popout/preview-grid-claim.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-grid-claim.ts
@@ -24,6 +24,7 @@ export function createPreviewGridClaim(args: {
   ptyId: string
   container: HTMLElement
   getTerminal: () => Terminal | null
+  getBaseFontSize: () => number
 }): { schedule: () => void; dispose: () => void } {
   let lastRequestedFit: string | null = null
   let timer: ReturnType<typeof setTimeout> | null = null
@@ -40,8 +41,12 @@ export function createPreviewGridClaim(args: {
       return
     }
     // offsetWidth/Height are layout dims, unaffected by the scale transform.
-    const cellWidth = screen.offsetWidth / Math.max(1, terminal.cols)
-    const cellHeight = screen.offsetHeight / Math.max(1, terminal.rows)
+    // Font fitting must not make a later claim ask for the oversized source
+    // grid again; normalize the rendered cells back to settings font metrics.
+    const currentFontSize = terminal.options.fontSize ?? args.getBaseFontSize()
+    const fontScale = args.getBaseFontSize() / currentFontSize
+    const cellWidth = (screen.offsetWidth / Math.max(1, terminal.cols)) * fontScale
+    const cellHeight = (screen.offsetHeight / Math.max(1, terminal.rows)) * fontScale
     if (
       !Number.isFinite(cellWidth) ||
       !Number.isFinite(cellHeight) ||

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.test.ts
@@ -39,6 +39,55 @@ describe('planPreviewFitScale', () => {
     expect(plan.residualScale).toBeLessThan(1)
   })
 
+  it('rounds down when the nearest step would exceed the residual blur budget', () => {
+    const plan = planPreviewFitScale({
+      boxWidth: 518,
+      screenWidth: 1000,
+      currentFontSize: 14,
+      baseFontSize: 14
+    })
+    // ideal 7.252; rounding to 7.5 would require scale(0.967), so use 7px natively.
+    expect(plan.fontSize).toBe(7)
+    expect(plan.residualScale).toBe(1)
+  })
+
+  it('converges instead of alternating across rounded xterm measurements', () => {
+    let fontSize = 14
+    const plannedSizes: number[] = []
+    // These are the observed 84-column widths that previously produced the
+    // unbounded 14 -> 6 -> 6.5 -> 6 cycle in a 315px box.
+    const measuredWidths = new Map([
+      [14, 706],
+      [6, 302],
+      [6.5, 328]
+    ])
+    for (let step = 0; step < 5; step += 1) {
+      const plan = planPreviewFitScale({
+        boxWidth: 315,
+        screenWidth: measuredWidths.get(fontSize)!,
+        currentFontSize: fontSize,
+        baseFontSize: 14,
+        maxFontSize: step === 0 ? 14 : fontSize
+      })
+      fontSize = plan.fontSize
+      plannedSizes.push(fontSize)
+    }
+
+    expect(plannedSizes).toEqual([6, 6, 6, 6, 6])
+  })
+
+  it('holds a same-layout font when residual scaling alone suggests the adjacent step', () => {
+    const plan = planPreviewFitScale({
+      boxWidth: 372,
+      screenWidth: 354,
+      currentFontSize: 7,
+      baseFontSize: 14,
+      maxFontSize: 7
+    })
+    expect(plan.fontSize).toBe(7)
+    expect(plan.residualScale).toBe(1)
+  })
+
   it('never scales the font above the settings base when the box grows back', () => {
     const plan = planPreviewFitScale({
       boxWidth: 2000,
@@ -48,6 +97,26 @@ describe('planPreviewFitScale', () => {
     })
     expect(plan.fontSize).toBe(14)
     expect(plan.residualScale).toBe(1)
+  })
+
+  it('restores the base font after the preview grid claim succeeds', () => {
+    const fallback = planPreviewFitScale({
+      boxWidth: 800,
+      screenWidth: 1600,
+      currentFontSize: 14,
+      baseFontSize: 14
+    })
+    expect(fallback.fontSize).toBe(7)
+
+    // The accepted claim halves the grid, so its 7px rendering is now 400px wide.
+    const claimed = planPreviewFitScale({
+      boxWidth: 800,
+      screenWidth: 400,
+      currentFontSize: fallback.fontSize,
+      baseFontSize: 14
+    })
+    expect(claimed.fontSize).toBe(14)
+    expect(claimed.residualScale).toBe(1)
   })
 
   it('holds steady within tolerance so measure-apply loops cannot oscillate', () => {

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.test.ts
@@ -1,0 +1,83 @@
+import { describe, expect, it } from 'vitest'
+import { planPreviewFitScale } from './preview-terminal-fit-scale'
+
+describe('planPreviewFitScale', () => {
+  it('keeps the base font and no transform when the screen already fits', () => {
+    const plan = planPreviewFitScale({
+      boxWidth: 900,
+      screenWidth: 800,
+      currentFontSize: 14,
+      baseFontSize: 14
+    })
+    expect(plan.fontSize).toBe(14)
+    expect(plan.residualScale).toBe(1)
+  })
+
+  it('shrinks the font instead of relying on a large transform', () => {
+    // Source pane ~2x wider than the box: the old code applied scale(0.5) and
+    // smeared every glyph. The plan must express (almost) all of it as font.
+    const plan = planPreviewFitScale({
+      boxWidth: 500,
+      screenWidth: 1000,
+      currentFontSize: 14,
+      baseFontSize: 14
+    })
+    expect(plan.fontSize).toBe(7)
+    expect(plan.residualScale).toBe(1)
+  })
+
+  it('leaves only a sub-step residual for non-half-px ratios', () => {
+    const plan = planPreviewFitScale({
+      boxWidth: 530,
+      screenWidth: 1000,
+      currentFontSize: 14,
+      baseFontSize: 14
+    })
+    // ideal 7.42 → rounds to 7.5; predicted width 1000*7.5/14 ≈ 535.7 → tiny shrink.
+    expect(plan.fontSize).toBe(7.5)
+    expect(plan.residualScale).toBeGreaterThan(0.97)
+    expect(plan.residualScale).toBeLessThan(1)
+  })
+
+  it('never scales the font above the settings base when the box grows back', () => {
+    const plan = planPreviewFitScale({
+      boxWidth: 2000,
+      screenWidth: 500,
+      currentFontSize: 7,
+      baseFontSize: 14
+    })
+    expect(plan.fontSize).toBe(14)
+    expect(plan.residualScale).toBe(1)
+  })
+
+  it('holds steady within tolerance so measure-apply loops cannot oscillate', () => {
+    // After the first shrink lands, the re-measure produces a near-identical
+    // ideal; a repeated plan must return the current font unchanged.
+    const settled = planPreviewFitScale({
+      boxWidth: 500,
+      screenWidth: 501,
+      currentFontSize: 7,
+      baseFontSize: 14
+    })
+    expect(settled.fontSize).toBe(7)
+    expect(settled.residualScale).toBeGreaterThan(0.99)
+  })
+
+  it('falls back to transform below the minimum readable font', () => {
+    const plan = planPreviewFitScale({
+      boxWidth: 100,
+      screenWidth: 1000,
+      currentFontSize: 14,
+      baseFontSize: 14
+    })
+    expect(plan.fontSize).toBe(4)
+    // 1000*4/14 ≈ 285.7 wide at the floor → the rest stays a transform.
+    expect(plan.residualScale).toBeCloseTo(100 / (1000 * (4 / 14)), 3)
+  })
+
+  it('is inert on degenerate measurements', () => {
+    expect(
+      planPreviewFitScale({ boxWidth: 0, screenWidth: 0, currentFontSize: 14, baseFontSize: 14 })
+    ).toEqual({ fontSize: 14, residualScale: 1 })
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.ts
@@ -28,8 +28,10 @@ export function planPreviewFitScale(args: {
   currentFontSize: number
   /** The settings-configured font size the preview must never exceed. */
   baseFontSize: number
+  /** Same-layout remeasurement caps growth to prevent adjacent-step cycles. */
+  maxFontSize?: number
 }): PreviewFitScalePlan {
-  const { boxWidth, screenWidth, currentFontSize, baseFontSize } = args
+  const { boxWidth, screenWidth, currentFontSize, baseFontSize, maxFontSize = baseFontSize } = args
   if (boxWidth <= 0 || screenWidth <= 0 || currentFontSize <= 0 || baseFontSize <= 0) {
     return { fontSize: currentFontSize > 0 ? currentFontSize : baseFontSize, residualScale: 1 }
   }
@@ -37,7 +39,20 @@ export function planPreviewFitScale(args: {
   // within the tolerance and the residual transform absorbs rounding.
   const naturalWidthAtBase = (screenWidth / currentFontSize) * baseFontSize
   const idealFontSize = baseFontSize * (boxWidth / naturalWidthAtBase)
-  const fontSize = Math.round(clamp(idealFontSize, MIN_PREVIEW_FONT_PX, baseFontSize) * 2) / 2
+  const clampedFontSize = clamp(
+    idealFontSize,
+    MIN_PREVIEW_FONT_PX,
+    Math.min(baseFontSize, maxFontSize)
+  )
+  const nearestFontSize = Math.round(clampedFontSize * 2) / 2
+  const nearestPredictedWidth = (screenWidth / currentFontSize) * nearestFontSize
+  const nearestResidualScale = Math.min(1, boxWidth / nearestPredictedWidth)
+  // Prefer the next smaller native step when nearest rounding would leave a
+  // visible transform; below the readability floor, the fallback is accepted.
+  const fontSize =
+    clampedFontSize > MIN_PREVIEW_FONT_PX && nearestResidualScale < 1 - FONT_FIT_TOLERANCE
+      ? Math.floor(clampedFontSize * 2) / 2
+      : nearestFontSize
   const withinTolerance =
     Math.abs(fontSize - currentFontSize) / currentFontSize <= FONT_FIT_TOLERANCE
   const effectiveFontSize = withinTolerance ? currentFontSize : fontSize

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit-scale.ts
@@ -1,0 +1,51 @@
+/**
+ * Why font-scaling instead of `transform: scale()`: the preview must keep the
+ * PTY's real cols/rows (replaying serialized ANSI into different dimensions
+ * rewraps into garbage), but CSS-downscaling a rendered terminal resamples the
+ * glyph bitmaps into visible smear — the "Orca text is blurry" reports. Scaling
+ * the font size instead re-rasterizes every glyph natively at the final size:
+ * same grid, crisp text. A residual transform remains only for the sliver the
+ * discrete font-size step cannot express, and for the floor below MIN_FONT_PX.
+ */
+
+/** Below this, glyphs are unreadable either way; cheaper to transform-scale. */
+const MIN_PREVIEW_FONT_PX = 4
+/** Ignore sub-2% drift so measure→apply→measure cannot oscillate. */
+const FONT_FIT_TOLERANCE = 0.02
+
+export type PreviewFitScalePlan = {
+  /** Font size the preview terminal should render at (never above base). */
+  fontSize: number
+  /** Remaining CSS scale after the font change; 1 means no transform needed. */
+  residualScale: number
+}
+
+export function planPreviewFitScale(args: {
+  boxWidth: number
+  /** Current rendered width of the xterm screen element. */
+  screenWidth: number
+  /** Font size the screen was rendered at (the current terminal option). */
+  currentFontSize: number
+  /** The settings-configured font size the preview must never exceed. */
+  baseFontSize: number
+}): PreviewFitScalePlan {
+  const { boxWidth, screenWidth, currentFontSize, baseFontSize } = args
+  if (boxWidth <= 0 || screenWidth <= 0 || currentFontSize <= 0 || baseFontSize <= 0) {
+    return { fontSize: currentFontSize > 0 ? currentFontSize : baseFontSize, residualScale: 1 }
+  }
+  // Cell width tracks font size near-linearly; one proportional step converges
+  // within the tolerance and the residual transform absorbs rounding.
+  const naturalWidthAtBase = (screenWidth / currentFontSize) * baseFontSize
+  const idealFontSize = baseFontSize * (boxWidth / naturalWidthAtBase)
+  const fontSize = Math.round(clamp(idealFontSize, MIN_PREVIEW_FONT_PX, baseFontSize) * 2) / 2
+  const withinTolerance =
+    Math.abs(fontSize - currentFontSize) / currentFontSize <= FONT_FIT_TOLERANCE
+  const effectiveFontSize = withinTolerance ? currentFontSize : fontSize
+  const predictedWidth = (screenWidth / currentFontSize) * effectiveFontSize
+  const residualScale = Math.min(1, boxWidth / predictedWidth)
+  return { fontSize: effectiveFontSize, residualScale }
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.min(max, Math.max(min, value))
+}

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit.test.ts
@@ -1,0 +1,102 @@
+// @vitest-environment happy-dom
+
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createPreviewFitScheduler } from './preview-terminal-fit'
+
+function dimension(element: HTMLElement, name: string, get: () => number): void {
+  Object.defineProperty(element, name, { configurable: true, get })
+}
+
+describe('createPreviewFitScheduler', () => {
+  afterEach(() => vi.unstubAllGlobals())
+
+  it('settles the reported adjacent-size cycle without another frame', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    const box = document.createElement('div')
+    const container = document.createElement('div')
+    const screen = document.createElement('div')
+    screen.className = 'xterm-screen'
+    box.appendChild(container)
+    container.appendChild(screen)
+    const terminal = {
+      cols: 84,
+      rows: 24,
+      options: { fontSize: 14 },
+      buffer: { active: { cursorY: 0 } }
+    }
+    const measuredWidths = new Map([
+      [14, 706],
+      [6, 302],
+      [6.5, 328]
+    ])
+    dimension(box, 'clientWidth', () => 315)
+    dimension(box, 'clientHeight', () => 480)
+    dimension(screen, 'offsetWidth', () => measuredWidths.get(terminal.options.fontSize)!)
+    dimension(screen, 'offsetHeight', () => 384)
+    const { scheduleFit } = createPreviewFitScheduler({
+      container,
+      getTerminal: () => terminal as never,
+      getBaseFontSize: () => 14
+    })
+
+    scheduleFit()
+    frames.shift()!(0)
+    expect(terminal.options.fontSize).toBe(6)
+    expect(frames).toHaveLength(1)
+
+    frames.shift()!(0)
+    expect(terminal.options.fontSize).toBe(6)
+    expect(frames).toHaveLength(0)
+  })
+
+  it('allows the base font to return after a successful grid claim', () => {
+    const frames: FrameRequestCallback[] = []
+    vi.stubGlobal('requestAnimationFrame', (callback: FrameRequestCallback) => {
+      frames.push(callback)
+      return frames.length
+    })
+    const box = document.createElement('div')
+    const container = document.createElement('div')
+    const screen = document.createElement('div')
+    screen.className = 'xterm-screen'
+    box.appendChild(container)
+    container.appendChild(screen)
+    const terminal = {
+      cols: 200,
+      rows: 24,
+      options: { fontSize: 7 },
+      buffer: { active: { cursorY: 0 } }
+    }
+    dimension(box, 'clientWidth', () => 800)
+    dimension(box, 'clientHeight', () => 480)
+    dimension(
+      screen,
+      'offsetWidth',
+      () => (terminal.cols === 200 ? 800 : 400) * (terminal.options.fontSize / 7)
+    )
+    dimension(screen, 'offsetHeight', () => 192)
+    const { scheduleFit } = createPreviewFitScheduler({
+      container,
+      getTerminal: () => terminal as never,
+      getBaseFontSize: () => 14
+    })
+
+    scheduleFit()
+    frames.shift()!(0)
+    expect(terminal.options.fontSize).toBe(7)
+
+    terminal.cols = 100
+    scheduleFit()
+    frames.shift()!(0)
+    expect(terminal.options.fontSize).toBe(14)
+    expect(frames).toHaveLength(1)
+
+    frames.shift()!(0)
+    expect(terminal.options.fontSize).toBe(14)
+    expect(frames).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit.ts
@@ -13,6 +13,7 @@ export function createPreviewFitScheduler(args: {
   getBaseFontSize: () => number
 }): { scheduleFit: () => void } {
   const { container, getTerminal, getBaseFontSize } = args
+  let lastFitContext: { boxWidth: number; cols: number; baseFontSize: number } | null = null
 
   const fitToBox = (): void => {
     const terminal = getTerminal()
@@ -22,12 +23,20 @@ export function createPreviewFitScheduler(args: {
       return
     }
     const baseFontSize = getBaseFontSize()
+    const currentFontSize = terminal.options.fontSize ?? baseFontSize
+    const allowFontGrowth =
+      !lastFitContext ||
+      box.clientWidth > lastFitContext.boxWidth ||
+      terminal.cols !== lastFitContext.cols ||
+      baseFontSize !== lastFitContext.baseFontSize
     const plan = planPreviewFitScale({
       boxWidth: box.clientWidth,
       screenWidth: Math.max(1, screen.offsetWidth),
-      currentFontSize: terminal.options.fontSize ?? baseFontSize,
-      baseFontSize
+      currentFontSize,
+      baseFontSize,
+      maxFontSize: allowFontGrowth ? baseFontSize : currentFontSize
     })
+    lastFitContext = { boxWidth: box.clientWidth, cols: terminal.cols, baseFontSize }
     if (plan.fontSize !== terminal.options.fontSize) {
       terminal.options.fontSize = plan.fontSize
       // Re-measure next frame: the renderer applies the new metrics async.

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-fit.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-fit.ts
@@ -1,0 +1,62 @@
+import type { Terminal } from '@xterm/xterm'
+import { planPreviewFitScale } from './preview-terminal-fit-scale'
+
+/**
+ * Fits the preview terminal into its box without resampling blur: shrink the
+ * font (same cols/rows, so replayed content never rewraps) and keep a CSS
+ * transform only for the sliver the half-px font step cannot express (see
+ * planPreviewFitScale). Anchors whichever end keeps the cursor row in view.
+ */
+export function createPreviewFitScheduler(args: {
+  container: HTMLElement
+  getTerminal: () => Terminal | null
+  getBaseFontSize: () => number
+}): { scheduleFit: () => void } {
+  const { container, getTerminal, getBaseFontSize } = args
+
+  const fitToBox = (): void => {
+    const terminal = getTerminal()
+    const screen = container.querySelector<HTMLElement>('.xterm-screen')
+    const box = container.parentElement
+    if (!screen || !box || !terminal) {
+      return
+    }
+    const baseFontSize = getBaseFontSize()
+    const plan = planPreviewFitScale({
+      boxWidth: box.clientWidth,
+      screenWidth: Math.max(1, screen.offsetWidth),
+      currentFontSize: terminal.options.fontSize ?? baseFontSize,
+      baseFontSize
+    })
+    if (plan.fontSize !== terminal.options.fontSize) {
+      terminal.options.fontSize = plan.fontSize
+      // Re-measure next frame: the renderer applies the new metrics async.
+      scheduleFit()
+    }
+    const scale = plan.residualScale
+    container.style.transform = scale < 1 ? `scale(${scale})` : ''
+    // Anchor whichever end keeps the CURSOR row in view when the terminal is
+    // taller than the box: a fresh shell prompts at the TOP of its screen
+    // (blind bottom-anchoring clipped it away), while a busy TUI keeps its
+    // action at the bottom.
+    const cellHeight = screen.offsetHeight / Math.max(1, terminal.rows)
+    const cursorBottom = (terminal.buffer.active.cursorY + 1) * cellHeight * scale
+    const anchorTop = cursorBottom <= box.clientHeight
+    box.style.alignItems = anchorTop ? 'flex-start' : 'flex-end'
+    container.style.transformOrigin = anchorTop ? 'top left' : 'bottom left'
+  }
+
+  // Re-fit after every parsed write (cursor may move ends); rAF coalesces.
+  let fitScheduled = false
+  const scheduleFit = (): void => {
+    if (fitScheduled) {
+      return
+    }
+    fitScheduled = true
+    requestAnimationFrame(() => {
+      fitScheduled = false
+      fitToBox()
+    })
+  }
+  return { scheduleFit }
+}


### PR DESCRIPTION
## Summary

Fixes a standing blur in the agent terminal preview. (Correction: an earlier revision of this description attributed the Aug 7 field screenshot to this surface — that screenshot is a regular split pane, and its blur is still under investigation. This PR stands on its own: the preview's claim-denied path has always rendered smeared.) When the PTY grid is owned elsewhere (the live pane in the worktree, a phone), `AgentTerminalPreview` correctly keeps the source cols/rows (replaying serialized ANSI into different dimensions rewraps into garbage) but shrank the whole rendered terminal with `transform: scale(<1)` — resampling every glyph into smear. Measured signature of the CSS-scaled path: stretched character advance with lumpy resampled edges versus the crisp floored-advance rendering of an unscaled terminal.

The preview now shrinks the **font size** instead: same grid (no rewrap), glyphs rasterize natively at the final size. A residual CSS transform remains only for the sliver the half-px font step cannot express (≤2%, imperceptible) and below a 4 px readability floor. The base font is restored when the box grows or the grid claim succeeds, and the settings-appearance effect re-runs the fit after it rewrites `fontSize`. Fit-scale planning lives in a pure module (`preview-terminal-fit-scale.ts`) with a measure→apply→measure oscillation guard; the fit/anchor logic moved to `preview-terminal-fit.ts` (also keeps the component under its max-lines cap). Cursor anchoring behavior is unchanged.

## Screenshots

Visual before/after on a live claim-denied preview is owed at review time (needs a grid owned by a live pane). The fix makes the preview rasterize at the final size, which removes the resample step entirely.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — targeted: full `src/renderer/src/components/dashboard-popout/` suite (207 tests) green locally; full suite left to CI
- [ ] `pnpm build` — left to CI
- [x] Added or updated high-quality tests that would catch regressions: 7 planner tests (fits-already, full shrink expressed as font, sub-step residual, never-above-base restore, oscillation hold within tolerance, min-font transform fallback, degenerate-measure inertness); Terminal mock now models the live `options` bag the fit path reads/writes

## AI Review Report

Reviewed by the implementing agent. Main risks checked: (1) rewrap — cols/rows are never touched; only `fontSize` changes, which re-renders cells without reflowing the buffer; (2) oscillation — the planner holds the current font within a 2% tolerance and rounds to half-px steps, so measure→apply→measure settles in one pass with the residual transform absorbing rounding; (3) appearance-settings clobber — the appearance effect rewrites `fontSize` from settings, so it now re-schedules the fit through a ref (nulled on unmount); (4) restore path — when the box grows or `createPreviewGridClaim` resizes the terminal to fit, the plan clamps back to the settings base font and drops the transform; (5) anchor math — cursor anchoring uses the residual scale against post-font-change measurements, preserving the top/bottom anchoring contract. Cross-platform: renderer-only, DOM renderer (the preview never takes WebGL), no shortcuts/labels/paths/shell/Electron platform differences; fractional CSS font sizes render fine on macOS/Linux/Windows.

## Security Audit

Renderer-internal layout logic only. No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes.

## Notes

- Lineage (not a regression from another PR): the CSS `transform: scale(<1)` fallback has been the preview's fit strategy since the component was extracted in #9392. #9997 already identified the scaled path as blurry ("rendered the pane's serialized frame at its original cols/rows and CSS-scaled it down to fit") and narrowed it by claiming the PTY grid for the dialog box — this PR fixes the remaining claim-denied fallback (grid owned by a live pane or phone). No recent changes to the grid-claim arbitration made this more common; it was always the owned-grid behavior.
- Related blur routes fixed earlier: #12944 (hidden-pane metric mis-measure) and #12945 (DOM-renderer-stuck panes). The Aug 7 field report (blur in a normal split pane after switching back to a worktree, on an RC containing both) is a separate, still-open investigation — this PR does not claim to fix it.
- At extreme shrink (<4 px font) the preview still transform-scales the remainder — unreadable either way, but no worse than before.
