### PR TITLE
fix(cli): normalize Windows path: worktree selectors

### DIFF
--- a/src/cli/selectors-windows-path.test.ts
+++ b/src/cli/selectors-windows-path.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeWorktreeSelector } from './selectors'
+
+describe('normalizeWorktreeSelector Windows path: (#12303)', () => {
+  it('folds drive-letter backslashes to forward slashes', () => {
+    expect(
+      normalizeWorktreeSelector(
+        'path:D:\\work\\orgs\\KT\\ops\\windows-captain\\demo-product',
+        'C:\\Users\\me'
+      )
+    ).toBe('path:D:/work/orgs/KT/ops/windows-captain/demo-product')
+  })
+
+  it('leaves already-forward Windows paths unchanged', () => {
+    expect(normalizeWorktreeSelector('path:D:/work/orgs/demo-product', 'C:\\Users\\me')).toBe(
+      'path:D:/work/orgs/demo-product'
+    )
+  })
+
+  it('does not rewrite POSIX paths that contain backslash characters', () => {
+    expect(normalizeWorktreeSelector('path:/srv/team\\repo', '/tmp')).toBe('path:/srv/team\\repo')
+  })
+
+  it('leaves branch/name selectors alone', () => {
+    expect(normalizeWorktreeSelector('branch:feature/foo', '/tmp')).toBe('branch:feature/foo')
+  })
+})

--- a/src/cli/selectors.ts
+++ b/src/cli/selectors.ts
@@ -4,7 +4,11 @@ import type {
   RuntimeWorktreeListResult,
   RuntimeWorktreeRecord
 } from '../shared/runtime-types'
-import { isPathInsideOrEqual } from '../shared/cross-platform-path'
+import {
+  isPathInsideOrEqual,
+  isWindowsAbsolutePathLike,
+  normalizeRuntimePathSeparators
+} from '../shared/cross-platform-path'
 import type { RuntimeClient } from './runtime-client'
 import { RuntimeClientError } from './runtime/types'
 import { getOptionalStringFlag, getRequiredStringFlag } from './flags'
@@ -27,6 +31,15 @@ export function buildCurrentWorktreeSelector(cwd: string): string {
 export function normalizeWorktreeSelector(selector: string, cwd: string): string {
   if (selector === 'active' || selector === 'current') {
     return buildCurrentWorktreeSelector(cwd)
+  }
+  // Why: PowerShell / Resolve-Path emit backslashes; registered worktree paths use
+  // forward slashes. Fold only Windows-shaped path: selectors so POSIX filenames
+  // that contain `\` stay literal (#12303).
+  if (selector.startsWith('path:')) {
+    const pathPart = selector.slice('path:'.length)
+    if (isWindowsAbsolutePathLike(pathPart)) {
+      return `path:${normalizeRuntimePathSeparators(pathPart)}`
+    }
   }
   return selector
 }

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -237,12 +237,16 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus'],
     notes: [
       'Creates a visible terminal tab without switching focus when possible; falls back to a background handle if the UI cannot adopt it. Pass --focus to switch to it.',
-      'Use this, not worktree create, for a fresh agent in the current checkout.'
+      'Use this, not worktree create, for a fresh agent in the current checkout.',
+      'On Windows, `path:D:\\foo\\bar` is accepted and normalized to forward slashes ' +
+        '(`path:D:/foo/bar`) before lookup. Prefer forward slashes or `id:<repoId>::D:/path` ' +
+        'from `orca worktree list --json` when scripting (#12303).'
     ],
     examples: [
       'orca terminal create --json',
       'orca terminal create --worktree active --command "codex" --json',
       'orca terminal create --worktree path:/projects/myapp --title "RUNNER" --command "opencode"',
+      'orca terminal create --worktree path:D:/projects/myapp --title "RUNNER" --json',
       'orca terminal create --worktree path:/projects/myapp --command "opencode" --focus'
     ]
   },


### PR DESCRIPTION
## Summary

- On Windows, `path:D:\\...` selectors failed to match worktrees registered as `D:/...` after PowerShell path expansion (#12303).
- Normalize only Windows drive/UNC-shaped `path:` selectors to forward slashes at CLI ingress (POSIX paths that contain `\` stay literal).
- Runtime comparison already folds separators; this makes the client send the same spelling as `worktree list`.

## Scope note

This PR addresses the **path-separator** acceptance criterion of #12303 only. Remaining issue criteria (terminal create `--title` surviving `--command` process-name overwrite; `selector_not_found` errors that include the normalized path/hint) are **not** implemented here and should stay open.

## Test plan

- [x] Unit: drive backslash → forward slash
- [x] Unit: POSIX `/srv/team\\repo` unchanged
- [x] Unit: branch selectors unchanged
- [ ] Manual on Windows: `orca terminal create --worktree "path:D:\\..."` --json resolves

Related to #12303 (partial; path: separator only)