### PR TITLE
fix(terminal): pin park verdict on slow notice-limit churn

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.test.ts
@@ -1,6 +1,12 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
-import type { ParkVerdictFlipRecord } from './terminal-park-verdict-flip-telemetry'
+import {
+  TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS,
+  TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
+  TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+  recordParkVerdictFlips,
+  type ParkVerdictFlipRecord
+} from './terminal-park-verdict-flip-telemetry'
 import { withholdUnparkableTerminalTabs } from './terminal-cold-park-withheld-tabs'
 
 const coverage = vi.hoisted(() => ({ byTabId: new Map<string, boolean>() }))
@@ -94,6 +100,44 @@ describe('withholdUnparkableTerminalTabs', () => {
 
     expect(parkedTabIds.has('tab-a')).toBe(true)
     expect(parkVerdictPinUntilMsByTabId.size).toBe(0)
+  })
+
+  // Why: field #12596 notice-limit pin must reach this gate, not only burst pins.
+  it('withholds a tab pinned by slow notice-limit churn', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    const tabId = 'tab-a'
+    let lastNow = 1_000
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      lastNow = 1_000 + i * TERMINAL_TAB_PARK_FLIP_BURST_WINDOW_MS * 4
+      recordParkVerdictFlips({
+        records,
+        liveTabIds: new Set([tabId]),
+        nextParkedTabIds: i % 2 === 0 ? new Set([tabId]) : new Set(),
+        nowMs: lastNow
+      })
+    }
+
+    const live = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab(tabId)],
+      coldParkedTabIds: new Set([tabId]),
+      parkVerdictRecords: records,
+      nowMs: lastNow
+    })
+    expect(live.parkedTabIds.has(tabId)).toBe(false)
+    expect(live.parkVerdictPinUntilMsByTabId.get(tabId)).toBe(
+      lastNow + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+    )
+
+    const lapsed = withholdUnparkableTerminalTabs({
+      worktreeId: WORKTREE,
+      terminalTabs: [terminalTab(tabId)],
+      coldParkedTabIds: new Set([tabId]),
+      parkVerdictRecords: records,
+      nowMs: lastNow + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+    })
+    expect(lapsed.parkedTabIds.has(tabId)).toBe(true)
+    expect(lapsed.parkVerdictPinUntilMsByTabId.size).toBe(0)
   })
 
   it('does not consult non-candidates and leaves the input set untouched', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-cold-park-withheld-tabs.ts
@@ -2,9 +2,9 @@
  * Last gate between a cold-park candidate and an unmounted pane.
  *
  * Two reasons withhold a tab, both settling on the safe mounted side: the byte
- * watchers cannot cover it, or a verdict-flip burst pinned it. The pin deadline
- * is returned because it is also the only remaining recheck wakeup once damping
- * has stopped the churn that was waking the parking effect.
+ * watchers cannot cover it, or a verdict-flip pin (burst or notice-limit) holds
+ * it. The pin deadline is returned because it is also the only remaining recheck
+ * wakeup once damping has stopped the churn that was waking the parking effect.
  */
 import type { TerminalTab } from '../../../../shared/terminal-tab-types'
 import {

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -77,7 +77,7 @@ describe('recordParkVerdictFlips', () => {
   })
 
   // Why: the two triggers answer different questions — 'burst' means damping
-  // engaged before React could bail, 'window' means churn too slow to loop.
+  // engaged before React could bail, 'window' means field-rate churn (#12596).
   it('separates a damped burst from slow churn', () => {
     const tightRecords = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 40; i += 1) {
@@ -106,20 +106,23 @@ describe('recordParkVerdictFlips', () => {
         trigger: 'window',
         flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
         elapsedMs: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT * SLOW_CHURN_STEP_MS,
-        windowMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+        windowMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+        pinnedForMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
       })
     )
   })
 
-  // Why: slow churn must not be damped — parking it out for a minute would cost
-  // a mounted pane's memory for a verdict that was never near React's bail.
-  it('does not pin churn spread past the burst window', () => {
+  // Why: field #12596 measure-lease churn is ~2.5s/flip — never hits the 1s
+  // burst window, so the notice limit must pin too.
+  it('pins slow notice-limit churn from the measure-lease period', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
+    let lastNow = 1_000
     for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
-      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * SLOW_CHURN_STEP_MS })
+      lastNow = 1_000 + i * SLOW_CHURN_STEP_MS
+      observe({ records, parked: i % 2 === 0, nowMs: lastNow })
     }
 
-    expect(records.get(TAB)?.pinnedUntilMs ?? null).toBeNull()
+    expect(records.get(TAB)?.pinnedUntilMs).toBe(lastNow + TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
   })
 
   it('re-arms after the window elapses', () => {

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.test.ts
@@ -78,7 +78,7 @@ describe('recordParkVerdictFlips', () => {
   })
 
   // Why: the two triggers answer different questions — 'burst' means damping
-  // engaged before React could bail, 'window' means churn too slow to loop.
+  // engaged before React could bail, 'window' means field-rate churn (#12596).
   it('separates a damped burst from slow churn', () => {
     const tightRecords = new Map<string, ParkVerdictFlipRecord>()
     for (let i = 0; i < 40; i += 1) {
@@ -107,20 +107,32 @@ describe('recordParkVerdictFlips', () => {
         trigger: 'window',
         flips: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT,
         elapsedMs: TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT * SLOW_CHURN_STEP_MS,
-        windowMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+        windowMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS,
+        pinnedForMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
       })
     )
   })
 
-  // Why: slow churn must not be damped — parking it out for a minute would cost
-  // a mounted pane's memory for a verdict that was never near React's bail.
-  it('does not pin churn spread past the burst window', () => {
+  // Why: field #12596 measure-lease churn is ~2.5s/flip — never hits the 1s
+  // burst window, so the notice limit must pin too.
+  it('pins slow notice-limit churn from the measure-lease period', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
+    let lastNow = 1_000
     for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
-      observe({ records, parked: i % 2 === 0, nowMs: 1_000 + i * SLOW_CHURN_STEP_MS })
+      lastNow = 1_000 + i * SLOW_CHURN_STEP_MS
+      observe({ records, parked: i % 2 === 0, nowMs: lastNow })
     }
 
-    expect(records.get(TAB)?.pinnedUntilMs ?? null).toBeNull()
+    expect(records.get(TAB)?.pinnedUntilMs).toBe(lastNow + TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
+
+    // A live notice pin must not emit a second window crumb.
+    observe({
+      records,
+      parked: (TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1) % 2 === 0,
+      nowMs: lastNow + SLOW_CHURN_STEP_MS
+    })
+    expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
   })
 
   it('re-arms after the window elapses', () => {
@@ -180,7 +192,12 @@ describe('recordParkVerdictFlips', () => {
     expect(recordBreadcrumb).toHaveBeenCalledTimes(1)
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ trigger: 'window', flips: 3, windowMs: 5_000 })
+      expect.objectContaining({
+        trigger: 'window',
+        flips: 3,
+        windowMs: 5_000,
+        pinnedForMs: 5_000
+      })
     )
   })
 
@@ -260,6 +277,22 @@ describe('getParkVerdictUnparkPinUntilMs', () => {
     )
   })
 
+  it('reports a notice-limit pin deadline, then re-arms after expiry', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    let pinnedAtMs = 1_000
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      pinnedAtMs = 1_000 + i * SLOW_CHURN_STEP_MS
+      observe({ records, parked: i % 2 === 0, nowMs: pinnedAtMs })
+    }
+    const pinUntilMs = pinnedAtMs + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinnedAtMs + 1 })).toBe(
+      pinUntilMs
+    )
+    expect(getParkVerdictUnparkPinUntilMs({ records, tabId: TAB, nowMs: pinUntilMs })).toBeNull()
+    expect(records.get(TAB)?.pinnedUntilMs).toBeNull()
+  })
+
   // Why: a backwards clock jump must release the pin, not strand it for a window.
   it('releases the pin when the clock jumps backwards', () => {
     const records = new Map<string, ParkVerdictFlipRecord>()
@@ -334,8 +367,12 @@ describe('expired pins stop gating breadcrumbs', () => {
 
     expect(recordBreadcrumb).toHaveBeenCalledWith(
       'terminal_park_verdict_churn',
-      expect.objectContaining({ trigger: 'window' })
+      expect.objectContaining({
+        trigger: 'window',
+        pinnedForMs: TERMINAL_TAB_PARK_FLIP_WINDOW_MS
+      })
     )
+    expect(records.get(TAB)?.pinnedUntilMs).toBeGreaterThan(afterPinMs)
   })
 
   // Why: the pin is set from flips on the rendered verdict, so it has to be
@@ -356,6 +393,28 @@ describe('expired pins stop gating breadcrumbs', () => {
       records,
       tabIds: [TAB],
       nowMs: 1_000 + TERMINAL_TAB_PARK_FLIP_WINDOW_MS * 3
+    })
+    expect(lapsed.pinnedTabIds.size).toBe(0)
+    expect(lapsed.earliestPinExpiryMs).toBeNull()
+    expect(records.get(TAB)?.pinnedUntilMs).toBeNull()
+  })
+
+  it('selects and expires a notice-limit pin the same way as a burst pin', () => {
+    const records = new Map<string, ParkVerdictFlipRecord>()
+    let lastNow = 1_000
+    for (let i = 0; i < TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT + 1; i += 1) {
+      lastNow = 1_000 + i * SLOW_CHURN_STEP_MS
+      observe({ records, parked: i % 2 === 0, nowMs: lastNow })
+    }
+
+    const pinned = selectParkVerdictPinnedTabIds({ records, tabIds: [TAB], nowMs: lastNow })
+    expect(pinned.pinnedTabIds).toEqual(new Set([TAB]))
+    expect(pinned.earliestPinExpiryMs).toBe(lastNow + TERMINAL_TAB_PARK_FLIP_WINDOW_MS)
+
+    const lapsed = selectParkVerdictPinnedTabIds({
+      records,
+      tabIds: [TAB],
+      nowMs: lastNow + TERMINAL_TAB_PARK_FLIP_WINDOW_MS
     })
     expect(lapsed.pinnedTabIds.size).toBe(0)
     expect(lapsed.earliestPinExpiryMs).toBeNull()

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -1,18 +1,19 @@
 /**
  * Cold-park verdict telemetry and a safe-side circuit breaker.
  * Field breadcrumbs prove render-cadence flips, but not which eligibility input
- * oscillates; burst damping keeps the pane mounted before React reaches #185.
+ * oscillates. Damping pins the verdict mounted on:
+ *   - **burst** — flips inside 1s (React #185 risk), and
+ *   - **window** — notice-limit flips inside 60s (field #12596: measure-lease
+ *     churn at ~2.5s/flip never hit the burst window).
  *
- * Scope: flips are counted on the rendered verdict, but the pin can only
- * subtract from the cold-park candidate set. Churn driven by the other parked
- * inputs (forced parking, portal ownership, deferred activation mounts) is
- * observed and breadcrumbed, not damped — read a repeating `burst` crumb for
- * one tab as "damping did not reach the oscillating input".
+ * Scope: the pin only subtracts from the cold-park candidate set. Forced
+ * parking / portal ownership / deferred activation can still flip; read a
+ * repeating crumb after pin as "damping did not reach that input".
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 
 export const TERMINAL_TAB_PARK_FLIP_WINDOW_MS = 60_000
-/** Flips per window that no sane park policy should reach. Breadcrumb only. */
+/** Flips per 60s window that engage slow-churn pin + breadcrumb (#12596). */
 export const TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT = 12
 
 /** react-dom 19.2.x nested commit limit. */
@@ -38,7 +39,7 @@ export type ParkVerdictFlipRecord = {
   notified: boolean
   burstStartMs: number
   burstFlips: number
-  /** Set when a flip burst engaged damping; the verdict stays unparked until then. */
+  /** Set when burst or notice-limit damping engages; verdict stays unparked until then. */
   pinnedUntilMs?: number | null
 }
 
@@ -158,6 +159,10 @@ export function recordParkVerdictFlips(args: {
     // exists to keep down.
     if (!isParkVerdictPinLive(record, nowMs) && !record.notified && record.flips >= noticeLimit) {
       record.notified = true
+      // Why: field #12596 saw 12 flips / ~30s from the ~3s measure lease — too
+      // slow for the burst window, but long enough to thrash remounts/reloads.
+      // Pin for the remaining notice window so cold-park withholds unparking.
+      record.pinnedUntilMs = nowMs + flipWindowMs
       // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
       // field that separates slow churn from a burst the damping already caught.
       recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
@@ -165,7 +170,8 @@ export function recordParkVerdictFlips(args: {
         trigger: 'window',
         flips: record.flips,
         elapsedMs: nowMs - record.windowStartMs,
-        windowMs: flipWindowMs
+        windowMs: flipWindowMs,
+        pinnedForMs: flipWindowMs
       })
     }
   }

--- a/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-park-verdict-flip-telemetry.ts
@@ -1,20 +1,23 @@
 /**
  * Cold-park verdict telemetry and a safe-side circuit breaker.
  * Field breadcrumbs prove render-cadence flips, but not which eligibility input
- * oscillates; burst damping keeps the pane mounted before React reaches #185.
+ * oscillates. Damping pins the verdict mounted on:
+ *   - **burst** — flips inside 1s (React #185 risk), and
+ *   - **window** — notice-limit flips inside 60s (field #12596: measure-lease
+ *     churn at ~2.5s/flip never hit the burst window).
  *
  * Scope: flips are counted on the rendered verdict and the pin subtracts from
  * that same verdict (selectParkVerdictPinnedTabIds), so churn driven by any
  * parked input — worktree-level park, portal ownership, deferred activation
- * mounts — is damped, not only the cold-park candidate set. A repeating `burst`
- * crumb for one tab therefore means the driver keeps re-proposing the park once
+ * mounts — is damped, not only the cold-park candidate set. A repeating crumb
+ * for one tab therefore means the driver keeps re-proposing the park once
  * each pin lapses, not that damping never reached it.
  */
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
 import { REACT_NESTED_UPDATE_LIMIT } from '../../../../shared/react-update-depth-attribution'
 
 export const TERMINAL_TAB_PARK_FLIP_WINDOW_MS = 60_000
-/** Flips per window that no sane park policy should reach. Breadcrumb only. */
+/** Flips per 60s window that engage slow-churn pin + breadcrumb (#12596). */
 export const TERMINAL_TAB_PARK_FLIP_NOTICE_LIMIT = 12
 
 /** Measured upper bound after the passive-effect pin engages. */
@@ -38,7 +41,7 @@ export type ParkVerdictFlipRecord = {
   notified: boolean
   burstStartMs: number
   burstFlips: number
-  /** Set when a flip burst engaged damping; the verdict stays unparked until then. */
+  /** Set when burst or notice-limit damping engages; verdict stays unparked until then. */
   pinnedUntilMs?: number | null
 }
 
@@ -158,6 +161,10 @@ export function recordParkVerdictFlips(args: {
     // exists to keep down.
     if (!isParkVerdictPinLive(record, nowMs) && !record.notified && record.flips >= noticeLimit) {
       record.notified = true
+      // Why: field #12596 saw 12 flips / ~30s from the ~3s measure lease — too
+      // slow for the burst window, but long enough to thrash remounts/reloads.
+      // Pin so withholdUnparkableTerminalTabs keeps the pane mounted.
+      record.pinnedUntilMs = nowMs + flipWindowMs
       // Why: flips is always exactly noticeLimit here, so elapsedMs is the only
       // field that separates slow churn from a burst the damping already caught.
       recordRendererCrashBreadcrumb('terminal_park_verdict_churn', {
@@ -165,7 +172,8 @@ export function recordParkVerdictFlips(args: {
         trigger: 'window',
         flips: record.flips,
         elapsedMs: nowMs - record.windowStartMs,
-        windowMs: flipWindowMs
+        windowMs: flipWindowMs,
+        pinnedForMs: flipWindowMs
       })
     }
   }


### PR DESCRIPTION
## Summary

When a terminal's park verdict changes 12 times within 60 seconds, keep that pane mounted for the following 60 seconds. Previously, only rapid bursts engaged this damping; slower repeated changes emitted a breadcrumb while remount churn continued. The window breadcrumb now records the pin duration.

The existing rendered-verdict gate consumes the pin, including worktree-driven parking. Burst damping, expiration, backward-clock handling and duplicate-breadcrumb suppression remain intact. Tests replace the old expectation that slow churn never pins and cover release after expiration.

Addresses the slow-churn case in #12596.

## Validation

At `4d76e4b8bcadbbbcc2c7f4a2e0016cb447042a88`, independent verification passed 29 tests across telemetry, withholding, cold-park loop and worktree-driver loop suites. Web TypeScript (`--composite false`), changed-file lint, formatting and diff whitespace checks passed. Independent Cursor review passed for this exact commit.

Full repository tests, packaging and live Electron/SSH smoke tests were not run for this scoped renderer change. No layout, OS-path, shortcut or wire-contract changes; SSH and folder workspaces use the same verdict gate.

## AI disclosure

Cursor ported and reviewed this change; Codex independently checked the source, original requirements and validation results before updating the PR.
