### PR TITLE
fix(terminal): deliver SIGWINCH to the PTY foreground process group

### DIFF
--- a/src/main/daemon/pty-subprocess.ts
+++ b/src/main/daemon/pty-subprocess.ts
@@ -17,6 +17,8 @@ import {
   validateWorkingDirectory
 } from '../providers/local-pty-utils'
 import { wrapShellSpawnForMacosTccAttribution } from '../providers/macos-tcc-login-shell'
+import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
+import { readPtsName } from '../pty/node-pty-pts-name'
 import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
 import {
   resolveEffectiveWindowsPowerShell,
@@ -1239,11 +1241,22 @@ export function createPtySubprocess(opts: PtySubprocessOptions): SubprocessHandl
       if (dead) {
         return
       }
-      try {
-        process.kill(proc.pid, sig)
-      } catch {
-        // Process may already be dead
+      const signalRootPid = (): void => {
+        try {
+          process.kill(proc.pid, sig)
+        } catch {
+          // Process may already be dead
+        }
       }
+      // Why only SIGWINCH: the kernel delivers a real resize to the tty's foreground
+      // group, and proc.pid is never in it (the shell setpgid's away, and on macOS
+      // proc.pid is login(1), which drops SIGWINCH). Destructive signals keep the
+      // narrower root-pid target.
+      if (sig === 'SIGWINCH') {
+        signalPosixPtyForegroundGroup(proc.pid, readPtsName(proc), sig, signalRootPid)
+        return
+      }
+      signalRootPid()
     },
     onData: (cb) => {
       onDataCb = cb

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -67,6 +67,8 @@ import { PhysicalExitTracker } from '../../shared/physical-exit-tracker'
 import { mergeGitConfigEnvProtocol } from '../../shared/git-credential-prompt-env'
 import { PtyStartupIngress, type PtyIngressEmission } from '../../shared/pty-startup-ingress'
 import { resolvePtyOwnerBackend } from '../../shared/pty-owner-backend'
+import { signalPosixPtyForegroundGroup } from '../pty/posix-pty-foreground-group'
+import { readPtsName } from '../pty/node-pty-pts-name'
 import {
   createPtySlaveEchoProbe,
   readPtySlavePath
@@ -1207,11 +1209,20 @@ export class LocalPtyProvider implements IPtyProvider {
     if (!proc) {
       return
     }
-    try {
-      process.kill(proc.pid, signal)
-    } catch {
-      /* Process may already be dead */
+    const signalRootPid = (): void => {
+      try {
+        process.kill(proc.pid, signal)
+      } catch {
+        /* Process may already be dead */
+      }
     }
+    // Why only SIGWINCH: see posix-pty-foreground-group — a real resize reaches the
+    // tty's foreground group, which proc.pid is never a member of.
+    if (signal === 'SIGWINCH') {
+      signalPosixPtyForegroundGroup(proc.pid, readPtsName(proc), signal, signalRootPid)
+      return
+    }
+    signalRootPid()
   }
 
   async getCwd(id: string): Promise<string> {

--- a/src/main/pty/node-pty-pts-name.ts
+++ b/src/main/pty/node-pty-pts-name.ts
@@ -1,0 +1,10 @@
+/**
+ * node-pty's unix terminal exposes the slave device path (`/dev/ttys003`,
+ * `/dev/pts/3`) but does not declare it on IPty, and the Windows terminal has no
+ * equivalent. Read it defensively so callers get `undefined` rather than a throw
+ * on a platform or version that lacks it.
+ */
+export function readPtsName(proc: unknown): string | undefined {
+  const value = (proc as { ptsName?: unknown } | null | undefined)?.ptsName
+  return typeof value === 'string' && value.length > 0 ? value : undefined
+}

--- a/src/main/pty/posix-pty-foreground-group.test.ts
+++ b/src/main/pty/posix-pty-foreground-group.test.ts
@@ -137,12 +137,16 @@ describe('process table lookup', () => {
       })
 
       expect(execFileSyncMock).toHaveBeenCalled()
+      let timeoutBudget = 0
       for (const call of execFileSyncMock.mock.calls) {
         const args = call[1] as string[]
+        const options = call[2] as { timeout: number }
         const pidArg = args[args.indexOf('-p') + 1]
         expect(pidArg).toMatch(/^\d+$/)
         expect(args.filter((arg) => arg === '-p')).toHaveLength(1)
+        timeoutBudget += options.timeout
       }
+      expect(timeoutBudget).toBeLessThanOrEqual(250)
     } finally {
       kill.mockRestore()
     }

--- a/src/main/pty/posix-pty-foreground-group.test.ts
+++ b/src/main/pty/posix-pty-foreground-group.test.ts
@@ -1,0 +1,150 @@
+import { describe, expect, it, vi } from 'vitest'
+import { execFileSync } from 'node:child_process'
+import {
+  getPosixPtyForegroundGroup,
+  signalPosixPtyForegroundGroup
+} from './posix-pty-foreground-group'
+
+vi.mock('node:child_process', () => ({ execFileSync: vi.fn(() => '') }))
+
+// The concatenated output of two `ps -p <pid> -o pid=,tpgid=,tty=` calls.
+const macosTable = ['84644 84985 ttys318', '  4242     4242 ttys002'].join('\n')
+
+describe('getPosixPtyForegroundGroup', () => {
+  it('returns the tty foreground group, not the root pid group', () => {
+    // Why: on macOS the root is login(1) and the shell setpgid's into its own group,
+    // so the root pid is never a member of the group a real resize signals.
+    expect(getPosixPtyForegroundGroup(macosTable, 84644, '/dev/ttys318', 4242)).toBe(84985)
+  })
+
+  it('accepts a Linux pts device name', () => {
+    expect(getPosixPtyForegroundGroup('900 931 pts/3', 900, '/dev/pts/3', 4242)).toBe(931)
+  })
+
+  it('refuses when the pid now answers for a different tty', () => {
+    // Why: `ps -p` answers for whoever owns the pid now — a recycled pid must not
+    // aim a group signal at a real terminal.
+    expect(getPosixPtyForegroundGroup(macosTable, 84644, '/dev/ttys999', 4242)).toBeNull()
+  })
+
+  it('refuses when this process shares the PTY', () => {
+    // Why: a dev daemon can inherit its launch TTY; group-signalling would hit Orca.
+    const shared = ['84644 84985 ttys318', '4242 84985 ttys318'].join('\n')
+    expect(getPosixPtyForegroundGroup(shared, 84644, '/dev/ttys318', 4242)).toBeNull()
+  })
+
+  it('refuses a detached tty or an unowned foreground group', () => {
+    expect(getPosixPtyForegroundGroup('84644 84985 ??', 84644, '/dev/ttys318', 4242)).toBeNull()
+    expect(getPosixPtyForegroundGroup('84644 -1 ttys318', 84644, '/dev/ttys318', 4242)).toBeNull()
+    expect(getPosixPtyForegroundGroup('84644 1 ttys318', 84644, '/dev/ttys318', 4242)).toBeNull()
+  })
+
+  it('refuses when the root pid is absent from the table', () => {
+    expect(getPosixPtyForegroundGroup('4242 4242 ttys002', 84644, '/dev/ttys318', 4242)).toBeNull()
+  })
+})
+
+describe('signalPosixPtyForegroundGroup', () => {
+  const table = (): string => macosTable
+
+  it('signals the negated foreground group', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+    const fallback = vi.fn()
+    try {
+      signalPosixPtyForegroundGroup(84644, '/dev/ttys318', 'SIGWINCH', fallback, {
+        platform: 'darwin',
+        currentPid: 4242,
+        readProcessTable: table
+      })
+      expect(kill).toHaveBeenCalledWith(-84985, 'SIGWINCH')
+      expect(fallback).not.toHaveBeenCalled()
+    } finally {
+      kill.mockRestore()
+    }
+  })
+
+  it('falls back to the root pid on Windows', () => {
+    // Why: a negative pid is invalid there, and SIGTERM/SIGINT mean terminate.
+    const fallback = vi.fn()
+    signalPosixPtyForegroundGroup(84644, undefined, 'SIGWINCH', fallback, {
+      platform: 'win32',
+      currentPid: 4242,
+      readProcessTable: table
+    })
+    expect(fallback).toHaveBeenCalledOnce()
+  })
+
+  it('falls back when the slave device name is unknown', () => {
+    const fallback = vi.fn()
+    signalPosixPtyForegroundGroup(84644, undefined, 'SIGWINCH', fallback, {
+      platform: 'darwin',
+      currentPid: 4242,
+      readProcessTable: table
+    })
+    expect(fallback).toHaveBeenCalledOnce()
+  })
+
+  it('falls back when the process table cannot be read', () => {
+    const fallback = vi.fn()
+    signalPosixPtyForegroundGroup(84644, '/dev/ttys318', 'SIGWINCH', fallback, {
+      platform: 'darwin',
+      currentPid: 4242,
+      readProcessTable: () => {
+        throw new Error('ps timed out')
+      }
+    })
+    expect(fallback).toHaveBeenCalledOnce()
+  })
+
+  it('treats a vanished foreground group as done rather than falling back', () => {
+    // Why: the fallback target is just as stale, and re-signalling a recycled pid is worse.
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('no such process') as NodeJS.ErrnoException
+      error.code = 'ESRCH'
+      throw error
+    })
+    const fallback = vi.fn()
+    try {
+      signalPosixPtyForegroundGroup(84644, '/dev/ttys318', 'SIGWINCH', fallback, {
+        platform: 'darwin',
+        currentPid: 4242,
+        readProcessTable: table
+      })
+      expect(fallback).not.toHaveBeenCalled()
+    } finally {
+      kill.mockRestore()
+    }
+  })
+})
+
+describe('process table lookup', () => {
+  it('asks ps for one pid at a time', () => {
+    // Why pinned: macOS ps only takes its by-pid fast path for a SINGLE pid. Any list
+    // form walks the whole process table (~3.6s on a busy machine vs ~3ms), which
+    // exceeds this module's timeout and silently reinstates root-pid delivery — the
+    // exact bug it exists to fix. Regressing this looks like a working feature.
+    const execFileSyncMock = vi.mocked(execFileSync)
+    execFileSyncMock.mockClear()
+    execFileSyncMock.mockReturnValue('84644 84985 ttys318' as never)
+    // Why stubbed: the resolver succeeds against the mocked table, so a live
+    // process.kill would aim a real group signal at whatever owns pgid 84985 here.
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => true)
+
+    try {
+      signalPosixPtyForegroundGroup(84644, '/dev/ttys318', 'SIGWINCH', vi.fn(), {
+        platform: 'darwin',
+        currentPid: 4242
+      })
+
+      expect(execFileSyncMock).toHaveBeenCalled()
+      for (const call of execFileSyncMock.mock.calls) {
+        const args = call[1] as string[]
+        const pidArg = args[args.indexOf('-p') + 1]
+        expect(pidArg).toMatch(/^\d+$/)
+        expect(args.filter((arg) => arg === '-p')).toHaveLength(1)
+      }
+    } finally {
+      kill.mockRestore()
+    }
+  })
+})

--- a/src/main/pty/posix-pty-foreground-group.test.ts
+++ b/src/main/pty/posix-pty-foreground-group.test.ts
@@ -66,7 +66,7 @@ describe('signalPosixPtyForegroundGroup', () => {
   it('falls back to the root pid on Windows', () => {
     // Why: a negative pid is invalid there, and SIGTERM/SIGINT mean terminate.
     const fallback = vi.fn()
-    signalPosixPtyForegroundGroup(84644, undefined, 'SIGWINCH', fallback, {
+    signalPosixPtyForegroundGroup(84644, '/dev/ttys318', 'SIGWINCH', fallback, {
       platform: 'win32',
       currentPid: 4242,
       readProcessTable: table
@@ -111,6 +111,25 @@ describe('signalPosixPtyForegroundGroup', () => {
         readProcessTable: table
       })
       expect(fallback).not.toHaveBeenCalled()
+    } finally {
+      kill.mockRestore()
+    }
+  })
+
+  it('falls back when foreground group signalling fails', () => {
+    const kill = vi.spyOn(process, 'kill').mockImplementation(() => {
+      const error = new Error('operation not permitted') as NodeJS.ErrnoException
+      error.code = 'EPERM'
+      throw error
+    })
+    const fallback = vi.fn()
+    try {
+      signalPosixPtyForegroundGroup(84644, '/dev/ttys318', 'SIGWINCH', fallback, {
+        platform: 'darwin',
+        currentPid: 4242,
+        readProcessTable: table
+      })
+      expect(fallback).toHaveBeenCalledOnce()
     } finally {
       kill.mockRestore()
     }

--- a/src/main/pty/posix-pty-foreground-group.ts
+++ b/src/main/pty/posix-pty-foreground-group.ts
@@ -1,0 +1,135 @@
+import { execFileSync } from 'node:child_process'
+
+const PROCESS_TABLE_TIMEOUT_MS = 250
+const PROCESS_TABLE_MAX_BYTES = 64 * 1024
+
+export type PosixPtyForegroundGroupDeps = {
+  platform?: NodeJS.Platform
+  currentPid?: number
+  readProcessTable?: () => string
+}
+
+type ProcessRow = {
+  pid: number
+  tpgid: number
+  tty: string
+}
+
+/** `ps` prints `ttys003` / `pts/3`; node-pty reports `/dev/ttys003` / `/dev/pts/3`. */
+function normalizeTty(value: string): string {
+  return value.replace(/^\/dev\//, '')
+}
+
+function hasUsableTty(tty: string): boolean {
+  return tty !== '?' && tty !== '??' && tty !== '-'
+}
+
+function runPs(pid: number): string {
+  return execFileSync('ps', ['-p', String(pid), '-o', 'pid=,tpgid=,tty='], {
+    encoding: 'utf8',
+    timeout: PROCESS_TABLE_TIMEOUT_MS,
+    maxBuffer: PROCESS_TABLE_MAX_BYTES
+  })
+}
+
+/**
+ * Why two calls instead of `-p a,b`: macOS `ps` only takes the KERN_PROC_PID fast
+ * path for a single pid. ANY pid list — even a duplicate of one pid — walks the
+ * whole process table, measured at ~3.6s on a busy machine versus ~3ms here. That
+ * blew the timeout below, so the group lookup silently fell back to the very
+ * root-pid delivery this module exists to replace.
+ */
+function readForegroundGroupTable(rootPid: number, currentPid: number): string {
+  return `${runPs(rootPid)}\n${runPs(currentPid)}`
+}
+
+function parseProcessRows(output: string): ProcessRow[] {
+  const rows: ProcessRow[] = []
+  for (const line of output.split(/\r?\n/)) {
+    const match = /^\s*(\d+)\s+(-?\d+)\s+(\S+)/.exec(line)
+    if (!match) {
+      continue
+    }
+    const pid = Number(match[1])
+    if (pid > 0) {
+      rows.push({ pid, tpgid: Number(match[2]), tty: match[3] })
+    }
+  }
+  return rows
+}
+
+/**
+ * Resolves the foreground process group of one PTY, which is who the kernel
+ * signals on a real window-size change.
+ *
+ * Why not the root pid: the shell calls `setpgid` for job control, so it leaves
+ * the root's group immediately, and on macOS the root is `login(1)` — which
+ * neither handles nor forwards SIGWINCH. A foreground TUI is a third group
+ * again, so only the tty's `tpgid` reproduces a kernel resize.
+ */
+export function getPosixPtyForegroundGroup(
+  output: string,
+  rootPid: number,
+  ptsName: string,
+  currentPid = process.pid
+): number | null {
+  const rows = parseProcessRows(output)
+  const root = rows.find((row) => row.pid === rootPid)
+  if (!root || !hasUsableTty(root.tty)) {
+    return null
+  }
+  // Why: `ps -p` answers for whatever owns the pid now. Without pinning the tty we
+  // captured at spawn, a recycled pid could aim a group signal at a real terminal.
+  if (normalizeTty(root.tty) !== normalizeTty(ptsName)) {
+    return null
+  }
+  // Why: a development daemon can inherit its launch TTY. Never group-signal when
+  // this process shares the PTY; fall back to the already-scoped root signal.
+  if (rows.some((row) => row.pid === currentPid && row.tty === root.tty)) {
+    return null
+  }
+  // tpgid is -1 when no foreground group owns the tty, and pid 1 is never one.
+  return root.tpgid > 1 ? root.tpgid : null
+}
+
+/**
+ * Sends `signal` to the PTY's foreground process group, falling back to the
+ * supplied root-pid delivery when the group cannot be established safely.
+ *
+ * Scoped to SIGWINCH by callers on purpose: a destructive signal must keep the
+ * narrower root-pid target plus the descendant-sweep identity machinery.
+ */
+export function signalPosixPtyForegroundGroup(
+  rootPid: number,
+  ptsName: string | undefined,
+  signal: NodeJS.Signals | string,
+  fallback: () => void,
+  deps: PosixPtyForegroundGroupDeps = {}
+): void {
+  if ((deps.platform ?? process.platform) === 'win32' || !ptsName) {
+    fallback()
+    return
+  }
+  const currentPid = deps.currentPid ?? process.pid
+  let pgid: number | null
+  try {
+    pgid = getPosixPtyForegroundGroup(
+      (deps.readProcessTable ?? (() => readForegroundGroupTable(rootPid, currentPid)))(),
+      rootPid,
+      ptsName,
+      currentPid
+    )
+  } catch {
+    pgid = null
+  }
+  if (pgid === null) {
+    fallback()
+    return
+  }
+  try {
+    process.kill(-pgid, signal as NodeJS.Signals)
+  } catch {
+    // Why: the group can exit between `ps` and `kill`. The fallback would be just
+    // as stale, so a vanished foreground group is success, not a reason to retry.
+  }
+}

--- a/src/main/pty/posix-pty-foreground-group.ts
+++ b/src/main/pty/posix-pty-foreground-group.ts
@@ -129,8 +129,11 @@ export function signalPosixPtyForegroundGroup(
   }
   try {
     process.kill(-pgid, signal as NodeJS.Signals)
-  } catch {
+  } catch (error) {
     // Why: the group can exit between `ps` and `kill`. The fallback would be just
     // as stale, so a vanished foreground group is success, not a reason to retry.
+    if ((error as NodeJS.ErrnoException | undefined)?.code !== 'ESRCH') {
+      fallback()
+    }
   }
 }

--- a/src/main/pty/posix-pty-foreground-group.ts
+++ b/src/main/pty/posix-pty-foreground-group.ts
@@ -1,6 +1,7 @@
 import { execFileSync } from 'node:child_process'
 
-const PROCESS_TABLE_TIMEOUT_MS = 250
+const PROCESS_TABLE_LOOKUP_TIMEOUT_MS = 250
+const PROCESS_TABLE_QUERY_TIMEOUT_MS = PROCESS_TABLE_LOOKUP_TIMEOUT_MS / 2
 const PROCESS_TABLE_MAX_BYTES = 64 * 1024
 
 export type PosixPtyForegroundGroupDeps = {
@@ -27,7 +28,7 @@ function hasUsableTty(tty: string): boolean {
 function runPs(pid: number): string {
   return execFileSync('ps', ['-p', String(pid), '-o', 'pid=,tpgid=,tty='], {
     encoding: 'utf8',
-    timeout: PROCESS_TABLE_TIMEOUT_MS,
+    timeout: PROCESS_TABLE_QUERY_TIMEOUT_MS,
     maxBuffer: PROCESS_TABLE_MAX_BYTES
   })
 }

--- a/src/relay/pty-handler.ts
+++ b/src/relay/pty-handler.ts
@@ -56,6 +56,8 @@ import {
   ClaimedAgentPtyOwnerRegistry
 } from '../shared/claimed-agent-pty-owner'
 import type { RelayPtySourceOutput } from './relay-pty-source-output'
+import { signalPosixPtyForegroundGroup } from '../main/pty/posix-pty-foreground-group'
+import { readPtsName } from '../main/pty/node-pty-pts-name'
 import type { RelayPtySourcePublication } from './relay-pty-source-publication'
 import type {
   PtySourceRecoveryRequest,
@@ -1742,6 +1744,16 @@ export class PtyHandler {
     // Why: dispose neutralizes pty.kill on POSIX; treat disposed as not-found so signals don't silently no-op.
     if (!managed || managed.disposed) {
       throw new Error(`PTY "${id}" not found`)
+    }
+    // Why only SIGWINCH: a real resize reaches the tty's foreground process group,
+    // and node-pty's kill targets the root pid, which the shell setpgid's away from.
+    // Host-local behavior only — no wire change, so an older client simply gets a
+    // SIGWINCH that now lands. Destructive signals keep node-pty's own path.
+    if (signal === 'SIGWINCH') {
+      signalPosixPtyForegroundGroup(managed.pty.pid, readPtsName(managed.pty), signal, () => {
+        managed.pty.kill(signal)
+      })
+      return
     }
     managed.pty.kill(signal)
   }


### PR DESCRIPTION
## Summary

Orca's explicit `SIGWINCH` — the one that makes a restored TUI repaint after a reattach replay — has never reached a running TUI on any platform, and on macOS never reached the shell either.

The kernel delivers a real window-size change to the terminal's **foreground process group**. Delivery here was `process.kill(rootPid, signal)`, and `rootPid` is never in that group:

- the shell calls `setpgid` for job control, so it leaves the root's group immediately;
- a foreground TUI forms a third group again;
- on macOS `rootPid` is `/usr/bin/login`, which Orca wraps shells in for TCC attribution (`macos-tcc-login-shell.ts:321`). `login` neither handles nor forwards `SIGWINCH`, so the signal evaporates.

Measured on a real wrapped PTY (`ps -p <root> -o pid=,ppid=,pgid=,tpgid=,tty=`), the three groups are always distinct:

```
# at a prompt                          pgid   tpgid
58831 ... 58831 58837 ttys222  Ss   /usr/bin/login ... orca-tcc-login /bin/zsh /bin/zsh -l
58837 ... 58837 58837 ttys222  S+   -/bin/zsh -l

# with a foreground TUI
58831 ... 58831 59359 ttys222  Ss   /usr/bin/login ...
58837 ... 58837 59359 ttys222  S    -/bin/zsh -l
59359 ... 59359 59359 ttys222  S+   node tui.js
```

This resolves the pty's `tpgid` and signals `-pgid`, which is what a kernel resize does. Scoped to `SIGWINCH` on purpose: destructive signals keep the narrower root-pid target and the existing descendant-sweep identity machinery. POSIX-only — Windows keeps today's behavior, where a negative pid is invalid and `SIGTERM`/`SIGINT` mean *terminate*.

Applied at all three delivery sites, including the relay so SSH hosts get it too. The relay change is host-local with no wire change (params and allowed-signal set unchanged), so an older client talking to a newer host simply gets a `SIGWINCH` that now lands.

## Screenshots

`No visual change` — this fixes signal delivery. Evidence is the measured matrix below.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

**Real-PTY A/B**, macOS, TCC login wrapper **active** (`ORCA_DISABLE_MACOS_LOGIN_SHELL` unset), spawned with Orca's exact wrapped argv, using the shipped defaults (no injected deps, no lifted timeout). Counts are SIGWINCH deliveries observed by a `trap … WINCH` in the shell and a handler in a foreground TUI:

| Case | Delivery | Target | shell | TUI |
|---|---|---|---|---|
| prompt | old, root pid | pid 58831 | **0** | 0 |
| prompt | **new, foreground group** | -58837 (zsh) | **1** | 0 |
| fg TUI | old, root pid | pid 58831 | **0** | 0 |
| fg TUI | **new, foreground group** | -59359 (TUI) | 0 | **1** |

A control using a genuine `pty.resize()` fired throughout, proving the probes were live.

Cost on the production path, on a 3,400-process machine under load 16.7: **16 ms median, 21 ms p95**, 0 fallbacks and 0 timeouts across 20 consecutive calls, against the module's 250 ms cap.

Unit tests cover the parse and every refusal branch. `src/main/providers/` is fully green; `pty-handler.test.ts` (2), `pty-subprocess.test.ts` (2) and `ipc/pty.test.ts` (9) fail identically before and after this change — same test names, environment-shaped (`ORCA_*` / real `HOME` leaking into env-assertion tests).

## AI Review Report

The empirical review caught a **blocking defect in the first version of this change**, worth recording because it is invisible by inspection:

- The lookup used one `ps -p <root>,<current>` call. macOS `ps` only takes the `KERN_PROC_PID` fast path for a **single** pid — any list form, *even a duplicate of the same pid*, walks the whole process table. Measured 3,644 ms versus 3 ms, which blew the 250 ms cap, hit the `catch`, and silently fell back to the exact root-pid delivery this module replaces. It looked shipped and did nothing. Now two single-pid calls, with a test pinning the invocation shape so the regression can't come back quietly.
- A test in that first version called `process.kill(-84985)` for real against a mocked process table, which would have group-signalled whatever owned that pgid on the dev machine. `process.kill` is stubbed now.

Safety of the group signal, verified against live `ps` output:

- The pty slave is a fresh session (node-pty `setsid`s; confirmed `Ss`/`Ss+` on the root), so only processes in that session can be the tty's foreground group — the signal structurally cannot reach the Electron main process, the daemon, or another terminal.
- The one real hazard is **PID reuse**: if the root pid died and was recycled onto a process whose controlling terminal is a developer's real terminal, `ps -p` would answer for *that* terminal. Guarded by pinning the `ptsName` captured at spawn against the tty `ps` reports — verified to return `null` for a wrong tty, a Linux-style name on macOS, another live tty, an empty name, and an unknown pid.
- Refuses to group-signal when this process shares the pty, reusing the guard from `posix-pty-process-groups.ts:66` (a dev daemon can inherit its launch TTY).
- Blast radius even on a mis-read is `SIGWINCH`, whose default disposition is ignore. This deliberately does **not** generalize to `SIGTERM`/`SIGKILL`.

Cross-platform: **macOS** is the motivating case. **Linux** has no login wrapper, but the old delivery still missed a foreground TUI there, so this is a strict improvement (`ps -o tpgid` and `/dev/pts/N` both handled). **Windows** is excluded by an explicit `platform !== 'win32'` gate and keeps its current swallowed no-op; the relay's Windows path still throws from node-pty exactly as before. **SSH/remote** is fixed on the host side, where the pty actually lives; `ssh-pty-provider.ts` is a pure forwarder and is untouched.

## Security Audit

No new IPC surface, no wire change, no input handling, no path handling, no auth or secrets, no dependency changes. One new outward action: `process.kill` with a negated pgid, derived from `ps` output for a pid Orca owns and cross-checked against the slave device captured at spawn, restricted to `SIGWINCH`. The `ps` invocation takes no user-controlled input — only integer pids via `String(pid)` and a fixed format string, passed as an argv array to `execFileSync` (no shell), with a timeout and a `maxBuffer` cap. Command injection is not reachable.

## Notes

- Prerequisite half is #13155, which makes the signal get *sent* when the pane was hidden during reattach. This PR makes it get *delivered*. They are independent and can land in either order.
- If a single-pid `ps` ever stalls past 250 ms, the module falls back to root-pid delivery silently. That is the intended degradation, but it is unobservable today — worth a counter if this area gets more attention.
- Not changed: `relay/pty-handler.ts` also allows `SIGINT`/`SIGTSTP`/`SIGCONT` through the same entry point, and those are *also* semantically foreground-group signals. Routing them through the same resolver is a defensible follow-up, but it is a behavior change for job control and belongs in its own PR.


## Reliability Gate

- Invariant: terminal-signal.foreground-group-delivery — an explicit POSIX SIGWINCH for a live PTY reaches the tty foreground process group without broadening destructive-signal targets.
- Failure source: root-PID delivery misses job-control groups and macOS login(1), so restored TUIs do not repaint.
- Oracle: focused resolver/provider/daemon/relay tests, real macOS PTYs, and a disposable Ubuntu 22.04 SSH relay PTY whose foreground handler reports matching PID/PGID/TPGID after Orca signals it.
- Gate: terminal-geometry.visible-convergence covers the downstream repaint behavior; the absence of a dedicated foreground-group manifest entry remains an accepted gap backed by the focused tests and real-PTY evidence here.
- Provider/platform coverage: local PTY, daemon PTY, and SSH relay are covered; Linux and macOS are exercised; Windows keeps root-target behavior behind the explicit win32 guard; WSL artifacts build; mobile is unaffected because delivery is host-owned.
- Performance budget: the two synchronous process-table probes share one 250 ms aggregate cap and run only for explicit repaint signals, not normal resize/drag. Real macOS lookup measured 6.6 ms median, 7.0 ms p95, 11.7 ms max.
- Diagnostics: focused fallback/error tests plus SSH/app/relay logs make delivery failures observable during validation.
- Residual gaps: the JavaScript layer uses bounded ps tpgid lookup because node-pty does not expose tcgetpgrp; there is no production fallback counter or dedicated reliability-manifest entry yet.