### PR TITLE
fix(worktrees): guard lineage pruning from failed scans

### DIFF
--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -3,13 +3,10 @@ import { ipcMain, type BrowserWindow } from 'electron'
 import { readFile, stat } from 'node:fs/promises'
 import { randomUUID } from 'node:crypto'
 import type { Store } from '../persistence'
+import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
 import { isFolderRepo } from '../../shared/repo-kind'
 import { readBranchRenameFailureOutputForDisplay } from '../agent-hooks/branch-rename-failure-output'
-import {
-  isWorkspaceKey,
-  parseWorkspaceKey,
-  worktreeWorkspaceKey
-} from '../../shared/workspace-scope'
+import { parseWorkspaceKey } from '../../shared/workspace-scope'
 import { inspectSetupScriptImportCandidates } from '../../shared/setup-script-imports'
 import { getProjectHostSetupWorktreeMeta } from '../../shared/project-host-setup-projection'
 import { TaskSourceContextSchema } from '../../shared/task-source-context-schema'
@@ -724,58 +721,6 @@ function rememberLocalWorktreeRoots(
     repo.path,
     ...gitWorktrees.map((worktree) => worktree.path)
   ])
-}
-
-function pruneLineageForMissingRepoWorktrees(
-  store: Store,
-  repo: Repo,
-  gitWorktrees: GitWorktreeInfo[]
-): void {
-  if (
-    typeof store.getAllWorktreeLineage !== 'function' ||
-    typeof store.removeWorktreeLineage !== 'function'
-  ) {
-    return
-  }
-  const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
-  const repoPrefix = `${repo.id}::`
-  const expectedHostId = getRepoExecutionHostId(repo)
-  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
-  const canMutateWorktree = (worktreeId: string): boolean => {
-    const hostId = store.getWorktreeMeta(worktreeId)?.hostId
-    return hostId ? hostId === expectedHostId : repoOwners.length === 1
-  }
-  for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
-    const childScope = parseWorkspaceKey(childWorkspaceKey)
-    if (
-      childScope?.type === 'worktree' &&
-      childScope.worktreeId.startsWith(repoPrefix) &&
-      canMutateWorktree(childScope.worktreeId) &&
-      !liveIds.has(childScope.worktreeId)
-    ) {
-      if (isWorkspaceKey(childWorkspaceKey)) {
-        store.removeWorkspaceLineage?.(childWorkspaceKey)
-      }
-    }
-  }
-  for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-    if (childId.startsWith(repoPrefix) && canMutateWorktree(childId) && !liveIds.has(childId)) {
-      // Why: path-derived IDs can be reused; once a scan proves the child is gone, drop its lineage so a future same-path worktree can't inherit it.
-      store.removeWorktreeLineage(childId)
-      store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
-    }
-    if (
-      lineage.parentWorktreeId.startsWith(repoPrefix) &&
-      canMutateWorktree(lineage.parentWorktreeId) &&
-      !liveIds.has(lineage.parentWorktreeId)
-    ) {
-      const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
-      if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
-        // Why: keep child lineage for the "Missing parent" UI, but rotate the absent parent's identity once so a path reuse can't inherit it.
-        store.setWorktreeMeta(lineage.parentWorktreeId, { instanceId: randomUUID() })
-      }
-    }
-  }
 }
 
 type SshWorktreeMetaCandidate = {

--- a/src/main/runtime/multi-client-navigation-isolation.integration.test.ts
+++ b/src/main/runtime/multi-client-navigation-isolation.integration.test.ts
@@ -18,18 +18,19 @@ const CLIENT_A2_WORKTREE_ID = worktreeId('client-a2')
 const CLIENT_B_WORKTREE_ID = worktreeId('client-b')
 const SESSION_WORKTREE_ID = worktreeId('session')
 
-vi.mock('../git/worktree', () => ({
-  listWorktrees: vi.fn().mockResolvedValue(
-    ['host', 'client-a', 'client-a2', 'client-b', 'session'].map((name) => ({
-      path: `/tmp/${name}`,
-      head: name,
-      branch: name,
-      isBare: false,
-      isMainWorktree: false
-    }))
-  ),
-  listWorktreesStrict: vi.fn().mockResolvedValue([])
-}))
+vi.mock('../git/worktree', () => {
+  const worktrees = ['host', 'client-a', 'client-a2', 'client-b', 'session'].map((name) => ({
+    path: `/tmp/${name}`,
+    head: name,
+    branch: name,
+    isBare: false,
+    isMainWorktree: false
+  }))
+  return {
+    listWorktrees: vi.fn().mockResolvedValue(worktrees),
+    listWorktreesStrict: vi.fn().mockResolvedValue(worktrees)
+  }
+})
 
 type PairedSession = {
   ws: WebSocket

--- a/src/main/runtime/orca-runtime-linked-issue-live-meta.integration.test.ts
+++ b/src/main/runtime/orca-runtime-linked-issue-live-meta.integration.test.ts
@@ -17,7 +17,8 @@ const mocks = vi.hoisted(() => ({
 
 vi.mock('../git/worktree', async () => ({
   ...(await vi.importActual<typeof WorktreeModule>('../git/worktree')),
-  listWorktrees: mocks.listWorktrees
+  listWorktrees: mocks.listWorktrees,
+  listWorktreesStrict: mocks.listWorktrees
 }))
 
 vi.mock('../git/status', async () => ({

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -202,6 +202,7 @@ const restoreLocalWatcherAfterFailedRemovalMock = vi.hoisted(() => vi.fn())
 const restoreRemoteWatcherAfterFailedRemovalMock = vi.hoisted(() => vi.fn())
 const forgetLocalWatcherRemovalSnapshotMock = vi.hoisted(() => vi.fn())
 const forgetRemoteWatcherRemovalSnapshotMock = vi.hoisted(() => vi.fn())
+const scanLocalRepoWorktreesForResolutionMock = vi.hoisted(() => vi.fn())
 
 vi.mock('electron', () => electronMocks)
 vi.mock('../ipc/filesystem-watcher', () => ({
@@ -412,6 +413,10 @@ vi.mock('../git/worktree', () => ({
   addWorktree: addWorktreeMock,
   removeWorktree: removeWorktreeMock,
   forceDeleteLocalBranch: forceDeleteLocalBranchMock
+}))
+
+vi.mock('./repo-worktree-resolution-scan', () => ({
+  scanLocalRepoWorktreesForResolution: scanLocalRepoWorktreesForResolutionMock
 }))
 
 vi.mock('../terminal-history-deletion', () => ({
@@ -653,6 +658,18 @@ function resetRuntimeTestMocks(): void {
   forgetRemoteWatcherRemovalSnapshotMock.mockReset()
   vi.mocked(listWorktrees).mockResolvedValue(MOCK_GIT_WORKTREES)
   vi.mocked(listWorktreesStrict).mockResolvedValue(MOCK_GIT_WORKTREES)
+  scanLocalRepoWorktreesForResolutionMock
+    .mockReset()
+    .mockImplementation(async (repoPath: string, options: { wslDistro?: string }) => {
+      try {
+        const worktrees = options.wslDistro
+          ? await listWorktrees(repoPath, options)
+          : await listWorktrees(repoPath)
+        return { ok: true, worktrees }
+      } catch {
+        return { ok: false, worktrees: [] }
+      }
+    })
   vi.mocked(addWorktree).mockReset()
   vi.mocked(assertWorktreeCleanForRemoval).mockReset()
   vi.mocked(assertWorktreeCleanForRemoval).mockResolvedValue(undefined)

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -39241,24 +39241,31 @@ describe('OrcaRuntimeService', () => {
     }
   })
 
-  it('worktree scan cache: does not cache non-authoritative scan failures', async () => {
-    vi.mocked(listWorktrees).mockClear()
-    const runtime = createRuntime()
-    vi.mocked(listWorktrees)
+  it('worktree scan cache: does not cache non-authoritative SSH scan failures', async () => {
+    const remoteRepo = { ...store.getRepo(TEST_REPO_ID)!, connectionId: 'ssh-1' }
+    const remoteStore = {
+      ...store,
+      getRepo: (id: string) => (id === remoteRepo.id ? remoteRepo : undefined),
+      getRepos: () => [remoteRepo]
+    }
+    const provider = { listWorktrees: vi.fn() }
+    provider.listWorktrees
       .mockRejectedValueOnce(new Error('git unavailable'))
       .mockResolvedValueOnce([makeWorktreeInfo(TEST_WORKTREE_PATH)])
+    registerSshGitProvider('ssh-1', provider as never)
+    const runtime = new OrcaRuntimeService(remoteStore as never)
 
-    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
-      {
-        authoritative: false
-      }
-    )
-    await expect(runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)).resolves.toMatchObject(
-      {
-        authoritative: true
-      }
-    )
-    expect(listWorktrees).toHaveBeenCalledTimes(2)
+    try {
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: false })
+      await expect(
+        runtime.listDetectedManagedWorktrees(`id:${TEST_REPO_ID}`)
+      ).resolves.toMatchObject({ authoritative: true })
+      expect(provider.listWorktrees).toHaveBeenCalledTimes(2)
+    } finally {
+      unregisterSshGitProvider('ssh-1')
+    }
   })
 
   it('worktree scan cache: invalidates when SSH availability changes', async () => {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -2607,7 +2607,7 @@ type WorktreeLineageResolution =
 type RuntimeWorktreeScanCache = {
   generation: number
   runtimeKey: string
-  result: Extract<RuntimeWorktreeScanResult, { ok: true }>
+  result: RuntimeWorktreeScanResult
   expiresAt: number
 }
 
@@ -28873,8 +28873,9 @@ export class OrcaRuntimeService {
     this.worktreeScanInFlight.set(repo.id, { generation, runtimeKey, promise })
     try {
       const result = await promise
+      // Why: back off local spawn failures under resource pressure while disconnected SSH can recover on the next poll.
       if (
-        result.ok &&
+        (result.ok || !repo.connectionId) &&
         generation === (this.worktreeScanGenerations.get(repo.id) ?? 0) &&
         this.worktreeScanInFlight.get(repo.id)?.promise === promise
       ) {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -436,7 +436,6 @@ import { resolveTerminalStartupCwd } from '../../shared/terminal-startup-cwd'
 import { isWslUncPath, parseWslUncPath } from '../../shared/wsl-paths'
 import {
   folderWorkspaceKey,
-  isWorkspaceKey,
   parseWorkspaceKey,
   worktreeWorkspaceKey
 } from '../../shared/workspace-scope'
@@ -673,6 +672,10 @@ import { resolveLocalProjectRuntimeForWorktreeId } from '../local-project-runtim
 import type { ProjectExecutionRuntimeResolution } from '../../shared/project-execution-runtime'
 import { resolveTerminalOrchestrationCliCommand } from './orchestration/cli-command'
 import {
+  scanLocalRepoWorktreesForResolution,
+  type RuntimeWorktreeScanResult
+} from './repo-worktree-resolution-scan'
+import {
   getLocalWorktreePathAccess,
   removeLocalWorktreePath,
   toLocalWorktreeRuntimePath
@@ -864,7 +867,7 @@ import {
   FLOATING_TERMINAL_WORKTREE_ID,
   getDefaultVoiceSettings
 } from '../../shared/constants'
-import { listRepoWorktrees } from '../repo-worktrees'
+import { pruneLineageForMissingRepoWorktrees } from '../worktree-lineage-pruning'
 import {
   createWorktreeCopiedPaths,
   createWorktreeLinkedPaths,
@@ -2600,10 +2603,6 @@ type WorktreeLineageResolution =
       kind: 'none'
       warnings: WorktreeLineageWarning[]
     }
-
-type RuntimeWorktreeScanResult =
-  | { ok: true; worktrees: GitWorktreeInfo[] }
-  | { ok: false; worktrees: GitWorktreeInfo[] }
 
 type RuntimeWorktreeScanCache = {
   generation: number
@@ -20826,7 +20825,7 @@ export class OrcaRuntimeService {
       scan = { ok: false, worktrees: [] }
     }
     if (scan.ok) {
-      this.pruneLineageForMissingRepoWorktrees(repo, scan.worktrees)
+      pruneLineageForMissingRepoWorktrees(store, repo, scan.worktrees)
     }
     const agentScratchWorktreePathMatcher = createAgentScratchWorktreePathMatcher([
       repo.path,
@@ -28793,7 +28792,7 @@ export class OrcaRuntimeService {
           )) ?? { ok: false, worktrees: this.listStoredWorktreesForResolution(repo) }
         const gitWorktrees = scan.worktrees
         if (scan.ok) {
-          this.pruneLineageForMissingRepoWorktrees(repo, gitWorktrees)
+          pruneLineageForMissingRepoWorktrees(this.requireStore(), repo, gitWorktrees)
         }
         return gitWorktrees.map((gitWorktree) => {
           const worktreeId = `${repo.id}::${gitWorktree.path}`
@@ -28838,48 +28837,6 @@ export class OrcaRuntimeService {
       }
     }
     return { worktrees, platformByRepoId }
-  }
-
-  private pruneLineageForMissingRepoWorktrees(repo: Repo, gitWorktrees: GitWorktreeInfo[]): void {
-    const store = this.store
-    if (
-      !store ||
-      typeof store.getAllWorktreeLineage !== 'function' ||
-      typeof store.removeWorktreeLineage !== 'function'
-    ) {
-      return
-    }
-    const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
-    const repoPrefix = `${repo.id}::`
-    for (const childWorkspaceKey of Object.keys(store.getAllWorkspaceLineage?.() ?? {})) {
-      const childScope = parseWorkspaceKey(childWorkspaceKey)
-      if (
-        childScope?.type === 'worktree' &&
-        childScope.worktreeId.startsWith(repoPrefix) &&
-        !liveIds.has(childScope.worktreeId)
-      ) {
-        if (isWorkspaceKey(childWorkspaceKey)) {
-          store.removeWorkspaceLineage?.(childWorkspaceKey)
-        }
-      }
-    }
-    for (const [childId, lineage] of Object.entries(store.getAllWorktreeLineage())) {
-      if (childId.startsWith(repoPrefix) && !liveIds.has(childId)) {
-        // Why: once a scan proves the child gone, purge stale lineage so it can't survive into a same-path replacement checkout.
-        store.removeWorktreeLineage(childId)
-        store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
-      }
-      if (
-        lineage.parentWorktreeId.startsWith(repoPrefix) &&
-        !liveIds.has(lineage.parentWorktreeId)
-      ) {
-        const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
-        if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
-          // Why: a missing parent path needs one fresh identity so same-path replacement checkouts can't validate old lineage.
-          store.setWorktreeMeta(lineage.parentWorktreeId, { instanceId: randomUUID() })
-        }
-      }
-    }
   }
 
   private async listRepoWorktreesForResolution(
@@ -28941,13 +28898,10 @@ export class OrcaRuntimeService {
     projectRuntime: ProjectExecutionRuntimeResolution | undefined
   ): Promise<RuntimeWorktreeScanResult> {
     if (!repo.connectionId) {
-      return {
-        ok: true,
-        worktrees: await listRepoWorktrees(
-          repo,
-          getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime)
-        )
-      }
+      return await scanLocalRepoWorktreesForResolution(
+        repo.path,
+        getLocalProjectWorktreeGitOptionsForRuntime(repo, projectRuntime)
+      )
     }
     const provider = getSshGitProvider(repo.connectionId)
     if (!provider) {

--- a/src/main/runtime/repo-worktree-resolution-scan.test.ts
+++ b/src/main/runtime/repo-worktree-resolution-scan.test.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { listWorktreesStrict } from '../git/worktree'
+import { scanLocalRepoWorktreesForResolution } from './repo-worktree-resolution-scan'
+
+vi.mock('../git/worktree', () => ({ listWorktreesStrict: vi.fn() }))
+
+describe('scanLocalRepoWorktreesForResolution', () => {
+  beforeEach(() => {
+    vi.mocked(listWorktreesStrict).mockReset()
+  })
+
+  it('degrades a local Git execution failure instead of reporting an empty success', async () => {
+    vi.mocked(listWorktreesStrict).mockRejectedValue(
+      Object.assign(new Error('spawn git EAGAIN'), { code: 'EAGAIN' })
+    )
+
+    await expect(scanLocalRepoWorktreesForResolution('/repo', {})).resolves.toEqual({
+      ok: false,
+      worktrees: []
+    })
+  })
+
+  it('preserves a successful empty scan verdict', async () => {
+    vi.mocked(listWorktreesStrict).mockResolvedValue([])
+
+    await expect(
+      scanLocalRepoWorktreesForResolution('/repo', { wslDistro: 'Ubuntu' })
+    ).resolves.toEqual({ ok: true, worktrees: [] })
+    expect(listWorktreesStrict).toHaveBeenCalledWith('/repo', { wslDistro: 'Ubuntu' })
+  })
+})

--- a/src/main/runtime/repo-worktree-resolution-scan.ts
+++ b/src/main/runtime/repo-worktree-resolution-scan.ts
@@ -1,0 +1,21 @@
+import type { GitWorktreeInfo } from '../../shared/types'
+import { listWorktreesStrict } from '../git/worktree'
+import type { LocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+
+export type RuntimeWorktreeScanResult =
+  | { ok: true; worktrees: GitWorktreeInfo[] }
+  | { ok: false; worktrees: GitWorktreeInfo[] }
+
+export async function scanLocalRepoWorktreesForResolution(
+  repoPath: string,
+  options: LocalProjectWorktreeGitOptions
+): Promise<RuntimeWorktreeScanResult> {
+  try {
+    const worktrees = options.wslDistro
+      ? await listWorktreesStrict(repoPath, options)
+      : await listWorktreesStrict(repoPath)
+    return { ok: true, worktrees }
+  } catch {
+    return { ok: false, worktrees: [] }
+  }
+}

--- a/src/main/runtime/runtime-rpc.test.ts
+++ b/src/main/runtime/runtime-rpc.test.ts
@@ -29,8 +29,8 @@ import { DeviceRegistry } from './device-registry'
 import { DEVICE_REGISTRY_FILENAME, E2EE_KEYPAIR_FILENAME } from './mobile-pairing-files'
 import { ORCHESTRATION_CONTRACT_VERSION } from '../../shared/protocol-version'
 
-vi.mock('../git/worktree', () => ({
-  listWorktrees: vi.fn().mockResolvedValue([
+vi.mock('../git/worktree', () => {
+  const worktrees = [
     {
       path: '/tmp/worktree-a',
       head: 'abc',
@@ -38,9 +38,12 @@ vi.mock('../git/worktree', () => ({
       isBare: false,
       isMainWorktree: false
     }
-  ]),
-  listWorktreesStrict: vi.fn().mockResolvedValue([])
-}))
+  ]
+  return {
+    listWorktrees: vi.fn().mockResolvedValue(worktrees),
+    listWorktreesStrict: vi.fn().mockResolvedValue(worktrees)
+  }
+})
 
 async function sendRequest(
   endpoint: string,

--- a/src/main/runtime/worktree-ps-degraded-repo-scan.test.ts
+++ b/src/main/runtime/worktree-ps-degraded-repo-scan.test.ts
@@ -23,10 +23,10 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
   requireSshGitProvider: (connectionId: string) => getSshGitProviderMock(connectionId)
 }))
 
-const listWorktreesMock = vi.hoisted(() => vi.fn())
+const listWorktreesStrictMock = vi.hoisted(() => vi.fn())
 vi.mock('../git/worktree', async (importOriginal) => ({
   ...(await importOriginal<Record<string, unknown>>()),
-  listWorktrees: listWorktreesMock
+  listWorktreesStrict: listWorktreesStrictMock
 }))
 
 import { LOCAL_EXECUTION_HOST_ID } from '../../shared/execution-host'
@@ -155,8 +155,8 @@ async function advancePastRepoScanBudget<T>(pending: Promise<T>): Promise<T> {
 describe('worktree.ps on a degraded repo scan', () => {
   beforeEach(() => {
     getSshGitProviderMock.mockReset()
-    listWorktreesMock.mockReset()
-    listWorktreesMock.mockResolvedValue([])
+    listWorktreesStrictMock.mockReset()
+    listWorktreesStrictMock.mockResolvedValue([])
   })
 
   it('keeps persisted worktrees when a remote scan stalls past the per-repo budget', async () => {
@@ -185,7 +185,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   it('keeps persisted worktrees when a local scan stalls past the per-repo budget', async () => {
     vi.useFakeTimers()
     try {
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(makeStore() as never)
 
       const result = await advancePastRepoScanBudget(runtime.getWorktreePs(10_000))
@@ -199,7 +199,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   // Why: `withTimeout` resolves its fallback on rejection as well as on timeout, so an unabsorbed rejection would silently widen
   // selector resolution for local repos the way a stall does.
   it('treats a rejected scan as a real answer instead of restoring persisted worktrees', async () => {
-    listWorktreesMock.mockRejectedValue(new Error('git unavailable'))
+    listWorktreesStrictMock.mockRejectedValue(new Error('git unavailable'))
     const runtime = new OrcaRuntimeService(makeStore() as never)
 
     const result = await runtime.getWorktreePs(10_000)
@@ -208,7 +208,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   })
 
   it('still reports selector_not_found for a local worktree when the scan rejects', async () => {
-    listWorktreesMock.mockRejectedValue(new Error('git unavailable'))
+    listWorktreesStrictMock.mockRejectedValue(new Error('git unavailable'))
     const runtime = new OrcaRuntimeService(makeStore() as never)
 
     await expect(runtime.showManagedWorktree(`id:${WORKTREE_ID}`)).rejects.toThrow(
@@ -216,25 +216,40 @@ describe('worktree.ps on a degraded repo scan', () => {
     )
   })
 
-  // Why: the scan cache only stores `ok` results, so calling a zero-row local scan degraded would re-spawn `git worktree list`
-  // on every ~1s snapshot recompute for a repo whose directory is permanently gone.
+  // Why: an authoritative empty scan must retain the normal backoff instead of spawning Git on every ~1s snapshot.
   it('caches a zero-row local scan instead of rescanning on every poll', async () => {
     vi.useFakeTimers()
     try {
-      listWorktreesMock.mockResolvedValue([])
+      listWorktreesStrictMock.mockResolvedValue([])
       const runtime = new OrcaRuntimeService(makeStore() as never)
 
       await runtime.getWorktreePs(10_000)
       await vi.advanceTimersByTimeAsync(2_000)
       await runtime.getWorktreePs(10_000)
 
-      expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+      expect(listWorktreesStrictMock).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
   })
 
-  // Why: the scan cache stores `ok` results only, so a degraded answer must not pin the repo to persisted rows after the host recovers.
+  it('caches a failed local scan instead of respawning Git on every poll', async () => {
+    vi.useFakeTimers()
+    try {
+      listWorktreesStrictMock.mockRejectedValue(new Error('spawn git EAGAIN'))
+      const runtime = new OrcaRuntimeService(makeStore() as never)
+
+      await runtime.getWorktreePs(10_000)
+      await vi.advanceTimersByTimeAsync(2_000)
+      await runtime.getWorktreePs(10_000)
+
+      expect(listWorktreesStrictMock).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  // Why: remote disconnects should recover on the next poll; only local failures need backoff against spawn storms.
   it('rescans a degraded remote repo on the next poll instead of caching the failure', async () => {
     vi.useFakeTimers()
     try {
@@ -261,7 +276,7 @@ describe('worktree.ps on a degraded repo scan', () => {
     vi.useFakeTimers()
     try {
       getSshGitProviderMock.mockReturnValue(makeHealthySshScan())
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(
         makeStore({
           connectionId: SSH_CONNECTION_ID,
@@ -291,7 +306,7 @@ describe('worktree.ps on a degraded repo scan', () => {
     vi.useFakeTimers()
     try {
       getSshGitProviderMock.mockReturnValue(makeHealthySshScan())
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(
         makeStore({
           connectionId: SSH_CONNECTION_ID,
@@ -317,7 +332,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   it('restores persisted rows stamped for this host when its only owner stalls', async () => {
     vi.useFakeTimers()
     try {
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(
         makeStore({
           metaById: {
@@ -352,13 +367,13 @@ describe('worktree.ps on a degraded repo scan', () => {
   it('does not re-spawn the git scan on every poll while a scan stays stalled', async () => {
     vi.useFakeTimers()
     try {
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(makeStore() as never)
 
       await advancePastRepoScanBudget(runtime.getWorktreePs(10_000))
       await advancePastRepoScanBudget(runtime.getWorktreePs(10_000))
 
-      expect(listWorktreesMock).toHaveBeenCalledTimes(1)
+      expect(listWorktreesStrictMock).toHaveBeenCalledTimes(1)
     } finally {
       vi.useRealTimers()
     }
@@ -367,7 +382,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   it('drops and prunes a worktree that a healthy scan no longer reports', async () => {
     const removeWorktreeLineage = vi.fn()
     const removeWorkspaceLineage = vi.fn()
-    listWorktreesMock.mockResolvedValue([
+    listWorktreesStrictMock.mockResolvedValue([
       { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true }
     ])
     const runtime = new OrcaRuntimeService(
@@ -386,7 +401,7 @@ describe('worktree.ps on a degraded repo scan', () => {
     try {
       const removeWorktreeLineage = vi.fn()
       const removeWorkspaceLineage = vi.fn()
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(
         makeStore({ removeWorktreeLineage, removeWorkspaceLineage }) as never
       )
@@ -401,7 +416,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   })
 
   it('does not re-read persisted worktree metadata on a healthy scan', async () => {
-    listWorktreesMock.mockResolvedValue([
+    listWorktreesStrictMock.mockResolvedValue([
       { path: REPO_PATH, head: 'abc', branch: 'main', isBare: false, isMainWorktree: true }
     ])
     const store = makeStore()
@@ -415,7 +430,7 @@ describe('worktree.ps on a degraded repo scan', () => {
   it('lists restored worktrees while a scan is stalled and still hides agent scratch', async () => {
     vi.useFakeTimers()
     try {
-      listWorktreesMock.mockImplementation(neverSettles)
+      listWorktreesStrictMock.mockImplementation(neverSettles)
       const runtime = new OrcaRuntimeService(
         makeStore({
           metaById: {

--- a/src/main/worktree-lineage-pruning.test.ts
+++ b/src/main/worktree-lineage-pruning.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { Repo, WorktreeLineage, WorkspaceLineage, WorktreeMeta } from '../shared/types'
+import { worktreeWorkspaceKey } from '../shared/workspace-scope'
+import { pruneLineageForMissingRepoWorktrees } from './worktree-lineage-pruning'
+
+const repo: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'repo',
+  badgeColor: 'blue',
+  addedAt: 1
+}
+
+function lineage(childId: string, parentId: string): WorktreeLineage {
+  return {
+    worktreeId: childId,
+    worktreeInstanceId: `${childId}-instance`,
+    parentWorktreeId: parentId,
+    parentWorktreeInstanceId: `${parentId}-instance`,
+    origin: 'manual',
+    capture: { source: 'manual-action', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+function workspaceLineage(childId: string, parentId: string): WorkspaceLineage {
+  return {
+    childWorkspaceKey: worktreeWorkspaceKey(childId),
+    childInstanceId: `${childId}-instance`,
+    parentWorkspaceKey: worktreeWorkspaceKey(parentId),
+    parentInstanceId: `${parentId}-instance`,
+    origin: 'manual',
+    capture: { source: 'manual-action', confidence: 'explicit' },
+    createdAt: 1
+  }
+}
+
+function createStore(
+  worktreeLineageById: Record<string, WorktreeLineage>,
+  workspaceLineageByChildKey: Record<string, WorkspaceLineage>,
+  metaById: Record<string, WorktreeMeta>
+) {
+  return {
+    getRepos: () => [repo],
+    getAllWorktreeLineage: () => worktreeLineageById,
+    getAllWorkspaceLineage: () => workspaceLineageByChildKey,
+    getWorktreeMeta: (id: string) => metaById[id],
+    removeWorktreeLineage: vi.fn((id: string) => delete worktreeLineageById[id]),
+    removeWorkspaceLineage: vi.fn((key: string) => delete workspaceLineageByChildKey[key]),
+    setWorktreeMeta: vi.fn((id: string, updates: Partial<WorktreeMeta>) => {
+      metaById[id] = { ...metaById[id], ...updates }
+      return metaById[id]
+    })
+  }
+}
+
+describe('pruneLineageForMissingRepoWorktrees', () => {
+  it('refuses an empty scan when the repo still has registered lineage', () => {
+    const parentId = 'repo-1::/repo/parent'
+    const childId = 'repo-1::/repo/child'
+    const edge = lineage(childId, parentId)
+    const workspaceEdge = workspaceLineage(childId, parentId)
+    const worktreeLineageById = { [childId]: edge }
+    const workspaceLineageByChildKey = { [worktreeWorkspaceKey(childId)]: workspaceEdge }
+    const metaById = {
+      [parentId]: { instanceId: edge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [])
+
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalled()
+    expect(store.removeWorkspaceLineage).not.toHaveBeenCalled()
+    expect(store.setWorktreeMeta).not.toHaveBeenCalled()
+    expect(worktreeLineageById[childId]).toBe(edge)
+    expect(workspaceLineageByChildKey[worktreeWorkspaceKey(childId)]).toBe(workspaceEdge)
+  })
+
+  it('prunes missing children and rotates missing parents after a trusted non-empty scan', () => {
+    const liveParentId = 'repo-1::/repo/live-parent'
+    const missingChildId = 'repo-1::/repo/missing-child'
+    const liveChildId = 'repo-1::/repo/live-child'
+    const missingParentId = 'repo-1::/repo/missing-parent'
+    const missingChildEdge = lineage(missingChildId, liveParentId)
+    const missingParentEdge = lineage(liveChildId, missingParentId)
+    const worktreeLineageById = {
+      [missingChildId]: missingChildEdge,
+      [liveChildId]: missingParentEdge
+    }
+    const workspaceLineageByChildKey = {
+      [worktreeWorkspaceKey(missingChildId)]: workspaceLineage(missingChildId, liveParentId),
+      [worktreeWorkspaceKey(liveChildId)]: workspaceLineage(liveChildId, missingParentId)
+    }
+    const metaById = {
+      [liveParentId]: { instanceId: missingChildEdge.parentWorktreeInstanceId } as WorktreeMeta,
+      [missingParentId]: { instanceId: missingParentEdge.parentWorktreeInstanceId } as WorktreeMeta
+    }
+    const store = createStore(worktreeLineageById, workspaceLineageByChildKey, metaById)
+
+    pruneLineageForMissingRepoWorktrees(store as never, repo, [
+      {
+        path: '/repo/live-parent',
+        head: 'a',
+        branch: 'main',
+        isBare: false,
+        isMainWorktree: false
+      },
+      {
+        path: '/repo/live-child',
+        head: 'b',
+        branch: 'child',
+        isBare: false,
+        isMainWorktree: false
+      }
+    ])
+
+    expect(store.removeWorktreeLineage).toHaveBeenCalledWith(missingChildId)
+    expect(store.removeWorktreeLineage).not.toHaveBeenCalledWith(liveChildId)
+    expect(store.setWorktreeMeta).toHaveBeenCalledWith(missingParentId, {
+      instanceId: expect.any(String)
+    })
+    expect(store.setWorktreeMeta).not.toHaveBeenCalledWith(liveParentId, expect.anything())
+    expect(metaById[missingParentId].instanceId).not.toBe(
+      missingParentEdge.parentWorktreeInstanceId
+    )
+  })
+})

--- a/src/main/worktree-lineage-pruning.ts
+++ b/src/main/worktree-lineage-pruning.ts
@@ -1,0 +1,97 @@
+import { randomUUID } from 'node:crypto'
+import type { GitWorktreeInfo, Repo, WorktreeLineage, WorkspaceLineage } from '../shared/types'
+import { getRepoExecutionHostId } from '../shared/execution-host'
+import { isWorkspaceKey, parseWorkspaceKey, worktreeWorkspaceKey } from '../shared/workspace-scope'
+import type { Store } from './persistence'
+
+function worktreeIdBelongsToRepo(worktreeId: string, repoPrefix: string): boolean {
+  return worktreeId.startsWith(repoPrefix)
+}
+
+function workspaceKeyBelongsToRepo(workspaceKey: string, repoPrefix: string): boolean {
+  const scope = parseWorkspaceKey(workspaceKey)
+  return scope?.type === 'worktree' && worktreeIdBelongsToRepo(scope.worktreeId, repoPrefix)
+}
+
+function hasStoredRepoLineage(
+  repoPrefix: string,
+  worktreeLineage: Readonly<Record<string, WorktreeLineage>>,
+  workspaceLineage: Readonly<Record<string, WorkspaceLineage>>
+): boolean {
+  return (
+    Object.entries(worktreeLineage).some(
+      ([childId, lineage]) =>
+        worktreeIdBelongsToRepo(childId, repoPrefix) ||
+        worktreeIdBelongsToRepo(lineage.parentWorktreeId, repoPrefix)
+    ) ||
+    Object.values(workspaceLineage).some(
+      (lineage) =>
+        workspaceKeyBelongsToRepo(lineage.childWorkspaceKey, repoPrefix) ||
+        workspaceKeyBelongsToRepo(lineage.parentWorkspaceKey, repoPrefix)
+    )
+  )
+}
+
+export function pruneLineageForMissingRepoWorktrees(
+  store: Store,
+  repo: Repo,
+  gitWorktrees: GitWorktreeInfo[]
+): void {
+  if (
+    typeof store.getAllWorktreeLineage !== 'function' ||
+    typeof store.removeWorktreeLineage !== 'function'
+  ) {
+    return
+  }
+  const worktreeLineage = store.getAllWorktreeLineage()
+  const workspaceLineage = store.getAllWorkspaceLineage?.() ?? {}
+  const repoPrefix = `${repo.id}::`
+  // Why: one empty observation cannot prove every registered lineage edge disappeared at once.
+  if (
+    gitWorktrees.length === 0 &&
+    hasStoredRepoLineage(repoPrefix, worktreeLineage, workspaceLineage)
+  ) {
+    return
+  }
+  const liveIds = new Set(gitWorktrees.map((worktree) => `${repo.id}::${worktree.path}`))
+  const expectedHostId = getRepoExecutionHostId(repo)
+  const repoOwners = store.getRepos().filter((candidate) => candidate.id === repo.id)
+  const canMutateWorktree = (worktreeId: string): boolean => {
+    const hostId = store.getWorktreeMeta(worktreeId)?.hostId
+    return hostId ? hostId === expectedHostId : repoOwners.length === 1
+  }
+  for (const childWorkspaceKey of Object.keys(workspaceLineage)) {
+    const childScope = parseWorkspaceKey(childWorkspaceKey)
+    if (
+      childScope?.type === 'worktree' &&
+      worktreeIdBelongsToRepo(childScope.worktreeId, repoPrefix) &&
+      canMutateWorktree(childScope.worktreeId) &&
+      !liveIds.has(childScope.worktreeId) &&
+      isWorkspaceKey(childWorkspaceKey)
+    ) {
+      store.removeWorkspaceLineage?.(childWorkspaceKey)
+    }
+  }
+  for (const [childId, lineage] of Object.entries(worktreeLineage)) {
+    if (
+      worktreeIdBelongsToRepo(childId, repoPrefix) &&
+      canMutateWorktree(childId) &&
+      !liveIds.has(childId)
+    ) {
+      // Why: a proven-missing path must not transfer its lineage to a future checkout at that path.
+      store.removeWorktreeLineage(childId)
+      store.removeWorkspaceLineage?.(worktreeWorkspaceKey(childId))
+    }
+    if (
+      worktreeIdBelongsToRepo(lineage.parentWorktreeId, repoPrefix) &&
+      canMutateWorktree(lineage.parentWorktreeId) &&
+      !liveIds.has(lineage.parentWorktreeId)
+    ) {
+      const parentMeta = store.getWorktreeMeta(lineage.parentWorktreeId)
+      if (!parentMeta || parentMeta.instanceId === lineage.parentWorktreeInstanceId) {
+        // Why: rotate a proven-missing parent's identity once so path reuse cannot validate old lineage.
+        store.setWorktreeMeta(lineage.parentWorktreeId, { instanceId: randomUUID() })
+      }
+    }
+  }
+}


### PR DESCRIPTION
## Problem

A failed `git worktree list` (spawn failure under resource exhaustion — EAGAIN/ENOMEM, git killed, etc.) is swallowed into an empty list by `listWorktreesUnshared`, which the local branch of `listRepoWorktreesForResolutionUncached` then wraps as `{ok: true, worktrees: []}`. Both prune call sites gate on `scan.ok`, so `pruneLineageForMissingRepoWorktrees` treats every lineage child as "proven gone": it purges **all** `worktreeLineageById` / `workspaceLineageByChildKey` entries for the repo and re-mints parent `instanceId`s.

This is not theoretical: on 2026-08-07 ~19:00 PDT, under system load 579 / 91 MB free RAM, this path wiped all 268 lineage entries on a production profile (1.4.177-hourly), flattening every worktree in the sidebar to root level. Data was recovered only because the hourly `orca-data.json.bak.N` rotation (5 kept) hadn't yet aged out the pre-wipe snapshot.

## Fix

Two independent guards, defense in depth:

1. **Truthful scan results** — local runtime scans now propagate Git failures strictly and degrade to `ok: false` (mirroring the existing SSH-branch behavior), so a failed scan can never masquerade as an authoritative empty catalog. Extracted into `repo-worktree-resolution-scan.ts`.
2. **Empty-scan circuit breaker** — shared, host-aware guard in `worktree-lineage-pruning.ts`: pruning refuses to act on an empty scan while the store still has registered lineage for the repo. Applied to both consumers (runtime + `ipc/worktrees.ts`).

## Tests

- Same-model review found and fixed one scoped performance issue in `a3899ed9c9`: degraded local scans now use the existing 30-second cache, preventing repeated `git worktree list` spawns under EAGAIN/ENOMEM while remaining `ok: false`; SSH retry behavior is unchanged. A repeat review returned clean.
- Reviewer verification: nine affected suites passed (1,441 passed, 1 skipped), plus Node typecheck, affected-file lint/format, max-lines ratchet, and `git diff --check`.
- Coordinator verification: full `pnpm run typecheck`, full `pnpm run lint`, and `git diff --check origin/main...HEAD` passed.
- Focused lineage/scan suites passed 20/20: `repo-worktree-resolution-scan.test.ts`, `worktree-lineage-pruning.test.ts`, and `worktree-ps-degraded-repo-scan.test.ts`.
- CI is green across Node 24/26 tests, static analysis/typecheck, Git 2.25 compatibility, Windows packaging, shell contracts, remote-wire compatibility, and package checks.
- Electron-over-SSH QA passed at `a3899ed9c98a9fbbd30f362adad227575665f0a4`: a real remote parent/child worktree lineage remained intact in the UI, store, and persisted `orca-data.json` after a forced relay kill, disconnect + refresh, and reconnect + refresh. Parent `instanceId` remained stable and remote Git still reported all three worktrees. [Screenshots and full QA evidence](https://github.com/stablyai/orca/pull/13248#issuecomment-5227737300).
- The live run validates SSH disconnect/degraded behavior. The exact local empty-scan/EAGAIN circuit breaker is covered deterministically by the focused unit suites rather than forcing an in-process spawn failure during Electron QA.

## Incident forensics

Root-caused from the hourly state backups (268 → 0 lineage entries between the 18:50 and 19:50 snapshots, worktreeMeta intact, 25 lineage-parent instanceIds re-minted, no crash/restart/migration in the window) plus main-process traces. Happy to share the full writeup.
