### PR TITLE
fix(terminal): inset grid padding on both axes

### DIFF
--- a/src/renderer/src/assets/terminal-container-geometry.test.ts
+++ b/src/renderer/src/assets/terminal-container-geometry.test.ts
@@ -6,13 +6,29 @@ const terminalCss = fs.readFileSync(new URL('./terminal.css', import.meta.url), 
 describe('terminal container geometry', () => {
   it('keeps the hidden link tooltip out of the fitted terminal height', () => {
     expect(terminalCss).toMatch(
-      /\.xterm-container\s*{[^}]*height:\s*calc\(100% - var\(--pane-padding-y, 4px\)\);/s
+      /\.xterm-container\s*{[^}]*height:\s*calc\(100% - \(2 \* var\(--pane-padding-y, 4px\)\)\);/s
     )
     expect(terminalCss).toMatch(
-      /\.pane\[data-has-title\] \.xterm-container\s*{[^}]*height:\s*calc\(100% - var\(--orca-pane-title-height\)\);/s
+      /\.pane\[data-has-title\] \.xterm-container\s*{[^}]*height:\s*calc\(100% - var\(--orca-pane-title-height\) - \(2 \* var\(--pane-padding-y, 4px\)\)\);/s
     )
     expect(terminalCss).toMatch(
       /\.pane-link-tooltip\s*{[^}]*height:\s*var\(--orca-terminal-link-tooltip-height\);/s
+    )
+  })
+
+  // Why: #13252 — Padding X/Y must inset both axes; start-only margins left right/bottom flush.
+  it('insets the xterm grid on both axes from pane padding', () => {
+    expect(terminalCss).toMatch(
+      /\.xterm-container\s*{[^}]*width:\s*calc\(100% - \(2 \* var\(--pane-padding-x, 4px\)\)\);/s
+    )
+    expect(terminalCss).toMatch(
+      /\.xterm-container\s*{[^}]*margin-top:\s*var\(--pane-padding-y, 4px\);/s
+    )
+    expect(terminalCss).toMatch(
+      /\.xterm-container\s*{[^}]*margin-left:\s*var\(--pane-padding-x, 4px\);/s
+    )
+    expect(terminalCss).toMatch(
+      /\.pane\[data-has-title\] \.xterm-container\s*{[^}]*margin-top:\s*calc\(var\(--orca-pane-title-height\) \+ var\(--pane-padding-y, 4px\)\);/s
     )
   })
 })

--- a/src/renderer/src/assets/terminal.css
+++ b/src/renderer/src/assets/terminal.css
@@ -500,23 +500,27 @@
 
 /* Baseline xterm-container layout — padding is driven by CSS custom properties
    so Ghostty-imported window-padding-x/y can be applied without inline styles.
-   The fallback 4px preserves the legacy default. */
+   The fallback 4px preserves the legacy default.
+   Why 2× on width/height: only margin-top/left were applied historically, so
+   right and bottom stayed flush with the pane edge while the setting only
+   inset the start edges (#13252). Size shrinks by both sides; the trailing
+   gap is the matching padding. */
 .xterm-container {
   box-sizing: border-box;
   position: relative;
-  width: calc(100% - var(--pane-padding-x, 4px));
-  height: calc(100% - var(--pane-padding-y, 4px));
+  width: calc(100% - (2 * var(--pane-padding-x, 4px)));
+  height: calc(100% - (2 * var(--pane-padding-y, 4px)));
   margin-top: var(--pane-padding-y, 4px);
   margin-left: var(--pane-padding-x, 4px);
 }
 
 /* When a pane has a title, shift the terminal content down to make room.
    The .pane container uses position: relative, so the absolutely-positioned
-   title bar occupies the top title-height pixels. Height is reduced by the
-   same amount to prevent overflow/clipping. */
+   title bar occupies the top title-height pixels. Keep vertical padding below
+   the title and at the bottom so settings still inset both edges. */
 .pane[data-has-title] .xterm-container {
-  margin-top: var(--orca-pane-title-height);
-  height: calc(100% - var(--orca-pane-title-height)); /* match margin-top */
+  margin-top: calc(var(--orca-pane-title-height) + var(--pane-padding-y, 4px));
+  height: calc(100% - var(--orca-pane-title-height) - (2 * var(--pane-padding-y, 4px)));
 }
 
 /* Ghostty-style URL hover: glued to the pane's true bottom-left corner. */

--- a/src/renderer/src/components/terminal-pane/terminal-appearance.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-appearance.ts
@@ -233,7 +233,8 @@ export function applyTerminalAppearance(
     opacityTransitionMs: paneStyles.opacityTransitionMs,
     dividerThicknessPx: paneStyles.dividerThicknessPx,
     focusFollowsMouse: paneStyles.focusFollowsMouse,
-    paddingX: settings.terminalPaddingX,
-    paddingY: settings.terminalPaddingY
+    // Why: match settings UI defaults so unset config still stamps CSS vars (not only the 4px fallback).
+    paddingX: settings.terminalPaddingX ?? 4,
+    paddingY: settings.terminalPaddingY ?? 4
   })
 }


### PR DESCRIPTION
## Summary

Terminal Padding X/Y only applied `margin-top` / `margin-left` and subtracted a single padding value from width/height. The right and bottom edges of the xterm grid stayed flush with the pane; raising the setting only grew the start-edge inset and made the imbalance more obvious.

- Size the grid with `2 ×` padding so trailing edges get the same inset
- Keep vertical padding under pane titles (title + padY top, padY bottom)
- Stamp CSS vars with the settings UI default (4px) when unset

Fixes #13252

## Test plan

- [x] `pnpm exec vitest run src/renderer/src/assets/terminal-container-geometry.test.ts`
- [ ] Manually: Settings → Terminal → Padding X/Y; confirm text is inset on left **and** right (and top/bottom)