### PR TITLE
fix(status-bar): show Fable remaining time in compact usage mode

### DIFF
--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -172,6 +172,7 @@ describe('UsageRow', () => {
   })
 
   it('uses the same compact selection for Claude subscription windows', () => {
+    const fableResetsAt = mocks.now + 3 * 24 * 60 * 60_000 + 11 * 60 * 60_000
     const markup = renderToStaticMarkup(
       <UsageRow
         p={{
@@ -191,7 +192,7 @@ describe('UsageRow', () => {
           fableWeekly: {
             usedPercent: 75,
             windowMinutes: 10_080,
-            resetsAt: null,
+            resetsAt: fableResetsAt,
             resetDescription: null
           },
           updatedAt: 0,
@@ -208,7 +209,9 @@ describe('UsageRow', () => {
 
     expect(markup.match(/data-usage-window=/g)).toHaveLength(1)
     expect(markup).not.toContain('data-usage-bar')
-    expect(markup).toContain('Fable')
+    // Why (#13041): compact chips show remaining time like Codex/Grok, not the fixed "Fable" word.
+    expect(markup).not.toContain('Fable')
+    expect(markup).toContain('3d 11h')
     expect(markup).toContain('75%')
     expect(markup).not.toContain('25%')
     expect(markup).not.toContain('60%')

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -39,22 +39,27 @@ function providerMaxUsed(sections: UsageSection[]): number {
 function shortLabel(
   p: ProviderRateLimits,
   section: UsageSection,
-  useRemainingDuration = false
+  useRemainingDuration = false,
+  now: number = Date.now()
 ): string {
   if (p.buckets?.some((b) => b.name === section.label)) {
     return section.label
   }
-  // fableWeekly shares the 7d window with weekly; label it distinctly so the two
-  // don't both render as "wk".
+  // Compact mode shows remaining time for every window (Codex/Grok/Kimi).
+  // Only verbose needs a distinct fixed "Fable" so it does not share "wk" with weekly.
+  if (useRemainingDuration) {
+    return formatRateLimitWindowChipLabel(section.window, now)
+  }
   if (section.window === p.fableWeekly) {
     return 'Fable'
   }
-  return useRemainingDuration
-    ? formatRateLimitWindowChipLabel(section.window)
-    : formatWindowLabel(section.window.windowMinutes)
+  return formatWindowLabel(section.window.windowMinutes)
 }
 
-export function getTightestUsageSection(p: ProviderRateLimits): UsageSection | null {
+export function getTightestUsageSection(
+  p: ProviderRateLimits,
+  now: number = Date.now()
+): UsageSection | null {
   const sections = usedSections(p)
   if (sections.length === 0) {
     return null
@@ -66,7 +71,7 @@ export function getTightestUsageSection(p: ProviderRateLimits): UsageSection | n
       ? candidate
       : current
   )
-  return { ...tightest, label: shortLabel(p, tightest, true) }
+  return { ...tightest, label: shortLabel(p, tightest, true, now) }
 }
 
 // The soonest-resetting window summarizes the agent's next reset in one line.
@@ -130,7 +135,8 @@ export function UsageRow({
   const name = getProviderDisplayName(p.provider)
   const plan = formatPlanLabel(p.planType)
   const reset = hasUsage ? soonestResetLabel(sections, now) : null
-  const tightest = mode === 'compact' ? getTightestUsageSection(p) : null
+  // Why: pass `now` so Fable/session remaining chips tick with the shared clock (#13041).
+  const tightest = mode === 'compact' ? getTightestUsageSection(p, now) : null
 
   return (
     <div data-usage-mode={mode} className="flex min-w-0 flex-1 flex-col gap-1">


### PR DESCRIPTION
## Summary

- Compact usage chips for Claude's Fable window showed the fixed word **Fable** instead of remaining time (unlike Codex/Grok/Kimi).
- Prefer `formatRateLimitWindowChipLabel` for every window when building the compact tightest-window label; keep the fixed **Fable** label only in verbose mode so it stays distinct from weekly `wk`.
- Pass the shared countdown `now` into `getTightestUsageSection` so the chip ticks with the roster clock.

Fixes #13041

## Test plan

- [x] Updated compact Claude Fable test to expect remaining duration (`3d 11h`) and not `Fable`
- [x] Usage roster / provider-segment / inline-usage-bars tests pass
- [x] oxlint clean
- [x] Codex review — no code findings (do not commit `.memory/`)