### PR TITLE
feat(voice): add custom vocabulary and local transcript correction

### DIFF
--- a/mobile/app/h/[hostId]/session/[worktreeId].tsx
+++ b/mobile/app/h/[hostId]/session/[worktreeId].tsx
@@ -94,6 +94,7 @@ import { MOBILE_AI_VAULT_CAPABILITY } from '../../../../src/agent-history/agent-
 import type { ConnectionState, RpcFailure, RpcSuccess } from '../../../../src/transport/types'
 import { headlessActivationNeedsHostRenderer } from '../../../../src/worktree/worktree-activation-result'
 import { useMobileDictation } from '../../../../src/hooks/use-mobile-dictation'
+import { showMobileDictationCorrectionAlert } from '../../../../src/dictation/mobile-dictation-correction-alert'
 import {
   triggerMediumImpact,
   triggerSelection,
@@ -1016,6 +1017,9 @@ export default function SessionScreen() {
   const [showDictationSetup, setShowDictationSetup] = useState(false)
   // 'hold' = press-and-hold mic, 'toggle' = tap-to-start/stop; mirrors Settings ▸ Voice ▸ Dictation Mode.
   const [dictationMode, setDictationMode] = useState<'toggle' | 'hold'>('toggle')
+  const [dictationCorrectionMode, setDictationCorrectionMode] = useState<
+    'off' | 'preview' | 'auto'
+  >('off')
   const [toastMessage, setToastMessage] = useState<string | null>(null)
   const toastOpacityRef = useRef(new Animated.Value(0))
   const toastHideTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
@@ -1238,44 +1242,46 @@ export default function SessionScreen() {
   const { toggleTabChatView, showNativeChat, showNativeChatRef } = nativeChatController
   nativeChatSendError.bannerMountedRef.current = showNativeChat
 
+  const insertDictationTranscript = (text: string): void => {
+    const routeContext = dictationRouteContextRef.current
+    dictationRouteContextRef.current = null
+    // Why: dictation belongs to the visible composer — native chat consumes it locally, terminal mode keeps live-input routing.
+    if (showNativeChatRef.current) {
+      nativeChatController.setChatComposerText((current) => appendBufferedDictation(current, text))
+      showToast('Dictation inserted')
+      return
+    }
+    const route = routeDictationTranscript(text, routeContext?.liveInputEnabled ?? liveInputEnabled)
+    if (route.kind === 'live-insert') {
+      const insertHandle = routeContext?.handle ?? activeHandleRef.current
+      if (!insertHandle) {
+        return
+      }
+      void (async () => {
+        const flushedPendingInput = await flushPendingLiveInputBeforeExternalSend(insertHandle)
+        if (!flushedPendingInput) {
+          return
+        }
+        const sent = await sendLiveTerminalInput(insertHandle, route.text)
+        if (sent) {
+          showToast('Dictation inserted')
+        }
+      })()
+      return
+    }
+    setInput((current) => appendBufferedDictation(current, route.text))
+    showToast('Dictation inserted')
+  }
+
   const dictation = useMobileDictation({
     client,
     enabled: canSend,
-    onTranscript: (text) => {
-      // Why: dictation belongs to the visible composer — native chat consumes it locally, terminal mode keeps live-input routing.
-      if (showNativeChatRef.current) {
-        nativeChatController.setChatComposerText((current) =>
-          appendBufferedDictation(current, text)
-        )
-        showToast('Dictation inserted')
-        return
-      }
-      // Live mode inserts the transcript into its PTY as text (no Return); buffered mode appends to the command field.
-      const routeContext = dictationRouteContextRef.current
-      dictationRouteContextRef.current = null
-      const route = routeDictationTranscript(
-        text,
-        routeContext?.liveInputEnabled ?? liveInputEnabled
-      )
-      if (route.kind === 'live-insert') {
-        const insertHandle = routeContext?.handle ?? activeHandleRef.current
-        if (!insertHandle) {
-          return
-        }
-        void (async () => {
-          const flushedPendingInput = await flushPendingLiveInputBeforeExternalSend(insertHandle)
-          if (!flushedPendingInput) {
-            return
-          }
-          const sent = await sendLiveTerminalInput(insertHandle, route.text)
-          if (sent) {
-            showToast('Dictation inserted')
-          }
-        })()
-        return
-      }
-      setInput((current) => appendBufferedDictation(current, route.text))
-      showToast('Dictation inserted')
+    correctionMode: dictationCorrectionMode,
+    onTranscript: insertDictationTranscript,
+    onTranscriptPreview: (preview) => {
+      showMobileDictationCorrectionAlert(preview, insertDictationTranscript, () => {
+        dictationRouteContextRef.current = null
+      })
     },
     onError: (err) => {
       dictationRouteContextRef.current = null
@@ -1337,23 +1343,24 @@ export default function SessionScreen() {
     }
   }, [cancelDictation, dictation])
 
-  const refreshDictationMode = useCallback(async () => {
+  const refreshDictationPreferences = useCallback(async () => {
     if (!client) {
       return
     }
     try {
       const setup = await fetchDictationSetup(client)
       setDictationMode(setup.dictationMode)
+      setDictationCorrectionMode(setup.dictationCorrectionMode ?? 'off')
     } catch {
       // Non-fatal: fall back to the default toggle behavior.
     }
   }, [client])
 
-  // Re-read on focus so a Settings ▸ Voice dictation-mode change is reflected on return.
+  // Re-read on focus so Settings ▸ Voice dictation preferences are reflected on return.
   useFocusEffect(
     useCallback(() => {
-      void refreshDictationMode()
-    }, [refreshDictationMode])
+      void refreshDictationPreferences()
+    }, [refreshDictationPreferences])
   )
 
   useEffect(() => {

--- a/mobile/app/voice-settings.tsx
+++ b/mobile/app/voice-settings.tsx
@@ -17,6 +17,7 @@ import type { HostProfile } from '../src/transport/types'
 import { useFocusedSettingsHostClients } from '../src/transport/settings-host-client-connections'
 import type { RpcClient } from '../src/transport/rpc-client'
 import { BottomDrawer } from '../src/components/BottomDrawer'
+import { VoiceDictationPreferences } from '../src/components/VoiceDictationPreferences'
 import { VoiceModelList } from '../src/components/VoiceModelList'
 import { useDictationSetupPoller } from '../src/dictation/use-dictation-setup-poller'
 import {
@@ -30,11 +31,6 @@ import {
 } from '../src/dictation/mobile-dictation-setup'
 
 const POLL_INTERVAL_MS = 1500
-
-const DICTATION_MODES = [
-  { value: 'toggle', label: 'Toggle' },
-  { value: 'hold', label: 'Hold' }
-] as const
 
 type ModelBusyAction = { modelId: string; type: 'download' | 'select' | 'delete' }
 
@@ -117,6 +113,23 @@ export default function VoiceSettingsScreen(): React.JSX.Element {
       setSetup((prev) => (prev ? { ...prev, dictationMode } : prev))
       try {
         setSetup(await setDictationConfig(client, { dictationMode }))
+      } catch (err) {
+        setError(err instanceof Error ? err.message : 'Could not update')
+        void refreshSetup()
+      }
+    },
+    [client, refreshSetup]
+  )
+
+  const handleSelectCorrectionMode = useCallback(
+    async (dictationCorrectionMode: 'off' | 'preview' | 'auto') => {
+      if (!client) {
+        return
+      }
+      setError(null)
+      setSetup((prev) => (prev ? { ...prev, dictationCorrectionMode } : prev))
+      try {
+        setSetup(await setDictationConfig(client, { dictationCorrectionMode }))
       } catch (err) {
         setError(err instanceof Error ? err.message : 'Could not update')
         void refreshSetup()
@@ -234,33 +247,13 @@ export default function VoiceSettingsScreen(): React.JSX.Element {
 
             <View style={styles.separator} />
 
-            <View
-              style={[styles.row, !enabled && styles.disabled]}
-              pointerEvents={enabled ? 'auto' : 'none'}
-            >
-              <View style={styles.rowContent}>
-                <Text style={styles.rowLabel}>Dictation Mode</Text>
-                <Text style={styles.rowSublabel}>
-                  Toggle: press once to start, again to stop. Hold: dictate while held.
-                </Text>
-              </View>
-              <View style={styles.segmented}>
-                {DICTATION_MODES.map((mode) => {
-                  const active = setup.dictationMode === mode.value
-                  return (
-                    <Pressable
-                      key={mode.value}
-                      onPress={() => void handleSelectMode(mode.value)}
-                      style={[styles.segment, active && styles.segmentActive]}
-                    >
-                      <Text style={[styles.segmentText, active && styles.segmentTextActive]}>
-                        {mode.label}
-                      </Text>
-                    </Pressable>
-                  )
-                })}
-              </View>
-            </View>
+            <VoiceDictationPreferences
+              enabled={enabled}
+              dictationMode={setup.dictationMode}
+              correctionMode={setup.dictationCorrectionMode ?? 'off'}
+              onSelectDictationMode={(mode) => void handleSelectMode(mode)}
+              onSelectCorrectionMode={(mode) => void handleSelectCorrectionMode(mode)}
+            />
           </View>
 
           <Text style={[styles.groupHeading, styles.inputGroupGap]}>SPEECH MODEL</Text>
@@ -392,20 +385,5 @@ const styles = StyleSheet.create({
     backgroundColor: colors.borderSubtle,
     marginHorizontal: spacing.md
   },
-  segmented: {
-    flexDirection: 'row',
-    alignItems: 'center',
-    backgroundColor: colors.bgBase,
-    borderRadius: radii.button,
-    padding: 2
-  },
-  segment: {
-    paddingHorizontal: spacing.md,
-    paddingVertical: 6,
-    borderRadius: radii.button - 1
-  },
-  segmentActive: { backgroundColor: colors.bgRaised },
-  segmentText: { fontSize: typography.metaSize, color: colors.textSecondary, fontWeight: '600' },
-  segmentTextActive: { color: colors.textPrimary },
   error: { color: colors.statusRed, fontSize: typography.metaSize, marginTop: spacing.md }
 })

--- a/mobile/src/components/VoiceDictationPreferences.tsx
+++ b/mobile/src/components/VoiceDictationPreferences.tsx
@@ -1,0 +1,153 @@
+import { Pressable, StyleSheet, Text, View } from 'react-native'
+import type { DictationCorrectionMode, DictationMode } from '../../../src/shared/speech-types'
+import { colors, radii, spacing, typography } from '../theme/mobile-theme'
+
+const DICTATION_MODES = [
+  { value: 'toggle', label: 'Toggle' },
+  { value: 'hold', label: 'Hold' }
+] as const
+
+const CORRECTION_MODES = [
+  { value: 'off', label: 'Off' },
+  { value: 'preview', label: 'Preview' },
+  { value: 'auto', label: 'Auto' }
+] as const
+
+type VoiceDictationPreferencesProps = {
+  enabled: boolean
+  dictationMode: DictationMode
+  correctionMode: DictationCorrectionMode
+  onSelectDictationMode: (mode: DictationMode) => void
+  onSelectCorrectionMode: (mode: DictationCorrectionMode) => void
+}
+
+export function VoiceDictationPreferences({
+  enabled,
+  dictationMode,
+  correctionMode,
+  onSelectDictationMode,
+  onSelectCorrectionMode
+}: VoiceDictationPreferencesProps): React.JSX.Element {
+  return (
+    <>
+      <View
+        style={[styles.row, !enabled && styles.disabled]}
+        pointerEvents={enabled ? 'auto' : 'none'}
+      >
+        <View style={styles.rowContent}>
+          <Text style={styles.rowLabel}>Dictation Mode</Text>
+          <Text style={styles.rowSublabel}>
+            Toggle: press once to start, again to stop. Hold: dictate while held.
+          </Text>
+        </View>
+        <View style={styles.segmented}>
+          {DICTATION_MODES.map((mode) => (
+            <Segment
+              key={mode.value}
+              active={dictationMode === mode.value}
+              label={mode.label}
+              onPress={() => onSelectDictationMode(mode.value)}
+            />
+          ))}
+        </View>
+      </View>
+
+      <View style={styles.separator} />
+
+      <View
+        style={[styles.correctionRow, !enabled && styles.disabled]}
+        pointerEvents={enabled ? 'auto' : 'none'}
+      >
+        <View>
+          <Text style={styles.rowLabel}>Transcript Correction</Text>
+          <Text style={styles.rowSublabel}>
+            Local punctuation, spacing, and vocabulary cleanup before insertion.
+          </Text>
+        </View>
+        <View style={styles.segmented}>
+          {CORRECTION_MODES.map((mode) => (
+            <Segment
+              key={mode.value}
+              active={correctionMode === mode.value}
+              label={mode.label}
+              onPress={() => onSelectCorrectionMode(mode.value)}
+              fill
+            />
+          ))}
+        </View>
+      </View>
+    </>
+  )
+}
+
+function Segment({
+  active,
+  label,
+  onPress,
+  fill = false
+}: {
+  active: boolean
+  label: string
+  onPress: () => void
+  fill?: boolean
+}): React.JSX.Element {
+  return (
+    <Pressable
+      accessibilityRole="button"
+      accessibilityState={{ selected: active }}
+      onPress={onPress}
+      style={[styles.segment, fill && styles.segmentFill, active && styles.segmentActive]}
+    >
+      <Text style={[styles.segmentText, active && styles.segmentTextActive]}>{label}</Text>
+    </Pressable>
+  )
+}
+
+const styles = StyleSheet.create({
+  row: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    gap: spacing.sm + 2,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  correctionRow: {
+    gap: spacing.sm,
+    paddingVertical: spacing.md,
+    paddingHorizontal: spacing.md + 2
+  },
+  rowContent: { flex: 1 },
+  rowLabel: {
+    fontSize: typography.bodySize,
+    fontWeight: '500',
+    color: colors.textPrimary
+  },
+  rowSublabel: {
+    fontSize: typography.bodySize - 2,
+    color: colors.textSecondary,
+    marginTop: 2
+  },
+  separator: {
+    height: StyleSheet.hairlineWidth,
+    backgroundColor: colors.borderSubtle,
+    marginHorizontal: spacing.md
+  },
+  segmented: {
+    flexDirection: 'row',
+    alignItems: 'center',
+    backgroundColor: colors.bgBase,
+    borderRadius: radii.button,
+    padding: 2
+  },
+  segment: {
+    paddingHorizontal: spacing.md,
+    paddingVertical: 6,
+    borderRadius: radii.button - 1,
+    alignItems: 'center'
+  },
+  segmentFill: { flex: 1 },
+  segmentActive: { backgroundColor: colors.bgRaised },
+  segmentText: { fontSize: typography.metaSize, color: colors.textSecondary, fontWeight: '600' },
+  segmentTextActive: { color: colors.textPrimary },
+  disabled: { opacity: 0.5 }
+})

--- a/mobile/src/dictation/mobile-dictation-correction-alert.ts
+++ b/mobile/src/dictation/mobile-dictation-correction-alert.ts
@@ -1,0 +1,19 @@
+import { Alert } from 'react-native'
+import type { MobileDictationTranscriptPreview } from '../hooks/mobile-dictation-session-state'
+
+export function showMobileDictationCorrectionAlert(
+  preview: MobileDictationTranscriptPreview,
+  onInsert: (text: string) => void,
+  onDiscard: () => void
+): void {
+  Alert.alert(
+    'Review dictation correction',
+    `${preview.correctedText}\n\nOriginal:\n${preview.rawText}`,
+    [
+      { text: 'Discard', style: 'cancel', onPress: onDiscard },
+      { text: 'Use original', onPress: () => onInsert(preview.rawText) },
+      { text: 'Insert corrected', onPress: () => onInsert(preview.correctedText) }
+    ],
+    { cancelable: true, onDismiss: onDiscard }
+  )
+}

--- a/mobile/src/dictation/mobile-dictation-finish-result.test.ts
+++ b/mobile/src/dictation/mobile-dictation-finish-result.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { resolveMobileDictationFinishResult } from './mobile-dictation-finish-result'
+
+describe('resolveMobileDictationFinishResult', () => {
+  it('uses corrected text when the runtime selected auto mode', () => {
+    expect(
+      resolveMobileDictationFinishResult(
+        {
+          text: '你好，Qwen3-ASR。',
+          rawText: '你好 逗号 q w e n 3 a s r 句号',
+          correctedText: '你好，Qwen3-ASR。',
+          dictationCorrectionMode: 'auto'
+        },
+        'off'
+      )
+    ).toEqual({ text: '你好，Qwen3-ASR。', preview: null })
+  })
+
+  it('keeps the raw text recoverable when the runtime selected preview mode', () => {
+    expect(
+      resolveMobileDictationFinishResult(
+        {
+          text: 'q w e n 3 a s r comma ready',
+          rawText: 'q w e n 3 a s r comma ready',
+          correctedText: 'Qwen3-ASR, ready',
+          dictationCorrectionMode: 'preview'
+        },
+        'off'
+      )
+    ).toEqual({
+      text: 'q w e n 3 a s r comma ready',
+      preview: {
+        rawText: 'q w e n 3 a s r comma ready',
+        correctedText: 'Qwen3-ASR, ready'
+      }
+    })
+  })
+
+  it('uses the legacy text field when paired with an older runtime', () => {
+    expect(resolveMobileDictationFinishResult({ text: 'legacy transcript' }, 'preview')).toEqual({
+      text: 'legacy transcript',
+      preview: null
+    })
+  })
+
+  it('treats an explicit runtime mode as authoritative over the mobile fallback', () => {
+    expect(
+      resolveMobileDictationFinishResult(
+        {
+          text: 'raw transcript',
+          rawText: 'raw transcript',
+          correctedText: 'corrected transcript',
+          dictationCorrectionMode: 'off'
+        },
+        'auto'
+      )
+    ).toEqual({ text: 'raw transcript', preview: null })
+  })
+})

--- a/mobile/src/dictation/mobile-dictation-finish-result.ts
+++ b/mobile/src/dictation/mobile-dictation-finish-result.ts
@@ -1,0 +1,40 @@
+import type { DictationCorrectionMode } from '../../../src/shared/speech-types'
+import type { MobileDictationTranscriptPreview } from '../hooks/mobile-dictation-session-state'
+
+type RuntimeDictationFinishResult = {
+  text?: unknown
+  rawText?: unknown
+  correctedText?: unknown
+  dictationCorrectionMode?: unknown
+}
+
+export type ResolvedMobileDictationFinishResult = {
+  text: string
+  preview: MobileDictationTranscriptPreview | null
+}
+
+function readText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function readRuntimeCorrectionMode(value: unknown): DictationCorrectionMode | null {
+  return value === 'off' || value === 'preview' || value === 'auto' ? value : null
+}
+
+export function resolveMobileDictationFinishResult(
+  value: unknown,
+  fallbackMode: DictationCorrectionMode
+): ResolvedMobileDictationFinishResult {
+  const result = (value ?? {}) as RuntimeDictationFinishResult
+  const responseText = readText(result.text)
+  const rawText = readText(result.rawText) || responseText
+  const correctedText = readText(result.correctedText) || responseText
+  const correctionMode = readRuntimeCorrectionMode(result.dictationCorrectionMode) ?? fallbackMode
+  const text = correctionMode === 'auto' ? correctedText || rawText : rawText || responseText
+  const preview =
+    correctionMode === 'preview' && rawText && correctedText && rawText !== correctedText
+      ? { rawText, correctedText }
+      : null
+
+  return { text, preview }
+}

--- a/mobile/src/dictation/mobile-dictation-setup.test.ts
+++ b/mobile/src/dictation/mobile-dictation-setup.test.ts
@@ -104,12 +104,16 @@ describe('rpc wrappers', () => {
   it('sets config', async () => {
     const setup: MobileSpeechSetup = { enabled: true, selectedModelId: 'm1', models: [] }
     const client = clientWith([ok(setup)])
-    await expect(setDictationConfig(client, { enabled: true, modelId: 'm1' })).resolves.toEqual(
-      setup
-    )
+    await expect(
+      setDictationConfig(client, {
+        enabled: true,
+        modelId: 'm1',
+        dictationCorrectionMode: 'preview'
+      })
+    ).resolves.toEqual(setup)
     expect(client.calls[0]).toEqual({
       method: 'speech.dictation.setup',
-      params: { enabled: true, modelId: 'm1' }
+      params: { enabled: true, modelId: 'm1', dictationCorrectionMode: 'preview' }
     })
   })
 

--- a/mobile/src/dictation/mobile-dictation-setup.ts
+++ b/mobile/src/dictation/mobile-dictation-setup.ts
@@ -78,7 +78,12 @@ export async function deleteDictationModel(
 
 export async function setDictationConfig(
   client: Pick<RpcClient, 'sendRequest'>,
-  params: { enabled?: boolean; modelId?: string; dictationMode?: 'toggle' | 'hold' }
+  params: {
+    enabled?: boolean
+    modelId?: string
+    dictationMode?: 'toggle' | 'hold'
+    dictationCorrectionMode?: 'off' | 'preview' | 'auto'
+  }
 ): Promise<MobileSpeechSetup> {
   const response = await client.sendRequest('speech.dictation.setup', params)
   if (!response.ok) {

--- a/mobile/src/hooks/mobile-dictation-session-state.ts
+++ b/mobile/src/hooks/mobile-dictation-session-state.ts
@@ -3,14 +3,22 @@
 import { Buffer } from 'buffer'
 
 import type { RpcClient } from '../transport/rpc-client'
+import type { DictationCorrectionMode } from '../../../src/shared/speech-types'
 
 export type DictationStatus = 'idle' | 'starting' | 'recording' | 'processing' | 'error'
 
 export type UseMobileDictationOptions = {
   client: RpcClient | null
   enabled: boolean
+  correctionMode?: DictationCorrectionMode
   onTranscript: (text: string) => void
+  onTranscriptPreview?: (preview: MobileDictationTranscriptPreview) => void
   onError?: (error: Error) => void
+}
+
+export type MobileDictationTranscriptPreview = {
+  rawText: string
+  correctedText: string
 }
 
 export type UseMobileDictationResult = {

--- a/mobile/src/hooks/use-mobile-dictation-source.test.ts
+++ b/mobile/src/hooks/use-mobile-dictation-source.test.ts
@@ -51,8 +51,10 @@ describe('useMobileDictation source invariants', () => {
     expect(mirrorEffect).toContain('clientRef.current = client')
     expect(mirrorEffect).toContain('enabledRef.current = enabled')
     expect(mirrorEffect).toContain('onTranscriptRef.current = onTranscript')
+    expect(mirrorEffect).toContain('onTranscriptPreviewRef.current = onTranscriptPreview')
+    expect(mirrorEffect).toContain('correctionModeRef.current = correctionMode')
     expect(mirrorEffect).toContain('onErrorRef.current = onError')
-    expect(mirrorEffect).toContain('}, [client, enabled, onTranscript, onError])')
+    expect(mirrorEffect).toContain('client, correctionMode, enabled, onError')
   })
 
   it('reserves pending audio bytes before encoding microphone chunks', () => {
@@ -208,6 +210,15 @@ describe('useMobileDictation source invariants', () => {
     expect(stopBody.indexOf('} finally {')).toBeLessThan(
       stopBody.indexOf('void keepAwakeOwner.release')
     )
+  })
+
+  it('keeps raw mobile transcripts recoverable in preview mode', () => {
+    const stopBody = sliceBetween('const stop = useCallback(async () => {', 'const cancel =')
+
+    expect(stopBody).toContain('resolveMobileDictationFinishResult(')
+    expect(stopBody).toContain('correctionModeRef.current')
+    expect(stopBody).toContain('onTranscriptPreviewRef.current(transcript.preview)')
+    expect(stopBody).toContain('onTranscriptRef.current(transcript.text)')
   })
 
   it('reacquires the wake tag when Android returns to the foreground mid-dictation', () => {

--- a/mobile/src/hooks/use-mobile-dictation.ts
+++ b/mobile/src/hooks/use-mobile-dictation.ts
@@ -10,6 +10,7 @@ import { MobileDictationPendingAudioBudget } from './mobile-dictation-pending-au
 import { enqueueMobileDictationAudioChunk } from './mobile-dictation-audio-chunk'
 import { createMobileDictationKeepAwakeOwner } from './mobile-dictation-keep-awake'
 import { useMobileDictationForegroundKeepAwake } from './mobile-dictation-foreground-keep-awake'
+import { resolveMobileDictationFinishResult } from '../dictation/mobile-dictation-finish-result'
 import {
   DICTATION_FINISH_TIMEOUT_MS,
   createMobileDictationId,
@@ -25,7 +26,14 @@ import type {
 export type { UseMobileDictationResult } from './mobile-dictation-session-state'
 
 export function useMobileDictation(options: UseMobileDictationOptions): UseMobileDictationResult {
-  const { client, enabled, onTranscript, onError } = options
+  const {
+    client,
+    enabled,
+    correctionMode = 'off',
+    onTranscript,
+    onTranscriptPreview,
+    onError
+  } = options
   const keepAwakeOwner = useMemo(createMobileDictationKeepAwakeOwner, [])
   const [status, setStatus] = useState<DictationStatus>('idle')
   const [error, setError] = useState<string | null>(null)
@@ -33,6 +41,8 @@ export function useMobileDictation(options: UseMobileDictationOptions): UseMobil
   const clientRef = useRef(client)
   const enabledRef = useRef(enabled)
   const onTranscriptRef = useRef(onTranscript)
+  const onTranscriptPreviewRef = useRef(onTranscriptPreview)
+  const correctionModeRef = useRef(correctionMode)
   const onErrorRef = useRef(onError)
   const pendingChunksRef = useRef<Set<Promise<void>>>(new Set())
   const pendingAudioBudgetRef = useRef(new MobileDictationPendingAudioBudget())
@@ -46,8 +56,10 @@ export function useMobileDictation(options: UseMobileDictationOptions): UseMobil
     clientRef.current = client
     enabledRef.current = enabled
     onTranscriptRef.current = onTranscript
+    onTranscriptPreviewRef.current = onTranscriptPreview
+    correctionModeRef.current = correctionMode
     onErrorRef.current = onError
-  }, [client, enabled, onTranscript, onError])
+  }, [client, correctionMode, enabled, onError, onTranscript, onTranscriptPreview])
 
   const reportError = useCallback((err: unknown) => {
     const normalized = err instanceof Error ? err : new Error(String(err))
@@ -230,15 +242,19 @@ export function useMobileDictation(options: UseMobileDictationOptions): UseMobil
       ) {
         return
       }
-      const result = response.result as { text?: unknown }
-      const text = typeof result.text === 'string' ? result.text.trim() : ''
+      const transcript = resolveMobileDictationFinishResult(
+        response.result,
+        correctionModeRef.current
+      )
       activeIdRef.current = null
       finishingIdRef.current = null
       pendingChunksRef.current.clear()
       pendingAudioBudgetRef.current.reset()
       setStatus('idle')
-      if (text) {
-        onTranscriptRef.current(text)
+      if (transcript.preview && onTranscriptPreviewRef.current) {
+        onTranscriptPreviewRef.current(transcript.preview)
+      } else if (transcript.text) {
+        onTranscriptRef.current(transcript.text)
       } else {
         reportError(new Error('No speech detected.'))
       }

--- a/src/main/ipc/speech.ts
+++ b/src/main/ipc/speech.ts
@@ -1,10 +1,8 @@
 import { ipcMain, BrowserWindow, systemPreferences } from 'electron'
-import { join } from 'node:path'
-import { writeFile, unlink } from 'node:fs/promises'
-import { createHash } from 'node:crypto'
 import { SPEECH_MODEL_CATALOG } from '../speech/model-catalog'
 import { deleteLocalSpeechModel } from '../speech/speech-model-deletion'
 import { getSpeechModelManager, getSpeechSttService } from '../speech/speech-runtime-service'
+import { acquireSpeechHotwordsFile, type SpeechHotwordsFileLease } from '../speech/hotwords-file'
 import {
   clearOpenAiSpeechApiKey,
   hasOpenAiSpeechApiKey,
@@ -78,13 +76,6 @@ export function registerSpeechHandlers(store: Store): void {
     })
   })
 
-  const getHotwordsFilePath = (content: string): string => {
-    const digest = createHash('sha256').update(content).digest('hex').slice(0, 12)
-    // Why: sherpa-onnx cannot read non-ASCII Windows paths, so co-locate the
-    // hotwords file with the ASCII-safe model cache instead of userData.
-    return join(getSpeechModelManager(store).getModelsDir(), `speech-hotwords-${digest}.txt`)
-  }
-
   const getDesktopOwner = (senderId: number, sessionId: string): string =>
     `desktop:${senderId}:${sessionId}`
 
@@ -95,7 +86,7 @@ export function registerSpeechHandlers(store: Store): void {
       if (!window) {
         return
       }
-      let resolvedHotwordsPath: string | undefined
+      let hotwordsFile: SpeechHotwordsFileLease | undefined
       let windowClosed = false
       const owner = getDesktopOwner(event.sender.id, sessionId)
       const cleanupOnWindowClosed = (): void => {
@@ -103,9 +94,7 @@ export function registerSpeechHandlers(store: Store): void {
         void getSpeechSttService(store)
           .stopDictation(owner)
           .finally(() => {
-            if (resolvedHotwordsPath) {
-              unlink(resolvedHotwordsPath).catch(() => {})
-            }
+            void hotwordsFile?.release()
           })
           .catch(() => {})
       }
@@ -133,18 +122,16 @@ export function registerSpeechHandlers(store: Store): void {
           }
         }
 
-        if (hotwords && hotwords.length > 0) {
-          const content = `${hotwords.map((w) => `${w} :2.0`).join('\n')}\n`
-          const hotwordsFilePath = getHotwordsFilePath(content)
-          await writeFile(hotwordsFilePath, content, 'utf-8')
-          resolvedHotwordsPath = hotwordsFilePath
-        }
+        // Why: sherpa-onnx cannot read non-ASCII Windows paths, so co-locate the
+        // bounded hotwords file with the ASCII-safe model cache instead of userData.
+        hotwordsFile = await acquireSpeechHotwordsFile(
+          hotwords,
+          getSpeechModelManager(store).getModelsDir()
+        )
 
         if (windowClosed || window.isDestroyed()) {
           cleanupSessionListener()
-          if (resolvedHotwordsPath) {
-            unlink(resolvedHotwordsPath).catch(() => {})
-          }
+          void hotwordsFile?.release()
           return
         }
 
@@ -177,17 +164,13 @@ export function registerSpeechHandlers(store: Store): void {
                 break
             }
           },
-          resolvedHotwordsPath,
+          hotwordsFile?.filePath,
           owner
         )
-        if (resolvedHotwordsPath) {
-          unlink(resolvedHotwordsPath).catch(() => {})
-        }
+        void hotwordsFile?.release()
       } catch (err) {
         cleanupSessionListener()
-        if (resolvedHotwordsPath) {
-          unlink(resolvedHotwordsPath).catch(() => {})
-        }
+        void hotwordsFile?.release()
         throw err
       }
     }

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -782,6 +782,38 @@ describe('Store', () => {
     expect(store.getUI().usagePercentageDisplayChangeNoticeDismissed).toBe(true)
   })
 
+  it('normalizes custom vocabulary when loading and updating voice settings', async () => {
+    const persisted = getDefaultPersistedState(testState.dir)
+    writeDataFile({
+      ...persisted,
+      settings: {
+        ...persisted.settings,
+        voice: {
+          ...persisted.settings.voice,
+          customVocabulary: [
+            ' Orca ',
+            'orca',
+            'line\nbreak',
+            'Qwen3-ASR',
+            42
+          ] as unknown as string[]
+        }
+      }
+    })
+
+    const store = await createStore()
+
+    expect(store.getSettings().voice?.customVocabulary).toEqual(['Orca', 'Qwen3-ASR'])
+
+    store.updateSettings({
+      voice: {
+        ...store.getSettings().voice!,
+        customVocabulary: [' Fun-ASR ', 'fun-asr', '中文术语']
+      }
+    })
+    expect(store.getSettings().voice?.customVocabulary).toEqual(['Fun-ASR', '中文术语'])
+  })
+
   it('defaults minimizeToTrayOnClose to false when unset', async () => {
     const store = await createStore()
     expect(store.getSettings().minimizeToTrayOnClose).toBe(false)

--- a/src/main/persistence.test.ts
+++ b/src/main/persistence.test.ts
@@ -796,7 +796,8 @@ describe('Store', () => {
             'line\nbreak',
             'Qwen3-ASR',
             42
-          ] as unknown as string[]
+          ] as unknown as string[],
+          dictationCorrectionMode: 'cloud' as never
         }
       }
     })
@@ -804,14 +805,17 @@ describe('Store', () => {
     const store = await createStore()
 
     expect(store.getSettings().voice?.customVocabulary).toEqual(['Orca', 'Qwen3-ASR'])
+    expect(store.getSettings().voice?.dictationCorrectionMode).toBe('off')
 
     store.updateSettings({
       voice: {
         ...store.getSettings().voice!,
+        dictationCorrectionMode: 'auto',
         customVocabulary: [' Fun-ASR ', 'fun-asr', '中文术语']
       }
     })
     expect(store.getSettings().voice?.customVocabulary).toEqual(['Fun-ASR', '中文术语'])
+    expect(store.getSettings().voice?.dictationCorrectionMode).toBe('auto')
   })
 
   it('defaults minimizeToTrayOnClose to false when unset', async () => {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -135,6 +135,7 @@ import {
   ONBOARDING_FINAL_STEP
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
+import { normalizeSpeechHotwords } from '../shared/speech-hotwords'
 import { normalizeUsagePercentageDisplay } from '../shared/usage-percentage-display'
 import { normalizeStatusBarUsageMode } from '../shared/status-bar-usage-mode'
 import { isExistingPersistedProfile } from '../shared/project-order-manual-default-notice'
@@ -3471,7 +3472,8 @@ export class Store {
             ),
             voice: {
               ...getDefaultVoiceSettings(),
-              ...parsed.settings?.voice
+              ...parsed.settings?.voice,
+              customVocabulary: normalizeSpeechHotwords(parsed.settings?.voice?.customVocabulary)
             }
           },
           // Why: legacy 'recent' meant the smart sort; migrate once on the raw value so a fresh 'recent' default isn't remigrated.
@@ -5849,6 +5851,16 @@ export class Store {
     }
     if ('uiLanguage' in updates) {
       sanitizedUpdates.uiLanguage = normalizeUiLanguage(updates.uiLanguage)
+    }
+    if (updates.voice && typeof updates.voice === 'object') {
+      const currentVoice = this.state.settings.voice ?? getDefaultVoiceSettings()
+      const rawVocabulary = Object.prototype.hasOwnProperty.call(updates.voice, 'customVocabulary')
+        ? updates.voice.customVocabulary
+        : currentVoice.customVocabulary
+      sanitizedUpdates.voice = {
+        ...updates.voice,
+        customVocabulary: normalizeSpeechHotwords(rawVocabulary)
+      }
     }
     if ('prBotAuthorOverrides' in updates) {
       // Why: every writer (desktop IPC, web RPC, migrations) hits this boundary, so the persisted list stays bounded and well-formed.

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -136,6 +136,7 @@ import {
 } from '../shared/constants'
 import { parseWorkspaceSession } from '../shared/workspace-session-schema'
 import { normalizeSpeechHotwords } from '../shared/speech-hotwords'
+import { normalizeDictationCorrectionMode } from '../shared/speech-transcript-correction'
 import { normalizeUsagePercentageDisplay } from '../shared/usage-percentage-display'
 import { normalizeStatusBarUsageMode } from '../shared/status-bar-usage-mode'
 import { isExistingPersistedProfile } from '../shared/project-order-manual-default-notice'
@@ -3473,6 +3474,9 @@ export class Store {
             voice: {
               ...getDefaultVoiceSettings(),
               ...parsed.settings?.voice,
+              dictationCorrectionMode: normalizeDictationCorrectionMode(
+                parsed.settings?.voice?.dictationCorrectionMode
+              ),
               customVocabulary: normalizeSpeechHotwords(parsed.settings?.voice?.customVocabulary)
             }
           },
@@ -5857,8 +5861,15 @@ export class Store {
       const rawVocabulary = Object.prototype.hasOwnProperty.call(updates.voice, 'customVocabulary')
         ? updates.voice.customVocabulary
         : currentVoice.customVocabulary
+      const rawCorrectionMode = Object.prototype.hasOwnProperty.call(
+        updates.voice,
+        'dictationCorrectionMode'
+      )
+        ? updates.voice.dictationCorrectionMode
+        : currentVoice.dictationCorrectionMode
       sanitizedUpdates.voice = {
         ...updates.voice,
+        dictationCorrectionMode: normalizeDictationCorrectionMode(rawCorrectionMode),
         customVocabulary: normalizeSpeechHotwords(rawVocabulary)
       }
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -999,7 +999,8 @@ import type { RateLimitService } from '../rate-limits/service'
 import { applyPRBotAuthorOverride } from '../../shared/pr-bot-author-overrides'
 import type { CodexRateLimitResetOutcome, RateLimitState } from '../../shared/rate-limit-types'
 import type { CodexResetCreditExpectedScope } from '../../shared/codex-reset-credit-scope'
-import type { VoiceSettings } from '../../shared/speech-types'
+import type { DictationCorrectionMode, VoiceSettings } from '../../shared/speech-types'
+import { correctSpeechTranscript } from '../../shared/speech-transcript-correction'
 import { getSpeechModelManager, getSpeechSttService } from '../speech/speech-runtime-service'
 import { acquireSpeechHotwordsFile, type SpeechHotwordsFileLease } from '../speech/hotwords-file'
 import { getCatalogModel, isLocalSpeechModel, SPEECH_MODEL_CATALOG } from '../speech/model-catalog'
@@ -3369,6 +3370,8 @@ export class OrcaRuntimeService {
     partialText: string
     finalTexts: string[]
     errors: string[]
+    correctionMode: DictationCorrectionMode
+    correctionVocabulary: string[]
   } | null = null
 
   constructor(
@@ -12820,6 +12823,7 @@ export class OrcaRuntimeService {
       enabled: voice.enabled === true,
       selectedModelId: voice.sttModel ?? '',
       dictationMode: voice.dictationMode === 'hold' ? 'hold' : 'toggle',
+      dictationCorrectionMode: voice.dictationCorrectionMode ?? 'off',
       models
     }
   }
@@ -12872,6 +12876,7 @@ export class OrcaRuntimeService {
     enabled?: boolean
     modelId?: string
     dictationMode?: 'toggle' | 'hold'
+    dictationCorrectionMode?: DictationCorrectionMode
   }): Promise<RuntimeSpeechSetupState> {
     if (!this.store?.getSettings || !this.store.updateSettings) {
       throw new Error('voice_dictation_unavailable')
@@ -12887,7 +12892,10 @@ export class OrcaRuntimeService {
       ...current,
       ...(params.enabled !== undefined ? { enabled: params.enabled } : {}),
       ...(params.modelId !== undefined ? { sttModel: params.modelId } : {}),
-      ...(params.dictationMode !== undefined ? { dictationMode: params.dictationMode } : {})
+      ...(params.dictationMode !== undefined ? { dictationMode: params.dictationMode } : {}),
+      ...(params.dictationCorrectionMode !== undefined
+        ? { dictationCorrectionMode: params.dictationCorrectionMode }
+        : {})
     }
     this.store.updateSettings({ voice: nextVoice }, { notifyListeners: true })
     return this.listMobileSpeechModels()
@@ -12934,6 +12942,10 @@ export class OrcaRuntimeService {
       voice.customVocabulary,
       modelManager.getModelsDir()
     )
+    if (this.mobileDictation) {
+      void hotwordsFile?.release()
+      throw new Error('dictation_already_active')
+    }
     const owner = `mobile:${params.dictationId}`
     this.mobileDictation = {
       id: params.dictationId,
@@ -12944,7 +12956,9 @@ export class OrcaRuntimeService {
       state: 'starting',
       partialText: '',
       finalTexts: [],
-      errors: []
+      errors: [],
+      correctionMode: voice.dictationCorrectionMode ?? 'off',
+      correctionVocabulary: voice.customVocabulary ?? []
     }
 
     try {
@@ -13028,6 +13042,9 @@ export class OrcaRuntimeService {
   }): Promise<{
     dictationId: string
     text: string
+    rawText: string
+    correctedText: string
+    dictationCorrectionMode: DictationCorrectionMode
   }> {
     const session = this.mobileDictation
     if (!session || session.id !== params.dictationId) {
@@ -13045,8 +13062,16 @@ export class OrcaRuntimeService {
       if (session.errors.length > 0) {
         throw new Error(session.errors[0])
       }
-      const text = [...session.finalTexts, session.partialText].join(' ').trim()
-      return { dictationId: params.dictationId, text }
+      const rawText = [...session.finalTexts, session.partialText].join(' ').trim()
+      const correctedText = correctSpeechTranscript(rawText, session.correctionVocabulary)
+      const text = session.correctionMode === 'auto' ? correctedText : rawText
+      return {
+        dictationId: params.dictationId,
+        text,
+        rawText,
+        correctedText,
+        dictationCorrectionMode: session.correctionMode
+      }
     } finally {
       void session.hotwordsFile?.release()
       if (this.mobileDictation?.id === session.id) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -1001,6 +1001,7 @@ import type { CodexRateLimitResetOutcome, RateLimitState } from '../../shared/ra
 import type { CodexResetCreditExpectedScope } from '../../shared/codex-reset-credit-scope'
 import type { VoiceSettings } from '../../shared/speech-types'
 import { getSpeechModelManager, getSpeechSttService } from '../speech/speech-runtime-service'
+import { acquireSpeechHotwordsFile, type SpeechHotwordsFileLease } from '../speech/hotwords-file'
 import { getCatalogModel, isLocalSpeechModel, SPEECH_MODEL_CATALOG } from '../speech/model-catalog'
 import {
   deleteLocalSpeechModel,
@@ -3362,6 +3363,7 @@ export class OrcaRuntimeService {
     id: string
     owner: string
     clientId?: string
+    hotwordsFile?: SpeechHotwordsFileLease
     connectionId?: string
     state: 'starting' | 'active' | 'closing'
     partialText: string
@@ -12914,7 +12916,8 @@ export class OrcaRuntimeService {
       throw new Error('voice_model_not_selected')
     }
 
-    const modelState = await getSpeechModelManager(this.store).getModelState(modelId)
+    const modelManager = getSpeechModelManager(this.store)
+    const modelState = await modelManager.getModelState(modelId)
     if (modelState.status !== 'ready') {
       throw new Error(`voice_model_not_ready:${modelState.status}`)
     }
@@ -12927,11 +12930,16 @@ export class OrcaRuntimeService {
       throw new Error('dictation_already_active')
     }
 
+    const hotwordsFile = await acquireSpeechHotwordsFile(
+      voice.customVocabulary,
+      modelManager.getModelsDir()
+    )
     const owner = `mobile:${params.dictationId}`
     this.mobileDictation = {
       id: params.dictationId,
       owner,
       clientId: params.clientId,
+      hotwordsFile,
       connectionId: params.connectionId,
       state: 'starting',
       partialText: '',
@@ -12959,14 +12967,16 @@ export class OrcaRuntimeService {
             session.errors.push(event.error ?? 'Speech worker error')
           }
         },
-        undefined,
+        hotwordsFile?.filePath,
         owner
       )
       if (this.mobileDictation?.id !== params.dictationId) {
         throw new Error('dictation_canceled')
       }
       this.mobileDictation.state = 'active'
+      void hotwordsFile?.release()
     } catch (error) {
+      void hotwordsFile?.release()
       if (this.mobileDictation?.id === params.dictationId) {
         this.mobileDictation = null
       }
@@ -13038,6 +13048,7 @@ export class OrcaRuntimeService {
       const text = [...session.finalTexts, session.partialText].join(' ').trim()
       return { dictationId: params.dictationId, text }
     } finally {
+      void session.hotwordsFile?.release()
       if (this.mobileDictation?.id === session.id) {
         this.mobileDictation = null
       }
@@ -13060,6 +13071,7 @@ export class OrcaRuntimeService {
       try {
         await getSpeechSttService(this.store!).stopDictation(session.owner)
       } finally {
+        void session.hotwordsFile?.release()
         if (this.mobileDictation?.id === session.id) {
           this.mobileDictation = null
         }
@@ -13076,6 +13088,7 @@ export class OrcaRuntimeService {
     void getSpeechSttService(this.store!)
       .stopDictation(session.owner)
       .finally(() => {
+        void session.hotwordsFile?.release()
         if (this.mobileDictation?.id === session.id) {
           this.mobileDictation = null
         }

--- a/src/main/runtime/rpc/methods/speech.test.ts
+++ b/src/main/runtime/rpc/methods/speech.test.ts
@@ -141,10 +141,44 @@ describe('speech RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: SPEECH_METHODS })
 
     const response = await dispatcher.dispatch(
-      makeRequest('speech.dictation.setup', { enabled: true, modelId: 'm1' })
+      makeRequest('speech.dictation.setup', {
+        enabled: true,
+        modelId: 'm1',
+        dictationCorrectionMode: 'preview'
+      })
     )
 
-    expect(runtime.configureMobileDictation).toHaveBeenCalledWith({ enabled: true, modelId: 'm1' })
+    expect(runtime.configureMobileDictation).toHaveBeenCalledWith({
+      enabled: true,
+      modelId: 'm1',
+      dictationCorrectionMode: 'preview'
+    })
     expect(response).toMatchObject({ ok: true, result: { enabled: true, selectedModelId: 'm1' } })
+  })
+
+  it('returns raw and corrected transcripts from dictation finish', async () => {
+    const result = {
+      dictationId: 'dict-1',
+      text: 'q w e n 3 a s r comma ready',
+      rawText: 'q w e n 3 a s r comma ready',
+      correctedText: 'Qwen3-ASR, ready',
+      dictationCorrectionMode: 'preview' as const
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      finishMobileDictation: vi.fn().mockResolvedValue(result)
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SPEECH_METHODS })
+
+    const response = await dispatcher.dispatch(
+      makeRequest('speech.dictation.finish', { dictationId: 'dict-1' })
+    )
+
+    expect(runtime.finishMobileDictation).toHaveBeenCalledWith({
+      dictationId: 'dict-1',
+      clientId: undefined,
+      connectionId: undefined
+    })
+    expect(response).toMatchObject({ ok: true, result })
   })
 })

--- a/src/main/runtime/rpc/methods/speech.ts
+++ b/src/main/runtime/rpc/methods/speech.ts
@@ -45,7 +45,8 @@ const SpeechModelAction = z.object({
 const DictationSetup = z.object({
   enabled: z.boolean().optional(),
   modelId: OptionalString,
-  dictationMode: z.enum(['toggle', 'hold']).optional()
+  dictationMode: z.enum(['toggle', 'hold']).optional(),
+  dictationCorrectionMode: z.enum(['off', 'preview', 'auto']).optional()
 })
 
 export const SPEECH_METHODS: RpcMethod[] = [
@@ -71,7 +72,10 @@ export const SPEECH_METHODS: RpcMethod[] = [
       runtime.configureMobileDictation({
         ...(params.enabled !== undefined ? { enabled: params.enabled } : {}),
         ...(params.modelId !== undefined ? { modelId: params.modelId } : {}),
-        ...(params.dictationMode !== undefined ? { dictationMode: params.dictationMode } : {})
+        ...(params.dictationMode !== undefined ? { dictationMode: params.dictationMode } : {}),
+        ...(params.dictationCorrectionMode !== undefined
+          ? { dictationCorrectionMode: params.dictationCorrectionMode }
+          : {})
       })
   }),
   defineMethod({

--- a/src/main/speech/hotwords-file.test.ts
+++ b/src/main/speech/hotwords-file.test.ts
@@ -1,0 +1,57 @@
+import { access, mkdtemp, readFile, rm } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { acquireSpeechHotwordsFile } from './hotwords-file'
+
+const tempDirectories: string[] = []
+
+async function makeTempDirectory(): Promise<string> {
+  const directory = await mkdtemp(join(tmpdir(), 'orca-speech-hotwords-'))
+  tempDirectories.push(directory)
+  return directory
+}
+
+afterEach(async () => {
+  await Promise.all(
+    tempDirectories.splice(0).map((directory) => rm(directory, { recursive: true }))
+  )
+})
+
+describe('acquireSpeechHotwordsFile', () => {
+  it('writes normalized sherpa hotwords with stable scoring', async () => {
+    const directory = await makeTempDirectory()
+    const lease = await acquireSpeechHotwordsFile(
+      [' Orca ', 'orca', 'Qwen3-ASR', '中文术语', 'line\nbreak'],
+      directory
+    )
+
+    expect(lease?.filePath).toMatch(/speech-hotwords-[a-f0-9]{12}\.txt$/)
+    expect(await readFile(lease!.filePath, 'utf-8')).toBe(
+      'Orca :2.0\nQwen3-ASR :2.0\n中文术语 :2.0\n'
+    )
+    await lease?.release()
+  })
+
+  it('does not create a file when no valid hotwords remain', async () => {
+    const directory = await makeTempDirectory()
+
+    await expect(acquireSpeechHotwordsFile(['', 'line\nbreak'], directory)).resolves.toBeUndefined()
+  })
+
+  it('keeps a shared digest file until every lease is released', async () => {
+    const directory = await makeTempDirectory()
+    const first = await acquireSpeechHotwordsFile(['Orca'], directory)
+    const second = await acquireSpeechHotwordsFile(['Orca'], directory)
+
+    expect(first?.filePath).toBe(second?.filePath)
+    await first?.release()
+    await expect(access(second!.filePath)).resolves.toBeUndefined()
+
+    await first?.release()
+    await expect(access(second!.filePath)).resolves.toBeUndefined()
+
+    await second?.release()
+    await expect(access(second!.filePath)).rejects.toThrow()
+  })
+})

--- a/src/main/speech/hotwords-file.ts
+++ b/src/main/speech/hotwords-file.ts
@@ -1,0 +1,78 @@
+import { createHash } from 'node:crypto'
+import * as fs from 'node:fs/promises'
+import * as path from 'node:path'
+import { normalizeSpeechHotwords } from '../../shared/speech-hotwords'
+
+type HotwordsFileState = {
+  references: number
+  operation: Promise<void>
+}
+
+export type SpeechHotwordsFileLease = {
+  filePath: string
+  release: () => Promise<void>
+}
+
+// Why: digest paths preserve warm-worker reuse; leases prevent concurrent starts from deleting a shared file.
+const hotwordsFileStates = new Map<string, HotwordsFileState>()
+
+function enqueueFileOperation(
+  state: HotwordsFileState,
+  operation: () => Promise<void>
+): Promise<void> {
+  const result = state.operation.then(operation)
+  state.operation = result.catch(() => undefined)
+  return result
+}
+
+async function releaseFileReference(filePath: string, state: HotwordsFileState): Promise<void> {
+  state.references = Math.max(0, state.references - 1)
+  if (state.references > 0) {
+    return
+  }
+
+  await enqueueFileOperation(state, async () => {
+    if (state.references > 0) {
+      return
+    }
+    await fs.unlink(filePath).catch(() => undefined)
+    if (state.references === 0 && hotwordsFileStates.get(filePath) === state) {
+      hotwordsFileStates.delete(filePath)
+    }
+  })
+}
+
+export async function acquireSpeechHotwordsFile(
+  hotwords: unknown,
+  targetDirectory: string
+): Promise<SpeechHotwordsFileLease | undefined> {
+  const normalizedHotwords = normalizeSpeechHotwords(hotwords)
+  if (normalizedHotwords.length === 0) {
+    return undefined
+  }
+
+  const content = `${normalizedHotwords.map((word) => `${word} :2.0`).join('\n')}\n`
+  const digest = createHash('sha256').update(content).digest('hex').slice(0, 12)
+  const hotwordsFilePath = path.join(targetDirectory, `speech-hotwords-${digest}.txt`)
+  const state = hotwordsFileStates.get(hotwordsFilePath) ?? {
+    references: 0,
+    operation: Promise.resolve()
+  }
+  hotwordsFileStates.set(hotwordsFilePath, state)
+  state.references += 1
+
+  let releasePromise: Promise<void> | null = null
+  const release = (): Promise<void> => {
+    releasePromise ??= releaseFileReference(hotwordsFilePath, state)
+    return releasePromise
+  }
+
+  try {
+    await enqueueFileOperation(state, () => fs.writeFile(hotwordsFilePath, content, 'utf-8'))
+  } catch (error) {
+    await release()
+    throw error
+  }
+
+  return { filePath: hotwordsFilePath, release }
+}

--- a/src/renderer/src/components/dictation/DictationController.test.tsx
+++ b/src/renderer/src/components/dictation/DictationController.test.tsx
@@ -1,0 +1,146 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultVoiceSettings } from '../../../../shared/constants'
+import { DictationController } from './DictationController'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const {
+  startCaptureMock,
+  stopCaptureMock,
+  flushBufferedAudioMock,
+  discardBufferedAudioMock,
+  useAppStoreMock,
+  useHoldDictationGestureMock
+} = vi.hoisted(() => ({
+  startCaptureMock: vi.fn(async () => undefined),
+  stopCaptureMock: vi.fn(),
+  flushBufferedAudioMock: vi.fn(async () => undefined),
+  discardBufferedAudioMock: vi.fn(),
+  useAppStoreMock: vi.fn(),
+  useHoldDictationGestureMock: vi.fn()
+}))
+
+vi.mock('@/store', () => ({ useAppStore: useAppStoreMock }))
+
+vi.mock('@/hooks/use-audio-capture', () => ({
+  useAudioCapture: () => ({
+    start: startCaptureMock,
+    stop: stopCaptureMock,
+    flushBufferedAudio: flushBufferedAudioMock,
+    discardBufferedAudio: discardBufferedAudioMock,
+    getCapturedChunkCount: () => 0
+  })
+}))
+
+vi.mock('./DictationIndicator', () => ({ DictationIndicator: () => null }))
+vi.mock('./use-hold-dictation-gesture', () => ({
+  useHoldDictationGesture: useHoldDictationGestureMock
+}))
+vi.mock('sonner', () => {
+  const toast = Object.assign(vi.fn(), {
+    error: vi.fn(),
+    message: vi.fn()
+  })
+  return { toast }
+})
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+let root: Root | null = null
+let dictationKeyHandler: (() => void) | null = null
+let startDictationMock: ReturnType<typeof vi.fn>
+
+function installWindowApi(): void {
+  startDictationMock = vi.fn(async () => undefined)
+  Object.defineProperty(window, 'api', {
+    configurable: true,
+    value: {
+      speech: {
+        startDictation: startDictationMock,
+        stopDictation: vi.fn(async () => undefined),
+        onPartialTranscript: vi.fn(() => () => undefined),
+        onFinalTranscript: vi.fn(() => () => undefined),
+        onStopped: vi.fn(() => () => undefined),
+        onError: vi.fn(() => () => undefined)
+      },
+      ui: {
+        onDictationKeyDown: vi.fn((callback: () => void) => {
+          dictationKeyHandler = callback
+          return () => undefined
+        })
+      }
+    }
+  })
+}
+
+function renderController(): void {
+  const state = {
+    dictationState: 'idle',
+    setDictationState: vi.fn(),
+    setPartialTranscript: vi.fn(),
+    recordFeatureInteraction: vi.fn(),
+    settings: {
+      voice: {
+        ...getDefaultVoiceSettings(),
+        enabled: true,
+        sttModel: 'ready-model',
+        customVocabulary: ['Orca', 'Qwen3-ASR', '中文术语']
+      }
+    },
+    keybindings: []
+  }
+  useAppStoreMock.mockImplementation((selector: (value: typeof state) => unknown) =>
+    selector(state)
+  )
+  Object.assign(useAppStoreMock, {
+    getState: vi.fn(() => ({ openSettingsTarget: vi.fn(), openSettingsPage: vi.fn() }))
+  })
+
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+  act(() => {
+    root?.render(<DictationController />)
+  })
+}
+
+describe('DictationController custom vocabulary', () => {
+  beforeEach(() => {
+    installWindowApi()
+    startCaptureMock.mockClear()
+    stopCaptureMock.mockClear()
+    flushBufferedAudioMock.mockClear()
+    discardBufferedAudioMock.mockClear()
+    useAppStoreMock.mockReset()
+    dictationKeyHandler = null
+  })
+
+  afterEach(() => {
+    act(() => root?.unmount())
+    root = null
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('passes saved vocabulary to the speech start request', async () => {
+    renderController()
+
+    await act(async () => {
+      dictationKeyHandler?.()
+      await Promise.resolve()
+      await Promise.resolve()
+      await Promise.resolve()
+    })
+
+    expect(startDictationMock).toHaveBeenCalledWith(
+      'ready-model',
+      ['Orca', 'Qwen3-ASR', '中文术语'],
+      '1'
+    )
+  })
+})

--- a/src/renderer/src/components/dictation/DictationController.test.tsx
+++ b/src/renderer/src/components/dictation/DictationController.test.tsx
@@ -4,6 +4,7 @@ import { act } from 'react'
 import { createRoot, type Root } from 'react-dom/client'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultVoiceSettings } from '../../../../shared/constants'
+import type { DictationCorrectionMode } from '../../../../shared/speech-types'
 import { DictationController } from './DictationController'
 
 globalThis.IS_REACT_ACT_ENVIRONMENT = true
@@ -54,6 +55,8 @@ vi.mock('@/i18n/i18n', () => ({
 let root: Root | null = null
 let dictationKeyHandler: (() => void) | null = null
 let startDictationMock: ReturnType<typeof vi.fn>
+let finalTranscriptHandler: ((data: { text: string; sessionId: string }) => void) | null = null
+let stoppedHandler: ((data: { sessionId: string }) => void) | null = null
 
 function installWindowApi(): void {
   startDictationMock = vi.fn(async () => undefined)
@@ -64,8 +67,16 @@ function installWindowApi(): void {
         startDictation: startDictationMock,
         stopDictation: vi.fn(async () => undefined),
         onPartialTranscript: vi.fn(() => () => undefined),
-        onFinalTranscript: vi.fn(() => () => undefined),
-        onStopped: vi.fn(() => () => undefined),
+        onFinalTranscript: vi.fn(
+          (callback: (data: { text: string; sessionId: string }) => void) => {
+            finalTranscriptHandler = callback
+            return () => undefined
+          }
+        ),
+        onStopped: vi.fn((callback: (data: { sessionId: string }) => void) => {
+          stoppedHandler = callback
+          return () => undefined
+        }),
         onError: vi.fn(() => () => undefined)
       },
       ui: {
@@ -78,7 +89,7 @@ function installWindowApi(): void {
   })
 }
 
-function renderController(): void {
+function renderController(correctionMode: DictationCorrectionMode = 'off'): void {
   const state = {
     dictationState: 'idle',
     setDictationState: vi.fn(),
@@ -89,6 +100,7 @@ function renderController(): void {
         ...getDefaultVoiceSettings(),
         enabled: true,
         sttModel: 'ready-model',
+        dictationCorrectionMode: correctionMode,
         customVocabulary: ['Orca', 'Qwen3-ASR', '中文术语']
       }
     },
@@ -118,6 +130,8 @@ describe('DictationController custom vocabulary', () => {
     discardBufferedAudioMock.mockClear()
     useAppStoreMock.mockReset()
     dictationKeyHandler = null
+    finalTranscriptHandler = null
+    stoppedHandler = null
   })
 
   afterEach(() => {
@@ -143,4 +157,69 @@ describe('DictationController custom vocabulary', () => {
       '1'
     )
   })
+
+  it('automatically corrects the complete transcript before insertion', async () => {
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+    renderController('auto')
+
+    await startDictationSession()
+    await finishDictationSession('你好 逗号 q w e n 3 a s r 句号')
+
+    expect(textarea.value).toBe('你好，Qwen3-ASR。')
+  })
+
+  it('keeps preview correction reversible until the user chooses', async () => {
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+    renderController('preview')
+
+    await startDictationSession()
+    await finishDictationSession('q w e n 3 a s r comma ready', 'Qwen3-ASR')
+
+    expect(textarea.value).toBe('')
+    const useOriginal = Array.from(document.querySelectorAll('button')).find(
+      (button) => button.textContent === 'Use original'
+    )
+    expect(useOriginal).toBeDefined()
+    await act(async () => useOriginal?.click())
+    expect(textarea.value).toBe('q w e n 3 a s r comma ready')
+  })
+
+  it('inserts preview-mode transcripts directly when correction makes no change', async () => {
+    const textarea = document.createElement('textarea')
+    document.body.appendChild(textarea)
+    textarea.focus()
+    renderController('preview')
+
+    await startDictationSession()
+    await finishDictationSession('already clean')
+
+    expect(textarea.value).toBe('already clean')
+    expect(document.body.textContent).not.toContain('Review dictation correction')
+  })
 })
+
+async function startDictationSession(): Promise<void> {
+  await act(async () => {
+    dictationKeyHandler?.()
+    await Promise.resolve()
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function finishDictationSession(text: string, expectedPreviewText?: string): Promise<void> {
+  await act(async () => {
+    finalTranscriptHandler?.({ text, sessionId: '1' })
+    dictationKeyHandler?.()
+    stoppedHandler?.({ sessionId: '1' })
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+  if (expectedPreviewText) {
+    expect(document.body.textContent).toContain(expectedPreviewText)
+  }
+}

--- a/src/renderer/src/components/dictation/DictationController.tsx
+++ b/src/renderer/src/components/dictation/DictationController.tsx
@@ -183,7 +183,11 @@ export function DictationController() {
         return
       }
 
-      await window.api.speech.startDictation(modelId, undefined, sessionId)
+      await window.api.speech.startDictation(
+        modelId,
+        settings.voice.customVocabulary ?? [],
+        sessionId
+      )
       if (dictationRunRef.current !== runId) {
         discardBufferedAudio()
         insertionTargetRef.current = null

--- a/src/renderer/src/components/dictation/DictationController.tsx
+++ b/src/renderer/src/components/dictation/DictationController.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useRef, useCallback } from 'react'
+import { useEffect, useRef, useCallback, useState } from 'react'
 import { useAppStore } from '@/store'
 import { useAudioCapture } from '@/hooks/use-audio-capture'
 import { toast } from 'sonner'
@@ -8,12 +8,21 @@ import {
   insertText,
   type DictationInsertionTarget
 } from './dictation-insertion-target'
-import { formatFinalTranscriptSegment } from './dictation-final-segments'
-import { recordStoppedSession, waitForStoppedSession } from './dictation-stopped-sessions'
+import { waitForStoppedSession } from './dictation-stopped-sessions'
 import { translate } from '@/i18n/i18n'
 import { showDictationStartErrorToast } from './dictation-start-error-toast'
 import { useHoldDictationGesture } from './use-hold-dictation-gesture'
 import { DICTATION_CONTROL_EVENT, type DictationControlAction } from './dictation-control-events'
+import { DictationCorrectionPreview } from './DictationCorrectionPreview'
+import { correctSpeechTranscript } from '../../../../shared/speech-transcript-correction'
+import type { DictationCorrectionMode } from '../../../../shared/speech-types'
+import { useDictationSpeechEvents } from './use-dictation-speech-events'
+
+type PendingCorrectionPreview = {
+  rawText: string
+  correctedText: string
+  target: DictationInsertionTarget
+}
 
 export function DictationController() {
   const dictationState = useAppStore((s) => s.dictationState)
@@ -42,7 +51,12 @@ export function DictationController() {
   const finalTranscriptReceivedRef = useRef(false)
   const erroredSessionIdsRef = useRef(new Set<string>())
   const intentionalTargetCancellationRef = useRef(false)
-  const insertedFinalTranscriptRef = useRef('')
+  const finalTranscriptRef = useRef('')
+  const correctionModeRef = useRef<DictationCorrectionMode>('off')
+  const correctionVocabularyRef = useRef<string[]>([])
+  const [correctionPreview, setCorrectionPreview] = useState<PendingCorrectionPreview | null>(null)
+  const correctionPreviewRef = useRef(correctionPreview)
+  correctionPreviewRef.current = correctionPreview
   // Why: push-to-talk restarts capture per utterance; toast once per preference,
   // not once per press, while the selected mic stays gone.
   const micFallbackNotifiedForRef = useRef<string | null>(null)
@@ -75,9 +89,26 @@ export function DictationController() {
           )
         )
       }
+      const rawText = finalTranscriptRef.current.trim()
+      const target = insertionTargetRef.current
+      if (!sessionErrored && rawText && correctionModeRef.current !== 'off') {
+        const correctedText = correctSpeechTranscript(rawText, correctionVocabularyRef.current)
+        if (target && correctionModeRef.current === 'preview' && correctedText !== rawText) {
+          setCorrectionPreview({ rawText, correctedText, target })
+        } else if (target) {
+          insertText(correctedText, target)
+        } else if (!intentionalTargetCancellationRef.current) {
+          toast.message(
+            translate(
+              'auto.components.dictation.DictationController.7afff43472',
+              'Dictation finished, but no text field was focused.'
+            )
+          )
+        }
+      }
       insertionTargetRef.current = null
       finalTranscriptReceivedRef.current = false
-      insertedFinalTranscriptRef.current = ''
+      finalTranscriptRef.current = ''
       intentionalTargetCancellationRef.current = false
       stopRequestedDuringStartRef.current = false
       if (activeSessionIdRef.current === sessionId) {
@@ -91,7 +122,7 @@ export function DictationController() {
   )
 
   const startDictation = useCallback(async () => {
-    if (dictationStateRef.current !== 'idle') {
+    if (dictationStateRef.current !== 'idle' || correctionPreviewRef.current) {
       return
     }
 
@@ -122,10 +153,12 @@ export function DictationController() {
     dictationRunRef.current = runId
     activeSessionIdRef.current = sessionId
     insertionTargetRef.current = captureInsertionTarget()
+    correctionModeRef.current = settings.voice.dictationCorrectionMode ?? 'off'
+    correctionVocabularyRef.current = settings.voice.customVocabulary ?? []
     stopRequestedDuringStartRef.current = false
     finalTranscriptReceivedRef.current = false
     erroredSessionIdsRef.current.clear()
-    insertedFinalTranscriptRef.current = ''
+    finalTranscriptRef.current = ''
     intentionalTargetCancellationRef.current = false
     dictationStateRef.current = 'starting'
     setDictationState('starting')
@@ -230,7 +263,7 @@ export function DictationController() {
       stopRequestedDuringStartRef.current = false
       finalTranscriptReceivedRef.current = false
       erroredSessionIdsRef.current.clear()
-      insertedFinalTranscriptRef.current = ''
+      finalTranscriptRef.current = ''
       activeSessionIdRef.current = null
       setPartialTranscript('')
       if (message.includes('dictation_canceled')) {
@@ -280,6 +313,17 @@ export function DictationController() {
   // Why: capture-loss fires from a stream opened before stopDictation exists;
   // route through a ref so the two callbacks do not depend on each other.
   stopDictationRef.current = () => void stopDictation()
+
+  const settleCorrectionPreview = useCallback((choice: 'corrected' | 'raw' | 'discard'): void => {
+    const preview = correctionPreviewRef.current
+    correctionPreviewRef.current = null
+    setCorrectionPreview(null)
+    if (preview && choice !== 'discard') {
+      insertText(choice === 'corrected' ? preview.correctedText : preview.rawText, preview.target, {
+        restoreFocus: true
+      })
+    }
+  }, [])
 
   // Toggle mode: use IPC from main process (before-input-event intercepts
   // the keyDown so Cmd+E doesn't reach xterm or trigger system shortcuts).
@@ -354,82 +398,37 @@ export function DictationController() {
     stopDictation
   })
 
-  useEffect(() => {
-    const cleanupPartial = window.api.speech.onPartialTranscript((data) => {
-      if (data.sessionId !== activeSessionIdRef.current) {
-        return
-      }
-      setPartialTranscript(data.text)
-    })
+  useDictationSpeechEvents({
+    activeSessionIdRef,
+    dictationStateRef,
+    insertionTargetRef,
+    intentionalTargetCancellationRef,
+    finalTranscriptRef,
+    finalTranscriptReceivedRef,
+    correctionModeRef,
+    stoppedSessionIdsRef,
+    stoppedResolversRef,
+    erroredSessionIdsRef,
+    dictationRunRef,
+    stopRequestedDuringStartRef,
+    setPartialTranscript,
+    setDictationState,
+    stopCapture,
+    discardBufferedAudio
+  })
 
-    const cleanupFinal = window.api.speech.onFinalTranscript((data) => {
-      if (data.sessionId !== activeSessionIdRef.current || !data.text) {
-        return
-      }
-      setPartialTranscript('')
-      finalTranscriptReceivedRef.current = true
-      const target = insertionTargetRef.current
-      if (target) {
-        const textToInsert = formatFinalTranscriptSegment(
-          data.text,
-          insertedFinalTranscriptRef.current
-        )
-        insertText(textToInsert, target)
-        insertedFinalTranscriptRef.current += textToInsert
-      } else if (!intentionalTargetCancellationRef.current) {
-        toast.message(
-          translate(
-            'auto.components.dictation.DictationController.7afff43472',
-            'Dictation finished, but no text field was focused.'
-          )
-        )
-      }
-    })
-
-    const cleanupStopped = window.api.speech.onStopped((data) => {
-      recordStoppedSession(data.sessionId, stoppedSessionIdsRef, stoppedResolversRef)
-    })
-
-    const cleanupError = window.api.speech.onError((data) => {
-      if (data.sessionId !== activeSessionIdRef.current) {
-        return
-      }
-      const sessionId = data.sessionId
-      erroredSessionIdsRef.current.add(sessionId)
-      dictationRunRef.current += 1
-      activeSessionIdRef.current = null
-      toast.error(
-        translate(
-          'auto.components.dictation.DictationController.de136f1199',
-          'Speech error: {{value0}}',
-          { value0: data.error }
-        )
-      )
-      dictationStateRef.current = 'stopping'
-      setDictationState('stopping')
-      stopCapture()
-      discardBufferedAudio()
-      void (async () => {
-        await window.api.speech.stopDictation(sessionId).catch(() => undefined)
-        await waitForStoppedSession(sessionId, stoppedSessionIdsRef, stoppedResolversRef)
-        insertionTargetRef.current = null
-        intentionalTargetCancellationRef.current = false
-        stopRequestedDuringStartRef.current = false
-        finalTranscriptReceivedRef.current = false
-        insertedFinalTranscriptRef.current = ''
-        dictationStateRef.current = 'idle'
-        setDictationState('idle')
-        setPartialTranscript('')
-      })()
-    })
-
-    return () => {
-      cleanupPartial()
-      cleanupFinal()
-      cleanupStopped()
-      cleanupError()
-    }
-  }, [setPartialTranscript, setDictationState, stopCapture, discardBufferedAudio])
-
-  return <DictationIndicator />
+  return (
+    <>
+      <DictationIndicator />
+      {correctionPreview ? (
+        <DictationCorrectionPreview
+          rawText={correctionPreview.rawText}
+          correctedText={correctionPreview.correctedText}
+          onInsertCorrected={() => settleCorrectionPreview('corrected')}
+          onInsertRaw={() => settleCorrectionPreview('raw')}
+          onDiscard={() => settleCorrectionPreview('discard')}
+        />
+      ) : null}
+    </>
+  )
 }

--- a/src/renderer/src/components/dictation/DictationCorrectionPreview.tsx
+++ b/src/renderer/src/components/dictation/DictationCorrectionPreview.tsx
@@ -1,0 +1,102 @@
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import { translate } from '@/i18n/i18n'
+
+type DictationCorrectionPreviewProps = {
+  rawText: string
+  correctedText: string
+  onInsertCorrected: () => void
+  onInsertRaw: () => void
+  onDiscard: () => void
+}
+
+export function DictationCorrectionPreview({
+  rawText,
+  correctedText,
+  onInsertCorrected,
+  onInsertRaw,
+  onDiscard
+}: DictationCorrectionPreviewProps): React.JSX.Element {
+  return (
+    <Dialog open onOpenChange={(open) => !open && onDiscard()}>
+      <DialogContent showCloseButton className="sm:max-w-xl">
+        <DialogHeader>
+          <DialogTitle>
+            {translate(
+              'auto.components.dictation.DictationCorrectionPreview.title',
+              'Review dictation correction'
+            )}
+          </DialogTitle>
+          <DialogDescription>
+            {translate(
+              'auto.components.dictation.DictationCorrectionPreview.description',
+              'Correction runs locally. Choose the corrected text or keep the original transcript.'
+            )}
+          </DialogDescription>
+        </DialogHeader>
+        <div className="grid min-w-0 gap-3">
+          <TranscriptPreview
+            label={translate(
+              'auto.components.dictation.DictationCorrectionPreview.corrected',
+              'Corrected'
+            )}
+            text={correctedText}
+          />
+          <TranscriptPreview
+            label={translate(
+              'auto.components.dictation.DictationCorrectionPreview.original',
+              'Original'
+            )}
+            text={rawText}
+            muted
+          />
+        </div>
+        <DialogFooter>
+          <Button type="button" variant="ghost" onClick={onDiscard}>
+            {translate('auto.components.dictation.DictationCorrectionPreview.discard', 'Discard')}
+          </Button>
+          <Button type="button" variant="outline" onClick={onInsertRaw}>
+            {translate(
+              'auto.components.dictation.DictationCorrectionPreview.useOriginal',
+              'Use original'
+            )}
+          </Button>
+          <Button type="button" autoFocus onClick={onInsertCorrected}>
+            {translate(
+              'auto.components.dictation.DictationCorrectionPreview.insertCorrected',
+              'Insert corrected'
+            )}
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  )
+}
+
+function TranscriptPreview({
+  label,
+  text,
+  muted = false
+}: {
+  label: string
+  text: string
+  muted?: boolean
+}): React.JSX.Element {
+  return (
+    <div className="min-w-0 space-y-1">
+      <div className="text-xs font-medium text-muted-foreground">{label}</div>
+      <div
+        className={`scrollbar-sleek max-h-36 overflow-y-auto whitespace-pre-wrap break-words rounded-md border border-border bg-muted/35 px-3 py-2 text-sm ${muted ? 'text-muted-foreground' : 'text-foreground'}`}
+      >
+        {text}
+      </div>
+    </div>
+  )
+}

--- a/src/renderer/src/components/dictation/dictation-insertion-target.test.ts
+++ b/src/renderer/src/components/dictation/dictation-insertion-target.test.ts
@@ -8,7 +8,7 @@ import {
   TEXT_CONTROL_PASTE_MAX_BYTES,
   getTextControlPasteByteLength
 } from '@/lib/text-control-paste'
-import { insertText } from './dictation-insertion-target'
+import { captureInsertionTarget, insertText } from './dictation-insertion-target'
 
 type DocumentWithExecCommand = Document & {
   execCommand?: (commandId: string, showUi?: boolean, value?: string) => boolean
@@ -82,6 +82,32 @@ describe('dictation insertion target', () => {
     expect(inputEvents).toHaveLength(1)
     expect(inputEvents[0].inputType).toBe('insertText')
     expect(inputEvents[0].data ?? '').toBe('')
+  })
+
+  it('restores the captured textarea selection after a correction preview takes focus', async () => {
+    const textarea = appendTextarea()
+    textarea.value = 'hello world'
+    textarea.setSelectionRange(6, 11)
+    const target = captureInsertionTarget()
+    const previewButton = document.createElement('button')
+    document.body.appendChild(previewButton)
+    previewButton.focus()
+
+    expect(target?.kind).toBe('text')
+    insertText('Orca', target!, { restoreFocus: true })
+
+    await vi.waitFor(() => expect(textarea.value).toBe('hello Orca'))
+    expect(document.activeElement).toBe(textarea)
+    expect(textarea.selectionStart).toBe(10)
+    expect(textarea.selectionEnd).toBe(10)
+  })
+
+  it('ignores a detached contenteditable correction target', () => {
+    const editor = appendContentEditable()
+    const target = captureInsertionTarget()
+    editor.remove()
+
+    expect(() => insertText('Orca', target!, { restoreFocus: true })).not.toThrow()
   })
 
   it('chunks large contenteditable dictation through bounded insertText calls', async () => {

--- a/src/renderer/src/components/dictation/dictation-insertion-target.ts
+++ b/src/renderer/src/components/dictation/dictation-insertion-target.ts
@@ -11,8 +11,13 @@ import {
 
 export type DictationInsertionTarget =
   | { kind: 'terminal'; tabId: string; paneId: number }
-  | { kind: 'text'; element: HTMLInputElement | HTMLTextAreaElement }
-  | { kind: 'contentEditable'; element: HTMLElement }
+  | {
+      kind: 'text'
+      element: HTMLInputElement | HTMLTextAreaElement
+      selectionStart?: number | null
+      selectionEnd?: number | null
+    }
+  | { kind: 'contentEditable'; element: HTMLElement; selectionRange?: Range | null }
 
 export function captureInsertionTarget(): DictationInsertionTarget | null {
   const activeElement = document.activeElement
@@ -33,17 +38,28 @@ export function captureInsertionTarget(): DictationInsertionTarget | null {
   }
 
   if (activeElement instanceof HTMLInputElement || activeElement instanceof HTMLTextAreaElement) {
-    return { kind: 'text', element: activeElement }
+    return {
+      kind: 'text',
+      element: activeElement,
+      selectionStart: activeElement.selectionStart,
+      selectionEnd: activeElement.selectionEnd
+    }
   }
 
   if (activeElement instanceof HTMLElement && activeElement.isContentEditable) {
-    return { kind: 'contentEditable', element: activeElement }
+    const selection = activeElement.ownerDocument.getSelection()
+    const selectionRange = selection?.rangeCount ? selection.getRangeAt(0).cloneRange() : null
+    return { kind: 'contentEditable', element: activeElement, selectionRange }
   }
 
   return null
 }
 
-export function insertText(text: string, target: DictationInsertionTarget): void {
+export function insertText(
+  text: string,
+  target: DictationInsertionTarget,
+  options: { restoreFocus?: boolean } = {}
+): void {
   if (target.kind === 'terminal') {
     document.dispatchEvent(
       new CustomEvent('dictation:insertText', {
@@ -58,17 +74,52 @@ export function insertText(text: string, target: DictationInsertionTarget): void
     if (!element.isConnected) {
       return
     }
+    const restoreSelection = (): void => restoreTextSelection(target)
+    let canRestoreAfterAsyncBoundary = options.restoreFocus === true
+    if (canRestoreAfterAsyncBoundary) {
+      restoreSelection()
+    }
     void pasteTextIntoTextControl(element, text, {
       source: 'programmatic',
       inputType: 'insertText',
-      canContinue: (candidate) => candidate.ownerDocument.activeElement === candidate
+      canContinue: (candidate) => {
+        if (canRestoreAfterAsyncBoundary && candidate.ownerDocument.activeElement !== candidate) {
+          canRestoreAfterAsyncBoundary = false
+          restoreSelection()
+        }
+        return candidate.ownerDocument.activeElement === candidate
+      }
     }).catch(() => {})
     return
   }
 
   if (target.kind === 'contentEditable') {
-    void insertTextIntoContentEditableTarget(target.element, text).catch(() => {})
+    const restoreSelection = options.restoreFocus
+      ? () => restoreContentEditableSelection(target.element, target.selectionRange)
+      : undefined
+    restoreSelection?.()
+    void insertTextIntoContentEditableTarget(target.element, text, restoreSelection).catch(() => {})
   }
+}
+
+function restoreTextSelection(target: Extract<DictationInsertionTarget, { kind: 'text' }>): void {
+  target.element.focus()
+  if (typeof target.selectionStart === 'number' && typeof target.selectionEnd === 'number') {
+    target.element.setSelectionRange(target.selectionStart, target.selectionEnd)
+  }
+}
+
+function restoreContentEditableSelection(element: HTMLElement, range?: Range | null): void {
+  if (!element.isConnected) {
+    return
+  }
+  element.focus()
+  if (!range || !element.contains(range.commonAncestorContainer)) {
+    return
+  }
+  const selection = element.ownerDocument.getSelection()
+  selection?.removeAllRanges()
+  selection?.addRange(range)
 }
 
 function findClosestEditorElement(element: HTMLElement): HTMLElement | null {
@@ -77,13 +128,17 @@ function findClosestEditorElement(element: HTMLElement): HTMLElement | null {
 
 async function insertTextIntoContentEditableTarget(
   element: HTMLElement,
-  text: string
+  text: string,
+  restoreSelection?: () => void
 ): Promise<void> {
   const directByteLength = measureTextControlPasteByteLength(text, {
     stopAfterBytes: TEXT_CONTROL_PASTE_DIRECT_MAX_BYTES
   })
   if (directByteLength.byteLength === 0) {
     return
+  }
+  if (!isContentEditableDictationTargetCurrent(element) && restoreSelection) {
+    restoreSelection()
   }
   if (!isContentEditableDictationTargetCurrent(element)) {
     return
@@ -99,6 +154,9 @@ async function insertTextIntoContentEditableTarget(
   })
   if (maxByteLength.exceededLimit) {
     return
+  }
+  if (!isContentEditableDictationTargetCurrent(element) && restoreSelection) {
+    restoreSelection()
   }
 
   let textIndex = 0

--- a/src/renderer/src/components/dictation/use-dictation-speech-events.ts
+++ b/src/renderer/src/components/dictation/use-dictation-speech-events.ts
@@ -1,0 +1,139 @@
+import { useEffect } from 'react'
+import { toast } from 'sonner'
+import type { DictationCorrectionMode, DictationState } from '../../../../shared/speech-types'
+import { translate } from '@/i18n/i18n'
+import { insertText, type DictationInsertionTarget } from './dictation-insertion-target'
+import { formatFinalTranscriptSegment } from './dictation-final-segments'
+import { recordStoppedSession, waitForStoppedSession } from './dictation-stopped-sessions'
+
+type MutableRef<T> = { current: T }
+
+type DictationSpeechEventOptions = {
+  activeSessionIdRef: MutableRef<string | null>
+  dictationStateRef: MutableRef<DictationState>
+  insertionTargetRef: MutableRef<DictationInsertionTarget | null>
+  intentionalTargetCancellationRef: MutableRef<boolean>
+  finalTranscriptRef: MutableRef<string>
+  finalTranscriptReceivedRef: MutableRef<boolean>
+  correctionModeRef: MutableRef<DictationCorrectionMode>
+  stoppedSessionIdsRef: MutableRef<Set<string>>
+  stoppedResolversRef: MutableRef<Map<string, () => void>>
+  erroredSessionIdsRef: MutableRef<Set<string>>
+  dictationRunRef: MutableRef<number>
+  stopRequestedDuringStartRef: MutableRef<boolean>
+  setPartialTranscript: (text: string) => void
+  setDictationState: (state: DictationState) => void
+  stopCapture: () => void
+  discardBufferedAudio: () => void
+}
+
+export function useDictationSpeechEvents(options: DictationSpeechEventOptions): void {
+  const {
+    activeSessionIdRef,
+    dictationStateRef,
+    insertionTargetRef,
+    intentionalTargetCancellationRef,
+    finalTranscriptRef,
+    finalTranscriptReceivedRef,
+    correctionModeRef,
+    stoppedSessionIdsRef,
+    stoppedResolversRef,
+    erroredSessionIdsRef,
+    dictationRunRef,
+    stopRequestedDuringStartRef,
+    setPartialTranscript,
+    setDictationState,
+    stopCapture,
+    discardBufferedAudio
+  } = options
+
+  useEffect(() => {
+    const cleanupPartial = window.api.speech.onPartialTranscript((data) => {
+      if (data.sessionId === activeSessionIdRef.current) {
+        setPartialTranscript(data.text)
+      }
+    })
+
+    const cleanupFinal = window.api.speech.onFinalTranscript((data) => {
+      if (data.sessionId !== activeSessionIdRef.current || !data.text) {
+        return
+      }
+      setPartialTranscript('')
+      finalTranscriptReceivedRef.current = true
+      const textToInsert = formatFinalTranscriptSegment(data.text, finalTranscriptRef.current)
+      finalTranscriptRef.current += textToInsert
+      const target = insertionTargetRef.current
+      if (correctionModeRef.current === 'off' && target) {
+        insertText(textToInsert, target)
+      } else if (correctionModeRef.current === 'off' && !intentionalTargetCancellationRef.current) {
+        toast.message(
+          translate(
+            'auto.components.dictation.DictationController.7afff43472',
+            'Dictation finished, but no text field was focused.'
+          )
+        )
+      }
+    })
+
+    const cleanupStopped = window.api.speech.onStopped((data) => {
+      recordStoppedSession(data.sessionId, stoppedSessionIdsRef, stoppedResolversRef)
+    })
+
+    const cleanupError = window.api.speech.onError((data) => {
+      if (data.sessionId !== activeSessionIdRef.current) {
+        return
+      }
+      const sessionId = data.sessionId
+      erroredSessionIdsRef.current.add(sessionId)
+      dictationRunRef.current += 1
+      activeSessionIdRef.current = null
+      toast.error(
+        translate(
+          'auto.components.dictation.DictationController.de136f1199',
+          'Speech error: {{value0}}',
+          { value0: data.error }
+        )
+      )
+      dictationStateRef.current = 'stopping'
+      setDictationState('stopping')
+      stopCapture()
+      discardBufferedAudio()
+      void (async () => {
+        await window.api.speech.stopDictation(sessionId).catch(() => undefined)
+        await waitForStoppedSession(sessionId, stoppedSessionIdsRef, stoppedResolversRef)
+        insertionTargetRef.current = null
+        intentionalTargetCancellationRef.current = false
+        stopRequestedDuringStartRef.current = false
+        finalTranscriptReceivedRef.current = false
+        finalTranscriptRef.current = ''
+        dictationStateRef.current = 'idle'
+        setDictationState('idle')
+        setPartialTranscript('')
+      })()
+    })
+
+    return () => {
+      cleanupPartial()
+      cleanupFinal()
+      cleanupStopped()
+      cleanupError()
+    }
+  }, [
+    activeSessionIdRef,
+    correctionModeRef,
+    dictationRunRef,
+    dictationStateRef,
+    discardBufferedAudio,
+    erroredSessionIdsRef,
+    finalTranscriptReceivedRef,
+    finalTranscriptRef,
+    insertionTargetRef,
+    intentionalTargetCancellationRef,
+    setDictationState,
+    setPartialTranscript,
+    stopCapture,
+    stoppedResolversRef,
+    stoppedSessionIdsRef,
+    stopRequestedDuringStartRef
+  ])
+}

--- a/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
+++ b/src/renderer/src/components/settings/VoiceDictationSettingsSection.tsx
@@ -5,6 +5,24 @@ import { useShortcutLabel } from '@/hooks/useShortcutLabel'
 import { translate } from '@/i18n/i18n'
 import { VoiceMicrophoneSetting } from './VoiceMicrophoneSetting'
 
+const CORRECTION_MODES = ['off', 'preview', 'auto'] as const
+
+function getCorrectionModeLabel(mode: (typeof CORRECTION_MODES)[number]): string {
+  if (mode === 'preview') {
+    return translate(
+      'auto.components.settings.VoiceDictationSettingsSection.correction.preview',
+      'Preview'
+    )
+  }
+  if (mode === 'auto') {
+    return translate(
+      'auto.components.settings.VoiceDictationSettingsSection.correction.auto',
+      'Auto'
+    )
+  }
+  return translate('auto.components.settings.VoiceDictationSettingsSection.correction.off', 'Off')
+}
+
 type VoiceDictationSettingsSectionProps = {
   voiceSettings: VoiceSettings
   permissionPending: boolean
@@ -91,6 +109,45 @@ export function VoiceDictationSettingsSection({
                 : translate('auto.components.settings.VoicePane.174da92062', 'Hold')}
             </button>
           ))}
+        </div>
+      </div>
+
+      <Separator />
+
+      <div className="flex items-center justify-between gap-4 py-2">
+        <div className="space-y-0.5">
+          <Label>
+            {translate(
+              'auto.components.settings.VoiceDictationSettingsSection.correctionLabel',
+              'Transcript Correction'
+            )}
+          </Label>
+          <p className="max-w-[34rem] text-xs text-muted-foreground">
+            {translate(
+              'auto.components.settings.VoiceDictationSettingsSection.correctionDescription',
+              'Locally fixes spoken punctuation, spacing, and saved vocabulary. Preview asks before inserting; Auto inserts the corrected text.'
+            )}
+          </p>
+        </div>
+        <div className="flex shrink-0 items-center rounded-md border border-border/60 bg-background/50 p-0.5">
+          {CORRECTION_MODES.map((mode) => {
+            const label = getCorrectionModeLabel(mode)
+            return (
+              <button
+                key={mode}
+                aria-label={label}
+                onClick={() => onUpdateVoiceSettings({ dictationCorrectionMode: mode })}
+                disabled={!voiceSettings.enabled}
+                className={`rounded-sm px-2.5 py-1 text-sm transition-colors ${
+                  (voiceSettings.dictationCorrectionMode ?? 'off') === mode
+                    ? 'bg-accent font-medium text-accent-foreground'
+                    : 'text-muted-foreground hover:text-foreground'
+                } ${!voiceSettings.enabled ? 'cursor-not-allowed opacity-50' : ''}`}
+              >
+                {label}
+              </button>
+            )
+          })}
         </div>
       </div>
 

--- a/src/renderer/src/components/settings/VoicePane.tsx
+++ b/src/renderer/src/components/settings/VoicePane.tsx
@@ -10,6 +10,7 @@ import { OpenAiTranscriptionSettingsRow } from './OpenAiTranscriptionSettingsRow
 import { handleVoiceDictationToggle } from './voice-dictation-toggle'
 import { VoiceDictationSettingsSection } from './VoiceDictationSettingsSection'
 import { VoiceSpeechModelSection } from './VoiceSpeechModelSection'
+import { VoiceVocabularySection } from './VoiceVocabularySection'
 import { matchesSettingsSearch } from './settings-search'
 import { getOpenaiTranscriptionSearchEntry } from './voice-pane-search'
 import { translate } from '@/i18n/i18n'
@@ -208,6 +209,13 @@ export function VoicePane({ settings, updateSettings }: VoicePaneProps): React.J
         onToggleVoiceDictation={() => void toggleVoiceDictation()}
         onUpdateVoiceSettings={updateVoiceSettings}
       />
+
+      <VoiceVocabularySection
+        voiceSettings={voiceSettings}
+        onUpdateVoiceSettings={updateVoiceSettings}
+      />
+
+      <Separator />
 
       <VoiceSpeechModelSection
         voiceSettings={voiceSettings}

--- a/src/renderer/src/components/settings/VoiceVocabularySection.test.tsx
+++ b/src/renderer/src/components/settings/VoiceVocabularySection.test.tsx
@@ -1,0 +1,62 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot } from 'react-dom/client'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultVoiceSettings } from '../../../../shared/constants'
+import { parseCustomVocabularyDraft, VoiceVocabularySection } from './VoiceVocabularySection'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+describe('parseCustomVocabularyDraft', () => {
+  it('normalizes comma and newline separated mixed-language terms', () => {
+    expect(parseCustomVocabularyDraft('  Orca\n\norca, Qwen3-ASR，中文术语  ')).toEqual([
+      'Orca',
+      'Qwen3-ASR',
+      '中文术语'
+    ])
+  })
+})
+
+describe('VoiceVocabularySection', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+  })
+
+  it('persists normalized vocabulary when the textarea loses focus', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const root = createRoot(container)
+    const onUpdateVoiceSettings = vi.fn()
+
+    act(() => {
+      root.render(
+        <VoiceVocabularySection
+          voiceSettings={{ ...getDefaultVoiceSettings(), enabled: true }}
+          onUpdateVoiceSettings={onUpdateVoiceSettings}
+        />
+      )
+    })
+
+    const textarea = container.querySelector('textarea')
+    expect(textarea).not.toBeNull()
+    await act(async () => {
+      const valueSetter = Object.getOwnPropertyDescriptor(
+        HTMLTextAreaElement.prototype,
+        'value'
+      )?.set
+      valueSetter?.call(textarea, ' Orca\nQwen3-ASR\nORCA ')
+      textarea?.dispatchEvent(new Event('input', { bubbles: true }))
+      textarea?.dispatchEvent(new FocusEvent('focusout', { bubbles: true }))
+    })
+
+    expect(onUpdateVoiceSettings).toHaveBeenCalledWith({
+      customVocabulary: ['Orca', 'Qwen3-ASR']
+    })
+    act(() => root.unmount())
+  })
+})

--- a/src/renderer/src/components/settings/VoiceVocabularySection.tsx
+++ b/src/renderer/src/components/settings/VoiceVocabularySection.tsx
@@ -1,0 +1,73 @@
+import { useEffect, useState } from 'react'
+import type { VoiceSettings } from '../../../../shared/speech-types'
+import { normalizeSpeechHotwords } from '../../../../shared/speech-hotwords'
+import { Label } from '../ui/label'
+import { translate } from '@/i18n/i18n'
+
+const EMPTY_VOCABULARY: string[] = []
+
+export function parseCustomVocabularyDraft(value: string): string[] {
+  return normalizeSpeechHotwords(value.split(/[,，\n]/u))
+}
+
+type VoiceVocabularySectionProps = {
+  voiceSettings: VoiceSettings
+  onUpdateVoiceSettings: (updates: Partial<VoiceSettings>) => void
+}
+
+function areTermsEqual(left: string[], right: string[]): boolean {
+  return left.length === right.length && left.every((term, index) => term === right[index])
+}
+
+export function VoiceVocabularySection({
+  voiceSettings,
+  onUpdateVoiceSettings
+}: VoiceVocabularySectionProps): React.JSX.Element {
+  const vocabulary = voiceSettings.customVocabulary ?? EMPTY_VOCABULARY
+  const [draft, setDraft] = useState(() => vocabulary.join('\n'))
+
+  useEffect(() => {
+    setDraft(vocabulary.join('\n'))
+  }, [vocabulary])
+
+  const saveDraft = (): void => {
+    const nextVocabulary = parseCustomVocabularyDraft(draft)
+    setDraft(nextVocabulary.join('\n'))
+    if (!areTermsEqual(vocabulary, nextVocabulary)) {
+      onUpdateVoiceSettings({ customVocabulary: nextVocabulary })
+    }
+  }
+
+  return (
+    <div className="flex items-start justify-between gap-4 py-2">
+      <div className="min-w-0 flex-1 space-y-0.5">
+        <Label htmlFor="voice-custom-vocabulary">
+          {translate('auto.components.settings.VoiceVocabularySection.label', 'Custom Vocabulary')}
+        </Label>
+        <p
+          id="voice-custom-vocabulary-description"
+          className="max-w-[34rem] text-xs text-muted-foreground"
+        >
+          {translate(
+            'auto.components.settings.VoiceVocabularySection.description',
+            'Add names, technical terms, and mixed-language phrases. Supported local models use them to improve recognition.'
+          )}
+        </p>
+      </div>
+      <textarea
+        id="voice-custom-vocabulary"
+        aria-describedby="voice-custom-vocabulary-description"
+        value={draft}
+        onChange={(event) => setDraft(event.currentTarget.value)}
+        onBlur={saveDraft}
+        rows={4}
+        spellCheck={false}
+        placeholder={translate(
+          'auto.components.settings.VoiceVocabularySection.placeholder',
+          'Orca\nQwen3-ASR\nPowerShell'
+        )}
+        className="min-h-24 w-64 resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/settings/VoiceVocabularySection.tsx
+++ b/src/renderer/src/components/settings/VoiceVocabularySection.tsx
@@ -2,6 +2,7 @@ import { useEffect, useState } from 'react'
 import type { VoiceSettings } from '../../../../shared/speech-types'
 import { normalizeSpeechHotwords } from '../../../../shared/speech-hotwords'
 import { Label } from '../ui/label'
+import { Textarea } from '../ui/textarea'
 import { translate } from '@/i18n/i18n'
 
 const EMPTY_VOCABULARY: string[] = []
@@ -54,7 +55,7 @@ export function VoiceVocabularySection({
           )}
         </p>
       </div>
-      <textarea
+      <Textarea
         id="voice-custom-vocabulary"
         aria-describedby="voice-custom-vocabulary-description"
         value={draft}
@@ -66,7 +67,7 @@ export function VoiceVocabularySection({
           'auto.components.settings.VoiceVocabularySection.placeholder',
           'Orca\nQwen3-ASR\nPowerShell'
         )}
-        className="min-h-24 w-64 resize-y rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 dark:bg-input/30"
+        className="min-h-24 w-64 resize-y"
       />
     </div>
   )

--- a/src/renderer/src/components/settings/voice-pane-search.ts
+++ b/src/renderer/src/components/settings/voice-pane-search.ts
@@ -74,6 +74,35 @@ export const getVoicePaneSearchEntries = createLocalizedCatalog(() => [
     ]
   },
   {
+    title: translate(
+      'auto.components.settings.voice.pane.search.correctionTitle',
+      'Transcript Correction'
+    ),
+    description: translate(
+      'auto.components.settings.voice.pane.search.correctionDescription',
+      'Locally correct spoken punctuation, spacing, and custom vocabulary before insertion.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.voice.pane.search.7640ed9848', 'voice'),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.089d31a45b',
+        'dictation'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.correctionKeyword',
+        'correction'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.autocorrectKeyword',
+        'autocorrect'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.punctuationKeyword',
+        'punctuation'
+      )
+    ]
+  },
+  {
     title: translate('auto.components.settings.voice.pane.search.microphoneTitle', 'Microphone'),
     description: translate(
       'auto.components.settings.voice.pane.search.microphoneDescription',

--- a/src/renderer/src/components/settings/voice-pane-search.ts
+++ b/src/renderer/src/components/settings/voice-pane-search.ts
@@ -98,6 +98,32 @@ export const getVoicePaneSearchEntries = createLocalizedCatalog(() => [
       )
     ]
   },
+  {
+    title: translate(
+      'auto.components.settings.voice.pane.search.customVocabularyTitle',
+      'Custom Vocabulary'
+    ),
+    description: translate(
+      'auto.components.settings.voice.pane.search.customVocabularyDescription',
+      'Improve supported local speech models with names, technical terms, and mixed-language phrases.'
+    ),
+    keywords: [
+      ...translateSearchKeyword('auto.components.settings.voice.pane.search.7640ed9848', 'voice'),
+      ...translateSearchKeyword('auto.components.settings.voice.pane.search.3d8b853963', 'speech'),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.customVocabularyKeyword',
+        'vocabulary'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.hotwordsKeyword',
+        'hotwords'
+      ),
+      ...translateSearchKeyword(
+        'auto.components.settings.voice.pane.search.technicalTermsKeyword',
+        'technical terms'
+      )
+    ]
+  },
   getOpenaiTranscriptionSearchEntry(),
   {
     title: translate('auto.components.settings.voice.pane.search.7e62cd7c41', 'Speech Model'),

--- a/src/renderer/src/components/ui/textarea.tsx
+++ b/src/renderer/src/components/ui/textarea.tsx
@@ -1,0 +1,18 @@
+import * as React from 'react'
+
+import { cn } from '@/lib/utils'
+
+function Textarea({ className, ...props }: React.ComponentProps<'textarea'>) {
+  return (
+    <textarea
+      data-slot="textarea"
+      className={cn(
+        'min-h-16 w-full rounded-md border border-input bg-transparent px-3 py-2 text-sm shadow-xs outline-none transition-[color,box-shadow] placeholder:text-muted-foreground/60 focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 disabled:cursor-not-allowed disabled:opacity-50 dark:bg-input/30',
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export { Textarea }

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -9371,7 +9371,9 @@
               "micInput": "input",
               "micDevice": "device",
               "micAirpods": "airpods",
-              "micDefault": "system default"
+              "micDefault": "system default",
+              "customVocabularyTitle": "Custom Vocabulary",
+              "customVocabularyDescription": "Improve supported local speech models with names, technical terms, and mixed-language phrases."
             }
           }
         },
@@ -10451,6 +10453,11 @@
           "openAutomationsDescription": "Create schedules and inspect recent runs.",
           "title": "Automations",
           "description": "Schedule agent work and choose whether Automations appears in the sidebar."
+        },
+        "VoiceVocabularySection": {
+          "label": "Custom Vocabulary",
+          "description": "Add names, technical terms, and mixed-language phrases. Supported local models use them to improve recognition.",
+          "placeholder": "Orca\nQwen3-ASR\nPowerShell"
         }
       },
       "right": {

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -7713,6 +7713,15 @@
           "1eac933202": "Opened macOS Privacy & Security. Enable dictation again after granting access.",
           "cd9fe37556": "Microphone permission granted"
         },
+        "VoiceDictationSettingsSection": {
+          "correctionLabel": "Transcript Correction",
+          "correctionDescription": "Locally fixes spoken punctuation, spacing, and saved vocabulary. Preview asks before inserting; Auto inserts the corrected text.",
+          "correction": {
+            "off": "Off",
+            "preview": "Preview",
+            "auto": "Auto"
+          }
+        },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "Remove {{value0}}",
           "b814c618e2": "Linked paths",
@@ -9373,7 +9382,12 @@
               "micAirpods": "airpods",
               "micDefault": "system default",
               "customVocabularyTitle": "Custom Vocabulary",
-              "customVocabularyDescription": "Improve supported local speech models with names, technical terms, and mixed-language phrases."
+              "customVocabularyDescription": "Improve supported local speech models with names, technical terms, and mixed-language phrases.",
+              "correctionTitle": "Transcript Correction",
+              "correctionDescription": "Locally correct spoken punctuation, spacing, and custom vocabulary before insertion.",
+              "correctionKeyword": "correction",
+              "autocorrectKeyword": "autocorrect",
+              "punctuationKeyword": "punctuation"
             }
           }
         },
@@ -13739,6 +13753,15 @@
         },
         "DictationIndicator": {
           "335e1bc6cb": "Stop dictation"
+        },
+        "DictationCorrectionPreview": {
+          "title": "Review dictation correction",
+          "description": "Correction runs locally. Choose the corrected text or keep the original transcript.",
+          "corrected": "Corrected",
+          "original": "Original",
+          "discard": "Discard",
+          "useOriginal": "Use original",
+          "insertCorrected": "Insert corrected"
         }
       },
       "dashboard": {

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -7432,6 +7432,15 @@
           "cd9fe37556": "已授予麦克风权限",
           "6fa734ed95": "删除 {{value0}}"
         },
+        "VoiceDictationSettingsSection": {
+          "correctionLabel": "听写自动校正",
+          "correctionDescription": "在本地修正口述标点、空格和已保存词汇。预览模式会在插入前确认，自动模式会直接插入校正后的文本。",
+          "correction": {
+            "off": "关闭",
+            "preview": "预览",
+            "auto": "自动"
+          }
+        },
         "WorktreeSymlinksSection": {
           "1c1e35b219": "删除 {{value0}}",
           "b814c618e2": "链接路径",
@@ -9081,7 +9090,14 @@
               "20574cbc72": "启用语音听写",
               "322d457a0d": "转录",
               "dcc7846641": "配置用于云语音转文本模型的 OpenAI API 密钥。",
-              "ebfd0b32e5": "OpenAI 转录"
+              "ebfd0b32e5": "OpenAI 转录",
+              "customVocabularyTitle": "自定义词汇",
+              "customVocabularyDescription": "通过姓名、技术术语和中英混合短语提高受支持本地语音模型的识别效果。",
+              "correctionTitle": "听写自动校正",
+              "correctionDescription": "在插入前本地修正口述标点、空格和自定义词汇。",
+              "correctionKeyword": "校正",
+              "autocorrectKeyword": "自动校正",
+              "punctuationKeyword": "标点"
             }
           }
         },
@@ -10112,6 +10128,11 @@
           "description": "用于语音听写的输入设备，系统默认会跟随操作系统的麦克风设置。",
           "accessHint": "允许麦克风访问以列出输入设备。",
           "allowAccess": "允许访问"
+        },
+        "VoiceVocabularySection": {
+          "label": "自定义词汇",
+          "description": "添加姓名、技术术语和中英混合短语。受支持的本地模型会使用这些词汇改善识别。",
+          "placeholder": "Orca\nQwen3-ASR\nPowerShell"
         }
       },
       "right": {
@@ -13325,6 +13346,15 @@
         },
         "DictationIndicator": {
           "335e1bc6cb": "停止听写"
+        },
+        "DictationCorrectionPreview": {
+          "title": "检查听写校正",
+          "description": "校正在本地完成。请选择校正后的文本，或保留原始听写内容。",
+          "corrected": "校正后",
+          "original": "原文",
+          "discard": "丢弃",
+          "useOriginal": "使用原文",
+          "insertCorrected": "插入校正文"
         }
       },
       "dashboard": {

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -399,6 +399,7 @@ export function getDefaultVoiceSettings(): VoiceSettings {
     modelsDir: '',
     language: 'en',
     dictationMode: 'toggle' as const,
+    dictationCorrectionMode: 'off' as const,
     customVocabulary: [],
     terminalConfirmBeforeInsert: false,
     userModels: [],

--- a/src/shared/constants.ts
+++ b/src/shared/constants.ts
@@ -399,6 +399,7 @@ export function getDefaultVoiceSettings(): VoiceSettings {
     modelsDir: '',
     language: 'en',
     dictationMode: 'toggle' as const,
+    customVocabulary: [],
     terminalConfirmBeforeInsert: false,
     userModels: [],
     openAiApiKeyConfigured: false,

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -41,6 +41,7 @@ import type { RemoteServerUpdateSupport } from './remote-server-update'
 import type { ExecutionHostId } from './execution-host'
 import type { PtyIncarnationId } from './pty-incarnation'
 import type { RasterImageDimensions } from './raster-image-dimensions'
+import type { DictationCorrectionMode } from './speech-types'
 
 export type { RuntimeMarkdownReadTabResult, RuntimeMarkdownSaveTabResult }
 
@@ -818,6 +819,8 @@ export type RuntimeSpeechSetupState = {
   selectedModelId: string
   /** 'toggle' = press once to start/stop; 'hold' = dictate while held. */
   dictationMode: 'toggle' | 'hold'
+  /** Optional so updated mobile clients remain compatible with older runtimes. */
+  dictationCorrectionMode?: DictationCorrectionMode
   models: RuntimeSpeechModelSummary[]
 }
 

--- a/src/shared/speech-hotwords.test.ts
+++ b/src/shared/speech-hotwords.test.ts
@@ -1,0 +1,43 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_SPEECH_HOTWORD_LENGTH,
+  MAX_SPEECH_HOTWORDS,
+  normalizeSpeechHotwords
+} from './speech-hotwords'
+
+describe('normalizeSpeechHotwords', () => {
+  it('trims terms and deduplicates mixed Chinese and English vocabulary', () => {
+    expect(normalizeSpeechHotwords([' Orca ', 'orca', 'Qwen3-ASR', '中文术语'])).toEqual([
+      'Orca',
+      'Qwen3-ASR',
+      '中文术语'
+    ])
+  })
+
+  it('drops non-strings, control characters, score delimiters, and oversized terms', () => {
+    expect(
+      normalizeSpeechHotwords([
+        null,
+        42,
+        '',
+        'line\nbreak',
+        'tab\tbreak',
+        'weight:3.0',
+        'paragraph\u2029break',
+        'x'.repeat(MAX_SPEECH_HOTWORD_LENGTH + 1),
+        'PowerShell'
+      ])
+    ).toEqual(['PowerShell'])
+  })
+
+  it('bounds vocabulary received across IPC', () => {
+    const input = Array.from({ length: MAX_SPEECH_HOTWORDS + 20 }, (_, index) => `term-${index}`)
+
+    expect(normalizeSpeechHotwords(input)).toHaveLength(MAX_SPEECH_HOTWORDS)
+    expect(normalizeSpeechHotwords(input).at(-1)).toBe(`term-${MAX_SPEECH_HOTWORDS - 1}`)
+  })
+
+  it('returns an empty list for non-array input', () => {
+    expect(normalizeSpeechHotwords('Orca')).toEqual([])
+  })
+})

--- a/src/shared/speech-hotwords.ts
+++ b/src/shared/speech-hotwords.ts
@@ -1,0 +1,40 @@
+export const MAX_SPEECH_HOTWORDS = 200
+export const MAX_SPEECH_HOTWORD_LENGTH = 120
+
+function containsUnsupportedCharacters(value: string): boolean {
+  for (const character of value) {
+    const code = character.charCodeAt(0)
+    if (code <= 0x1f || code === 0x7f || code === 0x2028 || code === 0x2029 || character === ':') {
+      return true
+    }
+  }
+  return false
+}
+
+export function normalizeSpeechHotwords(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+
+  const seen = new Set<string>()
+  const normalized: string[] = []
+  for (const item of value) {
+    if (typeof item !== 'string') {
+      continue
+    }
+    const word = item.trim()
+    if (!word || word.length > MAX_SPEECH_HOTWORD_LENGTH || containsUnsupportedCharacters(word)) {
+      continue
+    }
+    const key = word.toLowerCase()
+    if (seen.has(key)) {
+      continue
+    }
+    seen.add(key)
+    normalized.push(word)
+    if (normalized.length >= MAX_SPEECH_HOTWORDS) {
+      break
+    }
+  }
+  return normalized
+}

--- a/src/shared/speech-transcript-correction.test.ts
+++ b/src/shared/speech-transcript-correction.test.ts
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_DICTATION_CORRECTION_CODE_UNITS,
+  correctSpeechTranscript,
+  normalizeDictationCorrectionMode
+} from './speech-transcript-correction'
+
+describe('correctSpeechTranscript', () => {
+  it('converts spoken Chinese punctuation and restores mixed-language vocabulary', () => {
+    expect(correctSpeechTranscript('你好 逗号 我们用 q w e n 3 a s r 句号', ['Qwen3-ASR'])).toBe(
+      '你好，我们用 Qwen3-ASR。'
+    )
+  })
+
+  it('converts standalone English punctuation without matching word fragments', () => {
+    expect(
+      correctSpeechTranscript('run power shell comma then periodic task period', ['PowerShell'])
+    ).toBe('run PowerShell, then periodic task.')
+  })
+
+  it('preserves explicit paragraph structure from spoken commands', () => {
+    expect(correctSpeechTranscript('第一行 换行 second line new paragraph third line')).toBe(
+      '第一行\nsecond line\n\nthird line'
+    )
+  })
+
+  it('prefers the longest vocabulary term at a word boundary', () => {
+    expect(correctSpeechTranscript('use power shell core', ['PowerShell', 'PowerShell Core'])).toBe(
+      'use PowerShell Core'
+    )
+  })
+
+  it('does not restore vocabulary across punctuation segment breaks', () => {
+    expect(correctSpeechTranscript('q,w,e,n,3,a,s,r', ['Qwen3-ASR'])).toBe('q,w,e,n,3,a,s,r')
+  })
+
+  it('keeps oversized transcripts unchanged to bound synchronous post-processing', () => {
+    const text = ` ${'a'.repeat(MAX_DICTATION_CORRECTION_CODE_UNITS + 1)} `
+    expect(correctSpeechTranscript(text, ['A'])).toBe(text.trim())
+  })
+})
+
+describe('normalizeDictationCorrectionMode', () => {
+  it('accepts supported modes and defaults unknown values off', () => {
+    expect(normalizeDictationCorrectionMode('preview')).toBe('preview')
+    expect(normalizeDictationCorrectionMode('auto')).toBe('auto')
+    expect(normalizeDictationCorrectionMode('cloud')).toBe('off')
+    expect(normalizeDictationCorrectionMode(null)).toBe('off')
+  })
+})

--- a/src/shared/speech-transcript-correction.ts
+++ b/src/shared/speech-transcript-correction.ts
@@ -1,0 +1,230 @@
+import { normalizeSpeechHotwords } from './speech-hotwords'
+import type { DictationCorrectionMode } from './speech-types'
+
+export const MAX_DICTATION_CORRECTION_CODE_UNITS = 100_000
+
+const LETTER_OR_NUMBER_RE = /[\p{L}\p{N}]/u
+const CJK_RE = /[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]/u
+const REGEXP_SPECIAL_RE = /[.*+?^${}()|[\]\\]/g
+const VOCABULARY_SEPARATOR_RE = /[\s._-]/u
+const VOCABULARY_SEGMENT_BREAK = '\0'
+
+const CHINESE_SPOKEN_PUNCTUATION = [
+  ['换一行', '\n'],
+  ['下一行', '\n'],
+  ['换行', '\n'],
+  ['左括号', '（'],
+  ['右括号', '）'],
+  ['问号', '？'],
+  ['感叹号', '！'],
+  ['叹号', '！'],
+  ['逗号', '，'],
+  ['句号', '。'],
+  ['冒号', '：'],
+  ['分号', '；']
+] as const
+
+const ENGLISH_SPOKEN_PUNCTUATION = [
+  ['new paragraph', '\n\n'],
+  ['new line', '\n'],
+  ['open parenthesis', '('],
+  ['close parenthesis', ')'],
+  ['question mark', '?'],
+  ['exclamation mark', '!'],
+  ['full stop', '.'],
+  ['semicolon', ';'],
+  ['comma', ','],
+  ['period', '.'],
+  ['colon', ':']
+] as const
+
+export function normalizeDictationCorrectionMode(value: unknown): DictationCorrectionMode {
+  return value === 'preview' || value === 'auto' ? value : 'off'
+}
+
+function escapeRegExp(value: string): string {
+  return value.replace(REGEXP_SPECIAL_RE, '\\$&')
+}
+
+function replaceSpokenPunctuation(text: string): string {
+  let corrected = text
+  for (const [spoken, punctuation] of CHINESE_SPOKEN_PUNCTUATION) {
+    corrected = corrected.replaceAll(spoken, punctuation)
+  }
+  for (const [spoken, punctuation] of ENGLISH_SPOKEN_PUNCTUATION) {
+    const pattern = escapeRegExp(spoken).replaceAll(' ', '\\s+')
+    corrected = corrected.replace(
+      new RegExp(`(^|[^\\p{L}\\p{N}])(?:${pattern})(?=$|[^\\p{L}\\p{N}])`, 'giu'),
+      (_match, prefix: string) => `${prefix}${punctuation}`
+    )
+  }
+  return corrected
+}
+
+function getVocabularyKey(term: string): string | null {
+  const characters = Array.from(term.normalize('NFKC')).filter((character) =>
+    LETTER_OR_NUMBER_RE.test(character)
+  )
+  if (characters.length < 2 || characters.some((character) => CJK_RE.test(character))) {
+    return null
+  }
+  return characters.join('').toLowerCase()
+}
+
+type VocabularyTrieNode = {
+  children: Map<string, VocabularyTrieNode>
+  term?: string
+}
+
+function buildVocabularyTrie(vocabulary: readonly string[]): VocabularyTrieNode {
+  const root: VocabularyTrieNode = { children: new Map() }
+  for (const term of normalizeSpeechHotwords(vocabulary)) {
+    const key = getVocabularyKey(term)
+    if (!key) {
+      continue
+    }
+    let node = root
+    for (let index = 0; index < key.length; index += 1) {
+      const character = key[index]
+      let child = node.children.get(character)
+      if (!child) {
+        child = { children: new Map() }
+        node.children.set(character, child)
+      }
+      node = child
+    }
+    node.term ??= term
+  }
+  return root
+}
+
+type SearchableTranscript = {
+  foldedText: string
+  sourceStarts: number[]
+  sourceEnds: number[]
+  startsAtBoundary: boolean[]
+  endsAtBoundary: boolean[]
+}
+
+function buildSearchableTranscript(text: string): SearchableTranscript {
+  let foldedText = ''
+  const sourceStarts: number[] = []
+  const sourceEnds: number[] = []
+  const startsAtBoundary: boolean[] = []
+  const endsAtBoundary: boolean[] = []
+  let previousWasLetterOrNumber = false
+
+  for (let sourceStart = 0; sourceStart < text.length; ) {
+    const character = String.fromCodePoint(text.codePointAt(sourceStart) ?? 0)
+    const sourceEnd = sourceStart + character.length
+    const isLetterOrNumber = LETTER_OR_NUMBER_RE.test(character)
+    if (isLetterOrNumber) {
+      const nextCharacter =
+        sourceEnd < text.length ? String.fromCodePoint(text.codePointAt(sourceEnd) ?? 0) : ''
+      const foldedCharacter = character.toLowerCase()
+      for (let index = 0; index < foldedCharacter.length; index += 1) {
+        foldedText += foldedCharacter[index]
+        sourceStarts.push(sourceStart)
+        sourceEnds.push(sourceEnd)
+        startsAtBoundary.push(index === 0 && !previousWasLetterOrNumber)
+        endsAtBoundary.push(
+          index === foldedCharacter.length - 1 && !LETTER_OR_NUMBER_RE.test(nextCharacter)
+        )
+      }
+    } else if (!VOCABULARY_SEPARATOR_RE.test(character)) {
+      foldedText += VOCABULARY_SEGMENT_BREAK
+      sourceStarts.push(sourceStart)
+      sourceEnds.push(sourceEnd)
+      startsAtBoundary.push(false)
+      endsAtBoundary.push(false)
+    }
+    previousWasLetterOrNumber = isLetterOrNumber
+    sourceStart = sourceEnd
+  }
+
+  return { foldedText, sourceStarts, sourceEnds, startsAtBoundary, endsAtBoundary }
+}
+
+function restoreVocabularyTerms(text: string, vocabulary: readonly string[]): string {
+  const trie = buildVocabularyTrie(vocabulary)
+  if (trie.children.size === 0) {
+    return text
+  }
+  const searchable = buildSearchableTranscript(text)
+  const replacements: { start: number; end: number; term: string }[] = []
+
+  for (let start = 0; start < searchable.foldedText.length; start += 1) {
+    if (!searchable.startsAtBoundary[start]) {
+      continue
+    }
+    let node: VocabularyTrieNode | undefined = trie
+    let bestMatch: { end: number; term: string } | null = null
+    for (let end = start; end < searchable.foldedText.length; end += 1) {
+      node = node.children.get(searchable.foldedText[end])
+      if (!node) {
+        break
+      }
+      if (node.term && searchable.endsAtBoundary[end]) {
+        bestMatch = { end, term: node.term }
+      }
+    }
+    if (!bestMatch) {
+      continue
+    }
+    replacements.push({
+      start: searchable.sourceStarts[start],
+      end: searchable.sourceEnds[bestMatch.end],
+      term: bestMatch.term
+    })
+    start = bestMatch.end
+  }
+
+  if (replacements.length === 0) {
+    return text
+  }
+  let sourceIndex = 0
+  let corrected = ''
+  for (const replacement of replacements) {
+    corrected += text.slice(sourceIndex, replacement.start) + replacement.term
+    sourceIndex = replacement.end
+  }
+  return corrected + text.slice(sourceIndex)
+}
+
+function stripTranscriptControlCharacters(text: string): string {
+  let result = ''
+  for (const character of text) {
+    const code = character.charCodeAt(0)
+    if ((code <= 0x1f && character !== '\n' && character !== '\t') || code === 0x7f) {
+      continue
+    }
+    result += character
+  }
+  return result
+}
+
+function normalizeTranscriptSpacing(text: string): string {
+  return stripTranscriptControlCharacters(text)
+    .replace(/\r\n?/g, '\n')
+    .replace(/[^\S\n]+/g, ' ')
+    .replace(/ *\n */g, '\n')
+    .replace(/\n{3,}/g, '\n\n')
+    .replace(/ +([,.;!?%。，、！？；：)\]}》」』])/gu, '$1')
+    .replace(/(\[|[({（【《「『]) +/gu, '$1')
+    .replace(/([，。！？；：、]) +/gu, '$1')
+    .replace(
+      /([\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}]) +(?=[\p{Script=Han}\p{Script=Hiragana}\p{Script=Katakana}\p{Script=Hangul}])/gu,
+      '$1'
+    )
+    .trim()
+}
+
+export function correctSpeechTranscript(text: string, vocabulary: readonly string[] = []): string {
+  const rawText = text.trim()
+  if (!rawText || rawText.length > MAX_DICTATION_CORRECTION_CODE_UNITS) {
+    return rawText
+  }
+  return normalizeTranscriptSpacing(
+    restoreVocabularyTerms(replaceSpokenPunctuation(rawText), vocabulary)
+  )
+}

--- a/src/shared/speech-types.ts
+++ b/src/shared/speech-types.ts
@@ -66,12 +66,15 @@ export type UserModelConfig = {
 
 export type DictationMode = 'toggle' | 'hold'
 
+export type DictationCorrectionMode = 'off' | 'preview' | 'auto'
+
 export type VoiceSettings = {
   enabled: boolean
   sttModel: string
   modelsDir: string
   language: string
   dictationMode: DictationMode
+  dictationCorrectionMode: DictationCorrectionMode
   customVocabulary: string[]
   terminalConfirmBeforeInsert: boolean
   userModels: UserModelConfig[]

--- a/src/shared/speech-types.ts
+++ b/src/shared/speech-types.ts
@@ -72,6 +72,7 @@ export type VoiceSettings = {
   modelsDir: string
   language: string
   dictationMode: DictationMode
+  customVocabulary: string[]
   terminalConfirmBeforeInsert: boolean
   userModels: UserModelConfig[]
   openAiApiKeyConfigured: boolean


### PR DESCRIPTION
## Summary

Adds a local, mixed-language dictation improvement layer for Chinese with occasional English:

- Adds **Settings > Voice > Custom Vocabulary** for names, technical terms, commands, and mixed-language phrases.
- Sends the saved vocabulary through desktop and mobile dictation, including bounded sherpa-onnx hotword files for supported transducer models.
- Adds transcript-correction modes on desktop and mobile:
  - **Off** preserves the existing behavior.
  - **Preview** shows corrected and original text before insertion, with corrected/original/discard choices.
  - **Auto** inserts the locally corrected transcript directly.
- Corrects spoken Chinese/English punctuation, spacing and line breaks, and restores saved Latin-script vocabulary spelling, capitalization, separators, and letter-by-letter recognition (for example, `q w e n 3 a s r` → `Qwen3-ASR`).
- Keeps the original transcript recoverable and restores the captured desktop input target, focus, and selection after preview.
- Supports updated mobile clients paired with older desktop runtimes by treating all new RPC fields as optional.

This addresses the custom-vocabulary and deterministic post-transcription-cleanup slices of #7885. Correction is intentionally conservative and rule-based; it is not an LLM semantic rewrite.

## Screenshots

Not captured from a runnable Windows build. The checkout and validation environment is WSL, while the installed Windows Orca build does not contain this branch. The UI changes are the Voice settings correction selector, custom-vocabulary textarea, desktop review dialog, and mobile review alert.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm build`
- [x] `git diff --check`
- [x] Changed desktop test files: 5 files, 480 tests passed.
- [x] Changed mobile test files: 3 files, 32 tests passed with Vitest 4.1.9.
- [x] Added regression coverage for persistence normalization, RPC compatibility, desktop preview/auto insertion, mobile legacy-runtime fallback, focus/selection restoration, punctuation boundaries, and longest vocabulary matching.

Full-suite WSL run:

- 48,278 passed, 15 failed, 152 skipped.
- Failures were confined to 10 unchanged updater, timeout/performance, GPU-environment, GitHub-project import, session-map, and PTY files. Single-worker reruns continued to show environment/timing-sensitive failures; the two unaffected PTY suites passed, while two `pty-subprocess` assertions still observe the real WSL distro/Linux cwd instead of their mocked Windows fallback.

Build notes:

- The repository requests Node 24; validation used Node 22.22.3 and emitted the existing engine warning.
- Existing CSS `::highlight` optimizer warnings remained non-fatal.
- The dev CLI installer could not create `/usr/local/bin/orca-dev` without elevation; the build completed successfully.

## Performance and reliability

- Transcript correction is capped at 100,000 UTF-16 code units.
- Vocabulary remains capped at 200 normalized entries of 120 characters each.
- Vocabulary restoration uses a bounded trie scan rather than one full-text regular expression per term. A pathological 100,000-code-unit/200-term local benchmark dropped from about 17.5 seconds to about 0.21 seconds in this WSL environment.
- Desktop and mobile snapshot the correction mode and vocabulary at dictation start, so mid-session settings changes cannot produce a mixed result.
- Concurrent mobile starts release any acquired hotword lease before returning `dictation_already_active`.

## AI Review Report

Reviewed persistence boundaries, desktop/mobile lifecycle behavior, sherpa-onnx initialization, worker reuse, mixed-version settings, preview recovery, focus management, localization, Windows/WSL paths, and synchronous correction cost.

Issues found and addressed during review:

- Content-hashed hotword paths could race when desktop and mobile starts used the same vocabulary. Files now use idempotent reference-counted leases with serialized writes/deletes.
- `:` is sherpa-onnx's per-hotword score delimiter. Vocabulary normalization rejects it, control characters, and Unicode line/paragraph separators.
- A per-term flexible-regex implementation had a pathological multi-second synchronous case. It was replaced with a bounded trie scan.
- A detached contenteditable preview target could be focused after unmount. Restoration now exits safely when the target or saved range is no longer valid.

## Security Audit

- Correction runs entirely on the paired desktop/runtime; it adds no cloud request or transcript upload.
- Input is normalized at persistence load/update and again immediately before hotword-file use.
- The renderer cannot choose a hotword path: filenames are SHA-256-derived and joined under the managed speech-model directory.
- File cleanup is idempotent and reference-counted to avoid cross-session deletion races.
- New mobile response/setup fields are optional, so mixed-version peers degrade to legacy text/off behavior.
- No new dependency, command execution, auth flow, secret storage, or unrestricted IPC channel was introduced.

## Notes

- For the current catalog, **Zipformer Bilingual** remains the relevant Chinese/English local model.
- #11023 already implements Qwen3-ASR 0.6B int8, so this PR does not duplicate that model integration. Its hotword-specific wiring can be handled after that model lands.
- Runtime behavior was built and tested in WSL/Linux; a real Windows microphone/model session was not executed from this checkout.
