### PR TITLE
test(e2e): close the captured line for a chord that emits no terminator

### DIFF
--- a/tests/e2e/terminal-macos-korean-chord-commit-native.spec.ts
+++ b/tests/e2e/terminal-macos-korean-chord-commit-native.spec.ts
@@ -93,21 +93,25 @@ test.describe('Native macOS 2-Set Korean terminal chord commit @headful', () => 
     'Requires macOS with 2-Set Korean available and Accessibility access'
   )
 
-  // `renderer` is what onData emits; `pty` is what the child reads after the tty converts CR to LF.
-  // Asserting both makes the conversion evidence that the capture reached past the renderer, rather
-  // than a constant a later reader "corrects" back to the renderer form.
+  // `pty` is what the child reads. The trailing LF is the standing proof the capture got past the
+  // renderer: onData emits CR and only the tty converts it, so a reader "correcting" a constant
+  // back to the renderer form would show CR here (#11936/#11951).
+  //
+  // `flushesOwnLine` says whether the chord's own bytes end the line. The reader splits on 0x0a,
+  // so CSI-u — carrying no line terminator — needs a plain Return after it, or the line stays open
+  // and the capture times out at zero however correct the product was.
   for (const chord of [
     {
       name: 'Shift+Enter',
       modifier: 'shift' as const,
-      renderer: '하 하 하\u001b\r',
+      flushesOwnLine: true,
       pty: '하 하 하\u001b\n'
     },
     {
       name: 'Ctrl+Enter',
       modifier: 'control' as const,
-      renderer: '하 하 하\u001b[13;5u',
-      pty: '하 하 하\u001b[13;5u'
+      flushesOwnLine: false,
+      pty: '하 하 하\u001b[13;5u\n'
     }
   ]) {
     test(`commits the preedit before physical ${chord.name}`, async ({
@@ -151,6 +155,12 @@ test.describe('Native macOS 2-Set Korean terminal chord commit @headful', () => 
         // Finish `하 하 하`: the control already left `하` composing, so send the remainder.
         typeNativeKeyCodes(processId, HA_HA_HA_KEY_CODES.slice(2))
         pressReturnChord(processId, chord.modifier)
+        if (!chord.flushesOwnLine) {
+          // Safe to send unmodified: the chord above already committed the preedit, which the
+          // assertion's leading `하 하 하` proves — a surviving preedit would eat this Return and
+          // put its own commit ahead of the chord's bytes.
+          typeNativeKeyCodes(processId, [RETURN_KEY_CODE])
+        }
 
         // The sibling spec's :364/:383 assert at the RENDERER (onData), where the terminator is CR.
         // This reads the PTY child, so the tty has already converted CR to LF — see #11936/#11951,


### PR DESCRIPTION
## What

`terminal-macos-korean-chord-commit-native.spec.ts › commits the preedit before
physical Ctrl+Enter` has never passed. Its sibling row, Shift+Enter, always has.

## Why it could not pass

`terminal-ime-byte-reader.ts` emits a capture only when it finds a newline, and
it splits on nothing else:

```js
let newlineIndex = pending.indexOf(0x0a)
while (newlineIndex >= 0) { ... }
```

The Shift+Enter row ends in CR, the tty converts it to LF, the line closes, one
capture. Ctrl+Enter sends CSI-u (`ESC [ 13 ; 5 u`), which carries no line
terminator at all — so the line never closes and the reader times out at zero
captures no matter what the product sent. `Expected: 1, Received: 0`.

This is a harness defect, not a product one. The bytes were always arriving.

## Bisect

- today's `main` (`6da7b8e9cf`): fails
- `17b3dff3c4` — #13128, the commit that introduced the spec: fails identically

It stays green in CI because the spec is gated behind
`ORCA_E2E_NATIVE_MACOS_KOREAN=1`, which CI does not set. It only runs for someone
who opts in locally, which is why it took a second machine reporting it to
surface.

## The fix

A plain Return follows the chord for the row whose bytes do not end a line, and
the expectation carries the LF it produces. Sending it unmodified is safe because
the chord already committed the preedit — the assertion's leading `하 하 하` is
what proves that, since a surviving preedit would eat the Return and put its own
commit ahead of the chord's bytes.

This is the same idiom the parked-terminal and cursor-chord specs use to get a
line out of this reader.

Also drops the `renderer` field from the chord table. Its comment claimed both
forms were asserted; nothing ever read it. The CR-to-LF evidence that comment was
reaching for is exactly what the `pty` expectation's trailing LF already carries,
so the claim now matches the code.

## Verification

Run by hand on macOS 26.5.1 with 2-Set Korean and Accessibility granted:
**2/2 passed on three consecutive runs.** Before the change, the same machine
reproduced the reported failure at all three commits above.

`oxlint`, `pnpm typecheck`, and `check:max-lines-ratchet` clean.

Test-only. No product code touched.
