### PR TITLE
fix(browser): report app-bound encrypted cookies instead of a silent zero

### DIFF
--- a/src/main/browser/browser-cookie-import-app-bound-surface.test.ts
+++ b/src/main/browser/browser-cookie-import-app-bound-surface.test.ts
@@ -1,0 +1,131 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { appGetPathMock, execFileSyncMock, sessionFromPartitionMock } = vi.hoisted(() => ({
+  appGetPathMock: vi.fn(),
+  execFileSyncMock: vi.fn(),
+  sessionFromPartitionMock: vi.fn()
+}))
+
+vi.mock('./browser-session-registry', () => ({
+  browserSessionRegistry: {
+    setPendingCookieImport: vi.fn(),
+    clearPendingCookieImport: vi.fn(),
+    persistUserAgent: vi.fn()
+  }
+}))
+vi.mock('node:child_process', () => ({ execFileSync: execFileSyncMock }))
+vi.mock('electron', () => ({
+  app: { getPath: appGetPathMock },
+  dialog: { showOpenDialog: vi.fn() },
+  session: { fromPartition: sessionFromPartitionMock }
+}))
+
+import { importCookiesFromBrowser } from './browser-cookie-import'
+import { createChromiumCookieTestDatabase } from './browser-cookie-import-test-database'
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+
+/** A Chrome 140+ app-bound cookie: the `v20` prefix over an opaque blob. */
+function appBoundEncryptedValue(): Buffer {
+  return Buffer.concat([Buffer.from('v20'), Buffer.from([0x01, 0x02, 0x03, 0x04, 0x05])])
+}
+
+function chromeBrowser(cookiesPath: string) {
+  return {
+    family: 'chrome' as const,
+    label: 'Google Chrome',
+    cookiesPath,
+    keychainService: 'Chrome Safe Storage',
+    keychainAccount: 'Chrome',
+    profiles: [{ name: 'Default', directory: 'Default' }],
+    selectedProfile: 'Default'
+  }
+}
+
+describe('app-bound encrypted cookies reach the import summary', () => {
+  let tmpDir: string
+
+  beforeEach(() => {
+    tmpDir = mkdtempSync(join(tmpdir(), 'orca-cookie-app-bound-'))
+    appGetPathMock.mockReset().mockReturnValue(join(tmpDir, 'userData'))
+    // Why: a real Chrome 140 profile on Windows HAS a working key — the rows still fail because
+    // they are app-bound, which is the scenario under test.
+    execFileSyncMock.mockReset().mockReturnValue('safe-storage-password')
+    sessionFromPartitionMock.mockReset().mockReturnValue({
+      cookies: {
+        flushStore: vi.fn().mockResolvedValue(undefined),
+        get: vi.fn().mockResolvedValue([]),
+        remove: vi.fn().mockResolvedValue(undefined),
+        set: vi.fn().mockResolvedValue(undefined)
+      },
+      clearStorageData: vi.fn().mockResolvedValue(undefined)
+    })
+  })
+
+  afterEach(() => {
+    rmSync(tmpDir, { recursive: true, force: true })
+  })
+
+  // Why: the predicate alone proves nothing — before this fix the rows decoded to nothing and were
+  // folded into the generic skip count, so the import reported a clean zero (#13192). This drives
+  // the real import and asserts the cause reaches the caller.
+  it('reports the cause instead of a silent zero', async () => {
+    const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')
+    createChromiumCookieTestDatabase(sourceCookiesPath, [
+      {
+        domain: '.github.com',
+        name: 'session',
+        value: '',
+        encryptedValue: appBoundEncryptedValue()
+      },
+      { domain: '.example.com', name: 'token', value: '', encryptedValue: appBoundEncryptedValue() }
+    ]).close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    try {
+      const result = await importCookiesFromBrowser(
+        chromeBrowser(sourceCookiesPath),
+        'persist:test'
+      )
+
+      if (!result.ok) {
+        throw new Error(`import failed: ${result.reason}`)
+      }
+      expect(result.summary.importedCookies).toBe(0)
+      expect(result.summary.totalCookies).toBe(2)
+      expect(result.summary.warning).toEqual({
+        code: 'app-bound-encryption',
+        encryptedCookies: 2
+      })
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+
+  it('leaves a decryptable profile without the warning', async () => {
+    const sourceCookiesPath = join(tmpDir, 'Chrome', 'Default', 'Network', 'Cookies')
+    const targetCookiesPath = join(tmpDir, 'userData', 'Partitions', 'test', 'Network', 'Cookies')
+    createChromiumCookieTestDatabase(sourceCookiesPath, [
+      { domain: '.github.com', name: 'plain', value: 'readable' }
+    ]).close()
+    createChromiumCookieTestDatabase(targetCookiesPath, []).close()
+    const platformSpy = vi.spyOn(process, 'platform', 'get').mockReturnValue('darwin')
+
+    try {
+      const result = await importCookiesFromBrowser(
+        chromeBrowser(sourceCookiesPath),
+        'persist:test'
+      )
+      expect(result.ok).toBe(true)
+      if (!result.ok) {
+        return
+      }
+      expect(result.summary.warning).toBeUndefined()
+    } finally {
+      platformSpy.mockRestore()
+    }
+  })
+})

--- a/src/main/browser/browser-cookie-import-app-bound.test.ts
+++ b/src/main/browser/browser-cookie-import-app-bound.test.ts
@@ -1,0 +1,29 @@
+import { describe, expect, it } from 'vitest'
+import { isAppBoundEncryptedCookie } from './browser-cookie-import'
+
+function encryptedCookie(versionPrefix: string): Buffer {
+  return Buffer.concat([Buffer.from(versionPrefix), Buffer.from([0xde, 0xad, 0xbe, 0xef])])
+}
+
+describe('isAppBoundEncryptedCookie', () => {
+  // Why: Chrome/Edge 140+ on Windows wrap every cookie in app-bound encryption, which only the
+  // browser's elevation service can unwrap — the import otherwise reports a clean zero (#13192).
+  it('detects the v20 app-bound prefix', () => {
+    expect(isAppBoundEncryptedCookie(encryptedCookie('v20'))).toBe(true)
+  })
+
+  it.each(['v10', 'v11'])('leaves the decryptable %s prefix alone', (prefix) => {
+    expect(isAppBoundEncryptedCookie(encryptedCookie(prefix))).toBe(false)
+  })
+
+  it('does not treat a plaintext value as app-bound', () => {
+    expect(isAppBoundEncryptedCookie(Buffer.from('session=abc123'))).toBe(false)
+  })
+
+  it.each([
+    ['empty', Buffer.alloc(0)],
+    ['shorter than the prefix', Buffer.from('v2')]
+  ])('handles a buffer %s without throwing', (_label, buffer) => {
+    expect(isAppBoundEncryptedCookie(buffer)).toBe(false)
+  })
+})

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1766,6 +1766,13 @@ export async function importCookiesFromBrowser(
     if (decryptedCookies.length === 0) {
       closeStagingDb()
       discardStagingFile()
+      // Why: an all-app-bound profile decrypts nothing, so it returns here — before the warning
+      // block below. Without this the very case #13192 reports still reads as a clean zero.
+      if (appBoundEncrypted > 0) {
+        diag(
+          `  ${appBoundEncrypted} cookies use app-bound encryption (v20) and cannot be decrypted`
+        )
+      }
       return {
         ok: true,
         profileId: '',
@@ -1774,7 +1781,15 @@ export async function importCookiesFromBrowser(
           importedCookies: 0,
           skippedCookies: skipped + integritySkipped + nonTransplantableSkipped,
           ...(googleCookiesSkipped > 0 ? { googleCookiesSkipped } : {}),
-          domains: []
+          domains: [],
+          ...(appBoundEncrypted > 0
+            ? {
+                warning: {
+                  code: 'app-bound-encryption' as const,
+                  encryptedCookies: appBoundEncrypted
+                }
+              }
+            : {})
         }
       }
     }

--- a/src/main/browser/browser-cookie-import.ts
+++ b/src/main/browser/browser-cookie-import.ts
@@ -1068,6 +1068,14 @@ function stripHmac(buf: Buffer): Buffer {
   return hasHmacPrefix(buf) ? buf.subarray(CHROMIUM_COOKIE_HMAC_LEN) : buf
 }
 
+/**
+ * Chrome/Edge 140+ on Windows prefix every cookie with `v20` (app-bound encryption). Only the
+ * browser's own elevation service can unwrap that layer, so these rows can never decrypt here.
+ */
+export function isAppBoundEncryptedCookie(encryptedBuffer: Buffer): boolean {
+  return encryptedBuffer.length >= 3 && encryptedBuffer.subarray(0, 3).toString('utf-8') === 'v20'
+}
+
 function decryptCookieValueRaw(
   encryptedBuffer: Buffer,
   keyResult: EncryptionKeyResult
@@ -1614,6 +1622,7 @@ export async function importCookiesFromBrowser(
 
     let imported = 0
     let skipped = 0
+    let appBoundEncrypted = 0
     let integritySkipped = 0
     let nonTransplantableSkipped = 0
     let memoryLoaded = 0
@@ -1681,6 +1690,11 @@ export async function importCookiesFromBrowser(
 
       let decryptedValue: Buffer
       if (encBuf && encBuf.length > 0) {
+        // Why: once decrypt returns null an app-bound row looks exactly like a malformed one, so
+        // record it before trying (#13192).
+        if (isAppBoundEncryptedCookie(encBuf)) {
+          appBoundEncrypted++
+        }
         const raw = sourceKey ? decryptCookieValueRaw(encBuf, sourceKey) : null
         if (!raw) {
           skipped++
@@ -1819,6 +1833,12 @@ export async function importCookiesFromBrowser(
     diag(`  memory load: ${memoryLoaded} OK, ${memoryFailed} failed`)
 
     let warning: BrowserCookieImportSummary['warning']
+    // Why: without this the import reports a clean zero, which reads as "no cookies to import"
+    // rather than "this browser encrypts cookies in a way Orca cannot read" (#13192).
+    if (imported === 0 && appBoundEncrypted > 0) {
+      warning = { code: 'app-bound-encryption', encryptedCookies: appBoundEncrypted }
+      diag(`  ${appBoundEncrypted} cookies use app-bound encryption (v20) and cannot be decrypted`)
+    }
     if (memoryFailed > 0 && stagingAvailable) {
       // Why: keep the staging DB so the failed cookies load from SQLite on next cold start, where CookieMonster skips validation.
       browserSessionRegistry.setPendingCookieImport(targetPartition, stagingCookiesPath)

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -759,7 +759,8 @@
               "restartFallbackUnavailablePartial": "Imported {{value0}} of {{value1}} cookies. The rest could not be loaded, and the restart fallback was unavailable. Try the import again.",
               "googleCookiesSkipped": "Google cookies were not imported. Open a browser in Orca with this profile, then sign into Google.",
               "googleDirectSignInAction": "Sign in to Google",
-              "googleDirectSignInUnavailable": "Could not open the browser profile. Open it and sign in at accounts.google.com."
+              "googleDirectSignInUnavailable": "Could not open the browser profile. Open it and sign in at accounts.google.com.",
+              "appBoundEncryption": "This browser encrypts its {{value0}} cookies with app-bound encryption, which only the browser itself can unlock. Export them from the browser and use Import from File instead."
             }
           }
         }

--- a/src/renderer/src/lib/browser-cookie-import-toast.ts
+++ b/src/renderer/src/lib/browser-cookie-import-toast.ts
@@ -22,6 +22,12 @@ function formatCookieImportWarning(warning: CookieImportWarning): string {
               value1: warning.loadedCookies + warning.failedCookies
             }
           )
+    case 'app-bound-encryption':
+      return translate(
+        'auto.lib.browser.cookie.import.toast.appBoundEncryption',
+        'This browser encrypts its {{value0}} cookies with app-bound encryption, which only the browser itself can unlock. Export them from the browser and use Import from File instead.',
+        { value0: warning.encryptedCookies }
+      )
   }
 }
 

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -1081,11 +1081,19 @@ export type BrowserCookieImportSummary = {
   skippedCookies: number
   googleCookiesSkipped?: number
   domains: string[]
-  warning?: {
-    code: 'restart-fallback-unavailable'
-    loadedCookies: number
-    failedCookies: number
-  }
+  warning?:
+    | {
+        code: 'restart-fallback-unavailable'
+        loadedCookies: number
+        failedCookies: number
+      }
+    // Why: Chrome/Edge 140+ on Windows wrap every cookie in app-bound encryption (v20), which only
+    // the browser's own elevation service can unwrap — the rows decode to nothing and the import
+    // otherwise reports a clean zero (#13192).
+    | {
+        code: 'app-bound-encryption'
+        encryptedCookies: number
+      }
 }
 
 export type BrowserCookieImportResult =


### PR DESCRIPTION
Closes #13192.

## Summary

Importing cookies from Chrome/Edge 140+ on Windows now says why it failed instead of reporting a clean zero.

Before, the summary read `importedCookies: 0` with `totalCookies > 0` and no error — indistinguishable from an empty profile. Now the import surfaces a warning naming the cause and the workaround: export the cookies from the browser and use **Import from File**.

### Root cause

`decryptCookieValueRaw` validates the version prefix as `/^v\d\d$/` and then routes anything on Windows to the AES-256-GCM path:

```ts
const version = encryptedBuffer.subarray(0, 3).toString('utf-8')
if (!/^v\d\d$/.test(version)) return null
if (keyResult.mode === 'aes-256-gcm') return decryptAes256Gcm(encryptedBuffer.subarray(3), keyResult.key)
```

`v20` satisfies that regex, so every app-bound row is fed to GCM with the user's DPAPI key, fails, and returns `null`. The caller then collapses it into the generic skip:

```ts
if (!raw) { skipped++; continue }
```

which is the same branch a malformed row takes. That is why the failure is invisible: the rows are read fine, they just decode to nothing, and nothing distinguishes "one bad row" from "this entire profile uses an encryption scheme we cannot read".

### What changed

- `isAppBoundEncryptedCookie()` — exported predicate for the `v20` prefix.
- The row scan counts app-bound rows before attempting decryption, since after `decryptCookieValueRaw` returns `null` they are indistinguishable from malformed ones.
- When nothing imported and app-bound rows were present, the summary carries a new `app-bound-encryption` warning with the count.
- Toast copy for the new warning code, with the catalog key generated via `pnpm run sync:localization-catalog`.

**Decryption behaviour is unchanged.** The `v10`/`v11` paths on macOS and Linux are untouched, and no attempt is made to decrypt `v20` — as the issue notes, that requires the browser's own elevation service (`IElevator::DecryptData`) and is not viable from Electron. An honest, actionable error is the useful outcome.

Credit to the reporter for the diagnosis; this implements the "at a minimum" suggestion from the issue rather than the fork patch, which I did not have access to.

## Screenshots

A warning toast where there was previously a silent success. No layout or component change — it reuses the existing warning-toast mechanism and its discriminated union, so it renders exactly like the import warnings already in the flow.

I don't have a Windows machine with a Chrome 140 profile to capture it against, which is the same reason the end-to-end note below exists.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — scoped to the touched tree, not the full suite (see below)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`pnpm typecheck` and `oxlint` pass. All three localization verifiers (`catalog`, `extraction`, `coverage`) exit 0. 603 tests across `src/main/browser/` pass, including the existing cookie-import suites. Scoped suites rather than a full `pnpm build`; no packaging or dependency surface is touched.

New `browser-cookie-import-app-bound.test.ts` covers the `v20` prefix, the `v10`/`v11` prefixes it must not touch, a plaintext value, and short/empty buffers.

Verified non-blind: stubbing the predicate to `return false` fails only the detection assertion while the four negative cases keep passing — so the test distinguishes the fix from its absence rather than merely exercising the function.

**I could not reproduce on Windows from this machine**, so the detection is verified at the byte level and by unit test rather than against a live Chrome 140 profile. Worth a maintainer with Windows confirming the toast end to end before this lands.

## AI Review Report

Reviewed with Claude Opus 5 against the CONTRIBUTING checklist.

- **Cross-platform (macOS/Linux/Windows)** — the predicate is byte-level and platform-independent, but only reachable in practice where `v20` appears, which is Windows. macOS/Linux `v10`/`v11` decryption is untouched and covered by the existing suites; the new negative cases pin that those prefixes are not caught by the predicate. No path handling, shell behaviour, accelerator or shortcut label involved.
- **SSH/remote/local** — cookie import is a local-profile operation; no wire, IPC or remote surface changes.
- **Agent/integration/git provider** — none touched.
- **Performance** — one 3-byte prefix comparison per row, on a path that already decrypts every row.
- **UI quality** — reuses the existing warning-toast mechanism; no new component, token or layout. Copy is localized through the normal catalog flow rather than hardcoded.

What it flagged and I acted on: the first cut inferred app-bound encryption from "imported 0 of N", which would also fire on a profile whose rows all failed for unrelated reasons. It now counts the `v20` rows explicitly before decryption is attempted, so the warning names a cause it actually observed.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency and IPC risk. This one touches cookie material, so it got the closest look.

- **No decryption weakened or bypassed.** The change adds a predicate and a counter. No key handling, no new crypto path, no fallback that would decrypt something the old code refused. `v10`/`v11` GCM and DPAPI paths are byte-for-byte unchanged.
- **No cookie values logged or surfaced.** The predicate reads the first three bytes of the encrypted blob — the scheme tag, not plaintext. The diagnostic line and the toast carry a **count** only. No host, name, or value from any row reaches the log or the UI.
- **Input handling** — inputs are rows from a local SQLite profile the user already pointed us at. Short and empty buffers are covered by tests so the prefix read cannot over-read.
- **Command execution / path handling** — none added.
- **IPC** — the summary already crossed the existing channel; this adds one warning code to a discriminated union that is already validated on the other side. No new surface.
- **Dependencies** — none added.

Follow-up: none required for this change. The underlying inability to read `v20` is a browser-imposed limit, not something to work around.

## Notes

Windows-specific in practice — `v20` app-bound encryption ships in Chrome/Edge 140+ on Windows only. The code path is platform-neutral but will not fire on macOS or Linux profiles.

The one open item is the end-to-end confirmation on a real Windows profile, flagged above. If someone on the team has one handy I'd appreciate the check; if it looks wrong I'll fix it.

X: [@manuaudiomix](https://x.com/manuaudiomix)
