### PR TITLE
fix(remote): preserve local file tab order

### DIFF
--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -29,6 +29,7 @@ import {
 } from './web-agent-session-handoff'
 import {
   _getWebSessionTabsTrackingCountsForTest,
+  _mergeMirroredHostTabOrderForTest,
   acceptReplayedWebSessionTabsSnapshot,
   applyFreshWebSessionTabsSnapshot,
   applyWebSessionTabsSnapshot,
@@ -1625,6 +1626,25 @@ describe('applyWebSessionTabsSnapshot', () => {
       localBrowserTab.id,
       secondTerminalId
     ])
+  })
+
+  it('does not consume host order for stale mirrored entries before live tabs', () => {
+    const staleMirroredId = toWebTerminalSurfaceTabId('host-tab-stale')
+    const firstTerminalId = toWebTerminalSurfaceTabId('host-tab-1')
+    const secondTerminalId = toWebTerminalSurfaceTabId('host-tab-2')
+    const localFileTabId = 'local-file-tab'
+    const currentOrder = [staleMirroredId, localFileTabId, firstTerminalId]
+    const mirroredIds = new Set([staleMirroredId, firstTerminalId, secondTerminalId])
+    const validIds = new Set([localFileTabId, firstTerminalId, secondTerminalId])
+
+    expect(
+      _mergeMirroredHostTabOrderForTest(
+        currentOrder,
+        [firstTerminalId, secondTerminalId],
+        mirroredIds,
+        validIds
+      )
+    ).toEqual([localFileTabId, firstTerminalId, secondTerminalId])
   })
 
   it('keeps retained local-only groups reachable when applying a host layout', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -1620,6 +1620,11 @@ describe('applyWebSessionTabsSnapshot', () => {
       localBrowserTab.id,
       secondTerminalId
     ])
+    expect(patch.groupsByWorktree?.[WT]?.[0]?.tabOrder).toEqual([
+      firstTerminalId,
+      localBrowserTab.id,
+      secondTerminalId
+    ])
   })
 
   it('keeps retained local-only groups reachable when applying a host layout', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1326,6 +1326,9 @@ function mergeMirroredHostTabOrder(
   const seen = new Set<string>()
   let hostIndex = 0
   for (const tabId of currentTabOrder) {
+    if (!validUnifiedTabIds.has(tabId)) {
+      continue
+    }
     const nextTabId = mirroredUnifiedIds.has(tabId) ? hostTabOrder[hostIndex++] : tabId
     if (nextTabId && validUnifiedTabIds.has(nextTabId) && !seen.has(nextTabId)) {
       merged.push(nextTabId)
@@ -1341,6 +1344,8 @@ function mergeMirroredHostTabOrder(
   }
   return merged
 }
+
+export const _mergeMirroredHostTabOrderForTest = mergeMirroredHostTabOrder
 
 function buildMirroredHostGroups({
   currentGroups,

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1316,6 +1316,32 @@ function updateHostSessionTabIdMappings(args: {
   }
 }
 
+function mergeMirroredHostTabOrder(
+  currentTabOrder: readonly string[],
+  hostTabOrder: readonly string[],
+  mirroredUnifiedIds: ReadonlySet<string>,
+  validUnifiedTabIds: ReadonlySet<string>
+): string[] {
+  const merged: string[] = []
+  const seen = new Set<string>()
+  let hostIndex = 0
+  for (const tabId of currentTabOrder) {
+    const nextTabId = mirroredUnifiedIds.has(tabId) ? hostTabOrder[hostIndex++] : tabId
+    if (nextTabId && validUnifiedTabIds.has(nextTabId) && !seen.has(nextTabId)) {
+      merged.push(nextTabId)
+      seen.add(nextTabId)
+    }
+  }
+  for (; hostIndex < hostTabOrder.length; hostIndex += 1) {
+    const tabId = hostTabOrder[hostIndex]
+    if (tabId && !seen.has(tabId)) {
+      merged.push(tabId)
+      seen.add(tabId)
+    }
+  }
+  return merged
+}
+
 function buildMirroredHostGroups({
   currentGroups,
   hostGroups,
@@ -1353,13 +1379,17 @@ function buildMirroredHostGroups({
 
   for (const hostGroup of hostGroups) {
     const existing = groupsById.get(hostGroup.id)
+    const currentGroup = currentGroups.find((group) => group.id === hostGroup.id)
     const localHostOrder = hostGroup.tabOrder
       .map((tabId) => hostToLocalTabId.get(tabId))
       .filter((tabId): tabId is string => tabId !== undefined && validUnifiedTabIds.has(tabId))
-    const hostTabOrder = [
-      ...(existing?.tabOrder.filter((tabId) => !localHostOrder.includes(tabId)) ?? []),
-      ...localHostOrder
-    ]
+    // Why: keep local file tabs in their existing slots while applying the host's order to mirrored tabs.
+    const hostTabOrder = mergeMirroredHostTabOrder(
+      currentGroup?.tabOrder ?? existing?.tabOrder ?? [],
+      localHostOrder,
+      mirroredUnifiedIds,
+      validUnifiedTabIds
+    )
     // Why: a pending client reorder wins over a stale pre-move host order until the host echoes the move (or membership changes).
     const tabOrder = resolveWebSessionReorderedOrder(
       { environmentId },


### PR DESCRIPTION
## Description

Remote file tabs opened from terminal output now preserve their local file-tab positions when the remote tab snapshot is reconciled.
The sync layer stops treating host-owned remote layout data as authoritative for local file tabs that were opened on the client.

## Focused fix

- In scope: preserve local file-tab insertion order during remote session-tab synchronization.
- Out of scope (explicit): changing general tab-group ordering or remote host layout persistence.

## Preserves

- Remote terminal and agent tabs continue to follow the host snapshot.
- Existing file-tab reuse and activation behavior are unchanged.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/runtime/web-session-tabs-sync.test.ts`
- Regression: the test keeps an existing local file-tab position across a remote snapshot update.

## User-regression-tradeoffs

- A local file tab may intentionally differ from the host's file-tab ordering so the user's client-side insertion choice is not overwritten.

Fixes #13055
