### PR TITLE
fix(ssh): report offline expired-only terminate as abandoned

### DIFF
--- a/src/main/ipc/ssh.test.ts
+++ b/src/main/ipc/ssh.test.ts
@@ -2669,7 +2669,10 @@ describe('SSH IPC handlers', () => {
 
     await expect(
       handlers.get('ssh:terminateSessions')!(null, { targetId: 'ssh-1' })
-    ).resolves.toBeUndefined()
+    ).resolves.toEqual({
+      remoteSessionsTerminated: 0,
+      abandonedUnreachable: 1
+    })
 
     expect(mockPtyProvider.shutdown).not.toHaveBeenCalled()
     expect(mockConnectionManager.disconnect).toHaveBeenCalledWith('ssh-1')

--- a/src/main/ipc/ssh.ts
+++ b/src/main/ipc/ssh.ts
@@ -154,7 +154,7 @@ export async function removeRegisteredSshTarget(targetId: string): Promise<void>
 
 // One session per SSH target owns the whole relay lifecycle (mux, providers, abort controller, state machine).
 const activeSessions = new Map<string, SshRelaySession>()
-const targetLifecycleInFlight = new Map<string, Promise<void>>()
+const targetLifecycleInFlight = new Map<string, Promise<unknown>>()
 
 export function getActiveSshAiVaultHostInfo(targetId: string): SshRelayAiVaultHostInfo | null {
   if (isRuntimeOwnedSshTargetId(targetId)) {
@@ -203,15 +203,15 @@ export async function requestActiveSshAiVaultSessionTitles(
   return session.requestAiVaultSessionTitles(params, options)
 }
 
-function runTargetLifecycle(targetId: string, operation: () => Promise<void>): Promise<void> {
+function runTargetLifecycle<T>(targetId: string, operation: () => Promise<T>): Promise<T> {
   const prior = targetLifecycleInFlight.get(targetId)
   const operationPromise = (async () => {
     if (prior) {
       await prior.catch(() => undefined)
     }
-    await operation()
+    return await operation()
   })()
-  let trackedPromise!: Promise<void>
+  let trackedPromise!: Promise<T>
   trackedPromise = operationPromise.finally(() => {
     if (targetLifecycleInFlight.get(targetId) === trackedPromise) {
       targetLifecycleInFlight.delete(targetId)
@@ -1295,7 +1295,7 @@ export function registerSshHandlers(
 
   ipcMain.handle('ssh:terminateSessions', async (_event, args: { targetId: string }) => {
     invalidateConnectAttempt(args.targetId)
-    await runTargetLifecycle(args.targetId, async () => {
+    return await runTargetLifecycle(args.targetId, async () => {
       const provider = getSshPtyProvider(args.targetId)
       const leases = persistedStore!.getSshRemotePtyLeases(args.targetId)
       const ptyIdsByRelayId = new Map<string, string>()
@@ -1332,14 +1332,22 @@ export function registerSshHandlers(
           `${SSH_TERMINATE_RECONNECT_REQUIRED}: SSH relay is not connected; reconnect before terminating remote sessions.`
         )
       }
-      const shutdownResults = provider
-        ? await Promise.allSettled(
-            ptyIds.map(({ appPtyId }) =>
-              provider.shutdown(appPtyId, { immediate: true, keepHistory: false })
-            )
-          )
-        : []
+      // Why (#12661): expired-only offline terminate used to look successful while remote shells
+      // stayed live. Still tear down local transport, but report abandonedUnreachable.
+      if (!provider) {
+        await teardownSshTargetTransport(args.targetId, (session) => session.disposeAndPersist())
+        return {
+          remoteSessionsTerminated: 0,
+          abandonedUnreachable: ptyIds.length
+        }
+      }
+      const shutdownResults = await Promise.allSettled(
+        ptyIds.map(({ appPtyId }) =>
+          provider.shutdown(appPtyId, { immediate: true, keepHistory: false })
+        )
+      )
       const shutdownFailures: string[] = []
+      let remoteSessionsTerminated = 0
       for (const [index, result] of shutdownResults.entries()) {
         const { appPtyId, relayPtyId } = ptyIds[index]
         if (result.status !== 'fulfilled' && !isSshPtyNotFoundError(result.reason)) {
@@ -1348,6 +1356,7 @@ export function registerSshHandlers(
           )
           continue
         }
+        remoteSessionsTerminated += 1
         clearProviderPtyState(appPtyId)
         deletePtyOwnership(appPtyId)
         persistedStore!.markSshRemotePtyLease(args.targetId, relayPtyId, 'terminated')
@@ -1357,6 +1366,10 @@ export function registerSshHandlers(
         throw new Error(`Failed to terminate SSH host sessions: ${shutdownFailures.join('; ')}`)
       }
       await teardownSshTargetTransport(args.targetId, (session) => session.disposeAndPersist())
+      return {
+        remoteSessionsTerminated,
+        abandonedUnreachable: 0
+      }
     })
   })
 

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -73,6 +73,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { SshTerminateSessionsResult } from '../shared/ssh-terminate-sessions-result'
 import type {
   CreateLocalOrcaProfileArgs,
   CreateLocalOrcaProfileResult,
@@ -3500,7 +3501,7 @@ export type PreloadApi = {
     resolveConfigHost: (args: { alias: string }) => Promise<SshConfigHostResolution | null>
     connect: (args: { targetId: string }) => Promise<SshConnectionState | null>
     disconnect: (args: { targetId: string }) => Promise<void>
-    terminateSessions: (args: { targetId: string }) => Promise<void>
+    terminateSessions: (args: { targetId: string }) => Promise<SshTerminateSessionsResult>
     resetRelay: (args: { targetId: string }) => Promise<void>
     getState: (args: { targetId: string }) => Promise<SshConnectionState | null>
     needsPassphrasePrompt: (args: { targetId: string }) => Promise<boolean>

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -42,6 +42,7 @@ import type {
   PortForwardEntry,
   EnrichedDetectedPort
 } from '../shared/ssh-types'
+import type { SshTerminateSessionsResult } from '../shared/ssh-terminate-sessions-result'
 import {
   admitSshConnectionStateForAuthorityReconciliation,
   admitSshDetectedPorts
@@ -4514,7 +4515,7 @@ const api = {
     disconnect: (args: { targetId: string }): Promise<void> =>
       ipcRenderer.invoke('ssh:disconnect', args),
 
-    terminateSessions: (args: { targetId: string }): Promise<void> =>
+    terminateSessions: (args: { targetId: string }): Promise<SshTerminateSessionsResult> =>
       ipcRenderer.invoke('ssh:terminateSessions', args),
 
     resetRelay: (args: { targetId: string }): Promise<void> =>

--- a/src/renderer/src/components/settings/SshPane.tsx
+++ b/src/renderer/src/components/settings/SshPane.tsx
@@ -6,7 +6,12 @@ import { useAppStore } from '@/store'
 import { useMountedRef } from '@/hooks/useMountedRef'
 import { Button } from '../ui/button'
 import { removeSshTargetWithBestEffortCleanup } from './ssh-target-remove'
-import { terminateSshSessionsWithReconnect } from './ssh-session-termination'
+import {
+  connectSshTarget,
+  disconnectSshTarget,
+  resetSshTargetRelay,
+  terminateSshTargetSessions
+} from './ssh-pane-session-actions'
 import { SshTargetCard } from './SshTargetCard'
 import { SshTargetDestructiveActions } from './SshTargetDestructiveActions'
 import { SshTargetForm, EMPTY_FORM, type EditingTarget } from './SshTargetForm'
@@ -190,72 +195,15 @@ export function SshPane({ addTargetIntentSignal }: SshPaneProps): React.JSX.Elem
     setShowForm(true)
   }
 
-  const handleConnect = async (targetId: string): Promise<void> => {
-    try {
-      await window.api.ssh.connect({ targetId })
-      recordFeatureInteraction('ssh')
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : translate('auto.components.settings.SshPane.e95d5ae10e', 'Connection failed')
-      )
-    }
-  }
-
-  const handleDisconnect = async (targetId: string): Promise<void> => {
-    try {
-      await window.api.ssh.disconnect({ targetId })
-      recordFeatureInteraction('ssh')
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : translate('auto.components.settings.SshPane.a43de1d3ee', 'Disconnect failed')
-      )
-    }
-  }
-
-  const handleTerminateSessions = async (targetId: string): Promise<void> => {
-    try {
-      await terminateSshSessionsWithReconnect(targetId)
-      toast.success(
-        translate('auto.components.settings.SshPane.90e308c98b', 'Remote terminals ended')
-      )
-    } catch (err) {
-      toast.error(
-        err instanceof Error
-          ? err.message
-          : translate(
-              'auto.components.settings.SshPane.025e107643',
-              'Failed to end remote terminals'
-            )
-      )
-    }
-  }
-
-  const handleResetRelay = async (targetId: string): Promise<void> => {
-    try {
-      await window.api.ssh.resetRelay({ targetId })
-      if (mountedRef.current) {
-        toast.success(
-          translate('auto.components.settings.SshPane.db2e48975e', 'Remote relay reset')
-        )
-      }
-      await loadTargets()
-    } catch (err) {
-      if (mountedRef.current) {
-        toast.error(
-          err instanceof Error
-            ? err.message
-            : translate(
-                'auto.components.settings.SshPane.2c4ee7332b',
-                'Failed to reset remote relay'
-              )
-        )
-      }
-    }
-  }
+  const handleConnect = (targetId: string): Promise<void> => connectSshTarget(targetId)
+  const handleDisconnect = (targetId: string): Promise<void> => disconnectSshTarget(targetId)
+  const handleTerminateSessions = (targetId: string): Promise<void> =>
+    terminateSshTargetSessions(targetId)
+  const handleResetRelay = (targetId: string): Promise<void> =>
+    resetSshTargetRelay(targetId, {
+      isMounted: () => mountedRef.current,
+      reload: loadTargets
+    })
 
   const handleTest = async (targetId: string): Promise<void> => {
     setTestingIds((prev) => new Set(prev).add(targetId))

--- a/src/renderer/src/components/settings/ssh-pane-session-actions.test.ts
+++ b/src/renderer/src/components/settings/ssh-pane-session-actions.test.ts
@@ -1,5 +1,14 @@
-import { describe, expect, it } from 'vitest'
-import { formatSshTerminateSessionsNotice } from './ssh-terminate-sessions-result'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string, values?: { value0?: number }) =>
+    fallback.replace('{{value0}}', String(values?.value0 ?? ''))
+}))
+vi.mock('sonner', () => ({ toast: {} }))
+vi.mock('@/store', () => ({ useAppStore: { getState: vi.fn() } }))
+vi.mock('./ssh-session-termination', () => ({ terminateSshSessionsWithReconnect: vi.fn() }))
+
+import { formatSshTerminateSessionsNotice } from './ssh-pane-session-actions'
 
 describe('formatSshTerminateSessionsNotice', () => {
   it('is silent when every remote session was reached', () => {
@@ -8,7 +17,7 @@ describe('formatSshTerminateSessionsNotice', () => {
     ).toBeNull()
   })
 
-  it('warns when abandoned sessions could not be killed offline', () => {
+  it('formats localized singular and plural warnings', () => {
     expect(
       formatSshTerminateSessionsNotice({ remoteSessionsTerminated: 0, abandonedUnreachable: 1 })
     ).toBe('1 abandoned remote session was not killed — reconnect to terminate it.')

--- a/src/renderer/src/components/settings/ssh-pane-session-actions.ts
+++ b/src/renderer/src/components/settings/ssh-pane-session-actions.ts
@@ -1,0 +1,77 @@
+import { toast } from 'sonner'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import { formatSshTerminateSessionsNotice } from '../../../../shared/ssh-terminate-sessions-result'
+import { terminateSshSessionsWithReconnect } from './ssh-session-termination'
+
+function recordSshInteraction(): void {
+  useAppStore.getState().recordFeatureInteraction('ssh')
+}
+
+export async function connectSshTarget(targetId: string): Promise<void> {
+  try {
+    await window.api.ssh.connect({ targetId })
+    recordSshInteraction()
+  } catch (err) {
+    toast.error(
+      err instanceof Error
+        ? err.message
+        : translate('auto.components.settings.SshPane.e95d5ae10e', 'Connection failed')
+    )
+  }
+}
+
+export async function disconnectSshTarget(targetId: string): Promise<void> {
+  try {
+    await window.api.ssh.disconnect({ targetId })
+    recordSshInteraction()
+  } catch (err) {
+    toast.error(
+      err instanceof Error
+        ? err.message
+        : translate('auto.components.settings.SshPane.a43de1d3ee', 'Disconnect failed')
+    )
+  }
+}
+
+export async function terminateSshTargetSessions(targetId: string): Promise<void> {
+  try {
+    const result = await terminateSshSessionsWithReconnect(targetId)
+    const abandonedNotice = formatSshTerminateSessionsNotice(result)
+    if (abandonedNotice) {
+      // Why (#12661): offline expired-only terminate is local cleanup only — not a remote kill.
+      toast.warning(abandonedNotice)
+      return
+    }
+    toast.success(
+      translate('auto.components.settings.SshPane.90e308c98b', 'Remote terminals ended')
+    )
+  } catch (err) {
+    toast.error(
+      err instanceof Error
+        ? err.message
+        : translate('auto.components.settings.SshPane.025e107643', 'Failed to end remote terminals')
+    )
+  }
+}
+
+export async function resetSshTargetRelay(
+  targetId: string,
+  options: { isMounted: () => boolean; reload: () => Promise<void> }
+): Promise<void> {
+  try {
+    await window.api.ssh.resetRelay({ targetId })
+    if (options.isMounted()) {
+      toast.success(translate('auto.components.settings.SshPane.db2e48975e', 'Remote relay reset'))
+    }
+    await options.reload()
+  } catch (err) {
+    if (options.isMounted()) {
+      toast.error(
+        err instanceof Error
+          ? err.message
+          : translate('auto.components.settings.SshPane.2c4ee7332b', 'Failed to reset remote relay')
+      )
+    }
+  }
+}

--- a/src/renderer/src/components/settings/ssh-pane-session-actions.ts
+++ b/src/renderer/src/components/settings/ssh-pane-session-actions.ts
@@ -1,7 +1,6 @@
 import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
-import { formatSshTerminateSessionsNotice } from '../../../../shared/ssh-terminate-sessions-result'
 import { terminateSshSessionsWithReconnect } from './ssh-session-termination'
 
 function recordSshInteraction(): void {
@@ -37,10 +36,25 @@ export async function disconnectSshTarget(targetId: string): Promise<void> {
 export async function terminateSshTargetSessions(targetId: string): Promise<void> {
   try {
     const result = await terminateSshSessionsWithReconnect(targetId)
-    const abandonedNotice = formatSshTerminateSessionsNotice(result)
-    if (abandonedNotice) {
-      // Why (#12661): offline expired-only terminate is local cleanup only — not a remote kill.
-      toast.warning(abandonedNotice)
+    // Why (#12661): offline expired-only terminate is local cleanup only — not a remote kill.
+    // Translate here (not in shared) so catalogs extract the notice like other SshPane toasts.
+    if (result.abandonedUnreachable === 1) {
+      toast.warning(
+        translate(
+          'auto.components.settings.SshPane.abandonedUnreachableOne',
+          '1 abandoned remote session was not killed — reconnect to terminate it.'
+        )
+      )
+      return
+    }
+    if (result.abandonedUnreachable > 1) {
+      toast.warning(
+        translate(
+          'auto.components.settings.SshPane.abandonedUnreachableMany',
+          '{{value0}} abandoned remote sessions were not killed — reconnect to terminate them.',
+          { value0: result.abandonedUnreachable }
+        )
+      )
       return
     }
     toast.success(

--- a/src/renderer/src/components/settings/ssh-pane-session-actions.ts
+++ b/src/renderer/src/components/settings/ssh-pane-session-actions.ts
@@ -2,6 +2,25 @@ import { toast } from 'sonner'
 import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import { terminateSshSessionsWithReconnect } from './ssh-session-termination'
+import type { SshTerminateSessionsResult } from '../../../../shared/ssh-terminate-sessions-result'
+
+export function formatSshTerminateSessionsNotice(
+  result: SshTerminateSessionsResult
+): string | null {
+  if (result.abandonedUnreachable === 1) {
+    return translate(
+      'auto.components.settings.SshPane.abandonedUnreachableOne',
+      '1 abandoned remote session was not killed — reconnect to terminate it.'
+    )
+  }
+  return result.abandonedUnreachable > 1
+    ? translate(
+        'auto.components.settings.SshPane.abandonedUnreachableMany',
+        '{{value0}} abandoned remote sessions were not killed — reconnect to terminate them.',
+        { value0: result.abandonedUnreachable }
+      )
+    : null
+}
 
 function recordSshInteraction(): void {
   useAppStore.getState().recordFeatureInteraction('ssh')
@@ -38,23 +57,9 @@ export async function terminateSshTargetSessions(targetId: string): Promise<void
     const result = await terminateSshSessionsWithReconnect(targetId)
     // Why (#12661): offline expired-only terminate is local cleanup only — not a remote kill.
     // Translate here (not in shared) so catalogs extract the notice like other SshPane toasts.
-    if (result.abandonedUnreachable === 1) {
-      toast.warning(
-        translate(
-          'auto.components.settings.SshPane.abandonedUnreachableOne',
-          '1 abandoned remote session was not killed — reconnect to terminate it.'
-        )
-      )
-      return
-    }
-    if (result.abandonedUnreachable > 1) {
-      toast.warning(
-        translate(
-          'auto.components.settings.SshPane.abandonedUnreachableMany',
-          '{{value0}} abandoned remote sessions were not killed — reconnect to terminate them.',
-          { value0: result.abandonedUnreachable }
-        )
-      )
+    const notice = formatSshTerminateSessionsNotice(result)
+    if (notice) {
+      toast.warning(notice)
       return
     }
     toast.success(

--- a/src/renderer/src/components/settings/ssh-session-termination.ts
+++ b/src/renderer/src/components/settings/ssh-session-termination.ts
@@ -1,8 +1,11 @@
 import { SSH_TERMINATE_RECONNECT_REQUIRED } from '../../../../shared/constants'
+import type { SshTerminateSessionsResult } from '../../../../shared/ssh-terminate-sessions-result'
 
-export async function terminateSshSessionsWithReconnect(targetId: string): Promise<void> {
+export async function terminateSshSessionsWithReconnect(
+  targetId: string
+): Promise<SshTerminateSessionsResult> {
   try {
-    await window.api.ssh.terminateSessions({ targetId })
+    return await window.api.ssh.terminateSessions({ targetId })
   } catch (err) {
     const message = err instanceof Error ? err.message : String(err)
     if (!message.includes(SSH_TERMINATE_RECONNECT_REQUIRED)) {
@@ -11,6 +14,6 @@ export async function terminateSshSessionsWithReconnect(targetId: string): Promi
     // Why: disconnect is now non-destructive, so preserved remote PTYs may
     // require a fresh relay attachment before they can be explicitly killed.
     await window.api.ssh.connect({ targetId })
-    await window.api.ssh.terminateSessions({ targetId })
+    return await window.api.ssh.terminateSessions({ targetId })
   }
 }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7352,7 +7352,9 @@
           "4db9afce1c": "Port must be between 1 and 65535",
           "0e5aa04161": "Host or SSH config alias is required",
           "f1fc50dad2": "Failed to load SSH targets",
-          "0cda732f43": "Connection test failed"
+          "0cda732f43": "Connection test failed",
+          "abandonedUnreachableOne": "1 abandoned remote session was not killed — reconnect to terminate it.",
+          "abandonedUnreachableMany": "{{value0}} abandoned remote sessions were not killed — reconnect to terminate them."
         },
         "SshPassphraseDialog": {
           "d5a234456f": "Cancel",

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3314,7 +3314,9 @@ function createSshApi(): NonNullable<Partial<PreloadApi>['ssh']> {
       return state
     },
     disconnect: () => Promise.resolve(),
-    terminateSessions: () => Promise.resolve(),
+    // Why: Settings formats SshTerminateSessionsResult; undefined crashes toast (#12661 review).
+    terminateSessions: () =>
+      Promise.resolve({ remoteSessionsTerminated: 0, abandonedUnreachable: 0 }),
     resetRelay: () => Promise.resolve(),
     getState: async (args) => {
       if (!requireActiveEnvironmentOrNull()) {

--- a/src/shared/ssh-terminate-sessions-result.test.ts
+++ b/src/shared/ssh-terminate-sessions-result.test.ts
@@ -1,0 +1,19 @@
+import { describe, expect, it } from 'vitest'
+import { formatSshTerminateSessionsNotice } from './ssh-terminate-sessions-result'
+
+describe('formatSshTerminateSessionsNotice', () => {
+  it('is silent when every remote session was reached', () => {
+    expect(
+      formatSshTerminateSessionsNotice({ remoteSessionsTerminated: 2, abandonedUnreachable: 0 })
+    ).toBeNull()
+  })
+
+  it('warns when abandoned sessions could not be killed offline', () => {
+    expect(
+      formatSshTerminateSessionsNotice({ remoteSessionsTerminated: 0, abandonedUnreachable: 1 })
+    ).toBe('1 abandoned remote session was not killed — reconnect to terminate it.')
+    expect(
+      formatSshTerminateSessionsNotice({ remoteSessionsTerminated: 0, abandonedUnreachable: 3 })
+    ).toBe('3 abandoned remote sessions were not killed — reconnect to terminate them.')
+  })
+})

--- a/src/shared/ssh-terminate-sessions-result.ts
+++ b/src/shared/ssh-terminate-sessions-result.ts
@@ -1,0 +1,22 @@
+/** Result of `ssh:terminateSessions` so offline expired-only cleanup cannot look like a remote kill (#12661). */
+export type SshTerminateSessionsResult = {
+  /** Remote PTYs successfully shut down (or already gone) via the connected provider. */
+  remoteSessionsTerminated: number
+  /**
+   * Leases that still named a remote session but could not be reached because the
+   * relay/provider was offline (typically expired-only). Local transport was still torn down.
+   */
+  abandonedUnreachable: number
+}
+
+export function formatSshTerminateSessionsNotice(
+  result: SshTerminateSessionsResult
+): string | null {
+  if (result.abandonedUnreachable <= 0) {
+    return null
+  }
+  const n = result.abandonedUnreachable
+  return n === 1
+    ? '1 abandoned remote session was not killed — reconnect to terminate it.'
+    : `${n} abandoned remote sessions were not killed — reconnect to terminate them.`
+}

--- a/src/shared/ssh-terminate-sessions-result.ts
+++ b/src/shared/ssh-terminate-sessions-result.ts
@@ -8,15 +8,3 @@ export type SshTerminateSessionsResult = {
    */
   abandonedUnreachable: number
 }
-
-export function formatSshTerminateSessionsNotice(
-  result: SshTerminateSessionsResult
-): string | null {
-  if (result.abandonedUnreachable <= 0) {
-    return null
-  }
-  const n = result.abandonedUnreachable
-  return n === 1
-    ? '1 abandoned remote session was not killed — reconnect to terminate it.'
-    : `${n} abandoned remote sessions were not killed — reconnect to terminate them.`
-}


### PR DESCRIPTION
## Summary

- `ssh:terminateSessions` returns `{ remoteSessionsTerminated, abandonedUnreachable }`.
- Offline expired-only cleanup no longer looks like a successful remote kill; Settings shows a warning.

Fixes #12661

## Test plan

- [x] Offline expired-only returns abandonedUnreachable: 1
- [x] Connected paths still pass
- [x] Notice formatter unit tests
- [x] max-lines: extracted session actions from SshPane