### PR TITLE
feat(terminal): open custom app scheme links with user approval

### DIFF
--- a/src/main/external-app-url-open.test.ts
+++ b/src/main/external-app-url-open.test.ts
@@ -1,0 +1,81 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { openExternalMock, showMessageBoxMock } = vi.hoisted(() => ({
+  openExternalMock: vi.fn(),
+  showMessageBoxMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  shell: { openExternal: openExternalMock },
+  dialog: { showMessageBox: showMessageBoxMock }
+}))
+
+import { openExternalAppUrlWithUserApproval } from './external-app-url-open'
+
+describe('openExternalAppUrlWithUserApproval', () => {
+  beforeEach(() => {
+    openExternalMock.mockReset()
+    showMessageBoxMock.mockReset()
+    openExternalMock.mockResolvedValue(undefined)
+  })
+
+  it('opens http without prompting', async () => {
+    await expect(openExternalAppUrlWithUserApproval('https://example.com/')).resolves.toBe('opened')
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+    expect(openExternalMock).toHaveBeenCalledWith('https://example.com/')
+  })
+
+  it('prompts for custom schemes and cancels by default path', async () => {
+    showMessageBoxMock.mockResolvedValueOnce({ response: 1 })
+    await expect(
+      openExternalAppUrlWithUserApproval('oktaverify://bind', {
+        requestingOrigin: 'https://login.example.com'
+      })
+    ).resolves.toBe('cancelled')
+    expect(showMessageBoxMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        detail: expect.stringContaining('oktaverify://bind'),
+        message: expect.stringContaining('oktaverify')
+      })
+    )
+    expect(showMessageBoxMock.mock.calls[0]?.[0]?.detail).toContain(
+      'Requested by: https://login.example.com'
+    )
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('opens custom schemes after confirm', async () => {
+    showMessageBoxMock.mockResolvedValueOnce({ response: 0 })
+    await expect(openExternalAppUrlWithUserApproval('oktaverify://bind')).resolves.toBe('opened')
+    expect(openExternalMock).toHaveBeenCalledWith('oktaverify://bind')
+  })
+
+  it('denies dangerous schemes', async () => {
+    await expect(openExternalAppUrlWithUserApproval('javascript:alert(1)')).resolves.toBe('denied')
+    expect(showMessageBoxMock).not.toHaveBeenCalled()
+    expect(openExternalMock).not.toHaveBeenCalled()
+  })
+
+  it('serializes concurrent custom-scheme prompts', async () => {
+    let releaseFirst!: (value: { response: number }) => void
+    showMessageBoxMock
+      .mockImplementationOnce(
+        () =>
+          new Promise<{ response: number }>((resolve) => {
+            releaseFirst = resolve
+          })
+      )
+      .mockResolvedValueOnce({ response: 1 })
+
+    const first = openExternalAppUrlWithUserApproval('oktaverify://one')
+    const second = openExternalAppUrlWithUserApproval('oktaverify://two')
+
+    // Second must wait until the first dialog resolves.
+    await Promise.resolve()
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(1)
+    releaseFirst({ response: 1 })
+    await expect(first).resolves.toBe('cancelled')
+    await expect(second).resolves.toBe('cancelled')
+    expect(showMessageBoxMock).toHaveBeenCalledTimes(2)
+  })
+})

--- a/src/main/external-app-url-open.ts
+++ b/src/main/external-app-url-open.ts
@@ -1,0 +1,62 @@
+import { dialog, shell } from 'electron'
+import { classifyExternalAppUrl } from '../shared/external-app-url'
+
+export type OpenExternalAppUrlResult = 'opened' | 'cancelled' | 'denied' | 'invalid' | 'failed'
+
+// Why: will-navigate + window.open can fire many custom schemes at once; serialize
+// confirm dialogs so a hostile page cannot stack unbounded MessageBoxes (#12719).
+let customSchemePromptTail: Promise<unknown> = Promise.resolve()
+
+/**
+ * Open a custom app-scheme URL after an explicit user confirm dialog.
+ * http(s) open without prompt (caller should use normal paths for those).
+ */
+export async function openExternalAppUrlWithUserApproval(
+  rawUrl: string,
+  options: { requestingOrigin?: string } = {}
+): Promise<OpenExternalAppUrlResult> {
+  const classified = classifyExternalAppUrl(rawUrl)
+  if (!classified.ok) {
+    return classified.reason === 'denied' ? 'denied' : 'invalid'
+  }
+  if (classified.kind === 'http') {
+    try {
+      await shell.openExternal(classified.url)
+      return 'opened'
+    } catch {
+      return 'failed'
+    }
+  }
+
+  const runPrompt = async (): Promise<OpenExternalAppUrlResult> => {
+    const originLine = options.requestingOrigin?.trim()
+      ? `\n\nRequested by: ${options.requestingOrigin.trim()}`
+      : ''
+    const prompt = await dialog.showMessageBox({
+      type: 'question',
+      buttons: ['Open', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      title: 'Open external app link?',
+      message: `Open this ${classified.schemeLabel} link in the registered app?`,
+      detail: `${classified.url}${originLine}`,
+      noLink: true
+    })
+    if (prompt.response !== 0) {
+      return 'cancelled'
+    }
+    try {
+      await shell.openExternal(classified.url)
+      return 'opened'
+    } catch {
+      return 'failed'
+    }
+  }
+
+  const resultPromise = customSchemePromptTail.then(runPrompt, runPrompt)
+  customSchemePromptTail = resultPromise.then(
+    () => undefined,
+    () => undefined
+  )
+  return resultPromise
+}

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -22,17 +22,23 @@ const {
   statMock: vi.fn()
 }))
 
+const { openExternalMock, showMessageBoxMock } = vi.hoisted(() => ({
+  openExternalMock: vi.fn(),
+  showMessageBoxMock: vi.fn()
+}))
+
 vi.mock('electron', () => ({
   ipcMain: {
     handle: handleMock
   },
   shell: {
     showItemInFolder: showItemInFolderMock,
-    openExternal: vi.fn(),
+    openExternal: openExternalMock,
     openPath: openPathMock
   },
   dialog: {
-    showOpenDialog: showOpenDialogMock
+    showOpenDialog: showOpenDialogMock,
+    showMessageBox: showMessageBoxMock
   }
 }))
 
@@ -104,9 +110,11 @@ describe('registerShellHandlers', () => {
     handleMock.mockReset()
     getSpawnArgsForWindowsMock.mockReset()
     openPathMock.mockReset()
+    openExternalMock.mockReset()
     resolveCliCommandMock.mockReset()
     showItemInFolderMock.mockReset()
     showOpenDialogMock.mockReset()
+    showMessageBoxMock.mockReset()
     spawnMock.mockReset()
     statMock.mockReset()
     settings.activeRuntimeEnvironmentId = null
@@ -745,6 +753,47 @@ describe('registerShellHandlers', () => {
 
       await expect(handler({}, 'https://example.com/file.md')).resolves.toBeUndefined()
       expect(openPathMock).not.toHaveBeenCalled()
+    })
+
+    it('opens http URLs without a prompt', async () => {
+      openExternalMock.mockResolvedValueOnce(undefined)
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'https://example.com/docs')
+      expect(showMessageBoxMock).not.toHaveBeenCalled()
+      expect(openExternalMock).toHaveBeenCalledWith('https://example.com/docs')
+    })
+
+    it('prompts before opening custom app schemes and cancels by default', async () => {
+      showMessageBoxMock.mockResolvedValueOnce({ response: 1 })
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'obsidian://open?vault=notes')
+      expect(showMessageBoxMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('obsidian'),
+          detail: 'obsidian://open?vault=notes'
+        })
+      )
+      expect(openExternalMock).not.toHaveBeenCalled()
+    })
+
+    it('opens custom app schemes after the user confirms', async () => {
+      showMessageBoxMock.mockResolvedValueOnce({ response: 0 })
+      openExternalMock.mockResolvedValueOnce(undefined)
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'obsidian://open?vault=notes')
+      expect(openExternalMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+    })
+
+    it('never opens denied schemes', async () => {
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'javascript:alert(1)')
+      await handler({}, 'file:///etc/passwd')
+      expect(showMessageBoxMock).not.toHaveBeenCalled()
+      expect(openExternalMock).not.toHaveBeenCalled()
     })
 
     it('does not open remote file URIs', async () => {

--- a/src/main/ipc/shell.test.ts
+++ b/src/main/ipc/shell.test.ts
@@ -5,18 +5,22 @@ import { pathToFileURL } from 'node:url'
 const {
   getSpawnArgsForWindowsMock,
   handleMock,
+  openExternalMock,
   openPathMock,
   resolveCliCommandMock,
   showItemInFolderMock,
+  showMessageBoxMock,
   showOpenDialogMock,
   spawnMock,
   statMock
 } = vi.hoisted(() => ({
   getSpawnArgsForWindowsMock: vi.fn(),
   handleMock: vi.fn(),
+  openExternalMock: vi.fn(),
   openPathMock: vi.fn(),
   resolveCliCommandMock: vi.fn(),
   showItemInFolderMock: vi.fn(),
+  showMessageBoxMock: vi.fn(),
   showOpenDialogMock: vi.fn(),
   spawnMock: vi.fn(),
   statMock: vi.fn()
@@ -28,11 +32,12 @@ vi.mock('electron', () => ({
   },
   shell: {
     showItemInFolder: showItemInFolderMock,
-    openExternal: vi.fn(),
+    openExternal: openExternalMock,
     openPath: openPathMock
   },
   dialog: {
-    showOpenDialog: showOpenDialogMock
+    showOpenDialog: showOpenDialogMock,
+    showMessageBox: showMessageBoxMock
   }
 }))
 
@@ -103,9 +108,11 @@ describe('registerShellHandlers', () => {
   beforeEach(() => {
     handleMock.mockReset()
     getSpawnArgsForWindowsMock.mockReset()
+    openExternalMock.mockReset()
     openPathMock.mockReset()
     resolveCliCommandMock.mockReset()
     showItemInFolderMock.mockReset()
+    showMessageBoxMock.mockReset()
     showOpenDialogMock.mockReset()
     spawnMock.mockReset()
     statMock.mockReset()
@@ -738,6 +745,49 @@ describe('registerShellHandlers', () => {
 
       await expect(handler({}, filePath)).resolves.toBe(false)
       expect(openPathMock).toHaveBeenCalledWith(normalize(filePath))
+    })
+
+    it('opens http URLs without a prompt', async () => {
+      openExternalMock.mockResolvedValueOnce(undefined)
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'https://example.com/docs')
+      expect(showMessageBoxMock).not.toHaveBeenCalled()
+      expect(openExternalMock).toHaveBeenCalledWith('https://example.com/docs')
+    })
+
+    it('prompts before opening custom app schemes and cancels by default', async () => {
+      showMessageBoxMock.mockResolvedValueOnce({ response: 1 })
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'obsidian://open?vault=notes')
+      expect(showMessageBoxMock).toHaveBeenCalledWith(
+        expect.objectContaining({
+          message: expect.stringContaining('obsidian'),
+          detail: 'obsidian://open?vault=notes',
+          defaultId: 1,
+          cancelId: 1
+        })
+      )
+      expect(openExternalMock).not.toHaveBeenCalled()
+    })
+
+    it('opens custom app schemes after the user confirms', async () => {
+      showMessageBoxMock.mockResolvedValueOnce({ response: 0 })
+      openExternalMock.mockResolvedValueOnce(undefined)
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'obsidian://open?vault=notes')
+      expect(openExternalMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+    })
+
+    it('never opens denied schemes', async () => {
+      const handler = getHandler('shell:openUrl')
+
+      await handler({}, 'javascript:alert(1)')
+      await handler({}, 'file:///etc/passwd')
+      expect(showMessageBoxMock).not.toHaveBeenCalled()
+      expect(openExternalMock).not.toHaveBeenCalled()
     })
 
     it('does not open non-file URIs', async () => {

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -7,6 +7,7 @@ import type {
   ShellOpenExternalEditorResult,
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
+import { classifyExternalAppUrl } from '../../shared/external-app-url'
 import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
 import type { Store } from '../persistence'
 import {
@@ -153,19 +154,30 @@ export function registerShellHandlers(store: Store): void {
       openInExternalEditor(store, request)
   )
 
-  ipcMain.handle('shell:openUrl', (_event, rawUrl: string) => {
-    let parsed: URL
-    try {
-      parsed = new URL(rawUrl)
-    } catch {
+  ipcMain.handle('shell:openUrl', async (_event, rawUrl: string) => {
+    const classified = classifyExternalAppUrl(rawUrl)
+    if (!classified.ok) {
       return
     }
-
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
+    if (classified.kind === 'http') {
+      return shell.openExternal(classified.url)
+    }
+    // Why: custom schemes open OS-registered apps; require an explicit user
+    // gesture confirmation so terminal/agent output cannot auto-launch (#13225).
+    const prompt = await dialog.showMessageBox({
+      type: 'question',
+      buttons: ['Open', 'Cancel'],
+      defaultId: 1,
+      cancelId: 1,
+      title: 'Open external app link?',
+      message: `Open this ${classified.schemeLabel} link in the registered app?`,
+      detail: classified.url,
+      noLink: true
+    })
+    if (prompt.response !== 0) {
       return
     }
-
-    return shell.openExternal(parsed.toString())
+    return shell.openExternal(classified.url)
   })
 
   ipcMain.handle('shell:openFilePath', async (_event, filePath: string): Promise<boolean> => {

--- a/src/main/ipc/shell.ts
+++ b/src/main/ipc/shell.ts
@@ -8,13 +8,14 @@ import type {
   ShellOpenLocalPathResult
 } from '../../shared/shell-open-types'
 import { MAX_REPO_ICON_UPLOAD_BYTES } from '../../shared/repo-icon'
-import type { Store } from '../persistence'
+import { openExternalAppUrlWithUserApproval } from '../external-app-url-open'
 import {
   EXTERNAL_EDITOR_CLI_COMMAND,
   launchExternalEditor,
   resolveExternalEditorLaunchSpec,
   resolveVsCodeRemoteSshLaunchSpec
 } from '../external-editor-launch'
+import type { Store } from '../persistence'
 import { resolveVsCodeSshAuthority } from '../ssh/vscode-ssh-authority'
 
 export { EXTERNAL_EDITOR_CLI_COMMAND }
@@ -153,19 +154,8 @@ export function registerShellHandlers(store: Store): void {
       openInExternalEditor(store, request)
   )
 
-  ipcMain.handle('shell:openUrl', (_event, rawUrl: string) => {
-    let parsed: URL
-    try {
-      parsed = new URL(rawUrl)
-    } catch {
-      return
-    }
-
-    if (parsed.protocol !== 'https:' && parsed.protocol !== 'http:') {
-      return
-    }
-
-    return shell.openExternal(parsed.toString())
+  ipcMain.handle('shell:openUrl', async (_event, rawUrl: string) => {
+    await openExternalAppUrlWithUserApproval(rawUrl)
   })
 
   ipcMain.handle('shell:openFilePath', async (_event, filePath: string): Promise<boolean> => {

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.test.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.test.ts
@@ -1,0 +1,81 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { WebLinksAddonMock } = vi.hoisted(() => ({
+  WebLinksAddonMock: vi.fn()
+}))
+
+vi.mock('@xterm/addon-web-links', () => ({
+  WebLinksAddon: WebLinksAddonMock
+}))
+
+vi.mock('@/lib/pane-manager/terminal-link-provider-guard', () => ({
+  installGuardedLinkProviderRegistration: vi.fn()
+}))
+
+import { installPreviewTerminalLinks } from './preview-terminal-links'
+
+const openUrlMock = vi.fn()
+
+function previewLinkHandler(): (event: MouseEvent, uri: string) => void {
+  const terminal = {
+    loadAddon: vi.fn(),
+    clearSelection: vi.fn()
+  }
+  installPreviewTerminalLinks(terminal as never)
+  const handler = WebLinksAddonMock.mock.calls.at(-1)?.[0] as
+    | ((event: MouseEvent, uri: string) => void)
+    | undefined
+  if (!handler) {
+    throw new Error('Expected WebLinksAddon handler')
+  }
+  return handler
+}
+
+function mouseEvent(init: Partial<MouseEvent>): MouseEvent {
+  return {
+    button: 0,
+    metaKey: false,
+    ctrlKey: false,
+    altKey: false,
+    shiftKey: false,
+    preventDefault: vi.fn(),
+    ...init
+  } as MouseEvent
+}
+
+describe('installPreviewTerminalLinks custom schemes', () => {
+  beforeEach(() => {
+    WebLinksAddonMock.mockClear()
+    openUrlMock.mockReset()
+    openUrlMock.mockResolvedValue(undefined)
+    vi.stubGlobal('window', { api: { shell: { openUrl: openUrlMock } } })
+    vi.stubGlobal('navigator', { userAgent: 'Macintosh' })
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('does not hand off a custom app URL on a plain click', () => {
+    previewLinkHandler()(mouseEvent({}), 'obsidian://open?vault=notes')
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('does not hand off a custom app URL on the wrong platform modifier', () => {
+    previewLinkHandler()(mouseEvent({ ctrlKey: true }), 'obsidian://open?vault=notes')
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('opens custom app schemes with ⌘+click on Mac', () => {
+    previewLinkHandler()(mouseEvent({ metaKey: true }), 'obsidian://open?vault=notes')
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+  })
+
+  it('opens custom app schemes with Ctrl+click on non-Mac', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows NT 10.0' })
+    previewLinkHandler()(mouseEvent({ ctrlKey: true }), 'obsidian://open?vault=notes')
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+  })
+})

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
@@ -2,6 +2,7 @@ import type { Terminal } from '@xterm/xterm'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { installGuardedLinkProviderRegistration } from '@/lib/pane-manager/terminal-link-provider-guard'
 import { isTerminalHttpLinkActivation } from '@/components/terminal-pane/terminal-http-link-activation'
+import { TERMINAL_WEB_AND_APP_URL_REGEX } from '../../../../shared/external-app-url'
 
 /**
  * Makes URLs in the preview clickable under the same Mod+click gesture a pane
@@ -14,13 +15,16 @@ export function installPreviewTerminalLinks(terminal: Terminal): void {
   // and kills the renderer — guard before any provider registers.
   installGuardedLinkProviderRegistration(terminal)
   terminal.loadAddon(
-    new WebLinksAddon((event, uri) => {
-      if (!isTerminalHttpLinkActivation(event)) {
-        return
-      }
-      event.preventDefault()
-      void window.api.shell.openUrl(uri).catch(() => undefined)
-      terminal.clearSelection()
-    })
+    new WebLinksAddon(
+      (event, uri) => {
+        if (!isTerminalHttpLinkActivation(event)) {
+          return
+        }
+        event.preventDefault()
+        void window.api.shell.openUrl(uri).catch(() => undefined)
+        terminal.clearSelection()
+      },
+      { urlRegex: TERMINAL_WEB_AND_APP_URL_REGEX }
+    )
   )
 }

--- a/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
+++ b/src/renderer/src/components/dashboard-popout/preview-terminal-links.ts
@@ -2,7 +2,11 @@ import type { Terminal } from '@xterm/xterm'
 import { WebLinksAddon } from '@xterm/addon-web-links'
 import { installGuardedLinkProviderRegistration } from '@/lib/pane-manager/terminal-link-provider-guard'
 import { isTerminalHttpLinkActivation } from '@/components/terminal-pane/terminal-http-link-activation'
-import { TERMINAL_WEB_AND_APP_URL_REGEX } from '../../../../shared/external-app-url'
+import { isTerminalLinkDirectActivation } from '@/components/terminal-pane/terminal-link-activation'
+import {
+  classifyExternalAppUrl,
+  TERMINAL_WEB_AND_APP_URL_REGEX
+} from '../../../../shared/external-app-url'
 
 /**
  * Makes URLs in the preview clickable under the same Mod+click gesture a pane
@@ -17,6 +21,16 @@ export function installPreviewTerminalLinks(terminal: Terminal): void {
   terminal.loadAddon(
     new WebLinksAddon(
       (event, uri) => {
+        const classified = classifyExternalAppUrl(uri)
+        if (classified.ok && classified.kind === 'custom') {
+          if (!isTerminalLinkDirectActivation(event)) {
+            return
+          }
+          event.preventDefault()
+          void window.api.shell.openUrl(classified.url).catch(() => undefined)
+          terminal.clearSelection()
+          return
+        }
         if (!isTerminalHttpLinkActivation(event)) {
           return
         }

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.test.ts
@@ -1,5 +1,9 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
-import { getTerminalUrlOpenHint, terminalUrlOpenHintOptionsFor } from './terminal-link-open-hints'
+import {
+  getTerminalCustomAppSchemeOpenHint,
+  getTerminalUrlOpenHint,
+  terminalUrlOpenHintOptionsFor
+} from './terminal-link-open-hints'
 
 function stubPlatform(isMac: boolean): void {
   vi.stubGlobal('navigator', { userAgent: isMac ? 'Mac OS X' : 'Windows NT 10.0' })
@@ -163,5 +167,14 @@ describe('terminalUrlOpenHintOptionsFor', () => {
     )
 
     expect(options.modifierInverts).toBe(true)
+  })
+})
+
+describe('getTerminalCustomAppSchemeOpenHint', () => {
+  it('names the registered app on Mac and other platforms', () => {
+    stubPlatform(true)
+    expect(getTerminalCustomAppSchemeOpenHint()).toBe('⌘+click to open in the registered app')
+    stubPlatform(false)
+    expect(getTerminalCustomAppSchemeOpenHint()).toBe('Ctrl+click to open in the registered app')
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
@@ -89,6 +89,13 @@ export function getTerminalUrlOpenHint(options: TerminalUrlOpenHintOptions = {})
     : `${prefix}Ctrl+click to open, or Shift+Ctrl+click for system browser`
 }
 
+/** Custom app schemes always go through confirm → openExternal registered app. */
+export function getTerminalCustomAppSchemeOpenHint(): string {
+  return isMacPlatform()
+    ? '⌘+click to open in the registered app'
+    : 'Ctrl+click to open in the registered app'
+}
+
 export function getTerminalUrlSystemBrowserHint(): string {
   return isMacPlatform() ? '⇧⌘+click for system browser' : 'Shift+Ctrl+click for system browser'
 }

--- a/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-open-hints.ts
@@ -74,6 +74,13 @@ export function getTerminalUrlOpenHint(options: TerminalUrlOpenHintOptions = {})
     : `${prefix}Ctrl+click to open, or Shift+Ctrl+click for system browser`
 }
 
+/** Custom app schemes always go through confirm → openExternal registered app. */
+export function getTerminalCustomAppSchemeOpenHint(): string {
+  return isMacPlatform()
+    ? '⌘+click to open in the registered app'
+    : 'Ctrl+click to open in the registered app'
+}
+
 export function getTerminalUrlSystemBrowserHint(): string {
   return isMacPlatform() ? '⇧⌘+click for system browser' : 'Shift+Ctrl+click for system browser'
 }

--- a/src/renderer/src/components/terminal-pane/terminal-link-osc-url-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-osc-url-routing.test.ts
@@ -217,6 +217,33 @@ describe('handleOscLink', () => {
     expect(createBrowserTabMock).not.toHaveBeenCalled()
   })
 
+  it('does not hand off a custom OSC URL on a plain click', () => {
+    setPlatform('Macintosh')
+
+    expect(
+      handleOscLink('obsidian://open?vault=notes', { metaKey: false, ctrlKey: false }, deps)
+    ).toBe(false)
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('does not hand off a custom OSC URL on the wrong platform modifier', () => {
+    setPlatform('Macintosh')
+
+    expect(
+      handleOscLink('obsidian://open?vault=notes', { metaKey: false, ctrlKey: true }, deps)
+    ).toBe(false)
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('opens custom OSC schemes with Ctrl+click on non-Mac', () => {
+    setPlatform('Windows')
+
+    expect(
+      handleOscLink('obsidian://open?vault=notes', { metaKey: false, ctrlKey: true }, deps)
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+  })
+
   it('does not open custom app schemes without an owned gesture', () => {
     setPlatform('Macintosh')
 

--- a/src/renderer/src/components/terminal-pane/terminal-link-osc-url-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-link-osc-url-routing.test.ts
@@ -207,6 +207,32 @@ describe('handleOscLink', () => {
     expect(createBrowserTabMock).not.toHaveBeenCalled()
   })
 
+  it('opens custom app schemes through shell after an owned gesture', () => {
+    setPlatform('Macintosh')
+
+    expect(
+      handleOscLink('obsidian://open?vault=notes', { metaKey: true, ctrlKey: false }, deps)
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+    expect(createBrowserTabMock).not.toHaveBeenCalled()
+  })
+
+  it('does not open custom app schemes without an owned gesture', () => {
+    setPlatform('Macintosh')
+
+    expect(handleOscLink('obsidian://open?vault=notes', undefined, deps)).toBe(false)
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('does not open denied schemes from OSC 8', () => {
+    setPlatform('Macintosh')
+
+    expect(handleOscLink('javascript:alert(1)', { metaKey: true, ctrlKey: false }, deps)).toBe(
+      false
+    )
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
   it('falls back to the system browser when no worktree owns the terminal pane', () => {
     setPlatform('Macintosh')
     storeState.settings = { openLinksInApp: true }

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -1,5 +1,6 @@
 import { resolveTerminalFileLinkText } from '@/lib/terminal-links'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { resolveTerminalFileUrlTarget } from '../../../../shared/terminal-file-url-target'
 import {
@@ -149,6 +150,13 @@ export function handleOscLink(
         rawText
       )
     )
+  }
+
+  // Why: OSC 8 custom schemes must match plain-text WebLinks: confirm then openExternal (#13225).
+  const classified = classifyExternalAppUrl(rawText)
+  if (classified.ok && classified.kind === 'custom') {
+    void window.api.shell.openUrl(classified.url).catch(() => undefined)
+    return true
   }
   return false
 }

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -1,5 +1,6 @@
 import { resolveTerminalFileLinkText } from '@/lib/terminal-links'
 import { isWindowsAbsolutePathLike } from '../../../../shared/cross-platform-path'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { resolveTerminalFileUrlTarget } from '../../../../shared/terminal-file-url-target'
 import {
@@ -149,6 +150,13 @@ export function handleOscLink(
         rawText
       )
     )
+  }
+
+  // Why: OSC 8 custom schemes must match plain-text WebLinks: confirm then openExternal (#13225).
+  const classified = classifyExternalAppUrl(rawText)
+  if (classified.ok && classified.kind === 'custom') {
+    void Promise.resolve(window.api.shell.openUrl(classified.url)).catch(() => undefined)
+    return finish(true)
   }
   return false
 }

--- a/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-osc-link-routing.ts
@@ -152,9 +152,12 @@ export function handleOscLink(
     )
   }
 
-  // Why: OSC 8 custom schemes must match plain-text WebLinks: confirm then openExternal (#13225).
+  // Why: OSC custom handoff matches WebLinks: real Mod/Ctrl only, not plain action (#13225).
   const classified = classifyExternalAppUrl(rawText)
   if (classified.ok && classified.kind === 'custom') {
+    if (!isTerminalLinkDirectActivation(event)) {
+      return false
+    }
     void Promise.resolve(window.api.shell.openUrl(classified.url)).catch(() => undefined)
     return finish(true)
   }

--- a/src/renderer/src/components/terminal-pane/terminal-pane-lifecycle-primitives.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-lifecycle-primitives.test.ts
@@ -1,0 +1,15 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { formatTerminalUrlTooltip } from './terminal-pane-lifecycle-primitives'
+
+describe('formatTerminalUrlTooltip', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('uses the registered-app hint for custom schemes', async () => {
+    vi.stubGlobal('navigator', { userAgent: 'Macintosh' })
+    await expect(
+      formatTerminalUrlTooltip('obsidian://open?vault=notes', 'http hint', { kind: 'local' })
+    ).resolves.toBe('obsidian://open?vault=notes (⌘+click to open in the registered app)')
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-pane-lifecycle-primitives.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-pane-lifecycle-primitives.ts
@@ -7,6 +7,8 @@ import { RESET_KITTY_KEYBOARD_PROTOCOL } from '../../../../shared/terminal-mode-
 import type { TerminalPaneSplitSource } from '../../../../shared/feature-education-telemetry'
 import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
 import { resolveLocalhostHttpLinkDisplayUrl } from '@/lib/http-link-routing'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
+import { getTerminalCustomAppSchemeOpenHint } from './terminal-link-open-hints'
 import { recordCreatedTerminalPaneSplit } from './terminal-pane-split-completion'
 import { PRIMARY_SELECTION_MAX_LENGTH } from '@/lib/primary-selection'
 
@@ -67,6 +69,11 @@ export async function formatTerminalUrlTooltip(
   openLinkHint: string,
   sourceOwner: HttpLinkSourceOwner
 ): Promise<string | null> {
+  const classified = classifyExternalAppUrl(url)
+  if (classified.ok && classified.kind === 'custom') {
+    // Why: custom schemes never use Orca/browser routing; avoid HTTP-style hints (#13225).
+    return `${url} (${getTerminalCustomAppSchemeOpenHint()})`
+  }
   const labeledUrl = await resolveLocalhostHttpLinkDisplayUrl(url, sourceOwner)
   if (!labeledUrl) {
     return null

--- a/src/renderer/src/components/terminal-pane/terminal-url-link-click.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-url-link-click.test.ts
@@ -533,4 +533,40 @@ describe('hard-wrapped terminal HTTP clicks', () => {
     expect(openUrlMock).not.toHaveBeenCalled()
     disposable.dispose()
   })
+
+  it('opens custom app schemes through shell and skips HTTP routing', () => {
+    const { terminal, clearSelection } = makeTerminal({
+      urlRows: ['obsidian://open?vault=notes']
+    })
+    const event = mouseEventForRow(0)
+
+    expect(
+      handleTerminalWebLinkClick('obsidian://open?vault=notes', event, {
+        terminal,
+        worktreeId: 'wt-1',
+        worktreePath: '/tmp',
+        startupCwd: '/tmp'
+      })
+    ).toBe(true)
+    expect(event.preventDefault).toHaveBeenCalled()
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+    expect(clearSelection).toHaveBeenCalled()
+  })
+
+  it('does not open custom app schemes without an owned gesture', () => {
+    const { terminal } = makeTerminal({
+      urlRows: ['obsidian://open?vault=notes']
+    })
+
+    expect(
+      handleTerminalWebLinkClick('obsidian://open?vault=notes', undefined, {
+        terminal,
+        worktreeId: 'wt-1',
+        worktreePath: '/tmp',
+        startupCwd: '/tmp'
+      })
+    ).toBe(false)
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-url-link-click.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-url-link-click.test.ts
@@ -534,6 +534,65 @@ describe('hard-wrapped terminal HTTP clicks', () => {
     disposable.dispose()
   })
 
+  it('does not hand off a custom app URL on a plain click', () => {
+    const { terminal } = makeTerminal({ urlRows: ['obsidian://open?vault=notes'] })
+    const event = mouseEventForRow(0, { plain: true })
+    handleTerminalWebLinkClick('obsidian://open?vault=notes', event, {
+      terminal,
+      worktreeId: 'wt-1',
+      worktreePath: '/tmp',
+      startupCwd: '/tmp'
+    })
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('does not hand off a custom app URL on the wrong platform modifier', () => {
+    const { terminal } = makeTerminal({ urlRows: ['obsidian://open?vault=notes'] })
+    const event = {
+      button: 0,
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+      preventDefault: vi.fn()
+    } as unknown as MouseEvent
+    expect(
+      handleTerminalWebLinkClick('obsidian://open?vault=notes', event, {
+        terminal,
+        worktreeId: 'wt-1',
+        worktreePath: '/tmp',
+        startupCwd: '/tmp'
+      })
+    ).toBe(false)
+    expect(openUrlMock).not.toHaveBeenCalled()
+  })
+
+  it('opens custom app schemes with Ctrl+click on non-Mac', () => {
+    vi.stubGlobal('navigator', { userAgent: 'Windows NT 10.0' })
+    const { terminal, clearSelection } = makeTerminal({
+      urlRows: ['obsidian://open?vault=notes']
+    })
+    const event = {
+      button: 0,
+      metaKey: false,
+      ctrlKey: true,
+      altKey: false,
+      shiftKey: false,
+      preventDefault: vi.fn()
+    } as unknown as MouseEvent
+    expect(
+      handleTerminalWebLinkClick('obsidian://open?vault=notes', event, {
+        terminal,
+        worktreeId: 'wt-1',
+        worktreePath: '/tmp',
+        startupCwd: '/tmp'
+      })
+    ).toBe(true)
+    expect(openUrlMock).toHaveBeenCalledOnce()
+    expect(openUrlMock).toHaveBeenCalledWith('obsidian://open?vault=notes')
+    expect(clearSelection).toHaveBeenCalled()
+  })
+
   it('opens custom app schemes through shell and skips HTTP routing', () => {
     const { terminal, clearSelection } = makeTerminal({
       urlRows: ['obsidian://open?vault=notes']

--- a/src/renderer/src/components/terminal-pane/terminal-web-link-click.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-web-link-click.ts
@@ -10,6 +10,7 @@ import {
 } from './terminal-url-link-hit-testing'
 import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
 import type { TerminalLinkActionContext } from './terminal-link-action-request'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
 
 type TerminalWebLinkClickDeps = Pick<
   LinkHandlerDeps,
@@ -29,6 +30,15 @@ export function handleTerminalWebLinkClick(
 ): boolean {
   if (!event || !isTerminalOwnedLinkGesture(event)) {
     return false
+  }
+
+  // Why: custom app schemes skip in-app browser routing; main prompts then openExternal (#13225).
+  const classified = classifyExternalAppUrl(url)
+  if (classified.ok && classified.kind === 'custom') {
+    event.preventDefault()
+    void window.api.shell.openUrl(classified.url).catch(() => undefined)
+    deps.terminal?.clearSelection()
+    return true
   }
 
   let handled: boolean

--- a/src/renderer/src/components/terminal-pane/terminal-web-link-click.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-web-link-click.ts
@@ -1,6 +1,9 @@
 import type { Terminal } from '@xterm/xterm'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
-import { isTerminalOwnedLinkGesture } from './terminal-link-activation'
+import {
+  isTerminalLinkDirectActivation,
+  isTerminalOwnedLinkGesture
+} from './terminal-link-activation'
 import { handleOscLink } from './terminal-osc-link-routing'
 import {
   findHttpLinkAtTerminalMouseEvent,
@@ -28,17 +31,25 @@ export function handleTerminalWebLinkClick(
   event: MouseEvent | undefined,
   deps: TerminalWebLinkClickDeps
 ): boolean {
-  if (!event || !isTerminalOwnedLinkGesture(event)) {
+  if (!event) {
     return false
   }
 
-  // Why: custom app schemes skip in-app browser routing; main prompts then openExternal (#13225).
+  // Why: custom OS handoff is Mod/Ctrl only. Plain click stays on the HTTP action
+  // menu path and must not open a confirm dialog (#13225).
   const classified = classifyExternalAppUrl(url)
   if (classified.ok && classified.kind === 'custom') {
+    if (!isTerminalLinkDirectActivation(event)) {
+      return false
+    }
     event.preventDefault()
     void Promise.resolve(window.api.shell.openUrl(classified.url)).catch(() => undefined)
     deps.terminal?.clearSelection()
     return true
+  }
+
+  if (!isTerminalOwnedLinkGesture(event)) {
+    return false
   }
 
   let handled: boolean

--- a/src/renderer/src/components/terminal-pane/terminal-web-link-click.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-web-link-click.ts
@@ -10,6 +10,7 @@ import {
 } from './terminal-url-link-hit-testing'
 import type { HttpLinkSourceOwner } from '@/lib/http-link-routing'
 import type { TerminalLinkActionContext } from './terminal-link-action-request'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
 
 type TerminalWebLinkClickDeps = Pick<
   LinkHandlerDeps,
@@ -29,6 +30,15 @@ export function handleTerminalWebLinkClick(
 ): boolean {
   if (!event || !isTerminalOwnedLinkGesture(event)) {
     return false
+  }
+
+  // Why: custom app schemes skip in-app browser routing; main prompts then openExternal (#13225).
+  const classified = classifyExternalAppUrl(url)
+  if (classified.ok && classified.kind === 'custom') {
+    event.preventDefault()
+    void Promise.resolve(window.api.shell.openUrl(classified.url)).catch(() => undefined)
+    deps.terminal?.clearSelection()
+    return true
   }
 
   let handled: boolean

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -33,9 +33,11 @@ import {
   installFilePathLinkClickFallback
 } from './terminal-link-handlers'
 import {
+  getTerminalCustomAppSchemeOpenHint,
   terminalHttpLinkActionDestinationsFor,
   terminalUrlOpenHintOptionsFor
 } from './terminal-link-open-hints'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
 import { createTerminalHandleLinkProvider } from './terminal-handle-links'
 import type { LinkHandlerDeps } from './terminal-link-handlers'
 import { handleOscLink } from './terminal-osc-link-routing'
@@ -215,6 +217,11 @@ async function formatTerminalUrlTooltip(
   openLinkHint: string,
   sourceOwner: HttpLinkSourceOwner
 ): Promise<string | null> {
+  const classified = classifyExternalAppUrl(url)
+  if (classified.ok && classified.kind === 'custom') {
+    // Why: custom schemes never use Orca/browser routing; avoid HTTP-style hints (#13225).
+    return `${url} (${getTerminalCustomAppSchemeOpenHint()})`
+  }
   const labeledUrl = await resolveLocalhostHttpLinkDisplayUrl(url, sourceOwner)
   if (!labeledUrl) {
     return null

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.test.ts
@@ -1,11 +1,17 @@
 // @vitest-environment happy-dom
 import { describe, expect, it, vi } from 'vitest'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+import { TERMINAL_WEB_AND_APP_URL_REGEX } from '../../../../shared/external-app-url'
+import { getTerminalCustomAppSchemeOpenHint } from '@/components/terminal-pane/terminal-link-open-hints'
 import { createPaneDOM } from './pane-dom-creation'
 
 const webLinksAddonMock = vi.hoisted(() => ({
   handler: null as ((event: MouseEvent, uri: string) => void) | null,
-  options: null as { hover?: (event: MouseEvent, uri: string) => void; leave?: () => void } | null
+  options: null as {
+    hover?: (event: MouseEvent, uri: string) => void
+    leave?: () => void
+    urlRegex?: RegExp
+  } | null
 }))
 
 vi.mock('@xterm/addon-fit', () => ({
@@ -155,5 +161,38 @@ describe('createPaneDOM link tooltips', () => {
     webLinksAddonMock.handler?.(event, 'https://example.com')
 
     expect(onLinkClick).toHaveBeenCalledWith(7, event, 'https://example.com')
+  })
+
+  it('linkifies custom app schemes with the shared matcher', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+    createPaneDOM(
+      1,
+      leafId,
+      { linkOpenHint: () => 'open hint' },
+      { active: null } as never,
+      {} as never,
+      vi.fn(),
+      vi.fn()
+    )
+
+    expect(webLinksAddonMock.options?.urlRegex).toBe(TERMINAL_WEB_AND_APP_URL_REGEX)
+  })
+
+  it('uses the registered-app hint for custom scheme hover text', () => {
+    const leafId = '11111111-1111-4111-8111-111111111111' as TerminalLeafId
+    const pane = createPaneDOM(
+      1,
+      leafId,
+      { linkOpenHint: () => 'http hint' },
+      { active: null } as never,
+      {} as never,
+      vi.fn(),
+      vi.fn()
+    )
+
+    webLinksAddonMock.options?.hover?.({} as MouseEvent, 'obsidian://open?vault=notes')
+    expect(pane.linkTooltip.textContent).toBe(
+      `obsidian://open?vault=notes (${getTerminalCustomAppSchemeOpenHint()})`
+    )
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -6,7 +6,10 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
-import { TERMINAL_WEB_AND_APP_URL_REGEX } from '../../../../shared/external-app-url'
+import {
+  classifyExternalAppUrl,
+  TERMINAL_WEB_AND_APP_URL_REGEX
+} from '../../../../shared/external-app-url'
 import type { DragReorderCallbacks, DragReorderState } from './pane-drag-reorder'
 import { attachPaneDrag } from './pane-drag-pointer'
 import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
@@ -16,7 +19,16 @@ import { ENABLE_WEBGL_RENDERER } from './pane-webgl-renderer'
 import { installGuardedLinkProviderRegistration } from './terminal-link-provider-guard'
 import { installWindowsCtrlAltChordRepair } from './terminal-windows-ctrl-alt-chord-classification'
 
+function customAppSchemeOpenHint(): string {
+  const mac = typeof navigator !== 'undefined' && navigator.userAgent.includes('Mac')
+  return mac ? '⌘+click to open in the registered app' : 'Ctrl+click to open in the registered app'
+}
+
 function defaultLinkTooltipText(uri: string, openLinkHint: string): string {
+  const classified = classifyExternalAppUrl(uri)
+  if (classified.ok && classified.kind === 'custom') {
+    return `${uri} (${customAppSchemeOpenHint()})`
+  }
   return `${uri} (${openLinkHint})`
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -6,6 +6,7 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+import { TERMINAL_WEB_AND_APP_URL_REGEX } from '../../../../shared/external-app-url'
 import type { DragReorderCallbacks, DragReorderState } from './pane-drag-reorder'
 import { attachPaneDrag } from './pane-drag-pointer'
 import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
@@ -72,6 +73,9 @@ export function createPaneDOM(
   const webLinksAddon = new WebLinksAddon(
     options.onLinkClick ? (event, uri) => options.onLinkClick!(id, event, uri) : undefined,
     {
+      // Why: include custom app schemes (obsidian://, vscode://, …) so agents'
+      // OS-handler links are clickable; open still requires main-process approval (#13225).
+      urlRegex: TERMINAL_WEB_AND_APP_URL_REGEX,
       hover: (_event, uri) => {
         if (uri) {
           linkTooltipHoverToken += 1

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -6,6 +6,11 @@ import { WebLinksAddon } from '@xterm/addon-web-links'
 import { Terminal } from '@xterm/xterm'
 import type { ITerminalOptions } from '@xterm/xterm'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
+import {
+  classifyExternalAppUrl,
+  TERMINAL_WEB_AND_APP_URL_REGEX
+} from '../../../../shared/external-app-url'
+import { getTerminalCustomAppSchemeOpenHint } from '@/components/terminal-pane/terminal-link-open-hints'
 import type { DragReorderCallbacks, DragReorderState } from './pane-drag-reorder'
 import { attachPaneDrag } from './pane-drag-pointer'
 import type { ManagedPaneInternal, PaneManagerOptions } from './pane-manager-types'
@@ -16,6 +21,10 @@ import { installGuardedLinkProviderRegistration } from './terminal-link-provider
 import { installWindowsCtrlAltChordRepair } from './terminal-windows-ctrl-alt-chord-classification'
 
 function defaultLinkTooltipText(uri: string, openLinkHint: string): string {
+  const classified = classifyExternalAppUrl(uri)
+  if (classified.ok && classified.kind === 'custom') {
+    return `${uri} (${getTerminalCustomAppSchemeOpenHint()})`
+  }
   return `${uri} (${openLinkHint})`
 }
 
@@ -72,6 +81,9 @@ export function createPaneDOM(
   const webLinksAddon = new WebLinksAddon(
     options.onLinkClick ? (event, uri) => options.onLinkClick!(id, event, uri) : undefined,
     {
+      // Why: include custom app schemes (obsidian://, vscode://, …) so agents'
+      // OS-handler links are clickable; open still requires main-process approval (#13225).
+      urlRegex: TERMINAL_WEB_AND_APP_URL_REGEX,
       hover: (_event, uri) => {
         if (uri) {
           linkTooltipHoverToken += 1

--- a/src/renderer/src/web/preload-api/web-shell-api.ts
+++ b/src/renderer/src/web/preload-api/web-shell-api.ts
@@ -1,4 +1,5 @@
 import type { PreloadApi } from '../../../../preload/api-types'
+import { classifyExternalAppUrl } from '../../../../shared/external-app-url'
 import { resolveRuntimeFilePath } from './web-runtime-worktree-catalog'
 
 export function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
@@ -8,7 +9,15 @@ export function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
       Promise.resolve(window.open(path, '_blank', 'noopener,noreferrer') as never),
     openInFileManager: () => Promise.resolve(openResult),
     openInExternalEditor: () => Promise.resolve(openResult),
-    openUrl: (url) => Promise.resolve(window.open(url, '_blank', 'noopener,noreferrer') as never),
+    openUrl: async (url) => {
+      // Why: desktop has a Cancel-default confirmation for custom schemes; web
+      // has no controlled approval surface, so only HTTP(S) may leave the app.
+      const classified = classifyExternalAppUrl(url)
+      if (!classified.ok || classified.kind !== 'http') {
+        return
+      }
+      window.open(classified.url, '_blank', 'noopener,noreferrer')
+    },
     openFilePath: () => Promise.resolve(false),
     openFileUri: (uri) =>
       Promise.resolve(window.open(uri, '_blank', 'noopener,noreferrer') as never),

--- a/src/renderer/src/web/web-preload-api-shell.test.ts
+++ b/src/renderer/src/web/web-preload-api-shell.test.ts
@@ -1,0 +1,28 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { installApi } from './web-preload-api-test-harness'
+
+describe('web shell URL policy', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+    vi.doUnmock('./web-runtime-client')
+  })
+
+  it('opens HTTP links but refuses custom app schemes without a controlled confirmation UI', async () => {
+    const { api, window } = await installApi('Linux')
+    const open = vi.fn()
+    const confirm = vi.fn()
+    Object.assign(window, { open, confirm })
+
+    await api.shell.openUrl('hTtPs://example.com/path')
+    expect(open).toHaveBeenCalledWith('https://example.com/path', '_blank', 'noopener,noreferrer')
+
+    open.mockClear()
+    await api.shell.openUrl('obsidian://vault/note')
+    expect(confirm).not.toHaveBeenCalled()
+    expect(open).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -9,6 +9,7 @@ import type {
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import { parseHostAccessLink } from '../../../shared/remote-pairing-address'
 import { verifyRemotePairingRuntimeStatus } from '../../../shared/remote-pairing-verification'
+import { classifyExternalAppUrl } from '../../../shared/external-app-url'
 import type { AiVaultDeleteSessionArgs } from '../../../shared/ai-vault-session-deletion'
 import type { AiVaultListArgs, AiVaultListResult } from '../../../shared/ai-vault-types'
 import type {
@@ -3216,7 +3217,24 @@ function createShellApi(): NonNullable<Partial<PreloadApi>['shell']> {
       Promise.resolve(window.open(path, '_blank', 'noopener,noreferrer') as never),
     openInFileManager: () => Promise.resolve(openResult),
     openInExternalEditor: () => Promise.resolve(openResult),
-    openUrl: (url) => Promise.resolve(window.open(url, '_blank', 'noopener,noreferrer') as never),
+    openUrl: async (url) => {
+      // Why: desktop shell:openUrl classifies + confirms custom schemes; web must not
+      // silently window.open app handlers (no openExternal confirm dialog) (#13225).
+      const classified = classifyExternalAppUrl(url)
+      if (!classified.ok) {
+        return
+      }
+      if (classified.kind === 'http') {
+        window.open(classified.url, '_blank', 'noopener,noreferrer')
+        return
+      }
+      const ok = window.confirm(
+        `Open this ${classified.schemeLabel} link in the registered app?\n\n${classified.url}`
+      )
+      if (ok) {
+        window.open(classified.url, '_blank', 'noopener,noreferrer')
+      }
+    },
     openFilePath: () => Promise.resolve(false),
     openFileUri: (uri) =>
       Promise.resolve(window.open(uri, '_blank', 'noopener,noreferrer') as never),

--- a/src/shared/external-app-url.test.ts
+++ b/src/shared/external-app-url.test.ts
@@ -39,6 +39,22 @@ describe('classifyExternalAppUrl', () => {
       ok: false,
       reason: 'denied'
     })
+    expect(classifyExternalAppUrl('smb://server/share')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('jnlp://example.com/app.jnlp')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('ms-msdt://idpcmdi?page=...')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('search-ms:query=test')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
   })
 
   it('rejects invalid input', () => {
@@ -52,5 +68,12 @@ describe('TERMINAL_WEB_AND_APP_URL_REGEX', () => {
     const text = 'see https://ex.com and obsidian://open?vault=v file.md'
     const matches = text.match(new RegExp(TERMINAL_WEB_AND_APP_URL_REGEX.source, 'g'))
     expect(matches).toEqual(expect.arrayContaining(['https://ex.com', 'obsidian://open?vault=v']))
+  })
+
+  it('does not linkify denied schemes', () => {
+    const text =
+      'file:///etc/passwd javascript:alert(1) chrome://settings data:text/html,hi smb://host/share jnlp://x/app.jnlp'
+    const matches = text.match(new RegExp(TERMINAL_WEB_AND_APP_URL_REGEX.source, 'g'))
+    expect(matches).toBeNull()
   })
 })

--- a/src/shared/external-app-url.test.ts
+++ b/src/shared/external-app-url.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { classifyExternalAppUrl, TERMINAL_WEB_AND_APP_URL_REGEX } from './external-app-url'
+
+describe('classifyExternalAppUrl', () => {
+  it('accepts http and https', () => {
+    expect(classifyExternalAppUrl('https://example.com/a')).toMatchObject({
+      ok: true,
+      kind: 'http'
+    })
+    expect(classifyExternalAppUrl('http://localhost:3000')).toMatchObject({
+      ok: true,
+      kind: 'http'
+    })
+  })
+
+  it('accepts custom app schemes', () => {
+    expect(classifyExternalAppUrl('obsidian://open?vault=notes&file=Inbox.md')).toMatchObject({
+      ok: true,
+      kind: 'custom',
+      schemeLabel: 'obsidian'
+    })
+    expect(classifyExternalAppUrl('vscode://file/tmp/x')).toMatchObject({
+      ok: true,
+      kind: 'custom',
+      schemeLabel: 'vscode'
+    })
+  })
+
+  it('denies dangerous schemes', () => {
+    expect(classifyExternalAppUrl('javascript:alert(1)')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('data:text/html,hi')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('file:///etc/passwd')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+  })
+
+  it('rejects invalid input', () => {
+    expect(classifyExternalAppUrl('')).toEqual({ ok: false, reason: 'invalid' })
+    expect(classifyExternalAppUrl('not a url')).toEqual({ ok: false, reason: 'invalid' })
+  })
+})
+
+describe('TERMINAL_WEB_AND_APP_URL_REGEX', () => {
+  it('matches http and custom app URLs in text', () => {
+    const text = 'see https://ex.com and obsidian://open?vault=v file.md'
+    const matches = text.match(new RegExp(TERMINAL_WEB_AND_APP_URL_REGEX.source, 'g'))
+    expect(matches).toEqual(expect.arrayContaining(['https://ex.com', 'obsidian://open?vault=v']))
+  })
+})

--- a/src/shared/external-app-url.test.ts
+++ b/src/shared/external-app-url.test.ts
@@ -1,0 +1,96 @@
+import { describe, expect, it } from 'vitest'
+import { classifyExternalAppUrl, TERMINAL_WEB_AND_APP_URL_REGEX } from './external-app-url'
+
+describe('classifyExternalAppUrl', () => {
+  it('accepts http and https', () => {
+    expect(classifyExternalAppUrl('https://example.com/a')).toMatchObject({
+      ok: true,
+      kind: 'http'
+    })
+    expect(classifyExternalAppUrl('http://localhost:3000')).toMatchObject({
+      ok: true,
+      kind: 'http'
+    })
+  })
+
+  it('accepts custom app schemes', () => {
+    expect(classifyExternalAppUrl('obsidian://open?vault=notes&file=Inbox.md')).toMatchObject({
+      ok: true,
+      kind: 'custom',
+      schemeLabel: 'obsidian'
+    })
+    expect(classifyExternalAppUrl('vscode://file/tmp/x')).toMatchObject({
+      ok: true,
+      kind: 'custom',
+      schemeLabel: 'vscode'
+    })
+  })
+
+  it('denies dangerous schemes', () => {
+    expect(classifyExternalAppUrl('javascript:alert(1)')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('data:text/html,hi')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('vbscript:msgbox(1)')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('file:///etc/passwd')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('smb://server/share')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('jnlp://example.com/app.jnlp')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('ms-msdt://idpcmdi?page=...')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+    expect(classifyExternalAppUrl('search-ms:query=test')).toEqual({
+      ok: false,
+      reason: 'denied'
+    })
+  })
+
+  it('rejects invalid input', () => {
+    expect(classifyExternalAppUrl('')).toEqual({ ok: false, reason: 'invalid' })
+    expect(classifyExternalAppUrl('not a url')).toEqual({ ok: false, reason: 'invalid' })
+  })
+
+  it('rejects uppercase custom schemes', () => {
+    expect(classifyExternalAppUrl('Error://example')).toEqual({
+      ok: false,
+      reason: 'unsupported'
+    })
+  })
+})
+
+describe('TERMINAL_WEB_AND_APP_URL_REGEX', () => {
+  it('matches http and custom app URLs in text', () => {
+    const text = 'see https://ex.com and obsidian://open?vault=v file.md'
+    const matches = text.match(new RegExp(TERMINAL_WEB_AND_APP_URL_REGEX.source, 'g'))
+    expect(matches).toEqual(expect.arrayContaining(['https://ex.com', 'obsidian://open?vault=v']))
+  })
+
+  it('does not linkify denied schemes', () => {
+    const text =
+      'file:///etc/passwd javascript:alert(1) vbscript://msgbox chrome://settings data:text/html,hi smb://host/share jnlp://x/app.jnlp'
+    const matches = text.match(new RegExp(TERMINAL_WEB_AND_APP_URL_REGEX.source, 'g'))
+    expect(matches).toBeNull()
+  })
+
+  it('does not linkify uppercase custom schemes', () => {
+    expect(
+      'Error://example'.match(new RegExp(TERMINAL_WEB_AND_APP_URL_REGEX.source, 'g'))
+    ).toBeNull()
+  })
+})

--- a/src/shared/external-app-url.ts
+++ b/src/shared/external-app-url.ts
@@ -1,0 +1,64 @@
+/**
+ * Classify URLs for shell handoff. http(s) stay on the existing path;
+ * other schemes need an explicit user-approved openExternal (#13225).
+ */
+
+const DENIED_PROTOCOLS = new Set([
+  'javascript:',
+  'data:',
+  'vbscript:',
+  'file:',
+  'about:',
+  'blob:',
+  'chrome:',
+  'chrome-extension:',
+  'ms-appx:',
+  'ms-appx-web:'
+])
+
+export type ExternalAppUrlClassification =
+  | { ok: true; kind: 'http'; url: string; protocol: string }
+  | { ok: true; kind: 'custom'; url: string; protocol: string; schemeLabel: string }
+  | { ok: false; reason: 'invalid' | 'denied' | 'unsupported' }
+
+/** Match http(s) and custom app schemes like obsidian://, vscode:// in terminal text. */
+// Why: trailing punctuation stripped like xterm's default http regex; ^/[ unescaped
+// inside [] (oxlint no-useless-escape).
+export const TERMINAL_WEB_AND_APP_URL_REGEX =
+  /(?:https?|HTTPS?|[a-zA-Z][a-zA-Z0-9+.-]{1,31}):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/
+
+export function classifyExternalAppUrl(rawUrl: string): ExternalAppUrlClassification {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) {
+    return { ok: false, reason: 'invalid' }
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return { ok: false, reason: 'invalid' }
+  }
+  const protocol = parsed.protocol.toLowerCase()
+  if (protocol === 'http:' || protocol === 'https:') {
+    return { ok: true, kind: 'http', url: parsed.toString(), protocol }
+  }
+  if (DENIED_PROTOCOLS.has(protocol)) {
+    return { ok: false, reason: 'denied' }
+  }
+  // Why: scheme must look like an app protocol (letters + optional +.-), not a
+  // single-letter drive-style or empty host with no path (noise from false matches).
+  if (!/^[a-z][a-z0-9+.-]*:$/i.test(protocol) || protocol.length < 3) {
+    return { ok: false, reason: 'unsupported' }
+  }
+  if (!parsed.hostname && !parsed.pathname && !parsed.search && !parsed.hash) {
+    return { ok: false, reason: 'invalid' }
+  }
+  const schemeLabel = protocol.slice(0, -1)
+  return {
+    ok: true,
+    kind: 'custom',
+    url: parsed.toString(),
+    protocol,
+    schemeLabel
+  }
+}

--- a/src/shared/external-app-url.ts
+++ b/src/shared/external-app-url.ts
@@ -3,6 +3,8 @@
  * other schemes need an explicit user-approved openExternal (#13225).
  */
 
+// Why: hard-deny schemes that can hand off to shell/exec paths even after a
+// confirm (Follina-style / UNC / JNLP). User cancel is not enough (#13225).
 const DENIED_PROTOCOLS = new Set([
   'javascript:',
   'data:',
@@ -13,7 +15,21 @@ const DENIED_PROTOCOLS = new Set([
   'chrome:',
   'chrome-extension:',
   'ms-appx:',
-  'ms-appx-web:'
+  'ms-appx-web:',
+  'smb:',
+  'jnlp:',
+  'ms-msdt:',
+  'search-ms:',
+  'search:',
+  'shell:',
+  'hcp:',
+  'ms-appinstaller:',
+  'ms-its:',
+  'ms-help:',
+  'ms-cxh:',
+  'ms-cxh-full:',
+  'jar:',
+  'view-source:'
 ])
 
 export type ExternalAppUrlClassification =
@@ -23,9 +39,11 @@ export type ExternalAppUrlClassification =
 
 /** Match http(s) and custom app schemes like obsidian://, vscode:// in terminal text. */
 // Why: trailing punctuation stripped like xterm's default http regex; ^/[ unescaped
-// inside [] (oxlint no-useless-escape).
+// inside [] (oxlint no-useless-escape). Lookbehind prevents mid-token restarts
+// (file → ile://); negative lookahead skips denied schemes so they are not
+// underlined as dead links (#13225).
 export const TERMINAL_WEB_AND_APP_URL_REGEX =
-  /(?:https?|HTTPS?|[a-zA-Z][a-zA-Z0-9+.-]{1,31}):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/
+  /(?<![a-zA-Z0-9+.-])(?:https?|HTTPS?|(?!(?:javascript|data|vbscript|file|about|blob|chrome-extension|chrome|ms-appx-web|ms-appx|smb|jnlp|ms-msdt|search-ms|search|shell|hcp|ms-appinstaller|ms-its|ms-help|ms-cxh-full|ms-cxh|jar|view-source)(?![a-zA-Z0-9+.-]))[a-z][a-z0-9+.-]{1,31}):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/
 
 export function classifyExternalAppUrl(rawUrl: string): ExternalAppUrlClassification {
   const trimmed = rawUrl.trim()

--- a/src/shared/external-app-url.ts
+++ b/src/shared/external-app-url.ts
@@ -1,0 +1,86 @@
+/**
+ * Classify URLs for shell handoff. http(s) stay on the existing path;
+ * other schemes need an explicit user-approved openExternal (#13225).
+ */
+
+// Why: hard-deny schemes that can hand off to shell/exec paths even after a
+// confirm (Follina-style / UNC / JNLP). User cancel is not enough (#13225).
+const DENIED_PROTOCOLS = new Set([
+  'javascript:',
+  'data:',
+  'vbscript:',
+  'file:',
+  'about:',
+  'blob:',
+  'chrome:',
+  'chrome-extension:',
+  'ms-appx:',
+  'ms-appx-web:',
+  'smb:',
+  'jnlp:',
+  'ms-msdt:',
+  'search-ms:',
+  'search:',
+  'shell:',
+  'hcp:',
+  'ms-appinstaller:',
+  'ms-its:',
+  'ms-help:',
+  'ms-cxh:',
+  'ms-cxh-full:',
+  'jar:',
+  'view-source:'
+])
+
+export type ExternalAppUrlClassification =
+  | { ok: true; kind: 'http'; url: string; protocol: string }
+  | { ok: true; kind: 'custom'; url: string; protocol: string; schemeLabel: string }
+  | { ok: false; reason: 'invalid' | 'denied' | 'unsupported' }
+
+/** Match http(s) and custom app schemes like obsidian://, vscode:// in terminal text. */
+// Why: trailing punctuation stripped like xterm's default http regex; ^/[ unescaped
+// inside [] (oxlint no-useless-escape). Lookbehind prevents mid-token restarts
+// (file → ile://); negative lookahead skips denied schemes so they are not
+// underlined as dead links (#13225).
+export const TERMINAL_WEB_AND_APP_URL_REGEX =
+  /(?<![a-zA-Z0-9+.-])(?:https?|HTTPS?|(?!(?:javascript|data|vbscript|file|about|blob|chrome-extension|chrome|ms-appx-web|ms-appx|smb|jnlp|ms-msdt|search-ms|search|shell|hcp|ms-appinstaller|ms-its|ms-help|ms-cxh-full|ms-cxh|jar|view-source)(?![a-zA-Z0-9+.-]))[a-z][a-z0-9+.-]{1,31}):[/]{2}[^\s"'!*(){}|\\^<>`]*[^\s"':,.!?{}|\\^~[\]`()<>]/
+
+export function classifyExternalAppUrl(rawUrl: string): ExternalAppUrlClassification {
+  const trimmed = rawUrl.trim()
+  if (!trimmed) {
+    return { ok: false, reason: 'invalid' }
+  }
+  const rawScheme = /^([a-z][a-z0-9+.-]*):/i.exec(trimmed)?.[1]
+  if (rawScheme && !/^(?:https?)$/i.test(rawScheme) && rawScheme !== rawScheme.toLowerCase()) {
+    return { ok: false, reason: 'unsupported' }
+  }
+  let parsed: URL
+  try {
+    parsed = new URL(trimmed)
+  } catch {
+    return { ok: false, reason: 'invalid' }
+  }
+  const protocol = parsed.protocol.toLowerCase()
+  if (protocol === 'http:' || protocol === 'https:') {
+    return { ok: true, kind: 'http', url: parsed.toString(), protocol }
+  }
+  if (DENIED_PROTOCOLS.has(protocol)) {
+    return { ok: false, reason: 'denied' }
+  }
+  // Why: scheme must look like an app protocol (letters + optional +.-), not a
+  // single-letter drive-style or empty host with no path (noise from false matches).
+  if (!/^[a-z][a-z0-9+.-]*:$/i.test(protocol) || protocol.length < 3) {
+    return { ok: false, reason: 'unsupported' }
+  }
+  if (!parsed.hostname && !parsed.pathname && !parsed.search && !parsed.hash) {
+    return { ok: false, reason: 'invalid' }
+  }
+  const schemeLabel = protocol.slice(0, -1)
+  return {
+    ok: true,
+    kind: 'custom',
+    url: parsed.toString(),
+    protocol,
+    schemeLabel
+  }
+}


### PR DESCRIPTION
## Summary

Desktop terminal links such as `obsidian://` and `vscode://` now support an explicit OS handoff. Cmd-click on macOS or Ctrl-click on other platforms opens a main-process Open/Cancel dialog with the full URL; Cancel is the default. Ordinary clicks, missing mouse events and the wrong platform modifier cannot launch the custom-scheme confirmation path.

The gesture applies to detected text links, OSC 8 links and popout previews. Main classifies every request, rejects denied schemes and serializes confirmation dialogs. Existing HTTP(S) link actions and file-link routing remain intact. Web clients retain HTTP(S)-only opening because they have no equivalent native confirmation surface.

Partially addresses #13225. Remembered permissions and a Settings revocation list remain outside this change. Related: #13240 carries the embedded-browser surface. Both currently include the shared classifier and opening helper independently; reconcile those shared files when either lands.

## Validation

At `ba57c32610baa33963285c68b95995d156296ed2`:

- Independent verification: 374 tests passed and 1 skipped across 37 files, covering plain-click rejection, platform modifiers, OSC links, popouts, tooltips, IPC classification and web behavior.
- CLI, Node and Web TypeScript checks passed with `--composite false`; changed-file lint, formatting, diff whitespace and native-runtime preflight passed.
- Independent Cursor security review passed for this exact commit with no medium-or-higher findings.

Full repository tests, packaged builds and a manual registered-app launch were not run. Unit tests mock the native confirmation dialog. No new RPC or stream opcode; terminal gestures and the desktop main-process gate also apply to SSH and folder workspaces.

## AI disclosure

Cursor ported and reviewed this change; Codex independently checked the code and validation results before updating the PR.
