### PR TITLE
fix(sidebar): scope the worktree-visibility toggle to its own host

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -644,7 +644,7 @@ type VirtualizedWorktreeViewportProps = {
   collapsedGroups: Set<string>
   handleCreateForRepo: (projectId: string) => void
   handleOpenRepoSettings: (projectId: string, sectionId?: string) => void
-  handleOpenWorktreeVisibility: (projectId: string) => void
+  handleOpenWorktreeVisibility: (projectId: string, hostId?: ExecutionHostId) => void
   handleShowImportedWorktrees: (projectId: string) => void
   handleKeepImportedWorktreesHidden: (projectId: string) => void
   importedWorktreeCardActionState: ReadonlyMap<string, ImportedWorktreeCardActionState>
@@ -4584,7 +4584,10 @@ const VirtualizedWorktreeViewport = React.memo(function VirtualizedWorktreeViewp
                               <DropdownMenuItem
                                 onSelect={() => {
                                   if (row.repo) {
-                                    handleOpenWorktreeVisibility(row.repo.id)
+                                    handleOpenWorktreeVisibility(
+                                      row.repo.id,
+                                      getRepoExecutionHostId(row.repo)
+                                    )
                                   }
                                 }}
                               >
@@ -5978,8 +5981,10 @@ const WorktreeList = React.memo(function WorktreeList({
   )
 
   const handleOpenWorktreeVisibility = useCallback(
-    (projectId: string) => {
-      openModal('worktree-visibility', { repoId: projectId })
+    (projectId: string, hostId?: ExecutionHostId) => {
+      // Why: the id can exist on several hosts, so carry the row's own host when the caller
+      // knows it — otherwise the dialog reads and writes whichever row resolves first.
+      openModal('worktree-visibility', { repoId: projectId, ...(hostId ? { hostId } : {}) })
     },
     [openModal]
   )

--- a/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeVisibilityDialog.tsx
@@ -18,6 +18,8 @@ import {
   effectiveExternalWorktreeVisibility,
   isLegacyRepoForExternalWorktreeVisibility
 } from '../../../../shared/worktree-ownership'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 
 export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
@@ -28,9 +30,21 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
   const updateRepo = useAppStore((s) => s.updateRepo)
   const fetchWorktrees = useAppStore((s) => s.fetchWorktrees)
   const detectedWorktreesByRepo = useAppStore((s) => s.detectedWorktreesByRepo)
+  const settings = useAppStore((s) => s.settings)
 
   const repoId = typeof modalData.repoId === 'string' ? modalData.repoId : ''
-  const repo = repos.find((candidate) => candidate.id === repoId) ?? null
+  // Why: a repo id can exist on several hosts, so read and write the row the caller meant
+  // rather than whichever one matches the id first.
+  const hostId =
+    normalizeExecutionHostId(typeof modalData.hostId === 'string' ? modalData.hostId : null) ??
+    undefined
+  // Why: findRepoForHost deliberately returns null when a bare id is ambiguous across hosts.
+  // Fall back to the previous first-match so a host-less caller still opens the dialog rather
+  // than silently rendering nothing.
+  const repo =
+    findRepoForHost(repos, repoId, { hostId, settings }) ??
+    repos.find((candidate) => candidate.id === repoId) ??
+    null
   const detected = repoId ? detectedWorktreesByRepo[repoId] : undefined
   const showOther = repo
     ? effectiveExternalWorktreeVisibility(repo, isLegacyRepoForExternalWorktreeVisibility(repo)) ===
@@ -45,17 +59,21 @@ export default function WorktreeVisibilityDialog(): React.JSX.Element | null {
     if (!repoId) {
       return
     }
-    await updateRepo(repoId, {
-      externalWorktreeVisibility: showOther ? 'hide' : 'show',
-      // Why: showing hidden externals again should re-enable the inbox if the
-      // user previously opted out of discovery prompts for this repo.
-      // Why: null is the transport sentinel for clearing on remote runtime paths
-      // where `undefined` is stripped before persistence.
-      ...(!showOther ? { externalWorktreeDiscoverySuppressedAt: null } : {})
-    })
+    await updateRepo(
+      repoId,
+      {
+        externalWorktreeVisibility: showOther ? 'hide' : 'show',
+        // Why: showing hidden externals again should re-enable the inbox if the
+        // user previously opted out of discovery prompts for this repo.
+        // Why: null is the transport sentinel for clearing on remote runtime paths
+        // where `undefined` is stripped before persistence.
+        ...(!showOther ? { externalWorktreeDiscoverySuppressedAt: null } : {})
+      },
+      hostId ? { hostId } : undefined
+    )
     await fetchWorktrees(repoId)
     closeModal()
-  }, [closeModal, fetchWorktrees, repoId, showOther, updateRepo])
+  }, [closeModal, fetchWorktrees, hostId, repoId, showOther, updateRepo])
 
   if (activeModal !== 'worktree-visibility' || !repo || !isGitRepoKind(repo)) {
     return null

--- a/src/renderer/src/components/sidebar/worktree-visibility-host-identity.test.tsx
+++ b/src/renderer/src/components/sidebar/worktree-visibility-host-identity.test.tsx
@@ -1,0 +1,90 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render, screen } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { Repo } from '../../../../shared/types'
+
+const { storeState } = vi.hoisted(() => ({
+  storeState: {
+    activeModal: 'worktree-visibility' as string,
+    modalData: {} as Record<string, unknown>,
+    closeModal: vi.fn(),
+    repos: [] as Repo[],
+    updateRepo: vi.fn().mockResolvedValue(true),
+    fetchWorktrees: vi.fn().mockResolvedValue(true),
+    detectedWorktreesByRepo: {} as Record<string, unknown>,
+    settings: {} as Record<string, unknown>
+  }
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: typeof storeState) => unknown) => selector(storeState),
+    { getState: () => storeState }
+  )
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  i18n: { language: 'en' },
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+import WorktreeVisibilityDialog from './WorktreeVisibilityDialog'
+
+/** Same repo id on two hosts; only host-a currently shows its external worktrees. */
+function reposOnTwoHosts(): Repo[] {
+  const base = { id: 'repo-1', badgeColor: '#000000', addedAt: 0, kind: 'git' as const }
+  return [
+    {
+      ...base,
+      path: '/repos/b',
+      displayName: 'on host B',
+      connectionId: 'host-b',
+      externalWorktreeVisibility: 'hide'
+    },
+    {
+      ...base,
+      path: '/repos/a',
+      displayName: 'on host A',
+      connectionId: 'host-a',
+      externalWorktreeVisibility: 'show'
+    }
+  ] as unknown as Repo[]
+}
+
+afterEach(cleanup)
+
+describe('WorktreeVisibilityDialog host identity', () => {
+  // Why: one repo id can exist on several hosts. Resolved by bare id, the dialog reads whichever
+  // row matches first — so it can show host B's state while the user opened it for host A, then
+  // write the toggle to the wrong row.
+  it('writes the toggle to the host the dialog was opened for', async () => {
+    storeState.repos = reposOnTwoHosts()
+    storeState.modalData = { repoId: 'repo-1', hostId: 'ssh:host-a' }
+    storeState.updateRepo = vi.fn().mockResolvedValue(true)
+
+    render(<WorktreeVisibilityDialog />)
+    fireEvent.click(await screen.findByRole('button', { name: /import|hide/i }))
+
+    expect(storeState.updateRepo).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({ externalWorktreeVisibility: 'hide' }),
+      { hostId: 'ssh:host-a' }
+    )
+  })
+
+  it('omits the host option when the caller could not supply one', async () => {
+    storeState.repos = reposOnTwoHosts()
+    storeState.modalData = { repoId: 'repo-1' }
+    storeState.updateRepo = vi.fn().mockResolvedValue(true)
+
+    render(<WorktreeVisibilityDialog />)
+    fireEvent.click(await screen.findByRole('button', { name: /import|hide/i }))
+
+    expect(storeState.updateRepo).toHaveBeenCalledWith(
+      'repo-1',
+      expect.objectContaining({}),
+      undefined
+    )
+  })
+})


### PR DESCRIPTION
Same defect class as #13071 (P1), in a different flow. No separate issue filed — happy to open one if you'd rather track it on its own.

## Summary

The worktree-visibility toggle could show you one host's state and write the change to another host's project.

`WorktreeVisibilityDialog` resolves its repo with a bare id and then mutates without a host:

```ts
const repo = repos.find((candidate) => candidate.id === repoId) ?? null
...
await updateRepo(repoId, { externalWorktreeVisibility: showOther ? 'hide' : 'show', ... })
```

`updateRepo`'s own signature documents why that matters:

> `options.hostId` targets a specific host's row + RPC target when the id exists on multiple hosts; else the focused host is assumed.

So when one repo id exists on two hosts (two clones of a remote, the same repo added twice, local + SSH copies), the dialog **reads whichever row matches first** and **writes to whichever row `updateRepo` assumes**. Those need not be the same row, and neither need be the one the user opened the menu on.

`RepositoryPane.tsx:93` already passes `{ hostId: selectedHostId }` for exactly this reason, so the correct pattern is established in-tree.

### What changed

The menu that opens the dialog already has the full `Repo`:

```ts
handleOpenWorktreeVisibility(row.repo.id)   // host discarded
```

Carry it through the modal data into `updateRepo`, and resolve the row with `findRepoForHost` so the dialog reads the same row it writes. The host is narrowed with `normalizeExecutionHostId` rather than cast.

## Screenshots

No visual change. The only user-visible difference is that the dialog now reflects the project you opened it on.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — scoped to the touched tree, not the full suite (see below)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

`pnpm typecheck` and `oxlint` pass; 2011 tests across `src/renderer/src/components/sidebar/` pass. I ran the scoped suites rather than a full `pnpm build` on this branch — it is renderer-only identity plumbing with no packaging, dependency or main-process surface. Glad to run the full build if you want it on the record.

New `worktree-visibility-host-identity.test.tsx` renders the real dialog with one repo id on two hosts and clicks the toggle:

- with a host, `updateRepo` is called with `{ hostId: 'ssh:host-a' }` and the value derived from **host A's** state
- without a host, the dialog still opens and calls `updateRepo` with no host option

Verified non-blind: reverting the plumbing fails the first test while the second keeps passing — it pins the unchanged host-less path, so the pair distinguishes the fix from its absence rather than just exercising the component.

Note the dialog renders through a Radix portal, so `renderToStaticMarkup` sees nothing; the test uses `@testing-library/react` under `happy-dom`, matching the existing `SelectedTextCopyMenu` test.

## AI Review Report

Reviewed with Claude Opus 5 against the CONTRIBUTING checklist.

- **Cross-platform (macOS/Linux/Windows)** — pure renderer identity plumbing. No path construction, shell behaviour, accelerator, shortcut label or Electron platform branch is touched, so there is nothing to guard.
- **SSH/remote/local** — this is the SSH-relevant path. Local rows resolve to the local host id and behave as before; SSH rows now resolve to their own `ssh:<target>`. `updateRepo`'s existing per-host RPC targeting is unchanged, it simply receives the host the user meant. No wire change.
- **Folder workspaces** — the dialog is gated on `isGitRepoKind`, unchanged.
- **Agent/integration/git provider** — none touched.
- **Performance** — a filter over the same list, on a user-initiated dialog open.
- **UI quality** — no layout, token or component change.

What it flagged and I acted on: making the host mandatory looked cleaner, but the review caught that the inbox-recovery caller (`onOpenRecovery`) only has a bare id, and `findRepoForHost` returns `null` for an ambiguous bare id by design — that path would have become a menu item that opens an empty dialog. The resolve now falls back to the previous first-match when no host is supplied. My own test caught the same thing independently, which is why the host-less case is pinned.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependency and IPC risk.

- **Mutation targeting** — the substance of the change: narrows a persisted mutation to an explicitly identified row instead of an inferred one, removing a path where a user's toggle lands on a project they were not looking at.
- **Input handling** — the host id read out of modal data is narrowed with `normalizeExecutionHostId`, not cast, so a malformed value falls back instead of propagating into an RPC target.
- **Command execution / path handling** — none added.
- **IPC** — no new surface. `updateRepo`'s existing channel and its already-validated `hostId` parameter are unchanged; this only populates a parameter that was already there.
- **Auth, secrets, dependencies** — untouched, no new dependency.

No follow-up needed.

## Notes

This is the third site in the same family. #13117 covers the removal flow from #13071 (three sidebar sites plus the orphan purge in `worktrees.ts`); this one covers the visibility toggle. A fourth remains — `selectProjectGroupRemovalTargets` discards the host when building group-removal targets — which I left alone because it changes a shared selector's shape and its callers. Happy to take that one too if it is wanted.

X: [@manuaudiomix](https://x.com/manuaudiomix)
