### PR TITLE
fix(sidebar): disambiguate same-named projects by host role

### DIFF
--- a/src/renderer/src/lib/repo-display-labels.test.ts
+++ b/src/renderer/src/lib/repo-display-labels.test.ts
@@ -56,19 +56,20 @@ describe('getRepoDisplayLabelsByPath', () => {
     expect(labels.size).toBe(2)
   })
 
-  it('keeps cross-host repos with identical path AND name as separate entries', () => {
-    // Hardening: when paths are byte-identical the same-name collision loop runs
-    // and re-sets each entry, so host scoping must survive that pass too — neither
-    // host may overwrite the other. Label text can still coincide; that residual is
-    // disambiguated by the host section/badge, not this map.
-    const localRepo = { path: '/Users/alice', displayName: 'home' }
-    const sshRepo = { path: '/Users/alice', displayName: 'home', connectionId: 'prod-ssh' }
-    const labels = getRepoDisplayLabelsByPath([localRepo, sshRepo])
+  it('disambiguates cross-host same-name projects with Local/SSH/Remote roles', () => {
+    // Why: path-segment expansion cannot separate identical paths across hosts and
+    // used to fall through to near-absolute path labels (#13221).
+    const localRepo = { path: '/Users/me/workspace/foo', displayName: 'foo' }
+    const runtimeRepo = {
+      path: '/Users/me/workspace/foo',
+      displayName: 'foo',
+      executionHostId: 'runtime:env-1' as const
+    }
+    const labels = getRepoDisplayLabelsByPath([localRepo, runtimeRepo])
 
-    expect(getRepoDisplayLabelKey(localRepo)).not.toBe(getRepoDisplayLabelKey(sshRepo))
-    expect(labels.size).toBe(2)
-    expect(labels.get(getRepoDisplayLabelKey(localRepo))).toBeDefined()
-    expect(labels.get(getRepoDisplayLabelKey(sshRepo))).toBeDefined()
+    expect(getRepoDisplayLabelKey(localRepo)).not.toBe(getRepoDisplayLabelKey(runtimeRepo))
+    expect(labels.get(getRepoDisplayLabelKey(localRepo))).toBe('foo · Local')
+    expect(labels.get(getRepoDisplayLabelKey(runtimeRepo))).toBe('foo · Remote')
   })
 
   it('normalizes Windows separators to slash display labels', () => {

--- a/src/renderer/src/lib/repo-display-labels.test.ts
+++ b/src/renderer/src/lib/repo-display-labels.test.ts
@@ -72,6 +72,28 @@ describe('getRepoDisplayLabelsByPath', () => {
     expect(labels.get(getRepoDisplayLabelKey(runtimeRepo))).toBe('foo · Remote')
   })
 
+  it('path-expands same-role collisions before appending the host role', () => {
+    // Two Local apis must stay distinct when a Remote api joins the collision group.
+    const payments = { path: '/workspace/platform/payments/api', displayName: 'api' }
+    const billing = { path: '/workspace/platform/billing/api', displayName: 'api' }
+    const remote = {
+      path: '/workspace/platform/payments/api',
+      displayName: 'api',
+      executionHostId: 'runtime:env-1' as const
+    }
+    const ssh = {
+      path: '/workspace/platform/api',
+      displayName: 'api',
+      connectionId: 'ssh-prod'
+    }
+    const labels = getRepoDisplayLabelsByPath([payments, billing, remote, ssh])
+
+    expect(labels.get(getRepoDisplayLabelKey(payments))).toBe('payments/api · Local')
+    expect(labels.get(getRepoDisplayLabelKey(billing))).toBe('billing/api · Local')
+    expect(labels.get(getRepoDisplayLabelKey(remote))).toBe('api · Remote')
+    expect(labels.get(getRepoDisplayLabelKey(ssh))).toBe('api · SSH')
+  })
+
   it('normalizes Windows separators to slash display labels', () => {
     const labels = getRepoDisplayLabelsByPath([
       { path: 'C:\\workspace\\payments\\api', displayName: 'api' },

--- a/src/renderer/src/lib/repo-display-labels.ts
+++ b/src/renderer/src/lib/repo-display-labels.ts
@@ -1,4 +1,8 @@
-import { getRepoExecutionHostId, type ExecutionHostId } from '../../../shared/execution-host'
+import {
+  getRepoExecutionHostId,
+  parseExecutionHostId,
+  type ExecutionHostId
+} from '../../../shared/execution-host'
 
 type RepoDisplayLabelItem = {
   path: string
@@ -36,6 +40,20 @@ function hasDuplicateLabels(labels: readonly string[]): boolean {
   return new Set(labels).size !== labels.length
 }
 
+/** Compact host role for project headers when the same name exists on multiple hosts. */
+export function getRepoDisplayHostRole(
+  item: Pick<RepoDisplayLabelItem, 'connectionId' | 'executionHostId'>
+): 'Local' | 'SSH' | 'Remote' {
+  const parsed = parseExecutionHostId(getRepoExecutionHostId(item))
+  if (!parsed || parsed.kind === 'local') {
+    return 'Local'
+  }
+  if (parsed.kind === 'ssh') {
+    return 'SSH'
+  }
+  return 'Remote'
+}
+
 export function getRepoDisplayLabelsByPath(
   items: readonly RepoDisplayLabelItem[]
 ): Map<string, string> {
@@ -52,6 +70,19 @@ export function getRepoDisplayLabelsByPath(
 
   for (const collidingItems of itemsByName.values()) {
     if (collidingItems.length < 2) {
+      continue
+    }
+    // Why: same path+name across local/remote cannot be disambiguated by parent
+    // path segments — expanding to a full path is what #13221 reports. Prefer a
+    // Local/SSH/Remote role when hosts differ; keep path expansion for same-host clashes.
+    const hostRoles = new Set(collidingItems.map((item) => getRepoDisplayHostRole(item)))
+    if (hostRoles.size > 1) {
+      for (const item of collidingItems) {
+        labels.set(
+          getRepoDisplayLabelKey(item),
+          `${item.displayName} · ${getRepoDisplayHostRole(item)}`
+        )
+      }
       continue
     }
     const maxDepth = Math.max(

--- a/src/renderer/src/lib/repo-display-labels.ts
+++ b/src/renderer/src/lib/repo-display-labels.ts
@@ -73,31 +73,31 @@ export function getRepoDisplayLabelsByPath(
       continue
     }
     // Why: same path+name across local/remote cannot be disambiguated by parent
-    // path segments — expanding to a full path is what #13221 reports. Prefer a
-    // Local/SSH/Remote role when hosts differ; keep path expansion for same-host clashes.
+    // path alone (#13221). Path-expand within each host role first so two Local
+    // apis stay payments/api vs billing/api, then append Local/SSH/Remote when
+    // the collision group spans more than one role.
     const hostRoles = new Set(collidingItems.map((item) => getRepoDisplayHostRole(item)))
-    if (hostRoles.size > 1) {
-      for (const item of collidingItems) {
-        labels.set(
-          getRepoDisplayLabelKey(item),
-          `${item.displayName} · ${getRepoDisplayHostRole(item)}`
-        )
+    const appendHostRole = hostRoles.size > 1
+    const itemsByRole = new Map<string, RepoDisplayLabelItem[]>()
+    for (const item of collidingItems) {
+      const role = getRepoDisplayHostRole(item)
+      const group = itemsByRole.get(role) ?? []
+      group.push(item)
+      itemsByRole.set(role, group)
+    }
+    for (const [role, roleItems] of itemsByRole) {
+      const maxDepth = Math.max(...roleItems.map((item) => normalizePathSegments(item.path).length))
+      let depth = 1
+      let nextLabels = roleItems.map((item) => labelForDepth(item, depth))
+      while (depth < maxDepth && hasDuplicateLabels(nextLabels)) {
+        depth += 1
+        nextLabels = roleItems.map((item) => labelForDepth(item, depth))
       }
-      continue
+      roleItems.forEach((item, index) => {
+        const base = nextLabels[index] ?? item.displayName
+        labels.set(getRepoDisplayLabelKey(item), appendHostRole ? `${base} · ${role}` : base)
+      })
     }
-    const maxDepth = Math.max(
-      ...collidingItems.map((item) => normalizePathSegments(item.path).length)
-    )
-    let depth = 1
-    let nextLabels = collidingItems.map((item) => labelForDepth(item, depth))
-    while (depth < maxDepth && hasDuplicateLabels(nextLabels)) {
-      depth += 1
-      nextLabels = collidingItems.map((item) => labelForDepth(item, depth))
-    }
-    collidingItems.forEach((item, index) => {
-      labels.set(getRepoDisplayLabelKey(item), nextLabels[index] ?? item.displayName)
-    })
   }
-
   return labels
 }


### PR DESCRIPTION
## Summary
- Cross-host project name collisions now render as `foo · Local` / `foo · Remote` / `foo · SSH` instead of expanding into a near-full absolute path.
- Same-host basename collisions still use minimal parent path segments.
- Host-scoped keys unchanged so Local and Remote entries stay distinct.

## Why
Closes #13221 — Local + remote-runtime projects sharing a path/name fell through path disambiguation to full-path labels with no Local/Remote cue.

## Test plan
- [x] Unit: cross-host same path+name → Local/Remote roles
- [x] Existing same-host path collision tests still pass
- [ ] Manual: open same repo as Local and via remote runtime; sidebar shows `name · Local` and `name · Remote`