### PR TITLE
feat(codex): scope model discovery to pinned PTY accounts

### DIFF
--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -60,13 +60,20 @@ import {
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   getWslSelectionKey,
+  getCodexSelectionLaneKey,
+  getCodexSelectionTargetForAccount,
   getSelectedCodexAccountIdForTarget,
   normalizeCodexRuntimeSelection,
   setSelectedCodexAccountIdForTarget,
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
-import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-path'
+import {
+  environmentCodexHomeOverrideContextsEqual,
+  getCustomCodexHomeOverrideForLaunch,
+  hasCustomCodexHomeOverrideForLaunch,
+  shellStartupCodexHomeOverrideMatches
+} from '../codex/codex-real-home-path'
 import {
   hasCompletedCodexSessionBackfillMarker,
   invalidateCodexSessionBackfillMarker
@@ -258,6 +265,83 @@ export class CodexRuntimeHomeService {
       resolveHostCodexSessionSourceHome(this.store.getSettings())
     )
     return this.getRuntimeHomePath()
+  }
+
+  /**
+   * Resolves the immutable CODEX_HOME captured for a live PTY without changing
+   * the user's active account. Undefined asks callers to use legacy discovery.
+   */
+  resolveCodexHomeForPaneModelDiscovery(
+    ptyId: string,
+    target?: CodexAccountSelectionTarget
+  ): string | null | undefined {
+    const record = getCodexPaneAccount(ptyId)
+    if (!record || !record.homeRoute) {
+      return undefined
+    }
+    const normalizedTarget = target ?? { runtime: 'host' as const }
+    if (record.selectionKey !== getCodexSelectionLaneKey(normalizedTarget)) {
+      throw new Error('Codex pane account lane no longer matches the discovery runtime.')
+    }
+    if (record.homeRoute === 'real-home') {
+      if (record.accountId !== null || normalizedTarget.runtime === 'wsl') {
+        throw new Error('Codex pane real-home provenance is invalid.')
+      }
+      // Why: an explicit path prevents a user CODEX_HOME exported after this
+      // PTY launched from silently retargeting its account-scoped probe.
+      return getSystemCodexHomePath()
+    }
+    if (record.homeRoute === 'shared-home') {
+      return this.getRuntimeHomePath()
+    }
+    if (record.homeRoute === 'custom-home') {
+      if (record.environmentHomeOverride) {
+        const current = getCustomCodexHomeOverrideForLaunch()
+        if (
+          current?.source === 'environment' &&
+          environmentCodexHomeOverrideContextsEqual(record.environmentHomeOverride, current.context)
+        ) {
+          return record.environmentHomeOverride.codexHome
+        }
+      }
+      if (
+        record.shellStartupHomeOverride &&
+        shellStartupCodexHomeOverrideMatches(record.shellStartupHomeOverride)
+      ) {
+        return record.shellStartupHomeOverride.codexHome
+      }
+      throw new Error('Codex pane custom home can no longer be verified.')
+    }
+    if (record.accountId === null) {
+      if (record.homeRoute !== 'wsl-home' || normalizedTarget.runtime !== 'wsl') {
+        throw new Error('Codex pane account provenance is incomplete.')
+      }
+      return this.getWslSystemCodexHomePath(normalizedTarget)
+    }
+    const account = this.store
+      .getSettings()
+      .codexManagedAccounts.find((candidate) => candidate.id === record.accountId)
+    if (
+      !account ||
+      getCodexSelectionLaneKey(getCodexSelectionTargetForAccount(account)) !== record.selectionKey
+    ) {
+      throw new Error('Codex pane account is no longer available.')
+    }
+    if (record.homeRoute === 'account-home') {
+      const trustedHome = this.getTrustedSelfContainedManagedHomePath(account)
+      if (!trustedHome) {
+        throw new Error('Codex pane account home is no longer trusted.')
+      }
+      return trustedHome
+    }
+    if (record.homeRoute === 'wsl-home' && normalizedTarget.runtime === 'wsl') {
+      const managedHome = this.getWslManagedHomePath(account)
+      if (!managedHome) {
+        throw new Error('Codex pane WSL account home is unavailable.')
+      }
+      return managedHome
+    }
+    throw new Error('Codex pane home route is incompatible with model discovery.')
   }
 
   beginHostSystemDefaultSessionMigrationLaunch(

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1430,6 +1430,8 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     automations,
     {
       prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
+      prepareForCodexPtyLaunch: (ptyId, target) =>
+        codexRuntimeHome!.resolveCodexHomeForPaneModelDiscovery(ptyId, target),
       prepareForClaudeLaunch: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
     },
     agentAwakeService ?? undefined,
@@ -2665,6 +2667,8 @@ void app.whenReady().then(async () => {
   runtimeService.setCommitMessageAgentEnvironmentResolvers({
     // Why: Codex hooks/auth live in Orca's managed runtime home even for the default path, so every launch must resolve CODEX_HOME via runtime-home.
     prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
+    prepareForCodexPtyLaunch: (ptyId, target) =>
+      codexRuntimeHome!.resolveCodexHomeForPaneModelDiscovery(ptyId, target),
     prepareForClaudeLaunch: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
   })
   const pluginSystemStartupStartedAt = performance.now()

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1561,7 +1561,7 @@ export function registerFilesystemHandlers(
     'git:discoverCommitMessageModels',
     async (
       _event,
-      args: { agentId: string; worktreePath?: string; connectionId?: string }
+      args: { agentId: string; worktreePath?: string; connectionId?: string; ptyId?: string }
     ): Promise<DiscoverCommitMessageModelsResult> => {
       const agentId = args.agentId
       const agentCommandOverride = store.getSettings().agentCmdOverrides?.[agentId as TuiAgent]
@@ -1601,7 +1601,8 @@ export function registerFilesystemHandlers(
       const localEnv = await prepareLocalCommitMessageAgentEnv(
         agentId,
         commitMessageAgentEnv,
-        localRuntimeTarget
+        localRuntimeTarget,
+        args.ptyId
       )
       if (!localEnv.ok) {
         return { success: false, error: localEnv.error }

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -852,7 +852,8 @@ export class RuntimeGitCommands {
   async discoverRuntimeCommitMessageModels(
     worktreeSelector: string,
     agentId: string,
-    settingsOverride?: Pick<RuntimeCommitMessageSettingsOverride, 'agentCmdOverrides'>
+    settingsOverride?: Pick<RuntimeCommitMessageSettingsOverride, 'agentCmdOverrides'>,
+    ptyId?: string
   ): Promise<DiscoverCommitMessageModelsResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const typedAgentId = agentId as TuiAgent
@@ -877,7 +878,8 @@ export class RuntimeGitCommands {
     const localEnv = await prepareLocalCommitMessageAgentEnv(
       typedAgentId,
       this.host.getCommitMessageAgentEnvironment?.(),
-      localAgentRuntimeTargetForTarget(target)
+      localAgentRuntimeTargetForTarget(target),
+      ptyId
     )
     if (!localEnv.ok) {
       return { success: false, error: localEnv.error }

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -184,7 +184,8 @@ export const GitGenerateCommitMessage = WorktreeSelector.extend({
 
 export const GitDiscoverCommitMessageModels = WorktreeSelector.extend({
   agentId: z.string().min(1, 'Missing agent id'),
-  agentCmdOverrides: z.record(z.string(), z.string()).optional()
+  agentCmdOverrides: z.record(z.string(), z.string()).optional(),
+  ptyId: z.string().min(1).optional()
 })
 
 export const GitGeneratePullRequestFields = GitGenerateCommitMessage.extend({

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -299,7 +299,8 @@ describe('git RPC methods', () => {
       makeRequest('git.discoverCommitMessageModels', {
         worktree: 'id:wt-1',
         agentId: 'cursor',
-        agentCmdOverrides: { cursor: 'cursor-agent' }
+        agentCmdOverrides: { cursor: 'cursor-agent' },
+        ptyId: 'pty-account-b'
       })
     )
     await dispatcher.dispatch(
@@ -330,9 +331,12 @@ describe('git RPC methods', () => {
 
     expect(runtime.commitRuntimeGit).toHaveBeenCalledWith('id:wt-1', 'feat: test')
     expect(runtime.generateRuntimeCommitMessage).toHaveBeenCalledWith('id:wt-1')
-    expect(runtime.discoverRuntimeCommitMessageModels).toHaveBeenCalledWith('id:wt-1', 'cursor', {
-      agentCmdOverrides: { cursor: 'cursor-agent' }
-    })
+    expect(runtime.discoverRuntimeCommitMessageModels).toHaveBeenCalledWith(
+      'id:wt-1',
+      'cursor',
+      { agentCmdOverrides: { cursor: 'cursor-agent' } },
+      'pty-account-b'
+    )
     expect(runtime.cancelRuntimeGenerateCommitMessage).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.abortRuntimeGitMerge).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.abortRuntimeGitRebase).toHaveBeenCalledWith('id:wt-1')

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -299,7 +299,8 @@ export const GIT_METHODS: RpcMethod[] = [
           ? {
               agentCmdOverrides: params.agentCmdOverrides as GlobalSettings['agentCmdOverrides']
             }
-          : {}
+          : {},
+        params.ptyId
       )
   }),
   defineMethod({

--- a/src/main/text-generation/commit-message-agent-environment.test.ts
+++ b/src/main/text-generation/commit-message-agent-environment.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { prepareLocalCommitMessageAgentEnv } from './commit-message-agent-environment'
 
 const originalEnv = { ...process.env }
@@ -121,6 +121,42 @@ describe('prepareLocalCommitMessageAgentEnv', () => {
       env: expect.objectContaining({
         CODEX_HOME: 'C:\\Users\\tester\\AppData\\Roaming\\Orca\\codex-accounts\\a\\home'
       })
+    })
+  })
+
+  it('prefers the account home pinned to the requested Codex PTY', async () => {
+    const prepareForCodexLaunch = vi.fn(() => '/managed/account-a/home')
+    const prepareForCodexPtyLaunch = vi.fn(() => '/managed/account-b/home')
+
+    const result = await prepareLocalCommitMessageAgentEnv(
+      'codex',
+      { prepareForCodexLaunch, prepareForCodexPtyLaunch },
+      { runtime: 'host' },
+      'pty-account-b'
+    )
+
+    expect(prepareForCodexPtyLaunch).toHaveBeenCalledWith('pty-account-b', { runtime: 'host' })
+    expect(prepareForCodexLaunch).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: true,
+      env: expect.objectContaining({ CODEX_HOME: '/managed/account-b/home' })
+    })
+  })
+
+  it('uses legacy account discovery when the runtime cannot scope an unknown PTY', async () => {
+    const prepareForCodexLaunch = vi.fn(() => '/managed/current/home')
+
+    const result = await prepareLocalCommitMessageAgentEnv(
+      'codex',
+      { prepareForCodexLaunch, prepareForCodexPtyLaunch: () => undefined },
+      { runtime: 'host' },
+      'pty-unrecorded'
+    )
+
+    expect(prepareForCodexLaunch).toHaveBeenCalledWith({ runtime: 'host' })
+    expect(result).toEqual({
+      ok: true,
+      env: expect.objectContaining({ CODEX_HOME: '/managed/current/home' })
     })
   })
 

--- a/src/main/text-generation/commit-message-agent-environment.ts
+++ b/src/main/text-generation/commit-message-agent-environment.ts
@@ -5,6 +5,10 @@ import { parseWslUncPath } from '../../shared/wsl-paths'
 
 export type CommitMessageAgentEnvironmentResolvers = {
   prepareForCodexLaunch?: (target?: CommitMessageAgentRuntimeTarget) => string | null
+  prepareForCodexPtyLaunch?: (
+    ptyId: string,
+    target?: CommitMessageAgentRuntimeTarget
+  ) => string | null | undefined
   prepareForClaudeLaunch?: (
     target?: CommitMessageAgentRuntimeTarget
   ) => Promise<ClaudeRuntimeAuthPreparation>
@@ -86,7 +90,8 @@ function prepareShellConfigDirEnv(agentId: string): { ok: true; env?: NodeJS.Pro
 export async function prepareLocalCommitMessageAgentEnv(
   agentId: string,
   resolvers: CommitMessageAgentEnvironmentResolvers | undefined,
-  target?: CommitMessageAgentRuntimeTarget
+  target?: CommitMessageAgentRuntimeTarget,
+  ptyId?: string
 ): Promise<{ ok: true; env?: NodeJS.ProcessEnv } | { ok: false; error: string }> {
   // Why: a non-null result short-circuits the resolvers below, so any agent added
   // to prepareShellConfigDirEnv must not also need a Codex/Claude-style resolver.
@@ -99,8 +104,19 @@ export async function prepareLocalCommitMessageAgentEnv(
   }
 
   try {
-    if (agentId === 'codex' && resolvers.prepareForCodexLaunch) {
-      const codexHomePath = resolvers.prepareForCodexLaunch(target)
+    if (
+      agentId === 'codex' &&
+      (resolvers.prepareForCodexLaunch || (ptyId && resolvers.prepareForCodexPtyLaunch))
+    ) {
+      // Why: undefined means this runtime cannot scope the probe (old host or an
+      // unrecorded PTY); null is an authoritative real-home route.
+      const scopedCodexHomePath = ptyId
+        ? resolvers.prepareForCodexPtyLaunch?.(ptyId, target)
+        : undefined
+      const codexHomePath =
+        scopedCodexHomePath !== undefined
+          ? scopedCodexHomePath
+          : (resolvers.prepareForCodexLaunch?.(target) ?? null)
       const wslCodexHome = codexHomePath ? parseWslUncPath(codexHomePath) : null
       if (target?.runtime === 'wsl') {
         const codexHomeForTarget = wslCodexHome?.linuxPath ?? null

--- a/src/preload/api/git-inspection-api.ts
+++ b/src/preload/api/git-inspection-api.ts
@@ -101,6 +101,7 @@ export type GitInspectionApi = {
     agentId: string
     worktreePath?: string
     connectionId?: string
+    ptyId?: string
   }) => Promise<
     | {
         success: true

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3470,6 +3470,7 @@ const api = {
       agentId: string
       worktreePath?: string
       connectionId?: string
+      ptyId?: string
     }): Promise<unknown> => ipcRenderer.invoke('git:discoverCommitMessageModels', args),
     cancelGenerateCommitMessage: (args: {
       worktreePath: string

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   createClaudeCatalogOptions,
+  createCodexCatalogOptions,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -80,7 +81,7 @@ export async function discoverNativeChatCatalogModels(
     result.models.length === 0 ||
     // Why: a spec's static fallback list must never pass as a probe result for an
     // agent whose published list replaces rather than extends the seed.
-    ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
+    ((agent === 'claude' || agent === 'codex' || catalog?.discoveredModelsAreAuthoritative) &&
       result.catalogOrigin !== 'probe')
   ) {
     return null
@@ -96,6 +97,11 @@ export async function discoverNativeChatCatalogModels(
             effortLevelIds: model.thinkingLevels?.map(({ id }) => id) ?? [],
             supportsFastMode: model.supportsFastMode
           })
-        : []
+        : agent === 'codex'
+          ? createCodexCatalogOptions({
+              effortLevels: model.thinkingLevels ?? [],
+              ...(model.defaultThinkingLevel ? { defaultEffort: model.defaultThinkingLevel } : {})
+            })
+          : []
   }))
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -72,9 +72,10 @@ export function resolveNativeChatModelDiscoveryContext(
 
 export async function discoverNativeChatCatalogModels(
   agent: AgentType,
-  context: RuntimeGitContext
+  context: RuntimeGitContext,
+  ptyId?: string
 ): Promise<CatalogModel[] | null> {
-  const result = await discoverRuntimeCommitMessageModels(context, agent)
+  const result = await discoverRuntimeCommitMessageModels(context, agent, ptyId)
   const catalog = getAgentSessionOptionCatalog(agent)
   if (
     !result.success ||

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -317,4 +317,78 @@ describe('native chat session option enrichment', () => {
       })
     ).resolves.toBeNull()
   })
+
+  it('uses discovered Codex models and their per-model reasoning levels', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        {
+          id: 'gpt-5.6-sol',
+          label: 'GPT-5.6 Sol',
+          thinkingLevels: [
+            { id: 'low', label: 'Low' },
+            { id: 'high', label: 'High' },
+            { id: 'max', label: 'Max' },
+            { id: 'ultra', label: 'Ultra' }
+          ],
+          defaultThinkingLevel: 'high'
+        },
+        { id: 'account-only-model', label: 'Account only model' }
+      ]
+    })
+
+    const discovered = await discoverNativeChatCatalogModels('codex', {
+      settings: {},
+      worktreeId: 'repo::/worktree',
+      worktreePath: '/worktree'
+    })
+    expect(discovered?.map(({ id }) => id)).toEqual(['gpt-5.6-sol', 'account-only-model'])
+    expect(discovered?.[0].options[0].kind).toMatchObject({
+      type: 'select',
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultra', label: 'Ultra' }
+      ],
+      defaultValue: 'high'
+    })
+    expect(discovered?.[1].options).toEqual([])
+
+    const listener = vi.fn()
+    subscribeNativeChatEnrichedModels('codex', 'local', listener)
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      discover: async () => discovered
+    })
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+    const enriched = readNativeChatEnrichedModels('codex', 'local')!
+    expect(enriched.map(({ id }) => id)).toEqual(['gpt-5.6-sol', 'account-only-model'])
+    expect(enriched[0].options[0].kind).toMatchObject({
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultra', label: 'Ultra' }
+      ]
+    })
+  })
+
+  it('does not advertise the Codex spec fallback when probing is unavailable', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'spec',
+      models: [{ id: 'gpt-5.5', label: 'GPT-5.5' }]
+    })
+
+    await expect(
+      discoverNativeChatCatalogModels('codex', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    ).resolves.toBeNull()
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -70,6 +70,37 @@ describe('native chat session option enrichment', () => {
     expect(readNativeChatEnrichedModels('cursor', 'local')).toBeNull()
   })
 
+  it('keeps Codex discovery caches separate for PTYs pinned to different accounts', async () => {
+    const discoverA = vi
+      .fn()
+      .mockResolvedValue([{ id: 'account-a-model', label: 'Account A', options: [] }])
+    const discoverB = vi
+      .fn()
+      .mockResolvedValue([{ id: 'account-b-model', label: 'Account B', options: [] }])
+
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      ptyId: 'pty-a',
+      discover: discoverA
+    })
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      ptyId: 'pty-b',
+      discover: discoverB
+    })
+    await vi.waitFor(() => expect(discoverB).toHaveBeenCalledOnce())
+
+    expect(readNativeChatEnrichedModels('codex', 'local', 'pty-a')?.map(({ id }) => id)).toEqual([
+      'account-a-model'
+    ])
+    expect(readNativeChatEnrichedModels('codex', 'local', 'pty-b')?.map(({ id }) => id)).toEqual([
+      'account-b-model'
+    ])
+    expect(readNativeChatEnrichedModels('codex', 'local')).toBeNull()
+  })
+
   it('does not probe agents whose catalogs have no discovery command', () => {
     const discover = vi.fn()
     ensureNativeChatModelEnrichment({ agent: 'gemini', hostKey: 'local', discover })
@@ -384,11 +415,20 @@ describe('native chat session option enrichment', () => {
     })
 
     await expect(
-      discoverNativeChatCatalogModels('codex', {
-        settings: {},
-        worktreeId: 'repo::/worktree',
-        worktreePath: '/worktree'
-      })
+      discoverNativeChatCatalogModels(
+        'codex',
+        {
+          settings: {},
+          worktreeId: 'repo::/worktree',
+          worktreePath: '/worktree'
+        },
+        'pty-account-a'
+      )
     ).resolves.toBeNull()
+    expect(mocks.discoverRuntimeCommitMessageModels).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'repo::/worktree' }),
+      'codex',
+      'pty-account-a'
+    )
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -18,34 +18,36 @@ type CatalogEnrichmentEntry = {
   listeners: Set<(models: CatalogModel[]) => void>
 }
 
-const enrichmentByAgentHost = new Map<string, CatalogEnrichmentEntry>()
+const enrichmentByScope = new Map<string, CatalogEnrichmentEntry>()
 
-function enrichmentKey(agent: AgentType, hostKey: string): string {
-  return JSON.stringify([agent, hostKey])
+function enrichmentKey(agent: AgentType, hostKey: string, ptyId?: string): string {
+  return JSON.stringify([agent, hostKey, ptyId ?? null])
 }
 
 export function readNativeChatEnrichedModels(
   agent: AgentType,
-  hostKey: string
+  hostKey: string,
+  ptyId?: string
 ): CatalogModel[] | null {
-  const models = enrichmentByAgentHost.get(enrichmentKey(agent, hostKey))?.models
+  const models = enrichmentByScope.get(enrichmentKey(agent, hostKey, ptyId))?.models
   return models ? [...models] : null
 }
 
 export function subscribeNativeChatEnrichedModels(
   agent: AgentType,
   hostKey: string,
-  listener: (models: CatalogModel[]) => void
+  listener: (models: CatalogModel[]) => void,
+  ptyId?: string
 ): () => void {
-  const key = enrichmentKey(agent, hostKey)
-  const entry = enrichmentByAgentHost.get(key) ?? {
+  const key = enrichmentKey(agent, hostKey, ptyId)
+  const entry = enrichmentByScope.get(key) ?? {
     agent,
     state: 'idle' as const,
     models: null,
     listeners: new Set<(models: CatalogModel[]) => void>()
   }
   entry.listeners.add(listener)
-  enrichmentByAgentHost.set(key, entry)
+  enrichmentByScope.set(key, entry)
   return () => entry.listeners.delete(listener)
 }
 
@@ -58,7 +60,7 @@ export function resolveNativeChatLaunchSessionOptions(
     return values
   }
   let probed = false
-  for (const entry of enrichmentByAgentHost.values()) {
+  for (const entry of enrichmentByScope.values()) {
     if (entry.agent === agent && entry.models) {
       probed = true
       if (entry.models.some((model) => model.id === values.model)) {
@@ -72,14 +74,15 @@ export function resolveNativeChatLaunchSessionOptions(
 export function ensureNativeChatModelEnrichment(args: {
   agent: AgentType
   hostKey: string
+  ptyId?: string
   discover: () => Promise<readonly CatalogModel[] | null>
 }): void {
   const catalog = getAgentSessionOptionCatalog(args.agent)
   if (!catalog?.listModels) {
     return
   }
-  const key = enrichmentKey(args.agent, args.hostKey)
-  const existing = enrichmentByAgentHost.get(key)
+  const key = enrichmentKey(args.agent, args.hostKey, args.ptyId)
+  const existing = enrichmentByScope.get(key)
   if (existing?.state === 'pending' || existing?.state === 'settled') {
     return
   }
@@ -90,10 +93,10 @@ export function ensureNativeChatModelEnrichment(args: {
     listeners: new Set()
   }
   entry.state = 'pending'
-  enrichmentByAgentHost.set(key, entry)
+  enrichmentByScope.set(key, entry)
 
   // Why: model discovery must never delay rendering or launching; the seed is
-  // immediately usable while this once-per-host probe runs in the background.
+  // immediately usable while this once-per-discovery-scope probe runs in the background.
   void args
     .discover()
     .then((discovered) => {
@@ -117,5 +120,5 @@ export function ensureNativeChatModelEnrichment(args: {
 }
 
 export function clearNativeChatModelEnrichmentForTests(): void {
-  enrichmentByAgentHost.clear()
+  enrichmentByScope.clear()
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -102,7 +102,7 @@ export function ensureNativeChatModelEnrichment(args: {
         return
       }
       entry.models =
-        args.agent === 'claude'
+        args.agent === 'claude' || args.agent === 'codex'
           ? [...discovered]
           : catalog.discoveredModelsAreAuthoritative
             ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -96,6 +96,7 @@ export function useNativeChatSessionOptions(args: {
 } {
   const { agent, terminalTabId, targetPtyId, dispatchCommand, onAgentPicker, readTerminalScreen } =
     args
+  const modelDiscoveryPtyId = agent === 'codex' ? (targetPtyId ?? undefined) : undefined
   // The screen text that last parsed into reported values, so a later model
   // discovery can re-resolve it against the host's real ids.
   const reportedScreenRef = useRef<string | null>(null)
@@ -111,7 +112,7 @@ export function useNativeChatSessionOptions(args: {
     }
     const scopeKey = targetPtyId ?? terminalTabId
     const discoveredModels = discoveryContext
-      ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+      ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey, modelDiscoveryPtyId)
       : null
     const reportedValues =
       agent === 'claude'
@@ -125,7 +126,7 @@ export function useNativeChatSessionOptions(args: {
       scopeKey,
       ...(targetPtyId ? { fallbackScopeKey: terminalTabId } : {}),
       // Why: the catalog seed carries version-neutral family labels, so it is
-      // safe on every host while the once-per-host probe runs or after it fails
+      // safe on every host while the scoped probe runs or after it fails
       // — without it the whole picker would pop in late or never appear.
       ...(discoveryContext ? { initialModels: discoveredModels ?? undefined } : {}),
       mode: targetPtyId ? 'live' : 'draft',
@@ -148,6 +149,7 @@ export function useNativeChatSessionOptions(args: {
     agent,
     dispatchCommand,
     discoveryContext,
+    modelDiscoveryPtyId,
     onAgentPicker,
     readTerminalScreen,
     targetPtyId,
@@ -175,7 +177,7 @@ export function useNativeChatSessionOptions(args: {
         }
       }
       const models = discoveryContext
-        ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+        ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey, modelDiscoveryPtyId)
         : null
       for (const screen of [authoritativeScreen, readTerminalScreen?.() ?? null]) {
         const reportedValues = readClaudeSessionOptionsFromTerminalScreen(
@@ -200,7 +202,7 @@ export function useNativeChatSessionOptions(args: {
     return () => {
       cancelled = true
     }
-  }, [agent, discoveryContext, readTerminalScreen, surface, targetPtyId])
+  }, [agent, discoveryContext, modelDiscoveryPtyId, readTerminalScreen, surface, targetPtyId])
 
   useEffect(() => {
     if (!surface || !discoveryContext) {
@@ -220,21 +222,28 @@ export function useNativeChatSessionOptions(args: {
         }
         // A failed settings write must not surface as an unhandled rejection.
         void retirePersistedModelMissingFromDiscovery(agent, models).catch(() => undefined)
-      }
+      },
+      modelDiscoveryPtyId
     )
     // Why: the subscription never replays, so a probe that settled before this
     // pane mounted would leave a retired persisted model in place forever.
-    const cached = readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+    const cached = readNativeChatEnrichedModels(
+      agent,
+      discoveryContext.hostKey,
+      modelDiscoveryPtyId
+    )
     if (cached) {
       void retirePersistedModelMissingFromDiscovery(agent, cached).catch(() => undefined)
     }
     ensureNativeChatModelEnrichment({
       agent,
       hostKey: discoveryContext.hostKey,
-      discover: () => discoverNativeChatCatalogModels(agent, discoveryContext.runtime)
+      ...(modelDiscoveryPtyId ? { ptyId: modelDiscoveryPtyId } : {}),
+      discover: () =>
+        discoverNativeChatCatalogModels(agent, discoveryContext.runtime, modelDiscoveryPtyId)
     })
     return unsubscribe
-  }, [agent, discoveryContext, surface])
+  }, [agent, discoveryContext, modelDiscoveryPtyId, surface])
 
   const snapshot = useSyncExternalStore(
     surface?.subscribe ?? subscribeEmpty,

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -725,16 +725,41 @@ describe('runtime git client', () => {
         worktreeId: 'wt-1',
         worktreePath: '/repo'
       },
-      'cursor'
+      'cursor',
+      'remote:env-1@@pty-account-b'
     )
 
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.discoverCommitMessageModels',
-      params: { worktree: 'id:wt-1', agentId: 'cursor', agentCmdOverrides },
+      params: {
+        worktree: 'id:wt-1',
+        agentId: 'cursor',
+        agentCmdOverrides,
+        ptyId: 'pty-account-b'
+      },
       timeoutMs: 75_000
     })
     expect(gitDiscoverCommitMessageModels).not.toHaveBeenCalled()
+  })
+
+  it('passes a local PTY id through model discovery IPC', async () => {
+    await discoverRuntimeCommitMessageModels(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo'
+      },
+      'codex',
+      'pty-account-a'
+    )
+
+    expect(gitDiscoverCommitMessageModels).toHaveBeenCalledWith({
+      agentId: 'codex',
+      worktreePath: '/repo',
+      connectionId: undefined,
+      ptyId: 'pty-account-a'
+    })
   })
 
   it('passes the raw worktree id to local generation IPC', async () => {

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -25,6 +25,7 @@ import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/c
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree/id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
+import { parseRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 
 export type RuntimeGenerateCommitMessageResult =
@@ -691,14 +692,17 @@ export async function generateRuntimeCommitMessage(
 
 export async function discoverRuntimeCommitMessageModels(
   context: RuntimeGitContext,
-  agentId: string
+  agentId: string,
+  ptyId?: string
 ): Promise<RuntimeDiscoverCommitMessageModelsResult> {
   const target = getActiveRuntimeTarget(context.settings)
+  const remotePty = ptyId ? parseRemoteRuntimePtyId(ptyId) : null
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.discoverCommitMessageModels({
       agentId,
       worktreePath: resolveLocalWorktreePath(context),
-      connectionId: context.connectionId
+      connectionId: context.connectionId,
+      ...(!remotePty && ptyId ? { ptyId } : {})
     }) as Promise<RuntimeDiscoverCommitMessageModelsResult>
   }
   return callRuntimeRpc<RuntimeDiscoverCommitMessageModelsResult>(
@@ -707,6 +711,7 @@ export async function discoverRuntimeCommitMessageModels(
     {
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       agentId,
+      ...(ptyId ? { ptyId: remotePty?.handle ?? ptyId } : {}),
       ...(context.settings?.agentCmdOverrides
         ? { agentCmdOverrides: context.settings.agentCmdOverrides }
         : {})

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -10,6 +10,7 @@ import {
   parseClaudeModelList
 } from './claude-model-list-probe'
 import { hasFlag } from './agent-cli-flag-detection'
+import { CODEX_MODEL_LIST_COMMAND, parseCodexModelList } from './codex-model-list-probe'
 
 function hasCodexEffortOverride(tokens: readonly string[]): boolean {
   if (hasFlag(tokens, ['--reasoning-effort'])) {
@@ -190,17 +191,20 @@ const CODEX_EFFORT_CHOICES = [
   { value: 'ultra', label: 'Ultra' }
 ]
 
-// Why: Codex can clamp higher values, so expose only each model's advertised levels.
-function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
-  const ceilingIndex = CODEX_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+type CodexEffortChoice = { value: string; label: string }
+
+function codexEffortWithChoices(
+  choices: readonly CodexEffortChoice[],
+  defaultValue: string
+): CatalogOption {
   return {
     id: 'effort',
     label: 'Reasoning effort',
     category: 'thought_level',
     kind: {
       type: 'select',
-      choices: CODEX_EFFORT_CHOICES.slice(0, ceilingIndex + 1),
-      defaultValue: 'medium'
+      choices: [...choices],
+      defaultValue
     },
     apply: {
       launchArgs: (value) => ['-c', `model_reasoning_effort=${String(value)}`],
@@ -209,6 +213,53 @@ function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
       midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
     }
   }
+}
+
+// Why: Codex can clamp higher values, so expose only each model's advertised levels.
+function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
+  const ceilingIndex = CODEX_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+  return codexEffortWithChoices(CODEX_EFFORT_CHOICES.slice(0, ceilingIndex + 1), 'medium')
+}
+
+function labelCodexEffort(effort: string): string {
+  if (effort === 'xhigh') {
+    return 'Extra high'
+  }
+  return effort.charAt(0).toUpperCase() + effort.slice(1)
+}
+
+export function createCodexCatalogOptions(args: {
+  effortLevels: readonly { id: string; label: string }[]
+  defaultEffort?: string
+}): CatalogOption[] {
+  const choices = args.effortLevels.map(({ id, label }) => ({ value: id, label }))
+  if (choices.length === 0) {
+    return []
+  }
+  const choiceIds = choices.map(({ value }) => value)
+  const defaultEffort = choiceIds.includes(args.defaultEffort ?? '')
+    ? args.defaultEffort!
+    : choiceIds.includes('medium')
+      ? 'medium'
+      : choiceIds[0]
+  return [codexEffortWithChoices(choices, defaultEffort)]
+}
+
+function parseCodexCatalogModels(stdout: string): CatalogModel[] {
+  return parseCodexModelList(stdout).map((model) => {
+    const effortLevels = model.effortLevels.map((effort) => ({
+      id: effort,
+      label: labelCodexEffort(effort)
+    }))
+    return {
+      id: model.id,
+      label: model.label,
+      options: createCodexCatalogOptions({
+        effortLevels,
+        ...(model.defaultEffort ? { defaultEffort: model.defaultEffort } : {})
+      })
+    }
+  })
 }
 
 export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
@@ -234,5 +285,9 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // command and let its own picker apply the account-supported model.
     midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
   },
-  unknownModelOptions: [codexEffort('xhigh')]
+  unknownModelOptions: [codexEffort('xhigh')],
+  listModels: {
+    command: CODEX_MODEL_LIST_COMMAND,
+    parse: parseCodexCatalogModels
+  }
 }

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -108,6 +108,91 @@ describe('agent session option catalog', () => {
     expect(parse('garbage')).toEqual([])
   })
 
+  it('parses Codex discovery into model-specific reasoning options', () => {
+    const catalog = getAgentSessionOptionCatalog('codex')!
+    expect(catalog.listModels?.command).toBe('codex debug models')
+
+    const parsed = catalog.listModels!.parse(
+      JSON.stringify({
+        models: [
+          {
+            slug: 'gpt-account-frontier',
+            display_name: 'GPT Account Frontier',
+            default_reasoning_level: 'high',
+            supported_reasoning_levels: [
+              { effort: 'low' },
+              { effort: 'high' },
+              { effort: 'max' },
+              { effort: 'ultra' }
+            ]
+          },
+          {
+            slug: 'gpt-account-fast',
+            display_name: 'GPT Account Fast',
+            supported_reasoning_levels: [{ effort: 'minimal' }]
+          },
+          { slug: 'gpt-account-plain', display_name: 'GPT Account Plain' }
+        ]
+      })
+    )
+
+    expect(parsed.map(({ id }) => id)).toEqual([
+      'gpt-account-frontier',
+      'gpt-account-fast',
+      'gpt-account-plain'
+    ])
+    const frontierEffort = parsed[0].options[0]
+    expect(frontierEffort.kind).toMatchObject({ defaultValue: 'high' })
+    expect(
+      frontierEffort.kind.type === 'select'
+        ? frontierEffort.kind.choices.map(({ value, label }) => ({ value, label }))
+        : []
+    ).toEqual([
+      { value: 'low', label: 'Low' },
+      { value: 'high', label: 'High' },
+      { value: 'max', label: 'Max' },
+      { value: 'ultra', label: 'Ultra' }
+    ])
+    expect(parsed[1].options[0].kind).toMatchObject({
+      choices: [{ value: 'minimal', label: 'Minimal' }],
+      defaultValue: 'minimal'
+    })
+    expect(parsed[2].options).toEqual([])
+  })
+
+  it('keeps the Codex seed when model discovery output is malformed', () => {
+    const parse = getAgentSessionOptionCatalog('codex')!.listModels!.parse
+    expect(parse('')).toEqual([])
+    expect(parse('{"models":false}')).toEqual([])
+    expect(parse('garbage')).toEqual([])
+  })
+
+  it('deduplicates Codex models and reasoning levels from discovery', () => {
+    const parse = getAgentSessionOptionCatalog('codex')!.listModels!.parse
+    const parsed = parse(
+      JSON.stringify({
+        models: [
+          {
+            slug: 'gpt-account-frontier',
+            display_name: 'GPT Account Frontier',
+            supported_reasoning_levels: [{ effort: 'low' }, { effort: 'low' }, { effort: 'high' }]
+          },
+          { slug: 'gpt-account-frontier', display_name: 'Duplicate row' }
+        ]
+      })
+    )
+
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].label).toBe('GPT Account Frontier')
+    expect(parsed[0].options[0].kind).toMatchObject({
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' }
+      ],
+      defaultValue: 'low'
+    })
+  })
+
   it('merges discovered Claude variants after the seed and overlays matched labels', () => {
     const catalog = getAgentSessionOptionCatalog('claude')!
     const merged = mergeCatalogModels(catalog.models, [

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -2,7 +2,8 @@ import type { AgentType } from './agent-status-types'
 import {
   CLAUDE_SESSION_OPTION_CATALOG,
   CODEX_SESSION_OPTION_CATALOG,
-  createClaudeCatalogOptions
+  createClaudeCatalogOptions,
+  createCodexCatalogOptions
 } from './agent-session-option-catalog-claude-codex'
 import {
   CURSOR_SESSION_OPTION_CATALOG,
@@ -26,7 +27,7 @@ export type {
   CatalogOption,
   CatalogOptionApply
 } from './agent-session-option-catalog-types'
-export { createClaudeCatalogOptions }
+export { createClaudeCatalogOptions, createCodexCatalogOptions }
 
 const CATALOGS: AgentSessionOptionCatalogMap = {
   claude: CLAUDE_SESSION_OPTION_CATALOG,

--- a/src/shared/codex-model-list-probe.test.ts
+++ b/src/shared/codex-model-list-probe.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CODEX_MODEL_LIST_MAX_JSON_CHARACTERS, parseCodexModelList } from './codex-model-list-probe'
+
+describe('Codex model list probe', () => {
+  it('rejects oversized output before JSON.parse', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      expect(parseCodexModelList(' '.repeat(CODEX_MODEL_LIST_MAX_JSON_CHARACTERS + 1))).toEqual([])
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+})

--- a/src/shared/codex-model-list-probe.ts
+++ b/src/shared/codex-model-list-probe.ts
@@ -1,0 +1,80 @@
+import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
+
+export const CODEX_MODEL_LIST_ARGS = ['debug', 'models'] as const
+export const CODEX_MODEL_LIST_COMMAND = `codex ${CODEX_MODEL_LIST_ARGS.join(' ')}`
+
+export const CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS = {
+  structuralTokens: 64 * 1024,
+  nestingDepth: 16
+} as const
+
+export type CodexModelListModel = {
+  id: string
+  label: string
+  effortLevels: string[]
+  defaultEffort: string | null
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  return value.trim() || null
+}
+
+function uniqueEffortLevels(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const seen = new Set<string>()
+  const levels: string[] = []
+  for (const entry of value) {
+    const effort =
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? nonEmptyString((entry as { effort?: unknown }).effort)
+        : null
+    if (effort && !seen.has(effort)) {
+      seen.add(effort)
+      levels.push(effort)
+    }
+  }
+  return levels
+}
+
+export function parseCodexModelList(stdout: string): CodexModelListModel[] {
+  try {
+    assertJsonTextStructureWithinLimits(stdout, CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS)
+    const parsed: unknown = JSON.parse(stdout)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return []
+    }
+    const models = (parsed as { models?: unknown }).models
+    if (!Array.isArray(models)) {
+      return []
+    }
+
+    const seen = new Set<string>()
+    const result: CodexModelListModel[] = []
+    for (const value of models) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        continue
+      }
+      const model = value as Record<string, unknown>
+      const id = nonEmptyString(model.slug)
+      const label = nonEmptyString(model.display_name)
+      if (!id || !label || seen.has(id)) {
+        continue
+      }
+      seen.add(id)
+      result.push({
+        id,
+        label,
+        effortLevels: uniqueEffortLevels(model.supported_reasoning_levels),
+        defaultEffort: nonEmptyString(model.default_reasoning_level)
+      })
+    }
+    return result
+  } catch {
+    return []
+  }
+}

--- a/src/shared/codex-model-list-probe.ts
+++ b/src/shared/codex-model-list-probe.ts
@@ -2,6 +2,7 @@ import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit
 
 export const CODEX_MODEL_LIST_ARGS = ['debug', 'models'] as const
 export const CODEX_MODEL_LIST_COMMAND = `codex ${CODEX_MODEL_LIST_ARGS.join(' ')}`
+export const CODEX_MODEL_LIST_MAX_JSON_CHARACTERS = 4 * 1024 * 1024
 
 export const CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS = {
   structuralTokens: 64 * 1024,
@@ -43,6 +44,9 @@ function uniqueEffortLevels(value: unknown): string[] {
 
 export function parseCodexModelList(stdout: string): CodexModelListModel[] {
   try {
+    if (stdout.length > CODEX_MODEL_LIST_MAX_JSON_CHARACTERS) {
+      return []
+    }
     assertJsonTextStructureWithinLimits(stdout, CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS)
     const parsed: unknown = JSON.parse(stdout)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -1,12 +1,16 @@
 import type { TuiAgent } from './tui-agent'
 import { isTuiAgentEnabled } from './tui-agent-selection'
-import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
 import {
   CLAUDE_MODEL_LIST_ARGS,
   CLAUDE_MODEL_LIST_STDIN,
   parseClaudeModelList
 } from './claude-model-list-probe'
 import { labelFromModelId } from './model-id-label'
+import {
+  CODEX_MODEL_LIST_ARGS,
+  CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS,
+  parseCodexModelList
+} from './codex-model-list-probe'
 
 /* eslint-disable max-lines -- Why: this is the single registry for non-interactive commit-message agents, their model discovery parsers, and UI capabilities. */
 
@@ -81,10 +85,7 @@ export type CommitMessageAgentCapability = {
   defaultModelId: string
 }
 
-export const COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS = {
-  structuralTokens: 64 * 1024,
-  nestingDepth: 16
-} as const
+export const COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS = CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS
 
 const BASIC_THINKING_LEVELS: ThinkingLevel[] = [
   { id: 'low', label: 'Low' },
@@ -172,39 +173,25 @@ export function parseClaudeModels(stdout: string): CommitMessageModel[] {
 }
 
 export function parseCodexModels(stdout: string): CommitMessageModel[] {
-  try {
-    assertJsonTextStructureWithinLimits(stdout, COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS)
-    const parsed = JSON.parse(stdout) as {
-      models?: {
-        slug?: string
-        display_name?: string
-        supported_reasoning_levels?: { effort?: string }[]
-        default_reasoning_level?: string
-      }[]
-    }
-    return uniqueModels(
-      (parsed.models ?? [])
-        .filter((model) => model.slug && model.display_name)
-        .map((model) => ({
-          id: model.slug!,
-          label: model.display_name!,
-          ...(model.supported_reasoning_levels?.length
-            ? {
-                thinkingLevels: model.supported_reasoning_levels
-                  .map((level) => level.effort)
-                  .filter((effort): effort is string => Boolean(effort))
-                  .map((effort) => ({
-                    id: effort,
-                    label: effort === 'xhigh' ? 'Extra High' : labelFromModelId(effort)
-                  })),
-                defaultThinkingLevel: model.default_reasoning_level ?? 'low'
-              }
-            : {})
-        }))
-    )
-  } catch {
-    return []
-  }
+  return uniqueModels(
+    parseCodexModelList(stdout).map((model) => ({
+      id: model.id,
+      label: model.label,
+      ...(model.effortLevels.length > 0
+        ? {
+            thinkingLevels: model.effortLevels.map((effort) => ({
+              id: effort,
+              label: effort === 'xhigh' ? 'Extra High' : labelFromModelId(effort)
+            })),
+            defaultThinkingLevel: model.effortLevels.includes(model.defaultEffort ?? '')
+              ? model.defaultEffort!
+              : model.effortLevels.includes('low')
+                ? 'low'
+                : model.effortLevels[0]
+          }
+        : {})
+    }))
+  )
 }
 
 export function parseLineModels(stdout: string): CommitMessageModel[] {
@@ -401,7 +388,7 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     modelSource: 'dynamic',
     modelDiscovery: {
       binary: 'codex',
-      args: ['debug', 'models'],
+      args: [...CODEX_MODEL_LIST_ARGS],
       parse: parseCodexModels
     },
     // Why: ordered to match the official `codex` model picker — descending


### PR DESCRIPTION
## Summary

Codex model discovery can now resolve the managed account pinned to a PTY and run the existing model probe with that account's effective `CODEX_HOME`. Native-chat enrichment scopes its cache by host and pinned account so switching accounts does not reuse another account's discovered model catalog.

The new `ptyId` field is optional throughout the renderer, preload, main-process, and runtime Git path. Older callers and runtimes continue to use the existing global Codex environment.

This PR is stacked on #13183. Please review it after that PR lands; the shared runtime model-discovery changes will disappear from this diff once the base is merged.

## Screenshots

No visual layout change. The existing native Codex model and reasoning controls receive account-scoped choices when a PTY has a managed Codex account pinned.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- Focused Vitest suite covering runtime-home resolution, IPC, runtime Git, commit-message environments, native-chat enrichment, renderer runtime Git, and the shared Codex catalog — 353 tests passed, 1 skipped.
- `pnpm run build:desktop` — passed.
- `git diff --check` — passed.
- Conflict scan against the current `origin/main` — no conflicts found.

Local environment note: the repository requests Node 24, while this workstation currently exposes Node 25.8.1. The desktop build completed; its development CLI install step reported the expected permission warning for `/usr/local/bin/orca-dev` without failing the build.

## AI Review Report

The review covered optional-field compatibility, PTY-to-account resolution, account-scoped cache identity, main-process ownership of managed account paths, commit-message discovery, and fallback behavior when no account is pinned.

Regression tests cover account-specific environment selection, unknown PTYs, IPC forwarding, runtime Git forwarding, and cache separation without changing the existing unscoped path.

Cross-platform review:

- Managed account homes remain resolved by the existing main-process service; renderer code receives no credential paths.
- Local, WSL, SSH, and remote runtime ownership remains in the existing discovery path.
- The wire addition is optional so older callers retain the current behavior.

## Security Audit

- Renderer and preload code pass only the opaque PTY identifier; they do not receive `CODEX_HOME`, auth files, tokens, or managed-home paths.
- Main validates the PTY lookup through the existing Codex pane-account registry before applying an account environment.
- Unknown or deleted account references fail safely to the existing unscoped environment.
- No user-controlled shell command is introduced; the fixed Codex model probe remains unchanged.
- Dependencies and persistent credential formats are unchanged.

## Notes

- Depends on #13183.
- Account selection and persistence are intentionally deferred to the next PRs in the series.
- X/Twitter: `@rp0927`
