### PR TITLE
fix(terminal): detach the Korean input-source probe when its setting goes off

### DIFF
--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-korean-prefetch-gate.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-korean-prefetch-gate.test.tsx
@@ -6,8 +6,10 @@ import { cleanup, renderHook } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const prefetchKoreanInputSource = vi.fn()
+const stopKoreanInputSourcePrefetch = vi.fn()
 vi.mock('@/lib/keyboard-layout/korean-input-source', () => ({
   prefetchKoreanInputSource: (...args: unknown[]) => prefetchKoreanInputSource(...args),
+  stopKoreanInputSourcePrefetch: (...args: unknown[]) => stopKoreanInputSourcePrefetch(...args),
   isKoreanInputSourceActive: () => false,
   isKoreanInputSourceId: () => false
 }))
@@ -51,6 +53,7 @@ function deps(koreanWonToBackquoteEnabled: boolean): KeyboardHandlersDeps {
 
 beforeEach(() => {
   prefetchKoreanInputSource.mockClear()
+  stopKoreanInputSourcePrefetch.mockClear()
   vi.spyOn(navigator, 'userAgent', 'get').mockReturnValue(
     'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7)'
   )
@@ -71,5 +74,13 @@ describe('Korean input-source prefetch gate', () => {
   it('probes once the setting is on', () => {
     renderHook(() => useTerminalKeyboardShortcuts(deps(true)))
     expect(prefetchKoreanInputSource).toHaveBeenCalled()
+  })
+
+  // The probe's listeners are global and its attach is idempotent, so without an explicit
+  // disposer they outlive the setting being switched off and keep spawning the refresh.
+  it('detaches the probe when the setting is switched off', () => {
+    renderHook(() => useTerminalKeyboardShortcuts(deps(false)))
+    expect(stopKoreanInputSourcePrefetch).toHaveBeenCalled()
+    expect(prefetchKoreanInputSource).not.toHaveBeenCalled()
   })
 })

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -35,7 +35,10 @@ import {
   getLayoutBaseCharacterForCode,
   prefetchLayoutBaseCharacters
 } from '@/lib/keyboard-layout/layout-base-character'
-import { prefetchKoreanInputSource } from '@/lib/keyboard-layout/korean-input-source'
+import {
+  prefetchKoreanInputSource,
+  stopKoreanInputSourcePrefetch
+} from '@/lib/keyboard-layout/korean-input-source'
 import { normalizeSelectedTextForFileSearch } from '@/lib/file-search-selection'
 import { isFindQueryTooLarge } from '@/lib/find-query-bounds'
 import { handleEmptyFloatingWorkspacePanelCloseShortcut } from '@/lib/floating-workspace-terminal-actions'
@@ -283,8 +286,12 @@ export function useTerminalKeyboardShortcuts({
       // Why: the Korean Won rewrite gate reads the active input source ID through the async IPC.
       // Gated on the setting because each refresh shells out to `defaults export | plutil | plutil`
       // and the default is off, so an ungated prefetch costs every macOS user four processes.
+      // Synced in the effect body, not its cleanup: cleanup also runs on tab switches and on any
+      // dep-identity change, so disposing there would reattach and re-probe constantly.
       if (koreanWonToBackquoteEnabled) {
         prefetchKoreanInputSource()
+      } else {
+        stopKoreanInputSourcePrefetch()
       }
     }
 

--- a/src/renderer/src/lib/keyboard-layout/korean-input-source.ts
+++ b/src/renderer/src/lib/keyboard-layout/korean-input-source.ts
@@ -65,6 +65,7 @@ let cachedIsKorean: boolean | null = null
 let refreshGeneration = 0
 let lastRefreshAt = 0
 let listenerAttached = false
+let prefetchEpoch = 0
 let focusTarget: Pick<Window, 'addEventListener' | 'removeEventListener'> | null = null
 let focusCallback: (() => void) | null = null
 let keyboardActivityCallback: ((event: KeyboardEvent) => void) | null = null
@@ -158,7 +159,7 @@ export function prefetchKoreanInputSource(options: PrefetchKoreanInputSourceOpti
   // both keydown and keyup so a held toggle key still refreshes on release.
   target.addEventListener('keydown', keyboardActivityCallback, true)
   target.addEventListener('keyup', keyboardActivityCallback, true)
-  void runInitialProbe(readInputSourceId, target)
+  void runInitialProbe(readInputSourceId, ++prefetchEpoch)
 }
 
 /** Why: a keystroke-triggered refresh is async, so it can never classify the
@@ -167,12 +168,13 @@ export function prefetchKoreanInputSource(options: PrefetchKoreanInputSourceOpti
  *  reader yields an ID rather than leaving the gate cold for the session. */
 async function runInitialProbe(
   readInputSourceId: InputSourceIdReader,
-  target: Pick<Window, 'addEventListener' | 'removeEventListener'>
+  epoch: number
 ): Promise<void> {
   for (const delayMs of INITIAL_PROBE_BACKOFF_MS) {
-    // Why: a reset (or a prefetch onto another window) must stop this loop, or
-    // it repopulates the cache the reset just cleared.
-    if (!listenerAttached || focusTarget !== target) {
+    // Why: an epoch, not window identity — production always passes the same
+    // window, so an identity check is dead there and a stop/start would let a
+    // sleeping loop wake and race the new one.
+    if (!listenerAttached || epoch !== prefetchEpoch) {
       return
     }
     lastRefreshAt = Date.now()
@@ -182,7 +184,7 @@ async function runInitialProbe(
     }
     await new Promise((resolve) => setTimeout(resolve, delayMs))
   }
-  if (!listenerAttached || focusTarget !== target) {
+  if (!listenerAttached || epoch !== prefetchEpoch) {
     return
   }
   lastRefreshAt = Date.now()
@@ -203,8 +205,11 @@ export function _setKoreanInputSourceForTests(value: boolean | null): void {
 
 /** Test-only: reset cache, detach listeners, and invalidate any in-flight
  *  refreshes so a stale probe cannot repopulate the cache. */
-export function _resetKoreanInputSourceForTests(): void {
+/** Detaches the probe. Without this the global listeners outlive the setting
+ *  being switched off and keep spawning the refresh. */
+export function stopKoreanInputSourcePrefetch(): void {
   refreshGeneration += 1
+  prefetchEpoch += 1
   if (focusTarget && focusCallback && keyboardActivityCallback) {
     focusTarget.removeEventListener('focus', focusCallback)
     focusTarget.removeEventListener('keydown', keyboardActivityCallback, true)
@@ -216,4 +221,8 @@ export function _resetKoreanInputSourceForTests(): void {
   listenerAttached = false
   cachedIsKorean = null
   lastRefreshAt = 0
+}
+
+export function _resetKoreanInputSourceForTests(): void {
+  stopKoreanInputSourcePrefetch()
 }


### PR DESCRIPTION
Two defects in the Korean input-source probe, both found by review of my own earlier changes. Independent of the IME revert (#13282) — this touches only the Won-key feature's probe, which stayed on main.

**1. The probe outlived its setting.** #13181 gated the *call site* so the probe never attaches when `terminalKoreanWonToBackquote` is off. But `prefetchKoreanInputSource` installs global `focus`/`keydown`/`keyup` listeners behind an idempotent `listenerAttached` guard, and its only teardown was test-only. So switching the setting off mid-session left the listeners live and still spawning `defaults export | plutil | plutil` — four processes — on keyboard activity. Confirmed empirically rather than by reading: a test that enables, disables, then dispatches a `Lang1` keydown saw the reader called again after the setting was off.

Adds a real disposer and calls it from the effect **body**, not its cleanup. Cleanup also runs on tab switches and on any dep-identity change, so disposing there would detach and re-probe constantly — a worse regression than the leak. Body-side sync is naturally idempotent.

No reference counting: only the active tab's effect ever prefetches, so a refcount would be machinery with no second owner to count.

**2. The initial-probe abort guard was dead code in production.** It compared `focusTarget !== target`, but production always passes the same `window` singleton, so the check could never fire. Harmless until a disposer exists — with one, a stop/start sequence lets the old sleeping probe loop wake, pass the guard, and race the new one, each bumping `refreshGeneration` and discarding the other's read. Replaced with an epoch counter.

The existing tests missed this because `makeMockWindow()` returns a fresh object per call, so the identity check is meaningful in tests and dead in the app.

Verified: keyboard-layout + the gate test 6 files / 68 tests pass, typecheck clean across all three configs with `config/*.tsbuildinfo` cleared first. Rebased onto post-revert main.

Made with [Orca](https://github.com/stablyai/orca) 🐋
