### PR TITLE
fix(daemon): surface failed attach-only orphan retire for support

### DIFF
--- a/src/main/daemon/daemon-attach-only-orphan-event.test.ts
+++ b/src/main/daemon/daemon-attach-only-orphan-event.test.ts
@@ -1,0 +1,40 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const trackMock = vi.hoisted(() => vi.fn())
+vi.mock('../telemetry/client', () => ({ track: trackMock }))
+
+import {
+  classifyAttachOnlyKillError,
+  trackAttachOnlyOrphanRisk
+} from './daemon-attach-only-orphan-event'
+
+describe('classifyAttachOnlyKillError', () => {
+  it('buckets kill failures without free text', () => {
+    expect(classifyAttachOnlyKillError(new Error('Not connected'))).toBe('transport')
+    expect(classifyAttachOnlyKillError(new Error('Connection lost'))).toBe('transport')
+    expect(classifyAttachOnlyKillError(new Error('Disconnected'))).toBe('transport')
+    expect(classifyAttachOnlyKillError(new Error('request timed out'))).toBe('timeout')
+    expect(classifyAttachOnlyKillError(new Error('Session not found: x'))).toBe('not_found')
+    expect(classifyAttachOnlyKillError(new Error('weird'))).toBe('unknown')
+  })
+
+  it('classifies rejection values whose string conversion throws as unknown', () => {
+    const rejection = {
+      [Symbol.toPrimitive]: () => {
+        throw new Error('conversion failed')
+      }
+    }
+    expect(classifyAttachOnlyKillError(rejection)).toBe('unknown')
+  })
+})
+
+describe('trackAttachOnlyOrphanRisk', () => {
+  it('emits the closed telemetry shape', () => {
+    trackMock.mockClear()
+    trackAttachOnlyOrphanRisk({ protocolVersion: 30, killErrorClass: 'transport' })
+    expect(trackMock).toHaveBeenCalledWith('daemon_attach_only_orphan_risk', {
+      protocol_version: 30,
+      kill_error_class: 'transport'
+    })
+  })
+})

--- a/src/main/daemon/daemon-attach-only-orphan-event.ts
+++ b/src/main/daemon/daemon-attach-only-orphan-event.ts
@@ -1,0 +1,42 @@
+// Why: a failed attach-only retire leaves an untracked shell on a pre-v31
+// daemon. Console alone is not enough for packaged/headless support (#12662).
+
+import { track } from '../telemetry/client'
+
+export function trackAttachOnlyOrphanRisk(props: {
+  protocolVersion: number
+  killErrorClass: 'transport' | 'timeout' | 'not_found' | 'unknown'
+}): void {
+  try {
+    track('daemon_attach_only_orphan_risk', {
+      protocol_version: props.protocolVersion,
+      kill_error_class: props.killErrorClass
+    })
+  } catch {
+    // Telemetry must never block attach refusal.
+  }
+}
+
+export function classifyAttachOnlyKillError(
+  error: unknown
+): 'transport' | 'timeout' | 'not_found' | 'unknown' {
+  try {
+    const message = error instanceof Error ? error.message : String(error)
+    if (
+      /not connected|connection lost|disconnected|EPIPE|ECONNRESET|ECONNREFUSED|socket closed/i.test(
+        message
+      )
+    ) {
+      return 'transport'
+    }
+    if (/timed? ?out|timeout/i.test(message)) {
+      return 'timeout'
+    }
+    if (/not found|Session not found/i.test(message)) {
+      return 'not_found'
+    }
+  } catch {
+    return 'unknown'
+  }
+  return 'unknown'
+}

--- a/src/main/daemon/daemon-attach-only-retire.test.ts
+++ b/src/main/daemon/daemon-attach-only-retire.test.ts
@@ -1,0 +1,20 @@
+import { describe, expect, it, vi } from 'vitest'
+import { retireAccidentalAttachOnlySpawn } from './daemon-attach-only-retire'
+
+describe('retireAccidentalAttachOnlySpawn', () => {
+  it('reports success when kill resolves', async () => {
+    const kill = vi.fn().mockResolvedValue(undefined)
+    await expect(retireAccidentalAttachOnlySpawn({ kill })).resolves.toEqual({ ok: true })
+    expect(kill).toHaveBeenCalledTimes(1)
+  })
+
+  it('reports failure without a second kill attempt', async () => {
+    const error = new Error('kill transport lost')
+    const kill = vi.fn().mockRejectedValue(error)
+    await expect(retireAccidentalAttachOnlySpawn({ kill })).resolves.toEqual({
+      ok: false,
+      error
+    })
+    expect(kill).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/daemon/daemon-attach-only-retire.ts
+++ b/src/main/daemon/daemon-attach-only-retire.ts
@@ -1,0 +1,22 @@
+/**
+ * Pre-v31 daemons ignore `attachOnly`, so attach can accidentally spawn a shell.
+ * Retire that spawn before refusing the attach (#12662 / #12589).
+ *
+ * One kill only: the kill RPC is session-id keyed (not incarnation-fenced), so a
+ * retry after an ambiguous timeout can murder a legitimate re-create under the
+ * same stable id. Observability of a failed retire is the support surface.
+ */
+
+export type AttachOnlyRetireResult = { ok: true } | { ok: false; error: unknown }
+
+/** Kill an accidental attach-only spawn once. */
+export async function retireAccidentalAttachOnlySpawn(args: {
+  kill: () => Promise<void>
+}): Promise<AttachOnlyRetireResult> {
+  try {
+    await args.kill()
+    return { ok: true }
+  } catch (error) {
+    return { ok: false, error }
+  }
+}

--- a/src/main/daemon/daemon-attach-only-retire.ts
+++ b/src/main/daemon/daemon-attach-only-retire.ts
@@ -2,9 +2,9 @@
  * Pre-v31 daemons ignore `attachOnly`, so attach can accidentally spawn a shell.
  * Retire that spawn before refusing the attach (#12662 / #12589).
  *
- * One kill only: the kill RPC is session-id keyed (not incarnation-fenced), so a
- * retry after an ambiguous timeout can murder a legitimate re-create under the
- * same stable id. Observability of a failed retire is the support surface.
+ * Retire only through recognized `killOwned`. If the spawn result has no
+ * incarnation, or the peer does not implement `killOwned`, skip kill and fail
+ * closed. Ordinary `kill` is unchanged. One attempt only.
  */
 
 export type AttachOnlyRetireResult = { ok: true } | { ok: false; error: unknown }

--- a/src/main/daemon/daemon-attach-only-retirement.test.ts
+++ b/src/main/daemon/daemon-attach-only-retirement.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+
+const trackMock = vi.hoisted(() => vi.fn())
+vi.mock('../telemetry/client', () => ({ track: trackMock }))
+
+import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from './daemon-errors'
+import { retireUnexpectedAttachOnlySpawn } from './daemon-attach-only-retirement'
+
+describe('retireUnexpectedAttachOnlySpawn', () => {
+  it('returns after a successful single kill', async () => {
+    const kill = vi.fn().mockResolvedValue(undefined)
+    await expect(retireUnexpectedAttachOnlySpawn(30, 'session', kill)).resolves.toBeUndefined()
+    expect(kill).toHaveBeenCalledTimes(1)
+    expect(trackMock).not.toHaveBeenCalled()
+  })
+
+  it('treats SessionNotFound as a completed retire', async () => {
+    const kill = vi.fn().mockRejectedValue(new SessionNotFoundError('session'))
+    await expect(retireUnexpectedAttachOnlySpawn(30, 'session', kill)).resolves.toBeUndefined()
+    expect(kill).toHaveBeenCalledTimes(1)
+    expect(trackMock).not.toHaveBeenCalled()
+  })
+
+  it('surfaces a failed kill with redacted support fields and no retry', async () => {
+    const kill = vi.fn().mockRejectedValue(new Error('Connection lost'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await expect(retireUnexpectedAttachOnlySpawn(30, 'session', kill)).rejects.toBeInstanceOf(
+        TerminalSessionOwnerUnverifiedError
+      )
+      expect(kill).toHaveBeenCalledTimes(1)
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[daemon] attach-only retire of accidental legacy spawn failed; orphan may remain',
+        { protocolVersion: 30, killErrorClass: 'transport' }
+      )
+      expect(trackMock).toHaveBeenCalledWith('daemon_attach_only_orphan_risk', {
+        protocol_version: 30,
+        kill_error_class: 'transport'
+      })
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+})

--- a/src/main/daemon/daemon-attach-only-retirement.test.ts
+++ b/src/main/daemon/daemon-attach-only-retirement.test.ts
@@ -1,10 +1,69 @@
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const trackMock = vi.hoisted(() => vi.fn())
 vi.mock('../telemetry/client', () => ({ track: trackMock }))
 
 import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from './daemon-errors'
-import { retireUnexpectedAttachOnlySpawn } from './daemon-attach-only-retirement'
+import {
+  retireAttachOnlyAccidentalSpawn,
+  retireUnexpectedAttachOnlySpawn
+} from './daemon-attach-only-retirement'
+
+beforeEach(() => trackMock.mockClear())
+
+describe('retireAttachOnlyAccidentalSpawn', () => {
+  it('sends killOwned once when incarnation proof is present', async () => {
+    const request = vi.fn().mockResolvedValue(undefined)
+    await expect(
+      retireAttachOnlyAccidentalSpawn(36, 'session', 'inc-1', { request })
+    ).resolves.toBeUndefined()
+    expect(request).toHaveBeenCalledTimes(1)
+    expect(request).toHaveBeenCalledWith('killOwned', {
+      sessionId: 'session',
+      immediate: true,
+      expectedIncarnationId: 'inc-1'
+    })
+    expect(trackMock).not.toHaveBeenCalled()
+  })
+
+  it('fails closed without ordinary kill when an older peer rejects killOwned', async () => {
+    const request = vi.fn().mockRejectedValue(new Error('Unknown request type: killOwned'))
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await expect(
+        retireAttachOnlyAccidentalSpawn(30, 'session', 'inc-1', { request })
+      ).rejects.toBeInstanceOf(TerminalSessionOwnerUnverifiedError)
+      expect(request).toHaveBeenCalledExactlyOnceWith('killOwned', {
+        sessionId: 'session',
+        immediate: true,
+        expectedIncarnationId: 'inc-1'
+      })
+      expect(trackMock).toHaveBeenCalledWith('daemon_attach_only_orphan_risk', {
+        protocol_version: 30,
+        kill_error_class: 'unknown'
+      })
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+
+  it('does not send kill or killOwned when incarnation proof is absent', async () => {
+    const request = vi.fn()
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    try {
+      await expect(
+        retireAttachOnlyAccidentalSpawn(30, 'session', undefined, { request })
+      ).rejects.toBeInstanceOf(TerminalSessionOwnerUnverifiedError)
+      expect(request).not.toHaveBeenCalled()
+      expect(trackMock).toHaveBeenCalledWith('daemon_attach_only_orphan_risk', {
+        protocol_version: 30,
+        kill_error_class: 'unknown'
+      })
+    } finally {
+      errorSpy.mockRestore()
+    }
+  })
+})
 
 describe('retireUnexpectedAttachOnlySpawn', () => {
   it('returns after a successful single kill', async () => {

--- a/src/main/daemon/daemon-attach-only-retirement.ts
+++ b/src/main/daemon/daemon-attach-only-retirement.ts
@@ -1,19 +1,28 @@
+import {
+  classifyAttachOnlyKillError,
+  trackAttachOnlyOrphanRisk
+} from './daemon-attach-only-orphan-event'
+import { retireAccidentalAttachOnlySpawn } from './daemon-attach-only-retire'
 import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from './daemon-errors'
 
 export async function retireUnexpectedAttachOnlySpawn(
+  protocolVersion: number,
   sessionId: string,
-  retire: () => Promise<unknown>
+  kill: () => Promise<unknown>
 ): Promise<void> {
-  try {
-    await retire()
-  } catch (error) {
-    if (error instanceof SessionNotFoundError) {
-      return
+  const retire = await retireAccidentalAttachOnlySpawn({
+    kill: async () => {
+      await kill()
     }
-    console.warn('[daemon] attach-only retire of unexpected spawn failed', {
-      sessionId,
-      error
-    })
-    throw new TerminalSessionOwnerUnverifiedError(sessionId)
+  })
+  if (retire.ok || retire.error instanceof SessionNotFoundError) {
+    return
   }
+  const killErrorClass = classifyAttachOnlyKillError(retire.error)
+  console.error(
+    '[daemon] attach-only retire of accidental legacy spawn failed; orphan may remain',
+    { protocolVersion, killErrorClass }
+  )
+  trackAttachOnlyOrphanRisk({ protocolVersion, killErrorClass })
+  throw new TerminalSessionOwnerUnverifiedError(sessionId)
 }

--- a/src/main/daemon/daemon-attach-only-retirement.ts
+++ b/src/main/daemon/daemon-attach-only-retirement.ts
@@ -5,6 +5,42 @@ import {
 import { retireAccidentalAttachOnlySpawn } from './daemon-attach-only-retire'
 import { SessionNotFoundError, TerminalSessionOwnerUnverifiedError } from './daemon-errors'
 
+export async function refuseAttachOnlyAccidentalSpawn(
+  protocolVersion: number,
+  context: { requestedSessionId: string; operation: { ignoreNextExit: boolean } },
+  incarnationId: string | undefined,
+  client: { request: (type: string, payload: unknown) => Promise<unknown> }
+): Promise<never> {
+  context.operation.ignoreNextExit = true
+  await retireAttachOnlyAccidentalSpawn(
+    protocolVersion,
+    context.requestedSessionId,
+    incarnationId,
+    client
+  )
+  throw new SessionNotFoundError(context.requestedSessionId)
+}
+
+export async function retireAttachOnlyAccidentalSpawn(
+  protocolVersion: number,
+  sessionId: string,
+  incarnationId: string | undefined,
+  client: { request: (type: string, payload: unknown) => Promise<unknown> }
+): Promise<void> {
+  if (!incarnationId) {
+    console.error('[daemon] attach-only retire skipped; no kill-owned proof', { protocolVersion })
+    trackAttachOnlyOrphanRisk({ protocolVersion, killErrorClass: 'unknown' })
+    throw new TerminalSessionOwnerUnverifiedError(sessionId)
+  }
+  await retireUnexpectedAttachOnlySpawn(protocolVersion, sessionId, () =>
+    client.request('killOwned', {
+      sessionId,
+      immediate: true,
+      expectedIncarnationId: incarnationId
+    })
+  )
+}
+
 export async function retireUnexpectedAttachOnlySpawn(
   protocolVersion: number,
   sessionId: string,

--- a/src/main/daemon/daemon-kill-owned.ts
+++ b/src/main/daemon/daemon-kill-owned.ts
@@ -1,0 +1,48 @@
+import { SessionNotFoundError, type SessionInfo } from './types'
+import type { KillOwnedPayload } from './daemon-kill-request'
+import type { DaemonPtySpawnPreparations } from './daemon-pty-spawn-preparations'
+import type { DaemonSessionAttachments } from './daemon-session-attachments'
+import type { DaemonFileLog } from './daemon-file-log'
+import type { TerminalHost } from './terminal-host'
+
+export function assertOwnedLiveSession(
+  sessions: readonly SessionInfo[],
+  sessionId: string,
+  expectedIncarnationId: string
+): void {
+  const live = sessions.find((session) => session.sessionId === sessionId)
+  if (!expectedIncarnationId || !live?.isAlive || live.incarnationId !== expectedIncarnationId) {
+    throw new SessionNotFoundError(sessionId)
+  }
+}
+
+export async function routeKillOwned(
+  options: {
+    host: TerminalHost
+    preparations: DaemonPtySpawnPreparations
+    attachments: DaemonSessionAttachments
+    log: DaemonFileLog
+  },
+  clientId: string,
+  payload: KillOwnedPayload
+): Promise<Record<string, never>> {
+  const { sessionId, expectedIncarnationId, immediate } = payload
+  assertOwnedLiveSession(options.host.listSessions(), sessionId, expectedIncarnationId)
+  const canceledPendingSpawn = options.preparations.cancel(sessionId)
+  options.attachments.clearInput(sessionId)
+  const attribution = { sessionId, immediate: immediate === true, clientId }
+  try {
+    await options.host.kill(sessionId, { immediate })
+  } catch (error) {
+    if (!(canceledPendingSpawn && error instanceof SessionNotFoundError)) {
+      options.log.log('session-kill-failed', {
+        ...attribution,
+        errorName: error instanceof Error ? error.name : typeof error,
+        error: error instanceof Error ? error.message : String(error)
+      })
+      throw error
+    }
+  }
+  options.log.log('session-killed', attribution)
+  return {}
+}

--- a/src/main/daemon/daemon-kill-request.ts
+++ b/src/main/daemon/daemon-kill-request.ts
@@ -1,0 +1,20 @@
+export type KillRequest = {
+  id: string
+  type: 'kill'
+  payload: {
+    sessionId: string
+    immediate?: boolean
+  }
+}
+
+export type KillOwnedRequest = {
+  id: string
+  type: 'killOwned'
+  payload: {
+    sessionId: string
+    expectedIncarnationId: string
+    immediate?: boolean
+  }
+}
+
+export type KillOwnedPayload = KillOwnedRequest['payload']

--- a/src/main/daemon/daemon-pty-adapter-attach-only-ownership.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-attach-only-ownership.test.ts
@@ -1,0 +1,44 @@
+import { describe, expect, it, vi } from 'vitest'
+import { join } from 'node:path'
+import { tmpdir } from 'node:os'
+import { DaemonClient } from './client'
+import { DaemonPtyAdapter } from './daemon-pty-adapter'
+import { TerminalSessionOwnerUnverifiedError } from './daemon-errors'
+
+const socketPath = join(tmpdir(), 'orca-attach-only-mocked.sock')
+const tokenPath = join(tmpdir(), 'orca-attach-only-mocked.token')
+
+describe('attach-only ownership refusal', () => {
+  it('fails closed without kill when an attach-only spawn omits incarnation proof', async () => {
+    const ensureConnected = vi.spyOn(DaemonClient.prototype, 'ensureConnected').mockResolvedValue()
+    const request = vi.spyOn(DaemonClient.prototype, 'request').mockResolvedValueOnce({
+      isNew: true,
+      snapshot: null,
+      pid: 4321,
+      shellState: 'unsupported'
+    })
+    const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
+    try {
+      await expect(
+        legacy.spawn({
+          cols: 80,
+          rows: 24,
+          sessionId: 'unfenced-legacy-session',
+          attachOnly: true
+        })
+      ).rejects.toBeInstanceOf(TerminalSessionOwnerUnverifiedError)
+      expect(request.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(0)
+      expect(request.mock.calls.filter((call) => call[0] === 'killOwned')).toHaveLength(0)
+      expect(errorSpy).toHaveBeenCalledWith(
+        '[daemon] attach-only retire skipped; no kill-owned proof',
+        { protocolVersion: 30 }
+      )
+    } finally {
+      legacy.dispose()
+      errorSpy.mockRestore()
+      request.mockRestore()
+      ensureConnected.mockRestore()
+    }
+  })
+})

--- a/src/main/daemon/daemon-pty-adapter-session-adoption.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-session-adoption.test.ts
@@ -284,6 +284,45 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         ensureConnected.mockRestore()
       }
     })
+
+    it('does not retry a raced-out v30 attach when its single retire attempt fails', async () => {
+      const ensureConnected = vi
+        .spyOn(DaemonClient.prototype, 'ensureConnected')
+        .mockResolvedValue()
+      const request = vi
+        .spyOn(DaemonClient.prototype, 'request')
+        .mockResolvedValueOnce({
+          isNew: true,
+          snapshot: null,
+          pid: 4321,
+          shellState: 'unsupported',
+          incarnationId: 'legacy-orphan-incarnation'
+        })
+        .mockRejectedValueOnce(new Error('Connection lost'))
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
+      const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
+      try {
+        await expect(
+          legacy.spawn({
+            cols: 80,
+            rows: 24,
+            sessionId: 'orphaned-legacy-session',
+            attachOnly: true
+          })
+        ).rejects.toBeInstanceOf(TerminalSessionOwnerUnverifiedError)
+        expect(request.mock.calls.filter((call) => call[0] === 'createOrAttach')).toHaveLength(1)
+        expect(request.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(1)
+        expect(errorSpy).toHaveBeenCalledWith(
+          '[daemon] attach-only retire of accidental legacy spawn failed; orphan may remain',
+          { protocolVersion: 30, killErrorClass: 'transport' }
+        )
+      } finally {
+        legacy.dispose()
+        errorSpy.mockRestore()
+        request.mockRestore()
+        ensureConnected.mockRestore()
+      }
+    })
   })
 
   describe('attach', () => {
@@ -469,20 +508,21 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           }
           throw new Error('kill transport lost')
         })
-      const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+      const errorSpy = vi.spyOn(console, 'error').mockImplementation(() => {})
       const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
       try {
         await expect(legacy.attach('orphaned-legacy-session')).rejects.toBeInstanceOf(
           TerminalSessionOwnerUnverifiedError
         )
 
-        expect(warnSpy).toHaveBeenCalledWith(
-          '[daemon] attach-only retire of unexpected spawn failed',
-          expect.objectContaining({ sessionId: 'orphaned-legacy-session' })
+        expect(requestSpy.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(1)
+        expect(errorSpy).toHaveBeenCalledWith(
+          '[daemon] attach-only retire of accidental legacy spawn failed; orphan may remain',
+          { protocolVersion: 30, killErrorClass: 'unknown' }
         )
       } finally {
         legacy.dispose()
-        warnSpy.mockRestore()
+        errorSpy.mockRestore()
         requestSpy.mockRestore()
         ensureConnectedSpy.mockRestore()
       }

--- a/src/main/daemon/daemon-pty-adapter-session-adoption.test.ts
+++ b/src/main/daemon/daemon-pty-adapter-session-adoption.test.ts
@@ -273,9 +273,10 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           'createOrAttach',
           expect.objectContaining({ command: undefined })
         )
-        expect(request).toHaveBeenNthCalledWith(2, 'kill', {
+        expect(request).toHaveBeenNthCalledWith(2, 'killOwned', {
           sessionId: 'raced-out-legacy-session',
-          immediate: true
+          immediate: true,
+          expectedIncarnationId: 'legacy-replacement-incarnation'
         })
         expect(legacy.getActiveSessionIds()).toEqual([])
       } finally {
@@ -311,7 +312,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           })
         ).rejects.toBeInstanceOf(TerminalSessionOwnerUnverifiedError)
         expect(request.mock.calls.filter((call) => call[0] === 'createOrAttach')).toHaveLength(1)
-        expect(request.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(1)
+        expect(request.mock.calls.filter((call) => call[0] === 'killOwned')).toHaveLength(1)
+        expect(request.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(0)
         expect(errorSpy).toHaveBeenCalledWith(
           '[daemon] attach-only retire of accidental legacy spawn failed; orphan may remain',
           { protocolVersion: 30, killErrorClass: 'transport' }
@@ -432,7 +434,13 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           type === 'getSize'
             ? ({ size: { cols: 100, rows: 30 } } as never)
             : type === 'createOrAttach'
-              ? ({ isNew: true, pid: 77, shellState: 'unsupported', snapshot: null } as never)
+              ? ({
+                  isNew: true,
+                  pid: 77,
+                  shellState: 'unsupported',
+                  snapshot: null,
+                  incarnationId: 'owned-incarnation'
+                } as never)
               : ({} as never)
         )
       const current = new DaemonPtyAdapter({ socketPath, tokenPath })
@@ -445,9 +453,10 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           'createOrAttach',
           expect.objectContaining({ cols: 100, rows: 30, attachOnly: true })
         )
-        expect(requestSpy).toHaveBeenCalledWith('kill', {
+        expect(requestSpy).toHaveBeenCalledWith('killOwned', {
           sessionId: 'raced-current-session',
-          immediate: true
+          immediate: true,
+          expectedIncarnationId: 'owned-incarnation'
         })
         expect(current.getActiveSessionIds()).toEqual([])
       } finally {
@@ -467,7 +476,13 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           type === 'getSize'
             ? ({ size: { cols: 100, rows: 30 } } as never)
             : type === 'createOrAttach'
-              ? ({ isNew: true, pid: 77, shellState: 'unsupported', snapshot: null } as never)
+              ? ({
+                  isNew: true,
+                  pid: 77,
+                  shellState: 'unsupported',
+                  snapshot: null,
+                  incarnationId: 'owned-incarnation'
+                } as never)
               : ({} as never)
         )
       const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
@@ -482,9 +497,10 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
         )
         const createPayload = requestSpy.mock.calls.find(([type]) => type === 'createOrAttach')?.[1]
         expect(createPayload).not.toHaveProperty('attachOnly')
-        expect(requestSpy).toHaveBeenCalledWith('kill', {
+        expect(requestSpy).toHaveBeenCalledWith('killOwned', {
           sessionId: 'raced-legacy-session',
-          immediate: true
+          immediate: true,
+          expectedIncarnationId: 'owned-incarnation'
         })
       } finally {
         legacy.dispose()
@@ -504,7 +520,13 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
             return { size: { cols: 100, rows: 30 } } as never
           }
           if (type === 'createOrAttach') {
-            return { isNew: true, pid: 77, shellState: 'unsupported', snapshot: null } as never
+            return {
+              isNew: true,
+              pid: 77,
+              shellState: 'unsupported',
+              snapshot: null,
+              incarnationId: 'owned-incarnation'
+            } as never
           }
           throw new Error('kill transport lost')
         })
@@ -515,7 +537,8 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
           TerminalSessionOwnerUnverifiedError
         )
 
-        expect(requestSpy.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(1)
+        expect(requestSpy.mock.calls.filter((call) => call[0] === 'killOwned')).toHaveLength(1)
+        expect(requestSpy.mock.calls.filter((call) => call[0] === 'kill')).toHaveLength(0)
         expect(errorSpy).toHaveBeenCalledWith(
           '[daemon] attach-only retire of accidental legacy spawn failed; orphan may remain',
           { protocolVersion: 30, killErrorClass: 'unknown' }

--- a/src/main/daemon/daemon-pty-spawn-result.ts
+++ b/src/main/daemon/daemon-pty-spawn-result.ts
@@ -1,11 +1,11 @@
 import { isAgentSessionClaimedSpawnResult } from '../../shared/agent-session-host-authority'
 import { parseTerminalKittyKeyboardFlags } from '../../shared/terminal-kitty-keyboard-flags'
-import { retireUnexpectedAttachOnlySpawn } from './daemon-attach-only-retirement'
+import { refuseAttachOnlyAccidentalSpawn } from './daemon-attach-only-retirement'
 import { DaemonPtySpawnRequest, type DaemonPtySpawnContext } from './daemon-pty-spawn-request'
 import { providerSequenceFromCreateOrAttach } from './daemon-pty-provider-sequence'
 import { takeHistoryRecoveryFreeze } from './daemon-history-recovery-freeze'
 import { getRecoveredHistorySeedSegments } from './terminal-history-seed-segments'
-import { SessionNotFoundError, type CreateOrAttachResult } from './types'
+import type { CreateOrAttachResult } from './types'
 import type { PtySpawnResult } from '../providers/types'
 
 export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
@@ -61,11 +61,12 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
       historySeedSegments = null
     }
     if (attachOnly && result.isNew) {
-      operation.ignoreNextExit = true
-      await retireUnexpectedAttachOnlySpawn(this.protocolVersion, requestedSessionId, () =>
-        this.client.request('kill', { sessionId: requestedSessionId, immediate: true })
+      await refuseAttachOnlyAccidentalSpawn(
+        this.protocolVersion,
+        context,
+        result.incarnationId,
+        this.client
       )
-      throw new SessionNotFoundError(requestedSessionId)
     }
     await adoptSpawnResultSession(result)
     // Both ids: adoptSpawnResultSession may have rewritten sessionId to the claim owner.

--- a/src/main/daemon/daemon-pty-spawn-result.ts
+++ b/src/main/daemon/daemon-pty-spawn-result.ts
@@ -62,7 +62,7 @@ export abstract class DaemonPtySpawnResult extends DaemonPtySpawnRequest {
     }
     if (attachOnly && result.isNew) {
       operation.ignoreNextExit = true
-      await retireUnexpectedAttachOnlySpawn(requestedSessionId, () =>
+      await retireUnexpectedAttachOnlySpawn(this.protocolVersion, requestedSessionId, () =>
         this.client.request('kill', { sessionId: requestedSessionId, immediate: true })
       )
       throw new SessionNotFoundError(requestedSessionId)

--- a/src/main/daemon/daemon-request-router-kill-owned.test.ts
+++ b/src/main/daemon/daemon-request-router-kill-owned.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DaemonServer } from './daemon-server'
+import { SessionNotFoundError, type DaemonRequest, type SessionInfo } from './types'
+
+type DaemonServerPrivate = {
+  host: {
+    kill: (sessionId: string, opts?: { immediate?: boolean }) => void | Promise<void>
+    listSessions: () => SessionInfo[]
+  }
+  preparations: {
+    pending: Map<string, Set<{ canceled: boolean; clientId: string }>>
+    cancel: (sessionId: string) => boolean
+  }
+  attachments: { clearInput: (sessionId: string) => void }
+  requestRouter: {
+    route(clientId: string, request: DaemonRequest): Promise<unknown>
+  }
+}
+
+function liveSession(incarnationId: string): SessionInfo {
+  return {
+    sessionId: 'agent-session',
+    incarnationId,
+    state: 'running',
+    shellState: 'unsupported',
+    isAlive: true,
+    pid: 1,
+    cwd: null,
+    cols: 80,
+    rows: 24,
+    createdAt: 0
+  }
+}
+
+describe('daemon killOwned router ownership', () => {
+  let server: DaemonServer
+  let dir: string
+
+  afterEach(async () => {
+    await server?.shutdown()
+    rmSync(dir, { recursive: true, force: true })
+  })
+
+  function startDaemon(): DaemonServerPrivate {
+    dir = mkdtempSync(join(tmpdir(), 'daemon-kill-owned-'))
+    server = new DaemonServer({
+      socketPath: join(dir, 'daemon.sock'),
+      tokenPath: join(dir, 'daemon.token'),
+      log: { log: vi.fn(), close: vi.fn() },
+      spawnSubprocess: () => {
+        throw new Error('not used')
+      }
+    })
+    return server as unknown as DaemonServerPrivate
+  }
+
+  it('does not cancel or clear a replacement before rejecting a stale killOwned', async () => {
+    const daemon = startDaemon()
+    const pendingPreparation = {
+      canceled: false,
+      controller: new AbortController(),
+      clientId: 'control-42'
+    }
+    daemon.preparations.pending.set('agent-session', new Set([pendingPreparation]))
+    vi.spyOn(daemon.host, 'listSessions').mockReturnValue([liveSession('replacement')])
+    const kill = vi.spyOn(daemon.host, 'kill')
+    const clearInput = vi.spyOn(daemon.attachments, 'clearInput')
+    const cancel = vi.spyOn(daemon.preparations, 'cancel')
+
+    await expect(
+      daemon.requestRouter.route('control-42', {
+        id: 'kill-owned-1',
+        type: 'killOwned',
+        payload: {
+          sessionId: 'agent-session',
+          expectedIncarnationId: 'stale-orphan',
+          immediate: true
+        }
+      })
+    ).rejects.toBeInstanceOf(SessionNotFoundError)
+
+    expect(pendingPreparation.canceled).toBe(false)
+    expect(cancel).not.toHaveBeenCalled()
+    expect(clearInput).not.toHaveBeenCalled()
+    expect(kill).not.toHaveBeenCalled()
+  })
+
+  it('kills only after killOwned ownership matches the live incarnation', async () => {
+    const daemon = startDaemon()
+    vi.spyOn(daemon.host, 'listSessions').mockReturnValue([liveSession('owned-incarnation')])
+    const kill = vi.spyOn(daemon.host, 'kill').mockResolvedValue()
+    const clearInput = vi.spyOn(daemon.attachments, 'clearInput')
+
+    await daemon.requestRouter.route('control-42', {
+      id: 'kill-owned-2',
+      type: 'killOwned',
+      payload: {
+        sessionId: 'agent-session',
+        expectedIncarnationId: 'owned-incarnation',
+        immediate: true
+      }
+    })
+
+    expect(clearInput).toHaveBeenCalledWith('agent-session')
+    expect(kill).toHaveBeenCalledWith('agent-session', { immediate: true })
+  })
+
+  it('leaves ordinary kill cancel-before-host behavior unchanged', async () => {
+    const daemon = startDaemon()
+    const pendingPreparation = {
+      canceled: false,
+      controller: new AbortController(),
+      clientId: 'control-42'
+    }
+    daemon.preparations.pending.set('agent-session', new Set([pendingPreparation]))
+    vi.spyOn(daemon.host, 'kill').mockRejectedValue(new SessionNotFoundError('agent-session'))
+    const listSessions = vi.spyOn(daemon.host, 'listSessions')
+
+    await daemon.requestRouter.route('control-42', {
+      id: 'kill-1',
+      type: 'kill',
+      payload: { sessionId: 'agent-session', immediate: true }
+    })
+
+    expect(pendingPreparation.canceled).toBe(true)
+    expect(listSessions).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/daemon/daemon-request-router.ts
+++ b/src/main/daemon/daemon-request-router.ts
@@ -12,6 +12,7 @@ import type { DaemonTerminalAdmission } from './daemon-terminal-admission'
 import type { TerminalHistorySeedTransferRegistry } from './terminal-history-seed-transfer-registry'
 import type { TerminalHost } from './terminal-host'
 import { SessionNotFoundError, type DaemonRequest } from './types'
+import { routeKillOwned } from './daemon-kill-owned'
 
 type DaemonRequestRouterOptions = {
   host: TerminalHost
@@ -92,6 +93,8 @@ export class DaemonRequestRouter {
         )
       case 'kill':
         return this.kill(clientId, request.payload.sessionId, request.payload.immediate)
+      case 'killOwned':
+        return routeKillOwned(this.options, clientId, request.payload)
       case 'signal':
         this.options.host.signal(request.payload.sessionId, request.payload.signal)
         return {}

--- a/src/main/daemon/types.ts
+++ b/src/main/daemon/types.ts
@@ -1,3 +1,4 @@
+import type { KillRequest, KillOwnedRequest } from './daemon-kill-request'
 import type {
   ConfirmForegroundProcessRequest,
   ConfirmShellForegroundRequest,
@@ -161,14 +162,7 @@ export type SetSessionBackgroundRequest = {
   }
 }
 
-export type KillRequest = {
-  id: string
-  type: 'kill'
-  payload: {
-    sessionId: string
-    immediate?: boolean
-  }
-}
+export type { KillRequest } from './daemon-kill-request'
 
 export type SignalRequest = {
   id: string
@@ -311,6 +305,7 @@ export type DaemonRequest =
   | ResumePtyRequest
   | SetSessionBackgroundRequest
   | KillRequest
+  | KillOwnedRequest
   | SignalRequest
   | ListSessionsRequest
   | ShutdownIfIdleRequest

--- a/src/shared/telemetry-daemon-event-schemas.ts
+++ b/src/shared/telemetry-daemon-event-schemas.ts
@@ -25,6 +25,15 @@ import { errorClassSchema, settingsChangedKeySchema } from './telemetry-property
 // Why: daemon start-failure signal (fleet-wide outage like v1.4.129-rc.1); enum-only so raw stderr never reaches the wire.
 export const daemonStartFailedSchema = z.object({ error_class: errorClassSchema }).strict()
 
+// Why (#12662): pre-v31 attachOnly ignore leaves an orphan shell when kill fails;
+// enum-only so no session paths reach the wire; rare (≪1/user/day).
+export const daemonAttachOnlyOrphanRiskSchema = z
+  .object({
+    protocol_version: z.number().int().nonnegative(),
+    kill_error_class: z.enum(['transport', 'timeout', 'not_found', 'unknown'])
+  })
+  .strict()
+
 export const runtimeRpcStartErrorClassSchema = z.enum([
   'permission_denied',
   'address_in_use',

--- a/src/shared/telemetry-event-registry.ts
+++ b/src/shared/telemetry-event-registry.ts
@@ -15,6 +15,7 @@ import {
   agentHookUnattributedSchema,
   codexTrustGrantSchema,
   daemonAdoptedSchema,
+  daemonAttachOnlyOrphanRiskSchema,
   daemonAuditEligibilitySchema,
   daemonLifecycleSchema,
   daemonPtyCwdDeniedSchema,
@@ -122,6 +123,7 @@ export const eventSchemas = {
   agent_hook_transport_blocked: agentHookTransportBlockedSchema,
 
   daemon_start_failed: daemonStartFailedSchema,
+  daemon_attach_only_orphan_risk: daemonAttachOnlyOrphanRiskSchema,
   main_thread_hang_detected: mainThreadHangDetectedSchema,
   daemon_lifecycle: daemonLifecycleSchema,
   daemon_adopted: daemonAdoptedSchema,


### PR DESCRIPTION
## Summary

When an attach-only request unexpectedly creates a terminal, refuse the attach and retire the accidental spawn only through `killOwned`, carrying the returned session incarnation. The daemon checks that incarnation against the live session before canceling pending preparations, clearing queued input or killing the process. A stale request leaves a replacement untouched.

If the spawn has no incarnation, no kill request is sent. If an older daemon rejects the new request type, cleanup fails closed without retrying ordinary `kill`. Failed cleanup still emits the support event and redacted diagnostic fields (protocol version and fixed error category), then reports unverified ownership. Already-missing or replaced incarnations need no destructive cleanup. Ordinary `kill` callers retain their existing request shape and behavior. Related: #12662.

This supersedes the previous single-unfenced-kill strategy: even one session-ID-only kill could race with a legitimate replacement. The new daemon request fails explicitly on an unsupported peer; it does not rely on old peers honoring a newly added optional field. No runtime RPC or terminal stream opcode was added. SSH and folder-workspace attachment share this adapter policy.

## Validation

At `418da1ccaa146d2664d2127d4134177e67dea5d4`:

- Independent verification: 87 tests passed across 7 files, including adapter attachment, absent incarnation, unknown old-peer request without fallback, replacement protection before router side effects, telemetry and protocol compatibility. Two regression tests first failed against the original published parent.
- CLI, Node and Web non-composite TypeScript checks and all 11 changed files' lint/format checks passed; diff whitespace passed. Existing attach assertions now require incarnation-fenced cleanup; the new missing-proof adapter test was moved to its own file to retain coverage within existing line limits.
- Independent Cursor review passed for this exact commit.

Full repository tests, packaging, native real-PTY and live legacy-daemon/SSH pair smoke checks were not run. Daemon tests use mocked subprocesses; they do not establish a native cross-version deployment result. An old peer lacking the proof or request may leave the accidental process running; ownership remains unverified and the diagnostic records that outcome.

## AI disclosure

Cursor prepared the initial correction. Codex independently reproduced the bug, completed the compatibility tests and final implementation, and verified the candidate before independent Cursor security review and publication.
