### PR TITLE
chore(terminal): drop a third-party product name from a fit comment

### DIFF
--- a/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-fit-resize-observer.ts
@@ -90,8 +90,8 @@ export function requestStablePaneFit(pane: StableFitPane, onSettled?: () => void
     stableFitCallbacks.delete(pane)
     return
   }
-  // Why: keep xterm fit work off the divider pointermove hot path and let
-  // the browser coalesce drag-driven size changes the same way Superset does.
+  // Why: keep xterm fit work off the divider pointermove hot path and let the
+  // browser coalesce drag-driven size changes, which is the conventional approach.
   //
   // Windows can report a short-lived one-column anchor/scrollbar wobble when
   // the right sidebar is open. Requiring a stable proposed grid before fitting


### PR DESCRIPTION
## Summary

A comment in `pane-fit-resize-observer.ts` justified coalescing drag-driven resizes by citing another product by name. The engineering reasoning stands on its own; the attribution does not belong in shipped source.

Comment only — no behavior change.

## Screenshots

`No visual change`

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

No tests — this changes two lines of comment text and no executable code. `oxlint` and `oxfmt --check` pass on the file.

## AI Review Report

Swept `src/` and `docs/` for similar references. The remaining matches are all legitimate and deliberately left alone:

- `superset` used as the ordinary English word ("a superset of its internal guards").
- `src/shared/setup-script-imports.ts`, which reads `.superset/config.json` as a user-facing setup-script **import source**. That is interop with a real config format the user may have on disk, plus its user-visible provider label — removing it would break a feature, not scrub a citation.

Cross-platform: comment text only.

## Security Audit

No code change. No IPC, input handling, command execution, path handling, auth, secrets, or dependencies touched.

## Notes

Split out from the floating-workspace restore work (#13258) rather than folded in, since it is unrelated to that fix.