### PR TITLE
docs(cli): document status --json runtime capability flags

### DIFF
--- a/src/cli/handlers/core.test.ts
+++ b/src/cli/handlers/core.test.ts
@@ -131,3 +131,38 @@ describe('orca claude-teams CLI handler', () => {
     }
   )
 })
+
+describe('orca status CLI capability docs', () => {
+  it('attaches capabilityDocs on --json for advertised flags', async () => {
+    const log = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const client = {
+      getCliStatus: vi.fn().mockResolvedValue({
+        result: {
+          app: { running: true, pid: 1 },
+          runtime: {
+            state: 'ready',
+            reachable: true,
+            runtimeId: 'rt-1',
+            capabilities: ['aiVault.v1', 'unknown.future.v9']
+          },
+          graph: { state: 'ready' }
+        }
+      })
+    } as unknown as RuntimeClient
+
+    await CORE_HANDLERS.status({
+      flags: new Map(),
+      client,
+      cwd: '/tmp/repo',
+      json: true
+    })
+
+    const payload = JSON.parse(String(log.mock.calls[0]?.[0])) as {
+      result: { runtime: { capabilities: string[]; capabilityDocs: Record<string, string> } }
+    }
+    expect(payload.result.runtime.capabilities).toEqual(['aiVault.v1', 'unknown.future.v9'])
+    expect(payload.result.runtime.capabilityDocs['aiVault.v1']).toMatch(/Agent Session History/)
+    expect(payload.result.runtime.capabilityDocs['unknown.future.v9']).toBeUndefined()
+    log.mockRestore()
+  })
+})

--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -1,4 +1,5 @@
 import { spawn } from 'node:child_process'
+import { describeRuntimeCapabilities } from '../../shared/runtime-capability-docs'
 import type { CommandHandler } from '../dispatch'
 import { formatCliStatus, formatStatus, printResult } from '../format'
 import { RuntimeClientError, serveOrcaApp } from '../runtime-client'
@@ -137,6 +138,24 @@ export const CORE_HANDLERS: Record<string, CommandHandler> = {
     const result = await client.getCliStatus()
     if (!json && !result.result.runtime.reachable) {
       process.exitCode = 1
+    }
+    if (json) {
+      // Why: status --json historically listed bare capability names with no
+      // semantics (#13202). Attach a one-line map so agents can reason without
+      // trial-and-error. Client-side only — no wire change for older hosts.
+      const capabilityDocs = describeRuntimeCapabilities(result.result.runtime.capabilities)
+      const enriched = {
+        ...result,
+        result: {
+          ...result.result,
+          runtime: {
+            ...result.result.runtime,
+            capabilityDocs
+          }
+        }
+      }
+      printResult(enriched, json, formatStatus)
+      return
     }
     printResult(result, json, formatStatus)
   }

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -16,6 +16,11 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     summary: 'Show app/runtime/graph readiness',
     usage: 'orca status [--json]',
     allowedFlags: [...GLOBAL_FLAGS],
+    notes: [
+      'JSON includes runtime.capabilities (flag names the host advertises) and runtime.capabilityDocs (one-line semantics per known flag).',
+      'Use capabilityDocs to decide whether an RPC or client feature is safe before calling it; unknown future flags appear only in capabilities.',
+      'Absence of a flag means the host does not support that feature — do not invent behavior from the name alone.'
+    ],
     examples: ['orca status', 'orca status --json']
   },
   {

--- a/src/shared/runtime-capability-docs.test.ts
+++ b/src/shared/runtime-capability-docs.test.ts
@@ -1,0 +1,39 @@
+import { describe, expect, it } from 'vitest'
+import {
+  RUNTIME_CAPABILITIES,
+  BROWSER_HEADLESS_RUNTIME_CAPABILITY,
+  BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY
+} from './protocol-version'
+import {
+  RUNTIME_CAPABILITY_DOCS,
+  describeRuntimeCapabilities,
+  listUndocumentedRuntimeCapabilities
+} from './runtime-capability-docs'
+
+describe('runtime capability docs', () => {
+  it('documents every static RUNTIME_CAPABILITIES entry', () => {
+    expect(listUndocumentedRuntimeCapabilities()).toEqual([])
+    for (const name of RUNTIME_CAPABILITIES) {
+      expect(RUNTIME_CAPABILITY_DOCS[name]?.length).toBeGreaterThan(10)
+    }
+  })
+
+  it('documents conditional browser capabilities used by getStatus', () => {
+    expect(RUNTIME_CAPABILITY_DOCS[BROWSER_HEADLESS_RUNTIME_CAPABILITY]).toBeTruthy()
+    expect(RUNTIME_CAPABILITY_DOCS[BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY]).toBeTruthy()
+  })
+
+  it('projects only advertised flags into capabilityDocs', () => {
+    expect(
+      describeRuntimeCapabilities([
+        'aiVault.v1',
+        'not-a-real-capability.v9',
+        BROWSER_HEADLESS_RUNTIME_CAPABILITY
+      ])
+    ).toEqual({
+      'aiVault.v1': RUNTIME_CAPABILITY_DOCS['aiVault.v1'],
+      [BROWSER_HEADLESS_RUNTIME_CAPABILITY]:
+        RUNTIME_CAPABILITY_DOCS[BROWSER_HEADLESS_RUNTIME_CAPABILITY]
+    })
+  })
+})

--- a/src/shared/runtime-capability-docs.ts
+++ b/src/shared/runtime-capability-docs.ts
@@ -1,0 +1,120 @@
+import {
+  ACCOUNT_IMPORT_RUNTIME_CAPABILITY,
+  AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
+  AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY,
+  AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  AI_VAULT_RUNTIME_CAPABILITY,
+  BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY,
+  BROWSER_HEADLESS_RUNTIME_CAPABILITY,
+  CODEX_RESET_CREDIT_RUNTIME_CAPABILITY,
+  FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
+  FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY,
+  LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY,
+  ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY,
+  ORCHESTRATION_FEDERATION_CONTROL_MAIL_RUNTIME_CAPABILITY,
+  ORCHESTRATION_FEDERATION_RUNTIME_CAPABILITY,
+  ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY,
+  PROJECT_HOST_SETUP_RUNTIME_CAPABILITY,
+  REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY,
+  REMOTE_SERVER_UPDATE_CAPABILITY,
+  RUNTIME_CAPABILITIES,
+  SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
+  TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY,
+  TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
+  TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY,
+  TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY,
+  TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY,
+  WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY,
+  WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
+  WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY,
+  type RuntimeCapability
+} from './protocol-version'
+
+/**
+ * One-line agent-readable semantics for each runtime capability flag advertised
+ * by `orca status --json` (#13202). Unknown/future flags are omitted.
+ */
+export const RUNTIME_CAPABILITY_DOCS: Readonly<Record<string, string>> = {
+  'runtime.status.compat.v1':
+    'Host advertises protocol compatibility fields on status (protocol version bounds).',
+  'runtime.environments.v1':
+    'Host supports remote environment inventory (environment list/show/add/rm RPCs).',
+  [REMOTE_RUNTIME_SHARED_CONTROL_CAPABILITY]:
+    'Paired clients may open the shared remote-control channel for multi-client coordination.',
+  [ORCHESTRATION_FEDERATION_RUNTIME_CAPABILITY]:
+    'Orchestration can place workers on connected Orca servers (federated worker-start).',
+  [ORCHESTRATION_FEDERATION_CONTROL_MAIL_RUNTIME_CAPABILITY]:
+    'Federated workers exchange control mail (stop/observe) across servers.',
+  [ORCHESTRATION_WORKER_LAUNCH_PREFERENCES_RUNTIME_CAPABILITY]:
+    'worker-start accepts per-invocation model/effort launch preferences.',
+  [ORCHESTRATION_CONTRACT_RUNTIME_CAPABILITY]:
+    'Host speaks the current orchestration contract (Runs/Tasks/Dispatches/worker_*).',
+  'browser.screencast.v1':
+    'Host can create and stream browser pages (desktop webview or headless offscreen).',
+  [BROWSER_HEADLESS_RUNTIME_CAPABILITY]:
+    'Host owns browser pages with no desktop renderer (headless serve); do not fall back to local tabs.',
+  [BROWSER_CERTIFICATE_TRUST_RUNTIME_CAPABILITY]:
+    'Host can proceed past certificate errors for hosted browser pages (Proceed Anyway).',
+  'terminal.binary-stream.v1':
+    'Terminal I/O uses binary stream framing (required for modern PTY consumers).',
+  'terminal.multiplex.v1': 'Multiple clients may attach to the same terminal stream.',
+  'workspace-ports.v1': 'Host exposes workspace port scanning / port-forward inventory.',
+  'mobile.tasks.v1': 'Host serves the mobile tasks surface over runtime RPC.',
+  [PROJECT_HOST_SETUP_RUNTIME_CAPABILITY]:
+    'Project host setup RPCs (setup-create/clone/import) are available.',
+  [TASK_SOURCE_CONTEXT_RUNTIME_CAPABILITY]:
+    'Worktrees can carry task-source context (GitHub/Linear/Jira provenance on create).',
+  [WORKSPACE_RUN_CONTEXT_RUNTIME_CAPABILITY]:
+    'Workspaces can bind orchestration Run context for supervised work.',
+  [WORKTREE_LINKED_WORK_ITEM_CONTEXT_RUNTIME_CAPABILITY]:
+    'Worktrees can store linked work-item context (issue/PR metadata).',
+  [FOLDER_WORKSPACE_PATH_STATUS_RUNTIME_CAPABILITY]:
+    'Folder workspaces report path/status health separate from git worktrees.',
+  [LINEAR_ISSUE_ATTRIBUTE_FILTER_RUNTIME_CAPABILITY]:
+    'Linear issue lists support attribute filters over RPC.',
+  [AI_VAULT_RUNTIME_CAPABILITY]:
+    'Agent Session History (aiVault.listSessions) is available on this host.',
+  [TERMINAL_QUERY_REPLY_INPUT_RUNTIME_CAPABILITY]:
+    'terminal.send accepts inputKind for xterm query replies without taking the floor.',
+  [TERMINAL_PAIRED_PARKING_RUNTIME_CAPABILITY]:
+    'Host can park paired terminals and return bounded scrollback for lossless reveal.',
+  [TERMINAL_QUICK_COMMANDS_RUNTIME_CAPABILITY]:
+    'Host supports Quick Commands / agentPrompt on terminal create and settings RPCs.',
+  [WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY]:
+    'worktree.create accepts clientMutationId for safe cutover retries.',
+  [TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY]:
+    'terminal.create accepts clientMutationId and can reconcile after a lost reply.',
+  [SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY]:
+    'Clients can publish session-tab close intents over shared remote control.',
+  [AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY]:
+    'Host publishes agent-session boundary events for multi-client session ownership.',
+  [REMOTE_SERVER_UPDATE_CAPABILITY]:
+    'Paired client may drive remote Orca server updates (updater.remote-control).',
+  [AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY]:
+    'Host-authoritative agent session resume/attach path is available.',
+  [AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY]:
+    'OMP (OpenCode multi-provider) sessions support the host resume path.',
+  [FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY]:
+    'File mutation RPCs accept ownership fences; older hosts strip them.',
+  [ACCOUNT_IMPORT_RUNTIME_CAPABILITY]:
+    'Host can import Claude/Codex credentials from the host environment into managed accounts.',
+  [CODEX_RESET_CREDIT_RUNTIME_CAPABILITY]: 'Host supports Codex reset-credit account operations.'
+} as const
+
+export function describeRuntimeCapabilities(
+  capabilities: readonly string[] | null | undefined
+): Record<string, string> {
+  const docs: Record<string, string> = {}
+  for (const name of capabilities ?? []) {
+    const doc = RUNTIME_CAPABILITY_DOCS[name]
+    if (doc) {
+      docs[name] = doc
+    }
+  }
+  return docs
+}
+
+/** Every static capability in RUNTIME_CAPABILITIES must have a doc entry. */
+export function listUndocumentedRuntimeCapabilities(): RuntimeCapability[] {
+  return RUNTIME_CAPABILITIES.filter((name) => !RUNTIME_CAPABILITY_DOCS[name])
+}


### PR DESCRIPTION
## Summary
- Adds a one-line semantics map for every static runtime capability flag (`RUNTIME_CAPABILITY_DOCS`).
- `orca status --json` now includes `runtime.capabilityDocs` for the advertised flags (client-side enrichment; no wire change).
- `orca status --help` notes describe how to use `capabilities` + `capabilityDocs`.
- Tests lock full catalog coverage and JSON enrichment.

## Why
Closes #13202 — status advertised ~31 bare flag names with no agent-readable semantics.

## Test plan
- [x] Unit: every `RUNTIME_CAPABILITIES` entry has a doc line
- [x] Unit: status --json attaches capabilityDocs for known flags only
- [ ] Manual: `orca status --json | jq '.result.runtime.capabilityDocs'`