### PR TITLE
fix(repos): surface Git dubious ownership instead of empty imports

### DIFF
--- a/src/main/git/git-safe-directory.test.ts
+++ b/src/main/git/git-safe-directory.test.ts
@@ -1,9 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 
-const gitExecFileSyncMock = vi.hoisted(() => vi.fn())
+const gitExecFileAsyncMock = vi.hoisted(() => vi.fn())
 
 vi.mock('./runner', () => ({
-  gitExecFileSync: gitExecFileSyncMock
+  gitExecFileAsync: gitExecFileAsyncMock
 }))
 
 import {
@@ -14,7 +14,7 @@ import {
 
 describe('git safe.directory / dubious ownership', () => {
   afterEach(() => {
-    gitExecFileSyncMock.mockReset()
+    gitExecFileAsyncMock.mockReset()
   })
 
   it('classifies dubious ownership from stderr and message', () => {
@@ -31,47 +31,51 @@ describe('git safe.directory / dubious ownership', () => {
   })
 
   it('formats a remediation that names the path without shell-quoted injection surface', () => {
-    const message = formatGitDubiousOwnershipRemediation('D:/workspace/$(open -a Calculator)')
-    expect(message).toContain('D:/workspace/$(open -a Calculator)')
+    const message = formatGitDubiousOwnershipRemediation(
+      'D:/workspace/$(open -a Calculator)/`touch owned`\nnext'
+    )
+    expect(message).not.toContain('$(open -a Calculator)')
+    expect(message).not.toContain('`touch owned`')
+    expect(message).not.toContain('\nnext')
+    expect(message).toContain('\\u0024(open -a Calculator)')
+    expect(message).toContain('\\u0060touch owned\\u0060\\nnext')
     expect(message).toContain('safe.directory')
     expect(message).toContain('git config --global --add safe.directory <path>')
-    // Why: path must not appear inside a double-quoted shell command fragment.
-    expect(message).not.toMatch(/safe\.directory "[^"]*\$\(/)
     expect(message).toContain('re-add')
   })
 
-  it('ownership remediation still names the path on its own line', () => {
+  it('ownership remediation still names an ordinary path', () => {
     const message = formatGitDubiousOwnershipRemediation('D:/workspace/example')
     expect(message).toContain('D:/workspace/example')
     expect(message).toContain('WSL')
   })
 
-  it('returns null when Git can open the repo', () => {
-    gitExecFileSyncMock.mockReturnValue('.git\n')
-    expect(getLocalGitRepoAccessBlocker('D:/workspace/ok')).toBeNull()
-    expect(gitExecFileSyncMock).toHaveBeenCalledWith(['rev-parse', '--git-dir'], {
+  it('returns null when Git can open the repo', async () => {
+    gitExecFileAsyncMock.mockResolvedValue('.git\n')
+    await expect(getLocalGitRepoAccessBlocker('D:/workspace/ok')).resolves.toBeNull()
+    expect(gitExecFileAsyncMock).toHaveBeenCalledWith(['rev-parse', '--git-dir'], {
       cwd: 'D:/workspace/ok'
     })
   })
 
-  it('returns remediation when rev-parse fails for dubious ownership', () => {
-    gitExecFileSyncMock.mockImplementation(() => {
-      throw Object.assign(new Error('fatal: detected dubious ownership in repository'), {
+  it('returns remediation when rev-parse fails for dubious ownership', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('fatal: detected dubious ownership in repository'), {
         stderr: "fatal: detected dubious ownership in repository at 'D:/workspace/example'"
       })
-    })
-    const blocker = getLocalGitRepoAccessBlocker('D:/workspace/example')
+    )
+    const blocker = await getLocalGitRepoAccessBlocker('D:/workspace/example')
     expect(blocker).toContain('dubious ownership')
     expect(blocker).toContain('D:/workspace/example')
     expect(blocker).toContain('safe.directory')
   })
 
-  it('does not block import for unrelated Git failures', () => {
-    gitExecFileSyncMock.mockImplementation(() => {
-      throw Object.assign(new Error('fatal: not a git repository'), {
+  it('does not block import for unrelated Git failures', async () => {
+    gitExecFileAsyncMock.mockRejectedValue(
+      Object.assign(new Error('fatal: not a git repository'), {
         stderr: 'fatal: not a git repository (or any of the parent directories): .git'
       })
-    })
-    expect(getLocalGitRepoAccessBlocker('D:/not-a-repo')).toBeNull()
+    )
+    await expect(getLocalGitRepoAccessBlocker('D:/not-a-repo')).resolves.toBeNull()
   })
 })

--- a/src/main/git/git-safe-directory.test.ts
+++ b/src/main/git/git-safe-directory.test.ts
@@ -1,0 +1,77 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const gitExecFileSyncMock = vi.hoisted(() => vi.fn())
+
+vi.mock('./runner', () => ({
+  gitExecFileSync: gitExecFileSyncMock
+}))
+
+import {
+  formatGitDubiousOwnershipRemediation,
+  getLocalGitRepoAccessBlocker,
+  isGitDubiousOwnershipError
+} from './git-safe-directory'
+
+describe('git safe.directory / dubious ownership', () => {
+  afterEach(() => {
+    gitExecFileSyncMock.mockReset()
+  })
+
+  it('classifies dubious ownership from stderr and message', () => {
+    expect(
+      isGitDubiousOwnershipError(
+        Object.assign(new Error('fatal: detected dubious ownership in repository at X'), {
+          stderr:
+            "fatal: detected dubious ownership in repository at 'D:/workspace/example'\n" +
+            'To add an exception for this directory, call:\n\n\tgit config --global --add safe.directory D:/workspace/example\n'
+        })
+      )
+    ).toBe(true)
+    expect(isGitDubiousOwnershipError(new Error('fatal: not a git repository'))).toBe(false)
+  })
+
+  it('formats a remediation that names the path without shell-quoted injection surface', () => {
+    const message = formatGitDubiousOwnershipRemediation('D:/workspace/$(open -a Calculator)')
+    expect(message).toContain('D:/workspace/$(open -a Calculator)')
+    expect(message).toContain('safe.directory')
+    expect(message).toContain('git config --global --add safe.directory <path>')
+    // Why: path must not appear inside a double-quoted shell command fragment.
+    expect(message).not.toMatch(/safe\.directory "[^"]*\$\(/)
+    expect(message).toContain('re-add')
+  })
+
+  it('ownership remediation still names the path on its own line', () => {
+    const message = formatGitDubiousOwnershipRemediation('D:/workspace/example')
+    expect(message).toContain('D:/workspace/example')
+    expect(message).toContain('WSL')
+  })
+
+  it('returns null when Git can open the repo', () => {
+    gitExecFileSyncMock.mockReturnValue('.git\n')
+    expect(getLocalGitRepoAccessBlocker('D:/workspace/ok')).toBeNull()
+    expect(gitExecFileSyncMock).toHaveBeenCalledWith(['rev-parse', '--git-dir'], {
+      cwd: 'D:/workspace/ok'
+    })
+  })
+
+  it('returns remediation when rev-parse fails for dubious ownership', () => {
+    gitExecFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('fatal: detected dubious ownership in repository'), {
+        stderr: "fatal: detected dubious ownership in repository at 'D:/workspace/example'"
+      })
+    })
+    const blocker = getLocalGitRepoAccessBlocker('D:/workspace/example')
+    expect(blocker).toContain('dubious ownership')
+    expect(blocker).toContain('D:/workspace/example')
+    expect(blocker).toContain('safe.directory')
+  })
+
+  it('does not block import for unrelated Git failures', () => {
+    gitExecFileSyncMock.mockImplementation(() => {
+      throw Object.assign(new Error('fatal: not a git repository'), {
+        stderr: 'fatal: not a git repository (or any of the parent directories): .git'
+      })
+    })
+    expect(getLocalGitRepoAccessBlocker('D:/not-a-repo')).toBeNull()
+  })
+})

--- a/src/main/git/git-safe-directory.ts
+++ b/src/main/git/git-safe-directory.ts
@@ -3,7 +3,7 @@
  * actionable import errors so repos:add never persists an empty kind:git project (#12627).
  */
 import { extractExecError } from './exec-error'
-import { gitExecFileSync } from './runner'
+import { gitExecFileAsync } from './runner'
 
 export function isGitDubiousOwnershipError(error: unknown): boolean {
   const { stderr, stdout } = extractExecError(error)
@@ -13,12 +13,13 @@ export function isGitDubiousOwnershipError(error: unknown): boolean {
 }
 
 export function formatGitDubiousOwnershipRemediation(repoPath: string): string {
-  // Why: never embed the path inside a shell-quoted command — directory names can contain
-  // `$()`, backticks, or quotes that run when the user pastes the hint (#12627 review).
+  const escapedPath = JSON.stringify(repoPath)
+    .replaceAll('$', '\\u0024')
+    .replaceAll('`', '\\u0060')
+    .replaceAll('!', '\\u0021')
   return [
     'Git refuses to use this repository because of dubious ownership.',
-    `Repository path:`,
-    repoPath,
+    `Repository path (escaped display): ${escapedPath}`,
     'Trust that exact path with Git safe.directory (quote it for your shell), for example:',
     'git config --global --add safe.directory <path>',
     'On WSL-backed checkouts, run that inside the distro using the Linux path Git sees, not a Windows UNC path.',
@@ -31,9 +32,9 @@ export function formatGitDubiousOwnershipRemediation(repoPath: string): string {
  * Returns a remediation message for ownership blocks; null when Git can open the repo
  * or the failure is unrelated (caller keeps existing behavior).
  */
-export function getLocalGitRepoAccessBlocker(repoPath: string): string | null {
+export async function getLocalGitRepoAccessBlocker(repoPath: string): Promise<string | null> {
   try {
-    gitExecFileSync(['rev-parse', '--git-dir'], { cwd: repoPath })
+    await gitExecFileAsync(['rev-parse', '--git-dir'], { cwd: repoPath })
     return null
   } catch (error) {
     if (isGitDubiousOwnershipError(error)) {

--- a/src/main/git/git-safe-directory.ts
+++ b/src/main/git/git-safe-directory.ts
@@ -1,0 +1,44 @@
+/**
+ * Detect Git "dubious ownership" / safe.directory failures and turn them into
+ * actionable import errors so repos:add never persists an empty kind:git project (#12627).
+ */
+import { extractExecError } from './exec-error'
+import { gitExecFileSync } from './runner'
+
+export function isGitDubiousOwnershipError(error: unknown): boolean {
+  const { stderr, stdout } = extractExecError(error)
+  const text = `${stderr}\n${stdout}`
+  // Why: Git prints "detected dubious ownership" and names safe.directory in the hint.
+  return /dubious ownership|safe\.directory/i.test(text)
+}
+
+export function formatGitDubiousOwnershipRemediation(repoPath: string): string {
+  // Why: never embed the path inside a shell-quoted command — directory names can contain
+  // `$()`, backticks, or quotes that run when the user pastes the hint (#12627 review).
+  return [
+    'Git refuses to use this repository because of dubious ownership.',
+    `Repository path:`,
+    repoPath,
+    'Trust that exact path with Git safe.directory (quote it for your shell), for example:',
+    'git config --global --add safe.directory <path>',
+    'On WSL-backed checkouts, run that inside the distro using the Linux path Git sees, not a Windows UNC path.',
+    'Then re-add the project in Orca. Prefer a scoped development root over safe.directory=*.'
+  ].join('\n')
+}
+
+/**
+ * Probe whether Git will actually operate on this path.
+ * Returns a remediation message for ownership blocks; null when Git can open the repo
+ * or the failure is unrelated (caller keeps existing behavior).
+ */
+export function getLocalGitRepoAccessBlocker(repoPath: string): string | null {
+  try {
+    gitExecFileSync(['rev-parse', '--git-dir'], { cwd: repoPath })
+    return null
+  } catch (error) {
+    if (isGitDubiousOwnershipError(error)) {
+      return formatGitDubiousOwnershipRemediation(repoPath)
+    }
+    return null
+  }
+}

--- a/src/main/ipc/repos-local-add-and-project-setup.test.ts
+++ b/src/main/ipc/repos-local-add-and-project-setup.test.ts
@@ -98,6 +98,75 @@ describe('repos:add + repos:clone', () => {
     expect(result).toHaveProperty('repo.externalWorktreeVisibilityLegacy', false)
   })
 
+  it('refuses repos:add when Git reports dubious ownership instead of creating a zero-worktree project', async () => {
+    const safeDirectory = await import('../git/git-safe-directory')
+    const accessSpy = vi
+      .spyOn(safeDirectory, 'getLocalGitRepoAccessBlocker')
+      .mockReturnValue(
+        [
+          'Git refuses to use this repository because of dubious ownership.',
+          'Repository path:',
+          'D:/workspace/example',
+          'Trust that exact path with Git safe.directory (quote it for your shell), for example:',
+          'git config --global --add safe.directory <path>',
+          'Then re-add the project in Orca.'
+        ].join('\n')
+      )
+
+    try {
+      const result = await handlers.get('repos:add')!(null, {
+        path: 'D:/workspace/example',
+        kind: 'git'
+      })
+
+      expect(result).toMatchObject({
+        error: expect.stringMatching(
+          /dubious ownership[\s\S]*D:\/workspace\/example[\s\S]*safe\.directory/
+        )
+      })
+      expect(mockStore.addRepo).not.toHaveBeenCalled()
+      expect(prepareLocalWorktreeRootForRepoMock).not.toHaveBeenCalled()
+      expect(accessSpy).toHaveBeenCalledWith('D:/workspace/example')
+    } finally {
+      accessSpy.mockRestore()
+    }
+  })
+
+  it('surfaces safe.directory when re-adding a previously empty git project', async () => {
+    const existing = {
+      id: 'repo-empty-import',
+      path: 'D:/workspace/example',
+      displayName: 'example',
+      kind: 'git' as const,
+      badgeColor: '#22c55e'
+    }
+    mockStore.getRepos.mockReturnValue([existing])
+    const safeDirectory = await import('../git/git-safe-directory')
+    const accessSpy = vi
+      .spyOn(safeDirectory, 'getLocalGitRepoAccessBlocker')
+      .mockReturnValue(
+        [
+          'Git refuses to use this repository because of dubious ownership.',
+          'Repository path:',
+          'D:/workspace/example',
+          'git config --global --add safe.directory <path>'
+        ].join('\n')
+      )
+
+    try {
+      const result = await handlers.get('repos:add')!(null, {
+        path: 'D:/workspace/example',
+        kind: 'git'
+      })
+      expect(result).toMatchObject({
+        error: expect.stringContaining('dubious ownership')
+      })
+      expect(mockStore.addRepo).not.toHaveBeenCalled()
+    } finally {
+      accessSpy.mockRestore()
+    }
+  })
+
   it('prepares the worktree root when adding a local git repo', async () => {
     await handlers.get('repos:add')!(null, { path: '/tmp/from-add', kind: 'git' })
 

--- a/src/main/ipc/repos-local-add-and-project-setup.test.ts
+++ b/src/main/ipc/repos-local-add-and-project-setup.test.ts
@@ -102,7 +102,7 @@ describe('repos:add + repos:clone', () => {
     const safeDirectory = await import('../git/git-safe-directory')
     const accessSpy = vi
       .spyOn(safeDirectory, 'getLocalGitRepoAccessBlocker')
-      .mockReturnValue(
+      .mockResolvedValue(
         [
           'Git refuses to use this repository because of dubious ownership.',
           'Repository path:',
@@ -144,7 +144,7 @@ describe('repos:add + repos:clone', () => {
     const safeDirectory = await import('../git/git-safe-directory')
     const accessSpy = vi
       .spyOn(safeDirectory, 'getLocalGitRepoAccessBlocker')
-      .mockReturnValue(
+      .mockResolvedValue(
         [
           'Git refuses to use this repository because of dubious ownership.',
           'Repository path:',

--- a/src/main/ipc/repos-local-add-and-project-setup.test.ts
+++ b/src/main/ipc/repos-local-add-and-project-setup.test.ts
@@ -142,16 +142,15 @@ describe('repos:add + repos:clone', () => {
     }
     mockStore.getRepos.mockReturnValue([existing])
     const safeDirectory = await import('../git/git-safe-directory')
+    const blocker = [
+      'Git refuses to use this repository because of dubious ownership.',
+      'Repository path:',
+      'D:/workspace/example',
+      'git config --global --add safe.directory <path>'
+    ].join('\n')
     const accessSpy = vi
       .spyOn(safeDirectory, 'getLocalGitRepoAccessBlocker')
-      .mockResolvedValue(
-        [
-          'Git refuses to use this repository because of dubious ownership.',
-          'Repository path:',
-          'D:/workspace/example',
-          'git config --global --add safe.directory <path>'
-        ].join('\n')
-      )
+      .mockResolvedValue(blocker)
 
     try {
       const result = await handlers.get('repos:add')!(null, {
@@ -161,7 +160,9 @@ describe('repos:add + repos:clone', () => {
       expect(result).toMatchObject({
         error: expect.stringContaining('dubious ownership')
       })
+      expect(result).toEqual({ error: blocker })
       expect(mockStore.addRepo).not.toHaveBeenCalled()
+      expect(prepareLocalWorktreeRootForRepoMock).not.toHaveBeenCalled()
     } finally {
       accessSpy.mockRestore()
     }

--- a/src/main/ipc/repos/local-repo-registration.ts
+++ b/src/main/ipc/repos/local-repo-registration.ts
@@ -33,13 +33,13 @@ export async function addLocalRepoFromPath(
   const resolvedPath = repoKind === 'git' ? getGitRepoRoot(path) : path
   const pathKey = normalizeRuntimePathForComparison(path)
 
-  const blockIfGitInaccessible = (repoPath: string): { error: string } | null => {
+  const blockIfGitInaccessible = async (repoPath: string): Promise<{ error: string } | null> => {
     // Why: isGitRepo may accept a .git marker after rev-parse fails for ownership; without this
     // probe we persist or re-surface kind:git with zero worktrees and no remediation (#12627).
     if (repoKind !== 'git') {
       return null
     }
-    const accessBlocker = getLocalGitRepoAccessBlocker(repoPath)
+    const accessBlocker = await getLocalGitRepoAccessBlocker(repoPath)
     return accessBlocker ? { error: accessBlocker } : null
   }
 
@@ -48,7 +48,7 @@ export async function addLocalRepoFromPath(
     .find((repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === pathKey)
   if (existing) {
     // Why: re-add of a pre-fix empty record must surface safe.directory, not silently "succeed".
-    const blocked = blockIfGitInaccessible(existing.path)
+    const blocked = await blockIfGitInaccessible(existing.path)
     if (blocked) {
       return blocked
     }
@@ -64,7 +64,7 @@ export async function addLocalRepoFromPath(
           !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === resolvedPathKey
       )
     if (existingAfterRootResolve) {
-      const blocked = blockIfGitInaccessible(existingAfterRootResolve.path)
+      const blocked = await blockIfGitInaccessible(existingAfterRootResolve.path)
       if (blocked) {
         return blocked
       }
@@ -90,14 +90,14 @@ export async function addLocalRepoFromPath(
             normalizeRuntimePathForComparison(repo.path) === mainRepoKey
         )
       if (trackedMainRepo) {
-        const blocked = blockIfGitInaccessible(trackedMainRepo.path)
+        const blocked = await blockIfGitInaccessible(trackedMainRepo.path)
         if (blocked) {
           return blocked
         }
         return { repo: trackedMainRepo, alreadyExisted: true }
       }
     }
-    const blocked = blockIfGitInaccessible(resolvedPath)
+    const blocked = await blockIfGitInaccessible(resolvedPath)
     if (blocked) {
       return blocked
     }

--- a/src/main/ipc/repos/local-repo-registration.ts
+++ b/src/main/ipc/repos/local-repo-registration.ts
@@ -13,6 +13,7 @@ import {
 } from '../../git/repo'
 import { LOCAL_EXECUTION_HOST_ID } from '../../../shared/execution-host'
 import { detectRepoIconAndUpstream } from '../../repo-icon-autodetect'
+import { getLocalGitRepoAccessBlocker } from '../../git/git-safe-directory'
 import { prepareLocalWorktreeRootForRepo } from '../../worktree-root-preparation'
 
 export async function addLocalRepoFromPath(
@@ -31,10 +32,26 @@ export async function addLocalRepoFromPath(
 
   const resolvedPath = repoKind === 'git' ? getGitRepoRoot(path) : path
   const pathKey = normalizeRuntimePathForComparison(path)
+
+  const blockIfGitInaccessible = (repoPath: string): { error: string } | null => {
+    // Why: isGitRepo may accept a .git marker after rev-parse fails for ownership; without this
+    // probe we persist or re-surface kind:git with zero worktrees and no remediation (#12627).
+    if (repoKind !== 'git') {
+      return null
+    }
+    const accessBlocker = getLocalGitRepoAccessBlocker(repoPath)
+    return accessBlocker ? { error: accessBlocker } : null
+  }
+
   const existing = store
     .getRepos()
     .find((repo) => !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === pathKey)
   if (existing) {
+    // Why: re-add of a pre-fix empty record must surface safe.directory, not silently "succeed".
+    const blocked = blockIfGitInaccessible(existing.path)
+    if (blocked) {
+      return blocked
+    }
     return { repo: existing, alreadyExisted: true }
   }
 
@@ -47,6 +64,10 @@ export async function addLocalRepoFromPath(
           !repo.connectionId && normalizeRuntimePathForComparison(repo.path) === resolvedPathKey
       )
     if (existingAfterRootResolve) {
+      const blocked = blockIfGitInaccessible(existingAfterRootResolve.path)
+      if (blocked) {
+        return blocked
+      }
       return { repo: existingAfterRootResolve, alreadyExisted: true }
     }
   }
@@ -69,8 +90,16 @@ export async function addLocalRepoFromPath(
             normalizeRuntimePathForComparison(repo.path) === mainRepoKey
         )
       if (trackedMainRepo) {
+        const blocked = blockIfGitInaccessible(trackedMainRepo.path)
+        if (blocked) {
+          return blocked
+        }
         return { repo: trackedMainRepo, alreadyExisted: true }
       }
+    }
+    const blocked = blockIfGitInaccessible(resolvedPath)
+    if (blocked) {
+      return blocked
     }
   }
 

--- a/src/main/ipc/repos/nested-repo-import-handler.ts
+++ b/src/main/ipc/repos/nested-repo-import-handler.ts
@@ -95,7 +95,7 @@ export function registerNestedRepoImportHandler(mainWindow: BrowserWindow, store
             importRepoPath = await importTargetResolver.resolveLocal(repoPath)
             // Why: marker-based isGitRepo can accept an owned-by-Administrators checkout while
             // Git itself refuses every worktree scan (#12627).
-            const accessBlocker = getLocalGitRepoAccessBlocker(importRepoPath)
+            const accessBlocker = await getLocalGitRepoAccessBlocker(importRepoPath)
             if (accessBlocker) {
               results.push({ path: repoPath, status: 'failed', error: accessBlocker })
               continue

--- a/src/main/ipc/repos/nested-repo-import-handler.ts
+++ b/src/main/ipc/repos/nested-repo-import-handler.ts
@@ -7,6 +7,7 @@ import type { ProjectGroupImportResult } from '../../../shared/project-group-typ
 import { DEFAULT_REPO_BADGE_COLOR } from '../../../shared/constants'
 import { normalizeRuntimePathForComparison } from '../../../shared/cross-platform-path'
 import { awaitWindowsHostGitEnvironmentReady } from '../../git/runner'
+import { getLocalGitRepoAccessBlocker } from '../../git/git-safe-directory'
 import { isGitRepo, getRepoName } from '../../git/repo'
 import {
   createNestedProjectGroupResolver,
@@ -92,6 +93,13 @@ export function registerNestedRepoImportHandler(mainWindow: BrowserWindow, store
               continue
             }
             importRepoPath = await importTargetResolver.resolveLocal(repoPath)
+            // Why: marker-based isGitRepo can accept an owned-by-Administrators checkout while
+            // Git itself refuses every worktree scan (#12627).
+            const accessBlocker = getLocalGitRepoAccessBlocker(importRepoPath)
+            if (accessBlocker) {
+              results.push({ path: repoPath, status: 'failed', error: accessBlocker })
+              continue
+            }
           }
           const normalizedImportRepoPath = normalizeRuntimePathForComparison(importRepoPath)
           const alreadyImportedProjectId =

--- a/src/main/runtime/runtime-nested-repo-import.ts
+++ b/src/main/runtime/runtime-nested-repo-import.ts
@@ -83,7 +83,7 @@ export class RuntimeNestedRepoImport {
           continue
         }
         const importRepoPath = await importTargetResolver.resolveLocal(repoPath)
-        const accessBlocker = getLocalGitRepoAccessBlocker(importRepoPath)
+        const accessBlocker = await getLocalGitRepoAccessBlocker(importRepoPath)
         if (accessBlocker) {
           results.push({ path: repoPath, status: 'failed', error: accessBlocker })
           continue

--- a/src/main/runtime/runtime-nested-repo-import.ts
+++ b/src/main/runtime/runtime-nested-repo-import.ts
@@ -9,6 +9,7 @@ import type {
 } from '../../shared/project-group-types'
 import type { Repo } from '../../shared/repo-types'
 import { awaitWindowsHostGitEnvironmentReady } from '../git/runner'
+import { getLocalGitRepoAccessBlocker } from '../git/git-safe-directory'
 import { getRepoName, isGitRepo } from '../git/repo'
 import { scanNestedRepos } from '../project-groups/nested-repo-discovery'
 import {
@@ -82,6 +83,11 @@ export class RuntimeNestedRepoImport {
           continue
         }
         const importRepoPath = await importTargetResolver.resolveLocal(repoPath)
+        const accessBlocker = getLocalGitRepoAccessBlocker(importRepoPath)
+        if (accessBlocker) {
+          results.push({ path: repoPath, status: 'failed', error: accessBlocker })
+          continue
+        }
         const normalizedImportRepoPath = normalizeRuntimePathForComparison(importRepoPath)
         const alreadyImportedProjectId = importedProjectIdsByRepoPath.get(normalizedImportRepoPath)
         if (alreadyImportedProjectId) {

--- a/src/main/runtime/runtime-repository-registration-controller.ts
+++ b/src/main/runtime/runtime-repository-registration-controller.ts
@@ -9,6 +9,7 @@ import {
 } from '../../shared/execution-host'
 import type { Repo } from '../../shared/repo-types'
 import { gitExecFileAsync, awaitWindowsHostGitEnvironmentReady } from '../git/runner'
+import { getLocalGitRepoAccessBlocker } from '../git/git-safe-directory'
 import { getRepoName, isGitRepo } from '../git/repo'
 import { invalidateAuthorizedRootsCache, isENOENT } from '../ipc/filesystem-auth'
 import { detectRepoIconAndUpstream } from '../repo-icon-autodetect'
@@ -43,12 +44,27 @@ export class RuntimeRepositoryRegistrationController {
     if (kind === 'git' && !isGitRepo(path)) {
       throw new Error(`Not a valid git repository: ${path}`)
     }
+    if (kind === 'git') {
+      // Why: marker-based isGitRepo can accept an Administrators-owned checkout while Git
+      // refuses worktree scans — same zero-worktree silent import as local repos:add (#12627).
+      const accessBlocker = getLocalGitRepoAccessBlocker(path)
+      if (accessBlocker) {
+        throw new Error(accessBlocker)
+      }
+    }
+
     const existing = store.getRepos().find((repo) => {
       return (
         runtimePathsEqual(repo.path, path) && runtimeRepoMatchesExecutionHost(repo, executionHostId)
       )
     })
     if (existing) {
+      if (existing.kind === 'git' || kind === 'git') {
+        const accessBlocker = getLocalGitRepoAccessBlocker(existing.path)
+        if (accessBlocker) {
+          throw new Error(accessBlocker)
+        }
+      }
       if (
         existing.executionHostId == null &&
         parseExecutionHostId(executionHostId)?.kind === 'runtime'

--- a/src/main/runtime/runtime-repository-registration-controller.ts
+++ b/src/main/runtime/runtime-repository-registration-controller.ts
@@ -47,7 +47,7 @@ export class RuntimeRepositoryRegistrationController {
     if (kind === 'git') {
       // Why: marker-based isGitRepo can accept an Administrators-owned checkout while Git
       // refuses worktree scans — same zero-worktree silent import as local repos:add (#12627).
-      const accessBlocker = getLocalGitRepoAccessBlocker(path)
+      const accessBlocker = await getLocalGitRepoAccessBlocker(path)
       if (accessBlocker) {
         throw new Error(accessBlocker)
       }
@@ -60,7 +60,7 @@ export class RuntimeRepositoryRegistrationController {
     })
     if (existing) {
       if (existing.kind === 'git' || kind === 'git') {
-        const accessBlocker = getLocalGitRepoAccessBlocker(existing.path)
+        const accessBlocker = await getLocalGitRepoAccessBlocker(existing.path)
         if (accessBlocker) {
           throw new Error(accessBlocker)
         }


### PR DESCRIPTION
## Summary

When Git rejects a checkout for dubious ownership, marker-based repository detection can still succeed and leave Orca showing an empty Git project. Probe `git rev-parse --git-dir` before registration or local nested import, including re-adds of existing empty records, and surface an actionable ownership error.

The remediation displays the path without embedding it in a shell command. Folder workspaces skip the Git probe; local IPC keeps the SSH import path separate. The headless runtime applies the same check on its executing host. No trust settings are changed automatically.

Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`, adapting the original fix to the current registration/import module split.

Closes #12627

## Validation

- 25 focused ownership-classification, remediation and repository add/re-add tests passed.
- Changed-file lint/format, Node non-composite typecheck and diff checks passed.
- Cursor reviewed the final candidate; Codex independently checked all affected registration paths and reran the focused tests before publication.
- Full suite/build, default composite typecheck and live Windows/WSL/SSH ownership smoke were not run for this scoped import change. Default composite has the previously reproduced baseline TS2883 limitation.
