### PR TITLE
fix(claude): honor supportsAdaptiveThinking from list_models

### DIFF
--- a/src/shared/claude-model-list-probe.test.ts
+++ b/src/shared/claude-model-list-probe.test.ts
@@ -58,9 +58,19 @@ describe('parseClaudeModelList', () => {
       label: 'Opus (1M context)',
       description: 'Opus 5 with 1M context · Best for everyday, complex tasks · $5/$25 per Mtok',
       effortLevels: ['low', 'medium', 'high', 'xhigh', 'max'],
-      supportsFastMode: true
+      supportsFastMode: true,
+      supportsAdaptiveThinking: false
     })
-    expect(parsed[2]).toMatchObject({ effortLevels: [], supportsFastMode: false })
+    expect(parsed[1]).toMatchObject({
+      id: 'sonnet',
+      supportsAdaptiveThinking: true,
+      description: expect.stringContaining('Adaptive thinking')
+    })
+    expect(parsed[2]).toMatchObject({
+      effortLevels: [],
+      supportsFastMode: false,
+      supportsAdaptiveThinking: false
+    })
   })
 
   it('skips init noise, CRLF endings, and duplicate values', () => {
@@ -73,14 +83,26 @@ describe('parseClaudeModelList', () => {
         { value: '  ', displayName: 'Blank' }
       ])}\r\n`
     expect(parseClaudeModelList(stdout)).toEqual([
-      { id: 'sonnet', label: 'Sonnet', effortLevels: [], supportsFastMode: false }
+      {
+        id: 'sonnet',
+        label: 'Sonnet',
+        effortLevels: [],
+        supportsFastMode: false,
+        supportsAdaptiveThinking: false
+      }
     ])
   })
 
   it('skips non-object model entries instead of failing the discovery response', () => {
     const stdout = controlResponseLine([null, 7, [], { value: 'sonnet', displayName: 'Sonnet' }])
     expect(parseClaudeModelList(stdout)).toEqual([
-      { id: 'sonnet', label: 'Sonnet', effortLevels: [], supportsFastMode: false }
+      {
+        id: 'sonnet',
+        label: 'Sonnet',
+        effortLevels: [],
+        supportsFastMode: false,
+        supportsAdaptiveThinking: false
+      }
     ])
   })
 

--- a/src/shared/claude-model-list-probe.ts
+++ b/src/shared/claude-model-list-probe.ts
@@ -31,6 +31,8 @@ export type ClaudeListedModel = {
   /** `--effort` values this model accepts; empty when it has no effort control. */
   effortLevels: string[]
   supportsFastMode: boolean
+  /** Model can use adaptive thinking budgets when the host CLI reports the flag (#13208). */
+  supportsAdaptiveThinking: boolean
 }
 
 const CLAUDE_MODEL_LIST_JSON_LIMITS = {
@@ -53,6 +55,7 @@ type RawListedModel = {
   supportsEffort?: unknown
   supportedEffortLevels?: unknown
   supportsFastMode?: unknown
+  supportsAdaptiveThinking?: unknown
 }
 
 function toListedModel(value: unknown): ClaudeListedModel | null {
@@ -65,18 +68,27 @@ function toListedModel(value: unknown): ClaudeListedModel | null {
     return null
   }
   const label = typeof raw.displayName === 'string' && raw.displayName.trim() ? raw.displayName : id
-  const description =
+  let description =
     typeof raw.description === 'string' && raw.description.trim() ? raw.description : undefined
   const effortLevels =
     raw.supportsEffort === true && Array.isArray(raw.supportedEffortLevels)
       ? raw.supportedEffortLevels.filter((level): level is string => typeof level === 'string')
       : []
+  const supportsAdaptiveThinking = raw.supportsAdaptiveThinking === true
+  // Why: the catalog previously dropped this flag entirely (#13208); surface it
+  // on the picker description so hosts that report it are not silent.
+  if (supportsAdaptiveThinking && description && !/adaptive thinking/i.test(description)) {
+    description = `${description} · Adaptive thinking`
+  } else if (supportsAdaptiveThinking && !description) {
+    description = 'Adaptive thinking'
+  }
   return {
     id,
     label,
     ...(description ? { description } : {}),
     effortLevels,
-    supportsFastMode: raw.supportsFastMode === true
+    supportsFastMode: raw.supportsFastMode === true,
+    supportsAdaptiveThinking
   }
 }
 


### PR DESCRIPTION
## Summary
- `parseClaudeModelList` reads `supportsAdaptiveThinking` from Claude Code's `list_models` control response.
- When true, the model picker's description includes an **Adaptive thinking** cue (if the CLI description did not already).
- Complements #13213 (`supportsAutoMode` → Auto effort). This PR only addresses the adaptive-thinking half of #13208.

## Why
Orca already consumes `supportsFastMode` from the same object and previously ignored adjacent capability flags. Adaptive thinking has no separate mid-session toggle in Orca today; surfacing the host-reported capability closes the “silently dropped” bug for that field.

## Test plan
- [x] Unit: LIVE_MODELS sonnet with `supportsAdaptiveThinking: true` → field + description
- [x] Unit: models without the flag default to false
- [x] agent-session-option-catalog suite green