### PR TITLE
fix(claude): offer Auto effort when the model catalog allows it

### DIFF
--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -61,6 +61,7 @@ const STANDARD_EFFORT_CHOICES = [
 ]
 
 const EXTENDED_EFFORT_CHOICES = [
+  { value: 'auto', label: 'Auto' },
   ...STANDARD_EFFORT_CHOICES,
   { value: 'xhigh', label: 'Extra high' },
   { value: 'max', label: 'Max' }

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { getAgentSessionOptionCatalog, mergeCatalogModels } from './agent-session-option-catalog'
+import { createClaudeCatalogOptions } from './agent-session-option-catalog-claude-codex'
 import { resolveAgentSessionOptionLaunch } from './agent-session-option-launch'
 import {
   resolveNativeChatSessionOptionDefaults,
@@ -17,6 +18,18 @@ describe('agent session option catalog', () => {
       catalog?.models.find((model) => model.id === 'opus')?.options.map(({ id }) => id)
     ).toEqual(['effort', 'fastMode'])
     expect(catalog?.models.find((model) => model.id === 'haiku')?.options).toEqual([])
+  })
+
+  it('offers Auto effort when the model catalog includes auto', () => {
+    const options = createClaudeCatalogOptions({
+      effortLevelIds: ['auto', 'low', 'medium', 'high', 'xhigh', 'max'],
+      supportsFastMode: true
+    })
+    const effort = options.find((option) => option.id === 'effort')
+    expect(effort?.kind).toMatchObject({
+      type: 'select',
+      choices: expect.arrayContaining([{ value: 'auto', label: 'Auto' }])
+    })
   })
 
   it('merges discovered labels while preserving cataloged option shapes', () => {

--- a/src/shared/claude-model-list-probe.test.ts
+++ b/src/shared/claude-model-list-probe.test.ts
@@ -111,4 +111,35 @@ describe('parseClaudeModelList', () => {
     )
     expect(parsed[0]?.effortLevels).toEqual([])
   })
+
+  it('prepends auto when supportsAutoMode is true', () => {
+    const parsed = parseClaudeModelList(
+      controlResponseLine([
+        {
+          value: 'opus[1m]',
+          displayName: 'Opus (1M context)',
+          supportsEffort: true,
+          supportedEffortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
+          supportsAutoMode: true,
+          supportsFastMode: true
+        }
+      ])
+    )
+    expect(parsed[0]?.effortLevels).toEqual(['auto', 'low', 'medium', 'high', 'xhigh', 'max'])
+  })
+
+  it('does not duplicate auto when the CLI already lists it', () => {
+    const parsed = parseClaudeModelList(
+      controlResponseLine([
+        {
+          value: 'sonnet',
+          displayName: 'Sonnet',
+          supportsEffort: true,
+          supportedEffortLevels: ['auto', 'low', 'high'],
+          supportsAutoMode: true
+        }
+      ])
+    )
+    expect(parsed[0]?.effortLevels).toEqual(['auto', 'low', 'high'])
+  })
 })

--- a/src/shared/claude-model-list-probe.ts
+++ b/src/shared/claude-model-list-probe.ts
@@ -53,6 +53,7 @@ type RawListedModel = {
   supportsEffort?: unknown
   supportedEffortLevels?: unknown
   supportsFastMode?: unknown
+  supportsAutoMode?: unknown
 }
 
 function toListedModel(value: unknown): ClaudeListedModel | null {
@@ -71,6 +72,11 @@ function toListedModel(value: unknown): ClaudeListedModel | null {
     raw.supportsEffort === true && Array.isArray(raw.supportedEffortLevels)
       ? raw.supportedEffortLevels.filter((level): level is string => typeof level === 'string')
       : []
+  // Why: Claude's /effort picker offers "auto" when supportsAutoMode is true, but
+  // the CLI does not always list "auto" inside supportedEffortLevels (#13208).
+  if (raw.supportsAutoMode === true && !effortLevels.includes('auto')) {
+    effortLevels.unshift('auto')
+  }
   return {
     id,
     label,


### PR DESCRIPTION
## Summary
- Parses Claude Code `supportsAutoMode` from `list_models` and prepends `auto` to effort levels when true.
- Adds **Auto** to the Claude effort select choices so the UI can show it (matching `/effort auto`).
- Tests cover probe parsing (including no-duplicate auto) and catalog choice presence.

## Why
Closes #13208 — catalog carried `supportsAutoMode: true` but Orca never read it, so Auto effort was never offered.

## Test plan
- [x] Unit: supportsAutoMode prepends auto
- [x] Unit: does not duplicate auto when already listed
- [x] Unit: createClaudeCatalogOptions includes Auto choice
- [ ] Manual: paired Claude pane effort selector shows Auto for Opus/Sonnet