### PR TITLE
fix(mobile): preview remote terminal HTML taps

### DIFF
--- a/mobile/src/session/mobile-file-tap-open.test.ts
+++ b/mobile/src/session/mobile-file-tap-open.test.ts
@@ -338,7 +338,7 @@ describe('openMobileFileTap', () => {
     )
   })
 
-  it('does not open SSH worktree HTML paths as local browser file URLs', async () => {
+  it('opens SSH worktree HTML paths through the mobile preview route', async () => {
     const client = createClient([
       ok({
         worktree: 'wt-1',
@@ -352,10 +352,11 @@ describe('openMobileFileTap', () => {
           relativePath: 'report.html',
           absolutePath: '/home/me/repo/report.html'
         }
-      }),
-      ok({ opened: true })
+      })
     ])
     const openBrowser = vi.fn()
+    const pushPreviewRoute = vi.fn()
+    const triggerOpenFeedback = vi.fn()
 
     openMobileFileTap({
       client,
@@ -364,9 +365,9 @@ describe('openMobileFileTap', () => {
       pathText: 'report.html',
       line: null,
       column: null,
-      pushPreviewRoute: vi.fn(),
+      pushPreviewRoute,
       openBrowser,
-      triggerOpenFeedback: vi.fn(),
+      triggerOpenFeedback,
       fetchSessionTabs: vi.fn(),
       getSessionTabs: () => [],
       getActiveSessionTabId: () => null,
@@ -378,11 +379,18 @@ describe('openMobileFileTap', () => {
     await Promise.resolve()
 
     expect(openBrowser).not.toHaveBeenCalled()
-    expect(client.sendRequest).toHaveBeenCalledWith(
-      'files.open',
-      { worktree: 'id:wt-1', relativePath: 'report.html' },
-      { timeoutMs: 15_000 }
-    )
+    expect(pushPreviewRoute).toHaveBeenCalledWith({
+      pathname: '/h/[hostId]/files/preview/[worktreeId]',
+      params: expect.objectContaining({
+        hostId: 'host-1',
+        worktreeId: 'wt-1',
+        source: 'worktree',
+        relativePath: 'report.html',
+        name: 'report.html'
+      })
+    })
+    expect(triggerOpenFeedback).toHaveBeenCalledTimes(1)
+    expect(client.sendRequest).not.toHaveBeenCalledWith('files.open', expect.anything())
   })
 
   it('does not navigate an absolute artifact after the user leaves the source terminal', async () => {

--- a/mobile/src/session/mobile-file-tap-open.ts
+++ b/mobile/src/session/mobile-file-tap-open.ts
@@ -161,6 +161,22 @@ async function openMobileFileTapAsync<T extends FileTapSessionTab>(
     options.openBrowser(filesystemPathToFileUri(resolved.openTarget.absolutePath))
     return
   }
+  if (
+    classifyMobileArtifact(openedPath) === 'html' &&
+    resolved.openTarget?.kind === 'worktree-file'
+  ) {
+    options.pushPreviewRoute(
+      createMobileFilePreviewHref({
+        hostId: options.hostId,
+        worktreeId: resolvedWorktreeId,
+        source: 'worktree',
+        relativePath: openedPath,
+        name: displayNameFromPath(openedPath),
+        ...(resolvedWorktreeName ? { worktreeName: resolvedWorktreeName } : {})
+      })
+    )
+    return
+  }
   const openResponse = await options.client.sendRequest(
     'files.open',
     { worktree: resolvedWorktree, relativePath: openedPath },


### PR DESCRIPTION
## Description

HTML files opened from a remote or hosted terminal on Orca Mobile now use the mobile file-preview surface instead of falling through to a desktop-style file tab.
The existing local worktree `file://` browser handoff remains unchanged, while non-local HTML taps stay inside the authorized preview route.

## Focused fix

- In scope: route non-local HTML terminal taps through the mobile file-preview flow.
- Out of scope (explicit): changing local browser handoffs, file authorization, or HTML rendering policies.

## Preserves

- Terminal path resolution and terminal artifact grants remain required before navigation.
- Local HTML artifacts continue to open with the existing browser handoff so relative assets keep their local file context.

## Evidence

- Test: `pnpm exec vitest run src/session/mobile-file-tap-open.test.ts` from `mobile/`
- Regression: the remote HTML test verifies preview-route navigation, no browser handoff, and no `files.open` request.
- Quality: `pnpm exec oxlint src/session/mobile-file-tap-open.ts src/session/mobile-file-tap-open.test.ts`, `pnpm run typecheck`, and `pnpm exec oxfmt --check src/session/mobile-file-tap-open.ts src/session/mobile-file-tap-open.test.ts` from `mobile/`.

## User-regression-tradeoffs

- Remote HTML previews now stay in the mobile preview route and therefore use the existing mobile HTML sandbox; local HTML behavior is intentionally unchanged.

Fixes #13144
