### PR TITLE
perf(native-chat): probe WSL transcript paths asynchronously

### DIFF
--- a/src/main/ai-vault/session-scanner-directory-reader.test.ts
+++ b/src/main/ai-vault/session-scanner-directory-reader.test.ts
@@ -1,0 +1,46 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { mkdir, mkdtemp, readdir, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { walkSessionFiles } from './session-scanner-discovery'
+
+let tempRoot: string | null = null
+
+afterEach(async () => {
+  if (tempRoot) {
+    await rm(tempRoot, { recursive: true, force: true })
+    tempRoot = null
+  }
+})
+
+describe('walkSessionFiles directory reader', () => {
+  it('uses the injected reader for the root and nested directories', async () => {
+    tempRoot = await mkdtemp(join(tmpdir(), 'orca-session-reader-'))
+    const nested = join(tempRoot, '2026', '08', '09')
+    await mkdir(nested, { recursive: true })
+    const rollout = join(nested, 'rollout-session.jsonl')
+    await writeFile(rollout, '{}\n')
+    const readDirectory = vi.fn((dirPath: string) => readdir(dirPath, { withFileTypes: true }))
+
+    await expect(
+      walkSessionFiles(tempRoot, 'codex', [], {
+        extensions: new Set(['.jsonl']),
+        readDirectory
+      })
+    ).resolves.toEqual([rollout])
+    expect(readDirectory).toHaveBeenCalledTimes(4)
+  })
+
+  it('preserves unreadable-directory handling for an injected reader', async () => {
+    const readDirectory = vi.fn(async () => {
+      throw new Error('unreachable')
+    })
+
+    await expect(
+      walkSessionFiles('missing', 'codex', [], {
+        extensions: new Set(['.jsonl']),
+        readDirectory
+      })
+    ).resolves.toEqual([])
+  })
+})

--- a/src/main/ai-vault/session-scanner-directory-reader.test.ts
+++ b/src/main/ai-vault/session-scanner-directory-reader.test.ts
@@ -43,4 +43,21 @@ describe('walkSessionFiles directory reader', () => {
       })
     ).resolves.toEqual([])
   })
+
+  it('does not turn cancellation into an unreadable-directory miss', async () => {
+    const controller = new AbortController()
+    const cancelled = new Error('scan cancelled')
+    const readDirectory = vi.fn(async () => {
+      controller.abort(cancelled)
+      throw cancelled
+    })
+
+    await expect(
+      walkSessionFiles('cancelled', 'codex', [], {
+        extensions: new Set(['.jsonl']),
+        readDirectory,
+        signal: controller.signal
+      })
+    ).rejects.toBe(cancelled)
+  })
 })

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -54,20 +54,24 @@ export async function walkSessionFiles(
     // rootDir, so pruned subtrees are never stat'd or parsed.
     directoryPredicate?: (name: string, depth: number) => boolean
     readDirectory?: (dirPath: string) => Promise<Dirent[]>
+    signal?: AbortSignal
   },
   depth = 0
 ): Promise<string[]> {
+  options.signal?.throwIfAborted()
   let entries
   try {
     entries = options.readDirectory
       ? await options.readDirectory(dirPath)
       : await readdir(dirPath, { withFileTypes: true })
   } catch {
+    options.signal?.throwIfAborted()
     return []
   }
 
   const files: string[] = []
   for (const entry of entries) {
+    options.signal?.throwIfAborted()
     const fullPath = join(dirPath, entry.name)
     if (entry.isDirectory()) {
       // Skip whole subtrees an agent never wants (e.g. subagent transcripts),

--- a/src/main/ai-vault/session-scanner-discovery.ts
+++ b/src/main/ai-vault/session-scanner-discovery.ts
@@ -1,3 +1,4 @@
+import type { Dirent } from 'node:fs'
 import { readdir, stat } from 'node:fs/promises'
 import { extname, join } from 'node:path'
 import type { AiVaultAgent, AiVaultScanIssue } from '../../shared/ai-vault-types'
@@ -52,12 +53,15 @@ export async function walkSessionFiles(
     // Return false to skip descending into a directory; depth 0 is a child of
     // rootDir, so pruned subtrees are never stat'd or parsed.
     directoryPredicate?: (name: string, depth: number) => boolean
+    readDirectory?: (dirPath: string) => Promise<Dirent[]>
   },
   depth = 0
 ): Promise<string[]> {
   let entries
   try {
-    entries = await readdir(dirPath, { withFileTypes: true })
+    entries = options.readDirectory
+      ? await options.readDirectory(dirPath)
+      : await readdir(dirPath, { withFileTypes: true })
   } catch {
     return []
   }

--- a/src/main/ipc/native-chat-subscribe-lifecycle.test.ts
+++ b/src/main/ipc/native-chat-subscribe-lifecycle.test.ts
@@ -126,6 +126,14 @@ function initialSnapshot(callIndex: number): InitialSnapshotCallback {
   return (call[0] as { onInitialSnapshot: InitialSnapshotCallback }).onInitialSnapshot
 }
 
+function setupSignal(callIndex: number): AbortSignal {
+  const signal = subscribeTranscript.mock.calls[callIndex]?.[1]
+  if (!(signal instanceof AbortSignal)) {
+    throw new Error('subscribe setup signal was not provided')
+  }
+  return signal
+}
+
 function unsubscribe(sender: SenderHarness['sender'], subscriptionId: string): void {
   const listener = listeners.get('nativeChat:unsubscribe')
   if (!listener) {
@@ -151,8 +159,10 @@ describe('nativeChat subscribe lifecycle', () => {
     const renderer = createSender(1)
 
     subscribe(renderer.sender, 'unmount')
+    expect(setupSignal(0).aborted).toBe(false)
     expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(1)
     unsubscribe(renderer.sender, 'unmount')
+    expect(setupSignal(0).aborted).toBe(true)
     expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(0)
     unsubscribe(renderer.sender, 'unmount')
     expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(0)
@@ -171,7 +181,9 @@ describe('nativeChat subscribe lifecycle', () => {
     const renderer = createSender(2)
 
     subscribe(renderer.sender, 'destroy')
+    expect(setupSignal(0).aborted).toBe(false)
     renderer.destroy()
+    expect(setupSignal(0).aborted).toBe(true)
     expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(0)
     expect(_getNativeChatSenderCleanupCountForTest()).toBe(0)
 
@@ -186,7 +198,10 @@ describe('nativeChat subscribe lifecycle', () => {
     const renderer = createSender(3)
 
     subscribe(renderer.sender, 'same-id')
+    const olderSignal = setupSignal(0)
     subscribe(renderer.sender, 'same-id')
+    expect(olderSignal.aborted).toBe(true)
+    expect(setupSignal(1).aborted).toBe(false)
     expect(_getNativeChatPendingSubscriptionCountForTest()).toBe(1)
 
     newer.resolve()

--- a/src/main/ipc/native-chat.ts
+++ b/src/main/ipc/native-chat.ts
@@ -9,7 +9,8 @@ import type { ReadTranscriptResult } from '../native-chat/transcript-reader'
 import {
   subscribeNativeChatTranscript,
   readNativeChatTranscriptTail,
-  type NativeChatTranscriptSubscription
+  type NativeChatTranscriptSubscription,
+  type SubscribeNativeChatTranscriptArgs
 } from '../native-chat/transcript-watch'
 
 // Re-export so existing test imports of `clearNativeChatTranscriptCache` from
@@ -81,17 +82,22 @@ type LiveSubscription = {
   subscription: NativeChatTranscriptSubscription
 }
 
+type PendingSubscription = {
+  controller: AbortController
+}
+
 // Why: live subscriptions are keyed by (webContents.id, subscriptionId) so the
 // same renderer can watch several panes, and a destroyed window tears down all
 // of its watchers — strict teardown to avoid fd leaks (plan U4 risk).
 const liveSubscriptions = new Map<number, Map<string, LiveSubscription>>()
 // Why: unsubscribe and renderer destruction must invalidate async watcher setup
 // before it can publish a late subscription into the live map.
-const pendingSubscriptions = new Map<number, Map<string, symbol>>()
+const pendingSubscriptions = new Map<number, Map<string, PendingSubscription>>()
 const senderCleanupRegistered = new Set<number>()
 
 function teardownSubscription(senderId: number, subscriptionId: string): void {
   const pendingBySubId = pendingSubscriptions.get(senderId)
+  pendingBySubId?.get(subscriptionId)?.controller.abort()
   pendingBySubId?.delete(subscriptionId)
   if (pendingBySubId?.size === 0) {
     pendingSubscriptions.delete(senderId)
@@ -111,6 +117,9 @@ function teardownSubscription(senderId: number, subscriptionId: string): void {
 function teardownAllForSender(senderId: number): void {
   // The destroyed event can arrive before async subscription setup stores a watcher.
   senderCleanupRegistered.delete(senderId)
+  for (const pending of pendingSubscriptions.get(senderId)?.values() ?? []) {
+    pending.controller.abort()
+  }
   pendingSubscriptions.delete(senderId)
   const bySubId = liveSubscriptions.get(senderId)
   if (!bySubId) {
@@ -131,18 +140,22 @@ function registerSenderCleanup(sender: WebContents): void {
   sender.once('destroyed', () => teardownAllForSender(sender.id))
 }
 
-function beginPendingSubscription(senderId: number, subscriptionId: string): symbol {
+function beginPendingSubscription(senderId: number, subscriptionId: string): PendingSubscription {
   teardownSubscription(senderId, subscriptionId)
-  const token = Symbol(subscriptionId)
-  const bySubId = pendingSubscriptions.get(senderId) ?? new Map<string, symbol>()
-  bySubId.set(subscriptionId, token)
+  const pending = { controller: new AbortController() }
+  const bySubId = pendingSubscriptions.get(senderId) ?? new Map<string, PendingSubscription>()
+  bySubId.set(subscriptionId, pending)
   pendingSubscriptions.set(senderId, bySubId)
-  return token
+  return pending
 }
 
-function takePendingSubscription(senderId: number, subscriptionId: string, token: symbol): boolean {
+function takePendingSubscription(
+  senderId: number,
+  subscriptionId: string,
+  pending: PendingSubscription
+): boolean {
   const bySubId = pendingSubscriptions.get(senderId)
-  if (bySubId?.get(subscriptionId) !== token) {
+  if (bySubId?.get(subscriptionId) !== pending) {
     return false
   }
   bySubId.delete(subscriptionId)
@@ -160,71 +173,72 @@ async function handleSubscribe(event: IpcMainEvent, args: NativeChatSubscribeArg
   const { subscriptionId, agent, sessionId, transcriptPath } = args
   const limit = args.limit && args.limit > 0 ? Math.floor(args.limit) : DESKTOP_READ_WINDOW
   // Replace any prior subscription under the same id (session change/resubscribe).
-  const pendingToken = beginPendingSubscription(sender.id, subscriptionId)
+  const pending = beginPendingSubscription(sender.id, subscriptionId)
   registerSenderCleanup(sender)
 
+  const subscribeArgs: SubscribeNativeChatTranscriptArgs = {
+    agent,
+    sessionId,
+    transcriptPath,
+    initialLimit: limit,
+    onInitialSnapshot: (messages, hasMore, _beforeOffset, error, lifecycle) => {
+      if (sender.isDestroyed()) {
+        return
+      }
+      // Forward an initial-drain error so a watching client's first frame carries it
+      // instead of stranding the view at 'loading' when the read keeps throwing.
+      const payload: NativeChatAppendedPayload = {
+        subscriptionId,
+        frame: {
+          type: 'snapshot',
+          messages,
+          hasMore,
+          ...(error ? { error } : {}),
+          ...(lifecycle ? { lifecycle } : {})
+        }
+      }
+      sender.send('nativeChat:appended', payload)
+    },
+    onReplace: (messages, hasMore, _beforeOffset, lifecycle) => {
+      if (sender.isDestroyed()) {
+        return
+      }
+      sender.send('nativeChat:appended', {
+        subscriptionId,
+        frame: {
+          type: 'replacement',
+          messages,
+          hasMore,
+          ...(lifecycle ? { lifecycle } : {})
+        }
+      } satisfies NativeChatAppendedPayload)
+    },
+    onAppend: (messages, lifecycle) => {
+      if (sender.isDestroyed()) {
+        return
+      }
+      const payload: NativeChatAppendedPayload = {
+        subscriptionId,
+        frame: {
+          type: 'appended',
+          messages,
+          ...(lifecycle ? { lifecycle } : {})
+        }
+      }
+      sender.send('nativeChat:appended', payload)
+    }
+  }
   let subscription: NativeChatTranscriptSubscription
   try {
-    subscription = await subscribeNativeChatTranscript({
-      agent,
-      sessionId,
-      transcriptPath,
-      initialLimit: limit,
-      onInitialSnapshot: (messages, hasMore, _beforeOffset, error, lifecycle) => {
-        if (sender.isDestroyed()) {
-          return
-        }
-        // Forward an initial-drain error so a watching client's first frame carries it
-        // instead of stranding the view at 'loading' when the read keeps throwing.
-        const payload: NativeChatAppendedPayload = {
-          subscriptionId,
-          frame: {
-            type: 'snapshot',
-            messages,
-            hasMore,
-            ...(error ? { error } : {}),
-            ...(lifecycle ? { lifecycle } : {})
-          }
-        }
-        sender.send('nativeChat:appended', payload)
-      },
-      onReplace: (messages, hasMore, _beforeOffset, lifecycle) => {
-        if (sender.isDestroyed()) {
-          return
-        }
-        sender.send('nativeChat:appended', {
-          subscriptionId,
-          frame: {
-            type: 'replacement',
-            messages,
-            hasMore,
-            ...(lifecycle ? { lifecycle } : {})
-          }
-        } satisfies NativeChatAppendedPayload)
-      },
-      onAppend: (messages, lifecycle) => {
-        if (sender.isDestroyed()) {
-          return
-        }
-        const payload: NativeChatAppendedPayload = {
-          subscriptionId,
-          frame: {
-            type: 'appended',
-            messages,
-            ...(lifecycle ? { lifecycle } : {})
-          }
-        }
-        sender.send('nativeChat:appended', payload)
-      }
-    })
+    subscription = await subscribeNativeChatTranscript(subscribeArgs, pending.controller.signal)
   } catch {
-    takePendingSubscription(sender.id, subscriptionId, pendingToken)
+    takePendingSubscription(sender.id, subscriptionId, pending)
     return
   }
 
   // Why: unmount, destruction, or a newer same-id subscribe can invalidate setup
-  // while path resolution is pending; only the owning token may publish its watcher.
-  const stillCurrent = takePendingSubscription(sender.id, subscriptionId, pendingToken)
+  // while path resolution is pending; only the owning generation may publish its watcher.
+  const stillCurrent = takePendingSubscription(sender.id, subscriptionId, pending)
   if (sender.isDestroyed() || !stillCurrent) {
     subscription.unsubscribe()
     return

--- a/src/main/native-chat/host-readable-transcript-path-fs-gate.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path-fs-gate.test.ts
@@ -89,10 +89,11 @@ describe('WSL transcript filesystem gate', () => {
     const wslProbe = toHostReadableTranscriptPath(firstGuestPath, wslDeps())
     await vi.waitFor(() => expect(fsMocks.access).toHaveBeenCalledWith(firstUncPath))
 
-    const localPath = 'C:\\Users\\ada\\rollout.jsonl'
-    await expect(toHostReadableTranscriptPath(localPath, { platform: 'win32' })).resolves.toBe(
-      localPath
-    )
+    const localPath = import.meta.filename
+    await expect(
+      toHostReadableTranscriptPath(localPath, { platform: process.platform })
+    ).resolves.toBe(localPath)
+    expect(fsMocks.access).toHaveBeenCalledTimes(1)
     releaseWsl?.()
     await expect(wslProbe).resolves.toBe(firstUncPath)
   })

--- a/src/main/native-chat/host-readable-transcript-path-fs-gate.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path-fs-gate.test.ts
@@ -1,0 +1,99 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFsPromisesModule from 'node:fs/promises'
+
+const UBUNTU_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
+const firstGuestPath = '/home/ada/.codex/sessions/first.jsonl'
+const secondGuestPath = '/home/ada/.codex/sessions/second.jsonl'
+const firstUncPath = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions\\first.jsonl'
+const secondUncPath = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions\\second.jsonl'
+
+const fsMocks = vi.hoisted(() => ({
+  access: vi.fn<(path: string) => Promise<void>>()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFsPromisesModule>()),
+  access: fsMocks.access
+}))
+
+import {
+  resetHostReadableTranscriptPathCacheForTests,
+  toHostReadableTranscriptPath
+} from './host-readable-transcript-path'
+
+type AccessControl = {
+  resolve: () => void
+  reject: (error: Error) => void
+}
+
+function wslDeps(): {
+  platform: NodeJS.Platform
+  listWslHomeDirs: () => Promise<string[]>
+} {
+  return { platform: 'win32', listWslHomeDirs: async () => [UBUNTU_HOME] }
+}
+
+beforeEach(() => {
+  resetHostReadableTranscriptPathCacheForTests()
+  fsMocks.access.mockReset()
+})
+
+describe('WSL transcript filesystem gate', () => {
+  it('serializes distinct probes and releases the permit after failure', async () => {
+    const controls: AccessControl[] = []
+    fsMocks.access.mockImplementation(
+      () =>
+        new Promise<void>((resolve, reject) => {
+          controls.push({ resolve: () => resolve(), reject })
+        })
+    )
+
+    const first = toHostReadableTranscriptPath(firstGuestPath, wslDeps())
+    const second = toHostReadableTranscriptPath(secondGuestPath, wslDeps())
+
+    await vi.waitFor(() => expect(fsMocks.access).toHaveBeenCalledTimes(1))
+    controls[0].reject(new Error('stopped distro'))
+    await expect(first).resolves.toBeNull()
+    await vi.waitFor(() => expect(fsMocks.access).toHaveBeenCalledTimes(2))
+    controls[1].resolve()
+    await expect(second).resolves.toBe(secondUncPath)
+  })
+
+  it('deduplicates identical in-flight probes', async () => {
+    let release: (() => void) | undefined
+    fsMocks.access.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          release = resolve
+        })
+    )
+
+    const first = toHostReadableTranscriptPath(firstGuestPath, wslDeps())
+    const duplicate = toHostReadableTranscriptPath(firstGuestPath, wslDeps())
+
+    await vi.waitFor(() => expect(fsMocks.access).toHaveBeenCalledTimes(1))
+    release?.()
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([firstUncPath, firstUncPath])
+  })
+
+  it('does not queue local filesystem work behind a stalled WSL probe', async () => {
+    let releaseWsl: (() => void) | undefined
+    fsMocks.access.mockImplementation((path) =>
+      path === firstUncPath
+        ? new Promise<void>((resolve) => {
+            releaseWsl = resolve
+          })
+        : Promise.resolve()
+    )
+
+    const wslProbe = toHostReadableTranscriptPath(firstGuestPath, wslDeps())
+    await vi.waitFor(() => expect(fsMocks.access).toHaveBeenCalledWith(firstUncPath))
+
+    const localPath = 'C:\\Users\\ada\\rollout.jsonl'
+    await expect(toHostReadableTranscriptPath(localPath, { platform: 'win32' })).resolves.toBe(
+      localPath
+    )
+    releaseWsl?.()
+    await expect(wslProbe).resolves.toBe(firstUncPath)
+  })
+})

--- a/src/main/native-chat/host-readable-transcript-path.test.ts
+++ b/src/main/native-chat/host-readable-transcript-path.test.ts
@@ -46,7 +46,7 @@ describe('toHostReadableTranscriptPath', () => {
     await expect(
       toHostReadableTranscriptPath(ROLLOUT_LINUX, {
         platform: 'win32',
-        pathExists: (candidate) => candidate === ROLLOUT_UNC,
+        pathExists: async (candidate) => candidate === ROLLOUT_UNC,
         listWslHomeDirs: async () => [UBUNTU_HOME]
       })
     ).resolves.toBe(ROLLOUT_UNC)
@@ -59,7 +59,7 @@ describe('toHostReadableTranscriptPath', () => {
     await expect(
       toHostReadableTranscriptPath('/home/ada/x.jsonl', {
         platform: 'win32',
-        pathExists: (candidate) => {
+        pathExists: async (candidate) => {
           seen.push(candidate)
           return true
         },
@@ -75,7 +75,7 @@ describe('toHostReadableTranscriptPath', () => {
       await expect(
         toHostReadableTranscriptPath(path, {
           platform: 'win32',
-          pathExists: (candidate) => candidate === path,
+          pathExists: async (candidate) => candidate === path,
           listWslHomeDirs: async () => {
             throw new Error('should not enumerate distros')
           }
@@ -89,7 +89,7 @@ describe('toHostReadableTranscriptPath', () => {
     await expect(
       toHostReadableTranscriptPath('/home/ada/.codex/sessions/rollout.jsonl', {
         platform: 'win32',
-        pathExists: (candidate) => {
+        pathExists: async (candidate) => {
           seen.push(candidate)
           return true
         },
@@ -103,7 +103,7 @@ describe('toHostReadableTranscriptPath', () => {
     await expect(
       toHostReadableTranscriptPath(ROLLOUT_LINUX, {
         platform: 'win32',
-        pathExists: () => false,
+        pathExists: async () => false,
         listWslHomeDirs: async () => [UBUNTU_HOME]
       })
     ).resolves.toBeNull()
@@ -113,7 +113,7 @@ describe('toHostReadableTranscriptPath', () => {
     await expect(
       toHostReadableTranscriptPath('/home/ada/rollout.jsonl', {
         platform: 'darwin',
-        pathExists: (candidate) => candidate === '/home/ada/rollout.jsonl',
+        pathExists: async (candidate) => candidate === '/home/ada/rollout.jsonl',
         listWslHomeDirs: async () => {
           throw new Error('should not enumerate distros')
         }
@@ -128,7 +128,7 @@ describe('toHostReadableTranscriptPath', () => {
     for (let tick = 0; tick < 5; tick += 1) {
       await toHostReadableTranscriptPath(ROLLOUT_LINUX, {
         platform: 'win32',
-        pathExists: () => false,
+        pathExists: async () => false,
         listWslHomeDirs
       })
     }
@@ -151,7 +151,7 @@ describe('toHostReadableTranscriptPath', () => {
       const call = (): Promise<string | null> =>
         toHostReadableTranscriptPath('/home/other/x.jsonl', {
           platform: 'win32',
-          pathExists: (candidate) => candidate === debianRollout,
+          pathExists: async (candidate) => candidate === debianRollout,
           listWslHomeDirs
         })
 

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -1,4 +1,4 @@
-import { existsSync } from 'node:fs'
+import { access } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
 import { parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
@@ -30,9 +30,21 @@ export function needsWslHostTranslation(
 
 export type HostReadableTranscriptPathDeps = {
   platform?: NodeJS.Platform
-  pathExists?: (path: string) => boolean
+  pathExists?: (path: string) => Promise<boolean>
   /** Each installed WSL distro's `$HOME` as a Windows UNC path. */
   listWslHomeDirs?: () => Promise<string[]>
+}
+
+// Why: candidates are `\\wsl.localhost` UNC paths served over 9P. A sync probe
+// against a stopped or unreachable distro would stall the Electron main thread
+// instead of falling through to the next candidate, so keep this off the loop.
+async function pathExistsAsync(path: string): Promise<boolean> {
+  try {
+    await access(path)
+    return true
+  } catch {
+    return false
+  }
 }
 
 // Why: resolveSessionFilePath runs on a 500ms–5s poll loop. listWslDistrosAsync
@@ -100,19 +112,21 @@ export async function toHostReadableTranscriptPath(
   if (!path) {
     return null
   }
-  const pathExists = deps.pathExists ?? existsSync
+  const pathExists = deps.pathExists ?? pathExistsAsync
   const platform = deps.platform ?? process.platform
   // Why: classify BEFORE probing — Win32 resolves a bare `/home/…` against the
   // current drive (`C:\home\…`), so a probe first could bind chat to a local
   // look-alike file instead of the real WSL transcript.
   if (!needsWslHostTranslation(path, platform)) {
-    return pathExists(path) ? path : null
+    return (await pathExists(path)) ? path : null
   }
 
   const homeDirs = await wslHomeDirs(deps.listWslHomeDirs ?? defaultListWslHomeDirs)
+  // Sequential on purpose: the ranked order picks the owning distro, and probing
+  // every distro at once would fan out 9P calls to ones the user left stopped.
   for (const distro of rankDistrosForGuestPath(homeDirs, path)) {
     const uncPath = toWindowsWslPath(path, distro)
-    if (pathExists(uncPath)) {
+    if (await pathExists(uncPath)) {
       return uncPath
     }
   }

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -1,11 +1,7 @@
+import { existsSync } from 'node:fs'
 import { access } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
-import {
-  foldWslUncPathCaseInsensitiveParts,
-  isWslUncPath,
-  parseWslUncPath,
-  toWindowsWslPath
-} from '../../shared/wsl-paths'
+import { isWslUncPath, parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
 import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
@@ -37,6 +33,7 @@ export function needsWslHostTranslation(
 export type HostReadableTranscriptPathDeps = {
   platform?: NodeJS.Platform
   pathExists?: (path: string) => Promise<boolean>
+  signal?: AbortSignal
   /** Each installed WSL distro's `$HOME` as a Windows UNC path. */
   listWslHomeDirs?: () => Promise<string[]>
 }
@@ -44,7 +41,11 @@ export type HostReadableTranscriptPathDeps = {
 // Why: candidates are `\\wsl.localhost` UNC paths served over 9P. A sync probe
 // against a stopped or unreachable distro would stall the Electron main thread
 // instead of falling through to the next candidate, so keep this off the loop.
-async function pathExistsAsync(path: string): Promise<boolean> {
+async function pathExistsAsync(path: string, signal?: AbortSignal): Promise<boolean> {
+  signal?.throwIfAborted()
+  if (!isWslUncPath(path)) {
+    return existsSync(path)
+  }
   const probe = async (): Promise<boolean> => {
     try {
       await access(path)
@@ -53,11 +54,7 @@ async function pathExistsAsync(path: string): Promise<boolean> {
       return false
     }
   }
-  if (!isWslUncPath(path)) {
-    return probe()
-  }
-  const identity = foldWslUncPathCaseInsensitiveParts(path) ?? path
-  return runWslTranscriptFsTask(JSON.stringify(['access', identity]), probe)
+  return runWslTranscriptFsTask({ operation: 'access', path, priority: 'exact', signal }, probe)
 }
 
 // Why: resolveSessionFilePath runs on a 500ms–5s poll loop. listWslDistrosAsync
@@ -125,7 +122,9 @@ export async function toHostReadableTranscriptPath(
   if (!path) {
     return null
   }
-  const pathExists = deps.pathExists ?? pathExistsAsync
+  deps.signal?.throwIfAborted()
+  const pathExists =
+    deps.pathExists ?? ((candidate: string) => pathExistsAsync(candidate, deps.signal))
   const platform = deps.platform ?? process.platform
   // Why: classify BEFORE probing — Win32 resolves a bare `/home/…` against the
   // current drive (`C:\home\…`), so a probe first could bind chat to a local

--- a/src/main/native-chat/host-readable-transcript-path.ts
+++ b/src/main/native-chat/host-readable-transcript-path.ts
@@ -1,8 +1,14 @@
 import { access } from 'node:fs/promises'
 import { isAbsolute } from 'node:path'
-import { parseWslUncPath, toWindowsWslPath } from '../../shared/wsl-paths'
+import {
+  foldWslUncPathCaseInsensitiveParts,
+  isWslUncPath,
+  parseWslUncPath,
+  toWindowsWslPath
+} from '../../shared/wsl-paths'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
 import { getWslHomeAsync, listWslDistrosAsync } from '../wsl'
+import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
 
 /**
  * True for guest-absolute Linux paths that Win32 cannot open as-is.
@@ -39,12 +45,19 @@ export type HostReadableTranscriptPathDeps = {
 // against a stopped or unreachable distro would stall the Electron main thread
 // instead of falling through to the next candidate, so keep this off the loop.
 async function pathExistsAsync(path: string): Promise<boolean> {
-  try {
-    await access(path)
-    return true
-  } catch {
-    return false
+  const probe = async (): Promise<boolean> => {
+    try {
+      await access(path)
+      return true
+    } catch {
+      return false
+    }
   }
+  if (!isWslUncPath(path)) {
+    return probe()
+  }
+  const identity = foldWslUncPathCaseInsensitiveParts(path) ?? path
+  return runWslTranscriptFsTask(JSON.stringify(['access', identity]), probe)
 }
 
 // Why: resolveSessionFilePath runs on a 500ms–5s poll loop. listWslDistrosAsync

--- a/src/main/native-chat/session-file-resolver-codex-roots.test.ts
+++ b/src/main/native-chat/session-file-resolver-codex-roots.test.ts
@@ -1,0 +1,45 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const MANAGED_HOME = '/tmp/orca-user-data/codex-runtime-home/home'
+
+// Why: only the path-only variant may run on the resolve poll — the getter
+// mkdirSyncs the runtime home, which is launch-time work and blocks the main
+// thread on every tick.
+vi.mock('../codex/codex-home-paths', () => ({
+  getOrcaManagedCodexHomePath: vi.fn(() => MANAGED_HOME),
+  resolveOrcaManagedCodexHomePath: vi.fn(() => MANAGED_HOME)
+}))
+
+// Keeps the WSL fallback tier inert so this stays a host-roots test on any platform.
+vi.mock('../wsl', () => ({
+  listWslDistrosAsync: vi.fn(async () => []),
+  getWslHomeAsync: vi.fn(async () => null)
+}))
+
+const scanned = vi.hoisted(() => ({ dirs: [] as string[] }))
+vi.mock('../ai-vault/session-scanner-discovery', () => ({
+  walkSessionFiles: async (dir: string) => {
+    scanned.dirs.push(dir)
+    return []
+  }
+}))
+
+import { join } from 'node:path'
+import { getOrcaManagedCodexHomePath } from '../codex/codex-home-paths'
+import { resetHostReadableTranscriptPathCacheForTests } from './host-readable-transcript-path'
+import { resolveSessionFilePath } from './session-file-resolver'
+
+beforeEach(() => {
+  resetHostReadableTranscriptPathCacheForTests()
+  vi.mocked(getOrcaManagedCodexHomePath).mockClear()
+  scanned.dirs = []
+})
+
+describe('codex sessions roots', () => {
+  it('scans the managed home without materializing it', async () => {
+    await resolveSessionFilePath('codex', 'sess-1')
+
+    expect(scanned.dirs).toContain(join(MANAGED_HOME, 'sessions'))
+    expect(vi.mocked(getOrcaManagedCodexHomePath)).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
@@ -1,0 +1,64 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const WSL_SESSIONS_DIR = '\\\\wsl.localhost\\Ubuntu\\home\\ada\\.codex\\sessions'
+const LOCAL_SESSIONS_DIR = 'C:\\Users\\ada\\.codex\\sessions'
+
+const mocks = vi.hoisted(() => ({
+  gate: vi.fn(async () => []),
+  share: vi.fn(async (_key: string, task: () => Promise<string[]>) => task()),
+  walk: vi.fn(
+    async (
+      dir: string,
+      _agent: string,
+      _issues: unknown[],
+      options: { readDirectory?: (dirPath: string) => Promise<unknown[]> }
+    ) => {
+      await options.readDirectory?.(dir)
+      return [] as string[]
+    }
+  )
+}))
+
+vi.mock('./wsl-transcript-fs-gate', () => ({
+  runWslTranscriptFsTask: mocks.gate,
+  shareWslTranscriptFsTask: mocks.share
+}))
+vi.mock('../ai-vault/session-scanner-discovery', () => ({
+  walkSessionFiles: mocks.walk
+}))
+
+import { resolveSessionFilePath } from './session-file-resolver'
+
+beforeEach(() => {
+  mocks.gate.mockClear()
+  mocks.share.mockClear()
+  mocks.walk.mockClear()
+})
+
+describe('Codex WSL scan gate', () => {
+  it('routes WSL session-tree scans through the shared filesystem gate', async () => {
+    await resolveSessionFilePath('codex', 'session-id', {
+      codexSessionsDirs: [WSL_SESSIONS_DIR]
+    })
+
+    expect(mocks.share).toHaveBeenCalledWith(
+      expect.stringContaining('"codex-scan"'),
+      expect.any(Function)
+    )
+    expect(mocks.gate).toHaveBeenCalledWith(
+      expect.stringContaining('"codex-readdir"'),
+      expect.any(Function)
+    )
+    expect(mocks.walk).toHaveBeenCalledWith(WSL_SESSIONS_DIR, 'codex', [], expect.any(Object))
+  })
+
+  it('keeps local session-tree scans outside the WSL gate', async () => {
+    await resolveSessionFilePath('codex', 'session-id', {
+      codexSessionsDirs: [LOCAL_SESSIONS_DIR]
+    })
+
+    expect(mocks.share).not.toHaveBeenCalled()
+    expect(mocks.gate).not.toHaveBeenCalled()
+    expect(mocks.walk).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl-scan-gate.test.ts
@@ -5,7 +5,6 @@ const LOCAL_SESSIONS_DIR = 'C:\\Users\\ada\\.codex\\sessions'
 
 const mocks = vi.hoisted(() => ({
   gate: vi.fn(async () => []),
-  share: vi.fn(async (_key: string, task: () => Promise<string[]>) => task()),
   walk: vi.fn(
     async (
       dir: string,
@@ -20,8 +19,7 @@ const mocks = vi.hoisted(() => ({
 }))
 
 vi.mock('./wsl-transcript-fs-gate', () => ({
-  runWslTranscriptFsTask: mocks.gate,
-  shareWslTranscriptFsTask: mocks.share
+  runWslTranscriptFsTask: mocks.gate
 }))
 vi.mock('../ai-vault/session-scanner-discovery', () => ({
   walkSessionFiles: mocks.walk
@@ -31,7 +29,6 @@ import { resolveSessionFilePath } from './session-file-resolver'
 
 beforeEach(() => {
   mocks.gate.mockClear()
-  mocks.share.mockClear()
   mocks.walk.mockClear()
 })
 
@@ -41,12 +38,8 @@ describe('Codex WSL scan gate', () => {
       codexSessionsDirs: [WSL_SESSIONS_DIR]
     })
 
-    expect(mocks.share).toHaveBeenCalledWith(
-      expect.stringContaining('"codex-scan"'),
-      expect.any(Function)
-    )
     expect(mocks.gate).toHaveBeenCalledWith(
-      expect.stringContaining('"codex-readdir"'),
+      expect.objectContaining({ operation: 'readdir', priority: 'scan' }),
       expect.any(Function)
     )
     expect(mocks.walk).toHaveBeenCalledWith(WSL_SESSIONS_DIR, 'codex', [], expect.any(Object))
@@ -57,7 +50,6 @@ describe('Codex WSL scan gate', () => {
       codexSessionsDirs: [LOCAL_SESSIONS_DIR]
     })
 
-    expect(mocks.share).not.toHaveBeenCalled()
     expect(mocks.gate).not.toHaveBeenCalled()
     expect(mocks.walk).toHaveBeenCalledTimes(1)
   })

--- a/src/main/native-chat/session-file-resolver-wsl.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as NodeFsModule from 'node:fs'
+import type * as NodeFsPromisesModule from 'node:fs/promises'
 
 const UBUNTU_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
 const WSL_MANAGED_SESSIONS_DIR = `${UBUNTU_HOME}\\.local\\share\\orca\\codex-runtime-home\\home\\sessions`
@@ -15,13 +15,15 @@ vi.mock('../wsl', () => ({
 
 // Only WSL UNC paths are readable; the guest Linux path is not (as on a real
 // Windows host, where it would misresolve against the current drive).
-const fsState = vi.hoisted(() => ({ existsAll: false }))
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof NodeFsModule>()
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromisesModule>()
   return {
     ...actual,
-    existsSync: (path: string) =>
-      fsState.existsAll || path.startsWith('\\\\wsl.localhost\\') || actual.existsSync(path)
+    access: async (path: string) => {
+      if (!path.startsWith('\\\\wsl.localhost\\')) {
+        await actual.access(path)
+      }
+    }
   }
 })
 
@@ -53,7 +55,6 @@ beforeEach(() => {
   vi.mocked(listWslDistrosAsync).mockClear()
   scanned.dirs = []
   scanned.hostRootHasRollout = false
-  fsState.existsAll = false
   setPlatform('win32')
 })
 
@@ -79,7 +80,6 @@ describe('resolveSessionFilePath on a Windows host with WSL', () => {
   it('does not enumerate WSL distros when a host Codex root already has the rollout', async () => {
     // Why: listing WSL homes spawns wsl.exe per distro, which boots distros the
     // user deliberately left stopped. It must stay a last resort.
-    fsState.existsAll = true
     scanned.hostRootHasRollout = true
 
     await expect(resolveSessionFilePath('codex', 'wsl-sess')).resolves.toBe(HOST_ROLLOUT)

--- a/src/main/native-chat/session-file-resolver-wsl.test.ts
+++ b/src/main/native-chat/session-file-resolver-wsl.test.ts
@@ -13,8 +13,12 @@ vi.mock('../wsl', () => ({
   getWslHomeAsync: vi.fn(async () => UBUNTU_HOME)
 }))
 
-// Only WSL UNC paths are readable; the guest Linux path is not (as on a real
-// Windows host, where it would misresolve against the current drive).
+// Only these UNC fixtures are readable. Every other `\\wsl.localhost\` path —
+// wrong distro, missing file — must reject, or the mock would mask a misresolve.
+// Non-WSL paths hit the real fs, so the guest Linux path stays unreadable as on a
+// real Windows host, where it would misresolve against the current drive.
+const READABLE_WSL_UNC_PATHS = new Set([ROLLOUT_UNC])
+
 vi.mock('node:fs/promises', async (importOriginal) => {
   const actual = await importOriginal<typeof NodeFsPromisesModule>()
   return {
@@ -22,6 +26,10 @@ vi.mock('node:fs/promises', async (importOriginal) => {
     access: async (path: string) => {
       if (!path.startsWith('\\\\wsl.localhost\\')) {
         await actual.access(path)
+        return
+      }
+      if (!READABLE_WSL_UNC_PATHS.has(path)) {
+        throw Object.assign(new Error(`ENOENT: ${path}`), { code: 'ENOENT' })
       }
     }
   }
@@ -69,6 +77,14 @@ describe('resolveSessionFilePath on a Windows host with WSL', () => {
       codexSessionsDirs: []
     })
     expect(resolved).toBe(ROLLOUT_UNC)
+  })
+
+  it('does not return a UNC twin that no distro actually has', async () => {
+    const resolved = await resolveSessionFilePath('codex', 'wsl-sess', {
+      transcriptPath: '/home/ada/.codex/sessions/2026/07/24/rollout-gone.jsonl',
+      codexSessionsDirs: []
+    })
+    expect(resolved).toBeNull()
   })
 
   it('searches the WSL managed Codex sessions root when no hook path is known', async () => {

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -1,10 +1,8 @@
-import type { Dirent } from 'node:fs'
-import { readdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import type { AgentType } from '../../shared/native-chat-types'
 import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
-import { foldWslUncPathCaseInsensitiveParts, isWslUncPath } from '../../shared/wsl-paths'
+import { isWslUncPath } from '../../shared/wsl-paths'
 import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from '../ai-vault/session-scanner-omp-subagent-transcripts'
 import { normalizeAgentSessionsDir } from '../ai-vault/session-scanner-values'
@@ -14,7 +12,7 @@ import {
   resolveGrokSessionsDir
 } from '../../shared/grok-session-paths'
 import { toHostReadableTranscriptPath, wslCodexSessionsDirs } from './host-readable-transcript-path'
-import { runWslTranscriptFsTask, shareWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+import { findWslCodexSessionPath } from './wsl-codex-session-path-scan'
 
 // Why: these mirror the path constants in ai-vault/session-scanner.ts. Reads
 // run in the main process against the runtime's own home directory; over SSH
@@ -32,9 +30,8 @@ function claudeProjectsDir(): string {
 // fall back to CODEX_HOME/~/.codex so a non-Orca Codex transcript still resolves.
 // Duplicates are filtered so a managed-home symlink to ~/.codex isn't scanned twice.
 // WSL roots are a separate lazy tier — see resolveCodexSessionFile.
-// Why: resolve-only, so use the path-only variant — getOrcaManagedCodexHomePath
-// mkdirSyncs, and this runs on the 500ms–5s resolve poll. Creating the runtime
-// home is launch-time work, and a missing root already walks to no matches.
+// Why: resolveOrcaManagedCodexHomePath avoids the mkdirSync performed by the
+// getter; creating the runtime home belongs to launch, not this resolve poll.
 function codexSessionsDirs(): string[] {
   const candidates = [
     join(resolveOrcaManagedCodexHomePath(), 'sessions'),
@@ -86,8 +83,10 @@ export type ResolveSessionFileOptions = {
 export async function resolveSessionFilePath(
   agent: AgentType,
   sessionId: string,
-  options: ResolveSessionFileOptions = {}
+  options: ResolveSessionFileOptions = {},
+  signal?: AbortSignal
 ): Promise<string | null> {
+  signal?.throwIfAborted()
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
   if (!transcriptAgent) {
     return null
@@ -98,7 +97,7 @@ export async function resolveSessionFilePath(
   // stale/missing paths fall through to the id-based search.
   const hookPath = options.transcriptPath?.trim()
   if (hookPath && extname(hookPath) === '.jsonl') {
-    const hostReadable = await toHostReadableTranscriptPath(hookPath)
+    const hostReadable = await toHostReadableTranscriptPath(hookPath, { signal })
     if (hostReadable) {
       return hostReadable
     }
@@ -110,7 +109,11 @@ export async function resolveSessionFilePath(
   }
 
   if (transcriptAgent === 'claude') {
-    return resolveClaudeSessionFile(trimmedId, options.claudeProjectsDir ?? claudeProjectsDir())
+    return resolveClaudeSessionFile(
+      trimmedId,
+      options.claudeProjectsDir ?? claudeProjectsDir(),
+      signal
+    )
   }
   if (transcriptAgent === 'codex') {
     const overrideDirs = options.codexSessionsDirs
@@ -119,26 +122,29 @@ export async function resolveSessionFilePath(
       overrideDirs ?? codexSessionsDirs(),
       // Why: enumerating WSL homes spawns wsl.exe per distro, which boots ones the
       // user left stopped. Only pay that after this host's own Codex roots miss.
-      overrideDirs ? undefined : wslCodexSessionsDirs
+      overrideDirs ? undefined : wslCodexSessionsDirs,
+      signal
     )
   }
   if (transcriptAgent === 'grok') {
-    return resolveGrokSessionFile(trimmedId, options.grokSessionsDir ?? grokSessionsDir())
+    return resolveGrokSessionFile(trimmedId, options.grokSessionsDir ?? grokSessionsDir(), signal)
   }
   if (transcriptAgent === 'omp') {
-    return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir())
+    return resolveOmpSessionFile(trimmedId, options.ompSessionsDir ?? ompSessionsDir(), signal)
   }
   return null
 }
 
 async function resolveClaudeSessionFile(
   sessionId: string,
-  projectsDir: string
+  projectsDir: string,
+  signal?: AbortSignal
 ): Promise<string | null> {
   const targetName = `${sessionId}.jsonl`
   const files = await walkSessionFiles(projectsDir, 'claude', [], {
     extensions: new Set(['.jsonl']),
-    filePredicate: (path) => basename(path) === targetName
+    filePredicate: (path) => basename(path) === targetName,
+    signal
   })
   return files[0] ?? null
 }
@@ -146,27 +152,31 @@ async function resolveClaudeSessionFile(
 async function resolveCodexSessionFile(
   sessionId: string,
   sessionsDirs: string[],
-  loadFallbackDirs?: () => Promise<string[]>
+  loadFallbackDirs?: () => Promise<string[]>,
+  signal?: AbortSignal
 ): Promise<string | null> {
   // Codex rollout file names embed the session id (rollout-<ts>-<id>.jsonl), so
   // match the id as a suffix of the file's base name rather than an exact name.
   // Search each candidate root (managed home first) and stop at the first match.
-  const hit = await findCodexRolloutInDirs(sessionId, sessionsDirs)
+  const hit = await findCodexRolloutInDirs(sessionId, sessionsDirs, signal)
   if (hit) {
     return hit
   }
   if (!loadFallbackDirs) {
     return null
   }
+  signal?.throwIfAborted()
   // Why: a WSL-hosted session's rollout only exists inside the distro, so fall
   // back to each distro's Codex homes when the host's own roots came up empty (#10326).
   const fallbackDirs = (await loadFallbackDirs()).filter((dir) => !sessionsDirs.includes(dir))
-  return findCodexRolloutInDirs(sessionId, fallbackDirs)
+  signal?.throwIfAborted()
+  return findCodexRolloutInDirs(sessionId, fallbackDirs, signal)
 }
 
 async function findCodexRolloutInDirs(
   sessionId: string,
-  sessionsDirs: string[]
+  sessionsDirs: string[],
+  signal?: AbortSignal
 ): Promise<string | null> {
   for (const sessionsDir of sessionsDirs) {
     // Why: no existence pre-check — walkSessionFiles already yields [] for a
@@ -180,36 +190,31 @@ async function findCodexRolloutInDirs(
       }
     }
     const isWslRoot = isWslUncPath(sessionsDir)
-    const identity = foldWslUncPathCaseInsensitiveParts(sessionsDir) ?? sessionsDir
     const files = isWslRoot
-      ? await shareWslTranscriptFsTask(JSON.stringify(['codex-scan', identity, sessionId]), () =>
-          walkSessionFiles(sessionsDir, 'codex', [], {
+      ? await findWslCodexSessionPath(sessionsDir, sessionId, signal)
+      : (
+          await walkSessionFiles(sessionsDir, 'codex', [], {
             ...scanOptions,
-            readDirectory: readWslCodexSessionDirectory
+            signal
           })
-        )
-      : await walkSessionFiles(sessionsDir, 'codex', [], scanOptions)
-    if (files[0]) {
-      return files[0]
+        )[0]
+    if (files) {
+      return files
     }
   }
   return null
 }
 
-function readWslCodexSessionDirectory(dirPath: string): Promise<Dirent[]> {
-  const identity = foldWslUncPathCaseInsensitiveParts(dirPath) ?? dirPath
-  return runWslTranscriptFsTask(JSON.stringify(['codex-readdir', identity]), () =>
-    readdir(dirPath, { withFileTypes: true })
-  )
-}
-
 async function resolveGrokSessionFile(
   sessionId: string,
-  sessionsDir: string
+  sessionsDir: string,
+  signal?: AbortSignal
 ): Promise<string | null> {
   // Why: Native Chat runs on the main thread; use the bounded async direct-layout
   // lookup instead of blocking, then repeating, a recursive full-tree scan.
+  signal?.throwIfAborted()
   const history = await findGrokChatHistoryBySessionId(sessionsDir, sessionId)
+  signal?.throwIfAborted()
   return history
 }
 
@@ -219,7 +224,8 @@ async function resolveGrokSessionFile(
 // walk cover the per-cwd subdirectories.
 async function resolveOmpSessionFile(
   sessionId: string,
-  sessionsDir: string
+  sessionsDir: string,
+  signal?: AbortSignal
 ): Promise<string | null> {
   const files = await walkSessionFiles(sessionsDir, 'omp', [], {
     extensions: new Set(['.jsonl']),
@@ -235,7 +241,8 @@ async function resolveOmpSessionFile(
     filePredicate: (path) => {
       const name = basename(path, extname(path))
       return name === sessionId || name.endsWith(`_${sessionId}`)
-    }
+    },
+    signal
   })
   return files[0] ?? null
 }

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -1,4 +1,3 @@
-import { existsSync } from 'node:fs'
 import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import type { AgentType } from '../../shared/native-chat-types'
@@ -163,9 +162,9 @@ async function findCodexRolloutInDirs(
   sessionsDirs: string[]
 ): Promise<string | null> {
   for (const sessionsDir of sessionsDirs) {
-    if (!existsSync(sessionsDir)) {
-      continue
-    }
+    // Why: no existence pre-check — walkSessionFiles already yields [] for a
+    // missing/unreadable root, and a sync probe would block the main thread on a
+    // `\\wsl.localhost` root whose distro is stopped.
     const files = await walkSessionFiles(sessionsDir, 'codex', [], {
       extensions: new Set(['.jsonl']),
       filePredicate: (path) => {

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -1,7 +1,10 @@
+import type { Dirent } from 'node:fs'
+import { readdir } from 'node:fs/promises'
 import { homedir } from 'node:os'
 import { basename, extname, join } from 'node:path'
 import type { AgentType } from '../../shared/native-chat-types'
 import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
+import { foldWslUncPathCaseInsensitiveParts, isWslUncPath } from '../../shared/wsl-paths'
 import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from '../ai-vault/session-scanner-omp-subagent-transcripts'
 import { normalizeAgentSessionsDir } from '../ai-vault/session-scanner-values'
@@ -11,6 +14,7 @@ import {
   resolveGrokSessionsDir
 } from '../../shared/grok-session-paths'
 import { toHostReadableTranscriptPath, wslCodexSessionsDirs } from './host-readable-transcript-path'
+import { runWslTranscriptFsTask, shareWslTranscriptFsTask } from './wsl-transcript-fs-gate'
 
 // Why: these mirror the path constants in ai-vault/session-scanner.ts. Reads
 // run in the main process against the runtime's own home directory; over SSH
@@ -168,18 +172,35 @@ async function findCodexRolloutInDirs(
     // Why: no existence pre-check — walkSessionFiles already yields [] for a
     // missing/unreadable root, and a sync probe would block the main thread on a
     // `\\wsl.localhost` root whose distro is stopped.
-    const files = await walkSessionFiles(sessionsDir, 'codex', [], {
+    const scanOptions = {
       extensions: new Set(['.jsonl']),
-      filePredicate: (path) => {
+      filePredicate: (path: string): boolean => {
         const name = basename(path, extname(path))
         return name === sessionId || name.endsWith(`-${sessionId}`)
       }
-    })
+    }
+    const isWslRoot = isWslUncPath(sessionsDir)
+    const identity = foldWslUncPathCaseInsensitiveParts(sessionsDir) ?? sessionsDir
+    const files = isWslRoot
+      ? await shareWslTranscriptFsTask(JSON.stringify(['codex-scan', identity, sessionId]), () =>
+          walkSessionFiles(sessionsDir, 'codex', [], {
+            ...scanOptions,
+            readDirectory: readWslCodexSessionDirectory
+          })
+        )
+      : await walkSessionFiles(sessionsDir, 'codex', [], scanOptions)
     if (files[0]) {
       return files[0]
     }
   }
   return null
+}
+
+function readWslCodexSessionDirectory(dirPath: string): Promise<Dirent[]> {
+  const identity = foldWslUncPathCaseInsensitiveParts(dirPath) ?? dirPath
+  return runWslTranscriptFsTask(JSON.stringify(['codex-readdir', identity]), () =>
+    readdir(dirPath, { withFileTypes: true })
+  )
 }
 
 async function resolveGrokSessionFile(

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -5,7 +5,7 @@ import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent
 import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
 import { OMP_SESSION_ARTIFACT_DIR_PATTERN } from '../ai-vault/session-scanner-omp-subagent-transcripts'
 import { normalizeAgentSessionsDir } from '../ai-vault/session-scanner-values'
-import { getOrcaManagedCodexHomePath } from '../codex/codex-home-paths'
+import { resolveOrcaManagedCodexHomePath } from '../codex/codex-home-paths'
 import {
   findGrokChatHistoryBySessionId,
   resolveGrokSessionsDir
@@ -28,9 +28,12 @@ function claudeProjectsDir(): string {
 // fall back to CODEX_HOME/~/.codex so a non-Orca Codex transcript still resolves.
 // Duplicates are filtered so a managed-home symlink to ~/.codex isn't scanned twice.
 // WSL roots are a separate lazy tier — see resolveCodexSessionFile.
+// Why: resolve-only, so use the path-only variant — getOrcaManagedCodexHomePath
+// mkdirSyncs, and this runs on the 500ms–5s resolve poll. Creating the runtime
+// home is launch-time work, and a missing root already walks to no matches.
 function codexSessionsDirs(): string[] {
   const candidates = [
-    join(getOrcaManagedCodexHomePath(), 'sessions'),
+    join(resolveOrcaManagedCodexHomePath(), 'sessions'),
     join(process.env.CODEX_HOME?.trim() || join(homedir(), '.codex'), 'sessions')
   ]
   return candidates.filter((dir, index) => candidates.indexOf(dir) === index)

--- a/src/main/native-chat/transcript-tail-reader-cancellation.test.ts
+++ b/src/main/native-chat/transcript-tail-reader-cancellation.test.ts
@@ -1,0 +1,52 @@
+import type * as NodeFsPromisesModule from 'node:fs/promises'
+import { describe, expect, it, vi } from 'vitest'
+
+const fsMocks = vi.hoisted(() => ({
+  open: vi.fn(),
+  stat: vi.fn()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof NodeFsPromisesModule>()),
+  open: fsMocks.open,
+  stat: fsMocks.stat
+}))
+
+import { readNativeChatTranscriptTail } from './transcript-tail-reader'
+
+describe('native chat transcript tail cancellation', () => {
+  it('rejects after pending tail I/O closes when the request is canceled', async () => {
+    let finishRead: (() => void) | undefined
+    const close = vi.fn(async () => {})
+    const read = vi.fn(
+      (buffer: Buffer) =>
+        new Promise<{ bytesRead: number; buffer: Buffer }>((resolve) => {
+          finishRead = () => {
+            buffer[0] = 0x0a
+            resolve({ bytesRead: 1, buffer })
+          }
+        })
+    )
+    fsMocks.stat.mockResolvedValue({ size: 1 })
+    fsMocks.open.mockResolvedValue({ close, read })
+    const controller = new AbortController()
+    const canceled = new Error('request canceled')
+    const pending = readNativeChatTranscriptTail(
+      {
+        agent: 'claude',
+        sessionId: 'session-id',
+        filePath: 'transcript.jsonl',
+        limit: 40
+      },
+      controller.signal
+    )
+    const rejection = expect(pending).rejects.toBe(canceled)
+    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce())
+
+    controller.abort(canceled)
+    finishRead?.()
+
+    await rejection
+    expect(close).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -204,7 +204,8 @@ export async function readNativeChatTranscriptTail(
     filePath?: string
     limit: number
     beforeOffset?: number
-  }
+  },
+  signal?: AbortSignal
 ): Promise<
   | {
       messages: NativeChatMessage[]
@@ -216,7 +217,9 @@ export async function readNativeChatTranscriptTail(
 > {
   const decode = nativeChatLineDecoderForAgent(args.agent)
   const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
-  const filePath = args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args))
+  const filePath =
+    args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args, signal))
+  signal?.throwIfAborted()
   if (!decode) {
     return { error: 'Transcript unavailable' }
   }

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -237,6 +237,7 @@ export async function readNativeChatTranscriptTail(
       args.beforeOffset,
       decodeLifecycle
     )
+    signal?.throwIfAborted()
     return {
       messages: result.messages,
       // Why: an older pagination page must not rewind the live lifecycle; only
@@ -248,6 +249,7 @@ export async function readNativeChatTranscriptTail(
       beforeOffset: result.beforeOffset
     }
   } catch (error) {
+    signal?.throwIfAborted()
     const message = error instanceof Error ? error.message : String(error)
     return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
       ? { error: message, notFound: true }

--- a/src/main/native-chat/transcript-watch-resolve-poll.test.ts
+++ b/src/main/native-chat/transcript-watch-resolve-poll.test.ts
@@ -148,4 +148,59 @@ describe('native chat transcript resolve polling', () => {
     subscription.unsubscribe()
     expect(receivedSignal?.aborted).toBe(true)
   })
+
+  it('does not install after initial resolution is cancelled', async () => {
+    let finishResolve: ((path: string) => void) | undefined
+    mocks.resolve.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          finishResolve = resolve
+        })
+    )
+    const controller = new AbortController()
+    const cancelled = new Error('setup cancelled')
+    const setup = subscribeNativeChatTranscript(
+      {
+        agent: 'codex',
+        sessionId: 'session-id',
+        onAppend: () => {}
+      },
+      controller.signal
+    )
+
+    controller.abort(cancelled)
+    finishResolve?.('/transcript.jsonl')
+    await expect(setup).rejects.toBe(cancelled)
+    expect(mocks.install).not.toHaveBeenCalled()
+  })
+
+  it('tears down a watcher returned after initial setup is cancelled', async () => {
+    mocks.resolve.mockResolvedValue('/transcript.jsonl')
+    const installControl: {
+      finish?: (subscription: { unsubscribe: () => void; watching: boolean }) => void
+    } = {}
+    const unsubscribe = vi.fn()
+    mocks.install.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          installControl.finish = resolve
+        })
+    )
+    const controller = new AbortController()
+    const cancelled = new Error('setup cancelled')
+    const setup = subscribeNativeChatTranscript(
+      {
+        agent: 'codex',
+        sessionId: 'session-id',
+        onAppend: () => {}
+      },
+      controller.signal
+    )
+    await vi.waitFor(() => expect(mocks.install).toHaveBeenCalledOnce())
+
+    controller.abort(cancelled)
+    installControl.finish?.({ unsubscribe, watching: true })
+    await expect(setup).rejects.toBe(cancelled)
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
 })

--- a/src/main/native-chat/transcript-watch-resolve-poll.test.ts
+++ b/src/main/native-chat/transcript-watch-resolve-poll.test.ts
@@ -124,4 +124,28 @@ describe('native chat transcript resolve polling', () => {
     expect(mocks.resolve.mock.calls.length).toBeGreaterThan(1)
     subscription.unsubscribe()
   })
+
+  it('cancels queued WSL resolution when the subscription closes', async () => {
+    setPlatform('win32')
+    let receivedSignal: AbortSignal | undefined
+    mocks.toHostReadable.mockImplementation(
+      (_path: string, deps: { signal?: AbortSignal }) =>
+        new Promise<null>((_resolve, reject) => {
+          receivedSignal = deps.signal
+          deps.signal?.addEventListener('abort', () => reject(deps.signal?.reason), { once: true })
+        })
+    )
+    const subscription = await subscribeNativeChatTranscript({
+      agent: 'codex',
+      sessionId: 'session-id',
+      transcriptPath: '/home/ada/.codex/sessions/rollout-session-id.jsonl',
+      resolvePollIntervalMs: 10,
+      onAppend: () => {}
+    })
+
+    await vi.advanceTimersByTimeAsync(10)
+    expect(receivedSignal?.aborted).toBe(false)
+    subscription.unsubscribe()
+    expect(receivedSignal?.aborted).toBe(true)
+  })
 })

--- a/src/main/native-chat/transcript-watch-resolve-poll.test.ts
+++ b/src/main/native-chat/transcript-watch-resolve-poll.test.ts
@@ -68,7 +68,7 @@ describe('native chat transcript resolve polling', () => {
   })
 
   it('retries the WSL translation on the slow cadence, never installing the raw guest path', async () => {
-    // Why: each translation sync-stats the UNC twin per distro over the 9P
+    // Why: each translation probes the UNC twin per distro over the 9P
     // share; doing it every fast tick would hammer the main process (#10326).
     setPlatform('win32')
     const subscription = await subscribeNativeChatTranscript({

--- a/src/main/native-chat/transcript-watch-wsl-exact-path.test.ts
+++ b/src/main/native-chat/transcript-watch-wsl-exact-path.test.ts
@@ -1,5 +1,5 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import type * as NodeFsModule from 'node:fs'
+import type * as NodeFsPromisesModule from 'node:fs/promises'
 
 const UBUNTU_HOME = '\\\\wsl.localhost\\Ubuntu\\home\\ada'
 const ROLLOUT_LINUX =
@@ -23,11 +23,15 @@ vi.mock('../wsl', () => ({
   listWslDistrosAsync: vi.fn(async () => ['Ubuntu']),
   getWslHomeAsync: vi.fn(async () => UBUNTU_HOME)
 }))
-vi.mock('node:fs', async (importOriginal) => {
-  const actual = await importOriginal<typeof NodeFsModule>()
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromisesModule>()
   return {
     ...actual,
-    existsSync: (path: string) => path === ROLLOUT_UNC || actual.existsSync(path)
+    access: async (path: string) => {
+      if (path !== ROLLOUT_UNC) {
+        await actual.access(path)
+      }
+    }
   }
 })
 

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -28,10 +28,16 @@ async function attemptInstall(
 ): Promise<NativeChatTranscriptSubscription | null> {
   const filePath =
     args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args, signal))
+  signal?.throwIfAborted()
   if (!filePath) {
     return null
   }
-  return installTranscriptWatcher(filePath, decode, args)
+  const installed = await installTranscriptWatcher(filePath, decode, args)
+  if (signal?.aborted) {
+    installed?.unsubscribe()
+    signal.throwIfAborted()
+  }
+  return installed
 }
 
 // Why: Claude Code (and other agents) can take from ~3s to minutes to flush a
@@ -185,8 +191,10 @@ function subscribeViaResolvePoll(
  * than returning a no-op that never recovers.
  */
 export async function subscribeNativeChatTranscript(
-  args: SubscribeNativeChatTranscriptArgs
+  args: SubscribeNativeChatTranscriptArgs,
+  setupSignal?: AbortSignal
 ): Promise<NativeChatTranscriptSubscription> {
+  setupSignal?.throwIfAborted()
   const decode = nativeChatLineDecoderForAgent(args.agent)
   if (!decode) {
     // Nothing watchable — return a no-op teardown so callers can unconditionally
@@ -199,9 +207,10 @@ export async function subscribeNativeChatTranscript(
     return { unsubscribe: () => {}, watching: false }
   }
 
-  const installed = await attemptInstall(args, decode)
+  const installed = await attemptInstall(args, decode, setupSignal)
   if (installed) {
     return installed
   }
+  setupSignal?.throwIfAborted()
   return subscribeViaResolvePoll(args, decode)
 }

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -106,7 +106,7 @@ function subscribeViaResolvePoll(
           // not-yet-created file, so don't spend an extra probe per tick.
           hostReadableExactPath = exactPath
         } else if (Date.now() - lastWslTranslateAt >= FALLBACK_RESOLVE_POLL_MS) {
-          // Why: translating sync-stats the UNC twin per distro over the 9P
+          // Why: translating probes the UNC twin per distro over the 9P
           // share, and the guest file usually appears well after the hook does,
           // so retry on the slow cadence rather than every fast tick. The raw
           // guest path is never installed on Windows — it would resolve against

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -23,9 +23,11 @@ export type {
  *  is unresolved; native-watch failure degrades to reconciliation-only mode. */
 async function attemptInstall(
   args: SubscribeNativeChatTranscriptArgs,
-  decode: (line: string, fallbackId: string) => NativeChatMessage | null
+  decode: (line: string, fallbackId: string) => NativeChatMessage | null,
+  signal?: AbortSignal
 ): Promise<NativeChatTranscriptSubscription | null> {
-  const filePath = args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args))
+  const filePath =
+    args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args, signal))
   if (!filePath) {
     return null
   }
@@ -69,6 +71,7 @@ function subscribeViaResolvePoll(
   // the exact-path install doesn't wait on the slower id-glob (#10326).
   let hostReadableExactPath: string | null = null
   let lastWslTranslateAt = 0
+  const resolveController = new AbortController()
 
   function scheduleAttempt(): void {
     if (closed) {
@@ -112,18 +115,24 @@ function subscribeViaResolvePoll(
           // guest path is never installed on Windows — it would resolve against
           // the current drive (`C:\home\…`) and bind chat to a look-alike file.
           lastWslTranslateAt = Date.now()
-          hostReadableExactPath = await toHostReadableTranscriptPath(exactPath)
+          hostReadableExactPath = await toHostReadableTranscriptPath(exactPath, {
+            signal: resolveController.signal
+          })
         }
       }
       result = hostReadableExactPath
-        ? await attemptInstall({ ...args, filePath: hostReadableExactPath }, decode)
+        ? await attemptInstall(
+            { ...args, filePath: hostReadableExactPath },
+            decode,
+            resolveController.signal
+          )
         : null
       if (
         !result &&
         (!exactPath || Date.now() - lastFallbackResolveAt >= FALLBACK_RESOLVE_POLL_MS)
       ) {
         lastFallbackResolveAt = Date.now()
-        result = await attemptInstall(args, decode)
+        result = await attemptInstall(args, decode, resolveController.signal)
       }
     } catch {
       // Why: a transient resolve failure (EACCES/EIO during the glob) must not
@@ -151,6 +160,7 @@ function subscribeViaResolvePoll(
         return
       }
       closed = true
+      resolveController.abort()
       if (pollTimer) {
         clearTimeout(pollTimer)
         pollTimer = null

--- a/src/main/native-chat/wsl-codex-session-path-scan.test.ts
+++ b/src/main/native-chat/wsl-codex-session-path-scan.test.ts
@@ -1,0 +1,79 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mocks = vi.hoisted(() => ({ walk: vi.fn() }))
+
+vi.mock('../ai-vault/session-scanner-discovery', () => ({
+  walkSessionFiles: mocks.walk
+}))
+
+import { findWslCodexSessionPath } from './wsl-codex-session-path-scan'
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  return { promise: new Promise<T>((res) => (resolve = res)), resolve }
+}
+
+beforeEach(() => {
+  mocks.walk.mockReset()
+})
+
+describe('WSL Codex session path scans', () => {
+  it('shares one root snapshot across concurrent session ids', async () => {
+    const scan = deferred<string[]>()
+    mocks.walk.mockReturnValue(scan.promise)
+
+    const first = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'first')
+    const second = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'second')
+    scan.resolve([
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-first.jsonl',
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-second.jsonl'
+    ])
+
+    await expect(Promise.all([first, second])).resolves.toEqual([
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-first.jsonl',
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-second.jsonl'
+    ])
+    expect(mocks.walk).toHaveBeenCalledOnce()
+  })
+
+  it('refreshes a shared miss so post-start file creation is visible', async () => {
+    const initial = deferred<string[]>()
+    mocks.walk
+      .mockReturnValueOnce(initial.promise)
+      .mockResolvedValueOnce(['\\\\wsl.localhost\\Ubuntu\\sessions\\2026\\rollout-created.jsonl'])
+
+    const initialCaller = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'absent')
+    const laterCaller = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'created')
+    initial.resolve([])
+
+    await expect(initialCaller).resolves.toBeNull()
+    await expect(laterCaller).resolves.toBe(
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\2026\\rollout-created.jsonl'
+    )
+    expect(mocks.walk).toHaveBeenCalledTimes(2)
+  })
+
+  it('aborts an abandoned scan when its final waiter closes', async () => {
+    let scanSignal: AbortSignal | undefined
+    mocks.walk.mockImplementation(
+      (_root: string, _agent: string, _issues: unknown[], options: { signal?: AbortSignal }) => {
+        scanSignal = options.signal
+        return new Promise<string[]>((_resolve, reject) => {
+          options.signal?.addEventListener('abort', () => reject(options.signal?.reason), {
+            once: true
+          })
+        })
+      }
+    )
+    const controller = new AbortController()
+    const scan = findWslCodexSessionPath(
+      '\\\\wsl.localhost\\Ubuntu\\sessions',
+      'closed',
+      controller.signal
+    )
+
+    controller.abort(new Error('closed'))
+    await expect(scan).rejects.toThrow('closed')
+    expect(scanSignal?.aborted).toBe(true)
+  })
+})

--- a/src/main/native-chat/wsl-codex-session-path-scan.test.ts
+++ b/src/main/native-chat/wsl-codex-session-path-scan.test.ts
@@ -20,20 +20,34 @@ beforeEach(() => {
 describe('WSL Codex session path scans', () => {
   it('shares one root snapshot across concurrent session ids', async () => {
     const scan = deferred<string[]>()
-    mocks.walk.mockReturnValue(scan.promise)
+    let filePredicate: ((path: string) => boolean) | undefined
+    mocks.walk.mockImplementation(
+      (
+        _root: string,
+        _agent: string,
+        _issues: unknown[],
+        options: { filePredicate?: (path: string) => boolean }
+      ) => {
+        filePredicate = options.filePredicate
+        return scan.promise
+      }
+    )
 
     const first = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'first')
     const second = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'second')
-    scan.resolve([
+    const candidates = [
       '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-first.jsonl',
-      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-second.jsonl'
-    ])
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-second.jsonl',
+      '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-unrelated.jsonl'
+    ]
+    scan.resolve(candidates.filter((path) => filePredicate?.(path)))
 
     await expect(Promise.all([first, second])).resolves.toEqual([
       '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-first.jsonl',
       '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-second.jsonl'
     ])
     expect(mocks.walk).toHaveBeenCalledOnce()
+    expect(filePredicate?.(candidates[2])).toBe(false)
   })
 
   it('refreshes a shared miss so post-start file creation is visible', async () => {
@@ -75,5 +89,91 @@ describe('WSL Codex session path scans', () => {
     controller.abort(new Error('closed'))
     await expect(scan).rejects.toThrow('closed')
     expect(scanSignal?.aborted).toBe(true)
+  })
+
+  it('does not attach new callers to an abandoned scan', async () => {
+    const abandoned = deferred<string[]>()
+    const replacementScan = deferred<string[]>()
+    const replacementPath = '\\\\wsl.localhost\\Ubuntu\\sessions\\rollout-replacement.jsonl'
+    mocks.walk.mockReturnValueOnce(abandoned.promise).mockReturnValueOnce(replacementScan.promise)
+    const controller = new AbortController()
+    const first = findWslCodexSessionPath(
+      '\\\\wsl.localhost\\Ubuntu\\sessions',
+      'first',
+      controller.signal
+    )
+    await vi.waitFor(() => expect(mocks.walk).toHaveBeenCalledOnce())
+
+    controller.abort(new Error('closed'))
+    await expect(first).rejects.toThrow('closed')
+    const replacement = findWslCodexSessionPath(
+      '\\\\wsl.localhost\\Ubuntu\\sessions',
+      'replacement'
+    )
+    expect(mocks.walk).toHaveBeenCalledTimes(2)
+
+    abandoned.resolve([])
+    await Promise.resolve()
+    await Promise.resolve()
+    const duplicate = findWslCodexSessionPath('\\\\wsl.localhost\\Ubuntu\\sessions', 'replacement')
+    replacementScan.resolve([replacementPath])
+
+    await expect(Promise.all([replacement, duplicate])).resolves.toEqual([
+      replacementPath,
+      replacementPath
+    ])
+    expect(mocks.walk).toHaveBeenCalledTimes(2)
+  })
+
+  it('removes canceled joiners from a scan that still has an active waiter', async () => {
+    const scan = deferred<string[]>()
+    const scanThen = vi.spyOn(scan.promise, 'then')
+    let filePredicate: ((path: string) => boolean) | undefined
+    mocks.walk.mockImplementation(
+      (
+        _root: string,
+        _agent: string,
+        _issues: unknown[],
+        options: { filePredicate?: (path: string) => boolean }
+      ) => {
+        filePredicate = options.filePredicate
+        return scan.promise
+      }
+    )
+    const root = '\\\\wsl.localhost\\Ubuntu\\sessions'
+    const keeperPath = `${root}\\rollout-keeper.jsonl`
+    const keeper = findWslCodexSessionPath(root, 'keeper')
+    const initialThenCount = scanThen.mock.calls.length
+    const duplicateController = new AbortController()
+    const duplicate = findWslCodexSessionPath(root, 'keeper', duplicateController.signal)
+    const uniqueCanceled = Array.from({ length: 256 }, (_, index) => {
+      const controller = new AbortController()
+      return {
+        controller,
+        path: `${root}\\rollout-canceled-${index}.jsonl`,
+        promise: findWslCodexSessionPath(root, `canceled-${index}`, controller.signal)
+      }
+    })
+    const canceledResults = Promise.allSettled([
+      duplicate,
+      ...uniqueCanceled.map(({ promise }) => promise)
+    ])
+
+    duplicateController.abort(new Error('duplicate closed'))
+    for (const { controller } of uniqueCanceled) {
+      controller.abort(new Error('joiner closed'))
+    }
+
+    const results = await canceledResults
+    expect(results.every(({ status }) => status === 'rejected')).toBe(true)
+    expect(scanThen).toHaveBeenCalledTimes(initialThenCount)
+    expect(filePredicate?.(keeperPath)).toBe(true)
+    expect(uniqueCanceled.every(({ path }) => filePredicate?.(path) === false)).toBe(true)
+
+    const candidates = [keeperPath, ...uniqueCanceled.map(({ path }) => path)]
+    scan.resolve(candidates.filter((path) => filePredicate?.(path)))
+
+    await expect(keeper).resolves.toBe(keeperPath)
+    expect(mocks.walk).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/native-chat/wsl-codex-session-path-scan.test.ts
+++ b/src/main/native-chat/wsl-codex-session-path-scan.test.ts
@@ -85,6 +85,7 @@ describe('WSL Codex session path scans', () => {
       'closed',
       controller.signal
     )
+    await vi.waitFor(() => expect(mocks.walk).toHaveBeenCalledOnce())
 
     controller.abort(new Error('closed'))
     await expect(scan).rejects.toThrow('closed')
@@ -110,7 +111,7 @@ describe('WSL Codex session path scans', () => {
       '\\\\wsl.localhost\\Ubuntu\\sessions',
       'replacement'
     )
-    expect(mocks.walk).toHaveBeenCalledTimes(2)
+    await vi.waitFor(() => expect(mocks.walk).toHaveBeenCalledTimes(2))
 
     abandoned.resolve([])
     await Promise.resolve()

--- a/src/main/native-chat/wsl-codex-session-path-scan.ts
+++ b/src/main/native-chat/wsl-codex-session-path-scan.ts
@@ -1,0 +1,99 @@
+import type { Dirent } from 'node:fs'
+import { readdir } from 'node:fs/promises'
+import { basename, extname } from 'node:path'
+import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
+import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+
+type ScanGeneration = {
+  controller: AbortController
+  promise: Promise<string[]>
+  settled: boolean
+  waiterCount: number
+}
+
+const inFlightScans = new Map<string, ScanGeneration>()
+
+function readDirectory(dirPath: string, signal: AbortSignal): Promise<Dirent[]> {
+  return runWslTranscriptFsTask(
+    { operation: 'readdir', path: dirPath, priority: 'scan', signal },
+    () => readdir(dirPath, { withFileTypes: true })
+  )
+}
+
+function startScan(root: string): ScanGeneration {
+  const controller = new AbortController()
+  const scan: ScanGeneration = {
+    controller,
+    promise: walkSessionFiles(root, 'codex', [], {
+      extensions: new Set(['.jsonl']),
+      readDirectory: (dirPath) => readDirectory(dirPath, controller.signal),
+      signal: controller.signal
+    }),
+    settled: false,
+    waiterCount: 0
+  }
+  inFlightScans.set(root, scan)
+  const clear = (): void => {
+    scan.settled = true
+    if (inFlightScans.get(root) === scan) {
+      inFlightScans.delete(root)
+    }
+  }
+  void scan.promise.then(clear, clear)
+  return scan
+}
+
+function waitForScan(scan: ScanGeneration, signal?: AbortSignal): Promise<string[]> {
+  signal?.throwIfAborted()
+  scan.waiterCount += 1
+  let onAbort: (() => void) | undefined
+  const aborted = signal
+    ? new Promise<never>((_resolve, reject) => {
+        onAbort = () => reject(signal.reason ?? new Error('Codex session scan aborted'))
+        signal.addEventListener('abort', onAbort, { once: true })
+      })
+    : null
+  return Promise.race(aborted ? [scan.promise, aborted] : [scan.promise]).finally(() => {
+    if (signal && onAbort) {
+      signal.removeEventListener('abort', onAbort)
+    }
+    scan.waiterCount -= 1
+    if (!scan.settled && scan.waiterCount === 0) {
+      scan.controller.abort()
+    }
+  })
+}
+
+async function scanRoot(
+  root: string,
+  signal?: AbortSignal
+): Promise<{ paths: string[]; joined: boolean }> {
+  signal?.throwIfAborted()
+  const existing = inFlightScans.get(root)
+  const scan = existing ?? startScan(root)
+  return { paths: await waitForScan(scan, signal), joined: Boolean(existing) }
+}
+
+function findSessionPath(paths: string[], sessionId: string): string | null {
+  return (
+    paths.find((path) => {
+      const name = basename(path, extname(path))
+      return name === sessionId || name.endsWith(`-${sessionId}`)
+    }) ?? null
+  )
+}
+
+/** Share tree discovery, then refresh a shared miss for post-start file creation. */
+export async function findWslCodexSessionPath(
+  root: string,
+  sessionId: string,
+  signal?: AbortSignal
+): Promise<string | null> {
+  const first = await scanRoot(root, signal)
+  const firstHit = findSessionPath(first.paths, sessionId)
+  if (firstHit || !first.joined) {
+    return firstHit
+  }
+  const refreshed = await scanRoot(root, signal)
+  return findSessionPath(refreshed.paths, sessionId)
+}

--- a/src/main/native-chat/wsl-codex-session-path-scan.ts
+++ b/src/main/native-chat/wsl-codex-session-path-scan.ts
@@ -4,11 +4,20 @@ import { basename, extname } from 'node:path'
 import { walkSessionFiles } from '../ai-vault/session-scanner-discovery'
 import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
 
+type ScanWaiter = {
+  sessionId: string
+  resolve: (paths: string[]) => void
+  reject: (error: unknown) => void
+  signal?: AbortSignal
+  onAbort?: () => void
+}
+
 type ScanGeneration = {
+  root: string
   controller: AbortController
-  promise: Promise<string[]>
+  sessionIdRefCounts: Map<string, number>
+  waiters: Set<ScanWaiter>
   settled: boolean
-  waiterCount: number
 }
 
 const inFlightScans = new Map<string, ScanGeneration>()
@@ -20,67 +29,139 @@ function readDirectory(dirPath: string, signal: AbortSignal): Promise<Dirent[]> 
   )
 }
 
-function startScan(root: string): ScanGeneration {
-  const controller = new AbortController()
-  const scan: ScanGeneration = {
-    controller,
-    promise: walkSessionFiles(root, 'codex', [], {
-      extensions: new Set(['.jsonl']),
-      readDirectory: (dirPath) => readDirectory(dirPath, controller.signal),
-      signal: controller.signal
-    }),
-    settled: false,
-    waiterCount: 0
-  }
-  inFlightScans.set(root, scan)
-  const clear = (): void => {
-    scan.settled = true
-    if (inFlightScans.get(root) === scan) {
-      inFlightScans.delete(root)
+function sessionFileName(path: string): string {
+  return basename(path, extname(path))
+}
+
+function nameMatchesSessionId(name: string, sessionId: string): boolean {
+  return name === sessionId || name.endsWith(`-${sessionId}`)
+}
+
+function matchesRequestedSession(path: string, sessionIds: Map<string, number>): boolean {
+  const name = sessionFileName(path)
+  for (const sessionId of sessionIds.keys()) {
+    if (nameMatchesSessionId(name, sessionId)) {
+      return true
     }
   }
-  void scan.promise.then(clear, clear)
+  return false
+}
+
+function createScan(root: string): ScanGeneration {
+  const scan: ScanGeneration = {
+    root,
+    controller: new AbortController(),
+    sessionIdRefCounts: new Map(),
+    waiters: new Set(),
+    settled: false
+  }
+  inFlightScans.set(root, scan)
   return scan
 }
 
-function waitForScan(scan: ScanGeneration, signal?: AbortSignal): Promise<string[]> {
-  signal?.throwIfAborted()
-  scan.waiterCount += 1
-  let onAbort: (() => void) | undefined
-  const aborted = signal
-    ? new Promise<never>((_resolve, reject) => {
-        onAbort = () => reject(signal.reason ?? new Error('Codex session scan aborted'))
-        signal.addEventListener('abort', onAbort, { once: true })
-      })
-    : null
-  return Promise.race(aborted ? [scan.promise, aborted] : [scan.promise]).finally(() => {
-    if (signal && onAbort) {
-      signal.removeEventListener('abort', onAbort)
+function clearScan(scan: ScanGeneration): void {
+  if (inFlightScans.get(scan.root) === scan) {
+    inFlightScans.delete(scan.root)
+  }
+}
+
+function removeWaiter(scan: ScanGeneration, waiter: ScanWaiter): boolean {
+  if (!scan.waiters.delete(waiter)) {
+    return false
+  }
+  if (waiter.signal && waiter.onAbort) {
+    waiter.signal.removeEventListener('abort', waiter.onAbort)
+  }
+  const count = scan.sessionIdRefCounts.get(waiter.sessionId)
+  if (count === 1) {
+    scan.sessionIdRefCounts.delete(waiter.sessionId)
+  } else if (count) {
+    scan.sessionIdRefCounts.set(waiter.sessionId, count - 1)
+  }
+  return true
+}
+
+function settleScan(scan: ScanGeneration, outcome: { paths: string[] } | { error: unknown }): void {
+  if (scan.settled) {
+    return
+  }
+  scan.settled = true
+  clearScan(scan)
+  for (const waiter of scan.waiters) {
+    removeWaiter(scan, waiter)
+    if ('paths' in outcome) {
+      waiter.resolve(outcome.paths)
+    } else {
+      waiter.reject(outcome.error)
     }
-    scan.waiterCount -= 1
-    if (!scan.settled && scan.waiterCount === 0) {
-      scan.controller.abort()
+  }
+}
+
+function startScan(scan: ScanGeneration): void {
+  try {
+    const promise = walkSessionFiles(scan.root, 'codex', [], {
+      extensions: new Set(['.jsonl']),
+      filePredicate: (path) => matchesRequestedSession(path, scan.sessionIdRefCounts),
+      readDirectory: (dirPath) => readDirectory(dirPath, scan.controller.signal),
+      signal: scan.controller.signal
+    })
+    void promise.then(
+      (paths) => settleScan(scan, { paths }),
+      (error: unknown) => settleScan(scan, { error })
+    )
+  } catch (error) {
+    settleScan(scan, { error })
+  }
+}
+
+function waitForScan(
+  scan: ScanGeneration,
+  sessionId: string,
+  signal?: AbortSignal
+): Promise<string[]> {
+  signal?.throwIfAborted()
+  return new Promise<string[]>((resolve, reject) => {
+    const waiter: ScanWaiter = { sessionId, resolve, reject, signal }
+    scan.waiters.add(waiter)
+    scan.sessionIdRefCounts.set(sessionId, (scan.sessionIdRefCounts.get(sessionId) ?? 0) + 1)
+    if (!signal) {
+      return
+    }
+    waiter.onAbort = () => {
+      if (!removeWaiter(scan, waiter)) {
+        return
+      }
+      reject(signal.reason ?? new Error('Codex session scan aborted'))
+      if (!scan.settled && scan.waiters.size === 0) {
+        scan.settled = true
+        clearScan(scan)
+        scan.controller.abort()
+      }
+    }
+    signal.addEventListener('abort', waiter.onAbort, { once: true })
+    if (signal.aborted) {
+      waiter.onAbort()
     }
   })
 }
 
 async function scanRoot(
   root: string,
+  sessionId: string,
   signal?: AbortSignal
 ): Promise<{ paths: string[]; joined: boolean }> {
   signal?.throwIfAborted()
   const existing = inFlightScans.get(root)
-  const scan = existing ?? startScan(root)
-  return { paths: await waitForScan(scan, signal), joined: Boolean(existing) }
+  const scan = existing ?? createScan(root)
+  const pending = waitForScan(scan, sessionId, signal)
+  if (!existing) {
+    startScan(scan)
+  }
+  return { paths: await pending, joined: Boolean(existing) }
 }
 
 function findSessionPath(paths: string[], sessionId: string): string | null {
-  return (
-    paths.find((path) => {
-      const name = basename(path, extname(path))
-      return name === sessionId || name.endsWith(`-${sessionId}`)
-    }) ?? null
-  )
+  return paths.find((path) => nameMatchesSessionId(sessionFileName(path), sessionId)) ?? null
 }
 
 /** Share tree discovery, then refresh a shared miss for post-start file creation. */
@@ -89,11 +170,11 @@ export async function findWslCodexSessionPath(
   sessionId: string,
   signal?: AbortSignal
 ): Promise<string | null> {
-  const first = await scanRoot(root, signal)
+  const first = await scanRoot(root, sessionId, signal)
   const firstHit = findSessionPath(first.paths, sessionId)
   if (firstHit || !first.joined) {
     return firstHit
   }
-  const refreshed = await scanRoot(root, signal)
+  const refreshed = await scanRoot(root, sessionId, signal)
   return findSessionPath(refreshed.paths, sessionId)
 }

--- a/src/main/native-chat/wsl-transcript-fs-gate.test.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.test.ts
@@ -1,53 +1,146 @@
 import { describe, expect, it, vi } from 'vitest'
-import { runWslTranscriptFsTask, shareWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+import { runWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (error: unknown) => void
+  return {
+    promise: new Promise<T>((res, rej) => ((resolve = res), (reject = rej))),
+    resolve,
+    reject
+  }
+}
+
+function run(
+  path: string,
+  priority: 'exact' | 'scan',
+  task: () => Promise<string>,
+  signal?: AbortSignal
+): Promise<string> {
+  return runWslTranscriptFsTask(
+    { operation: priority === 'exact' ? 'access' : 'readdir', path, priority, signal },
+    task
+  )
+}
 
 describe('WSL transcript filesystem task scheduling', () => {
-  it('allows an exact probe to run between directory reads from one scan', async () => {
-    const started: string[] = []
-    let finishFirstRead: (() => void) | undefined
-    let finishExactProbe: (() => void) | undefined
+  it('does not block an exact probe behind a running scan on the same route', async () => {
+    const stalled = deferred<string>()
+    const scanTask = vi.fn(() => stalled.promise)
+    const scan = run('\\\\wsl.localhost\\Ubuntu\\tree', 'scan', scanTask)
+    await vi.waitFor(() => expect(scanTask).toHaveBeenCalledOnce())
 
-    const scan = shareWslTranscriptFsTask('scan:yield', async () => {
-      await runWslTranscriptFsTask(
-        'readdir:first',
-        () =>
-          new Promise<void>((resolve) => {
-            started.push('first-read')
-            finishFirstRead = resolve
-          })
-      )
-      await runWslTranscriptFsTask('readdir:second', async () => {
-        started.push('second-read')
-      })
-    })
-
-    await vi.waitFor(() => expect(started).toEqual(['first-read']))
-    const exactProbe = runWslTranscriptFsTask(
-      'access:exact',
-      () =>
-        new Promise<void>((resolve) => {
-          started.push('exact-probe')
-          finishExactProbe = resolve
-        })
-    )
-
-    finishFirstRead?.()
-    await vi.waitFor(() => expect(started).toEqual(['first-read', 'exact-probe']))
-    finishExactProbe?.()
-    await Promise.all([scan, exactProbe])
-    expect(started).toEqual(['first-read', 'exact-probe', 'second-read'])
+    await expect(
+      run('\\\\wsl.localhost\\Ubuntu\\transcript.jsonl', 'exact', async () => 'exact')
+    ).resolves.toBe('exact')
+    stalled.resolve('scan')
+    await expect(scan).resolves.toBe('scan')
   })
 
-  it('shares identical multi-read scans without consuming another permit', async () => {
-    const scanTask = vi.fn(async () => ['rollout.jsonl'])
+  it('allows healthy distros and provider routes to bypass a stalled lane', async () => {
+    const stalled = deferred<string>()
+    const ubuntuLocalhost = run('\\\\wsl.localhost\\Ubuntu\\home\\a', 'scan', () => stalled.promise)
+    const debian = vi.fn(async () => 'debian')
+    const ubuntuLegacy = vi.fn(async () => 'legacy')
 
-    const first = shareWslTranscriptFsTask('scan:same', scanTask)
-    const duplicate = shareWslTranscriptFsTask('scan:same', scanTask)
+    await expect(run('\\\\wsl.localhost\\Debian\\home\\a', 'exact', debian)).resolves.toBe('debian')
+    await expect(run('\\\\wsl$\\Ubuntu\\home\\a', 'exact', ubuntuLegacy)).resolves.toBe('legacy')
+    expect(debian).toHaveBeenCalledOnce()
+    expect(ubuntuLegacy).toHaveBeenCalledOnce()
 
-    await expect(Promise.all([first, duplicate])).resolves.toEqual([
-      ['rollout.jsonl'],
-      ['rollout.jsonl']
-    ])
-    expect(scanTask).toHaveBeenCalledTimes(1)
+    stalled.resolve('localhost')
+    await expect(ubuntuLocalhost).resolves.toBe('localhost')
+  })
+
+  it('runs an exact probe before older queued scan work', async () => {
+    const ubuntu = deferred<string>()
+    const debian = deferred<string>()
+    const occupied: string[] = []
+    const started: string[] = []
+    const first = run('\\\\wsl.localhost\\Ubuntu\\a', 'exact', () => {
+      occupied.push('ubuntu')
+      return ubuntu.promise
+    })
+    const second = run('\\\\wsl.localhost\\Debian\\a', 'exact', () => {
+      occupied.push('debian')
+      return debian.promise
+    })
+    await vi.waitFor(() => expect(occupied).toEqual(['ubuntu', 'debian']))
+
+    const scan = run('\\\\wsl.localhost\\Fedora\\tree', 'scan', async () => {
+      started.push('scan')
+      return 'scan'
+    })
+    const exact = run('\\\\wsl.localhost\\Fedora\\file', 'exact', async () => {
+      started.push('exact')
+      return 'exact'
+    })
+
+    debian.resolve('debian')
+    await expect(exact).resolves.toBe('exact')
+    expect(started).toEqual(['exact', 'scan'])
+    await expect(scan).resolves.toBe('scan')
+    ubuntu.resolve('ubuntu')
+    await expect(Promise.all([first, second])).resolves.toEqual(['ubuntu', 'debian'])
+  })
+
+  it('drops abandoned queued work before it reaches the filesystem', async () => {
+    const ubuntu = deferred<string>()
+    const debian = deferred<string>()
+    const first = run('\\\\wsl.localhost\\Ubuntu\\a', 'scan', () => ubuntu.promise)
+    const second = run('\\\\wsl.localhost\\Debian\\a', 'scan', () => debian.promise)
+    const controller = new AbortController()
+    const abandonedTask = vi.fn(async () => 'unused')
+    const abandoned = run('\\\\wsl.localhost\\Fedora\\a', 'scan', abandonedTask, controller.signal)
+
+    controller.abort(new Error('closed subscription'))
+    await expect(abandoned).rejects.toThrow('closed subscription')
+    ubuntu.resolve('ubuntu')
+    debian.resolve('debian')
+    await Promise.all([first, second])
+    expect(abandonedTask).not.toHaveBeenCalled()
+  })
+
+  it('shares only byte-identical requests', async () => {
+    const firstTask = vi.fn(async () => 'first')
+    const duplicateTask = vi.fn(async () => 'duplicate')
+    const first = run('\\\\wsl.localhost\\Ubuntu\\home\\a', 'exact', firstTask)
+    const duplicate = run('\\\\wsl.localhost\\Ubuntu\\home\\a', 'exact', duplicateTask)
+
+    await expect(Promise.all([first, duplicate])).resolves.toEqual(['first', 'first'])
+    expect(firstTask).toHaveBeenCalledOnce()
+    expect(duplicateTask).not.toHaveBeenCalled()
+  })
+
+  it('keeps shared work needed by a remaining waiter', async () => {
+    const pending = deferred<string>()
+    const task = vi.fn(() => pending.promise)
+    const firstController = new AbortController()
+    const secondController = new AbortController()
+    const first = run('\\\\wsl.localhost\\Ubuntu\\shared', 'exact', task, firstController.signal)
+    const second = run('\\\\wsl.localhost\\Ubuntu\\shared', 'exact', task, secondController.signal)
+    await vi.waitFor(() => expect(task).toHaveBeenCalledOnce())
+
+    firstController.abort(new Error('first closed'))
+    await expect(first).rejects.toThrow('first closed')
+    pending.resolve('second')
+    await expect(second).resolves.toBe('second')
+    expect(task).toHaveBeenCalledOnce()
+  })
+
+  it('does not conflate provider aliases or Linux path case', async () => {
+    const paths = [
+      '\\\\wsl.localhost\\Ubuntu\\home\\a',
+      '\\\\wsl$\\Ubuntu\\home\\a',
+      '\\\\wsl.localhost\\Ubuntu\\mnt\\C\\a',
+      '\\\\wsl.localhost\\Ubuntu\\mnt\\c\\a'
+    ]
+    const tasks = paths.map((path, index) => run(path, 'exact', async () => String(index)))
+
+    await expect(Promise.all(tasks)).resolves.toEqual(['0', '1', '2', '3'])
   })
 })

--- a/src/main/native-chat/wsl-transcript-fs-gate.test.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.test.ts
@@ -1,0 +1,53 @@
+import { describe, expect, it, vi } from 'vitest'
+import { runWslTranscriptFsTask, shareWslTranscriptFsTask } from './wsl-transcript-fs-gate'
+
+describe('WSL transcript filesystem task scheduling', () => {
+  it('allows an exact probe to run between directory reads from one scan', async () => {
+    const started: string[] = []
+    let finishFirstRead: (() => void) | undefined
+    let finishExactProbe: (() => void) | undefined
+
+    const scan = shareWslTranscriptFsTask('scan:yield', async () => {
+      await runWslTranscriptFsTask(
+        'readdir:first',
+        () =>
+          new Promise<void>((resolve) => {
+            started.push('first-read')
+            finishFirstRead = resolve
+          })
+      )
+      await runWslTranscriptFsTask('readdir:second', async () => {
+        started.push('second-read')
+      })
+    })
+
+    await vi.waitFor(() => expect(started).toEqual(['first-read']))
+    const exactProbe = runWslTranscriptFsTask(
+      'access:exact',
+      () =>
+        new Promise<void>((resolve) => {
+          started.push('exact-probe')
+          finishExactProbe = resolve
+        })
+    )
+
+    finishFirstRead?.()
+    await vi.waitFor(() => expect(started).toEqual(['first-read', 'exact-probe']))
+    finishExactProbe?.()
+    await Promise.all([scan, exactProbe])
+    expect(started).toEqual(['first-read', 'exact-probe', 'second-read'])
+  })
+
+  it('shares identical multi-read scans without consuming another permit', async () => {
+    const scanTask = vi.fn(async () => ['rollout.jsonl'])
+
+    const first = shareWslTranscriptFsTask('scan:same', scanTask)
+    const duplicate = shareWslTranscriptFsTask('scan:same', scanTask)
+
+    await expect(Promise.all([first, duplicate])).resolves.toEqual([
+      ['rollout.jsonl'],
+      ['rollout.jsonl']
+    ])
+    expect(scanTask).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/native-chat/wsl-transcript-fs-gate.test.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.test.ts
@@ -132,6 +132,38 @@ describe('WSL transcript filesystem task scheduling', () => {
     expect(task).toHaveBeenCalledOnce()
   })
 
+  it('does not attach new callers to abandoned running work', async () => {
+    const stalled = deferred<string>()
+    const firstTask = vi.fn(() => stalled.promise)
+    const firstController = new AbortController()
+    const first = run(
+      '\\\\wsl.localhost\\Ubuntu\\abandoned',
+      'exact',
+      firstTask,
+      firstController.signal
+    )
+    await vi.waitFor(() => expect(firstTask).toHaveBeenCalledOnce())
+
+    firstController.abort(new Error('first closed'))
+    await expect(first).rejects.toThrow('first closed')
+    const replacementWork = deferred<string>()
+    const replacementTask = vi.fn(() => replacementWork.promise)
+    const replacement = run('\\\\wsl.localhost\\Ubuntu\\abandoned', 'exact', replacementTask)
+
+    stalled.resolve('abandoned')
+    await vi.waitFor(() => expect(replacementTask).toHaveBeenCalledOnce())
+    const duplicateTask = vi.fn(async () => 'duplicate')
+    const duplicate = run('\\\\wsl.localhost\\Ubuntu\\abandoned', 'exact', duplicateTask)
+    replacementWork.resolve('replacement')
+
+    await expect(Promise.all([replacement, duplicate])).resolves.toEqual([
+      'replacement',
+      'replacement'
+    ])
+    expect(replacementTask).toHaveBeenCalledOnce()
+    expect(duplicateTask).not.toHaveBeenCalled()
+  })
+
   it('does not conflate provider aliases or Linux path case', async () => {
     const paths = [
       '\\\\wsl.localhost\\Ubuntu\\home\\a',

--- a/src/main/native-chat/wsl-transcript-fs-gate.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.ts
@@ -60,10 +60,11 @@ function abandonTaskIfUnused(task: UnknownScheduledTask): void {
     return
   }
   task.controller.abort()
+  // Running I/O keeps its permit; new callers need a reusable controller.
+  clearTask(task)
   if (task.state === 'queued') {
     task.state = 'settled'
     removeQueuedTask(task)
-    clearTask(task)
     pumpTasks()
   }
 }

--- a/src/main/native-chat/wsl-transcript-fs-gate.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.ts
@@ -1,0 +1,53 @@
+const MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS = 1
+
+let activeTaskCount = 0
+const permitWaiters: (() => void)[] = []
+const inFlightTasks = new Map<string, Promise<unknown>>()
+
+function acquirePermit(): Promise<void> {
+  if (activeTaskCount < MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS) {
+    activeTaskCount += 1
+    return Promise.resolve()
+  }
+  return new Promise((resolve) => permitWaiters.push(resolve))
+}
+
+function releasePermit(): void {
+  const next = permitWaiters.shift()
+  if (next) {
+    next()
+    return
+  }
+  activeTaskCount -= 1
+}
+
+/** Keep stopped-distro 9P work from exhausting libuv's shared filesystem pool. */
+export function runWslTranscriptFsTask<T>(key: string, task: () => Promise<T>): Promise<T> {
+  return shareWslTranscriptFsTask(key, async () => {
+    await acquirePermit()
+    try {
+      return await task()
+    } finally {
+      releasePermit()
+    }
+  })
+}
+
+/** Share a multi-read WSL operation without holding one permit for its lifetime. */
+export function shareWslTranscriptFsTask<T>(key: string, task: () => Promise<T>): Promise<T> {
+  const existing = inFlightTasks.get(key) as Promise<T> | undefined
+  if (existing) {
+    return existing
+  }
+
+  const pending = task()
+  inFlightTasks.set(key, pending)
+
+  const clear = (): void => {
+    if (inFlightTasks.get(key) === pending) {
+      inFlightTasks.delete(key)
+    }
+  }
+  void pending.then(clear, clear)
+  return pending
+}

--- a/src/main/native-chat/wsl-transcript-fs-gate.ts
+++ b/src/main/native-chat/wsl-transcript-fs-gate.ts
@@ -1,53 +1,195 @@
-const MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS = 1
+import { parseWslUncPath } from '../../shared/wsl-paths'
+
+const MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS = 2
+
+export type WslTranscriptFsTaskPriority = 'exact' | 'scan'
+
+type TaskWaiter<T> = {
+  resolve: (value: T) => void
+  reject: (error: unknown) => void
+  signal?: AbortSignal
+  onAbort?: () => void
+}
+
+type ScheduledTask<T> = {
+  key: string
+  laneKey: string
+  priority: WslTranscriptFsTaskPriority
+  operation: (signal: AbortSignal) => Promise<T>
+  controller: AbortController
+  waiters: Set<TaskWaiter<T>>
+  state: 'queued' | 'running' | 'settled'
+}
+
+type UnknownScheduledTask = ScheduledTask<unknown>
 
 let activeTaskCount = 0
-const permitWaiters: (() => void)[] = []
-const inFlightTasks = new Map<string, Promise<unknown>>()
+let activeScanCount = 0
+const activeLaneKeys = new Set<string>()
+const queuedTasks: UnknownScheduledTask[] = []
+const inFlightTasks = new Map<string, UnknownScheduledTask>()
 
-function acquirePermit(): Promise<void> {
-  if (activeTaskCount < MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS) {
-    activeTaskCount += 1
-    return Promise.resolve()
-  }
-  return new Promise((resolve) => permitWaiters.push(resolve))
+function abortReason(signal: AbortSignal): unknown {
+  return signal.reason ?? new Error('WSL transcript filesystem task aborted')
 }
 
-function releasePermit(): void {
-  const next = permitWaiters.shift()
-  if (next) {
-    next()
+function routeKey(path: string): string {
+  const normalized = path.replace(/\\/g, '/')
+  const match = normalized.match(/^\/\/(wsl\.localhost|wsl\$)\/([^/]+)/i)
+  if (match) {
+    return `${match[1].toLowerCase()}/${match[2].trim().toLowerCase()}`
+  }
+  return parseWslUncPath(path)?.distro.trim().toLowerCase() ?? path
+}
+
+function removeQueuedTask(task: UnknownScheduledTask): void {
+  const index = queuedTasks.indexOf(task)
+  if (index !== -1) {
+    queuedTasks.splice(index, 1)
+  }
+}
+
+function clearTask(task: UnknownScheduledTask): void {
+  if (inFlightTasks.get(task.key) === task) {
+    inFlightTasks.delete(task.key)
+  }
+}
+
+function abandonTaskIfUnused(task: UnknownScheduledTask): void {
+  if (task.waiters.size > 0 || task.state === 'settled') {
     return
   }
-  activeTaskCount -= 1
+  task.controller.abort()
+  if (task.state === 'queued') {
+    task.state = 'settled'
+    removeQueuedTask(task)
+    clearTask(task)
+    pumpTasks()
+  }
 }
 
-/** Keep stopped-distro 9P work from exhausting libuv's shared filesystem pool. */
-export function runWslTranscriptFsTask<T>(key: string, task: () => Promise<T>): Promise<T> {
-  return shareWslTranscriptFsTask(key, async () => {
-    await acquirePermit()
-    try {
-      return await task()
-    } finally {
-      releasePermit()
+function attachWaiter<T>(task: ScheduledTask<T>, signal?: AbortSignal): Promise<T> {
+  if (signal?.aborted) {
+    abandonTaskIfUnused(task as UnknownScheduledTask)
+    return Promise.reject(abortReason(signal))
+  }
+  return new Promise<T>((resolve, reject) => {
+    const waiter: TaskWaiter<T> = { resolve, reject, signal }
+    if (signal) {
+      waiter.onAbort = () => {
+        if (!task.waiters.delete(waiter)) {
+          return
+        }
+        reject(abortReason(signal))
+        abandonTaskIfUnused(task as UnknownScheduledTask)
+      }
+      signal.addEventListener('abort', waiter.onAbort, { once: true })
     }
+    task.waiters.add(waiter)
   })
 }
 
-/** Share a multi-read WSL operation without holding one permit for its lifetime. */
-export function shareWslTranscriptFsTask<T>(key: string, task: () => Promise<T>): Promise<T> {
-  const existing = inFlightTasks.get(key) as Promise<T> | undefined
-  if (existing) {
-    return existing
+function settleTask<T>(task: ScheduledTask<T>, result: { value: T } | { error: unknown }): void {
+  if (task.state !== 'running') {
+    return
   }
-
-  const pending = task()
-  inFlightTasks.set(key, pending)
-
-  const clear = (): void => {
-    if (inFlightTasks.get(key) === pending) {
-      inFlightTasks.delete(key)
+  task.state = 'settled'
+  activeTaskCount -= 1
+  if (task.priority === 'scan') {
+    activeScanCount -= 1
+  }
+  activeLaneKeys.delete(task.laneKey)
+  clearTask(task as UnknownScheduledTask)
+  for (const waiter of task.waiters) {
+    if (waiter.signal && waiter.onAbort) {
+      waiter.signal.removeEventListener('abort', waiter.onAbort)
+    }
+    if ('value' in result) {
+      waiter.resolve(result.value)
+    } else {
+      waiter.reject(result.error)
     }
   }
-  void pending.then(clear, clear)
-  return pending
+  task.waiters.clear()
+  pumpTasks()
+}
+
+function nextTaskIndex(): number {
+  for (const priority of ['exact', 'scan'] as const) {
+    // Why: keep one libuv slot available for a live transcript probe.
+    if (priority === 'scan' && activeScanCount > 0) {
+      continue
+    }
+    const index = queuedTasks.findIndex(
+      (task) => task.priority === priority && !activeLaneKeys.has(task.laneKey)
+    )
+    if (index !== -1) {
+      return index
+    }
+  }
+  return -1
+}
+
+function pumpTasks(): void {
+  while (activeTaskCount < MAX_CONCURRENT_WSL_TRANSCRIPT_FS_TASKS) {
+    const index = nextTaskIndex()
+    if (index === -1) {
+      return
+    }
+    const task = queuedTasks.splice(index, 1)[0]
+    if (!task || task.state !== 'queued') {
+      continue
+    }
+    task.state = 'running'
+    activeTaskCount += 1
+    if (task.priority === 'scan') {
+      activeScanCount += 1
+    }
+    activeLaneKeys.add(task.laneKey)
+    void Promise.resolve()
+      .then(() => {
+        task.controller.signal.throwIfAborted()
+        return task.operation(task.controller.signal)
+      })
+      .then(
+        (value) => settleTask(task, { value }),
+        (error: unknown) => settleTask(task, { error })
+      )
+  }
+}
+
+/** Bound 9P work without letting scans delay exact transcript probes. */
+export function runWslTranscriptFsTask<T>(
+  options: {
+    operation: 'access' | 'readdir'
+    path: string
+    priority: WslTranscriptFsTaskPriority
+    signal?: AbortSignal
+  },
+  task: (signal: AbortSignal) => Promise<T>
+): Promise<T> {
+  // Why: route spelling and Linux path case can change provider behavior, so
+  // only byte-identical filesystem requests are safe to share.
+  const key = JSON.stringify([options.operation, options.path])
+  const existing = inFlightTasks.get(key) as ScheduledTask<T> | undefined
+  if (existing) {
+    return attachWaiter(existing, options.signal)
+  }
+
+  const scheduled: ScheduledTask<T> = {
+    key,
+    laneKey: `${routeKey(options.path)}:${options.priority}`,
+    priority: options.priority,
+    operation: task,
+    controller: new AbortController(),
+    waiters: new Set(),
+    state: 'queued'
+  }
+  inFlightTasks.set(key, scheduled as UnknownScheduledTask)
+  const result = attachWaiter(scheduled, options.signal)
+  if (scheduled.state === 'queued' && scheduled.waiters.size > 0) {
+    queuedTasks.push(scheduled as UnknownScheduledTask)
+    queueMicrotask(pumpTasks)
+  }
+  return result
 }

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -21,6 +21,7 @@ const cachedResult = vi.hoisted(() => ({
     }
   }
 }))
+const tailRead = vi.hoisted(() => ({ signal: undefined as AbortSignal | undefined }))
 const watcher = vi.hoisted(() => ({
   args: null as null | {
     onInitialSnapshot?: (
@@ -53,10 +54,17 @@ const watcher = vi.hoisted(() => ({
       }
     ) => void
   },
-  watching: true
+  watching: true,
+  setupSignal: undefined as AbortSignal | undefined,
+  setupPromise: null as Promise<{ unsubscribe: () => void; watching: boolean }> | null,
+  setupFactory: null as
+    | ((signal?: AbortSignal) => Promise<{ unsubscribe: () => void; watching: boolean }>)
+    | null,
+  unsubscribe: vi.fn()
 }))
 vi.mock('../../../native-chat/transcript-watch', () => ({
-  readNativeChatTranscriptTail: ({ limit }: { limit: number }) => {
+  readNativeChatTranscriptTail: ({ limit }: { limit: number }, signal?: AbortSignal) => {
+    tailRead.signal = signal
     const messages = cachedResult.value.messages
     return Promise.resolve({
       messages: messages.slice(-limit),
@@ -65,9 +73,17 @@ vi.mock('../../../native-chat/transcript-watch', () => ({
       ...(cachedResult.value.lifecycle ? { lifecycle: cachedResult.value.lifecycle } : {})
     })
   },
-  subscribeNativeChatTranscript: (args: NonNullable<typeof watcher.args>) => {
+  subscribeNativeChatTranscript: (
+    args: NonNullable<typeof watcher.args>,
+    setupSignal?: AbortSignal
+  ) => {
     watcher.args = args
-    return Promise.resolve({ unsubscribe: vi.fn(), watching: watcher.watching })
+    watcher.setupSignal = setupSignal
+    return (
+      watcher.setupFactory?.(setupSignal) ??
+      watcher.setupPromise ??
+      Promise.resolve({ unsubscribe: watcher.unsubscribe, watching: watcher.watching })
+    )
   }
 }))
 
@@ -141,6 +157,14 @@ function activeWatcherArgs(): NonNullable<typeof watcher.args> {
 }
 
 describe('nativeChat.readSession clientKind truncation gating', () => {
+  it('passes request cancellation to transcript resolution', async () => {
+    const controller = new AbortController()
+    const context = { ...ctxWith('runtime'), signal: controller.signal }
+    await readSessionHandler()({ agent: 'claude', sessionId: 's' }, context)
+
+    expect(tailRead.signal).toBe(controller.signal)
+  })
+
   it('clips oversized tool output for mobile clients', async () => {
     cachedResult.value = { messages: [makeMessage(OVERSIZED)] }
     const result = await readSessionHandler()(
@@ -522,6 +546,95 @@ describe('nativeChat.subscribe initial snapshot', () => {
         lifecycle: completed
       }
     ])
+  })
+
+  it('cancels pending setup when the stream is cleaned up', async () => {
+    const cleanups = new Map<string, () => void>()
+    const context = streamingContext('mobile')
+    vi.mocked(context.runtime.registerSubscriptionCleanup).mockImplementation((id, cleanup) => {
+      cleanups.set(id, cleanup)
+    })
+    const setupControl: {
+      finish?: (subscription: { unsubscribe: () => void; watching: boolean }) => void
+    } = {}
+    const lateUnsubscribe = vi.fn()
+    watcher.setupSignal = undefined
+    watcher.setupPromise = new Promise((resolve) => {
+      setupControl.finish = resolve
+    })
+    const emitted: unknown[] = []
+
+    try {
+      const handling = subscribeHandler()(
+        { agent: 'claude', sessionId: 'pending' },
+        context,
+        (value) => emitted.push(value)
+      )
+      await vi.waitFor(() => expect(watcher.setupSignal).toBeDefined())
+      const setupSignal = watcher.setupSignal as unknown as AbortSignal
+      const cleanup = [...cleanups.values()][0]
+      expect(cleanup).toBeDefined()
+
+      cleanup?.()
+      expect(setupSignal.aborted).toBe(true)
+      setupControl.finish?.({ unsubscribe: lateUnsubscribe, watching: true })
+      await handling
+
+      expect(lateUnsubscribe).toHaveBeenCalledOnce()
+      expect(emitted).toEqual([{ type: 'end' }])
+    } finally {
+      watcher.setupPromise = null
+    }
+  })
+
+  it('handles request cancellation while setup rejects', async () => {
+    const cleanups = new Map<string, () => void>()
+    const controller = new AbortController()
+    const context = { ...streamingContext('mobile'), signal: controller.signal }
+    vi.mocked(context.runtime.registerSubscriptionCleanup).mockImplementation((id, cleanup) => {
+      cleanups.set(id, cleanup)
+    })
+    vi.mocked(context.runtime.cleanupSubscription).mockImplementation((id) => {
+      cleanups.get(id)?.()
+    })
+    watcher.setupSignal = undefined
+    watcher.setupFactory = (signal) =>
+      new Promise((_resolve, reject) => {
+        signal?.addEventListener('abort', () => reject(signal.reason), { once: true })
+      })
+    const emitted: unknown[] = []
+
+    try {
+      const handling = subscribeHandler()(
+        { agent: 'claude', sessionId: 'pending-abort' },
+        context,
+        (value) => emitted.push(value)
+      )
+      await vi.waitFor(() => expect(watcher.setupSignal).toBeDefined())
+      controller.abort(new Error('request closed'))
+      await handling
+
+      expect(context.runtime.cleanupSubscription).toHaveBeenCalledOnce()
+      expect(emitted).toEqual([{ type: 'end' }])
+    } finally {
+      watcher.setupFactory = null
+    }
+  })
+
+  it('skips setup for an already-cancelled request', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const context = { ...streamingContext('mobile'), signal: controller.signal }
+    watcher.args = null
+    const emitted: unknown[] = []
+
+    await subscribeHandler()({ agent: 'claude', sessionId: 'already-closed' }, context, (value) =>
+      emitted.push(value)
+    )
+
+    expect(context.runtime.registerSubscriptionCleanup).not.toHaveBeenCalled()
+    expect(watcher.args).toBeNull()
+    expect(emitted).toEqual([])
   })
 })
 

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -6,7 +6,9 @@ import type {
 } from '../../../../shared/native-chat-types'
 import {
   readNativeChatTranscriptTail,
-  subscribeNativeChatTranscript
+  subscribeNativeChatTranscript,
+  type NativeChatTranscriptSubscription,
+  type SubscribeNativeChatTranscriptArgs
 } from '../../../native-chat/transcript-watch'
 import { defineMethod, defineStreamingMethod, type RpcAnyMethod, type RpcContext } from '../core'
 
@@ -190,15 +192,18 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
   defineMethod({
     name: 'nativeChat.readSession',
     params: NativeChatSession,
-    handler: async (params, { clientKind }) => {
+    handler: async (params, { clientKind, signal }) => {
       const limit = params.limit ?? MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
-      const result = await readNativeChatTranscriptTail({
-        agent: params.agent,
-        sessionId: params.sessionId,
-        transcriptPath: params.transcriptPath,
-        limit,
-        beforeOffset: params.beforeOffset
-      })
+      const result = await readNativeChatTranscriptTail(
+        {
+          agent: params.agent,
+          sessionId: params.sessionId,
+          transcriptPath: params.transcriptPath,
+          limit,
+          beforeOffset: params.beforeOffset
+        },
+        signal
+      )
       return 'messages' in result
         ? {
             messages: windowForClient(result.messages, clientKind, limit),
@@ -212,9 +217,13 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
   defineStreamingMethod({
     name: 'nativeChat.subscribe',
     params: NativeChatSession,
-    handler: async (params, { runtime, connectionId, clientKind }, emit) => {
+    handler: async (params, { runtime, connectionId, clientKind, signal }, emit) => {
+      if (signal?.aborted) {
+        return
+      }
       let closed = false
       let unsubscribe = (): void => {}
+      const setupController = new AbortController()
       // Why: the first drain is a bounded tail snapshot; later drains emit only
       // appended turns. This avoids parsing or shipping full long transcripts.
       // Clients merge by message id, so the initial windowed batch doubles as the
@@ -225,19 +234,29 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
       const cleanupToken = params.subscriptionId ?? `${params.agent}:${params.sessionId}`
       const subscriptionId = `nativeChat:${connectionId ?? 'local'}:${cleanupToken}`
       const limit = params.limit ?? MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
-      runtime.registerSubscriptionCleanup(
-        subscriptionId,
-        () => {
-          closed = true
-          unsubscribe()
-          emit({ type: 'end' })
-        },
-        connectionId
-      )
+      const cleanup = (): void => {
+        if (closed) {
+          return
+        }
+        closed = true
+        signal?.removeEventListener('abort', handleAbort)
+        setupController.abort()
+        unsubscribe()
+        emit({ type: 'end' })
+      }
+      function handleAbort(): void {
+        runtime.cleanupSubscription(subscriptionId)
+      }
+      signal?.addEventListener('abort', handleAbort, { once: true })
+      runtime.registerSubscriptionCleanup(subscriptionId, cleanup, connectionId)
+      if (signal?.aborted) {
+        runtime.cleanupSubscription(subscriptionId)
+        return
+      }
       if (closed) {
         return
       }
-      const subscription = await subscribeNativeChatTranscript({
+      const subscribeArgs: SubscribeNativeChatTranscriptArgs = {
         agent: params.agent,
         sessionId: params.sessionId,
         transcriptPath: params.transcriptPath,
@@ -279,7 +298,16 @@ export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [
             ...(lifecycle ? { lifecycle } : {})
           })
         }
-      })
+      }
+      let subscription: NativeChatTranscriptSubscription
+      try {
+        subscription = await subscribeNativeChatTranscript(subscribeArgs, setupController.signal)
+      } catch (error) {
+        if (closed || setupController.signal.aborted) {
+          return
+        }
+        throw error
+      }
       // The connection may have closed while the file was being resolved.
       if (closed) {
         subscription.unsubscribe()


### PR DESCRIPTION
## Summary

Prevents native-chat transcript discovery from blocking Electron's main thread on stopped or unreachable WSL distros. WSL UNC `access`/`readdir` work now runs asynchronously behind a bounded, priority-aware, cancellation-aware gate; concurrent Codex scans share traversal without retaining unrelated paths or canceled callers. Resolve polling no longer creates the managed Codex home, and IPC/RPC subscription setup/read cancellation now propagates through transcript resolution.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — fresh static-analysis CI passed; local normal, native-plugin, type-aware, reliability, and max-lines checks also pass. The local aggregate command alone reports bundled-skill manifest files that are byte-identical to current `main`.
- [x] `pnpm typecheck`
- [x] `pnpm test` — 149/149 rebased targeted tests pass, and all 32 Node 24/26 PR test shards pass. The unsharded local Windows run has unrelated platform/environment fixture failures.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, including abandoned-generation ABA, setup cancellation, late watcher teardown, RPC abort propagation, post-I/O read cancellation, high-cardinality scan filtering, and canceled-joiner retention/reaction growth.

## AI Review Report

Three adversarial review lanes repeatedly audited correctness, performance, tests, and compatibility. They checked async ownership, cancellation before/during/after setup, stale-generation ABA, late callbacks, permanently stalled WSL I/O, queue bounds/fairness, high-cardinality scans, memory retention, Windows/macOS/Linux branching, SSH and folder workspaces, and mixed-version remote clients.

The review found and fixed:

- abandoned running gate tasks remaining joinable through an aborted controller;
- shared scans retaining every JSONL path (37.6 MiB at 96k files and a stack overflow at 156k files);
- abandoned scan generations remaining joinable;
- uncancelled IPC/RPC subscription setup and RPC reads;
- canceled joiners retained by a stalled scan (61.9 MiB at 50k callers plus an unbounded session-ID predicate).
- aborts during transcript tail I/O returning a completed result, plus timing-sensitive scan lifecycle assertions.

After the fixes, independent rebased-head passes are clean. A range-diff confirmed all five reviewed patches survived the rebase unchanged. Targeted validation passed 149/149 tests, full typecheck, direct lint modes, reliability/max-lines gates, formatting/diff checks, and the production build.

Cross-platform review confirmed WSL-specific behavior remains behind runtime/path checks; local macOS/Linux, SSH, and folder-workspace resolution paths are unchanged. No keyboard/UI behavior is touched.

## Security Audit

Reviewed path handling, IPC/RPC lifecycle ownership, cancellation, task deduplication keys, resource exhaustion, command execution, auth, secrets, and remote-wire exposure. The change adds no shell command construction, dependency, credential, auth, schema, or stream-opcode changes. Filesystem work remains read-only and is bounded to two concurrent WSL transcript operations, with one scan slot and identity-safe cleanup. No follow-up security work is required.

## Notes

- No RPC schema or payload changed; client/server mixed-version wire compatibility is preserved.
- WSL paths use Node/Electron path utilities and the existing WSL UNC parser; local and remote hosts do not enter the WSL gate.
- The local unsharded Windows suite also reproduces existing `HOME`/`os.homedir()`, POSIX symlink/shell, and Xterm artifact fixture failures outside this PR. Fresh GitHub checks are required before merge.