### PR TITLE
build(preload): fail the build when a sandboxed preload needs a Node builtin

### DIFF
--- a/config/build-plugins/preload-sandbox-builtin-guard-write-path.test.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard-write-path.test.ts
@@ -1,0 +1,60 @@
+// Why: direct-hook unit calls cannot show ordering. These drive a real Vite write path to prove
+// a rejected preload leaves nothing on disk while a clean one still emits.
+import { mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { build } from 'vite'
+import { createPreloadSandboxBuiltinGuardPlugin } from './preload-sandbox-builtin-guard'
+
+const roots: string[] = []
+
+afterEach(async () => {
+  await Promise.all(roots.splice(0).map((root) => rm(root, { force: true, recursive: true })))
+})
+
+async function buildPreload(source: string): Promise<{ outDir: string }> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-preload-guard-'))
+  roots.push(root)
+  const outDir = join(root, 'out')
+  await writeFile(join(root, 'preload.ts'), source, 'utf8')
+  await build({
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    build: {
+      outDir,
+      // Matches the preload target: builtins stay external instead of being browser-polyfilled.
+      ssr: true,
+      write: true,
+      emptyOutDir: true,
+      minify: false,
+      rollupOptions: {
+        input: { preload: join(root, 'preload.ts') },
+        external: ['electron'],
+        output: { format: 'cjs', entryFileNames: '[name].js' },
+        plugins: [createPreloadSandboxBuiltinGuardPlugin()]
+      }
+    }
+  })
+  return { outDir }
+}
+
+describe('preload sandbox guard on a real build write path', () => {
+  it('leaves no output on disk when the preload imports a Node builtin', async () => {
+    const attempt = buildPreload(
+      "import { join } from 'node:path'\nimport { contextBridge } from 'electron'\n" +
+        "contextBridge.exposeInMainWorld('api', { join })\n"
+    )
+    await expect(attempt).rejects.toThrow('node:path')
+    await expect(readdir(join(roots.at(-1)!, 'out'))).rejects.toThrow(/ENOENT/)
+  }, 60_000)
+
+  it('writes a preload whose only external is electron', async () => {
+    const { outDir } = await buildPreload(
+      "import { contextBridge } from 'electron'\n" +
+        "contextBridge.exposeInMainWorld('api', { encode: (v: string) => new TextEncoder().encode(v) })\n"
+    )
+    await expect(readdir(outDir)).resolves.toContain('preload.js')
+  }, 60_000)
+})

--- a/config/build-plugins/preload-sandbox-builtin-guard.test.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import type { Rollup } from 'vite'
+import {
+  assertPreloadSandboxBundleSafe,
+  assertPreloadSandboxChunkSafe,
+  createPreloadSandboxBuiltinGuardPlugin,
+  findPreloadSandboxViolations
+} from './preload-sandbox-builtin-guard'
+
+type OutputChunk = Rollup.OutputChunk
+
+function chunk(fileName: string, code: string, imports: string[] = []): OutputChunk {
+  return {
+    type: 'chunk',
+    fileName,
+    code,
+    imports,
+    dynamicImports: []
+  } as unknown as OutputChunk
+}
+
+function runGuard(
+  plugin: ReturnType<typeof createPreloadSandboxBuiltinGuardPlugin>,
+  bundle: Record<string, OutputChunk>
+): void {
+  const hook = plugin.generateBundle
+  if (typeof hook !== 'function') {
+    throw new Error('guard plugin must expose a generateBundle hook')
+  }
+  hook.call({ meta: { watchMode: true } } as never, {} as never, bundle as never, false)
+}
+
+describe('preload sandbox guard detection', () => {
+  it('detects static CommonJS and ESM Node builtin requests', () => {
+    expect(
+      findPreloadSandboxViolations(
+        'require("node:util"); import("node:path");\nimport value from "node:buffer";\nimport "node:fs"'
+      )
+    ).toEqual([
+      { kind: 'node-builtin', detail: 'node:buffer' },
+      { kind: 'node-builtin', detail: 'node:fs' },
+      { kind: 'node-builtin', detail: 'node:path' },
+      { kind: 'node-builtin', detail: 'node:util' }
+    ])
+  })
+
+  it('detects bundler-renamed require shims', () => {
+    expect(findPreloadSandboxViolations('var x = __require("fs")')).toEqual([
+      { kind: 'node-builtin', detail: 'fs' }
+    ])
+  })
+
+  it('detects non-literal require and import requests', () => {
+    const violations = findPreloadSandboxViolations(
+      'const m = require(name);\nconst d = await import(specifier)'
+    )
+    expect(violations.map((violation) => violation.kind)).toEqual([
+      'nonliteral-module-request',
+      'nonliteral-module-request'
+    ])
+    expect(violations.map((violation) => violation.detail)).toEqual([
+      'import(specifier)',
+      'require(name);'
+    ])
+  })
+
+  it('rejects a bare npm external that a sandboxed preload cannot load', () => {
+    expect(findPreloadSandboxViolations('require("zod")')).toEqual([
+      { kind: 'unsupported-external', detail: 'zod' }
+    ])
+  })
+
+  it('rejects an emitted Rollup helper chunk', () => {
+    expect(findPreloadSandboxViolations('require("./chunks/shared-abc123.js")')).toEqual([
+      { kind: 'helper-chunk', detail: './chunks/shared-abc123.js' }
+    ])
+  })
+
+  it('rejects a shared chunk reported by its bare emitted path', () => {
+    expect(() =>
+      assertPreloadSandboxChunkSafe(
+        chunk('index.js', 'export {}', ['chunks/chunk-BTjIgr6M.js', 'ssh2'])
+      )
+    ).toThrow(
+      'unloadable emitted chunks: chunks/chunk-BTjIgr6M.js; unsupported bare externals: ssh2'
+    )
+  })
+
+  it('accepts the explicit Electron preload surface and browser-safe code', () => {
+    expect(
+      findPreloadSandboxViolations(
+        'require("electron"); const bytes = new TextEncoder().encode("safe")'
+      )
+    ).toEqual([])
+  })
+
+  it('rejects Electron subpath exports the emitted preload never uses', () => {
+    expect(findPreloadSandboxViolations('require("electron/renderer")')).toEqual([
+      { kind: 'unsupported-external', detail: 'electron/renderer' }
+    ])
+  })
+
+  it('does not flag identifiers or quoted data that merely look like module requests', () => {
+    expect(
+      findPreloadSandboxViolations(
+        'const api = { importPetsFrom: () => ipc.invoke("a"), importPetBundle: () => ipc.invoke("b") };\n' +
+          'const label = "import x from \'node:fs\'";\nconst got = cache.require("node:fs")'
+      )
+    ).toEqual([])
+  })
+})
+
+describe('preload sandbox guard assertions', () => {
+  it('names every offending specifier and the supported surface', () => {
+    expect(() =>
+      assertPreloadSandboxBundleSafe('index.js', 'require("node:util"); require("zod")')
+    ).toThrow(
+      /"index\.js" requests unsupported Node builtins: node:util; unsupported bare externals: zod\..*resolves only electron;/s
+    )
+  })
+
+  it('rejects a resolved external that never appears in the emitted source', () => {
+    expect(() =>
+      assertPreloadSandboxChunkSafe(chunk('index.js', 'export {}', ['node:crypto']))
+    ).toThrow('node:crypto')
+  })
+
+  it('accepts a chunk whose only resolved import is electron', () => {
+    expect(() =>
+      assertPreloadSandboxChunkSafe(chunk('index.js', 'var e = require("electron")', ['electron']))
+    ).not.toThrow()
+  })
+})
+
+describe('preload sandbox guard plugin', () => {
+  it('fails in generateBundle, before Rollup writes the unsafe output', () => {
+    const plugin = createPreloadSandboxBuiltinGuardPlugin()
+    expect(plugin.writeBundle).toBeUndefined()
+    expect(() =>
+      runGuard(plugin, { 'index.js': chunk('index.js', 'require("node:path")') })
+    ).toThrow('node:path')
+  })
+
+  it('guards only the included outputs when the build also emits Node entries', () => {
+    const plugin = createPreloadSandboxBuiltinGuardPlugin({
+      include: ['browser-window-close-preload.js']
+    })
+    expect(() =>
+      runGuard(plugin, {
+        'index.js': chunk('index.js', 'require("node:fs")', ['node:fs']),
+        'browser-window-close-preload.js': chunk(
+          'browser-window-close-preload.js',
+          'var { contextBridge } = require("electron")',
+          ['electron']
+        )
+      })
+    ).not.toThrow()
+  })
+
+  it('guards the second sandboxed preload emitted by the main build', () => {
+    const plugin = createPreloadSandboxBuiltinGuardPlugin({
+      include: ['browser-window-close-preload.js']
+    })
+    expect(() =>
+      runGuard(plugin, {
+        'index.js': chunk('index.js', 'require("node:fs")'),
+        'browser-window-close-preload.js': chunk(
+          'browser-window-close-preload.js',
+          'require("node:os")'
+        )
+      })
+    ).toThrow('browser-window-close-preload.js')
+  })
+
+  it('fails when a guarded preload output is renamed out of the bundle', () => {
+    const plugin = createPreloadSandboxBuiltinGuardPlugin({
+      include: ['browser-window-close-preload.js']
+    })
+    expect(() =>
+      runGuard(plugin, { 'index.js': chunk('index.js', 'require("electron")') })
+    ).toThrow('guarded preload output missing from the bundle: browser-window-close-preload.js')
+  })
+
+  it('fails watch rebuilds too, so no dev out/ tree holds an unsafe preload', () => {
+    const plugin = createPreloadSandboxBuiltinGuardPlugin()
+    expect(() =>
+      runGuard(plugin, { 'index.js': chunk('index.js', 'require("node:path")') })
+    ).toThrow('node:path')
+  })
+})

--- a/config/build-plugins/preload-sandbox-builtin-guard.test.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard.test.ts
@@ -173,6 +173,19 @@ describe('preload sandbox guard lexical masking', () => {
       [{ kind: 'node-builtin', detail: 'node:tty' }]
     )
   })
+
+  // `return /re/` is a regex, not division. The bare previous-character
+  // heuristic sees the `n` of `return` and leaves the pattern unmasked, so a
+  // safe preload fails to build.
+  it('ignores a module call inside a regex that follows a keyword', () => {
+    expect(findPreloadSandboxViolations('function f() { return /require("node:fs")/ }')).toEqual([])
+  })
+
+  it('still treats a slash after an identifier as division', () => {
+    expect(
+      findPreloadSandboxViolations('const r = total / count; const fs = require("node:fs")')
+    ).toEqual([{ kind: 'node-builtin', detail: 'node:fs' }])
+  })
 })
 
 describe('preload sandbox guard assertions', () => {

--- a/config/build-plugins/preload-sandbox-builtin-guard.test.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard.test.ts
@@ -110,6 +110,71 @@ describe('preload sandbox guard detection', () => {
   })
 })
 
+// Why: the case above only covers identifier prefixes, a quoted *static import statement* off
+// statement position, and member-access `require`. None of them exercise call syntax inside a
+// literal, so the guard used to fail the build on comments and ordinary strings.
+describe('preload sandbox guard lexical masking', () => {
+  it('ignores a module call quoted inside a string literal', () => {
+    expect(findPreloadSandboxViolations(`const help = "Call require('fs')"`)).toEqual([])
+  })
+
+  it('ignores a module call in a line comment, which survives an unminified chunk', () => {
+    expect(findPreloadSandboxViolations("// use require('fs')\nexport {}")).toEqual([])
+  })
+
+  it('ignores a module call in a block comment', () => {
+    expect(findPreloadSandboxViolations("/* see require('fs')\n   and import('path') */")).toEqual(
+      []
+    )
+  })
+
+  it('ignores a module call inside a template literal', () => {
+    expect(findPreloadSandboxViolations('const t = `see import("path") here`')).toEqual([])
+  })
+
+  it('ignores a fake require after an escaped quote, which naive masking would end early', () => {
+    expect(findPreloadSandboxViolations('const s = "a\\"require(\'fs\')\\"b"')).toEqual([])
+  })
+
+  it('still flags a real request inside a template interpolation', () => {
+    expect(findPreloadSandboxViolations('const t = `${require("fs")}`')).toEqual([
+      { kind: 'node-builtin', detail: 'fs' }
+    ])
+  })
+
+  it('still flags a real request nested in an interpolated object literal', () => {
+    expect(findPreloadSandboxViolations('const t = `${({ a: require("net") }).a}` + "x"')).toEqual([
+      { kind: 'node-builtin', detail: 'net' }
+    ])
+  })
+
+  it('still flags a real request on the line after a comment', () => {
+    expect(findPreloadSandboxViolations('// hi\nconst x = require("node:os")')).toEqual([
+      { kind: 'node-builtin', detail: 'node:os' }
+    ])
+  })
+
+  // Why: same line on purpose — an unterminated string already stops at a newline, so only a
+  // same-line regex can swallow the request that follows it.
+  it('still flags a real request after a regex holding an unpaired quote', () => {
+    expect(findPreloadSandboxViolations('const q = /["]/; const x = require("node:zlib")')).toEqual(
+      [{ kind: 'node-builtin', detail: 'node:zlib' }]
+    )
+  })
+
+  it('still flags a real request after a division, which is not a regex', () => {
+    expect(findPreloadSandboxViolations('const r = t / 2; const x = require("node:dns")')).toEqual([
+      { kind: 'node-builtin', detail: 'node:dns' }
+    ])
+  })
+
+  it('still flags a real static import that follows a quoted decoy', () => {
+    expect(findPreloadSandboxViolations('const d = "require(\'fs\')";\nimport "node:tty"')).toEqual(
+      [{ kind: 'node-builtin', detail: 'node:tty' }]
+    )
+  })
+})
+
 describe('preload sandbox guard assertions', () => {
   it('names every offending specifier and the supported surface', () => {
     expect(() =>

--- a/config/build-plugins/preload-sandbox-builtin-guard.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard.ts
@@ -63,19 +63,123 @@ function collect(
   }
 }
 
+/** A NUL can never appear in real source, so a masked offset is unambiguous. */
+const MASKED = '\u0000'
+
+/**
+ * Marks every comment and string-literal character, preserving offsets, so a match can be tested
+ * for whether it sits in code or in data. Interpolations stay code: `${require('fs')}` is real.
+ */
+function maskLexicalSpans(code: string): string {
+  const chars = code.split('')
+  const mask = (from: number, to: number): void => {
+    for (let at = from; at < Math.min(to, chars.length); at += 1) {
+      chars[at] = MASKED
+    }
+  }
+  const interpolations: number[] = [] // brace depth inside each enclosing `${}`
+  let inTemplate = false
+  // A `/` here starts a regex, not a division; anything else makes it an operator.
+  let regexAllowed = true
+  let index = 0
+  while (index < code.length) {
+    const char = code[index]
+    const pair = code.slice(index, index + 2)
+    if (inTemplate) {
+      if (char === '`') {
+        inTemplate = false
+        regexAllowed = false
+        index += 1
+      } else if (pair === '${') {
+        interpolations.push(0)
+        inTemplate = false
+        index += 2
+      } else {
+        const width = char === '\\' ? 2 : 1
+        mask(index, index + width)
+        index += width
+      }
+      continue
+    }
+    if (pair === '//' || pair === '/*') {
+      const close = pair === '//' ? code.indexOf('\n', index) : code.indexOf('*/', index + 2)
+      const end = close === -1 ? code.length : pair === '//' ? close : close + 2
+      mask(index, end)
+      index = end
+      continue
+    }
+    if (char === "'" || char === '"') {
+      let scan = index + 1
+      // A raw newline ends an unterminated literal; nothing after it is still that string.
+      while (scan < code.length && code[scan] !== char && code[scan] !== '\n') {
+        scan += code[scan] === '\\' ? 2 : 1
+      }
+      mask(index, scan + 1)
+      index = scan + 1
+      regexAllowed = false
+      continue
+    }
+    // Why: an unpaired quote inside a regex would otherwise open a string over real code.
+    if (char === '/' && regexAllowed) {
+      let scan = index + 1
+      let inClass = false
+      while (scan < code.length && code[scan] !== '\n' && (inClass || code[scan] !== '/')) {
+        if (code[scan] === '\\') {
+          scan += 1
+        } else if (code[scan] === '[' || code[scan] === ']') {
+          inClass = code[scan] === '['
+        }
+        scan += 1
+      }
+      mask(index, scan + 1)
+      index = scan + 1
+      regexAllowed = false
+      continue
+    }
+    if (!/\s/.test(char)) {
+      regexAllowed = !/[\w$)\]]/.test(char)
+    }
+    if (char === '`') {
+      inTemplate = true
+    } else if (interpolations.length > 0 && (char === '{' || char === '}')) {
+      const last = interpolations.length - 1
+      if (char === '{') {
+        interpolations[last] += 1
+      } else if (interpolations[last] > 0) {
+        interpolations[last] -= 1
+      } else {
+        interpolations.pop()
+        inTemplate = true
+      }
+    }
+    index += 1
+  }
+  return chars.join('')
+}
+
 export function findPreloadSandboxViolations(code: string): PreloadSandboxViolation[] {
   const violations = new Map<string, PreloadSandboxViolation>()
+  // Why: the patterns still run on real source, so specifiers survive; the mask only vetoes
+  // matches whose module keyword is inside a comment or string.
+  const masked = maskLexicalSpans(code)
+  const isData = (match: RegExpExecArray | RegExpMatchArray): boolean => {
+    const keyword = Math.max(match[0].search(/import|export|require/), 0)
+    return masked[(match.index ?? 0) + keyword] === MASKED
+  }
   for (const pattern of [LITERAL_MODULE_CALL_RE, STATIC_MODULE_SOURCE_RE]) {
     pattern.lastIndex = 0
     for (const match of code.matchAll(pattern)) {
       const specifier = match[2]
-      if (specifier !== undefined) {
+      if (specifier !== undefined && !isData(match)) {
         collect(violations, classifySpecifier(specifier))
       }
     }
   }
   NONLITERAL_MODULE_CALL_RE.lastIndex = 0
   for (const match of code.matchAll(NONLITERAL_MODULE_CALL_RE)) {
+    if (isData(match)) {
+      continue
+    }
     collect(violations, {
       kind: 'nonliteral-module-request',
       detail: code

--- a/config/build-plugins/preload-sandbox-builtin-guard.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard.ts
@@ -1,0 +1,157 @@
+import { builtinModules } from 'node:module'
+import type { Plugin, Rollup } from 'vite'
+
+type NormalizedOutputOptions = Rollup.NormalizedOutputOptions
+type OutputBundle = Rollup.OutputBundle
+type OutputChunk = Rollup.OutputChunk
+
+const SANDBOX_UNSUPPORTED_BUILTINS = new Set([
+  ...builtinModules,
+  ...builtinModules.map((moduleName) => `node:${moduleName}`)
+])
+
+/** The only module a sandboxed preload can resolve; everything else throws at load. */
+const SANDBOX_SUPPORTED_EXTERNALS = new Set(['electron'])
+
+// `[\w$]*require` also catches bundler-renamed shims such as `__require("fs")`.
+const LITERAL_MODULE_CALL_RE = /(?<![\w$.])(?:[\w$]*require|import)\s*\(\s*(['"])([^'"]*)\1\s*\)/g
+const NONLITERAL_MODULE_CALL_RE =
+  /(?<![\w$.])(?:[\w$]*require|import)\s*\((?!\s*(['"])[^'"]*\1\s*\))/g
+// Anchored at statement position so a quoted `from` inside bundled data can't match.
+const STATIC_MODULE_SOURCE_RE =
+  /(?:^|[;}])\s*(?:import|export)\s+(?:[^'";()]*?\bfrom\s*)?(['"])([^'"]*)\1/gm
+
+export type PreloadSandboxViolationKind =
+  | 'node-builtin'
+  | 'unsupported-external'
+  | 'helper-chunk'
+  | 'nonliteral-module-request'
+
+export type PreloadSandboxViolation = Readonly<{
+  kind: PreloadSandboxViolationKind
+  /** The module specifier, or the call source for a non-literal request. */
+  detail: string
+}>
+
+const VIOLATION_LABELS: Record<PreloadSandboxViolationKind, string> = {
+  'node-builtin': 'unsupported Node builtins',
+  'unsupported-external': 'unsupported bare externals',
+  'helper-chunk': 'unloadable emitted chunks',
+  'nonliteral-module-request': 'non-literal module requests'
+}
+
+function classifySpecifier(specifier: string): PreloadSandboxViolation | null {
+  if (SANDBOX_SUPPORTED_EXTERNALS.has(specifier)) {
+    return null
+  }
+  if (SANDBOX_UNSUPPORTED_BUILTINS.has(specifier)) {
+    return { kind: 'node-builtin', detail: specifier }
+  }
+  // Rollup names a shared chunk by its emitted path, which is bare relative to the output dir.
+  if (/^[./]/.test(specifier) || /\.[cm]?js$/.test(specifier)) {
+    return { kind: 'helper-chunk', detail: specifier }
+  }
+  return { kind: 'unsupported-external', detail: specifier }
+}
+
+function collect(
+  violations: Map<string, PreloadSandboxViolation>,
+  violation: PreloadSandboxViolation | null
+): void {
+  if (violation) {
+    violations.set(`${violation.kind}:${violation.detail}`, violation)
+  }
+}
+
+export function findPreloadSandboxViolations(code: string): PreloadSandboxViolation[] {
+  const violations = new Map<string, PreloadSandboxViolation>()
+  for (const pattern of [LITERAL_MODULE_CALL_RE, STATIC_MODULE_SOURCE_RE]) {
+    pattern.lastIndex = 0
+    for (const match of code.matchAll(pattern)) {
+      const specifier = match[2]
+      if (specifier !== undefined) {
+        collect(violations, classifySpecifier(specifier))
+      }
+    }
+  }
+  NONLITERAL_MODULE_CALL_RE.lastIndex = 0
+  for (const match of code.matchAll(NONLITERAL_MODULE_CALL_RE)) {
+    collect(violations, {
+      kind: 'nonliteral-module-request',
+      detail: code
+        .slice(match.index, match.index + match[0].length + 24)
+        .split('\n')[0]
+        .trim()
+    })
+  }
+  return [...violations.values()].sort((left, right) =>
+    `${left.kind}:${left.detail}`.localeCompare(`${right.kind}:${right.detail}`)
+  )
+}
+
+function formatViolations(
+  fileName: string,
+  violations: readonly PreloadSandboxViolation[]
+): string {
+  const grouped = new Map<PreloadSandboxViolationKind, string[]>()
+  for (const violation of violations) {
+    grouped.set(violation.kind, [...(grouped.get(violation.kind) ?? []), violation.detail])
+  }
+  const parts = [...grouped].map(
+    ([kind, details]) => `${VIOLATION_LABELS[kind]}: ${details.join(', ')}`
+  )
+  return (
+    `[preload-sandbox-builtin-guard] "${fileName}" requests ${parts.join('; ')}. ` +
+    `A sandboxed preload resolves only ${[...SANDBOX_SUPPORTED_EXTERNALS].join(', ')}; ` +
+    'keep it browser-safe and do not polyfill Node modules.'
+  )
+}
+
+export function assertPreloadSandboxBundleSafe(fileName: string, code: string): void {
+  const violations = findPreloadSandboxViolations(code)
+  if (violations.length > 0) {
+    throw new Error(formatViolations(fileName, violations))
+  }
+}
+
+/** Rollup's resolved import lists catch externals and shared chunks a source scan can miss. */
+export function assertPreloadSandboxChunkSafe(chunk: OutputChunk): void {
+  const violations = new Map<string, PreloadSandboxViolation>()
+  for (const specifier of [...chunk.imports, ...chunk.dynamicImports]) {
+    collect(violations, classifySpecifier(specifier))
+  }
+  for (const violation of findPreloadSandboxViolations(chunk.code)) {
+    collect(violations, violation)
+  }
+  if (violations.size > 0) {
+    throw new Error(formatViolations(chunk.fileName, [...violations.values()]))
+  }
+}
+
+export function createPreloadSandboxBuiltinGuardPlugin(
+  options?: Readonly<{
+    /** Emitted file names to guard. Every chunk is guarded when omitted. */
+    include?: readonly string[]
+  }>
+): Plugin {
+  const include = options?.include ? new Set(options.include) : null
+  return {
+    name: 'orca-preload-sandbox-builtin-guard',
+    // Why: generateBundle precedes the write, so no unsafe preload reaches out/ for a later
+    // `pnpm start` or packaging step to pick up — including on watch rebuilds.
+    generateBundle(_options: NormalizedOutputOptions, bundle: OutputBundle) {
+      for (const item of Object.values(bundle)) {
+        if (item.type === 'chunk' && (!include || include.has(item.fileName))) {
+          assertPreloadSandboxChunkSafe(item)
+        }
+      }
+      // Why: a renamed entry would otherwise silently leave the preload unguarded.
+      const missing = include ? [...include].filter((fileName) => !(fileName in bundle)) : []
+      if (missing.length > 0) {
+        throw new Error(
+          `[preload-sandbox-builtin-guard] guarded preload output missing from the bundle: ${missing.join(', ')}`
+        )
+      }
+    }
+  }
+}

--- a/config/build-plugins/preload-sandbox-builtin-guard.ts
+++ b/config/build-plugins/preload-sandbox-builtin-guard.ts
@@ -70,6 +70,32 @@ const MASKED = '\u0000'
  * Marks every comment and string-literal character, preserving offsets, so a match can be tested
  * for whether it sits in code or in data. Interpolations stay code: `${require('fs')}` is real.
  */
+/** A `/` after one of these starts a regex; after any other identifier it divides. */
+const REGEX_PRECEDING_KEYWORDS = new Set([
+  'return',
+  'typeof',
+  'instanceof',
+  'in',
+  'of',
+  'new',
+  'delete',
+  'void',
+  'throw',
+  'case',
+  'do',
+  'else',
+  'yield',
+  'await'
+])
+
+function identifierEndingAt(code: string, endIndex: number): string {
+  let start = endIndex
+  while (start > 0 && /[\w$]/.test(code[start - 1]!)) {
+    start -= 1
+  }
+  return code.slice(start, endIndex + 1)
+}
+
 function maskLexicalSpans(code: string): string {
   const chars = code.split('')
   const mask = (from: number, to: number): void => {
@@ -137,7 +163,12 @@ function maskLexicalSpans(code: string): string {
       continue
     }
     if (!/\s/.test(char)) {
-      regexAllowed = !/[\w$)\]]/.test(char)
+      // Why the keyword check: `return /re/` is a regex, but the char before the
+      // slash is a word character, so the bare heuristic would call it division
+      // and leave the pattern's contents unmasked.
+      regexAllowed = /[\w$]/.test(char)
+        ? REGEX_PRECEDING_KEYWORDS.has(identifierEndingAt(code, index))
+        : !/[)\]]/.test(char)
     }
     if (char === '`') {
       inTemplate = true

--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
     include: [
       'src/**/*.test.ts',
       'src/**/*.test.tsx',
+      'config/build-plugins/**/*.test.ts',
       'config/scripts/**/*.test.ts',
       'config/scripts/**/*.test.mjs',
       'tests/tools/**/*.test.mjs',

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -5,7 +5,11 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { createBootstrapFatalExitBanner } from './config/build-plugins/bootstrap-fatal-exit-banner'
 import { createPlainNodeEntryGuardPlugin } from './config/build-plugins/plain-node-entry-guard'
+import { createPreloadSandboxBuiltinGuardPlugin } from './config/build-plugins/preload-sandbox-builtin-guard'
 import packageJson from './package.json' with { type: 'json' }
+
+// The sandboxed preload the main config emits; the entry name and the guarded output must agree.
+const BROWSER_WINDOW_CLOSE_PRELOAD_ENTRY = 'browser-window-close-preload'
 
 const BUNDLED_MAIN_DEPENDENCIES = new Set([
   '@xterm/headless',
@@ -208,7 +212,7 @@ export const electronViteConfig: UserConfig = {
         input: {
           index: resolve('src/main/index.ts'),
           // Why: sandboxed webview preloads cannot load Rollup helper chunks.
-          'browser-window-close-preload': resolve('src/preload/browser-window-close.ts'),
+          [BROWSER_WINDOW_CLOSE_PRELOAD_ENTRY]: resolve('src/preload/browser-window-close.ts'),
           'daemon-entry': resolve('src/main/daemon/daemon-entry.ts'),
           'plugin-host-entry': resolve('src/main/plugins/plugin-host-entry.ts'),
           'computer-sidecar': resolve('src/main/computer/sidecar-entry.ts'),
@@ -251,7 +255,15 @@ export const electronViteConfig: UserConfig = {
           entryFileNames: '[name].js',
           chunkFileNames: 'chunks/[name]-[hash].js'
         },
-        plugins: [createMainBootstrapPlugin(), createPlainNodeEntryGuardPlugin()]
+        plugins: [
+          createMainBootstrapPlugin(),
+          createPlainNodeEntryGuardPlugin(),
+          // Why: this entry is a sandboxed guest-WebContents preload built by the main
+          // config, so it needs the same browser-safe guarantee as out/preload.
+          createPreloadSandboxBuiltinGuardPlugin({
+            include: [`${BROWSER_WINDOW_CLOSE_PRELOAD_ENTRY}.js`]
+          })
+        ]
       }
     },
     // Why: compile-time substitution for the telemetry gate. See the block
@@ -277,6 +289,12 @@ export const electronViteConfig: UserConfig = {
     build: {
       externalizeDeps: {
         exclude: ['@electron-toolkit/preload']
+      },
+      rollupOptions: {
+        // Electron is the only privileged preload external; bundling the npm
+        // package would pull its Node-only installer (fs/path/child_process).
+        external: ['electron'],
+        plugins: [createPreloadSandboxBuiltinGuardPlugin()]
       }
     }
   },


### PR DESCRIPTION
## The problem

A sandboxed preload can resolve exactly one module: `electron`. Anything else — a Node builtin, a bare npm external, or a Rollup helper chunk — throws at load.

The TypeScript import graph does not show this. The violation only exists in the *emitted bundle*, so a refactor can introduce one and every static check still passes.

## The fix

Guard the artifact boundary. The plugin runs in `generateBundle`, **before Rollup writes**, so an unsafe preload never reaches `out/` for a later `pnpm start` or packaging step to pick up — including on watch rebuilds.

Coverage:
- every `out/preload` chunk, plus the main build's `browser-window-close-preload` entry
- fails closed if that guarded entry is ever renamed out of the bundle
- reads Rollup's resolved import lists *and* scans emitted source, so bare/static imports, dynamic imports, helper chunks, and literal, renamed (`__require`), or non-literal `require` forms all fail

## Verification

- 19 tests, including a real-build write-path case asserting **no output lands on disk** when a preload imports a Node builtin
- `pnpm run build:electron-vite` exits 0 with the guard active
- `oxfmt`, `oxlint`, `typecheck`, `git diff --check` clean

157 production LOC. Independent of any other in-flight terminal work.

Made with [Orca](https://github.com/stablyai/orca) 🐋
