### PR TITLE
fix(serve): validate in-process serve flags like the CLI

### DIFF
--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -3,6 +3,7 @@ import type { CommandHandler } from '../dispatch'
 import { formatCliStatus, formatStatus, printResult } from '../format'
 import { RuntimeClientError, serveOrcaApp } from '../runtime-client'
 import { stripElectronRunAsNode } from '../runtime/launch'
+import { getServeOptionGuardError } from '../../shared/serve-option-guards'
 
 function envRecord(): Record<string, string> {
   // Why: the `orca` launcher runs Orca's Electron binary as Node, so this CLI
@@ -92,31 +93,16 @@ export const CORE_HANDLERS: Record<string, CommandHandler> = {
     printResult(result, json, formatCliStatus)
   },
   serve: async ({ flags, json }) => {
-    if (flags.get('no-pairing') === true && flags.get('mobile-pairing') === true) {
-      throw new RuntimeClientError(
-        'invalid_argument',
-        'Use either --mobile-pairing or --no-pairing, not both.'
-      )
-    }
-    if (flags.get('recipe-json') === true && flags.get('no-pairing') === true) {
-      throw new RuntimeClientError(
-        'invalid_argument',
-        'Recipe JSON output requires runtime pairing; remove --no-pairing.'
-      )
-    }
-    if (flags.get('recipe-json') === true && flags.get('mobile-pairing') === true) {
-      throw new RuntimeClientError(
-        'invalid_argument',
-        'Recipe JSON output requires runtime pairing; remove --mobile-pairing.'
-      )
-    }
     const projectRoot =
       typeof flags.get('project-root') === 'string' ? (flags.get('project-root') as string) : null
-    if (flags.get('recipe-json') === true && !projectRoot) {
-      throw new RuntimeClientError(
-        'invalid_argument',
-        'Recipe JSON output requires --project-root.'
-      )
+    const guardError = getServeOptionGuardError({
+      noPairing: flags.get('no-pairing') === true,
+      mobilePairing: flags.get('mobile-pairing') === true,
+      recipeJson: flags.get('recipe-json') === true,
+      projectRoot
+    })
+    if (guardError) {
+      throw new RuntimeClientError('invalid_argument', guardError)
     }
     const port = getOptionalServePort(flags)
     const exitCode = await serveOrcaApp({

--- a/src/cli/serve-electron-flag-parity.test.ts
+++ b/src/cli/serve-electron-flag-parity.test.ts
@@ -53,17 +53,21 @@ describe('serve flag parity between the CLI spec and the Electron argv rewrite',
   })
 
   it('emits the same --serve-* names the CLI spawns with and the main process reads', () => {
-    // Why source text: serveOrcaApp spawns a real process and getServeOptions is not exported, so
-    // both ends of the contract are only readable statically. Without this leg the rewrite could
-    // emit a name nothing reads and every behavioural assertion above would still pass.
+    // Why source text: serveOrcaApp spawns a real process; getServeOptions lives in
+    // startup/serve-options.ts and is only readable statically for the flag names it
+    // accepts. Without this leg the rewrite could emit a name nothing reads and every
+    // behavioural assertion above would still pass.
     const launchSource = readFileSync(join(process.cwd(), 'src/cli/runtime/launch.ts'), 'utf8')
-    const mainSource = readFileSync(join(process.cwd(), 'src/main/index.ts'), 'utf8')
-    const start = mainSource.indexOf('function getServeOptions(')
+    const serveOptionsSource = readFileSync(
+      join(process.cwd(), 'src/main/startup/serve-options.ts'),
+      'utf8'
+    )
+    const start = serveOptionsSource.indexOf('export function getServeOptions(')
     // Why bound the anchor: an unresolved indexOf slices to EOF and passes vacuously.
     expect(start).toBeGreaterThanOrEqual(0)
-    const end = mainSource.indexOf('\n}', start)
+    const end = serveOptionsSource.indexOf('\n}', start)
     expect(end).toBeGreaterThan(start)
-    const getServeOptionsBody = mainSource.slice(start, end)
+    const getServeOptionsBody = serveOptionsSource.slice(start, end)
 
     for (const flag of translatedFlags) {
       expect(launchSource).toContain(`'--serve-${flag}'`)

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -74,6 +74,7 @@ import {
 import { callRuntimeEnvironment } from './ipc/runtime-environment-transport-routing'
 import { resolveEnvironment } from '../shared/runtime-environment-store'
 import { getPreferredPairingOffer } from '../shared/runtime-environments'
+import { getServeOptions, type ServeOptions } from './startup/serve-options'
 import { OrcaRuntimeRpcServer } from './runtime/runtime-rpc'
 import {
   recordRuntimeRpcStartFailure,
@@ -1762,45 +1763,6 @@ const syntheticTitleSpinnerByPaneKey = new Map<
 >()
 let syntheticTitleSpinnerTimer: ReturnType<typeof setInterval> | null = null
 
-type ServeOptions = {
-  json: boolean
-  wsPort?: number
-  pairingAddress: string | null
-  noPairing: boolean
-  mobilePairing: boolean
-  recipeJson: boolean
-  projectRoot: string | null
-}
-
-function getServeOptions(argv = process.argv): ServeOptions {
-  const valueAfter = (flag: string): string | null => {
-    const index = argv.indexOf(flag)
-    if (index === -1) {
-      return null
-    }
-    const value = argv[index + 1]
-    return value && !value.startsWith('--') ? value : null
-  }
-  const rawPort = valueAfter('--serve-port')
-  let wsPort: number | undefined
-  if (rawPort) {
-    const parsedPort = Number(rawPort)
-    if (!Number.isInteger(parsedPort) || parsedPort < 0 || parsedPort > 65535) {
-      throw new Error(`Invalid --serve-port value: ${rawPort}`)
-    }
-    wsPort = parsedPort
-  }
-  return {
-    json: argv.includes('--serve-json'),
-    ...(wsPort !== undefined ? { wsPort } : {}),
-    pairingAddress: valueAfter('--serve-pairing-address'),
-    noPairing: argv.includes('--serve-no-pairing'),
-    mobilePairing: argv.includes('--serve-mobile-pairing'),
-    recipeJson: argv.includes('--serve-recipe-json'),
-    projectRoot: valueAfter('--serve-project-root')
-  }
-}
-
 function getBundledWebClientRoot(): string | undefined {
   const appPath = app.getAppPath()
   const roots = [
@@ -2848,7 +2810,7 @@ void app.whenReady().then(async () => {
   const devWsPort = is.dev && !isE2E ? 6769 : undefined
   let serveOptions: ServeOptions | null = null
   try {
-    serveOptions = isServeMode ? getServeOptions() : null
+    serveOptions = isServeMode ? getServeOptions(process.argv) : null
   } catch (error) {
     console.error(error instanceof Error ? error.message : String(error))
     app.exit(1)

--- a/src/main/startup/serve-options.test.ts
+++ b/src/main/startup/serve-options.test.ts
@@ -74,4 +74,36 @@ describe('getServeOptions', () => {
       noPairing: false
     })
   })
+
+  it('ignores recognized serve flags after the option terminator', () => {
+    expect(
+      getServeOptions(['/AppRun', '--serve', '--', '--serve-port', '1', '--serve-no-pairing'])
+    ).toEqual({
+      json: false,
+      pairingAddress: null,
+      noPairing: false,
+      mobilePairing: false,
+      recipeJson: false,
+      projectRoot: null
+    })
+  })
+
+  it.each(['--serve-port', '--serve-pairing-address', '--serve-project-root'])(
+    'rejects a missing value for %s',
+    (flag) => {
+      expect(() => getServeOptions(['/AppRun', '--serve', flag])).toThrow(
+        `Missing value for ${flag}.`
+      )
+    }
+  )
+
+  it.each([
+    ['an empty value', ''],
+    ['another flag', '--serve-json'],
+    ['the option terminator', '--']
+  ])('rejects %s after --serve-port', (_description, value) => {
+    expect(() => getServeOptions(['/AppRun', '--serve', '--serve-port', value])).toThrow(
+      'Missing value for --serve-port.'
+    )
+  })
 })

--- a/src/main/startup/serve-options.test.ts
+++ b/src/main/startup/serve-options.test.ts
@@ -1,0 +1,77 @@
+import { describe, expect, it } from 'vitest'
+import { getServeOptions } from './serve-options'
+import { normalizeServeModeArgv } from './serve-mode-argv'
+
+describe('getServeOptions', () => {
+  it('parses a clean no-pairing launch', () => {
+    expect(
+      getServeOptions(['/AppRun', '--serve', '--serve-port', '6768', '--serve-no-pairing'])
+    ).toEqual({
+      json: false,
+      wsPort: 6768,
+      pairingAddress: null,
+      noPairing: true,
+      mobilePairing: false,
+      recipeJson: false,
+      projectRoot: null
+    })
+  })
+
+  it('rejects no-pairing with mobile-pairing after CLI-form normalize', () => {
+    const argv = normalizeServeModeArgv([
+      '/opt/Orca/orca-ide',
+      'serve',
+      '--port',
+      '6768',
+      '--no-pairing',
+      '--mobile-pairing'
+    ])
+    expect(() => getServeOptions(argv)).toThrow(/either --mobile-pairing or --no-pairing/i)
+  })
+
+  it('rejects recipe-json with no-pairing', () => {
+    expect(() =>
+      getServeOptions([
+        'orca',
+        '--serve',
+        '--serve-recipe-json',
+        '--serve-no-pairing',
+        '--serve-project-root',
+        '/tmp/project'
+      ])
+    ).toThrow(/requires runtime pairing.*--no-pairing/i)
+  })
+
+  it('rejects recipe-json without project-root', () => {
+    expect(() => getServeOptions(['orca', '--serve', '--serve-recipe-json'])).toThrow(
+      /requires --project-root/i
+    )
+  })
+
+  it('rejects a --no-pairing typo that would keep pairing on', () => {
+    const argv = normalizeServeModeArgv([
+      '/opt/Orca/orca-ide',
+      'serve',
+      '--port',
+      '6768',
+      '--no-pairng'
+    ])
+    expect(() => getServeOptions(argv)).toThrow(/Unknown flag --no-pairng.*--no-pairing/i)
+  })
+
+  it('still allows unrelated Chromium switches', () => {
+    expect(
+      getServeOptions([
+        '/AppRun',
+        '--serve',
+        '--serve-port',
+        '6768',
+        '--disable-gpu',
+        '--enable-features=Foo'
+      ])
+    ).toMatchObject({
+      wsPort: 6768,
+      noPairing: false
+    })
+  })
+})

--- a/src/main/startup/serve-options.ts
+++ b/src/main/startup/serve-options.ts
@@ -16,19 +16,24 @@ export type ServeOptions = {
  * can cover the same guards the packaged binary runs (#13006).
  */
 export function getServeOptions(argv: readonly string[]): ServeOptions {
+  const terminatorIndex = argv.indexOf('--')
+  const optionArgv = terminatorIndex === -1 ? argv : argv.slice(0, terminatorIndex)
   // Why: packaged-binary CLI-form serve skips the CLI parser (#13006 / #12818).
   // Reject pairing-flag typos before they silently keep pairing enabled.
-  const typoError = getServeFlagTypoError(argv)
+  const typoError = getServeFlagTypoError(optionArgv)
   if (typoError) {
     throw new Error(typoError)
   }
   const valueAfter = (flag: string): string | null => {
-    const index = argv.indexOf(flag)
+    const index = optionArgv.indexOf(flag)
     if (index === -1) {
       return null
     }
-    const value = argv[index + 1]
-    return value && !value.startsWith('--') ? value : null
+    const value = optionArgv[index + 1]
+    if (!value || value.startsWith('--')) {
+      throw new Error(`Missing value for ${flag}.`)
+    }
+    return value
   }
   const rawPort = valueAfter('--serve-port')
   let wsPort: number | undefined
@@ -40,12 +45,12 @@ export function getServeOptions(argv: readonly string[]): ServeOptions {
     wsPort = parsedPort
   }
   const options: ServeOptions = {
-    json: argv.includes('--serve-json'),
+    json: optionArgv.includes('--serve-json'),
     ...(wsPort !== undefined ? { wsPort } : {}),
     pairingAddress: valueAfter('--serve-pairing-address'),
-    noPairing: argv.includes('--serve-no-pairing'),
-    mobilePairing: argv.includes('--serve-mobile-pairing'),
-    recipeJson: argv.includes('--serve-recipe-json'),
+    noPairing: optionArgv.includes('--serve-no-pairing'),
+    mobilePairing: optionArgv.includes('--serve-mobile-pairing'),
+    recipeJson: optionArgv.includes('--serve-recipe-json'),
     projectRoot: valueAfter('--serve-project-root')
   }
   const guardError = getServeOptionGuardError(options)

--- a/src/main/startup/serve-options.ts
+++ b/src/main/startup/serve-options.ts
@@ -1,0 +1,56 @@
+import { getServeFlagTypoError, getServeOptionGuardError } from '../../shared/serve-option-guards'
+
+export type ServeOptions = {
+  json: boolean
+  wsPort?: number
+  pairingAddress: string | null
+  noPairing: boolean
+  mobilePairing: boolean
+  recipeJson: boolean
+  projectRoot: string | null
+}
+
+/**
+ * Parse and validate headless-serve options from process argv (after
+ * `normalizeServeModeArgv`). Shared by the Electron main entry so unit tests
+ * can cover the same guards the packaged binary runs (#13006).
+ */
+export function getServeOptions(argv: readonly string[]): ServeOptions {
+  // Why: packaged-binary CLI-form serve skips the CLI parser (#13006 / #12818).
+  // Reject pairing-flag typos before they silently keep pairing enabled.
+  const typoError = getServeFlagTypoError(argv)
+  if (typoError) {
+    throw new Error(typoError)
+  }
+  const valueAfter = (flag: string): string | null => {
+    const index = argv.indexOf(flag)
+    if (index === -1) {
+      return null
+    }
+    const value = argv[index + 1]
+    return value && !value.startsWith('--') ? value : null
+  }
+  const rawPort = valueAfter('--serve-port')
+  let wsPort: number | undefined
+  if (rawPort) {
+    const parsedPort = Number(rawPort)
+    if (!Number.isInteger(parsedPort) || parsedPort < 0 || parsedPort > 65535) {
+      throw new Error(`Invalid --serve-port value: ${rawPort}`)
+    }
+    wsPort = parsedPort
+  }
+  const options: ServeOptions = {
+    json: argv.includes('--serve-json'),
+    ...(wsPort !== undefined ? { wsPort } : {}),
+    pairingAddress: valueAfter('--serve-pairing-address'),
+    noPairing: argv.includes('--serve-no-pairing'),
+    mobilePairing: argv.includes('--serve-mobile-pairing'),
+    recipeJson: argv.includes('--serve-recipe-json'),
+    projectRoot: valueAfter('--serve-project-root')
+  }
+  const guardError = getServeOptionGuardError(options)
+  if (guardError) {
+    throw new Error(guardError)
+  }
+  return options
+}

--- a/src/shared/serve-option-guards.test.ts
+++ b/src/shared/serve-option-guards.test.ts
@@ -1,0 +1,103 @@
+import { describe, expect, it } from 'vitest'
+import { getServeFlagTypoError, getServeOptionGuardError } from './serve-option-guards'
+
+describe('getServeOptionGuardError', () => {
+  it('accepts a clean pairing-off launch', () => {
+    expect(
+      getServeOptionGuardError({
+        noPairing: true,
+        mobilePairing: false,
+        recipeJson: false,
+        projectRoot: null
+      })
+    ).toBeNull()
+  })
+
+  it('rejects no-pairing with mobile-pairing', () => {
+    expect(
+      getServeOptionGuardError({
+        noPairing: true,
+        mobilePairing: true,
+        recipeJson: false,
+        projectRoot: null
+      })
+    ).toMatch(/either --mobile-pairing or --no-pairing/i)
+  })
+
+  it('rejects recipe-json with no-pairing', () => {
+    expect(
+      getServeOptionGuardError({
+        noPairing: true,
+        mobilePairing: false,
+        recipeJson: true,
+        projectRoot: '/tmp/project'
+      })
+    ).toMatch(/requires runtime pairing.*--no-pairing/i)
+  })
+
+  it('rejects recipe-json with mobile-pairing', () => {
+    expect(
+      getServeOptionGuardError({
+        noPairing: false,
+        mobilePairing: true,
+        recipeJson: true,
+        projectRoot: '/tmp/project'
+      })
+    ).toMatch(/requires runtime pairing.*--mobile-pairing/i)
+  })
+
+  it('rejects recipe-json without project-root', () => {
+    expect(
+      getServeOptionGuardError({
+        noPairing: false,
+        mobilePairing: false,
+        recipeJson: true,
+        projectRoot: null
+      })
+    ).toMatch(/requires --project-root/i)
+  })
+})
+
+describe('getServeFlagTypoError', () => {
+  it('accepts known serve flags and unrelated Chromium switches', () => {
+    expect(
+      getServeFlagTypoError([
+        '/opt/Orca/orca-ide',
+        '--serve',
+        '--serve-port',
+        '6768',
+        '--serve-no-pairing',
+        '--disable-gpu',
+        '--enable-features=Foo'
+      ])
+    ).toBeNull()
+  })
+
+  it('rejects a --no-pairing typo that would silently keep pairing on', () => {
+    expect(getServeFlagTypoError(['/AppRun', 'serve', '--port', '6768', '--no-pairng'])).toMatch(
+      /Unknown flag --no-pairng.*--no-pairing/i
+    )
+  })
+
+  it('rejects a one-letter --no-pairing omission (--no-paring)', () => {
+    expect(getServeFlagTypoError(['/opt/Orca/orca-ide', 'serve', '--no-paring'])).toMatch(
+      /Unknown flag --no-paring.*--no-pairing/i
+    )
+  })
+
+  it('rejects a --mobile-pairing typo', () => {
+    expect(getServeFlagTypoError(['orca', '--serve', '--mobile-pairng'])).toMatch(
+      /Unknown flag --mobile-pairng.*--mobile-pairing/i
+    )
+  })
+
+  it('does not flag the exact known forms', () => {
+    expect(
+      getServeFlagTypoError(['orca', 'serve', '--no-pairing', '--mobile-pairing', '--recipe-json'])
+    ).toBeNull()
+  })
+
+  it('does not scan past the option terminator', () => {
+    expect(getServeFlagTypoError(['/AppRun', 'serve', '--', '--no-pairng'])).toBeNull()
+  })
+})

--- a/src/shared/serve-option-guards.ts
+++ b/src/shared/serve-option-guards.ts
@@ -1,0 +1,136 @@
+/**
+ * Shared serve-option guards for the CLI (`orca serve`) and the in-process
+ * packaged-binary path (`<binary> serve …` → getServeOptions). Keep both
+ * surfaces identical so a typo or contradictory flag cannot silently open a
+ * network-exposed runtime with pairing still enabled (#13006).
+ */
+
+export type ServeOptionGuardInput = {
+  noPairing: boolean
+  mobilePairing: boolean
+  recipeJson: boolean
+  projectRoot: string | null | undefined
+}
+
+/** Cross-flag incompatibilities; null when the combination is valid. */
+export function getServeOptionGuardError(input: ServeOptionGuardInput): string | null {
+  if (input.noPairing && input.mobilePairing) {
+    return 'Use either --mobile-pairing or --no-pairing, not both.'
+  }
+  if (input.recipeJson && input.noPairing) {
+    return 'Recipe JSON output requires runtime pairing; remove --no-pairing.'
+  }
+  if (input.recipeJson && input.mobilePairing) {
+    return 'Recipe JSON output requires runtime pairing; remove --mobile-pairing.'
+  }
+  if (input.recipeJson && !input.projectRoot) {
+    return 'Recipe JSON output requires --project-root.'
+  }
+  return null
+}
+
+/**
+ * Known serve flag tokens (CLI form + rewritten `--serve-*` form). Tokens
+ * outside this set that still look like serve pairing flags are treated as
+ * typos — Chromium switches do not share these names.
+ */
+const KNOWN_SERVE_FLAG_NAMES = new Set([
+  '--json',
+  '--serve-json',
+  '--no-pairing',
+  '--serve-no-pairing',
+  '--mobile-pairing',
+  '--serve-mobile-pairing',
+  '--recipe-json',
+  '--serve-recipe-json',
+  '--port',
+  '--serve-port',
+  '--pairing-address',
+  '--serve-pairing-address',
+  '--project-root',
+  '--serve-project-root',
+  '--serve',
+  '--help',
+  '-h'
+])
+
+/** Security-shaped flags: a near-miss must not silently keep pairing on. */
+const SECURITY_SERVE_FLAGS = [
+  '--no-pairing',
+  '--serve-no-pairing',
+  '--mobile-pairing',
+  '--serve-mobile-pairing',
+  '--recipe-json',
+  '--serve-recipe-json',
+  '--pairing-address',
+  '--serve-pairing-address'
+] as const
+
+function flagName(token: string): string {
+  const eq = token.indexOf('=')
+  return eq === -1 ? token : token.slice(0, eq)
+}
+
+/** Small Levenshtein for short flag names (edit distance ≤ 2 is a typo). */
+function editDistance(a: string, b: string): number {
+  if (a === b) {
+    return 0
+  }
+  const rows = a.length + 1
+  const cols = b.length + 1
+  const dist: number[] = Array.from({ length: cols }, (_, i) => i)
+  for (let i = 1; i < rows; i += 1) {
+    let prev = dist[0]!
+    dist[0] = i
+    for (let j = 1; j < cols; j += 1) {
+      const temp = dist[j]!
+      const cost = a[i - 1] === b[j - 1] ? 0 : 1
+      dist[j] = Math.min(dist[j]! + 1, dist[j - 1]! + 1, prev + cost)
+      prev = temp
+    }
+  }
+  return dist[b.length]!
+}
+
+function closestSecurityServeFlag(name: string): string | null {
+  let best: string | null = null
+  let bestDistance = Number.POSITIVE_INFINITY
+  for (const candidate of SECURITY_SERVE_FLAGS) {
+    // Skip when lengths differ too much to be a 1–2 edit typo.
+    if (Math.abs(name.length - candidate.length) > 2) {
+      continue
+    }
+    const distance = editDistance(name, candidate)
+    if (distance > 0 && distance <= 2 && distance < bestDistance) {
+      best = candidate
+      bestDistance = distance
+    }
+  }
+  return best
+}
+
+/**
+ * Reject serve-related typos (e.g. `--no-pairng`, `--no-paring`) that would
+ * otherwise pass through to Electron and leave pairing enabled. Open Chromium
+ * switches are far from the security flag set, so they still ride through.
+ * Stops at `--` so post-terminator positionals are not re-interpreted.
+ */
+export function getServeFlagTypoError(argv: readonly string[]): string | null {
+  for (const token of argv) {
+    if (token === '--') {
+      break
+    }
+    if (!token.startsWith('-')) {
+      continue
+    }
+    const name = flagName(token)
+    if (KNOWN_SERVE_FLAG_NAMES.has(name)) {
+      continue
+    }
+    const suggestion = closestSecurityServeFlag(name)
+    if (suggestion) {
+      return `Unknown flag ${name}. Did you mean ${suggestion}?`
+    }
+  }
+  return null
+}


### PR DESCRIPTION
## Summary

- Extract `getServeOptions` to `src/main/startup/serve-options.ts` and share cross-flag guards with `orca serve` via `src/shared/serve-option-guards.ts`.
- Reject contradictory combinations (`--no-pairing` + `--mobile-pairing`, recipe-json without pairing / without `--project-root`) on the in-process path the same way the CLI does.
- Reject security-shaped pairing-flag typos (e.g. `--no-pairng`, `--no-paring`) so they cannot silently keep pairing on; stop scanning after `--`.

Fixes #13006

## Test plan

- [x] Unit tests for `getServeOptionGuardError` / `getServeFlagTypoError`
- [x] Unit tests for `getServeOptions` including CLI-form normalize + typo path
- [x] Serve Electron flag parity test updated for extracted module
- [x] oxlint clean
- [x] Codex review — cleared (only residual note: do not commit `.memory/`)