### PR TITLE
fix(sidebar): focus multi-agent rows across sibling worktree keys

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -51,6 +51,7 @@ let mockAgents: DashboardAgentRowData[] = []
 let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 let mockTabsByWorktree: Record<string, { id: string }[]> = {}
 let mockAgentStatusByPaneKey: Record<string, { worktreeId?: string }> = {}
+let mockActiveWorktreeId: string | null = null
 let mockActiveTabId: string | null = null
 let mockActiveTabType: string = 'editor'
 const mockSetActiveTab = vi.fn((tabId: string) => {
@@ -75,6 +76,7 @@ function buildMockStoreState(): Record<string, unknown> {
     agentSendPopoverTargetMode: null,
     agentStatusByPaneKey: mockAgentStatusByPaneKey,
     agentStatusEpoch: 0,
+    activeWorktreeId: mockActiveWorktreeId,
     activeTabId: mockActiveTabId,
     activeTabType: mockActiveTabType,
     setActiveTab: mockSetActiveTab,
@@ -155,6 +157,7 @@ describe('WorktreeCardAgents activation', () => {
     mockAgentActivityDisplayMode = undefined
     mockTabsByWorktree = {}
     mockAgentStatusByPaneKey = {}
+    mockActiveWorktreeId = null
     mockActiveTabId = null
     mockActiveTabType = 'editor'
     capturedRowActivations = []
@@ -261,7 +264,7 @@ describe('WorktreeCardAgents activation', () => {
 
   it('focuses an agent tab hosted under a sibling worktree key in the same project graph', async () => {
     // #12739: multi-agent remote projects can index tabs under a different worktree key
-    // than the sidebar card that renders the row.
+    // than the sidebar card that renders the row. setActiveTab only accepts the owner key.
     mockAgentActivityDisplayMode = 'full'
     const tabId = 'remote-agent-tab'
     const paneKey = makePaneKey(tabId, LEAF_A)
@@ -275,6 +278,7 @@ describe('WorktreeCardAgents activation', () => {
       })
     ]
     mockTabsByWorktree = { 'wt-sibling': [{ id: tabId }] }
+    mockActiveWorktreeId = 'wt-1'
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
@@ -282,7 +286,9 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenNthCalledWith(1, 'wt-1')
+    // Why: retarget the owning key so setActiveTab ownership can stick.
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenNthCalledWith(2, 'wt-sibling')
     expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
       ackPaneKeyOnSuccess: paneKey,
       flashFocusedPane: true,

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -259,6 +259,78 @@ describe('WorktreeCardAgents activation', () => {
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
   })
 
+  it('focuses an agent tab hosted under a sibling worktree key in the same project graph', async () => {
+    // #12739: multi-agent remote projects can index tabs under a different worktree key
+    // than the sidebar card that renders the row.
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'remote-agent-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'claude',
+        prompt: 'Remote multi-agent',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockTabsByWorktree = { 'wt-sibling': [{ id: tabId }] }
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+      ackPaneKeyOnSuccess: paneKey,
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+  })
+
+  it('retries focus once after reveal when the remote tab lands on the next frame', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'late-remote-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'codex',
+        prompt: 'Late tab',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    let rAF: FrameRequestCallback | null = null
+    const originalRAF = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rAF = cb
+      return 1
+    }) as typeof requestAnimationFrame
+
+    try {
+      const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+      renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+      capturedRowActivations[0].onActivate(tabId, paneKey)
+      expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+
+      mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+      expect(rAF).not.toBeNull()
+      rAF?.(0)
+
+      expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+        ackPaneKeyOnSuccess: paneKey,
+        flashFocusedPane: true,
+        scrollToBottomIfOutputSinceLastView: true
+      })
+    } finally {
+      globalThis.requestAnimationFrame = originalRAF
+    }
+  })
+
   it('does not pane-focus a fallback terminal when the worker tab is still missing after reveal', async () => {
     mockAgentActivityDisplayMode = 'full'
     const tabId = 'worker-tab'

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -302,6 +302,78 @@ describe('WorktreeCardAgents activation', () => {
     expect(staleAgentRowMocks.dismissStaleAgentRowByKey).not.toHaveBeenCalled()
   })
 
+  it('focuses an agent tab hosted under a sibling worktree key in the same project graph', async () => {
+    // #12739: multi-agent remote projects can index tabs under a different worktree key
+    // than the sidebar card that renders the row.
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'remote-agent-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'claude',
+        prompt: 'Remote multi-agent',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockTabsByWorktree = { 'wt-sibling': [{ id: tabId }] }
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+
+    renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+    expect(capturedRowActivations).toHaveLength(1)
+    capturedRowActivations[0].onActivate(tabId, paneKey)
+
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+      ackPaneKeyOnSuccess: paneKey,
+      flashFocusedPane: true,
+      scrollToBottomIfOutputSinceLastView: true
+    })
+  })
+
+  it('retries focus once after reveal when the remote tab lands on the next frame', async () => {
+    mockAgentActivityDisplayMode = 'full'
+    const tabId = 'late-remote-tab'
+    const paneKey = makePaneKey(tabId, LEAF_A)
+    mockAgents = [
+      mockAgent({
+        paneKey,
+        tabId,
+        agentType: 'codex',
+        prompt: 'Late tab',
+        worktreeId: 'wt-1'
+      })
+    ]
+    mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
+    let rAF: FrameRequestCallback | null = null
+    const originalRAF = globalThis.requestAnimationFrame
+    globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
+      rAF = cb
+      return 1
+    }) as typeof requestAnimationFrame
+
+    try {
+      const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
+      renderToStaticMarkup(<WorktreeCardAgents worktreeId="wt-1" />)
+      capturedRowActivations[0].onActivate(tabId, paneKey)
+      expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
+
+      mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
+      expect(rAF).not.toBeNull()
+      rAF?.(0)
+
+      expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
+        ackPaneKeyOnSuccess: paneKey,
+        flashFocusedPane: true,
+        scrollToBottomIfOutputSinceLastView: true
+      })
+    } finally {
+      globalThis.requestAnimationFrame = originalRAF
+    }
+  })
+
   it('does not pane-focus a fallback terminal when the worker tab is still missing after reveal', async () => {
     mockAgentActivityDisplayMode = 'full'
     const tabId = 'worker-tab'

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -53,6 +53,7 @@ let mockAgentActivityDisplayMode: 'compact' | 'full' | undefined
 let mockTabsByWorktree: Record<string, { id: string }[]> = {}
 let mockStructuredTabIds = new Set<string>()
 let mockAgentStatusByPaneKey: Record<string, { worktreeId?: string }> = {}
+let mockActiveWorktreeId: string | null = null
 let mockActiveTabId: string | null = null
 let mockActiveTabType: string = 'editor'
 const mockSetActiveTab = vi.fn((tabId: string) => {
@@ -77,6 +78,7 @@ function buildMockStoreState(): Record<string, unknown> {
     agentSendPopoverTargetMode: null,
     agentStatusByPaneKey: mockAgentStatusByPaneKey,
     agentStatusEpoch: 0,
+    activeWorktreeId: mockActiveWorktreeId,
     activeTabId: mockActiveTabId,
     activeTabType: mockActiveTabType,
     setActiveTab: mockSetActiveTab,
@@ -166,6 +168,7 @@ describe('WorktreeCardAgents activation', () => {
     mockTabsByWorktree = {}
     mockStructuredTabIds = new Set()
     mockAgentStatusByPaneKey = {}
+    mockActiveWorktreeId = null
     mockActiveTabId = null
     mockActiveTabType = 'editor'
     capturedRowActivations = []
@@ -304,7 +307,7 @@ describe('WorktreeCardAgents activation', () => {
 
   it('focuses an agent tab hosted under a sibling worktree key in the same project graph', async () => {
     // #12739: multi-agent remote projects can index tabs under a different worktree key
-    // than the sidebar card that renders the row.
+    // than the sidebar card that renders the row. setActiveTab only accepts the owner key.
     mockAgentActivityDisplayMode = 'full'
     const tabId = 'remote-agent-tab'
     const paneKey = makePaneKey(tabId, LEAF_A)
@@ -318,6 +321,7 @@ describe('WorktreeCardAgents activation', () => {
       })
     ]
     mockTabsByWorktree = { 'wt-sibling': [{ id: tabId }] }
+    mockActiveWorktreeId = 'wt-1'
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
     const { default: WorktreeCardAgents } = await import('./WorktreeCardAgents')
 
@@ -325,7 +329,9 @@ describe('WorktreeCardAgents activation', () => {
     expect(capturedRowActivations).toHaveLength(1)
     capturedRowActivations[0].onActivate(tabId, paneKey)
 
-    expect(activationMocks.activateAndRevealWorktree).toHaveBeenCalledWith('wt-1')
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenNthCalledWith(1, 'wt-1')
+    // Why: retarget the owning key so setActiveTab ownership can stick.
+    expect(activationMocks.activateAndRevealWorktree).toHaveBeenNthCalledWith(2, 'wt-sibling')
     expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
       ackPaneKeyOnSuccess: paneKey,
       flashFocusedPane: true,

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.activation.test.tsx
@@ -353,10 +353,10 @@ describe('WorktreeCardAgents activation', () => {
       })
     ]
     mockAgentStatusByPaneKey = { [paneKey]: { worktreeId: 'wt-1' } }
-    let rAF: FrameRequestCallback | null = null
+    const scheduledFrames: FrameRequestCallback[] = []
     const originalRAF = globalThis.requestAnimationFrame
     globalThis.requestAnimationFrame = ((cb: FrameRequestCallback) => {
-      rAF = cb
+      scheduledFrames.push(cb)
       return 1
     }) as typeof requestAnimationFrame
 
@@ -367,8 +367,8 @@ describe('WorktreeCardAgents activation', () => {
       expect(activationMocks.activateTabAndFocusPane).not.toHaveBeenCalled()
 
       mockTabsByWorktree = { 'wt-1': [{ id: tabId }] }
-      expect(rAF).not.toBeNull()
-      rAF?.(0)
+      expect(scheduledFrames).toHaveLength(1)
+      scheduledFrames[0]!(0)
 
       expect(activationMocks.activateTabAndFocusPane).toHaveBeenCalledWith(tabId, LEAF_A, {
         ackPaneKeyOnSuccess: paneKey,

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -164,23 +164,38 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         dismissStaleAgentRowByKey(paneKey)
         return
       }
-      // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
-      activateAndRevealWorktree(worktreeId)
-      const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
-      if (tabs.some((t) => t.id === tabId)) {
+      const focusAgentTab = (): boolean => {
+        // Why: remote/paired projects can host the tab under a sibling worktree key in the
+        // same project graph; only this card's list would miss a live multi-agent tab (#12739).
+        const tabsByWorktree = useAppStore.getState().tabsByWorktree
+        const tabPresent = Object.values(tabsByWorktree).some((tabs) =>
+          tabs?.some((tab) => tab.id === tabId)
+        )
+        if (!tabPresent) {
+          return false
+        }
         activateTabAndFocusPane(tabId, parsed.leafId, {
           ackPaneKeyOnSuccess: paneKey,
           flashFocusedPane: true,
           scrollToBottomIfOutputSinceLastView: true
         })
-      } else {
-        const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
-        if (liveEntry?.worktreeId === worktreeId) {
-          // Why: orchestration worker status can be worktree-attributed before the renderer knows its tab; keep the live row instead of dismissing as stale.
-          return
-        }
-        dismissStaleAgentRowByKey(paneKey)
+        return true
       }
+      // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
+      activateAndRevealWorktree(worktreeId)
+      if (focusAgentTab()) {
+        return
+      }
+      const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
+      if (liveEntry?.worktreeId === worktreeId) {
+        // Why: reveal can land remote tabs on the next paint; retry once before
+        // treating a worktree-attributed multi-agent row as inert (#12739).
+        requestAnimationFrame(() => {
+          focusAgentTab()
+        })
+        return
+      }
+      dismissStaleAgentRowByKey(paneKey)
     },
     [worktreeId]
   )

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -167,12 +167,21 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
       const focusAgentTab = (): boolean => {
         // Why: remote/paired projects can host the tab under a sibling worktree key in the
         // same project graph; only this card's list would miss a live multi-agent tab (#12739).
-        const tabsByWorktree = useAppStore.getState().tabsByWorktree
-        const tabPresent = Object.values(tabsByWorktree).some((tabs) =>
-          tabs?.some((tab) => tab.id === tabId)
-        )
-        if (!tabPresent) {
+        const state = useAppStore.getState()
+        let ownerWorktreeId: string | null = null
+        for (const [wtId, tabs] of Object.entries(state.tabsByWorktree)) {
+          if (tabs?.some((tab) => tab.id === tabId)) {
+            ownerWorktreeId = wtId
+            break
+          }
+        }
+        if (!ownerWorktreeId) {
           return false
+        }
+        // Why: setActiveTab only accepts tabs owned by activeWorktreeId; activating the
+        // card key alone leaves activeTabId unchanged when the tab lives under a sibling.
+        if (state.activeWorktreeId !== ownerWorktreeId) {
+          activateAndRevealWorktree(ownerWorktreeId)
         }
         activateTabAndFocusPane(tabId, parsed.leafId, {
           ackPaneKeyOnSuccess: paneKey,
@@ -182,6 +191,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         return true
       }
       // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
+      // Prefer the card worktree first for nav history; focusAgentTab re-targets the owner if needed.
       activateAndRevealWorktree(worktreeId)
       if (focusAgentTab()) {
         return

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -169,23 +169,41 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         dismissStaleAgentRowByKey(paneKey)
         return
       }
-      // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
-      activateAndRevealWorktree(worktreeId)
-      const tabs = useAppStore.getState().tabsByWorktree[worktreeId] ?? []
-      if (tabs.some((t) => t.id === tabId)) {
+      const focusAgentTab = (): boolean => {
+        // Why: remote/paired projects can host the tab under a sibling worktree key in the
+        // same project graph; only this card's list would miss a live multi-agent tab (#12739).
+        const tabsByWorktree = useAppStore.getState().tabsByWorktree
+        const tabPresent = Object.values(tabsByWorktree).some((tabs) =>
+          tabs?.some((tab) => tab.id === tabId)
+        )
+        if (!tabPresent) {
+          return false
+        }
         activateTabAndFocusPane(tabId, parsed.leafId, {
           ackPaneKeyOnSuccess: paneKey,
           flashFocusedPane: true,
           scrollToBottomIfOutputSinceLastView: true
         })
-      } else if (!activateStructuredAgentSessionTab({ worktreeId, tabId })) {
-        const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
-        if (liveEntry?.worktreeId === worktreeId) {
-          // Why: orchestration worker status can be worktree-attributed before the renderer knows its tab; keep the live row instead of dismissing as stale.
-          return
-        }
-        dismissStaleAgentRowByKey(paneKey)
+        return true
       }
+      // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
+      activateAndRevealWorktree(worktreeId)
+      if (focusAgentTab()) {
+        return
+      }
+      if (activateStructuredAgentSessionTab({ worktreeId, tabId })) {
+        return
+      }
+      const liveEntry = useAppStore.getState().agentStatusByPaneKey[paneKey]
+      if (liveEntry?.worktreeId === worktreeId) {
+        // Why: reveal can land remote tabs on the next paint; retry once before
+        // treating a worktree-attributed multi-agent row as inert (#12739).
+        requestAnimationFrame(() => {
+          focusAgentTab()
+        })
+        return
+      }
+      dismissStaleAgentRowByKey(paneKey)
     },
     [worktreeId]
   )

--- a/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCardAgents.tsx
@@ -172,12 +172,21 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
       const focusAgentTab = (): boolean => {
         // Why: remote/paired projects can host the tab under a sibling worktree key in the
         // same project graph; only this card's list would miss a live multi-agent tab (#12739).
-        const tabsByWorktree = useAppStore.getState().tabsByWorktree
-        const tabPresent = Object.values(tabsByWorktree).some((tabs) =>
-          tabs?.some((tab) => tab.id === tabId)
-        )
-        if (!tabPresent) {
+        const state = useAppStore.getState()
+        let ownerWorktreeId: string | null = null
+        for (const [wtId, tabs] of Object.entries(state.tabsByWorktree)) {
+          if (tabs?.some((tab) => tab.id === tabId)) {
+            ownerWorktreeId = wtId
+            break
+          }
+        }
+        if (!ownerWorktreeId) {
           return false
+        }
+        // Why: setActiveTab only accepts tabs owned by activeWorktreeId; activating the
+        // card key alone leaves activeTabId unchanged when the tab lives under a sibling.
+        if (state.activeWorktreeId !== ownerWorktreeId) {
+          activateAndRevealWorktree(ownerWorktreeId)
         }
         activateTabAndFocusPane(tabId, parsed.leafId, {
           ackPaneKeyOnSuccess: paneKey,
@@ -187,6 +196,7 @@ const WorktreeCardAgentsBody = React.memo(function WorktreeCardAgentsBody({
         return true
       }
       // Why: design-doc rule — every user-initiated worktree switch must route through activateAndRevealWorktree (cross-repo activation + nav history).
+      // Prefer the card worktree first for nav history; focusAgentTab re-targets the owner if needed.
       activateAndRevealWorktree(worktreeId)
       if (focusAgentTab()) {
         return


### PR DESCRIPTION
## Summary

A sidebar agent row can belong to a tab stored under a sibling worktree key in remote multi-agent layouts. Look up the actual owner, reveal it before activating the tab, and retry once on the next animation frame when the live row precedes tab hydration.

Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`. Current structured-session activation, malformed-key handling and live hydrating-row retention remain intact. A retry that still misses does not dismiss a live row.

Closes #12739

## Validation

- 40 sidebar component/activation tests passed, covering sibling ownership, delayed tab hydration and existing fallback cases.
- Changed-file lint/format, Web non-composite typecheck and diff checks passed.
- Cursor reviewed the final candidate; Codex independently checked the activation path and reran the focused tests before publication.
- Full suite/build, default composite typecheck and rendered Electron/live paired-SSH validation were not run for this scoped activation change. Default composite has the previously reproduced baseline TS2883 limitation.
