### PR TITLE
fix(orchestration): keep heartbeats from waking coordinators

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -33438,6 +33438,68 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
+  it('keeps valid Run heartbeats silent without hiding substantive mail', async () => {
+    vi.useFakeTimers()
+    try {
+      const runtime = new OrcaRuntimeService(store)
+      const db = new InMemoryOrchestrationMessages()
+      const write = vi.fn().mockReturnValue(true)
+      setInMemoryOrchestrationMessages(runtime, db)
+      runtime.setPtyController({
+        write,
+        kill: vi.fn(),
+        getForegroundProcess: async () => null
+      })
+      syncSinglePty(runtime)
+
+      const [terminal] = (await runtime.listTerminals()).terminals
+      db.setRun({
+        id: 'run_heartbeat_mailbox',
+        coordinator_handle: terminal.handle,
+        coordinator_pane_key: `${terminal.tabId}:${terminal.leafId}`
+      })
+      runtime.onPtyData('pty-1', '\x1b]0;Codex working\x07', 100)
+      runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+      db.insertMessage({
+        from: 'term_worker',
+        to: 'run:run_heartbeat_mailbox',
+        subject: 'alive',
+        type: 'heartbeat'
+      })
+
+      runtime.notifyMessageArrived('run:run_heartbeat_mailbox', 'heartbeat')
+      await Promise.resolve()
+      expect(write).not.toHaveBeenCalled()
+
+      db.insertMessage({
+        from: 'term_worker',
+        to: 'run:run_heartbeat_mailbox',
+        subject: 'Rejected heartbeat: invalid sender',
+        type: 'heartbeat',
+        priority: 'high',
+        payload: JSON.stringify({
+          _orcaLifecycleRejection: { code: 'sender_not_assignee', reason: 'invalid sender' }
+        })
+      })
+      db.insertMessage({
+        from: 'term_worker',
+        to: 'run:run_heartbeat_mailbox',
+        subject: 'work complete',
+        type: 'worker_done'
+      })
+
+      runtime.notifyMessageArrived('run:run_heartbeat_mailbox', 'worker_done')
+      await Promise.resolve()
+      expect(write).toHaveBeenCalledWith(
+        'pty-1',
+        '\nYou have 2 orchestration messages. Run `orca orchestration check`.\n'
+      )
+      db.close()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('points already-idle Run mail after Codex replaces its completion title', async () => {
     const runtime = new OrcaRuntimeService(store)
     const db = new InMemoryOrchestrationMessages()

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -107,7 +107,7 @@ import { isAbsolute, join, resolve } from 'node:path'
 import { mkdir, readFile, readdir, rm, stat } from 'node:fs/promises'
 import { resolveWorktreeCreateBase } from '../worktree-create-base'
 import { resolveWorktreeAddBaseRef } from '../../shared/worktree-base-ref'
-import { OrchestrationDb } from './orchestration/db'
+import { hasLifecycleRejectionMarker, OrchestrationDb } from './orchestration/db'
 import { reconcileRequestedWorkerTerminalReleases } from './orchestration/worker-terminal-release-reconciliation'
 import { OrchestrationError } from './orchestration/orchestration-error'
 import {
@@ -32086,6 +32086,7 @@ export class OrcaRuntimeService {
       .getUndeliveredUnreadMessages(mailboxHandle)
       .filter(
         (message) =>
+          (message.type !== 'heartbeat' || hasLifecycleRejectionMarker(message.payload)) &&
           !options.reservedTypes?.has(message.type) &&
           !messageTypeHasLiveWaiter(waiters, message.type)
       )

--- a/src/main/runtime/orchestration/db.ts
+++ b/src/main/runtime/orchestration/db.ts
@@ -131,7 +131,7 @@ function addLifecycleRejectionMarker(payload: string | null, code: string, reaso
   })
 }
 
-function hasLifecycleRejectionMarker(payload: string | null): boolean {
+export function hasLifecycleRejectionMarker(payload: string | null): boolean {
   try {
     const value: unknown = JSON.parse(payload ?? 'null')
     if (!value || typeof value !== 'object' || Array.isArray(value)) {


### PR DESCRIPTION
## Summary

- keep valid orchestration heartbeats out of push-on-idle wake batches
- preserve rejected heartbeats as high-priority coordinator notifications
- leave valid heartbeat rows unread so explicit heartbeat checks remain auditable

## Why

Heartbeat-only traffic currently starts coordinator turns and accumulated heartbeats can inflate a later wake batch. Heartbeats already update dispatch liveness during lifecycle reconciliation, so they do not need to wake an idle coordinator.

## Verification

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts` (1074 passed, 1 skipped)
- `pnpm run typecheck`
- `pnpm exec oxlint src/main/runtime/orchestration/db.ts src/main/runtime/orca-runtime.ts src/main/runtime/orca-runtime.test.ts`
