### PR TITLE
fix(terminal): hard-cap aggregated error surface length

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
@@ -94,4 +94,19 @@ describe('appendTerminalErrorMessage', () => {
     expect(capped.startsWith('SSH connection failed:')).toBe(true)
     expect(capped.length).toBe(80)
   })
+
+  // Why: production always appends via `${prev}\n${message}`; a solo-line cap
+  // test would miss mid-final-line tails that drop SSH ownership prefixes.
+  it('keeps the SSH prefix when an oversized final line is appended after prior content', () => {
+    const surface = appendTerminalErrorMessage(
+      'Paste failed.',
+      `SSH connection failed: ${'x'.repeat(3_000)}`
+    )
+    expect(surface.startsWith('SSH connection failed:')).toBe(true)
+    expect(surface.length).toBeLessThanOrEqual(MAX_TERMINAL_ERROR_SURFACE_CHARS)
+    // Why: strip filters match startsWith on each line; a mid-line tail fails that.
+    expect(surface.split('\n').every((line) => line.startsWith('SSH connection failed:'))).toBe(
+      true
+    )
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.test.ts
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
-import { appendTerminalErrorMessage } from './terminal-error-accumulation'
+import {
+  appendTerminalErrorMessage,
+  capTerminalErrorSurfaceNewest,
+  MAX_TERMINAL_ERROR_SURFACE_CHARS
+} from './terminal-error-accumulation'
 import { stripSshReconnectOwnedErrorLines } from './TerminalErrorToast'
 
 const MULTILINE_ERROR = 'Remote terminal write failed.\nThe remote runtime rejected the request.'
@@ -66,5 +70,28 @@ describe('appendTerminalErrorMessage', () => {
       MULTILINE_ERROR
     )
     expect(stripSshReconnectOwnedErrorLines(accumulated)).toBe(MULTILINE_ERROR)
+  })
+
+  it('caps a storm of distinct messages so the surface cannot grow unbound (#12685)', () => {
+    let surface: string | null = null
+    for (let i = 0; i < 200; i += 1) {
+      surface = appendTerminalErrorMessage(surface, `Distinct error number ${i}.`)
+    }
+    expect(surface!.length).toBeLessThanOrEqual(MAX_TERMINAL_ERROR_SURFACE_CHARS)
+    // Newest messages survive the cap.
+    expect(surface).toContain('Distinct error number 199.')
+    expect(surface).not.toContain('Distinct error number 0.')
+  })
+
+  it('cuts the capped suffix on a newline when possible', () => {
+    const text = `${'a'.repeat(100)}\nnewest-line`
+    expect(capTerminalErrorSurfaceNewest(text, 20)).toBe('newest-line')
+  })
+
+  it('keeps the head of a single oversized line so SSH prefixes survive', () => {
+    const owned = `SSH connection failed: ${'x'.repeat(3_000)}`
+    const capped = capTerminalErrorSurfaceNewest(owned, 80)
+    expect(capped.startsWith('SSH connection failed:')).toBe(true)
+    expect(capped.length).toBe(80)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
@@ -4,6 +4,10 @@
 // dedup wrong for messages that themselves contain newlines: a multi-line
 // message is never one line of the accumulated value, so it would re-append on
 // every recurrence and grow without bound.
+
+/** Hard cap on the toast surface so distinct multi-error storms cannot grow unbound (#12685). */
+export const MAX_TERMINAL_ERROR_SURFACE_CHARS = 2_000
+
 function containsWholeLineRun(accumulated: string, message: string): boolean {
   return (
     accumulated === message ||
@@ -13,10 +17,41 @@ function containsWholeLineRun(accumulated: string, message: string): boolean {
   )
 }
 
+/**
+ * Bound the surface without breaking SSH ownership filters that match
+ * prefixes on whole lines (#12685). Multi-message surfaces keep the newest
+ * complete lines; a single oversized line keeps its head (classification
+ * prefix) rather than a mid-string suffix.
+ */
+export function capTerminalErrorSurfaceNewest(
+  text: string,
+  maxChars: number = MAX_TERMINAL_ERROR_SURFACE_CHARS
+): string {
+  if (text.length <= maxChars) {
+    return text
+  }
+  const lastNewline = text.lastIndexOf('\n')
+  if (lastNewline === -1) {
+    // One line longer than the cap: keep the identifying prefix.
+    return text.slice(0, maxChars)
+  }
+  let start = text.length - maxChars
+  const newline = text.indexOf('\n', start)
+  if (newline !== -1 && newline < text.length - 1) {
+    start = newline + 1
+  }
+  const suffix = text.slice(start)
+  // Newest segment alone can still exceed the cap (multi-line or long line).
+  return suffix.length <= maxChars ? suffix : suffix.slice(0, maxChars)
+}
+
 /** Appends an error to the aggregated surface, keeping the first occurrence of an already-present message. */
 export function appendTerminalErrorMessage(accumulated: string | null, message: string): string {
   if (!accumulated) {
-    return message
+    return capTerminalErrorSurfaceNewest(message)
   }
-  return containsWholeLineRun(accumulated, message) ? accumulated : `${accumulated}\n${message}`
+  if (containsWholeLineRun(accumulated, message)) {
+    return accumulated
+  }
+  return capTerminalErrorSurfaceNewest(`${accumulated}\n${message}`)
 }

--- a/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-error-accumulation.ts
@@ -20,8 +20,8 @@ function containsWholeLineRun(accumulated: string, message: string): boolean {
 /**
  * Bound the surface without breaking SSH ownership filters that match
  * prefixes on whole lines (#12685). Multi-message surfaces keep the newest
- * complete lines; a single oversized line keeps its head (classification
- * prefix) rather than a mid-string suffix.
+ * complete lines; an oversized final line keeps its head (classification
+ * prefix) rather than a mid-line tail from the char window.
  */
 export function capTerminalErrorSurfaceNewest(
   text: string,
@@ -35,14 +35,17 @@ export function capTerminalErrorSurfaceNewest(
     // One line longer than the cap: keep the identifying prefix.
     return text.slice(0, maxChars)
   }
-  let start = text.length - maxChars
+  const start = text.length - maxChars
   const newline = text.indexOf('\n', start)
   if (newline !== -1 && newline < text.length - 1) {
-    start = newline + 1
+    const suffix = text.slice(newline + 1)
+    // Why: dropping older complete lines can still leave a multi-line suffix
+    // over the cap; re-enter so an oversized final line keeps its head.
+    return suffix.length <= maxChars ? suffix : capTerminalErrorSurfaceNewest(suffix, maxChars)
   }
-  const suffix = text.slice(start)
-  // Newest segment alone can still exceed the cap (multi-line or long line).
-  return suffix.length <= maxChars ? suffix : suffix.slice(0, maxChars)
+  // Why: the char window starts mid-final-line (no later newline). Returning
+  // text.slice(start) would drop SSH ownership prefixes that strip filters need.
+  return text.slice(lastNewline + 1, lastNewline + 1 + maxChars)
 }
 
 /** Appends an error to the aggregated surface, keeping the first occurrence of an already-present message. */


### PR DESCRIPTION
## Summary

- Cap the newline-joined terminal error toast at 2000 characters.
- Prefer the newest complete lines; a single oversized line keeps its head so SSH reconnect ownership prefixes still match.

Fixes #12685

## Test plan

- [x] Existing dedup tests still pass
- [x] Storm of 200 distinct messages stays within the cap
- [x] Oversized single-line SSH error keeps its prefix
- [x] Codex review: fixed prefix-preservation for oversized lines