### PR TITLE
fix(terminal): keep the reattach grid push past an exhausted fit budget

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-fit-continuation-registry.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-continuation-registry.ts
@@ -126,13 +126,21 @@ export function pruneStaleSafeFitContinuations(pane: ManagedPane): void {
   }
 }
 
-export function failPendingSafeFitContinuations(pane: ManagedPane): void {
+/**
+ * Ends every pending continuation for a pane whose layout wait ran out.
+ *
+ * Why not a plain drop: the reattach grid push is the only client size the PTY
+ * will ever be told after a replay, so exhausting a frame budget must not be the
+ * thing that strands it. Opt-in continuations survive to the first measurable fit;
+ * everything else keeps the bounded-degradation contract and is discarded.
+ */
+export function releasePendingSafeFitContinuationsUntilMeasurable(pane: ManagedPane): void {
   const operations = pendingSafeFitContinuations.get(pane)
   if (!operations) {
     return
   }
   for (const [operationKey, pending] of Array.from(operations.entries())) {
-    settlePendingSafeFitContinuation(pane, operationKey, pending, false)
+    releaseSafeFitContinuationUntilMeasurable(pane, operationKey, pending)
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-fit.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.test.ts
@@ -210,6 +210,30 @@ describe('safeFitAndThen unmeasurable-pane retry', () => {
     expect(continuation).not.toHaveBeenCalled()
   })
 
+  it('keeps an opt-in continuation alive past the exhausted frame budget', async () => {
+    // Why: the reattach grid push is the only client size the PTY is told after a replay,
+    // so running out of layout frames must not be what strands it. The bounded-degradation
+    // contract still holds for every caller that did not opt in (see the test above).
+    const pane = createPane({ rect: { width: 0, height: 0 } })
+    const continuation = vi.fn()
+
+    const handle = safeFitAndThen(pane, 'reattach-pty-resize', continuation, {
+      retryIfUnmeasurable: true,
+      deferIfHidden: true
+    })
+    for (let frame = 0; frame < 40; frame += 1) {
+      flushAnimationFrames(frame * 16)
+      vi.advanceTimersByTime(16)
+    }
+
+    await expect(handle.completion).resolves.toBe(false)
+    expect(continuation).not.toHaveBeenCalled()
+
+    pane.setRect({ width: 800, height: 600 })
+    safeFit(pane)
+    expect(continuation).toHaveBeenCalledTimes(1)
+  })
+
   it('runs a display:none pane continuation on the first fit after it is revealed', async () => {
     // Why: a restored floating-workspace pane is display:none for its whole reattach, so the
     // reattach grid push has to survive to the reveal — dropping it strands the PTY at the

--- a/src/renderer/src/lib/pane-manager/pane-fit.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit.ts
@@ -25,7 +25,7 @@ import { flushDeferredPaneMetricOptions } from './pane-metric-options-deferral'
 import { canMeasurePaneForFit, getProposedPaneDimensions } from './pane-fit-measurability'
 import {
   cancelPendingSafeFitContinuation,
-  failPendingSafeFitContinuations,
+  releasePendingSafeFitContinuationsUntilMeasurable,
   flushPendingSafeFitContinuations,
   hasPendingSafeFitContinuations,
   isPendingSafeFitContinuationCurrent,
@@ -176,8 +176,9 @@ function armSafeFitContinuationRetry(pane: ManagedPane): void {
     },
     onExhausted: () => {
       // Why: a reveal transaction must degrade after its bounded layout wait;
-      // leaving completion pending forever blocks deferred output release.
-      failPendingSafeFitContinuations(pane)
+      // leaving completion pending forever blocks deferred output release. The
+      // reattach grid push still outlives the budget — it is the PTY's only size.
+      releasePendingSafeFitContinuationsUntilMeasurable(pane)
     }
   })
 }


### PR DESCRIPTION
## Summary

> **Stacked on #13155.** Review only the last commit. Retarget to `main` once #13155 merges.

#13155 stopped a `display:none` pane from dropping the reattach grid push. The same continuation is still dropped by the *other* unmeasurable path: a pane that is laid out but has no usable box burns the 40-frame retry budget, and `onExhausted` discards the continuation outright.

That push is the only client size the PTY is ever told after a replay — nothing downstream re-sends it, because a fit that lands on the grid xterm already has fires no `onResize`. So running out of layout frames is currently enough to strand a restored terminal at the replay grid.

Exhaustion now ends the wait the same way a hidden pane does: the completion promise still resolves `false` immediately, so a reveal transaction still degrades after its bounded wait and never blocks deferred output release, but an opt-in continuation survives to the first measurable fit. Only the reattach grid push opts in (`deferIfHidden`), so every other caller keeps the existing bounded-degradation contract unchanged — including the two tests that assert it.

## Screenshots

`No visual change`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

One test, `pane-fit.test.ts` — "keeps an opt-in continuation alive past the exhausted frame budget": burns all 40 frames, asserts the handle still resolves `false` (the degradation contract) and that the continuation has not run, then makes the pane measurable and asserts it runs exactly once.

Verified non-vacuous by reverting only the behavior — swapping the release back to a plain settle — which fails exactly this test while the two pre-existing exhaustion tests ("resolves failure after the bounded frame budget", "resolves failure when hidden-window animation frames are withheld") keep passing. That is the point: this narrows the drop to callers that did not opt in, rather than flipping the contract for everyone.

3672 renderer tests green.

## AI Review Report

This closes the last of the gaps found in the reattach-sizing review that preceded #13155, where the guarantee "the pty always receives a client size at the end of replay, regardless of visibility" held elsewhere but not in Orca. The other candidates from that review were checked against the code and are **not** defects, so they are deliberately not in this PR:

- *Missing snapshot dimensions replaying at the wrong width* — not reachable. `snapshotCols`/`snapshotRows` come from `result.snapshot.cols/rows` (`daemon-pty-adapter.ts:848`) and the daemon resizes its emulator with the session (`session.ts:245`), so they are always present and correct; the null branch in `resolvePositiveTerminalDimensions` is defensive.
- *Replay spanning a resize needs per-segment geometry* — already handled by a different mechanism: the record stream carries `{kind: 'resize'}` entries (`session.ts:247`), so cold-restore replay reflows at the right points without per-segment tags.

Risk reviewed: the deferred entry is one-shot, cleared on pane teardown, cleared when a newer registration takes the same key, cleared by `cancel()`, gated by `shouldContinue` (generation + pty id), and re-checks mobile PTY ownership at fire time — all established in #13155. Cross-platform: renderer-only bookkeeping, no platform-dependent behavior, no shortcuts/labels/paths touched. SSH and folder-workspace cases share this path with no difference.

## Security Audit

No IPC, input handling, command execution, path handling, auth, secrets, or dependency changes. Renderer-local lifetime change to a callback that already existed.

## Notes

- Depends on the `deferIfHidden` opt-in and the deferred bucket introduced in #13155; it is a two-line behavior change on top of that machinery.
- The fallback remains silent — if the budget is exhausted *and* the pane is never revealed, nothing reports it. Consistent with today, and noted rather than fixed here.
