### PR TITLE
feat(cli): add orca skills remove for headless uninstall

### DIFF
--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -933,7 +933,7 @@ orca skills remove --skill orca-cli --local --dry-run     # print project-local 
 
 Install, update, and remove all write onto the machine that runs them. In an
 Orca SSH workspace or the WSL bridge the `orca` shim forwards commands to the
-Orca host, so they refuse to run there and print the command to run on the
+Orca host, so these commands refuse to run there. Run the same command on the
 machine you want.
 
 ## Troubleshooting

--- a/docs/reference/headless-linux-server.md
+++ b/docs/reference/headless-linux-server.md
@@ -918,12 +918,23 @@ orca skills update --skill orca-cli --dry-run             # print the npx comman
 generally, a 0 exit means the `skills` CLI ran without erroring, not that it
 wrote anything; read its output to confirm what changed.
 
+To uninstall skills on a headless host, `orca skills remove` uses the same
+selection flags and resolves to `npx skills remove <names...>` — with `--global`
+by default, or project scope when you pass `--local` (the skills CLI's default
+when `--global` is omitted):
+
+```bash
+orca skills remove --skill computer-use                   # remove globally
+orca skills remove --skill orca-cli --local --dry-run     # print project-local remove command
+```
+
 `--json` covers the skill listing and `--dry-run`. A real run streams the
 `skills` CLI's own non-JSON output and rejects `--json`.
 
-Both commands install onto the machine that runs them. In an Orca SSH workspace
-or the WSL bridge the `orca` shim forwards commands to the Orca host, so they
-refuse to run there and print the command to run on the machine you want.
+Install, update, and remove all write onto the machine that runs them. In an
+Orca SSH workspace or the WSL bridge the `orca` shim forwards commands to the
+Orca host, so they refuse to run there and print the command to run on the
+machine you want.
 
 ## Troubleshooting
 

--- a/src/cli/handler-group-manifest.ts
+++ b/src/cli/handler-group-manifest.ts
@@ -249,7 +249,7 @@ export const HANDLER_GROUPS: readonly HandlerGroup[] = [
   },
   {
     name: 'skills',
-    keys: ['skills list', 'skills get', 'skills install', 'skills update'],
+    keys: ['skills list', 'skills get', 'skills install', 'skills update', 'skills remove'],
     load: async () => (await import('./handlers/skills.js')).SKILL_HANDLERS
   }
 ]

--- a/src/cli/handlers/skills.ts
+++ b/src/cli/handlers/skills.ts
@@ -20,6 +20,7 @@ import {
 import { isSkillsCliAgentKeyShaped, toSkillsCliAgentKeys } from '../../shared/skills-cli-agent-keys'
 import {
   buildAgentFeatureSkillInstallArgs,
+  buildAgentFeatureSkillRemoveArgs,
   buildAgentFeatureSkillUpdateArgs
 } from '../../shared/agent-feature-install-commands'
 
@@ -114,7 +115,7 @@ function runNpxSkills(args: string[]): Promise<number> {
   })
 }
 
-type SkillMutationVerb = 'install' | 'update'
+type SkillMutationVerb = 'install' | 'update' | 'remove'
 
 /** Agents Orca can see on this host, as `skills --agent` keys. */
 function detectSkillsCliAgentKeys(): string[] {
@@ -186,7 +187,9 @@ function buildNpxSkillsArgs(
   const skillArgs =
     verb === 'install'
       ? buildAgentFeatureSkillInstallArgs(skillNames, { global, yes: true, agents })
-      : buildAgentFeatureSkillUpdateArgs(skillNames, { global, yes: true })
+      : verb === 'update'
+        ? buildAgentFeatureSkillUpdateArgs(skillNames, { global, yes: true })
+        : buildAgentFeatureSkillRemoveArgs(skillNames, { global, yes: true })
   // Why: a cold package cache makes bare `npx` prompt before it will fetch
   // `skills`, which strands an unattended host just like the picker does.
   return ['--yes', ...skillArgs]
@@ -235,7 +238,7 @@ function createSkillMutationHandler(verb: SkillMutationVerb): CommandHandler {
     }
 
     const global = flags.get('local') !== true
-    // Why: install scopes its targets; update only refreshes what is already placed.
+    // Why: install scopes its targets; update/remove only touch what is already placed.
     const agents = verb === 'install' ? resolveInstallAgentKeys(flags) : []
     const npxArgs = buildNpxSkillsArgs(verb, skillNames, global, agents)
     const command = formatNpxCommand(npxArgs)
@@ -283,5 +286,6 @@ export const SKILL_HANDLERS: Record<string, CommandHandler> = {
   },
   ...SKILL_GUIDE_GET_HANDLER,
   'skills install': createSkillMutationHandler('install'),
-  'skills update': createSkillMutationHandler('update')
+  'skills update': createSkillMutationHandler('update'),
+  'skills remove': createSkillMutationHandler('remove')
 }

--- a/src/cli/root-help-text-primary.ts
+++ b/src/cli/root-help-text-primary.ts
@@ -25,6 +25,7 @@ export const ROOT_HELP_TEXT_PRIMARY = [
   '  skills get                Print a version-matched skill guide as Markdown',
   '  skills install            Install bundled Orca skills globally via the community skills CLI',
   '  skills update             Update already-installed Orca skills via the community skills CLI',
+  '  skills remove             Remove installed Orca skills via the community skills CLI',
   '',
   'Hosts:',
   '  host list                 List targetable machines and how to name each one',

--- a/src/cli/skills-remove.test.ts
+++ b/src/cli/skills-remove.test.ts
@@ -1,0 +1,224 @@
+import { EventEmitter } from 'node:events'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as CodexCliCommandModule from '../shared/node-cli-command-resolution'
+
+const {
+  detectCommandsMock,
+  guideModuleLoadMock,
+  resolveCliCommandMock,
+  runtimeClientConstructorMock,
+  spawnMock
+} = vi.hoisted(() => ({
+  detectCommandsMock: vi.fn(() => new Set<string>(['claude'])),
+  guideModuleLoadMock: vi.fn(),
+  resolveCliCommandMock: vi.fn(() => 'npx'),
+  runtimeClientConstructorMock: vi.fn(),
+  spawnMock: vi.fn()
+}))
+
+// Why: pin detection so remove assertions do not depend on the runner host.
+vi.mock('../shared/local-agent-install-dir-detection', () => ({
+  detectCommandsInInstallDirs: detectCommandsMock
+}))
+
+vi.mock('../shared/node-cli-command-resolution', async (importOriginal) => ({
+  ...(await importOriginal<typeof CodexCliCommandModule>()),
+  resolveCliCommand: resolveCliCommandMock
+}))
+
+vi.mock('node:child_process', () => ({
+  spawn: spawnMock
+}))
+
+vi.mock('./bundled-skill-guides.js', () => {
+  guideModuleLoadMock()
+  return {
+    BUNDLED_SKILL_GUIDES: [
+      {
+        name: 'zeta',
+        description: 'Use when zeta work\nspans lines.',
+        markdown: '# Zeta\n',
+        fullMarkdown: '# Zeta\n\n## References\n\nZeta reference.\n',
+        aliases: []
+      },
+      {
+        name: 'alpha',
+        description: 'Use when alpha work is needed.',
+        markdown: '# Alpha\n\nShort.\n',
+        fullMarkdown: '# Alpha\n\nShort.\n\n## References\n\nFull.\n',
+        aliases: ['legacy-alpha']
+      },
+      {
+        name: 'gamma',
+        description: 'Use when gamma work is needed.',
+        markdown: '# Gamma\n',
+        fullMarkdown: '# Gamma\n\n## References\n\nGamma reference.\n',
+        aliases: []
+      }
+    ]
+  }
+})
+
+vi.mock('./runtime-client', async () => {
+  const { RuntimeClientError, RuntimeRpcFailureError } = await import('./runtime/types.js')
+
+  class RuntimeClient {
+    constructor() {
+      runtimeClientConstructorMock()
+    }
+  }
+
+  return {
+    RuntimeClient,
+    RuntimeClientError,
+    RuntimeRpcFailureError,
+    serveOrcaApp: vi.fn(),
+    getDefaultUserDataPath: vi.fn(() => '/tmp/orca-user-data')
+  }
+})
+
+import { main } from './index'
+
+describe('orca skills remove CLI', () => {
+  beforeEach(() => {
+    vi.restoreAllMocks()
+    runtimeClientConstructorMock.mockClear()
+    resolveCliCommandMock.mockReset()
+    resolveCliCommandMock.mockReturnValue('npx')
+    detectCommandsMock.mockReset()
+    detectCommandsMock.mockReturnValue(new Set<string>(['claude']))
+    spawnMock.mockReset()
+    process.exitCode = undefined
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.unstubAllEnvs()
+  })
+
+  it('lists removable skills when no --skill/--all is given', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    await main(['skills', 'remove'], '/tmp/repo')
+
+    expect(stdoutText(stdoutSpy)).toBe(
+      [
+        'Choose one or more skills to remove:',
+        '  alpha',
+        '  gamma',
+        '  zeta',
+        '',
+        'Usage: orca skills remove --skill <name> [--skill <name> ...]',
+        '   or: orca skills remove --all',
+        ''
+      ].join('\n')
+    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('prints the resolved remove command without running it for --dry-run', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    await main(['skills', 'remove', '--skill', 'legacy-alpha', '--dry-run'], '/tmp/repo')
+
+    expect(stdoutText(stdoutSpy)).toBe(
+      'npx --yes skills remove alpha --global -y\n\nRerun without --dry-run to remove now.\n'
+    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+
+  it('omits --global for project-local remove (skills CLI default scope)', async () => {
+    const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+
+    await main(
+      ['skills', 'remove', '--skill', 'alpha', '--local', '--dry-run', '--json'],
+      '/tmp/repo'
+    )
+
+    expect(stdoutText(stdoutSpy)).toBe(
+      `${JSON.stringify(
+        {
+          command: 'npx --yes skills remove alpha -y',
+          skills: ['alpha'],
+          global: false,
+          executed: false
+        },
+        null,
+        2
+      )}\n`
+    )
+  })
+
+  it('never sends --agent for a remove, and never refuses on a bare host', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child)
+    // Why: remove only deletes what is already placed, so the no-agent install
+    // refusal must not reach it.
+    detectCommandsMock.mockReturnValue(new Set<string>())
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const resultPromise = main(['skills', 'remove', '--skill', 'alpha'], '/tmp/repo')
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    child.emit('exit', 0, null)
+    await resultPromise
+
+    expect(spawnMock.mock.calls[0]?.[1]).not.toContain('--agent')
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npx',
+      ['--yes', 'skills', 'remove', 'alpha', '--global', '-y'],
+      expect.objectContaining({ stdio: 'inherit' })
+    )
+  })
+
+  it('runs npx skills remove for --all and forwards its exit code', async () => {
+    const child = createFakeChild()
+    spawnMock.mockReturnValue(child)
+    vi.spyOn(process.stderr, 'write').mockImplementation(() => true)
+
+    const resultPromise = main(['skills', 'remove', '--all'], '/tmp/repo')
+    await vi.waitFor(() => expect(spawnMock).toHaveBeenCalled())
+    child.emit('exit', 3, null)
+    await resultPromise
+
+    expect(spawnMock).toHaveBeenCalledWith(
+      'npx',
+      ['--yes', 'skills', 'remove', 'alpha', 'gamma', 'zeta', '--global', '-y'],
+      expect.objectContaining({ stdio: 'inherit' })
+    )
+    expect(process.exitCode).toBe(3)
+  })
+
+  it('rejects --json for a real (non-dry-run) remove', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['skills', 'remove', '--skill', 'alpha', '--json'], '/tmp/repo')
+
+    expect(process.exitCode).toBe(1)
+    expect(logSpy).toHaveBeenCalledWith(
+      JSON.stringify(
+        {
+          id: 'local',
+          ok: false,
+          error: {
+            code: 'invalid_argument',
+            message:
+              "orca skills remove --json only supports --dry-run. Real removes stream npx's " +
+              "own output, which isn't JSON."
+          },
+          _meta: { runtimeId: null }
+        },
+        null,
+        2
+      )
+    )
+    expect(spawnMock).not.toHaveBeenCalled()
+  })
+})
+
+function stdoutText(spy: ReturnType<typeof vi.spyOn>): string {
+  return spy.mock.calls.map((call) => String(call[0])).join('')
+}
+
+function createFakeChild(): EventEmitter {
+  return new EventEmitter()
+}

--- a/src/cli/skills-remove.test.ts
+++ b/src/cli/skills-remove.test.ts
@@ -96,6 +96,18 @@ describe('orca skills remove CLI', () => {
     vi.unstubAllEnvs()
   })
 
+  it('documents skills remove on group help and root help', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['skills', '--help'], '/tmp/repo')
+    await main(['--help'], '/tmp/repo')
+
+    expect(String(logSpy.mock.calls[0]?.[0])).toContain(
+      'remove             Remove installed Orca skills'
+    )
+    expect(String(logSpy.mock.calls[1]?.[0])).toContain('skills remove')
+  })
+
   it('lists removable skills when no --skill/--all is given', async () => {
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
 

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -227,8 +227,12 @@ describe('orca skills CLI', () => {
     expect(String(logSpy.mock.calls[1]?.[0])).toContain(
       'update             Update already-installed Orca skills'
     )
+    expect(String(logSpy.mock.calls[1]?.[0])).toContain(
+      'remove             Remove installed Orca skills'
+    )
     expect(String(logSpy.mock.calls[2]?.[0])).toContain('Skills:\n  skills installed')
     expect(String(logSpy.mock.calls[2]?.[0])).toContain('skills update')
+    expect(String(logSpy.mock.calls[2]?.[0])).toContain('skills remove')
     expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
   })
 

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -227,12 +227,8 @@ describe('orca skills CLI', () => {
     expect(String(logSpy.mock.calls[1]?.[0])).toContain(
       'update             Update already-installed Orca skills'
     )
-    expect(String(logSpy.mock.calls[1]?.[0])).toContain(
-      'remove             Remove installed Orca skills'
-    )
     expect(String(logSpy.mock.calls[2]?.[0])).toContain('Skills:\n  skills installed')
     expect(String(logSpy.mock.calls[2]?.[0])).toContain('skills update')
-    expect(String(logSpy.mock.calls[2]?.[0])).toContain('skills remove')
     expect(runtimeClientConstructorMock).not.toHaveBeenCalled()
   })
 

--- a/src/cli/specs/skills.ts
+++ b/src/cli/specs/skills.ts
@@ -123,5 +123,31 @@ export const SKILL_COMMAND_SPECS: CommandSpec[] = [
       'orca skills update --skill orca-cli --local',
       'orca skills update --all --dry-run'
     ]
+  },
+  {
+    path: ['skills', 'remove'],
+    summary: 'Remove installed Orca skills via the community skills CLI',
+    usage: 'orca skills remove [--skill <name>]... [--all] [--local] [--dry-run] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'skill', 'all', 'local', 'dry-run'],
+    notes: [
+      'Reads the bundled skill registry locally without contacting the Orca runtime.',
+      'Resolves to the same `npx skills remove <names...>` command used by Orca Settings, ' +
+        'plus the non-interactive flags an unattended host needs (`npx --yes` and `-y`), ' +
+        'then runs it and forwards its output and exit code.',
+      'Removes the global install (all projects, adds --global) by default. Use --local to ' +
+        'remove from the current project only (project is the skills CLI default scope).',
+      'Only removes skills that are already installed; use `orca skills install` first.',
+      'Use --dry-run to print the resolved command without running it.',
+      'With --json, the skill listing and --dry-run emit JSON; a real remove streams ' +
+        "npx's own non-JSON output live and rejects --json.",
+      'Omit --skill and --all to list removable skill names.',
+      'Intended for headless hosts (SSH, containers, CI) with no desktop Settings UI to copy the remove command from.'
+    ],
+    examples: [
+      'orca skills remove',
+      'orca skills remove --skill computer-use',
+      'orca skills remove --skill orca-cli --local',
+      'orca skills remove --all --dry-run'
+    ]
   }
 ]

--- a/src/shared/agent-feature-install-commands.test.ts
+++ b/src/shared/agent-feature-install-commands.test.ts
@@ -5,6 +5,9 @@ import {
   ORCA_CLI_SKILL_INSTALL_COMMAND,
   buildAgentFeatureSkillUpdateArgs,
   buildAgentFeatureSkillUpdateCommand,
+  buildAgentFeatureSkillRemoveArgs,
+  buildAgentFeatureSkillRemoveCommand,
+  COMPUTER_USE_SKILL_REMOVE_COMMAND,
   COMPUTER_USE_SKILL_UPDATE_COMMAND,
   EPHEMERAL_VMS_SKILL_UPDATE_COMMAND,
   LINEAR_TICKETS_SKILL_UPDATE_COMMAND,
@@ -128,5 +131,25 @@ describe('agent feature skill commands', () => {
     expect(ORCA_CLI_ORCHESTRATION_SKILL_INSTALL_COMMAND).toBe(
       buildAgentFeatureSkillInstallCommand(['orca-cli', 'orchestration'])
     )
+  })
+
+  it('builds remove commands with global default and project-local scope', () => {
+    expect(buildAgentFeatureSkillRemoveCommand('computer-use')).toBe(
+      'npx skills remove computer-use --global'
+    )
+    expect(buildAgentFeatureSkillRemoveCommand(['orca-cli', 'orchestration'], { yes: true })).toBe(
+      'npx skills remove orca-cli orchestration --global -y'
+    )
+    expect(buildAgentFeatureSkillRemoveCommand(['orca-cli'], { global: false })).toBe(
+      'npx skills remove orca-cli'
+    )
+    expect(buildAgentFeatureSkillRemoveArgs(['orca-cli'], { global: false, yes: true })).toEqual([
+      'skills',
+      'remove',
+      'orca-cli',
+      '-y'
+    ])
+    expect(COMPUTER_USE_SKILL_REMOVE_COMMAND).toBe('npx skills remove computer-use --global')
+    expect(() => buildAgentFeatureSkillRemoveCommand([])).toThrow('A skill name is required.')
   })
 })

--- a/src/shared/agent-feature-install-commands.ts
+++ b/src/shared/agent-feature-install-commands.ts
@@ -90,6 +90,33 @@ export function buildAgentFeatureSkillUpdateCommand(
   return `npx ${buildAgentFeatureSkillUpdateArgs(skillNames, options).join(' ')}`
 }
 
+export function buildAgentFeatureSkillRemoveArgs(
+  skillNames: string | readonly string[],
+  options: AgentFeatureSkillCommandOptions = {}
+): string[] {
+  const rawNames = typeof skillNames === 'string' ? [skillNames] : skillNames
+  const names = rawNames.map((name) => name.trim()).filter((name) => name.length > 0)
+  if (names.length === 0) {
+    throw new Error('A skill name is required.')
+  }
+  const global = options.global ?? true
+  return [
+    'skills',
+    'remove',
+    ...names,
+    // Why: skills remove uses -g/--global; project-local is the default (no --project flag).
+    ...(global ? ['--global'] : []),
+    ...(options.yes ? ['-y'] : [])
+  ]
+}
+
+export function buildAgentFeatureSkillRemoveCommand(
+  skillNames: string | readonly string[],
+  options: AgentFeatureSkillCommandOptions = {}
+): string {
+  return `npx ${buildAgentFeatureSkillRemoveArgs(skillNames, options).join(' ')}`
+}
+
 export const ORCA_CLI_SKILL_INSTALL_COMMAND = buildAgentFeatureSkillInstallCommand([
   ORCA_CLI_SKILL_NAME
 ])
@@ -103,6 +130,9 @@ export const COMPUTER_USE_SKILL_INSTALL_COMMAND = buildAgentFeatureSkillInstallC
 
 export const COMPUTER_USE_SKILL_UPDATE_COMMAND =
   buildAgentFeatureSkillUpdateCommand(COMPUTER_USE_SKILL_NAME)
+
+export const COMPUTER_USE_SKILL_REMOVE_COMMAND =
+  buildAgentFeatureSkillRemoveCommand(COMPUTER_USE_SKILL_NAME)
 
 export const ORCHESTRATION_SKILL_INSTALL_COMMAND = buildAgentFeatureSkillInstallCommand([
   ORCHESTRATION_SKILL_NAME


### PR DESCRIPTION
Add `orca skills remove` for headless uninstall, using the existing skill registry and mutation runner. It supports listing, aliases, repeated skill selection, `--all`, global default, project scope with `--local`, and `--dry-run` JSON. Real execution forwards the skills CLI output and exit code and rejects `--json`.

Removal uses `npx --yes skills remove <names...> [--global] -y`. It preserves the SSH/WSL forwarding refusal so a forwarded shell cannot uninstall from the unintended host. Unlike installation it does not require a detected agent or send `--agent`. Existing install/update behavior and assertions are retained; new help assertions live in the separate remove test file. Refs #13099.

Validation on the refreshed candidate (2026-09-09):

- Cursor review tied to the final commit; independently inspected by Codex.
- 71 focused tests passed in both Cursor and Codex runs.
- CLI typecheck with `--composite false --noEmit`, changed-file oxlint/oxfmt and diff checks passed.
- Full build and live Windows/WSL/SSH end-to-end checks were not run. Default composite typecheck is not claimed green (baseline TS2883); non-composite checks above are explicit.

Reviewed and checked commit: `c1c0277e4da0a3af5dd3afd2173ff380b24735e3`. Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`. No rendered UI changes.
