### PR TITLE
perf(terminal): gate the Korean input-source probe on its setting

### DIFF
--- a/src/renderer/src/components/terminal-pane/TerminalPane.tsx
+++ b/src/renderer/src/components/terminal-pane/TerminalPane.tsx
@@ -1665,6 +1665,7 @@ function TerminalPane(
     panePtyBindingsRef,
     paneCwdRef,
     fallbackCwd: cwd ?? '',
+    koreanWonToBackquoteEnabled: settings?.terminalKoreanWonToBackquote === true,
     expandedPaneIdRef,
     setExpandedPane,
     restoreExpandedLayout,

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-korean-prefetch-gate.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-korean-prefetch-gate.test.tsx
@@ -1,0 +1,75 @@
+// @vitest-environment happy-dom
+// The Korean input-source probe shells out to `defaults export | plutil | plutil` — four processes
+// in the main process — on a 2 s refresh cooldown. terminalKoreanWonToBackquote defaults to off, so
+// prefetching it for every macOS user spends that on a feature almost nobody has enabled.
+import { cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const prefetchKoreanInputSource = vi.fn()
+vi.mock('@/lib/keyboard-layout/korean-input-source', () => ({
+  prefetchKoreanInputSource: (...args: unknown[]) => prefetchKoreanInputSource(...args),
+  isKoreanInputSourceActive: () => false,
+  isKoreanInputSourceId: () => false
+}))
+
+import { useTerminalKeyboardShortcuts } from './keyboard-handlers'
+
+type KeyboardHandlersDeps = Parameters<typeof useTerminalKeyboardShortcuts>[0]
+
+function deps(koreanWonToBackquoteEnabled: boolean): KeyboardHandlersDeps {
+  const scope = document.createElement('div')
+  document.body.appendChild(scope)
+  return {
+    tabId: 'tab-1',
+    worktreeId: 'wt-1',
+    isActive: true,
+    keyboardScopeRef: { current: scope },
+    managerRef: { current: null },
+    paneTransportsRef: { current: new Map() },
+    panePtyBindingsRef: { current: new Map() },
+    paneCwdRef: { current: new Map() },
+    fallbackCwd: '/tmp',
+    koreanWonToBackquoteEnabled,
+    expandedPaneIdRef: { current: null },
+    setExpandedPane: vi.fn(),
+    restoreExpandedLayout: vi.fn(),
+    refreshPaneSizes: vi.fn(),
+    persistLayoutSnapshot: vi.fn(),
+    toggleExpandPane: vi.fn(),
+    setSearchOpen: vi.fn(),
+    onSearchSelectedText: vi.fn(),
+    onRequestClosePane: vi.fn(),
+    onClearPaneScrollback: vi.fn(),
+    onSetTitle: vi.fn(),
+    onClearPaneTitle: vi.fn(),
+    searchOpenRef: { current: false },
+    searchStateRef: { current: { query: '', caseSensitive: false, regex: false } },
+    macOptionAsAltRef: { current: 'off' },
+    paneKittyKeyboardModesRef: { current: null }
+  } as unknown as KeyboardHandlersDeps
+}
+
+beforeEach(() => {
+  prefetchKoreanInputSource.mockClear()
+  vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
+    'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
+  )
+})
+
+afterEach(() => {
+  cleanup()
+  vi.restoreAllMocks()
+  document.body.replaceChildren()
+})
+
+describe('Korean input-source prefetch gate', () => {
+  it('does not probe the input source when the setting is off', () => {
+    renderHook(() => useTerminalKeyboardShortcuts(deps(false)))
+    expect(prefetchKoreanInputSource).not.toHaveBeenCalled()
+  })
+
+  it('probes once the setting is on', () => {
+    renderHook(() => useTerminalKeyboardShortcuts(deps(true)))
+    expect(prefetchKoreanInputSource).toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -197,6 +197,8 @@ type KeyboardHandlersDeps = {
   paneCwdRef: React.RefObject<PaneCwdMap>
   /** Worktree-root cwd used when OSC 7 and pty.getCwd both fail. */
   fallbackCwd: string
+  /** Gates the Korean input-source probe; its refresh spawns four processes. */
+  koreanWonToBackquoteEnabled?: boolean
   expandedPaneIdRef: React.RefObject<number | null>
   setExpandedPane: (paneId: number | null) => void
   restoreExpandedLayout: () => void
@@ -232,6 +234,7 @@ export function useTerminalKeyboardShortcuts({
   panePtyBindingsRef,
   paneCwdRef,
   fallbackCwd,
+  koreanWonToBackquoteEnabled,
   expandedPaneIdRef,
   setExpandedPane,
   restoreExpandedLayout,
@@ -265,7 +268,11 @@ export function useTerminalKeyboardShortcuts({
     if (isMac) {
       prefetchLayoutBaseCharacters()
       // Why: the Korean Won rewrite gate reads the active input source ID through the async IPC.
-      prefetchKoreanInputSource()
+      // Gated on the setting because each refresh shells out to `defaults export | plutil | plutil`
+      // and the default is off, so an ungated prefetch costs every macOS user four processes.
+      if (koreanWonToBackquoteEnabled) {
+        prefetchKoreanInputSource()
+      }
     }
 
     // Why: KeyboardEvent.location on a character key (e.g. Period) always
@@ -654,6 +661,7 @@ export function useTerminalKeyboardShortcuts({
     panePtyBindingsRef,
     paneCwdRef,
     fallbackCwd,
+    koreanWonToBackquoteEnabled,
     expandedPaneIdRef,
     setExpandedPane,
     restoreExpandedLayout,


### PR DESCRIPTION
Follow-up to #13104, from my review there. Non-blocking then, cheap to fix now.

`prefetchKoreanInputSource()` ran under a bare `isMac` check, so it was not the Korean feature's cost — it was every macOS user's cost. Each refresh runs `/usr/bin/defaults export com.apple.HIToolbox - | /usr/bin/plutil -extract … | /usr/bin/plutil -convert json …`, four processes in the main process, on a ≤1-per-2000ms-of-typing cooldown. Input-source toggle keys pass `force: true`, so a single Caps Lock press costs two probes regardless of cooldown. `terminalKoreanWonToBackquote` defaults to `false` (`src/shared/constants.ts:349`).

`keyboard-handlers.ts` has no `settings` in scope, so this threads the flag through `KeyboardHandlersDeps` from `TerminalPane.tsx`, which already reads `settings`. It is in the effect's dependency array deliberately: toggling the setting mid-session re-runs the effect and warms the cache before the first Backquote, so the feature does not silently miss its first keystroke.

I verified the test discriminates rather than just passing — removing the gate makes the setting-off case fail.

Verified: typecheck across all three configs (with `config/*.tsbuildinfo` cleared first — stale buildinfo has produced false greens here), oxlint clean, terminal-pane 259 files / 2997 tests. No `max-lines` disable added; the one at the top of `keyboard-handlers.ts` is pre-existing.

cc @hyein-cbio — no defect in your change, just moving its cost behind its own switch.

Made with [Orca](https://github.com/stablyai/orca) 🐋
