### PR TITLE
test(daemon): stop skipping killStaleDaemon checks on Windows

### DIFF
--- a/src/main/daemon/daemon-health.test.ts
+++ b/src/main/daemon/daemon-health.test.ts
@@ -170,29 +170,26 @@ describe('daemon health', () => {
     }
   })
 
-  it.skipIf(process.platform === 'win32')(
-    'does not unlink a live socket when the pid file does not match this daemon',
-    async () => {
-      const server = createServer((socket) => socket.end())
-      await new Promise<void>((resolve, reject) => {
-        server.once('error', reject)
-        server.listen(socketPath, () => {
-          server.off('error', reject)
-          resolve()
-        })
+  it('does not unlink a live socket when the pid file does not match this daemon', async () => {
+    const server = createServer((socket) => socket.end())
+    await new Promise<void>((resolve, reject) => {
+      server.once('error', reject)
+      server.listen(socketPath, () => {
+        server.off('error', reject)
+        resolve()
       })
-      writeFileSync(getDaemonPidPath(dir), String(process.pid), { mode: 0o600 })
+    })
+    writeFileSync(getDaemonPidPath(dir), String(process.pid), { mode: 0o600 })
 
-      try {
-        await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toMatchObject({
-          killed: false
-        })
-        await expect(canConnect(socketPath)).resolves.toBe(true)
-      } finally {
-        await closeServer(server)
-      }
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toMatchObject({
+        killed: false
+      })
+      await expect(canConnect(socketPath)).resolves.toBe(true)
+    } finally {
+      await closeServer(server)
     }
-  )
+  })
 })
 
 describe('parseDaemonPidFile', () => {
@@ -354,7 +351,7 @@ describe('startTimeMatches', () => {
     expect(startTimeMatches(process.pid, actual + 500)).toBe(true)
   })
 
-  it.skipIf(process.platform === 'win32')('returns false for start times outside tolerance', () => {
+  it('returns false for start times outside tolerance', () => {
     const actual = getProcessStartedAtMs(process.pid)
     if (actual === null) {
       return
@@ -415,37 +412,34 @@ describe('killStaleDaemon pid identity guards', () => {
     rmSync(dir, { recursive: true, force: true })
   })
 
-  it.skipIf(process.platform === 'win32')(
-    'does not SIGTERM when the saved startedAtMs mismatches the current process',
-    async () => {
-      // Why: seed a pid file that claims the daemon is `process.pid` (us) but
-      // was started 1 hour ago. Our real start time is "now," so startTimeMatches
-      // returns false and isDaemonProcess rejects. killStaleDaemon must not call
-      // process.kill in that case.
-      const bogusStartedAtMs = Date.now() - 60 * 60 * 1000
-      writeFileSync(
-        getDaemonPidPath(dir),
-        serializeDaemonPidFile({ pid: process.pid, startedAtMs: bogusStartedAtMs }),
-        { mode: 0o600 }
-      )
+  it('does not SIGTERM when the saved startedAtMs mismatches the current process', async () => {
+    // Why: seed a pid file that claims the daemon is `process.pid` (us) but
+    // was started 1 hour ago. Our real start time is "now," so startTimeMatches
+    // returns false and isDaemonProcess rejects. killStaleDaemon must not call
+    // process.kill in that case.
+    const bogusStartedAtMs = Date.now() - 60 * 60 * 1000
+    writeFileSync(
+      getDaemonPidPath(dir),
+      serializeDaemonPidFile({ pid: process.pid, startedAtMs: bogusStartedAtMs }),
+      { mode: 0o600 }
+    )
 
-      // isDaemonProcess uses process.kill(pid, 0) as a liveness probe; that's
-      // expected and not a real kill. We only care that no actual termination
-      // signal is sent.
-      const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
-      try {
-        await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toMatchObject({
-          killed: false
-        })
-        const terminationSignals = killSpy.mock.calls.filter(
-          ([, sig]) => sig === 'SIGTERM' || sig === 'SIGKILL'
-        )
-        expect(terminationSignals).toEqual([])
-      } finally {
-        killSpy.mockRestore()
-      }
+    // isDaemonProcess uses process.kill(pid, 0) as a liveness probe; that's
+    // expected and not a real kill. We only care that no actual termination
+    // signal is sent.
+    const killSpy = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    try {
+      await expect(killStaleDaemon(dir, socketPath, tokenPath)).resolves.toMatchObject({
+        killed: false
+      })
+      const terminationSignals = killSpy.mock.calls.filter(
+        ([, sig]) => sig === 'SIGTERM' || sig === 'SIGKILL'
+      )
+      expect(terminationSignals).toEqual([])
+    } finally {
+      killSpy.mockRestore()
     }
-  )
+  })
 })
 
 describe('killStaleDaemon ownership decisions', () => {


### PR DESCRIPTION
## What

Removes three `skipIf(process.platform === 'win32')` guards in `daemon-health.test.ts`.

## Why

While verifying #12882 on a real Windows host, I stripped every win32 guard in the daemon suite and ran it. Most of the skips are structural and must stay — 31 of the unskipped tests fail with `listen EACCES: permission denied C:\Users\...\Temp\...`, because they bind Unix domain sockets at filesystem paths, which Windows does not provide.

But these three **pass on Windows**:

- `does not unlink a live socket when the pid file does not match this daemon`
- `returns false for start times outside tolerance`
- `does not SIGTERM when the saved startedAtMs mismatches the current process`

They assert PID-record and start-time logic, and the file's own `daemonTestSocketPath` helper already returns a real named pipe (`\\.\pipe\...`) on win32 — so nothing in them needs a Unix socket. The guards were costing coverage for no reason.

That matters because `killStaleDaemon`'s ownership decisions are exactly what #12882 changed, and Windows was the one platform where none of that logic ran.

## What stays

The fourth guard in this file is kept deliberately. That test spawns a real child process and binds a filesystem socket path, and it genuinely fails on Windows.

## Verification

Windows host, full daemon suite with all 31 guards stripped: these three passed. macOS: `daemon-health.test.ts` green (33 tests) — unchanged there, since the guard only ever applied to win32.

The Windows-only failures observed in that run (`daemon-preflight-client-replacement`, `pty-subprocess` WSL) are pre-existing and unrelated — an identical failure set reproduces on the commit before #12882.

Made with [Orca](https://github.com/stablyai/orca) 🐋
