### PR TITLE
fix(agent-status): notify Claude turn complete while background work runs

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -2079,4 +2079,63 @@ describe('agent completion coordinator', () => {
       })
     )
   })
+
+  // Why: #13245 — lead Stop with bg inventory stays working; still notify once, and skip the late done.
+  it('notifies once for turnCompleteWhileBackground and suppresses the later done edge', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-claude:leaf-1',
+      getPtyId: () => 'pty-claude',
+      getSettings: () => null,
+      inspectProcess: async () => processResult('claude'),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'verify cells',
+      agentType: 'claude'
+    })
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'verify cells',
+      agentType: 'claude',
+      turnCompleteWhileBackground: true,
+      lastAssistantMessage: 'Which cells need hand-verification?',
+      stateStartedAt: 1_700_000_020_000,
+      subagents: [
+        {
+          id: 'a1',
+          state: 'working',
+          startedAt: 1_700_000_019_000,
+          agentType: 'general-purpose'
+        }
+      ]
+    })
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'verify cells',
+      agentType: 'claude',
+      subagents: [
+        {
+          id: 'a1',
+          state: 'working',
+          startedAt: 1_700_000_019_000,
+          agentType: 'general-purpose'
+        }
+      ]
+    })
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'verify cells',
+      agentType: 'claude',
+      lastAssistantMessage: 'Which cells need hand-verification?',
+      stateStartedAt: 1_700_000_050_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts
@@ -704,7 +704,13 @@ describe('agent completion coordinator', () => {
     coordinator.observeTitle('codex done')
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({ state: 'done' })
+      })
+    )
   })
 
   it('suppresses delayed title completion after process inspection changes sessions', async () => {
@@ -729,7 +735,13 @@ describe('agent completion coordinator', () => {
     coordinator.observeClassifiedTitleCompletion('codex done')
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({ state: 'done' })
+      })
+    )
   })
 
   it('suppresses late process-exit backstop after process inspection follows hook completion', async () => {
@@ -757,7 +769,13 @@ describe('agent completion coordinator', () => {
     await flushAsyncTicks()
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
-    expect(dispatchCompletion).toHaveBeenCalledWith('codex')
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'codex',
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({ state: 'done' })
+      })
+    )
   })
 
   it('suppresses process-exit in another coordinator after a hook completion notified', async () => {
@@ -1279,7 +1297,13 @@ describe('agent completion coordinator', () => {
       agentType
     })
 
-    expect(dispatchCompletion).toHaveBeenCalledWith(agentType)
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      agentType,
+      expect.objectContaining({
+        source: 'hook',
+        agentStatus: expect.objectContaining({ state: 'done', agentType })
+      })
+    )
   })
 
   it.each(['pi', 'omp'])(
@@ -2083,12 +2107,14 @@ describe('agent completion coordinator', () => {
   // Why: #13245 — lead Stop with bg inventory stays working; still notify once, and skip the late done.
   it('notifies once for turnCompleteWhileBackground and suppresses the later done edge', () => {
     const dispatchCompletion = vi.fn()
+    const dispatchHookLifecycle = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-claude:leaf-1',
       getPtyId: () => 'pty-claude',
       getSettings: () => null,
       inspectProcess: async () => processResult('claude'),
       dispatchCompletion,
+      dispatchHookLifecycle,
       isLive: () => true
     })
 
@@ -2114,7 +2140,36 @@ describe('agent completion coordinator', () => {
       ]
     })
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    expect(dispatchCompletion).toHaveBeenCalledWith(
+      'claude',
+      expect.objectContaining({
+        source: 'hook',
+        quietedHookDone: false,
+        agentStatus: expect.objectContaining({
+          state: 'done',
+          agentType: 'claude',
+          // Synthetic edge is strictly later so notification supersession stays clear.
+          stateStartedAt: 1_700_000_020_001
+        })
+      })
+    )
+    // Banner only — store/lifecycle keep the real working payload (not synthetic done).
+    expect(dispatchHookLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({
+        state: 'working',
+        turnCompleteWhileBackground: true
+      })
+    )
+    expect(dispatchHookLifecycle).not.toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'done' })
+    )
 
+    // Shell/cron-style intermediate working has no subagent rows; suppress must stick.
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'verify cells',
+      agentType: 'claude'
+    })
     coordinator.observeHookStatus({
       state: 'working',
       prompt: 'verify cells',

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -87,6 +87,9 @@ export function createAgentCompletionCoordinator(
   let lastAttentionToken: string | null = null
   let lastForegroundAgent: RecognizedAgentProcess | null = null
   let requiresFreshWorking = false
+  // Why: lead Stop can notify while pane stays working for bg inventory; later real `done`
+  // for that same turn must not re-fire (#13245).
+  let turnCompleteWhileBackgroundNotified = false
   let pollTimer: ReturnType<typeof setTimeout> | null = null
   let pendingTitleTimer: ReturnType<typeof setTimeout> | null = null
   let pendingHookDoneTimer: ReturnType<typeof setTimeout> | null = null
@@ -792,11 +795,48 @@ export function createAgentCompletionCoordinator(
       establishAgentEvidence()
     }
     if (payload.state === 'working') {
+      if (payload.turnCompleteWhileBackground === true) {
+        // Why: Claude lead Stop already finished the turn; bg inventory only keeps the pane
+        // working for the sidebar. Mint the completion edge now so banners are not deferred
+        // for the full subagent/shell lifetime (#13245).
+        if (workingStatusObserved && !requiresFreshWorking) {
+          clearPendingCodexAttention()
+          const completionPayload: AgentCompletionStatusSnapshot = {
+            ...payload,
+            state: 'done'
+          }
+          const hookIdentity = hookCompletionIdentity(completionPayload)
+          lastCompletionIdentity = hookIdentity
+            ? {
+                source: 'hook',
+                identity: hookIdentity,
+                agentIdentity: hookCompletionAgentIdentity(completionPayload)
+              }
+            : {
+                source: 'hook',
+                identity: `turn-bg:${payload.agentType ?? ''}:${currentTurn}`,
+                agentIdentity: hookCompletionAgentIdentity(completionPayload)
+              }
+          turnCompleteWhileBackgroundNotified = true
+          dispatchCompletion('hook', payload.agentType ?? options.paneKey, {
+            agentStatus: completionPayload,
+            completionIdentity: lastCompletionIdentity
+          })
+        }
+        clearPendingHookDone()
+        options.dispatchHookLifecycle?.(payload)
+        return
+      }
       clearPendingHookDone()
       // Why: resumed work cancels the debounced attention so a self-resolving pause never notifies.
       clearPendingCodexAttention()
       workingStatusObserved = true
       requiresFreshWorking = false
+      // Why: child lifecycle re-emits working while bg children run; keep the suppress flag so
+      // the later all-clear `done` does not double-notify (#13245).
+      if (!payload.subagents?.some((subagent) => subagent.state === 'working')) {
+        turnCompleteWhileBackgroundNotified = false
+      }
       lastCompletionIdentity = null
       lastAttentionToken = null
       currentTurn += 1
@@ -822,6 +862,21 @@ export function createAgentCompletionCoordinator(
       clearPendingCodexAttention()
       if (isRecognizedAgentType(payload.agentType)) {
         establishAgentEvidence()
+      }
+      if (turnCompleteWhileBackgroundNotified) {
+        // Already announced at lead Stop; drain the late all-clear without a second banner.
+        turnCompleteWhileBackgroundNotified = false
+        clearPendingHookDone()
+        const hookIdentity = hookCompletionIdentity(payload)
+        lastCompletionIdentity = hookIdentity
+          ? {
+              source: 'hook',
+              identity: hookIdentity,
+              agentIdentity: hookCompletionAgentIdentity(payload)
+            }
+          : lastCompletionIdentity
+        options.dispatchHookLifecycle?.(payload)
+        return
       }
       const hookIdentity = hookCompletionIdentity(payload)
       if (
@@ -902,6 +957,7 @@ export function createAgentCompletionCoordinator(
     lastAttentionToken = null
     lastForegroundAgent = null
     requiresFreshWorking = options.requireFreshWorking ?? false
+    turnCompleteWhileBackgroundNotified = false
     inspectionGeneration += 1
   }
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -272,6 +272,8 @@ export function createAgentCompletionCoordinator(
       terminalIdleConfirmed?: boolean
       agentStatus?: AgentCompletionStatusSnapshot
       completionIdentity?: LastCompletionIdentity | null
+      /** Banner only — do not lifecycle-dispatch synthetic done while pane stays working. */
+      notifyWithoutLifecycle?: boolean
     } = {}
   ): void {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
@@ -301,11 +303,20 @@ export function createAgentCompletionCoordinator(
     if (optionsOverride.completionIdentity) {
       lastCompletionIdentityByPaneKey.set(options.paneKey, optionsOverride.completionIdentity)
     }
-    if (source === 'hook' && optionsOverride.agentStatus) {
+    if (
+      source === 'hook' &&
+      optionsOverride.agentStatus &&
+      optionsOverride.notifyWithoutLifecycle !== true
+    ) {
       options.dispatchHookLifecycle?.(optionsOverride.agentStatus)
     }
-    if (optionsOverride.quietedHookDone === true || source === 'process-exit') {
-      // Why: confirmed process death is independent completion evidence; keep its provenance so stale hook rows can't veto it later.
+    if (
+      optionsOverride.quietedHookDone === true ||
+      source === 'process-exit' ||
+      optionsOverride.agentStatus
+    ) {
+      // Why: process death / quieted done keep provenance; agentStatus also rides for
+      // turn-complete-while-background so notification gates see a done snapshot (#13245).
       options.dispatchCompletion(title, {
         source,
         quietedHookDone: optionsOverride.quietedHookDone === true,
@@ -801,9 +812,14 @@ export function createAgentCompletionCoordinator(
         // for the full subagent/shell lifetime (#13245).
         if (workingStatusObserved && !requiresFreshWorking) {
           clearPendingCodexAttention()
+          // Why: store stays working; mint a strictly later stateStartedAt so the done
+          // snapshot is not treated as superseded by same-timestamp working≠done.
+          const baseStartedAt =
+            typeof payload.stateStartedAt === 'number' ? payload.stateStartedAt : Date.now()
           const completionPayload: AgentCompletionStatusSnapshot = {
             ...payload,
-            state: 'done'
+            state: 'done',
+            stateStartedAt: baseStartedAt + 1
           }
           const hookIdentity = hookCompletionIdentity(completionPayload)
           lastCompletionIdentity = hookIdentity
@@ -820,7 +836,8 @@ export function createAgentCompletionCoordinator(
           turnCompleteWhileBackgroundNotified = true
           dispatchCompletion('hook', payload.agentType ?? options.paneKey, {
             agentStatus: completionPayload,
-            completionIdentity: lastCompletionIdentity
+            completionIdentity: lastCompletionIdentity,
+            notifyWithoutLifecycle: true
           })
         }
         clearPendingHookDone()
@@ -832,11 +849,8 @@ export function createAgentCompletionCoordinator(
       clearPendingCodexAttention()
       workingStatusObserved = true
       requiresFreshWorking = false
-      // Why: child lifecycle re-emits working while bg children run; keep the suppress flag so
-      // the later all-clear `done` does not double-notify (#13245).
-      if (!payload.subagents?.some((subagent) => subagent.state === 'working')) {
-        turnCompleteWhileBackgroundNotified = false
-      }
+      // Why: keep suppress sticky while bg inventory can re-emit working without subagent rows
+      // (shell/cron). Only the late all-clear done path (or reset) clears it (#13245).
       lastCompletionIdentity = null
       lastAttentionToken = null
       currentTurn += 1

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3113,7 +3113,9 @@ export function useIpcEvents(): void {
         interrupted: data.interrupted,
         sessionBoundary: data.sessionBoundary,
         // Why: same trap as interactivePrompt — this rebuild is a field whitelist, so subagent child rows vanish if omitted.
-        subagents: data.subagents
+        subagents: data.subagents,
+        // Why: #13245 lead-Stop-while-bg flag must survive this rebuild or the coordinator never sees it on IPC.
+        turnCompleteWhileBackground: data.turnCompleteWhileBackground
       })
       if (!payload) {
         return 'dropped'

--- a/src/shared/agent-hook-listener.test.ts
+++ b/src/shared/agent-hook-listener.test.ts
@@ -3285,6 +3285,8 @@ describe('shared agent-hook-listener', () => {
         ]
       })
       expect(stop?.payload.state).toBe('working')
+      // Why: #13245 — lead turn finished; notifiers need the turn-finished edge even while bg inventory holds working.
+      expect(stop?.payload.turnCompleteWhileBackground).toBe(true)
       expect(stop?.payload.subagents).toEqual([
         {
           id: 'a1',
@@ -3300,7 +3302,20 @@ describe('shared agent-hook-listener', () => {
       claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
       const finalStop = claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
       expect(finalStop?.payload.state).toBe('done')
+      expect(finalStop?.payload.turnCompleteWhileBackground).toBeUndefined()
       expect(finalStop?.payload.subagents).toBeUndefined()
+    })
+
+    it('marks turnCompleteWhileBackground for background shells on lead Stop', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'run shell' })
+      const stop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+      })
+      expect(stop?.payload).toMatchObject({
+        state: 'working',
+        turnCompleteWhileBackground: true
+      })
     })
 
     it('emits a status refresh with the lead state on subagent lifecycle events', () => {

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -2907,11 +2907,20 @@ function normalizeClaudeEvent(
     state: reportedStateName,
     interrupted
   })
+  // Why: lead Stop/StopFailure already finished the turn; background inventory only keeps the
+  // pane working for sidebar liveness. Notifiers need the turn-finished edge now (#13245).
+  const turnCompleteWhileBackground =
+    isTurnBoundary &&
+    eventAgentId === undefined &&
+    reportedStateName === 'done' &&
+    effectiveState === 'working' &&
+    interrupted !== true
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,
     updateToolSnapshot: true,
-    interrupted
+    interrupted,
+    ...(turnCompleteWhileBackground ? { turnCompleteWhileBackground: true } : {})
   })
 }
 
@@ -2926,6 +2935,7 @@ function buildClaudeStatusPayload(
     updateToolSnapshot: boolean
     interrupted?: boolean
     sessionBoundary?: boolean
+    turnCompleteWhileBackground?: boolean
   }
 ): ParsedAgentStatusPayload | null {
   // Why: child-driven refreshes are roster bookkeeping, not lead tool activity; read the cached snapshot without merging so they can't clear a live AskUserQuestion card or clobber the tool preview.
@@ -2950,6 +2960,7 @@ function buildClaudeStatusPayload(
     lastAssistantMessage: snapshot.lastAssistantMessage,
     interrupted: options.interrupted,
     sessionBoundary: options.sessionBoundary,
+    turnCompleteWhileBackground: options.turnCompleteWhileBackground,
     subagents: claudeRosterToSnapshots(state.claudeSubagentRosterByPaneKey.get(paneKey))
   })
 }

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -435,6 +435,19 @@ Fix dispatch fallback preview for normalized status prompts`
     ).toBeUndefined()
   })
 
+  it('preserves turnCompleteWhileBackground only on working', () => {
+    expect(
+      parseAgentStatusPayload('{"state":"working","turnCompleteWhileBackground":true}')!
+        .turnCompleteWhileBackground
+    ).toBe(true)
+    for (const state of ['done', 'blocked', 'waiting'] as const) {
+      const result = parseAgentStatusPayload(
+        `{"state":"${state}","turnCompleteWhileBackground":true}`
+      )
+      expect(result!.turnCompleteWhileBackground).toBeUndefined()
+    }
+  })
+
   it('requires strict boolean true for interrupted (rejects truthy non-boolean)', () => {
     // Why: parser uses `=== true`, so truthy string/number sentinels don't count.
     expect(

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -177,6 +177,12 @@ export type AgentStatusPayload = {
    *  completions (notifications, automation runs, unread badges, finished timestamps)
    *  must ignore it. Only meaningful on `done`. */
   sessionBoundary?: boolean
+  /**
+   * True when the lead turn ended but the pane stays `working` because Claude still has
+   * background subagents/shells/crons. Sidebar keeps working; completion notifiers should
+   * still treat this as a turn-finished edge (#13245). Only meaningful on `working`.
+   */
+  turnCompleteWhileBackground?: boolean
   /** Live in-process children of the reporting session. See AgentStatusEntry. */
   subagents?: AgentSubagentSnapshot[]
 }
@@ -210,6 +216,9 @@ export function pickParsedAgentStatusPayload(
       : {}),
     ...(row.interrupted !== undefined ? { interrupted: row.interrupted } : {}),
     ...(row.sessionBoundary !== undefined ? { sessionBoundary: row.sessionBoundary } : {}),
+    ...(row.turnCompleteWhileBackground !== undefined
+      ? { turnCompleteWhileBackground: row.turnCompleteWhileBackground }
+      : {}),
     ...(row.subagents !== undefined ? { subagents: row.subagents } : {})
   }
 }
@@ -410,6 +419,9 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
     // Why: only meaningful on `done`; coerce to undefined elsewhere so it can't leak stale truth across transitions.
     interrupted: obj.interrupted === true && state === 'done' ? true : undefined,
     sessionBoundary: obj.sessionBoundary === true && state === 'done' ? true : undefined,
+    // Why: only meaningful on `working` (lead done gated up by background inventory).
+    turnCompleteWhileBackground:
+      obj.turnCompleteWhileBackground === true && state === 'working' ? true : undefined,
     subagents: normalizeSubagentsField(obj.subagents)
   }
 }


### PR DESCRIPTION
## Summary

When a Claude lead turn ends while background subagents/shells/crons are still registered, `resolveClaudePaneState` keeps the pane `working` so the sidebar does not go grey. That also suppressed the `working → done` edge that mints completion notifications — turns that end by asking the user something stay silent for the whole background lifetime (or forever for background shells).

- Stamp `turnCompleteWhileBackground` on lead Stop/StopFailure when inventory gates the pane to `working`
- Notify immediately from that edge (sidebar stays working)
- Suppress the later all-clear `done` so the same turn does not double-fire

Fixes #13245

## Test plan

- [x] `pnpm exec vitest run src/shared/agent-status-types.test.ts src/shared/agent-hook-listener.test.ts src/shared/claude-background-task-status.test.ts src/renderer/src/components/terminal-pane/agent-completion-coordinator.test.ts`