### PR TITLE
fix(status-bar): show the Fable reset countdown beside its usage percent

### DIFF
--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1218,7 +1218,10 @@ function VerboseProviderUsage({
       ? {
           key: 'fableWeekly',
           window: p.fableWeekly,
-          label: translate('auto.components.status.bar.StatusBar.a79c64f87e', 'Fable')
+          // Why: every neighbouring chip is a live reset countdown, so a bare "Fable" reads as a
+          // missing value (#13041). Keep the name — it is all that separates this chip from the
+          // plain weekly one — and append the countdown the others already show.
+          label: `${translate('auto.components.status.bar.StatusBar.a79c64f87e', 'Fable')} ${formatRateLimitWindowChipLabel(p.fableWeekly)}`
         }
       : null,
     // Why: monthly stays inline for monthly-only providers; otherwise the detail panel carries it.

--- a/src/renderer/src/components/status-bar/StatusBar.tsx
+++ b/src/renderer/src/components/status-bar/StatusBar.tsx
@@ -1221,7 +1221,11 @@ function VerboseProviderUsage({
           // Why: every neighbouring chip is a live reset countdown, so a bare "Fable" reads as a
           // missing value (#13041). Keep the name — it is all that separates this chip from the
           // plain weekly one — and append the countdown the others already show.
-          label: `${translate('auto.components.status.bar.StatusBar.a79c64f87e', 'Fable')} ${formatRateLimitWindowChipLabel(p.fableWeekly)}`
+          label: translate(
+            'auto.components.status.bar.StatusBar.fableResetCountdown',
+            'Fable {{resetCountdown}}',
+            { resetCountdown: formatRateLimitWindowChipLabel(p.fableWeekly) }
+          )
         }
       : null,
     // Why: monthly stays inline for monthly-only providers; otherwise the detail panel carries it.

--- a/src/renderer/src/components/status-bar/provider-segment-fable-countdown.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-fable-countdown.test.tsx
@@ -1,0 +1,89 @@
+import { renderToStaticMarkup } from 'react-dom/server'
+import { describe, expect, it, vi } from 'vitest'
+import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string, values?: Record<string, string>) => {
+    let result = fallback
+    for (const [key, value] of Object.entries(values ?? {})) {
+      result = result.replace(`{{${key}}}`, value)
+    }
+    return result
+  }
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  AgentIcon: () => null
+}))
+
+vi.mock('../../store', () => ({
+  useAppStore: (selector: (state: { usagePercentageDisplay: 'used' | 'remaining' }) => unknown) =>
+    selector({ usagePercentageDisplay: 'used' })
+}))
+
+/** Why: React separates adjacent text nodes with comment markers; assert on the visible text. */
+function textOf(markup: string): string {
+  return markup.replace(/<!--.*?-->/g, '').replace(/<[^>]*>/g, '')
+}
+
+function windowOf(
+  usedPercent: number,
+  windowMinutes: number,
+  resetsAt: number | null
+): RateLimitWindow {
+  return { usedPercent, windowMinutes, resetsAt, resetDescription: null }
+}
+
+function claudeLimitsWithFable(): ProviderRateLimits {
+  const now = Date.now()
+  return {
+    provider: 'claude',
+    session: windowOf(10, 300, now + 4 * 60 * 60 * 1000),
+    weekly: windowOf(20, 10080, now + 2 * 24 * 60 * 60 * 1000),
+    fableWeekly: windowOf(30, 10080, now + 3 * 24 * 60 * 60 * 1000),
+    monthly: null,
+    updatedAt: now,
+    error: null,
+    status: 'ok'
+  }
+}
+
+describe('ProviderSegment Fable chip', () => {
+  // Why: the session and weekly chips beside it are live reset countdowns, so a bare "Fable"
+  // reads as a missing value rather than a label (#13041).
+  it('shows the Fable reset countdown, not just the word', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={claudeLimitsWithFable()} compact={true} display="used" mode="verbose" />
+    )
+
+    // Why: a live countdown formats as "2d" or "1d 23h" depending on the millisecond the test
+    // renders, so assert a duration follows the name rather than a wall-clock value.
+    expect(textOf(markup)).toMatch(/30% used Fable \d+[dhm]/)
+  })
+
+  it('keeps the Fable name so the chip stays distinct from the plain weekly one', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={claudeLimitsWithFable()} compact={true} display="used" mode="verbose" />
+    )
+
+    expect(textOf(markup)).toMatch(/20% used \d+[dhm]/)
+    expect(textOf(markup)).toContain('Fable')
+  })
+
+  it('falls back to the window length when Claude reports no reset timestamp', async () => {
+    const { ProviderSegment } = await import('./StatusBar')
+    const limits = claudeLimitsWithFable()
+    limits.fableWeekly = windowOf(30, 10080, null)
+
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={limits} compact={true} display="used" mode="verbose" />
+    )
+
+    expect(textOf(markup)).toContain('30% used Fable wk')
+  })
+})

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3349,7 +3349,8 @@
             "antigravityUsageDetails": "Open Antigravity usage details",
             "grokUsageAria": "Open Grok usage details",
             "grokUsageMenu": "Grok Usage",
-            "floatingTerminalNewActivity": "{{label}}, new activity"
+            "floatingTerminalNewActivity": "{{label}}, new activity",
+            "fableResetCountdown": "Fable {{resetCountdown}}"
           },
           "StatusBarUsageEmptyCta": {
             "828c764a79": "Connect an account",


### PR DESCRIPTION
Closes #13041.

## Summary

The Fable chip in the status bar now shows its reset countdown, like every chip beside it.

Before, the provider segment read:

```
10% used 3h 59m · 20% used 1d 23h · 30% used Fable
```

The session and weekly chips show a live countdown; Fable showed only its name, so it read as a missing value. Now:

```
10% used 3h 59m · 20% used 1d 23h · 30% used Fable 2d 23h
```

### Why the name stays

The reporter asked for "the weekly limit remaining time instead of just word fable", which could be read as replacing the label. I kept it and appended the countdown instead, because the name is the only thing distinguishing this chip from the plain weekly one — both are 7-day windows, and with the label gone you would get two adjacent countdowns with no way to tell which is Fable. Easy to change if the reporter meant it the other way.

### Scope

Only `VerboseProviderUsage` changes. There are two places that label a Fable window, and only this one was inconsistent:

- **`VerboseProviderUsage`** — `session`, `weekly` and `monthly` all render `formatRateLimitWindowChipLabel(...)`; `fableWeekly` alone rendered a hardcoded string. That is the bug.
- **`InlineUsageBars`** — deliberately uses short static labels (`wk`, `Fable`) and is left alone. Its existing assertions (`'20% used wk'`, `'30% used Fable'`) are unchanged.

## Screenshots

One chip gains a duration; no layout, token or component change. The before/after strings above are the whole visual delta — happy to attach a capture if you want one on the record.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — scoped to the touched tree, not the full suite (see below)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`pnpm typecheck` and `oxlint` pass. All 272 tests in `src/renderer/src/components/status-bar/` pass, including the pre-existing `InlineUsageBars` and tooltip assertions that mention Fable. Scoped suites rather than a full `pnpm build` — this is a one-line renderer string change. Glad to run it if wanted.

New `provider-segment-fable-countdown.test.tsx` covers the countdown, the retained name, and the `resetsAt: null` fallback (`Fable wk`).

Verified non-blind: reverting the one-line change fails the two countdown tests while the "name is retained" test correctly keeps passing — it is a guard against dropping the label, not a regression test.

Two notes on the test, since both cost me a wrong first attempt:

- Assertions run against text with tags **and React's `<!-- -->` text-node separators** stripped. Adjacent JSX expressions are not contiguous in the raw markup, so `toContain('20% used 1d 23h')` cannot match.
- The countdown formats as `2d` or `1d 23h` depending on the millisecond the test renders, because `resetsAt` is built in the fixture and formatted at render. The assertions match `\d+[dhm]` after the label rather than a wall-clock value; run 5× to confirm stability.

## AI Review Report

Reviewed with Claude Opus 5 against the CONTRIBUTING checklist.

- **Cross-platform (macOS/Linux/Windows)** — pure renderer string composition. No path handling, shell behaviour, accelerator, shortcut label or Electron platform branch, so there is nothing platform-dependent to guard. The chip renders identically on all three.
- **SSH/remote/local** — none; the segment renders whatever `ProviderRateLimits` it is given, from any host. No wire or IPC change.
- **Agent/integration/git provider** — provider-neutral. Only the Claude-specific `fableWeekly` window is touched; other providers render exactly as before.
- **Performance** — one extra string format per render of an already-rendering chip.
- **UI quality** — follows the existing chip idiom (`{percent} {label}`) rather than adding a new one; no new tokens, sizes or components. Text is still routed through `translate` so the name stays localizable.

What it flagged and I acted on: the first cut dropped the "Fable" label entirely, which is the literal reading of the request. The review caught that this produces two indistinguishable adjacent countdowns; the label stays and the countdown is appended.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency and IPC risk.

- **No new inputs.** The change reads `resetsAt` from a `ProviderRateLimits` object the component already receives and already renders for three other windows.
- **Command execution, path handling, IPC, filesystem** — none added or touched.
- **Auth and secrets** — no token, key or account identifier is read or rendered. A usage percentage and a relative duration are not sensitive, and are already displayed for the adjacent windows.
- **Dependencies** — none added.

No follow-up needed.

## Notes

No platform-specific or remote-specific behaviour. The one thing worth a maintainer's opinion is the label question above — if the reporter meant "replace the word Fable with the time", that is a one-line change from here.

X: [@manuaudiomix](https://x.com/manuaudiomix)
