### PR TITLE
fix(sidebar): remove the project on its own host, not another host's row

### DIFF
--- a/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
@@ -9,6 +9,8 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/store'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 
 // Why: interpolated into the sentence so locales control where the name sits;
@@ -23,6 +25,11 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
 
   const isOpen = activeModal === 'confirm-remove-folder'
   const repoId = typeof modalData.repoId === 'string' ? modalData.repoId : ''
+  // Why: both openers carry the row's host so a repo id duplicated across hosts removes the
+  // intended row instead of whichever one the unique-candidate fallback picks (#13071).
+  const hostId =
+    normalizeExecutionHostId(typeof modalData.hostId === 'string' ? modalData.hostId : null) ??
+    undefined
   const displayName = typeof modalData.displayName === 'string' ? modalData.displayName : ''
 
   // Why: for an SSH project the files live on the remote host's disk, not the
@@ -30,7 +37,12 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   // removed-target label when it's a ghost) so the user knows where it remains
   // and that re-adding that host recovers it.
   const sshHostLabel = useAppStore((s) => {
-    const connectionId = s.repos.find((r) => r.id === repoId)?.connectionId?.trim()
+    // Why: a bare first-by-id lookup can name a different host's row in the confirmation text
+    // than the one removal actually targets (#13071).
+    const connectionId = findRepoForHost(s.repos, repoId, {
+      hostId,
+      settings: s.settings
+    })?.connectionId?.trim()
     if (!connectionId) {
       return null
     }
@@ -59,10 +71,10 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
 
   const handleConfirm = useCallback(() => {
     if (repoId) {
-      void removeProject(repoId, { errorFeedback: 'toast' })
+      void removeProject(repoId, { hostId, errorFeedback: 'toast' })
     }
     closeModal()
-  }, [closeModal, removeProject, repoId])
+  }, [closeModal, hostId, removeProject, repoId])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -6158,6 +6158,8 @@ const WorktreeList = React.memo(function WorktreeList({
     (repo: Repo) => {
       openModal('confirm-remove-folder', {
         repoId: repo.id,
+        // Why: carry the row's own host so removal cannot resolve to another host's row (#13071).
+        hostId: getRepoExecutionHostId(repo),
         displayName: repo.displayName
       })
     },

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -12,9 +12,10 @@ const mocks = vi.hoisted(() => {
         path: string
         displayName: string
         isMainWorktree: boolean
+        hostId?: string
       }
     >(),
-    repos: [] as { id: string; displayName: string }[],
+    repos: [] as { id: string; displayName: string; connectionId?: string }[],
     worktreeLineageById: {},
     allWorktrees: () => Array.from(state.worktreeMap.values()),
     clearWorktreeDeleteState: vi.fn((worktreeId: string) => {
@@ -84,6 +85,7 @@ function setWorktrees(
     path?: string
     displayName?: string
     isMainWorktree?: boolean
+    hostId?: string
   }[]
 ): void {
   mocks.state.worktreeMap = new Map(
@@ -95,7 +97,8 @@ function setWorktrees(
         repoId: worktree.repoId ?? 'repo-1',
         path: worktree.path ?? `/workspaces/${worktree.id}`,
         displayName: worktree.displayName ?? worktree.id,
-        isMainWorktree: worktree.isMainWorktree ?? false
+        isMainWorktree: worktree.isMainWorktree ?? false,
+        ...(worktree.hostId ? { hostId: worktree.hostId } : {})
       }
     ])
   )
@@ -320,6 +323,34 @@ describe('runWorktreeBatchDelete', () => {
     expect(mocks.state.openModal).toHaveBeenCalledWith('confirm-remove-folder', {
       repoId: 'repo-1',
       displayName: 'orca'
+    })
+  })
+
+  // Why: repo ids can repeat across hosts. When the owning host's row has dropped from the
+  // catalog, a bare id lookup resolves to the *other* host's live row — and removal would then
+  // tear down that working project instead (#13071).
+  it('carries the owning host into project removal when the id exists on another host', () => {
+    mocks.state.settings = { skipDeleteWorktreeConfirm: true }
+    setWorktrees([
+      {
+        id: 'main',
+        repoId: 'repo-1',
+        displayName: 'orca on host A',
+        isMainWorktree: true,
+        hostId: 'ssh:host-a'
+      }
+    ])
+    // Host A's row has dropped from the catalog; only host B's live row remains under this id.
+    mocks.state.repos = [{ id: 'repo-1', displayName: 'orca on host B', connectionId: 'host-b' }]
+
+    runWorktreeDelete('main')
+
+    expect(mocks.state.openModal).toHaveBeenCalledWith('confirm-remove-folder', {
+      repoId: 'repo-1',
+      hostId: 'ssh:host-a',
+      // Host B's name must not leak in — naming it here is the tell that removal resolved
+      // to the wrong row.
+      displayName: 'orca on host A'
     })
   })
 

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -219,10 +219,15 @@ export function runWorktreeDelete(worktreeId: string): void {
     return
   }
   if (target.isMainWorktree) {
-    const repo = state.repos.find((entry) => entry.id === target.repoId)
+    // Why: a bare id lookup can name (and later remove) another host's row when the id is duplicated across hosts (#13071).
+    const repo = findRepoForHost(state.repos, target.repoId, {
+      hostId: target.hostId,
+      settings: state.settings
+    })
     // Why: git refuses to delete the primary checkout; users can still remove the owning project from Orca (disk contents kept).
     state.openModal('confirm-remove-folder', {
       repoId: target.repoId,
+      hostId: target.hostId,
       displayName: repo?.displayName ?? target.displayName
     })
     return

--- a/src/renderer/src/components/sidebar/remove-folder-dialog-host-identity.test.tsx
+++ b/src/renderer/src/components/sidebar/remove-folder-dialog-host-identity.test.tsx
@@ -1,0 +1,98 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+
+const { storeState } = vi.hoisted(() => ({
+  storeState: {
+    activeModal: 'confirm-remove-folder' as string,
+    modalData: {} as Record<string, unknown>,
+    closeModal: vi.fn(),
+    repos: [] as Repo[],
+    removeProject: vi.fn().mockResolvedValue(undefined),
+    sshTargetLabels: new Map<string, string>(),
+    removedSshTargetLabels: new Map<string, string>(),
+    settings: {} as Record<string, unknown>
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof storeState) => unknown) => selector(storeState),
+    { getState: () => storeState }
+  )
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replace(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+
+import RemoveFolderDialog from './RemoveFolderDialog'
+
+/** The same repo id registered on two SSH hosts. */
+function reposOnTwoHosts(): Repo[] {
+  const base = { id: 'repo-1', badgeColor: '#000000', addedAt: 0, kind: 'git' as const }
+  return [
+    { ...base, path: '/repos/b', displayName: 'on host B', connectionId: 'host-b' },
+    { ...base, path: '/repos/a', displayName: 'on host A', connectionId: 'host-a' }
+  ] as unknown as Repo[]
+}
+
+afterEach(cleanup)
+
+describe('RemoveFolderDialog host identity', () => {
+  // Why: the opener carries the host and removeProject honours it, but nothing proved this
+  // dialog forwards it between them. If it silently dropped the host, removal would resolve
+  // through findRepoForHost's fallback and could tear down another host's project (#13071).
+  it('forwards the modal host to removeProject', async () => {
+    storeState.repos = reposOnTwoHosts()
+    storeState.modalData = { repoId: 'repo-1', hostId: 'ssh:host-a', displayName: 'on host A' }
+    storeState.removeProject = vi.fn().mockResolvedValue(undefined)
+
+    render(<RemoveFolderDialog />)
+    fireEvent.click(await screen.findByRole('button', { name: /^remove$/i }))
+
+    expect(storeState.removeProject).toHaveBeenCalledWith('repo-1', {
+      hostId: 'ssh:host-a',
+      errorFeedback: 'toast'
+    })
+  })
+
+  it('passes no host when the opener could not supply one', async () => {
+    storeState.repos = reposOnTwoHosts()
+    storeState.modalData = { repoId: 'repo-1', displayName: 'on host A' }
+    storeState.removeProject = vi.fn().mockResolvedValue(undefined)
+
+    render(<RemoveFolderDialog />)
+    fireEvent.click(await screen.findByRole('button', { name: /^remove$/i }))
+
+    expect(storeState.removeProject).toHaveBeenCalledWith('repo-1', {
+      hostId: undefined,
+      errorFeedback: 'toast'
+    })
+  })
+
+  // Why: a malformed host must not be cast through — it should degrade to the previous
+  // behaviour rather than be handed to removeProject as a bogus execution host.
+  it('ignores a host that is not a valid execution host id', async () => {
+    storeState.repos = reposOnTwoHosts()
+    storeState.modalData = { repoId: 'repo-1', hostId: 'not-a-host', displayName: 'on host A' }
+    storeState.removeProject = vi.fn().mockResolvedValue(undefined)
+
+    render(<RemoveFolderDialog />)
+    fireEvent.click(await screen.findByRole('button', { name: /^remove$/i }))
+
+    expect(storeState.removeProject).toHaveBeenCalledWith('repo-1', {
+      hostId: undefined,
+      errorFeedback: 'toast'
+    })
+  })
+})

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1820,14 +1820,16 @@ async function purgeOrphanedRuntimeSshProjects(
     }
   }
   // A repo whose only host was the destroyed runtime can outlive its setup (pruned first by a projection refresh); remove it directly so no dead project lingers.
-  const orphanedRepoIds = get()
+  // Why: keep each row's own host — purging by bare id can resolve to a live row on another
+  // host when the id is duplicated across hosts (#13071).
+  const orphanedRepos = get()
     .repos.filter(
       (repo) => destroyedTargetIds.has(repo.connectionId ?? '') && !purgedRepoIds.has(repo.id)
     )
-    .map((repo) => repo.id)
-  for (const repoId of orphanedRepoIds) {
+    .map((repo) => ({ id: repo.id, hostId: getRepoExecutionHostId(repo) }))
+  for (const orphaned of orphanedRepos) {
     try {
-      await get().removeProject(repoId)
+      await get().removeProject(orphaned.id, { hostId: orphaned.hostId })
     } catch (error) {
       console.error('Failed to purge orphaned per-workspace-env repo:', error)
     }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -34,7 +34,11 @@ import {
   remapClosedTerminalTabSnapshotCwds,
   type ClosedTerminalTabSnapshot
 } from './recently-closed-tabs'
-import { findRepoForHost } from './repo-host-identity'
+import {
+  findRepoForHost,
+  getRepoHostIdentity,
+  getRepoHostIdentityForParts
+} from './repo-host-identity'
 import {
   dropWorktreeRowsForRemovedRuntimeEnvironments,
   isRemovedRuntimeHostId
@@ -1805,15 +1809,17 @@ async function purgeOrphanedRuntimeSshProjects(
   const destroyedHostIds = new Set<ExecutionHostId>(
     destroyedSshTargetIds.map((id) => toSshExecutionHostId(id))
   )
-  const orphanedSetupIds = get()
+  const orphanedSetups = get()
     .projectHostSetups.filter((setup) => destroyedHostIds.has(setup.hostId))
-    .map((setup) => setup.id)
-  const purgedRepoIds = new Set<string>()
-  for (const setupId of orphanedSetupIds) {
+    .map((setup) => ({ id: setup.id, hostId: setup.hostId }))
+  // Why: a bare id would let a purge on one destroyed host suppress the orphan sweep for the
+  // same id on another destroyed host, stranding that row.
+  const purgedRepoIdentities = new Set<string>()
+  for (const setup of orphanedSetups) {
     try {
-      const result = await get().deleteProjectHostSetup({ setupId })
+      const result = await get().deleteProjectHostSetup({ setupId: setup.id })
       if (result?.repo) {
-        purgedRepoIds.add(result.repo.id)
+        purgedRepoIdentities.add(getRepoHostIdentityForParts(result.repo.id, setup.hostId))
       }
     } catch (error) {
       console.error('Failed to purge orphaned per-workspace-env project:', error)
@@ -1824,7 +1830,9 @@ async function purgeOrphanedRuntimeSshProjects(
   // host when the id is duplicated across hosts (#13071).
   const orphanedRepos = get()
     .repos.filter(
-      (repo) => destroyedTargetIds.has(repo.connectionId ?? '') && !purgedRepoIds.has(repo.id)
+      (repo) =>
+        destroyedTargetIds.has(repo.connectionId ?? '') &&
+        !purgedRepoIdentities.has(getRepoHostIdentity(repo))
     )
     .map((repo) => ({ id: repo.id, hostId: getRepoExecutionHostId(repo) }))
   for (const orphaned of orphanedRepos) {


### PR DESCRIPTION
Closes #13071.

## Summary

Removing a project from the sidebar can no longer destroy a *different* host's project.

When a repo id exists on two hosts and the owning host's row has dropped out of the renderer catalog, the sidebar remove flow resolved the id to whichever row was left — the other host's live one. Removal then killed that host's PTYs, purged its worktrees and dropped its row, while the orphan rows it was supposed to clean up survived. You lose the working project and keep the broken one.

### Root cause

`findRepoForHost` (`store/slices/repo-host-identity.ts:45-47`) has a unique-candidate fallback: when no `hostId` is supplied and exactly one row carries the id, it returns that row **regardless of which host it belongs to**.

`removeProject` already accepts `options.hostId` and already scopes its RPC target and local row deletion to the owning host — the sidebar callers simply never passed it, even though every one of them had the host in hand:

| site | had | passed |
| --- | --- | --- |
| `RemoveFolderDialog.tsx:62` | modal data | — |
| `WorktreeList.tsx:6159` | the full `Repo` | — |
| `delete-worktree-flow.ts:224` | `target.hostId` | — |

`ssh-host-remove-workspaces.ts:45-51` documents this exact hazard and defends against it with an explicit `hostId`; the sidebar flow predates that defense.

### What changed

- `delete-worktree-flow.ts` — carries `target.hostId` into the modal, and resolves the display name with `findRepoForHost` instead of a bare `repos.find`.
- `WorktreeList.tsx` — `handleRemoveProject` carries `getRepoExecutionHostId(repo)`.
- `RemoveFolderDialog.tsx` — reads the host from modal data, forwards it to `removeProject`, and resolves the SSH host label via `findRepoForHost` so the confirmation text names the row that will actually be removed.
- `worktrees.ts` — the orphaned per-workspace-env purge keeps each row's own host instead of mapping down to bare ids.

The host is narrowed out of modal data with `normalizeExecutionHostId` rather than cast, so a malformed value degrades to today's behavior instead of lying to the type system.

## Screenshots

No visual change. The only user-visible difference in text is that the removal confirmation can now name the correct SSH host.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 5 pre-existing failures, evidence below
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Rebased onto current `main` and re-run from scratch: `pnpm lint`, `pnpm typecheck` and `pnpm build` all clean, and 4331 tests across the touched trees (`components/sidebar/`, `store/slices/`) pass in 370 files.

### On the full-suite failures

`pnpm test` exits 1 on this branch. Rather than assert that's unrelated, I ran a full-suite baseline on clean `main` and a second full run on the branch:

| | clean `main` | branch, run 1 | branch, run 2 |
| --- | --- | --- | --- |
| `check-root-directory-entries` | 3 fail | 3 fail | 3 fail |
| `agent-exec-handler` | 2 fail | 2 fail | 2 fail |
| `run-electron-vite-dev-web` | pass | 1 fail | pass |
| `remote-runtime-shared-control-connection` | pass | 1 fail | pass |
| `orchestration-adopted-run-binding` | pass | 1 fail | pass |
| `ai-vault-session-worktree-map` | pass | pass | 1 fail |

**Only the first two are constant**, and they reproduce identically on clean `main`, so they are local-environment artifacts rather than regressions: the root-directory guard shells out to a script using `declare -A` (bash 4+) while macOS ships bash 3.2, and `agent-exec-handler` asserts the spawned env contains all of `process.env`, which fails on any dev machine whose shell exports a var the handler overrides (e.g. `GIT_ASKPASS`).

The rest reshuffle between runs, which is the tell — a regression fails deterministically. Every one of them is a **wall-clock or throughput budget**, not a behavioural assertion:

- `orchestration-adopted-run-binding` — `expected 0.107 to be less than 0.0887` (scaling ratio)
- `ai-vault-session-worktree-map` — `expected 156.2 to be less than 150` (a 4% miss on a 150ms budget; runs in 25ms in isolation)
- `remote-runtime-shared-control-connection` — throughput under a stalled socket

Run 1 took 389s against the baseline's 294s because a full `pnpm build` had just finished on the same machine; run 2, unloaded, came in at 298s and cleared all three. Each passes in isolation on this branch.

None of these files import any of the six this PR changes — it is renderer-only, four files under `components/sidebar/` plus one store slice. Flagging the pattern rather than burying it, in case the timing budgets are worth loosening on CI runners.

New regression test in `delete-worktree-flow.test.ts` models the issue's scenario directly: host A's row dropped from the catalog, host B's live row the only one left under the id. It asserts the modal carries `hostId: 'ssh:host-a'` **and** that the confirmation names host A's project — host B's name appearing is the tell that resolution went to the wrong row.

Verified non-blind: reverting the plumbing makes it fail with exactly the bug —

```
-     "displayName": "orca on host A",
-     "hostId": "ssh:host-a",
+     "displayName": "orca on host B",
```

On a full `pnpm test` run, the handful that don't pass are local-environment artifacts that reproduce on a clean checkout with this branch stashed: `check-root-directory-entries` ×3 (the guard shells out to a script using `declare -A`, and macOS ships bash 3.2) and `agent-exec-handler` ×2 (asserts the spawned env contains all of `process.env`, which fails on any dev machine whose shell exports a var the handler overrides, e.g. `GIT_ASKPASS`).

## AI Review Report

Reviewed with Claude Opus 5 against the CONTRIBUTING checklist.

- **Cross-platform (macOS/Linux/Windows)** — no platform-dependent behavior touched: no path construction, no shell invocation, no accelerator or shortcut label, no `metaKey`/`ctrlKey` branch. This is identity plumbing between renderer modules, so there is nothing for a platform check to guard.
- **SSH/remote/local** — this is the SSH-relevant path. Local rows resolve to the local host id and behave as before; SSH rows now resolve to their own `ssh:<target>` host. `removeProject`'s existing per-host RPC targeting and `removeForHost` branch are unchanged — they simply now receive the host the user actually meant. No wire format changes, so mixed client/host versions are unaffected.
- **Folder workspaces** — unchanged; a folder workspace's main worktree routes through the same `isMainWorktree` branch and now carries its host.
- **Agent/integration/git provider** — none touched. Nothing here is provider-specific.
- **Performance** — `findRepoForHost` replaces `Array.find` with a filter over the same list, on a user-initiated removal. Not a hot path.
- **UI quality** — no layout, token or component change.

What it flagged and I acted on: the first cut resolved the host with a cast out of modal data. That silently accepts a malformed value, so it now goes through `normalizeExecutionHostId` and degrades to the previous behavior instead.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency and IPC risk.

- **Destructive-operation targeting** — this is the substance of the change. It narrows a destructive operation (PTY teardown, worktree purge, row deletion) to an explicitly identified host instead of an inferred one, and removes a path where a dropped catalog row causes an unintended teardown of a live project. Net reduction in blast radius.
- **Input handling** — the one new untrusted-ish input is the host id read out of modal data. It is narrowed with `normalizeExecutionHostId`, not cast, so a malformed value falls back rather than propagating into an RPC target.
- **Command execution / path handling** — none added. No new spawn, shell, or filesystem path is constructed.
- **IPC** — no new IPC surface. `removeProject`'s existing channel and its `hostId` parameter are unchanged; this only populates a parameter that was already there and already validated on the other side.
- **Auth, secrets, dependencies** — untouched. No new dependency.

No follow-up needed for this PR. The related gap worth its own change is noted below.

## Notes

**On the `worktrees.ts` change.** Flagged as possibly out of scope, so to be explicit: this is the same defect, not adjacent cleanup. #13071's title is *"removeProject without a hostId can delete the wrong host's project"*. The orphaned per-workspace-env purge calls `removeProject(repoId)` with no host while iterating full `Repo` objects — so it hits that exact fallback and can purge another host's row. The issue body enumerates the three sidebar sites; this is a fourth caller of the same function with the same omission, and it had the host in hand. Leaving it out would fix the bug on three paths and leave it live on a fourth. Happy to split it into its own PR if you'd rather keep this one to the enumerated sites.

**What I deliberately did not do.** The issue also suggests making `removeProject` refuse the unique-candidate / focused-host fallbacks for removals. I left that alone because it would silently break group removal: `selectProjectGroupRemovalTargets` (`store/slices/project-group-removal-targets.ts:26-30`) iterates full `Repo` objects and pushes `repo.id`, discarding the host — so `removeProject` is legitimately called there with no host available. A blanket refusal would turn those calls into silent no-ops and strand the projects. That site is a fifth instance of the same defect class and deserves its own fix (carry the host through `ProjectGroupRemovalTargets`), but it changes a shared selector's shape and its callers, so it does not belong here. Glad to follow up with it, or to add the guard here once that site can supply a host.

X: [@manuaudiomix](https://x.com/manuaudiomix)
