### PR TITLE
fix(remote-runtime): only spend auto-recovery on the real deadline

### DIFF
--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -197,6 +197,25 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     state.dispose()
   })
 
+  it('resets deadline-spent state when retryNow starts a new epoch', async () => {
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    const retry = vi.fn()
+    const firstEpoch = state.begin()
+    state.parkRetryForExternalTrigger(firstEpoch, retry)
+
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+    expect(state.didSpendAutoRecoveryWindow).toBe(true)
+
+    expect(state.retryNow()).toBe(true)
+    expect(retry).toHaveBeenCalledWith(firstEpoch + 1)
+    expect(state.didSpendAutoRecoveryWindow).toBe(false)
+
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+    expect(state.didSpendAutoRecoveryWindow).toBe(true)
+    state.dispose()
+  })
+
   it('revives a parked retry that never armed a backoff timer', async () => {
     vi.useFakeTimers()
     const state = new RemoteRuntimePtyRecoveryState()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.test.ts
@@ -122,6 +122,27 @@ describe('RemoteRuntimePtyRecoveryState', () => {
     state.dispose()
   })
 
+  it('spends the auto-recovery window only on the real deadline, not markDisconnected', async () => {
+    // #12683: UI latch must not enable same-handle reattach fencing.
+    vi.useFakeTimers()
+    const state = new RemoteRuntimePtyRecoveryState()
+    expect(state.didSpendAutoRecoveryWindow).toBe(false)
+
+    state.markDisconnected()
+    expect(state.currentPhase).toBe('disconnected')
+    expect(state.didSpendAutoRecoveryWindow).toBe(false)
+
+    state.begin()
+    expect(state.didSpendAutoRecoveryWindow).toBe(false)
+    await vi.advanceTimersByTimeAsync(REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)
+    expect(state.currentPhase).toBe('disconnected')
+    expect(state.didSpendAutoRecoveryWindow).toBe(true)
+
+    state.cancel()
+    expect(state.didSpendAutoRecoveryWindow).toBe(false)
+    state.dispose()
+  })
+
   it('cancels scheduled work when a caller reaches its own recovery cutoff', async () => {
     vi.useFakeTimers()
     const state = new RemoteRuntimePtyRecoveryState()

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -147,6 +147,7 @@ export class RemoteRuntimePtyRecoveryState {
       // Why: the deadline only stops auto-retry; an explicit trigger opens a fresh recovery window.
       this.epoch += 1
       this.attempt = 0
+      this.autoRecoveryWindowSpentByDeadline = false
       this.armDeadline(this.epoch)
     }
     const epoch = this.epoch

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-recovery-state.ts
@@ -34,6 +34,9 @@ export class RemoteRuntimePtyRecoveryState {
   private deadlineTimer: ReturnType<typeof setTimeout> | null = null
   private pendingRetry: ((epoch: number) => void) | null = null
   private pendingEpoch: number | null = null
+  // Why: only the real 60s auto-recovery deadline may spend the window; UI latches via
+  // markDisconnected must not defeat require-replacement same-handle fencing (#12683).
+  private autoRecoveryWindowSpentByDeadline = false
 
   constructor(private readonly onChange?: () => void) {}
 
@@ -53,6 +56,10 @@ export class RemoteRuntimePtyRecoveryState {
     return this.attempt
   }
 
+  get didSpendAutoRecoveryWindow(): boolean {
+    return this.autoRecoveryWindowSpentByDeadline
+  }
+
   begin(): number {
     if (this.phase === 'disposed') {
       return this.epoch
@@ -60,6 +67,7 @@ export class RemoteRuntimePtyRecoveryState {
     if (!this.isActive) {
       this.epoch += 1
       this.attempt = 0
+      this.autoRecoveryWindowSpentByDeadline = false
       this.armDeadline(this.epoch)
     }
     this.clearRetryTimer()
@@ -153,6 +161,7 @@ export class RemoteRuntimePtyRecoveryState {
       return
     }
     this.clearTimers()
+    this.autoRecoveryWindowSpentByDeadline = false
     this.phase = 'idle'
     this.attempt = 0
     this.onChange?.()
@@ -162,6 +171,7 @@ export class RemoteRuntimePtyRecoveryState {
     if (this.phase === 'disposed') {
       return
     }
+    // Why: UI latch only — do not spend the auto-recovery window (#12683).
     this.clearTimers()
     this.phase = 'disconnected'
     this.onChange?.()
@@ -173,6 +183,7 @@ export class RemoteRuntimePtyRecoveryState {
     }
     this.epoch += 1
     this.clearTimers()
+    this.autoRecoveryWindowSpentByDeadline = false
     this.phase = 'idle'
     this.attempt = 0
     this.onChange?.()
@@ -194,6 +205,7 @@ export class RemoteRuntimePtyRecoveryState {
       this.deadlineTimer = null
       // Why: the cutoff stops self-initiated retries but must keep the pane revivable by online/resume/reconnect.
       this.stopRetryTimer()
+      this.autoRecoveryWindowSpentByDeadline = true
       this.phase = 'disconnected'
       this.onChange?.()
     }, REMOTE_RUNTIME_AUTO_RECOVERY_TIMEOUT_MS)

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -247,7 +247,11 @@ export function createRemoteRuntimePtyTransport(
       clearPublishedHandleWait()
     }
     if (recovery.currentPhase === 'disconnected') {
-      autoRecoveryWindowSpent = true
+      // Why: only the real auto-recovery deadline spends the window; bare markDisconnected
+      // must not enable same-handle reattach under require-replacement (#12683).
+      if (recovery.didSpendAutoRecoveryWindow) {
+        autoRecoveryWindowSpent = true
+      }
       // Why: cached pixels may remain, but no stream from the exhausted epoch may keep delivering or accepting terminal traffic.
       subscriptionGeneration += 1
       closeMultiplexedStream()


### PR DESCRIPTION
## Summary

- A UI-only disconnect latch no longer spends the 60-second automatic recovery window.
- Only the real recovery deadline records evidence that permits one same-handle reattach under the require-replacement fence.
- An explicit online, resume, or Reconnect retry opens a fresh recovery epoch and resets its per-epoch deadline state while preserving the separate transport evidence.

Closes #12683

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
  - The package script is blocked in this environment by the Node 24 and patched `node-pty` native-runtime preflight.
  - Focused direct Vitest coverage passed: 10 remote-runtime files, 170 tests.
- [ ] `pnpm build`
  - Not run; this change is limited to an internal renderer recovery state machine and full typecheck passed.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

The new fake-timer regression proves that the first deadline marks its epoch spent, `retryNow()` advances to the next epoch and clears that state, and the second deadline marks the new epoch spent again.

## AI Review Report

Grok 4.6 independently reviewed the epoch reset, timer ordering, transport-latch separation, and regression coverage. Its first pass challenged stale deadline timers, transport short-circuiting, and other epoch entry points. Source inspection confirmed that the old deadline callback clears its timer before latching, every non-terminal epoch entry resets the per-epoch state, and the transport latch is covered by same-handle, online, resume, and repeated-revival integration tests. Grok re-reviewed that evidence and returned `PASS`.

Cross-platform compatibility was explicitly checked. The change touches no shortcuts, labels, paths, shell behavior, native modules, or Electron platform branches; it uses platform-neutral timers and boolean state and the full typecheck and lint gates passed for the shared codebase.

## Security Audit

No new external input, command execution, path handling, authentication, secrets, dependencies, or IPC surface is introduced. The change only resets internal recovery-epoch state. The main risk was accidentally erasing the separate transport authorization evidence or permitting stale timers to mutate a new epoch; both were traced in source and covered by the transport and state-machine tests.

## Notes

The transport-level `autoRecoveryWindowSpent` latch intentionally remains unchanged across an explicit retry so a host snapshot can license one same-handle reattach. The reset applies only to `RemoteRuntimePtyRecoveryState.autoRecoveryWindowSpentByDeadline`, which is scoped to the current epoch.