### PR TITLE
fix(windows): keep Ctrl-W in Git Bash terminals

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -40,14 +40,16 @@ import { isFindQueryTooLarge } from '@/lib/find-query-bounds'
 import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
-import { useAppStore } from '@/store'
+import { useAppStore, type AppState } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalSelection } from './terminal-selection-copy'
 import { isLocalWindowsConptyPaneForCtrlArrow } from './terminal-ctrl-arrow-conpty'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
+import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
 import { hasCtrlEnterCsiUAuthorityForPane } from './terminal-ctrl-enter'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
+import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -67,7 +69,8 @@ export function resolveTerminalKeyboardShortcutAction(
   getWindowsShiftEnterEncoding: Parameters<typeof resolveTerminalShortcutAction>[9],
   isWindowsTerminalHost: NonNullable<Parameters<typeof resolveTerminalShortcutAction>[10]>,
   terminalShortcutPolicy: Parameters<typeof resolveTerminalShortcutAction>[11] = 'orca-first',
-  hasCtrlEnterCsiUAuthority?: Parameters<typeof resolveTerminalShortcutAction>[12]
+  hasCtrlEnterCsiUAuthority?: Parameters<typeof resolveTerminalShortcutAction>[12],
+  isWindowsGitBashPane?: Parameters<typeof resolveTerminalShortcutAction>[13]
 ): ReturnType<typeof resolveTerminalShortcutAction> {
   // Why: keep the host callback required at the production boundary so a
   // caller cannot silently fall back to client-OS byte routing.
@@ -84,7 +87,29 @@ export function resolveTerminalKeyboardShortcutAction(
     getWindowsShiftEnterEncoding,
     isWindowsTerminalHost,
     terminalShortcutPolicy,
-    hasCtrlEnterCsiUAuthority
+    hasCtrlEnterCsiUAuthority,
+    isWindowsGitBashPane
+  )
+}
+
+export function isWindowsGitBashPaneForShortcut(args: {
+  isWindowsTerminalHost: boolean
+  state: Pick<AppState, 'tabsByWorktree' | 'settings'>
+  worktreeId: string
+  tabId: string
+  sessionShellOverride?: string | null
+}): boolean {
+  if (!args.isWindowsTerminalHost) {
+    return false
+  }
+  const tabShellOverride = args.state.tabsByWorktree[args.worktreeId]?.find(
+    (candidate) => candidate.id === args.tabId
+  )?.shellOverride
+  return (
+    resolveWindowsShellOverride(
+      args.sessionShellOverride ?? tabShellOverride,
+      args.state.settings?.terminalWindowsShell
+    ) === WINDOWS_GIT_BASH_SHELL
   )
 }
 
@@ -401,6 +426,25 @@ export function useTerminalKeyboardShortcuts({
       )
     }
 
+    const isActivePaneWindowsGitBash = (): boolean => {
+      const manager = managerRef.current
+      const activePane = manager?.getActivePane() ?? manager?.getPanes()[0]
+      if (!activePane) {
+        return false
+      }
+      const state = useAppStore.getState()
+      const sessionShellOverride = paneTransportsRef.current
+        .get(activePane.id)
+        ?.getLocalSessionMetadata?.()?.shellOverride
+      return isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: isActivePaneWindowsTerminalHost(),
+        state,
+        worktreeId,
+        tabId,
+        sessionShellOverride
+      })
+    }
+
     // Why: the pane's TUI opted into kitty keyboard reporting via CSI > u;
     // the tracker mirrors that from PTY output so the policy can encode
     // Option chords the way the application negotiated.
@@ -445,7 +489,8 @@ export function useTerminalKeyboardShortcuts({
         getActivePaneWindowsShiftEnterEncoding,
         isActivePaneWindowsTerminalHost,
         terminalShortcutPolicy,
-        hasActivePaneCtrlEnterCsiUAuthority
+        hasActivePaneCtrlEnterCsiUAuthority,
+        isActivePaneWindowsGitBash
       )
 
     const createCapturedInputSender = (

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -40,16 +40,15 @@ import { isFindQueryTooLarge } from '@/lib/find-query-bounds'
 import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { splitTerminalPaneWithInheritedCwd } from './terminal-pane-split-with-inherited-cwd'
-import { useAppStore, type AppState } from '@/store'
+import { useAppStore } from '@/store'
 import { recordTerminalUserInputForLeaf } from './terminal-input-activity'
 import { copyTerminalSelection } from './terminal-selection-copy'
 import { isLocalWindowsConptyPaneForCtrlArrow } from './terminal-ctrl-arrow-conpty'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
-import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
 import { resolveWindowsShiftEnterEncodingForPane } from './terminal-windows-shift-enter'
 import { hasCtrlEnterCsiUAuthorityForPane } from './terminal-ctrl-enter'
 import { resolveTerminalInputHostPlatform } from './terminal-input-host-platform'
-import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
+import { isWindowsGitBashPaneForShortcut } from './windows-git-bash-shortcut'
 import {
   markTerminalFollowOutput,
   markTerminalPinnedViewport,
@@ -89,27 +88,6 @@ export function resolveTerminalKeyboardShortcutAction(
     terminalShortcutPolicy,
     hasCtrlEnterCsiUAuthority,
     isWindowsGitBashPane
-  )
-}
-
-export function isWindowsGitBashPaneForShortcut(args: {
-  isWindowsTerminalHost: boolean
-  state: Pick<AppState, 'tabsByWorktree' | 'settings'>
-  worktreeId: string
-  tabId: string
-  sessionShellOverride?: string | null
-}): boolean {
-  if (!args.isWindowsTerminalHost) {
-    return false
-  }
-  const tabShellOverride = args.state.tabsByWorktree[args.worktreeId]?.find(
-    (candidate) => candidate.id === args.tabId
-  )?.shellOverride
-  return (
-    resolveWindowsShellOverride(
-      args.sessionShellOverride ?? tabShellOverride,
-      args.state.settings?.terminalWindowsShell
-    ) === WINDOWS_GIT_BASH_SHELL
   )
 }
 
@@ -433,15 +411,18 @@ export function useTerminalKeyboardShortcuts({
         return false
       }
       const state = useAppStore.getState()
-      const sessionShellOverride = paneTransportsRef.current
+      const localSessionMetadata = paneTransportsRef.current
         .get(activePane.id)
-        ?.getLocalSessionMetadata?.()?.shellOverride
+        ?.getLocalSessionMetadata?.()
+      const tabShellOverride = state.tabsByWorktree[worktreeId]?.find(
+        (candidate) => candidate.id === tabId
+      )?.shellOverride
       return isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: isActivePaneWindowsTerminalHost(),
-        state,
-        worktreeId,
-        tabId,
-        sessionShellOverride
+        hasLocalSessionMetadata: localSessionMetadata != null,
+        sessionShellOverride: localSessionMetadata?.shellOverride,
+        tabShellOverride,
+        globalWindowsShell: state.settings?.terminalWindowsShell
       })
     }
 

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -410,19 +410,12 @@ export function useTerminalKeyboardShortcuts({
       if (!activePane) {
         return false
       }
-      const state = useAppStore.getState()
       const localSessionMetadata = paneTransportsRef.current
         .get(activePane.id)
         ?.getLocalSessionMetadata?.()
-      const tabShellOverride = state.tabsByWorktree[worktreeId]?.find(
-        (candidate) => candidate.id === tabId
-      )?.shellOverride
       return isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: isActivePaneWindowsTerminalHost(),
-        hasLocalSessionMetadata: localSessionMetadata != null,
-        sessionShellOverride: localSessionMetadata?.shellOverride,
-        tabShellOverride,
-        globalWindowsShell: state.settings?.terminalWindowsShell
+        sessionShellOverride: localSessionMetadata?.shellOverride
       })
     }
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
@@ -1,13 +1,9 @@
-import { describe, expect, it } from 'vitest'
-import type { AppState } from '@/store'
-import { isWindowsGitBashPaneForShortcut } from './keyboard-handlers'
+import { describe, expect, it, vi } from 'vitest'
 import {
   resolveTerminalShortcutAction,
   type TerminalShortcutEvent
 } from './terminal-shortcut-policy'
-
-const WORKTREE_ID = 'repo::C:\\repo'
-const TAB_ID = 'tab-1'
+import { isWindowsGitBashPaneForShortcut } from './windows-git-bash-shortcut'
 
 function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
   return {
@@ -19,26 +15,6 @@ function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent
     shiftKey: false,
     repeat: false,
     ...overrides
-  }
-}
-
-function shortcutState(args: {
-  tabShellOverride?: string
-  terminalWindowsShell?: string
-}): Pick<AppState, 'tabsByWorktree' | 'settings'> {
-  const tabsByWorktree = {
-    [WORKTREE_ID]: [
-      {
-        id: TAB_ID,
-        ...(args.tabShellOverride ? { shellOverride: args.tabShellOverride } : {})
-      }
-    ]
-  } as unknown as AppState['tabsByWorktree']
-  return {
-    tabsByWorktree,
-    settings: {
-      terminalWindowsShell: args.terminalWindowsShell
-    } as AppState['settings']
   }
 }
 
@@ -93,53 +69,113 @@ describe('Windows Git Bash terminal-first Ctrl+W', () => {
     })
   })
 
-  it('detects Git Bash from active-pane session metadata', () => {
+  it('uses physical KeyW across IME-rewritten logical keys', () => {
+    expect(
+      resolveWindowsCtrlW({
+        terminalFirst: true,
+        gitBash: true,
+        windows: true,
+        input: event({ key: 'ㅈ', code: 'KeyW', ctrlKey: true })
+      })
+    ).toBeNull()
+    expect(
+      resolveWindowsCtrlW({
+        terminalFirst: true,
+        gitBash: true,
+        windows: true,
+        input: event({ key: 'w', code: '', ctrlKey: true })
+      })
+    ).toBeNull()
+  })
+
+  it('does not classify modified or non-W chords as plain Ctrl+W', () => {
+    const gitBash = vi.fn(() => true)
+    const resolve = (input: TerminalShortcutEvent, terminalFirst = true) =>
+      resolveTerminalShortcutAction(
+        input,
+        false,
+        'false',
+        0,
+        true,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        () => true,
+        terminalFirst ? 'terminal-first' : 'orca-first',
+        undefined,
+        gitBash
+      )
+
+    expect(resolve(event({ key: 'w', code: 'KeyW', ctrlKey: true, altKey: true }))).toBeNull()
+    resolve(event({ key: 'c', code: 'KeyC', ctrlKey: true }))
+    expect(resolve(event({ key: 'w', code: 'KeyW', ctrlKey: true }), false)).toEqual({
+      type: 'closeActivePane'
+    })
+    expect(gitBash).not.toHaveBeenCalled()
+  })
+
+  it('detects Git Bash from authoritative local session metadata', () => {
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        state: shortcutState({
-          tabShellOverride: 'powershell.exe',
-          terminalWindowsShell: 'cmd.exe'
-        }),
-        worktreeId: WORKTREE_ID,
-        tabId: TAB_ID,
-        sessionShellOverride: 'git-bash'
+        hasLocalSessionMetadata: true,
+        sessionShellOverride: 'git-bash',
+        tabShellOverride: 'powershell.exe',
+        globalWindowsShell: 'cmd.exe'
       })
     ).toBe(true)
   })
 
-  it('keeps non-Git-Bash Windows shells and non-Windows hosts on the close path', () => {
-    const state = shortcutState({
-      tabShellOverride: 'cmd.exe',
-      terminalWindowsShell: 'git-bash'
-    })
-
+  it('keeps PowerShell, cmd, remote, and non-Windows panes on the close path', () => {
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        state,
-        worktreeId: WORKTREE_ID,
-        tabId: TAB_ID,
-        sessionShellOverride: 'powershell.exe'
+        hasLocalSessionMetadata: true,
+        sessionShellOverride: 'powershell.exe',
+        globalWindowsShell: 'git-bash'
+      })
+    ).toBe(false)
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: true,
+        hasLocalSessionMetadata: true,
+        sessionShellOverride: 'cmd.exe',
+        globalWindowsShell: 'git-bash'
+      })
+    ).toBe(false)
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: true,
+        hasLocalSessionMetadata: false,
+        tabShellOverride: 'git-bash',
+        globalWindowsShell: 'git-bash'
       })
     ).toBe(false)
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: false,
-        state: shortcutState({ tabShellOverride: 'git-bash' }),
-        worktreeId: WORKTREE_ID,
-        tabId: TAB_ID
+        hasLocalSessionMetadata: true,
+        sessionShellOverride: 'git-bash'
       })
     ).toBe(false)
   })
 
-  it('falls back to the global Windows shell when no pane or tab shell is set', () => {
+  it('falls back through the tab and global shell configuration', () => {
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        state: shortcutState({ terminalWindowsShell: 'git-bash' }),
-        worktreeId: WORKTREE_ID,
-        tabId: TAB_ID
+        hasLocalSessionMetadata: true,
+        tabShellOverride: 'git-bash',
+        globalWindowsShell: 'powershell.exe'
+      })
+    ).toBe(true)
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: true,
+        hasLocalSessionMetadata: true,
+        globalWindowsShell: 'git-bash'
       })
     ).toBe(true)
   })

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import {
+  resolveTerminalShortcutAction,
+  type TerminalShortcutEvent
+} from './terminal-shortcut-policy'
+
+function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
+  return {
+    key: '',
+    code: '',
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    repeat: false,
+    ...overrides
+  }
+}
+
+describe('Windows Git Bash terminal-first Ctrl+W', () => {
+  it('lets Git Bash own Ctrl+W only under the Windows Terminal-first boundary', () => {
+    const ctrlW = event({ key: 'w', code: 'KeyW', ctrlKey: true })
+    const resolveWindowsCtrlW = (args: {
+      terminalFirst: boolean
+      gitBash: boolean
+      windows: boolean
+    }) =>
+      resolveTerminalShortcutAction(
+        ctrlW,
+        false,
+        'false',
+        0,
+        args.windows,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        undefined,
+        () => args.windows,
+        args.terminalFirst ? 'terminal-first' : 'orca-first',
+        undefined,
+        () => args.gitBash
+      )
+
+    expect(resolveWindowsCtrlW({ terminalFirst: true, gitBash: true, windows: true })).toBeNull()
+    expect(resolveWindowsCtrlW({ terminalFirst: false, gitBash: true, windows: true })).toEqual({
+      type: 'closeActivePane'
+    })
+    expect(resolveWindowsCtrlW({ terminalFirst: true, gitBash: false, windows: true })).toEqual({
+      type: 'closeActivePane'
+    })
+    expect(resolveWindowsCtrlW({ terminalFirst: true, gitBash: true, windows: false })).toEqual({
+      type: 'closeActivePane'
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
@@ -1,8 +1,13 @@
 import { describe, expect, it } from 'vitest'
+import type { AppState } from '@/store'
+import { isWindowsGitBashPaneForShortcut } from './keyboard-handlers'
 import {
   resolveTerminalShortcutAction,
   type TerminalShortcutEvent
 } from './terminal-shortcut-policy'
+
+const WORKTREE_ID = 'repo::C:\\repo'
+const TAB_ID = 'tab-1'
 
 function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent {
   return {
@@ -17,31 +22,52 @@ function event(overrides: Partial<TerminalShortcutEvent>): TerminalShortcutEvent
   }
 }
 
-describe('Windows Git Bash terminal-first Ctrl+W', () => {
-  it('lets Git Bash own Ctrl+W only under the Windows Terminal-first boundary', () => {
-    const ctrlW = event({ key: 'w', code: 'KeyW', ctrlKey: true })
-    const resolveWindowsCtrlW = (args: {
-      terminalFirst: boolean
-      gitBash: boolean
-      windows: boolean
-    }) =>
-      resolveTerminalShortcutAction(
-        ctrlW,
-        false,
-        'false',
-        0,
-        args.windows,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        undefined,
-        () => args.windows,
-        args.terminalFirst ? 'terminal-first' : 'orca-first',
-        undefined,
-        () => args.gitBash
-      )
+function shortcutState(args: {
+  tabShellOverride?: string
+  terminalWindowsShell?: string
+}): Pick<AppState, 'tabsByWorktree' | 'settings'> {
+  const tabsByWorktree = {
+    [WORKTREE_ID]: [
+      {
+        id: TAB_ID,
+        ...(args.tabShellOverride ? { shellOverride: args.tabShellOverride } : {})
+      }
+    ]
+  } as unknown as AppState['tabsByWorktree']
+  return {
+    tabsByWorktree,
+    settings: {
+      terminalWindowsShell: args.terminalWindowsShell
+    } as AppState['settings']
+  }
+}
 
+describe('Windows Git Bash terminal-first Ctrl+W', () => {
+  const ctrlW = event({ key: 'w', code: 'KeyW', ctrlKey: true })
+  const resolveWindowsCtrlW = (args: {
+    terminalFirst: boolean
+    gitBash: boolean
+    windows: boolean
+    input?: TerminalShortcutEvent
+  }) =>
+    resolveTerminalShortcutAction(
+      args.input ?? ctrlW,
+      false,
+      'false',
+      0,
+      args.windows,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      () => args.windows,
+      args.terminalFirst ? 'terminal-first' : 'orca-first',
+      undefined,
+      () => args.gitBash
+    )
+
+  it('lets Git Bash own Ctrl+W only under the Windows Terminal-first boundary', () => {
     expect(resolveWindowsCtrlW({ terminalFirst: true, gitBash: true, windows: true })).toBeNull()
     expect(resolveWindowsCtrlW({ terminalFirst: false, gitBash: true, windows: true })).toEqual({
       type: 'closeActivePane'
@@ -52,5 +78,69 @@ describe('Windows Git Bash terminal-first Ctrl+W', () => {
     expect(resolveWindowsCtrlW({ terminalFirst: true, gitBash: true, windows: false })).toEqual({
       type: 'closeActivePane'
     })
+  })
+
+  it('keeps mismatched logical w events on the pane-close path', () => {
+    expect(
+      resolveWindowsCtrlW({
+        terminalFirst: true,
+        gitBash: true,
+        windows: true,
+        input: event({ key: 'w', code: 'KeyQ', ctrlKey: true })
+      })
+    ).toEqual({
+      type: 'closeActivePane'
+    })
+  })
+
+  it('detects Git Bash from active-pane session metadata', () => {
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: true,
+        state: shortcutState({
+          tabShellOverride: 'powershell.exe',
+          terminalWindowsShell: 'cmd.exe'
+        }),
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        sessionShellOverride: 'git-bash'
+      })
+    ).toBe(true)
+  })
+
+  it('keeps non-Git-Bash Windows shells and non-Windows hosts on the close path', () => {
+    const state = shortcutState({
+      tabShellOverride: 'cmd.exe',
+      terminalWindowsShell: 'git-bash'
+    })
+
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: true,
+        state,
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID,
+        sessionShellOverride: 'powershell.exe'
+      })
+    ).toBe(false)
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: false,
+        state: shortcutState({ tabShellOverride: 'git-bash' }),
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID
+      })
+    ).toBe(false)
+  })
+
+  it('falls back to the global Windows shell when no pane or tab shell is set', () => {
+    expect(
+      isWindowsGitBashPaneForShortcut({
+        isWindowsTerminalHost: true,
+        state: shortcutState({ terminalWindowsShell: 'git-bash' }),
+        worktreeId: WORKTREE_ID,
+        tabId: TAB_ID
+      })
+    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy-windows-git-bash.test.ts
@@ -120,10 +120,7 @@ describe('Windows Git Bash terminal-first Ctrl+W', () => {
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        hasLocalSessionMetadata: true,
-        sessionShellOverride: 'git-bash',
-        tabShellOverride: 'powershell.exe',
-        globalWindowsShell: 'cmd.exe'
+        sessionShellOverride: 'git-bash'
       })
     ).toBe(true)
   })
@@ -132,51 +129,26 @@ describe('Windows Git Bash terminal-first Ctrl+W', () => {
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        hasLocalSessionMetadata: true,
-        sessionShellOverride: 'powershell.exe',
-        globalWindowsShell: 'git-bash'
+        sessionShellOverride: 'powershell.exe'
       })
     ).toBe(false)
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        hasLocalSessionMetadata: true,
-        sessionShellOverride: 'cmd.exe',
-        globalWindowsShell: 'git-bash'
+        sessionShellOverride: 'cmd.exe'
       })
     ).toBe(false)
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: true,
-        hasLocalSessionMetadata: false,
-        tabShellOverride: 'git-bash',
-        globalWindowsShell: 'git-bash'
+        sessionShellOverride: undefined
       })
     ).toBe(false)
     expect(
       isWindowsGitBashPaneForShortcut({
         isWindowsTerminalHost: false,
-        hasLocalSessionMetadata: true,
         sessionShellOverride: 'git-bash'
       })
     ).toBe(false)
-  })
-
-  it('falls back through the tab and global shell configuration', () => {
-    expect(
-      isWindowsGitBashPaneForShortcut({
-        isWindowsTerminalHost: true,
-        hasLocalSessionMetadata: true,
-        tabShellOverride: 'git-bash',
-        globalWindowsShell: 'powershell.exe'
-      })
-    ).toBe(true)
-    expect(
-      isWindowsGitBashPaneForShortcut({
-        isWindowsTerminalHost: true,
-        hasLocalSessionMetadata: true,
-        globalWindowsShell: 'git-bash'
-      })
-    ).toBe(true)
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -5,6 +5,7 @@ import {
   type KeybindingOverrides,
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
+import { isLatinShortcutKey } from '@/lib/ime-latin-shortcut-key'
 import type { WindowsShiftEnterEncoding } from './terminal-windows-shift-enter'
 
 export type TerminalShortcutEvent = {
@@ -92,7 +93,7 @@ function isPlainCtrlW(event: TerminalShortcutEvent): boolean {
     !event.metaKey &&
     !event.altKey &&
     !event.shiftKey &&
-    (event.code === 'KeyW' || event.key.toLowerCase() === 'w')
+    isLatinShortcutKey(event, 'w')
   )
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -5,7 +5,6 @@ import {
   type KeybindingOverrides,
   type TerminalShortcutPolicy
 } from '../../../../shared/keybindings'
-import { isLatinShortcutKey } from '@/lib/ime-latin-shortcut-key'
 import type { WindowsShiftEnterEncoding } from './terminal-windows-shift-enter'
 
 export type TerminalShortcutEvent = {
@@ -88,12 +87,13 @@ function resolveUnshiftedCharacterForCode(code: string | undefined): string | un
 }
 
 function isPlainCtrlW(event: TerminalShortcutEvent): boolean {
+  const code = event.code?.trim()
   return (
     event.ctrlKey &&
     !event.metaKey &&
     !event.altKey &&
     !event.shiftKey &&
-    isLatinShortcutKey(event, 'w')
+    (code ? code === 'KeyW' : event.key.toLowerCase() === 'w')
   )
 }
 

--- a/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-shortcut-policy.ts
@@ -86,6 +86,16 @@ function resolveUnshiftedCharacterForCode(code: string | undefined): string | un
   return PUNCTUATION_CODE_MAP[code]
 }
 
+function isPlainCtrlW(event: TerminalShortcutEvent): boolean {
+  return (
+    event.ctrlKey &&
+    !event.metaKey &&
+    !event.altKey &&
+    !event.shiftKey &&
+    (event.code === 'KeyW' || event.key.toLowerCase() === 'w')
+  )
+}
+
 /**
  * Resolves terminal keyboard events before xterm receives them, centralizing
  * Orca shortcuts and terminal byte fallbacks in one platform-aware policy.
@@ -110,7 +120,9 @@ export function resolveTerminalShortcutAction(
   // Why: gates the tab.close pane-close alias — under terminal-first a remapped tab.close yields to the shell (terminal.closePane, scope terminal, still closes).
   terminalShortcutPolicy: TerminalShortcutPolicy = 'orca-first',
   // Why: query-only Droid/Grok consumers need CSI-u even when the live kitty flags remain inactive.
-  hasCtrlEnterCsiUAuthority?: () => boolean
+  hasCtrlEnterCsiUAuthority?: () => boolean,
+  // Why: Windows Git Bash uses Ctrl+W for readline word erase, so Terminal-first must yield that chord even though terminal.closePane is terminal-scoped.
+  isWindowsGitBashPane?: () => boolean
 ): TerminalShortcutAction | null {
   const platform: NodeJS.Platform = isMac ? 'darwin' : isWindows ? 'win32' : 'linux'
 
@@ -165,6 +177,12 @@ export function resolveTerminalShortcutAction(
     // Why: recognize the active tab.close binding as a pane-close alias too, so a user who remaps
     // tab.close alone still closes the focused split pane (never the whole tab); L2 always defers to us.
     if (
+      !(
+        terminalShortcutPolicy === 'terminal-first' &&
+        platform === 'win32' &&
+        isPlainCtrlW(event) &&
+        isWindowsGitBashPane?.() === true
+      ) &&
       isTerminalPaneCloseChord(event, platform, keybindings, undefined, {
         context: 'terminal',
         terminalShortcutPolicy

--- a/src/renderer/src/components/terminal-pane/windows-git-bash-shortcut.ts
+++ b/src/renderer/src/components/terminal-pane/windows-git-bash-shortcut.ts
@@ -1,20 +1,7 @@
 import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
-import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
-
 export function isWindowsGitBashPaneForShortcut(args: {
   isWindowsTerminalHost: boolean
-  hasLocalSessionMetadata: boolean
   sessionShellOverride?: string | null
-  tabShellOverride?: string | null
-  globalWindowsShell?: string | null
 }): boolean {
-  if (!args.isWindowsTerminalHost || !args.hasLocalSessionMetadata) {
-    return false
-  }
-  return (
-    resolveWindowsShellOverride(
-      args.sessionShellOverride ?? args.tabShellOverride,
-      args.globalWindowsShell
-    ) === WINDOWS_GIT_BASH_SHELL
-  )
+  return args.isWindowsTerminalHost && args.sessionShellOverride === WINDOWS_GIT_BASH_SHELL
 }

--- a/src/renderer/src/components/terminal-pane/windows-git-bash-shortcut.ts
+++ b/src/renderer/src/components/terminal-pane/windows-git-bash-shortcut.ts
@@ -1,0 +1,20 @@
+import { WINDOWS_GIT_BASH_SHELL } from '../../../../shared/windows-terminal-shell'
+import { resolveWindowsShellOverride } from '@/lib/pane-manager/windows-pty-compatibility'
+
+export function isWindowsGitBashPaneForShortcut(args: {
+  isWindowsTerminalHost: boolean
+  hasLocalSessionMetadata: boolean
+  sessionShellOverride?: string | null
+  tabShellOverride?: string | null
+  globalWindowsShell?: string | null
+}): boolean {
+  if (!args.isWindowsTerminalHost || !args.hasLocalSessionMetadata) {
+    return false
+  }
+  return (
+    resolveWindowsShellOverride(
+      args.sessionShellOverride ?? args.tabShellOverride,
+      args.globalWindowsShell
+    ) === WINDOWS_GIT_BASH_SHELL
+  )
+}

--- a/tests/e2e/terminal-windows-git-bash-ctrl-w.spec.ts
+++ b/tests/e2e/terminal-windows-git-bash-ctrl-w.spec.ts
@@ -113,6 +113,7 @@ test.describe('Windows Git Bash Ctrl+W ownership', () => {
     })
     await installTerminalPtyWriteSpy(electronApp)
     await sendToTerminal(orcaPage, ptyId, 'echo CTRLW_BUFFER_alpha doomed')
+    await waitForTerminalOutput(orcaPage, 'echo CTRLW_BUFFER_alpha doomed', 10_000)
     await clearTerminalPtyWriteLog(electronApp)
 
     await focusActiveTerminalInput(orcaPage)

--- a/tests/e2e/terminal-windows-git-bash-ctrl-w.spec.ts
+++ b/tests/e2e/terminal-windows-git-bash-ctrl-w.spec.ts
@@ -1,0 +1,237 @@
+import type { Page } from '@stablyai/playwright-test'
+import { WINDOWS_GIT_BASH_SHELL } from '../../src/shared/windows-terminal-shell'
+import { test, expect } from './helpers/orca-app'
+import {
+  focusActiveTerminalInput,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForTerminalOutput
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  clearTerminalPtyWriteLog,
+  installTerminalPtyWriteSpy,
+  readTerminalPtyWrites
+} from './helpers/terminal-pty-write-spy'
+
+type WindowsShell = 'cmd.exe' | 'powershell.exe' | typeof WINDOWS_GIT_BASH_SHELL
+
+async function createShellTab(
+  page: Page,
+  args: {
+    globalShell: WindowsShell
+    tabShell?: WindowsShell
+    policy: 'terminal-first' | 'orca-first'
+  }
+): Promise<{ tabId: string; ptyId: string }> {
+  const tabId = await page.evaluate(async (settings) => {
+    const store = window.__store
+    if (!store) {
+      throw new Error('Store unavailable')
+    }
+    const worktreeId = store.getState().activeWorktreeId
+    if (!worktreeId) {
+      throw new Error('No active worktree')
+    }
+    await store.getState().updateSettings({
+      terminalShortcutPolicy: settings.policy,
+      terminalWindowsShell: settings.globalShell
+    })
+    const tab = store.getState().createTab(worktreeId, undefined, settings.tabShell)
+    store.getState().setActiveTab(tab.id)
+    store.getState().setActiveTabType('terminal')
+    return tab.id
+  }, args)
+
+  await expect(page.locator(`[data-testid="sortable-tab"][data-tab-id="${tabId}"]`)).toBeVisible()
+  await waitForActiveTerminalManager(page, 30_000)
+  return { tabId, ptyId: await waitForActivePanePtyId(page, 30_000) }
+}
+
+async function activeTopology(
+  page: Page,
+  tabId: string
+): Promise<{
+  active: boolean
+  exists: boolean
+  paneCount: number
+  ptyId: string | null
+}> {
+  return page.evaluate((targetTabId) => {
+    const state = window.__store?.getState()
+    const manager = window.__paneManagers?.get(targetTabId)
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const worktreeId = state?.activeWorktreeId
+    return {
+      active: state?.activeTabId === targetTabId,
+      exists: Boolean(
+        worktreeId && state?.tabsByWorktree[worktreeId]?.some((tab) => tab.id === targetTabId)
+      ),
+      paneCount: manager?.getPanes?.().length ?? 0,
+      ptyId: pane?.container.dataset.ptyId ?? null
+    }
+  }, tabId)
+}
+
+async function pressCtrlWAndSettleClose(page: Page, tabId: string): Promise<void> {
+  await focusActiveTerminalInput(page)
+  await page.keyboard.press('Control+w')
+  const confirmButton = page.getByRole('button', { name: /Stop and Close/i })
+  await expect
+    .poll(
+      async () => {
+        if (await confirmButton.isVisible().catch(() => false)) {
+          await confirmButton.click()
+        }
+        return (await activeTopology(page, tabId)).exists
+      },
+      { timeout: 10_000, message: `Ctrl+W did not close terminal tab ${tabId}` }
+    )
+    .toBe(false)
+}
+
+test.describe('Windows Git Bash Ctrl+W ownership', () => {
+  test.beforeEach(async ({ orcaPage }) => {
+    test.skip(process.platform !== 'win32', 'Git Bash Ctrl+W coverage is Windows-only')
+    test.skip(
+      !(await orcaPage.evaluate(() => window.api.gitBash.isAvailable())),
+      'Git Bash unavailable'
+    )
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+  })
+
+  test('Terminal-first global Git Bash keeps the tab and sends readline Ctrl+W', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const { tabId, ptyId } = await createShellTab(orcaPage, {
+      globalShell: WINDOWS_GIT_BASH_SHELL,
+      policy: 'terminal-first'
+    })
+    await installTerminalPtyWriteSpy(electronApp)
+    await sendToTerminal(orcaPage, ptyId, 'echo CTRLW_BUFFER_alpha doomed')
+    await clearTerminalPtyWriteLog(electronApp)
+
+    await focusActiveTerminalInput(orcaPage)
+    await orcaPage.keyboard.press('Control+w')
+
+    await expect
+      .poll(async () =>
+        (await readTerminalPtyWrites(electronApp)).filter((data) => data === '\x17')
+      )
+      .toEqual(['\x17'])
+    expect(await activeTopology(orcaPage, tabId)).toEqual({
+      active: true,
+      exists: true,
+      paneCount: 1,
+      ptyId
+    })
+
+    await orcaPage.keyboard.type('kept')
+    await orcaPage.keyboard.press('Enter')
+    await waitForTerminalOutput(orcaPage, 'CTRLW_BUFFER_alpha kept', 10_000)
+  })
+
+  test('Terminal-first honors an active Git Bash tab override over PowerShell', async ({
+    electronApp,
+    orcaPage
+  }) => {
+    const { tabId, ptyId } = await createShellTab(orcaPage, {
+      globalShell: 'powershell.exe',
+      tabShell: WINDOWS_GIT_BASH_SHELL,
+      policy: 'terminal-first'
+    })
+    await installTerminalPtyWriteSpy(electronApp)
+    await clearTerminalPtyWriteLog(electronApp)
+    await focusActiveTerminalInput(orcaPage)
+    await orcaPage.keyboard.press('Control+w')
+
+    await expect
+      .poll(async () =>
+        (await readTerminalPtyWrites(electronApp)).filter((data) => data === '\x17')
+      )
+      .toEqual(['\x17'])
+    expect(await activeTopology(orcaPage, tabId)).toEqual({
+      active: true,
+      exists: true,
+      paneCount: 1,
+      ptyId
+    })
+  })
+
+  test('Orca-first Git Bash and Terminal-first native Windows shells keep pane-close ownership', async ({
+    orcaPage
+  }) => {
+    const orcaFirst = await createShellTab(orcaPage, {
+      globalShell: WINDOWS_GIT_BASH_SHELL,
+      policy: 'orca-first'
+    })
+    await pressCtrlWAndSettleClose(orcaPage, orcaFirst.tabId)
+
+    for (const shell of ['powershell.exe', 'cmd.exe'] as const) {
+      const nativeShell = await createShellTab(orcaPage, {
+        globalShell: shell,
+        policy: 'terminal-first'
+      })
+      await pressCtrlWAndSettleClose(orcaPage, nativeShell.tabId)
+    }
+  })
+
+  test('a logical w on physical KeyQ stays on the Orca pane-close path', async ({ orcaPage }) => {
+    const { tabId } = await createShellTab(orcaPage, {
+      globalShell: WINDOWS_GIT_BASH_SHELL,
+      policy: 'terminal-first'
+    })
+    await focusActiveTerminalInput(orcaPage)
+    await orcaPage.evaluate(() => {
+      const textarea = document.activeElement
+      if (!(textarea instanceof HTMLTextAreaElement)) {
+        throw new Error('Active xterm textarea unavailable')
+      }
+      textarea.dispatchEvent(
+        new KeyboardEvent('keydown', {
+          key: 'w',
+          code: 'KeyQ',
+          ctrlKey: true,
+          bubbles: true,
+          cancelable: true
+        })
+      )
+    })
+    await expect.poll(async () => (await activeTopology(orcaPage, tabId)).exists).toBe(false)
+  })
+
+  test('Terminal-first Git Bash keeps global Ctrl+W ownership on a non-terminal surface', async ({
+    orcaPage
+  }) => {
+    const { tabId } = await createShellTab(orcaPage, {
+      globalShell: WINDOWS_GIT_BASH_SHELL,
+      policy: 'terminal-first'
+    })
+    await orcaPage.evaluate(() => {
+      const state = window.__store?.getState()
+      state?.setSettingsSearchQuery('')
+      state?.openSettingsPage()
+    })
+    const search = orcaPage.getByPlaceholder('Search settings')
+    await expect(search).toBeVisible()
+    await search.focus()
+    const defaultPrevented = await search.evaluate((input) => {
+      const event = new KeyboardEvent('keydown', {
+        key: 'w',
+        code: 'KeyW',
+        ctrlKey: true,
+        bubbles: true,
+        cancelable: true
+      })
+      input.dispatchEvent(event)
+      return event.defaultPrevented
+    })
+
+    expect(defaultPrevented).toBe(true)
+    expect((await activeTopology(orcaPage, tabId)).exists).toBe(true)
+  })
+})

--- a/tests/e2e/terminal-windows-git-bash-ctrl-w.spec.ts
+++ b/tests/e2e/terminal-windows-git-bash-ctrl-w.spec.ts
@@ -74,9 +74,7 @@ async function activeTopology(
   }, tabId)
 }
 
-async function pressCtrlWAndSettleClose(page: Page, tabId: string): Promise<void> {
-  await focusActiveTerminalInput(page)
-  await page.keyboard.press('Control+w')
+async function settleTerminalClose(page: Page, tabId: string): Promise<void> {
   const confirmButton = page.getByRole('button', { name: /Stop and Close/i })
   await expect
     .poll(
@@ -89,6 +87,12 @@ async function pressCtrlWAndSettleClose(page: Page, tabId: string): Promise<void
       { timeout: 10_000, message: `Ctrl+W did not close terminal tab ${tabId}` }
     )
     .toBe(false)
+}
+
+async function pressCtrlWAndSettleClose(page: Page, tabId: string): Promise<void> {
+  await focusActiveTerminalInput(page)
+  await page.keyboard.press('Control+w')
+  await settleTerminalClose(page, tabId)
 }
 
 test.describe('Windows Git Bash Ctrl+W ownership', () => {
@@ -202,7 +206,7 @@ test.describe('Windows Git Bash Ctrl+W ownership', () => {
         })
       )
     })
-    await expect.poll(async () => (await activeTopology(orcaPage, tabId)).exists).toBe(false)
+    await settleTerminalClose(orcaPage, tabId)
   })
 
   test('Terminal-first Git Bash keeps global Ctrl+W ownership on a non-terminal surface', async ({


### PR DESCRIPTION
## Description

On native Windows, Git Bash now receives physical Ctrl+W when the terminal-first shortcut policy is enabled instead of Orca closing the active tab. The exception is fail-closed: it requires an active terminal pane, `KeyW`, Ctrl with no other modifiers, an authoritative active local-session shell override identifying Git Bash, and a native Windows terminal host.

## Focused fix

- In scope: route physical Ctrl+W to an active native Windows Git Bash session under Terminal first.
- Preserved: Orca first, non-terminal surfaces, non-Git-Bash Windows shells, mismatched physical keys, and modified chords retain Orca's existing close/shortcut behavior.
- Held: WSL and IME behavior are unchanged.

## Compatibility and gaps

- No RPC, stream, persisted-data, dependency, workflow, or downloaded-content changes.
- macOS, Linux, SSH, and mixed-version native execution were not exercised; the exception is gated away from those paths.
- Folder workspaces remain supported because the decision uses active terminal-session metadata rather than Git worktree assumptions.

## Evidence

- Focused policy/metadata regression: 15/15.
- Native Windows Git Bash Electron E2E: 5/5, covering readline delivery, global and per-tab Git Bash selection, negative shell/policy cases, physical-key mismatch, and non-terminal ownership.
- Rebase seal on current main: stable patch IDs and aggregate patch are unchanged; affected shortcut/PTY unit suites 131/131, renderer/CLI/node typecheck, direct changed-file oxlint, and Electron/CLI build passed.

## User-regression tradeoffs

Ctrl+W is intentionally consumed by Git Bash only for an authoritative active native Windows Git Bash pane under Terminal first, matching Bash previous-word deletion instead of tab closure.

Fixes #13015