### PR TITLE
fix(browser): route page-scoped keyboard input through CDP

### DIFF
--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -2335,7 +2335,6 @@ describe('AgentBrowserBridge', () => {
 
   it.each([
     ['fill', (b: AgentBrowserBridge, text: string) => b.fill('@textarea', text)],
-    ['type', (b: AgentBrowserBridge, text: string) => b.type(text)],
     ['keyboard insert', (b: AgentBrowserBridge, text: string) => b.keyboardInsertText(text)]
   ])('yields before spawning agent-browser for accepted large %s text', async (_name, run) => {
     vi.useFakeTimers()
@@ -2357,22 +2356,54 @@ describe('AgentBrowserBridge', () => {
     }
   })
 
-  it('chunks large agent-browser type text before keyboard transport', async () => {
+  it('targets the requested page directly when typing text', async () => {
+    const wc = mockWebContents(100)
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.type('HELLO-SOLO', undefined, 'tab-1')
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(wc.debugger.sendCommand).toHaveBeenCalledWith('Input.insertText', {
+      text: 'HELLO-SOLO'
+    })
+  })
+
+  it('chunks large browser type text before direct CDP insertion', async () => {
     const text = ['y'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'zz'].join('')
-    succeedWith({ typed: true })
+    const wc = mockWebContents(100)
+    webContentsFromIdMock.mockReturnValue(wc)
 
-    await bridge.type(text)
+    await bridge.type(text, undefined, 'tab-1')
 
-    const typeCalls = execFileMock.mock.calls.filter((call: unknown[]) => {
-      const args = call[1] as string[]
-      return args.includes('keyboard') && args.includes('type')
-    })
-    const chunks = typeCalls.map((call: unknown[]) => {
-      const args = call[1] as string[]
-      return args[args.indexOf('type') + 1]
-    })
+    const chunks = wc.debugger.sendCommand.mock.calls
+      .filter((call) => call[0] === 'Input.insertText')
+      .map((call) => (call[1] as { text: string }).text)
 
     expect(chunks).toEqual(['y'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'zz'])
+  })
+
+  it('dispatches keypresses to the requested page instead of the focused window', async () => {
+    const wc = mockWebContents(100)
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    const result = await bridge.keypress('Control+a', undefined, 'tab-1')
+
+    expect(result).toEqual({ pressed: 'Control+a' })
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      key: 'a',
+      code: 'KeyA',
+      modifiers: 2,
+      windowsVirtualKeyCode: 65
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      key: 'a',
+      code: 'KeyA',
+      modifiers: 2,
+      windowsVirtualKeyCode: 65
+    })
   })
 
   it('chunks large agent-browser keyboard insert text before transport', async () => {

--- a/src/main/browser/agent-browser-bridge.test.ts
+++ b/src/main/browser/agent-browser-bridge.test.ts
@@ -2382,6 +2382,78 @@ describe('AgentBrowserBridge', () => {
     expect(chunks).toEqual(['y'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'zz'])
   })
 
+  it.each([
+    [
+      '+',
+      {
+        key: '+',
+        code: '',
+        modifiers: 0,
+        windowsVirtualKeyCode: 43,
+        text: '+'
+      }
+    ],
+    [
+      'Control++',
+      {
+        key: '+',
+        code: '',
+        modifiers: 2,
+        windowsVirtualKeyCode: 43,
+        text: '+',
+        unmodifiedText: '+'
+      }
+    ],
+    [
+      'Shift+a',
+      {
+        key: 'a',
+        code: 'KeyA',
+        modifiers: 8,
+        windowsVirtualKeyCode: 65,
+        text: 'a',
+        unmodifiedText: 'a'
+      }
+    ],
+    [
+      'Shift+1',
+      {
+        key: '1',
+        code: 'Digit1',
+        modifiers: 8,
+        windowsVirtualKeyCode: 49,
+        text: '1',
+        unmodifiedText: '1'
+      }
+    ],
+    [
+      'Control+Shift+a',
+      {
+        key: 'a',
+        code: 'KeyA',
+        modifiers: 10,
+        windowsVirtualKeyCode: 65,
+        text: 'a',
+        unmodifiedText: 'a'
+      }
+    ]
+  ])('dispatches direct keypress payload for %s', async (key, expectedDefinition) => {
+    const wc = mockWebContents(100)
+    webContentsFromIdMock.mockReturnValue(wc)
+
+    await bridge.keypress(key, undefined, 'tab-1')
+
+    expect(execFileMock).not.toHaveBeenCalled()
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(1, 'Input.dispatchKeyEvent', {
+      type: 'keyDown',
+      ...expectedDefinition
+    })
+    expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
+      type: 'keyUp',
+      ...expectedDefinition
+    })
+  })
+
   it('dispatches keypresses to the requested page instead of the focused window', async () => {
     const wc = mockWebContents(100)
     webContentsFromIdMock.mockReturnValue(wc)
@@ -2395,6 +2467,7 @@ describe('AgentBrowserBridge', () => {
       key: 'a',
       code: 'KeyA',
       modifiers: 2,
+      unmodifiedText: 'a',
       windowsVirtualKeyCode: 65
     })
     expect(wc.debugger.sendCommand).toHaveBeenNthCalledWith(2, 'Input.dispatchKeyEvent', {
@@ -2402,9 +2475,53 @@ describe('AgentBrowserBridge', () => {
       key: 'a',
       code: 'KeyA',
       modifiers: 2,
+      unmodifiedText: 'a',
       windowsVirtualKeyCode: 65
     })
   })
+
+  it.each([
+    ['type', (b: AgentBrowserBridge) => b.type('hello', undefined, 'tab-1')],
+    ['keypress', (b: AgentBrowserBridge) => b.keypress('a', undefined, 'tab-1')]
+  ])(
+    'translates direct %s debugger attachment failures while the page is live',
+    async (_name, run) => {
+      const wc = mockWebContents(100)
+      wc.debugger.isAttached.mockReturnValue(false)
+      wc.debugger.attach.mockImplementation(() => {
+        throw new Error('Cannot attach debugger')
+      })
+      webContentsFromIdMock.mockReturnValue(wc)
+
+      await expect(run(bridge)).rejects.toMatchObject({
+        code: 'browser_error',
+        message: expect.stringContaining('Cannot attach debugger')
+      })
+      expect(execFileMock).not.toHaveBeenCalled()
+    }
+  )
+
+  it.each([
+    ['type', (b: AgentBrowserBridge) => b.type('hello', undefined, 'tab-1')],
+    ['keypress', (b: AgentBrowserBridge) => b.keypress('a', undefined, 'tab-1')]
+  ])(
+    'maps direct %s attachment races to page unavailable after the page closes',
+    async (_name, run) => {
+      const wc = mockWebContents(100)
+      wc.debugger.isAttached.mockReturnValue(false)
+      wc.debugger.attach.mockImplementation(() => {
+        wc.isDestroyed = () => true
+        throw new Error('Object has been destroyed')
+      })
+      webContentsFromIdMock.mockReturnValue(wc)
+
+      await expect(run(bridge)).rejects.toMatchObject({
+        code: 'browser_tab_not_found',
+        message: 'Browser page tab-1 is no longer available'
+      })
+      expect(execFileMock).not.toHaveBeenCalled()
+    }
+  )
 
   it('chunks large agent-browser keyboard insert text before transport', async () => {
     const text = ['z'.repeat(AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES), 'qq'].join('')

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -49,7 +49,7 @@ import type {
 } from '../../shared/runtime-types'
 import { assertClipboardTextWriteWithinLimitWithYield } from '../../shared/clipboard-text'
 import { normalizeBrowserNavigationUrl } from '../../shared/browser-url'
-import { iterateBrowserTextInsertionChunks } from './browser-text-insertion'
+import { insertTextThroughCdp, iterateBrowserTextInsertionChunks } from './browser-text-insertion'
 
 // Why: must exceed agent-browser's internal timeouts (goto 30s, wait 60s) so the bridge never kills a command before its own timeout fires.
 const EXEC_TIMEOUT_MS = 90_000
@@ -59,6 +59,70 @@ const STALE_SESSION_CLOSE_TIMEOUT_MS = 3_000
 const EMBEDDED_NAVIGATION_TIMEOUT_MS = 30_000
 export const AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES = 8 * 1024
 export const AGENT_BROWSER_CLIPBOARD_WRITE_MAX_BYTES = AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
+
+type DirectKeyDefinition = {
+  key: string
+  code: string
+  modifiers?: number
+  windowsVirtualKeyCode?: number
+  text?: string
+}
+
+const DIRECT_KEY_DEFINITIONS: Record<string, DirectKeyDefinition> = {
+  Enter: { key: 'Enter', code: 'Enter', windowsVirtualKeyCode: 13, text: '\r' },
+  Tab: { key: 'Tab', code: 'Tab', windowsVirtualKeyCode: 9, text: '\t' },
+  Escape: { key: 'Escape', code: 'Escape', windowsVirtualKeyCode: 27 },
+  Backspace: { key: 'Backspace', code: 'Backspace', windowsVirtualKeyCode: 8 },
+  Delete: { key: 'Delete', code: 'Delete', windowsVirtualKeyCode: 46 },
+  ArrowUp: { key: 'ArrowUp', code: 'ArrowUp', windowsVirtualKeyCode: 38 },
+  ArrowDown: { key: 'ArrowDown', code: 'ArrowDown', windowsVirtualKeyCode: 40 },
+  ArrowLeft: { key: 'ArrowLeft', code: 'ArrowLeft', windowsVirtualKeyCode: 37 },
+  ArrowRight: { key: 'ArrowRight', code: 'ArrowRight', windowsVirtualKeyCode: 39 },
+  Home: { key: 'Home', code: 'Home', windowsVirtualKeyCode: 36 },
+  End: { key: 'End', code: 'End', windowsVirtualKeyCode: 35 },
+  PageUp: { key: 'PageUp', code: 'PageUp', windowsVirtualKeyCode: 33 },
+  PageDown: { key: 'PageDown', code: 'PageDown', windowsVirtualKeyCode: 34 },
+  Space: { key: ' ', code: 'Space', windowsVirtualKeyCode: 32, text: ' ' }
+}
+
+function resolveDirectKeyDefinition(input: string): DirectKeyDefinition {
+  const parts = input.split('+')
+  const key = parts.pop() ?? input
+  let modifiers = 0
+  for (const modifier of parts) {
+    if (modifier === 'Alt') {
+      modifiers |= 1
+    } else if (modifier === 'Control' || modifier === 'Ctrl') {
+      modifiers |= 2
+    } else if (modifier === 'Meta' || modifier === 'Command' || modifier === 'Cmd') {
+      modifiers |= 4
+    } else if (modifier === 'Shift') {
+      modifiers |= 8
+    }
+  }
+
+  const known = DIRECT_KEY_DEFINITIONS[key]
+  if (known) {
+    return modifiers > 0 ? { ...known, modifiers } : known
+  }
+  if (key.length === 1) {
+    const charCode = key.charCodeAt(0)
+    if (charCode >= 48 && charCode <= 57) {
+      return { key, code: `Digit${key}`, windowsVirtualKeyCode: charCode, text: key, modifiers }
+    }
+    if ((charCode >= 65 && charCode <= 90) || (charCode >= 97 && charCode <= 122)) {
+      return {
+        key,
+        code: `Key${key.toUpperCase()}`,
+        windowsVirtualKeyCode: key.toUpperCase().charCodeAt(0),
+        text: modifiers === 0 || (modifiers & 8) !== 0 ? key : undefined,
+        modifiers
+      }
+    }
+    return { key, code: '', windowsVirtualKeyCode: charCode, text: key, modifiers }
+  }
+  return { key, code: key, modifiers }
+}
 
 type SessionState = {
   proxy: CdpWsProxy
@@ -973,16 +1037,29 @@ export class AgentBrowserBridge {
     return this.enqueueTargetedCommand(
       worktreeId,
       browserPageId,
-      async (sessionName) => {
-        for (const chunk of iterateBrowserTextInsertionChunks(
-          input,
-          AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES
-        )) {
-          await this.execAgentBrowser(sessionName, ['keyboard', 'type', chunk])
+      async (_sessionName, target) => {
+        const wc = this.requireTargetWebContents(target)
+        const releaseDebugger = acquireElectronDebugger(wc).release
+        try {
+          await insertTextThroughCdp(
+            (method, params) => wc.debugger.sendCommand(method, params),
+            input,
+            { maxChunkBytes: AGENT_BROWSER_TEXT_ARGUMENT_MAX_BYTES }
+          )
+          return { typed: true }
+        } catch (error) {
+          if (!this.getWebContents(target.webContentsId)) {
+            throw this.createPageUnavailableError(`orca-tab-${target.browserPageId}`)
+          }
+          throw new BrowserError(
+            'browser_error',
+            `Failed to type into browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        } finally {
+          releaseDebugger()
         }
-        return { typed: true } as BrowserTypeResult
       },
-      { requireScopedTarget: true }
+      { ensureSession: false, requireScopedTarget: true }
     )
   }
 
@@ -1768,9 +1845,37 @@ export class AgentBrowserBridge {
     worktreeId?: string,
     browserPageId?: string
   ): Promise<BrowserKeypressResult> {
-    return this.enqueueTargetedCommand(worktreeId, browserPageId, async (sessionName) => {
-      return (await this.execAgentBrowser(sessionName, ['press', key])) as BrowserKeypressResult
-    })
+    return this.enqueueTargetedCommand(
+      worktreeId,
+      browserPageId,
+      async (_sessionName, target) => {
+        const wc = this.requireTargetWebContents(target)
+        const releaseDebugger = acquireElectronDebugger(wc).release
+        const keyDefinition = resolveDirectKeyDefinition(key)
+        try {
+          await wc.debugger.sendCommand('Input.dispatchKeyEvent', {
+            type: 'keyDown',
+            ...keyDefinition
+          })
+          await wc.debugger.sendCommand('Input.dispatchKeyEvent', {
+            type: 'keyUp',
+            ...keyDefinition
+          })
+          return { pressed: key }
+        } catch (error) {
+          if (!this.getWebContents(target.webContentsId)) {
+            throw this.createPageUnavailableError(`orca-tab-${target.browserPageId}`)
+          }
+          throw new BrowserError(
+            'browser_error',
+            `Failed to press key in browser page ${target.browserPageId}: ${error instanceof Error ? error.message : String(error)}`
+          )
+        } finally {
+          releaseDebugger()
+        }
+      },
+      { ensureSession: false }
+    )
   }
 
   async pdf(worktreeId?: string, browserPageId?: string): Promise<BrowserPdfResult> {

--- a/src/main/browser/agent-browser-bridge.ts
+++ b/src/main/browser/agent-browser-bridge.ts
@@ -66,6 +66,7 @@ type DirectKeyDefinition = {
   modifiers?: number
   windowsVirtualKeyCode?: number
   text?: string
+  unmodifiedText?: string
 }
 
 const DIRECT_KEY_DEFINITIONS: Record<string, DirectKeyDefinition> = {
@@ -87,7 +88,11 @@ const DIRECT_KEY_DEFINITIONS: Record<string, DirectKeyDefinition> = {
 
 function resolveDirectKeyDefinition(input: string): DirectKeyDefinition {
   const parts = input.split('+')
-  const key = parts.pop() ?? input
+  let key = parts.pop() ?? input
+  if (key === '' && parts.at(-1) === '') {
+    parts.pop()
+    key = '+'
+  }
   let modifiers = 0
   for (const modifier of parts) {
     if (modifier === 'Alt') {
@@ -108,18 +113,34 @@ function resolveDirectKeyDefinition(input: string): DirectKeyDefinition {
   if (key.length === 1) {
     const charCode = key.charCodeAt(0)
     if (charCode >= 48 && charCode <= 57) {
-      return { key, code: `Digit${key}`, windowsVirtualKeyCode: charCode, text: key, modifiers }
+      return {
+        key,
+        code: `Digit${key}`,
+        windowsVirtualKeyCode: charCode,
+        text: key,
+        modifiers,
+        ...(modifiers > 0 ? { unmodifiedText: key } : {})
+      }
     }
     if ((charCode >= 65 && charCode <= 90) || (charCode >= 97 && charCode <= 122)) {
+      const text = modifiers === 0 || (modifiers & 8) !== 0 ? key : undefined
       return {
         key,
         code: `Key${key.toUpperCase()}`,
         windowsVirtualKeyCode: key.toUpperCase().charCodeAt(0),
-        text: modifiers === 0 || (modifiers & 8) !== 0 ? key : undefined,
+        ...(text !== undefined ? { text } : {}),
+        ...(modifiers > 0 ? { unmodifiedText: key } : {}),
         modifiers
       }
     }
-    return { key, code: '', windowsVirtualKeyCode: charCode, text: key, modifiers }
+    return {
+      key,
+      code: '',
+      windowsVirtualKeyCode: charCode,
+      text: key,
+      modifiers,
+      ...(modifiers > 0 ? { unmodifiedText: key } : {})
+    }
   }
   return { key, code: key, modifiers }
 }
@@ -1039,8 +1060,9 @@ export class AgentBrowserBridge {
       browserPageId,
       async (_sessionName, target) => {
         const wc = this.requireTargetWebContents(target)
-        const releaseDebugger = acquireElectronDebugger(wc).release
+        let releaseDebugger = (): void => {}
         try {
+          releaseDebugger = acquireElectronDebugger(wc).release
           await insertTextThroughCdp(
             (method, params) => wc.debugger.sendCommand(method, params),
             input,
@@ -1850,9 +1872,10 @@ export class AgentBrowserBridge {
       browserPageId,
       async (_sessionName, target) => {
         const wc = this.requireTargetWebContents(target)
-        const releaseDebugger = acquireElectronDebugger(wc).release
         const keyDefinition = resolveDirectKeyDefinition(key)
+        let releaseDebugger = (): void => {}
         try {
+          releaseDebugger = acquireElectronDebugger(wc).release
           await wc.debugger.sendCommand('Input.dispatchKeyEvent', {
             type: 'keyDown',
             ...keyDefinition


### PR DESCRIPTION
## Description

Browser `type` and `keypress` commands now deliver page-scoped input to the requested browser `webContents` instead of the OS-focused window.
The bridge uses direct CDP input dispatch for targeted pages and reports success only after the target page accepted the command.

## Focused fix

- In scope: honor `--page` for focus-based browser text and key input, including chunked text insertion.
- Out of scope (explicit): changing element-scoped fill/insert-text commands or browser focus policy outside a targeted page.

## Preserves

- Commands without a scoped page continue through the existing target-selection contract.
- Browser page-unavailable and CDP failures remain explicit bridge errors.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/main/browser/agent-browser-bridge.test.ts`
- Regression: tests verify direct target-page CDP calls, large-text chunking, modifier key dispatch, and no OS helper invocation.

## User-regression-tradeoffs

- Direct CDP key definitions cover the supported browser key forms while avoiding OS focus side effects; unsupported multi-character keys retain their explicit CDP representation.

Fixes #12912
