### PR TITLE
feat(codex): discover native session models from the runtime

### DIFF
--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   createClaudeCatalogOptions,
+  createCodexCatalogOptions,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -80,7 +81,7 @@ export async function discoverNativeChatCatalogModels(
     result.models.length === 0 ||
     // Why: a spec's static fallback list must never pass as a probe result for an
     // agent whose published list replaces rather than extends the seed.
-    ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
+    ((agent === 'claude' || agent === 'codex' || catalog?.discoveredModelsAreAuthoritative) &&
       result.catalogOrigin !== 'probe')
   ) {
     return null
@@ -96,6 +97,11 @@ export async function discoverNativeChatCatalogModels(
             effortLevelIds: model.thinkingLevels?.map(({ id }) => id) ?? [],
             supportsFastMode: model.supportsFastMode
           })
-        : []
+        : agent === 'codex'
+          ? createCodexCatalogOptions({
+              effortLevels: model.thinkingLevels ?? [],
+              ...(model.defaultThinkingLevel ? { defaultEffort: model.defaultThinkingLevel } : {})
+            })
+          : []
   }))
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -317,4 +317,78 @@ describe('native chat session option enrichment', () => {
       })
     ).resolves.toBeNull()
   })
+
+  it('uses discovered Codex models and their per-model reasoning levels', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        {
+          id: 'gpt-5.6-sol',
+          label: 'GPT-5.6 Sol',
+          thinkingLevels: [
+            { id: 'low', label: 'Low' },
+            { id: 'high', label: 'High' },
+            { id: 'max', label: 'Max' },
+            { id: 'ultra', label: 'Ultra' }
+          ],
+          defaultThinkingLevel: 'high'
+        },
+        { id: 'account-only-model', label: 'Account only model' }
+      ]
+    })
+
+    const discovered = await discoverNativeChatCatalogModels('codex', {
+      settings: {},
+      worktreeId: 'repo::/worktree',
+      worktreePath: '/worktree'
+    })
+    expect(discovered?.map(({ id }) => id)).toEqual(['gpt-5.6-sol', 'account-only-model'])
+    expect(discovered?.[0].options[0].kind).toMatchObject({
+      type: 'select',
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultra', label: 'Ultra' }
+      ],
+      defaultValue: 'high'
+    })
+    expect(discovered?.[1].options).toEqual([])
+
+    const listener = vi.fn()
+    subscribeNativeChatEnrichedModels('codex', 'local', listener)
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      discover: async () => discovered
+    })
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+    const enriched = readNativeChatEnrichedModels('codex', 'local')!
+    expect(enriched.map(({ id }) => id)).toEqual(['gpt-5.6-sol', 'account-only-model'])
+    expect(enriched[0].options[0].kind).toMatchObject({
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultra', label: 'Ultra' }
+      ]
+    })
+  })
+
+  it('does not advertise the Codex spec fallback when probing is unavailable', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'spec',
+      models: [{ id: 'gpt-5.5', label: 'GPT-5.5' }]
+    })
+
+    await expect(
+      discoverNativeChatCatalogModels('codex', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    ).resolves.toBeNull()
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -102,7 +102,7 @@ export function ensureNativeChatModelEnrichment(args: {
         return
       }
       entry.models =
-        args.agent === 'claude'
+        args.agent === 'claude' || args.agent === 'codex'
           ? [...discovered]
           : catalog.discoveredModelsAreAuthoritative
             ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -10,6 +10,7 @@ import {
   parseClaudeModelList
 } from './claude-model-list-probe'
 import { hasFlag } from './agent-cli-flag-detection'
+import { CODEX_MODEL_LIST_COMMAND, parseCodexModelList } from './codex-model-list-probe'
 
 function hasCodexEffortOverride(tokens: readonly string[]): boolean {
   if (hasFlag(tokens, ['--reasoning-effort'])) {
@@ -190,17 +191,20 @@ const CODEX_EFFORT_CHOICES = [
   { value: 'ultra', label: 'Ultra' }
 ]
 
-// Why: Codex can clamp higher values, so expose only each model's advertised levels.
-function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
-  const ceilingIndex = CODEX_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+type CodexEffortChoice = { value: string; label: string }
+
+function codexEffortWithChoices(
+  choices: readonly CodexEffortChoice[],
+  defaultValue: string
+): CatalogOption {
   return {
     id: 'effort',
     label: 'Reasoning effort',
     category: 'thought_level',
     kind: {
       type: 'select',
-      choices: CODEX_EFFORT_CHOICES.slice(0, ceilingIndex + 1),
-      defaultValue: 'medium'
+      choices: [...choices],
+      defaultValue
     },
     apply: {
       launchArgs: (value) => ['-c', `model_reasoning_effort=${String(value)}`],
@@ -209,6 +213,53 @@ function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
       midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
     }
   }
+}
+
+// Why: Codex can clamp higher values, so expose only each model's advertised levels.
+function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
+  const ceilingIndex = CODEX_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+  return codexEffortWithChoices(CODEX_EFFORT_CHOICES.slice(0, ceilingIndex + 1), 'medium')
+}
+
+function labelCodexEffort(effort: string): string {
+  if (effort === 'xhigh') {
+    return 'Extra high'
+  }
+  return effort.charAt(0).toUpperCase() + effort.slice(1)
+}
+
+export function createCodexCatalogOptions(args: {
+  effortLevels: readonly { id: string; label: string }[]
+  defaultEffort?: string
+}): CatalogOption[] {
+  const choices = args.effortLevels.map(({ id, label }) => ({ value: id, label }))
+  if (choices.length === 0) {
+    return []
+  }
+  const choiceIds = choices.map(({ value }) => value)
+  const defaultEffort = choiceIds.includes(args.defaultEffort ?? '')
+    ? args.defaultEffort!
+    : choiceIds.includes('medium')
+      ? 'medium'
+      : choiceIds[0]
+  return [codexEffortWithChoices(choices, defaultEffort)]
+}
+
+function parseCodexCatalogModels(stdout: string): CatalogModel[] {
+  return parseCodexModelList(stdout).map((model) => {
+    const effortLevels = model.effortLevels.map((effort) => ({
+      id: effort,
+      label: labelCodexEffort(effort)
+    }))
+    return {
+      id: model.id,
+      label: model.label,
+      options: createCodexCatalogOptions({
+        effortLevels,
+        ...(model.defaultEffort ? { defaultEffort: model.defaultEffort } : {})
+      })
+    }
+  })
 }
 
 export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
@@ -234,5 +285,9 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // command and let its own picker apply the account-supported model.
     midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
   },
-  unknownModelOptions: [codexEffort('xhigh')]
+  unknownModelOptions: [codexEffort('xhigh')],
+  listModels: {
+    command: CODEX_MODEL_LIST_COMMAND,
+    parse: parseCodexCatalogModels
+  }
 }

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -108,6 +108,91 @@ describe('agent session option catalog', () => {
     expect(parse('garbage')).toEqual([])
   })
 
+  it('parses Codex discovery into model-specific reasoning options', () => {
+    const catalog = getAgentSessionOptionCatalog('codex')!
+    expect(catalog.listModels?.command).toBe('codex debug models')
+
+    const parsed = catalog.listModels!.parse(
+      JSON.stringify({
+        models: [
+          {
+            slug: 'gpt-account-frontier',
+            display_name: 'GPT Account Frontier',
+            default_reasoning_level: 'high',
+            supported_reasoning_levels: [
+              { effort: 'low' },
+              { effort: 'high' },
+              { effort: 'max' },
+              { effort: 'ultra' }
+            ]
+          },
+          {
+            slug: 'gpt-account-fast',
+            display_name: 'GPT Account Fast',
+            supported_reasoning_levels: [{ effort: 'minimal' }]
+          },
+          { slug: 'gpt-account-plain', display_name: 'GPT Account Plain' }
+        ]
+      })
+    )
+
+    expect(parsed.map(({ id }) => id)).toEqual([
+      'gpt-account-frontier',
+      'gpt-account-fast',
+      'gpt-account-plain'
+    ])
+    const frontierEffort = parsed[0].options[0]
+    expect(frontierEffort.kind).toMatchObject({ defaultValue: 'high' })
+    expect(
+      frontierEffort.kind.type === 'select'
+        ? frontierEffort.kind.choices.map(({ value, label }) => ({ value, label }))
+        : []
+    ).toEqual([
+      { value: 'low', label: 'Low' },
+      { value: 'high', label: 'High' },
+      { value: 'max', label: 'Max' },
+      { value: 'ultra', label: 'Ultra' }
+    ])
+    expect(parsed[1].options[0].kind).toMatchObject({
+      choices: [{ value: 'minimal', label: 'Minimal' }],
+      defaultValue: 'minimal'
+    })
+    expect(parsed[2].options).toEqual([])
+  })
+
+  it('keeps the Codex seed when model discovery output is malformed', () => {
+    const parse = getAgentSessionOptionCatalog('codex')!.listModels!.parse
+    expect(parse('')).toEqual([])
+    expect(parse('{"models":false}')).toEqual([])
+    expect(parse('garbage')).toEqual([])
+  })
+
+  it('deduplicates Codex models and reasoning levels from discovery', () => {
+    const parse = getAgentSessionOptionCatalog('codex')!.listModels!.parse
+    const parsed = parse(
+      JSON.stringify({
+        models: [
+          {
+            slug: 'gpt-account-frontier',
+            display_name: 'GPT Account Frontier',
+            supported_reasoning_levels: [{ effort: 'low' }, { effort: 'low' }, { effort: 'high' }]
+          },
+          { slug: 'gpt-account-frontier', display_name: 'Duplicate row' }
+        ]
+      })
+    )
+
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].label).toBe('GPT Account Frontier')
+    expect(parsed[0].options[0].kind).toMatchObject({
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' }
+      ],
+      defaultValue: 'low'
+    })
+  })
+
   it('merges discovered Claude variants after the seed and overlays matched labels', () => {
     const catalog = getAgentSessionOptionCatalog('claude')!
     const merged = mergeCatalogModels(catalog.models, [

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -2,7 +2,8 @@ import type { AgentType } from './agent-status-types'
 import {
   CLAUDE_SESSION_OPTION_CATALOG,
   CODEX_SESSION_OPTION_CATALOG,
-  createClaudeCatalogOptions
+  createClaudeCatalogOptions,
+  createCodexCatalogOptions
 } from './agent-session-option-catalog-claude-codex'
 import {
   CURSOR_SESSION_OPTION_CATALOG,
@@ -26,7 +27,7 @@ export type {
   CatalogOption,
   CatalogOptionApply
 } from './agent-session-option-catalog-types'
-export { createClaudeCatalogOptions }
+export { createClaudeCatalogOptions, createCodexCatalogOptions }
 
 const CATALOGS: AgentSessionOptionCatalogMap = {
   claude: CLAUDE_SESSION_OPTION_CATALOG,

--- a/src/shared/codex-model-list-probe.test.ts
+++ b/src/shared/codex-model-list-probe.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CODEX_MODEL_LIST_MAX_JSON_CHARACTERS, parseCodexModelList } from './codex-model-list-probe'
+
+describe('Codex model list probe', () => {
+  it('rejects oversized output before JSON.parse', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      expect(parseCodexModelList(' '.repeat(CODEX_MODEL_LIST_MAX_JSON_CHARACTERS + 1))).toEqual([])
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+})

--- a/src/shared/codex-model-list-probe.ts
+++ b/src/shared/codex-model-list-probe.ts
@@ -1,0 +1,80 @@
+import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
+
+export const CODEX_MODEL_LIST_ARGS = ['debug', 'models'] as const
+export const CODEX_MODEL_LIST_COMMAND = `codex ${CODEX_MODEL_LIST_ARGS.join(' ')}`
+
+export const CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS = {
+  structuralTokens: 64 * 1024,
+  nestingDepth: 16
+} as const
+
+export type CodexModelListModel = {
+  id: string
+  label: string
+  effortLevels: string[]
+  defaultEffort: string | null
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  return value.trim() || null
+}
+
+function uniqueEffortLevels(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const seen = new Set<string>()
+  const levels: string[] = []
+  for (const entry of value) {
+    const effort =
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? nonEmptyString((entry as { effort?: unknown }).effort)
+        : null
+    if (effort && !seen.has(effort)) {
+      seen.add(effort)
+      levels.push(effort)
+    }
+  }
+  return levels
+}
+
+export function parseCodexModelList(stdout: string): CodexModelListModel[] {
+  try {
+    assertJsonTextStructureWithinLimits(stdout, CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS)
+    const parsed: unknown = JSON.parse(stdout)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return []
+    }
+    const models = (parsed as { models?: unknown }).models
+    if (!Array.isArray(models)) {
+      return []
+    }
+
+    const seen = new Set<string>()
+    const result: CodexModelListModel[] = []
+    for (const value of models) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        continue
+      }
+      const model = value as Record<string, unknown>
+      const id = nonEmptyString(model.slug)
+      const label = nonEmptyString(model.display_name)
+      if (!id || !label || seen.has(id)) {
+        continue
+      }
+      seen.add(id)
+      result.push({
+        id,
+        label,
+        effortLevels: uniqueEffortLevels(model.supported_reasoning_levels),
+        defaultEffort: nonEmptyString(model.default_reasoning_level)
+      })
+    }
+    return result
+  } catch {
+    return []
+  }
+}

--- a/src/shared/codex-model-list-probe.ts
+++ b/src/shared/codex-model-list-probe.ts
@@ -2,6 +2,7 @@ import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit
 
 export const CODEX_MODEL_LIST_ARGS = ['debug', 'models'] as const
 export const CODEX_MODEL_LIST_COMMAND = `codex ${CODEX_MODEL_LIST_ARGS.join(' ')}`
+export const CODEX_MODEL_LIST_MAX_JSON_CHARACTERS = 4 * 1024 * 1024
 
 export const CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS = {
   structuralTokens: 64 * 1024,
@@ -43,6 +44,9 @@ function uniqueEffortLevels(value: unknown): string[] {
 
 export function parseCodexModelList(stdout: string): CodexModelListModel[] {
   try {
+    if (stdout.length > CODEX_MODEL_LIST_MAX_JSON_CHARACTERS) {
+      return []
+    }
     assertJsonTextStructureWithinLimits(stdout, CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS)
     const parsed: unknown = JSON.parse(stdout)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -1,12 +1,16 @@
 import type { TuiAgent } from './tui-agent'
 import { isTuiAgentEnabled } from './tui-agent-selection'
-import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
 import {
   CLAUDE_MODEL_LIST_ARGS,
   CLAUDE_MODEL_LIST_STDIN,
   parseClaudeModelList
 } from './claude-model-list-probe'
 import { labelFromModelId } from './model-id-label'
+import {
+  CODEX_MODEL_LIST_ARGS,
+  CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS,
+  parseCodexModelList
+} from './codex-model-list-probe'
 
 /* eslint-disable max-lines -- Why: this is the single registry for non-interactive commit-message agents, their model discovery parsers, and UI capabilities. */
 
@@ -81,10 +85,7 @@ export type CommitMessageAgentCapability = {
   defaultModelId: string
 }
 
-export const COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS = {
-  structuralTokens: 64 * 1024,
-  nestingDepth: 16
-} as const
+export const COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS = CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS
 
 const BASIC_THINKING_LEVELS: ThinkingLevel[] = [
   { id: 'low', label: 'Low' },
@@ -172,39 +173,25 @@ export function parseClaudeModels(stdout: string): CommitMessageModel[] {
 }
 
 export function parseCodexModels(stdout: string): CommitMessageModel[] {
-  try {
-    assertJsonTextStructureWithinLimits(stdout, COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS)
-    const parsed = JSON.parse(stdout) as {
-      models?: {
-        slug?: string
-        display_name?: string
-        supported_reasoning_levels?: { effort?: string }[]
-        default_reasoning_level?: string
-      }[]
-    }
-    return uniqueModels(
-      (parsed.models ?? [])
-        .filter((model) => model.slug && model.display_name)
-        .map((model) => ({
-          id: model.slug!,
-          label: model.display_name!,
-          ...(model.supported_reasoning_levels?.length
-            ? {
-                thinkingLevels: model.supported_reasoning_levels
-                  .map((level) => level.effort)
-                  .filter((effort): effort is string => Boolean(effort))
-                  .map((effort) => ({
-                    id: effort,
-                    label: effort === 'xhigh' ? 'Extra High' : labelFromModelId(effort)
-                  })),
-                defaultThinkingLevel: model.default_reasoning_level ?? 'low'
-              }
-            : {})
-        }))
-    )
-  } catch {
-    return []
-  }
+  return uniqueModels(
+    parseCodexModelList(stdout).map((model) => ({
+      id: model.id,
+      label: model.label,
+      ...(model.effortLevels.length > 0
+        ? {
+            thinkingLevels: model.effortLevels.map((effort) => ({
+              id: effort,
+              label: effort === 'xhigh' ? 'Extra High' : labelFromModelId(effort)
+            })),
+            defaultThinkingLevel: model.effortLevels.includes(model.defaultEffort ?? '')
+              ? model.defaultEffort!
+              : model.effortLevels.includes('low')
+                ? 'low'
+                : model.effortLevels[0]
+          }
+        : {})
+    }))
+  )
 }
 
 export function parseLineModels(stdout: string): CommitMessageModel[] {
@@ -401,7 +388,7 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     modelSource: 'dynamic',
     modelDiscovery: {
       binary: 'codex',
-      args: ['debug', 'models'],
+      args: [...CODEX_MODEL_LIST_ARGS],
       parse: parseCodexModels
     },
     // Why: ordered to match the official `codex` model picker — descending


### PR DESCRIPTION
## Suggested title

`feat(codex): discover native session models from the runtime`

## Summary

Native Codex session controls now discover the models exposed by the effective runtime instead of relying only on the static seed catalog. The discovery path reuses the existing bounded `codex debug models` parser and converts each model's supported reasoning levels into model-specific native-chat options.

The static catalog remains available immediately while discovery runs and remains the fallback when the CLI is unavailable, returns no models, or emits malformed output.

This is intentionally the first, narrow step toward account-scoped model discovery. It does not add an account picker or change account selection. A follow-up can bind discovery to a PTY-pinned managed account without expanding this PR's wire surface.

## Screenshots

No visual layout change. Existing native Codex model and reasoning controls receive runtime-discovered choices after the asynchronous probe completes.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/codex-model-list-probe.test.ts src/shared/agent-session-option-catalog.test.ts src/shared/commit-message-agent-spec.test.ts src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts` — 70 tests passed after rebasing onto the current `main`.
- `pnpm run check:max-lines-ratchet` — passed with no new bypasses.
- `git diff --check` — passed.
- Node 24 full test run — 47,059 tests passed, 6 failed, and 85 were skipped.
- Node 24 `pnpm run build:desktop` — passed as part of the full build attempt.
- Node 24 `env -u npm_execpath node config/scripts/build-native-for-platform.mjs` — passed.

Local environment notes:

- The workstation default is Node 25.8.1, so the full validation was rerun with an isolated Node 24.19.0 runtime.
- The full `pnpm test` run reported six remaining failures in `config/scripts/check-root-directory-entries.test.mjs` and `src/main/ssh/ssh-posix-command-wrapper.test.ts`. The same failures reproduced from a clean detached `origin/main` worktree. Another 23 failures caused by inherited Orca `CODEX_HOME` and Git environment variables passed after those variables were removed.
- The full `pnpm build` reached the native stage after desktop compilation succeeded. The native wrapper then attempted to execute this workstation's standalone Mach-O `npm_execpath` with Node. Running the same native build script without that injected variable passed. No build script is changed in this PR.

## AI Review Report

The review checked the shared parser extraction, fallback behavior, asynchronous enrichment, model-specific reasoning defaults, duplicate input handling, and preservation of existing Claude and Cursor behavior.

It flagged two missing regression assertions:

1. a successful Codex probe must replace the static seed rather than mix unavailable seed models into the discovered account catalog;
2. duplicate model rows and duplicate reasoning levels must be removed deterministically.

Both assertions were added. Automated review also identified the missing total-output bound; the parser now rejects input over 4,194,304 characters before structural scanning or `JSON.parse`. All cases pass in the focused 70-test suite.

Cross-platform review:

- No platform-specific path, keyboard, label, shell quoting, or Electron API behavior was added.
- Probe execution continues through the existing runtime model-discovery path, preserving local, WSL, SSH, and remote execution ownership.
- No Git command or provider-specific source-control behavior changed.
- The renderer probe remains asynchronous and once-per-agent/host, so it does not block rendering or launch.

## Security Audit

- Codex JSON is rejected above 4,194,304 characters and still passes through structural-token and nesting-depth limits before `JSON.parse`.
- The parser accepts only non-empty model IDs, labels, and reasoning-level strings; malformed rows are ignored and duplicate IDs are removed.
- No token, auth file, managed-home path, account identifier, or credential content is added to renderer state, logs, IPC, or cache keys.
- No new command is constructed from user-controlled values. The existing fixed `codex debug models` invocation and runtime command-override handling are reused.
- Probe failures fail safely to the static catalog; they do not switch credentials or retry under another account.
- Dependencies and remote wire contracts are unchanged.

## Notes

- This PR does not make the cache PTY-account-aware. That follow-up requires an optional PTY identity and resolution through the existing managed-account registry.
