### PR TITLE
docs(cli): document terminal read --json result schema

### DIFF
--- a/src/cli/specs/core-terminal-read-help.test.ts
+++ b/src/cli/specs/core-terminal-read-help.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+
+import { CORE_COMMAND_SPECS } from './core'
+import { formatCommandHelp } from '../help'
+
+function terminalReadHelp(): string {
+  const found = CORE_COMMAND_SPECS.find((entry) => entry.path.join(' ') === 'terminal read')
+  if (!found) {
+    throw new Error('Missing terminal read command spec')
+  }
+  return formatCommandHelp(found)
+}
+
+describe('terminal read help', () => {
+  // Why: agents consume --json without reading TypeScript; nextCursor vs latestCursor
+  // is the field that drives paging and was previously only in the human formatter.
+  it('documents the --json terminal result schema and cursor roles', () => {
+    const help = terminalReadHelp()
+
+    expect(help).toContain('With --json, the RPC result is')
+    expect(help).toContain('nextCursor')
+    expect(help).toContain('latestCursor')
+    expect(help).toContain('oldestCursor')
+    expect(help).toContain('status is running | exited | unknown')
+    expect(help).toContain('Pass nextCursor to a later --cursor')
+    expect(help).toContain('returnedLineCount')
+  })
+})

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -202,7 +202,17 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
       'Omit --terminal to target the active terminal in the current worktree.',
       'Use --cursor with the nextCursor value from a previous read to get only new output since that read.',
       'Use --limit to request more retained lines for long agent responses; output reports oldestCursor when older lines were dropped.',
-      'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.'
+      'Useful for capturing the response to a command: read before sending, then read --cursor <prev> after waiting.',
+      'With --json, the RPC result is `{ terminal: { handle, status, tail, truncated, limited?, ' +
+        'oldestCursor?, nextCursor, latestCursor?, returnedLineCount? } }`.',
+      'status is running | exited | unknown. tail is the retained line array for this page.',
+      'truncated means older retained history was dropped; limited means this response hit --limit ' +
+        'and more output may exist.',
+      'Pass nextCursor to a later --cursor to page forward. latestCursor is the tip of retained ' +
+        'output (do not pass it as --cursor unless you want only output after the tip). ' +
+        'oldestCursor is the first retained line when a tail preview dropped earlier history; ' +
+        'use it with --limit to page retained output from the start of the buffer.',
+      'returnedLineCount is the number of lines in tail when the runtime reports it.'
     ],
     examples: [
       'orca terminal read --json',


### PR DESCRIPTION
## Summary

- `orca terminal read --help` documented flags but not the `--json` result shape (#7433).
- Agents misread `latestCursor` as the paging token; only `nextCursor` should feed a later `--cursor`.
- Add Notes covering `result.terminal` fields and cursor roles, with a unit test on rendered help.

## Test plan

- [x] `pnpm exec vitest run src/cli/specs/core-terminal-read-help.test.ts`
- [x] Help text includes nextCursor / latestCursor / oldestCursor / status / limited / truncated
- [ ] Manual: `orca terminal read --help` shows the new Notes block

Fixes #7433