### PR TITLE
fix(windows): restore agents with the actual terminal shell

### DIFF
--- a/src/main/daemon/daemon-create-or-attach-result.ts
+++ b/src/main/daemon/daemon-create-or-attach-result.ts
@@ -12,6 +12,8 @@ export type DaemonCreateOrAttachResult = {
   launchAgent?: TuiAgent
   /** Undefined only when talking to a daemon predating WSL session context. */
   wslDistro?: string | null
+  /** Undefined when talking to a daemon predating actual-shell reporting. */
+  resolvedShellOverride?: string
   agentSessionEnsure?: AgentSessionClaimedSpawnResult
   incarnationId?: PtyIncarnationId
 }

--- a/src/main/daemon/daemon-create-or-attach-result.ts
+++ b/src/main/daemon/daemon-create-or-attach-result.ts
@@ -12,7 +12,7 @@ export type DaemonCreateOrAttachResult = {
   launchAgent?: TuiAgent
   /** Undefined only when talking to a daemon predating WSL session context. */
   wslDistro?: string | null
-  /** Undefined when talking to a daemon predating actual-shell reporting. */
+  /** Undefined for older daemons or providers that do not report a resolved shell. */
   resolvedShellOverride?: string
   agentSessionEnsure?: AgentSessionClaimedSpawnResult
   incarnationId?: PtyIncarnationId

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -652,6 +652,10 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
     const launchIdentity = (): { launchAgent?: NonNullable<typeof result.launchAgent> } =>
       result.launchAgent ? { launchAgent: result.launchAgent } : {}
+    const resolvedShell = ():
+      | Pick<PtySpawnResult, 'resolvedShellOverride'>
+      | Record<string, never> =>
+      result.resolvedShellOverride ? { resolvedShellOverride: result.resolvedShellOverride } : {}
 
     if (effectiveCwd) {
       this.initialCwds.set(sessionId, effectiveCwd)
@@ -679,6 +683,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         pid,
         ...claimResult(),
         ...launchIdentity(),
+        ...resolvedShell(),
         coldRestore: cachedRestore,
         ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
         ...(!result.isNew ? { isReattach: true } : {})
@@ -771,6 +776,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
           pid,
           ...claimResult(),
           ...launchIdentity(),
+          ...resolvedShell(),
           coldRestore,
           ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
           ...(providerSequence ? { providerSequence } : {}),
@@ -783,6 +789,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         pid,
         ...claimResult(),
         ...launchIdentity(),
+        ...resolvedShell(),
         ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
         ...(providerSequence ? { providerSequence } : {})
       }
@@ -824,6 +831,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
         pid,
         ...claimResult(),
         ...launchIdentity(),
+        ...resolvedShell(),
         ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
         ...(providerSequence ? { providerSequence } : {}),
         ...(isReattach ? { isReattach: true } : {})
@@ -843,6 +851,7 @@ export class DaemonPtyAdapter implements IPtyProvider {
       pid,
       ...claimResult(),
       ...launchIdentity(),
+      ...resolvedShell(),
       ...(providerWslDistro !== undefined ? { wslDistro: providerWslDistro } : {}),
       snapshot: snapshotPayload,
       snapshotCols: result.snapshot.cols,

--- a/src/main/daemon/daemon-server.ts
+++ b/src/main/daemon/daemon-server.ts
@@ -1104,6 +1104,9 @@ export class DaemonServer {
           incarnationId: result.incarnationId,
           ...(result.launchAgent ? { launchAgent: result.launchAgent } : {}),
           wslDistro: result.wslDistro,
+          ...(result.resolvedShellOverride
+            ? { resolvedShellOverride: result.resolvedShellOverride }
+            : {}),
           ...(result.historySeeded !== undefined ? { historySeeded: result.historySeeded } : {}),
           ...(result.agentSessionEnsure ? { agentSessionEnsure: result.agentSessionEnsure } : {})
         }

--- a/src/main/daemon/terminal-host-create-contract.ts
+++ b/src/main/daemon/terminal-host-create-contract.ts
@@ -50,6 +50,8 @@ export type CreateOrAttachResult = {
   historySeeded?: boolean
   launchAgent?: TuiAgent
   wslDistro: string | null
+  /** Actual shell executable selected by the daemon after launch fallback. */
+  resolvedShellOverride?: string
   attachToken: symbol
   incarnationId: PtyIncarnationId
   agentSessionEnsure?: AgentSessionClaimedSpawnResult

--- a/src/main/daemon/terminal-host-session-create.ts
+++ b/src/main/daemon/terminal-host-session-create.ts
@@ -137,6 +137,7 @@ export async function createOrAttachTerminalSession(
     pid: subprocess.pid,
     shellState: session.shellState,
     incarnationId: session.incarnationId,
+    ...(subprocess.shellPath ? { resolvedShellOverride: subprocess.shellPath } : {}),
     ...getDaemonSessionResultMetadata(session),
     attachToken: token
   }

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -400,6 +400,7 @@ function reattachLocalPty(id: string, cols: number, rows: number): PtySpawnResul
   return {
     id,
     pid: existing.pid,
+    ...(ptyShellName.get(id) ? { resolvedShellOverride: ptyShellName.get(id) } : {}),
     ...(ptyWslDistroById.has(id) ? { wslDistro: ptyWslDistroById.get(id) ?? null } : {}),
     isReattach: true
   }
@@ -1065,6 +1066,7 @@ export class LocalPtyProvider implements IPtyProvider {
       id,
       incarnationId,
       pid,
+      resolvedShellOverride: getSpawnedShellName(shellPath),
       ...(spawnedWslDistro !== undefined ? { wslDistro: spawnedWslDistro } : {})
     }
   }

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -25,6 +25,8 @@ export type PtySpawnResult = {
   launchAgent?: TuiAgent
   /** Local WSL context: null is native; undefined is unavailable/legacy. */
   wslDistro?: string | null
+  /** Actual shell executable selected by the provider after launch fallback. */
+  resolvedShellOverride?: string
   /** ANSI snapshot of the terminal screen, present when reattaching to an
    *  existing daemon session. Write this to xterm.js to restore visual state. */
   snapshot?: string

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -329,6 +329,7 @@ type MockTransport = {
   resize: ReturnType<typeof vi.fn>
   getPtyId: ReturnType<typeof vi.fn>
   getConnectionId: ReturnType<typeof vi.fn>
+  getLocalSessionMetadata: ReturnType<typeof vi.fn>
   serializeBuffer?: ReturnType<typeof vi.fn>
 }
 
@@ -445,7 +446,10 @@ vi.mock('./pty-dispatcher', async (importOriginal) => {
   }
 })
 
-function createMockTransport(initialPtyId: string | null = null): MockTransport {
+function createMockTransport(
+  initialPtyId: string | null = null,
+  localSessionMetadata: { cwd?: string; shellOverride?: string } | null = null
+): MockTransport {
   let ptyId = initialPtyId
   const transport = {
     attach: vi.fn(({ existingPtyId }: { existingPtyId: string }) => {
@@ -466,6 +470,7 @@ function createMockTransport(initialPtyId: string | null = null): MockTransport 
     resize: vi.fn(() => true),
     getPtyId: vi.fn(() => ptyId),
     getConnectionId: vi.fn(() => null),
+    getLocalSessionMetadata: vi.fn(() => localSessionMetadata),
     serializeBuffer: undefined
   } as MockTransport
   const sendInput = transport.sendInput as unknown as (data: string) => boolean
@@ -4303,6 +4308,8 @@ describe('connectPanePty', () => {
       pendingTimeouts.push(fn)
       return 999 as unknown as ReturnType<typeof setTimeout>
     }) as unknown as typeof setTimeout
+    vi.resetModules()
+    vi.doMock('@/lib/new-workspace', () => ({ CLIENT_PLATFORM: 'win32' }))
 
     try {
       const { connectPanePty } = await import('./pty-connection')
@@ -8404,6 +8411,8 @@ describe('connectPanePty', () => {
   async function runWindowsColdRestoreResume(args: {
     terminalWindowsShell: string
     tabShellOverride?: string
+    actualShellOverride?: string
+    providerSessionId?: string
   }): Promise<string | undefined> {
     const restoreNavigator = temporarilySetNavigatorUserAgent(
       'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
@@ -8418,8 +8427,14 @@ describe('connectPanePty', () => {
     try {
       const { connectPanePty } = await import('./pty-connection')
       const paneKey = makePaneKey('tab-1', LEAF_2)
+      const providerSessionId = args.providerSessionId ?? 'codex-session-1'
       let activePtyId: string | null = 'restored-session'
-      const transport = createMockTransport('restored-session')
+      const transport = createMockTransport(
+        'restored-session',
+        args.actualShellOverride
+          ? { cwd: 'C:\\Users\\neil\\repo', shellOverride: args.actualShellOverride }
+          : null
+      )
       transport.getPtyId.mockImplementation(() => activePtyId)
       transport.disconnect.mockImplementation(() => {
         activePtyId = null
@@ -8465,7 +8480,7 @@ describe('connectPanePty', () => {
             tabId: 'tab-1',
             worktreeId: 'wt-1',
             agent: 'codex',
-            providerSession: { key: 'session_id', id: 'codex-session-1' },
+            providerSession: { key: 'session_id', id: providerSessionId },
             prompt: 'finish the task',
             state: 'done',
             origin: 'worktree-sleep',
@@ -8492,6 +8507,7 @@ describe('connectPanePty', () => {
       return (transport.connect.mock.calls.at(-1)?.[0] as { command?: string } | undefined)?.command
     } finally {
       globalThis.setTimeout = originalSetTimeout
+      vi.doUnmock('@/lib/new-workspace')
       restoreNavigator()
     }
   }
@@ -8514,6 +8530,15 @@ describe('connectPanePty', () => {
   it('keeps PowerShell quoting for a cold-restore resume on a PowerShell Windows tab', async () => {
     await expect(
       runWindowsColdRestoreResume({ terminalWindowsShell: 'powershell.exe' })
+    ).resolves.toBe("codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'")
+  })
+
+  it('uses the provider-resolved shell when a cold restore setting is stale', async () => {
+    await expect(
+      runWindowsColdRestoreResume({
+        terminalWindowsShell: 'wsl.exe',
+        actualShellOverride: 'powershell.exe'
+      })
     ).resolves.toBe("codex '--dangerously-bypass-approvals-and-sandbox' 'resume' 'codex-session-1'")
   })
 

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -5002,7 +5002,7 @@ export function connectPanePty(
         executionHostId,
         worktreePath: worktree?.path,
         terminalWindowsShell: state.settings?.terminalWindowsShell,
-        tabShellOverride: shellOverride
+        tabShellOverride: transport.getLocalSessionMetadata?.()?.shellOverride ?? shellOverride
       })
       const startupPlan = buildAgentResumeStartupPlan({
         agent,

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -43,6 +43,7 @@ export type PtyBufferSnapshot = {
 
 export type LocalPtySessionMetadata = {
   cwd?: string
+  /** Actual shell selected by the local provider after launch fallback. */
   shellOverride?: string
 }
 
@@ -66,6 +67,8 @@ export type PtyConnectResult = {
   startupCwdFallback?: { kind: 'worktree'; cwd: string }
   /** Main declined an unverifiable provider-session resume and launched fresh. */
   agentResumeUnavailable?: true
+  /** Actual shell selected by the local provider after launch fallback. */
+  resolvedShellOverride?: string
   /** Trailing partial escape the daemon emulator held mid-parse; the reattach
    *  replay writes it LAST (after the reset) so a racing live continuation
    *  completes it instead of rendering literally (#7329). */

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -557,6 +557,26 @@ describe('createIpcPtyTransport', () => {
     })
   })
 
+  it('uses the provider-resolved shell in local session metadata after spawn', async () => {
+    const { createIpcPtyTransport } = await import('./pty-transport')
+    const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>
+    spawn.mockResolvedValueOnce({
+      id: 'pty-actual-powershell',
+      resolvedShellOverride: 'powershell.exe'
+    })
+    const transport = createIpcPtyTransport({
+      cwd: 'C:\\repo',
+      shellOverride: 'wsl.exe'
+    })
+
+    await transport.connect({ url: '', callbacks: {} })
+
+    expect(transport.getLocalSessionMetadata?.()).toEqual({
+      cwd: 'C:\\repo',
+      shellOverride: 'powershell.exe'
+    })
+  })
+
   it('sends the missing-cwd fallback flag only for local IPC spawns', async () => {
     const { createIpcPtyTransport } = await import('./pty-transport')
     const spawn = window.api.pty.spawn as unknown as ReturnType<typeof vi.fn>

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -555,6 +555,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
   let connected = false
   let destroyed = false
   let ptyId: string | null = null
+  let actualShellOverride = shellOverride
   // Why: replayed eager-buffer data (often from a prior app session) must not fire fresh bells, unread marks, or notifications on reconnect.
   let suppressAttentionEvents = false
   const inputWriteQueue = createPtyInputWriteQueue({
@@ -813,6 +814,9 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ...(telemetry ? { telemetry } : {})
         })
         const spawnResult = result as PtyConnectResult & { isReattach?: boolean }
+        if (typeof spawnResult.resolvedShellOverride === 'string') {
+          actualShellOverride = spawnResult.resolvedShellOverride
+        }
         const resultLaunchAgent = isTuiAgent(spawnResult.launchAgent)
           ? spawnResult.launchAgent
           : undefined
@@ -1090,7 +1094,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
       // Why: input routing/diagnostics must follow the launched PTY session, not later project setting changes.
       return {
         ...(cwd ? { cwd } : {}),
-        ...(shellOverride ? { shellOverride } : {})
+        ...(actualShellOverride ? { shellOverride: actualShellOverride } : {})
       }
     },
 


### PR DESCRIPTION
## Description

Cold-restored agent commands now use the shell executable actually selected by the PTY provider instead of replaying the configured Windows shell setting.
The provider-resolved shell is carried through local and daemon session metadata so a stale `wsl.exe` preference cannot make a PowerShell pane parse POSIX quoting.

## Focused fix

- In scope: report and consume the resolved shell family for queued/cold-restored agent commands.
- Out of scope (explicit): translating Windows paths into WSL paths and changing the separate WSL working-directory contract.

## Preserves

- Existing shell selection, WSL context, and remote-provider behavior remain unchanged.
- Older daemons that do not report the new metadata keep the existing compatibility fallback.

## Evidence

- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-transport.test.ts -t "provider-resolved shell"`
- Test: `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-connection.test.ts -t "provider-resolved shell"`
- Quality: targeted oxlint/oxfmt, `pnpm run typecheck:web`, and `pnpm exec tsc --noEmit -p config/tsconfig.node.json --pretty false` passed.

## User-regression-tradeoffs

- A provider that cannot report the resolved shell remains on the legacy setting-based behavior for compatibility; providers that do report it now preserve the syntax of the shell that is actually running.

Fixes #13095
