### PR TITLE
fix(github): fall back when branch PR lookup is empty

### DIFF
--- a/src/main/github/client.test.ts
+++ b/src/main/github/client.test.ts
@@ -734,6 +734,117 @@ describe('getPRForBranch', () => {
     })
   })
 
+  it('falls back to branch list when REST branch lookup misses a PR from another fork', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValueOnce({
+      candidates: [{ owner: 'stablyai', repo: 'orca' }],
+      headRepo: { owner: 'innocarpe', repo: 'orca' }
+    })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify([
+          {
+            number: 12956,
+            title: 'Existing fork PR',
+            state: 'OPEN',
+            url: 'https://github.com/stablyai/orca/pull/12956',
+            statusCheckRollup: [],
+            updatedAt: '2026-08-08T00:00:00Z',
+            isDraft: false,
+            mergeable: 'MERGEABLE',
+            baseRefName: 'main',
+            headRefName: 'fix/pr-branch-fork-lookup',
+            baseRefOid: 'base-oid',
+            headRefOid: 'fallback-head-oid'
+          }
+        ])
+      })
+      .mockResolvedValueOnce({
+        stdout: JSON.stringify({
+          number: 12956,
+          title: 'Hydrated existing fork PR',
+          state: 'OPEN',
+          url: 'https://github.com/stablyai/orca/pull/12956',
+          statusCheckRollup: [],
+          updatedAt: '2026-08-08T00:00:00Z',
+          isDraft: false,
+          mergeable: 'MERGEABLE',
+          baseRefName: 'main',
+          headRefName: 'fix/pr-branch-fork-lookup',
+          baseRefOid: 'base-oid',
+          headRefOid: 'fallback-head-oid'
+        })
+      })
+
+    const pr = await getPRForBranch('/repo-root', 'fix/pr-branch-fork-lookup')
+
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      1,
+      [
+        'api',
+        'repos/stablyai/orca/pulls?head=innocarpe%3Afix%2Fpr-branch-fork-lookup&state=all&per_page=1'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      [
+        'pr',
+        'list',
+        '--repo',
+        'stablyai/orca',
+        '--head',
+        'fix/pr-branch-fork-lookup',
+        '--state',
+        'all',
+        '--limit',
+        '1',
+        '--json',
+        'number,title,state,url,statusCheckRollup,updatedAt,isDraft,mergeable,baseRefName,headRefName,baseRefOid,headRefOid'
+      ],
+      { cwd: '/repo-root' }
+    )
+    expect(pr).toMatchObject({
+      number: 12956,
+      title: 'Hydrated existing fork PR',
+      prRepo: { owner: 'stablyai', repo: 'orca' },
+      headRepo: { owner: 'innocarpe', repo: 'orca' }
+    })
+  })
+
+  it('reports no PR when REST and branch-list lookups both miss', async () => {
+    resolvePRRepositoryCandidatesMock.mockResolvedValueOnce({
+      candidates: [{ owner: 'stablyai', repo: 'orca' }],
+      headRepo: { owner: 'innocarpe', repo: 'orca' }
+    })
+    ghExecFileAsyncMock
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+      .mockResolvedValueOnce({ stdout: JSON.stringify([]) })
+
+    const outcome = await getPRForBranchOutcome('/repo-root', 'feature/test')
+
+    expect(outcome.kind).toBe('no-pr')
+    expect(ghExecFileAsyncMock).toHaveBeenCalledTimes(2)
+    expect(ghExecFileAsyncMock).toHaveBeenNthCalledWith(
+      2,
+      [
+        'pr',
+        'list',
+        '--repo',
+        'stablyai/orca',
+        '--head',
+        'feature/test',
+        '--state',
+        'all',
+        '--limit',
+        '1',
+        '--json',
+        'number,title,state,url,statusCheckRollup,updatedAt,isDraft,mergeable,baseRefName,headRefName,baseRefOid,headRefOid'
+      ],
+      { cwd: '/repo-root' }
+    )
+  })
+
   it('ignores merged PRs discovered only by branch lookup when the branch moved on', async () => {
     getOwnerRepoMock.mockResolvedValueOnce({ owner: 'acme', repo: 'widgets' })
     ghExecFileAsyncMock

--- a/src/main/github/client.ts
+++ b/src/main/github/client.ts
@@ -2776,7 +2776,7 @@ async function lookupPRByBranchName(args: {
     let hasPendingError = false
     for (const candidate of args.candidates) {
       try {
-        const branchData = args.headRepo
+        let branchData = args.headRepo
           ? await getRestPRForBranch(
               candidate,
               args.headRepo.owner,
@@ -2784,6 +2784,14 @@ async function lookupPRByBranchName(args: {
               args.ghOptions
             )
           : await getFallbackPRListForBranch(candidate, args.branchName, args.ghOptions)
+        if (
+          !branchData &&
+          args.headRepo &&
+          args.candidates.length === 1 &&
+          githubRepoIdentityKey(candidate) !== githubRepoIdentityKey(args.headRepo)
+        ) {
+          branchData = await getFallbackPRListForBranch(candidate, args.branchName, args.ghOptions)
+        }
         // Why: REST/list branch lookup identifies the PR cheaply; exact `gh pr view` carries review, merge-queue, and auto-merge state.
         const data = await hydrateBranchLookupWithExactPR(candidate, branchData, args.ghOptions)
         if (data) {


### PR DESCRIPTION
## Description

Branches hosted on a separately named fork now fall back to the existing CLI PR lookup when the inferred REST head-owner query returns an empty result.
The branch lookup no longer treats an empty response for an inferred owner as definitive, so externally created fork PRs can reach the Source Control blade.

## Focused fix

- In scope: retry the existing branch PR fallback when the REST branch lookup returns no PR.
- Out of scope (explicit): changing repository candidate discovery or persisting newly discovered PR links.

## Preserves

- Known `headRepo` lookups keep their existing REST behavior.
- The existing fallback remains the provider-compatible path for branch PR discovery.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/github/client.test.ts`
- Regression: the test covers an empty inferred-owner response followed by a successful fallback result.

## User-regression-tradeoffs

- An additional CLI lookup is made only after the inferred REST lookup returns no PR; successful lookups and existing error handling are unchanged.

Fixes #12956
