### PR TITLE
fix(ai-vault): support non-secure web contexts

### DIFF
--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts
@@ -21,6 +21,7 @@ const EMPTY_RESULT: AiVaultListResult = {
 }
 
 const THROTTLE_MS = 30_000
+const realCrypto = globalThis.crypto
 
 const listSessionsMock = vi.fn<(args: unknown) => Promise<AiVaultListResult>>()
 const cancelListSessionsMock = vi.fn<() => Promise<void>>()
@@ -201,11 +202,29 @@ afterEach(() => {
   roots.splice(0).forEach((root) => act(() => root.unmount()))
   document.body.replaceChildren()
   useAppStore.setState(initialAppState, true)
+  Object.defineProperty(globalThis, 'crypto', { configurable: true, value: realCrypto })
   vi.useRealTimers()
   vi.restoreAllMocks()
 })
 
 describe('useAiVaultSessionRefresh refocus behavior', () => {
+  it('mounts in a non-secure browser context without crypto.randomUUID', async () => {
+    Object.defineProperty(globalThis, 'crypto', {
+      configurable: true,
+      value: { getRandomValues: realCrypto.getRandomValues.bind(realCrypto) }
+    })
+
+    await renderHook()
+    await flushMicrotasks()
+
+    expect(listSessionsMock).toHaveBeenCalledTimes(1)
+    expect(lastCallArgs()).toMatchObject({
+      requestToken: expect.stringMatching(
+        /^[0-9a-f]{8}-[0-9a-f]{4}-4[0-9a-f]{3}-[0-9a-f]{4}-[0-9a-f]{12}$/
+      )
+    })
+  })
+
   it('uses the shared scan cache on local panel entry', async () => {
     await renderHook()
     await flushMicrotasks()

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-refresh.ts
@@ -5,6 +5,7 @@ import {
   type AiVaultSession
 } from '../../../../shared/ai-vault-types'
 import type { ExecutionHostScope } from '../../../../shared/execution-host'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 import { useAppStore } from '@/store'
 import type { AiVaultSessionLimit } from './ai-vault-session-limit'
 import {
@@ -45,7 +46,7 @@ export function useAiVaultSessionRefresh(
   const [scanResult, setScanResult] = useState<AiVaultListResult | null>(null)
   const [loading, setLoading] = useState(false)
   const [error, setError] = useState<string | null>(null)
-  const requestTokenRef = useRef(crypto.randomUUID())
+  const requestTokenRef = useRef(createBrowserUuid())
   const refreshIdRef = useRef(0)
   const refreshInFlightRef = useRef(false)
   const pendingRefreshRef = useRef(false)


### PR DESCRIPTION
## Summary

- Prevent Agent Session History from crashing the right sidebar on plain HTTP web clients.
- Use the existing `createBrowserUuid()` fallback for the AI Vault scan request token.
- Add a regression test that mounts the real refresh hook with `crypto.randomUUID` unavailable.

Root cause: browsers do not expose `crypto.randomUUID` in non-secure contexts such as a LAN or Tailscale web client served over plain HTTP. The AI Vault refresh hook called it unconditionally during render, so the right-sidebar error boundary replaced the panel before any session request could start.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- `vitest run --config config/vitest.config.ts src/renderer/src/components/right-sidebar/ai-vault-session-refresh.test.ts src/renderer/src/lib/non-secure-context-crypto.repro.test.ts` — 2 files, 31 tests passed after rebasing onto current `main` and again after the full build.
- The new test fails on the previous code with `TypeError: crypto.randomUUID is not a function` at `ai-vault-session-refresh.ts`.

The full test suite was attempted after the rebase, but this local sandbox forbids the Unix/TCP socket and DNS operations used by many integration tests (`listen EPERM`, `ENOTFOUND`), causing repeated 30–60 second infrastructure timeouts. The run was stopped after more than 12 minutes rather than reporting those environment failures as change-related results. Full lint, full typecheck, full desktop/web/native build, and the focused regression surface pass.

## AI Review Report

The review checked the render-time failure path, hook cleanup, request-token stability, existing UUID fallback behavior, and test isolation. No change-specific findings remained.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. The change introduces no shortcuts, labels, paths, shell behavior, native modules, or Electron-specific branches. SSH hosts and folder workspaces are unaffected because the token is created in the renderer before the existing IPC/runtime request.

Supported agents and integrations are unaffected. The change only replaces renderer-side request-token generation before the existing provider-neutral AI Vault API call; it does not branch on agent type, integration, Git provider, workspace type, or runtime transport.

Performance risk is negligible: `createBrowserUuid()` runs once per hook instance through the existing `useRef` initialization path, matching the previous UUID call's frequency. It adds no polling, I/O, subscription, or hot-path work. UI quality review is not applicable because there is no visual, layout, or interaction change beyond preventing the sidebar crash.

## Security Audit

No new input, command execution, path handling, authentication, secret, dependency, or IPC surface is introduced. The request token is a cancellation/correlation identifier rather than an authorization credential. In the affected non-secure browser context, the existing helper uses `crypto.getRandomValues`; its final `Math.random` fallback is unchanged and remains limited to non-security-sensitive UI identifiers.

## Notes

- Reproduced on an Orca web client served over plain HTTP through a Tailscale address.
- This follows the established fix pattern merged in #8804.
- Open PR #11525 broadly rewrites this hook and removes request tokens; current `main` remains affected, so this focused fix may need a trivial rebase if that PR lands first.
- `pnpm build` completed successfully, including desktop, web, relay, CLI, and macOS native targets.
