### PR TITLE
fix(orchestration): abandon/stop low-level dispatches without worker rows

### DIFF
--- a/src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts
+++ b/src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts
@@ -222,6 +222,51 @@ describe('OrchestrationDb worker Dispatch state', () => {
     expect(d.getTask(task.id)?.status).toBe('completed')
   })
 
+  // Why: #13005 — low-level orchestration.dispatch never inserts worker_dispatches; release
+  // verbs must still fence the context so the assignee terminal can be reused.
+  it('abandons and stops a context-only Dispatch without a worker_dispatches row', () => {
+    const d = createDb()
+    const abandonTask = d.createTask({ spec: 'mail-only abandon' })
+    const abandonDispatch = d.createDispatchContext(
+      abandonTask.id,
+      'term_mail_abandon',
+      'tab_mail:leaf_abandon'
+    )
+    expect(d.getWorkerDispatch(abandonDispatch.id)).toBeUndefined()
+
+    expect(d.abandonWorkerDispatch(abandonDispatch.id)).toMatchObject({
+      disposition: 'context_only',
+      state: 'abandoned',
+      alreadySettled: false,
+      releasedCurrentTask: true
+    })
+    expect(d.getDispatchContextById(abandonDispatch.id)).toMatchObject({
+      status: 'failed',
+      last_failure: 'abandoned'
+    })
+    expect(d.getTask(abandonTask.id)?.status).toBe('blocked')
+    expect(d.getActiveDispatchForIdentity('term_mail_abandon')).toBeUndefined()
+
+    const stopTask = d.createTask({ spec: 'mail-only stop' })
+    const stopDispatch = d.createDispatchContext(
+      stopTask.id,
+      'term_mail_stop',
+      'tab_mail:leaf_stop'
+    )
+    expect(d.beginWorkerStop(stopDispatch.id)).toMatchObject({
+      disposition: 'context_only',
+      state: 'stopped',
+      alreadySettled: false,
+      releasedCurrentTask: true
+    })
+    expect(d.getDispatchContextById(stopDispatch.id)).toMatchObject({
+      status: 'failed',
+      last_failure: 'stopped'
+    })
+    expect(d.getTask(stopTask.id)?.status).toBe('blocked')
+    expect(d.getActiveDispatchForIdentity('term_mail_stop')).toBeUndefined()
+  })
+
   it('lets the stop fence win before a late worker completion', () => {
     const d = createDb()
     const task = d.createTask({ spec: 'race' })


### PR DESCRIPTION
## Summary

Low-level `orchestration.dispatch` creates a `dispatch_contexts` row only. `worker-abandon` / `worker-stop` required a matching `worker_dispatches` row (from `worker-start`) and threw `dispatch_not_found` for live mail-only dispatch ids — while `dispatch-show` still returned them and the terminal stayed locked.

- Fence context-only dispatches in `abandonWorkerDispatch` and `beginWorkerStop`
- Free the assignee terminal / block the task without inventing a process stop
- Keep supervised worker rows on the existing path

Fixes #13005

## Test plan

- [x] `pnpm exec vitest run src/main/runtime/orchestration/orchestration-worker-dispatch-db.test.ts`
- [x] `pnpm exec vitest run src/main/runtime/rpc/methods/orchestration-workers-recovery.test.ts src/main/runtime/rpc/methods/orchestration-worker-release.test.ts`