### PR TITLE
feat(plugins): allow language packs to declare a native display name

### DIFF
--- a/src/main/plugins/plugin-language-pack-registry.test.ts
+++ b/src/main/plugins/plugin-language-pack-registry.test.ts
@@ -10,7 +10,10 @@ import { PluginLanguagePackRegistry } from './plugin-language-pack-registry'
 
 const roots: string[] = []
 
-async function pluginWithCatalog(catalog: unknown): Promise<ValidDiscoveredPlugin> {
+async function pluginWithCatalog(
+  catalog: unknown,
+  options: { displayName?: string } = {}
+): Promise<ValidDiscoveredPlugin> {
   const rootDir = await mkdtemp(join(tmpdir(), 'orca-plugin-language-registry-'))
   roots.push(rootDir)
   await mkdir(join(rootDir, 'locales'))
@@ -24,7 +27,13 @@ async function pluginWithCatalog(catalog: unknown): Promise<ValidDiscoveredPlugi
     engines: { orca: '>=1.0.0' },
     pluginApi: 1,
     contributes: {
-      languagePacks: [{ locale: 'pt-BR', path: 'locales/pt-BR.json' }]
+      languagePacks: [
+        {
+          locale: 'pt-BR',
+          path: 'locales/pt-BR.json',
+          ...(options.displayName ? { displayName: options.displayName } : {})
+        }
+      ]
     },
     capabilities: []
   })
@@ -74,5 +83,23 @@ describe('PluginLanguagePackRegistry', () => {
 
     await registry.reconcile([plugin], () => false)
     expect(registry.error(plugin.pluginKey)).toBeNull()
+  })
+
+  it('forwards an optional contribution displayName onto the registration', async () => {
+    const plugin = await pluginWithCatalog(
+      { common: { save: 'Salvar' } },
+      { displayName: 'Português (Brasil)' }
+    )
+    const registry = new PluginLanguagePackRegistry(new PluginContentVerifier())
+
+    await registry.reconcile([plugin], () => true)
+
+    expect(registry.list()).toEqual([
+      expect.objectContaining({
+        locale: 'pt-BR',
+        pluginKey: 'orca-samples.portuguese',
+        displayName: 'Português (Brasil)'
+      })
+    ])
   })
 })

--- a/src/main/plugins/plugin-language-pack-registry.ts
+++ b/src/main/plugins/plugin-language-pack-registry.ts
@@ -72,6 +72,7 @@ export class PluginLanguagePackRegistry {
                 resourceLanguage: pluginLanguageResourceId(id),
                 pluginKey: plugin.pluginKey,
                 locale: contribution.locale,
+                ...(contribution.displayName ? { displayName: contribution.displayName } : {}),
                 catalog: parsed.catalog
               }
             })

--- a/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
+++ b/src/renderer/src/components/settings/AppearanceInterfaceSection.tsx
@@ -24,6 +24,7 @@ import {
   getTypographyEntries,
   getZoomEntries
 } from './appearance-search'
+import { pluginLanguagePackPickerLabel } from '../../../../shared/plugins/plugin-language-pack-picker-label'
 import {
   getUiLanguageChoiceLabel,
   SHOW_UI_LANGUAGE_SETTING,
@@ -138,7 +139,7 @@ export function AppearanceInterfaceSection({
                   ))}
                   {pluginLanguagePacks.map((pack) => (
                     <SelectItem key={pack.id} value={pack.id}>
-                      {pack.locale} — {pack.pluginKey}
+                      {pluginLanguagePackPickerLabel(pack)}
                     </SelectItem>
                   ))}
                 </SelectContent>

--- a/src/shared/plugins/plugin-content-pack-contributions.test.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.test.ts
@@ -39,6 +39,36 @@ describe('content-pack manifest contributions', () => {
     expect(parsed.contributes.keybindings[0]?.key).toBe('Mod+Alt+T')
   })
 
+  it('accepts an optional native displayName on language packs', () => {
+    const parsed = pluginManifestSchema.parse(
+      manifest({
+        languagePacks: [
+          {
+            locale: 'zh-TW',
+            path: 'locales/zh-TW.json',
+            displayName: '中文（繁體）'
+          }
+        ]
+      })
+    )
+
+    expect(parsed.contributes.languagePacks[0]).toEqual({
+      locale: 'zh-TW',
+      path: 'locales/zh-TW.json',
+      displayName: '中文（繁體）'
+    })
+  })
+
+  it('rejects blank language-pack displayName', () => {
+    expect(
+      parsePluginManifest(
+        manifest({
+          languagePacks: [{ locale: 'zh-TW', path: 'locales/zh-TW.json', displayName: '   ' }]
+        })
+      ).ok
+    ).toBe(false)
+  })
+
   it('defaults every contribution registry to an empty array', () => {
     const parsed = pluginManifestSchema.parse(manifest({}))
 

--- a/src/shared/plugins/plugin-content-pack-contributions.ts
+++ b/src/shared/plugins/plugin-content-pack-contributions.ts
@@ -18,7 +18,11 @@ export const pluginLocaleIdSchema = z
 export const pluginLanguagePackContributionSchema = z
   .object({
     locale: pluginLocaleIdSchema,
-    path: pluginRelativePathSchema
+    path: pluginRelativePathSchema,
+    // Why (#13031): optional native name for the Settings language picker so
+    // community packs can match built-in labels (中文（繁體）) instead of
+    // `{locale} — {pluginKey}`.
+    displayName: z.string().trim().min(1).max(80).optional()
   })
   .strict()
 

--- a/src/shared/plugins/plugin-language-pack-artifact.ts
+++ b/src/shared/plugins/plugin-language-pack-artifact.ts
@@ -20,6 +20,8 @@ export type PluginLanguagePackRegistration = {
   resourceLanguage: `plugin${string}`
   pluginKey: string
   locale: string
+  /** Optional native picker label from the language-pack contribution (#13031). */
+  displayName?: string
   catalog: Record<string, unknown>
 }
 

--- a/src/shared/plugins/plugin-language-pack-picker-label.test.ts
+++ b/src/shared/plugins/plugin-language-pack-picker-label.test.ts
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+import { pluginLanguagePackPickerLabel } from './plugin-language-pack-picker-label'
+
+describe('pluginLanguagePackPickerLabel', () => {
+  it('prefers a declared native displayName', () => {
+    expect(
+      pluginLanguagePackPickerLabel({
+        locale: 'zh-TW',
+        pluginKey: 'farrrr.i18n-zh-tw',
+        displayName: '中文（繁體）'
+      })
+    ).toBe('中文（繁體）')
+  })
+
+  it('falls back to locale — pluginKey when displayName is absent', () => {
+    expect(
+      pluginLanguagePackPickerLabel({
+        locale: 'zh-TW',
+        pluginKey: 'farrrr.i18n-zh-tw'
+      })
+    ).toBe('zh-TW — farrrr.i18n-zh-tw')
+  })
+})

--- a/src/shared/plugins/plugin-language-pack-picker-label.ts
+++ b/src/shared/plugins/plugin-language-pack-picker-label.ts
@@ -1,0 +1,8 @@
+/** Settings language-picker label for a plugin language pack (#13031). */
+export function pluginLanguagePackPickerLabel(pack: {
+  displayName?: string
+  locale: string
+  pluginKey: string
+}): string {
+  return pack.displayName ?? `${pack.locale} — ${pack.pluginKey}`
+}


### PR DESCRIPTION
## Summary

- Optional `displayName` on `languagePacks` contributions (trimmed, 1–80 chars).
- Registry forwards it onto `PluginLanguagePackRegistration`.
- Appearance language picker uses `displayName` when present; otherwise `{locale} — {pluginKey}`.

Fixes #13031

## Test plan

- [x] Manifest accepts/rejects displayName
- [x] Registry forwards displayName
- [x] Picker label helper unit tests
- [x] oxlint clean
- [x] Codex review — no code findings