### PR TITLE
feat(codex): add account-scoped launch selectors

### DIFF
--- a/src/cli/handlers/account.test.ts
+++ b/src/cli/handlers/account.test.ts
@@ -46,7 +46,7 @@ vi.mock('../../shared/node-cli-command-resolution', () => ({
   resolveCliCommand: resolveCliCommandMock
 }))
 
-import { ACCOUNT_HANDLERS } from './account'
+import { ACCOUNT_HANDLERS, formatAccountsBlock } from './account'
 import type { HandlerContext } from '../dispatch'
 import type { RuntimeClient } from '../runtime-client'
 import {
@@ -91,6 +91,17 @@ describe('account CLI handlers', () => {
   const callMock = vi.fn()
   const client = { call: callMock } as unknown as RuntimeClient
   let logSpy: ReturnType<typeof vi.spyOn>
+
+  it('renders a friendly label and canonical UUID for launch selection', () => {
+    expect(
+      formatAccountsBlock('Codex', {
+        accounts: [
+          { id: 'account-uuid-a', email: 'user@example.com', workspaceLabel: 'Acme workspace' }
+        ],
+        activeAccountId: 'account-uuid-a'
+      })
+    ).toContain('Acme workspace (active)  account-uuid-a')
+  })
 
   function context(agent: string, json = false): HandlerContext {
     return {

--- a/src/cli/handlers/account.ts
+++ b/src/cli/handlers/account.ts
@@ -41,7 +41,7 @@ type AccountsListSnapshot = {
 // Why: Claude and Codex managed-account summaries both carry id+email+active id,
 // so one formatter renders either provider's block.
 type AccountsBlock = {
-  accounts: readonly { id: string; email: string }[]
+  accounts: readonly { id: string; email: string; workspaceLabel?: string | null }[]
   activeAccountId: string | null
   activeAccountIdsByRuntime?: {
     host: string | null
@@ -50,7 +50,7 @@ type AccountsBlock = {
 }
 
 /** Renders a provider's managed-account list as a human-readable block, marking the active account. */
-function formatAccountsBlock(label: string, block: AccountsBlock): string {
+export function formatAccountsBlock(label: string, block: AccountsBlock): string {
   if (block.accounts.length === 0) {
     return `No managed ${label} accounts.`
   }
@@ -60,7 +60,8 @@ function formatAccountsBlock(label: string, block: AccountsBlock): string {
     ...Object.values(block.activeAccountIdsByRuntime?.wsl ?? {})
   ])
   const lines = block.accounts.map(
-    (account) => `  ${account.email}${activeAccountIds.has(account.id) ? ' (active)' : ''}`
+    (account) =>
+      `  ${account.workspaceLabel?.trim() || account.email}${activeAccountIds.has(account.id) ? ' (active)' : ''}  ${account.id}`
   )
   return `Managed ${label} accounts (${block.accounts.length}):\n${lines.join('\n')}`
 }

--- a/src/cli/handlers/terminal.test.ts
+++ b/src/cli/handlers/terminal.test.ts
@@ -4,6 +4,7 @@ import { parseArgs } from '../args'
 import { printHelp } from '../help'
 import { COMMAND_SPECS } from '../specs'
 import { TERMINAL_HANDLERS } from './terminal'
+import { AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
 
 describe('terminal close CLI', () => {
   afterEach(() => {
@@ -133,5 +134,201 @@ describe('terminal send CLI', () => {
       interrupt: false,
       client: { id: 'orca-cli', type: 'desktop' }
     })
+  })
+})
+
+describe('terminal create account selection', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('resolves a canonical UUID and sends only the structured account launch', async () => {
+    const call = vi.fn(async (method: string) => {
+      if (method === 'status.get') {
+        return { result: { capabilities: [AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY] } }
+      }
+      if (method === 'accounts.list') {
+        return {
+          result: {
+            codex: {
+              accounts: [
+                {
+                  id: 'account-a',
+                  email: 'user@example.com',
+                  managedHomeRuntime: 'wsl',
+                  wslDistro: 'Ubuntu'
+                }
+              ],
+              activeAccountId: null
+            }
+          }
+        }
+      }
+      return {
+        result: {
+          disposition: 'created',
+          terminal: { handle: 'term-account-a', worktreeId: 'worktree-1', title: null }
+        }
+      }
+    })
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal create']({
+      flags: new Map([
+        ['worktree', 'id:worktree-1'],
+        ['agent', 'codex'],
+        ['account', 'account-a']
+      ]),
+      client: { call, isRemote: false } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+
+    expect(call).toHaveBeenCalledWith('accounts.list', { refreshUsage: false })
+    expect(call).toHaveBeenCalledWith(
+      'terminal.createAgentSession',
+      expect.objectContaining({
+        clientOperationId: expect.stringMatching(/^\d+-[a-f0-9]{32}$/),
+        worktree: 'id:worktree-1',
+        agent: 'codex',
+        providerAccountRef: {
+          provider: 'codex',
+          accountId: 'account-a',
+          runtime: 'wsl',
+          wslDistro: 'Ubuntu'
+        },
+        presentation: 'background'
+      })
+    )
+    expect(call).not.toHaveBeenCalledWith('terminal.create', expect.anything())
+  })
+
+  it('selects an explicit WSL system account without listing managed homes', async () => {
+    const call = vi.fn(async (method: string) =>
+      method === 'status.get'
+        ? { result: { capabilities: [AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY] } }
+        : {
+            result: {
+              disposition: 'created',
+              terminal: { handle: 'term-system', worktreeId: 'worktree-1', title: null }
+            }
+          }
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await TERMINAL_HANDLERS['terminal create']({
+      flags: new Map([
+        ['worktree', 'id:worktree-1'],
+        ['agent', 'codex'],
+        ['account', 'system'],
+        ['account-runtime', 'wsl'],
+        ['wsl-distro', 'Ubuntu']
+      ]),
+      client: { call, isRemote: false } as unknown as RuntimeClient,
+      cwd: '/tmp/worktree',
+      json: true
+    })
+
+    expect(call).not.toHaveBeenCalledWith('accounts.list', expect.anything())
+    expect(call).toHaveBeenCalledWith(
+      'terminal.createAgentSession',
+      expect.objectContaining({
+        providerAccountRef: {
+          provider: 'codex',
+          accountId: null,
+          runtime: 'wsl',
+          wslDistro: 'Ubuntu'
+        }
+      })
+    )
+  })
+
+  it('fails before account lookup or launch when the runtime lacks the capability', async () => {
+    const call = vi.fn().mockResolvedValue({ result: { capabilities: [] } })
+
+    await expect(
+      TERMINAL_HANDLERS['terminal create']({
+        flags: new Map([
+          ['worktree', 'id:worktree-1'],
+          ['agent', 'codex'],
+          ['account', 'account-a']
+        ]),
+        client: { call, isRemote: false } as unknown as RuntimeClient,
+        cwd: '/tmp/worktree',
+        json: true
+      })
+    ).rejects.toThrow('does not support account-scoped agent launches')
+
+    expect(call).toHaveBeenCalledTimes(1)
+    expect(call).not.toHaveBeenCalledWith('terminal.createAgentSession', expect.anything())
+  })
+
+  it('does not accept an email or deleted UUID as an account selector', async () => {
+    const call = vi.fn(async (method: string) =>
+      method === 'status.get'
+        ? { result: { capabilities: [AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY] } }
+        : { result: { codex: { accounts: [], activeAccountId: null } } }
+    )
+
+    await expect(
+      TERMINAL_HANDLERS['terminal create']({
+        flags: new Map([
+          ['worktree', 'id:worktree-1'],
+          ['agent', 'codex'],
+          ['account', 'user@example.com']
+        ]),
+        client: { call, isRemote: false } as unknown as RuntimeClient,
+        cwd: '/tmp/worktree',
+        json: true
+      })
+    ).rejects.toThrow('Unknown Codex account UUID')
+
+    expect(call).not.toHaveBeenCalledWith('terminal.createAgentSession', expect.anything())
+  })
+
+  it('rejects a valueless account flag instead of silently creating a default terminal', async () => {
+    const call = vi.fn()
+
+    await expect(
+      TERMINAL_HANDLERS['terminal create']({
+        flags: new Map([['account', true]]),
+        client: { call, isRemote: false } as unknown as RuntimeClient,
+        cwd: '/tmp/worktree',
+        json: true
+      })
+    ).rejects.toThrow('Missing required --account')
+
+    expect(call).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a managed WSL account has no distribution', async () => {
+    const call = vi.fn(async (method: string) =>
+      method === 'status.get'
+        ? { result: { capabilities: [AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY] } }
+        : {
+            result: {
+              codex: {
+                accounts: [
+                  { id: 'broken-wsl', email: 'user@example.com', managedHomeRuntime: 'wsl' }
+                ],
+                activeAccountId: null
+              }
+            }
+          }
+    )
+
+    await expect(
+      TERMINAL_HANDLERS['terminal create']({
+        flags: new Map([
+          ['agent', 'codex'],
+          ['account', 'broken-wsl']
+        ]),
+        client: { call, isRemote: false } as unknown as RuntimeClient,
+        cwd: '/tmp/worktree',
+        json: true
+      })
+    ).rejects.toThrow('has no WSL distribution')
+
+    expect(call).not.toHaveBeenCalledWith('terminal.createAgentSession', expect.anything())
   })
 })

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -14,7 +14,7 @@ import type {
 import type { RuntimeCreateAgentSessionResult } from '../../shared/agent-session-host-authority'
 import type { ProviderAccountRef } from '../../shared/provider-account-ref'
 import { AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
-import type { CodexRateLimitAccountsState } from '../../shared/types'
+import type { CodexRateLimitAccountsState } from '../../shared/managed-account-types'
 import type { CommandHandler } from '../dispatch'
 import { shouldUseRendererBackedInteractiveTerminal } from '../codex-command-classification'
 import {

--- a/src/cli/handlers/terminal.ts
+++ b/src/cli/handlers/terminal.ts
@@ -1,3 +1,4 @@
+import { randomBytes } from 'node:crypto'
 import type {
   RuntimeTerminalClose,
   RuntimeTerminalCreate,
@@ -10,6 +11,10 @@ import type {
   RuntimeTerminalSplit,
   RuntimeTerminalWait
 } from '../../shared/runtime-types'
+import type { RuntimeCreateAgentSessionResult } from '../../shared/agent-session-host-authority'
+import type { ProviderAccountRef } from '../../shared/provider-account-ref'
+import { AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY } from '../../shared/protocol-version'
+import type { CodexRateLimitAccountsState } from '../../shared/types'
 import type { CommandHandler } from '../dispatch'
 import { shouldUseRendererBackedInteractiveTerminal } from '../codex-command-classification'
 import {
@@ -30,7 +35,7 @@ import {
   getOptionalStringFlag,
   getRequiredStringFlag
 } from '../flags'
-import { RuntimeClientError } from '../runtime-client'
+import { RuntimeClientError, type RuntimeClient } from '../runtime-client'
 import {
   getBrowserWorktreeSelector,
   getOptionalWorktreeSelector,
@@ -42,6 +47,94 @@ import {
 // timeout. Even without an explicit server timeout, the client must allow
 // long waits instead of failing at the generic 15s transport cap.
 const DEFAULT_TERMINAL_WAIT_RPC_TIMEOUT_MS = 5 * 60 * 1000
+
+function createCliAgentSessionOperationId(): string {
+  return `${Date.now()}-${randomBytes(16).toString('hex')}`
+}
+
+async function resolveCodexLaunchAccountRef(
+  client: RuntimeClient,
+  flags: Map<string, string | boolean>
+): Promise<ProviderAccountRef | null> {
+  const readNewFlag = (name: string): string | undefined =>
+    flags.has(name) ? getRequiredStringFlag(flags, name) : undefined
+  const accountSelector = readNewFlag('account')
+  const agent = readNewFlag('agent')
+  const accountRuntime = readNewFlag('account-runtime')
+  const wslDistro = readNewFlag('wsl-distro')
+  if (accountSelector === undefined) {
+    if (agent !== undefined || accountRuntime !== undefined || wslDistro !== undefined) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        '--agent, --account-runtime, and --wsl-distro require --account.'
+      )
+    }
+    return null
+  }
+  if (agent !== 'codex') {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Codex account launches require `--agent codex`.'
+    )
+  }
+  const status = await client.call<{ capabilities?: string[] }>('status.get')
+  if (!status.result.capabilities?.includes(AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY)) {
+    throw new RuntimeClientError(
+      'incompatible_runtime',
+      'The running Orca runtime does not support account-scoped agent launches. Update or restart Orca and try again.'
+    )
+  }
+  if (accountSelector === 'system') {
+    const runtime = accountRuntime ?? 'host'
+    if (runtime !== 'host' && runtime !== 'wsl') {
+      throw new RuntimeClientError('invalid_argument', '--account-runtime must be "host" or "wsl".')
+    }
+    if ((runtime === 'wsl') !== Boolean(wslDistro)) {
+      throw new RuntimeClientError(
+        'invalid_argument',
+        'A WSL system account requires --wsl-distro, and a host account cannot use it.'
+      )
+    }
+    return {
+      provider: 'codex',
+      accountId: null,
+      runtime,
+      ...(wslDistro ? { wslDistro } : {})
+    }
+  }
+  if (accountRuntime !== undefined || wslDistro !== undefined) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      'Managed account UUIDs already identify their runtime; omit --account-runtime and --wsl-distro.'
+    )
+  }
+  const accounts = await client.call<{ codex: CodexRateLimitAccountsState }>('accounts.list', {
+    refreshUsage: false
+  })
+  const account = accounts.result.codex.accounts.find(
+    (candidate) => candidate.id === accountSelector
+  )
+  if (!account) {
+    throw new RuntimeClientError(
+      'invalid_argument',
+      `Unknown Codex account UUID "${accountSelector}". Run \`orca account list\` to see canonical selectors.`
+    )
+  }
+  const runtime = account.managedHomeRuntime ?? 'host'
+  const managedWslDistro = account.wslDistro?.trim()
+  if (runtime === 'wsl' && !managedWslDistro) {
+    throw new RuntimeClientError(
+      'invalid_state',
+      `Codex account "${account.id}" has no WSL distribution. Re-register the account before launching it.`
+    )
+  }
+  return {
+    provider: 'codex',
+    accountId: account.id,
+    runtime,
+    ...(runtime === 'wsl' ? { wslDistro: managedWslDistro } : {})
+  }
+}
 
 const terminalFocusHandler: CommandHandler = async ({ flags, client, cwd, json }) => {
   const result = await client.call<{ focus: RuntimeTerminalFocus }>('terminal.focus', {
@@ -138,13 +231,35 @@ export const TERMINAL_HANDLERS: Record<string, CommandHandler> = {
       )
     }
     const command = getOptionalStringFlag(flags, 'command')
+    const providerAccountRef = await resolveCodexLaunchAccountRef(client, flags)
+    const title = getOptionalStringFlag(flags, 'title')
     const useRendererBackedInteractiveTerminal =
       !client.isRemote && shouldUseRendererBackedInteractiveTerminal(command)
     const focus = flags.get('focus') === true
+    if (providerAccountRef) {
+      if (command !== undefined || title !== undefined) {
+        throw new RuntimeClientError(
+          'invalid_argument',
+          '--account builds the Codex launch on the runtime; omit --command and --title.'
+        )
+      }
+      const result = await client.call<RuntimeCreateAgentSessionResult>(
+        'terminal.createAgentSession',
+        {
+          clientOperationId: createCliAgentSessionOperationId(),
+          worktree: await getBrowserWorktreeSelector(flags, cwd, client),
+          agent: 'codex',
+          providerAccountRef,
+          presentation: focus ? 'focused' : 'background'
+        }
+      )
+      printResult(result, json, formatTerminalCreate)
+      return
+    }
     const result = await client.call<{ terminal: RuntimeTerminalCreate }>('terminal.create', {
       worktree: await getBrowserWorktreeSelector(flags, cwd, client),
       command,
-      title: getOptionalStringFlag(flags, 'title'),
+      title,
       // Why: interactive local agent TUIs need the renderer-backed terminal
       // path for browser-side features, but CLI creates must stay backgrounded
       // unless the caller explicitly asks for focus.

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -243,7 +243,7 @@ Common Commands:
   orca terminal send [--terminal <handle>] [--text <text>] [--enter] [--interrupt] [--json]
   orca terminal wait [--terminal <handle>] --for exit|tui-idle [--timeout-ms <ms>] [--json]
   orca terminal stop --worktree <selector> [--json]
-  orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--focus] [--json]
+  orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--agent codex --account <uuid|system> [--account-runtime host|wsl] [--wsl-distro <name>]] [--focus] [--json]
   orca terminal split [--terminal <handle>] [--direction horizontal|vertical] [--json]
   orca terminal switch [--terminal <handle>] [--json]
   orca terminal close [--terminal <handle>] [--tab] [--json]
@@ -294,6 +294,8 @@ Agent Sessions And Worktrees:
   \`worktree create --agent\` creates a new checkout with an agent.
   To start a fresh agent in the current worktree, use:
     orca terminal create --worktree active --command "codex"
+  To start Codex with a managed account UUID, use:
+    orca terminal create --worktree active --agent codex --account <uuid>
 
 Browser Workflow:
   1. Create or navigate:  orca tab create --url https://example.com
@@ -521,6 +523,8 @@ function formatCommandFlagHelp(flag: string, commandPath: string[]): string {
 
 export function formatFlagHelp(flag: string): string {
   const helpByFlag: Record<string, string> = {
+    account: '--account <uuid|system> Codex account selector for this launch',
+    'account-runtime': '--account-runtime <kind> Runtime for the system account: host or wsl',
     agent: '--agent <id>          Launch a known TUI agent in the first terminal',
     'base-branch': '--base-branch <ref>    Base branch/ref to create the worktree from',
     command: '--command <text>       Command to run in the terminal on startup',
@@ -534,6 +538,7 @@ export function formatFlagHelp(flag: string): string {
     'display-name': '--display-name <name>  Override the Orca display name',
     'element-index': '--element-index <n>   Element index from get-app-state',
     title: '--title <text>         Custom title for the terminal tab (omit to reset)',
+    'wsl-distro': '--wsl-distro <name>   WSL distribution for the system account',
     enter: '--enter                Append Enter after sending text',
     force: '--force                Force worktree removal when supported',
     focus: '--focus                Reveal the created terminal session in Orca',

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -233,15 +233,20 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
     path: ['terminal', 'create'],
     summary: 'Create a terminal session in the current worktree',
     usage:
-      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--focus] [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'worktree', 'command', 'title', 'focus'],
+      'orca terminal create [--worktree <selector>] [--title <name>] [--command <text>] [--agent codex --account <uuid|system> [--account-runtime host|wsl] [--wsl-distro <name>]] [--focus] [--json]',
+    allowedFlags: [
+      ...GLOBAL_FLAGS,
+      ...'worktree command title agent account account-runtime wsl-distro focus'.split(' ')
+    ],
     notes: [
       'Creates a visible terminal tab without switching focus when possible; falls back to a background handle if the UI cannot adopt it. Pass --focus to switch to it.',
-      'Use this, not worktree create, for a fresh agent in the current checkout.'
+      'Use this, not worktree create, for a fresh agent in the current checkout.',
+      'Use --agent codex --account <uuid> to launch with one managed account without changing the global default. UUIDs come from `orca account list`.',
+      'Use --account system for the system Codex login. Add --account-runtime wsl --wsl-distro <name> for a WSL system login.'
     ],
     examples: [
-      'orca terminal create --json',
       'orca terminal create --worktree active --command "codex" --json',
+      'orca terminal create --worktree active --agent codex --account <uuid> --json',
       'orca terminal create --worktree path:/projects/myapp --title "RUNNER" --command "opencode"',
       'orca terminal create --worktree path:/projects/myapp --command "opencode" --focus'
     ]

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -60,13 +60,20 @@ import {
 import { parseWslUncPath } from '../../shared/wsl-paths'
 import {
   getWslSelectionKey,
+  getCodexSelectionLaneKey,
+  getCodexSelectionTargetForAccount,
   getSelectedCodexAccountIdForTarget,
   normalizeCodexRuntimeSelection,
   setSelectedCodexAccountIdForTarget,
   type CodexAccountSelectionTarget
 } from './runtime-selection'
 import { getDefaultWslDistro, getWslHome } from '../wsl'
-import { hasCustomCodexHomeOverrideForLaunch } from '../codex/codex-real-home-path'
+import {
+  environmentCodexHomeOverrideContextsEqual,
+  getCustomCodexHomeOverrideForLaunch,
+  hasCustomCodexHomeOverrideForLaunch,
+  shellStartupCodexHomeOverrideMatches
+} from '../codex/codex-real-home-path'
 import {
   hasCompletedCodexSessionBackfillMarker,
   invalidateCodexSessionBackfillMarker
@@ -258,6 +265,83 @@ export class CodexRuntimeHomeService {
       resolveHostCodexSessionSourceHome(this.store.getSettings())
     )
     return this.getRuntimeHomePath()
+  }
+
+  /**
+   * Resolves the immutable CODEX_HOME captured for a live PTY without changing
+   * the user's active account. Undefined asks callers to use legacy discovery.
+   */
+  resolveCodexHomeForPaneModelDiscovery(
+    ptyId: string,
+    target?: CodexAccountSelectionTarget
+  ): string | null | undefined {
+    const record = getCodexPaneAccount(ptyId)
+    if (!record || !record.homeRoute) {
+      return undefined
+    }
+    const normalizedTarget = target ?? { runtime: 'host' as const }
+    if (record.selectionKey !== getCodexSelectionLaneKey(normalizedTarget)) {
+      throw new Error('Codex pane account lane no longer matches the discovery runtime.')
+    }
+    if (record.homeRoute === 'real-home') {
+      if (record.accountId !== null || normalizedTarget.runtime === 'wsl') {
+        throw new Error('Codex pane real-home provenance is invalid.')
+      }
+      // Why: an explicit path prevents a user CODEX_HOME exported after this
+      // PTY launched from silently retargeting its account-scoped probe.
+      return getSystemCodexHomePath()
+    }
+    if (record.homeRoute === 'shared-home') {
+      return this.getRuntimeHomePath()
+    }
+    if (record.homeRoute === 'custom-home') {
+      if (record.environmentHomeOverride) {
+        const current = getCustomCodexHomeOverrideForLaunch()
+        if (
+          current?.source === 'environment' &&
+          environmentCodexHomeOverrideContextsEqual(record.environmentHomeOverride, current.context)
+        ) {
+          return record.environmentHomeOverride.codexHome
+        }
+      }
+      if (
+        record.shellStartupHomeOverride &&
+        shellStartupCodexHomeOverrideMatches(record.shellStartupHomeOverride)
+      ) {
+        return record.shellStartupHomeOverride.codexHome
+      }
+      throw new Error('Codex pane custom home can no longer be verified.')
+    }
+    if (record.accountId === null) {
+      if (record.homeRoute !== 'wsl-home' || normalizedTarget.runtime !== 'wsl') {
+        throw new Error('Codex pane account provenance is incomplete.')
+      }
+      return this.getWslSystemCodexHomePath(normalizedTarget)
+    }
+    const account = this.store
+      .getSettings()
+      .codexManagedAccounts.find((candidate) => candidate.id === record.accountId)
+    if (
+      !account ||
+      getCodexSelectionLaneKey(getCodexSelectionTargetForAccount(account)) !== record.selectionKey
+    ) {
+      throw new Error('Codex pane account is no longer available.')
+    }
+    if (record.homeRoute === 'account-home') {
+      const trustedHome = this.getTrustedSelfContainedManagedHomePath(account)
+      if (!trustedHome) {
+        throw new Error('Codex pane account home is no longer trusted.')
+      }
+      return trustedHome
+    }
+    if (record.homeRoute === 'wsl-home' && normalizedTarget.runtime === 'wsl') {
+      const managedHome = this.getWslManagedHomePath(account)
+      if (!managedHome) {
+        throw new Error('Codex pane WSL account home is unavailable.')
+      }
+      return managedHome
+    }
+    throw new Error('Codex pane home route is incompatible with model discovery.')
   }
 
   beginHostSystemDefaultSessionMigrationLaunch(

--- a/src/main/codex-accounts/runtime-home-service.ts
+++ b/src/main/codex-accounts/runtime-home-service.ts
@@ -29,6 +29,7 @@ import {
 } from 'node:path'
 import { app } from 'electron'
 import type { CodexManagedAccount } from '../../shared/managed-account-types'
+import type { ProviderAccountRef } from '../../shared/provider-account-ref'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import type { Store } from '../persistence'
 import { WSL_CODEX_RUNTIME_HOME_SEGMENTS } from '../pty/codex-home-wsl-env'
@@ -265,6 +266,77 @@ export class CodexRuntimeHomeService {
       resolveHostCodexSessionSourceHome(this.store.getSettings())
     )
     return this.getRuntimeHomePath()
+  }
+
+  /** Resolves one launch without changing the user's global account selection. */
+  prepareForCodexAccountLaunch(
+    ref: ProviderAccountRef,
+    options?: { unavailableManagedHomePath?: string }
+  ): string | null {
+    if (ref.provider !== 'codex') {
+      throw new Error('agent_session_account_agent_mismatch')
+    }
+    const target: CodexAccountSelectionTarget =
+      ref.runtime === 'wsl'
+        ? { runtime: 'wsl', wslDistro: ref.wslDistro ?? null }
+        : { runtime: 'host' }
+    if (ref.accountId === null) {
+      if (ref.runtime === 'wsl') {
+        const wslTarget = this.resolveWslDefaultTarget(target)
+        const home = this.getWslSystemCodexHomePath(wslTarget)
+        if (!home) {
+          throw new Error('agent_session_account_unavailable')
+        }
+        this.syncWslConfigAndGlobalInstructionsForLaunch(wslTarget, home)
+        this.startWslSessionBridgeForLaunch(wslTarget, home)
+        return home
+      }
+      return null
+    }
+
+    const account = this.store
+      .getSettings()
+      .codexManagedAccounts.find((candidate) => candidate.id === ref.accountId)
+    if (!account) {
+      throw new Error('agent_session_account_unavailable')
+    }
+    if (
+      getCodexSelectionLaneKey(getCodexSelectionTargetForAccount(account)) !==
+      getCodexSelectionLaneKey(target)
+    ) {
+      throw new Error('agent_session_account_runtime_mismatch')
+    }
+    if (ref.runtime === 'wsl') {
+      const home = this.getWslManagedHomePath(account)
+      if (!home) {
+        throw new Error('agent_session_account_unavailable')
+      }
+      this.syncWslConfigAndGlobalInstructionsForLaunch(target, home)
+      this.startWslSessionBridgeForLaunch(target, home)
+      return home
+    }
+
+    const home = this.getTrustedSelfContainedManagedHomePath(account)
+    if (!home) {
+      throw new Error('agent_session_account_unavailable')
+    }
+    if (
+      options?.unavailableManagedHomePath &&
+      normalizeRuntimePathForComparison(options.unavailableManagedHomePath) ===
+        normalizeRuntimePathForComparison(home)
+    ) {
+      const absence = this.credentialAbsenceGrace.assess(join(home, 'auth.json'))
+      if (absence.state !== 'present' && absence.durable) {
+        throw new Error('agent_session_account_unavailable')
+      }
+    }
+    syncSystemCodexResourcesIntoManagedHome(home)
+    syncSystemConfigIntoManagedCodexHome({
+      runtimeHomePath: home,
+      systemHomePath: getSystemCodexHomePath()
+    })
+    this.startSelfContainedSessionBridgeForLaunch(home)
+    return home
   }
 
   /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -221,6 +221,7 @@ import { CodexAccountService } from './codex-accounts/service'
 import { CodexRuntimeHomeService } from './codex-accounts/runtime-home-service'
 import { markCodexProjectTrusted } from './agent-trust-presets'
 import {
+  getCodexSelectionLaneKey,
   normalizeCodexRuntimeSelection,
   type CodexAccountSelectionTarget
 } from './codex-accounts/runtime-selection'
@@ -1028,6 +1029,56 @@ function prepareCodexRuntimeHomeForLaunch(
       console.warn('[codex-project-trust] failed to pre-mark launch workspace:', error)
     }
   }
+  const explicitAccountRef = launchContext?.providerAccountRef
+  if (explicitAccountRef) {
+    if (launchContext?.launchAgent !== 'codex' || explicitAccountRef.provider !== 'codex') {
+      throw new Error('agent_session_account_agent_mismatch')
+    }
+    const actualTarget = target ?? { runtime: 'host' as const }
+    const resolvedAccountRef =
+      explicitAccountRef.runtime === 'wsl' && !explicitAccountRef.wslDistro?.trim()
+        ? { ...explicitAccountRef, wslDistro: actualTarget.wslDistro ?? null }
+        : explicitAccountRef
+    if (
+      getCodexSelectionLaneKey(actualTarget) !==
+      getCodexSelectionLaneKey({
+        runtime: resolvedAccountRef.runtime,
+        wslDistro: resolvedAccountRef.wslDistro ?? null
+      })
+    ) {
+      throw new Error('agent_session_account_runtime_mismatch')
+    }
+    if (explicitAccountRef.accountId === null && explicitAccountRef.runtime === 'host') {
+      ensureRealHomeCodexHookState({
+        hooksEnabled: isAgentStatusHooksEnabled(store?.getSettings()),
+        userDataPath: app.getPath('userData')
+      })
+      if (!isRealHomeCodexHookLaneUsable()) {
+        throw new Error('agent_session_account_unavailable')
+      }
+    }
+    const runtimeHomePath = codexRuntimeHome!.prepareForCodexAccountLaunch(resolvedAccountRef, {
+      unavailableManagedHomePath: launchContext?.unavailableManagedHomePath
+    })
+    const hooksEnabled = isAgentStatusHooksEnabled(store?.getSettings())
+    const hookTarget =
+      resolvedAccountRef.runtime === 'wsl'
+        ? { runtime: 'wsl' as const, wslDistro: resolvedAccountRef.wslDistro ?? null }
+        : { runtime: 'host' as const }
+    const status = hooksEnabled
+      ? (codexHookService.installForRuntimeHome(runtimeHomePath, hookTarget) ??
+        codexHookService.install(runtimeHomePath ?? undefined))
+      : (codexHookService.refreshRuntimeUserHooksForRuntimeHome(runtimeHomePath, hookTarget) ??
+        codexHookService.refreshRuntimeUserHooks(runtimeHomePath ?? undefined))
+    if (status.state === 'error') {
+      console.warn(
+        '[codex-hook-service] failed to prepare explicit account runtime hooks',
+        status.detail
+      )
+    }
+    return runtimeHomePath
+  }
+
   const ensureRealHomeHooksIfSelected = (): boolean => {
     if (
       target?.runtime === 'wsl' ||

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -1430,6 +1430,8 @@ function openMainWindow(options: { revealOnDidFinishLoad?: boolean } = {}): Brow
     automations,
     {
       prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
+      prepareForCodexPtyLaunch: (ptyId, target) =>
+        codexRuntimeHome!.resolveCodexHomeForPaneModelDiscovery(ptyId, target),
       prepareForClaudeLaunch: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
     },
     agentAwakeService ?? undefined,
@@ -2665,6 +2667,8 @@ void app.whenReady().then(async () => {
   runtimeService.setCommitMessageAgentEnvironmentResolvers({
     // Why: Codex hooks/auth live in Orca's managed runtime home even for the default path, so every launch must resolve CODEX_HOME via runtime-home.
     prepareForCodexLaunch: prepareCodexRuntimeHomeForLaunch,
+    prepareForCodexPtyLaunch: (ptyId, target) =>
+      codexRuntimeHome!.resolveCodexHomeForPaneModelDiscovery(ptyId, target),
     prepareForClaudeLaunch: (target) => claudeRuntimeAuth!.prepareForClaudeLaunch(target)
   })
   const pluginSystemStartupStartedAt = performance.now()

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -1561,7 +1561,7 @@ export function registerFilesystemHandlers(
     'git:discoverCommitMessageModels',
     async (
       _event,
-      args: { agentId: string; worktreePath?: string; connectionId?: string }
+      args: { agentId: string; worktreePath?: string; connectionId?: string; ptyId?: string }
     ): Promise<DiscoverCommitMessageModelsResult> => {
       const agentId = args.agentId
       const agentCommandOverride = store.getSettings().agentCmdOverrides?.[agentId as TuiAgent]
@@ -1601,7 +1601,8 @@ export function registerFilesystemHandlers(
       const localEnv = await prepareLocalCommitMessageAgentEnv(
         agentId,
         commitMessageAgentEnv,
-        localRuntimeTarget
+        localRuntimeTarget,
+        args.ptyId
       )
       if (!localEnv.ok) {
         return { success: false, error: localEnv.error }

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -202,6 +202,7 @@ import { setTerminalViewAttributes } from '../runtime/terminal-view-attribute-st
 import { validateTerminalViewAttributes } from '../../shared/terminal-view-attributes'
 import type { PtyModelRestoreReason } from '../../shared/pty-model-restore-marker'
 import type { CodexAccountSelectionTarget } from '../codex-accounts/runtime-selection'
+import { isProviderAccountRef, type ProviderAccountRef } from '../../shared/provider-account-ref'
 import {
   isCodexHomeAuthReadyForLaunch,
   waitForManagedCodexAuthReady
@@ -1243,6 +1244,7 @@ export type CodexHomeLaunchContext = {
   workspacePath?: string
   launchAgent?: TuiAgent
   unavailableManagedHomePath?: string
+  providerAccountRef?: ProviderAccountRef
 }
 
 export type GetSelectedCodexHomePath = (
@@ -4646,13 +4648,15 @@ export function registerPtyHandlers(
                       codexSelectionTarget,
                       getSelectedCodexHomePath?.(codexSelectionTarget, env, {
                         workspacePath: cwd,
-                        launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+                        launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined,
+                        providerAccountRef: args.providerAccountRef
                       }) ?? null
                     )
                   )
                 : (getSelectedCodexHomePath?.(codexSelectionTarget, env, {
                     workspacePath: cwd,
-                    launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+                    launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined,
+                    providerAccountRef: args.providerAccountRef
                   }) ?? null)
             )
           : null
@@ -4671,7 +4675,8 @@ export function registerPtyHandlers(
               codexSelectionTarget,
               getSelectedCodexHomePath?.(codexSelectionTarget, env, {
                 workspacePath: cwd,
-                launchAgent: 'codex'
+                launchAgent: 'codex',
+                providerAccountRef: args.providerAccountRef
               }) ?? null
             ),
           resolveAfterUnavailable: (unavailableManagedHomePath) =>
@@ -4680,6 +4685,7 @@ export function registerPtyHandlers(
               getSelectedCodexHomePath?.(codexSelectionTarget, env, {
                 workspacePath: cwd,
                 launchAgent: 'codex',
+                providerAccountRef: args.providerAccountRef,
                 unavailableManagedHomePath
               }) ?? null
             )
@@ -5247,7 +5253,7 @@ export function registerPtyHandlers(
           ptyId: result.id,
           isDaemonHostSpawn,
           isReattach: result.isReattach === true,
-          pinnedByResume: codexResumeHomeSelected,
+          pinnedByResume: codexResumeHomeSelected || args.providerAccountRef !== undefined,
           launchCodexHomePath: selectedCodexHomePath,
           launchEnv: args.env,
           target: codexSelectionTarget,
@@ -5893,6 +5899,7 @@ export function registerPtyHandlers(
         resumeProviderSession?: AgentProviderSessionMetadata
         launchToken?: unknown
         launchAgent?: TuiAgent
+        providerAccountRef?: unknown
         startupCommandDelivery?: StartupCommandDelivery
         connectionId?: string | null
         worktreeId?: string
@@ -5953,6 +5960,23 @@ export function registerPtyHandlers(
       const startupPromise = getLocalPtyStartupPromise(args.connectionId)
       if (startupPromise) {
         await startupPromise
+      }
+      const providerAccountRef =
+        args.providerAccountRef === undefined
+          ? undefined
+          : isProviderAccountRef(args.providerAccountRef)
+            ? args.providerAccountRef
+            : (() => {
+                throw new Error('Invalid provider account reference')
+              })()
+      if (
+        providerAccountRef &&
+        (args.launchAgent !== 'codex' || providerAccountRef.provider !== 'codex')
+      ) {
+        throw new Error('agent_session_account_agent_mismatch')
+      }
+      if (providerAccountRef && args.connectionId) {
+        throw new Error('agent_session_account_runtime_mismatch')
       }
       let cwd = resolvePtySpawnStartupCwd(args.worktreeId, args.cwd)
       let prevalidatedCwd: string | undefined
@@ -6330,13 +6354,15 @@ export function registerPtyHandlers(
                         codexSelectionTarget,
                         getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
                           workspacePath: cwd,
-                          launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+                          launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined,
+                          providerAccountRef
                         }) ?? null
                       )
                     )
                   : (getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
                       workspacePath: cwd,
-                      launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined
+                      launchAgent: isTuiAgent(args.launchAgent) ? args.launchAgent : undefined,
+                      providerAccountRef
                     }) ?? null)
               )
             : null
@@ -6351,7 +6377,8 @@ export function registerPtyHandlers(
                 codexSelectionTarget,
                 getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
                   workspacePath: cwd,
-                  launchAgent: 'codex'
+                  launchAgent: 'codex',
+                  providerAccountRef
                 }) ?? null
               ),
             resolveAfterUnavailable: (unavailableManagedHomePath) =>
@@ -6360,6 +6387,7 @@ export function registerPtyHandlers(
                 getSelectedCodexHomePath?.(codexSelectionTarget, baseEnv, {
                   workspacePath: cwd,
                   launchAgent: 'codex',
+                  providerAccountRef,
                   unavailableManagedHomePath
                 }) ?? null
               )
@@ -6756,7 +6784,7 @@ export function registerPtyHandlers(
           ptyId: result.id,
           isDaemonHostSpawn,
           isReattach: result.isReattach === true,
-          pinnedByResume: codexResumeHomeSelected,
+          pinnedByResume: codexResumeHomeSelected || providerAccountRef !== undefined,
           launchCodexHomePath: selectedCodexHomePath,
           launchEnv: baseEnv,
           target: codexSelectionTarget,

--- a/src/main/runtime/orca-runtime-agent-session-operation.test.ts
+++ b/src/main/runtime/orca-runtime-agent-session-operation.test.ts
@@ -67,6 +67,73 @@ function createRuntime(provider?: {
 }
 
 describe('agent-session create operation ledger', () => {
+  it('passes an attested Codex account reference to PTY creation', async () => {
+    const runtime = createRuntime()
+    const createTerminal = vi.spyOn(runtime, 'createTerminal').mockResolvedValue(terminal())
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'host'
+    } as const
+
+    await runtime.createAgentSession(request(operationId(), { providerAccountRef }))
+
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:worktree-1',
+      expect.objectContaining({ providerAccountRef })
+    )
+  })
+
+  it('rejects account references outside the launch agent and runtime owner', async () => {
+    const runtime = createRuntime()
+    const createTerminal = vi.spyOn(runtime, 'createTerminal').mockResolvedValue(terminal())
+
+    await expect(
+      runtime.createAgentSession(
+        request(operationId(), {
+          agent: 'claude',
+          providerAccountRef: { provider: 'codex', accountId: 'account-a', runtime: 'host' }
+        })
+      )
+    ).rejects.toThrow('agent_session_account_agent_mismatch')
+    await expect(
+      runtime.createAgentSession(
+        request(operationId(Date.now() + 1), {
+          providerAccountRef: {
+            provider: 'codex',
+            accountId: 'account-a',
+            runtime: 'wsl',
+            wslDistro: 'Ubuntu'
+          }
+        })
+      )
+    ).rejects.toThrow('agent_session_account_runtime_mismatch')
+    expect(createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('passes an attested Codex account reference to a resumed PTY', async () => {
+    const runtime = createRuntime()
+    const createTerminal = vi.spyOn(runtime, 'createTerminal').mockResolvedValue(terminal())
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'host'
+    } as const
+
+    await runtime.ensureAgentSession({
+      kind: 'explicit',
+      worktree: 'id:worktree-1',
+      agent: 'codex',
+      providerSession: { key: 'session_id', id: 'provider-session-1' },
+      providerAccountRef
+    })
+
+    expect(createTerminal).toHaveBeenCalledWith(
+      'id:worktree-1',
+      expect.objectContaining({ providerAccountRef })
+    )
+  })
+
   it('selects legacy before trust, spawn, or ledger state for an old daemon', async () => {
     const provider = {
       supportsAgentSessionClaims: vi.fn(() => false),
@@ -193,6 +260,18 @@ describe('agent-session create operation ledger', () => {
       runtime.createAgentSession(request(id, { agentArgs: '--profile changed' }), {
         clientId: 'device-a'
       })
+    ).rejects.toThrow('agent_session_operation_conflict')
+    await expect(
+      runtime.createAgentSession(
+        request(id, {
+          providerAccountRef: {
+            provider: 'codex',
+            accountId: 'account-b',
+            runtime: 'host'
+          }
+        }),
+        { clientId: 'device-a' }
+      )
     ).rejects.toThrow('agent_session_operation_conflict')
     finish(terminal())
     await expect(first).resolves.toMatchObject({ disposition: 'created' })

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -852,7 +852,8 @@ export class RuntimeGitCommands {
   async discoverRuntimeCommitMessageModels(
     worktreeSelector: string,
     agentId: string,
-    settingsOverride?: Pick<RuntimeCommitMessageSettingsOverride, 'agentCmdOverrides'>
+    settingsOverride?: Pick<RuntimeCommitMessageSettingsOverride, 'agentCmdOverrides'>,
+    ptyId?: string
   ): Promise<DiscoverCommitMessageModelsResult> {
     const target = await this.host.resolveRuntimeGitTarget(worktreeSelector)
     const typedAgentId = agentId as TuiAgent
@@ -877,7 +878,8 @@ export class RuntimeGitCommands {
     const localEnv = await prepareLocalCommitMessageAgentEnv(
       typedAgentId,
       this.host.getCommitMessageAgentEnvironment?.(),
-      localAgentRuntimeTargetForTarget(target)
+      localAgentRuntimeTargetForTarget(target),
+      ptyId
     )
     if (!localEnv.ok) {
       return { success: false, error: localEnv.error }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -63,6 +63,7 @@ import type {
   RuntimeEnsureAgentSessionRequest,
   RuntimeEnsureAgentSessionResult
 } from '../../shared/agent-session-host-authority'
+import type { ProviderAccountRef } from '../../shared/provider-account-ref'
 import {
   AGENT_SESSION_MAX_NEW_OPERATION_AGE_MS,
   AGENT_SESSION_OPERATION_FUTURE_SKEW_MS,
@@ -1418,6 +1419,7 @@ type TerminalCreateOptions = {
   resumeProviderSession?: AgentProviderSessionMetadata
   launchToken?: string
   launchAgent?: TuiAgent
+  providerAccountRef?: ProviderAccountRef
   // Why: agent ids are not shell commands (`cursor` is the Cursor desktop app; its
   // CLI is `cursor-agent`). Callers that know the agent name it here instead of
   // guessing a command, and the runtime builds the configured launch.
@@ -1728,6 +1730,7 @@ type RuntimePtyController = {
     cwd?: string
     command?: string
     launchAgent?: TuiAgent
+    providerAccountRef?: ProviderAccountRef
     commandDelivery?: 'renderer' | 'provider'
     startupCommandDelivery?: WorktreeStartupLaunch['startupCommandDelivery']
     env?: Record<string, string>
@@ -25746,6 +25749,26 @@ export class OrcaRuntimeService {
       throw new Error('runtime_unavailable')
     }
     const workspace = await this.resolveTerminalWorkspaceLaunchScope(request.worktree)
+    if (request.providerAccountRef) {
+      if (request.agent !== 'codex' || request.providerAccountRef.provider !== 'codex') {
+        throw new Error('agent_session_account_agent_mismatch')
+      }
+      if (workspace.connectionId) {
+        throw new Error('agent_session_account_runtime_mismatch')
+      }
+      const wsl = parseWslUncPath(workspace.path)
+      if ((request.providerAccountRef.runtime === 'wsl') !== Boolean(wsl)) {
+        throw new Error('agent_session_account_runtime_mismatch')
+      }
+      if (
+        wsl &&
+        request.providerAccountRef.wslDistro?.trim() &&
+        request.providerAccountRef.wslDistro.trim().toLocaleLowerCase('en-US') !==
+          wsl.distro.toLocaleLowerCase('en-US')
+      ) {
+        throw new Error('agent_session_account_runtime_mismatch')
+      }
+    }
     const namespace = this.getAgentSessionExecutionNamespace(workspace, request.agent)
     if (
       !namespace ||
@@ -25807,6 +25830,7 @@ export class OrcaRuntimeService {
       env: startup.env,
       launchConfig: startup.launchConfig,
       launchAgent: request.agent,
+      providerAccountRef: request.providerAccountRef,
       presentation: request.presentation ?? 'background',
       tabId: request.placement?.tabId,
       leafId: request.placement?.leafId,
@@ -25853,7 +25877,11 @@ export class OrcaRuntimeService {
           request.presentation ?? null,
           request.placement?.tabId ?? null,
           request.placement?.leafId ?? null,
-          request.viewMode ?? null
+          request.viewMode ?? null,
+          request.providerAccountRef?.provider ?? null,
+          request.providerAccountRef?.accountId ?? null,
+          request.providerAccountRef?.runtime ?? null,
+          request.providerAccountRef?.wslDistro ?? null
         ])
       )
       .digest('base64url')
@@ -25900,6 +25928,28 @@ export class OrcaRuntimeService {
         // Why: the exact legacy launch remains client-owned until this pre-spawn check succeeds.
         throw new Error('agent_session_legacy_required')
       }
+      if (request.providerAccountRef) {
+        if (request.agent !== 'codex' || request.providerAccountRef.provider !== 'codex') {
+          throw new Error('agent_session_account_agent_mismatch')
+        }
+        if (workspace.connectionId) {
+          // Why: an account ref belongs to this Orca runtime, not an SSH
+          // downstream whose credential registry this process cannot attest.
+          throw new Error('agent_session_account_runtime_mismatch')
+        }
+        const wsl = parseWslUncPath(workspace.path)
+        if ((request.providerAccountRef.runtime === 'wsl') !== Boolean(wsl)) {
+          throw new Error('agent_session_account_runtime_mismatch')
+        }
+        if (
+          wsl &&
+          request.providerAccountRef.wslDistro?.trim() &&
+          request.providerAccountRef.wslDistro.trim().toLocaleLowerCase('en-US') !==
+            wsl.distro.toLocaleLowerCase('en-US')
+        ) {
+          throw new Error('agent_session_account_runtime_mismatch')
+        }
+      }
       const startupCwd = this.resolveWorkspaceTerminalStartupCwd(workspace, request.startupCwd)
       // Why: aliases and object property order are client syntax, not authority;
       // fingerprint the host-resolved fields in one fixed order.
@@ -25919,7 +25969,11 @@ export class OrcaRuntimeService {
             request.presentation ?? null,
             request.placement?.tabId ?? null,
             request.placement?.leafId ?? null,
-            request.viewMode ?? null
+            request.viewMode ?? null,
+            request.providerAccountRef?.provider ?? null,
+            request.providerAccountRef?.accountId ?? null,
+            request.providerAccountRef?.runtime ?? null,
+            request.providerAccountRef?.wslDistro ?? null
           ])
         )
         .digest('base64url')
@@ -25998,6 +26052,7 @@ export class OrcaRuntimeService {
           leafId: operationLeafId,
           preAllocatedHandle: operationHandle,
           viewMode: request.viewMode,
+          providerAccountRef: request.providerAccountRef,
           persistHostSessionBinding: true,
           agentSessionCreateOperationId: executionOperationId,
           signal: caller.signal,
@@ -26234,6 +26289,7 @@ export class OrcaRuntimeService {
               ? launchOpts.command
               : (agentTeamsPlan?.command ?? launchOpts.command),
             launchAgent: launchOpts.launchAgent,
+            providerAccountRef: launchOpts.providerAccountRef,
             commandDelivery: 'provider',
             startupCommandDelivery: launchOpts.startupCommandDelivery,
             env,

--- a/src/main/runtime/rpc/methods/agent-session.test.ts
+++ b/src/main/runtime/rpc/methods/agent-session.test.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 import {
+  AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
   AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION,
@@ -40,6 +41,60 @@ function runtimeStub() {
 }
 
 describe('agent session RPC methods', () => {
+  it('accepts a bounded provider account reference for a fresh launch', async () => {
+    const runtime = runtimeStub()
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime as unknown as OrcaRuntimeService,
+      methods: AGENT_SESSION_METHODS
+    })
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'wsl',
+      wslDistro: 'Ubuntu'
+    } as const
+
+    const response = await dispatcher.dispatch(
+      request('terminal.createAgentSession', {
+        clientOperationId: '1752883200000-0123456789abcdef0123456789abcdef',
+        worktree: 'id:worktree-1',
+        agent: 'codex',
+        providerAccountRef
+      })
+    )
+
+    expect(response).toMatchObject({ ok: true })
+    expect(runtime.createAgentSession).toHaveBeenCalledWith(
+      expect.objectContaining({ providerAccountRef }),
+      {}
+    )
+  })
+
+  it.each([
+    { provider: '', accountId: 'account-a', runtime: 'host' },
+    { provider: 'codex', accountId: '', runtime: 'host' },
+    { provider: 'codex', accountId: 'account-a', runtime: 'host', wslDistro: 'Ubuntu' },
+    { provider: 'codex', accountId: 'account-a', runtime: 'other' }
+  ])('rejects an invalid provider account reference %#', async (providerAccountRef) => {
+    const runtime = runtimeStub()
+    const dispatcher = new RpcDispatcher({
+      runtime: runtime as unknown as OrcaRuntimeService,
+      methods: AGENT_SESSION_METHODS
+    })
+
+    const response = await dispatcher.dispatch(
+      request('terminal.createAgentSession', {
+        clientOperationId: '1752883200000-0123456789abcdef0123456789abcdef',
+        worktree: 'id:worktree-1',
+        agent: 'codex',
+        providerAccountRef
+      })
+    )
+
+    expect(response).toMatchObject({ ok: false, error: { code: 'invalid_argument' } })
+    expect(runtime.createAgentSession).not.toHaveBeenCalled()
+  })
+
   it('dispatches an explicit structured resume without an authoritative command', async () => {
     const runtime = runtimeStub()
     const dispatcher = new RpcDispatcher({
@@ -373,5 +428,6 @@ describe('agent session RPC methods', () => {
     expect(MIN_COMPATIBLE_RUNTIME_CLIENT_VERSION).toBe(2)
     expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY)
     expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY)
+    expect(RUNTIME_CAPABILITIES).toContain(AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY)
   })
 })

--- a/src/main/runtime/rpc/methods/agent-session.ts
+++ b/src/main/runtime/rpc/methods/agent-session.ts
@@ -12,6 +12,11 @@ import type {
   RuntimeEnsureAgentSessionResult
 } from '../../../../shared/agent-session-host-authority'
 import {
+  PROVIDER_ACCOUNT_REF_MAX_ID_LENGTH,
+  PROVIDER_ACCOUNT_REF_MAX_PROVIDER_LENGTH,
+  PROVIDER_ACCOUNT_REF_MAX_WSL_DISTRO_LENGTH
+} from '../../../../shared/provider-account-ref'
+import {
   AGENT_SESSION_OPERATION_FUTURE_SKEW_MS,
   parseAgentSessionOperationTimestamp
 } from '../../../../shared/agent-session-host-authority'
@@ -111,6 +116,21 @@ const ProviderSession = z
   })
   .strict()
 
+const ProviderAccountRefSchema = z
+  .object({
+    provider: z.string().trim().min(1).max(PROVIDER_ACCOUNT_REF_MAX_PROVIDER_LENGTH),
+    accountId: z.string().trim().min(1).max(PROVIDER_ACCOUNT_REF_MAX_ID_LENGTH).nullable(),
+    runtime: z.enum(['host', 'wsl']),
+    wslDistro: z
+      .string()
+      .trim()
+      .min(1)
+      .max(PROVIDER_ACCOUNT_REF_MAX_WSL_DISTRO_LENGTH)
+      .nullable()
+      .optional()
+  })
+  .strict()
+
 const AutomaticEnsure = z
   .object({
     kind: z.literal('automatic'),
@@ -132,6 +152,7 @@ const ExplicitEnsure = z
     ompResumeFilePath: OmpResumeFilePath.optional(),
     agentArgs: AgentArgs.optional(),
     launchPreferences: LaunchPreferences.optional(),
+    providerAccountRef: ProviderAccountRefSchema.optional(),
     presentation: Presentation.optional(),
     placement: Placement.optional()
   })
@@ -149,6 +170,26 @@ const ExplicitEnsure = z
         code: z.ZodIssueCode.custom,
         path: ['providerSession'],
         message: 'Provider session is not resumable for this agent'
+      })
+    }
+    if (
+      value.providerAccountRef &&
+      (value.agent !== 'codex' || value.providerAccountRef.provider !== 'codex')
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['providerAccountRef', 'provider'],
+        message: 'Account reference must match the resumed agent'
+      })
+    }
+    if (
+      value.providerAccountRef?.runtime === 'host' &&
+      value.providerAccountRef.wslDistro != null
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['providerAccountRef', 'wslDistro'],
+        message: 'Host account references cannot name a WSL distribution'
       })
     }
   })
@@ -179,7 +220,8 @@ export const CreateAgentSessionParams: z.ZodType<RuntimeCreateAgentSessionReques
     startupCwd: z.string().min(1).max(MAX_WORKTREE_SELECTOR_LENGTH).optional(),
     presentation: Presentation.optional(),
     placement: Placement.optional(),
-    viewMode: z.enum(['terminal', 'chat']).optional()
+    viewMode: z.enum(['terminal', 'chat']).optional(),
+    providerAccountRef: ProviderAccountRefSchema.optional()
   })
   .strict()
   .superRefine((value, context) => {
@@ -188,6 +230,16 @@ export const CreateAgentSessionParams: z.ZodType<RuntimeCreateAgentSessionReques
         code: z.ZodIssueCode.custom,
         path: ['prompt'],
         message: 'Draft delivery requires a non-empty prompt'
+      })
+    }
+    if (
+      value.providerAccountRef?.runtime === 'host' &&
+      value.providerAccountRef.wslDistro != null
+    ) {
+      context.addIssue({
+        code: z.ZodIssueCode.custom,
+        path: ['providerAccountRef', 'wslDistro'],
+        message: 'Host account references cannot name a WSL distribution'
       })
     }
   })

--- a/src/main/runtime/rpc/methods/git-params.ts
+++ b/src/main/runtime/rpc/methods/git-params.ts
@@ -184,7 +184,8 @@ export const GitGenerateCommitMessage = WorktreeSelector.extend({
 
 export const GitDiscoverCommitMessageModels = WorktreeSelector.extend({
   agentId: z.string().min(1, 'Missing agent id'),
-  agentCmdOverrides: z.record(z.string(), z.string()).optional()
+  agentCmdOverrides: z.record(z.string(), z.string()).optional(),
+  ptyId: z.string().min(1).optional()
 })
 
 export const GitGeneratePullRequestFields = GitGenerateCommitMessage.extend({

--- a/src/main/runtime/rpc/methods/git.test.ts
+++ b/src/main/runtime/rpc/methods/git.test.ts
@@ -299,7 +299,8 @@ describe('git RPC methods', () => {
       makeRequest('git.discoverCommitMessageModels', {
         worktree: 'id:wt-1',
         agentId: 'cursor',
-        agentCmdOverrides: { cursor: 'cursor-agent' }
+        agentCmdOverrides: { cursor: 'cursor-agent' },
+        ptyId: 'pty-account-b'
       })
     )
     await dispatcher.dispatch(
@@ -330,9 +331,12 @@ describe('git RPC methods', () => {
 
     expect(runtime.commitRuntimeGit).toHaveBeenCalledWith('id:wt-1', 'feat: test')
     expect(runtime.generateRuntimeCommitMessage).toHaveBeenCalledWith('id:wt-1')
-    expect(runtime.discoverRuntimeCommitMessageModels).toHaveBeenCalledWith('id:wt-1', 'cursor', {
-      agentCmdOverrides: { cursor: 'cursor-agent' }
-    })
+    expect(runtime.discoverRuntimeCommitMessageModels).toHaveBeenCalledWith(
+      'id:wt-1',
+      'cursor',
+      { agentCmdOverrides: { cursor: 'cursor-agent' } },
+      'pty-account-b'
+    )
     expect(runtime.cancelRuntimeGenerateCommitMessage).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.abortRuntimeGitMerge).toHaveBeenCalledWith('id:wt-1')
     expect(runtime.abortRuntimeGitRebase).toHaveBeenCalledWith('id:wt-1')

--- a/src/main/runtime/rpc/methods/git.ts
+++ b/src/main/runtime/rpc/methods/git.ts
@@ -299,7 +299,8 @@ export const GIT_METHODS: RpcMethod[] = [
           ? {
               agentCmdOverrides: params.agentCmdOverrides as GlobalSettings['agentCmdOverrides']
             }
-          : {}
+          : {},
+        params.ptyId
       )
   }),
   defineMethod({

--- a/src/main/text-generation/commit-message-agent-environment.test.ts
+++ b/src/main/text-generation/commit-message-agent-environment.test.ts
@@ -1,7 +1,7 @@
 import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { prepareLocalCommitMessageAgentEnv } from './commit-message-agent-environment'
 
 const originalEnv = { ...process.env }
@@ -121,6 +121,42 @@ describe('prepareLocalCommitMessageAgentEnv', () => {
       env: expect.objectContaining({
         CODEX_HOME: 'C:\\Users\\tester\\AppData\\Roaming\\Orca\\codex-accounts\\a\\home'
       })
+    })
+  })
+
+  it('prefers the account home pinned to the requested Codex PTY', async () => {
+    const prepareForCodexLaunch = vi.fn(() => '/managed/account-a/home')
+    const prepareForCodexPtyLaunch = vi.fn(() => '/managed/account-b/home')
+
+    const result = await prepareLocalCommitMessageAgentEnv(
+      'codex',
+      { prepareForCodexLaunch, prepareForCodexPtyLaunch },
+      { runtime: 'host' },
+      'pty-account-b'
+    )
+
+    expect(prepareForCodexPtyLaunch).toHaveBeenCalledWith('pty-account-b', { runtime: 'host' })
+    expect(prepareForCodexLaunch).not.toHaveBeenCalled()
+    expect(result).toEqual({
+      ok: true,
+      env: expect.objectContaining({ CODEX_HOME: '/managed/account-b/home' })
+    })
+  })
+
+  it('uses legacy account discovery when the runtime cannot scope an unknown PTY', async () => {
+    const prepareForCodexLaunch = vi.fn(() => '/managed/current/home')
+
+    const result = await prepareLocalCommitMessageAgentEnv(
+      'codex',
+      { prepareForCodexLaunch, prepareForCodexPtyLaunch: () => undefined },
+      { runtime: 'host' },
+      'pty-unrecorded'
+    )
+
+    expect(prepareForCodexLaunch).toHaveBeenCalledWith({ runtime: 'host' })
+    expect(result).toEqual({
+      ok: true,
+      env: expect.objectContaining({ CODEX_HOME: '/managed/current/home' })
     })
   })
 

--- a/src/main/text-generation/commit-message-agent-environment.ts
+++ b/src/main/text-generation/commit-message-agent-environment.ts
@@ -5,6 +5,10 @@ import { parseWslUncPath } from '../../shared/wsl-paths'
 
 export type CommitMessageAgentEnvironmentResolvers = {
   prepareForCodexLaunch?: (target?: CommitMessageAgentRuntimeTarget) => string | null
+  prepareForCodexPtyLaunch?: (
+    ptyId: string,
+    target?: CommitMessageAgentRuntimeTarget
+  ) => string | null | undefined
   prepareForClaudeLaunch?: (
     target?: CommitMessageAgentRuntimeTarget
   ) => Promise<ClaudeRuntimeAuthPreparation>
@@ -86,7 +90,8 @@ function prepareShellConfigDirEnv(agentId: string): { ok: true; env?: NodeJS.Pro
 export async function prepareLocalCommitMessageAgentEnv(
   agentId: string,
   resolvers: CommitMessageAgentEnvironmentResolvers | undefined,
-  target?: CommitMessageAgentRuntimeTarget
+  target?: CommitMessageAgentRuntimeTarget,
+  ptyId?: string
 ): Promise<{ ok: true; env?: NodeJS.ProcessEnv } | { ok: false; error: string }> {
   // Why: a non-null result short-circuits the resolvers below, so any agent added
   // to prepareShellConfigDirEnv must not also need a Codex/Claude-style resolver.
@@ -99,8 +104,19 @@ export async function prepareLocalCommitMessageAgentEnv(
   }
 
   try {
-    if (agentId === 'codex' && resolvers.prepareForCodexLaunch) {
-      const codexHomePath = resolvers.prepareForCodexLaunch(target)
+    if (
+      agentId === 'codex' &&
+      (resolvers.prepareForCodexLaunch || (ptyId && resolvers.prepareForCodexPtyLaunch))
+    ) {
+      // Why: undefined means this runtime cannot scope the probe (old host or an
+      // unrecorded PTY); null is an authoritative real-home route.
+      const scopedCodexHomePath = ptyId
+        ? resolvers.prepareForCodexPtyLaunch?.(ptyId, target)
+        : undefined
+      const codexHomePath =
+        scopedCodexHomePath !== undefined
+          ? scopedCodexHomePath
+          : (resolvers.prepareForCodexLaunch?.(target) ?? null)
       const wslCodexHome = codexHomePath ? parseWslUncPath(codexHomePath) : null
       if (target?.runtime === 'wsl') {
         const codexHomeForTarget = wslCodexHome?.linuxPath ?? null

--- a/src/preload/api/git-inspection-api.ts
+++ b/src/preload/api/git-inspection-api.ts
@@ -101,6 +101,7 @@ export type GitInspectionApi = {
     agentId: string
     worktreePath?: string
     connectionId?: string
+    ptyId?: string
   }) => Promise<
     | {
         success: true

--- a/src/preload/api/pty-api.ts
+++ b/src/preload/api/pty-api.ts
@@ -14,6 +14,7 @@ import type {
 import type { AgentKind, LaunchSource, RequestKind } from '../../shared/telemetry-events'
 import type { TerminalSideEffectBatch } from '../../shared/terminal-side-effect-facts'
 import type { TerminalViewAttributes } from '../../shared/terminal-view-attributes'
+import type { ProviderAccountRef } from '../../shared/provider-account-ref'
 import type { TuiAgent } from '../../shared/tui-agent'
 import type { PtyManagementApi } from './pty-management-api'
 
@@ -31,6 +32,7 @@ export type PtyApi = {
     resumeProviderSession?: AgentProviderSessionMetadata
     launchToken?: string
     launchAgent?: TuiAgent
+    providerAccountRef?: ProviderAccountRef
     startupCommandDelivery?: StartupCommandDelivery
     connectionId?: string | null
     worktreeId?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3470,6 +3470,7 @@ const api = {
       agentId: string
       worktreePath?: string
       connectionId?: string
+      ptyId?: string
     }): Promise<unknown> => ipcRenderer.invoke('git:discoverCommitMessageModels', args),
     cancelGenerateCommitMessage: (args: {
       worktreePath: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -23,6 +23,7 @@ import type { TerminalPaneSplitSource } from '../shared/feature-education-teleme
 import type { TerminalTabCreateReply } from '../shared/terminal-reveal-identity'
 import type { ProjectExecutionRuntimeResolution } from '../shared/project-execution-runtime'
 import type { StartupCommandDelivery } from '../shared/codex-startup-delivery'
+import type { ProviderAccountRef } from '../shared/provider-account-ref'
 import type {
   AgentProviderSessionMetadata,
   SleepingAgentLaunchConfig
@@ -967,6 +968,7 @@ const api = {
       resumeProviderSession?: AgentProviderSessionMetadata
       launchToken?: string
       launchAgent?: TuiAgent
+      providerAccountRef?: ProviderAccountRef
       startupCommandDelivery?: StartupCommandDelivery
       connectionId?: string | null
       worktreeId?: string

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -1,6 +1,7 @@
 import type { AgentType } from '../../../../shared/agent-status-types'
 import {
   createClaudeCatalogOptions,
+  createCodexCatalogOptions,
   getAgentSessionOptionCatalog,
   type CatalogModel
 } from '../../../../shared/agent-session-option-catalog'
@@ -80,7 +81,7 @@ export async function discoverNativeChatCatalogModels(
     result.models.length === 0 ||
     // Why: a spec's static fallback list must never pass as a probe result for an
     // agent whose published list replaces rather than extends the seed.
-    ((agent === 'claude' || catalog?.discoveredModelsAreAuthoritative) &&
+    ((agent === 'claude' || agent === 'codex' || catalog?.discoveredModelsAreAuthoritative) &&
       result.catalogOrigin !== 'probe')
   ) {
     return null
@@ -96,6 +97,11 @@ export async function discoverNativeChatCatalogModels(
             effortLevelIds: model.thinkingLevels?.map(({ id }) => id) ?? [],
             supportsFastMode: model.supportsFastMode
           })
-        : []
+        : agent === 'codex'
+          ? createCodexCatalogOptions({
+              effortLevels: model.thinkingLevels ?? [],
+              ...(model.defaultThinkingLevel ? { defaultEffort: model.defaultThinkingLevel } : {})
+            })
+          : []
   }))
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-discovery.ts
@@ -72,9 +72,10 @@ export function resolveNativeChatModelDiscoveryContext(
 
 export async function discoverNativeChatCatalogModels(
   agent: AgentType,
-  context: RuntimeGitContext
+  context: RuntimeGitContext,
+  ptyId?: string
 ): Promise<CatalogModel[] | null> {
-  const result = await discoverRuntimeCommitMessageModels(context, agent)
+  const result = await discoverRuntimeCommitMessageModels(context, agent, ptyId)
   const catalog = getAgentSessionOptionCatalog(agent)
   if (
     !result.success ||

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -317,4 +317,78 @@ describe('native chat session option enrichment', () => {
       })
     ).resolves.toBeNull()
   })
+
+  it('uses discovered Codex models and their per-model reasoning levels', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'probe',
+      models: [
+        {
+          id: 'gpt-5.6-sol',
+          label: 'GPT-5.6 Sol',
+          thinkingLevels: [
+            { id: 'low', label: 'Low' },
+            { id: 'high', label: 'High' },
+            { id: 'max', label: 'Max' },
+            { id: 'ultra', label: 'Ultra' }
+          ],
+          defaultThinkingLevel: 'high'
+        },
+        { id: 'account-only-model', label: 'Account only model' }
+      ]
+    })
+
+    const discovered = await discoverNativeChatCatalogModels('codex', {
+      settings: {},
+      worktreeId: 'repo::/worktree',
+      worktreePath: '/worktree'
+    })
+    expect(discovered?.map(({ id }) => id)).toEqual(['gpt-5.6-sol', 'account-only-model'])
+    expect(discovered?.[0].options[0].kind).toMatchObject({
+      type: 'select',
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultra', label: 'Ultra' }
+      ],
+      defaultValue: 'high'
+    })
+    expect(discovered?.[1].options).toEqual([])
+
+    const listener = vi.fn()
+    subscribeNativeChatEnrichedModels('codex', 'local', listener)
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      discover: async () => discovered
+    })
+    await vi.waitFor(() => expect(listener).toHaveBeenCalledOnce())
+    const enriched = readNativeChatEnrichedModels('codex', 'local')!
+    expect(enriched.map(({ id }) => id)).toEqual(['gpt-5.6-sol', 'account-only-model'])
+    expect(enriched[0].options[0].kind).toMatchObject({
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' },
+        { value: 'max', label: 'Max' },
+        { value: 'ultra', label: 'Ultra' }
+      ]
+    })
+  })
+
+  it('does not advertise the Codex spec fallback when probing is unavailable', async () => {
+    mocks.discoverRuntimeCommitMessageModels.mockResolvedValue({
+      success: true,
+      catalogOrigin: 'spec',
+      models: [{ id: 'gpt-5.5', label: 'GPT-5.5' }]
+    })
+
+    await expect(
+      discoverNativeChatCatalogModels('codex', {
+        settings: {},
+        worktreeId: 'repo::/worktree',
+        worktreePath: '/worktree'
+      })
+    ).resolves.toBeNull()
+  })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.test.ts
@@ -70,6 +70,37 @@ describe('native chat session option enrichment', () => {
     expect(readNativeChatEnrichedModels('cursor', 'local')).toBeNull()
   })
 
+  it('keeps Codex discovery caches separate for PTYs pinned to different accounts', async () => {
+    const discoverA = vi
+      .fn()
+      .mockResolvedValue([{ id: 'account-a-model', label: 'Account A', options: [] }])
+    const discoverB = vi
+      .fn()
+      .mockResolvedValue([{ id: 'account-b-model', label: 'Account B', options: [] }])
+
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      ptyId: 'pty-a',
+      discover: discoverA
+    })
+    ensureNativeChatModelEnrichment({
+      agent: 'codex',
+      hostKey: 'local',
+      ptyId: 'pty-b',
+      discover: discoverB
+    })
+    await vi.waitFor(() => expect(discoverB).toHaveBeenCalledOnce())
+
+    expect(readNativeChatEnrichedModels('codex', 'local', 'pty-a')?.map(({ id }) => id)).toEqual([
+      'account-a-model'
+    ])
+    expect(readNativeChatEnrichedModels('codex', 'local', 'pty-b')?.map(({ id }) => id)).toEqual([
+      'account-b-model'
+    ])
+    expect(readNativeChatEnrichedModels('codex', 'local')).toBeNull()
+  })
+
   it('does not probe agents whose catalogs have no discovery command', () => {
     const discover = vi.fn()
     ensureNativeChatModelEnrichment({ agent: 'gemini', hostKey: 'local', discover })
@@ -384,11 +415,20 @@ describe('native chat session option enrichment', () => {
     })
 
     await expect(
-      discoverNativeChatCatalogModels('codex', {
-        settings: {},
-        worktreeId: 'repo::/worktree',
-        worktreePath: '/worktree'
-      })
+      discoverNativeChatCatalogModels(
+        'codex',
+        {
+          settings: {},
+          worktreeId: 'repo::/worktree',
+          worktreePath: '/worktree'
+        },
+        'pty-account-a'
+      )
     ).resolves.toBeNull()
+    expect(mocks.discoverRuntimeCommitMessageModels).toHaveBeenCalledWith(
+      expect.objectContaining({ worktreeId: 'repo::/worktree' }),
+      'codex',
+      'pty-account-a'
+    )
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -18,34 +18,36 @@ type CatalogEnrichmentEntry = {
   listeners: Set<(models: CatalogModel[]) => void>
 }
 
-const enrichmentByAgentHost = new Map<string, CatalogEnrichmentEntry>()
+const enrichmentByScope = new Map<string, CatalogEnrichmentEntry>()
 
-function enrichmentKey(agent: AgentType, hostKey: string): string {
-  return JSON.stringify([agent, hostKey])
+function enrichmentKey(agent: AgentType, hostKey: string, ptyId?: string): string {
+  return JSON.stringify([agent, hostKey, ptyId ?? null])
 }
 
 export function readNativeChatEnrichedModels(
   agent: AgentType,
-  hostKey: string
+  hostKey: string,
+  ptyId?: string
 ): CatalogModel[] | null {
-  const models = enrichmentByAgentHost.get(enrichmentKey(agent, hostKey))?.models
+  const models = enrichmentByScope.get(enrichmentKey(agent, hostKey, ptyId))?.models
   return models ? [...models] : null
 }
 
 export function subscribeNativeChatEnrichedModels(
   agent: AgentType,
   hostKey: string,
-  listener: (models: CatalogModel[]) => void
+  listener: (models: CatalogModel[]) => void,
+  ptyId?: string
 ): () => void {
-  const key = enrichmentKey(agent, hostKey)
-  const entry = enrichmentByAgentHost.get(key) ?? {
+  const key = enrichmentKey(agent, hostKey, ptyId)
+  const entry = enrichmentByScope.get(key) ?? {
     agent,
     state: 'idle' as const,
     models: null,
     listeners: new Set<(models: CatalogModel[]) => void>()
   }
   entry.listeners.add(listener)
-  enrichmentByAgentHost.set(key, entry)
+  enrichmentByScope.set(key, entry)
   return () => entry.listeners.delete(listener)
 }
 
@@ -58,7 +60,7 @@ export function resolveNativeChatLaunchSessionOptions(
     return values
   }
   let probed = false
-  for (const entry of enrichmentByAgentHost.values()) {
+  for (const entry of enrichmentByScope.values()) {
     if (entry.agent === agent && entry.models) {
       probed = true
       if (entry.models.some((model) => model.id === values.model)) {
@@ -72,14 +74,15 @@ export function resolveNativeChatLaunchSessionOptions(
 export function ensureNativeChatModelEnrichment(args: {
   agent: AgentType
   hostKey: string
+  ptyId?: string
   discover: () => Promise<readonly CatalogModel[] | null>
 }): void {
   const catalog = getAgentSessionOptionCatalog(args.agent)
   if (!catalog?.listModels) {
     return
   }
-  const key = enrichmentKey(args.agent, args.hostKey)
-  const existing = enrichmentByAgentHost.get(key)
+  const key = enrichmentKey(args.agent, args.hostKey, args.ptyId)
+  const existing = enrichmentByScope.get(key)
   if (existing?.state === 'pending' || existing?.state === 'settled') {
     return
   }
@@ -90,10 +93,10 @@ export function ensureNativeChatModelEnrichment(args: {
     listeners: new Set()
   }
   entry.state = 'pending'
-  enrichmentByAgentHost.set(key, entry)
+  enrichmentByScope.set(key, entry)
 
   // Why: model discovery must never delay rendering or launching; the seed is
-  // immediately usable while this once-per-host probe runs in the background.
+  // immediately usable while this once-per-discovery-scope probe runs in the background.
   void args
     .discover()
     .then((discovered) => {
@@ -117,5 +120,5 @@ export function ensureNativeChatModelEnrichment(args: {
 }
 
 export function clearNativeChatModelEnrichmentForTests(): void {
-  enrichmentByAgentHost.clear()
+  enrichmentByScope.clear()
 }

--- a/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
+++ b/src/renderer/src/components/native-chat/native-chat-session-option-enrichment.ts
@@ -102,7 +102,7 @@ export function ensureNativeChatModelEnrichment(args: {
         return
       }
       entry.models =
-        args.agent === 'claude'
+        args.agent === 'claude' || args.agent === 'codex'
           ? [...discovered]
           : catalog.discoveredModelsAreAuthoritative
             ? mergeDiscoveredAuthoritativeModels(catalog.models, discovered)

--- a/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-session-options.ts
@@ -96,6 +96,7 @@ export function useNativeChatSessionOptions(args: {
 } {
   const { agent, terminalTabId, targetPtyId, dispatchCommand, onAgentPicker, readTerminalScreen } =
     args
+  const modelDiscoveryPtyId = agent === 'codex' ? (targetPtyId ?? undefined) : undefined
   // The screen text that last parsed into reported values, so a later model
   // discovery can re-resolve it against the host's real ids.
   const reportedScreenRef = useRef<string | null>(null)
@@ -111,7 +112,7 @@ export function useNativeChatSessionOptions(args: {
     }
     const scopeKey = targetPtyId ?? terminalTabId
     const discoveredModels = discoveryContext
-      ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+      ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey, modelDiscoveryPtyId)
       : null
     const reportedValues =
       agent === 'claude'
@@ -125,7 +126,7 @@ export function useNativeChatSessionOptions(args: {
       scopeKey,
       ...(targetPtyId ? { fallbackScopeKey: terminalTabId } : {}),
       // Why: the catalog seed carries version-neutral family labels, so it is
-      // safe on every host while the once-per-host probe runs or after it fails
+      // safe on every host while the scoped probe runs or after it fails
       // — without it the whole picker would pop in late or never appear.
       ...(discoveryContext ? { initialModels: discoveredModels ?? undefined } : {}),
       mode: targetPtyId ? 'live' : 'draft',
@@ -148,6 +149,7 @@ export function useNativeChatSessionOptions(args: {
     agent,
     dispatchCommand,
     discoveryContext,
+    modelDiscoveryPtyId,
     onAgentPicker,
     readTerminalScreen,
     targetPtyId,
@@ -175,7 +177,7 @@ export function useNativeChatSessionOptions(args: {
         }
       }
       const models = discoveryContext
-        ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+        ? readNativeChatEnrichedModels(agent, discoveryContext.hostKey, modelDiscoveryPtyId)
         : null
       for (const screen of [authoritativeScreen, readTerminalScreen?.() ?? null]) {
         const reportedValues = readClaudeSessionOptionsFromTerminalScreen(
@@ -200,7 +202,7 @@ export function useNativeChatSessionOptions(args: {
     return () => {
       cancelled = true
     }
-  }, [agent, discoveryContext, readTerminalScreen, surface, targetPtyId])
+  }, [agent, discoveryContext, modelDiscoveryPtyId, readTerminalScreen, surface, targetPtyId])
 
   useEffect(() => {
     if (!surface || !discoveryContext) {
@@ -220,21 +222,28 @@ export function useNativeChatSessionOptions(args: {
         }
         // A failed settings write must not surface as an unhandled rejection.
         void retirePersistedModelMissingFromDiscovery(agent, models).catch(() => undefined)
-      }
+      },
+      modelDiscoveryPtyId
     )
     // Why: the subscription never replays, so a probe that settled before this
     // pane mounted would leave a retired persisted model in place forever.
-    const cached = readNativeChatEnrichedModels(agent, discoveryContext.hostKey)
+    const cached = readNativeChatEnrichedModels(
+      agent,
+      discoveryContext.hostKey,
+      modelDiscoveryPtyId
+    )
     if (cached) {
       void retirePersistedModelMissingFromDiscovery(agent, cached).catch(() => undefined)
     }
     ensureNativeChatModelEnrichment({
       agent,
       hostKey: discoveryContext.hostKey,
-      discover: () => discoverNativeChatCatalogModels(agent, discoveryContext.runtime)
+      ...(modelDiscoveryPtyId ? { ptyId: modelDiscoveryPtyId } : {}),
+      discover: () =>
+        discoverNativeChatCatalogModels(agent, discoveryContext.runtime, modelDiscoveryPtyId)
     })
     return unsubscribe
-  }, [agent, discoveryContext, surface])
+  }, [agent, discoveryContext, modelDiscoveryPtyId, surface])
 
   const snapshot = useSyncExternalStore(
     surface?.subscribe ?? subscribeEmpty,

--- a/src/renderer/src/components/tab-bar/CodexLaunchAccountMenu.test.tsx
+++ b/src/renderer/src/components/tab-bar/CodexLaunchAccountMenu.test.tsx
@@ -1,0 +1,222 @@
+// @vitest-environment happy-dom
+
+import React, { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { CodexLaunchAccountMenu } from './CodexLaunchAccountMenu'
+
+globalThis.IS_REACT_ACT_ENVIRONMENT = true
+
+const { accountSnapshot, fetchAccountsMock, ownerTarget, supportsCapabilityMock } = vi.hoisted(
+  () => ({
+    accountSnapshot: {
+      codex: {
+        accounts: [
+          {
+            id: 'account-uuid-a',
+            email: 'owner@example.com',
+            workspaceLabel: 'Acme workspace',
+            managedHomeRuntime: 'host' as const,
+            createdAt: 1,
+            updatedAt: 1,
+            lastAuthenticatedAt: 1
+          }
+        ],
+        activeAccountId: null,
+        activeAccountIdsByRuntime: { host: null, wsl: {} }
+      },
+      claude: {
+        accounts: [],
+        activeAccountId: null,
+        activeAccountIdsByRuntime: { host: null, wsl: {} }
+      },
+      rateLimits: null
+    },
+    fetchAccountsMock: vi.fn(),
+    supportsCapabilityMock: vi.fn(),
+    ownerTarget: {
+      current: { kind: 'local' } as
+        | { kind: 'local' }
+        | { kind: 'runtime'; environmentId: string }
+        | { kind: 'ssh'; connectionId: string }
+        | undefined
+    }
+  })
+)
+
+vi.mock('@/hooks/useAgentDetectionTarget', () => ({
+  useAgentDetectionTargetForWorktree: () => ownerTarget.current
+}))
+
+vi.mock('@/runtime/runtime-provider-accounts-client', () => ({
+  fetchProviderAccountsSnapshot: fetchAccountsMock
+}))
+
+vi.mock('@/runtime/runtime-rpc-client', () => ({
+  runtimeEnvironmentSupportsCapability: supportsCapabilityMock
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: (selector: (state: unknown) => unknown) =>
+    selector({ worktreesByRepo: {}, repos: [] })
+}))
+
+vi.mock('@/lib/local-preflight-context', () => ({
+  getLocalAgentPreflightContext: () => undefined
+}))
+
+vi.mock('@/lib/agent-catalog', () => ({
+  AgentIcon: () => <span>codex-icon</span>
+}))
+
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenuSub: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DropdownMenuSubTrigger: ({ children, ...props }: React.ComponentProps<'button'>) => (
+    <button {...props}>{children}</button>
+  ),
+  DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) => <span>{children}</span>,
+  DropdownMenuItem: ({
+    children,
+    disabled,
+    onSelect,
+    ...props
+  }: React.ComponentProps<'button'> & { onSelect?: () => void }) => (
+    <button {...props} disabled={disabled} onClick={onSelect}>
+      {children}
+    </button>
+  )
+}))
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+  reject: (reason: unknown) => void
+} {
+  let resolve!: (value: T) => void
+  let reject!: (reason: unknown) => void
+  const promise = new Promise<T>((resolvePromise, rejectPromise) => {
+    resolve = resolvePromise
+    reject = rejectPromise
+  })
+  return { promise, resolve, reject }
+}
+
+function buttonWithText(container: ParentNode, text: string): HTMLButtonElement {
+  const match = Array.from(container.querySelectorAll('button')).find((button) =>
+    button.textContent?.includes(text)
+  )
+  if (!match) {
+    throw new Error(`Missing button containing: ${text}`)
+  }
+  return match
+}
+
+let container: HTMLDivElement
+let root: Root
+
+beforeEach(() => {
+  fetchAccountsMock.mockReset()
+  supportsCapabilityMock.mockReset()
+  supportsCapabilityMock.mockResolvedValue(true)
+  ownerTarget.current = { kind: 'local' }
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  root = createRoot(container)
+})
+
+afterEach(() => {
+  act(() => root.unmount())
+  container.remove()
+})
+
+describe('CodexLaunchAccountMenu', () => {
+  it('keeps current-default launch available while account discovery loads', async () => {
+    const request = deferred<typeof accountSnapshot>()
+    fetchAccountsMock.mockReturnValue(request.promise)
+    const onLaunch = vi.fn()
+
+    await act(async () => {
+      root.render(
+        <CodexLaunchAccountMenu worktreeId="worktree-1" shortcut="⌘⌥T" onLaunch={onLaunch} />
+      )
+    })
+
+    expect(container.querySelector('[aria-label="Launch Codex with an account"]')).not.toBeNull()
+    expect(container.textContent).toContain('Loading Codex accounts…')
+    await act(async () => buttonWithText(container, 'Current default').click())
+    expect(onLaunch).toHaveBeenCalledExactlyOnceWith()
+
+    await act(async () => request.resolve(accountSnapshot))
+  })
+
+  it('shows a friendly label and launches by the canonical managed-account UUID', async () => {
+    fetchAccountsMock.mockResolvedValue(accountSnapshot)
+    const onLaunch = vi.fn()
+
+    await act(async () => {
+      root.render(<CodexLaunchAccountMenu worktreeId="worktree-1" onLaunch={onLaunch} />)
+    })
+
+    expect(container.textContent).toContain('Acme workspace')
+    expect(container.textContent).toContain('account-uuid-a')
+    await act(async () => buttonWithText(container, 'Acme workspace').click())
+    expect(onLaunch).toHaveBeenCalledExactlyOnceWith({
+      provider: 'codex',
+      accountId: 'account-uuid-a',
+      runtime: 'host'
+    })
+  })
+
+  it('surfaces load failure and retains a retryable current-default fallback', async () => {
+    fetchAccountsMock.mockRejectedValueOnce(new Error('account service unavailable'))
+    fetchAccountsMock.mockResolvedValueOnce(accountSnapshot)
+    const onLaunch = vi.fn()
+
+    await act(async () => {
+      root.render(<CodexLaunchAccountMenu worktreeId="worktree-1" onLaunch={onLaunch} />)
+    })
+
+    expect(container.textContent).toContain('account service unavailable')
+    await act(async () => buttonWithText(container, 'Retry').click())
+    expect(fetchAccountsMock).toHaveBeenCalledTimes(2)
+    expect(container.textContent).toContain('Acme workspace')
+  })
+
+  it('does not fetch account data for SSH and keeps the legacy default launch available', async () => {
+    ownerTarget.current = { kind: 'ssh', connectionId: 'ssh-1' }
+    const onLaunch = vi.fn()
+
+    await act(async () => {
+      root.render(<CodexLaunchAccountMenu worktreeId="worktree-1" onLaunch={onLaunch} />)
+    })
+
+    expect(container.textContent).toContain('Account selection is unavailable for SSH workspaces.')
+    expect(fetchAccountsMock).not.toHaveBeenCalled()
+    await act(async () => buttonWithText(container, 'Current default').click())
+    expect(onLaunch).toHaveBeenCalledExactlyOnceWith()
+  })
+
+  it('limits an older paired runtime to current default before fetching accounts', async () => {
+    ownerTarget.current = { kind: 'runtime', environmentId: 'runtime-old' }
+    supportsCapabilityMock.mockResolvedValue(false)
+    const onLaunch = vi.fn()
+
+    await act(async () => {
+      root.render(<CodexLaunchAccountMenu worktreeId="worktree-1" onLaunch={onLaunch} />)
+    })
+
+    expect(supportsCapabilityMock).toHaveBeenCalledWith(
+      'runtime-old',
+      'agent-session.account-ref.v1'
+    )
+    expect(fetchAccountsMock).not.toHaveBeenCalled()
+    expect(container.textContent).toContain('This runtime only supports Current default.')
+    await act(async () => buttonWithText(container, 'Current default').click())
+    expect(onLaunch).toHaveBeenCalledExactlyOnceWith()
+  })
+})

--- a/src/renderer/src/components/tab-bar/CodexLaunchAccountMenu.tsx
+++ b/src/renderer/src/components/tab-bar/CodexLaunchAccountMenu.tsx
@@ -1,0 +1,206 @@
+import { useCallback, useEffect, useMemo, useState } from 'react'
+import { Loader2, RefreshCw } from 'lucide-react'
+import {
+  DropdownMenuItem,
+  DropdownMenuShortcut,
+  DropdownMenuSub,
+  DropdownMenuSubContent,
+  DropdownMenuSubTrigger
+} from '@/components/ui/dropdown-menu'
+import { AgentIcon } from '@/lib/agent-catalog'
+import { useAppStore } from '@/store'
+import { useAgentDetectionTargetForWorktree } from '@/hooks/useAgentDetectionTarget'
+import { fetchProviderAccountsSnapshot } from '@/runtime/runtime-provider-accounts-client'
+import { runtimeEnvironmentSupportsCapability } from '@/runtime/runtime-rpc-client'
+import { getLocalAgentPreflightContext } from '@/lib/local-preflight-context'
+import { getIndexedWorktreeById } from '@/store/worktree-repo-index'
+import { parseWslUncPath } from '../../../../shared/wsl-paths'
+import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
+import { AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY } from '../../../../shared/protocol-version'
+import { translate } from '@/i18n/i18n'
+import { buildCodexLaunchAccountOptions } from './codex-launch-account-options'
+
+type CodexLaunchAccountMenuProps = {
+  worktreeId: string
+  shortcut?: string | null
+  onLaunch: (providerAccountRef?: ProviderAccountRef) => void
+}
+
+export function CodexLaunchAccountMenu({
+  worktreeId,
+  shortcut,
+  onLaunch
+}: CodexLaunchAccountMenuProps): React.JSX.Element {
+  const target = useAgentDetectionTargetForWorktree(worktreeId)
+  const lane = useAppStore((state) => {
+    const worktreePath = getIndexedWorktreeById(state.worktreesByRepo ?? {}, worktreeId)?.path
+    const pathDistro = parseWslUncPath(worktreePath ?? '')?.distro ?? null
+    const localDistro = state.repos
+      ? getLocalAgentPreflightContext(state, undefined, undefined, worktreeId)?.wslDistro
+      : null
+    const wslDistro = pathDistro ?? localDistro ?? null
+    return wslDistro ? (`wsl:${wslDistro}` as const) : (`host` as const)
+  })
+  const [loadRevision, setLoadRevision] = useState(0)
+  const [state, setState] = useState<
+    | { status: 'loading' }
+    | { status: 'error'; message: string }
+    | {
+        status: 'ready'
+        accounts: Awaited<ReturnType<typeof fetchProviderAccountsSnapshot>>['codex']['accounts']
+      }
+  >({ status: 'loading' })
+
+  useEffect(() => {
+    let active = true
+    if (target === undefined) {
+      setState({ status: 'loading' })
+      return () => {
+        active = false
+      }
+    }
+    if (target.kind === 'ssh') {
+      setState({
+        status: 'error',
+        message: translate(
+          'auto.components.tab.bar.CodexLaunchAccountMenu.sshUnsupported',
+          'Account selection is unavailable for SSH workspaces.'
+        )
+      })
+      return () => {
+        active = false
+      }
+    }
+    setState({ status: 'loading' })
+    const loadAccounts = async (): ReturnType<typeof fetchProviderAccountsSnapshot> => {
+      if (target.kind === 'runtime') {
+        const supported = await runtimeEnvironmentSupportsCapability(
+          target.environmentId,
+          AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY
+        )
+        if (!supported) {
+          throw new Error(
+            translate(
+              'auto.components.tab.bar.CodexLaunchAccountMenu.runtimeUnsupported',
+              'This runtime only supports Current default. Update or restart Orca to select an account.'
+            )
+          )
+        }
+        return fetchProviderAccountsSnapshot({
+          activeRuntimeEnvironmentId: target.environmentId
+        })
+      }
+      return fetchProviderAccountsSnapshot({ activeRuntimeEnvironmentId: null })
+    }
+    void loadAccounts()
+      .then((snapshot) => {
+        if (active) {
+          setState({ status: 'ready', accounts: snapshot.codex.accounts })
+        }
+      })
+      .catch((error: unknown) => {
+        if (active) {
+          setState({
+            status: 'error',
+            message:
+              error instanceof Error
+                ? error.message
+                : translate(
+                    'auto.components.tab.bar.CodexLaunchAccountMenu.loadFailed',
+                    'Could not load Codex accounts.'
+                  )
+          })
+        }
+      })
+    return () => {
+      active = false
+    }
+  }, [loadRevision, target])
+
+  const launchOptions = useMemo(() => {
+    if (state.status !== 'ready') {
+      return []
+    }
+    const wslDistro = lane.startsWith('wsl:') ? lane.slice('wsl:'.length) : null
+    return buildCodexLaunchAccountOptions(
+      state.accounts,
+      wslDistro ? { runtime: 'wsl', wslDistro } : { runtime: 'host' }
+    )
+  }, [lane, state])
+  const retry = useCallback(() => setLoadRevision((revision) => revision + 1), [])
+
+  return (
+    <DropdownMenuSub>
+      <DropdownMenuSubTrigger
+        className="gap-2 rounded-[7px] px-2 py-1.5 text-[12px] leading-5 font-medium"
+        title={translate(
+          'auto.components.tab.bar.CodexLaunchAccountMenu.title',
+          'Launch Codex in a new terminal'
+        )}
+        aria-label={translate(
+          'auto.components.tab.bar.CodexLaunchAccountMenu.trigger',
+          'Launch Codex with an account'
+        )}
+      >
+        <AgentIcon agent="codex" size={14} />
+        <span className="flex-1">
+          {translate('auto.components.tab.bar.CodexLaunchAccountMenu.codex', 'Codex')}
+        </span>
+        {shortcut ? <DropdownMenuShortcut>{shortcut}</DropdownMenuShortcut> : null}
+      </DropdownMenuSubTrigger>
+      <DropdownMenuSubContent className="min-w-[18rem]">
+        {state.status === 'loading' ? (
+          <>
+            <DropdownMenuItem onSelect={() => onLaunch()}>
+              {translate(
+                'auto.components.tab.bar.CodexLaunchAccountMenu.currentDefault',
+                'Current default'
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled aria-live="polite">
+              <Loader2 className="size-3.5 animate-spin" aria-hidden="true" />
+              {translate(
+                'auto.components.tab.bar.CodexLaunchAccountMenu.loading',
+                'Loading Codex accounts…'
+              )}
+            </DropdownMenuItem>
+          </>
+        ) : state.status === 'error' ? (
+          <>
+            <DropdownMenuItem onSelect={() => onLaunch()}>
+              {translate(
+                'auto.components.tab.bar.CodexLaunchAccountMenu.currentDefault',
+                'Current default'
+              )}
+            </DropdownMenuItem>
+            <DropdownMenuItem disabled className="max-w-[18rem] whitespace-normal">
+              {state.message}
+            </DropdownMenuItem>
+            {target?.kind !== 'ssh' ? (
+              <DropdownMenuItem onSelect={retry}>
+                <RefreshCw className="size-3.5" aria-hidden="true" />
+                {translate('auto.components.tab.bar.CodexLaunchAccountMenu.retry', 'Retry')}
+              </DropdownMenuItem>
+            ) : null}
+          </>
+        ) : (
+          launchOptions.map((option) => (
+            <DropdownMenuItem
+              key={option.key}
+              onSelect={() => onLaunch(option.providerAccountRef)}
+              className="items-start"
+              title={option.description}
+            >
+              <span className="min-w-0">
+                <span className="block truncate">{option.label}</span>
+                <span className="block truncate font-mono text-[10px] font-normal text-muted-foreground">
+                  {option.description}
+                </span>
+              </span>
+            </DropdownMenuItem>
+          ))
+        )}
+      </DropdownMenuSubContent>
+    </DropdownMenuSub>
+  )
+}

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.test.ts
@@ -71,7 +71,13 @@ vi.mock('@/components/ui/dropdown-menu', async () => {
     DropdownMenuItem: ({ children, ...props }: { children: React.ReactNode }) =>
       ReactActual.createElement('div', props, children),
     DropdownMenuShortcut: ({ children }: { children: React.ReactNode }) =>
-      ReactActual.createElement('span', { 'data-dropdown-shortcut': 'true' }, children)
+      ReactActual.createElement('span', { 'data-dropdown-shortcut': 'true' }, children),
+    DropdownMenuSub: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement('div', null, children),
+    DropdownMenuSubContent: ({ children }: { children: React.ReactNode }) =>
+      ReactActual.createElement('div', null, children),
+    DropdownMenuSubTrigger: ({ children, ...props }: { children: React.ReactNode }) =>
+      ReactActual.createElement('div', props, children)
   }
 })
 

--- a/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
+++ b/src/renderer/src/components/tab-bar/QuickLaunchButton.tsx
@@ -10,11 +10,13 @@ import { useOptionalShortcutLabel } from '@/hooks/useShortcutLabel'
 import { launchAgentInNewTab } from '@/lib/launch-agent-in-new-tab'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { LaunchSource } from '../../../../shared/telemetry-events'
+import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
 import {
   DEFAULT_DISABLED_TUI_AGENTS,
   filterEnabledTuiAgents
 } from '../../../../shared/tui-agent-selection'
 import { translate } from '@/i18n/i18n'
+import { CodexLaunchAccountMenu } from './CodexLaunchAccountMenu'
 
 export type QuickLaunchAgentMenuItemsProps = {
   worktreeId: string
@@ -123,7 +125,7 @@ function QuickLaunchAgentMenuItemsInner({
   }, [openSettingsPage, openSettingsTarget])
 
   const runLaunch = useCallback(
-    (agent: TuiAgent) => {
+    (agent: TuiAgent, providerAccountRef?: ProviderAccountRef) => {
       const entry = getCatalogEntry(agent)
       const label = entry?.label ?? agent
       const result = launchAgentInNewTab({
@@ -133,7 +135,8 @@ function QuickLaunchAgentMenuItemsInner({
         ...(prompt !== undefined ? { prompt } : {}),
         ...(promptDelivery !== undefined ? { promptDelivery } : {}),
         ...(launchSource !== undefined ? { launchSource } : {}),
-        ...(onPromptDelivered !== undefined ? { onPromptDelivered } : {})
+        ...(onPromptDelivered !== undefined ? { onPromptDelivered } : {}),
+        ...(providerAccountRef ? { providerAccountRef } : {})
       })
       if (!result) {
         toast.error(
@@ -199,6 +202,16 @@ function QuickLaunchAgentMenuItemsInner({
         const label = entry?.label ?? agent
         const showsDefaultAgentShortcut =
           newAgentShortcut !== null && defaultAgent !== 'blank' && agent === defaultAgent
+        if (agent === 'codex') {
+          return (
+            <CodexLaunchAccountMenu
+              key={agent}
+              worktreeId={worktreeId}
+              shortcut={showsDefaultAgentShortcut ? newAgentShortcut : null}
+              onLaunch={(providerAccountRef) => runLaunch(agent, providerAccountRef)}
+            />
+          )
+        }
         return (
           <DropdownMenuItem
             key={agent}

--- a/src/renderer/src/components/tab-bar/codex-launch-account-options.test.ts
+++ b/src/renderer/src/components/tab-bar/codex-launch-account-options.test.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+import { buildCodexLaunchAccountOptions } from './codex-launch-account-options'
+
+const accounts = [
+  {
+    id: 'host-a',
+    email: 'host@example.com',
+    workspaceLabel: 'Host workspace',
+    managedHomeRuntime: 'host' as const,
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1
+  },
+  {
+    id: 'wsl-a',
+    email: 'wsl@example.com',
+    managedHomeRuntime: 'wsl' as const,
+    wslDistro: 'Ubuntu',
+    createdAt: 1,
+    updatedAt: 1,
+    lastAuthenticatedAt: 1
+  }
+]
+
+describe('buildCodexLaunchAccountOptions', () => {
+  it('keeps omission as current default and exposes UUIDs as canonical selectors', () => {
+    const options = buildCodexLaunchAccountOptions(accounts, { runtime: 'host' })
+
+    expect(options.map(({ key }) => key)).toEqual(['current-default', 'system-default', 'host-a'])
+    expect(options[0].providerAccountRef).toBeUndefined()
+    expect(options[1].providerAccountRef).toEqual({
+      provider: 'codex',
+      accountId: null,
+      runtime: 'host'
+    })
+    expect(options[2]).toMatchObject({
+      label: 'Host workspace',
+      description: 'host@example.com · host-a',
+      providerAccountRef: { accountId: 'host-a', runtime: 'host' }
+    })
+  })
+
+  it('filters managed accounts by WSL lane without case-sensitive distro drift', () => {
+    const options = buildCodexLaunchAccountOptions(accounts, {
+      runtime: 'wsl',
+      wslDistro: 'ubuntu'
+    })
+
+    expect(options.map(({ key }) => key)).toEqual(['current-default', 'system-default', 'wsl-a'])
+    expect(options[2].providerAccountRef).toMatchObject({
+      accountId: 'wsl-a',
+      runtime: 'wsl',
+      wslDistro: 'ubuntu'
+    })
+  })
+})

--- a/src/renderer/src/components/tab-bar/codex-launch-account-options.ts
+++ b/src/renderer/src/components/tab-bar/codex-launch-account-options.ts
@@ -1,5 +1,5 @@
 import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
-import type { CodexManagedAccountSummary } from '../../../../shared/types'
+import type { CodexManagedAccountSummary } from '../../../../shared/managed-account-types'
 import { translate } from '@/i18n/i18n'
 
 export type CodexLaunchAccountLane = {
@@ -71,7 +71,11 @@ export function buildCodexLaunchAccountOptions(
             provider: 'codex',
             accountId: account.id,
             runtime: lane.runtime,
-            ...(lane.wslDistro ? { wslDistro: lane.wslDistro } : {})
+            ...(account.wslDistro
+              ? { wslDistro: account.wslDistro }
+              : lane.wslDistro
+                ? { wslDistro: lane.wslDistro }
+                : {})
           }
         }
       })

--- a/src/renderer/src/components/tab-bar/codex-launch-account-options.ts
+++ b/src/renderer/src/components/tab-bar/codex-launch-account-options.ts
@@ -1,0 +1,79 @@
+import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
+import type { CodexManagedAccountSummary } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+
+export type CodexLaunchAccountLane = {
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+export type CodexLaunchAccountOption = {
+  key: string
+  label: string
+  description: string
+  providerAccountRef?: ProviderAccountRef
+}
+
+function sameLane(account: CodexManagedAccountSummary, lane: CodexLaunchAccountLane): boolean {
+  const accountRuntime = account.managedHomeRuntime ?? 'host'
+  if (accountRuntime !== lane.runtime) {
+    return false
+  }
+  if (accountRuntime === 'host') {
+    return true
+  }
+  return (
+    account.wslDistro?.trim().toLocaleLowerCase('en-US') ===
+    lane.wslDistro?.trim().toLocaleLowerCase('en-US')
+  )
+}
+
+export function buildCodexLaunchAccountOptions(
+  accounts: readonly CodexManagedAccountSummary[],
+  lane: CodexLaunchAccountLane
+): CodexLaunchAccountOption[] {
+  const laneLabel = lane.runtime === 'wsl' ? `WSL ${lane.wslDistro ?? ''}`.trim() : 'host'
+  return [
+    {
+      key: 'current-default',
+      label: translate(
+        'auto.components.tab.bar.CodexLaunchAccountMenu.currentDefault',
+        'Current default'
+      ),
+      description: translate(
+        'auto.components.tab.bar.CodexLaunchAccountMenu.currentDefaultDescription',
+        'Follow the account currently selected for this runtime'
+      )
+    },
+    {
+      key: 'system-default',
+      label: translate(
+        'auto.components.tab.bar.CodexLaunchAccountMenu.systemLogin',
+        'System Codex login'
+      ),
+      description: laneLabel,
+      providerAccountRef: {
+        provider: 'codex',
+        accountId: null,
+        runtime: lane.runtime,
+        ...(lane.wslDistro ? { wslDistro: lane.wslDistro } : {})
+      }
+    },
+    ...accounts
+      .filter((account) => sameLane(account, lane))
+      .map((account) => {
+        const label = account.workspaceLabel?.trim() || account.email
+        return {
+          key: account.id,
+          label,
+          description: `${label === account.email ? '' : `${account.email} · `}${account.id}`,
+          providerAccountRef: {
+            provider: 'codex',
+            accountId: account.id,
+            runtime: lane.runtime,
+            ...(lane.wslDistro ? { wslDistro: lane.wslDistro } : {})
+          }
+        }
+      })
+  ]
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-types.ts
@@ -16,6 +16,7 @@ import type { TerminalKittyKeyboardModeTracker } from '../../../../shared/termin
 import type { PtyTransportRecoveryState } from './pty-transport-types'
 import type { SessionOptionValue } from '../../../../shared/native-chat-session-options'
 import type { DirectSshPaneRetryAttemptId } from '@/store/slices/direct-ssh-terminal-recovery'
+import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
 
 export type PtyConnectionDeps = {
   tabId: string
@@ -33,6 +34,7 @@ export type PtyConnectionDeps = {
     resumeProviderSession?: AgentProviderSessionMetadata
     launchToken?: string
     launchAgent?: TuiAgent
+    providerAccountRef?: ProviderAccountRef
     /** Explicit CLI override for host-owned agent launches; omission uses host settings. */
     agentArgsOverride?: string | null
     draftPrompt?: string

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -3849,6 +3849,9 @@ export function connectPanePty(
     ...(agentLaunchPreferences ? { agentLaunchPreferences } : {}),
     ...(launchToken ? { launchToken } : {}),
     ...(paneStartup?.launchAgent ? { launchAgent: paneStartup.launchAgent } : {}),
+    ...(paneStartup?.providerAccountRef
+      ? { providerAccountRef: paneStartup.providerAccountRef }
+      : {}),
     ...(paneStartup?.telemetry ? { telemetry: paneStartup.telemetry } : {}),
     onPtyExit: onExit,
     onPtySpawn,

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -13,6 +13,7 @@ import type { EventProps } from '../../../../shared/telemetry-events'
 import type { TerminalOscColorQueryReplyColors } from '../../../../shared/terminal-osc-color-reply'
 import type { TuiAgent } from '../../../../shared/tui-agent'
 import type { ExecutionHostId } from '../../../../shared/execution-host'
+import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
 import type { PtyDataMeta } from './pty-dispatcher'
 import type { RemoteRuntimeSnapshotOutcome } from '../../runtime/remote-runtime-terminal-multiplexer'
 
@@ -234,6 +235,7 @@ export type IpcPtyTransportOptions = {
   agentLaunchPreferences?: AgentLaunchPreferences
   launchToken?: string
   launchAgent?: TuiAgent
+  providerAccountRef?: ProviderAccountRef
   startupCommandDelivery?: StartupCommandDelivery
   connectionId?: string | null
   executionHostId?: ExecutionHostId | null

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -565,6 +565,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
     resumeProviderSession,
     launchToken,
     launchAgent,
+    providerAccountRef,
     startupCommandDelivery,
     connectionId,
     worktreeId,
@@ -837,6 +838,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
           ...((options.launchAgent ?? launchAgent)
             ? { launchAgent: options.launchAgent ?? launchAgent }
             : {}),
+          ...(providerAccountRef ? { providerAccountRef } : {}),
           ...((options.startupCommandDelivery ?? startupCommandDelivery)
             ? { startupCommandDelivery: options.startupCommandDelivery ?? startupCommandDelivery }
             : {}),

--- a/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/remote-runtime-pty-transport.ts
@@ -20,6 +20,7 @@ import type {
   RuntimeTerminalSend
 } from '../../../../shared/runtime-types'
 import {
+  AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY
 } from '../../../../shared/protocol-version'
@@ -145,6 +146,7 @@ export function createRemoteRuntimePtyTransport(
     resumeProviderSession,
     launchToken,
     launchAgent,
+    providerAccountRef,
     terminalColorQueryReplies,
     agentPrompt,
     agentPromptDelivery,
@@ -2040,6 +2042,7 @@ export function createRemoteRuntimePtyTransport(
                       ...(agentLaunchPreferences
                         ? { launchPreferences: agentLaunchPreferences }
                         : {}),
+                      ...(providerAccountRef ? { providerAccountRef } : {}),
                       placement: { tabId, leafId },
                       presentation: 'background'
                     },
@@ -2060,6 +2063,7 @@ export function createRemoteRuntimePtyTransport(
                         ...(agentLaunchPreferences
                           ? { launchPreferences: agentLaunchPreferences }
                           : {}),
+                        ...(providerAccountRef ? { providerAccountRef } : {}),
                         placement: { tabId, leafId },
                         presentation: 'background'
                       },
@@ -2076,9 +2080,14 @@ export function createRemoteRuntimePtyTransport(
             : await runRemoteAgentSessionLaunch<RemoteAgentSessionLaunchResult | null>({
                 environmentId: createEnvironmentId,
                 hostAuthority: hostAuthorityCreate,
-                ...(resumeProviderSessionToSend && launchAgentToSend === 'omp'
-                  ? { hostAuthorityCapability: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY }
-                  : {}),
+                ...(providerAccountRef
+                  ? {
+                      hostAuthorityCapability: AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
+                      requireHostAuthority: true
+                    }
+                  : resumeProviderSessionToSend && launchAgentToSend === 'omp'
+                    ? { hostAuthorityCapability: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY }
+                    : {}),
                 legacy: legacyCreate
               })
           : await legacyCreate()

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -3268,6 +3268,19 @@
           "TabBarQuickCommandHostLoadStatus": {
             "82e294f3ca": "Host unavailable",
             "7c129b08ff": "Loading host…"
+          },
+          "CodexLaunchAccountMenu": {
+            "sshUnsupported": "Account selection is unavailable for SSH workspaces.",
+            "runtimeUnsupported": "This runtime only supports Current default. Update or restart Orca to select an account.",
+            "loadFailed": "Could not load Codex accounts.",
+            "title": "Launch Codex in a new terminal",
+            "trigger": "Launch Codex with an account",
+            "currentDefault": "Current default",
+            "loading": "Loading Codex accounts…",
+            "retry": "Retry",
+            "codex": "Codex",
+            "currentDefaultDescription": "Follow the account currently selected for this runtime",
+            "systemLogin": "System Codex login"
           }
         }
       },

--- a/src/renderer/src/lib/launch-agent-in-new-tab.account-scope.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.account-scope.test.ts
@@ -1,0 +1,215 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const mockCreateTab = vi.fn()
+const mockQueueTabStartupCommand = vi.fn()
+const mockSetActiveTabType = vi.fn()
+const mockSetTabBarOrder = vi.fn()
+const mockSetAgentStatus = vi.fn()
+const mockPasteDraftWhenAgentReady = vi.fn()
+const mockSeedNativeChatLaunchPrompt = vi.fn()
+const mockSeedNativeChatLaunchDraft = vi.fn()
+const mockMarkNativeChatLaunchPromptFailed = vi.fn()
+const mockTrack = vi.fn()
+const mockToastMessage = vi.fn()
+
+const store = {
+  activeRepoId: 'repo-1',
+  activeWorktreeId: 'wt-1',
+  settings: {
+    agentCmdOverrides: {},
+    agentDefaultArgs: {} as Record<string, string>,
+    agentDefaultEnv: {} as Record<string, Record<string, string>>,
+    activeRuntimeEnvironmentId: null as string | null
+  } as {
+    agentCmdOverrides: Record<string, string>
+    agentDefaultArgs: Record<string, string>
+    agentDefaultEnv: Record<string, Record<string, string>>
+    activeRuntimeEnvironmentId: string | null
+    terminalWindowsShell?: string
+    experimentalNativeChat?: boolean
+    openAgentTabsInChatByDefault?: boolean
+    nativeChatSessionOptions?: Record<
+      string,
+      { model?: string; valuesByModel?: Record<string, Record<string, string | boolean>> }
+    >
+  },
+  projects: [
+    {
+      id: 'repo-1',
+      localWindowsRuntimePreference: { kind: 'inherit-global' as const }
+    }
+  ] as {
+    id: string
+    localWindowsRuntimePreference:
+      | { kind: 'inherit-global' }
+      | { kind: 'windows-host' }
+      | { kind: 'wsl'; distro: string | null }
+  }[],
+  repos: [{ id: 'repo-1', connectionId: null as string | null, path: '/repo' }],
+  sshConnectionStates: new Map([['ssh-a', { status: 'connected' }]]),
+  transientClearedAgentStatusConnectionIds: {} as Record<string, true>,
+  worktreesByRepo: {
+    'repo-1': [
+      {
+        id: 'wt-1',
+        repoId: 'repo-1',
+        projectId: 'repo-1',
+        path: '/repo/worktree',
+        displayName: 'main'
+      }
+    ]
+  },
+  allWorktrees: vi.fn(() => store.worktreesByRepo['repo-1']),
+  tabsByWorktree: {
+    'wt-1': [{ id: 'tab-1' }]
+  },
+  openFiles: [] as { id: string; worktreeId: string }[],
+  browserTabsByWorktree: {} as Record<string, { id: string }[]>,
+  tabBarOrderByWorktree: {} as Record<string, string[]>,
+  terminalLayoutsByTabId: {} as Record<
+    string,
+    { activeLeafId: string | null; ptyIdsByLeafId?: Record<string, string> }
+  >,
+  ptyIdsByTabId: {} as Record<string, string[]>,
+  createTab: mockCreateTab,
+  closeTab: vi.fn(),
+  queueTabStartupCommand: mockQueueTabStartupCommand,
+  setActiveTabType: mockSetActiveTabType,
+  setTabBarOrder: mockSetTabBarOrder,
+  setAgentStatus: mockSetAgentStatus,
+  seedNativeChatLaunchPrompt: mockSeedNativeChatLaunchPrompt,
+  seedNativeChatLaunchDraft: mockSeedNativeChatLaunchDraft,
+  markNativeChatLaunchPromptFailed: mockMarkNativeChatLaunchPromptFailed
+}
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => store
+  }
+}))
+
+const mockToastError = vi.fn()
+
+vi.mock('sonner', () => ({
+  toast: { message: mockToastMessage, error: mockToastError }
+}))
+
+vi.mock('@/components/tab-bar/reconcile-order', () => ({
+  reconcileTabOrder: vi.fn(
+    (_stored, termIds: string[], editorIds: string[], browserIds: string[]) => [
+      ...termIds,
+      ...editorIds,
+      ...browserIds
+    ]
+  )
+}))
+
+vi.mock('@/lib/agent-paste-draft', () => ({
+  pasteDraftWhenAgentReady: mockPasteDraftWhenAgentReady
+}))
+
+vi.mock('@/lib/telemetry', () => ({
+  track: mockTrack,
+  tuiAgentToAgentKind: (agent: string) => agent
+}))
+
+const mockCreateWebRuntimeSessionTerminal = vi.fn()
+const mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft = vi.fn()
+const mockIsWebRuntimeSessionActive = vi.fn(() => false)
+
+vi.mock('@/runtime/web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: mockCreateWebRuntimeSessionTerminal,
+  createWebRuntimeAgentSessionTerminalWithLaunchDraft:
+    mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft,
+  isWebRuntimeSessionActive: mockIsWebRuntimeSessionActive,
+  isWebTerminalSurfaceTabId: vi.fn(() => false)
+}))
+
+describe('launchAgentInNewTab provider account scope', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mockIsWebRuntimeSessionActive.mockReturnValue(false)
+    mockCreateWebRuntimeSessionTerminal.mockResolvedValue({ status: 'created' })
+    mockCreateWebRuntimeAgentSessionTerminalWithLaunchDraft.mockResolvedValue({ status: 'created' })
+    store.activeRepoId = 'repo-1'
+    store.activeWorktreeId = 'wt-1'
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: null
+    }
+    store.projects = [
+      {
+        id: 'repo-1',
+        localWindowsRuntimePreference: { kind: 'inherit-global' }
+      }
+    ]
+    store.repos = [{ id: 'repo-1', connectionId: null, path: '/repo' }]
+    store.sshConnectionStates = new Map([['ssh-a', { status: 'connected' }]])
+    store.transientClearedAgentStatusConnectionIds = {}
+    store.worktreesByRepo = {
+      'repo-1': [
+        {
+          id: 'wt-1',
+          repoId: 'repo-1',
+          projectId: 'repo-1',
+          path: '/repo/worktree',
+          displayName: 'main'
+        }
+      ]
+    }
+    store.tabsByWorktree = { 'wt-1': [{ id: 'tab-1' }] }
+    store.openFiles = []
+    store.browserTabsByWorktree = {}
+    store.tabBarOrderByWorktree = {}
+    store.terminalLayoutsByTabId = {}
+    store.ptyIdsByTabId = {}
+    mockCreateTab.mockReturnValue({ id: 'tab-1' })
+    mockPasteDraftWhenAgentReady.mockResolvedValue(true)
+  })
+
+  it('queues a provider account reference with the local startup contract', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'host'
+    } as const
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', providerAccountRef })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ launchAgent: 'codex', providerAccountRef })
+    )
+    expect(mockCreateTab).toHaveBeenCalledWith(
+      'wt-1',
+      undefined,
+      undefined,
+      expect.not.objectContaining({ providerAccountRef })
+    )
+  })
+
+  it('passes a provider account reference to the paired host launch contract', async () => {
+    mockIsWebRuntimeSessionActive.mockReturnValue(true)
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: 'web-runtime'
+    }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'host'
+    } as const
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', providerAccountRef })
+
+    expect(mockCreateWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ providerAccountRef })
+    )
+  })
+})

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -449,6 +449,28 @@ describe('launchAgentInNewTab', () => {
     )
   })
 
+  it('queues a provider account reference with the local startup contract', async () => {
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'host'
+    } as const
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', providerAccountRef })
+
+    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
+      'tab-1',
+      expect.objectContaining({ launchAgent: 'codex', providerAccountRef })
+    )
+    expect(mockCreateTab).toHaveBeenCalledWith(
+      'wt-1',
+      undefined,
+      undefined,
+      expect.not.objectContaining({ providerAccountRef })
+    )
+  })
+
   it('preserves paired-host draft delivery and supported launch preferences', async () => {
     mockIsWebRuntimeSessionActive.mockReturnValue(true)
     store.settings = {
@@ -515,6 +537,28 @@ describe('launchAgentInNewTab', () => {
         agent: 'codex',
         viewMode: 'chat'
       })
+    )
+  })
+
+  it('passes a provider account reference to the paired host launch contract', async () => {
+    mockIsWebRuntimeSessionActive.mockReturnValue(true)
+    store.settings = {
+      agentCmdOverrides: {},
+      agentDefaultArgs: {},
+      agentDefaultEnv: {},
+      activeRuntimeEnvironmentId: 'web-runtime'
+    }
+    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
+    const providerAccountRef = {
+      provider: 'codex',
+      accountId: 'account-a',
+      runtime: 'host'
+    } as const
+
+    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', providerAccountRef })
+
+    expect(mockCreateWebRuntimeSessionTerminal).toHaveBeenCalledWith(
+      expect.objectContaining({ providerAccountRef })
     )
   })
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.test.ts
@@ -449,28 +449,6 @@ describe('launchAgentInNewTab', () => {
     )
   })
 
-  it('queues a provider account reference with the local startup contract', async () => {
-    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
-    const providerAccountRef = {
-      provider: 'codex',
-      accountId: 'account-a',
-      runtime: 'host'
-    } as const
-
-    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', providerAccountRef })
-
-    expect(mockQueueTabStartupCommand).toHaveBeenCalledWith(
-      'tab-1',
-      expect.objectContaining({ launchAgent: 'codex', providerAccountRef })
-    )
-    expect(mockCreateTab).toHaveBeenCalledWith(
-      'wt-1',
-      undefined,
-      undefined,
-      expect.not.objectContaining({ providerAccountRef })
-    )
-  })
-
   it('preserves paired-host draft delivery and supported launch preferences', async () => {
     mockIsWebRuntimeSessionActive.mockReturnValue(true)
     store.settings = {
@@ -537,28 +515,6 @@ describe('launchAgentInNewTab', () => {
         agent: 'codex',
         viewMode: 'chat'
       })
-    )
-  })
-
-  it('passes a provider account reference to the paired host launch contract', async () => {
-    mockIsWebRuntimeSessionActive.mockReturnValue(true)
-    store.settings = {
-      agentCmdOverrides: {},
-      agentDefaultArgs: {},
-      agentDefaultEnv: {},
-      activeRuntimeEnvironmentId: 'web-runtime'
-    }
-    const { launchAgentInNewTab } = await import('./launch-agent-in-new-tab')
-    const providerAccountRef = {
-      provider: 'codex',
-      accountId: 'account-a',
-      runtime: 'host'
-    } as const
-
-    launchAgentInNewTab({ agent: 'codex', worktreeId: 'wt-1', providerAccountRef })
-
-    expect(mockCreateWebRuntimeSessionTerminal).toHaveBeenCalledWith(
-      expect.objectContaining({ providerAccountRef })
     )
   })
 

--- a/src/renderer/src/lib/launch-agent-in-new-tab.ts
+++ b/src/renderer/src/lib/launch-agent-in-new-tab.ts
@@ -26,6 +26,7 @@ import { repoIsRemote } from '../../../shared/agent-launch-remote'
 import { seedCommandCodeSubmittedPromptStatus } from '@/lib/command-code-prompt-status-seed'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import type { LaunchSource } from '../../../shared/telemetry-events'
+import type { ProviderAccountRef } from '../../../shared/provider-account-ref'
 import { getConnectionIdFromState } from '@/lib/connection-context'
 import { resolveInitialNativeChatSessionOptions } from '@/components/native-chat/native-chat-launch-session-options'
 import { seedNativeChatAppliedSessionOptions } from '@/components/native-chat/native-chat-session-option-cache'
@@ -50,6 +51,7 @@ export type LaunchAgentInNewTabArgs = {
   launchPlatform?: NodeJS.Platform
   /** Called after the prompt is actually delivered to the agent input path. */
   onPromptDelivered?: () => void
+  providerAccountRef?: ProviderAccountRef
 }
 
 export type LaunchAgentInNewTabResult = {
@@ -81,7 +83,8 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     launchSource,
     quickCommandLabel,
     launchPlatform,
-    onPromptDelivered
+    onPromptDelivered,
+    providerAccountRef
   } = args
   const store = useAppStore.getState()
   const worktree = store.allWorktrees?.().find((entry: { id: string }) => entry.id === worktreeId)
@@ -161,7 +164,8 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
       // Why: omission means terminal locally, but would let a paired host apply
       // its own default; send the client's resolved terminal choice explicitly.
       viewMode: initialViewModeProps.viewMode ?? 'terminal',
-      onPromptDelivered
+      onPromptDelivered,
+      providerAccountRef
     })
     return {
       tabId: null,
@@ -190,6 +194,7 @@ export function launchAgentInNewTab(args: LaunchAgentInNewTabArgs): LaunchAgentI
     ...(startupPlan.env ? { env: startupPlan.env } : {}),
     launchConfig: startupPlan.launchConfig,
     launchAgent: agent,
+    ...(providerAccountRef ? { providerAccountRef } : {}),
     ...(agentArgs !== undefined ? { agentArgsOverride: agentArgs } : {}),
     ...(startupPlan.sessionOptions ? { sessionOptions: startupPlan.sessionOptions } : {}),
     ...(startupPlan.startupCommandDelivery

--- a/src/renderer/src/lib/launch-agent-web-host-tab.ts
+++ b/src/renderer/src/lib/launch-agent-web-host-tab.ts
@@ -12,6 +12,7 @@ import type { TuiAgent } from '../../../shared/tui-agent'
 import type { AgentPromptDelivery } from '../../../shared/agent-session-host-authority'
 import { translate } from '@/i18n/i18n'
 import { toAgentLaunchPreferences } from '@/runtime/agent-session-create-operation'
+import type { ProviderAccountRef } from '../../../shared/provider-account-ref'
 
 function removeStaleLocalAgentTabsForWebHostLaunch(worktreeId: string): void {
   const state = useAppStore.getState()
@@ -46,6 +47,7 @@ export function launchAgentInWebHostTab(args: {
   agentArgs?: string | null
   viewMode?: Tab['viewMode']
   onPromptDelivered?: () => void
+  providerAccountRef?: ProviderAccountRef
 }): Promise<{ delivered: boolean; failureNotified: boolean }> {
   const {
     agent,
@@ -60,7 +62,8 @@ export function launchAgentInWebHostTab(args: {
     submitPastedPrompt,
     agentArgs,
     viewMode,
-    onPromptDelivered
+    onPromptDelivered,
+    providerAccountRef
   } = args
   const hasPrompt = prompt.length > 0
   const launchPreferences = toAgentLaunchPreferences(startupPlan.sessionOptions)
@@ -91,7 +94,8 @@ export function launchAgentInWebHostTab(args: {
       ? { promptDelivery: structuredPromptDelivery }
       : {}),
     ...(agentArgs !== undefined ? { agentArgs } : {}),
-    ...(launchPreferences ? { launchPreferences } : {})
+    ...(launchPreferences ? { launchPreferences } : {}),
+    ...(providerAccountRef ? { providerAccountRef } : {})
   } as const
 
   const handleCreation = ({

--- a/src/renderer/src/lib/runtime-agent-background-create.ts
+++ b/src/renderer/src/lib/runtime-agent-background-create.ts
@@ -2,6 +2,8 @@ import type { SleepingAgentLaunchConfig } from '../../../shared/agent-session-re
 import type { StartupCommandDelivery } from '../../../shared/codex-startup-delivery'
 import type { SessionOptionValue } from '../../../shared/native-chat-session-options'
 import type { RuntimeTerminalCreate } from '../../../shared/runtime-types'
+import type { ProviderAccountRef } from '../../../shared/provider-account-ref'
+import { AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import type { TuiAgent } from '../../../shared/tui-agent'
 import {
   createAgentSessionCreateOperation,
@@ -20,6 +22,7 @@ export async function createRuntimeAgentBackgroundTerminal(args: {
   agent: TuiAgent
   prompt?: string
   sessionOptions?: Record<string, SessionOptionValue>
+  providerAccountRef?: ProviderAccountRef
   legacy: {
     command: string
     env: Record<string, string>
@@ -46,6 +49,7 @@ export async function createRuntimeAgentBackgroundTerminal(args: {
                 ? { prompt: args.prompt, promptDelivery: 'auto-submit' as const }
                 : {}),
               ...(launchPreferences ? { launchPreferences } : {}),
+              ...(args.providerAccountRef ? { providerAccountRef: args.providerAccountRef } : {}),
               placement: { tabId: args.tabId, leafId: args.leafId },
               // Why: local renderer owns the hidden tab; remote runtime should not reveal UI.
               presentation: 'background'
@@ -55,6 +59,12 @@ export async function createRuntimeAgentBackgroundTerminal(args: {
           { timeoutMs: 15_000 }
         )
       ),
+    ...(args.providerAccountRef
+      ? {
+          hostAuthorityCapability: AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
+          requireHostAuthority: true
+        }
+      : {}),
     legacy: ({ skipCompatibilityCheck }) =>
       callRuntimeRpc<{ terminal: RuntimeTerminalCreate }>(
         { kind: 'environment', environmentId: args.environmentId },

--- a/src/renderer/src/runtime/remote-agent-session-launch.test.ts
+++ b/src/renderer/src/runtime/remote-agent-session-launch.test.ts
@@ -56,6 +56,39 @@ describe('remote agent-session launch routing', () => {
     expect(hostAuthority).not.toHaveBeenCalled()
   })
 
+  it('fails closed instead of dropping a required account reference on an old host', async () => {
+    const hostAuthority = vi.fn().mockResolvedValue('structured')
+    const legacy = vi.fn().mockResolvedValue('legacy')
+    mocks.supportsCapability.mockResolvedValue(false)
+
+    await expect(
+      runRemoteAgentSessionLaunch({
+        environmentId: 'env-1',
+        hostAuthority,
+        hostAuthorityCapability: 'agent-session.account-ref.v1',
+        requireHostAuthority: true,
+        legacy
+      })
+    ).rejects.toThrow('agent_session_account_unsupported')
+    expect(hostAuthority).not.toHaveBeenCalled()
+    expect(legacy).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a required account capability probe is unavailable', async () => {
+    const legacy = vi.fn().mockResolvedValue('legacy')
+    mocks.supportsCapability.mockRejectedValue(new Error('status temporarily unavailable'))
+
+    await expect(
+      runRemoteAgentSessionLaunch({
+        environmentId: 'env-1',
+        hostAuthority: vi.fn(),
+        requireHostAuthority: true,
+        legacy
+      })
+    ).rejects.toThrow('agent_session_account_unsupported')
+    expect(legacy).not.toHaveBeenCalled()
+  })
+
   it('keeps legacy behavior when a read-only capability probe fails', async () => {
     const hostAuthority = vi.fn().mockResolvedValue('structured')
     const legacy = vi.fn().mockResolvedValue('legacy')
@@ -145,5 +178,18 @@ describe('remote agent-session launch routing', () => {
       'legacy'
     )
     expect(mocks.supportsCapability).not.toHaveBeenCalled()
+  })
+
+  it('does not use a legacy-only placement when account authority is required', async () => {
+    const legacy = vi.fn().mockResolvedValue('legacy')
+
+    await expect(
+      runRemoteAgentSessionLaunch({
+        environmentId: 'env-1',
+        requireHostAuthority: true,
+        legacy
+      })
+    ).rejects.toThrow('agent_session_account_unsupported')
+    expect(legacy).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/runtime/remote-agent-session-launch.ts
+++ b/src/renderer/src/runtime/remote-agent-session-launch.ts
@@ -7,9 +7,13 @@ export async function runRemoteAgentSessionLaunch<TResult>(args: {
   environmentId: string
   hostAuthority?: () => Promise<TResult>
   hostAuthorityCapability?: RuntimeCapability
+  requireHostAuthority?: boolean
   legacy: (options: { skipCompatibilityCheck: boolean }) => Promise<TResult>
 }): Promise<TResult> {
   if (!args.hostAuthority) {
+    if (args.requireHostAuthority) {
+      throw new Error('agent_session_account_unsupported')
+    }
     return await args.legacy({ skipCompatibilityCheck: false })
   }
   let supported: boolean
@@ -22,6 +26,9 @@ export async function runRemoteAgentSessionLaunch<TResult>(args: {
     if (isRuntimeCompatBlockError(error)) {
       throw error
     }
+    if (args.requireHostAuthority) {
+      throw new Error('agent_session_account_unsupported')
+    }
     // Why: a failed read-only probe has not launched anything, so preserving
     // the legacy path cannot duplicate an agent and keeps transient upgrades neutral.
     return await args.legacy({ skipCompatibilityCheck: true })
@@ -29,12 +36,16 @@ export async function runRemoteAgentSessionLaunch<TResult>(args: {
   // Why: choose before invoking either path; an ambiguous structured outcome
   // must never trigger a legacy retry that could spawn a duplicate.
   if (!supported) {
+    if (args.requireHostAuthority) {
+      throw new Error('agent_session_account_unsupported')
+    }
     return await args.legacy({ skipCompatibilityCheck: true })
   }
   try {
     return await args.hostAuthority()
   } catch (error) {
     if (
+      !args.requireHostAuthority &&
       error instanceof RuntimeRpcCallError &&
       (error.code === 'agent_session_legacy_required' || error.code === 'method_not_found')
     ) {

--- a/src/renderer/src/runtime/runtime-git-client.test.ts
+++ b/src/renderer/src/runtime/runtime-git-client.test.ts
@@ -725,16 +725,41 @@ describe('runtime git client', () => {
         worktreeId: 'wt-1',
         worktreePath: '/repo'
       },
-      'cursor'
+      'cursor',
+      'remote:env-1@@pty-account-b'
     )
 
     expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
       selector: 'env-1',
       method: 'git.discoverCommitMessageModels',
-      params: { worktree: 'id:wt-1', agentId: 'cursor', agentCmdOverrides },
+      params: {
+        worktree: 'id:wt-1',
+        agentId: 'cursor',
+        agentCmdOverrides,
+        ptyId: 'pty-account-b'
+      },
       timeoutMs: 75_000
     })
     expect(gitDiscoverCommitMessageModels).not.toHaveBeenCalled()
+  })
+
+  it('passes a local PTY id through model discovery IPC', async () => {
+    await discoverRuntimeCommitMessageModels(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo'
+      },
+      'codex',
+      'pty-account-a'
+    )
+
+    expect(gitDiscoverCommitMessageModels).toHaveBeenCalledWith({
+      agentId: 'codex',
+      worktreePath: '/repo',
+      connectionId: undefined,
+      ptyId: 'pty-account-a'
+    })
   })
 
   it('passes the raw worktree id to local generation IPC', async () => {

--- a/src/renderer/src/runtime/runtime-git-client.ts
+++ b/src/renderer/src/runtime/runtime-git-client.ts
@@ -25,6 +25,7 @@ import { getCommitMessageModelDiscoveryHostKeyForScope } from '../../../shared/c
 import type { GitHistoryOptions, GitHistoryResult } from '../../../shared/git-history'
 import { getRepoIdFromWorktreeId, splitWorktreeIdForFilesystem } from '../../../shared/worktree/id'
 import { callRuntimeRpc, getActiveRuntimeTarget } from './runtime-rpc-client'
+import { parseRemoteRuntimePtyId } from './runtime-terminal-stream'
 import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
 
 export type RuntimeGenerateCommitMessageResult =
@@ -691,14 +692,17 @@ export async function generateRuntimeCommitMessage(
 
 export async function discoverRuntimeCommitMessageModels(
   context: RuntimeGitContext,
-  agentId: string
+  agentId: string,
+  ptyId?: string
 ): Promise<RuntimeDiscoverCommitMessageModelsResult> {
   const target = getActiveRuntimeTarget(context.settings)
+  const remotePty = ptyId ? parseRemoteRuntimePtyId(ptyId) : null
   if (target.kind === 'local' || !context.worktreeId) {
     return window.api.git.discoverCommitMessageModels({
       agentId,
       worktreePath: resolveLocalWorktreePath(context),
-      connectionId: context.connectionId
+      connectionId: context.connectionId,
+      ...(!remotePty && ptyId ? { ptyId } : {})
     }) as Promise<RuntimeDiscoverCommitMessageModelsResult>
   }
   return callRuntimeRpc<RuntimeDiscoverCommitMessageModelsResult>(
@@ -707,6 +711,7 @@ export async function discoverRuntimeCommitMessageModels(
     {
       worktree: toRuntimeWorktreeSelector(context.worktreeId),
       agentId,
+      ...(ptyId ? { ptyId: remotePty?.handle ?? ptyId } : {}),
       ...(context.settings?.agentCmdOverrides
         ? { agentCmdOverrides: context.settings.agentCmdOverrides }
         : {})

--- a/src/renderer/src/runtime/web-runtime-session.ts
+++ b/src/renderer/src/runtime/web-runtime-session.ts
@@ -20,9 +20,11 @@ import type {
   AgentProviderSessionMetadata
 } from '../../../shared/agent-session-resume'
 import {
+  AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
   BROWSER_TAB_CREATE_KNOWN_ID_RUNTIME_CAPABILITY
 } from '../../../shared/protocol-version'
+import type { ProviderAccountRef } from '../../../shared/provider-account-ref'
 import type {
   AgentLaunchPreferences,
   AgentPromptDelivery,
@@ -175,6 +177,7 @@ type CreateWebRuntimeSessionTerminalArgs = {
   /** Explicit CLI override; omission leaves the remote host's defaults authoritative. */
   agentArgs?: string | null
   launchPreferences?: AgentLaunchPreferences
+  providerAccountRef?: ProviderAccountRef
   providerSession?: AgentProviderSessionMetadata
   viewMode?: 'terminal' | 'chat'
   activate?: boolean
@@ -304,6 +307,9 @@ async function createWebRuntimeSessionTerminalResult(
                       ...(args.launchPreferences
                         ? { launchPreferences: args.launchPreferences }
                         : {}),
+                      ...(args.providerAccountRef
+                        ? { providerAccountRef: args.providerAccountRef }
+                        : {}),
                       presentation: 'background'
                     },
                     timeoutMs: 15_000
@@ -327,6 +333,9 @@ async function createWebRuntimeSessionTerminalResult(
                         ...(args.launchPreferences
                           ? { launchPreferences: args.launchPreferences }
                           : {}),
+                        ...(args.providerAccountRef
+                          ? { providerAccountRef: args.providerAccountRef }
+                          : {}),
                         ...(args.cwd ? { startupCwd: args.cwd } : {}),
                         ...(args.viewMode ? { viewMode: args.viewMode } : {}),
                         presentation: 'background'
@@ -342,9 +351,14 @@ async function createWebRuntimeSessionTerminalResult(
       }>({
         environmentId,
         ...(hostAuthority ? { hostAuthority } : {}),
-        ...(args.agentSessionKind === 'resume' && agent === 'omp'
-          ? { hostAuthorityCapability: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY }
-          : {}),
+        ...(args.providerAccountRef
+          ? {
+              hostAuthorityCapability: AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
+              requireHostAuthority: true
+            }
+          : args.agentSessionKind === 'resume' && agent === 'omp'
+            ? { hostAuthorityCapability: AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY }
+            : {}),
         legacy: async () => {
           const response = await callEnvironment({
             method: 'session.tabs.createTerminal',

--- a/src/renderer/src/store/slices/terminals.ts
+++ b/src/renderer/src/store/slices/terminals.ts
@@ -14,6 +14,7 @@ import type {
   SleepingAgentLaunchConfig
 } from '../../../../shared/agent-session-resume'
 import type { DirectSshAuthority } from '../../../../shared/ssh-types'
+import type { ProviderAccountRef } from '../../../../shared/provider-account-ref'
 import { parseAppSshPtyId } from '../../../../shared/ssh-pty-id'
 import {
   DEFAULT_REPO_BADGE_COLOR,
@@ -570,6 +571,7 @@ export type TerminalSlice = {
       resumeProviderSession?: AgentProviderSessionMetadata
       launchToken?: string
       launchAgent?: TuiAgent
+      providerAccountRef?: ProviderAccountRef
       /** Explicit CLI override for host-owned agent launches; omission uses host settings. */
       agentArgsOverride?: string | null
       draftPrompt?: string
@@ -752,6 +754,7 @@ export type TerminalSlice = {
       resumeProviderSession?: AgentProviderSessionMetadata
       launchToken?: string
       launchAgent?: TuiAgent
+      providerAccountRef?: ProviderAccountRef
       agentArgsOverride?: string | null
       draftPrompt?: string
       sessionOptions?: Record<string, SessionOptionValue>
@@ -772,6 +775,7 @@ export type TerminalSlice = {
     resumeProviderSession?: AgentProviderSessionMetadata
     launchToken?: string
     launchAgent?: TuiAgent
+    providerAccountRef?: ProviderAccountRef
     agentArgsOverride?: string | null
     draftPrompt?: string
     sessionOptions?: Record<string, SessionOptionValue>

--- a/src/shared/agent-session-host-authority.ts
+++ b/src/shared/agent-session-host-authority.ts
@@ -5,6 +5,7 @@ import {
   type ResumableTuiAgent
 } from './agent-session-resume'
 import type { RuntimeTerminalCreate, RuntimeTerminalPresentation } from './runtime-types'
+import type { ProviderAccountRef } from './provider-account-ref'
 import { isTerminalLeafId } from './stable-pane-id'
 import { isValidTerminalTabId } from './terminal-tab-id'
 import type { TuiAgent } from './tui-agent'
@@ -23,6 +24,10 @@ export const AGENT_SESSION_RPC_ERROR_CODES = [
   'agent_session_operation_conflict',
   'agent_session_operation_expired',
   'agent_session_operation_capacity',
+  'agent_session_account_agent_mismatch',
+  'agent_session_account_runtime_mismatch',
+  'agent_session_account_unavailable',
+  'agent_session_account_unsupported',
   'agent_session_legacy_required',
   'execution_owner_reconciling',
   'execution_owner_unavailable'
@@ -110,6 +115,7 @@ export type RuntimeEnsureAgentSessionRequest =
       /** Explicit client override. Omission keeps launch defaults host-owned. */
       agentArgs?: string | null
       launchPreferences?: AgentLaunchPreferences
+      providerAccountRef?: ProviderAccountRef
       presentation?: RuntimeTerminalPresentation
       placement?: { tabId?: string; leafId?: string }
     }
@@ -132,6 +138,7 @@ export type RuntimeCreateAgentSessionRequest = {
   presentation?: RuntimeTerminalPresentation
   placement?: { tabId?: string; leafId?: string }
   viewMode?: 'terminal' | 'chat'
+  providerAccountRef?: ProviderAccountRef
 }
 
 export type RuntimeCreateAgentSessionResult = {

--- a/src/shared/agent-session-option-catalog-claude-codex.ts
+++ b/src/shared/agent-session-option-catalog-claude-codex.ts
@@ -10,6 +10,7 @@ import {
   parseClaudeModelList
 } from './claude-model-list-probe'
 import { hasFlag } from './agent-cli-flag-detection'
+import { CODEX_MODEL_LIST_COMMAND, parseCodexModelList } from './codex-model-list-probe'
 
 function hasCodexEffortOverride(tokens: readonly string[]): boolean {
   if (hasFlag(tokens, ['--reasoning-effort'])) {
@@ -190,17 +191,20 @@ const CODEX_EFFORT_CHOICES = [
   { value: 'ultra', label: 'Ultra' }
 ]
 
-// Why: Codex can clamp higher values, so expose only each model's advertised levels.
-function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
-  const ceilingIndex = CODEX_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+type CodexEffortChoice = { value: string; label: string }
+
+function codexEffortWithChoices(
+  choices: readonly CodexEffortChoice[],
+  defaultValue: string
+): CatalogOption {
   return {
     id: 'effort',
     label: 'Reasoning effort',
     category: 'thought_level',
     kind: {
       type: 'select',
-      choices: CODEX_EFFORT_CHOICES.slice(0, ceilingIndex + 1),
-      defaultValue: 'medium'
+      choices: [...choices],
+      defaultValue
     },
     apply: {
       launchArgs: (value) => ['-c', `model_reasoning_effort=${String(value)}`],
@@ -209,6 +213,53 @@ function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
       midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
     }
   }
+}
+
+// Why: Codex can clamp higher values, so expose only each model's advertised levels.
+function codexEffort(ceiling: 'xhigh' | 'max' | 'ultra'): CatalogOption {
+  const ceilingIndex = CODEX_EFFORT_CHOICES.findIndex((choice) => choice.value === ceiling)
+  return codexEffortWithChoices(CODEX_EFFORT_CHOICES.slice(0, ceilingIndex + 1), 'medium')
+}
+
+function labelCodexEffort(effort: string): string {
+  if (effort === 'xhigh') {
+    return 'Extra high'
+  }
+  return effort.charAt(0).toUpperCase() + effort.slice(1)
+}
+
+export function createCodexCatalogOptions(args: {
+  effortLevels: readonly { id: string; label: string }[]
+  defaultEffort?: string
+}): CatalogOption[] {
+  const choices = args.effortLevels.map(({ id, label }) => ({ value: id, label }))
+  if (choices.length === 0) {
+    return []
+  }
+  const choiceIds = choices.map(({ value }) => value)
+  const defaultEffort = choiceIds.includes(args.defaultEffort ?? '')
+    ? args.defaultEffort!
+    : choiceIds.includes('medium')
+      ? 'medium'
+      : choiceIds[0]
+  return [codexEffortWithChoices(choices, defaultEffort)]
+}
+
+function parseCodexCatalogModels(stdout: string): CatalogModel[] {
+  return parseCodexModelList(stdout).map((model) => {
+    const effortLevels = model.effortLevels.map((effort) => ({
+      id: effort,
+      label: labelCodexEffort(effort)
+    }))
+    return {
+      id: model.id,
+      label: model.label,
+      options: createCodexCatalogOptions({
+        effortLevels,
+        ...(model.defaultEffort ? { defaultEffort: model.defaultEffort } : {})
+      })
+    }
+  })
 }
 
 export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
@@ -234,5 +285,9 @@ export const CODEX_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // command and let its own picker apply the account-supported model.
     midSession: { kind: 'agent-picker', command: '/model', delivery: 'type' }
   },
-  unknownModelOptions: [codexEffort('xhigh')]
+  unknownModelOptions: [codexEffort('xhigh')],
+  listModels: {
+    command: CODEX_MODEL_LIST_COMMAND,
+    parse: parseCodexCatalogModels
+  }
 }

--- a/src/shared/agent-session-option-catalog.test.ts
+++ b/src/shared/agent-session-option-catalog.test.ts
@@ -108,6 +108,91 @@ describe('agent session option catalog', () => {
     expect(parse('garbage')).toEqual([])
   })
 
+  it('parses Codex discovery into model-specific reasoning options', () => {
+    const catalog = getAgentSessionOptionCatalog('codex')!
+    expect(catalog.listModels?.command).toBe('codex debug models')
+
+    const parsed = catalog.listModels!.parse(
+      JSON.stringify({
+        models: [
+          {
+            slug: 'gpt-account-frontier',
+            display_name: 'GPT Account Frontier',
+            default_reasoning_level: 'high',
+            supported_reasoning_levels: [
+              { effort: 'low' },
+              { effort: 'high' },
+              { effort: 'max' },
+              { effort: 'ultra' }
+            ]
+          },
+          {
+            slug: 'gpt-account-fast',
+            display_name: 'GPT Account Fast',
+            supported_reasoning_levels: [{ effort: 'minimal' }]
+          },
+          { slug: 'gpt-account-plain', display_name: 'GPT Account Plain' }
+        ]
+      })
+    )
+
+    expect(parsed.map(({ id }) => id)).toEqual([
+      'gpt-account-frontier',
+      'gpt-account-fast',
+      'gpt-account-plain'
+    ])
+    const frontierEffort = parsed[0].options[0]
+    expect(frontierEffort.kind).toMatchObject({ defaultValue: 'high' })
+    expect(
+      frontierEffort.kind.type === 'select'
+        ? frontierEffort.kind.choices.map(({ value, label }) => ({ value, label }))
+        : []
+    ).toEqual([
+      { value: 'low', label: 'Low' },
+      { value: 'high', label: 'High' },
+      { value: 'max', label: 'Max' },
+      { value: 'ultra', label: 'Ultra' }
+    ])
+    expect(parsed[1].options[0].kind).toMatchObject({
+      choices: [{ value: 'minimal', label: 'Minimal' }],
+      defaultValue: 'minimal'
+    })
+    expect(parsed[2].options).toEqual([])
+  })
+
+  it('keeps the Codex seed when model discovery output is malformed', () => {
+    const parse = getAgentSessionOptionCatalog('codex')!.listModels!.parse
+    expect(parse('')).toEqual([])
+    expect(parse('{"models":false}')).toEqual([])
+    expect(parse('garbage')).toEqual([])
+  })
+
+  it('deduplicates Codex models and reasoning levels from discovery', () => {
+    const parse = getAgentSessionOptionCatalog('codex')!.listModels!.parse
+    const parsed = parse(
+      JSON.stringify({
+        models: [
+          {
+            slug: 'gpt-account-frontier',
+            display_name: 'GPT Account Frontier',
+            supported_reasoning_levels: [{ effort: 'low' }, { effort: 'low' }, { effort: 'high' }]
+          },
+          { slug: 'gpt-account-frontier', display_name: 'Duplicate row' }
+        ]
+      })
+    )
+
+    expect(parsed).toHaveLength(1)
+    expect(parsed[0].label).toBe('GPT Account Frontier')
+    expect(parsed[0].options[0].kind).toMatchObject({
+      choices: [
+        { value: 'low', label: 'Low' },
+        { value: 'high', label: 'High' }
+      ],
+      defaultValue: 'low'
+    })
+  })
+
   it('merges discovered Claude variants after the seed and overlays matched labels', () => {
     const catalog = getAgentSessionOptionCatalog('claude')!
     const merged = mergeCatalogModels(catalog.models, [

--- a/src/shared/agent-session-option-catalog.ts
+++ b/src/shared/agent-session-option-catalog.ts
@@ -2,7 +2,8 @@ import type { AgentType } from './agent-status-types'
 import {
   CLAUDE_SESSION_OPTION_CATALOG,
   CODEX_SESSION_OPTION_CATALOG,
-  createClaudeCatalogOptions
+  createClaudeCatalogOptions,
+  createCodexCatalogOptions
 } from './agent-session-option-catalog-claude-codex'
 import {
   CURSOR_SESSION_OPTION_CATALOG,
@@ -26,7 +27,7 @@ export type {
   CatalogOption,
   CatalogOptionApply
 } from './agent-session-option-catalog-types'
-export { createClaudeCatalogOptions }
+export { createClaudeCatalogOptions, createCodexCatalogOptions }
 
 const CATALOGS: AgentSessionOptionCatalogMap = {
   claude: CLAUDE_SESSION_OPTION_CATALOG,

--- a/src/shared/codex-model-list-probe.test.ts
+++ b/src/shared/codex-model-list-probe.test.ts
@@ -1,0 +1,14 @@
+import { describe, expect, it, vi } from 'vitest'
+import { CODEX_MODEL_LIST_MAX_JSON_CHARACTERS, parseCodexModelList } from './codex-model-list-probe'
+
+describe('Codex model list probe', () => {
+  it('rejects oversized output before JSON.parse', () => {
+    const parseSpy = vi.spyOn(JSON, 'parse')
+    try {
+      expect(parseCodexModelList(' '.repeat(CODEX_MODEL_LIST_MAX_JSON_CHARACTERS + 1))).toEqual([])
+      expect(parseSpy).not.toHaveBeenCalled()
+    } finally {
+      parseSpy.mockRestore()
+    }
+  })
+})

--- a/src/shared/codex-model-list-probe.ts
+++ b/src/shared/codex-model-list-probe.ts
@@ -1,0 +1,80 @@
+import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
+
+export const CODEX_MODEL_LIST_ARGS = ['debug', 'models'] as const
+export const CODEX_MODEL_LIST_COMMAND = `codex ${CODEX_MODEL_LIST_ARGS.join(' ')}`
+
+export const CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS = {
+  structuralTokens: 64 * 1024,
+  nestingDepth: 16
+} as const
+
+export type CodexModelListModel = {
+  id: string
+  label: string
+  effortLevels: string[]
+  defaultEffort: string | null
+}
+
+function nonEmptyString(value: unknown): string | null {
+  if (typeof value !== 'string') {
+    return null
+  }
+  return value.trim() || null
+}
+
+function uniqueEffortLevels(value: unknown): string[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const seen = new Set<string>()
+  const levels: string[] = []
+  for (const entry of value) {
+    const effort =
+      entry && typeof entry === 'object' && !Array.isArray(entry)
+        ? nonEmptyString((entry as { effort?: unknown }).effort)
+        : null
+    if (effort && !seen.has(effort)) {
+      seen.add(effort)
+      levels.push(effort)
+    }
+  }
+  return levels
+}
+
+export function parseCodexModelList(stdout: string): CodexModelListModel[] {
+  try {
+    assertJsonTextStructureWithinLimits(stdout, CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS)
+    const parsed: unknown = JSON.parse(stdout)
+    if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+      return []
+    }
+    const models = (parsed as { models?: unknown }).models
+    if (!Array.isArray(models)) {
+      return []
+    }
+
+    const seen = new Set<string>()
+    const result: CodexModelListModel[] = []
+    for (const value of models) {
+      if (!value || typeof value !== 'object' || Array.isArray(value)) {
+        continue
+      }
+      const model = value as Record<string, unknown>
+      const id = nonEmptyString(model.slug)
+      const label = nonEmptyString(model.display_name)
+      if (!id || !label || seen.has(id)) {
+        continue
+      }
+      seen.add(id)
+      result.push({
+        id,
+        label,
+        effortLevels: uniqueEffortLevels(model.supported_reasoning_levels),
+        defaultEffort: nonEmptyString(model.default_reasoning_level)
+      })
+    }
+    return result
+  } catch {
+    return []
+  }
+}

--- a/src/shared/codex-model-list-probe.ts
+++ b/src/shared/codex-model-list-probe.ts
@@ -2,6 +2,7 @@ import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit
 
 export const CODEX_MODEL_LIST_ARGS = ['debug', 'models'] as const
 export const CODEX_MODEL_LIST_COMMAND = `codex ${CODEX_MODEL_LIST_ARGS.join(' ')}`
+export const CODEX_MODEL_LIST_MAX_JSON_CHARACTERS = 4 * 1024 * 1024
 
 export const CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS = {
   structuralTokens: 64 * 1024,
@@ -43,6 +44,9 @@ function uniqueEffortLevels(value: unknown): string[] {
 
 export function parseCodexModelList(stdout: string): CodexModelListModel[] {
   try {
+    if (stdout.length > CODEX_MODEL_LIST_MAX_JSON_CHARACTERS) {
+      return []
+    }
     assertJsonTextStructureWithinLimits(stdout, CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS)
     const parsed: unknown = JSON.parse(stdout)
     if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {

--- a/src/shared/commit-message-agent-spec.ts
+++ b/src/shared/commit-message-agent-spec.ts
@@ -1,12 +1,16 @@
 import type { TuiAgent } from './tui-agent'
 import { isTuiAgentEnabled } from './tui-agent-selection'
-import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
 import {
   CLAUDE_MODEL_LIST_ARGS,
   CLAUDE_MODEL_LIST_STDIN,
   parseClaudeModelList
 } from './claude-model-list-probe'
 import { labelFromModelId } from './model-id-label'
+import {
+  CODEX_MODEL_LIST_ARGS,
+  CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS,
+  parseCodexModelList
+} from './codex-model-list-probe'
 
 /* eslint-disable max-lines -- Why: this is the single registry for non-interactive commit-message agents, their model discovery parsers, and UI capabilities. */
 
@@ -81,10 +85,7 @@ export type CommitMessageAgentCapability = {
   defaultModelId: string
 }
 
-export const COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS = {
-  structuralTokens: 64 * 1024,
-  nestingDepth: 16
-} as const
+export const COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS = CODEX_MODEL_LIST_JSON_STRUCTURE_LIMITS
 
 const BASIC_THINKING_LEVELS: ThinkingLevel[] = [
   { id: 'low', label: 'Low' },
@@ -172,39 +173,25 @@ export function parseClaudeModels(stdout: string): CommitMessageModel[] {
 }
 
 export function parseCodexModels(stdout: string): CommitMessageModel[] {
-  try {
-    assertJsonTextStructureWithinLimits(stdout, COMMIT_MESSAGE_MODEL_JSON_STRUCTURE_LIMITS)
-    const parsed = JSON.parse(stdout) as {
-      models?: {
-        slug?: string
-        display_name?: string
-        supported_reasoning_levels?: { effort?: string }[]
-        default_reasoning_level?: string
-      }[]
-    }
-    return uniqueModels(
-      (parsed.models ?? [])
-        .filter((model) => model.slug && model.display_name)
-        .map((model) => ({
-          id: model.slug!,
-          label: model.display_name!,
-          ...(model.supported_reasoning_levels?.length
-            ? {
-                thinkingLevels: model.supported_reasoning_levels
-                  .map((level) => level.effort)
-                  .filter((effort): effort is string => Boolean(effort))
-                  .map((effort) => ({
-                    id: effort,
-                    label: effort === 'xhigh' ? 'Extra High' : labelFromModelId(effort)
-                  })),
-                defaultThinkingLevel: model.default_reasoning_level ?? 'low'
-              }
-            : {})
-        }))
-    )
-  } catch {
-    return []
-  }
+  return uniqueModels(
+    parseCodexModelList(stdout).map((model) => ({
+      id: model.id,
+      label: model.label,
+      ...(model.effortLevels.length > 0
+        ? {
+            thinkingLevels: model.effortLevels.map((effort) => ({
+              id: effort,
+              label: effort === 'xhigh' ? 'Extra High' : labelFromModelId(effort)
+            })),
+            defaultThinkingLevel: model.effortLevels.includes(model.defaultEffort ?? '')
+              ? model.defaultEffort!
+              : model.effortLevels.includes('low')
+                ? 'low'
+                : model.effortLevels[0]
+          }
+        : {})
+    }))
+  )
 }
 
 export function parseLineModels(stdout: string): CommitMessageModel[] {
@@ -401,7 +388,7 @@ export const COMMIT_MESSAGE_AGENT_SPECS: Partial<Record<TuiAgent, CommitMessageA
     modelSource: 'dynamic',
     modelDiscovery: {
       binary: 'codex',
-      args: ['debug', 'models'],
+      args: [...CODEX_MODEL_LIST_ARGS],
       parse: parseCodexModels
     },
     // Why: ordered to match the official `codex` model picker — descending

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -88,6 +88,9 @@ export const AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY =
   'agent-session.host-authority.v1' as const
 export const AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY =
   'agent-session.omp-resume-path.v1' as const
+// Why: older hosts strip this optional field and would silently launch under
+// another account, so clients must negotiate before sending it.
+export const AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY = 'agent-session.account-ref.v1' as const
 // Why: older runtimes strip mutation owner fields, so clients must fence writes before RPC.
 export const FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY = 'files.mutation-ownership.v1' as const
 export const FILE_MUTATION_OWNERSHIP_UPDATE_REQUIRED_MESSAGE =
@@ -130,6 +133,7 @@ export const RUNTIME_CAPABILITIES = [
   REMOTE_SERVER_UPDATE_CAPABILITY,
   AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY,
   AGENT_SESSION_OMP_RESUME_PATH_RUNTIME_CAPABILITY,
+  AGENT_SESSION_ACCOUNT_REF_RUNTIME_CAPABILITY,
   FILE_MUTATION_OWNERSHIP_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_DEFAULTS_RUNTIME_CAPABILITY,
   WORKTREE_VISIBILITY_SOURCE_DEFAULTS_RUNTIME_CAPABILITY,

--- a/src/shared/provider-account-ref.test.ts
+++ b/src/shared/provider-account-ref.test.ts
@@ -1,0 +1,25 @@
+import { describe, expect, it } from 'vitest'
+import { isProviderAccountRef } from './provider-account-ref'
+
+describe('isProviderAccountRef', () => {
+  it('accepts bounded host and WSL references', () => {
+    expect(isProviderAccountRef({ provider: 'codex', accountId: null, runtime: 'host' })).toBe(true)
+    expect(
+      isProviderAccountRef({
+        provider: 'codex',
+        accountId: 'account-a',
+        runtime: 'wsl',
+        wslDistro: 'Ubuntu'
+      })
+    ).toBe(true)
+  })
+
+  it.each([
+    { provider: 'codex\nother', accountId: null, runtime: 'host' },
+    { provider: 'codex', accountId: 'account\0other', runtime: 'host' },
+    { provider: 'codex', accountId: null, runtime: 'host', wslDistro: 'Ubuntu' },
+    { provider: 'codex', accountId: null, runtime: 'host', secret: 'not-allowed' }
+  ])('rejects malformed or over-scoped references: %o', (value) => {
+    expect(isProviderAccountRef(value)).toBe(false)
+  })
+})

--- a/src/shared/provider-account-ref.ts
+++ b/src/shared/provider-account-ref.ts
@@ -1,0 +1,44 @@
+export const PROVIDER_ACCOUNT_REF_MAX_ID_LENGTH = 256
+export const PROVIDER_ACCOUNT_REF_MAX_PROVIDER_LENGTH = 64
+export const PROVIDER_ACCOUNT_REF_MAX_WSL_DISTRO_LENGTH = 128
+
+export type ProviderAccountRef = {
+  provider: string
+  accountId: string | null
+  runtime: 'host' | 'wsl'
+  wslDistro?: string | null
+}
+
+function isBoundedRefString(value: unknown, maxLength: number): value is string {
+  return (
+    typeof value === 'string' &&
+    value.trim().length > 0 &&
+    value.length <= maxLength &&
+    !value.includes('\0') &&
+    !value.includes('\r') &&
+    !value.includes('\n')
+  )
+}
+
+export function isProviderAccountRef(value: unknown): value is ProviderAccountRef {
+  if (typeof value !== 'object' || value === null || Array.isArray(value)) {
+    return false
+  }
+  const ref = value as Partial<ProviderAccountRef>
+  const keys = Object.keys(value)
+  if (keys.some((key) => !['provider', 'accountId', 'runtime', 'wslDistro'].includes(key))) {
+    return false
+  }
+  if (
+    !isBoundedRefString(ref.provider, PROVIDER_ACCOUNT_REF_MAX_PROVIDER_LENGTH) ||
+    (ref.accountId !== null &&
+      !isBoundedRefString(ref.accountId, PROVIDER_ACCOUNT_REF_MAX_ID_LENGTH)) ||
+    (ref.runtime !== 'host' && ref.runtime !== 'wsl') ||
+    (ref.wslDistro !== undefined &&
+      ref.wslDistro !== null &&
+      !isBoundedRefString(ref.wslDistro, PROVIDER_ACCOUNT_REF_MAX_WSL_DISTRO_LENGTH))
+  ) {
+    return false
+  }
+  return ref.runtime === 'wsl' || ref.wslDistro === undefined || ref.wslDistro === null
+}

--- a/src/shared/worktree/launch-types.ts
+++ b/src/shared/worktree/launch-types.ts
@@ -4,6 +4,7 @@ import type { SleepingAgentLaunchConfig } from '../agent-session-resume'
 import type { SetupRunnerShell } from '../setup-runner-command'
 import type { OrcaDefaultTabTemplate } from '../orca-yaml-hook-types'
 import type { TuiAgent } from '../tui-agent'
+import type { ProviderAccountRef } from '../provider-account-ref'
 
 export type WorktreeSetupLaunch = {
   runnerScriptPath: string
@@ -19,6 +20,7 @@ export type WorktreeStartupLaunch = {
   launchConfig?: SleepingAgentLaunchConfig
   launchToken?: string
   launchAgent?: TuiAgent
+  providerAccountRef?: ProviderAccountRef
   viewMode?: 'terminal' | 'chat'
   startupCommandDelivery?: StartupCommandDelivery
   telemetry?: { agent_kind: AgentKind; launch_source: LaunchSource; request_kind: RequestKind }


### PR DESCRIPTION
## Summary

Codex launches now expose account selection in both the quick-launch menu and the Orca CLI. The UI keeps `Current default` available during loading and failures, shows friendly account labels, and sends the canonical managed-account UUID through the launch contract added by the preceding PR.

The CLI accepts an explicit account selector for Codex terminal creation, resolves UUIDs through the provider-account snapshot, and rejects email aliases, deleted accounts, unsupported runtimes, valueless flags, and mismatched WSL lanes before launch.

This PR is stacked on #13271, #13270, and #13183. Please review it after those PRs land; their changes will disappear from this diff as the stack advances.

## Screenshots

Not attached yet because this is a dependency-gated draft. Before marking it ready, I will capture the Codex quick-launch account submenu against the rebased branch.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- Focused Vitest suite covering CLI account/terminal handling, launch-option construction, quick launch, and loading/error UI states — 49 tests passed.
- `pnpm run build:desktop` — passed.
- `git diff --check` — passed.

Local environment note: the repository requests Node 24, while this workstation currently exposes Node 25.8.1. The desktop build completed; its development CLI install step reported the expected permission warning for `/usr/local/bin/orca-dev` without failing the build.

## AI Review Report

The review checked canonical UUID selection, current-default and system-default behavior, host/WSL lane filtering, remote capability gating, SSH fallback, loading/error/retry states, and the existing Radix dropdown keyboard behavior.

Regression tests cover loading fallback, friendly labels with UUID launch values, load errors and retry, SSH and older-runtime fallback, UUID-only CLI selection, WSL system selection, deleted/alias selectors, missing flag values, and managed WSL accounts without a distro.

Cross-platform review:

- Host and WSL accounts are filtered into separate launch lanes with case-insensitive distro matching.
- SSH workspaces keep the legacy default launch because this process cannot enumerate the remote credential registry.
- Older paired runtimes retain `Current default` until they advertise account-reference support.

## Security Audit

- Renderer and CLI select accounts by opaque UUID and forward only `ProviderAccountRef`.
- Email is display-only and is deliberately rejected as a CLI selector.
- Unsupported, deleted, and cross-lane account references fail before agent launch.
- Credential paths, auth files, and tokens remain main-process-owned and are not added to localization, renderer state, or CLI output.
- Dependencies and credential formats are unchanged.

## Notes

- Depends on #13271, #13270, and #13183.
- Current `origin/main` also changed `src/renderer/src/i18n/locales/en.json`; the draft therefore reports one localization-catalog conflict. It will be resolved by rebasing after the dependency stack advances, avoiding a force-rewrite of the reviewed PR 1 branch.
- X/Twitter: `@rp0927`
