### PR TITLE
fix(ci): make root-directory guard run on stock macOS bash 3.2

### DIFF
--- a/.github/scripts/check-root-directory-entries.sh
+++ b/.github/scripts/check-root-directory-entries.sh
@@ -11,14 +11,29 @@ head_sha=$2
 git rev-parse --verify "${base_sha}^{tree}" >/dev/null
 git rev-parse --verify "${head_sha}^{tree}" >/dev/null
 
-declare -A base_entries=()
+# Why plain array + linear scan: stock macOS ships bash 3.2 without associative
+# arrays (`declare -A`), and `pnpm test` invokes this script via PATH `bash`
+# (#12878). Root-level entries stay tiny, so O(n^2) membership is fine.
+base_entries=()
 while IFS= read -r -d '' entry; do
-  base_entries["$entry"]=1
+  base_entries+=("$entry")
 done < <(git ls-tree -z --name-only "$base_sha")
+
+base_has_entry() {
+  local candidate=$1
+  local existing
+  # Why + expansion: bash 3.2 with set -u rejects empty "${arr[@]}" expansion.
+  for existing in ${base_entries[@]+"${base_entries[@]}"}; do
+    if [[ "$existing" == "$candidate" ]]; then
+      return 0
+    fi
+  done
+  return 1
+}
 
 blocked_entries=()
 while IFS= read -r -d '' entry; do
-  if [[ -z "${base_entries[$entry]+present}" ]]; then
+  if ! base_has_entry "$entry"; then
     blocked_entries+=("$entry")
   fi
 done < <(git ls-tree -z --name-only "$head_sha")

--- a/config/scripts/check-root-directory-entries.test.mjs
+++ b/config/scripts/check-root-directory-entries.test.mjs
@@ -96,4 +96,12 @@ describe('root directory guard', () => {
     expect(guardStep.run).toContain('.github/scripts/check-root-directory-entries.sh')
     expect(workflow.jobs.verify.needs).toContain('root_directory_guard')
   })
+
+  it('stays runnable on stock macOS bash 3.2 without associative arrays (#12878)', () => {
+    const source = readFileSync(guardScript, 'utf8')
+    // Why: PATH bash on stock macOS is 3.2 and rejects declare -A with exit 2.
+    expect(source).not.toMatch(/^\s*declare\s+-A\b/m)
+    const syntax = spawnSync('/bin/bash', ['-n', guardScript], { encoding: 'utf8' })
+    expect(syntax.status).toBe(0)
+  })
 })


### PR DESCRIPTION
## Summary

- Root-directory guard used \`declare -A\` (bash 4+).
- Stock macOS ships \`/bin/bash\` 3.2; \`pnpm test\` invokes PATH \`bash\`, so three of four guard tests exited 2 before any assertion (#12878).
- Use a plain-array linear membership check (root entries are tiny) and pin a regression that the script has no \`declare -A\` and passes \`bash -n\` under \`/bin/bash\`.

Closes #12878

Note: related open PR #12879 takes a similar approach; this PR keeps the shell script portable and adds the bash-3.2 regression guard in the vitest suite.

## Test plan

- [x] \`pnpm exec vitest run --config config/vitest.config.ts config/scripts/check-root-directory-entries.test.mjs\` (5/5)
- [x] \`/bin/bash -n .github/scripts/check-root-directory-entries.sh\`