### PR TITLE
feat(cli): fingerprint skill guides for cross-version drift audits

### DIFF
--- a/config/scripts/verify-cli-bin.mjs
+++ b/config/scripts/verify-cli-bin.mjs
@@ -5,15 +5,20 @@ import { chmodSync, mkdirSync, readFileSync, statSync, writeFileSync } from 'nod
 import path from 'node:path'
 import { pathToFileURL } from 'node:url'
 
-const OUT_COMMONJS_PACKAGE_JSON = `${JSON.stringify(
-  {
-    name: 'orca-compiled-output',
-    type: 'commonjs',
-    private: true
-  },
-  null,
-  2
-)}\n`
+function buildOutCommonjsPackageJson(version) {
+  return `${JSON.stringify(
+    {
+      name: 'orca-compiled-output',
+      type: 'commonjs',
+      private: true,
+      // Why: packaged CLI (ELECTRON_RUN_AS_NODE) has no ORCA_APP_VERSION; skill
+      // guide fingerprints read this version for cliVersion (#13210/#13216).
+      ...(typeof version === 'string' && version.trim() ? { version: version.trim() } : {})
+    },
+    null,
+    2
+  )}\n`
+}
 
 /**
  * Verifies the published CLI entrypoint and the module-type boundary for the
@@ -49,7 +54,7 @@ export function verifyPackageCliBin({
   const outPackageJsonPath = path.join(projectDir, 'out', 'package.json')
   if (fixPackageJson) {
     mkdirSync(path.dirname(outPackageJsonPath), { recursive: true })
-    writeFileSync(outPackageJsonPath, OUT_COMMONJS_PACKAGE_JSON, 'utf8')
+    writeFileSync(outPackageJsonPath, buildOutCommonjsPackageJson(packageJson.version), 'utf8')
   }
   let outPackageJson
   try {

--- a/config/scripts/verify-cli-bin.mjs
+++ b/config/scripts/verify-cli-bin.mjs
@@ -75,6 +75,14 @@ export function verifyPackageCliBin({
       )}`
     )
   }
+  if (outPackageJson.version !== packageJson.version) {
+    throw new Error(
+      `compiled CLI package boundary version must match package.json (${packageJson.version}): ${path.relative(
+        projectDir,
+        outPackageJsonPath
+      )}`
+    )
+  }
 
   if (process.platform !== 'win32' && (stats.mode & 0o111) === 0) {
     if (!fixExecutable) {

--- a/config/scripts/verify-cli-bin.test.mjs
+++ b/config/scripts/verify-cli-bin.test.mjs
@@ -23,7 +23,12 @@ function makeProjectWithCli(
   mkdirSync(path.dirname(cliPath), { recursive: true })
   writeFileSync(
     path.join(projectDir, 'package.json'),
-    JSON.stringify({ bin: { orca: './out/cli/index.js' }, type: rootPackageType }),
+    JSON.stringify({
+      name: 'orca',
+      version: '1.2.3-test',
+      bin: { orca: './out/cli/index.js' },
+      type: rootPackageType
+    }),
     'utf8'
   )
   if (writeOutPackageJson) {
@@ -73,7 +78,8 @@ describe('verifyPackageCliBin', () => {
     expect(JSON.parse(readFileSync(outPackageJsonPath, 'utf8'))).toEqual({
       name: 'orca-compiled-output',
       type: 'commonjs',
-      private: true
+      private: true,
+      version: '1.2.3-test'
     })
   })
 

--- a/config/scripts/verify-cli-bin.test.mjs
+++ b/config/scripts/verify-cli-bin.test.mjs
@@ -32,7 +32,11 @@ function makeProjectWithCli(
     'utf8'
   )
   if (writeOutPackageJson) {
-    writeFileSync(outPackageJsonPath, JSON.stringify({ type: 'commonjs' }), 'utf8')
+    writeFileSync(
+      outPackageJsonPath,
+      JSON.stringify({ type: 'commonjs', version: '1.2.3-test' }),
+      'utf8'
+    )
   }
   writeFileSync(cliPath, content, 'utf8')
   if (process.platform !== 'win32') {
@@ -90,6 +94,21 @@ describe('verifyPackageCliBin', () => {
     writeFileSync(outPackageJsonPath, JSON.stringify({ type: 'module' }), 'utf8')
 
     expect(() => verifyPackageCliBin({ projectDir })).toThrow('type=commonjs')
+  })
+
+  it('rejects a compiled package version that differs from the project', () => {
+    const { projectDir, outPackageJsonPath } = makeProjectWithCli(
+      '#!/usr/bin/env node\nconsole.log("orca")\n'
+    )
+    writeFileSync(
+      outPackageJsonPath,
+      JSON.stringify({ type: 'commonjs', version: '0.0.0-stale' }),
+      'utf8'
+    )
+
+    expect(() => verifyPackageCliBin({ projectDir })).toThrow(
+      'compiled CLI package boundary version must match package.json (1.2.3-test)'
+    )
   })
 
   it.skipIf(process.platform === 'win32')('can repair the POSIX executable bit', () => {

--- a/src/cli/handlers/skills.ts
+++ b/src/cli/handlers/skills.ts
@@ -1,6 +1,7 @@
 import { spawn } from 'node:child_process'
 import type { CommandHandler } from '../dispatch'
 import { RuntimeClientError } from '../runtime-client'
+import { skillGuideCliVersion, skillGuideContentSha256 } from '../skill-guide-fingerprint'
 import { delimiter, dirname } from 'node:path'
 import { getRepeatedStringFlag } from '../flags'
 import { resolveCliCommand } from '../../shared/node-cli-command-resolution'
@@ -329,11 +330,12 @@ export const SKILL_HANDLERS: Record<string, CommandHandler> = {
     // canonical sorting keeps agent-visible output reproducible across builds.
     const topics = guides.map((guide) => ({
       name: guide.name,
-      description: guide.description.replace(/\s+/g, ' ').trim()
+      description: guide.description.replace(/\s+/g, ' ').trim(),
+      contentSha256: skillGuideContentSha256(guide.markdown)
     }))
     writeStdout(
       json
-        ? JSON.stringify({ topics }, null, 2)
+        ? JSON.stringify({ cliVersion: skillGuideCliVersion(), topics }, null, 2)
         : topics.map((topic) => `${topic.name}: ${topic.description}`).join('\n')
     )
   },
@@ -344,7 +346,21 @@ export const SKILL_HANDLERS: Record<string, CommandHandler> = {
     const guide = requireTopic(flags, guides)
     const full = flags.has('full')
     const markdown = full ? guide.fullMarkdown : guide.markdown
-    writeStdout(json ? JSON.stringify({ name: guide.name, full, markdown }, null, 2) : markdown)
+    writeStdout(
+      json
+        ? JSON.stringify(
+            {
+              name: guide.name,
+              full,
+              cliVersion: skillGuideCliVersion(),
+              contentSha256: skillGuideContentSha256(markdown),
+              markdown
+            },
+            null,
+            2
+          )
+        : markdown
+    )
   },
   'skills install': createSkillMutationHandler('install'),
   'skills update': createSkillMutationHandler('update')

--- a/src/cli/skill-guide-fingerprint.test.ts
+++ b/src/cli/skill-guide-fingerprint.test.ts
@@ -1,0 +1,38 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { skillGuideCliVersion, skillGuideContentSha256 } from './skill-guide-fingerprint'
+
+describe('skillGuideContentSha256', () => {
+  it('returns a stable 64-hex digest', () => {
+    expect(skillGuideContentSha256('hello')).toMatch(/^[a-f0-9]{64}$/)
+    expect(skillGuideContentSha256('hello')).toBe(skillGuideContentSha256('hello'))
+    expect(skillGuideContentSha256('hello')).not.toBe(skillGuideContentSha256('world'))
+  })
+})
+
+describe('skillGuideCliVersion', () => {
+  afterEach(() => {
+    vi.unstubAllEnvs()
+  })
+
+  it('prefers ORCA_APP_VERSION', () => {
+    vi.stubEnv('ORCA_APP_VERSION', '9.9.9-env')
+    vi.stubEnv('npm_package_version', '0.0.1')
+    expect(skillGuideCliVersion()).toBe('9.9.9-env')
+  })
+
+  it('falls back to npm_package_version when ORCA_APP_VERSION is blank', () => {
+    vi.stubEnv('ORCA_APP_VERSION', '   ')
+    vi.stubEnv('npm_package_version', '2.3.4-npm')
+    expect(skillGuideCliVersion()).toBe('2.3.4-npm')
+  })
+
+  it('reads a nearby package.json version when env is unset', () => {
+    vi.stubEnv('ORCA_APP_VERSION', '')
+    vi.stubEnv('npm_package_version', '')
+    delete process.env.ORCA_APP_VERSION
+    delete process.env.npm_package_version
+    // Repo root package.json is named orca and walks from this test file.
+    expect(skillGuideCliVersion()).toMatch(/^\d+\.\d+/)
+    expect(skillGuideCliVersion()).not.toBe('unknown')
+  })
+})

--- a/src/cli/skill-guide-fingerprint.test.ts
+++ b/src/cli/skill-guide-fingerprint.test.ts
@@ -2,9 +2,11 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import { skillGuideCliVersion, skillGuideContentSha256 } from './skill-guide-fingerprint'
 
 describe('skillGuideContentSha256', () => {
-  it('returns a stable 64-hex digest', () => {
+  it('returns the expected SHA-256 digest', () => {
     expect(skillGuideContentSha256('hello')).toMatch(/^[a-f0-9]{64}$/)
-    expect(skillGuideContentSha256('hello')).toBe(skillGuideContentSha256('hello'))
+    expect(skillGuideContentSha256('hello')).toBe(
+      '2cf24dba5fb0a30e26e83b2ac5b9e29e1b161e5c1fa7425e73043362938b9824'
+    )
     expect(skillGuideContentSha256('hello')).not.toBe(skillGuideContentSha256('world'))
   })
 })

--- a/src/cli/skill-guide-fingerprint.ts
+++ b/src/cli/skill-guide-fingerprint.ts
@@ -1,0 +1,47 @@
+import { createHash } from 'node:crypto'
+import { existsSync, readFileSync } from 'node:fs'
+import path from 'node:path'
+
+export function skillGuideContentSha256(markdown: string): string {
+  return createHash('sha256').update(markdown, 'utf8').digest('hex')
+}
+
+/**
+ * CLI build identity for skill guide captures (#13210 drift audits).
+ * Packaged launchers do not set ORCA_APP_VERSION; fall back to out/package.json
+ * (written by verify-cli-bin with the app version) then the repo package.json.
+ */
+export function skillGuideCliVersion(): string {
+  const env = process.env.ORCA_APP_VERSION?.trim() || process.env.npm_package_version?.trim() || ''
+  if (env) {
+    return env
+  }
+  return readNearbyPackageVersion() ?? 'unknown'
+}
+
+function readNearbyPackageVersion(): string | undefined {
+  let dir = typeof __dirname === 'string' ? __dirname : process.cwd()
+  for (let i = 0; i < 8; i += 1) {
+    const candidate = path.join(dir, 'package.json')
+    if (existsSync(candidate)) {
+      try {
+        const pkg = JSON.parse(readFileSync(candidate, 'utf8')) as {
+          name?: string
+          version?: string
+        }
+        const version = typeof pkg.version === 'string' ? pkg.version.trim() : ''
+        if (version && (pkg.name === 'orca' || pkg.name === 'orca-compiled-output' || !pkg.name)) {
+          return version
+        }
+      } catch {
+        // keep walking
+      }
+    }
+    const parent = path.dirname(dir)
+    if (parent === dir) {
+      break
+    }
+    dir = parent
+  }
+  return undefined
+}

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -162,45 +162,63 @@ describe('orca skills CLI', () => {
 
   it('gives list --json a stable canonical schema', async () => {
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const previousAppVersion = process.env.ORCA_APP_VERSION
+    process.env.ORCA_APP_VERSION = '1.2.3-test'
 
-    await main(['skills', 'list', '--json'], '/tmp/repo')
+    try {
+      await main(['skills', 'list', '--json'], '/tmp/repo')
 
-    expect(stdoutText(stdoutSpy)).toBe(
-      `${JSON.stringify(
-        {
-          topics: [
-            { name: 'alpha', description: 'Use when alpha work is needed.' },
-            {
-              name: 'gamma',
-              description:
-                'Use when gamma work spans several sentences describing exactly how a ' +
-                'coding agent should decide whether gamma applies to the current task at hand.'
-            },
-            { name: 'zeta', description: 'Use when zeta work spans lines.' }
-          ]
-        },
-        null,
-        2
-      )}\n`
-    )
+      const payload = JSON.parse(stdoutText(stdoutSpy)) as {
+        cliVersion: string
+        topics: { name: string; description: string; contentSha256: string }[]
+      }
+      expect(payload.cliVersion).toBe('1.2.3-test')
+      expect(payload.topics.map((topic) => topic.name)).toEqual(['alpha', 'gamma', 'zeta'])
+      expect(payload.topics[0]).toEqual({
+        name: 'alpha',
+        description: 'Use when alpha work is needed.',
+        contentSha256: '7091aa3a419cfbb8e5e237bafe33bb067aafba3c747011b873b2150da308aaa3'
+      })
+      expect(payload.topics[1]?.description).toContain('gamma work spans several sentences')
+      expect(payload.topics[1]?.contentSha256).toMatch(/^[a-f0-9]{64}$/)
+      expect(payload.topics[2]?.name).toBe('zeta')
+    } finally {
+      if (previousAppVersion === undefined) {
+        delete process.env.ORCA_APP_VERSION
+      } else {
+        process.env.ORCA_APP_VERSION = previousAppVersion
+      }
+    }
   })
 
   it('gives alias get --json the canonical name, selection, and Markdown', async () => {
     const stdoutSpy = vi.spyOn(process.stdout, 'write').mockImplementation(() => true)
+    const previousAppVersion = process.env.ORCA_APP_VERSION
+    process.env.ORCA_APP_VERSION = '1.2.3-test'
 
-    await main(['skills', 'get', 'legacy-alpha', '--full', '--json'], '/tmp/repo')
+    try {
+      await main(['skills', 'get', 'legacy-alpha', '--full', '--json'], '/tmp/repo')
 
-    expect(stdoutText(stdoutSpy)).toBe(
-      `${JSON.stringify(
-        {
-          name: 'alpha',
-          full: true,
-          markdown: '# Alpha\n\nShort.\n\n## References\n\nFull.\n'
-        },
-        null,
-        2
-      )}\n`
-    )
+      expect(stdoutText(stdoutSpy)).toBe(
+        `${JSON.stringify(
+          {
+            name: 'alpha',
+            full: true,
+            cliVersion: '1.2.3-test',
+            contentSha256: 'd10bf6caa49cacb4acf3c285312492060b40198dafaf236ea5dda2e9997a84b6',
+            markdown: '# Alpha\n\nShort.\n\n## References\n\nFull.\n'
+          },
+          null,
+          2
+        )}\n`
+      )
+    } finally {
+      if (previousAppVersion === undefined) {
+        delete process.env.ORCA_APP_VERSION
+      } else {
+        process.env.ORCA_APP_VERSION = previousAppVersion
+      }
+    }
   })
 
   it('shows leaf, group, and root help for skills', async () => {

--- a/src/cli/specs/skills.ts
+++ b/src/cli/specs/skills.ts
@@ -9,7 +9,8 @@ export const SKILL_COMMAND_SPECS: CommandSpec[] = [
     allowedFlags: [...GLOBAL_FLAGS],
     notes: [
       'Reads bundled guide metadata locally without contacting the Orca runtime.',
-      'With --json, prints a topics array of canonical names and one-line descriptions.',
+      'With --json, prints cliVersion plus a topics array of canonical names, one-line descriptions, and contentSha256 of each short guide.',
+      'Store list/get --json captures per cliVersion to audit guide drift between Orca builds without hand-diffing.',
       'Use `orca skills get <name>` for the full guide, or `orca skills install` to install skills.'
     ]
   },
@@ -23,7 +24,7 @@ export const SKILL_COMMAND_SPECS: CommandSpec[] = [
     notes: [
       'Reads bundled guide content locally without contacting the Orca runtime.',
       'Use --full to include bundled reference documents when the guide provides them.',
-      'Use --json for a deterministic object containing canonical topic metadata and content.'
+      'Use --json for name, full, cliVersion, contentSha256, and markdown — pin captures by cliVersion and compare contentSha256 to detect drift (partial #13210; no historical --diff).'
     ],
     examples: ['orca skills get orca-cli', 'orca skills get orchestration --full']
   },


### PR DESCRIPTION
## ELI5

Orca's bundled skill guides can change between CLI versions. JSON callers now receive both the CLI version and an exact SHA-256 fingerprint, so they can cheaply detect drift before deciding whether to capture or compare guide contents.

## What Changed

- Add `cliVersion` and `contentSha256` to `skills list --json` and `skills get --json`.
- Resolve the CLI version from `ORCA_APP_VERSION`, then `npm_package_version`, then a nearby stamped `package.json`.
- Stamp the built CLI package metadata with the app version.
- Document capture-by-version drift audits without claiming a historical `--diff` feature.
- Add schema, version-fallback, build-stamping, and exact SHA-256 known-vector coverage.

## Why

Version-matched guides need a deterministic, low-cost way to prove whether content changed. A standard SHA-256 plus the producing CLI version provides that evidence without adding persistence, history, or a new diff command.

## Linked Issue

Addresses the fingerprinting portion of #13210; historical diff/changelog support remains out of scope.

## Visual Proof

N/A — this is a CLI JSON metadata and test change with no rendered UI.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

- `pnpm exec vitest run --config config/vitest.config.ts src/cli/skill-guide-fingerprint.test.ts` — 4/4 passed
- `pnpm exec vitest run --config config/vitest.config.ts src/cli` — 59 files, 750/750 passed on this branch
- `pnpm run typecheck` — passed
- `pnpm run lint` — passed, including reliability, max-lines, bundled-skill, and localization gates
- `pnpm exec oxfmt --check src/cli/skill-guide-fingerprint.test.ts` — passed
- `git diff --check` — passed
- SHA-256 oracle independently matched `shasum -a 256`, OpenSSL, and Node `crypto`

`pnpm test` was not run because this Node 24 checkout fails the patched `node-pty` native preflight before the suite starts. `pnpm build` was not rerun for the test-only review follow-up.

## AI Disclosure

OpenAI Codex implemented and verified the change. Grok 4.5 independently reviewed the final known-vector follow-up and returned `PASS`.

## Review

- Security: the digest uses Node's standard SHA-256 implementation and contains no secrets; no new trust or authentication decision depends on it.
- Cross-platform: UTF-8 hashing and package metadata lookup use Node APIs and path utilities; no platform-specific path literals were introduced.
- Remote/SSH: output is produced by the CLI process on the executing host and adds optional JSON fields only; no RPC or remote-wire shape changed.
- Backwards compatibility: existing JSON fields and text output remain intact; consumers may ignore the added fields.
- Performance: hashing is bounded to the already-loaded guide content and adds no network or persistent storage operation.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [ ] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- GitHub: @bbingz
