### PR TITLE
AI Vault delete: fail closed when session liveness is unknown

### DIFF
--- a/src/main/ai-vault/session-delete-liveness.repro.test.ts
+++ b/src/main/ai-vault/session-delete-liveness.repro.test.ts
@@ -14,6 +14,10 @@ vi.mock('../wsl-unc-delete', () => ({ tryDeleteWslUncPath: vi.fn().mockResolvedV
 
 import { deleteAiVaultSessionFile } from './session-delete'
 import { resolveAiVaultSessionLiveness } from './session-liveness'
+import {
+  qualifyAiVaultSessionLiveness,
+  readAiVaultTranscriptFingerprint
+} from './session-transcript-quiescence'
 
 type AiVaultSessionLiveness = 'live' | 'not-live' | 'unknown'
 
@@ -34,7 +38,7 @@ async function createTranscript(): Promise<{ filePath: string; root: string }> {
 }
 
 async function attemptDelete(
-  getSessionLiveness: () => Promise<AiVaultSessionLiveness>
+  getSessionLiveness: (filePath: string) => Promise<AiVaultSessionLiveness>
 ): Promise<{ filePath: string; result: AiVaultDeleteSessionResult }> {
   const { filePath, root } = await createTranscript()
   const result = await deleteWithLiveness(
@@ -45,10 +49,39 @@ async function attemptDelete(
       executionHostId: 'local',
       rootOptions: { geminiSessionsDir: root }
     },
-    { getSessionLiveness }
+    { getSessionLiveness: () => getSessionLiveness(filePath) }
   )
   return { filePath, result }
 }
+
+// The production composition: the inventory verdict is only ever accepted after
+// the transcript corroborates it.
+function resolveThenQualify(
+  filePath: string,
+  deps: Parameters<typeof resolveAiVaultSessionLiveness>[1]
+): Promise<AiVaultSessionLiveness> {
+  return readAiVaultTranscriptFingerprint(filePath).then(async (observedBefore) =>
+    qualifyAiVaultSessionLiveness({
+      liveness: await resolveAiVaultSessionLiveness(
+        { agent: 'gemini', sessionId: 'session-live' },
+        deps
+      ),
+      filePath,
+      observedBefore,
+      nowMs: Date.now()
+    })
+  )
+}
+
+// Nothing Orca manages: no PTYs, no statuses — the shape every unmanaged owner
+// presents to the inventory.
+const EMPTY_INVENTORY = {
+  listProcesses: async () => [],
+  getStatusSnapshot: () => [],
+  inspectForegroundProcess: async () => ({ available: true, process: 'zsh' }),
+  getStatusPtyId: () => null,
+  getAgentHint: () => null
+} satisfies Parameters<typeof resolveAiVaultSessionLiveness>[1]
 
 describe('live AI Vault session delete safety invariant', () => {
   afterEach(async () => {
@@ -162,6 +195,82 @@ describe('live AI Vault session delete safety invariant', () => {
       reason: 'session-liveness-unknown'
     })
     expect.soft(existsSync(filePath), 'dismissed live transcript must survive on disk').toBe(true)
+  })
+
+  // The v1.4.177 regression class: the managed-PTY inventory can only ever
+  // describe processes Orca spawned, so every owner below is invisible to it and
+  // the raw inventory verdict is a confident, wrong "not-live".
+  it('survives a local agent launched outside Orca and absent from the PTY inventory', async () => {
+    trashItemMock.mockImplementation((path: string) => rm(path))
+
+    const { filePath, result } = await attemptDelete((path) =>
+      resolveThenQualify(path, EMPTY_INVENTORY)
+    )
+
+    expect.soft(result).toEqual({
+      outcome: 'rejected',
+      agent: 'gemini',
+      reason: 'session-liveness-unknown'
+    })
+    expect.soft(existsSync(filePath), 'unmanaged local transcript must survive on disk').toBe(true)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('survives a WSL-distro agent whose hook relay never reported a status', async () => {
+    trashItemMock.mockImplementation((path: string) => rm(path))
+    // A distro shell Orca did not spawn: the relay carries no status for it and
+    // the one managed PTY on the host is an unrelated shell.
+    const { filePath, result } = await attemptDelete((path) =>
+      resolveThenQualify(path, {
+        ...EMPTY_INVENTORY,
+        listProcesses: async () => [
+          { id: 'wsl-shell', terminalHandle: 'term_wsl-shell', cwd: '/workspace', title: 'bash' }
+        ]
+      })
+    )
+
+    expect.soft(result).toEqual({
+      outcome: 'rejected',
+      agent: 'gemini',
+      reason: 'session-liveness-unknown'
+    })
+    expect.soft(existsSync(filePath), 'WSL transcript must survive on disk').toBe(true)
+    expect(trashItemMock).not.toHaveBeenCalled()
+  })
+
+  it('survives when every other agent process is attributed but the target is not', async () => {
+    trashItemMock.mockImplementation((path: string) => rm(path))
+    const otherSession: AgentStatusIpcPayload = {
+      paneKey: 'tab:other',
+      terminalHandle: 'term_other',
+      connectionId: null,
+      receivedAt: 1,
+      stateStartedAt: 1,
+      state: 'working',
+      prompt: 'test',
+      agentType: 'gemini',
+      providerSession: { key: 'session_id', id: 'session-other' }
+    }
+
+    const { filePath, result } = await attemptDelete((path) =>
+      resolveThenQualify(path, {
+        ...EMPTY_INVENTORY,
+        listProcesses: async () => [
+          { id: 'other', terminalHandle: 'term_other', cwd: '/workspace', title: 'gemini' }
+        ],
+        getStatusSnapshot: () => [otherSession],
+        inspectForegroundProcess: async () => ({ available: true, process: 'gemini' }),
+        getStatusPtyId: () => 'other'
+      })
+    )
+
+    expect.soft(result).toEqual({
+      outcome: 'rejected',
+      agent: 'gemini',
+      reason: 'session-liveness-unknown'
+    })
+    expect.soft(existsSync(filePath), 'unattributed transcript must survive on disk').toBe(true)
+    expect(trashItemMock).not.toHaveBeenCalled()
   })
 
   it('fails closed when authoritative liveness is unavailable', async () => {

--- a/src/main/ai-vault/session-liveness.test.ts
+++ b/src/main/ai-vault/session-liveness.test.ts
@@ -1,4 +1,4 @@
-import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { lstat, mkdtemp, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it, vi } from 'vitest'
@@ -66,13 +66,20 @@ describe('resolveAiVaultSessionLiveness', () => {
           filePath
         })
       ).resolves.toEqual({ outcome: 'unknown' })
+      const stats = await lstat(filePath)
+      // The fingerprint pins the transcript as it was when identity was bound,
+      // so a write landing during liveness inspection stays detectable.
       await expect(
         readAiVaultSessionIdentity({
           agent: 'gemini',
           sessionId: 'authoritative-session',
           filePath
         })
-      ).resolves.toEqual({ outcome: 'found', sessionId: 'authoritative-session' })
+      ).resolves.toEqual({
+        outcome: 'found',
+        sessionId: 'authoritative-session',
+        fingerprint: { mtimeMs: stats.mtimeMs, sizeBytes: stats.size }
+      })
     } finally {
       await rm(root, { recursive: true, force: true })
     }

--- a/src/main/ai-vault/session-liveness.ts
+++ b/src/main/ai-vault/session-liveness.ts
@@ -7,6 +7,7 @@ import type { PtyProcessInfo } from '../providers/pty-process-info'
 import { isWslHookRelayConnectionId } from '../../shared/wsl-hook-relay-contract'
 import { lstat } from 'node:fs/promises'
 import { parseAgentSessionFileCached } from './session-scanner-parse-cache'
+import type { AiVaultTranscriptFingerprint } from './session-transcript-quiescence'
 
 const MAX_LIVENESS_PROCESSES = 512
 const PROCESS_INSPECTION_CONCURRENCY = 8
@@ -28,7 +29,9 @@ export type AiVaultSessionLivenessDependencies = {
 }
 
 export type AiVaultSessionIdentityRead =
-  | { outcome: 'found'; sessionId: string }
+  // The fingerprint is the transcript as it looked when identity was bound, so
+  // a write landing during liveness inspection is detectable afterwards.
+  | { outcome: 'found'; sessionId: string; fingerprint: AiVaultTranscriptFingerprint }
   | { outcome: 'missing' }
   | { outcome: 'unknown' }
 
@@ -57,7 +60,11 @@ export async function readAiVaultSessionIdentity(target: {
       process.platform
     )
     return session?.sessionId && session.sessionId === target.sessionId
-      ? { outcome: 'found', sessionId: session.sessionId }
+      ? {
+          outcome: 'found',
+          sessionId: session.sessionId,
+          fingerprint: { mtimeMs: fileStats.mtimeMs, sizeBytes: fileStats.size }
+        }
       : { outcome: 'unknown' }
   } catch (error) {
     return (error as NodeJS.ErrnoException).code === 'ENOENT'

--- a/src/main/ai-vault/session-transcript-quiescence.test.ts
+++ b/src/main/ai-vault/session-transcript-quiescence.test.ts
@@ -1,0 +1,118 @@
+import { mkdtemp, rm, utimes, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { AI_VAULT_SESSION_QUIESCENCE_MS } from '../../shared/ai-vault-session-deletion'
+import {
+  qualifyAiVaultSessionLiveness,
+  readAiVaultTranscriptFingerprint
+} from './session-transcript-quiescence'
+
+const fixtureRoots: string[] = []
+const NOW_MS = 1_770_000_000_000
+
+async function writeTranscript(contents: string, ageMs: number): Promise<string> {
+  const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-quiescence-'))
+  fixtureRoots.push(root)
+  const filePath = join(root, 'session.jsonl')
+  await writeFile(filePath, contents)
+  const writtenAt = new Date(NOW_MS - ageMs)
+  await utimes(filePath, writtenAt, writtenAt)
+  return filePath
+}
+
+async function qualify(
+  filePath: string,
+  overrides: Partial<Parameters<typeof qualifyAiVaultSessionLiveness>[0]> = {}
+) {
+  return qualifyAiVaultSessionLiveness({
+    liveness: 'not-live',
+    filePath,
+    observedBefore: await readAiVaultTranscriptFingerprint(filePath),
+    nowMs: NOW_MS,
+    ...overrides
+  })
+}
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((root) => rm(root, { recursive: true, force: true }))
+  )
+})
+
+describe('qualifyAiVaultSessionLiveness', () => {
+  it('confirms not-live once the transcript has been quiet for the whole window', async () => {
+    const filePath = await writeTranscript('{"sessionId":"s"}\n', AI_VAULT_SESSION_QUIESCENCE_MS)
+
+    await expect(qualify(filePath)).resolves.toBe('not-live')
+  })
+
+  // The release regression: an agent Orca never spawned owns the transcript, so
+  // the PTY inventory and status snapshot are both empty and report not-live.
+  it('fails closed for a transcript written moments ago by an unmanaged owner', async () => {
+    const filePath = await writeTranscript('{"sessionId":"s"}\n', 1_000)
+
+    await expect(qualify(filePath)).resolves.toBe('unknown')
+  })
+
+  it('fails closed when the transcript is appended to during liveness inspection', async () => {
+    const filePath = await writeTranscript(
+      '{"sessionId":"s"}\n',
+      AI_VAULT_SESSION_QUIESCENCE_MS * 2
+    )
+    const observedBefore = await readAiVaultTranscriptFingerprint(filePath)
+    // Same mtime, more bytes: a coarse-timestamp filesystem hides the write.
+    await writeFile(filePath, '{"sessionId":"s"}\n{"role":"user"}\n')
+    const writtenAt = new Date(NOW_MS - AI_VAULT_SESSION_QUIESCENCE_MS * 2)
+    await utimes(filePath, writtenAt, writtenAt)
+
+    await expect(qualify(filePath, { observedBefore })).resolves.toBe('unknown')
+  })
+
+  it('fails closed when the transcript stops being readable mid-authorization', async () => {
+    const filePath = await writeTranscript('{"sessionId":"s"}\n', AI_VAULT_SESSION_QUIESCENCE_MS)
+    const observedBefore = await readAiVaultTranscriptFingerprint(filePath)
+    await rm(filePath)
+
+    await expect(qualify(filePath, { observedBefore })).resolves.toBe('unknown')
+  })
+
+  it('fails closed when no fingerprint was captured before inspection', async () => {
+    const filePath = await writeTranscript('{"sessionId":"s"}\n', AI_VAULT_SESSION_QUIESCENCE_MS)
+
+    await expect(qualify(filePath, { observedBefore: null })).resolves.toBe('unknown')
+  })
+
+  // A transcript stamped in the future (clock skew, or a WSL/9P mount whose
+  // clock runs ahead) can never satisfy the window.
+  it('fails closed for a future write time', async () => {
+    const filePath = await writeTranscript('{"sessionId":"s"}\n', -60_000)
+
+    await expect(qualify(filePath)).resolves.toBe('unknown')
+  })
+
+  it.each(['live', 'unknown'] as const)('passes %s through untouched', async (liveness) => {
+    const filePath = await writeTranscript('{"sessionId":"s"}\n', AI_VAULT_SESSION_QUIESCENCE_MS)
+
+    await expect(qualify(filePath, { liveness })).resolves.toBe(liveness)
+  })
+})
+
+describe('readAiVaultTranscriptFingerprint', () => {
+  it('reads mtime and size for a regular file', async () => {
+    const filePath = await writeTranscript('12345', AI_VAULT_SESSION_QUIESCENCE_MS)
+
+    await expect(readAiVaultTranscriptFingerprint(filePath)).resolves.toEqual({
+      mtimeMs: NOW_MS - AI_VAULT_SESSION_QUIESCENCE_MS,
+      sizeBytes: 5
+    })
+  })
+
+  it('returns null for a directory and for a missing path', async () => {
+    const filePath = await writeTranscript('x', 0)
+    const dir = join(filePath, '..')
+
+    await expect(readAiVaultTranscriptFingerprint(dir)).resolves.toBeNull()
+    await expect(readAiVaultTranscriptFingerprint(join(dir, 'absent.jsonl'))).resolves.toBeNull()
+  })
+})

--- a/src/main/ai-vault/session-transcript-quiescence.ts
+++ b/src/main/ai-vault/session-transcript-quiescence.ts
@@ -1,0 +1,67 @@
+import { lstat } from 'node:fs/promises'
+import {
+  isAiVaultSessionQuiescent,
+  type AiVaultSessionLiveness
+} from '../../shared/ai-vault-session-deletion'
+
+// What the transcript looked like at one instant. Size joins mtime because a
+// coarse filesystem timestamp (FAT, some 9P mounts) can repeat within a second.
+export type AiVaultTranscriptFingerprint = { mtimeMs: number; sizeBytes: number }
+
+/** null for anything that is not a readable regular file — including ENOENT. */
+export async function readAiVaultTranscriptFingerprint(
+  filePath: string
+): Promise<AiVaultTranscriptFingerprint | null> {
+  try {
+    const stats = await lstat(filePath)
+    return stats.isFile() ? { mtimeMs: stats.mtimeMs, sizeBytes: stats.size } : null
+  } catch {
+    return null
+  }
+}
+
+/**
+ * Corroborates a `not-live` inventory verdict against the transcript itself, or
+ * downgrades it to `unknown`.
+ *
+ * The PTY inventory and the agent-status snapshot only ever describe
+ * Orca-managed processes. A local agent launched from an external terminal, one
+ * running inside a WSL distro Orca did not spawn, and a paired-runtime owner are
+ * all absent from both while writing to this very file — which is how a live
+ * session reads as "no owning process found". Two things have to hold before
+ * that absence counts as proof: the file did not change while liveness was being
+ * inspected, and it has been quiet for the whole quiescence window.
+ *
+ * `live` and `unknown` pass through untouched — this only ever removes
+ * permission to delete, never grants it.
+ */
+export async function qualifyAiVaultSessionLiveness(args: {
+  liveness: AiVaultSessionLiveness
+  filePath: string
+  observedBefore: AiVaultTranscriptFingerprint | null
+  nowMs: number
+  quiescenceWindowMs?: number
+}): Promise<AiVaultSessionLiveness> {
+  if (args.liveness !== 'not-live') {
+    return args.liveness
+  }
+  if (!args.observedBefore) {
+    return 'unknown'
+  }
+  const observedAfter = await readAiVaultTranscriptFingerprint(args.filePath)
+  // Unreadable now though it was readable a moment ago: something is moving it.
+  if (!observedAfter) {
+    return 'unknown'
+  }
+  // Appended to while the inventory was being walked — an owner exists whatever
+  // the inventory reported.
+  if (
+    observedAfter.mtimeMs !== args.observedBefore.mtimeMs ||
+    observedAfter.sizeBytes !== args.observedBefore.sizeBytes
+  ) {
+    return 'unknown'
+  }
+  return isAiVaultSessionQuiescent(observedAfter.mtimeMs, args.nowMs, args.quiescenceWindowMs)
+    ? 'not-live'
+    : 'unknown'
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -489,6 +489,7 @@ import {
   readAiVaultSessionIdentity,
   resolveAiVaultSessionLiveness
 } from '../ai-vault/session-liveness'
+import { qualifyAiVaultSessionLiveness } from '../ai-vault/session-transcript-quiescence'
 import type { AiVaultAgent, AiVaultListArgs, AiVaultListResult } from '../../shared/ai-vault-types'
 import type { AiVaultSessionLiveness } from '../../shared/ai-vault-session-deletion'
 import type {
@@ -4971,7 +4972,7 @@ export class OrcaRuntimeService {
       return 'unknown'
     }
     const deadlineMs = Date.now() + 3_000
-    return await resolveAiVaultSessionLiveness(
+    const liveness = await resolveAiVaultSessionLiveness(
       {
         agent: target.agent,
         sessionId: identity.sessionId
@@ -5023,6 +5024,14 @@ export class OrcaRuntimeService {
         }
       }
     )
+    // The inventory above can only speak for Orca-managed processes, so a
+    // "nothing owns it" answer still has to be corroborated by the transcript.
+    return await qualifyAiVaultSessionLiveness({
+      liveness,
+      filePath: target.filePath,
+      observedBefore: identity.fingerprint,
+      nowMs: Date.now()
+    })
   }
 
   prepareAiVaultSessionResume(

--- a/src/renderer/src/components/right-sidebar/AiVaultSessionRow.test.tsx
+++ b/src/renderer/src/components/right-sidebar/AiVaultSessionRow.test.tsx
@@ -20,7 +20,7 @@ const session = {
   codexHome: null,
   createdAt: null,
   updatedAt: null,
-  modifiedAt: 0,
+  modifiedAt: '2020-01-01T00:00:00.000Z',
   messageCount: 2,
   totalTokens: 0,
   previewMessages: [],

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-deletability.test.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-deletability.test.ts
@@ -1,4 +1,5 @@
 import { describe, expect, it } from 'vitest'
+import { AI_VAULT_SESSION_QUIESCENCE_MS } from '../../../../shared/ai-vault-session-deletion'
 import { aiVaultSessionDeleteBlockedReason } from './ai-vault-session-deletability'
 
 // translate() with no loaded catalog returns the English fallback, so these
@@ -6,11 +7,17 @@ import { aiVaultSessionDeleteBlockedReason } from './ai-vault-session-deletabili
 const NON_LOCAL = 'Only sessions on this device can be deleted.'
 const SYNTHETIC = "This session can't be deleted from Orca."
 const LIVE = 'This session is still running — wait for it to finish before deleting.'
+const RECENTLY_ACTIVE = 'This session was active moments ago — wait a few minutes before deleting.'
+
+// Long past the quiescence window against any real clock, so the cases below
+// exercise the gate they name rather than the recency gate.
+const QUIET_SINCE = '2020-01-01T00:00:00.000Z'
 
 const localGeminiSession = {
   agent: 'gemini' as const,
   executionHostId: 'local' as const,
-  filePath: '/home/user/.gemini/sessions/log.jsonl'
+  filePath: '/home/user/.gemini/sessions/log.jsonl',
+  modifiedAt: QUIET_SINCE
 }
 
 describe('aiVaultSessionDeleteBlockedReason', () => {
@@ -23,7 +30,8 @@ describe('aiVaultSessionDeleteBlockedReason', () => {
       aiVaultSessionDeleteBlockedReason({
         agent: 'claude',
         executionHostId: 'local',
-        filePath: '/home/user/.claude/projects/-proj/sess-1.jsonl'
+        filePath: '/home/user/.claude/projects/-proj/sess-1.jsonl',
+        modifiedAt: QUIET_SINCE
       })
     ).toBeNull()
   })
@@ -44,7 +52,12 @@ describe('aiVaultSessionDeleteBlockedReason', () => {
     // deletable, so "wait for it to finish" would mislead.
     expect(
       aiVaultSessionDeleteBlockedReason(
-        { agent: 'codex', executionHostId: 'local', filePath: '/home/user/.codex/x.jsonl' },
+        {
+          agent: 'codex',
+          executionHostId: 'local',
+          filePath: '/home/user/.codex/x.jsonl',
+          modifiedAt: QUIET_SINCE
+        },
         'working'
       )
     ).toBe("Codex sessions can't be deleted from Orca.")
@@ -63,7 +76,8 @@ describe('aiVaultSessionDeleteBlockedReason', () => {
       aiVaultSessionDeleteBlockedReason({
         agent: 'opencode',
         executionHostId: 'local',
-        filePath: '/home/user/.opencode/db.sqlite#sess_123'
+        filePath: '/home/user/.opencode/db.sqlite#sess_123',
+        modifiedAt: QUIET_SINCE
       })
     ).toBe(SYNTHETIC)
   })
@@ -73,7 +87,8 @@ describe('aiVaultSessionDeleteBlockedReason', () => {
       aiVaultSessionDeleteBlockedReason({
         agent: 'opencode',
         executionHostId: 'local',
-        filePath: '/home/user/.opencode/sessions/log.jsonl'
+        filePath: '/home/user/.opencode/sessions/log.jsonl',
+        modifiedAt: QUIET_SINCE
       })
     ).toBe("OpenCode sessions can't be deleted from Orca.")
   })
@@ -83,9 +98,68 @@ describe('aiVaultSessionDeleteBlockedReason', () => {
       aiVaultSessionDeleteBlockedReason({
         agent: 'antigravity',
         executionHostId: 'local',
-        filePath: '/home/user/.antigravity/brain/conv-1/.system_generated/logs/transcript.jsonl'
+        filePath: '/home/user/.antigravity/brain/conv-1/.system_generated/logs/transcript.jsonl',
+        modifiedAt: QUIET_SINCE
       })
     ).toBe("Antigravity sessions can't be deleted from Orca.")
+  })
+
+  // An agent Orca never spawned reports no live state, so the transcript's own
+  // write time is the only evidence it still has an owner. Main applies the same
+  // window, which keeps what the row offers a subset of what main authorizes.
+  describe('recently-active gate', () => {
+    const NOW_MS = Date.parse('2026-08-08T12:00:00.000Z')
+    const modifiedAgo = (ms: number) => new Date(NOW_MS - ms).toISOString()
+
+    it('blocks a session whose transcript was written inside the window', () => {
+      expect(
+        aiVaultSessionDeleteBlockedReason(
+          { ...localGeminiSession, modifiedAt: modifiedAgo(1_000) },
+          null,
+          NOW_MS
+        )
+      ).toBe(RECENTLY_ACTIVE)
+    })
+
+    it('offers Delete once the window has fully elapsed', () => {
+      expect(
+        aiVaultSessionDeleteBlockedReason(
+          { ...localGeminiSession, modifiedAt: modifiedAgo(AI_VAULT_SESSION_QUIESCENCE_MS) },
+          null,
+          NOW_MS
+        )
+      ).toBeNull()
+    })
+
+    it('blocks one millisecond short of the window', () => {
+      expect(
+        aiVaultSessionDeleteBlockedReason(
+          { ...localGeminiSession, modifiedAt: modifiedAgo(AI_VAULT_SESSION_QUIESCENCE_MS - 1) },
+          null,
+          NOW_MS
+        )
+      ).toBe(RECENTLY_ACTIVE)
+    })
+
+    it.each([
+      ['unparsable', 'not a date'],
+      ['empty', ''],
+      ['future-dated (clock skew)', '2026-08-08T12:05:00.000Z']
+    ])('blocks a %s modifiedAt', (_name, modifiedAt) => {
+      expect(
+        aiVaultSessionDeleteBlockedReason({ ...localGeminiSession, modifiedAt }, null, NOW_MS)
+      ).toBe(RECENTLY_ACTIVE)
+    })
+
+    it('keeps the live reason ahead of the recency reason', () => {
+      expect(
+        aiVaultSessionDeleteBlockedReason(
+          { ...localGeminiSession, modifiedAt: modifiedAgo(1_000) },
+          'working',
+          NOW_MS
+        )
+      ).toBe(LIVE)
+    })
   })
 
   it('prioritizes the host gate over the unsupported-agent reason', () => {
@@ -93,7 +167,8 @@ describe('aiVaultSessionDeleteBlockedReason', () => {
       aiVaultSessionDeleteBlockedReason({
         agent: 'claude',
         executionHostId: 'ssh:dev-box',
-        filePath: '/home/user/.claude/sessions/sess-dir/log.jsonl'
+        filePath: '/home/user/.claude/sessions/sess-dir/log.jsonl',
+        modifiedAt: QUIET_SINCE
       })
     ).toBe(NON_LOCAL)
   })

--- a/src/renderer/src/components/right-sidebar/ai-vault-session-deletability.ts
+++ b/src/renderer/src/components/right-sidebar/ai-vault-session-deletability.ts
@@ -1,4 +1,7 @@
-import { isAiVaultDeletableAgent } from '../../../../shared/ai-vault-session-deletion'
+import {
+  isAiVaultDeletableAgent,
+  isAiVaultSessionQuiescent
+} from '../../../../shared/ai-vault-session-deletion'
 import type { AiVaultSession } from '../../../../shared/ai-vault-types'
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import { translate } from '@/i18n/i18n'
@@ -25,8 +28,9 @@ function isSessionLive(liveState: AgentStatusState | null | undefined): boolean 
  * it does: both consult the same shared agent set and host/synthetic predicates.
  */
 export function aiVaultSessionDeleteBlockedReason(
-  session: Pick<AiVaultSession, 'agent' | 'executionHostId' | 'filePath'>,
-  liveState?: AgentStatusState | null
+  session: Pick<AiVaultSession, 'agent' | 'executionHostId' | 'filePath' | 'modifiedAt'>,
+  liveState?: AgentStatusState | null,
+  nowMs: number = Date.now()
 ): string | null {
   if (!canUseLocalAiVaultSessionPathActions(session.executionHostId)) {
     return translate(
@@ -54,6 +58,15 @@ export function aiVaultSessionDeleteBlockedReason(
     return translate(
       'auto.components.right.sidebar.AiVaultSessionRow.deleteReasonSessionLive',
       'This session is still running — wait for it to finish before deleting.'
+    )
+  }
+  // Last resort: an agent Orca never spawned shows no live state at all, so a
+  // still-growing transcript is the only sign it has an owner. Main enforces the
+  // same window, and would reject the delete anyway.
+  if (!isAiVaultSessionQuiescent(Date.parse(session.modifiedAt), nowMs)) {
+    return translate(
+      'auto.components.right.sidebar.AiVaultSessionRow.deleteReasonRecentlyActive',
+      'This session was active moments ago — wait a few minutes before deleting.'
     )
   }
   return null

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -11749,7 +11749,8 @@
             "deleteReasonNonLocalHost": "Only sessions on this device can be deleted.",
             "deleteReasonSyntheticPath": "This session can't be deleted from Orca.",
             "deleteReasonUnsupportedAgent": "{{value0}} sessions can't be deleted from Orca.",
-            "deleteReasonSessionLive": "This session is still running — wait for it to finish before deleting."
+            "deleteReasonSessionLive": "This session is still running — wait for it to finish before deleting.",
+            "deleteReasonRecentlyActive": "This session was active moments ago — wait a few minutes before deleting."
           },
           "AiVaultSessionDeleteDialog": {
             "title": "Delete this session?",

--- a/src/shared/ai-vault-session-deletion.ts
+++ b/src/shared/ai-vault-session-deletion.ts
@@ -76,6 +76,24 @@ export type AiVaultSessionDeleteRejectionCode =
 
 export type AiVaultSessionLiveness = 'live' | 'not-live' | 'unknown'
 
+// An agent Orca never spawned — an external terminal, a shell inside a WSL
+// distro, a paired runtime driving the same home — appends to the transcript
+// from a process no PTY inventory or status snapshot can see. So "no owning
+// process found" is not evidence of "not live"; only the transcript having
+// stopped changing is. Long enough to span the quiet gap while an agent runs a
+// slow tool call, short enough that a finished session becomes deletable soon.
+export const AI_VAULT_SESSION_QUIESCENCE_MS = 5 * 60_000
+
+// A non-finite or future write time (clock skew, an unparsable timestamp) is
+// never quiescent, so every caller of this fails closed by construction.
+export function isAiVaultSessionQuiescent(
+  lastWriteMs: number,
+  nowMs: number,
+  windowMs: number = AI_VAULT_SESSION_QUIESCENCE_MS
+): boolean {
+  return Number.isFinite(lastWriteMs) && nowMs - lastWriteMs >= windowMs
+}
+
 // One path the executor removes. A `kind` mismatch on disk is a rejection,
 // never a coerced delete. `roots` are what the path's realpath must still
 // resolve inside — a symlinked parent escapes the validator's textual check.


### PR DESCRIPTION
## Why

On the v1.4.177 release branch, `94c9050ff9` intentionally reverts #10249 (AI Vault session deletion): deletion could be authorized from an incomplete or stale view of which provider sessions were still running, and the contract is that **unknown liveness must fail closed and preserve the transcript**. Main keeps #10249 so forward fixes can land and soak — #13106 (contain WSL deletion) and #13108 (block deletion of live sessions) already did. This closes the gap those two left.

**No changes to `prod-release-v1.4.177-rc.0`.** This is main-only, for a post-1.4.177 re-land.

## The remaining gap

`resolveAiVaultSessionLiveness` walks the PTY inventory and the local agent-status snapshot, and is careful never to read *unavailable* evidence as absence. But the inventory itself can only ever describe processes **Orca spawned**. Three owners are absent from it while actively appending to the transcript:

- a local agent launched from an external terminal,
- an agent running inside a WSL distro Orca did not launch (no hook-relay status),
- a paired-runtime owner.

All three produced an empty match set, which resolved to a confident `not-live` — and the executor trashed a live transcript. Absence of a process was being treated as proof of absence of an owner.

## The guard

`qualifyAiVaultSessionLiveness` (`src/main/ai-vault/session-transcript-quiescence.ts`) corroborates any `not-live` verdict against the transcript itself. It survives only if:

1. the transcript did not change (mtime **or** size) while liveness was being inspected — an owner exists whatever the inventory said; and
2. it has been quiet for `AI_VAULT_SESSION_QUIESCENCE_MS` (5 min).

Anything else — including an unreadable file, a missing pre-inspection fingerprint, or a future-dated write time from clock skew — is `unknown`, which `deleteAiVaultSessionFile` already refuses. `live` and `unknown` pass through untouched: this only ever removes permission to delete, never grants it.

`readAiVaultSessionIdentity` now returns the transcript fingerprint it already stat'd, so the before/after comparison costs one extra `lstat`.

The renderer applies the same window via `modifiedAt`, keeping renderer-offered deletes a strict subset of main-authorized ones — so a blocked delete reads as "This session was active moments ago" in the row instead of a generic failure toast after the confirm dialog.

## Tests

`session-transcript-quiescence.test.ts` (new, real temp files + `utimes` for a deterministic clock) and three new end-to-end cases in `session-delete-liveness.repro.test.ts` that go through `deleteAiVaultSessionFile` and assert the file **survives on disk**:

- local agent launched outside Orca (empty inventory)
- WSL-distro agent with no hook-relay status
- every other agent process attributed, target unaccounted for

Each of these returned `not-live` and deleted the transcript before this change.

Also covered: written-during-inspection (same mtime, more bytes), unreadable mid-authorization, no pre-inspection fingerprint, future-dated write time, and the renderer window boundary (±1ms) plus gate ordering.

## Re-land readiness

`docs/reference/ai-vault-session-delete-safety.md` maps every authorization path, tabulates each fail-closed scenario to its test, and carries the checklist for when v1.4.177+N can safely re-include the feature. Two items are deliberately unchecked: a full release cycle of soak on main, and confirming no support reports of a transcript disappearing mid-session.

## Notes

- Rejections reuse the existing `session-liveness-unknown` code — no new IPC or stream opcode, nothing needing remote capability negotiation.
- The 5-minute window is a real UX cost: a just-finished session stays undeletable for 5 minutes, and the row says why. Shortening it narrows protection for exactly the class that caused the revert, so it is documented as part of the contract rather than a tunable constant.
- `pnpm typecheck` (node + web) clean; `oxlint` clean on touched files; localization catalog/extraction/coverage gates pass; 254 test files / 2190 tests green across `src/main/ai-vault`, `src/main/ipc/ai-vault`, and `src/renderer/.../right-sidebar`.

Made with [Orca](https://github.com/stablyai/orca) 🐋
