### PR TITLE
feat(terminals): breadcrumb tab-title writes attributed to the wrong worktree

### DIFF
--- a/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
+++ b/src/main/ipc/crash-reporting-renderer-breadcrumbs.test.ts
@@ -379,6 +379,49 @@ describe('renderer breadcrumb IPC routing', () => {
     ])
   })
 
+  // Why: the renderer guard is once per tab/worktree/site, so a worktree with
+  // many tabs can emit a crumb per tab in one burst.
+  it('coalesces tab-title write mismatches across tabs sharing a site', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_tab_title_write_worktree_mismatch',
+      data: { tabId: 'tab-1', site: 'pty-title-change', ownerCount: 1, sameRepo: true }
+    })
+    emitRendererBreadcrumb({
+      name: 'terminal_tab_title_write_worktree_mismatch',
+      data: { tabId: 'tab-2', site: 'pty-title-change', ownerCount: 1, sameRepo: true }
+    })
+
+    expect(recordCrashBreadcrumbMock).not.toHaveBeenCalled()
+    expect(recordCoalescedCrashBreadcrumbMock).toHaveBeenCalledTimes(2)
+    for (const call of recordCoalescedCrashBreadcrumbMock.mock.calls) {
+      expect(call[0]).toMatchObject({
+        coalesceKey: 'terminal_tab_title_write_worktree_mismatch:pty-title-change'
+      })
+    }
+  })
+
+  // Why site-scoped: coalescing keeps only the newest payload, so a chatty write
+  // path would erase the quieter one that actually explains the misattribution.
+  it('keeps tab-title write mismatches from different sites in separate slots', () => {
+    emitRendererBreadcrumb({
+      name: 'terminal_tab_title_write_worktree_mismatch',
+      data: { tabId: 'tab-1', site: 'pty-title-change', ownerCount: 1, sameRepo: true }
+    })
+    emitRendererBreadcrumb({
+      name: 'terminal_tab_title_write_worktree_mismatch',
+      data: { tabId: 'tab-1', site: 'ipc-agent-status-title', ownerCount: 1, sameRepo: true }
+    })
+
+    expect(
+      recordCoalescedCrashBreadcrumbMock.mock.calls.map(
+        (call) => (call[0] as { coalesceKey: string }).coalesceKey
+      )
+    ).toEqual([
+      'terminal_tab_title_write_worktree_mismatch:pty-title-change',
+      'terminal_tab_title_write_worktree_mismatch:ipc-agent-status-title'
+    ])
+  })
+
   it('records non-error renderer breadcrumbs without coalescing', () => {
     emitRendererBreadcrumb({ name: 'renderer_bootstrap_started', data: { dev: true } })
 

--- a/src/main/ipc/crash-reporting.ts
+++ b/src/main/ipc/crash-reporting.ts
@@ -328,12 +328,14 @@ function buildUncapturedCrashReportText(
 // suppressed count instead.
 const DUPLICATE_TAB_OWNER_BREADCRUMB = 'terminal_tab_id_owned_by_multiple_worktrees'
 const PARK_VERDICT_CHURN_BREADCRUMB = 'terminal_park_verdict_churn'
+const TAB_TITLE_WRITE_MISMATCH_BREADCRUMB = 'terminal_tab_title_write_worktree_mismatch'
 const COALESCED_RENDERER_BREADCRUMB_NAMES = new Set([
   'renderer_error',
   'renderer_unhandled_rejection',
   'terminal_safe_fit_retry_exhausted',
   DUPLICATE_TAB_OWNER_BREADCRUMB,
   PARK_VERDICT_CHURN_BREADCRUMB,
+  TAB_TITLE_WRITE_MISMATCH_BREADCRUMB,
   TERMINAL_WEBGL_DIAGNOSTIC_BREADCRUMB
 ])
 const RENDERER_BREADCRUMB_COALESCE_MS = 30_000
@@ -372,6 +374,11 @@ function rendererBreadcrumbCoalesceKey(
   // last-write coalescing cannot erase the other signal while remaining bounded.
   if (name === DUPLICATE_TAB_OWNER_BREADCRUMB) {
     return `${name}:${String(data?.resolvedToActiveWorktree ?? '')}`
+  }
+  // Why: keying by call site bounds a many-tab storm to one slot per site while
+  // keeping different write paths from masking each other.
+  if (name === TAB_TITLE_WRITE_MISMATCH_BREADCRUMB) {
+    return `${name}:${String(data?.site ?? '')}`
   }
   const primaryMessage = name === 'renderer_error' ? data?.message : data?.reasonMessage
   const fallbackMessage = name === 'renderer_error' ? data?.errorMessage : undefined

--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.test.ts
@@ -11,6 +11,10 @@ const PANE_KEY = `${TAB_ID}:${LEAF_ID}`
 const PANE_ID = 1
 // Mirrors PARKED_NOTIFICATION_GRACE_MS / AGENT_TASK_COMPLETE_NOTIFICATION_GRACE_MS.
 const NOTIFICATION_GRACE_MS = 250
+const TITLE_WRITE_CONTEXT = {
+  worktreeId: WORKTREE_ID,
+  site: 'parked-byte-watcher'
+}
 
 // Real agent-detection titles: braille spinner classifies as working,
 // the "✳ " Claude prefix as idle, and both as Claude agents.
@@ -169,8 +173,8 @@ describe('startParkedTerminalByteWatcher', () => {
       [TAB_ID, PANE_ID, IDLE_TITLE]
     ])
     expect(mockStoreState.updateTabTitle.mock.calls).toEqual([
-      [TAB_ID, '⠋ Build feature'],
-      [TAB_ID, IDLE_TITLE]
+      [TAB_ID, '⠋ Build feature', TITLE_WRITE_CONTEXT],
+      [TAB_ID, IDLE_TITLE, TITLE_WRITE_CONTEXT]
     ])
     dispose()
   })
@@ -758,7 +762,11 @@ describe('startParkedTerminalByteWatcher', () => {
 
       expect(getSideEffectSnapshot).toHaveBeenCalledWith(PTY_ID)
       expect(mockStoreState.setRuntimePaneTitle).toHaveBeenCalledWith(TAB_ID, PANE_ID, IDLE_TITLE)
-      expect(mockStoreState.updateTabTitle).toHaveBeenCalledWith(TAB_ID, IDLE_TITLE)
+      expect(mockStoreState.updateTabTitle).toHaveBeenCalledWith(
+        TAB_ID,
+        IDLE_TITLE,
+        TITLE_WRITE_CONTEXT
+      )
       expect(mockStoreState.markWorktreeUnread).not.toHaveBeenCalled()
       expect(mockStoreState.setCacheTimerStartedAt).not.toHaveBeenCalled()
       expect(dispatchTerminalNotification).not.toHaveBeenCalled()

--- a/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
+++ b/src/renderer/src/components/terminal-pane/parked-terminal-byte-watcher.ts
@@ -129,7 +129,10 @@ export function startParkedTerminalByteWatcher(
       wroteRuntimeTitleSlot = true
       state.setRuntimePaneTitle(tabId, paneId, title)
       if (drivesTabTitle) {
-        state.updateTabTitle(tabId, title)
+        state.updateTabTitle(tabId, title, {
+          worktreeId,
+          site: 'parked-byte-watcher'
+        })
       }
     },
     onBell: (): void => {

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -15,6 +15,7 @@ import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/termin
 import type { PtyTransportRecoveryState } from './pty-transport-types'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
+import type { TerminalTabTitleWriteContext } from '@/store/slices/tab-title-write-attribution'
 
 export type PtyConnectionDeps = {
   tabId: string
@@ -68,7 +69,11 @@ export type PtyConnectionDeps = {
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   isPtyShutdownPending: (ptyId: string) => boolean
-  updateTabTitle: (tabId: string, title: string) => void
+  updateTabTitle: (
+    tabId: string,
+    title: string,
+    writeContext?: TerminalTabTitleWriteContext
+  ) => void
   setRuntimePaneTitle: (tabId: string, paneId: number, title: string) => void
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
   updateTabPtyId: (

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -55,6 +55,15 @@ async function drainFakeTimerWork(limit = 20): Promise<void> {
   vi.clearAllTimers()
 }
 
+const TITLE_CHANGE_WRITE_CONTEXT = {
+  worktreeId: 'wt-1',
+  site: 'pty-title-change'
+}
+const INTERRUPT_CLEAR_WRITE_CONTEXT = {
+  worktreeId: 'wt-1',
+  site: 'pty-inferred-interrupt-clear'
+}
+
 // Why: a reveal remount reads the still-live park watcher entry at connect time to
 // tell itself apart from an in-place reattach; the host disposes it a beat later.
 async function parkTabForReveal(tabId: string, ptyId: string, worktreeId = 'wt-1'): Promise<void> {
@@ -2418,7 +2427,11 @@ describe('connectPanePty', () => {
 
     expect(transport.sendInput).toHaveBeenCalledWith('omp\r')
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'OMP ready')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'OMP ready')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      'OMP ready',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
     expect(mockStoreState.agentStatusByPaneKey[paneKey]).toMatchObject({
       state: 'done',
       agentType: 'omp',
@@ -2446,7 +2459,11 @@ describe('connectPanePty', () => {
 
     // Display/runtime/tab title and the GPU gate all come from the same decision.
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, '✦ Gemini CLI')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', '✦ Gemini CLI')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      '✦ Gemini CLI',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
     // Genuine Gemini under the default `auto` setting takes the DOM fallback.
     expect(manager.setPaneGpuRendering).toHaveBeenCalledWith(1, false)
   })
@@ -2710,7 +2727,11 @@ describe('connectPanePty', () => {
 
     expect(transport.sendInput).toHaveBeenCalledWith('pi\r')
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Pi ready')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Pi ready')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      'Pi ready',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
     expect(mockStoreState.agentStatusByPaneKey[paneKey]).toMatchObject({
       state: 'done',
       agentType: 'pi',
@@ -4585,7 +4606,11 @@ describe('connectPanePty', () => {
     await flushAsyncTicks()
 
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Terminal')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      'Terminal',
+      INTERRUPT_CLEAR_WRITE_CONTEXT
+    )
     expect(
       resolveWorktreeStatus({
         tabs: [{ id: 'tab-1', title: 'Codex working' }],
@@ -4645,7 +4670,11 @@ describe('connectPanePty', () => {
 
     expect(window.api.agentStatus.inferInterrupt).not.toHaveBeenCalled()
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Terminal')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Terminal')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      'Terminal',
+      INTERRUPT_CLEAR_WRITE_CONTEXT
+    )
   })
 
   it('does not clear title-only working indicators when interrupt writes are unacknowledged', async () => {
@@ -20399,7 +20428,11 @@ describe('connectPanePty', () => {
     titleHandler('Codex - action required', 'Codex - action required')
 
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, 'Codex - action required')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', 'Codex - action required')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      'Codex - action required',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
   })
 
   it('normalizes Pi-compatible remote titles to authoritative OMP launch identity', async () => {
@@ -20427,10 +20460,18 @@ describe('connectPanePty', () => {
     }
     titleHandler('\u280b Pi', '\u280b Pi')
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, '\u280b OMP')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', '\u280b OMP')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      '\u280b OMP',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
     titleHandler('π: tmp', 'π: tmp')
     expect(deps.setRuntimePaneTitle).toHaveBeenLastCalledWith('tab-1', 1, 'OMP ready')
-    expect(deps.updateTabTitle).toHaveBeenLastCalledWith('tab-1', 'OMP ready')
+    expect(deps.updateTabTitle).toHaveBeenLastCalledWith(
+      'tab-1',
+      'OMP ready',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
 
     const statusHandler = createdTransportOptions[0]?.onAgentStatus as
       | ((payload: { state: 'working'; prompt: string; agentType: 'pi' }) => void)
@@ -20509,7 +20550,11 @@ describe('connectPanePty', () => {
     expect(manager.setPaneGpuRendering).toHaveBeenCalledTimes(1)
     expect(manager.setPaneGpuRendering).toHaveBeenCalledWith(1, true)
     expect(deps.setRuntimePaneTitle).toHaveBeenCalledWith('tab-1', 1, '\u280b OMP')
-    expect(deps.updateTabTitle).toHaveBeenCalledWith('tab-1', '\u280b OMP')
+    expect(deps.updateTabTitle).toHaveBeenCalledWith(
+      'tab-1',
+      '\u280b OMP',
+      TITLE_CHANGE_WRITE_CONTEXT
+    )
   })
 
   it('leaves local IPC OSC 9999 status ownership in the main runtime', async () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -1762,7 +1762,10 @@ export function connectPanePty(
     // can still decide whether an agent TUI is truly alive.
     deps.setRuntimePaneTitle(deps.tabId, pane.id, neutralTitle)
     if (manager.getActivePane()?.id === pane.id) {
-      deps.updateTabTitle(deps.tabId, neutralTitle)
+      deps.updateTabTitle(deps.tabId, neutralTitle, {
+        worktreeId: deps.worktreeId,
+        site: 'pty-inferred-interrupt-clear'
+      })
     }
   }
   let titleOnlyInterruptTimer: ReturnType<typeof setTimeout> | null = null
@@ -2089,7 +2092,10 @@ export function connectPanePty(
     const neutralTitle = neutralTerminalTitle()
     deps.setRuntimePaneTitle(deps.tabId, pane.id, neutralTitle)
     if (manager.getActivePane()?.id === pane.id) {
-      deps.updateTabTitle(deps.tabId, neutralTitle)
+      deps.updateTabTitle(deps.tabId, neutralTitle, {
+        worktreeId: deps.worktreeId,
+        site: 'pty-confirmed-shell-clear'
+      })
     }
   }
   let deferredCommandFinishedStatusDrop: (() => void) | null = null
@@ -2828,7 +2834,10 @@ export function connectPanePty(
     // focus changes, onActivePaneChange syncs the newly active pane's stored
     // title to the tab.
     if (manager.getActivePane()?.id === pane.id) {
-      deps.updateTabTitle(deps.tabId, paneTitle)
+      deps.updateTabTitle(deps.tabId, paneTitle, {
+        worktreeId: deps.worktreeId,
+        site: 'pty-title-change'
+      })
     }
 
     if (!hasConsideredInitialCacheTimerSeed) {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -26,6 +26,7 @@ import { buildTerminalKeyboardProtocolOptions } from '@/lib/pane-manager/termina
 import { resolvePaneKeyboardProtocolAgent } from './terminal-keyboard-protocol-pane-agent'
 import { useAppStore } from '@/store'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
+import type { TerminalTabTitleWriteContext } from '@/store/slices/tab-title-write-attribution'
 import {
   createFilePathLinkProvider,
   getTerminalFileOpenHint,
@@ -275,7 +276,11 @@ type UseTerminalPaneLifecycleDeps = {
   clearTabPtyId: (tabId: string, ptyId: string) => void
   consumeSuppressedPtyExit: (ptyId: string) => boolean
   isPtyShutdownPending: (ptyId: string) => boolean
-  updateTabTitle: (tabId: string, title: string) => void
+  updateTabTitle: (
+    tabId: string,
+    title: string,
+    writeContext?: TerminalTabTitleWriteContext
+  ) => void
   setRuntimePaneTitle: (tabId: string, paneId: number, title: string) => void
   clearRuntimePaneTitle: (tabId: string, paneId: number) => void
   updateTabPtyId: (
@@ -1251,7 +1256,10 @@ export function useTerminalPaneLifecycle({
         if (newActivePane) {
           reportActiveRendererPtyForPane(paneTransportsRef.current, newActivePane.id)
           const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
-          updateTabTitle(tabId, resolveTabTitleAfterPaneClose(paneTitles, newActivePane.id))
+          updateTabTitle(tabId, resolveTabTitleAfterPaneClose(paneTitles, newActivePane.id), {
+            worktreeId,
+            site: 'pane-closed'
+          })
         }
         scheduleRuntimeGraphSync()
       },
@@ -1289,7 +1297,7 @@ export function useTerminalPaneLifecycle({
         const paneTitles = useAppStore.getState().runtimePaneTitlesByTabId[tabId] ?? {}
         const paneTitle = paneTitles[pane.id]
         if (paneTitle) {
-          updateTabTitle(tabId, paneTitle)
+          updateTabTitle(tabId, paneTitle, { worktreeId, site: 'pane-focus-sync' })
         }
       },
       onLayoutChanged: () => {

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -6698,7 +6698,10 @@ describe('useIpcEvents agent status snapshot integration', () => {
       expectWorktreeRouting('wt-1'),
       undefined
     )
-    expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Codex - action required')
+    expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Codex - action required', {
+      worktreeId: 'wt-1',
+      site: 'ipc-agent-status-title'
+    })
     expect(observeAgentHookCompletionForNotification).toHaveBeenCalledTimes(1)
   })
 
@@ -7423,7 +7426,11 @@ describe('useIpcEvents agent status snapshot integration', () => {
       undefined
     )
     expect(updateTabTitle).toHaveBeenCalledTimes(1)
-    expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Codex ready')
+    // The payload carried no worktree, so the context falls back to the store lookup.
+    expect(updateTabTitle).toHaveBeenCalledWith('tab-future', 'Codex ready', {
+      worktreeId: 'wt-1',
+      site: 'ipc-agent-status-title'
+    })
   })
 
   it('drops nested child done push events when the parent pane agent is still active', async () => {

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3288,7 +3288,7 @@ export function useIpcEvents(): void {
             }
           : undefined
       )
-      applyResolvedAgentTerminalTitleToTab(store, paneKey, title, terminalTitle)
+      applyResolvedAgentTerminalTitleToTab(store, paneKey, title, terminalTitle, statusWorktreeId)
       if (options?.replay !== true && statusWorktreeId) {
         // Why: local Codex/Claude hooks arrive via this main-process IPC path, not the PTY OSC fallback, so task-complete notifications must observe accepted hook state here too.
         const notificationPayload =
@@ -3707,7 +3707,8 @@ function applyResolvedAgentTerminalTitleToTab(
   store: ReturnType<typeof useAppStore.getState>,
   paneKey: string,
   previousTitle: string | undefined,
-  nextTitle: string | undefined
+  nextTitle: string | undefined,
+  worktreeId: string | undefined
 ): void {
   if (!nextTitle || nextTitle === previousTitle) {
     return
@@ -3721,7 +3722,11 @@ function applyResolvedAgentTerminalTitleToTab(
     return
   }
   // Why: hook completion can arrive while the pane transport is unmounted; keep the tab label synced to the resolved state title.
-  store.updateTabTitle(parsed.tabId, nextTitle)
+  store.updateTabTitle(
+    parsed.tabId,
+    nextTitle,
+    worktreeId === undefined ? undefined : { worktreeId, site: 'ipc-agent-status-title' }
+  )
 }
 
 /** Resolve a paneKey (tabId:leafId) to liveness, current title, owning worktree,

--- a/src/renderer/src/store/slices/tab-title-write-attribution.test.ts
+++ b/src/renderer/src/store/slices/tab-title-write-attribution.test.ts
@@ -1,0 +1,184 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('sonner', () => ({ toast: { info: vi.fn(), success: vi.fn(), error: vi.fn() } }))
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/pty-transport', () => ({
+  registerEagerPtyBuffer: vi.fn(),
+  ensurePtyDispatcher: vi.fn(),
+  unregisterPtyDataHandlers: vi.fn()
+}))
+vi.mock('@/components/terminal-pane/shutdown-buffer-captures', () => ({
+  shutdownBufferCaptures: vi.fn()
+}))
+
+const recordRendererCrashBreadcrumb = vi.fn()
+vi.mock('../../lib/crash-breadcrumb-recorder', () => ({
+  recordRendererCrashBreadcrumb: (...args: unknown[]) => recordRendererCrashBreadcrumb(...args)
+}))
+
+// @ts-expect-error -- minimal preload API stub for the slice's IPC writes
+globalThis.window = { api: {} }
+
+import type { TerminalTab } from '../../../../shared/types'
+import { createTestStore, makeTab, makeWorktree, seedStore } from './store-test-helpers'
+import {
+  _resetTabTitleWriteAttributionBreadcrumbsForTests,
+  recordTabTitleWriteWorktreeMismatch
+} from './tab-title-write-attribution'
+
+const BREADCRUMB = 'terminal_tab_title_write_worktree_mismatch'
+// Real worktree-id shape (`${repoId}::${absolutePath}`) so the repo comparison is exercised.
+const WT_A = 'repo1::/path/wt-a'
+const WT_B = 'repo1::/path/wt-b'
+const WT_OTHER_REPO = 'repo2::/path/other'
+
+function storeWithTabs(
+  tabsByWorktree: Record<string, TerminalTab[]>
+): ReturnType<typeof createTestStore> {
+  const store = createTestStore()
+  seedStore(store, {
+    worktreesByRepo: {
+      repo1: [
+        makeWorktree({ id: WT_A, repoId: 'repo1', path: '/path/wt-a' }),
+        makeWorktree({ id: WT_B, repoId: 'repo1', path: '/path/wt-b' })
+      ],
+      repo2: [makeWorktree({ id: WT_OTHER_REPO, repoId: 'repo2', path: '/path/other' })]
+    },
+    tabsByWorktree,
+    activeWorktreeId: WT_A
+  })
+  return store
+}
+
+function storeWithTabInWorktreeA(): ReturnType<typeof createTestStore> {
+  return storeWithTabs({
+    [WT_A]: [makeTab({ id: 'tab-1', worktreeId: WT_A, title: 'Terminal 1' })],
+    [WT_B]: []
+  })
+}
+
+beforeEach(() => {
+  recordRendererCrashBreadcrumb.mockClear()
+  _resetTabTitleWriteAttributionBreadcrumbsForTests()
+})
+
+describe('updateTabTitle write attribution', () => {
+  it('breadcrumbs a write whose worktree disagrees with the resolved owner', () => {
+    const store = storeWithTabInWorktreeA()
+
+    store.getState().updateTabTitle('tab-1', 'Claude Code', {
+      worktreeId: WT_B,
+      site: 'pty-title-change'
+    })
+
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledTimes(1)
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledWith(BREADCRUMB, {
+      tabId: 'tab-1',
+      site: 'pty-title-change',
+      ownerCount: 1,
+      sameRepo: true
+    })
+    // The write itself must land unchanged.
+    expect(store.getState().tabsByWorktree[WT_A]?.[0]?.title).toBe('Claude Code')
+  })
+
+  it('stays quiet when the writer agrees with the owner, and when no context is given', () => {
+    const store = storeWithTabInWorktreeA()
+
+    store.getState().updateTabTitle('tab-1', 'Claude Code', {
+      worktreeId: WT_A,
+      site: 'parked-byte-watcher'
+    })
+    store.getState().updateTabTitle('tab-1', 'Codex ready')
+
+    expect(recordRendererCrashBreadcrumb).not.toHaveBeenCalled()
+    expect(store.getState().tabsByWorktree[WT_A]?.[0]?.title).toBe('Codex ready')
+  })
+
+  // Why: an agent repaints its title continuously, so an unguarded crumb would
+  // flood the 30-entry ring and erase everything that led up to the mismatch.
+  it('records one crumb per tab/worktree/site combination however often it repeats', () => {
+    const store = storeWithTabInWorktreeA()
+    const context = { worktreeId: WT_B, site: 'pty-title-change' } as const
+
+    for (let i = 0; i < 5; i += 1) {
+      store.getState().updateTabTitle('tab-1', `Claude Code ${i}`, context)
+    }
+
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledTimes(1)
+  })
+
+  // Why: only a write that lands can misattribute a title; a no-op would otherwise
+  // spend the single slot this combination ever gets.
+  it('skips a write that leaves the title unchanged and records the one that changes it', () => {
+    const store = storeWithTabInWorktreeA()
+    const context = { worktreeId: WT_B, site: 'pane-focus-sync' } as const
+
+    store.getState().updateTabTitle('tab-1', 'Terminal 1', context)
+    expect(recordRendererCrashBreadcrumb).not.toHaveBeenCalled()
+
+    store.getState().updateTabTitle('tab-1', 'Claude Code', context)
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledTimes(1)
+  })
+
+  // ownerCount is what tells a tab id duplicated across buckets apart from a
+  // writer holding a stale worktree id.
+  it('counts every worktree bucket holding the tab id', () => {
+    const store = storeWithTabs({
+      [WT_A]: [makeTab({ id: 'tab-1', worktreeId: WT_A, title: 'Terminal 1' })],
+      [WT_B]: [makeTab({ id: 'tab-1', worktreeId: WT_B, title: 'Terminal 1' })]
+    })
+
+    // The owner lookup keeps the last bucket seen, so writing as wt-a mismatches.
+    store.getState().updateTabTitle('tab-1', 'Claude Code', {
+      worktreeId: WT_A,
+      site: 'pty-title-change'
+    })
+
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledWith(BREADCRUMB, {
+      tabId: 'tab-1',
+      site: 'pty-title-change',
+      ownerCount: 2,
+      sameRepo: true
+    })
+  })
+
+  it('reports sameRepo false when the writer belongs to another repo', () => {
+    const store = storeWithTabInWorktreeA()
+
+    store.getState().updateTabTitle('tab-1', 'Claude Code', {
+      worktreeId: WT_OTHER_REPO,
+      site: 'ipc-agent-status-title'
+    })
+
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledWith(BREADCRUMB, {
+      tabId: 'tab-1',
+      site: 'ipc-agent-status-title',
+      ownerCount: 1,
+      sameRepo: false
+    })
+  })
+
+  it('stops recording once the unpruned key set hits its cap', () => {
+    const tabsByWorktree = { [WT_A]: [] }
+    for (let i = 0; i < 256; i += 1) {
+      recordTabTitleWriteWorktreeMismatch({
+        tabId: `tab-${i}`,
+        ownerWorktreeId: WT_A,
+        tabsByWorktree,
+        context: { worktreeId: WT_B, site: 'pty-title-change' }
+      })
+    }
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledTimes(256)
+
+    recordTabTitleWriteWorktreeMismatch({
+      tabId: 'tab-256',
+      ownerWorktreeId: WT_A,
+      tabsByWorktree,
+      context: { worktreeId: WT_B, site: 'pty-title-change' }
+    })
+    expect(recordRendererCrashBreadcrumb).toHaveBeenCalledTimes(256)
+  })
+})

--- a/src/renderer/src/store/slices/tab-title-write-attribution.ts
+++ b/src/renderer/src/store/slices/tab-title-write-attribution.ts
@@ -1,0 +1,89 @@
+import { recordRendererCrashBreadcrumb } from '../../lib/crash-breadcrumb-recorder'
+import { getRepoIdFromWorktreeId } from '../../../../shared/worktree-id'
+import type { TerminalTab } from '../../../../shared/types'
+
+/** Which title-writing path made the call; distinguishes the contextful callers in a bundle. */
+export type TerminalTabTitleWriteSite =
+  | 'parked-byte-watcher'
+  | 'pty-title-change'
+  | 'pty-inferred-interrupt-clear'
+  | 'pty-confirmed-shell-clear'
+  | 'ipc-agent-status-title'
+  | 'pane-focus-sync'
+  | 'pane-closed'
+
+/**
+ * What the writer knows about itself, so the store can check its own owner lookup against it.
+ * Diagnostic only: nothing here changes what the write does.
+ */
+export type TerminalTabTitleWriteContext = {
+  worktreeId: string
+  site: TerminalTabTitleWriteSite
+}
+
+const reportedTitleWriteMismatches = new Set<string>()
+// Why capped: this set is never pruned and one key is added per distinct
+// tab/expected/owner/site combination. 256 is ample evidence for a bundle.
+const MAX_REPORTED_TITLE_WRITE_MISMATCHES = 256
+
+/** Test seam: the mismatch breadcrumb is once-per-combination per session. */
+export function _resetTabTitleWriteAttributionBreadcrumbsForTests(): void {
+  reportedTitleWriteMismatches.clear()
+}
+
+function countWorktreesOwningTab(
+  tabsByWorktree: Record<string, TerminalTab[]>,
+  tabId: string
+): number {
+  let owners = 0
+  for (const tabs of Object.values(tabsByWorktree)) {
+    if (tabs.some((tab) => tab.id === tabId)) {
+      owners += 1
+    }
+  }
+  return owners
+}
+
+/**
+ * Breadcrumb a title write whose writer worktree disagrees with the store's owner lookup.
+ *
+ * Why: a title from worktree A briefly landing on a tab shown for worktree B is
+ * reported but unexplained, and no existing trace records title writes at all.
+ * The writer already knows its own worktree; the store re-derives one from the
+ * tab id alone. This is the exact moment those two disagree.
+ *
+ * Raw worktree and pty ids are deliberately not carried: the crash sanitizer
+ * collapses every absolute path to one literal, so two worktrees of a repo
+ * arrive byte-identical. `ownerCount` and `sameRepo` separate a tab id
+ * duplicated across buckets from a writer holding a stale worktree id, and the
+ * opaque tab id survives intact. Titles are never carried — they can contain
+ * agent prompt text and crash bundles leave the device.
+ */
+export function recordTabTitleWriteWorktreeMismatch(args: {
+  tabId: string
+  ownerWorktreeId: string
+  tabsByWorktree: Record<string, TerminalTab[]>
+  context: TerminalTabTitleWriteContext | undefined
+}): void {
+  const { context, tabId, ownerWorktreeId } = args
+  if (!context || context.worktreeId === ownerWorktreeId) {
+    return
+  }
+
+  const mismatchKey = `${tabId}:${context.worktreeId}:${ownerWorktreeId}:${context.site}`
+  if (
+    reportedTitleWriteMismatches.has(mismatchKey) ||
+    reportedTitleWriteMismatches.size >= MAX_REPORTED_TITLE_WRITE_MISMATCHES
+  ) {
+    return
+  }
+  reportedTitleWriteMismatches.add(mismatchKey)
+
+  recordRendererCrashBreadcrumb('terminal_tab_title_write_worktree_mismatch', {
+    tabId,
+    site: context.site,
+    ownerCount: countWorktreesOwningTab(args.tabsByWorktree, tabId),
+    sameRepo:
+      getRepoIdFromWorktreeId(context.worktreeId) === getRepoIdFromWorktreeId(ownerWorktreeId)
+  })
+}

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -39,6 +39,10 @@ import {
 import { isValidHostTerminalTabId, isValidTerminalTabId } from '../../../../shared/terminal-tab-id'
 import { buildByIdIndex, buildWorktreeByIdIndex } from './worktree-by-id-index'
 import { resolveActiveTabOwnerWorktreeId } from './active-tab-owner-worktree'
+import {
+  recordTabTitleWriteWorktreeMismatch,
+  type TerminalTabTitleWriteContext
+} from './tab-title-write-attribution'
 import { isSameCodexRestartNoticeAccount } from './codex-restart-notice-account-identity'
 import {
   getRepoIdFromWorktreeId,
@@ -683,7 +687,11 @@ export type TerminalSlice = {
   setTabBarOrder: (worktreeId: string, order: string[]) => void
   setActiveTab: (tabId: string) => void
   setActiveTabForWorktree: (worktreeId: string, tabId: string) => void
-  updateTabTitle: (tabId: string, title: string) => void
+  updateTabTitle: (
+    tabId: string,
+    title: string,
+    writeContext?: TerminalTabTitleWriteContext
+  ) => void
   setAiVaultTabTitle: (tabId: string, aiVaultTitle: AiVaultSessionTitle | null) => void
   setGeneratedTabTitleFromAgentPrompt: (
     paneKey: string,
@@ -1988,7 +1996,7 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
     }))
   },
 
-  updateTabTitle: (tabId, title) => {
+  updateTabTitle: (tabId, title, writeContext) => {
     set((s) => {
       // Why: update only the owner to preserve selector equality for background worktrees.
       const ownerWorktreeId = getTerminalTabOwnerWorktreeId(s.tabsByWorktree, tabId)
@@ -2033,6 +2041,13 @@ export const createTerminalSlice: StateCreator<AppState, [], [], TerminalSlice> 
             }
           : s
       }
+      // Past both no-op returns: only writes that actually change the title are worth a crumb.
+      recordTabTitleWriteWorktreeMismatch({
+        tabId,
+        ownerWorktreeId,
+        tabsByWorktree: s.tabsByWorktree,
+        context: writeContext
+      })
       const ownerTabs = tabs.map((tab) =>
         tab.id === tabId
           ? {


### PR DESCRIPTION
## What

Records a crash breadcrumb when a terminal tab-title write's originating
worktree disagrees with the worktree the store derives from the tab id.

No behavior change. `updateTabTitle` gained an optional third argument; callers
that omit it skip the comparison entirely, and even with it the only effect is a
breadcrumb.

## Why

A title belonging to one workspace was seen briefly appearing on the first tab
of another workspace after switching workspaces in the sidebar, then correcting
itself. Persisted state was clean, so this is transient in-memory attribution,
not data corruption.

Nothing in the existing traces records title writes at all, so the moment cannot
be reconstructed afterwards. Two structural hypotheses were investigated and
both turned out to be reachable only through remote paths (SSH / paired
runtime), while the machine that saw the symptom is entirely local. **The cause
is still unknown** — this is instrumentation, not a fix.

Every path that *writes* a title targets its own tab id; the store then
re-derives an owner worktree from that tab id alone. This is the moment those
two disagree.

## Shape

Seven writers now pass what they already know about themselves, tagged so a
bundle says which path misattributed: `pty-title-change`,
`pty-inferred-interrupt-clear`, `pty-confirmed-shell-clear`,
`parked-byte-watcher`, `ipc-agent-status-title`, `pane-focus-sync`,
`pane-closed`.

`ipc-agent-status-title` is the one that matters most: its worktree comes from
the main process (`data.worktreeId`), so it is the only site whose two sides are
not both derived from the same renderer pass.

## Two details worth reviewing

**The payload carries no raw worktree or pty id.** `sanitizeCrashReportString`
rewrites every absolute path to `[redacted-path]`, and a worktree id is
`${repoId}::${absolutePath}` — so two worktrees of one repo arrive
byte-identical and prove nothing. Verified by running the real sanitizer.
Instead the crumb carries `ownerCount` (how many worktree buckets hold this tab
id) and `sameRepo`, which survive intact and separate a tab id duplicated across
buckets from a writer holding a stale worktree id — the two live hypotheses.
Titles are never carried, not even truncated: agent prompt text leaks into them
and crash bundles leave the device.

**The name joins `COALESCED_RENDERER_BREADCRUMB_NAMES`, keyed by call site.**
The ring holds 30 entries and the dedupe key includes the tab id, so an unkeyed
burst across a ten-tab workspace would evict the very trail the crumb exists to
sit inside.

The crumb is also recorded past both of `updateTabTitle`'s no-op early returns,
so decorative spinner frames and unchanged-title writes cannot spend the single
slot a combination gets.

## Verification

- 5 test files / 732 tests pass (`npx vitest run --config config/vitest.config.ts`).
- `pnpm typecheck` clean; `oxlint` clean on all 13 changed files;
  `check:max-lines-ratchet` clean, no new bypasses.

## Follow-ups, deliberately not here

- `collapseParkedExitedLeaf` (`terminal-parked-pty-watcher.ts`) is left
  uninstrumented: its enclosing function has no worktree in scope, and it
  selects from the tab's own runtime pane titles, so it cannot carry a foreign
  workspace's title.
- The investigation surfaced a separate real defect: the SSH and paired-runtime
  branches of `terminal-hidden-view-parking.ts` skip the worktree comparison the
  local branch performs. That is its own change.
