### PR TITLE
feat(editor): resize CSV table columns

### DIFF
--- a/src/renderer/src/components/editor/CsvColumnResizeHandle.tsx
+++ b/src/renderer/src/components/editor/CsvColumnResizeHandle.tsx
@@ -1,9 +1,10 @@
-import React, { useEffect, useEffectEvent, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useEffectEvent, useRef, useState } from 'react'
 import { translate } from '@/i18n/i18n'
-import { MIN_CSV_COLUMN_WIDTH } from './csv-column-widths'
+import { MAX_CSV_COLUMN_WIDTH, MIN_CSV_COLUMN_WIDTH } from './csv-column-widths'
 
 type CsvColumnResizeHandleProps = {
   columnIndex: number
+  columnLabel: string
   currentWidth: number
   onResize: (columnIndex: number, width: number) => void
 }
@@ -12,43 +13,64 @@ const KEYBOARD_STEP = 16
 
 export default function CsvColumnResizeHandle({
   columnIndex,
+  columnLabel,
   currentWidth,
   onResize
 }: CsvColumnResizeHandleProps): React.JSX.Element {
   const [dragging, setDragging] = useState(false)
-  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const dragRef = useRef<{
+    pointerId: number
+    startX: number
+    startWidth: number
+    previousCursor: string
+    previousUserSelect: string
+  } | null>(null)
   const notifyResize = useEffectEvent(onResize)
+
+  const stopResize = useCallback((): void => {
+    const drag = dragRef.current
+    if (!drag) {
+      return
+    }
+    dragRef.current = null
+    document.body.style.cursor = drag.previousCursor
+    document.body.style.userSelect = drag.previousUserSelect
+    setDragging(false)
+  }, [])
 
   useEffect(() => {
     if (!dragging) {
       return
     }
-    const onMove = (event: MouseEvent): void => {
+    const onMove = (event: PointerEvent): void => {
       const drag = dragRef.current
-      if (drag) {
+      if (drag?.pointerId === event.pointerId) {
         notifyResize(
           columnIndex,
-          Math.max(MIN_CSV_COLUMN_WIDTH, drag.startWidth + event.clientX - drag.startX)
+          Math.min(
+            MAX_CSV_COLUMN_WIDTH,
+            Math.max(MIN_CSV_COLUMN_WIDTH, drag.startWidth + event.clientX - drag.startX)
+          )
         )
       }
     }
-    const onUp = (): void => {
-      dragRef.current = null
-      setDragging(false)
+    const onEnd = (event: PointerEvent): void => {
+      if (dragRef.current?.pointerId === event.pointerId) {
+        stopResize()
+      }
     }
-    document.addEventListener('mousemove', onMove)
-    document.addEventListener('mouseup', onUp)
-    const previousCursor = document.body.style.cursor
-    const previousUserSelect = document.body.style.userSelect
-    document.body.style.cursor = 'col-resize'
-    document.body.style.userSelect = 'none'
+    window.addEventListener('pointermove', onMove)
+    window.addEventListener('pointerup', onEnd)
+    window.addEventListener('pointercancel', onEnd)
+    window.addEventListener('blur', stopResize)
     return () => {
-      document.removeEventListener('mousemove', onMove)
-      document.removeEventListener('mouseup', onUp)
-      document.body.style.cursor = previousCursor
-      document.body.style.userSelect = previousUserSelect
+      window.removeEventListener('pointermove', onMove)
+      window.removeEventListener('pointerup', onEnd)
+      window.removeEventListener('pointercancel', onEnd)
+      window.removeEventListener('blur', stopResize)
+      stopResize()
     }
-  }, [columnIndex, dragging])
+  }, [columnIndex, dragging, stopResize])
 
   return (
     <div
@@ -56,18 +78,28 @@ export default function CsvColumnResizeHandle({
       aria-orientation="vertical"
       aria-label={translate(
         'auto.components.editor.CsvColumnResizeHandle.resizeColumn',
-        'Resize column'
+        'Resize column {{value0}}',
+        { value0: columnLabel }
       )}
       aria-valuemin={MIN_CSV_COLUMN_WIDTH}
+      aria-valuemax={MAX_CSV_COLUMN_WIDTH}
       aria-valuenow={Math.round(currentWidth)}
       tabIndex={0}
       className="group absolute -right-1.5 top-0 z-30 flex h-full w-3 cursor-col-resize items-stretch justify-center outline-none"
-      onMouseDown={(event) => {
+      onPointerDown={(event) => {
         if (event.button !== 0) {
           return
         }
         event.preventDefault()
-        dragRef.current = { startX: event.clientX, startWidth: currentWidth }
+        dragRef.current = {
+          pointerId: event.pointerId,
+          startX: event.clientX,
+          startWidth: currentWidth,
+          previousCursor: document.body.style.cursor,
+          previousUserSelect: document.body.style.userSelect
+        }
+        document.body.style.cursor = 'col-resize'
+        document.body.style.userSelect = 'none'
         setDragging(true)
       }}
       onKeyDown={(event) => {
@@ -78,7 +110,10 @@ export default function CsvColumnResizeHandle({
         const direction = event.key === 'ArrowLeft' ? -1 : 1
         onResize(
           columnIndex,
-          Math.max(MIN_CSV_COLUMN_WIDTH, currentWidth + direction * KEYBOARD_STEP)
+          Math.min(
+            MAX_CSV_COLUMN_WIDTH,
+            Math.max(MIN_CSV_COLUMN_WIDTH, currentWidth + direction * KEYBOARD_STEP)
+          )
         )
       }}
     >

--- a/src/renderer/src/components/editor/CsvColumnResizeHandle.tsx
+++ b/src/renderer/src/components/editor/CsvColumnResizeHandle.tsx
@@ -1,0 +1,92 @@
+import React, { useEffect, useEffectEvent, useRef, useState } from 'react'
+import { translate } from '@/i18n/i18n'
+import { MIN_CSV_COLUMN_WIDTH } from './csv-column-widths'
+
+type CsvColumnResizeHandleProps = {
+  columnIndex: number
+  currentWidth: number
+  onResize: (columnIndex: number, width: number) => void
+}
+
+const KEYBOARD_STEP = 16
+
+export default function CsvColumnResizeHandle({
+  columnIndex,
+  currentWidth,
+  onResize
+}: CsvColumnResizeHandleProps): React.JSX.Element {
+  const [dragging, setDragging] = useState(false)
+  const dragRef = useRef<{ startX: number; startWidth: number } | null>(null)
+  const notifyResize = useEffectEvent(onResize)
+
+  useEffect(() => {
+    if (!dragging) {
+      return
+    }
+    const onMove = (event: MouseEvent): void => {
+      const drag = dragRef.current
+      if (drag) {
+        notifyResize(
+          columnIndex,
+          Math.max(MIN_CSV_COLUMN_WIDTH, drag.startWidth + event.clientX - drag.startX)
+        )
+      }
+    }
+    const onUp = (): void => {
+      dragRef.current = null
+      setDragging(false)
+    }
+    document.addEventListener('mousemove', onMove)
+    document.addEventListener('mouseup', onUp)
+    const previousCursor = document.body.style.cursor
+    const previousUserSelect = document.body.style.userSelect
+    document.body.style.cursor = 'col-resize'
+    document.body.style.userSelect = 'none'
+    return () => {
+      document.removeEventListener('mousemove', onMove)
+      document.removeEventListener('mouseup', onUp)
+      document.body.style.cursor = previousCursor
+      document.body.style.userSelect = previousUserSelect
+    }
+  }, [columnIndex, dragging])
+
+  return (
+    <div
+      role="separator"
+      aria-orientation="vertical"
+      aria-label={translate(
+        'auto.components.editor.CsvColumnResizeHandle.resizeColumn',
+        'Resize column'
+      )}
+      aria-valuemin={MIN_CSV_COLUMN_WIDTH}
+      aria-valuenow={Math.round(currentWidth)}
+      tabIndex={0}
+      className="group absolute -right-1.5 top-0 z-30 flex h-full w-3 cursor-col-resize items-stretch justify-center outline-none"
+      onMouseDown={(event) => {
+        if (event.button !== 0) {
+          return
+        }
+        event.preventDefault()
+        dragRef.current = { startX: event.clientX, startWidth: currentWidth }
+        setDragging(true)
+      }}
+      onKeyDown={(event) => {
+        if (event.key !== 'ArrowLeft' && event.key !== 'ArrowRight') {
+          return
+        }
+        event.preventDefault()
+        const direction = event.key === 'ArrowLeft' ? -1 : 1
+        onResize(
+          columnIndex,
+          Math.max(MIN_CSV_COLUMN_WIDTH, currentWidth + direction * KEYBOARD_STEP)
+        )
+      }}
+    >
+      <span
+        className={`h-full w-px transition-colors ${
+          dragging ? 'bg-ring' : 'bg-transparent group-hover:bg-ring/50 group-focus-visible:bg-ring'
+        }`}
+      />
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/CsvViewer.test.tsx
+++ b/src/renderer/src/components/editor/CsvViewer.test.tsx
@@ -23,7 +23,7 @@ describe('CSV column resizing', () => {
     const view = render(
       <CsvViewer
         content={'Name,Description\nAda,Short\nGrace,Longer value'}
-        filePath="people.csv"
+        filePath="drag.csv"
       />
     )
     const header = view.getAllByRole('row')[0] as HTMLElement
@@ -32,22 +32,22 @@ describe('CSV column resizing', () => {
     expect(header.style.gridTemplateColumns).toBe('48px 80px 108px')
     expect(firstDataRow.style.gridTemplateColumns).toBe(header.style.gridTemplateColumns)
 
-    const handles = view.getAllByRole('separator', { name: 'Resize column' })
-    fireEvent.mouseDown(handles[0]!, { button: 0, clientX: 100 })
+    const handles = view.getAllByRole('separator', { name: 'Resize column Name' })
+    fireEvent.pointerDown(handles[0]!, { button: 0, clientX: 100, pointerId: 1 })
     expect(document.body.style.cursor).toBe('col-resize')
-    fireEvent.mouseMove(document, { clientX: 160 })
+    fireEvent.pointerMove(window, { clientX: 160, pointerId: 1 })
 
     expect(header.style.gridTemplateColumns).toBe('48px 140px 108px')
     expect(firstDataRow.style.gridTemplateColumns).toBe(header.style.gridTemplateColumns)
 
-    fireEvent.mouseUp(document)
+    fireEvent.pointerUp(window, { pointerId: 1 })
     expect(document.body.style.cursor).toBe('')
   })
 
   it('supports keyboard resizing and clamps to the minimum width', () => {
-    const view = render(<CsvViewer content={'Name\nAda'} filePath="people.csv" />)
+    const view = render(<CsvViewer content={'Name\nAda'} filePath="keyboard.csv" />)
     const header = view.getAllByRole('row')[0] as HTMLElement
-    const handle = view.getByRole('separator', { name: 'Resize column' })
+    const handle = view.getByRole('separator', { name: 'Resize column Name' })
 
     fireEvent.keyDown(handle, { key: 'ArrowLeft' })
     expect(header.style.gridTemplateColumns).toBe('48px 80px')
@@ -55,24 +55,38 @@ describe('CSV column resizing', () => {
     fireEvent.keyDown(handle, { key: 'ArrowRight' })
     expect(header.style.gridTemplateColumns).toBe('48px 96px')
     expect(handle.getAttribute('aria-valuenow')).toBe('96')
+    expect(handle.getAttribute('aria-valuemax')).toBe('10000')
   })
 
-  it('keeps resized widths across content updates and resets them for another file', () => {
-    const view = render(<CsvViewer content={'Name\nAda'} filePath="people.csv" />)
-    let handle = view.getByRole('separator', { name: 'Resize column' })
+  it('keeps resized widths across content updates and remounts', () => {
+    const view = render(<CsvViewer content={'Name\nAda'} filePath="persistent.csv" />)
+    const handle = view.getByRole('separator', { name: 'Resize column Name' })
 
-    fireEvent.mouseDown(handle, { button: 0, clientX: 100 })
-    fireEvent.mouseMove(document, { clientX: 160 })
-    fireEvent.mouseUp(document)
+    fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 2 })
+    fireEvent.pointerMove(window, { clientX: 160, pointerId: 2 })
+    fireEvent.pointerUp(window, { pointerId: 2 })
 
-    view.rerender(<CsvViewer content={'Name\nAda\nGrace'} filePath="people.csv" />)
+    view.rerender(<CsvViewer content={'Name\nAda\nGrace'} filePath="persistent.csv" />)
     expect((view.getAllByRole('row')[0] as HTMLElement).style.gridTemplateColumns).toBe(
       '48px 140px'
     )
 
-    view.rerender(<CsvViewer content={'Code\nA'} filePath="codes.csv" />)
-    handle = view.getByRole('separator', { name: 'Resize column' })
-    expect((view.getAllByRole('row')[0] as HTMLElement).style.gridTemplateColumns).toBe('48px 80px')
-    expect(handle.getAttribute('aria-valuenow')).toBe('80')
+    view.unmount()
+    const reopened = render(<CsvViewer content={'Name\nAda\nGrace'} filePath="persistent.csv" />)
+    expect((reopened.getAllByRole('row')[0] as HTMLElement).style.gridTemplateColumns).toBe(
+      '48px 140px'
+    )
+  })
+
+  it('restores cursor and selection when a drag is interrupted', () => {
+    const view = render(<CsvViewer content={'Name\nAda'} filePath="cancel.csv" />)
+    const handle = view.getByRole('separator', { name: 'Resize column Name' })
+
+    fireEvent.pointerDown(handle, { button: 0, clientX: 100, pointerId: 3 })
+    expect(document.body.style.userSelect).toBe('none')
+
+    fireEvent.blur(window)
+    expect(document.body.style.cursor).toBe('')
+    expect(document.body.style.userSelect).toBe('')
   })
 })

--- a/src/renderer/src/components/editor/CsvViewer.test.tsx
+++ b/src/renderer/src/components/editor/CsvViewer.test.tsx
@@ -1,0 +1,78 @@
+// @vitest-environment happy-dom
+
+import { cleanup, fireEvent, render } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import CsvViewer from './CsvViewer'
+
+vi.mock('@tanstack/react-virtual', () => ({
+  useVirtualizer: ({ count }: { count: number }) => ({
+    getTotalSize: () => count * 28,
+    getVirtualItems: () =>
+      Array.from({ length: count }, (_, index) => ({
+        index,
+        key: index,
+        start: index * 28
+      }))
+  })
+}))
+
+afterEach(cleanup)
+
+describe('CSV column resizing', () => {
+  it('resizes a column by dragging its header boundary', () => {
+    const view = render(
+      <CsvViewer
+        content={'Name,Description\nAda,Short\nGrace,Longer value'}
+        filePath="people.csv"
+      />
+    )
+    const header = view.getAllByRole('row')[0] as HTMLElement
+    const firstDataRow = view.getAllByRole('row')[1] as HTMLElement
+
+    expect(header.style.gridTemplateColumns).toBe('48px 80px 108px')
+    expect(firstDataRow.style.gridTemplateColumns).toBe(header.style.gridTemplateColumns)
+
+    const handles = view.getAllByRole('separator', { name: 'Resize column' })
+    fireEvent.mouseDown(handles[0]!, { button: 0, clientX: 100 })
+    expect(document.body.style.cursor).toBe('col-resize')
+    fireEvent.mouseMove(document, { clientX: 160 })
+
+    expect(header.style.gridTemplateColumns).toBe('48px 140px 108px')
+    expect(firstDataRow.style.gridTemplateColumns).toBe(header.style.gridTemplateColumns)
+
+    fireEvent.mouseUp(document)
+    expect(document.body.style.cursor).toBe('')
+  })
+
+  it('supports keyboard resizing and clamps to the minimum width', () => {
+    const view = render(<CsvViewer content={'Name\nAda'} filePath="people.csv" />)
+    const header = view.getAllByRole('row')[0] as HTMLElement
+    const handle = view.getByRole('separator', { name: 'Resize column' })
+
+    fireEvent.keyDown(handle, { key: 'ArrowLeft' })
+    expect(header.style.gridTemplateColumns).toBe('48px 80px')
+
+    fireEvent.keyDown(handle, { key: 'ArrowRight' })
+    expect(header.style.gridTemplateColumns).toBe('48px 96px')
+    expect(handle.getAttribute('aria-valuenow')).toBe('96')
+  })
+
+  it('keeps resized widths across content updates and resets them for another file', () => {
+    const view = render(<CsvViewer content={'Name\nAda'} filePath="people.csv" />)
+    let handle = view.getByRole('separator', { name: 'Resize column' })
+
+    fireEvent.mouseDown(handle, { button: 0, clientX: 100 })
+    fireEvent.mouseMove(document, { clientX: 160 })
+    fireEvent.mouseUp(document)
+
+    view.rerender(<CsvViewer content={'Name\nAda\nGrace'} filePath="people.csv" />)
+    expect((view.getAllByRole('row')[0] as HTMLElement).style.gridTemplateColumns).toBe(
+      '48px 140px'
+    )
+
+    view.rerender(<CsvViewer content={'Code\nA'} filePath="codes.csv" />)
+    handle = view.getByRole('separator', { name: 'Resize column' })
+    expect((view.getAllByRole('row')[0] as HTMLElement).style.gridTemplateColumns).toBe('48px 80px')
+    expect(handle.getAttribute('aria-valuenow')).toBe('80')
+  })
+})

--- a/src/renderer/src/components/editor/CsvViewer.tsx
+++ b/src/renderer/src/components/editor/CsvViewer.tsx
@@ -12,6 +12,7 @@ type CsvViewerProps = {
 
 const ROW_HEIGHT = 28
 const OVERSCAN = 12
+const resizedCsvColumnsByFile = new Map<string, Record<number, number>>()
 
 // Why: CsvViewer is the table counterpart to source-mode Monaco for .csv/.tsv
 // files. Row virtualization via @tanstack/react-virtual keeps large files
@@ -47,27 +48,44 @@ export default function CsvViewer({ content, filePath }: CsvViewerProps): React.
     }
     return out
   }, [headerRow, columnCount])
+  const headerColumns = useMemo(() => {
+    const occurrences = new Map<string, number>()
+    return header.map((label) => {
+      const occurrence = occurrences.get(label) ?? 0
+      occurrences.set(label, occurrence + 1)
+      return { key: `${label}:${occurrence}`, label }
+    })
+  }, [header])
 
-  // Why: user overrides survive content updates but reset when this viewer is
-  // reused for another file. Unresized columns continue to follow auto-sizing.
+  // Why: session-scoped per-file overrides survive tab/view remounts without
+  // persisting workspace-specific paths. Unresized columns still auto-size.
   const [resizedColumns, setResizedColumns] = useState<{
     filePath: string
     widths: Record<number, number>
-  }>({ filePath, widths: {} })
+  }>({ filePath, widths: resizedCsvColumnsByFile.get(filePath) ?? {} })
   const autoColumnWidths = useMemo(
     () => getCsvColumnWidths(header, bodyRows, columnCount),
     [header, bodyRows, columnCount]
   )
   const columnWidths = useMemo(() => {
-    const overrides = resizedColumns.filePath === filePath ? resizedColumns.widths : {}
+    const overrides =
+      resizedColumns.filePath === filePath
+        ? resizedColumns.widths
+        : (resizedCsvColumnsByFile.get(filePath) ?? {})
     return autoColumnWidths.map((width, index) => overrides[index] ?? width)
   }, [autoColumnWidths, filePath, resizedColumns])
   const resizeColumn = useCallback(
     (index: number, width: number): void => {
-      setResizedColumns((current) => ({
-        filePath,
-        widths: { ...(current.filePath === filePath ? current.widths : {}), [index]: width }
-      }))
+      setResizedColumns((current) => {
+        const widths = {
+          ...(current.filePath === filePath
+            ? current.widths
+            : (resizedCsvColumnsByFile.get(filePath) ?? {})),
+          [index]: width
+        }
+        resizedCsvColumnsByFile.set(filePath, widths)
+        return { filePath, widths }
+      })
     },
     [filePath]
   )
@@ -117,17 +135,18 @@ export default function CsvViewer({ content, filePath }: CsvViewerProps): React.
             >
               #
             </div>
-            {header.map((cell, idx) => (
+            {headerColumns.map(({ key, label }, idx) => (
               <div
                 role="columnheader"
-                key={idx}
+                key={key}
                 className="relative flex items-center border-b border-r border-border/60 px-2 font-medium text-foreground"
               >
-                <span className="min-w-0 truncate" title={cell}>
-                  {cell}
+                <span className="min-w-0 truncate" title={label}>
+                  {label}
                 </span>
                 <CsvColumnResizeHandle
                   columnIndex={idx}
+                  columnLabel={label || String(idx + 1)}
                   currentWidth={columnWidths[idx]!}
                   onResize={resizeColumn}
                 />

--- a/src/renderer/src/components/editor/CsvViewer.tsx
+++ b/src/renderer/src/components/editor/CsvViewer.tsx
@@ -1,7 +1,9 @@
-import React, { useMemo, useRef } from 'react'
+import React, { useCallback, useMemo, useRef, useState } from 'react'
 import { useVirtualizer } from '@tanstack/react-virtual'
 import { detectCsvDelimiter, parseCsv } from './csv-parse'
 import { translate } from '@/i18n/i18n'
+import CsvColumnResizeHandle from './CsvColumnResizeHandle'
+import { getCsvColumnWidths, getCsvGridTemplate } from './csv-column-widths'
 
 type CsvViewerProps = {
   content: string
@@ -10,10 +12,6 @@ type CsvViewerProps = {
 
 const ROW_HEIGHT = 28
 const OVERSCAN = 12
-const MIN_COL_PX = 80
-const MAX_COL_PX = 320
-const ROW_NUMBER_COL_PX = 48
-const CHAR_PX = 7
 
 // Why: CsvViewer is the table counterpart to source-mode Monaco for .csv/.tsv
 // files. Row virtualization via @tanstack/react-virtual keeps large files
@@ -50,36 +48,30 @@ export default function CsvViewer({ content, filePath }: CsvViewerProps): React.
     return out
   }, [headerRow, columnCount])
 
-  // Why: size each column to its widest-seen value (sampled) so headers and
-  // body cells stay aligned. We cap sampling to the first 200 rows to avoid
-  // scanning huge files; uncommon long values clip with ellipsis rather than
-  // blowing out the viewport width.
-  const columnWidths = useMemo(() => {
-    const widths = Array.from<number>({ length: columnCount }).fill(MIN_COL_PX)
-    const consider = (cell: string | undefined, idx: number): void => {
-      if (!cell) {
-        return
-      }
-      const w = Math.min(MAX_COL_PX, Math.max(MIN_COL_PX, cell.length * CHAR_PX + 24))
-      if (w > widths[idx]!) {
-        widths[idx] = w
-      }
-    }
-    header.forEach(consider)
-    const sampleLimit = Math.min(bodyRows.length, 200)
-    for (let i = 0; i < sampleLimit; i += 1) {
-      const row = bodyRows[i]!
-      for (let c = 0; c < columnCount; c += 1) {
-        consider(row[c], c)
-      }
-    }
-    return widths
-  }, [header, bodyRows, columnCount])
-
-  const gridTemplate = useMemo(
-    () => `${ROW_NUMBER_COL_PX}px ${columnWidths.map((w) => `${w}px`).join(' ')}`,
-    [columnWidths]
+  // Why: user overrides survive content updates but reset when this viewer is
+  // reused for another file. Unresized columns continue to follow auto-sizing.
+  const [resizedColumns, setResizedColumns] = useState<{
+    filePath: string
+    widths: Record<number, number>
+  }>({ filePath, widths: {} })
+  const autoColumnWidths = useMemo(
+    () => getCsvColumnWidths(header, bodyRows, columnCount),
+    [header, bodyRows, columnCount]
   )
+  const columnWidths = useMemo(() => {
+    const overrides = resizedColumns.filePath === filePath ? resizedColumns.widths : {}
+    return autoColumnWidths.map((width, index) => overrides[index] ?? width)
+  }, [autoColumnWidths, filePath, resizedColumns])
+  const resizeColumn = useCallback(
+    (index: number, width: number): void => {
+      setResizedColumns((current) => ({
+        filePath,
+        widths: { ...(current.filePath === filePath ? current.widths : {}), [index]: width }
+      }))
+    },
+    [filePath]
+  )
+  const gridTemplate = useMemo(() => getCsvGridTemplate(columnWidths), [columnWidths])
 
   const virtualizer = useVirtualizer({
     count: bodyRows.length,
@@ -129,11 +121,16 @@ export default function CsvViewer({ content, filePath }: CsvViewerProps): React.
               <div
                 role="columnheader"
                 key={idx}
-                className="flex items-center overflow-hidden border-b border-r border-border/60 px-2 font-medium text-foreground"
+                className="relative flex items-center border-b border-r border-border/60 px-2 font-medium text-foreground"
               >
-                <span className="truncate" title={cell}>
+                <span className="min-w-0 truncate" title={cell}>
                   {cell}
                 </span>
+                <CsvColumnResizeHandle
+                  columnIndex={idx}
+                  currentWidth={columnWidths[idx]!}
+                  onResize={resizeColumn}
+                />
               </div>
             ))}
           </div>

--- a/src/renderer/src/components/editor/csv-column-widths.ts
+++ b/src/renderer/src/components/editor/csv-column-widths.ts
@@ -4,6 +4,7 @@ const CELL_HORIZONTAL_PADDING = 24
 const CHARACTER_WIDTH = 7
 
 export const MIN_CSV_COLUMN_WIDTH = AUTO_MIN_COLUMN_WIDTH
+export const MAX_CSV_COLUMN_WIDTH = 10_000
 export const CSV_ROW_NUMBER_COLUMN_WIDTH = 48
 
 // Sample a bounded prefix so opening a large CSV does not scan every cell.

--- a/src/renderer/src/components/editor/csv-column-widths.ts
+++ b/src/renderer/src/components/editor/csv-column-widths.ts
@@ -1,0 +1,43 @@
+const AUTO_MIN_COLUMN_WIDTH = 80
+const AUTO_MAX_COLUMN_WIDTH = 320
+const CELL_HORIZONTAL_PADDING = 24
+const CHARACTER_WIDTH = 7
+
+export const MIN_CSV_COLUMN_WIDTH = AUTO_MIN_COLUMN_WIDTH
+export const CSV_ROW_NUMBER_COLUMN_WIDTH = 48
+
+// Sample a bounded prefix so opening a large CSV does not scan every cell.
+// Manual resizing is not subject to the automatic 320px cap.
+export function getCsvColumnWidths(
+  header: readonly string[],
+  bodyRows: readonly string[][],
+  columnCount: number
+): number[] {
+  const widths = Array.from<number>({ length: columnCount }).fill(AUTO_MIN_COLUMN_WIDTH)
+  const consider = (cell: string | undefined, index: number): void => {
+    if (!cell) {
+      return
+    }
+    const width = Math.min(
+      AUTO_MAX_COLUMN_WIDTH,
+      Math.max(AUTO_MIN_COLUMN_WIDTH, cell.length * CHARACTER_WIDTH + CELL_HORIZONTAL_PADDING)
+    )
+    if (width > widths[index]!) {
+      widths[index] = width
+    }
+  }
+
+  header.forEach(consider)
+  const sampleLimit = Math.min(bodyRows.length, 200)
+  for (let rowIndex = 0; rowIndex < sampleLimit; rowIndex += 1) {
+    const row = bodyRows[rowIndex]!
+    for (let columnIndex = 0; columnIndex < columnCount; columnIndex += 1) {
+      consider(row[columnIndex], columnIndex)
+    }
+  }
+  return widths
+}
+
+export function getCsvGridTemplate(columnWidths: readonly number[]): string {
+  return `${CSV_ROW_NUMBER_COLUMN_WIDTH}px ${columnWidths.map((width) => `${width}px`).join(' ')}`
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13187,7 +13187,7 @@
           "69d4e210bb": "Unresolved"
         },
         "CsvColumnResizeHandle": {
-          "resizeColumn": "Resize column"
+          "resizeColumn": "Resize column {{value0}}"
         },
         "CsvViewer": {
           "eedd0d37a7": "columns",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13186,6 +13186,9 @@
           "8528a5eaf5": "Resolved",
           "69d4e210bb": "Unresolved"
         },
+        "CsvColumnResizeHandle": {
+          "resizeColumn": "Resize column"
+        },
         "CsvViewer": {
           "eedd0d37a7": "columns",
           "ac31d2cd60": "rows",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12720,7 +12720,7 @@
           "69d4e210bb": "Sin resolver"
         },
         "CsvColumnResizeHandle": {
-          "resizeColumn": "Cambiar el tamaño de la columna"
+          "resizeColumn": "Cambiar el tamaño de la columna {{value0}}"
         },
         "CsvViewer": {
           "eedd0d37a7": "columnas",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -12719,6 +12719,9 @@
           "8528a5eaf5": "Resuelto",
           "69d4e210bb": "Sin resolver"
         },
+        "CsvColumnResizeHandle": {
+          "resizeColumn": "Cambiar el tamaño de la columna"
+        },
         "CsvViewer": {
           "eedd0d37a7": "columnas",
           "ac31d2cd60": "filas",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12719,6 +12719,9 @@
           "8528a5eaf5": "解決済み",
           "69d4e210bb": "未解決"
         },
+        "CsvColumnResizeHandle": {
+          "resizeColumn": "列のサイズを変更"
+        },
         "CsvViewer": {
           "eedd0d37a7": "列",
           "ac31d2cd60": "行",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -12720,7 +12720,7 @@
           "69d4e210bb": "未解決"
         },
         "CsvColumnResizeHandle": {
-          "resizeColumn": "列のサイズを変更"
+          "resizeColumn": "列「{{value0}}」のサイズを変更"
         },
         "CsvViewer": {
           "eedd0d37a7": "列",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12719,6 +12719,9 @@
           "8528a5eaf5": "해결됨",
           "69d4e210bb": "해결되지 않은"
         },
+        "CsvColumnResizeHandle": {
+          "resizeColumn": "열 크기 조절"
+        },
         "CsvViewer": {
           "eedd0d37a7": "열",
           "ac31d2cd60": "행",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -12720,7 +12720,7 @@
           "69d4e210bb": "해결되지 않은"
         },
         "CsvColumnResizeHandle": {
-          "resizeColumn": "열 크기 조절"
+          "resizeColumn": "{{value0}} 열 크기 조절"
         },
         "CsvViewer": {
           "eedd0d37a7": "열",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12740,7 +12740,7 @@
           "69d4e210bb": "未解决"
         },
         "CsvColumnResizeHandle": {
-          "resizeColumn": "调整列宽"
+          "resizeColumn": "调整“{{value0}}”列的大小"
         },
         "CsvViewer": {
           "eedd0d37a7": "列",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -12739,6 +12739,9 @@
           "8528a5eaf5": "已解决",
           "69d4e210bb": "未解决"
         },
+        "CsvColumnResizeHandle": {
+          "resizeColumn": "调整列宽"
+        },
         "CsvViewer": {
           "eedd0d37a7": "列",
           "ac31d2cd60": "行",


### PR DESCRIPTION
## Summary

Part of #12915.

- add draggable resize handles to CSV table headers
- keep the header and virtualized body rows on the same column widths
- preserve manual widths per file for the current app session, including tab and view remounts
- support Arrow Left/Right resizing with an 80 px minimum and localized, column-specific separator labels
- clean up resize state when the pointer is cancelled or the window loses focus

Direct cell editing and row or column operations remain out of scope for this PR.

## Screenshots

![CSV table before and after resizing the Name column](https://raw.githubusercontent.com/hungrytech/orca/pr-evidence-csv-column-resize/csv-column-resize-before-after.png)

Captured from the Electron E2E app after dragging the first column boundary 120 px.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 4,574 files passed, 48,419 tests passed, 100 skipped
- [x] Added interaction coverage for drag resizing, header/body width synchronization, keyboard resizing, minimum-width clamping, remount persistence, and interrupted-drag cleanup

Focused tests:

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/components/editor/CsvViewer.test.tsx \
  src/renderer/src/components/editor/csv-parse.test.ts
```

Result before the follow-up hardening commit: 2 files passed, 18 tests passed.

The updated resize interaction suite was then rerun on the final commit: 1 file passed, 4 tests passed.

Electron proof:

- 1 Playwright test passed against the E2E app
- opened a real CSV file, dragged the first header boundary 120 px, and verified the shared grid template changed

Additional checks on the final commit:

- full TypeScript check passed
- focused Oxlint: 0 warnings and 0 errors
- React Doctor: 0 warnings and 0 errors
- localization audit passed
- reliability gates and max-lines ratchet passed
- `git diff --check` passed

A later local full-suite attempt on the final commit hit the command timeout after an unrelated `omp-shell-wrapper.node-pty` failure. No CSV test failed; the final focused CSV suite and full typecheck passed.

## AI Review Report

The review checked pointer lifecycle and cancellation, cursor and selection cleanup, keyboard access, header/body alignment, tab and view remounts, duplicate headers, and localization coverage. The interaction stays in the renderer and uses standard pointer and keyboard events, so macOS, Windows, and Linux use the same path. SSH, remote runtimes, agents, integrations, and git providers are untouched. Row virtualization is unchanged, and resize work is limited to updating the shared column template. React Doctor reported 0 warnings and 0 errors.

## Security Audit

No IPC, network access, dependencies, command execution, path handling, permissions, authentication, or secret handling were added. Column widths stay in a renderer-only, session-scoped cache and are not written to disk or to the CSV.

## Contributor

X handle: not provided.
