### PR TITLE
fix(mobile): open Create Workspace after its source drawer has closed

### DIFF
--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -86,6 +86,10 @@ import {
   type GitHubRepoSlugCacheEntry
 } from '../../../src/tasks/github-project-repo-match'
 import {
+  canCreateWorkspaceFromProjectRow,
+  projectRowType
+} from '../../../src/tasks/github-project-row-kind'
+import {
   parseGitHubProjectInput as parseProjectInput,
   type GitHubProjectOwnerType,
   type GitHubProjectPartialFailure,
@@ -930,22 +934,6 @@ function githubKindFromQuery(query: string, fallbackPreset: GitHubPreset): GitHu
   return fallbackPreset === 'prs' || fallbackPreset === 'my-prs' || fallbackPreset === 'review'
     ? 'prs'
     : 'issues'
-}
-
-function projectRowType(row: GitHubProjectRow): 'issue' | 'pr' | null {
-  if (row.itemType === 'ISSUE') {
-    return 'issue'
-  }
-  if (row.itemType === 'PULL_REQUEST') {
-    return 'pr'
-  }
-  return null
-}
-
-function canCreateWorkspaceFromProjectRow(row: GitHubProjectRow): boolean {
-  // Why: desktop only exposes Project "Start work" for backed issue/PR rows
-  // with enough GitHub identity to build the linked work item.
-  return projectRowType(row) !== null && row.content.number != null && Boolean(row.content.url)
 }
 
 function splitRepositorySlug(slug: string | null): { owner: string; repo: string } | null {

--- a/mobile/app/h/[hostId]/tasks.tsx
+++ b/mobile/app/h/[hostId]/tasks.tsx
@@ -45,6 +45,7 @@ import { StatusDot } from '../../../src/components/StatusDot'
 import { ActionSheetModal } from '../../../src/components/ActionSheetModal'
 import { BottomDrawer } from '../../../src/components/BottomDrawer'
 import { ConfirmModal } from '../../../src/components/ConfirmModal'
+import { useBottomDrawerFollowUp } from '../../../src/components/bottom-drawer-follow-up'
 import { MobileMarkdown } from '../../../src/components/MobileMarkdown'
 import { MobileAgentIcon } from '../../../src/components/MobileAgentIcon'
 import { MobileWorkspaceNameInput } from '../../../src/components/MobileWorkspaceNameInput'
@@ -2297,6 +2298,9 @@ export default function MobileTasksScreen() {
   const [pendingGitHubProjectViewSelection, setPendingGitHubProjectViewSelection] =
     useState<GitHubProjectRef | null>(null)
   const [projectRowItem, setProjectRowItem] = useState<GitHubProjectRow | null>(null)
+  const taskDetail = useBottomDrawerFollowUp(setActionItem)
+  const projectRow = useBottomDrawerFollowUp(setProjectRowItem)
+  const repoPicker = useBottomDrawerFollowUp(setWorkspaceRepoPickerItem)
   const [projectRowDetail, setProjectRowDetail] = useState<DetailPayload | null>(null)
   const [projectRowDetailLoading, setProjectRowDetailLoading] = useState(false)
   const [projectRowDetailError, setProjectRowDetailError] = useState('')
@@ -10866,12 +10870,12 @@ export default function MobileTasksScreen() {
         options={workspaceRepoOptions}
         selected={workspaceRepos[0]?.id ?? ''}
         onSelect={(repoId) => {
-          if (workspaceRepoPickerItem) {
-            openWorkspaceCreate(workspaceRepoPickerItem, repoId)
+          const item = workspaceRepoPickerItem
+          if (item) {
+            repoPicker.closeThen(() => openWorkspaceCreate(item, repoId))
           }
-          setWorkspaceRepoPickerItem(null)
         }}
-        onClose={() => setWorkspaceRepoPickerItem(null)}
+        {...repoPicker.drawerProps}
         zIndex={TASK_SECONDARY_DRAWER_Z_INDEX}
       />
 
@@ -11622,10 +11626,7 @@ export default function MobileTasksScreen() {
         ) : null}
       </BottomDrawer>
 
-      <BottomDrawer
-        visible={taskUiReady && projectRowItem != null}
-        onClose={() => setProjectRowItem(null)}
-      >
+      <BottomDrawer visible={taskUiReady && projectRowItem != null} {...projectRow.drawerProps}>
         {projectRowItem ? (
           <View>
             <View style={styles.sheetHeader}>
@@ -12548,7 +12549,9 @@ export default function MobileTasksScreen() {
                 <Pressable
                   style={styles.actionRow}
                   disabled={creatingKey === `github-project:${projectRowItem.id}`}
-                  onPress={() => void createWorkspaceFromProjectRow(projectRowItem)}
+                  onPress={() =>
+                    projectRow.closeThen(() => void createWorkspaceFromProjectRow(projectRowItem))
+                  }
                 >
                   <Plus size={16} color={colors.textPrimary} />
                   <Text style={styles.actionText}>Create Workspace</Text>
@@ -12658,7 +12661,7 @@ export default function MobileTasksScreen() {
         ) : null}
       </BottomDrawer>
 
-      <BottomDrawer visible={taskUiReady && actionItem != null} onClose={() => setActionItem(null)}>
+      <BottomDrawer visible={taskUiReady && actionItem != null} {...taskDetail.drawerProps}>
         {actionItem ? (
           <View>
             <View style={styles.sheetHeader}>
@@ -13416,13 +13419,15 @@ export default function MobileTasksScreen() {
               <Pressable
                 style={styles.actionRow}
                 disabled={creatingKey === actionItem.key}
-                onPress={() => {
-                  if (actionItem.provider === 'linear' && workspaceRepos.length > 1) {
-                    setWorkspaceRepoPickerItem(actionItem)
-                    return
-                  }
-                  openWorkspaceCreate(actionItem)
-                }}
+                onPress={() =>
+                  taskDetail.closeThen(() => {
+                    if (actionItem.provider === 'linear' && workspaceRepos.length > 1) {
+                      setWorkspaceRepoPickerItem(actionItem)
+                      return
+                    }
+                    openWorkspaceCreate(actionItem)
+                  })
+                }
               >
                 <Plus size={16} color={colors.textPrimary} />
                 <Text style={styles.actionText}>

--- a/mobile/src/components/bottom-drawer-follow-up.test.ts
+++ b/mobile/src/components/bottom-drawer-follow-up.test.ts
@@ -1,0 +1,130 @@
+import { createElement } from 'react'
+import { act, create, type ReactTestRenderer } from 'react-test-renderer'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { BottomDrawer } from './BottomDrawer'
+import {
+  createBottomDrawerFollowUp,
+  useBottomDrawerFollowUp,
+  type BottomDrawerFollowUp
+} from './bottom-drawer-follow-up'
+
+vi.mock('./mounted-bottom-drawer', () => ({
+  MountedBottomDrawer: 'MountedBottomDrawer'
+}))
+
+describe('createBottomDrawerFollowUp', () => {
+  it('closes first and holds the follow-up until the drawer is gone', () => {
+    const close = vi.fn()
+    const followUp = vi.fn()
+    const drawer = createBottomDrawerFollowUp(close)
+
+    drawer.closeThen(followUp)
+
+    expect(close).toHaveBeenCalledTimes(1)
+    expect(followUp).not.toHaveBeenCalled()
+
+    drawer.drawerProps.onAfterClose()
+
+    expect(followUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs a pending follow-up once, not on every later close', () => {
+    const drawer = createBottomDrawerFollowUp(vi.fn())
+    const followUp = vi.fn()
+
+    drawer.closeThen(followUp)
+    drawer.drawerProps.onAfterClose()
+    drawer.drawerProps.onAfterClose()
+
+    expect(followUp).toHaveBeenCalledTimes(1)
+  })
+
+  it('runs nothing when the drawer is dismissed instead of acted on', () => {
+    const close = vi.fn()
+    const drawer = createBottomDrawerFollowUp(close)
+
+    drawer.drawerProps.onClose()
+    drawer.drawerProps.onAfterClose()
+
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps the last action when two are taken before the close lands', () => {
+    const drawer = createBottomDrawerFollowUp(vi.fn())
+    const first = vi.fn()
+    const second = vi.fn()
+
+    drawer.closeThen(first)
+    drawer.closeThen(second)
+    drawer.drawerProps.onAfterClose()
+
+    expect(first).not.toHaveBeenCalled()
+    expect(second).toHaveBeenCalledTimes(1)
+  })
+})
+
+describe('useBottomDrawerFollowUp wired to a BottomDrawer', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    const originalConsoleError = console.error
+    vi.spyOn(console, 'error').mockImplementation((...args) => {
+      const message = args[0]
+      if (
+        typeof message === 'string' &&
+        (message.includes('react-test-renderer is deprecated') ||
+          message.includes('The current testing environment is not configured to support act'))
+      ) {
+        return
+      }
+      originalConsoleError(...args)
+    })
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  // Why: the screen-level contract behind the fix — a drawer action that opens
+  // another drawer must not fire while this drawer's native window is up.
+  it('defers the action until the drawer has unmounted', () => {
+    const openSecondDrawer = vi.fn()
+    const screen: {
+      item: string | null
+      drawer?: BottomDrawerFollowUp
+      renderer?: ReactTestRenderer
+    } = { item: 'task' }
+
+    function Host() {
+      const drawer = useBottomDrawerFollowUp<string>((next) => {
+        screen.item = typeof next === 'function' ? next(screen.item) : next
+      })
+      screen.drawer = drawer
+      return createElement(
+        BottomDrawer,
+        { visible: screen.item != null, ...drawer.drawerProps },
+        createElement('DrawerContent')
+      )
+    }
+
+    act(() => {
+      screen.renderer = create(createElement(Host))
+    })
+    const renderer = screen.renderer
+    const drawer = screen.drawer
+    if (!renderer || !drawer) {
+      throw new Error('Drawer host did not render')
+    }
+
+    act(() => drawer.closeThen(openSecondDrawer))
+    act(() => renderer.update(createElement(Host)))
+
+    expect(screen.item).toBeNull()
+    expect(openSecondDrawer).not.toHaveBeenCalled()
+    expect(renderer.toJSON()).not.toBeNull()
+
+    act(() => renderer.root.findByType('MountedBottomDrawer').props.onHidden())
+
+    expect(renderer.toJSON()).toBeNull()
+    expect(openSecondDrawer).toHaveBeenCalledTimes(1)
+  })
+})

--- a/mobile/src/components/bottom-drawer-follow-up.ts
+++ b/mobile/src/components/bottom-drawer-follow-up.ts
@@ -1,0 +1,46 @@
+import { useRef, type Dispatch, type SetStateAction } from 'react'
+
+type BottomDrawerCloseProps = {
+  onClose: () => void
+  onAfterClose: () => void
+}
+
+export type BottomDrawerFollowUp = {
+  /** Close the drawer, then run `followUp` once its native window is gone. */
+  closeThen: (followUp: () => void) => void
+  /** Spread onto the drawer whose close the follow-up waits for. */
+  drawerProps: BottomDrawerCloseProps
+}
+
+// Why: a drawer is a native iOS modal, and one presented while another is still
+// on screen is dropped — the source sheet stays up and the screen goes dead to
+// taps. An action that opens a second drawer has to wait out the close of the
+// drawer it was launched from.
+export function createBottomDrawerFollowUp(close: () => void): BottomDrawerFollowUp {
+  let pending: (() => void) | null = null
+  return {
+    closeThen(followUp) {
+      pending = followUp
+      close()
+    },
+    drawerProps: {
+      onClose: close,
+      onAfterClose() {
+        const followUp = pending
+        pending = null
+        followUp?.()
+      }
+    }
+  }
+}
+
+export function useBottomDrawerFollowUp<T>(
+  setDrawer: Dispatch<SetStateAction<T | null>>
+): BottomDrawerFollowUp {
+  // Why: state setters are stable, so one follow-up outlives every render.
+  const followUp = useRef<BottomDrawerFollowUp | null>(null)
+  if (!followUp.current) {
+    followUp.current = createBottomDrawerFollowUp(() => setDrawer(null))
+  }
+  return followUp.current
+}

--- a/mobile/src/tasks/github-project-row-kind.ts
+++ b/mobile/src/tasks/github-project-row-kind.ts
@@ -1,0 +1,24 @@
+/** The slice of a GitHub Projects row its kind can be decided from. */
+export type GitHubProjectRowKindSource = {
+  itemType: 'ISSUE' | 'PULL_REQUEST' | 'DRAFT_ISSUE' | 'REDACTED'
+  content: {
+    number: number | null
+    url: string | null
+  }
+}
+
+export function projectRowType(row: GitHubProjectRowKindSource): 'issue' | 'pr' | null {
+  if (row.itemType === 'ISSUE') {
+    return 'issue'
+  }
+  if (row.itemType === 'PULL_REQUEST') {
+    return 'pr'
+  }
+  return null
+}
+
+// Why: desktop only exposes Project "Start work" for backed issue/PR rows
+// with enough GitHub identity to build the linked work item.
+export function canCreateWorkspaceFromProjectRow(row: GitHubProjectRowKindSource): boolean {
+  return projectRowType(row) !== null && row.content.number != null && Boolean(row.content.url)
+}


### PR DESCRIPTION
## Summary

Starting a workspace from a task on iOS did nothing and left the screen stuck. The Tasks screen asked the **Create Workspace** drawer to open while the sheet it was launched from was still on screen. Every `BottomDrawer` presents its own native modal, and iOS drops a modal presented while another one is up — so the source sheet stayed put, Create Workspace never appeared, and the screen stopped taking taps.

Three entry points on `mobile/app/h/[hostId]/tasks.tsx` were affected:

- the **task detail sheet** → *Create Workspace* (also its Linear multi-repo path, which opens the repo picker)
- the **"Create Workspace In"** repo picker → repo selection, which opened the create draft and closed the picker in the same tick
- the **GitHub Projects row** sheet → *Create Workspace*, including its "repository is not added to Orca" notice on the error path

Each of these sheets now closes first and runs its action from `onAfterClose`, once its native window is gone. This is the same sequencing `MobileHomeQuickActions` already uses for **New Workspace** on the home screen: `BottomDrawer` and `PickerModal` already expose `onAfterClose`, the Tasks screen was simply never wired to it. The shared piece lives in `mobile/src/components/bottom-drawer-follow-up.ts`.

The first commit is a prerequisite, not drive-by cleanup: `tasks.tsx` sits exactly on its `max-lines` budget (14682 of 14682 counted lines), and `AGENTS.md` forbids both raising the per-file cap and suppressing the rule — so `projectRowType` and `canCreateWorkspaceFromProjectRow` move to their own module, typed against the row fields they actually read, to make room.

Alternative considered: hosting the Tasks drawers in `BottomDrawerModalHost`, which exists for exactly this class of bug. It needs a single-view state machine, and the Tasks screen carries ~15 drawers that deliberately stack by `zIndex` — too large a refactor to carry a bug fix. Sequencing matches the pattern already shipping on the home screen.

## Screenshots

No new UI, and no drawer content changed. The only visible difference is ordering: the source sheet now animates out before Create Workspace animates in, instead of Create Workspace never appearing at all.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Mobile package (what `Mobile Checks` runs): `pnpm typecheck`, `pnpm test` (434 files, 3388 tests), `pnpm lint`, `oxfmt --check` — all green.

One caveat on the root suite: 5 tests fail locally in `config/scripts/check-root-directory-entries.test.mjs` and `src/relay/agent-exec-handler.test.ts` (48307 pass). They fail identically on an untouched `main` in the same environment and neither file is reachable from this diff, which only touches `mobile/`.

`mobile/src/components/bottom-drawer-follow-up.test.ts` covers the contract the fix depends on: the action is held until the drawer's native window is gone, runs exactly once, keeps the last action when two are taken before the close lands, and replays nothing when the drawer is merely dismissed. The last case is exercised against a real `BottomDrawer`, so dropping the wiring on either side fails the suite.

Not verified on an iOS device — I had no device build in this environment. The failure mode is the one already documented in `mobile/src/components/bottom-drawer-modal-host.tsx` ("iOS cannot reliably dismiss one native modal and present another in the same beat … leaving the sheet dead to taps") and reproduced by a user on iOS from the task detail sheet. A maintainer pass on a device would be welcome.

## AI Review Report

Reviewed with an AI coding agent across the dimensions below.

- **Cross-platform (macOS / Linux / Windows):** no desktop code touched; the diff is confined to `mobile/`. No new keyboard shortcuts, accelerators, shortcut labels, path handling, or shell invocation. The sequencing is inert on Android and web, where presenting a second modal already worked — those platforms just gain one close animation before the create sheet.
- **SSH / remote / local:** no transport, RPC, or host-side behavior changed. The workspace creation request itself is untouched, including the SSH gate the create drawer applies before submitting.
- **Agents, integrations, git providers:** all three fixed flows are provider-neutral. GitHub, GitLab and Linear tasks travel the same path; the Linear-specific multi-repo branch is preserved verbatim, only deferred until the detail sheet is gone.
- **Performance:** the follow-up holder is created once per drawer via a ref and its props object is stable, so no extra renders and no new subscriptions or timers. `BottomDrawer` already tracked `onAfterClose`; this only supplies it.
- **UI quality:** no tokens, colors, spacing or components introduced. `STYLEGUIDE.md` has nothing to say about this diff.
- **Flagged and addressed:** the naive fix would have dropped the Linear "many repos → repo picker" branch from the detail sheet. It is kept, and now chains correctly — detail sheet closes, picker opens, picker closes, create drawer opens.
- **Flagged and accepted:** if a drawer's close animation is interrupted so `onHidden` never fires, the pending action is dropped rather than run at the wrong time. That is the safer failure, and it matches the existing `MobileHomeQuickActions` behavior.

## Security Audit

- **Input handling:** none added. No user input is parsed, and no new data crosses a trust boundary.
- **Command execution / path handling:** none. No process spawn, no filesystem access, no path construction.
- **Auth and secrets:** untouched. No credentials, tokens or Linear/GitHub API keys are read, logged or moved.
- **IPC / RPC:** no new messages, and no change to the params of the existing workspace-create request.
- **Dependencies:** no additions. The new module imports only `react`.
- **Residual risk:** the deferred callbacks close over a task item captured at press time. They run a few hundred milliseconds later against state that may have moved on, but they only open a local drawer — the create request is issued later from the drawer's own confirm action, against freshly read state.

## Notes

- iOS-specific bug; the change is inert but harmless on Android and web.
- The extraction in the first commit has no behavior change and can be reviewed independently of the fix.
- The Tasks screen remains at its `max-lines` ceiling. Anything added there in future needs the same trade, or a real split.
