### PR TITLE
fix(web): recover terminals after headless serve restarts

### DIFF
--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.test.ts
@@ -10,6 +10,7 @@ import {
   resolvePaneSeedCwd,
   resolveQueuedInitialCwd,
   resetTerminalKeyboardProtocolAfterInterrupt,
+  retryTerminalPaneRecoveriesOnVisibilityResume,
   retireMountedTerminalPaneSurface,
   shouldDetachPaneTransportOnUnmount,
   splitPaneWithOneShotStartup,
@@ -517,5 +518,19 @@ describe('terminal pane visibility resume tracking', () => {
       false
     )
     expect(isTerminalPaneVisibilityResume({ previousIsVisible: false, isVisible: true })).toBe(true)
+  })
+
+  it('retries only latched remote pane recoveries after a hidden pane is revealed', () => {
+    const healthyRetry = vi.fn(() => false)
+    const latchedRetry = vi.fn(() => true)
+    const transports = [{ retryRecovery: healthyRetry }, { retryRecovery: latchedRetry }, {}]
+
+    expect(retryTerminalPaneRecoveriesOnVisibilityResume(transports, false)).toBe(0)
+    expect(healthyRetry).not.toHaveBeenCalled()
+    expect(latchedRetry).not.toHaveBeenCalled()
+
+    expect(retryTerminalPaneRecoveriesOnVisibilityResume(transports, true)).toBe(1)
+    expect(healthyRetry).toHaveBeenCalledOnce()
+    expect(latchedRetry).toHaveBeenCalledOnce()
   })
 })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -499,6 +499,22 @@ export function isTerminalPaneVisibilityResume(args: {
   return args.previousIsVisible === false && args.isVisible
 }
 
+export function retryTerminalPaneRecoveriesOnVisibilityResume(
+  transports: Iterable<Pick<PtyTransport, 'retryRecovery'>>,
+  resumedFromHidden: boolean
+): number {
+  if (!resumedFromHidden) {
+    return 0
+  }
+  let retried = 0
+  for (const transport of transports) {
+    if (transport.retryRecovery?.()) {
+      retried += 1
+    }
+  }
+  return retried
+}
+
 type TerminalPaneVisibilitySnapshot = {
   tabId: string
   cwd: string | null | undefined
@@ -1898,6 +1914,13 @@ export function useTerminalPaneLifecycle({
         bindingWithVisibility.noteVisibilityResume?.()
       }
     }
+    // Why: internal tab/workspace switching keeps terminal panes mounted. A
+    // serve restart can leave a remote pane latched after its bounded retry
+    // window, so revealing it must act as an explicit recovery trigger.
+    retryTerminalPaneRecoveriesOnVisibilityResume(
+      paneTransportsRef.current.values(),
+      resumedFromHidden
+    )
     if (resumedFromHidden && typeof window.api.pty.hasPty === 'function') {
       // Why: a single-PTY liveness check preserves missed-exit recovery without a daemon-wide listSessions.
       reconcileMissingSessions({

--- a/src/renderer/src/runtime/web-session-tabs-sync.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.test.ts
@@ -3,6 +3,8 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { posix as pathPosix } from 'node:path'
 import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { tagRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
 import { makePaneKey } from '../../../shared/stable-pane-id'
 import { toWebTerminalSurfaceTabId } from '../../../shared/terminal-surface-id'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
@@ -40,6 +42,7 @@ import {
   shouldApplyWebSessionTabsSnapshot,
   shouldBootstrapInitialWebRuntimeTerminal,
   shouldRespawnWebRuntimeTerminalAfterWake,
+  shouldRefreshRuntimeStatusAfterSubscriptionReplay,
   shouldSyncRuntimeSessionTabs,
   type WebSessionTabsSyncState
 } from './web-session-tabs-sync'
@@ -177,6 +180,28 @@ describe('applyWebSessionTabsSnapshot', () => {
     expect(shouldApplyWebSessionTabsSnapshot(older, ENV)).toBe(false)
     const newer = makeSnapshot([], { snapshotVersion: 6, activeTabType: null })
     expect(shouldApplyWebSessionTabsSnapshot(newer, ENV)).toBe(true)
+  })
+
+  it('refreshes runtime status only when a replay reports a replacement runtime id', () => {
+    const response = tagRuntimeSubscriptionReplayResponse({
+      id: 'session-tabs-replay',
+      ok: true,
+      streaming: true,
+      result: { type: 'snapshots', snapshots: [] },
+      _meta: { runtimeId: 'runtime-new' }
+    }) as RuntimeRpcResponse<unknown>
+
+    expect(shouldRefreshRuntimeStatusAfterSubscriptionReplay(response, 'runtime-old')).toBe(true)
+    expect(shouldRefreshRuntimeStatusAfterSubscriptionReplay(response, 'runtime-new')).toBe(false)
+    const ordinaryResponse: RuntimeRpcResponse<unknown> = {
+      id: 'session-tabs-initial',
+      ok: true,
+      result: { type: 'snapshots', snapshots: [] },
+      _meta: { runtimeId: 'runtime-new' }
+    }
+    expect(shouldRefreshRuntimeStatusAfterSubscriptionReplay(ordinaryResponse, 'runtime-old')).toBe(
+      false
+    )
   })
 
   it('scopes the replay reset to the replayed environment and worktree', () => {

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -134,6 +134,17 @@ type VisibilityResumeOmission = {
   visibilityGeneration: number
 }
 
+export function shouldRefreshRuntimeStatusAfterSubscriptionReplay(
+  response: RuntimeRpcResponse<unknown>,
+  currentRuntimeId: string | null | undefined
+): boolean {
+  return (
+    response.ok &&
+    isRuntimeSubscriptionReplayResponse(response) &&
+    response._meta.runtimeId !== currentRuntimeId
+  )
+}
+
 const latestSessionTabsSnapshotByWorktree = new Map<string, SnapshotFreshness>()
 const replayableSessionTabsSnapshotByWorktree = new Map<string, SnapshotFreshness>()
 const latestReceivedSessionTabsSnapshotByWorktree = new Map<string, ReceivedSessionTabsSnapshot>()
@@ -3960,6 +3971,16 @@ export function useWebSessionTabsSync(): void {
                 }
                 const event = response.result as SessionTabsStreamEvent
                 const replayed = isRuntimeSubscriptionReplayResponse(response)
+                const currentRuntimeId = useAppStore
+                  .getState()
+                  .runtimeStatusByEnvironmentId.get(environmentId)?.status?.runtimeId
+                if (shouldRefreshRuntimeStatusAfterSubscriptionReplay(response, currentRuntimeId)) {
+                  // Why: subscription replay may be the first traffic from a
+                  // replacement serve process. Refresh the full status so the
+                  // renderer advances connection generation and invalidates
+                  // runtime-scoped capability/session caches.
+                  void useAppStore.getState().refreshRuntimeEnvironmentStatus(environmentId)
+                }
                 if (event.type === 'snapshots') {
                   const skipUnchangedResumeWork = awaitingVisibilityResumeInventory && !replayed
                   awaitingVisibilityResumeInventory = false

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -492,6 +492,7 @@ describe('web runtime environment identity', () => {
     const { installWebPreloadApi } = await import('./web-preload-api')
     installWebPreloadApi()
     const onResponse = vi.fn()
+    const setItem = vi.spyOn(globals.storage, 'setItem')
 
     await globals.window.api.runtimeEnvironments.subscribe(
       { selector: 'web-server-a', method: 'session.tabs.subscribeAll', params: {} },
@@ -505,11 +506,18 @@ describe('web runtime environment identity', () => {
       _meta: { runtimeId: 'runtime-after-serve-restart' }
     } as RuntimeRpcResponse<unknown>
     subscriptionCallbacks?.onResponse(response)
+    expect(setItem).toHaveBeenCalledOnce()
+    const storedAfterReplacement = globals.storage.getItem('orca.web.runtimeEnvironment.v1')
+
+    subscriptionCallbacks?.onResponse(response)
 
     await expect(globals.window.api.runtimeEnvironments.list()).resolves.toMatchObject([
       { id: 'web-server-a', runtimeId: 'runtime-after-serve-restart' }
     ])
-    expect(onResponse).toHaveBeenCalledWith(response)
+    expect(setItem).toHaveBeenCalledOnce()
+    expect(globals.storage.getItem('orca.web.runtimeEnvironment.v1')).toBe(storedAfterReplacement)
+    expect(onResponse).toHaveBeenCalledTimes(2)
+    expect(onResponse).toHaveBeenLastCalledWith(response)
   })
 
   it('fences a web runtime response that completes after manual disconnect', async () => {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -467,6 +467,51 @@ describe('web runtime environment identity', () => {
     ).toMatchObject({ pairedDeviceId: 'paired-device-a' })
   })
 
+  it('persists a replacement runtime id observed first by a subscription', async () => {
+    let subscriptionCallbacks:
+      | {
+          onResponse: (response: RuntimeRpcResponse<unknown>) => void
+        }
+      | undefined
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        subscribe(
+          _method: string,
+          _params: unknown,
+          callbacks: { onResponse: (response: RuntimeRpcResponse<unknown>) => void }
+        ): Promise<{ unsubscribe: () => void }> {
+          subscriptionCallbacks = callbacks
+          return Promise.resolve({ unsubscribe: vi.fn() })
+        }
+
+        close(): void {}
+      }
+    }))
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    const onResponse = vi.fn()
+
+    await globals.window.api.runtimeEnvironments.subscribe(
+      { selector: 'web-server-a', method: 'session.tabs.subscribeAll', params: {} },
+      { onResponse }
+    )
+    const response = {
+      id: 'session-tabs-replay',
+      ok: true,
+      streaming: true,
+      result: { type: 'snapshots', snapshots: [] },
+      _meta: { runtimeId: 'runtime-after-serve-restart' }
+    } as RuntimeRpcResponse<unknown>
+    subscriptionCallbacks?.onResponse(response)
+
+    await expect(globals.window.api.runtimeEnvironments.list()).resolves.toMatchObject([
+      { id: 'web-server-a', runtimeId: 'runtime-after-serve-restart' }
+    ])
+    expect(onResponse).toHaveBeenCalledWith(response)
+  })
+
   it('fences a web runtime response that completes after manual disconnect', async () => {
     let resolveCall!: (response: RuntimeRpcResponse<unknown>) => void
     const pendingCall = new Promise<RuntimeRpcResponse<unknown>>((resolve) => {

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1558,7 +1558,22 @@ function createRuntimeEnvironmentsApi(): NonNullable<Partial<PreloadApi>['runtim
     subscribe: async ({ selector, method, params, timeoutMs }, callbacks) => {
       const environment = resolveEnvironment(selector)
       const client = getClientForEnvironment(environment)
-      const subscription = await client.subscribe(method, params, callbacks, { timeoutMs })
+      const subscription = await client.subscribe(
+        method,
+        params,
+        {
+          ...callbacks,
+          onResponse: (response) => {
+            // Why: subscriptions can be the first successful traffic after a
+            // transparent serve replacement. Persist its new runtime identity
+            // just like unary calls so later status/catalog reads do not keep
+            // reporting the retired runtime.
+            updateEnvironmentFromResponse(environment, response)
+            callbacks.onResponse(response)
+          }
+        },
+        { timeoutMs }
+      )
       if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
         subscription.unsubscribe()
         throw new Error('runtime_manually_disconnected')

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -3731,7 +3731,13 @@ function updateEnvironmentFromResponse(
     typeof (response.result as { pairedDeviceId?: unknown }).pairedDeviceId === 'string'
       ? (response.result as { pairedDeviceId: string }).pairedDeviceId
       : undefined
-  activeEnvironment = updateStoredEnvironmentRuntimeId(environment, runtimeId, pairedDeviceId)
+  if (
+    runtimeId === activeEnvironment.runtimeId &&
+    (pairedDeviceId === undefined || pairedDeviceId === activeEnvironment.pairedDeviceId)
+  ) {
+    return
+  }
+  activeEnvironment = updateStoredEnvironmentRuntimeId(activeEnvironment, runtimeId, pairedDeviceId)
 }
 
 function getStoredSettings(): GlobalSettings {

--- a/src/renderer/src/web/web-runtime-client-subscription-replay.test.ts
+++ b/src/renderer/src/web/web-runtime-client-subscription-replay.test.ts
@@ -1,0 +1,163 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { encrypt } from '../../../shared/e2ee-crypto'
+import { isRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
+import { WebRuntimeClient } from './web-runtime-client'
+
+const fakeSockets: FakeWebSocket[] = []
+
+class FakeWebSocket {
+  static readonly CONNECTING = 0
+  static readonly OPEN = 1
+  readyState = FakeWebSocket.CONNECTING
+  binaryType = 'arraybuffer'
+  onopen: (() => void) | null = null
+  onmessage: ((event: { data: unknown }) => void) | null = null
+  onclose: (() => void) | null = null
+  onerror: (() => void) | null = null
+  close = vi.fn()
+  send = vi.fn()
+
+  constructor(readonly _url: string) {
+    fakeSockets.push(this)
+  }
+}
+
+type ClientInternals = {
+  ws: FakeWebSocket | null
+  sharedKey: Uint8Array | null
+  state: string
+  subscriptions: Map<string, { needsReplay: boolean; pendingReplayTag: boolean }>
+  subscribeOnCurrentConnection: WebRuntimeClient['subscribe']
+  handleInterruptedSubscriptions(): void
+  handleSocketMessage(rawData: unknown, sourceWs?: unknown): Promise<void>
+  setState(next: string): void
+}
+
+function createConnectedClient(): {
+  client: WebRuntimeClient
+  internals: ClientInternals
+  sharedKey: Uint8Array
+} {
+  const client = new WebRuntimeClient({
+    v: 2,
+    endpoint: 'ws://127.0.0.1:6768',
+    deviceToken: 'token',
+    publicKeyB64: Buffer.alloc(32).toString('base64')
+  })
+  fakeSockets[0]!.readyState = FakeWebSocket.OPEN
+  const sharedKey = new Uint8Array(32)
+  const internals = client as unknown as ClientInternals
+  internals.sharedKey = sharedKey
+  internals.state = 'connected'
+  return { client, internals, sharedKey }
+}
+
+function reconnect(internals: ClientInternals, sharedKey: Uint8Array): FakeWebSocket {
+  const replacementSocket = new FakeWebSocket('ws://127.0.0.1:6768')
+  replacementSocket.readyState = FakeWebSocket.OPEN
+  internals.ws = replacementSocket
+  internals.sharedKey = sharedKey
+  internals.setState('connected')
+  return replacementSocket
+}
+
+describe('WebRuntimeClient retained subscription replay', () => {
+  beforeEach(() => {
+    fakeSockets.length = 0
+    vi.stubGlobal('window', {
+      setTimeout,
+      clearTimeout,
+      setInterval,
+      clearInterval,
+      atob: (value: string) => Buffer.from(value, 'base64').toString('binary'),
+      btoa: (value: string) => Buffer.from(value, 'binary').toString('base64')
+    })
+    vi.stubGlobal('WebSocket', FakeWebSocket)
+  })
+
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it.each(['session.tabs.subscribeAll', 'notifications.subscribe'])(
+    'replays retained %s subscriptions and tags the first snapshot',
+    async (method) => {
+      const { client, internals, sharedKey } = createConnectedClient()
+      const onResponse = vi.fn()
+      const onClose = vi.fn()
+      const onTransportInterrupted = vi.fn()
+      const onTransportReplayed = vi.fn()
+      const handle = await internals.subscribeOnCurrentConnection(
+        method,
+        {},
+        { onResponse, onClose, onTransportInterrupted, onTransportReplayed }
+      )
+      const initialId = Array.from(internals.subscriptions.keys())[0]!
+
+      internals.handleInterruptedSubscriptions()
+
+      expect(onClose).not.toHaveBeenCalled()
+      expect(onTransportInterrupted).toHaveBeenCalledOnce()
+      expect(internals.subscriptions.get(initialId)?.needsReplay).toBe(true)
+
+      const replacementSocket = reconnect(internals, sharedKey)
+      const replacementId = Array.from(internals.subscriptions.keys())[0]!
+      expect(replacementId).not.toBe(initialId)
+      expect(onTransportReplayed).toHaveBeenCalledOnce()
+      expect(internals.subscriptions.get(replacementId)?.pendingReplayTag).toBe(true)
+
+      await internals.handleSocketMessage(
+        encrypt(
+          JSON.stringify({
+            id: replacementId,
+            ok: true,
+            streaming: true,
+            result: { type: 'snapshots', snapshots: [] },
+            _meta: { runtimeId: 'runtime-after-serve-restart' }
+          }),
+          sharedKey
+        ),
+        replacementSocket
+      )
+
+      expect(onResponse).toHaveBeenCalledOnce()
+      expect(isRuntimeSubscriptionReplayResponse(onResponse.mock.calls[0]?.[0])).toBe(true)
+      expect(internals.subscriptions.get(replacementId)?.pendingReplayTag).toBe(false)
+
+      handle.unsubscribe()
+      client.close()
+    }
+  )
+
+  it('closes a retained subscription when replay setup fails', async () => {
+    const { client, internals, sharedKey } = createConnectedClient()
+    const onResponse = vi.fn()
+    const onClose = vi.fn()
+    await internals.subscribeOnCurrentConnection(
+      'session.tabs.subscribeAll',
+      {},
+      { onResponse, onClose }
+    )
+    internals.handleInterruptedSubscriptions()
+
+    const replacementSocket = reconnect(internals, sharedKey)
+    const replacementId = Array.from(internals.subscriptions.keys())[0]!
+    await internals.handleSocketMessage(
+      encrypt(
+        JSON.stringify({
+          id: replacementId,
+          ok: false,
+          error: { code: 'method_not_found', message: 'subscription unavailable' },
+          _meta: { runtimeId: 'runtime-after-serve-restart' }
+        }),
+        sharedKey
+      ),
+      replacementSocket
+    )
+
+    expect(onResponse).toHaveBeenCalledOnce()
+    expect(onClose).toHaveBeenCalledOnce()
+    expect(internals.subscriptions.size).toBe(0)
+    client.close()
+  })
+})

--- a/src/renderer/src/web/web-runtime-client.ts
+++ b/src/renderer/src/web/web-runtime-client.ts
@@ -20,6 +20,7 @@ import {
 } from '../../../shared/protocol-version'
 import { createWebRuntimeUnauthorizedError } from './web-runtime-client-error'
 import { withReconnectJitter } from '../../../shared/reconnect-jitter'
+import { tagRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
 
 type WebRuntimeConnectionState =
   | 'disconnected'
@@ -50,6 +51,7 @@ type RuntimeSubscription = {
   params: unknown
   callbacks: SubscriptionCallbacks
   needsReplay: boolean
+  pendingReplayTag: boolean
 }
 
 export type WebRuntimeSubscriptionHandle = {
@@ -68,6 +70,17 @@ const CONNECT_TIMEOUT_MS = 12_000
 const HANDSHAKE_TIMEOUT_MS = 10_000
 const RECONNECT_DELAYS_MS = [500, 1000, 2000, 4000, 8000, 15_000]
 const SHARED_CONNECTION_SUBSCRIPTION_METHODS = new Set(['files.watch'])
+// Why: these snapshot/event streams can resume on the same logical owner after
+// a serve-process replacement. Terminal streams are excluded because their
+// pane transport must re-resolve the authoritative handle before subscribing.
+const REPLAYABLE_SUBSCRIPTION_METHODS = new Set([
+  'accounts.subscribe',
+  'files.watch',
+  'notifications.subscribe',
+  'runtime.clientEvents.subscribe',
+  'session.tabs.subscribe',
+  'session.tabs.subscribeAll'
+])
 // Why: browser WebSockets hide pings/pongs, so a half-open socket stays OPEN with no onclose/onerror — poll liveness in-app.
 const HEARTBEAT_INTERVAL_MS = 10_000
 const HEARTBEAT_IDLE_MS = 25_000
@@ -325,7 +338,14 @@ export class WebRuntimeClient {
   ): Promise<WebRuntimeSubscriptionHandle> {
     await this.waitForConnected(options?.timeoutMs)
     const id = this.nextId()
-    const subscription: RuntimeSubscription = { id, method, params, callbacks, needsReplay: false }
+    const subscription: RuntimeSubscription = {
+      id,
+      method,
+      params,
+      callbacks,
+      needsReplay: false,
+      pendingReplayTag: false
+    }
     this.subscriptions.set(id, subscription)
     if (!this.sendEncrypted({ id, deviceToken: this.pairing.deviceToken, method, params })) {
       this.subscriptions.delete(id)
@@ -552,7 +572,21 @@ export class WebRuntimeClient {
         this.subscriptions.delete(response.id)
       }
       // Why: subscription-backed unary RPCs can return ordinary success frames.
-      subscription.callbacks.onResponse(subscriptionResponse)
+      let deliveredResponse = subscriptionResponse
+      if (subscription.pendingReplayTag) {
+        subscription.pendingReplayTag = false
+        if (subscriptionResponse.ok) {
+          deliveredResponse = tagRuntimeSubscriptionReplayResponse(subscriptionResponse)
+        }
+      }
+      subscription.callbacks.onResponse(deliveredResponse)
+      if (subscriptionResponse.ok === false) {
+        // Why: public subscriptions use onClose to release their dedicated
+        // child WebSocket. A setup/replay failure is terminal for this logical
+        // subscription, so leaving the socket open leaks an idle connection.
+        subscription.callbacks.onClose?.()
+        return
+      }
       if (subscriptionResponse.ok && isEndResult(subscriptionResponse.result)) {
         this.subscriptions.delete(response.id)
         subscription.callbacks.onClose?.()
@@ -701,7 +735,7 @@ export class WebRuntimeClient {
 
   private handleInterruptedSubscriptions(): void {
     for (const [id, subscription] of Array.from(this.subscriptions)) {
-      if (!SHARED_CONNECTION_SUBSCRIPTION_METHODS.has(subscription.method)) {
+      if (!REPLAYABLE_SUBSCRIPTION_METHODS.has(subscription.method)) {
         this.subscriptions.delete(id)
         subscription.callbacks.onClose?.()
         continue
@@ -721,6 +755,7 @@ export class WebRuntimeClient {
       this.subscriptions.delete(subscription.id)
       subscription.id = this.nextId()
       subscription.needsReplay = false
+      subscription.pendingReplayTag = true
       this.subscriptions.set(subscription.id, subscription)
       if (
         this.sendEncrypted({

--- a/tests/e2e/headless-serve-paired-browser-terminal-restart.spec.ts
+++ b/tests/e2e/headless-serve-paired-browser-terminal-restart.spec.ts
@@ -69,13 +69,33 @@ async function callRuntime<TResult>(page: Page, method: string, params: unknown)
   ) as Promise<TResult>
 }
 
+async function waitForRuntimeReady(page: Page): Promise<void> {
+  await expect
+    .poll(
+      () =>
+        page.evaluate(async () => {
+          try {
+            const response = await window.api.runtime.call({ method: 'status.get' })
+            return response.ok ? response._meta.runtimeId : null
+          } catch {
+            return null
+          }
+        }),
+      {
+        timeout: 30_000,
+        message: 'Paired Web client runtime RPC never became callable'
+      }
+    )
+    .not.toBeNull()
+}
+
 async function createTerminal(
   page: Page,
   worktreeId: string,
   label: string
-): Promise<{ webTabId: string }> {
+): Promise<{ hostTabId: string; terminal: string; webTabId: string }> {
   const created = await callRuntime<{
-    tab: { parentTabId: string; terminal: string | null }
+    tab: { id: string; parentTabId: string; terminal: string | null }
   }>(page, 'session.tabs.createTerminal', {
     worktree: `id:${worktreeId}`,
     command: fixtureCommand(label),
@@ -87,8 +107,46 @@ async function createTerminal(
     throw new Error(`Headless serve did not publish the ${label} terminal`)
   }
   return {
+    hostTabId: created.tab.parentTabId,
+    terminal: created.tab.terminal,
     webTabId: toWebTerminalSurfaceTabId(created.tab.parentTabId)
   }
+}
+
+async function readHostPtyId(page: Page, terminal: string): Promise<string> {
+  const shown = await callRuntime<{ terminal: { ptyId: string | null } }>(page, 'terminal.show', {
+    terminal
+  })
+  if (!shown.terminal.ptyId) {
+    throw new Error(`Headless serve terminal ${terminal} did not expose its daemon PTY id`)
+  }
+  return shown.terminal.ptyId
+}
+
+async function findHostTerminalHandle(
+  page: Page,
+  worktreeId: string,
+  hostTabId: string
+): Promise<string> {
+  let terminal: string | null = null
+  await expect
+    .poll(
+      async () => {
+        const snapshot = await callRuntime<{
+          tabs: { parentTabId?: string; terminal?: string | null; type: string }[]
+        }>(page, 'session.tabs.list', { worktree: `id:${worktreeId}` })
+        terminal =
+          snapshot.tabs.find((tab) => tab.type === 'terminal' && tab.parentTabId === hostTabId)
+            ?.terminal ?? null
+        return terminal
+      },
+      { timeout: 30_000, message: `Headless serve did not republish terminal tab ${hostTabId}` }
+    )
+    .not.toBeNull()
+  if (!terminal) {
+    throw new Error(`Headless serve did not republish terminal tab ${hostTabId}`)
+  }
+  return terminal
 }
 
 async function clickTerminalTab(page: Page, webTabId: string): Promise<void> {
@@ -133,12 +191,14 @@ test('reattaches a hidden terminal in the same browser document after headless s
       throw new Error('Paired Web client did not receive the headless serve worktree')
     }
     await page.evaluate((id) => window.__store?.getState().setActiveWorktree(id), worktreeId)
+    await waitForRuntimeReady(page)
 
     const target = await createTerminal(page, worktreeId, 'target')
     const decoy = await createTerminal(page, worktreeId, 'decoy')
     await clickTerminalTab(page, target.webTabId)
     await expect.poll(() => getTerminalContent(page), { timeout: 30_000 }).toContain('READY:target')
-    const originalPtyId = await waitForActivePanePtyId(page, 30_000)
+    await waitForActivePanePtyId(page, 30_000)
+    const originalHostPtyId = await readHostPtyId(page, target.terminal)
     const beforeRestart = await page.evaluate(() => {
       const state = window.__store?.getState()
       const environmentId =
@@ -236,7 +296,7 @@ test('reattaches a hidden terminal in the same browser document after headless s
       .toBeGreaterThan(beforeRestart.connectionGeneration)
 
     await clickTerminalTab(page, target.webTabId)
-    expect(await waitForActivePanePtyId(page, 30_000)).toBe(originalPtyId)
+    await waitForActivePanePtyId(page, 30_000)
     const marker = `after-restart-${Date.now()}`
     const textarea = page.locator('.xterm-helper-textarea:visible').first()
     await textarea.focus()
@@ -245,6 +305,8 @@ test('reattaches a hidden terminal in the same browser document after headless s
     await expect
       .poll(() => getTerminalContent(page), { timeout: 30_000 })
       .toContain(`LIVE:target:${marker}`)
+    const currentTargetHandle = await findHostTerminalHandle(page, worktreeId, target.hostTabId)
+    expect(await readHostPtyId(page, currentTargetHandle)).toBe(originalHostPtyId)
   } finally {
     await context.close().catch(() => undefined)
     await session.dispose()

--- a/tests/e2e/headless-serve-paired-browser-terminal-restart.spec.ts
+++ b/tests/e2e/headless-serve-paired-browser-terminal-restart.spec.ts
@@ -1,0 +1,252 @@
+import { existsSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { Page } from '@stablyai/playwright-test'
+import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+import { toWebTerminalSurfaceTabId } from '../../src/shared/terminal-surface-id'
+import { expect, test } from './helpers/orca-app'
+import { createRestartableHeadlessPairedRuntimeHost } from './helpers/headless-paired-runtime-host'
+import { createPairedWebClientUrl } from './helpers/paired-web-client-url'
+import { getTerminalContent, waitForActivePanePtyId } from './helpers/terminal'
+
+const scratch = mkdtempSync(path.join(os.tmpdir(), 'orca-headless-serve-browser-restart-'))
+const fixturePath = path.join(scratch, 'terminal-echo.mjs')
+
+writeFileSync(
+  fixturePath,
+  [
+    "const label = process.argv[2] ?? 'terminal'",
+    'process.stdout.write(`READY:${label}\\r\\n`)',
+    "process.stdin.setEncoding('utf8')",
+    "let pending = ''",
+    "process.stdin.on('data', (data) => {",
+    '  pending += data',
+    '  const lines = pending.split(/\\r\\n|\\r|\\n/)',
+    "  pending = lines.pop() ?? ''",
+    '  for (const line of lines) process.stdout.write(`LIVE:${label}:${line}\\r\\n`)',
+    '})',
+    'process.stdin.resume()'
+  ].join('\n')
+)
+
+test.afterAll(() => {
+  rmSync(scratch, { recursive: true, force: true })
+})
+
+function shellQuote(value: string): string {
+  return `'${value.replaceAll("'", `'\\''`)}'`
+}
+
+function fixtureCommand(label: string): string {
+  const command = [process.execPath, fixturePath, label]
+  return process.platform === 'win32'
+    ? command.map((value) => `"${value.replaceAll('"', '""')}"`).join(' ')
+    : command.map(shellQuote).join(' ')
+}
+
+function readDaemonPid(userDataDir: string): number {
+  const pidFile = path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`)
+  if (!existsSync(pidFile)) {
+    throw new Error('Headless serve daemon pid file is missing')
+  }
+  const value = JSON.parse(readFileSync(pidFile, 'utf8')) as { pid?: unknown }
+  if (typeof value.pid !== 'number') {
+    throw new Error('Headless serve daemon pid file did not contain a numeric pid')
+  }
+  return value.pid
+}
+
+async function callRuntime<TResult>(page: Page, method: string, params: unknown): Promise<TResult> {
+  return page.evaluate(
+    async ({ method, params }) => {
+      const response = await window.api.runtime.call({ method, params })
+      if (!response.ok) {
+        throw new Error(`${response.error.code}: ${response.error.message}`)
+      }
+      return response.result
+    },
+    { method, params }
+  ) as Promise<TResult>
+}
+
+async function createTerminal(
+  page: Page,
+  worktreeId: string,
+  label: string
+): Promise<{ webTabId: string }> {
+  const created = await callRuntime<{
+    tab: { parentTabId: string; terminal: string | null }
+  }>(page, 'session.tabs.createTerminal', {
+    worktree: `id:${worktreeId}`,
+    command: fixtureCommand(label),
+    activate: false,
+    select: false,
+    navigation: 'caller'
+  })
+  if (!created.tab.terminal) {
+    throw new Error(`Headless serve did not publish the ${label} terminal`)
+  }
+  return {
+    webTabId: toWebTerminalSurfaceTabId(created.tab.parentTabId)
+  }
+}
+
+async function clickTerminalTab(page: Page, webTabId: string): Promise<void> {
+  const tab = page.locator(`[data-testid="sortable-tab"][data-tab-id="${webTabId}"]`)
+  await expect(tab).toBeVisible({ timeout: 30_000 })
+  await tab.click()
+  await expect(tab).toHaveAttribute('data-active', 'true')
+}
+
+test('reattaches a hidden terminal in the same browser document after headless serve restarts', async ({
+  browser,
+  testRepoPath
+}) => {
+  test.setTimeout(240_000)
+  const session = await createRestartableHeadlessPairedRuntimeHost()
+  const firstHost = await session.start().catch(async (error) => {
+    await session.dispose()
+    throw error
+  })
+  const context = await browser.newContext({ ignoreHTTPSErrors: true })
+  const page = await context.newPage()
+  try {
+    if (!firstHost.offer.webClientUrl) {
+      throw new Error('Headless serve did not publish a paired Web client URL')
+    }
+    await firstHost.client.call('repo.add', { path: testRepoPath, kind: 'git' })
+    await page.goto(
+      createPairedWebClientUrl(firstHost.offer.webClientUrl, {
+        terminalParkingDelayMs: 180_000
+      })
+    )
+    await page.locator('[data-worktree-sidebar]').waitFor({ state: 'visible', timeout: 30_000 })
+    await expect
+      .poll(() => page.evaluate(() => window.__store?.getState().allWorktrees()[0]?.id ?? null), {
+        timeout: 30_000
+      })
+      .not.toBeNull()
+    const worktreeId = await page.evaluate(
+      () => window.__store?.getState().allWorktrees()[0]?.id ?? null
+    )
+    if (!worktreeId) {
+      throw new Error('Paired Web client did not receive the headless serve worktree')
+    }
+    await page.evaluate((id) => window.__store?.getState().setActiveWorktree(id), worktreeId)
+
+    const target = await createTerminal(page, worktreeId, 'target')
+    const decoy = await createTerminal(page, worktreeId, 'decoy')
+    await clickTerminalTab(page, target.webTabId)
+    await expect.poll(() => getTerminalContent(page), { timeout: 30_000 }).toContain('READY:target')
+    const originalPtyId = await waitForActivePanePtyId(page, 30_000)
+    const beforeRestart = await page.evaluate(() => {
+      const state = window.__store?.getState()
+      const environmentId =
+        state?.settings.activeRuntimeEnvironmentId ??
+        state?.allWorktrees()[0]?.runtimeOwnerEnvironmentId ??
+        state?.runtimeEnvironments[0]?.id ??
+        null
+      const status = environmentId
+        ? state?.runtimeStatusByEnvironmentId.get(environmentId)
+        : undefined
+      document.documentElement.dataset.serveRestartSentinel = 'same-document'
+      return {
+        environmentId,
+        runtimeId: status?.status?.runtimeId ?? null,
+        connectionGeneration: status?.connectionGeneration ?? 0,
+        diagnostics: {
+          activeRuntimeEnvironmentId: state?.settings.activeRuntimeEnvironmentId ?? null,
+          runtimeEnvironments: state?.runtimeEnvironments ?? [],
+          runtimeStatuses: Array.from(state?.runtimeStatusByEnvironmentId.entries() ?? []),
+          worktreeRuntimeOwnerEnvironmentId:
+            state?.allWorktrees()[0]?.runtimeOwnerEnvironmentId ?? null
+        }
+      }
+    })
+    if (!beforeRestart.environmentId || !beforeRestart.runtimeId) {
+      throw new Error(
+        `Paired Web client did not publish its initial runtime identity: ${JSON.stringify(beforeRestart.diagnostics)}`
+      )
+    }
+
+    await clickTerminalTab(page, decoy.webTabId)
+    await expect.poll(() => getTerminalContent(page), { timeout: 30_000 }).toContain('READY:decoy')
+    await expect
+      .poll(
+        () =>
+          page.evaluate((tabId) => {
+            const pane = window.__paneManagers?.get(tabId)?.getPanes?.()[0]
+            return Boolean(pane?.container?.isConnected)
+          }, target.webTabId),
+        { message: 'Hidden target terminal was parked instead of remaining mounted' }
+      )
+      .toBe(true)
+
+    const daemonPid = readDaemonPid(session.userDataDir)
+    await session.stop()
+    await expect
+      .poll(
+        () =>
+          page.evaluate((tabId) => {
+            const pane = window.__paneManagers?.get(tabId)?.getPanes?.()[0]
+            return pane?.container?.dataset?.ptyRecoveryState ?? null
+          }, target.webTabId),
+        {
+          timeout: 90_000,
+          message: 'Hidden target terminal never reached the bounded disconnected state'
+        }
+      )
+      .toBe('disconnected')
+
+    await session.start()
+    expect(readDaemonPid(session.userDataDir)).toBe(daemonPid)
+    expect(page.isClosed()).toBe(false)
+    expect(
+      await page.evaluate(() => document.documentElement.dataset.serveRestartSentinel ?? null)
+    ).toBe('same-document')
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            (environmentId) =>
+              window.__store?.getState().runtimeStatusByEnvironmentId.get(environmentId)?.status
+                ?.runtimeId ?? null,
+            beforeRestart.environmentId
+          ),
+        {
+          timeout: 60_000,
+          message: 'Paired Web client did not observe the replacement serve runtime id'
+        }
+      )
+      .not.toBe(beforeRestart.runtimeId)
+    await expect
+      .poll(
+        () =>
+          page.evaluate(
+            (environmentId) =>
+              window.__store?.getState().runtimeStatusByEnvironmentId.get(environmentId)
+                ?.connectionGeneration ?? 0,
+            beforeRestart.environmentId
+          ),
+        {
+          timeout: 60_000,
+          message: 'Paired Web client did not advance its runtime connection generation'
+        }
+      )
+      .toBeGreaterThan(beforeRestart.connectionGeneration)
+
+    await clickTerminalTab(page, target.webTabId)
+    expect(await waitForActivePanePtyId(page, 30_000)).toBe(originalPtyId)
+    const marker = `after-restart-${Date.now()}`
+    const textarea = page.locator('.xterm-helper-textarea:visible').first()
+    await textarea.focus()
+    await page.keyboard.type(marker)
+    await page.keyboard.press('Enter')
+    await expect
+      .poll(() => getTerminalContent(page), { timeout: 30_000 })
+      .toContain(`LIVE:target:${marker}`)
+  } finally {
+    await context.close().catch(() => undefined)
+    await session.dispose()
+  }
+})

--- a/tests/e2e/helpers/headless-paired-runtime-host.ts
+++ b/tests/e2e/helpers/headless-paired-runtime-host.ts
@@ -1,4 +1,5 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createServer } from 'node:net'
 import os from 'node:os'
 import path from 'node:path'
 import { _electron as electron, type ElectronApplication } from '@stablyai/playwright-test'
@@ -30,6 +31,13 @@ export type HeadlessPairedRuntimeHost = {
   client: RuntimeClient
   dispose: () => Promise<void>
   offer: RuntimeDesktopPairingOffer
+}
+
+export type RestartableHeadlessPairedRuntimeHost = {
+  userDataDir: string
+  start: () => Promise<Omit<HeadlessPairedRuntimeHost, 'dispose'>>
+  stop: () => Promise<void>
+  dispose: () => Promise<void>
 }
 
 export class HeadlessPairedRuntimeStartupDiagnosticBuffer {
@@ -115,6 +123,22 @@ function redactPairingMaterial(value: string): string {
     .replace(WEB_CLIENT_PAIRING_PATTERN, '$1[redacted]')
 }
 
+async function reserveLoopbackPort(): Promise<number> {
+  const server = createServer()
+  return new Promise<number>((resolve, reject) => {
+    server.once('error', reject)
+    server.listen(0, '127.0.0.1', () => {
+      const address = server.address()
+      if (!address || typeof address === 'string') {
+        server.close()
+        reject(new Error('Headless serve fixture could not reserve a loopback port'))
+        return
+      }
+      server.close((error) => (error ? reject(error) : resolve(address.port)))
+    })
+  })
+}
+
 async function readPairingOffer(app: ElectronApplication): Promise<RuntimeDesktopPairingOffer> {
   const child = app.process()
   const stdout = child.stdout
@@ -183,64 +207,91 @@ async function readPairingOffer(app: ElectronApplication): Promise<RuntimeDeskto
   })
 }
 
-export async function launchHeadlessPairedRuntimeHost(): Promise<HeadlessPairedRuntimeHost> {
+export async function createRestartableHeadlessPairedRuntimeHost(): Promise<RestartableHeadlessPairedRuntimeHost> {
+  const servePort = await reserveLoopbackPort()
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-headless-paired-'))
-  let app: ElectronApplication | undefined
-  try {
-    writeFileSync(
-      path.join(userDataDir, 'orca-data.json'),
-      `${JSON.stringify(getE2ECompletedOnboardingProfile(), null, 2)}\n`
-    )
-    const { ELECTRON_RUN_AS_NODE: _unused, ...cleanEnv } = process.env
-    void _unused
-    const isolation = createElectronHomeIsolation({
-      inheritedEnv: cleanEnv,
-      launchEnv: {
-        NODE_ENV: 'development',
-        ORCA_E2E_ENFORCE_SINGLE_INSTANCE_LOCK: '1',
-        ORCA_E2E_HEADLESS: '1'
-      },
-      extraEnv: {},
-      userDataDir
-    })
-    const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
-    app = await electron.launch({
+  writeFileSync(
+    path.join(userDataDir, 'orca-data.json'),
+    `${JSON.stringify(getE2ECompletedOnboardingProfile(), null, 2)}\n`
+  )
+  const { ELECTRON_RUN_AS_NODE: _unused, ...cleanEnv } = process.env
+  void _unused
+  const isolation = createElectronHomeIsolation({
+    inheritedEnv: cleanEnv,
+    launchEnv: {
+      NODE_ENV: 'development',
+      ORCA_E2E_ENFORCE_SINGLE_INSTANCE_LOCK: '1',
+      ORCA_E2E_HEADLESS: '1'
+    },
+    extraEnv: {},
+    userDataDir
+  })
+  const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
+  let activeApp: ElectronApplication | undefined
+
+  const stop = async (): Promise<void> => {
+    const app = activeApp
+    activeApp = undefined
+    if (app) {
+      await closeElectronAppForE2E(app)
+    }
+  }
+
+  const start = async (): Promise<Omit<HeadlessPairedRuntimeHost, 'dispose'>> => {
+    if (activeApp) {
+      throw new Error('Headless paired runtime host is already running')
+    }
+    const app = await electron.launch({
       args: [
         ...getOrcaElectronLaunchArgs(mainPath, false),
         '--serve',
         '--serve-json',
         '--serve-port',
-        '0',
+        String(servePort),
         '--serve-pairing-address',
         '127.0.0.1'
       ],
       env: isolation.env
     })
-    const [offer] = await Promise.all([
-      readPairingOffer(app),
-      app
-        .evaluate(({ app: electronApp }) => electronApp.getPath('home'))
-        .then((home) => assertElectronResolvedIsolatedHome(home, isolation))
-    ])
-    return {
-      app,
-      client: new RuntimeClient(userDataDir, 5_000),
-      offer,
-      dispose: async () => {
-        await closeElectronAppForE2E(app)
-        await cleanupE2EDaemons(userDataDir)
-        rmSync(userDataDir, { recursive: true, force: true })
-      }
-    }
-  } catch (error) {
+    activeApp = app
     try {
-      if (app) {
-        await closeElectronAppForE2E(app)
+      const [offer] = await Promise.all([
+        readPairingOffer(app),
+        app
+          .evaluate(({ app: electronApp }) => electronApp.getPath('home'))
+          .then((home) => assertElectronResolvedIsolatedHome(home, isolation))
+      ])
+      return {
+        app,
+        client: new RuntimeClient(userDataDir, 5_000),
+        offer
       }
+    } catch (error) {
+      activeApp = undefined
+      await closeElectronAppForE2E(app)
+      throw error
+    }
+  }
+
+  return {
+    userDataDir,
+    start,
+    stop,
+    dispose: async () => {
+      await stop()
       await cleanupE2EDaemons(userDataDir)
-    } finally {
       rmSync(userDataDir, { recursive: true, force: true })
     }
+  }
+}
+
+export async function launchHeadlessPairedRuntimeHost(): Promise<HeadlessPairedRuntimeHost> {
+  const session = await createRestartableHeadlessPairedRuntimeHost()
+  try {
+    const host = await session.start()
+    return { ...host, dispose: session.dispose }
+  } catch (error) {
+    await session.dispose().catch(() => undefined)
     throw error
   }
 }


### PR DESCRIPTION
## Summary

Paired web terminals now recover after a headless `orca serve` host restart even when the user switches to another internal Orca tab and returns later.

Root cause:

- Web runtime subscriptions belonged to one WebSocket generation and safe subscriptions were not replayed after reconnect.
- A hidden-but-mounted terminal retried recovery on connection changes, but not when an internal tab/workspace reveal made the disconnected pane visible again.
- The headless paired-host E2E helper always selected an ephemeral serve port, so it could not exercise a retained browser document across a real serve restart.

The fix:

- Replays safe runtime subscriptions after reconnect while deliberately excluding stateful `terminal.multiplex` ownership.
- Tags the first replay response, closes failed child sockets, and refreshes runtime identity/generation from subscription traffic.
- Requests PTY recovery when a disconnected mounted pane transitions from hidden to visible.
- Adds a restartable fixed-port headless serve helper and a browser E2E that proves the browser document, daemon PID, PTY ID, keyboard input, and live terminal output survive the away/restart/back journey.

Existing coverage in #13158 exercises a headed host plus a separate paired Electron client. This PR adds the missing headless `orca serve` + retained browser document + internal tab reveal boundary.

## Screenshots

No visual change.

This is a recovery/reconnection behavior change with no new UI. The real-browser E2E covers the interaction journey.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — 48,417 passed and 102 skipped; 3 root-directory guard tests require Bash 4 associative arrays and fail under the macOS system Bash 3.2 before reaching change-specific code. Cross-version tests passed after fetching the required tags.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused verification:

- `vitest run` for terminal pane lifecycle, web session tab sync, web preload API, and subscription replay: 4 files, 199 tests passed on the final staged source.
- `ORCA_E2E_WEB_CLIENT=1 ... headless-serve-paired-browser-terminal-restart.spec.ts`: passed twice consecutively.
- The E2E keeps an independent Chromium page alive, waits beyond the 60-second disconnect cutoff while the target terminal is hidden, restarts headless serve on the same user data and port, returns through the Orca tab UI, verifies the original PTY ID, and proves fresh keyboard input/live output.
- Linux AppImage packaging passed the glibc 2.31 compatibility gate for 18 native binaries plus packaged daemon-entry and plugin-resource verification.

## AI Review Report

The AI review reported no blocking findings after checking:

- Cross-platform compatibility for macOS, Linux, and Windows: no shortcuts, labels, platform paths, shell behavior, or native/Electron platform branches are changed. Runtime and renderer changes use existing TypeScript/browser abstractions.
- Local, SSH, and remote compatibility: replay is limited to provider-neutral RPC subscriptions; the new behavior targets paired web runtimes without changing local terminal startup or SSH worktree semantics.
- Supported agents, integrations, and Git providers: no agent-specific, integration-specific, credential, or Git-provider behavior is introduced.
- Performance: subscription replay runs once per reconnect for the existing safe subscription set; visibility recovery is triggered only on hidden-to-visible transitions. No new polling or hot-path loop is added.
- UI quality: no visual/layout change. The internal tab reveal path now reconnects the already-mounted pane instead of leaving stale output.
- Resource ownership: failed setup/replay closes the child socket, replay state is generation-scoped, and stateful terminal multiplex subscriptions remain excluded.

## Security Audit

No new dependency, authentication, authorization, secret, filesystem path, or production command-execution surface is introduced.

The review checked:

- Replayed method names and parameters come only from subscriptions already accepted by the existing runtime client.
- `terminal.multiplex` is excluded because replaying stateful stream ownership could duplicate or corrupt terminal transport state.
- Failed replay/setup paths close owned sockets instead of leaking alternate live connections.
- Runtime identity updates use existing validated subscription payload metadata.
- Test-only shell commands use generated markers and do not affect production execution paths.

No security follow-up is required.

## Notes

- No visual change.
- The production behavior was additionally smoke-tested with a Linux glibc 2.31 AppImage, a retained browser document, and a headless paired runtime.
- The AI Vault plain-HTTP UUID fix is intentionally not duplicated here; it remains scoped to ready PR #13142.
- X/Twitter handle intentionally omitted.
