### PR TITLE
fix(ci): stop hourly prune from deleting the just-published release

### DIFF
--- a/.github/workflows/hourly-mac-build.yml
+++ b/.github/workflows/hourly-mac-build.yml
@@ -380,7 +380,10 @@ jobs:
             echo "::warning::Could not discard draft $TAG; remove it manually."
 
       - name: Prune old hourly releases
-        if: steps.freshness.outputs.should_build == 'true'
+        # Only after a live publish: $TAG is then a non-draft we must not delete,
+        # and failed runs should not reshuffle retention around a draft that the
+        # failure path is about to discard.
+        if: steps.publish_live.outcome == 'success'
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
@@ -398,17 +401,29 @@ jobs:
           # createdAt (bulk import / re-create), so createdAt ranking is unstable:
           # reverse of a stable sort then drops the just-published tag past the
           # retain window. publishedAt is real recency; tagName (...YYYYMMDDHHMM)
-          # is the deterministic tie-break. Never prune $TAG from this run.
+          # is the deterministic tie-break.
+          #
+          # Why force $TAG to the front before slicing: a hard retain-window seat
+          # for this run's release. Dropping $TAG from the list *before* the slice
+          # would permanently keep retain+1 releases; skipping it only in the
+          # delete loop would under-prune when the sort is still wrong. Partition
+          # keeps relative order of every other tag.
+          jq_filter='map(select(.isDraft | not)) | sort_by(.publishedAt // "", .tagName) | reverse'
+          if [[ -n "${TAG:-}" ]]; then
+            jq_filter+=" | (map(select(.tagName == \"${TAG//\"/\\\"}\")) + map(select(.tagName != \"${TAG//\"/\\\"}\")))"
+          fi
+          jq_filter+=" | .[${HOURLY_RETAIN_COUNT}:] | .[].tagName"
           stale="$(gh release list --repo "$HOURLY_REPO" --limit 200 --json tagName,publishedAt,isDraft \
-            --jq "map(select(.isDraft | not)) | sort_by(.publishedAt // \"\", .tagName) | reverse | .[${HOURLY_RETAIN_COUNT}:] | .[].tagName")"
+            --jq "$jq_filter")"
           if [[ -z "$stale" ]]; then
             echo "Nothing to prune; at or under $HOURLY_RETAIN_COUNT retained builds."
             exit 0
           fi
           while read -r tag; do
             [[ -n "$tag" ]] || continue
+            # Belt-and-suspenders: partition above should already exclude $TAG.
             if [[ -n "${TAG:-}" && "$tag" == "$TAG" ]]; then
-              echo "Skipping just-published $tag"
+              echo "::warning::Prune list still included just-published $tag after protect; skipping delete."
               continue
             fi
             echo "Pruning $tag"

--- a/.github/workflows/hourly-mac-build.yml
+++ b/.github/workflows/hourly-mac-build.yml
@@ -384,20 +384,33 @@ jobs:
         shell: bash
         env:
           GH_TOKEN: ${{ steps.app_token_publish.outputs.token }}
+          # Protect the tag this run just shipped; at the retain cap, a bad sort
+          # can otherwise mark the newest release as stale and delete it.
+          TAG: ${{ steps.release.outputs.tag }}
         run: |
           set -euo pipefail
           # Why: --cleanup-tag so pruning does not leave orphan tags behind that
           # keep showing up in tag lists with no release or assets attached.
           # Drafts are excluded so retention counts shipped builds only; a stale
           # draft is handled by the failure path, not by the retention window.
-          stale="$(gh release list --repo "$HOURLY_REPO" --limit 200 --json tagName,createdAt,isDraft \
-            --jq "map(select(.isDraft | not)) | sort_by(.createdAt) | reverse | .[${HOURLY_RETAIN_COUNT}:] | .[].tagName")"
+          #
+          # Sort by publishedAt (not createdAt). Many non-draft hourlies share one
+          # createdAt (bulk import / re-create), so createdAt ranking is unstable:
+          # reverse of a stable sort then drops the just-published tag past the
+          # retain window. publishedAt is real recency; tagName (...YYYYMMDDHHMM)
+          # is the deterministic tie-break. Never prune $TAG from this run.
+          stale="$(gh release list --repo "$HOURLY_REPO" --limit 200 --json tagName,publishedAt,isDraft \
+            --jq "map(select(.isDraft | not)) | sort_by(.publishedAt // \"\", .tagName) | reverse | .[${HOURLY_RETAIN_COUNT}:] | .[].tagName")"
           if [[ -z "$stale" ]]; then
             echo "Nothing to prune; at or under $HOURLY_RETAIN_COUNT retained builds."
             exit 0
           fi
           while read -r tag; do
             [[ -n "$tag" ]] || continue
+            if [[ -n "${TAG:-}" && "$tag" == "$TAG" ]]; then
+              echo "Skipping just-published $tag"
+              continue
+            fi
             echo "Pruning $tag"
             gh release delete "$tag" --repo "$HOURLY_REPO" --yes --cleanup-tag || \
               echo "::warning::Could not prune $tag"


### PR DESCRIPTION
## Summary

The hourly macOS pipeline (`.github/workflows/hourly-mac-build.yml`) has been publishing to `stablyai/orca-hourly` and then immediately deleting the release it just published.

**Bug (publish-then-self-prune):**
1. `HOURLY_RETAIN_COUNT=72` and the repo is already at 72 non-draft releases (at the cap).
2. Nearly every non-draft release shares the same `createdAt` (`2026-08-02T09:48:30Z`), so `sort_by(.createdAt)` does not rank by recency.
3. With tied `createdAt`, jq’s stable sort + `reverse` flips the default newest-first list, so the **just-published** release lands past the retain window.
4. Prune then deletes it with `--cleanup-tag`. The job still exits 0.

**Evidence:** run `31276157806` published `v1.4.177-hourly.202608082009` then logged `Pruning v1.4.177-hourly.202608082009`. That tag is now 404. Last surviving published hourly at diagnosis was `v1.4.177-hourly.202608080021`.

## Fix

In the prune step:

1. **Sort by real recency** — `publishedAt` (empty fallback), then `tagName` (`…-hourly.YYYYMMDDHHMM`) as a deterministic tie-break. Drafts still excluded from the retention count.
2. **Hard-guard the just-published tag with correct retain math** — partition `$TAG` to the front of the sorted list *before* the retain slice so this run always has a seat in the keep window. (Excluding `$TAG` before the slice would permanently keep `retain+1`; skipping only in the delete loop under-prunes when sort is still wrong.)
3. **Belt-and-suspenders delete skip** — if `$TAG` still appears in the stale list, log a `::warning::` and do not delete.
4. **Gate prune on `publish_live` success** — only reshape retention after a live publish; failed runs leave pruning to the next successful one (draft cleanup stays on the failure path).
5. Keep `--cleanup-tag` for genuinely stale releases.

## Screenshots

No visual change.

## Testing

- [x] Local `gh`/`jq` simulation against live `stablyai/orca-hourly` (72 non-draft releases)
  - `publishedAt` order keeps `…202608080021` first
  - retain=72 → nothing pruned
  - retain=71 → only oldest by `publishedAt` pruned
  - buggy `createdAt` sort without protect reproduces self-delete of newest
  - force-front protect keeps newest out of stale even under buggy sort
  - synthetic partition cases: protect newest / mid / bad-order all keep protected tag and still prune
- [ ] `pnpm lint` / `pnpm typecheck` / `pnpm test` / `pnpm build` — N/A (workflow YAML only)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed — no unit harness for this inline workflow jq; verified with live API + synthetic jq fixtures instead of a permanent test package
- [ ] Merge; confirm next `Hourly macOS Dev Build` run publishes a tag that remains listable (not pruned in the same run)

## AI Review Report

Reviewed the branch end-to-end (workflow control flow, retain math, sort stability, GHA step gating, live API fields).

**Main risks checked:**
- Self-delete of just-published tag at retain cap (root bug)
- Retain-count drift from naive protect strategies
- Draft vs non-draft counting
- Prune running on failed publish / empty `$TAG`
- `publishedAt` null / tied timestamps
- Cross-platform: workflow runs on macOS Blacksmith runners only; shell is bash; no app UI, shortcuts, paths, or Electron platform branches touched

**Flagged and fixed in follow-up commit:**
1. Loop-only skip under-prunes when sort is still wrong (keeps extras only when skip fires; does not force a correct oldest delete).
2. Exclude-`$TAG`-before-slice permanently keeps `retain+1` after every successful publish — rejected.
3. Replaced with **partition `$TAG` to front, then slice**, plus warning skip as backup.
4. Tightened step `if` to `steps.publish_live.outcome == 'success'`.

**Verified as OK:**
- `gh release list --json publishedAt` is populated for all current non-draft hourlies
- Default `success()` previously already skipped prune on hard failures; explicit publish gate is clearer and matches intent
- No Windows/Linux app surface in this change

## Security Audit

- No new secrets, auth paths, or token scopes. Reuses existing hourly GitHub App install token (`app_token_publish`) already required for publish/delete.
- `$TAG` is interpolated into a jq string after `"` escaping; tag values are pipeline-controlled (`v*-hourly.YYYYMMDDHHMM`), not user input.
- Prune still requires write token to `orca-hourly` only; no change to `stablyai/orca` write permissions (`contents: read` at workflow level).
- `--cleanup-tag` retained for intentional stale deletes only; just-published tag is protected.
- No dependency, IPC, or path-traversal surface.

## Notes

- macOS-only scheduled workflow; no Linux/Windows client changes.
- After merge, the next successful hourly cron is the real integration proof (tag must remain listable after the prune step logs).
- Related: many historical hourlies share one `createdAt` from bulk import; do not reintroduce `createdAt` ordering for retention.
- Out of scope: changing `HOURLY_RETAIN_COUNT`, re-publishing deleted hourlies, adhoc channel prune (uses age cutoff, not retain count).