### PR TITLE
fix(terminal): stop the Korean gate caching an unknown input source as negative

### DIFF
--- a/src/renderer/src/lib/keyboard-layout/korean-input-source.test.ts
+++ b/src/renderer/src/lib/keyboard-layout/korean-input-source.test.ts
@@ -256,3 +256,41 @@ describe('prefetchKoreanInputSource', () => {
     await vi.waitFor(() => expect(reader).toHaveBeenCalledTimes(2))
   })
 })
+
+describe('cold-start probe', () => {
+  beforeEach(() => {
+    _resetKoreanInputSourceForTests()
+  })
+
+  it('does not cache a null read as a confirmed non-Korean source', async () => {
+    // Why: on m4air a fresh session sent ₩ for the first presses — the startup
+    // read returned null (IPC not exposed yet) and was cached as "not Korean".
+    const win = makeMockWindow()
+    let call = 0
+    const reader = async (): Promise<string | null> => {
+      call += 1
+      return call === 1 ? null : 'com.apple.inputmethod.Korean.2SetKorean'
+    }
+
+    prefetchKoreanInputSource({ win, readInputSourceId: reader })
+    await vi.waitFor(() => expect(isKoreanInputSourceActive()).toBe(true))
+    expect(call).toBeGreaterThan(1)
+  })
+
+  it('gives up after a bounded number of probes when the reader never reports', async () => {
+    const win = makeMockWindow()
+    let call = 0
+    const reader = async (): Promise<string | null> => {
+      call += 1
+      return null
+    }
+
+    prefetchKoreanInputSource({ win, readInputSourceId: reader })
+    await vi.waitFor(() => expect(call).toBeGreaterThanOrEqual(4), { timeout: 5000 })
+    await new Promise((resolve) => setTimeout(resolve, 300))
+    // Each probe spawns four processes; an unbounded retry would be worse than
+    // the cold gate it fixes.
+    expect(call).toBeLessThanOrEqual(4)
+    expect(isKoreanInputSourceActive()).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/keyboard-layout/korean-input-source.ts
+++ b/src/renderer/src/lib/keyboard-layout/korean-input-source.ts
@@ -47,6 +47,10 @@ const INPUT_TOGGLE_KEY_CODES: ReadonlySet<string> = new Set(['CapsLock', 'Lang1'
 
 const KEYBOARD_ACTIVITY_REFRESH_COOLDOWN_MS = 2000
 
+/** Bounded so a host that never reports an input source costs four probes, not
+ *  one per keystroke — each probe spawns `defaults export | plutil | plutil`. */
+const INITIAL_PROBE_BACKOFF_MS: readonly number[] = [50, 200, 750]
+
 export function isKoreanInputSourceId(id: string | null | undefined): boolean {
   if (!id) {
     return false
@@ -101,6 +105,13 @@ async function refreshInputSourceId(readInputSourceId: InputSourceIdReader): Pro
     // misclassify the active input source until the next refresh.
     return
   }
+  if (id === null) {
+    // Why: the reader returns null for "no signal" (IPC not yet exposed at
+    // startup, transient rejection) as well as for a genuinely absent source.
+    // Caching that as false turns an unknown into a confirmed negative, which
+    // is what left the gate cold for the first keystrokes of a session.
+    return
+  }
   cachedIsKorean = isKoreanInputSourceId(id)
 }
 
@@ -147,7 +158,35 @@ export function prefetchKoreanInputSource(options: PrefetchKoreanInputSourceOpti
   // both keydown and keyup so a held toggle key still refreshes on release.
   target.addEventListener('keydown', keyboardActivityCallback, true)
   target.addEventListener('keyup', keyboardActivityCallback, true)
-  requestRefresh(readInputSourceId, true)
+  void runInitialProbe(readInputSourceId, target)
+}
+
+/** Why: a keystroke-triggered refresh is async, so it can never classify the
+ *  press that triggered it — the cache has to be warm BEFORE the first key. At
+ *  startup the IPC is not always exposed yet, so retry with backoff until the
+ *  reader yields an ID rather than leaving the gate cold for the session. */
+async function runInitialProbe(
+  readInputSourceId: InputSourceIdReader,
+  target: Pick<Window, 'addEventListener' | 'removeEventListener'>
+): Promise<void> {
+  for (const delayMs of INITIAL_PROBE_BACKOFF_MS) {
+    // Why: a reset (or a prefetch onto another window) must stop this loop, or
+    // it repopulates the cache the reset just cleared.
+    if (!listenerAttached || focusTarget !== target) {
+      return
+    }
+    lastRefreshAt = Date.now()
+    await refreshInputSourceId(readInputSourceId)
+    if (cachedIsKorean !== null) {
+      return
+    }
+    await new Promise((resolve) => setTimeout(resolve, delayMs))
+  }
+  if (!listenerAttached || focusTarget !== target) {
+    return
+  }
+  lastRefreshAt = Date.now()
+  await refreshInputSourceId(readInputSourceId)
 }
 
 /** Strict gate: only true when the active macOS input source is known to be a


### PR DESCRIPTION
Found by real-hardware verification of #13104 on macOS 26.5.2 with 2-Set Korean, reading PTY bytes rather than the UI.

**The good news first:** the concern I raised in review — that `return false` might not suppress the native ₩, giving the user both a backtick and a ₩ — is **disproven**. One press produces exactly one `0x60` and zero `e2 82 a9`, under fast taps and 120 ms held keys alike. The native insertion does still reach the DOM (`beforeinput`/`input` with `data="₩"`), but xterm swallows it and it never becomes PTY data. The setting-disabled control reproduces main's deliberate ₩-verbatim behavior, so the harness was measuring the right thing.

**What it did find:** on a cold session the rewrite silently does not fire at all.

| scenario | PTY bytes |
|---|---|
| cold session, 3 presses | `e282a9 e282a9 e282a9` — all ₩ |
| same session after an input-source round trip | `60 60 60` — all backtick |
| warm, 3 presses | `e282a9 60 60` — first press leaks |

Cause: `defaultInputSourceIdReader` returns `null` for *no signal* — the IPC is not exposed yet at startup — as well as for a genuinely absent source. `refreshInputSourceId` then committed `isKoreanInputSourceId(null)`, which is `false`. An unknown became a confirmed negative. Nothing recovered it promptly either, because a keystroke-triggered refresh is async and so can never classify the press that triggered it — which is why a 6 second wait did not help, only a *later* press did.

Fix is two halves: leave the cache unknown on a null read, and retry the startup probe with bounded backoff so the gate is warm before the first key. Bounded deliberately — each probe spawns `defaults export | plutil | plutil`, and an unbounded retry would be worse than the cold gate it fixes.

The retry loop aborts on reset or on a prefetch onto another window. I got that wrong first: the loop kept running across tests and repopulated a cache that had just been cleared, which the existing `reset detaches listeners and invalidates in-flight probes` test caught.

Both new tests fail with the fix reverted, so they discriminate rather than merely pass. Verified: keyboard-layout + terminal-pane 264 files / 3062 tests, typecheck across all three configs with `config/*.tsbuildinfo` cleared first, oxlint clean.

User-visible impact: without this, the first Backquote of every session types ₩ and the feature looks dead. Worth having before the next release.

cc @hyein-cbio

Made with [Orca](https://github.com/stablyai/orca) 🐋
