### PR TITLE
fix(terminal): preserve remote pane output after host restart

### DIFF
--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1506,6 +1506,20 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.snapshot).toContain('prompt$')
     })
 
+    it('returns the preserved sequence from attach-only adoption', async () => {
+      const sessionId = 'attach-sequence-handoff'
+      await adapter.spawn({ cols: 80, rows: 24, sessionId })
+      lastSubprocess._simulateData('preserved output')
+      await new Promise((r) => setTimeout(r, 50))
+
+      await expect(adapter.attach(sessionId)).resolves.toEqual({
+        providerSequence: {
+          value: 'preserved output'.length,
+          generation: 'continued'
+        }
+      })
+    })
+
     it('returns plain result for new sessionId', async () => {
       const result = await adapter.spawn({ cols: 80, rows: 24, sessionId: 'brand-new' })
       expect(result.id).toBe('brand-new')

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1683,6 +1683,33 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       adapter2.dispose()
     })
 
+    it('keeps legacy attach behavior when no output sequence is available', async () => {
+      const ensureConnected = vi
+        .spyOn(DaemonClient.prototype, 'ensureConnected')
+        .mockResolvedValue()
+      const request = vi
+        .spyOn(DaemonClient.prototype, 'request')
+        .mockImplementation(async (type: string) =>
+          type === 'getSize'
+            ? ({ size: { cols: 100, rows: 30 } } as never)
+            : ({
+                isNew: false,
+                snapshot: null,
+                pid: 4321,
+                shellState: 'unsupported',
+                incarnationId: 'legacy-attach-incarnation'
+              } as never)
+        )
+      const legacy = new DaemonPtyAdapter({ socketPath, tokenPath, protocolVersion: 30 })
+      try {
+        await expect(legacy.attach('legacy-session')).resolves.toBeUndefined()
+      } finally {
+        legacy.dispose()
+        request.mockRestore()
+        ensureConnected.mockRestore()
+      }
+    })
+
     it('refuses to create when the session is absent (attach-only)', async () => {
       const adapter2 = new DaemonPtyAdapter({ socketPath, tokenPath })
 

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -108,7 +108,7 @@ function takeRecoveryFreeze(
   historyRecovery.freeze = null
   return freeze
 }
-function providerSequenceForSpawn(
+function providerSequenceFromCreateOrAttach(
   result: CreateOrAttachResult
 ): PtySpawnResult['providerSequence'] {
   if (result.isNew) {
@@ -731,7 +731,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
 
     const wasAlreadyManaged = this.activeSessionIds.has(sessionId)
     this.activeSessionIds.add(sessionId)
-    const providerSequence = providerSequenceForSpawn(result)
+    const providerSequence = providerSequenceFromCreateOrAttach(result)
 
     // Cold restore: daemon made a new session but disk history shows an unclean shutdown → return saved scrollback.
     if (restoreInfo && (result.isNew || result.historySeeded === false)) {
@@ -892,7 +892,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
     return result.exitedBeforeSpawnReply === true
   }
 
-  async attach(id: string): Promise<void> {
+  async attach(id: string): Promise<Pick<PtySpawnResult, 'providerSequence'> | void> {
     await this.ensureConnected()
     if (!this.canDelegateBackgroundToDaemon) {
       this.setPtyBackgrounded(id, false)
@@ -924,6 +924,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
       throw new SessionNotFoundError(id)
     }
     this.clearSessionAwaitingDaemonRecovery(id)
+    const providerSequence = providerSequenceFromCreateOrAttach(result)
+    return providerSequence ? { providerSequence } : undefined
   }
 
   hasPty(id: string): boolean {

--- a/src/main/daemon/daemon-pty-router.test.ts
+++ b/src/main/daemon/daemon-pty-router.test.ts
@@ -229,6 +229,19 @@ it('preserves unavailable inspection from the owning legacy daemon', async () =>
   })
 })
 
+it('forwards the owning legacy daemon sequence from attach', async () => {
+  const legacy = createAdapter('legacy', ['legacy-session'])
+  const providerSequence = { value: 204, generation: 'continued' as const }
+  vi.mocked(legacy.attach).mockResolvedValueOnce({ providerSequence })
+  const router = new DaemonPtyRouter({
+    current: createAdapter('current'),
+    legacy: [legacy]
+  })
+  await router.discoverLegacySessions()
+
+  await expect(router.attach('legacy-session')).resolves.toEqual({ providerSequence })
+})
+
 describe('DaemonPtyRouter', () => {
   it('reports separate conservative resume and fresh-create boundaries', () => {
     const current = createAdapter(

--- a/src/main/daemon/daemon-pty-router.ts
+++ b/src/main/daemon/daemon-pty-router.ts
@@ -73,8 +73,8 @@ export class DaemonPtyRouter implements IPtyProvider {
     return this.current.supportsAgentSessionCreateOperations()
   }
 
-  async attach(id: string): Promise<void> {
-    await this.adapterFor(id).attach(id)
+  async attach(id: string): ReturnType<IPtyProvider['attach']> {
+    return await this.adapterFor(id).attach(id)
   }
 
   hasPty(id: string): boolean {

--- a/src/main/daemon/degraded-daemon-pty-provider.test.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.test.ts
@@ -317,6 +317,20 @@ describe('DegradedDaemonPtyProvider', () => {
     expect(fallback.attach).not.toHaveBeenCalled()
   })
 
+  it('forwards the owning daemon sequence from attach', async () => {
+    const legacy = createDaemonAdapter('legacy', ['daemon-session'])
+    const providerSequence = { value: 204, generation: 'continued' as const }
+    vi.mocked(legacy.attach).mockResolvedValueOnce({ providerSequence })
+    const provider = new DegradedDaemonPtyProvider({
+      current: createDaemonAdapter('current'),
+      legacy: [legacy],
+      fallback: createProvider('fallback')
+    })
+    await provider.discoverDaemonSessions()
+
+    await expect(provider.attach('daemon-session')).resolves.toEqual({ providerSequence })
+  })
+
   it('only delegates owner-listing authority to the provider that owns the id', async () => {
     const current = createDaemonAdapter('daemon', ['daemon-session'])
     const fallback = createProvider('fallback', [], true)

--- a/src/main/daemon/degraded-daemon-pty-provider.ts
+++ b/src/main/daemon/degraded-daemon-pty-provider.ts
@@ -86,7 +86,7 @@ export class DegradedDaemonPtyProvider implements IPtyProvider {
   spawn = (opts: PtySpawnOptions): Promise<PtySpawnResult> => this.ownerRecovery.spawn(opts)
 
   // Why refuse the fallback route (unknown ids resolve to it): see attachDaemonOwnedSession.
-  attach = (id: string): Promise<void> =>
+  attach = (id: string): ReturnType<IPtyProvider['attach']> =>
     attachDaemonOwnedSession(this.providerFor(id), this.fallback, id)
 
   hasPty(id: string): boolean {

--- a/src/main/daemon/degraded-daemon-session-routing.ts
+++ b/src/main/daemon/degraded-daemon-session-routing.ts
@@ -19,11 +19,11 @@ export async function attachDaemonOwnedSession(
   owner: IPtyProvider,
   fallback: IPtyProvider,
   sessionId: string
-): Promise<void> {
+): ReturnType<IPtyProvider['attach']> {
   if (owner === fallback) {
     throw new SessionNotFoundError(sessionId)
   }
-  await owner.attach(sessionId)
+  return await owner.attach(sessionId)
 }
 
 /** Probes providers for an id absent from the routing map and adopts the

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -761,7 +761,7 @@ describe('registerPtyHandlers', () => {
     terminalHandle: 'term_recovered'
   }
 
-  function registerAgentClaimController(): {
+  function registerAgentClaimController(runtimeOverrides: Record<string, unknown> = {}): {
     spawn: (args: Record<string, unknown>) => Promise<unknown>
     write: (ptyId: string, data: string) => boolean
     resize: (ptyId: string, cols: number, rows: number) => boolean
@@ -783,7 +783,8 @@ describe('registerPtyHandlers', () => {
       }),
       createPreAllocatedTerminalHandle: vi.fn(() => 'term_recovered'),
       registerPreAllocatedHandleForPty: vi.fn(),
-      registerPty: vi.fn()
+      registerPty: vi.fn(),
+      ...runtimeOverrides
     }
     registerPtyHandlers(mainWindow as never, runtime as never)
     if (!controller) {
@@ -926,6 +927,29 @@ describe('registerPtyHandlers', () => {
       clearPtyOwnershipForConnection('ssh-attach')
       clearProviderPtyState(ownedSshPtyId)
     }
+  })
+
+  it('synchronizes subscriber-driven attach to the daemon snapshot sequence', async () => {
+    const daemonPtyId = 'repo-1::/tmp/wt@@sequence-handoff'
+    const providerSequence = { value: 204, generation: 'continued' as const }
+    const localProvider = createAgentClaimProvider({})
+    localProvider.attach.mockResolvedValueOnce({ providerSequence })
+    setLocalPtyProvider(localProvider as never)
+    const getPtyOutputSequence = vi.fn(() => 0)
+    const synchronizePtyOutputSequenceFromProvider = vi.fn()
+    const controller = registerAgentClaimController({
+      getPtyOutputSequence,
+      synchronizePtyOutputSequenceFromProvider
+    })
+
+    await expect(controller.attach(daemonPtyId)).resolves.toBe(true)
+
+    expect(getPtyOutputSequence).toHaveBeenCalledWith(daemonPtyId)
+    expect(synchronizePtyOutputSequenceFromProvider).toHaveBeenCalledWith(
+      daemonPtyId,
+      providerSequence,
+      0
+    )
   })
 
   it('does not dispatch a runtime PTY spawn after its client disconnects', async () => {

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -5320,7 +5320,15 @@ export function registerPtyHandlers(
         return false
       }
       try {
-        await provider.attach(ptyId)
+        const sequenceBeforeProviderAttach = runtime?.getPtyOutputSequence?.(ptyId) ?? 0
+        const attachResult = await provider.attach(ptyId)
+        if (attachResult?.providerSequence) {
+          runtime?.synchronizePtyOutputSequenceFromProvider?.(
+            ptyId,
+            attachResult.providerSequence,
+            sequenceBeforeProviderAttach
+          )
+        }
         return true
       } catch {
         return false

--- a/src/main/providers/pty-provider-contract.ts
+++ b/src/main/providers/pty-provider-contract.ts
@@ -114,7 +114,7 @@ export type IPtyProvider = {
   providesAgentSessionOwnerListings?: (ptyId: string) => boolean
   /** Whether fresh structured creates can replay one spawn across a lost relay response. */
   supportsAgentSessionCreateOperations?: (options?: PtyProbeOptions) => boolean | Promise<boolean>
-  attach(id: string): Promise<void>
+  attach(id: string): Promise<Pick<PtySpawnResult, 'providerSequence'> | void>
   hasPty?: (id: string) => boolean
   /** Exact provider readback: false only when the provider answered that the PTY is absent. */
   probePtyLiveness?: (id: string) => Promise<boolean | null>

--- a/tests/e2e/paired-remote-terminal-host-restart-background-sync.spec.ts
+++ b/tests/e2e/paired-remote-terminal-host-restart-background-sync.spec.ts
@@ -380,6 +380,7 @@ test('foregrounds a preserved daemon PTY after the paired host relaunches', asyn
     expect(readDaemonPid(session.userDataDir), 'daemon must survive the host relaunch').toBe(
       daemonPid
     )
+    await openClientTab(client.page, worktreeId, target.webTabId)
     await expect
       .poll(
         () =>
@@ -391,15 +392,6 @@ test('foregrounds a preserved daemon PTY after the paired host relaunches', asyn
       )
       .toBe(true)
 
-    target.handle = await findTerminalHandle(client, worktreeId, target.parentTabId)
-    const shown = await callRuntime<{ terminal: { ptyId: string | null } }>(
-      client.page,
-      client.environmentId,
-      'terminal.show',
-      { terminal: target.handle }
-    )
-    expect(shown.terminal.ptyId).toBe(target.ptyId)
-    await openClientTab(client.page, worktreeId, target.webTabId)
     await waitForPaneConnected(client.page, target.webTabId)
     await expect
       .poll(
@@ -415,6 +407,7 @@ test('foregrounds a preserved daemon PTY after the paired host relaunches', asyn
       )
       .toBe(true)
     await expectTerminalInteractive(client, target, 'x')
+    target.handle = await findTerminalHandle(client, worktreeId, target.parentTabId)
 
     const reconnectControl = await createHostTerminal(client, worktreeId, 'reconnect-control')
     terminals.push(reconnectControl)


### PR DESCRIPTION
## Summary

Fix preserved remote terminal panes that stop updating after a paired host runtime restarts while its PTY daemon survives.

The subscriber-driven daemon attach path now forwards the daemon's atomic output sequence to the runtime's existing sequence synchronizer. This keeps snapshot deduplication and subsequent live stream chunks in the same sequence domain.

No reconnect timing, retry policy, subscription lifecycle, renderer recovery, PTY recreation, terminal resize, or wire protocol behavior changes.

## Root cause and reproduction

Live instrumentation on the affected pinned `milkfish` / `Setup` pane proved:

1. The surviving Windows daemon's authoritative snapshot sequence was 204.
2. The relaunched host runtime began its local sequence at 0.
3. New input advanced the daemon snapshot from 204 to 209 to 214.
4. The corresponding live chunks reached the multiplex stream and pane callback with runtime sequences 5 and 10.
5. Renderer reconciliation dropped those chunks as snapshot-covered duplicates because its restored baseline was still 204.
6. Clearing only that baseline allowed the next live chunk to reach xterm and render immediately.

The existing provider spawn/reattach path already synchronizes this sequence. The subscriber-driven attach path used after a paired viewer reconnects called the same atomic daemon `createOrAttach` operation but discarded its snapshot sequence.

The E2E regression now creates pane demand before reconnect and avoids `terminal.show`, which previously exercised the already-correct ordinary reattach path and masked this failure.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full lint is left to CI; changed-code quality and oxlint pre-commit checks pass
- [ ] `pnpm typecheck` — `pnpm run typecheck:node` passes
- [ ] `pnpm test` — focused suites pass: 619 tests
- [ ] `pnpm build` — the Electron E2E build and bundled CLI build pass
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Additional validation:

- Red before the fix: attach-only adoption returned no provider sequence and the subscriber-driven attach made zero synchronization calls.
- Green after the fix: adapter and IPC sequence-handoff contracts pass.
- Paired Electron host-restart E2E: 10/10 repeated runs pass, plus one pass after rebasing onto current `main`.
- `pnpm run check:code-quality:changed` passes with zero findings.
- `pnpm exec oxfmt --check` passes for all changed files.
- `git diff --check` passes.

## AI Review Report

The review traced renderer input/output through the paired runtime, multiplex stream, host runtime, daemon adapter, and surviving PTY. It checked the main regression risks: duplicate or missing bytes around the attach boundary, daemon generations, older daemon compatibility, unrelated PTY lifecycle changes, reconnect policy changes, broad fanout, and local/SSH provider behavior.

The implementation uses the daemon's existing atomic snapshot boundary and the runtime's existing synchronization function. It does not introduce polling or timers. The attach result is consumed only by the durable daemon provider; local and SSH providers continue returning no sequence.

Cross-platform compatibility was reviewed for macOS, Linux, and Windows. The change is platform-neutral TypeScript and touches no shortcuts, labels, paths, shell invocation, native module, or Electron platform branch. The reported failure was instrumented on the physical Windows paired host, and the deterministic paired Electron regression runs on the standard test topology.

## Security Audit

No new external input, command execution, path handling, authentication, secrets, dependency, or renderer IPC surface is introduced. The returned value is an existing daemon-produced numeric snapshot sequence, validated by the existing synchronizer as finite and non-negative before use. No follow-up security work is needed.

## Notes

- This is an internal provider contract change, not a remote wire-format change.
- Older daemons that do not publish `outputSequence` return no sequence and preserve existing behavior.
- The downside is a small increase in the internal `attach` contract surface and reliance on the daemon snapshot sequence being authoritative. That sequence is already the authority used by the ordinary reattach path, and the synchronizer rejects invalid values.
- There are no expected end-user changes beyond preserved remote panes continuing to update after host restart/reconnect.
