### PR TITLE
Allow sandboxed panels to read their plugin's own storage (storage.get/storage.keys)

### DIFF
--- a/src/main/plugins/plugin-host-conformance.test.ts
+++ b/src/main/plugins/plugin-host-conformance.test.ts
@@ -166,9 +166,12 @@ describe('plugin host main/relay conformance', () => {
   })
 
   it('serves panel storage reads through both transports with the storage capability', async () => {
-    const services = createServices()
-    const resolvePolicy = vi.fn().mockResolvedValue(createPolicy(['storage'], services))
-    for (const adapter of Object.values(createAdapters(resolvePolicy))) {
+    // Fresh service mocks per adapter so each transport's calls are asserted
+    // individually rather than in aggregate.
+    for (const adapterName of ['desktop-main', 'relay'] as const) {
+      const services = createServices()
+      const resolvePolicy = vi.fn().mockResolvedValue(createPolicy(['storage'], services))
+      const adapter = createAdapters(resolvePolicy)[adapterName]!
       await expect(
         adapter({ method: 'storage.get', params: { key: 'alpha' } }, true)
       ).resolves.toEqual({ ok: true, value: { value: 'stored' } })
@@ -176,9 +179,10 @@ describe('plugin host main/relay conformance', () => {
         ok: true,
         value: { keys: ['alpha'] }
       })
+      expect(services.storage.get, adapterName).toHaveBeenCalledExactlyOnceWith(PLUGIN_KEY, 'alpha')
+      expect(services.storage.keys, adapterName).toHaveBeenCalledExactlyOnceWith(PLUGIN_KEY)
+      expect(services.storage.set, adapterName).not.toHaveBeenCalled()
     }
-    expect(services.storage.get).toHaveBeenCalledWith(PLUGIN_KEY, 'alpha')
-    expect(services.storage.set).not.toHaveBeenCalled()
   })
 
   it('projects workspace context without host paths on main and relay', async () => {

--- a/src/main/plugins/plugin-host-conformance.test.ts
+++ b/src/main/plugins/plugin-host-conformance.test.ts
@@ -143,6 +143,44 @@ describe('plugin host main/relay conformance', () => {
     }
   })
 
+  it('keeps the panel surface read-only for plugin-private state', () => {
+    // No mutating plugin-private method and no secrets method may be panel-callable.
+    const panelActions = PLUGIN_HOST_API_V0.filter((entry) => entry.panel).map(
+      (entry) => entry.name
+    )
+    expect(panelActions).toEqual([
+      'workspace.readContext',
+      'terminal.sendText',
+      'notifications.show',
+      'storage.get',
+      'storage.keys'
+    ])
+    for (const entry of PLUGIN_HOST_API_V0) {
+      if (entry.panel && entry.scope === 'plugin-private') {
+        expect(entry.mutation, entry.name).toBe(false)
+      }
+      if (entry.name.startsWith('secrets.')) {
+        expect(entry.panel, entry.name).toBe(false)
+      }
+    }
+  })
+
+  it('serves panel storage reads through both transports with the storage capability', async () => {
+    const services = createServices()
+    const resolvePolicy = vi.fn().mockResolvedValue(createPolicy(['storage'], services))
+    for (const adapter of Object.values(createAdapters(resolvePolicy))) {
+      await expect(
+        adapter({ method: 'storage.get', params: { key: 'alpha' } }, true)
+      ).resolves.toEqual({ ok: true, value: { value: 'stored' } })
+      await expect(adapter({ method: 'storage.keys', params: {} }, true)).resolves.toEqual({
+        ok: true,
+        value: { keys: ['alpha'] }
+      })
+    }
+    expect(services.storage.get).toHaveBeenCalledWith(PLUGIN_KEY, 'alpha')
+    expect(services.storage.set).not.toHaveBeenCalled()
+  })
+
   it('projects workspace context without host paths on main and relay', async () => {
     const resolvePolicy = vi.fn().mockResolvedValue(createPolicy(['workspace:read']))
     for (const adapter of Object.values(createAdapters(resolvePolicy))) {
@@ -200,9 +238,16 @@ describe('plugin host main/relay conformance', () => {
     },
     {
       name: 'panel-forbidden method',
-      request: { method: 'storage.get', params: { key: 'alpha' } },
+      request: { method: 'storage.set', params: { key: 'alpha', value: 1 } },
       viaPanel: true,
       policy: () => createPolicy(['storage']),
+      code: 'panel_forbidden'
+    },
+    {
+      name: 'panel-forbidden secrets read',
+      request: { method: 'secrets.get', params: { key: 'alpha' } },
+      viaPanel: true,
+      policy: () => createPolicy(['secrets']),
       code: 'panel_forbidden'
     },
     {

--- a/src/shared/plugins/plugin-host-api.ts
+++ b/src/shared/plugins/plugin-host-api.ts
@@ -150,13 +150,15 @@ export const PLUGIN_HOST_API_V0: readonly PluginHostMethodSpec[] = [
     params: notificationsShowParams,
     result: notificationsShowResult
   }),
+  /** Panel-callable: the panel CSP blocks fetch, so reading own storage is a
+   *  panel's only data path from its worker. Mutations stay worker-only. */
   spec({
     name: 'storage.get',
     since: '1.0',
     scope: 'plugin-private',
     capability: 'storage',
     mutation: false,
-    panel: false,
+    panel: true,
     params: storageGetParams,
     result: storageGetResult
   }),
@@ -186,7 +188,7 @@ export const PLUGIN_HOST_API_V0: readonly PluginHostMethodSpec[] = [
     scope: 'plugin-private',
     capability: 'storage',
     mutation: false,
-    panel: false,
+    panel: true,
     params: storageKeysParams,
     result: storageKeysResult
   }),


### PR DESCRIPTION
# Allow sandboxed panels to read their plugin's own storage

## User-visible change

Plugin panels can now call `storage.get` and `storage.keys` over the panel
bridge (previously worker-only). This gives panels their first data path:
a plugin worker can prepare display data in its own storage and the panel can
read it live, instead of the only current workaround — regenerating the panel
entry HTML on disk, which defeats content hashing for installed plugins and
only refreshes on remount.

**No visual change.** No new UI; existing panels behave identically unless
their plugin starts using the new actions.

## Why this shape

- The panel shell CSP is `connect-src 'none'` by design, and workers cannot
  push to panels — so today a panel literally cannot display live data
  through any supported channel.
- `storage.get`/`storage.keys` are the two non-mutating, `plugin-private`
  scoped methods of the already-consented `storage` capability. Reading your
  own plugin's storage from your own plugin's panel crosses no trust
  boundary that the worker hasn't already crossed.
- The panel action surface, capability gate, bridge schema, and relay all
  derive from the spec table, so the change is two `panel:` flags; every
  enforcement point picks it up consistently (covered by the conformance
  suite on both desktop-main and relay transports).

## What stays locked down

- `storage.set` / `storage.delete` remain worker-only (a new conformance
  case uses `storage.set` via panel as the canonical `panel_forbidden`
  example).
- All `secrets.*` methods remain worker-only — a new invariant test asserts
  no secrets method and no mutating plugin-private method is ever
  panel-callable, so this can't regress silently.
- Capability gating is unchanged: a panel without consented `storage` gets
  `capability_denied`.
- Panel bridge byte/rate budgets apply to these actions like any other.

## Motivating use case

A read-only Hermes Kanban board panel (AVAS): a trusted worker polls a local
read-only API and maintains a snapshot; the sidebar panel needs to render it
live. Today this requires rewriting `panel/index.html` every poll cycle —
works only for dev plugins (hash-exempt) and refreshes only on remount. With
this change the worker writes to storage and the panel polls `storage.get`
within the existing budgets.

## Tests

- Conformance: panel-path success for `storage.get`/`storage.keys` on both
  transports; `storage.set` and `secrets.get` via panel remain
  `panel_forbidden`; exact panel action surface asserted.
- `pnpm lint`, `pnpm typecheck`, and the plugin suites
  (`src/shared/plugins/`, `src/main/plugins/`, renderer panel bridge host)
  pass.

## AI code review summary

Reviewed by the authoring agent for: cross-platform impact (none — shared,
Electron-free spec table; no platform-conditional code), SSH/remote/local
compatibility (relay conformance path exercises the same gate; results are
plain JSON over the existing panel action reply channel; no new wire opcode,
additive within the existing method call shape), agent/integration
compatibility (no agent-facing surface touched), performance (no hot-path
work added; panel calls remain budgeted), UI (no visual change), security
(read-only, plugin-private, capability-gated expansion; secrets and
mutations remain worker-only and are now invariant-tested). One note for
maintainers: storage values can be up to 256KB while panel → host request
budgets are 64KB; results flow on the reply channel like existing action
results, but if you prefer a result-size clamp for panel-path reads we're
happy to add one.

## Platform/remote notes

Behavior is identical across macOS/Linux/Windows and desktop/serve/relay —
enforced by the shared spec table and the conformance suite.
