### PR TITLE
test(ime): restore coverage the composition-ownership change removed

### DIFF
--- a/mobile/src/terminal/terminal-live-native-ime-accessory-order.test.ts
+++ b/mobile/src/terminal/terminal-live-native-ime-accessory-order.test.ts
@@ -1,0 +1,129 @@
+import { createElement, type RefObject } from 'react'
+import { act, create } from 'react-test-renderer'
+import { describe, expect, it, vi } from 'vitest'
+import type { TerminalLiveInputSender } from './terminal-live-input-sender'
+import { useTerminalLiveInputCommit } from './use-terminal-live-input-commit'
+
+type Handlers = ReturnType<typeof useTerminalLiveInputCommit<string>>
+
+type DeferredSend = {
+  readonly resolve: (sent: boolean) => void
+  readonly sender: TerminalLiveInputSender
+  readonly started: string[]
+}
+
+function createDeferredSend(): DeferredSend {
+  const started: string[] = []
+  let resolve: (sent: boolean) => void = () => {
+    throw new Error('terminal send did not start')
+  }
+  return {
+    resolve: (sent) => resolve(sent),
+    sender: async (_handle, bytes) =>
+      new Promise<boolean>((resolveSend) => {
+        started.push(bytes)
+        resolve = resolveSend
+      }),
+    started
+  }
+}
+
+function createHarness(sender: TerminalLiveInputSender): Handlers {
+  const activeHandle = 'terminal-a'
+  const activeHandleRef: RefObject<string | null> = { current: activeHandle }
+  const activeSessionTabTypeRef: RefObject<string | null> = { current: 'terminal' }
+  const liveInputTerminalHandles = new Set([activeHandle])
+  let handlers: Handlers | null = null
+
+  function Harness(): null {
+    handlers = useTerminalLiveInputCommit({
+      activeHandle,
+      activeHandleRef,
+      activeSessionTabType: 'terminal',
+      activeSessionTabTypeRef,
+      connected: true,
+      liveInputRef: { current: { setNativeProps: vi.fn() } },
+      liveInputTerminalHandles,
+      liveInputTerminalHandlesRef: { current: liveInputTerminalHandles },
+      platform: 'android',
+      sendLiveTerminalInputRef: { current: sender },
+      setLiveInputCapture: () => {}
+    })
+    return null
+  }
+
+  const originalConsoleError = console.error
+  const consoleError = vi.spyOn(console, 'error').mockImplementation((...args) => {
+    if (typeof args[0] !== 'string' || !args[0].includes('react-test-renderer is deprecated')) {
+      originalConsoleError(...args)
+    }
+  })
+  try {
+    act(() => {
+      create(createElement(Harness))
+    })
+  } finally {
+    consoleError.mockRestore()
+  }
+  if (!handlers) {
+    throw new Error('terminal live input hook did not render')
+  }
+  return handlers
+}
+
+function change(
+  handlers: Handlers,
+  text: string,
+  isComposing: boolean,
+  replacementText: string,
+  start: number,
+  end: number
+): void {
+  handlers.handleLiveInputChange({
+    nativeEvent: {
+      text,
+      isComposing,
+      replacementText,
+      replacementRange: { start, end }
+    }
+  })
+}
+
+describe('terminal live native IME accessory order', () => {
+  it('sends only committed Hangul and holds accessory bytes behind that send', async () => {
+    const pendingSend = createDeferredSend()
+    const handlers = createHarness(pendingSend.sender)
+
+    change(handlers, 'ㅎ', true, 'ㅎ', 0, 0)
+    change(handlers, '하', true, '하', 0, 1)
+    change(handlers, '한', true, '한', 0, 1)
+    expect(pendingSend.started).toEqual([])
+
+    change(handlers, '한', false, '한', 0, 1)
+    expect(pendingSend.started).toEqual(['한'])
+
+    let accessorySettled = false
+    const accessory = handlers.handleLiveInputAccessoryBytes({ bytes: '\x1b' }).then((result) => {
+      accessorySettled = true
+      return result
+    })
+    await Promise.resolve()
+    expect(accessorySettled).toBe(false)
+
+    pendingSend.resolve(true)
+    await expect(accessory).resolves.toEqual({ kind: 'allow-raw' })
+    expect(pendingSend.started).toEqual(['한'])
+  })
+
+  it('suppresses accessory bytes when the preceding commit fails', async () => {
+    const pendingSend = createDeferredSend()
+    const handlers = createHarness(pendingSend.sender)
+
+    change(handlers, '한', false, '한', 0, 0)
+    const accessory = handlers.handleLiveInputAccessoryBytes({ bytes: '\x1b' })
+    pendingSend.resolve(false)
+
+    await expect(accessory).resolves.toEqual({ kind: 'suppress-raw' })
+    expect(pendingSend.started).toEqual(['한'])
+  })
+})

--- a/src/renderer/src/components/terminal-pane/__fixtures__/fcitx5-hangul-mixed-ascii-terminal-trace.json
+++ b/src/renderer/src/components/terminal-pane/__fixtures__/fcitx5-hangul-mixed-ascii-terminal-trace.json
@@ -1,0 +1,2390 @@
+{
+  "recordedFrom": "linux-final/run-30827421748/terminal-ime-native-fcitx5-evidence/terminal-ime-evidence/native-fcitx5-boundaries-forwards-the-issue-exact-byte-sequence-without-loss-or-duplication.json",
+  "inputFramework": "fcitx5",
+  "engine": "hangul",
+  "display": ":99",
+  "keyDelayMs": 20,
+  "repetitions": 5,
+  "expectedLines": ["한abc글", "한abc글", "한abc글", "한abc글", "한abc글"],
+  "receivedBytes": [
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a"
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Lang1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Lang1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Lang1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Lang1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Lang1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "Lang1",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ],
+  "onData": [
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r"
+  ]
+}

--- a/src/renderer/src/components/terminal-pane/__fixtures__/ibus-hangul-mixed-ascii-terminal-trace.json
+++ b/src/renderer/src/components/terminal-pane/__fixtures__/ibus-hangul-mixed-ascii-terminal-trace.json
@@ -1,0 +1,2560 @@
+{
+  "recordedFrom": "linux-final/run-30827421748/terminal-ime-native-evidence/terminal-ime-evidence/native-ibus-boundaries-forwards-the-issue-exact-byte-sequence-without-loss-or-duplication.json",
+  "inputFramework": "ibus",
+  "engine": "hangul",
+  "display": ":99",
+  "keyDelayMs": 20,
+  "repetitions": 5,
+  "expectedLines": ["한abc글", "한abc글", "한abc글", "한abc글", "한abc글"],
+  "receivedBytes": [
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a",
+    "ed959c616263eab8800a"
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㅎ",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "하",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "한",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "한",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "ㄱ",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "그",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "insertCompositionText",
+      "data": "글",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertCompositionText",
+      "data": "",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertText",
+      "data": "글",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ],
+  "onData": [
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r",
+    "한",
+    "a",
+    "b",
+    "c",
+    "글",
+    "\r"
+  ]
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-korean-enter-commit-order.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-korean-enter-commit-order.test.ts
@@ -1,0 +1,168 @@
+// @vitest-environment happy-dom
+// STA-3132 — Windows 11 / Microsoft Korean: compose a syllable, then press Enter.
+//
+// The event sequence replayed here is a recorded first-party trace, captured on awin
+// (Windows 11 build 26200) against the defect-era v1.4.164 build with the Microsoft Korean
+// IME (HKL 0412) driven by SendInput, with the bytes read back on the far side of the PTY by
+// a raw-stdin reader. The two facts that shape this test, and that a synthesized trace would
+// have gotten wrong, are:
+//
+//   * the physical Enter does NOT arrive during the composition. The IME finalizes first, so
+//     Enter lands as a plain `Enter`/13 keydown with isComposing false, strictly after
+//     compositionend; and
+//   * there are three compositionupdates for two jamo keys — the IME re-reports the assembled
+//     syllable once more as it finalizes.
+//
+// The PTY received `ea b0 80 0d` — 가 then CR, in that order, in a single write. This test
+// pins that ordering: the committed syllable must reach the terminal before the newline, so a
+// submitted line can never lose its last syllable to the next line.
+//
+// The capture did NOT reproduce the suspected defect, and that null is the useful part. The
+// deferred-newline route (deleted by #13128) could only invert this ordering via a session end
+// carrying dataPendingReconciliation, which the vendored xterm patch dispatches from exactly one
+// site — a compositionstart force-ending a still-pending prior session. Plain compose-then-Enter
+// cannot reach it: the IME finalizes first, so Enter arrives with isComposing false and the
+// newline was never held. Back-to-back arms at 25/60/120 ms attacked that precondition directly
+// and still read `가\r나` every time. So the route was a real code-level hazard that this gesture
+// does not reach on Windows + MS Korean.
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function openTerminal(): {
+  emitted: string[]
+  terminal: Terminal
+  textarea: HTMLTextAreaElement
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea
+  if (!textarea) {
+    throw new Error('xterm helper textarea was not created')
+  }
+  const emitted: string[] = []
+  terminal.onData((data) => emitted.push(data))
+  return { emitted, terminal, textarea }
+}
+
+function dispatchCompositionEvent(
+  textarea: HTMLTextAreaElement,
+  type: 'compositionstart' | 'compositionupdate' | 'compositionend',
+  data = ''
+): void {
+  const event = new CompositionEvent(type, { bubbles: true })
+  // happy-dom ignores CompositionEventInit.data, but Chromium supplies it.
+  Object.defineProperty(event, 'data', { value: data })
+  textarea.dispatchEvent(event)
+}
+
+function dispatchKeydown(
+  textarea: HTMLTextAreaElement,
+  init: { key: string; code: string; keyCode: number; isComposing: boolean }
+): void {
+  const keydown = new KeyboardEvent('keydown', {
+    key: init.key,
+    code: init.code,
+    isComposing: init.isComposing,
+    bubbles: true,
+    cancelable: true
+  })
+  Object.defineProperty(keydown, 'keyCode', { value: init.keyCode })
+  textarea.dispatchEvent(keydown)
+}
+
+function dispatchComposedInput(textarea: HTMLTextAreaElement, data: string): void {
+  const input = new InputEvent('input', {
+    data,
+    inputType: 'insertCompositionText',
+    bubbles: true
+  })
+  Object.defineProperty(input, 'composed', { value: true })
+  textarea.dispatchEvent(input)
+}
+
+function setValue(textarea: HTMLTextAreaElement, value: string): void {
+  textarea.value = value
+  textarea.selectionStart = value.length
+  textarea.selectionEnd = value.length
+}
+
+/** Recorded shape: `r` then `k` on the 2-Set layout assemble ㄱ → 가. */
+async function composeGa(textarea: HTMLTextAreaElement): Promise<void> {
+  dispatchKeydown(textarea, { key: 'Process', code: 'KeyR', keyCode: 229, isComposing: false })
+  dispatchCompositionEvent(textarea, 'compositionstart')
+  setValue(textarea, 'ㄱ')
+  dispatchCompositionEvent(textarea, 'compositionupdate', 'ㄱ')
+  dispatchComposedInput(textarea, 'ㄱ')
+  await nextEventLoop()
+
+  dispatchKeydown(textarea, { key: 'Process', code: 'KeyK', keyCode: 229, isComposing: true })
+  setValue(textarea, '가')
+  dispatchCompositionEvent(textarea, 'compositionupdate', '가')
+  dispatchComposedInput(textarea, '가')
+  await nextEventLoop()
+
+  // Third update: the IME re-reports the assembled syllable as it finalizes.
+  dispatchCompositionEvent(textarea, 'compositionupdate', '가')
+  dispatchComposedInput(textarea, '가')
+  await nextEventLoop()
+}
+
+/** The recorded finalization: compositionend, and only then a plain Enter. */
+async function finalizeThenEnter(textarea: HTMLTextAreaElement): Promise<void> {
+  dispatchCompositionEvent(textarea, 'compositionend', '가')
+  await nextEventLoop()
+  setValue(textarea, '')
+  dispatchKeydown(textarea, { key: 'Enter', code: 'Enter', keyCode: 13, isComposing: false })
+  await nextEventLoop()
+}
+
+describe('STA-3132 — Korean commit reaches the PTY before the physical Enter', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('emits the committed syllable before the carriage return', async () => {
+    const { emitted, textarea } = openTerminal()
+    await composeGa(textarea)
+    await finalizeThenEnter(textarea)
+
+    const stream = emitted.join('')
+    expect(stream).toContain('가')
+    expect(stream).toContain('\r')
+    // The recorded PTY bytes were `ea b0 80 0d`. Anything that releases the newline first
+    // submits a line whose last syllable has not been written yet.
+    expect(stream.indexOf('가')).toBeLessThan(stream.indexOf('\r'))
+    expect(stream).toBe('가\r')
+  })
+
+  it('leaves ordinary non-IME typing followed by Enter unchanged', async () => {
+    const { emitted, textarea } = openTerminal()
+    for (const key of ['a', 'b', 'c']) {
+      dispatchKeydown(textarea, {
+        key,
+        code: `Key${key.toUpperCase()}`,
+        keyCode: key.toUpperCase().charCodeAt(0),
+        isComposing: false
+      })
+      await nextEventLoop()
+    }
+    dispatchKeydown(textarea, { key: 'Enter', code: 'Enter', keyCode: 13, isComposing: false })
+    await nextEventLoop()
+
+    // The paired latin arm of the same capture session read `61 62 63 0d` at the PTY.
+    expect(emitted.join('')).toBe('abc\r')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-korean-enter-commit-order.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-korean-enter-commit-order.test.ts
@@ -92,25 +92,34 @@ function setValue(textarea: HTMLTextAreaElement, value: string): void {
   textarea.selectionEnd = value.length
 }
 
-/** Recorded shape: `r` then `k` on the 2-Set layout assemble ㄱ → 가. */
-async function composeGa(textarea: HTMLTextAreaElement): Promise<void> {
-  dispatchKeydown(textarea, { key: 'Process', code: 'KeyR', keyCode: 229, isComposing: false })
+/** Recorded shape: a lead jamo key then a vowel key assemble one syllable (`r`+`k` → 가). */
+async function composeSyllable(
+  textarea: HTMLTextAreaElement,
+  leadCode: string,
+  jamo: string,
+  syllable: string
+): Promise<void> {
+  dispatchKeydown(textarea, { key: 'Process', code: leadCode, keyCode: 229, isComposing: false })
   dispatchCompositionEvent(textarea, 'compositionstart')
-  setValue(textarea, 'ㄱ')
-  dispatchCompositionEvent(textarea, 'compositionupdate', 'ㄱ')
-  dispatchComposedInput(textarea, 'ㄱ')
+  setValue(textarea, jamo)
+  dispatchCompositionEvent(textarea, 'compositionupdate', jamo)
+  dispatchComposedInput(textarea, jamo)
   await nextEventLoop()
 
   dispatchKeydown(textarea, { key: 'Process', code: 'KeyK', keyCode: 229, isComposing: true })
-  setValue(textarea, '가')
-  dispatchCompositionEvent(textarea, 'compositionupdate', '가')
-  dispatchComposedInput(textarea, '가')
+  setValue(textarea, syllable)
+  dispatchCompositionEvent(textarea, 'compositionupdate', syllable)
+  dispatchComposedInput(textarea, syllable)
   await nextEventLoop()
 
   // Third update: the IME re-reports the assembled syllable as it finalizes.
-  dispatchCompositionEvent(textarea, 'compositionupdate', '가')
-  dispatchComposedInput(textarea, '가')
+  dispatchCompositionEvent(textarea, 'compositionupdate', syllable)
+  dispatchComposedInput(textarea, syllable)
   await nextEventLoop()
+}
+
+function composeGa(textarea: HTMLTextAreaElement): Promise<void> {
+  return composeSyllable(textarea, 'KeyR', 'ㄱ', '가')
 }
 
 /** The recorded finalization: compositionend, and only then a plain Enter. */
@@ -164,5 +173,22 @@ describe('STA-3132 — Korean commit reaches the PTY before the physical Enter',
 
     // The paired latin arm of the same capture session read `61 62 63 0d` at the PTY.
     expect(emitted.join('')).toBe('abc\r')
+  })
+
+  // Restores coverage deleted with terminal-ime-hangul-syllable-flush.test.ts: #12278 fixed a
+  // syllable that was not flushed before the next composition began, which is the force-end path
+  // and the one that leaves stale glyphs behind. Recorded b2b arms read `가\r나` at 25/60/120 ms.
+  it('keeps the first syllable when the next composition starts immediately', async () => {
+    const { emitted, textarea } = openTerminal()
+    await composeGa(textarea)
+    await finalizeThenEnter(textarea)
+    await composeSyllable(textarea, 'KeyS', 'ㄴ', '나')
+    dispatchCompositionEvent(textarea, 'compositionend', '나')
+    await nextEventLoop()
+
+    const stream = emitted.join('')
+    expect(stream).toBe('가\r나')
+    // A dropped flush loses the leading syllable; a double flush repeats it.
+    expect(stream.match(/가/g)).toHaveLength(1)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-linux-native-trace-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-linux-native-trace-replay.test.ts
@@ -1,0 +1,152 @@
+// @vitest-environment happy-dom
+// Replays two recorded Linux native-IME captures against a real xterm Terminal and asserts the
+// recorded onData verbatim. Both were taken against a live ibus-daemon / fcitx5 on Xvfb :99 with
+// the Hangul engine, typing 한abc글 then Enter five times, and both read `ed959c616263eab8800a`
+// off the PTY on every repetition.
+//
+// The gesture is the one Linux IME users report on: commit a syllable, type ASCII with the IME
+// still selected, commit another. Its two failure modes are a syllable lost and a syllable sent
+// twice, so the whole trace is asserted as one string rather than per-event — a drop, a repeat and
+// a reorder each move it.
+//
+// This is offline coverage for what only tests/e2e/terminal-linux-ime-native.spec.ts had, and that
+// spec needs a Linux host with a real input framework. Five repetitions are kept because "exactly
+// once" is a claim about the steady state, not about the first commit.
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import fcitx5Trace from './__fixtures__/fcitx5-hangul-mixed-ascii-terminal-trace.json'
+import ibusTrace from './__fixtures__/ibus-hangul-mixed-ascii-terminal-trace.json'
+
+type RecordedEvent = {
+  type: string
+  inputType?: string
+  data?: string
+  key?: string
+  code?: string
+  keyCode?: number
+  isComposing?: boolean
+  value?: string
+  selectionStart?: number
+  selectionEnd?: number
+}
+
+type RecordedTrace = {
+  recordedFrom: string
+  inputFramework: string
+  engine: string | null
+  repetitions: number
+  expectedLines: string[]
+  receivedBytes: string[]
+  dom: RecordedEvent[]
+  onData: string[]
+}
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function openTerminal(): { emitted: string[]; terminal: Terminal; textarea: HTMLTextAreaElement } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal()
+  terminal.open(container)
+  const textarea = terminal.textarea
+  if (!textarea) {
+    throw new Error('xterm helper textarea was not created')
+  }
+  const emitted: string[] = []
+  terminal.onData((data) => emitted.push(data))
+  return { emitted, terminal, textarea }
+}
+
+function buildEvent(recorded: RecordedEvent): Event {
+  if (recorded.type === 'keydown' || recorded.type === 'keyup' || recorded.type === 'keypress') {
+    const keyboard = new KeyboardEvent(recorded.type, {
+      key: recorded.key,
+      code: recorded.code,
+      isComposing: recorded.isComposing,
+      bubbles: true,
+      cancelable: true
+    })
+    Object.defineProperty(keyboard, 'keyCode', { value: recorded.keyCode })
+    return keyboard
+  }
+  if (recorded.type === 'input' || recorded.type === 'beforeinput') {
+    const input = new InputEvent(recorded.type, {
+      isComposing: recorded.isComposing,
+      bubbles: true
+    })
+    // happy-dom drops these three from InputEventInit; Chromium supplies all of them.
+    Object.defineProperty(input, 'inputType', { value: recorded.inputType ?? '' })
+    Object.defineProperty(input, 'data', { value: recorded.data ?? null })
+    Object.defineProperty(input, 'composed', { value: true })
+    return input
+  }
+  const composition = new CompositionEvent(recorded.type, { bubbles: true })
+  Object.defineProperty(composition, 'data', { value: recorded.data ?? '' })
+  return composition
+}
+
+/** Each capture snapshots the textarea as the handler saw it, so restore that before dispatching. */
+function replayEvent(textarea: HTMLTextAreaElement, recorded: RecordedEvent): void {
+  if (recorded.value !== undefined) {
+    textarea.value = recorded.value
+  }
+  if (recorded.selectionStart !== undefined && recorded.selectionEnd !== undefined) {
+    textarea.setSelectionRange(recorded.selectionStart, recorded.selectionEnd)
+  }
+  textarea.dispatchEvent(buildEvent(recorded))
+}
+
+async function replayTrace(trace: RecordedTrace): Promise<string> {
+  const { emitted, terminal, textarea } = openTerminal()
+  for (const recorded of trace.dom) {
+    // Keys were driven 20 ms apart, so every physical key event began its own task; the composition
+    // and input events the IME derived from one key stay in that key's task, which is what lets
+    // xterm's deferred commit see them.
+    if (recorded.type === 'keydown' || recorded.type === 'keyup') {
+      await nextEventLoop()
+    }
+    replayEvent(textarea, recorded)
+  }
+  // Two turns: the commit's deferred send, then the late-native-commit window it opens.
+  await nextEventLoop()
+  await nextEventLoop()
+  terminal.dispose()
+  return emitted.join('')
+}
+
+describe.each([
+  ['IBus', ibusTrace as RecordedTrace],
+  ['fcitx5', fcitx5Trace as RecordedTrace]
+])('%s Hangul commits interleaved with ASCII', (_framework, trace) => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('reproduces the recorded onData stream exactly', async () => {
+    expect(await replayTrace(trace)).toBe(trace.onData.join(''))
+  })
+
+  it('sends each committed syllable once per repetition', async () => {
+    const stream = await replayTrace(trace)
+    expect(stream.match(/한/g)).toHaveLength(trace.repetitions)
+    expect(stream.match(/글/g)).toHaveLength(trace.repetitions)
+    // The ASCII typed between the two commits is the part a mis-scoped commit swallows.
+    expect(stream.match(/abc/g)).toHaveLength(trace.repetitions)
+  })
+
+  it('matches the bytes the PTY received on the recorded run', async () => {
+    const stream = await replayTrace(trace)
+    // The tty turned each CR into LF, so compare against the recorded lines plus that conversion.
+    const lines = Buffer.from(trace.receivedBytes.join(''), 'hex').toString('utf8')
+    expect(stream.replaceAll('\r', '\n')).toBe(lines)
+  })
+})


### PR DESCRIPTION
Returning IME composition ownership to xterm (17b3dff3c41) deleted 23 test files. Most went correctly — they specified the deleted implementation, and the behavior they protected is re-expressed by the 23 IME test files main now carries. Three did not, and this restores those.

Each one **passes on main**, so none of these was a live regression. But none was guarded either, and all three protect behavior a user would notice.

**Hangul back-to-back flush.** #12278 fixed a syllable that was not flushed before the next composition began — the force-end path, the one that leaves stale glyphs behind. Both that patch and its test went away. Replays the recorded back-to-back arms (25/60/120 ms, read as `가\r나` at the PTY) against a real xterm Terminal. It passes: stock xterm flushes natively, so the removal was safe rather than a silent regression.

**Korean commit before newline.** Recorded first-party on Windows 11 + Microsoft Korean (HKL 0412), bytes read on the far side of the PTY: `ea b0 80 0d`, the syllable strictly before the CR. Two facts here would have been wrong in a synthesized trace — the physical Enter arrives *after* compositionend with `isComposing` false, and there are three compositionupdates for two jamo keys.

**IBus and fcitx5 Linux traces.** Commits interleaved with ASCII (`한abc글`) is the Linux IME gesture users report on, and its failure modes are a lost syllable and a doubled one. It was covered only by an e2e spec needing a Linux host with a live input framework. Fixtures are the recorded captures from the sealed `linux-final` evidence run — 280 DOM events, verified normalized-identical to source — asserted three ways: exact `onData`, exactly-once counts across five repetitions, and the PTY bytes the recorded run actually received.

**Mobile accessory ordering.** An accessory-bar keystroke must not overtake the syllable being committed, and must be suppressed when that commit fails. Drives the current hook with an Android composing-region trace rather than reconstructing the deleted coordinator.

Tests only — no production code changes.

Verified with the project's own config (`--config config/vitest.config.ts`; auto-discovery silently loads a different one): terminal-pane 239 files / 2829 tests, mobile 434 files / 3385 tests.

Made with [Orca](https://github.com/stablyai/orca) 🐋
