### PR TITLE
feat(orchestration): classify ask --json outcome for engine resume

### DIFF
--- a/src/cli/handlers/orchestration.test.ts
+++ b/src/cli/handlers/orchestration.test.ts
@@ -532,7 +532,19 @@ describe('orchestration timeout flag validation', () => {
       ])
     )
 
-    expect(printResult).toHaveBeenCalledWith(response, true, expect.any(Function))
+    expect(printResult).toHaveBeenCalledWith(
+      {
+        ...response,
+        result: expect.objectContaining({
+          answer: 'yes',
+          messageId: 'msg_1',
+          outcome: 'answered',
+          pending: false
+        })
+      },
+      true,
+      expect.any(Function)
+    )
     expect(logSpy).not.toHaveBeenCalled()
   })
 

--- a/src/cli/handlers/orchestration.ts
+++ b/src/cli/handlers/orchestration.ts
@@ -13,6 +13,7 @@ import {
   clampOrchestrationAskTimeoutMs,
   resolveOrchestrationAskClientTimeoutMs
 } from '../../shared/orchestration-ask-timeout'
+import { withOrchestrationAskOutcome } from '../../shared/orchestration-ask-outcome'
 import { abbreviateOrchestrationTasks } from '../../shared/orchestration-task-summary'
 import { parsePositiveSafeIntegerText } from '../../shared/timer-delay'
 import type {
@@ -1137,9 +1138,12 @@ export const ORCHESTRATION_HANDLERS: Record<string, CommandHandler> = {
         orchestrationCapability: getOptionalStringFlag(flags, 'dispatch-capability')
       }
     )
+    // Why: engines need a first-class outcome/pending flag so exit 1 timeout is not
+    // misread as an internal error (#13184). Derived only from existing result fields.
+    const askResult = withOrchestrationAskOutcome(result.result)
     // Why: bypass printResult so --json emits a bare JSON object (no envelope) pipeable via `jq -r .answer`, unlike other verbs.
     if (json) {
-      console.log(JSON.stringify(result.result))
+      console.log(JSON.stringify(askResult))
     } else if (result.result.legacyCompatibility?.resumeRequired) {
       console.log(`Question ${result.result.messageId} committed.`)
       console.log(`Resume with: ${result.result.legacyCompatibility.resumeCommand}`)

--- a/src/cli/handlers/orchestration/question-handler.ts
+++ b/src/cli/handlers/orchestration/question-handler.ts
@@ -4,6 +4,7 @@ import { printResult } from '../../format'
 import { renderCommand } from '../../orchestration-mutation-recovery'
 import { RuntimeClientError } from '../../runtime-client'
 import { resolveOrchestrationCliExecutable } from '../../runtime/orchestration-recovery-command'
+import { withOrchestrationAskOutcome } from '../../../shared/orchestration-ask-outcome'
 import {
   clampOrchestrationAskTimeoutMs,
   resolveOrchestrationAskClientTimeoutMs
@@ -68,9 +69,11 @@ export const ORCHESTRATION_QUESTION_HANDLER: Record<string, CommandHandler> = {
         orchestrationCapability: getOptionalStringFlag(flags, 'dispatch-capability')
       }
     )
-    // Why: same {ok, result} envelope as every sibling verb; ask used to print a bare object.
+    // Why: engines need first-class outcome/pending so exit 1 timeout is not an
+    // internal error (#13184). Keep main's {ok, result} envelope; classify inside result.
+    const askResult = { ...result, result: withOrchestrationAskOutcome(result.result) }
     if (json) {
-      printResult(result, true, () => '')
+      printResult(askResult, true, () => '')
     } else if (result.result.legacyCompatibility?.resumeRequired) {
       console.log(`Question ${result.result.messageId} committed.`)
       console.log(`Resume with: ${result.result.legacyCompatibility.resumeCommand}`)

--- a/src/cli/specs/orchestration-ask-help.test.ts
+++ b/src/cli/specs/orchestration-ask-help.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { ORCHESTRATION_COMMAND_SPECS } from './orchestration'
+import { formatCommandHelp } from '../help'
+
+function askHelp(): string {
+  const found = ORCHESTRATION_COMMAND_SPECS.find(
+    (entry) => entry.path.join(' ') === 'orchestration ask'
+  )
+  if (!found) {
+    throw new Error('Missing orchestration ask command spec')
+  }
+  return formatCommandHelp(found)
+}
+
+describe('orchestration ask help contract (#13184)', () => {
+  it('documents outcome/pending, exit codes, and resume semantics for engines', () => {
+    const help = askHelp()
+    expect(help).toContain('outcome')
+    expect(help).toContain('timed_out_pending')
+    expect(help).toContain('pending=true')
+    expect(help).toContain('--resume')
+    expect(help).toContain('Exit codes')
+    expect(help).toContain('never creates a second question')
+  })
+})

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -200,7 +200,23 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'From an active Dispatch, a new question defaults to its owning Run mailbox.',
-      'Timeout leaves the question pending; resume with the original message ID.'
+      'Timeout leaves the question pending; resume with the original message ID via ' +
+        '`orca orchestration ask --resume <messageId> --json` (never re-ask with a new --question).',
+      'With --json, stdout is a bare object (no CLI envelope) including: answer, messageId, ' +
+        'threadId, timedOut, cancelled?, connectionLost?, timeoutMs?, answerMessageId?, ' +
+        'legacyCompatibility?, plus first-class outcome and pending (#13184).',
+      'outcome values: answered | timed_out_pending | connection_lost_pending | cancelled | ' +
+        'resume_required. pending=true means the question is still open and --resume is correct.',
+      'Exit codes: 0 answered; 1 timed_out_pending / connection_lost_pending / cancelled ' +
+        '(not an internal error when outcome is *_pending — read outcome/pending/messageId); ' +
+        '75 Windows two-step commit/resume (legacyCompatibility.resumeRequired + printed resume command).',
+      '--resume never creates a second question: it waits on the original messageId. Pass the same ' +
+        '--from / --dispatch-capability / --run as the original ask when the engine context requires them.',
+      '--options is only valid with --question, not --resume.'
+    ],
+    examples: [
+      'orca orchestration ask --question "Ship it?" --timeout-ms 60000 --json',
+      'orca orchestration ask --resume msg_abc123 --timeout-ms 600000 --json'
     ]
   },
   {

--- a/src/cli/specs/orchestration.ts
+++ b/src/cli/specs/orchestration.ts
@@ -215,7 +215,23 @@ export const ORCHESTRATION_COMMAND_SPECS: CommandSpec[] = [
     ],
     notes: [
       'From an active Dispatch, a new question defaults to its owning Run mailbox.',
-      'Timeout leaves the question pending; resume with the original message ID.'
+      'Timeout leaves the question pending; resume with the original message ID via ' +
+        '`orca orchestration ask --resume <messageId> --json` (never re-ask with a new --question).',
+      'With --json, stdout uses the shared {ok, result} envelope. result includes: answer, messageId, ' +
+        'threadId, timedOut, cancelled?, connectionLost?, timeoutMs?, answerMessageId?, ' +
+        'legacyCompatibility?, plus first-class outcome and pending (#13184).',
+      'outcome values: answered | timed_out_pending | connection_lost_pending | cancelled | ' +
+        'resume_required. pending=true means the question is still open and --resume is correct.',
+      'Exit codes: 0 answered; 1 timed_out_pending / connection_lost_pending / cancelled ' +
+        '(not an internal error when outcome is *_pending — read outcome/pending/messageId); ' +
+        '75 Windows two-step commit/resume (legacyCompatibility.resumeRequired + printed resume command).',
+      '--resume never creates a second question: it waits on the original messageId. Pass the same ' +
+        '--from / --dispatch-capability / --run as the original ask when the engine context requires them.',
+      '--options is only valid with --question, not --resume.'
+    ],
+    examples: [
+      'orca orchestration ask --question "Ship it?" --timeout-ms 60000 --json',
+      'orca orchestration ask --resume msg_abc123 --timeout-ms 600000 --json'
     ]
   },
   {

--- a/src/main/ssh/ssh-remote-orchestration-ask-output.test.ts
+++ b/src/main/ssh/ssh-remote-orchestration-ask-output.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { formatRemoteOrchestrationAsk } from './ssh-remote-orchestration-ask-output'
+
+describe('formatRemoteOrchestrationAsk', () => {
+  it('includes outcome/pending on timed-out --json results', () => {
+    const formatted = formatRemoteOrchestrationAsk(
+      {
+        ok: true,
+        result: {
+          answer: null,
+          timedOut: true,
+          cancelled: false,
+          messageId: 'msg_1',
+          threadId: 'thread_1',
+          timeoutMs: 1000
+        }
+      },
+      true
+    )
+    const payload = JSON.parse(formatted.stdout) as {
+      outcome: string
+      pending: boolean
+      timedOut: boolean
+    }
+    expect(payload.outcome).toBe('timed_out_pending')
+    expect(payload.pending).toBe(true)
+    expect(payload.timedOut).toBe(true)
+  })
+})

--- a/src/main/ssh/ssh-remote-orchestration-ask-output.test.ts
+++ b/src/main/ssh/ssh-remote-orchestration-ask-output.test.ts
@@ -5,6 +5,7 @@ describe('formatRemoteOrchestrationAsk', () => {
   it('includes outcome/pending on timed-out --json results', () => {
     const formatted = formatRemoteOrchestrationAsk(
       {
+        id: 'req_ask',
         ok: true,
         result: {
           answer: null,
@@ -13,7 +14,8 @@ describe('formatRemoteOrchestrationAsk', () => {
           messageId: 'msg_1',
           threadId: 'thread_1',
           timeoutMs: 1000
-        }
+        },
+        _meta: { runtimeId: 'runtime-test' }
       },
       true
     )

--- a/src/main/ssh/ssh-remote-orchestration-ask-output.ts
+++ b/src/main/ssh/ssh-remote-orchestration-ask-output.ts
@@ -1,4 +1,8 @@
 import type { RpcResponse } from '../runtime/rpc/core'
+import {
+  withOrchestrationAskOutcome,
+  type OrchestrationAskResultShape
+} from '../../shared/orchestration-ask-outcome'
 import { formatRemoteCli } from './ssh-remote-cli-format'
 import { hasRemoteLifecycleRejection } from './ssh-remote-orchestration-send'
 
@@ -12,7 +16,9 @@ export function formatRemoteOrchestrationAsk(
       : formatRemoteCli(response)
   }
   if (json) {
-    return { stdout: `${JSON.stringify(response.result)}\n`, stderr: '' }
+    // Why: match local `orca orchestration ask --json` so SSH remote engines get outcome/pending.
+    const askResult = withOrchestrationAskOutcome(response.result as OrchestrationAskResultShape)
+    return { stdout: `${JSON.stringify(askResult)}\n`, stderr: '' }
   }
   if (isRecord(response.result.legacyCompatibility)) {
     const compatibility = response.result.legacyCompatibility

--- a/src/shared/orchestration-ask-outcome.test.ts
+++ b/src/shared/orchestration-ask-outcome.test.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyOrchestrationAskOutcome,
+  withOrchestrationAskOutcome
+} from './orchestration-ask-outcome'
+
+describe('classifyOrchestrationAskOutcome', () => {
+  it('classifies answered questions as not pending', () => {
+    expect(
+      classifyOrchestrationAskOutcome({
+        answer: 'yes',
+        timedOut: false
+      })
+    ).toEqual({ outcome: 'answered', pending: false })
+  })
+
+  it('classifies timeout as resumable pending (not an internal error)', () => {
+    // Why: external engines historically mapped exit 1 + bare JSON to hard failure (#13184).
+    expect(
+      classifyOrchestrationAskOutcome({
+        answer: null,
+        timedOut: true
+      })
+    ).toEqual({ outcome: 'timed_out_pending', pending: true })
+  })
+
+  it('classifies connection-lost cancel as resumable pending', () => {
+    expect(
+      classifyOrchestrationAskOutcome({
+        answer: null,
+        timedOut: false,
+        cancelled: true,
+        connectionLost: true
+      })
+    ).toEqual({ outcome: 'connection_lost_pending', pending: true })
+  })
+
+  it('classifies Windows commit/resume split as resume_required', () => {
+    expect(
+      classifyOrchestrationAskOutcome({
+        answer: null,
+        timedOut: false,
+        legacyCompatibility: { resumeRequired: true }
+      })
+    ).toEqual({ outcome: 'resume_required', pending: true })
+  })
+
+  it('spreads outcome fields onto the JSON payload', () => {
+    const payload = withOrchestrationAskOutcome({
+      answer: null,
+      messageId: 'msg_q',
+      threadId: 'thr_1',
+      timedOut: true,
+      timeoutMs: 60_000
+    })
+    expect(payload.outcome).toBe('timed_out_pending')
+    expect(payload.pending).toBe(true)
+    expect(payload.messageId).toBe('msg_q')
+  })
+})

--- a/src/shared/orchestration-ask-outcome.ts
+++ b/src/shared/orchestration-ask-outcome.ts
@@ -1,0 +1,52 @@
+/**
+ * Stable ask result classification for external engines (#13184).
+ * Derived from existing fields — does not invent new wait semantics.
+ */
+export type OrchestrationAskOutcome =
+  | 'answered'
+  | 'timed_out_pending'
+  | 'connection_lost_pending'
+  | 'cancelled'
+  | 'resume_required'
+
+export type OrchestrationAskOutcomeFields = {
+  outcome: OrchestrationAskOutcome
+  /** True when the question remains open and `--resume <messageId>` is the right next step. */
+  pending: boolean
+}
+
+export type OrchestrationAskResultShape = {
+  answer: string | null
+  timedOut: boolean
+  cancelled?: boolean
+  connectionLost?: boolean
+  legacyCompatibility?: { resumeRequired?: boolean } | null
+}
+
+export function classifyOrchestrationAskOutcome(
+  result: OrchestrationAskResultShape
+): OrchestrationAskOutcomeFields {
+  if (result.legacyCompatibility?.resumeRequired) {
+    return { outcome: 'resume_required', pending: true }
+  }
+  if (result.answer !== null) {
+    return { outcome: 'answered', pending: false }
+  }
+  if (result.timedOut) {
+    return { outcome: 'timed_out_pending', pending: true }
+  }
+  if (result.cancelled && result.connectionLost) {
+    return { outcome: 'connection_lost_pending', pending: true }
+  }
+  if (result.cancelled) {
+    return { outcome: 'cancelled', pending: false }
+  }
+  // Why: null answer without timeout/cancel is unexpected; engines should not resume blindly.
+  return { outcome: 'cancelled', pending: false }
+}
+
+export function withOrchestrationAskOutcome<T extends OrchestrationAskResultShape>(
+  result: T
+): T & OrchestrationAskOutcomeFields {
+  return { ...result, ...classifyOrchestrationAskOutcome(result) }
+}


### PR DESCRIPTION
`orca orchestration ask --json` now classifies answered, timed-out pending, connection-lost pending, cancelled and Windows resume-required results. Engines can use `outcome`, `pending` and the original message ID to resume a wait instead of treating every exit 1 as an internal error.

The local CLI preserves current main's shared `{ok, result}` envelope and adds fields inside `result`. The SSH formatter preserves its existing bare-result output while adding the same classification fields. Wait behavior and exit codes are unchanged. Help documents resume-only usage and the existing Windows exit 75 flow. Fixes #13184.

The existing JSON printer assertion changes because the result intentionally gains the two derived fields; the envelope and original answer/message fields remain asserted.

Validation on the refreshed candidate (2026-09-09):

- Cursor review tied to the final commit; independently inspected by Codex.
- 40 focused tests passed in both Cursor and Codex runs.
- CLI and Node typecheck with `--composite false --noEmit`, changed-file oxlint/oxfmt and diff checks passed.
- Full build and live Windows/WSL/SSH end-to-end checks were not run. Default composite typecheck is not claimed green (baseline TS2883); non-composite checks above are explicit.

Reviewed and checked commit: `99d829f0a8de739b8159e61aa22d1bb2df119249`. Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`. No rendered UI changes.
