### PR TITLE
Add transcription language setting for cloud STT and register gpt-transcribe

### DIFF
--- a/src/main/speech/model-catalog.test.ts
+++ b/src/main/speech/model-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getCatalogModel, SPEECH_MODEL_CATALOG } from './model-catalog'
+import { OPENAI_TRANSCRIPTION_MODEL_BY_ID } from './openai-transcription-client'
 
 describe('SPEECH_MODEL_CATALOG', () => {
   it('includes the Japanese Parakeet TDT-CTC model with a valid manifest', () => {
@@ -44,5 +45,20 @@ describe('SPEECH_MODEL_CATALOG', () => {
     expect(model?.sizeBytes).toBe(239_549_735)
     expect(model?.downloadFiles).toHaveLength(2)
     expect(model?.downloadFiles?.map(({ name }) => name)).toEqual(['model.int8.onnx', 'tokens.txt'])
+  })
+
+  it('registers GPT Transcribe as a cloud transcription model', () => {
+    const model = getCatalogModel('openai-gpt-transcribe')
+    expect(model).toBeDefined()
+    expect(model?.type).toBe('openai')
+    expect(model?.provider).toBe('openai')
+    expect(model?.language).toBe('multilingual')
+    expect(model?.streaming).toBe(false)
+  })
+
+  it('maps every cloud catalog model to an OpenAI API model id', () => {
+    for (const model of SPEECH_MODEL_CATALOG.filter((m) => m.provider === 'openai')) {
+      expect(OPENAI_TRANSCRIPTION_MODEL_BY_ID[model.id]).toBeTruthy()
+    }
   })
 })

--- a/src/main/speech/model-catalog.ts
+++ b/src/main/speech/model-catalog.ts
@@ -143,6 +143,17 @@ export const SPEECH_MODEL_CATALOG: SpeechModelManifest[] = [
     language: 'multilingual',
     sampleRate: 16000,
     streaming: false
+  },
+  {
+    id: 'openai-gpt-transcribe',
+    label: 'GPT Transcribe',
+    description:
+      'Newest cloud transcription with the highest accuracy. Requires an OpenAI API key.',
+    type: 'openai',
+    provider: 'openai',
+    language: 'multilingual',
+    sampleRate: 16000,
+    streaming: false
   }
 ]
 

--- a/src/main/speech/openai-transcription-client.test.ts
+++ b/src/main/speech/openai-transcription-client.test.ts
@@ -1,5 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import { sanitizeOpenAiTranscriptionErrorMessage } from './openai-transcription-client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  normalizeTranscriptionLanguage,
+  OpenAiTranscriptionSession,
+  sanitizeOpenAiTranscriptionErrorMessage
+} from './openai-transcription-client'
 
 describe('sanitizeOpenAiTranscriptionErrorMessage', () => {
   it('does not expose the invalid OpenAI API key echoed by the provider', () => {
@@ -16,5 +20,59 @@ describe('sanitizeOpenAiTranscriptionErrorMessage', () => {
         'Request failed for sk-testSecret123 with Authorization: Bearer token-value_123'
       )
     ).toBe('Request failed for [redacted] with Authorization: Bearer [redacted]')
+  })
+})
+
+describe('normalizeTranscriptionLanguage', () => {
+  it('normalizes case and whitespace', () => {
+    expect(normalizeTranscriptionLanguage(' PL ')).toBe('pl')
+    expect(normalizeTranscriptionLanguage('zh-Hans')).toBe('zh-hans')
+  })
+
+  it('rejects empty and malformed values', () => {
+    expect(normalizeTranscriptionLanguage(undefined)).toBeUndefined()
+    expect(normalizeTranscriptionLanguage('')).toBeUndefined()
+    expect(normalizeTranscriptionLanguage('   ')).toBeUndefined()
+    expect(normalizeTranscriptionLanguage('polish!')).toBeUndefined()
+    expect(normalizeTranscriptionLanguage('not a language')).toBeUndefined()
+  })
+})
+
+describe('OpenAiTranscriptionSession language hint', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  async function finishSessionForm(readLanguage?: () => string | undefined): Promise<FormData> {
+    const fetchMock = vi.fn(
+      async (_input: string | URL | Request, _init?: RequestInit) =>
+        new Response(JSON.stringify({ text: 'ok' }), { status: 200 })
+    )
+    vi.stubGlobal('fetch', fetchMock)
+    const session = new OpenAiTranscriptionSession(
+      'openai-gpt-4o-mini-transcribe',
+      () => 'sk-test',
+      readLanguage
+    )
+    session.feedAudio(new Float32Array(1600), 16000)
+    await session.finish()
+    const request = fetchMock.mock.calls[0]?.[1]
+    expect(request?.body).toBeInstanceOf(FormData)
+    return request?.body as FormData
+  }
+
+  it('sends the configured transcription language', async () => {
+    const form = await finishSessionForm(() => 'pl')
+    expect(form.get('language')).toBe('pl')
+  })
+
+  it('omits the language field for auto-detect', async () => {
+    const form = await finishSessionForm(undefined)
+    expect(form.has('language')).toBe(false)
+  })
+
+  it('omits the language field for invalid stored values', async () => {
+    const form = await finishSessionForm(() => 'not a language')
+    expect(form.has('language')).toBe(false)
   })
 })

--- a/src/main/speech/openai-transcription-client.ts
+++ b/src/main/speech/openai-transcription-client.ts
@@ -2,7 +2,8 @@ import { resampleToRate } from './stt-audio-resample'
 
 export const OPENAI_TRANSCRIPTION_MODEL_BY_ID: Record<string, string> = {
   'openai-gpt-4o-mini-transcribe': 'gpt-4o-mini-transcribe',
-  'openai-gpt-4o-transcribe': 'gpt-4o-transcribe'
+  'openai-gpt-4o-transcribe': 'gpt-4o-transcribe',
+  'openai-gpt-transcribe': 'gpt-transcribe'
 }
 
 const OPENAI_TRANSCRIPTION_URL = 'https://api.openai.com/v1/audio/transcriptions'
@@ -14,6 +15,18 @@ type OpenAiTranscriptionResponse = {
   error?: {
     message?: unknown
   }
+}
+
+// Why: OpenAI rejects the whole request on a malformed language tag, so an
+// invalid stored value must degrade to auto-detect instead of breaking dictation.
+const ISO_639_1_LANGUAGE_RE = /^[a-z]{2,3}(-[a-z0-9]{2,8})?$/
+
+export function normalizeTranscriptionLanguage(value: string | undefined): string | undefined {
+  const trimmed = value?.trim().toLowerCase()
+  if (!trimmed || !ISO_639_1_LANGUAGE_RE.test(trimmed)) {
+    return undefined
+  }
+  return trimmed
 }
 
 export function sanitizeOpenAiTranscriptionErrorMessage(message: string): string {
@@ -83,7 +96,8 @@ export class OpenAiTranscriptionSession {
 
   constructor(
     private readonly modelId: string,
-    private readonly readApiKey: () => string
+    private readonly readApiKey: () => string,
+    private readonly readLanguage?: () => string | undefined
   ) {}
 
   feedAudio(samples: Float32Array, sampleRate: number): void {
@@ -111,6 +125,11 @@ export class OpenAiTranscriptionSession {
     const form = new FormData()
     form.append('model', apiModel)
     form.append('response_format', 'json')
+    const language = normalizeTranscriptionLanguage(this.readLanguage?.())
+    if (language) {
+      // Why: an explicit input language improves accuracy and latency vs auto-detect.
+      form.append('language', language)
+    }
     // Why: OpenAI's transcription endpoint expects a multipart file object;
     // a named WAV blob avoids filesystem temp files and works in packaged apps.
     form.append('file', new Blob([new Uint8Array(wav)], { type: 'audio/wav' }), 'dictation.wav')

--- a/src/main/speech/speech-runtime-service.ts
+++ b/src/main/speech/speech-runtime-service.ts
@@ -22,7 +22,12 @@ export function getSpeechModelManager(store: SpeechSettingsStore): ModelManager 
 
 export function getSpeechSttService(store: SpeechSettingsStore): SttService {
   if (!sttService) {
-    sttService = new SttService(getSpeechModelManager(store))
+    // Why: read at dictation time, not construction, so settings edits apply
+    // to the next session without restarting the app.
+    sttService = new SttService(
+      getSpeechModelManager(store),
+      () => store.getSettings().voice?.transcriptionLanguage
+    )
   }
   return sttService
 }

--- a/src/main/speech/stt-service.ts
+++ b/src/main/speech/stt-service.ts
@@ -52,7 +52,10 @@ export class SttService {
   // stale workers must not retain this service after error, exit, or teardown.
   private cleanupWorkerLifecycleListeners: (() => void) | null = null
 
-  constructor(modelManager: ModelManager) {
+  constructor(
+    modelManager: ModelManager,
+    private readonly readTranscriptionLanguage?: () => string | undefined
+  ) {
     this.modelManager = modelManager
   }
 
@@ -114,7 +117,11 @@ export class SttService {
         throw new Error(`Model not ready: ${modelState.status}`)
       }
 
-      this.cloudSession = new OpenAiTranscriptionSession(modelId, readOpenAiSpeechApiKey)
+      this.cloudSession = new OpenAiTranscriptionSession(
+        modelId,
+        readOpenAiSpeechApiKey,
+        this.readTranscriptionLanguage
+      )
       this.activeModelId = modelId
       this.activeHotwordsFilePath = undefined
       this.eventSink = sink

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -10,6 +10,7 @@ import { OpenAiTranscriptionSettingsRow } from './OpenAiTranscriptionSettingsRow
 import { handleVoiceDictationToggle } from './voice-dictation-toggle'
 import { VoiceDictationSettingsSection } from './VoiceDictationSettingsSection'
 import { VoiceSpeechModelSection } from './VoiceSpeechModelSection'
+import { VoiceTranscriptionLanguageSetting } from './VoiceTranscriptionLanguageSetting'
 import { matchesSettingsSearch } from './settings-search'
 import { getOpenaiTranscriptionSearchEntry } from './voice-pane-search'
 import { translate } from '@/i18n/i18n'
@@ -216,6 +217,14 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
         onUpdateVoiceSettings={updateVoiceSettings}
         onOpenOpenAiDialog={openOpenAiDialog}
         onRefreshModelStates={refreshModelStates}
+      />
+
+      <Separator />
+
+      <VoiceTranscriptionLanguageSetting
+        voiceSettings={voiceSettings}
+        selectedModel={selectedModel}
+        onUpdateVoiceSettings={updateVoiceSettings}
       />
 
       {showOpenAiSettingsRow && (

--- a/src/renderer/src/components/settings/VoiceTranscriptionLanguageSetting.test.tsx
+++ b/src/renderer/src/components/settings/VoiceTranscriptionLanguageSetting.test.tsx
@@ -1,0 +1,84 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, describe, expect, it } from 'vitest'
+import type { SpeechModelManifest, VoiceSettings } from '../../../../shared/speech-types'
+import { getDefaultVoiceSettings } from '../../../../shared/constants'
+import { VoiceTranscriptionLanguageSetting } from './VoiceTranscriptionLanguageSetting'
+
+const CLOUD_MODEL: SpeechModelManifest = {
+  id: 'openai-gpt-4o-mini-transcribe',
+  label: 'GPT-4o mini Transcribe',
+  description: 'Cloud transcription.',
+  type: 'openai',
+  provider: 'openai',
+  language: 'multilingual',
+  sampleRate: 16000,
+  streaming: false
+}
+
+const LOCAL_MODEL: SpeechModelManifest = {
+  ...CLOUD_MODEL,
+  id: 'local-model',
+  label: 'Local model',
+  type: 'senseVoice',
+  provider: 'local'
+}
+
+function render(args: {
+  voiceSettings?: Partial<VoiceSettings>
+  selectedModel: SpeechModelManifest | undefined
+}): { container: HTMLDivElement; root: Root } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const root = createRoot(container)
+  act(() => {
+    root.render(
+      <VoiceTranscriptionLanguageSetting
+        voiceSettings={{ ...getDefaultVoiceSettings(), enabled: true, ...args.voiceSettings }}
+        selectedModel={args.selectedModel}
+        onUpdateVoiceSettings={() => {}}
+      />
+    )
+  })
+  return { container, root }
+}
+
+function getTrigger(container: HTMLElement): HTMLButtonElement {
+  const trigger = container.querySelector<HTMLButtonElement>(
+    'button[aria-label="Transcription Language"]'
+  )
+  if (!trigger) {
+    throw new Error('Transcription language trigger was not rendered')
+  }
+  return trigger
+}
+
+describe('VoiceTranscriptionLanguageSetting', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('is enabled for a selected cloud model', () => {
+    const { container, root } = render({ selectedModel: CLOUD_MODEL })
+    expect(getTrigger(container).disabled).toBe(false)
+    act(() => root.unmount())
+  })
+
+  it('is disabled and explains why for a selected local model', () => {
+    const { container, root } = render({ selectedModel: LOCAL_MODEL })
+    expect(getTrigger(container).disabled).toBe(true)
+    expect(container.textContent).toContain('cloud (OpenAI) speech models only')
+    act(() => root.unmount())
+  })
+
+  it('is disabled when voice dictation is off', () => {
+    const { container, root } = render({
+      voiceSettings: { enabled: false },
+      selectedModel: CLOUD_MODEL
+    })
+    expect(getTrigger(container).disabled).toBe(true)
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/settings/VoiceTranscriptionLanguageSetting.tsx
+++ b/src/renderer/src/components/settings/VoiceTranscriptionLanguageSetting.tsx
@@ -1,0 +1,107 @@
+import type { SpeechModelManifest, VoiceSettings } from '../../../../shared/speech-types'
+import { Label } from '../ui/label'
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select'
+import { translate } from '@/i18n/i18n'
+
+// Why: Radix Select reserves '' for clearing, so auto-detect needs a sentinel.
+const AUTO_DETECT_VALUE = 'auto'
+
+// Native names stay untranslated so every speaker can find their language
+// whatever the current interface locale is.
+const TRANSCRIPTION_LANGUAGES: readonly { code: string; nativeName: string }[] = [
+  { code: 'cs', nativeName: 'Čeština' },
+  { code: 'da', nativeName: 'Dansk' },
+  { code: 'de', nativeName: 'Deutsch' },
+  { code: 'en', nativeName: 'English' },
+  { code: 'es', nativeName: 'Español' },
+  { code: 'fr', nativeName: 'Français' },
+  { code: 'it', nativeName: 'Italiano' },
+  { code: 'hu', nativeName: 'Magyar' },
+  { code: 'nl', nativeName: 'Nederlands' },
+  { code: 'no', nativeName: 'Norsk' },
+  { code: 'pl', nativeName: 'Polski' },
+  { code: 'pt', nativeName: 'Português' },
+  { code: 'ro', nativeName: 'Română' },
+  { code: 'sk', nativeName: 'Slovenčina' },
+  { code: 'fi', nativeName: 'Suomi' },
+  { code: 'sv', nativeName: 'Svenska' },
+  { code: 'tr', nativeName: 'Türkçe' },
+  { code: 'el', nativeName: 'Ελληνικά' },
+  { code: 'ru', nativeName: 'Русский' },
+  { code: 'uk', nativeName: 'Українська' },
+  { code: 'ar', nativeName: 'العربية' },
+  { code: 'hi', nativeName: 'हिन्दी' },
+  { code: 'ko', nativeName: '한국어' },
+  { code: 'ja', nativeName: '日本語' },
+  { code: 'zh', nativeName: '中文' }
+]
+
+type VoiceTranscriptionLanguageSettingProps = {
+  voiceSettings: VoiceSettings
+  selectedModel: SpeechModelManifest | undefined
+  onUpdateVoiceSettings: (updates: Partial<VoiceSettings>) => void
+}
+
+export function VoiceTranscriptionLanguageSetting({
+  voiceSettings,
+  selectedModel,
+  onUpdateVoiceSettings
+}: VoiceTranscriptionLanguageSettingProps): React.JSX.Element {
+  const label = translate(
+    'auto.components.settings.VoiceTranscriptionLanguageSetting.label',
+    'Transcription Language'
+  )
+  const selectedValue = voiceSettings.transcriptionLanguage || AUTO_DETECT_VALUE
+  // Why: the language hint is only sent to cloud transcription; local models
+  // have a fixed language, so the control would silently do nothing.
+  const appliesToSelectedModel = selectedModel?.provider === 'openai'
+  const disabled = !voiceSettings.enabled || !appliesToSelectedModel
+
+  return (
+    <div className="flex items-center justify-between gap-4 py-2">
+      <div className="min-w-0 space-y-0.5">
+        <Label>{label}</Label>
+        <p className="text-xs text-muted-foreground">
+          {appliesToSelectedModel || !voiceSettings.enabled
+            ? translate(
+                'auto.components.settings.VoiceTranscriptionLanguageSetting.description',
+                'Spoken language sent to cloud transcription. A fixed language improves accuracy over auto-detect.'
+              )
+            : translate(
+                'auto.components.settings.VoiceTranscriptionLanguageSetting.cloudOnly',
+                'Applies to cloud (OpenAI) speech models only. The selected local model has a fixed language.'
+              )}
+        </p>
+      </div>
+      <Select
+        value={selectedValue}
+        disabled={disabled}
+        onValueChange={(value) => {
+          onUpdateVoiceSettings({
+            transcriptionLanguage: value === AUTO_DETECT_VALUE ? '' : value
+          })
+        }}
+      >
+        <SelectTrigger
+          className={`h-7 w-52 shrink-0 text-xs ${disabled ? 'opacity-50' : ''}`}
+          aria-label={label}
+        >
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value={AUTO_DETECT_VALUE} className="text-xs">
+            {translate(
+              'auto.components.settings.VoiceTranscriptionLanguageSetting.autoDetect',
+              'Auto-detect'
+            )}
+          </SelectItem>
+          {TRANSCRIPTION_LANGUAGES.map((language) => (
+            <SelectItem key={language.code} value={language.code} className="text-xs">
+              {`${language.nativeName} (${language.code})`}
+            </SelectItem>
+          ))}
+        </SelectContent>
+      </Select>
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/voice-pane-search.ts
+++ b/src/renderer/src/components/settings/voice-pane-search.ts
@@ -100,6 +100,35 @@ export const getVoicePaneSearchEntries = createLocalizedCatalog(() => [
   },
   getOpenaiTranscriptionSearchEntry(),
   {
+    title: translate(
+      'auto.components.settings.voice.pane.search.transcriptionLanguageTitle',
+      'Transcription Language'
+    ),
+    description: translate(
+      'auto.components.settings.voice.pane.search.transcriptionLanguageDescription',
+      'Spoken language sent to cloud speech-to-text transcription.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.voice.pane.search.7640ed9848', 'voice'),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.089d31a45b',
+        'dictation'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.322d457a0d',
+        'transcription'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.transcriptionLanguageKeyword',
+        'language'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.transcriptionPolishKeyword',
+        'polish'
+      )
+    ]
+  },
+  {
     title: translate('auto.components.settings.voice.pane.search.7e62cd7c41', 'Speech Model'),
     description: translate(
       'auto.components.settings.voice.pane.search.56defcd6c3',

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9371,7 +9371,9 @@
               "micInput": "input",
               "micDevice": "device",
               "micAirpods": "airpods",
-              "micDefault": "system default"
+              "micDefault": "system default",
+              "transcriptionLanguageTitle": "Transcription Language",
+              "transcriptionLanguageDescription": "Spoken language sent to cloud speech-to-text transcription."
             }
           }
         },
@@ -10451,6 +10453,12 @@
           "openAutomationsDescription": "Create schedules and inspect recent runs.",
           "title": "Automations",
           "description": "Schedule agent work and choose whether Automations appears in the sidebar."
+        },
+        "VoiceTranscriptionLanguageSetting": {
+          "label": "Transcription Language",
+          "description": "Spoken language sent to cloud transcription. A fixed language improves accuracy over auto-detect.",
+          "cloudOnly": "Applies to cloud (OpenAI) speech models only. The selected local model has a fixed language.",
+          "autoDetect": "Auto-detect"
         }
       },
       "right": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -398,6 +398,7 @@ export function getDefaultVoiceSettings(): VoiceSettings {
     sttModel: '',
     modelsDir: '',
     language: 'en',
+    transcriptionLanguage: '',
     dictationMode: 'toggle' as const,
     terminalConfirmBeforeInsert: false,
     userModels: [],

--- a/src/shared/speech-types.ts
+++ b/src/shared/speech-types.ts
@@ -71,6 +71,8 @@ export type VoiceSettings = {
   sttModel: string
   modelsDir: string
   language: string
+  /** ISO-639-1 hint for cloud transcription; ''/absent = auto-detect */
+  transcriptionLanguage?: string
   dictationMode: DictationMode
   terminalConfirmBeforeInsert: boolean
   userModels: UserModelConfig[]


### PR DESCRIPTION
## Summary

Cloud dictation currently posts to `/v1/audio/transcriptions` without a `language` field, so GPT-4o (mini) Transcribe has to guess the spoken language on every dictation. For non-English speakers this measurably hurts accuracy (and OpenAI documents that supplying the input language in ISO-639-1 improves both accuracy and latency).

This PR adds a **Settings → Voice → Transcription Language** dropdown (default: **Auto-detect**, i.e. exactly today's behavior) and sends the selected code as the multipart `language` field.

It also registers the newer **`gpt-transcribe`** model, which uses the same `/v1/audio/transcriptions` endpoint and the existing API-key handling.

## Changes

- `VoiceSettings.transcriptionLanguage` — new optional field (`''`/absent = auto-detect), safe for remote wire compatibility.
- `OpenAiTranscriptionSession` accepts a `readLanguage` callback and appends `language` when set; `normalizeTranscriptionLanguage` validates the stored value so a malformed setting degrades to auto-detect instead of failing the request.
- The callback is wired through `SttService` → `getSpeechSttService(store)`, so it covers both the desktop IPC path and mobile dictation via the runtime, and reads fresh settings at each session start (no restart needed).
- New `VoiceTranscriptionLanguageSetting` row (~25 languages with native names + Auto-detect). Enabled only when the selected speech model is a cloud model — local models have a fixed language, so the control explains that instead of silently doing nothing.
- Settings search entries (`voice-pane-search.ts`) so the row is discoverable via "language", "transcription", "polish", etc.
- Catalog entry for `openai-gpt-transcribe` → API model `gpt-transcribe`.

## Testing

- New unit tests: `language` is appended for a configured code, omitted for auto-detect and for invalid stored values; normalization edge cases; catalog↔model-map consistency; render states of the new settings row.
- `pnpm run typecheck` clean; oxlint/oxfmt clean; localization catalog synced and `verify:localization-extraction` / `verify:localization-coverage` gates pass.
- Built and installed a packaged NSIS build on Windows and verified the new setting and model registration are present and wired in the packaged app.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
