### PR TITLE
fix(status-bar): show remaining duration for Claude Fable window in compact mode

### DIFF
--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -211,6 +211,7 @@ describe('UsageRow', () => {
     // fableWeekly falls back to the window-duration label when no reset time is
     // known; the window name is reserved for non-remaining display (#13041).
     expect(markup).not.toContain('Fable')
+    expect(markup).toContain('wk')
     expect(markup).toContain('75%')
     expect(markup).not.toContain('25%')
     expect(markup).not.toContain('60%')

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.test.tsx
@@ -208,7 +208,9 @@ describe('UsageRow', () => {
 
     expect(markup.match(/data-usage-window=/g)).toHaveLength(1)
     expect(markup).not.toContain('data-usage-bar')
-    expect(markup).toContain('Fable')
+    // fableWeekly falls back to the window-duration label when no reset time is
+    // known; the window name is reserved for non-remaining display (#13041).
+    expect(markup).not.toContain('Fable')
     expect(markup).toContain('75%')
     expect(markup).not.toContain('25%')
     expect(markup).not.toContain('60%')

--- a/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
+++ b/src/renderer/src/components/status-bar/UsageRosterPanel.tsx
@@ -45,9 +45,10 @@ function shortLabel(
     return section.label
   }
   // fableWeekly shares the 7d window with weekly; label it distinctly so the two
-  // don't both render as "wk".
+  // don't both render as "wk". When remaining duration is requested, the two
+  // windows' reset times differ, so the countdown labels never collide (#13041).
   if (section.window === p.fableWeekly) {
-    return 'Fable'
+    return useRemainingDuration ? formatRateLimitWindowChipLabel(section.window) : 'Fable'
   }
   return useRemainingDuration
     ? formatRateLimitWindowChipLabel(section.window)

--- a/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
+++ b/src/renderer/src/components/status-bar/provider-segment-monthly-window.test.tsx
@@ -1,5 +1,5 @@
 import { renderToStaticMarkup } from 'react-dom/server'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import type { ProviderRateLimits, RateLimitWindow } from '../../../../shared/rate-limit-types'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -211,5 +211,48 @@ describe('undefined provider window safety (crash d2c1da69 / bb74236c)', () => {
         <ProviderSegment p={partialProvider} compact={false} display="used" mode="compact" />
       )
     ).not.toThrow()
+  })
+})
+
+describe('fableWeekly compact label (issue #13041)', () => {
+  const NOW = 1_000_000_000
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('renders remaining duration instead of the Fable window name in compact mode', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+    const { ProviderSegment } = await import('./StatusBar')
+    const limits: ProviderRateLimits = {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      fableWeekly: windowOf(50, 10080, NOW + 3600_000),
+      updatedAt: NOW,
+      error: null,
+      status: 'ok'
+    }
+    const markup = renderToStaticMarkup(
+      <ProviderSegment p={limits} compact={false} display="used" mode="compact" />
+    )
+    expect(markup).toContain('50% used 1h')
+    expect(markup).not.toContain('Fable')
+  })
+
+  it('tightest fableWeekly section uses remaining duration, not the window name', async () => {
+    vi.spyOn(Date, 'now').mockReturnValue(NOW)
+    const { getTightestUsageSection } = await import('./UsageRosterPanel')
+    const limits: ProviderRateLimits = {
+      provider: 'claude',
+      session: null,
+      weekly: null,
+      fableWeekly: windowOf(80, 10080, NOW + 2 * 3600_000 + 30 * 60_000),
+      updatedAt: NOW,
+      error: null,
+      status: 'ok'
+    }
+    const tightest = getTightestUsageSection(limits)
+    expect(tightest?.label).toBe('2h 30m')
   })
 })


### PR DESCRIPTION
## Summary

In compact usage mode, the Claude Fable 7-day window was labeled with the hardcoded window name "Fable" instead of the reset countdown every other window shows. `getTightestUsageSection` calls `shortLabel(..., useRemainingDuration: true)`, but the fableWeekly branch returned `'Fable'` unconditionally, ignoring the requested remaining-duration format.

This changes the fableWeekly branch to respect `useRemainingDuration`: compact mode now shows the reset countdown (e.g. "1h", "2d 14h") just like session/weekly/monthly windows, and falls back to the duration label ("wk") when no reset time is known. The window-name label is preserved for non-remaining display.

## Test plan

- Added renderer test: compact mode renders "50% used 1h" (exact reset countdown with a pinned clock) and no longer contains "Fable".
- Added unit test: `getTightestUsageSection` returns the exact remaining-duration label ("2h 30m") for a fableWeekly window with a known reset time.
- Updated one pre-existing assertion that had encoded the buggy behavior (compact render must not contain "Fable"); the surrounding selection assertions are unchanged.
- Full status-bar suite passes: 271 tests across 39 files, plus oxlint and TypeScript checks.

Fixes #13041

I am a full-stack developer intern, passionate about contributing to the open-source community and giving back to the tools I love. I have reviewed and understood all the code changes in this PR, which I verified with unit tests, type checks, and lint.