### PR TITLE
fix(editor): support raw HTML tags like <br> in markdown viewers

### DIFF
--- a/src/renderer/src/components/editor/IpynbViewer.tsx
+++ b/src/renderer/src/components/editor/IpynbViewer.tsx
@@ -313,7 +313,7 @@ function NotebookHeaderButton({
 function MarkdownCell({ source }: { source: string }): React.JSX.Element {
   return (
     <div className="markdown-preview-body px-4 py-3 text-sm">
-      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw, rehypeSanitize]}>
+      <Markdown remarkPlugins={[remarkGfm]} rehypePlugins={[rehypeRaw, rehypeSanitize]} remarkRehypeOptions={{ allowDangerousHtml: true }}>
         {source || '\u00a0'}
       </Markdown>
     </div>

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -371,6 +371,7 @@ const MarkdownBody = memo(function MarkdownBody({
       urlTransform={markdownPreviewUrlTransform}
       remarkPlugins={MARKDOWN_REMARK_PLUGINS}
       rehypePlugins={MARKDOWN_REHYPE_PLUGINS}
+      remarkRehypeOptions={{ allowDangerousHtml: true }}
     >
       {content}
     </Markdown>

--- a/src/renderer/src/components/sidebar/CommentMarkdown.tsx
+++ b/src/renderer/src/components/sidebar/CommentMarkdown.tsx
@@ -238,6 +238,7 @@ const CommentMarkdown = React.memo(
         <Markdown
           remarkPlugins={activeRemarkPlugins}
           rehypePlugins={rehypePlugins}
+          remarkRehypeOptions={{ allowDangerousHtml: true }}
           components={components}
           urlTransform={
             allowFileUriLinks ? commentMarkdownFileUriUrlTransform : commentMarkdownUrlTransform


### PR DESCRIPTION
### Description
Fixes #13097

This PR resolves an issue where raw HTML tags (such as `<br>`) inside markdown tables and comments were being rendered as literal text instead of acting as actual HTML elements. 

### Cause
While the `rehype-raw` plugin was included in the Markdown viewers, the underlying `remark-rehype` parser defaults to escaping all HTML tags in newer versions of `react-markdown`. As a result, the `<br>` tags were converted to text entities (`&lt;br&gt;`) before `rehype-raw` could process them.

### Changes
Added `remarkRehypeOptions={{ allowDangerousHtml: true }}` to the `<Markdown>` components across the application. This ensures that raw HTML is safely passed down the pipeline where `rehype-raw` can properly parse and render it.

Files updated:
- `src/renderer/src/components/editor/MarkdownPreview.tsx`
- `src/renderer/src/components/editor/IpynbViewer.tsx`
- `src/renderer/src/components/sidebar/CommentMarkdown.tsx`
