### PR TITLE
fix(quick-open): bundle ripgrep so local search works without a user-installed rg

### DIFF
--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -172,6 +172,8 @@ module.exports = {
   // disappears from Agent Session History in packaged builds only. Worker
   // entries reached solely from the Electron main process stay packed, since
   // asar redirects their app.asar paths.
+  // Why: the bundled ripgrep is an executable spawned by Quick Open; it must sit
+  // on disk (and keep its +x bit) rather than inside app.asar.
   asarUnpack: [
     'out/package.json',
     'out/cli/**',
@@ -199,7 +201,8 @@ module.exports = {
     'node_modules/tweetnacl/**',
     'node_modules/zod/**',
     'node_modules/yaml/**',
-    'node_modules/sherpa-onnx*/**'
+    'node_modules/sherpa-onnx*/**',
+    'node_modules/@vscode/ripgrep-*/**'
   ],
   afterPack: async (context) => {
     // Why: a Linux runner-image glibc bump silently shipped a node-pty pty.node

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -405,6 +405,30 @@ function prunePackagedParcelWatcher(resourcesDir, electronPlatformName, electron
   }
 }
 
+function prunePackagedRipgrep(resourcesDir, electronPlatformName, electronArch) {
+  // Why: the bundled rg is asarUnpacked, so it lands beside app.asar rather than in
+  // the extraResources node_modules the other pruners walk.
+  const vscodeDir = join(resourcesDir, 'app.asar.unpacked', 'node_modules', '@vscode')
+  if (!existsSync(vscodeDir)) {
+    return
+  }
+
+  // Why: supportedArchitectures installs every @vscode/ripgrep-<platform>-<arch>
+  // optional subpackage, and electron-builder's collector does not filter by the
+  // os/cpu fields — without this each build ships ~25MB of foreign binaries.
+  const architecture = normalizeElectronArchitecture(electronArch)
+  const targetPackage = `ripgrep-${electronPlatformName}-${architecture}`
+  for (const entry of readdirSync(vscodeDir, { withFileTypes: true })) {
+    if (!entry.isDirectory() || !entry.name.startsWith('ripgrep-')) {
+      continue
+    }
+    if (entry.name === targetPackage) {
+      continue
+    }
+    rmSync(join(vscodeDir, entry.name), { recursive: true, force: true })
+  }
+}
+
 function prunePackagedRuntimeTypeDeclarations(resourcesDir) {
   const nodeModulesDir = join(resourcesDir, 'node_modules')
   if (!existsSync(nodeModulesDir)) {
@@ -448,6 +472,7 @@ function prunePackagedRuntimeNodeModules(resourcesDir, electronPlatformName, ele
   const architecture = normalizeElectronArchitecture(electronArch)
   prunePackagedNodePty(resourcesDir, electronPlatformName, architecture)
   prunePackagedParcelWatcher(resourcesDir, electronPlatformName, architecture)
+  prunePackagedRipgrep(resourcesDir, electronPlatformName, architecture)
   prunePackagedRuntimeTypeDeclarations(resourcesDir)
   prunePackagedSherpaOnnx(resourcesDir, electronPlatformName)
   prunePackagedZodSources(resourcesDir)
@@ -472,6 +497,7 @@ module.exports = {
   packageNameFromSpecifier,
   prunePackagedNodePty,
   prunePackagedParcelWatcher,
+  prunePackagedRipgrep,
   prunePackagedRuntimeNodeModules,
   prunePackagedSherpaOnnx,
   prunePackagedRuntimeTypeDeclarations,

--- a/config/scripts/electron-builder-ripgrep.test.mjs
+++ b/config/scripts/electron-builder-ripgrep.test.mjs
@@ -1,0 +1,80 @@
+import { mkdir, mkdtemp, readdir, rm } from 'node:fs/promises'
+import { createRequire } from 'node:module'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const electronBuilderConfig = require('../electron-builder.config.cjs')
+const { prunePackagedRipgrep } = require('../packaged-runtime-node-modules.cjs')
+
+const RIPGREP_PLATFORM_PACKAGES = [
+  'ripgrep-darwin-arm64',
+  'ripgrep-darwin-x64',
+  'ripgrep-linux-arm64',
+  'ripgrep-linux-x64',
+  'ripgrep-win32-arm64',
+  'ripgrep-win32-x64'
+]
+
+describe('bundled ripgrep packaging', () => {
+  // Why: rg is spawned as an executable, and a binary inside app.asar cannot be exec'd —
+  // packing it would silently drop Quick Open back to the git fallback (#9539).
+  it('unpacks the bundled ripgrep binaries', () => {
+    expect(electronBuilderConfig.asarUnpack).toEqual(
+      expect.arrayContaining(['node_modules/@vscode/ripgrep-*/**'])
+    )
+  })
+
+  it('prunes non-target ripgrep platform subpackages from app.asar.unpacked', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-ripgrep-prune-'))
+    try {
+      const vscodeDir = join(resourcesDir, 'app.asar.unpacked', 'node_modules', '@vscode')
+      await mkdir(join(vscodeDir, 'ripgrep'), { recursive: true })
+      for (const name of RIPGREP_PLATFORM_PACKAGES) {
+        await mkdir(join(vscodeDir, name), { recursive: true })
+      }
+
+      prunePackagedRipgrep(resourcesDir, 'darwin', 'arm64')
+
+      await expect(readdir(vscodeDir).then((entries) => entries.sort())).resolves.toEqual([
+        'ripgrep',
+        'ripgrep-darwin-arm64'
+      ])
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  // Why: electron-builder's ${platform} macro expands to the build host, not the target,
+  // so a cross-built artifact must be pruned from context.electronPlatformName instead.
+  it('prunes by the target platform, not the build host', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-ripgrep-prune-cross-'))
+    try {
+      const vscodeDir = join(resourcesDir, 'app.asar.unpacked', 'node_modules', '@vscode')
+      for (const name of RIPGREP_PLATFORM_PACKAGES) {
+        await mkdir(join(vscodeDir, name), { recursive: true })
+      }
+
+      prunePackagedRipgrep(resourcesDir, 'win32', 'x64')
+
+      await expect(readdir(vscodeDir)).resolves.toEqual(['ripgrep-win32-x64'])
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+
+  it('rejects an unsupported packaging architecture', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-ripgrep-prune-arch-'))
+    try {
+      await mkdir(join(resourcesDir, 'app.asar.unpacked', 'node_modules', '@vscode'), {
+        recursive: true
+      })
+      expect(() => prunePackagedRipgrep(resourcesDir, 'darwin', 'universal')).toThrow(
+        'Unsupported packaged runtime architecture: universal'
+      )
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
+  })
+})

--- a/package.json
+++ b/package.json
@@ -132,6 +132,7 @@
     "@floating-ui/dom": "1.7.6",
     "@linear/sdk": "^82.1.0",
     "@parcel/watcher": "^2.5.6",
+    "@vscode/ripgrep": "^1.18.0",
     "@xterm/addon-serialize": "0.15.0-beta.287",
     "@xterm/headless": "6.1.0-beta.287",
     "agent-browser": "~0.27.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -43,6 +43,9 @@ importers:
       '@parcel/watcher':
         specifier: ^2.5.6
         version: 2.5.6
+      '@vscode/ripgrep':
+        specifier: ^1.18.0
+        version: 1.18.0
       '@xterm/addon-serialize':
         specifier: 0.15.0-beta.287
         version: 0.15.0-beta.287(patch_hash=af3b156143ed2ee9903b753145b63dd4a2ee72cadd7ef333ab0f4d5d3ebfc32c)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
@@ -3374,6 +3377,69 @@ packages:
 
   '@vitest/utils@4.1.5':
     resolution: {integrity: sha512-76wdkrmfXfqGjueGgnb45ITPyUi1ycZ4IHgC2bhPDUfWHklY/q3MdLOAB+TF1e6xfl8NxNY0ZYaPCFNWSsw3Ug==}
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    resolution: {integrity: sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    resolution: {integrity: sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==}
+    cpu: [x64]
+    os: [darwin]
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    resolution: {integrity: sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==}
+    cpu: [arm64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    resolution: {integrity: sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==}
+    cpu: [arm]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    resolution: {integrity: sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==}
+    cpu: [ia32]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    resolution: {integrity: sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    resolution: {integrity: sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    resolution: {integrity: sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==}
+    cpu: [s390x]
+    os: [linux]
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    resolution: {integrity: sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==}
+    cpu: [x64]
+    os: [linux]
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    resolution: {integrity: sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==}
+    cpu: [arm64]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    resolution: {integrity: sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==}
+    cpu: [ia32]
+    os: [win32]
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    resolution: {integrity: sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==}
+    cpu: [x64]
+    os: [win32]
+
+  '@vscode/ripgrep@1.18.0':
+    resolution: {integrity: sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==}
 
   '@xmldom/xmldom@0.8.13':
     resolution: {integrity: sha512-KRYzxepc14G/CEpEGc3Yn+JKaAeT63smlDr+vjB8jRfgTBBI9wRj/nkQEO+ucV8p8I9bfKLWp37uHgFrbntPvw==}
@@ -9588,6 +9654,57 @@ snapshots:
       '@vitest/pretty-format': 4.1.5
       convert-source-map: 2.0.0
       tinyrainbow: 3.1.0
+
+  '@vscode/ripgrep-darwin-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-darwin-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-arm@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-ppc64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-riscv64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-s390x@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-linux-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-arm64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-ia32@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep-win32-x64@1.18.0':
+    optional: true
+
+  '@vscode/ripgrep@1.18.0':
+    optionalDependencies:
+      '@vscode/ripgrep-darwin-arm64': 1.18.0
+      '@vscode/ripgrep-darwin-x64': 1.18.0
+      '@vscode/ripgrep-linux-arm': 1.18.0
+      '@vscode/ripgrep-linux-arm64': 1.18.0
+      '@vscode/ripgrep-linux-ia32': 1.18.0
+      '@vscode/ripgrep-linux-ppc64': 1.18.0
+      '@vscode/ripgrep-linux-riscv64': 1.18.0
+      '@vscode/ripgrep-linux-s390x': 1.18.0
+      '@vscode/ripgrep-linux-x64': 1.18.0
+      '@vscode/ripgrep-win32-arm64': 1.18.0
+      '@vscode/ripgrep-win32-ia32': 1.18.0
+      '@vscode/ripgrep-win32-x64': 1.18.0
 
   '@xmldom/xmldom@0.8.13': {}
 

--- a/src/main/ipc/bundled-ripgrep.test.ts
+++ b/src/main/ipc/bundled-ripgrep.test.ts
@@ -1,0 +1,36 @@
+import { execFile as execFileCallback } from 'node:child_process'
+import { promisify } from 'node:util'
+import { describe, expect, it } from 'vitest'
+import { getBundledRgPath, resolveRgCommand } from './bundled-ripgrep'
+
+const execFile = promisify(execFileCallback)
+
+describe('bundled ripgrep', () => {
+  it('ships a prebuilt for every architecture the desktop app targets', () => {
+    expect(getBundledRgPath()).not.toBeNull()
+  })
+
+  it('resolves an rg that actually executes', async () => {
+    // Why: the whole point of #9539 — a path string proves nothing if the binary cannot run.
+    const { stdout } = await execFile(resolveRgCommand(), ['--version'])
+    expect(stdout).toMatch(/^ripgrep \d+\.\d+\.\d+/)
+  })
+
+  it('finds files under a directory, which is what Quick Open needs', async () => {
+    const { stdout } = await execFile(resolveRgCommand(), ['--files', '--max-count', '1'], {
+      cwd: process.cwd()
+    })
+    expect(stdout.split('\n').filter(Boolean).length).toBeGreaterThan(0)
+  })
+
+  it('prefers the bundled binary for a local search', () => {
+    expect(resolveRgCommand({ cwd: process.cwd() })).toBe(getBundledRgPath())
+  })
+
+  // Why: not gated on the host platform — a registered distro means the spawn is bound for
+  // WSL, and the desktop suite runs these Windows-shaped cases on every OS. UNC-path
+  // detection is delegated to parseWslPath, which is win32-only by design.
+  it('keeps PATH lookup when a WSL distro is registered', () => {
+    expect(resolveRgCommand({ cwd: 'C:\\repo', wslDistro: 'Ubuntu' })).toBe('rg')
+  })
+})

--- a/src/main/ipc/bundled-ripgrep.ts
+++ b/src/main/ipc/bundled-ripgrep.ts
@@ -1,0 +1,79 @@
+import { existsSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { join } from 'node:path'
+import { parseWslPath } from '../wsl'
+
+const requireFromMain = createRequire(__filename)
+
+/** PATH lookup — the pre-bundling behavior, still correct for WSL and remote hosts. */
+const PATH_RG = 'rg'
+
+function toUnpackedAsarPath(candidate: string): string {
+  return candidate
+    .replace(/app\.asar([/\\])/, 'app.asar.unpacked$1')
+    .replace(/node_modules\.asar([/\\])/, 'node_modules.asar.unpacked$1')
+}
+
+function bundledRgCandidates(): string[] {
+  const platformPackage = `ripgrep-${process.platform}-${process.arch}`
+  const binaryName = process.platform === 'win32' ? 'rg.exe' : 'rg'
+  const candidates: string[] = []
+
+  // Why: prefer the known packaged layout over module resolution, which would have to
+  // resolve a path inside app.asar for a file that packaging moved out of it.
+  if (process.resourcesPath) {
+    candidates.push(
+      join(
+        process.resourcesPath,
+        'app.asar.unpacked',
+        'node_modules',
+        '@vscode',
+        platformPackage,
+        'bin',
+        binaryName
+      )
+    )
+  }
+
+  try {
+    // Why: resolve the platform subpackage directly rather than importing @vscode/ripgrep —
+    // its entry is ESM-only and the main bundle is CommonJS.
+    candidates.push(
+      toUnpackedAsarPath(requireFromMain.resolve(`@vscode/${platformPackage}/bin/${binaryName}`))
+    )
+  } catch {
+    // No prebuilt subpackage is installed for this platform/arch.
+  }
+
+  return candidates
+}
+
+/**
+ * Absolute path to the bundled ripgrep for this host, or null when no prebuilt ships
+ * for the running platform/arch.
+ *
+ * Why the existsSync: handing spawn a path that is not on disk would fail the availability
+ * probe and silently drop Quick Open back to the git fallback — the bug this bundling fixes.
+ */
+export function getBundledRgPath(): string | null {
+  return bundledRgCandidates().find((candidate) => existsSync(candidate)) ?? null
+}
+
+/**
+ * Resolve the `rg` command for a `wslAwareSpawn`, preferring the bundled binary.
+ *
+ * Why: a spawn bound for a WSL distro executes inside it, where a host-side binary path is
+ * meaningless, so those keep PATH lookup. The check is deliberately not gated on
+ * `process.platform === 'win32'` — a registered distro means WSL intent regardless of the
+ * host, and falling back to PATH is the pre-existing behavior either way. Relay/SSH searches
+ * run on the remote host and never reach this resolver.
+ */
+export function resolveRgCommand(options: { cwd?: string; wslDistro?: string } = {}): string {
+  const routesThroughWsl = Boolean(
+    (options.cwd ? parseWslPath(options.cwd) : null) ?? options.wslDistro
+  )
+  if (routesThroughWsl) {
+    return PATH_RG
+  }
+  return getBundledRgPath() ?? PATH_RG
+}

--- a/src/main/ipc/bundled-ripgrep.ts
+++ b/src/main/ipc/bundled-ripgrep.ts
@@ -8,12 +8,14 @@ const requireFromMain = createRequire(__filename)
 /** PATH lookup — the pre-bundling behavior, still correct for WSL and remote hosts. */
 const PATH_RG = 'rg'
 
+/** Redirect an in-archive path to its `asarUnpack` copy, which is the one that can be exec'd. */
 function toUnpackedAsarPath(candidate: string): string {
   return candidate
     .replace(/app\.asar([/\\])/, 'app.asar.unpacked$1')
     .replace(/node_modules\.asar([/\\])/, 'node_modules.asar.unpacked$1')
 }
 
+/** Where the bundled binary may live, packaged layout first; empty when no prebuilt ships. */
 function bundledRgCandidates(): string[] {
   const platformPackage = `ripgrep-${process.platform}-${process.arch}`
   const binaryName = process.platform === 'win32' ? 'rg.exe' : 'rg'

--- a/src/main/ipc/filesystem-list-files-bundled-rg.test.ts
+++ b/src/main/ipc/filesystem-list-files-bundled-rg.test.ts
@@ -52,8 +52,9 @@ describe('Quick Open with the bundled ripgrep', () => {
     const repoPath = join(tempDir, 'repo')
     await execFile('git', ['init', '-q', repoPath])
     await writeFile(join(repoPath, 'tracked.ts'), 'export const a = 1')
-    // Why: untracked and uncommitted — git ls-files would miss it, so its presence
-    // proves the listing came from rg.
+    await execFile('git', ['add', 'tracked.ts'], { cwd: repoPath })
+    // Why: deliberately left unstaged, so git ls-files would miss it — its presence proves the
+    // listing came from rg, while tracked.ts keeps the tracked case covered too.
     await writeFile(join(repoPath, 'untracked.ts'), 'export const b = 2')
 
     const result = await listQuickOpenFiles(repoPath, makeStore(repoPath))

--- a/src/main/ipc/filesystem-list-files-bundled-rg.test.ts
+++ b/src/main/ipc/filesystem-list-files-bundled-rg.test.ts
@@ -53,8 +53,8 @@ describe('Quick Open with the bundled ripgrep', () => {
     await execFile('git', ['init', '-q', repoPath])
     await writeFile(join(repoPath, 'tracked.ts'), 'export const a = 1')
     await execFile('git', ['add', 'tracked.ts'], { cwd: repoPath })
-    // Why: deliberately left unstaged, so git ls-files would miss it — its presence proves the
-    // listing came from rg, while tracked.ts keeps the tracked case covered too.
+    // Why: untracked.ts is never staged, so a git ls-files listing would omit it — its presence
+    // proves the result came from rg, while the staged tracked.ts covers the tracked case.
     await writeFile(join(repoPath, 'untracked.ts'), 'export const b = 2')
 
     const result = await listQuickOpenFiles(repoPath, makeStore(repoPath))

--- a/src/main/ipc/filesystem-list-files-bundled-rg.test.ts
+++ b/src/main/ipc/filesystem-list-files-bundled-rg.test.ts
@@ -1,0 +1,64 @@
+import { execFile as execFileCallback } from 'node:child_process'
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { promisify } from 'node:util'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+
+const { listFilesWithGitMock } = vi.hoisted(() => ({
+  listFilesWithGitMock: vi.fn()
+}))
+
+// Why: the fallback is the degraded path #9539 is about — assert it is never reached,
+// which is only true when rg resolves without a user-installed binary on PATH.
+vi.mock('./filesystem-list-files-git-fallback', () => ({
+  listFilesWithGit: listFilesWithGitMock
+}))
+
+import { listQuickOpenFiles } from './filesystem-list-files'
+
+const execFile = promisify(execFileCallback)
+
+function makeStore(repoPath: string): Store {
+  return {
+    getRepos: () => [
+      {
+        id: 'repo-1',
+        path: repoPath,
+        displayName: 'repo',
+        badgeColor: '#000000',
+        addedAt: 0,
+        kind: 'git'
+      }
+    ],
+    getSettings: () => ({})
+  } as unknown as Store
+}
+
+describe('Quick Open with the bundled ripgrep', () => {
+  let tempDir: string | null = null
+
+  afterEach(async () => {
+    if (tempDir) {
+      await rm(tempDir, { recursive: true, force: true })
+      tempDir = null
+    }
+    vi.clearAllMocks()
+  })
+
+  it('lists files through rg without falling back to git listing', async () => {
+    tempDir = await mkdtemp(join(tmpdir(), 'orca-quick-open-bundled-rg-'))
+    const repoPath = join(tempDir, 'repo')
+    await execFile('git', ['init', '-q', repoPath])
+    await writeFile(join(repoPath, 'tracked.ts'), 'export const a = 1')
+    // Why: untracked and uncommitted — git ls-files would miss it, so its presence
+    // proves the listing came from rg.
+    await writeFile(join(repoPath, 'untracked.ts'), 'export const b = 2')
+
+    const result = await listQuickOpenFiles(repoPath, makeStore(repoPath))
+
+    expect(result).toEqual(expect.arrayContaining(['tracked.ts', 'untracked.ts']))
+    expect(listFilesWithGitMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/ipc/filesystem-list-files.ts
+++ b/src/main/ipc/filesystem-list-files.ts
@@ -3,6 +3,7 @@ import type { ChildProcess } from 'node:child_process'
 import type { Store } from '../persistence'
 import { resolveAuthorizedPath } from './filesystem-auth'
 import { checkRgAvailable } from './rg-availability'
+import { resolveRgCommand } from './bundled-ripgrep'
 import { wslAwareSpawn } from '../git/runner'
 import { parseWslPath, toWindowsWslPath } from '../wsl'
 import { getLocalGitOptionsForRegisteredWorktree } from './local-worktree-runtime-options'
@@ -68,6 +69,10 @@ export async function listQuickOpenFiles(
     return listWithoutRipgrep()
   }
 
+  const rgCommand = resolveRgCommand({
+    cwd: authorizedRootPath,
+    wslDistro: localGitOptions.wslDistro
+  })
   const files = new Set<string>()
   const children: {
     child: ChildProcess
@@ -121,7 +126,7 @@ export async function listQuickOpenFiles(
         return maxResults !== undefined && files.size >= maxResults
       }
 
-      const child = wslAwareSpawn('rg', args, {
+      const child = wslAwareSpawn(rgCommand, args, {
         cwd: authorizedRootPath,
         ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
         stdio: ['ignore', 'pipe', 'pipe']

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -112,6 +112,7 @@ import {
 } from './source-control-ai-linked-issue'
 import { listMarkdownDocuments, markdownDocumentsFromRelativePaths } from './markdown-documents'
 import { checkRgAvailable } from './rg-availability'
+import { resolveRgCommand } from './bundled-ripgrep'
 import {
   absorbPendingRipgrepSpawnError,
   isRipgrepUnavailableExit,
@@ -992,6 +993,8 @@ export function registerFilesystemHandlers(
         return searchWithGitGrep(rootPath, args, maxResults, localGitOptions)
       }
 
+      const rgCommand = resolveRgCommand({ cwd: rootPath, wslDistro: localGitOptions.wslDistro })
+
       return new Promise<SearchResult>((resolvePromise) => {
         const rgArgs = buildRgArgs(args.query, rootPath, args)
 
@@ -1046,7 +1049,7 @@ export function registerFilesystemHandlers(
           }
         }
 
-        const nextChild = wslAwareSpawn('rg', rgArgs, {
+        const nextChild = wslAwareSpawn(rgCommand, rgArgs, {
           cwd: rootPath,
           ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
           stdio: ['ignore', 'pipe', 'pipe']

--- a/src/main/ipc/rg-availability.test.ts
+++ b/src/main/ipc/rg-availability.test.ts
@@ -11,6 +11,7 @@ vi.mock('../git/runner', () => ({
 }))
 
 import { checkRgAvailable } from './rg-availability'
+import { resolveRgCommand } from './bundled-ripgrep'
 
 function createMockProcess(): ChildProcess {
   const child = new EventEmitter() as unknown as ChildProcess
@@ -31,10 +32,15 @@ describe('checkRgAvailable', () => {
     child.emit('close', 0)
 
     await expect(promise).resolves.toBe(true)
-    expect(wslAwareSpawnMock).toHaveBeenCalledWith('rg', ['--version'], {
-      cwd: '/repo',
-      stdio: 'ignore'
-    })
+    // Why: a local probe now runs the bundled binary, so it no longer depends on PATH.
+    expect(wslAwareSpawnMock).toHaveBeenCalledWith(
+      resolveRgCommand({ cwd: '/repo' }),
+      ['--version'],
+      {
+        cwd: '/repo',
+        stdio: 'ignore'
+      }
+    )
   })
 
   it('settles and detaches when rg availability check ignores timeout kills', async () => {

--- a/src/main/ipc/rg-availability.ts
+++ b/src/main/ipc/rg-availability.ts
@@ -1,4 +1,5 @@
 import { wslAwareSpawn } from '../git/runner'
+import { resolveRgCommand } from './bundled-ripgrep'
 
 const RG_AVAILABILITY_TIMEOUT_MS = 5000
 
@@ -19,7 +20,7 @@ export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promi
     let settled = false
     // Why: pass cwd plus project-runtime distro so WSL projects are checked
     // inside their distro even when the search root is a Windows path.
-    const child = wslAwareSpawn('rg', ['--version'], {
+    const child = wslAwareSpawn(resolveRgCommand({ cwd: searchPath, wslDistro }), ['--version'], {
       ...(searchPath ? { cwd: searchPath } : {}),
       ...(wslDistro ? { wslDistro } : {}),
       stdio: 'ignore'

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -58,6 +58,7 @@ import { listQuickOpenFiles } from '../ipc/filesystem-list-files'
 import { searchWithGitGrep } from '../ipc/filesystem-search-git'
 import { getLocalGitOptionsForRegisteredWorktree } from '../ipc/local-worktree-runtime-options'
 import { checkRgAvailable } from '../ipc/rg-availability'
+import { resolveRgCommand } from '../ipc/bundled-ripgrep'
 import {
   absorbPendingRipgrepSpawnError,
   isRipgrepUnavailableExit,
@@ -1933,6 +1934,11 @@ export class RuntimeFileCommands {
       return searchWithGitGrep(authorizedRootPath, options, maxResults, localGitOptions)
     }
 
+    const rgCommand = resolveRgCommand({
+      cwd: authorizedRootPath,
+      wslDistro: localGitOptions.wslDistro
+    })
+
     return new Promise<SearchResult>((resolvePromise) => {
       const searchKey = `${this.host.getRuntimeId()}:${authorizedRootPath}`
       const rgArgs = buildRgArgs(options.query, authorizedRootPath, options)
@@ -1997,7 +2003,7 @@ export class RuntimeFileCommands {
         }
       }
 
-      const nextChild = wslAwareSpawn('rg', rgArgs, {
+      const nextChild = wslAwareSpawn(rgCommand, rgArgs, {
         cwd: authorizedRootPath,
         ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
         stdio: ['ignore', 'pipe', 'pipe']


### PR DESCRIPTION
Closes #9539.

## Summary

Quick Open now works on a machine with no user-installed `rg`.

Previously, a local search on a host without ripgrep on `PATH` fell back to `git ls-files` / a `readdir` walk, and that fallback's budget blows on large repos — surfacing as `File listing exceeded 10000 files` even when you typed a single known filename. Installing ripgrep by hand was the only fix.

### Root cause

Orca only ever resolved ripgrep from the user's `PATH` (`checkRgAvailable()` spawns a bare `rg`). @AmethystLiang laid out the durable fix in #9539 — bundle ripgrep for the local host the way VS Code does — and noted that #9627 (merged) improved the *alerting* without removing the failure. This removes it.

### What changed

- Added `@vscode/ripgrep` (MIT). v1.18.0 ships prebuilts as **platform-specific `optionalDependencies`** — no postinstall, no install-time network fetch, no `onlyBuiltDependencies` entry needed.
- New `src/main/ipc/bundled-ripgrep.ts` — `resolveRgCommand()` returns the bundled binary's absolute path for a local spawn, else `'rg'` from `PATH`.
- Wired into the four main-process `rg` spawn sites: `rg-availability.ts`, `filesystem-list-files.ts`, `filesystem.ts`, `orca-runtime-files.ts`.
- `asarUnpack` entry so the executable lands on disk with its `+x` bit instead of inside `app.asar`.
- `prunePackagedRipgrep()` in the existing `afterPack` pruner.

## Screenshots

No visual change — same UI, same results, it just stops failing. The user-visible difference is the absence of a `File listing exceeded 10000 files` error on a machine without `rg`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Built and verified on macOS (arm64).

New tests:
- `src/main/ipc/bundled-ripgrep.test.ts` — a prebuilt resolves for the running arch, the resolved command **actually executes** (`rg --version`) and lists files, and a registered WSL distro keeps `PATH` lookup.
- `src/main/ipc/filesystem-list-files-bundled-rg.test.ts` — end to end through the real `listQuickOpenFiles`, asserting an untracked file is listed (which `git ls-files` would miss) **and** that the git fallback is never called.
- `config/scripts/electron-builder-ripgrep.test.mjs` — guards the `asarUnpack` entry, the pruner, and that pruning keys off the target platform rather than the build host. Kept as its own file because adding it to `electron-builder-config.test.mjs` would cross the 600-line `max-lines` limit, and AGENTS.md forbids adding a suppression.

Updated `src/main/ipc/rg-availability.test.ts`, whose assertion pinned the literal `'rg'` — that is the behavior this PR intentionally changes for local probes.

Verified non-blind: reverting `resolveRgCommand()` to `PATH`-only fails 5 of them. **The dev machine had no `rg` on `PATH` at all**, so this reproduces the issue's exact condition rather than simulating it.

On the full `pnpm test` run, five failures (`check-root-directory-entries` ×3, `agent-exec-handler` ×2) reproduce identically on a clean checkout with this branch stashed, so none are from this change. Both are local-environment artifacts: the root-directory guard shells out to `.github/scripts/check-root-directory-entries.sh`, which uses `declare -A` (bash 4+) while macOS ships bash 3.2; and `agent-exec-handler` asserts the spawned env contains all of `process.env`, which fails on any dev machine whose shell exports a var the handler overrides (e.g. `GIT_ASKPASS`).

## AI Review Report

Reviewed with Claude Opus 5 against the CONTRIBUTING checklist.

- **Cross-platform (macOS/Linux/Windows)** — no hardcoded separators; the binary name switches on `win32`; per-arch resolution via `process.arch`; mac targets are per-arch DMGs (not universal), so `process.arch` is unambiguous per build. **Linux glibc floor:** the bundled Linux binaries are statically linked (`static-pie linked` on x64, `statically linked` on arm64) with zero `GLIBC_*` symbols, so they clear the Ubuntu 20.04 / glibc 2.31 floor and `verifyLinuxGlibcFloor`. **Unsupported platform/arch:** `getBundledRgPath()` returns `null` when no prebuilt ships (e.g. `linux-ia32`) and the resolver degrades to today's `PATH` behavior rather than throwing. It also `existsSync`-checks the resolved path first, so a missing binary degrades instead of silently failing the availability probe and dropping back to the git fallback.
- **SSH/remote/local** — the relay's own `rg` spawns (`src/relay/fs-handler-utils.ts`, `fs-handler-list-files.ts`) run *on the remote host* and keep `PATH` lookup — shipping a client-side binary there would be wrong. Verified by grep that `src/relay/**` has no path into the new resolver. Remote searches still get the existing availability check and the #9627 install guidance, which is exactly the residual case @AmethystLiang described. No wire change, so mixed client/host versions are unaffected.
- **WSL** — when a distro is registered for the worktree, or the cwd is a WSL UNC path, the resolver returns `'rg'`; a host-side binary path is meaningless inside the distro. Deliberately **not** gated on `process.platform === 'win32'`: a registered distro signals WSL intent regardless of host, and the existing suite exercises Windows-shaped worktrees (`C:\repo` + `wslDistro`) while running on every OS. UNC detection is delegated to `parseWslPath`, which is win32-only by design.
- **Folder workspaces** — the resolver keys off nothing git-related, so non-git folder workspaces get the same benefit — and they're the likeliest to hit the readdir fallback, having no `git ls-files` to lean on.
- **Agent/integration/git provider** — none touched; Quick Open listing is provider-neutral and stays so.
- **Performance** — one `require.resolve` + `existsSync` per search, on a path that already spawns a subprocess. Deliberately uncached, matching the existing "why no cache" reasoning in `rg-availability.ts`.
- **UI quality** — no UI change.

What it flagged and I acted on: the declarative alternative (a `${platform}` macro in `files`) is a trap — `expandMacro` resolves `${platform}` to `process.platform`, the *build host*, not the target. Pruning has to key off `context.electronPlatformName`, which is what the existing pruners do and what the new test now pins.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency and IPC risk. This adds a dependency and changes what binary gets executed, so both got a close look.

- **New dependency.** `@vscode/ripgrep` v1.18.0, MIT, maintained by the VS Code team. It is the same package VS Code ships, chosen over alternatives because v1.18.0 distributes prebuilts as platform-specific `optionalDependencies` — **no postinstall script, and no install-time network fetch**, which is the supply-chain property that mattered. No `onlyBuiltDependencies` entry is needed precisely because nothing runs at install.
- **Command execution.** This changes `rg` from a `PATH` lookup to an absolute path inside the app bundle. That is a **hardening** step, not a regression: a bare `rg` on `PATH` is resolvable by anything earlier on the user's `PATH`, whereas the bundled path is not. The resolver returns an absolute path or the previous `'rg'` literal — it never builds a command string from user input, and the spawn sites are unchanged in how they pass arguments (still argv arrays, no shell).
- **Path handling.** The resolved path comes from `require.resolve` against the bundled package, not from user or renderer input. `existsSync` gates it, so a pruned-away or missing binary degrades to `PATH` rather than spawning something unexpected.
- **Packaging.** `asarUnpack` places the executable on disk with its `+x` bit. `prunePackagedRipgrep()` drops non-target-platform binaries in `afterPack`, mirroring the existing `prunePackagedParcelWatcher()`.
- **Input handling / IPC / auth / secrets** — no new IPC surface, no credentials, no network calls at runtime or install.

No follow-up needed.

## Notes

**Bundle size.** ~4.3–5.5 MB for the target platform. Worth flagging because it is the main cost of this change: `supportedArchitectures` installs all six subpackages and electron-builder's node-module collector does **not** filter by the `os`/`cpu` fields these packages declare, so without pruning every build would ship ~25 MB of foreign binaries. `prunePackagedRipgrep()` drops the non-target ones in `afterPack`.

**Remote hosts still need their own `rg`.** That is deliberate and matches the issue — the residual case @AmethystLiang described, already covered by the #9627 guidance.

This is the largest of the changes I have open and the only one that adds a dependency, so if the team would rather take it after the smaller fixes, that is completely reasonable.

X: [@manuaudiomix](https://x.com/manuaudiomix)
