### PR TITLE
fix(terminal): restore the floating workspace open and maximized

### DIFF
--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -75,6 +75,10 @@ import { shouldShowOnboarding } from './components/onboarding/should-show-onboar
 import { MarkdownTemplatePicker } from './components/editor/MarkdownTemplatePicker'
 import { FloatingTerminalToggleButton } from './components/floating-terminal/FloatingTerminalToggleButton'
 import {
+  persistFloatingTerminalPanelOpen,
+  readPersistedFloatingTerminalPanelViewState
+} from './components/floating-terminal/floating-terminal-panel-view-state'
+import {
   TOGGLE_FLOATING_TERMINAL_EVENT,
   requestFloatingTerminalOpenMaximized
 } from '@/lib/floating-terminal'
@@ -445,7 +449,11 @@ function App(): React.JSX.Element {
   const clearUnreadDockBadge = useUnreadDockBadge()
   useRadixBodyPointerEventsRecovery()
   useWebSessionTabsSync()
-  const [floatingTerminalOpen, setFloatingTerminalOpen] = useState(false)
+  // Why restored: leaving the panel closed forces the user to reopen and re-maximize it,
+  // and that size jump reflows a live TUI's buffer (see floating-terminal-panel-view-state).
+  const [floatingTerminalOpen, setFloatingTerminalOpen] = useState(
+    () => readPersistedFloatingTerminalPanelViewState()?.open === true
+  )
   const floatingWorkspaceTourInteractionSnapshotRef = useRef<{
     wasPreviouslyInteracted?: boolean
     persisted?: Promise<void>
@@ -637,6 +645,7 @@ function App(): React.JSX.Element {
         restoreFloatingTerminalReturnFocus()
       }
       setFloatingTerminalOpen(resolvedOpen)
+      persistFloatingTerminalPanelOpen(resolvedOpen)
     },
     [floatingTerminalOpen, rememberFloatingTerminalReturnFocus, restoreFloatingTerminalReturnFocus]
   )

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -548,6 +548,9 @@ function App(): React.JSX.Element {
   const historyBackShortcutLabel = useShortcutLabel('worktree.history.back')
   const historyForwardShortcutLabel = useShortcutLabel('worktree.history.forward')
   const floatingTerminalEnabled = useAppStore((s) => s.settings?.floatingTerminalEnabled === true)
+  // Why tracked separately: the flag reads false while settings are still loading, and a
+  // false read at boot must not be treated as the user disabling the feature.
+  const floatingTerminalSettingsHydrated = useAppStore((s) => s.settings !== undefined)
   const floatingTerminalTriggerLocation = useAppStore(
     (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
   )
@@ -671,10 +674,13 @@ function App(): React.JSX.Element {
   }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
 
   useEffect(() => {
-    if (!floatingTerminalEnabled) {
+    // Why the hydration gate: this effect fires on every boot while settings are still
+    // undefined, and closing there discards the restored open state before the real flag
+    // value arrives. Only a hydrated flag-off is an actual disable.
+    if (floatingTerminalSettingsHydrated && !floatingTerminalEnabled) {
       setFloatingTerminalOpenWithFocus(false)
     }
-  }, [floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
+  }, [floatingTerminalSettingsHydrated, floatingTerminalEnabled, setFloatingTerminalOpenWithFocus])
 
   const sidebarWidth = useAppStore((s) => s.sidebarWidth)
   const sidebarOpen = useAppStore((s) => s.sidebarOpen)

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -645,9 +645,19 @@ function App(): React.JSX.Element {
         restoreFloatingTerminalReturnFocus()
       }
       setFloatingTerminalOpen(resolvedOpen)
-      persistFloatingTerminalPanelOpen(resolvedOpen)
+      // Why gated on the flag: `settings` is undefined until it hydrates, so the
+      // feature-off effect force-closes the panel on every boot. Persisting there would
+      // overwrite the user's restored `open` with a value they never chose.
+      if (floatingTerminalEnabled) {
+        persistFloatingTerminalPanelOpen(resolvedOpen)
+      }
     },
-    [floatingTerminalOpen, rememberFloatingTerminalReturnFocus, restoreFloatingTerminalReturnFocus]
+    [
+      floatingTerminalEnabled,
+      floatingTerminalOpen,
+      rememberFloatingTerminalReturnFocus,
+      restoreFloatingTerminalReturnFocus
+    ]
   )
 
   useEffect(() => {

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -549,8 +549,9 @@ function App(): React.JSX.Element {
   const historyForwardShortcutLabel = useShortcutLabel('worktree.history.forward')
   const floatingTerminalEnabled = useAppStore((s) => s.settings?.floatingTerminalEnabled === true)
   // Why tracked separately: the flag reads false while settings are still loading, and a
-  // false read at boot must not be treated as the user disabling the feature.
-  const floatingTerminalSettingsHydrated = useAppStore((s) => s.settings !== undefined)
+  // false read at boot must not be treated as the user disabling the feature. The store
+  // initializes `settings` to null (not undefined) - fetchSettings replaces it atomically.
+  const floatingTerminalSettingsHydrated = useAppStore((s) => s.settings != null)
   const floatingTerminalTriggerLocation = useAppStore(
     (s) => s.settings?.floatingTerminalTriggerLocation ?? 'floating-button'
   )

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -18,6 +18,7 @@ import {
   consumeFloatingTerminalOpenMaximizedIntent,
   requestFloatingTerminalOpenMaximized
 } from '@/lib/floating-terminal'
+import { FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY } from './floating-terminal-panel-view-state'
 import {
   clearFloatingPanelReclaimIntent,
   consumeFloatingPanelReclaimIntent
@@ -1174,6 +1175,27 @@ describe('FloatingTerminalPanel close behavior', () => {
       FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
       expect.anything()
     )
+  })
+
+  it('restores saved normal bounds after starting maximized', async () => {
+    const savedBounds = { left: 120, top: 96, width: 760, height: 420 }
+    getMockedLocalStorage().getItem.mockImplementation((key: string) => {
+      if (key === FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY) {
+        return JSON.stringify(savedBounds)
+      }
+      return key === FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY
+        ? JSON.stringify({ open: true, maximized: true })
+        : null
+    })
+
+    let element = await renderPanel(true)
+    expect(getPanelStyleBounds(element)).toEqual(getMaximizedFloatingTerminalBounds())
+
+    const controls = findByTypeName(element, 'FloatingTerminalWindowControls')
+    ;(controls.props.onToggleMaximized as () => void)()
+    element = await renderPanel(true)
+
+    expect(getPanelStyleBounds(element)).toEqual(savedBounds)
   })
 
   it('restores committed normal bounds after maximizing from a skinny clamp', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.test.tsx
@@ -1156,14 +1156,24 @@ describe('FloatingTerminalPanel close behavior', () => {
 
     element = await renderPanel(true)
     expect(getPanelStyleBounds(element)).toEqual(getMaximizedFloatingTerminalBounds())
-    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+    // Why key-scoped rather than "no writes": maximize now persists panel view state under
+    // its own key. The invariant here is that the saved NORMAL bounds are never clobbered.
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalledWith(
+      FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
+      expect.anything()
+    )
 
     const restoredControls = findByTypeName(element, 'FloatingTerminalWindowControls')
     ;(restoredControls.props.onToggleMaximized as () => void)()
     element = await renderPanel(true)
 
     expect(getPanelStyleBounds(element)).toEqual(savedBounds)
-    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+    // Why key-scoped rather than "no writes": maximize now persists panel view state under
+    // its own key. The invariant here is that the saved NORMAL bounds are never clobbered.
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalledWith(
+      FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
+      expect.anything()
+    )
   })
 
   it('restores committed normal bounds after maximizing from a skinny clamp', async () => {
@@ -1198,7 +1208,12 @@ describe('FloatingTerminalPanel close behavior', () => {
       width: 920,
       height: 560
     })
-    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalled()
+    // Why key-scoped rather than "no writes": maximize now persists panel view state under
+    // its own key. The invariant here is that the saved NORMAL bounds are never clobbered.
+    expect(getMockedLocalStorage().setItem).not.toHaveBeenCalledWith(
+      FLOATING_TERMINAL_PANEL_BOUNDS_STORAGE_KEY,
+      expect.anything()
+    )
   })
 
   it('does not bootstrap a terminal tab when the panel opens empty', async () => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -94,18 +94,24 @@ export { FloatingTerminalToggleButton } from './FloatingTerminalToggleButton'
 import {
   anchorFloatingTerminalPanelBounds,
   clampFloatingTerminalBounds,
-  getDefaultFloatingTerminalCommittedBounds,
   getDefaultFloatingTerminalBounds,
+  getDefaultFloatingTerminalCommittedBounds,
   getMaximizedFloatingTerminalBounds,
   persistFloatingTerminalPanelBounds,
   readPersistedFloatingTerminalPanelBounds,
-  resolveFloatingTerminalPanelCommittedBounds,
   resolveFloatingTerminalPanelBounds,
+  resolveFloatingTerminalPanelCommittedBounds,
   shouldReconcileFloatingTerminalPanelBounds,
   type FloatingTerminalPanelBounds,
-  type FloatingTerminalPanelCommittedBounds,
-  type FloatingTerminalPanelBoundsSource
+  type FloatingTerminalPanelBoundsSource,
+  type FloatingTerminalPanelCommittedBounds
 } from './floating-terminal-panel-bounds'
+import {
+  persistFloatingTerminalPanelMaximized,
+  readPersistedFloatingTerminalPanelViewState
+} from './floating-terminal-panel-view-state'
+import { useSettledPanelViewport } from './use-settled-panel-viewport'
+import { shouldRestoreMaximizedPanelBounds } from './floating-terminal-panel-restore-geometry'
 import { translate } from '@/i18n/i18n'
 import { consumeFloatingTerminalOpenMaximizedIntent } from '@/lib/floating-terminal'
 import { selectFloatingTerminalPanelInputs } from './floating-terminal-panel-inputs'
@@ -161,6 +167,17 @@ function readInitialPanelBounds(): FloatingTerminalPanelBoundsState {
   const defaultCommittedBounds = getDefaultFloatingTerminalCommittedBounds()
   const defaultRenderedBounds = getDefaultFloatingTerminalBounds()
   const persistedBounds = readPersistedFloatingTerminalPanelBounds()
+  if (shouldRestoreMaximizedPanelBounds(readPersistedFloatingTerminalPanelViewState())) {
+    // Why maximized wins the RENDERED rect while the committed rect stays the restore
+    // target: the first paint must already be final geometry, or the panes fit at the
+    // smaller size and the later maximize reflows them. Un-maximizing still returns to
+    // the user's own bounds because those remain committed.
+    return {
+      committedBounds: persistedBounds ?? defaultCommittedBounds,
+      renderedBounds: getMaximizedFloatingTerminalBounds(),
+      source: persistedBounds ? 'user' : 'default'
+    }
+  }
   return persistedBounds
     ? {
         committedBounds: persistedBounds,
@@ -267,7 +284,10 @@ export function FloatingTerminalPanel({
     initialBoundsStateRef.current.committedBounds
   )
   const [bounds, setBounds] = useState(initialBoundsStateRef.current.renderedBounds)
-  const [maximized, setMaximized] = useState(false)
+  const [maximized, setMaximized] = useState(
+    () => readPersistedFloatingTerminalPanelViewState()?.maximized === true
+  )
+  const panelViewportSettled = useSettledPanelViewport()
   const [orchestrationDialogOpen, setOrchestrationDialogOpen] = useState(false)
   const [showOrchestrationSetup, setShowOrchestrationSetup] = useState(
     () => !hasOrchestrationSetupMarker() && !isOrchestrationSetupDismissed()
@@ -1126,6 +1146,7 @@ export function FloatingTerminalPanel({
       stagedBoundsRef.current = null
       setBounds(restoredBounds)
       setMaximized(false)
+      persistFloatingTerminalPanelMaximized(false)
       return
     }
     restoreBoundsRef.current = {
@@ -1136,6 +1157,7 @@ export function FloatingTerminalPanel({
     stagedBoundsRef.current = null
     setBounds(getMaximizedFloatingTerminalBounds())
     setMaximized(true)
+    persistFloatingTerminalPanelMaximized(true)
   }, [bounds, maximized])
 
   const maximizePanel = useCallback(() => {
@@ -1153,6 +1175,7 @@ export function FloatingTerminalPanel({
     stagedBoundsRef.current = null
     setBounds(getMaximizedFloatingTerminalBounds())
     setMaximized(true)
+    persistFloatingTerminalPanelMaximized(true)
   }, [bounds, maximized])
 
   useEffect(() => {
@@ -1830,7 +1853,11 @@ export function FloatingTerminalPanel({
             hasVisibleFloatingTabs ? 'floating-workspace-surface' : undefined
           }
         >
-          {cwd
+          {/* Why also gated on a settled viewport: a restored-maximized panel derives its
+              rect from the live viewport, so mounting terminals before the window finishes
+              maximizing fits them to a grid it is about to leave, and the correcting fit
+              reflows the buffer under a live TUI. */}
+          {cwd && panelViewportSettled
             ? tabs
                 .filter((tab) => !parkedTerminalTabIds.has(tab.id))
                 .map((tab) => {

--- a/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
+++ b/src/renderer/src/components/floating-terminal/FloatingTerminalPanel.tsx
@@ -1133,9 +1133,9 @@ export function FloatingTerminalPanel({
   const toggleMaximized = useCallback(() => {
     if (maximized) {
       const restoredState = restoreBoundsRef.current ?? {
-        committedBounds: getDefaultFloatingTerminalCommittedBounds(),
-        renderedBounds: getDefaultFloatingTerminalBounds(),
-        source: 'default' as const
+        committedBounds: committedBoundsRef.current,
+        renderedBounds: resolveFloatingTerminalPanelCommittedBounds(committedBoundsRef.current),
+        source: boundsSourceRef.current
       }
       restoreBoundsRef.current = null
       boundsSourceRef.current = restoredState.source

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-restore-geometry.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-restore-geometry.ts
@@ -1,0 +1,18 @@
+import { hasUsableFloatingTerminalPanelViewport } from './floating-terminal-panel-bounds'
+import type { FloatingTerminalPanelViewState } from './floating-terminal-panel-view-state'
+
+/**
+ * Whether the panel's first rendered rect should be the maximized one.
+ *
+ * Why this is a decision and not just a flag read: maximized geometry is derived from the
+ * live viewport, so restoring it against a viewport too small to hold the panel would pin
+ * the terminals to a grid the window is about to leave — the size jump this restore exists
+ * to remove. When the viewport cannot answer yet, fall back to the committed bounds and let
+ * the ordinary reconcile path maximize once layout is real.
+ */
+export function shouldRestoreMaximizedPanelBounds(
+  viewState: FloatingTerminalPanelViewState | null,
+  hasUsableViewport: () => boolean = hasUsableFloatingTerminalPanelViewport
+): boolean {
+  return viewState?.maximized === true && hasUsableViewport()
+}

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-view-state.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-view-state.test.ts
@@ -1,0 +1,81 @@
+/** @vitest-environment happy-dom */
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY,
+  persistFloatingTerminalPanelMaximized,
+  persistFloatingTerminalPanelOpen,
+  readPersistedFloatingTerminalPanelViewState
+} from './floating-terminal-panel-view-state'
+import { shouldRestoreMaximizedPanelBounds } from './floating-terminal-panel-restore-geometry'
+
+afterEach(() => {
+  window.localStorage.clear()
+})
+
+describe('floating terminal panel view state', () => {
+  it('returns null when nothing was ever persisted', () => {
+    expect(readPersistedFloatingTerminalPanelViewState()).toBeNull()
+  })
+
+  it('round-trips both flags', () => {
+    persistFloatingTerminalPanelOpen(true)
+    persistFloatingTerminalPanelMaximized(true)
+    expect(readPersistedFloatingTerminalPanelViewState()).toEqual({ open: true, maximized: true })
+  })
+
+  it('does not clobber the other owner_s flag', () => {
+    // Why: `open` is written by the app shell and `maximized` by the panel, so a
+    // whole-record write from either would drop the other's value.
+    persistFloatingTerminalPanelMaximized(true)
+    persistFloatingTerminalPanelOpen(false)
+    expect(readPersistedFloatingTerminalPanelViewState()).toEqual({ open: false, maximized: true })
+
+    persistFloatingTerminalPanelOpen(true)
+    persistFloatingTerminalPanelMaximized(false)
+    expect(readPersistedFloatingTerminalPanelViewState()).toEqual({ open: true, maximized: false })
+  })
+
+  it('restores the half a older record carries', () => {
+    // Why: a record written before the second flag existed must still restore.
+    window.localStorage.setItem(
+      FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY,
+      JSON.stringify({ open: true })
+    )
+    expect(readPersistedFloatingTerminalPanelViewState()).toEqual({ open: true, maximized: false })
+  })
+
+  it('treats malformed storage as absent instead of throwing', () => {
+    for (const value of ['not json', '[]', 'null', '"open"', '42']) {
+      window.localStorage.setItem(FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY, value)
+      expect(readPersistedFloatingTerminalPanelViewState()).toBeNull()
+    }
+  })
+
+  it('ignores non-boolean flag values rather than coercing them', () => {
+    window.localStorage.setItem(
+      FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY,
+      JSON.stringify({ open: 'yes', maximized: 1 })
+    )
+    expect(readPersistedFloatingTerminalPanelViewState()).toEqual({ open: false, maximized: false })
+  })
+})
+
+describe('shouldRestoreMaximizedPanelBounds', () => {
+  it('restores maximized geometry only when the viewport can hold it', () => {
+    expect(shouldRestoreMaximizedPanelBounds({ open: true, maximized: true }, () => true)).toBe(
+      true
+    )
+    // Why: maximized bounds come from the live viewport, so restoring against one too small
+    // pins terminals to a grid the window is about to leave - the jump this restore removes.
+    expect(shouldRestoreMaximizedPanelBounds({ open: true, maximized: true }, () => false)).toBe(
+      false
+    )
+  })
+
+  it('does not restore maximized geometry for a non-maximized or absent record', () => {
+    expect(shouldRestoreMaximizedPanelBounds({ open: true, maximized: false }, () => true)).toBe(
+      false
+    )
+    expect(shouldRestoreMaximizedPanelBounds(null, () => true)).toBe(false)
+  })
+})

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-view-state.test.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-view-state.test.ts
@@ -35,6 +35,18 @@ describe('floating terminal panel view state', () => {
     expect(readPersistedFloatingTerminalPanelViewState()).toEqual({ open: true, maximized: false })
   })
 
+  it('lets a later write destroy a restored open preference', () => {
+    // Why pinned: this is the hazard the App-side guard exists for. `settings` hydrates
+    // asynchronously, so the feature flag reads false on every boot before it resolves and
+    // the feature-off effect force-closes the panel. If that path persists, it overwrites a
+    // preference the user never changed - which is exactly what shipped and had to be fixed.
+    persistFloatingTerminalPanelOpen(true)
+    expect(readPersistedFloatingTerminalPanelViewState()?.open).toBe(true)
+
+    persistFloatingTerminalPanelOpen(false)
+    expect(readPersistedFloatingTerminalPanelViewState()?.open).toBe(false)
+  })
+
   it('restores the half a older record carries', () => {
     // Why: a record written before the second flag existed must still restore.
     window.localStorage.setItem(

--- a/src/renderer/src/components/floating-terminal/floating-terminal-panel-view-state.ts
+++ b/src/renderer/src/components/floating-terminal/floating-terminal-panel-view-state.ts
@@ -1,0 +1,66 @@
+export const FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY =
+  'orca-floating-terminal-panel-view-state-v1'
+
+export type FloatingTerminalPanelViewState = {
+  open: boolean
+  maximized: boolean
+}
+
+function getWindowStorage(): Storage | null {
+  return typeof window === 'undefined' ? null : window.localStorage
+}
+
+/**
+ * Why persisted separately from the bounds record: maximized geometry is derived
+ * from the live viewport rather than stored, so this is view state, not a rect.
+ * Keeping it out of the bounds union also keeps that type a pure rectangle.
+ *
+ * Why it matters: an unpersisted maximize means every restart drops the user into
+ * a default-sized panel that they re-maximize by hand. That size jump reflows the
+ * xterm buffer under a live relative-cursor TUI, which unwraps its rows and leaves
+ * permanently mangled scrollback. Restoring the panel as it was removes the jump.
+ */
+export function readPersistedFloatingTerminalPanelViewState(): FloatingTerminalPanelViewState | null {
+  try {
+    const serialized = getWindowStorage()?.getItem(FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY)
+    if (!serialized) {
+      return null
+    }
+    const parsed: unknown = JSON.parse(serialized)
+    if (parsed === null || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return null
+    }
+    const record = parsed as Record<string, unknown>
+    // Why each flag is read independently: a record written before the other flag
+    // existed must still restore the half it does carry.
+    return {
+      open: record.open === true,
+      maximized: record.maximized === true
+    }
+  } catch {
+    return null
+  }
+}
+
+export function persistFloatingTerminalPanelViewState(state: FloatingTerminalPanelViewState): void {
+  try {
+    getWindowStorage()?.setItem(
+      FLOATING_TERMINAL_PANEL_VIEW_STATE_STORAGE_KEY,
+      JSON.stringify(state)
+    )
+  } catch {
+    // Why: storage can be unavailable or full; losing the restore is not worth a crash.
+  }
+}
+
+// Why field-scoped writers: `open` is owned by the app shell and `maximized` by the panel,
+// so a whole-record write from either side would clobber the other's flag.
+export function persistFloatingTerminalPanelOpen(open: boolean): void {
+  const current = readPersistedFloatingTerminalPanelViewState()
+  persistFloatingTerminalPanelViewState({ maximized: current?.maximized === true, open })
+}
+
+export function persistFloatingTerminalPanelMaximized(maximized: boolean): void {
+  const current = readPersistedFloatingTerminalPanelViewState()
+  persistFloatingTerminalPanelViewState({ open: current?.open === true, maximized })
+}

--- a/src/renderer/src/components/floating-terminal/use-settled-panel-viewport.ts
+++ b/src/renderer/src/components/floating-terminal/use-settled-panel-viewport.ts
@@ -1,0 +1,69 @@
+import { useEffect, useState } from 'react'
+
+// Why two frames: the main window restores its saved bounds and only then maximizes, so
+// the renderer's first layout can be a size the window is about to leave. One unchanged
+// frame can land inside that gap; two straddle it.
+const REQUIRED_STABLE_FRAMES = 2
+// Why a cap: a window that never stops resizing (a drag, a display change) must not hold
+// the panel's terminals forever. Mounting at a stale size is recoverable; never mounting is not.
+const MAX_SETTLE_MS = 300
+
+function readViewport(): { width: number; height: number } {
+  return { width: window.innerWidth, height: window.innerHeight }
+}
+
+/**
+ * Reports true once the viewport has held one size across consecutive frames.
+ *
+ * Why the floating panel waits for this: its maximized rect is derived from the live
+ * viewport, so mounting terminals against a pre-maximize viewport fits them to a grid the
+ * window is about to leave. The correcting fit then reflows the xterm buffer under a live
+ * TUI, which is the damage this whole path exists to avoid. Latching true is deliberate —
+ * later resizes are ordinary user resizes and the normal fit path owns them.
+ */
+export function useSettledPanelViewport(): boolean {
+  const [settled, setSettled] = useState(false)
+
+  useEffect(() => {
+    if (settled || typeof window === 'undefined') {
+      return
+    }
+    if (typeof requestAnimationFrame !== 'function') {
+      setSettled(true)
+      return
+    }
+    let frameId: number | null = null
+    let previous = readViewport()
+    let stableFrames = 0
+    const settle = (): void => {
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId)
+        frameId = null
+      }
+      setSettled(true)
+    }
+    const capId = setTimeout(settle, MAX_SETTLE_MS)
+    const step = (): void => {
+      const current = readViewport()
+      stableFrames =
+        current.width === previous.width && current.height === previous.height
+          ? stableFrames + 1
+          : 0
+      previous = current
+      if (stableFrames >= REQUIRED_STABLE_FRAMES) {
+        settle()
+        return
+      }
+      frameId = requestAnimationFrame(step)
+    }
+    frameId = requestAnimationFrame(step)
+    return () => {
+      clearTimeout(capId)
+      if (frameId !== null) {
+        cancelAnimationFrame(frameId)
+      }
+    }
+  }, [settled])
+
+  return settled
+}


### PR DESCRIPTION
## Summary

Restores the Floating Workspace to the state it was left in — open and maximized — instead of dropping the user into a closed, default-sized panel after every restart.

This is the fix for the reported bug, and it is a different root cause than #13155/#13164/#13194.

**What was actually happening.** Reproduced on a real Electron instance against `main`. The panel's `open` and `maximized` flags are both unpersisted (`App.tsx:448`, `FloatingTerminalPanel.tsx:270`), so after a restart the user reopens the panel at the default size and re-maximizes by hand. On this machine that is **113 columns → 211 columns**, and `113/211 = 53.6%` — precisely the "content fills only the left ~55% of the panel" signature in the bug report.

That column jump reflows the xterm buffer. For a long-running relative-cursor TUI (an agent CLI redrawing a live region with cursor-up + erase-line), rows written at 113 columns carry `isWrapped` continuations that **unwrap** into the 211-column grid, producing interleaved line tails and stacked status lines:

```
status | working agent | width-marker: [XXXX…XXXX]e-187-2-line-187-2-line-187-2-…
                                      ^ old 113-col margin  ^ unwrapped tail of the next row
```

The live region self-heals within a second or two once SIGWINCH lands, because xterm's `reflowCursorLine` defaults to `false` and skips the cursor's wrapped run. **The reflowed scrollback never recovers** — that is the lasting damage, and no amount of correct PTY sizing undoes it. The only real fix is to not make the jump.

**What this changes:**

1. Persists `open` and `maximized` under their own key, with field-scoped writers since the app shell owns one flag and the panel owns the other.
2. Restores maximized geometry **in the bounds initializer, before first paint**, not in a post-mount effect. Restoring it after mount would fit the panes at the default size and then maximize them — reproducing the exact jump this removes.
3. Gates the panel's terminal panes on a settled viewport. The main window restores its saved bounds and only *then* maximizes, so the renderer's first layout can be a size the window is about to leave; mounting there would fit terminals to a doomed grid and reflow them when it corrects.

`committedBounds` still holds the user's own rect, so un-maximizing returns to it exactly as before.

## Screenshots

Before (on `main`, after restart → open → maximize) — the 53.6% band with interleaved tails and stacked status rows:

`validation-screenshots/arm-a-REPRO-open-max-immediate.png`

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New tests cover the persistence round-trip, the field-scoped writers not clobbering each other, a record written before the second flag existed, malformed storage, non-boolean coercion, and the restore-geometry decision (including refusing maximized restore when the viewport cannot hold it — restoring against a too-small viewport would pin terminals to a grid the window is about to leave, which is the failure this PR exists to remove).

Two existing panel tests asserted `localStorage.setItem` was **never** called after a maximize, as a proxy for "don't clobber the saved normal bounds". This PR writes a different key, so those assertions are now scoped to the bounds key — the invariant they protect is unchanged and still asserted.

1687 renderer test files green. One unrelated GitHub-project test failed only under the full parallel run and passes in isolation (load-order flake, nothing this PR touches).

**Verified end-to-end on a real Electron instance** (scripted A/B, five pass criteria fixed in advance, two full repetitions, negative control on `main` re-confirmed failing first). User flow: maximize → start a live diff-painting TUI at 211×55 → `SIGHUP` restart → observe untouched. On this branch, both repetitions:

- Panel returned **already open and maximized, terminals visible, zero clicks** (on `main`: closed).
- Storage held `{open:true, maximized:true}` through settle plus a 20s late-clobber wait.
- The TUI's own SIGWINCH log across the restart shows **only `211x55 (was 211x55)`** — no 80×24, no 113×32 intermediates (on `main`, reopening cascades `113x32 → 211x55`).
- No new garble: no left band, no interleaved fragments, no stacked multi-width rows; the buffer stayed clean across the restart.
- First paint at PTY/xterm 211×55.

Evidence: `validation-screenshots/FLOATING_TERMINAL_VERIFY4_REPORT.md` plus `verify4-*` screenshots in the branch's worktree. Arm proof per measurement batch fetched the served `App.tsx` through the dev server (no HMR trust).

A separate round verified the **closed-at-quit** direction (close the panel with a live TUI running → restart → open it later): the reopen paints directly at the persisted maximized geometry with no default-size step, the TUI's SIGWINCH log stays clean (no 80×24 / 113×32 intermediates — on `main` this same flow still cascades through 113×32), and storage honors the user's choice (`open:false` until the click, `maximized:true` throughout). Both repetitions passed. Evidence: `FLOATING_TERMINAL_VERIFY5_REPORT.md` / `verify5-*`.

It took four rig rounds to get here, and each of the first three failures was a distinct boot-ordering bug in this fix — worth recording for review:

1. Persisting the boot-time force-close overwrote the restored `open` (fixed: persist only while the feature flag is enabled).
2. The force-close still discarded the restored React state during settings hydration (fixed: gate the close on hydration).
3. The hydration gate itself tested the wrong sentinel — the settings store initializes to `null`, not `undefined` (fixed: `s.settings != null`; hydration is atomic, so null is sufficient).

None of these were visible to unit tests, because no App-level harness exercises settings hydration; only the live A/B caught them.

## AI Review Report

Design informed by a survey of how comparable terminal/IDE applications handle this, without adopting any of their code:

- **Persisting panel-open is universal**; every surveyed application does it, and two of the three that have a pane-maximize concept persist that too. Orca persisting neither is the outlier.
- **Restore ordering is the part that is easy to get wrong.** Two of the surveyed applications maximize the window *after* the renderer has already laid out and fitted at normal bounds — which is precisely the jump being fixed here. The strongest prior art applies geometry into the layout synchronously, before any terminal exists. This PR follows the latter.
- **Restore into the final grid, not through an intermediate.** Two surveyed applications resize to a saved grid, write the snapshot, then resize back — guaranteeing a re-wrap of everything they just restored. Orca already avoids that on the reattach path (`pty-connection.ts:8305`), and this PR keeps the same discipline for the restore path.
- **Rejected: immutable-width scrollback.** No comparable application does it, xterm.js has no seam for it, and it would mean forking buffer reflow. Removing the trigger is far cheaper.
- **Rejected: patching xterm reflow.** An alt-screen or DECAWM-gated reflow exemption would not even fix this bug, since a relative-cursor TUI owns the *primary* screen.

Cross-platform (macOS/Linux/Windows): renderer-only, `localStorage` and viewport measurement, no platform-dependent behavior, no shortcuts/labels/paths touched. SSH and folder-workspace cases share this path with no difference.

## Security Audit

No IPC, command execution, path handling, auth, secrets, or dependency changes. One new `localStorage` key holding two booleans, read defensively — malformed JSON, wrong types, arrays, and `null` all degrade to "not persisted" rather than throwing, and writes are wrapped so a full or unavailable store cannot crash the renderer.

## Notes

- **User-visible behavior change:** the Floating Workspace now reopens on launch if it was open when you quit. That is the intended fix and matches every comparable application surveyed; calling it out because it changes what you see at startup. It does not steal focus — the restore seeds state directly rather than going through the focus-managing setter.
- #13155, #13164 and #13194 remain correct fixes for real adjacent defects, but none of them removes this trigger. #13164 in particular is necessary-but-not-sufficient: it makes the repaint signal actually reach a running TUI.
- Unrelated hygiene spotted while surveying, fixed separately: a comment in `pane-fit-resize-observer.ts` names a third-party project.


