### PR TITLE
feat(orchestration): allow task-update --deps in place

### DIFF
--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -830,8 +830,18 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
   },
 
   'orchestration task-update': async ({ flags, client, cwd, json }) => {
-    const status = getRequiredStringFlag(flags, 'status')
-    if (!TASK_STATUS_VALUES.includes(status as (typeof TASK_STATUS_VALUES)[number])) {
+    const status = getOptionalStringFlag(flags, 'status')
+    const deps = getOptionalStringFlag(flags, 'deps')
+    if (status === undefined && deps === undefined) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'Provide --status and/or --deps (JSON array of task IDs)'
+      )
+    }
+    if (
+      status !== undefined &&
+      !TASK_STATUS_VALUES.includes(status as (typeof TASK_STATUS_VALUES)[number])
+    ) {
       throw new RuntimeClientError(
         'invalid_argument',
         `invalid status '${status}', expected one of: ${TASK_STATUS_VALUES.join(', ')}`
@@ -843,8 +853,9 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
       'orchestration.taskUpdate',
       {
         id: getRequiredStringFlag(flags, 'id'),
-        status,
+        ...(status !== undefined ? { status } : {}),
         result: getOptionalStringFlag(flags, 'result'),
+        ...(deps !== undefined ? { deps } : {}),
         run: getOptionalStringFlag(flags, 'run'),
         callerTerminalHandle: await resolveCoordinatorTerminalHandle(flags, cwd, client)
       }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -103,7 +103,7 @@ Orchestration:
   orchestration inbox       Show all messages across recipients
   orchestration task-create Create an orchestration task
   orchestration task-list   List orchestration tasks
-  orchestration task-update Update a task status
+  orchestration task-update Update a task status and/or dependencies
   orchestration dispatch    Dispatch a task to a terminal
   orchestration dispatch-show Show dispatch context for a task
   orchestration worker-start Start a supervised worker locally or on a connected Orca server

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -166,11 +166,13 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     notes: [
       'Provide --status and/or --deps. Valid --status values: pending, ready, dispatched, completed, failed, blocked.',
       '--deps is a JSON array of task IDs (same shape as task-create). Only pending or ready tasks accept deps changes; status flips between pending and ready from whether all deps are completed.',
+      'Shell quoting: use single-quoted JSON on macOS, Linux, or PowerShell; use the escaped double-quoted example in Windows Command Prompt.',
       '--result requires --status.'
     ],
     examples: [
       'orca orchestration task-update --id task_abc --status completed --json',
-      `orca orchestration task-update --id task_abc --deps '["task_dep1","task_dep2"]' --json`
+      `orca orchestration task-update --id task_abc --deps '["task_dep1","task_dep2"]' --json`,
+      `orca orchestration task-update --id task_abc --deps "[\\"task_dep1\\",\\"task_dep2\\"]" --json`
     ]
   },
   ...ORCHESTRATION_WORKER_COMMAND_SPECS,

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -150,11 +150,28 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
   },
   {
     path: ['orchestration', 'task-update'],
-    summary: 'Update a task status',
+    summary: 'Update a task status and/or dependencies',
     usage:
-      'orca orchestration task-update --id <task_id> --status <status> [--result <json>] [--run <run_id>] [--from <handle>] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'id', 'status', 'result', 'run', 'from', 'retry-request'],
-    notes: ['Valid --status values: pending, ready, dispatched, completed, failed, blocked.']
+      'orca orchestration task-update --id <task_id> [--status <status>] [--deps <json_array>] [--result <json>] [--run <run_id>] [--from <handle>] [--json]',
+    allowedFlags: [
+      ...GLOBAL_FLAGS,
+      'id',
+      'status',
+      'deps',
+      'result',
+      'run',
+      'from',
+      'retry-request'
+    ],
+    notes: [
+      'Provide --status and/or --deps. Valid --status values: pending, ready, dispatched, completed, failed, blocked.',
+      '--deps is a JSON array of task IDs (same shape as task-create). Only pending or ready tasks accept deps changes; status flips between pending and ready from whether all deps are completed.',
+      '--result requires --status.'
+    ],
+    examples: [
+      'orca orchestration task-update --id task_abc --status completed --json',
+      `orca orchestration task-update --id task_abc --deps '["task_dep1","task_dep2"]' --json`
+    ]
   },
   ...ORCHESTRATION_WORKER_COMMAND_SPECS,
   {

--- a/src/main/runtime/orchestration/db-task-deps.test.ts
+++ b/src/main/runtime/orchestration/db-task-deps.test.ts
@@ -39,4 +39,17 @@ describe('OrchestrationDb.updateTaskDeps', () => {
     d.updateTaskStatus(task.id, 'dispatched')
     expect(() => d.updateTaskDeps(task.id, [])).toThrow(/only pending or ready/)
   })
+
+  it('rejects a dependency that already reaches the updated task', () => {
+    const d = createDb()
+    const first = d.createTask({ spec: 'first' })
+    const second = d.createTask({ spec: 'second', deps: [first.id] })
+
+    expect(() => d.updateTaskDeps(first.id, [second.id])).toThrow(/dependency cycle/i)
+    expect(d.getTask(first.id)).toMatchObject({ status: 'ready', deps: '[]' })
+    expect(d.getTask(second.id)).toMatchObject({
+      status: 'pending',
+      deps: JSON.stringify([first.id])
+    })
+  })
 })

--- a/src/main/runtime/orchestration/db-task-deps.test.ts
+++ b/src/main/runtime/orchestration/db-task-deps.test.ts
@@ -1,0 +1,42 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { OrchestrationDb } from './db'
+
+describe('OrchestrationDb.updateTaskDeps', () => {
+  let db: OrchestrationDb | undefined
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  function createDb(): OrchestrationDb {
+    db = new OrchestrationDb(':memory:')
+    return db
+  }
+
+  it('updates deps in place and re-evaluates pending/ready', () => {
+    const d = createDb()
+    const t1 = d.createTask({ spec: 'a' })
+    const t2 = d.createTask({ spec: 'b' })
+    const child = d.createTask({ spec: 'c', deps: [t1.id] })
+    expect(child.status).toBe('pending')
+
+    const cleared = d.updateTaskDeps(child.id, [])
+    expect(cleared?.status).toBe('ready')
+    expect(JSON.parse(cleared!.deps)).toEqual([])
+
+    const reblocked = d.updateTaskDeps(child.id, [t2.id])
+    expect(reblocked?.status).toBe('pending')
+    expect(JSON.parse(reblocked!.deps)).toEqual([t2.id])
+
+    d.updateTaskStatus(t2.id, 'completed')
+    const withCompletedDep = d.updateTaskDeps(child.id, [t2.id])
+    expect(withCompletedDep?.status).toBe('ready')
+  })
+
+  it('refuses deps updates after dispatch', () => {
+    const d = createDb()
+    const task = d.createTask({ spec: 'work' })
+    d.updateTaskStatus(task.id, 'dispatched')
+    expect(() => d.updateTaskDeps(task.id, [])).toThrow(/only pending or ready/)
+  })
+})

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -3965,6 +3965,9 @@ export class OrchestrationDb {
       if (!dependency || dependency.run_id !== task.run_id) {
         throw new Error(`Dependency task ${depId} must belong to run ${task.run_id}`)
       }
+      if (this.dependencyPathReaches(depId, id)) {
+        throw new Error(`Dependency cycle: task ${depId} already depends on task ${id}`)
+      }
     }
     const allDepsCompleted = deps.every((depId) => {
       const dep = this.getTask(depId)
@@ -3975,6 +3978,62 @@ export class OrchestrationDb {
       .prepare('UPDATE tasks SET deps = ?, status = ? WHERE id = ?')
       .run(JSON.stringify(deps), nextStatus, id)
     return this.getTask(id)
+  }
+
+  private dependencyPathReaches(startTaskId: string, targetTaskId: string): boolean {
+    const pending = [startTaskId]
+    const visited = new Set<string>()
+    while (pending.length > 0) {
+      const taskId = pending.pop() as string
+      if (taskId === targetTaskId) {
+        return true
+      }
+      if (visited.has(taskId)) {
+        continue
+      }
+      visited.add(taskId)
+      const task = this.getTask(taskId)
+      if (task) {
+        pending.push(...(JSON.parse(task.deps) as string[]))
+      }
+    }
+    return false
+  }
+
+  updateTask(
+    id: string,
+    changes: { deps?: string[]; status?: TaskStatus; result?: string }
+  ): TaskRow | undefined {
+    if (changes.result !== undefined && changes.status === undefined) {
+      throw new Error('--result requires --status')
+    }
+    if (!this.getTask(id)) {
+      return undefined
+    }
+
+    this.db.exec('SAVEPOINT update_task')
+    try {
+      let task = this.getTask(id) as TaskRow
+      if (changes.deps !== undefined) {
+        task = this.updateTaskDeps(id, changes.deps) as TaskRow
+      }
+      if (changes.status === 'ready') {
+        const deps = JSON.parse(task.deps) as string[]
+        const incomplete = deps.find((depId) => this.getTask(depId)?.status !== 'completed')
+        if (incomplete) {
+          throw new Error(`Cannot set status ready while dependency ${incomplete} is incomplete`)
+        }
+      }
+      if (changes.status !== undefined) {
+        task = this.updateTaskStatus(id, changes.status, changes.result) as TaskRow
+      }
+      this.db.exec('RELEASE update_task')
+      return task
+    } catch (error) {
+      this.db.exec('ROLLBACK TO update_task')
+      this.db.exec('RELEASE update_task')
+      throw error
+    }
   }
 
   // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -3945,6 +3945,38 @@ export class OrchestrationDb {
     return this.getTask(id)
   }
 
+  // Why: deps were write-once at create; wrong --deps forced recreate-or-nuke (#7430).
+  // Only pending/ready tasks may change deps — dispatched work already owns a worker.
+  updateTaskDeps(id: string, deps: string[]): TaskRow | undefined {
+    const task = this.getTask(id)
+    if (!task) {
+      return undefined
+    }
+    if (task.status !== 'pending' && task.status !== 'ready') {
+      throw new Error(
+        `Cannot update deps for task ${id} in status ${task.status}; only pending or ready tasks accept --deps`
+      )
+    }
+    for (const depId of deps) {
+      if (depId === id) {
+        throw new Error(`Task ${id} cannot depend on itself`)
+      }
+      const dependency = this.getTask(depId)
+      if (!dependency || dependency.run_id !== task.run_id) {
+        throw new Error(`Dependency task ${depId} must belong to run ${task.run_id}`)
+      }
+    }
+    const allDepsCompleted = deps.every((depId) => {
+      const dep = this.getTask(depId)
+      return dep?.status === 'completed'
+    })
+    const nextStatus: TaskStatus = allDepsCompleted ? 'ready' : 'pending'
+    this.db
+      .prepare('UPDATE tasks SET deps = ?, status = ? WHERE id = ?')
+      .run(JSON.stringify(deps), nextStatus, id)
+    return this.getTask(id)
+  }
+
   // Why: runs in the status-update transaction, so a completed task never leaves its ready children unpromoted.
   private promoteReadyTasks(completedTaskId: string): void {
     const candidates = this.db

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1938,6 +1938,22 @@ describe('orchestration RPC methods', () => {
           status: 'ready'
         })
       ).rejects.toThrow(/Cannot set status ready while dependency/)
+      expect(db.getTask(child.id)).toMatchObject({ status: 'ready', deps: '[]' })
+    })
+
+    it('preserves deps and status when result is provided without status', async () => {
+      setup()
+      const blocker = db.createTask({ spec: 'blocker' })
+      const child = db.createTask({ spec: 'child' })
+
+      await expect(
+        call('orchestration.taskUpdate', {
+          id: child.id,
+          deps: JSON.stringify([blocker.id]),
+          result: '{"unexpected":true}'
+        })
+      ).rejects.toThrow('--result requires --status')
+      expect(db.getTask(child.id)).toMatchObject({ status: 'ready', deps: '[]' })
     })
   })
 

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1903,6 +1903,27 @@ describe('orchestration RPC methods', () => {
         call('orchestration.taskUpdate', { id: 'task_fake', status: 'completed' })
       ).rejects.toThrow('was not found')
     })
+
+    it('updates deps without requiring status', async () => {
+      setup()
+      const parent = db.createTask({ spec: 'parent' })
+      const child = db.createTask({ spec: 'child', deps: [parent.id] })
+      expect(child.status).toBe('pending')
+
+      const result = (await call('orchestration.taskUpdate', {
+        id: child.id,
+        deps: JSON.stringify([])
+      })) as { task: { status: string; deps: string } }
+
+      expect(result.task.status).toBe('ready')
+      expect(JSON.parse(result.task.deps)).toEqual([])
+    })
+
+    it('rejects taskUpdate with neither status nor deps', async () => {
+      setup()
+      const task = db.createTask({ spec: 'work' })
+      await expect(call('orchestration.taskUpdate', { id: task.id })).rejects.toThrow(/status|deps/)
+    })
   })
 
   describe('orchestration.dispatch', () => {

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -1924,6 +1924,21 @@ describe('orchestration RPC methods', () => {
       const task = db.createTask({ spec: 'work' })
       await expect(call('orchestration.taskUpdate', { id: task.id })).rejects.toThrow(/status|deps/)
     })
+
+    it('rejects ready when deps remain incomplete after a combined deps update', async () => {
+      setup()
+      const blocker = db.createTask({ spec: 'blocker' })
+      const child = db.createTask({ spec: 'child' })
+      expect(child.status).toBe('ready')
+
+      await expect(
+        call('orchestration.taskUpdate', {
+          id: child.id,
+          deps: JSON.stringify([blocker.id]),
+          status: 'ready'
+        })
+      ).rejects.toThrow(/Cannot set status ready while dependency/)
+    })
   })
 
   describe('orchestration.dispatch', () => {

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1206,9 +1206,8 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           `Task ${params.id} was not found in Run ${run.id}.`
         )
       }
-      let task = existing
+      let deps: string[] | undefined
       if (params.deps !== undefined) {
-        let deps: string[]
         try {
           const parsed = JSON.parse(params.deps)
           if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
@@ -1218,29 +1217,14 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         } catch {
           throw new Error('Invalid --deps: must be a JSON array of task IDs')
         }
-        const updated = db.updateTaskDeps(params.id, deps)
-        if (!updated) {
-          throw new Error(`Task not found: ${params.id}`)
-        }
-        task = updated
       }
-      if (params.status !== undefined) {
-        // Why: updateTaskStatus is a blind write; refuse ready while deps are still incomplete
-        // so `--deps incomplete --status ready` cannot create a dispatchable task (#13177 review).
-        if (params.status === 'ready') {
-          const deps: string[] = JSON.parse(task.deps)
-          const incomplete = deps.find((depId) => db.getTask(depId)?.status !== 'completed')
-          if (incomplete) {
-            throw new Error(`Cannot set status ready while dependency ${incomplete} is incomplete`)
-          }
-        }
-        const updated = db.updateTaskStatus(params.id, params.status, params.result)
-        if (!updated) {
-          throw new Error(`Task not found: ${params.id}`)
-        }
-        task = updated
-      } else if (params.result !== undefined) {
-        throw new Error('--result requires --status')
+      const task = db.updateTask(params.id, {
+        deps,
+        status: params.status,
+        result: params.result
+      })
+      if (!task) {
+        throw new Error(`Task not found: ${params.id}`)
       }
       return { task }
     }

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -1225,6 +1225,15 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         task = updated
       }
       if (params.status !== undefined) {
+        // Why: updateTaskStatus is a blind write; refuse ready while deps are still incomplete
+        // so `--deps incomplete --status ready` cannot create a dispatchable task (#13177 review).
+        if (params.status === 'ready') {
+          const deps: string[] = JSON.parse(task.deps)
+          const incomplete = deps.find((depId) => db.getTask(depId)?.status !== 'completed')
+          if (incomplete) {
+            throw new Error(`Cannot set status ready while dependency ${incomplete} is incomplete`)
+          }
+        }
         const updated = db.updateTaskStatus(params.id, params.status, params.result)
         if (!updated) {
           throw new Error(`Task not found: ${params.id}`)

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -171,25 +171,42 @@ const TaskListParams = z.object({
   callerTerminalHandle: OptionalString
 })
 
-const TaskUpdateParams = z.object({
-  id: requiredString('Missing --id'),
-  status: z
-    .unknown()
-    .transform((v) => {
-      if (typeof v === 'string' && TASK_STATUSES.includes(v as TaskStatus)) {
-        return v as TaskStatus
-      }
-      return ''
-    })
-    .pipe(
-      z.enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked'], {
-        message: 'Missing --status'
+const TaskUpdateParams = z
+  .object({
+    id: requiredString('Missing --id'),
+    status: z
+      .unknown()
+      .optional()
+      .transform((v) => {
+        if (v === undefined || v === null || v === '') {
+          return undefined
+        }
+        if (typeof v === 'string' && TASK_STATUSES.includes(v as TaskStatus)) {
+          return v as TaskStatus
+        }
+        return ''
       })
-    ),
-  result: OptionalString,
-  run: OptionalString,
-  callerTerminalHandle: OptionalString
-})
+      .pipe(
+        z
+          .enum(['pending', 'ready', 'dispatched', 'completed', 'failed', 'blocked'], {
+            message: 'Invalid --status'
+          })
+          .optional()
+      ),
+    result: OptionalString,
+    // Why: same JSON array shape as task-create --deps (#7430).
+    deps: OptionalString,
+    run: OptionalString,
+    callerTerminalHandle: OptionalString
+  })
+  .superRefine((value, ctx) => {
+    if (value.status === undefined && value.deps === undefined) {
+      ctx.addIssue({
+        code: z.ZodIssueCode.custom,
+        message: 'Provide --status and/or --deps'
+      })
+    }
+  })
 
 const DispatchParams = z.object({
   task: requiredString('Missing --task'),
@@ -1189,9 +1206,32 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
           `Task ${params.id} was not found in Run ${run.id}.`
         )
       }
-      const task = db.updateTaskStatus(params.id, params.status, params.result)
-      if (!task) {
-        throw new Error(`Task not found: ${params.id}`)
+      let task = existing
+      if (params.deps !== undefined) {
+        let deps: string[]
+        try {
+          const parsed = JSON.parse(params.deps)
+          if (!Array.isArray(parsed) || !parsed.every((d) => typeof d === 'string')) {
+            throw new Error('not an array of strings')
+          }
+          deps = parsed
+        } catch {
+          throw new Error('Invalid --deps: must be a JSON array of task IDs')
+        }
+        const updated = db.updateTaskDeps(params.id, deps)
+        if (!updated) {
+          throw new Error(`Task not found: ${params.id}`)
+        }
+        task = updated
+      }
+      if (params.status !== undefined) {
+        const updated = db.updateTaskStatus(params.id, params.status, params.result)
+        if (!updated) {
+          throw new Error(`Task not found: ${params.id}`)
+        }
+        task = updated
+      } else if (params.result !== undefined) {
+        throw new Error('--result requires --status')
       }
       return { task }
     }


### PR DESCRIPTION
## Summary

- \`task-update\` could only change status/result; wrong \`--deps\` at create forced recreate or \`reset --tasks\` (#7430).
- DB: \`updateTaskDeps\` for **pending/ready** tasks only; rewrites \`deps\` and flips status pending↔ready from whether all deps are completed.
- RPC + CLI: optional \`--deps\` JSON array (same shape as \`task-create\`); \`--status\` optional when \`--deps\` is set; either required.

## Test plan

- [x] DB: clear deps → ready; reblock → pending; completed dep → ready; refuse after dispatched
- [x] RPC: deps without status; reject neither status nor deps
- [x] Existing taskUpdate status tests still pass
- [ ] Manual: \`task-create --deps '["bad"]'\` then \`task-update --id … --deps '["task_real"]' --json\`

Fixes #7430