### PR TITLE
fix(mobile): let a new QR supersede deferred pairing recovery

### DIFF
--- a/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.test.ts
@@ -316,7 +316,7 @@ describe('mobile relay pairing journal store', () => {
   it.each([
     ['winner', { winner: 'direct' as const }],
     ['authorization mode', { authorizationMode: 'authenticated-direct' as const }]
-  ])('refuses replacement once the durable %s exists', async (_name, authorization) => {
+  ])('refuses same-offer replacement once the durable %s exists', async (_name, authorization) => {
     const created = createMobileRelayPairingJournal({
       offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
       hostId: 'host-1',
@@ -337,6 +337,42 @@ describe('mobile relay pairing journal store', () => {
     })
     await expect(saveMobileRelayPairingJournal(replacement)).rejects.toThrow(/recovery pending/)
     await expect(loadMobileRelayPairingJournal()).resolves.toEqual(journal)
+  })
+
+  it('lets a new QR supersede a deferred recovery journal from a previous invite', async () => {
+    // Why: recovery deferred forever blocked every later scan with the same error (#12708).
+    const created = createMobileRelayPairingJournal({
+      offer: offer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-1',
+      hostName: 'Blue Whale',
+      randomBytes: (length) => new Uint8Array(length).fill(10)
+    })
+    const journal = {
+      ...created,
+      metadata: {
+        ...created.metadata,
+        winner: 'relay' as const,
+        authorizationMode: 'relay-basis' as const
+      }
+    }
+    await saveMobileRelayPairingJournal(journal)
+
+    const rescanOffer = {
+      ...offer,
+      relay: {
+        ...offer.relay,
+        inviteToken: 'zyxwvutsrqponmlkjihgfedcbaHGFEDCBA987654321'
+      }
+    } satisfies PairingOffer
+    const rescan = createMobileRelayPairingJournal({
+      offer: rescanOffer as PairingOffer & { relay: NonNullable<PairingOffer['relay']> },
+      hostId: 'host-2',
+      hostName: 'Red Panda',
+      randomBytes: (length) => new Uint8Array(length).fill(14)
+    })
+
+    await expect(saveMobileRelayPairingJournal(rescan)).resolves.toBeUndefined()
+    await expect(loadMobileRelayPairingJournal()).resolves.toEqual(rescan)
   })
 
   it('self-heals an undecryptable Android secret so the next QR scan can pair', async () => {

--- a/mobile/src/transport/mobile-relay-pairing-journal-store.ts
+++ b/mobile/src/transport/mobile-relay-pairing-journal-store.ts
@@ -34,7 +34,18 @@ export async function saveMobileRelayPairingJournal(
       existing.journalId !== metadata.journalId &&
       (existing.winner !== undefined || existing.authorizationMode !== undefined)
     ) {
-      throw new Error('mobile relay pairing recovery pending')
+      // Why: recovery still owns same-offer reconcile. A different offerFingerprint
+      // means the user scanned a new QR; blocking that forever while recovery only
+      // deferred left pairing unusable after any interrupted attempt (#12708).
+      // Uncommitted server-side installs for the old invite expire on their own.
+      if (existing.offerFingerprint === metadata.offerFingerprint) {
+        throw new Error(
+          'mobile relay pairing recovery pending: a previous pairing for this invite ' +
+            'is still reconciling. Wait for recovery, or clear Orca Mobile pairing data ' +
+            'and scan a new QR code.'
+        )
+      }
+      await removeIncompleteJournal()
     }
     // Why: no install RPC can run before winner+authorization are durable, so
     // a new user-initiated scan may safely supersede a pre-authorization attempt.


### PR DESCRIPTION
## Summary

- After a partial relay pair stamped `winner`/`authorizationMode`, a later QR scan with a **different** invite hit `mobile relay pairing recovery pending` forever while recovery only deferred (#12708).
- Keep same-offer reconcile protection (recovery still owns that path).
- When `offerFingerprint` differs, clear the incomplete journal and allow the new scan.
- Clarify the same-offer error so users know to wait or clear pairing data.

## Test plan

- [x] Unit: same-offer replacement still throws recovery pending
- [x] Unit: new invite supersedes deferred recovery journal
- [x] Existing journal store suite green
- [ ] Manual: interrupt pairing, scan a fresh desktop QR, pairing proceeds

Fixes #12708