### PR TITLE
fix(file-explorer): expand symlinked directories that point outside the workspace

### DIFF
--- a/src/main/ipc/filesystem-symlink-target-authorization.test.ts
+++ b/src/main/ipc/filesystem-symlink-target-authorization.test.ts
@@ -1,0 +1,74 @@
+import path from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { lstatMock, realpathMock, realpathSyncMock } = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  realpathMock: vi.fn(),
+  realpathSyncMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  realpath: realpathMock
+}))
+
+vi.mock('node:fs', () => ({
+  realpathSync: realpathSyncMock
+}))
+
+import { isPathAllowed } from './filesystem-auth'
+import { authorizeSymlinkTargetPath } from './filesystem-symlink-target-authorization'
+
+const REPO_PATH = path.resolve('/workspace/repo')
+const LINK_PATH = path.join(REPO_PATH, 'linked-docs')
+const TARGET_PATH = path.resolve('/elsewhere/docs')
+
+const store = {
+  getRepos: () => [
+    { id: 'repo-1', path: REPO_PATH, displayName: 'repo', badgeColor: '#000', addedAt: 0 }
+  ],
+  getSettings: () => ({})
+} as never
+
+describe('authorizeSymlinkTargetPath', () => {
+  beforeEach(() => {
+    lstatMock.mockReset()
+    realpathMock.mockReset().mockImplementation(async (target: string) => target)
+    realpathSyncMock.mockReset().mockImplementation((target: string) => target)
+  })
+
+  it('authorizes a link target outside the workspace so its subtree becomes readable', async () => {
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => true })
+    realpathMock.mockImplementation(async (target: string) =>
+      target === LINK_PATH ? TARGET_PATH : target
+    )
+
+    expect(isPathAllowed(TARGET_PATH, store)).toBe(false)
+
+    await expect(authorizeSymlinkTargetPath(LINK_PATH, store)).resolves.toBe(TARGET_PATH)
+
+    expect(isPathAllowed(TARGET_PATH, store)).toBe(true)
+    expect(isPathAllowed(path.join(TARGET_PATH, 'guide', 'index.md'), store)).toBe(true)
+  })
+
+  it('authorizes nothing when the path is a regular directory', async () => {
+    const plainDirPath = path.join(REPO_PATH, 'src')
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => false })
+
+    await expect(authorizeSymlinkTargetPath(plainDirPath, store)).resolves.toBeNull()
+
+    expect(realpathSyncMock).not.toHaveBeenCalled()
+  })
+
+  it('refuses to follow a link that lives outside the allowed roots', async () => {
+    const outsideLinkPath = path.resolve('/somewhere-else/linked-docs')
+    lstatMock.mockResolvedValue({ isSymbolicLink: () => true })
+
+    await expect(authorizeSymlinkTargetPath(outsideLinkPath, store)).rejects.toThrow(
+      'Access denied'
+    )
+
+    expect(lstatMock).not.toHaveBeenCalled()
+    expect(isPathAllowed(path.resolve('/somewhere-else'), store)).toBe(false)
+  })
+})

--- a/src/main/ipc/filesystem-symlink-target-authorization.ts
+++ b/src/main/ipc/filesystem-symlink-target-authorization.ts
@@ -1,0 +1,24 @@
+import { lstat, realpath } from 'node:fs/promises'
+import type { Store } from '../persistence'
+import { authorizeExternalPath, resolveAuthorizedPath } from './filesystem-auth'
+
+/**
+ * Authorize the destination of a symlink that lives inside an already-allowed root, so an
+ * explicitly activated link to an external folder can be read.
+ *
+ * Returns the canonical target path, or null when the path is not a symlink.
+ */
+export async function authorizeSymlinkTargetPath(
+  linkPath: string,
+  store: Store
+): Promise<string | null> {
+  // Why: preserveSymlink canonicalizes the parent but keeps the leaf, so this proves the link
+  // itself sits in an allowed root without following it into an unauthorized destination.
+  const authorizedLinkPath = await resolveAuthorizedPath(linkPath, store, { preserveSymlink: true })
+  if (!(await lstat(authorizedLinkPath)).isSymbolicLink()) {
+    return null
+  }
+  const targetPath = await realpath(authorizedLinkPath)
+  authorizeExternalPath(targetPath)
+  return targetPath
+}

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -98,6 +98,7 @@ import {
   isENOENT,
   authorizeExternalPath
 } from './filesystem-auth'
+import { authorizeSymlinkTargetPath } from './filesystem-symlink-target-authorization'
 import { listQuickOpenFiles } from './filesystem-list-files'
 import { registerFilesystemMutationHandlers } from './filesystem-mutations'
 import { searchWithGitGrep } from './filesystem-search-git'
@@ -918,6 +919,12 @@ export function registerFilesystemHandlers(
   ipcMain.handle('fs:authorizeExternalPath', (_event, args: { targetPath: string }): void => {
     authorizeExternalPath(args.targetPath)
   })
+
+  ipcMain.handle(
+    'fs:authorizeSymlinkTarget',
+    async (_event, args: { targetPath: string }): Promise<string | null> =>
+      authorizeSymlinkTargetPath(args.targetPath, store)
+  )
 
   ipcMain.handle(
     'fs:stat',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2845,6 +2845,7 @@ export type PreloadApi = {
       } & SshMutationExpectation
     ) => Promise<void>
     authorizeExternalPath: (args: { targetPath: string }) => Promise<void>
+    authorizeSymlinkTarget: (args: { targetPath: string }) => Promise<string | null>
     stat: (args: {
       filePath: string
       connectionId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3160,6 +3160,8 @@ const api = {
     ): Promise<void> => ipcRenderer.invoke('fs:deletePath', args),
     authorizeExternalPath: (args: { targetPath: string }): Promise<void> =>
       ipcRenderer.invoke('fs:authorizeExternalPath', args),
+    authorizeSymlinkTarget: (args: { targetPath: string }): Promise<string | null> =>
+      ipcRenderer.invoke('fs:authorizeSymlinkTarget', args),
     stat: (args: {
       filePath: string
       connectionId?: string

--- a/src/renderer/src/components/right-sidebar/FileExplorer.tsx
+++ b/src/renderer/src/components/right-sidebar/FileExplorer.tsx
@@ -146,6 +146,7 @@ function FileExplorerFiles(): React.JSX.Element {
     rootError,
     loadDir,
     statPath,
+    authorizeSymlinkTarget,
     markPathAsDirectory,
     refreshTree,
     refreshDir,
@@ -504,6 +505,7 @@ function FileExplorerFiles(): React.JSX.Element {
       toggleDir: hasNameFilter ? handleToggleNameFilterDir : toggleDir,
       loadDir,
       statPath,
+      authorizeSymlinkTarget,
       markPathAsDirectory,
       setSelectedPath: setSingleSelectedPath,
       scrollRef

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.test.ts
@@ -72,6 +72,52 @@ describe('activateFileExplorerNode', () => {
     expect(openFile).not.toHaveBeenCalled()
   })
 
+  it('authorizes the symlink target before probing it', async () => {
+    const calls: string[] = []
+    const authorizeSymlinkTarget = vi.fn(async () => {
+      calls.push('authorize')
+    })
+    const statPath = vi.fn(async () => {
+      calls.push('stat')
+      return { isDirectory: true }
+    })
+
+    await activateFileExplorerNode({
+      node: symlinkNode,
+      activeWorktreeId: 'wt-1',
+      openFile: vi.fn(),
+      toggleDir: vi.fn(),
+      loadDir: vi.fn().mockResolvedValue(true),
+      statPath,
+      authorizeSymlinkTarget,
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(authorizeSymlinkTarget).toHaveBeenCalledWith('/repo/linked-docs')
+    expect(calls).toEqual(['authorize', 'stat'])
+  })
+
+  it('does not read a symlink target that authorization refuses', async () => {
+    const statPath = vi.fn()
+    const openFile = vi.fn()
+
+    await activateFileExplorerNode({
+      node: symlinkNode,
+      activeWorktreeId: 'wt-1',
+      openFile,
+      toggleDir: vi.fn(),
+      loadDir: vi.fn(),
+      statPath,
+      authorizeSymlinkTarget: vi.fn().mockRejectedValue(new Error('Access denied')),
+      markPathAsDirectory: vi.fn(),
+      setSelectedPath: vi.fn()
+    })
+
+    expect(statPath).not.toHaveBeenCalled()
+    expect(openFile).not.toHaveBeenCalled()
+  })
+
   it('falls back to opening a symlink as a file when directory loading fails', async () => {
     const openFile = vi.fn()
     useAppStore.setState({

--- a/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerHandlers.ts
@@ -40,6 +40,7 @@ type UseFileExplorerHandlersParams = {
     options?: { force?: boolean; failOnError?: boolean }
   ) => Promise<boolean>
   statPath: (path: string) => Promise<{ isDirectory: boolean }>
+  authorizeSymlinkTarget?: (path: string) => Promise<void>
   markPathAsDirectory: (path: string) => void
   setSelectedPath: (path: string) => void
   scrollRef: RefObject<HTMLDivElement | null>
@@ -64,6 +65,7 @@ export async function activateFileExplorerNode(args: {
   canToggleDirectories?: boolean
   loadDir: UseFileExplorerHandlersParams['loadDir']
   statPath: UseFileExplorerHandlersParams['statPath']
+  authorizeSymlinkTarget?: UseFileExplorerHandlersParams['authorizeSymlinkTarget']
   markPathAsDirectory: (path: string) => void
   setSelectedPath: (path: string) => void
 }): Promise<void> {
@@ -75,6 +77,7 @@ export async function activateFileExplorerNode(args: {
     canToggleDirectories = true,
     loadDir,
     statPath,
+    authorizeSymlinkTarget,
     markPathAsDirectory,
     setSelectedPath
   } = args
@@ -94,6 +97,9 @@ export async function activateFileExplorerNode(args: {
     // them only after the user explicitly activates the row.
     let targetIsDirectory = false
     try {
+      // Why: a link inside the workspace usually points outside it, and every read is gated on the
+      // workspace roots; activation is the consent that widens the allow-list to this destination.
+      await authorizeSymlinkTarget?.(node.path)
       targetIsDirectory = (await statPath(node.path)).isDirectory
     } catch {
       toast.error(
@@ -163,6 +169,7 @@ export function useFileExplorerHandlers({
   canToggleDirectories = true,
   loadDir,
   statPath,
+  authorizeSymlinkTarget,
   markPathAsDirectory,
   setSelectedPath,
   scrollRef
@@ -228,6 +235,7 @@ export function useFileExplorerHandlers({
         canToggleDirectories,
         loadDir,
         statPath,
+        authorizeSymlinkTarget,
         markPathAsDirectory,
         setSelectedPath
       })
@@ -241,6 +249,7 @@ export function useFileExplorerHandlers({
       markPathAsDirectory,
       openFile,
       statPath,
+      authorizeSymlinkTarget,
       toggleDir,
       setSelectedPath
     ]

--- a/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
+++ b/src/renderer/src/components/right-sidebar/useFileExplorerTree.ts
@@ -2,7 +2,7 @@ import type { Dispatch, SetStateAction } from 'react'
 import { useCallback, useRef, useState } from 'react'
 import type { DirCache, FileExplorerTreeRefreshOutcome } from './file-explorer-types'
 import { splitPathSegments } from './path-tree'
-import { statRuntimePath } from '@/runtime/runtime-file-client'
+import { authorizeRuntimeSymlinkTarget, statRuntimePath } from '@/runtime/runtime-file-client'
 import { createFileExplorerDirLoadTracker } from './file-explorer-dir-load-tracker'
 import {
   getFileExplorerOperationOwner,
@@ -28,6 +28,7 @@ type UseFileExplorerTreeResult = {
     options?: { force?: boolean; failOnError?: boolean }
   ) => Promise<boolean>
   statPath: (path: string) => Promise<{ isDirectory: boolean }>
+  authorizeSymlinkTarget: (path: string) => Promise<void>
   markPathAsDirectory: (path: string) => void
   refreshTree: () => Promise<FileExplorerTreeRefreshOutcome>
   refreshDir: (dirPath: string) => Promise<void>
@@ -155,6 +156,26 @@ export function useFileExplorerTree(
     [activeWorktreeId, worktreePath]
   )
 
+  const authorizeSymlinkTarget = useCallback(
+    async (path: string) => {
+      const operationOwner = getFileExplorerOperationOwner(activeWorktreeId)
+      const route = getFileExplorerOperationRoute(operationOwner)
+      if (!route) {
+        throw new Error(getFileExplorerOwnerUnresolvedMessage())
+      }
+      await authorizeRuntimeSymlinkTarget(
+        {
+          settings: route.settings,
+          worktreeId: activeWorktreeId,
+          worktreePath,
+          connectionId: route.connectionId
+        },
+        path
+      )
+    },
+    [activeWorktreeId, worktreePath]
+  )
+
   const refreshTree = useCallback(async (): Promise<FileExplorerTreeRefreshOutcome> => {
     if (!worktreePath) {
       // Why: not 'root-unreadable' — no read was attempted, and that outcome tells callers to DROP
@@ -252,6 +273,7 @@ export function useFileExplorerTree(
     rootError,
     loadDir,
     statPath,
+    authorizeSymlinkTarget,
     markPathAsDirectory,
     refreshTree,
     refreshDir,

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -3,6 +3,7 @@ preload API plus remote fallbacks; keeping route coverage together makes local
 versus environment behavior easy to audit. */
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
+  authorizeRuntimeSymlinkTarget,
   cancelRuntimeFileList,
   copyRuntimePath,
   createRuntimePath,
@@ -44,6 +45,7 @@ const fsCreateFile = vi.fn()
 const fsRename = vi.fn()
 const fsDeletePath = vi.fn()
 const fsStat = vi.fn()
+const fsAuthorizeSymlinkTarget = vi.fn()
 const fsPathExists = vi.fn()
 const fsSearch = vi.fn()
 const fsListFiles = vi.fn()
@@ -74,6 +76,7 @@ beforeEach(() => {
   fsRename.mockReset()
   fsDeletePath.mockReset()
   fsStat.mockReset()
+  fsAuthorizeSymlinkTarget.mockReset()
   fsPathExists.mockReset()
   fsSearch.mockReset()
   fsListFiles.mockReset()
@@ -118,6 +121,7 @@ beforeEach(() => {
         rename: fsRename,
         deletePath: fsDeletePath,
         stat: fsStat,
+        authorizeSymlinkTarget: fsAuthorizeSymlinkTarget,
         pathExists: fsPathExists,
         search: fsSearch,
         listFiles: fsListFiles,
@@ -2172,6 +2176,34 @@ describe('runtime file client', () => {
       params: { worktree: 'id:wt-1', relativePath: 'readme.md' },
       timeoutMs: 15_000
     })
+  })
+
+  it('authorizes symlink targets only for locally owned paths', async () => {
+    await authorizeRuntimeSymlinkTarget(
+      { settings: { activeRuntimeEnvironmentId: null }, worktreeId: 'wt-1', worktreePath: '/repo' },
+      '/repo/linked-docs'
+    )
+    expect(fsAuthorizeSymlinkTarget).toHaveBeenCalledWith({ targetPath: '/repo/linked-docs' })
+
+    fsAuthorizeSymlinkTarget.mockClear()
+    await authorizeRuntimeSymlinkTarget(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        connectionId: 'ssh-1'
+      },
+      '/repo/linked-docs'
+    )
+    await authorizeRuntimeSymlinkTarget(
+      {
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        worktreeId: 'wt-1',
+        worktreePath: '/remote/repo'
+      },
+      '/remote/repo/linked-docs'
+    )
+    expect(fsAuthorizeSymlinkTarget).not.toHaveBeenCalled()
   })
 
   it('uses quiet local path existence checks when no runtime environment is active', async () => {

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -1031,6 +1031,23 @@ export async function statRuntimePath(
   )
 }
 
+/**
+ * Widen the local allow-list to a symlink's destination before reading it.
+ *
+ * Why: only the local IPC layer rejects symlinks that escape the workspace roots; remote runtimes
+ * and SSH providers resolve links host-side and have no allow-list to widen.
+ */
+export async function authorizeRuntimeSymlinkTarget(
+  context: RuntimeFileOperationArgs,
+  absolutePath: string
+): Promise<void> {
+  if (context.connectionId || getRemoteFileArgs(context, absolutePath)) {
+    return
+  }
+  assertLocalFilesystemFallbackAllowed(context)
+  await window.api.fs.authorizeSymlinkTarget({ targetPath: absolutePath })
+}
+
 export async function subscribeRuntimeFileChanges(
   context: RuntimeFileOperationArgs,
   onPayload: (payload: FsChangedPayload) => void,

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1893,6 +1893,8 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       captureSession: captureWebFileMutationSession
     }),
     authorizeExternalPath: () => Promise.resolve(),
+    // Why: the paired host resolves symlinks itself; the web client has no local allow-list to widen.
+    authorizeSymlinkTarget: () => Promise.resolve(null),
     stat: async ({ filePath }) => {
       const file = await resolveRuntimeFilePath(filePath)
       return callRuntimeResult('files.stat', {


### PR DESCRIPTION
## Summary

A symlink inside a workspace could never be expanded in the File Explorer when it pointed outside the workspace roots — which is the normal case for links like `lems-web -> ../Hex/react-local-ems`. Clicking the row only produced the `Cannot open symlink target` toast, so linked folders were unreachable from the tree.

Directory listing intentionally does not follow symlinks (macOS TCC), and activation already resolves them lazily in `activateFileExplorerNode`. The blocker was the layer below: `fs:stat` and `fs:readDir` run the path through `resolveAuthorizedPath`, which canonicalizes it and rejects anything landing outside the allowed roots. A link's destination is outside them by definition, so the lazy resolution always failed.

This follows the pattern the app already uses for drag-dropped projects, terminal file links, and absolute-path tab opens: an explicit user action authorizes an external path. On activation the renderer calls a narrow new `fs:authorizeSymlinkTarget` IPC which:

1. validates the **link itself** sits inside an allowed root, using `preserveSymlink` so the check never follows the link,
2. confirms via `lstat` that the entry really is a symlink,
3. only then canonicalizes the destination and adds it to the authorized set.

Afterwards `fs:stat` succeeds, the row expands, and reads below the link resolve inside the now-authorized subtree. Listing still never follows links, so TCC-protected containers stay untouched until the user asks for them.

Remote runtimes and SSH providers already resolve symlinks host-side and keep no local allow-list, so the renderer skips the call for them (`authorizeRuntimeSymlinkTarget`), and the web client stubs it out.

## Screenshots

No visual change — the symlink row keeps its existing link icon and lazy (click-to-resolve) affordance. The difference is that activating it now expands the linked directory instead of showing `Cannot open symlink target`.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — see note below
- [x] `pnpm build`
- [x] Added tests

Test note: the full suite could not complete on this machine — unrelated cases try to download the Electron binary and failed on the network (`TypeError: terminated`). Instead every test in the areas this PR touches was run green under Node 24:

- `src/main/ipc` — 174 files, 2861 tests passed
- `src/renderer/src/components/right-sidebar`, `src/renderer/src/runtime`, `src/preload` — 272 files, 2426 tests passed

New/updated tests:

- `src/main/ipc/filesystem-symlink-target-authorization.test.ts` — authorizing a link target outside the workspace makes its subtree readable; a plain directory authorizes nothing; a link that lives outside the allowed roots is refused **before** `lstat` runs (no probing of unauthorized paths).
- `useFileExplorerHandlers.test.ts` — authorization runs before the target is probed, and a refused authorization neither stats nor opens the target.
- `runtime-file-client.test.ts` — the IPC is invoked only for locally owned paths, never for SSH or remote-runtime owners.

## AI Review Report

Reviewed with Claude Code (Opus 5). Risks checked:

- **Cross-platform (macOS / Linux / Windows):** no new path string handling — the new module composes `resolveAuthorizedPath`, `lstat`, and `realpath`, all of which already normalize per platform. Tests build paths with `path.resolve`/`path.join` so they hold on Windows separators. No shortcuts, labels, shell invocation, or Electron platform APIs are touched. The macOS-specific concern (following a link into a TCC-protected container) is preserved: listing still never follows links, and resolution happens only on explicit activation.
- **SSH / remote / local:** `authorizeRuntimeSymlinkTarget` returns early for `connectionId` (SSH) and for remote-runtime-owned paths, and reuses `assertLocalFilesystemFallbackAllowed` so a remote-owned path outside its worktree still fails the same way `statRuntimePath` does. The relay's own `readDir` already resolves symlinked directories, so remote hosts were never affected by this bug.
- **Folder workspaces vs worktrees:** authorization goes through the shared allowed-roots logic, which already covers repos, linked worktrees, folder workspaces, and project groups — nothing assumes a git worktree.
- **Agents / integrations / git providers:** not touched.
- **Performance:** one extra IPC round trip per explicit symlink activation. Nothing added to listing, refresh, or any hot path.
- **UI quality:** no new UI. The existing failure toast still covers a link whose target is gone or unreadable.

Flagged during review and addressed: the first sketch called the existing broad `fs:authorizeExternalPath` straight from the renderer, which would authorize any path the renderer names with no validation. It was replaced with the narrow handler that first proves the link sits inside an allowed root.

## Security Audit

- **Path handling / IPC:** the new `fs:authorizeSymlinkTarget` handler widens the allow-list only for a destination reached through a link that is already inside an allowed root, and only on explicit user activation. The containment check uses `preserveSymlink: true`, so an unauthorized path is rejected before any `lstat`/`realpath` touches it — a caller cannot use the handler to probe arbitrary paths. A non-symlink authorizes nothing and returns `null`.
- **Threat model change:** a repository can ship a symlink pointing at sensitive data (`~/.ssh`), and clicking that row now grants read access to that subtree for the session. That is the same consent model already used by drag-dropped folders, terminal file links, and absolute-path tab opens, and it requires a deliberate click on the link. Listing a directory never triggers it.
- **Scope:** authorization is session-scoped and in-memory (existing LRU-bounded set); nothing is persisted, so after a restart a previously expanded link must be activated again.
- **No** command execution, credentials, secrets, auth, or new dependencies are involved.

## Notes

- macOS-specific behavior preserved: symlinks are still never followed while listing a directory, so TCC-protected containers are not touched until the user activates the row.
- Follow-up worth considering (deliberately out of scope): an expanded symlinked directory is not re-authorized automatically after a restart, so it collapses until clicked once more.

X: @zhaozhen651856
