### PR TITLE
fix(pr): render GitPullRequestDraft icon for draft PRs

### DIFF
--- a/src/renderer/src/components/GitHubItemDialog.tsx
+++ b/src/renderer/src/components/GitHubItemDialog.tsx
@@ -28,6 +28,7 @@ import {
   GitMerge,
   GitPullRequest,
   GitPullRequestClosed,
+  GitPullRequestDraft,
   ListChecks,
   Link2,
   LoaderCircle,
@@ -3024,7 +3025,11 @@ function PRActionsPanel({
     <aside className="rounded-lg border border-border/50 bg-card/50 p-3 shadow-xs">
       <div className="mb-3 flex items-center justify-between gap-2">
         <div className="flex items-center gap-2">
-          <GitPullRequest className="size-3.5 text-muted-foreground" />
+          {item.state === 'draft' ? (
+            <GitPullRequestDraft className="size-3.5 text-muted-foreground" />
+          ) : (
+            <GitPullRequest className="size-3.5 text-muted-foreground" />
+          )}
           <span className="text-[13px] font-medium text-foreground">
             {translate('auto.components.GitHubItemDialog.a2495e4784', 'Pull request')}
           </span>
@@ -3111,6 +3116,8 @@ function PRActionsPanel({
             <LoaderCircle className="size-3.5 animate-spin" />
           ) : nextState === 'closed' ? (
             <GitPullRequestClosed className="size-3.5 text-destructive" />
+          ) : localState === 'draft' ? (
+            <GitPullRequestDraft className="size-3.5 text-muted-foreground" />
           ) : (
             <CircleDot className="size-3.5" />
           )}


### PR DESCRIPTION
## What
Draft PRs in GitHubItemDialog showed the generic PR icon and the closed-PR icon instead of a draft-specific icon.

## Evidence
- `src/renderer/src/components/GitHubItemDialog.tsx:3029` — PR header always rendered `<GitPullRequest>`
- `src/renderer/src/components/GitHubItemDialog.tsx:3118` — state toggle rendered `<GitPullRequestClosed>` for closed, `<CircleDot>` for everything else

## Fix
- Import `GitPullRequestDraft` from lucide-react
- Header: render `<GitPullRequestDraft>` when `item.state === draft`
- State button: render `<GitPullRequestDraft>` when `localState === draft`

## Test plan
- `pnpm exec vitest run src/renderer/src/components/github-item-dialog-source-boundary.test.ts` — 12/12 passed
- Existing boundary test coverage preserved

## Runtime Proof
Visual change only: draft PRs now show the draft icon (clipboard-style with folded corner) instead of the closed PR icon (red) or generic PR icon.

## Duplicate Scan
- Issue 13088 scan: no open PR mentions 13088
- Symbol scan (`draft PR icon`): no open PR targets this specific icon fix

## Risk
Low. Icon-only change in a single component. No behavior change, no API change.

Closes #13088