### PR TITLE
fix(pty): echo-safe live terminal query replies (color-scheme 997)

### DIFF
--- a/src/main/daemon/session.ts
+++ b/src/main/daemon/session.ts
@@ -18,6 +18,7 @@ import {
   type PtyIngressEmission,
   type PtyStartupIngressIntent
 } from '../../shared/pty-startup-ingress'
+import { needsCookedEchoSafeQueryReply } from '../../shared/terminal-query-reply'
 import type {
   PendingOutputRecord,
   SessionState,
@@ -229,6 +230,12 @@ export class Session {
     // direct write would race fresh input ahead of the buffered startup command.
     if (this._shellState === 'pending' || this.postReadyFlushGate.isPending) {
       this.preReadyStdinQueue.push(data)
+      return
+    }
+
+    // Why: daemon-hosted POSIX PTYs hit the same cooked-prompt 997 leak as local
+    // provider writes; share the ingress echo-safe path (#13137 / #13160 review).
+    if (needsCookedEchoSafeQueryReply(data) && this.startupIngress.answerLiveQueryReply(data)) {
       return
     }
 

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -66,6 +66,7 @@ import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../shared/hermes-startup-query
 import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
+import { isTerminalQueryReply } from '../../shared/terminal-query-reply'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
 import {
   createPtySlaveEchoProbe,
@@ -1075,6 +1076,15 @@ export class LocalPtyProvider implements IPtyProvider {
     return ptyProcesses.has(id)
   }
   write(id: string, data: string): void {
+    // Why: live xterm query replies (DSR color-scheme 997, CPR, DA, …) must use
+    // the ingress echo-safe path; raw master writes while ECHO is on paint
+    // `997;1n` into cooked prompts (#13137).
+    if (isTerminalQueryReply(data)) {
+      const ingress = startupIngressByPty.get(id)
+      if (ingress?.answerLiveQueryReply(data)) {
+        return
+      }
+    }
     ptyProcesses.get(id)?.write(data)
   }
   resize(id: string, cols: number, rows: number): void {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -66,7 +66,7 @@ import { ORCA_HERMES_STARTUP_QUERY_ENV } from '../../shared/hermes-startup-query
 import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
-import { isTerminalQueryReply } from '../../shared/terminal-query-reply'
+import { needsCookedEchoSafeQueryReply } from '../../shared/terminal-query-reply'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
 import {
   createPtySlaveEchoProbe,
@@ -1078,8 +1078,8 @@ export class LocalPtyProvider implements IPtyProvider {
   write(id: string, data: string): void {
     // Why: live xterm query replies (DSR color-scheme 997, CPR, DA, …) must use
     // the ingress echo-safe path; raw master writes while ECHO is on paint
-    // `997;1n` into cooked prompts (#13137).
-    if (isTerminalQueryReply(data)) {
+    // `997;1n` into cooked prompts (#13137). CPR/DA stay immediate (#7329).
+    if (needsCookedEchoSafeQueryReply(data)) {
       const ingress = startupIngressByPty.get(id)
       if (ingress?.answerLiveQueryReply(data)) {
         return

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -48,6 +48,7 @@ import {
   parsePtyStartupIngressIntent,
   type PtyIngressEmission
 } from '../shared/pty-startup-ingress'
+import { isTerminalQueryReply } from '../shared/terminal-query-reply'
 import { resolvePtyOwnerBackend, type PtyOwnerBackend } from '../shared/pty-owner-backend'
 import { RecentPtyOutputBuffer } from '../main/runtime/recent-pty-output-buffer'
 import { expandWindowsPathEnvironmentVariables } from '../shared/windows-environment-expansion'
@@ -1688,6 +1689,11 @@ export class PtyHandler {
     if (managed && !managed.disposed) {
       this.lastInputAtByPty.set(id, performance.now())
       this.interactiveOutputCharsByPty.set(id, 0)
+      // Why: live query replies (color-scheme 997, CPR, …) must share the startup
+      // echo-safe path or cooked prompts paint `997;1n` (#13137).
+      if (isTerminalQueryReply(data) && managed.startupIngress?.answerLiveQueryReply(data)) {
+        return
+      }
       managed.pty.write(data)
     }
   }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -48,7 +48,7 @@ import {
   parsePtyStartupIngressIntent,
   type PtyIngressEmission
 } from '../shared/pty-startup-ingress'
-import { isTerminalQueryReply } from '../shared/terminal-query-reply'
+import { needsCookedEchoSafeQueryReply } from '../shared/terminal-query-reply'
 import { resolvePtyOwnerBackend, type PtyOwnerBackend } from '../shared/pty-owner-backend'
 import { RecentPtyOutputBuffer } from '../main/runtime/recent-pty-output-buffer'
 import { expandWindowsPathEnvironmentVariables } from '../shared/windows-environment-expansion'
@@ -1689,9 +1689,12 @@ export class PtyHandler {
     if (managed && !managed.disposed) {
       this.lastInputAtByPty.set(id, performance.now())
       this.interactiveOutputCharsByPty.set(id, 0)
-      // Why: live query replies (color-scheme 997, CPR, …) must share the startup
-      // echo-safe path or cooked prompts paint `997;1n` (#13137).
-      if (isTerminalQueryReply(data) && managed.startupIngress?.answerLiveQueryReply(data)) {
+      // Why: cooked-echo-risk replies (color-scheme 997, OSC) must share the startup
+      // echo-safe path or cooked prompts paint `997;1n` (#13137). CPR stays immediate.
+      if (
+        needsCookedEchoSafeQueryReply(data) &&
+        managed.startupIngress?.answerLiveQueryReply(data)
+      ) {
         return
       }
       managed.pty.write(data)

--- a/src/shared/pty-startup-ingress-live-query-reply.test.ts
+++ b/src/shared/pty-startup-ingress-live-query-reply.test.ts
@@ -1,0 +1,81 @@
+// #13137: live xterm query replies (color-scheme 997) must use the same
+// ECHO-safe delivery as startup color replies so cooked prompts stay clean.
+import { describe, expect, it, vi } from 'vitest'
+import { PtyStartupIngress, type PtyIngressEmission } from './pty-startup-ingress'
+import type {
+  PtySlaveEchoProbe,
+  PtySlaveLineDisciplineEcho
+} from './pty-slave-line-discipline-echo'
+
+const COLOR_SCHEME_REPLY = '\x1b[?997;1n'
+const POSIX_COOKED_ECHOES = [
+  (reply: string): string => reply.replaceAll('\x1b', '^['),
+  (reply: string): string => reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', '')
+]
+
+function scriptedEchoProbe(...states: PtySlaveLineDisciplineEcho[]) {
+  let index = 0
+  const probe: PtySlaveEchoProbe & { calls: number } = Object.assign(
+    async () => {
+      probe.calls += 1
+      return states[Math.min(index++, states.length - 1)] ?? 'unknown'
+    },
+    { calls: 0 }
+  )
+  return probe
+}
+
+function visible(emissions: readonly PtyIngressEmission[]): string {
+  return emissions.map((emission) => emission.data).join('')
+}
+
+describe('PtyStartupIngress live query replies (#13137)', () => {
+  it('swallows a live color-scheme DSR reply echo after query authority closes', () => {
+    vi.useFakeTimers()
+    for (const echoOf of POSIX_COOKED_ECHOES) {
+      const writes: string[] = []
+      const emissions: PtyIngressEmission[] = []
+      let ingress!: PtyStartupIngress
+      ingress = new PtyStartupIngress({
+        ownerBackend: 'posix-pty',
+        write: (data) => {
+          writes.push(data)
+          ingress.accept(echoOf(data))
+        },
+        onEmission: (emission) => emissions.push(emission)
+      })
+
+      expect(ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)).toBe(true)
+      vi.advanceTimersByTime(0)
+      expect(writes).toEqual([COLOR_SCHEME_REPLY])
+      expect(visible(emissions)).toBe('')
+
+      ingress.accept('Ok to proceed? (y) ')
+      expect(visible(emissions)).toBe('Ok to proceed? (y) ')
+      ingress.drainAndClose()
+    }
+    vi.useRealTimers()
+  })
+
+  it('defers a live query reply while the slave is still echoing', async () => {
+    vi.useFakeTimers()
+    const writes: string[] = []
+    const probe = scriptedEchoProbe('echoing', 'echoing', 'quiet')
+    const ingress = new PtyStartupIngress({
+      ownerBackend: 'posix-pty',
+      echoProbe: probe,
+      write: (data) => writes.push(data),
+      onEmission: () => {}
+    })
+
+    expect(ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)).toBe(true)
+    await vi.advanceTimersByTimeAsync(0)
+    expect(writes).toEqual([])
+    await vi.advanceTimersByTimeAsync(20)
+    expect(writes).toEqual([])
+    await vi.advanceTimersByTimeAsync(20)
+    expect(writes).toEqual([COLOR_SCHEME_REPLY])
+    expect(probe.calls).toBe(3)
+    ingress.drainAndClose()
+  })
+})

--- a/src/shared/pty-startup-ingress-live-query-reply.test.ts
+++ b/src/shared/pty-startup-ingress-live-query-reply.test.ts
@@ -8,7 +8,11 @@ import type {
 } from './pty-slave-line-discipline-echo'
 
 const COLOR_SCHEME_REPLY = '\x1b[?997;1n'
-const POSIX_COOKED_ECHOES = [
+// Why: CSI replies only project ECHOCTL caret form — OSC-rewrite is identity and
+// would re-arm an ESC-led projection (#13160 review). OSC replies keep both.
+const POSIX_CSI_COOKED_ECHO = (reply: string): string => reply.replaceAll('\x1b', '^[')
+const OSC_COLOR_REPLY = '\x1b]11;rgb:00/00/00\x07'
+const POSIX_OSC_COOKED_ECHOES = [
   (reply: string): string => reply.replaceAll('\x1b', '^['),
   (reply: string): string => reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', '')
 ]
@@ -30,9 +34,34 @@ function visible(emissions: readonly PtyIngressEmission[]): string {
 }
 
 describe('PtyStartupIngress live query replies (#13137)', () => {
-  it('swallows a live color-scheme DSR reply echo after query authority closes', () => {
+  it('swallows a live color-scheme DSR caret echo after query authority closes', () => {
     vi.useFakeTimers()
-    for (const echoOf of POSIX_COOKED_ECHOES) {
+    const writes: string[] = []
+    const emissions: PtyIngressEmission[] = []
+    let ingress!: PtyStartupIngress
+    ingress = new PtyStartupIngress({
+      ownerBackend: 'posix-pty',
+      write: (data) => {
+        writes.push(data)
+        ingress.accept(POSIX_CSI_COOKED_ECHO(data))
+      },
+      onEmission: (emission) => emissions.push(emission)
+    })
+
+    expect(ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)).toBe(true)
+    vi.advanceTimersByTime(0)
+    expect(writes).toEqual([COLOR_SCHEME_REPLY])
+    expect(visible(emissions)).toBe('')
+
+    ingress.accept('Ok to proceed? (y) ')
+    expect(visible(emissions)).toBe('Ok to proceed? (y) ')
+    ingress.drainAndClose()
+    vi.useRealTimers()
+  })
+
+  it('swallows OSC color reply echoes under both POSIX projections', () => {
+    vi.useFakeTimers()
+    for (const echoOf of POSIX_OSC_COOKED_ECHOES) {
       const writes: string[] = []
       const emissions: PtyIngressEmission[] = []
       let ingress!: PtyStartupIngress
@@ -45,13 +74,10 @@ describe('PtyStartupIngress live query replies (#13137)', () => {
         onEmission: (emission) => emissions.push(emission)
       })
 
-      expect(ingress.answerLiveQueryReply(COLOR_SCHEME_REPLY)).toBe(true)
+      expect(ingress.answerLiveQueryReply(OSC_COLOR_REPLY)).toBe(true)
       vi.advanceTimersByTime(0)
-      expect(writes).toEqual([COLOR_SCHEME_REPLY])
+      expect(writes).toEqual([OSC_COLOR_REPLY])
       expect(visible(emissions)).toBe('')
-
-      ingress.accept('Ok to proceed? (y) ')
-      expect(visible(emissions)).toBe('Ok to proceed? (y) ')
       ingress.drainAndClose()
     }
     vi.useRealTimers()

--- a/src/shared/pty-startup-ingress.ts
+++ b/src/shared/pty-startup-ingress.ts
@@ -92,6 +92,18 @@ export class PtyStartupIngress {
     return this.rawHighWater
   }
 
+  /**
+   * Live emulator query replies (xterm onData CPR/DSR/DA/OSC/color-scheme 997).
+   * Uses the same ECHO-safe write + echo strip as startup color replies so cooked
+   * prompts (e.g. `npx` confirm) never show `997;1n` junk (#13137 / #12112 family).
+   */
+  answerLiveQueryReply(reply: string): boolean {
+    if (this.closed || reply.length === 0) {
+      return false
+    }
+    return this.delivery.answer(reply)
+  }
+
   drainAndClose(): number {
     this.enqueue({ kind: 'teardown' })
     return this.rawHighWater

--- a/src/shared/pty-startup-reply-delivery.ts
+++ b/src/shared/pty-startup-reply-delivery.ts
@@ -98,21 +98,24 @@ function replyEchoProjections(
   // reply, so a bare trailing ESC — how any read can end — is a strict prefix of it.
   // That read would be held as an echo candidate, and an expired hold releases its
   // bytes raw, past the query parser, so a query torn at its own ESC is never answered.
-  return [
-    // ECHOCTL (default cooked tty) renders each control byte as its caret form. This is
-    // the ONE projection the probe can retire, because it is the kernel's echo and a
-    // cleared ECHO bit is proof it cannot happen.
-    ...(kernelEchoImpossible ? [] : [reply.replaceAll('\x1b', '^[')]),
-    // readline: `ESC ]` is an unbound binding, so it is eaten (with a bell) and the
-    // remainder self-inserts; the ST is eaten the same way. Software echo — survives
-    // `quiet`, because readline does this with the tty already raw and ECHO off.
-    //
-    // This buys display cleanliness ONLY. The bytes self-inserted into readline's edit
-    // buffer are still there, so a user who then presses Enter runs them: `bash: 10:
-    // command not found`, with nothing on screen to explain it. Not fixable by
-    // suppressing harder — undoing it means writing a kill-line into someone's prompt.
-    reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', '')
-  ]
+  const projections: string[] = []
+  // ECHOCTL (default cooked tty) renders each control byte as its caret form. This is
+  // the ONE projection the probe can retire, because it is the kernel's echo and a
+  // cleared ECHO bit is proof it cannot happen.
+  if (!kernelEchoImpossible) {
+    projections.push(reply.replaceAll('\x1b', '^['))
+  }
+  // readline: `ESC ]` is an unbound binding, so it is eaten (with a bell) and the
+  // remainder self-inserts; the ST is eaten the same way. Software echo — survives
+  // `quiet`, because readline does this with the tty already raw and ECHO off.
+  //
+  // Only emit when the reply actually contains OSC open/ST. For CSI (e.g. ?997;1n)
+  // the replace is a no-op and would re-project the verbatim ESC-led reply — which
+  // violates the no-ESC-prefix rule and 500ms-holds partial ESC tails (#13160 review).
+  if (reply.includes('\x1b]')) {
+    projections.push(reply.replaceAll('\x1b]', '\x07').replaceAll('\x1b\\', ''))
+  }
+  return projections
 }
 
 /** Earliest offset whose suffix of `data` is a strict prefix of `projection`, else -1. */

--- a/src/shared/terminal-query-reply.test.ts
+++ b/src/shared/terminal-query-reply.test.ts
@@ -1,6 +1,6 @@
 import { Terminal } from '@xterm/headless'
 import { describe, expect, it } from 'vitest'
-import { isTerminalQueryReply } from './terminal-query-reply'
+import { isTerminalQueryReply, needsCookedEchoSafeQueryReply } from './terminal-query-reply'
 
 describe('isTerminalQueryReply', () => {
   it('matches synthetic query replies that must be sent immediately', () => {
@@ -62,6 +62,16 @@ describe('isTerminalQueryReply', () => {
     // Classified as a reply on purpose: order is still preserved (the immediate
     // path flushes pending input first); see the comment in terminal-query-reply.ts.
     expect(isTerminalQueryReply('\x1b[1;2R')).toBe(true)
+  })
+
+  it('routes only cooked-echo-risk replies through the ECHO-safe write path', () => {
+    // Color-scheme private DSR + OSC color — cooked prompt paint risk (#13137).
+    expect(needsCookedEchoSafeQueryReply('\x1b[?997;1n')).toBe(true)
+    expect(needsCookedEchoSafeQueryReply('\x1b]11;rgb:00/00/00\x07')).toBe(true)
+    // Latency-critical CPR / public DSR / DA stay immediate (#7329 / #13160 review).
+    expect(needsCookedEchoSafeQueryReply('\x1b[3;1R')).toBe(false)
+    expect(needsCookedEchoSafeQueryReply('\x1b[0n')).toBe(false)
+    expect(needsCookedEchoSafeQueryReply('\x1b[?1;2c')).toBe(false)
   })
 
   it('does NOT match ordinary typed input or navigation sequences', () => {

--- a/src/shared/terminal-query-reply.test.ts
+++ b/src/shared/terminal-query-reply.test.ts
@@ -9,6 +9,9 @@ describe('isTerminalQueryReply', () => {
     expect(isTerminalQueryReply('\x1b[22;1R')).toBe(true)
     // DSR device status.
     expect(isTerminalQueryReply('\x1b[0n')).toBe(true)
+    // Contour color-scheme report (answer to CSI ?996n / mode-2031 push).
+    expect(isTerminalQueryReply('\x1b[?997;1n')).toBe(true)
+    expect(isTerminalQueryReply('\x1b[?997;2n')).toBe(true)
     // DA1/DA2/DA3 device attributes.
     expect(isTerminalQueryReply('\x1b[?1;2c')).toBe(true)
     expect(isTerminalQueryReply('\x1b[?61;4c')).toBe(true)

--- a/src/shared/terminal-query-reply.ts
+++ b/src/shared/terminal-query-reply.ts
@@ -41,6 +41,8 @@ const OSC_RESPONSE_RE = new RegExp('^\\u001b\\][0-9]+;[^\\u0007\\u001b]*(?:\\u00
 // DCS-framed reports xterm emits: DECRQSS "ESC P 1 $ r Pt ST" / "ESC P 0 $ r ST"
 // (vim queries cursor style this way) and XTVERSION "ESC P > | text ST".
 const DCS_RESPONSE_RE = new RegExp('^\\u001bP(?:[01]\\$r[^\\u001b]*|>\\|[^\\u001b]*)\\u001b\\\\$')
+// Private-mode DSR (CSI ? … n) — e.g. color-scheme `?997;1n` — often lands cooked.
+const COOKED_ECHO_RISK_PRIVATE_DSR_RE = new RegExp('^\\u001b\\[\\?[0-9;]*n$')
 /* oxlint-enable no-control-regex */
 
 /**
@@ -66,4 +68,16 @@ export function isTerminalQueryReply(data: string): boolean {
     OSC_RESPONSE_RE.test(data) ||
     DCS_RESPONSE_RE.test(data)
   )
+}
+
+/**
+ * Query replies that must use the ECHO-safe write path on POSIX PTYs so cooked
+ * prompts do not paint reply bytes (e.g. `997;1n` on `npx` confirm, #13137).
+ * Latency-critical CPR/DSR without `?` stay on the immediate write path.
+ */
+export function needsCookedEchoSafeQueryReply(data: string): boolean {
+  if (data.length < 4 || data[0] !== ESC) {
+    return false
+  }
+  return COOKED_ECHO_RISK_PRIVATE_DSR_RE.test(data) || OSC_RESPONSE_RE.test(data)
 }


### PR DESCRIPTION
## Summary

- xterm answers Contour color-scheme queries (\`CSI ?996n\`) with \`CSI ?997;1n\` / \`;2n\` via \`onData\` → PTY write.
- On POSIX, writing that reply while the slave still has **ECHO** on paints the reply into cooked prompts — e.g. \`npx skills update\` confirm shows \`997;1n\`.
- Startup color replies already use \`PtyStartupReplyDelivery\` (#12112). Live query replies now take the same path on local + SSH relay writes.

Closes #13137

## Test plan

- [x] Live color-scheme reply echo swallowed after query authority closes
- [x] Live reply deferred while echo probe says echoing
- [x] \`isTerminalQueryReply\` recognizes \`?997;1n\` / \`?997;2n\`
- [x] Existing startup ingress suite green