### PR TITLE
Show a preedit the IME resumes without a compositionstart

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ patchedDependencies:
     hash: 6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258
     path: config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch
   '@xterm/xterm@6.1.0-beta.287':
-    hash: 037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8
+    hash: 8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
     hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
@@ -45,7 +45,7 @@ importers:
         version: 2.5.6
       '@xterm/addon-serialize':
         specifier: 0.15.0-beta.287
-        version: 0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/headless':
         specifier: 6.1.0-beta.287
         version: 6.1.0-beta.287
@@ -208,25 +208,25 @@ importers:
         version: 5.2.0(rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.8.4))
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.287
-        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/addon-ligatures':
         specifier: 0.11.0-beta.287
-        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/addon-search':
         specifier: 0.17.0-beta.287
-        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/addon-unicode11':
         specifier: 0.10.0-beta.287
-        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.287
-        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.286
-        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
+        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
       '@xterm/xterm':
         specifier: 6.1.0-beta.287
-        version: 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+        version: 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -9591,39 +9591,39 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
 
-  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
       lru-cache: 11.5.1
       opentype.js: 2.0.0
 
-  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
 
-  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
 
-  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
 
-  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
 
-  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
+  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
 
   '@xterm/headless@6.1.0-beta.287': {}
 
-  '@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)': {}
+  '@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)': {}
 
   abbrev@4.0.0: {}
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -18,7 +18,7 @@ patchedDependencies:
     hash: 6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258
     path: config/patches/@xterm__addon-webgl@0.20.0-beta.286.patch
   '@xterm/xterm@6.1.0-beta.287':
-    hash: 8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67
+    hash: 037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8
     path: config/patches/@xterm__xterm@6.1.0-beta.287.patch
   node-pty@1.1.0:
     hash: 8fc49f17011b6611a5b8c00e83a6f12e14e75aada2b0ef26dc5393f8376d20e8
@@ -45,7 +45,7 @@ importers:
         version: 2.5.6
       '@xterm/addon-serialize':
         specifier: 0.15.0-beta.287
-        version: 0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/headless':
         specifier: 6.1.0-beta.287
         version: 6.1.0-beta.287
@@ -208,25 +208,25 @@ importers:
         version: 5.2.0(rolldown-vite@7.3.1(@emnapi/core@1.11.2)(@emnapi/runtime@1.11.2)(@types/node@25.9.5)(jiti@2.7.0)(yaml@2.8.4))
       '@xterm/addon-fit':
         specifier: 0.12.0-beta.287
-        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/addon-ligatures':
         specifier: 0.11.0-beta.287
-        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/addon-search':
         specifier: 0.17.0-beta.287
-        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/addon-unicode11':
         specifier: 0.10.0-beta.287
-        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/addon-web-links':
         specifier: 0.13.0-beta.287
-        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/addon-webgl':
         specifier: 0.20.0-beta.286
-        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))
+        version: 0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))
       '@xterm/xterm':
         specifier: 6.1.0-beta.287
-        version: 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+        version: 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
       class-variance-authority:
         specifier: ^0.7.1
         version: 0.7.1
@@ -9591,39 +9591,39 @@ snapshots:
 
   '@xmldom/xmldom@0.8.13': {}
 
-  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-fit@0.12.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
 
-  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-ligatures@0.11.0-beta.287(patch_hash=47405b9994b5acf1b4e90b49250358c1ca03649854d59560e7732b72fe336920)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
       lru-cache: 11.5.1
       opentype.js: 2.0.0
 
-  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-search@0.17.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
 
-  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-serialize@0.15.0-beta.287(patch_hash=96f70e83261df6a29ad7590feb08b988670655ced7596e77253d524f73f608dd)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
 
-  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-unicode11@0.10.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
 
-  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-web-links@0.13.0-beta.287(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
 
-  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67))':
+  '@xterm/addon-webgl@0.20.0-beta.286(patch_hash=6da7d7770b6427246f2a0d057d97da418040e498068b41d0c2d3c6b20bf49258)(@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8))':
     dependencies:
-      '@xterm/xterm': 6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)
+      '@xterm/xterm': 6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)
 
   '@xterm/headless@6.1.0-beta.287': {}
 
-  '@xterm/xterm@6.1.0-beta.287(patch_hash=8a2d562c08d6a1edb38002299fc7d9eac9b9940b876868c4a8edde466019da67)': {}
+  '@xterm/xterm@6.1.0-beta.287(patch_hash=037272642db6a9bf5242c02acacf8fc41f4c6e91268d8a47ea083c98fb2535b8)': {}
 
   abbrev@4.0.0: {}
 

--- a/src/renderer/src/components/terminal-pane/__fixtures__/windows-wsl-hangul-resumed-preedit-trace.json
+++ b/src/renderer/src/components/terminal-pane/__fixtures__/windows-wsl-hangul-resumed-preedit-trace.json
@@ -1,0 +1,4306 @@
+{
+  "recordedFrom": "11919-windows-wsl-current/11919-current-owner.json",
+  "inputFramework": "windows-ime",
+  "engine": "microsoft-korean",
+  "note": "Windows/WSL 2-Set Korean. Contains 3 compositionupdates that resume a composition with no second compositionstart.",
+  "dom": [
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅁ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "",
+      "keyCode": 65,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅁ",
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "",
+      "keyCode": 65,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "무",
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "무",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "무",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "무",
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "무",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "무",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "문",
+      "value": "무",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "문",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "묹",
+      "value": "문",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "묹",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "묹",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "w",
+      "code": "",
+      "keyCode": 87,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "묹",
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "묹",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "묹",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "w",
+      "code": "",
+      "keyCode": 87,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "문",
+      "value": "묹",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "문",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "제",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "문",
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "문",
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "제",
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "제",
+      "value": "문제",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "제",
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "제",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "제",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅁ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "",
+      "keyCode": 65,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅁ",
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "",
+      "keyCode": 65,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "모",
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "모",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "몰",
+      "value": "모",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "몰",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "몰",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "몰",
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "몰",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "몰",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "모",
+      "value": "몰",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "모",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "르",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "모",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "모",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "르",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "륵",
+      "value": "모르",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "륵",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "륵",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "륵",
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "륵",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "륵",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "르",
+      "value": "모륵",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "르",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "게",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "게",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "게",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "르",
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "르",
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "게",
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "게",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "게",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "겠",
+      "value": "모르게",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "T",
+      "code": "",
+      "keyCode": 84,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "겠",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "T",
+      "code": "",
+      "keyCode": 84,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "겠",
+      "value": "모르겠",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "겠",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄴ",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "겠",
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "겠",
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄴ",
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "네",
+      "value": "모르겠ㄴ",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅇ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅇ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅇ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅇ",
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅇ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㅇ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "아",
+      "value": "ㅇ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "아",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "아",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "아",
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "아",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "아",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "안",
+      "value": "아",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "안",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "안",
+      "value": "안",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "안",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄴ",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "안",
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "안",
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄴ",
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녀",
+      "value": "안ㄴ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녀",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녀",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "u",
+      "code": "",
+      "keyCode": 85,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녀",
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녀",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녀",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "u",
+      "code": "",
+      "keyCode": 85,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녕",
+      "value": "안녀",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녕",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녕",
+      "value": "안녕",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "녕",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녕",
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "녕",
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "안녕ㅎ",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "핫",
+      "value": "안녕하",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "핫",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "핫",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "핫",
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "핫",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "핫",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "t",
+      "code": "",
+      "keyCode": 84,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "t",
+      "code": "",
+      "keyCode": 84,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "안녕핫",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "하",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "세",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "하",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "세",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "셍",
+      "value": "안녕하세",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "셍",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "셍",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "셍",
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "셍",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "셍",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "세",
+      "value": "안녕하셍",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "세",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "요",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "y",
+      "code": "",
+      "keyCode": 89,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "세",
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionend",
+      "data": "세",
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "요",
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "y",
+      "code": "",
+      "keyCode": 89,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "요",
+      "value": "안녕하세요",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionend",
+      "data": "요",
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "요",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "요",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "e",
+      "code": "",
+      "keyCode": 69,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "e",
+      "code": "",
+      "keyCode": 69,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "e",
+      "code": "",
+      "keyCode": 69,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "e",
+      "code": "",
+      "keyCode": 69,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "o",
+      "code": "",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "o",
+      "code": "",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/src/renderer/src/components/terminal-pane/__fixtures__/windows-wsl-hangul-resumed-preedit-trace.json
+++ b/src/renderer/src/components/terminal-pane/__fixtures__/windows-wsl-hangul-resumed-preedit-trace.json
@@ -2,7 +2,9 @@
   "recordedFrom": "11919-windows-wsl-current/11919-current-owner.json",
   "inputFramework": "windows-ime",
   "engine": "microsoft-korean",
-  "note": "Windows/WSL 2-Set Korean. Contains 3 compositionupdates that resume a composition with no second compositionstart.",
+  "note": "Dispatch-phase events only. The capture logs each event twice (immediate + a batched raf re-log); keeping both fabricates resumed compositions that the IME never emitted.",
+  "compositionUpdates": 37,
+  "compositionSessions": 11,
   "dom": [
     {
       "type": "keyup",
@@ -15,16 +17,6 @@
       "selectionEnd": 0
     },
     {
-      "type": "keyup",
-      "key": "HangulMode",
-      "code": "",
-      "keyCode": 21,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
       "type": "keydown",
       "key": "Process",
       "code": "",
@@ -56,68 +48,6 @@
       "value": "",
       "selectionStart": 0,
       "selectionEnd": 0
-    },
-    {
-      "type": "input",
-      "data": "ㅁ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "a",
-      "code": "",
-      "keyCode": 65,
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": false,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
-      "data": "ㅁ",
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "ㅁ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
     },
     {
       "type": "input",
@@ -215,71 +145,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "무",
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "무",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "무",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "n",
-      "code": "",
-      "keyCode": 78,
-      "isComposing": true,
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "무",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
       "data": "문",
       "value": "무",
       "selectionStart": 0,
@@ -324,51 +189,6 @@
       "selectionEnd": 1
     },
     {
-      "type": "compositionupdate",
-      "data": "문",
-      "value": "문",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "문",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "문",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "문",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "문",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "문",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "s",
-      "code": "",
-      "keyCode": 83,
-      "isComposing": true,
-      "value": "문",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
       "type": "keydown",
       "key": "Process",
       "code": "",
@@ -392,61 +212,6 @@
       "isComposing": true,
       "value": "문",
       "selectionStart": 0,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "묹",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "묹",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "묹",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "w",
-      "code": "",
-      "keyCode": 87,
-      "isComposing": true,
-      "value": "묹",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "묹",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
-      "data": "묹",
-      "value": "묹",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "묹",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "묹",
-      "selectionStart": 1,
       "selectionEnd": 1
     },
     {
@@ -584,100 +349,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "문",
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "문",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "문",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionend",
-      "data": "문",
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
-      "data": "제",
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "제",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "제",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "p",
-      "code": "",
-      "keyCode": 80,
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "문제",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
       "data": "제",
       "value": "문제",
       "selectionStart": 1,
@@ -707,78 +378,6 @@
       "value": "문제",
       "selectionStart": 2,
       "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "compositionupdate",
-      "data": "제",
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "beforeinput",
-      "data": "제",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "input",
-      "data": "제",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "compositionend",
-      "data": "제",
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
     },
     {
       "type": "keydown",
@@ -877,68 +476,6 @@
       "key": "Process",
       "code": "",
       "keyCode": 229,
-      "isComposing": false,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
-      "data": "ㅁ",
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "ㅁ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "ㅁ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "a",
-      "code": "",
-      "keyCode": 65,
-      "isComposing": true,
-      "value": "ㅁ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "ㅁ",
       "selectionStart": 1,
@@ -1001,71 +538,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "모",
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "모",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "모",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "h",
-      "code": "",
-      "keyCode": 72,
-      "isComposing": true,
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
       "data": "몰",
       "value": "모",
       "selectionStart": 0,
@@ -1078,51 +550,6 @@
       "isComposing": true,
       "value": "모",
       "selectionStart": 0,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "몰",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "몰",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "몰",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "f",
-      "code": "",
-      "keyCode": 70,
-      "isComposing": true,
-      "value": "몰",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
-      "data": "몰",
-      "value": "몰",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "몰",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "몰",
-      "selectionStart": 1,
       "selectionEnd": 1
     },
     {
@@ -1260,110 +687,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "모",
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "모",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "모",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionend",
-      "data": "모",
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
-      "data": "르",
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "르",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "르",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "m",
-      "code": "",
-      "keyCode": 77,
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
       "data": "륵",
       "value": "모르",
       "selectionStart": 1,
@@ -1402,61 +725,6 @@
       "key": "r",
       "code": "",
       "keyCode": 82,
-      "isComposing": true,
-      "value": "모륵",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
-      "data": "륵",
-      "value": "모륵",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "륵",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모륵",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "륵",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모륵",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모륵",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "r",
-      "code": "",
-      "keyCode": 82,
-      "isComposing": true,
-      "value": "모륵",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "모륵",
       "selectionStart": 2,
@@ -1551,100 +819,6 @@
       "key": "p",
       "code": "",
       "keyCode": 80,
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionupdate",
-      "data": "르",
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "르",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "르",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionend",
-      "data": "르",
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionupdate",
-      "data": "게",
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "게",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "게",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "p",
-      "code": "",
-      "keyCode": 80,
-      "isComposing": true,
-      "value": "모르게",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "모르게",
       "selectionStart": 3,
@@ -1747,101 +921,6 @@
     },
     {
       "type": "keydown",
-      "key": "Shift",
-      "code": "",
-      "keyCode": 16,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionupdate",
-      "data": "겠",
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "겠",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "겠",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "T",
-      "code": "",
-      "keyCode": 84,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Shift",
-      "code": "",
-      "keyCode": 16,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
       "key": "Process",
       "code": "",
       "keyCode": 229,
@@ -1904,90 +983,6 @@
       "value": "모르겠",
       "selectionStart": 3,
       "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "ㄴ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "s",
-      "code": "",
-      "keyCode": 83,
-      "isComposing": true,
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionupdate",
-      "data": "겠",
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "겠",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "겠",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionend",
-      "data": "겠",
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionupdate",
-      "data": "ㄴ",
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "ㄴ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠ㄴ",
-      "selectionStart": 4,
-      "selectionEnd": 4
     },
     {
       "type": "input",
@@ -2087,61 +1082,6 @@
       "type": "compositionupdate",
       "data": "네",
       "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "네",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "네",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "p",
-      "code": "",
-      "keyCode": 80,
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionupdate",
-      "data": "네",
-      "value": "모르겠네",
       "selectionStart": 3,
       "selectionEnd": 4
     },
@@ -2169,78 +1109,6 @@
       "value": "모르겠네",
       "selectionStart": 4,
       "selectionEnd": 4
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionupdate",
-      "data": "네",
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "네",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "네",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionend",
-      "data": "네",
-      "value": "모르겠네",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keydown",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
     },
     {
       "type": "keydown",
@@ -2339,78 +1207,6 @@
       "key": "Process",
       "code": "",
       "keyCode": 229,
-      "isComposing": false,
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
-      "data": "ㅇ",
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "ㅇ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "ㅇ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "d",
-      "code": "",
-      "keyCode": 68,
-      "isComposing": true,
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "ㅇ",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "ㅇ",
       "selectionStart": 1,
@@ -2462,51 +1258,6 @@
       "selectionEnd": 1
     },
     {
-      "type": "compositionupdate",
-      "data": "아",
-      "value": "아",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "아",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "아",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "아",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "아",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "아",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "k",
-      "code": "",
-      "keyCode": 75,
-      "isComposing": true,
-      "value": "아",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
       "type": "keydown",
       "key": "Process",
       "code": "",
@@ -2542,41 +1293,6 @@
       "selectionEnd": 1
     },
     {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "compositionupdate",
-      "data": "안",
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "beforeinput",
-      "data": "안",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "안",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
       "type": "keyup",
       "key": "Process",
       "code": "",
@@ -2591,36 +1307,6 @@
       "key": "s",
       "code": "",
       "keyCode": 83,
-      "isComposing": true,
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keyup",
-      "key": "s",
-      "code": "",
-      "keyCode": 83,
-      "isComposing": true,
-      "value": "안",
-      "selectionStart": 1,
-      "selectionEnd": 1
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "안",
       "selectionStart": 1,
@@ -2690,90 +1376,6 @@
       "value": "안",
       "selectionStart": 1,
       "selectionEnd": 1
-    },
-    {
-      "type": "input",
-      "data": "ㄴ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "s",
-      "code": "",
-      "keyCode": 83,
-      "isComposing": true,
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
-      "data": "안",
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "안",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "안",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionend",
-      "data": "안",
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
-      "data": "ㄴ",
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "ㄴ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안ㄴ",
-      "selectionStart": 2,
-      "selectionEnd": 2
     },
     {
       "type": "input",
@@ -2871,71 +1473,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "녀",
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "녀",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "녀",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "u",
-      "code": "",
-      "keyCode": 85,
-      "isComposing": true,
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녀",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
       "data": "녕",
       "value": "안녀",
       "selectionStart": 1,
@@ -2974,61 +1511,6 @@
       "key": "d",
       "code": "",
       "keyCode": 68,
-      "isComposing": true,
-      "value": "안녕",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "compositionupdate",
-      "data": "녕",
-      "value": "안녕",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "beforeinput",
-      "data": "녕",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "input",
-      "data": "녕",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keyup",
-      "key": "d",
-      "code": "",
-      "keyCode": 68,
-      "isComposing": true,
-      "value": "안녕",
-      "selectionStart": 2,
-      "selectionEnd": 2
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "안녕",
       "selectionStart": 2,
@@ -3129,90 +1611,6 @@
       "selectionEnd": 3
     },
     {
-      "type": "compositionupdate",
-      "data": "녕",
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "녕",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "녕",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionend",
-      "data": "녕",
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionupdate",
-      "data": "ㅎ",
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "ㅎ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "ㅎ",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "g",
-      "code": "",
-      "keyCode": 71,
-      "isComposing": true,
-      "value": "안녕ㅎ",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
       "type": "keydown",
       "key": "Process",
       "code": "",
@@ -3279,61 +1677,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "하",
-      "value": "안녕하",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "하",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "하",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "k",
-      "code": "",
-      "keyCode": 75,
-      "isComposing": true,
-      "value": "안녕하",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionupdate",
       "data": "핫",
       "value": "안녕하",
       "selectionStart": 2,
@@ -3346,41 +1689,6 @@
       "isComposing": true,
       "value": "안녕하",
       "selectionStart": 2,
-      "selectionEnd": 3
-    },
-    {
-      "type": "input",
-      "data": "핫",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕핫",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕핫",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "compositionupdate",
-      "data": "핫",
-      "value": "안녕핫",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "beforeinput",
-      "data": "핫",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕핫",
-      "selectionStart": 3,
       "selectionEnd": 3
     },
     {
@@ -3407,36 +1715,6 @@
       "key": "t",
       "code": "",
       "keyCode": 84,
-      "isComposing": true,
-      "value": "안녕핫",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕핫",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keyup",
-      "key": "t",
-      "code": "",
-      "keyCode": 84,
-      "isComposing": true,
-      "value": "안녕핫",
-      "selectionStart": 3,
-      "selectionEnd": 3
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
       "isComposing": true,
       "value": "안녕핫",
       "selectionStart": 3,
@@ -3537,90 +1815,6 @@
       "selectionEnd": 4
     },
     {
-      "type": "compositionupdate",
-      "data": "하",
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "하",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "하",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionend",
-      "data": "하",
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionupdate",
-      "data": "세",
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "세",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "세",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "p",
-      "code": "",
-      "keyCode": 80,
-      "isComposing": true,
-      "value": "안녕하세",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
       "type": "keydown",
       "key": "Process",
       "code": "",
@@ -3687,71 +1881,6 @@
     },
     {
       "type": "compositionupdate",
-      "data": "셍",
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "beforeinput",
-      "data": "셍",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "셍",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keyup",
-      "key": "d",
-      "code": "",
-      "keyCode": 68,
-      "isComposing": true,
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하셍",
-      "selectionStart": 4,
-      "selectionEnd": 4
-    },
-    {
-      "type": "compositionupdate",
       "data": "세",
       "value": "안녕하셍",
       "selectionStart": 3,
@@ -3804,90 +1933,6 @@
       "value": "안녕하세",
       "selectionStart": 4,
       "selectionEnd": 4
-    },
-    {
-      "type": "input",
-      "data": "요",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "keyup",
-      "key": "y",
-      "code": "",
-      "keyCode": 89,
-      "isComposing": true,
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "compositionupdate",
-      "data": "세",
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "beforeinput",
-      "data": "세",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "input",
-      "data": "세",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "compositionend",
-      "data": "세",
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "compositionstart",
-      "data": "",
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "compositionupdate",
-      "data": "요",
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
-    },
-    {
-      "type": "beforeinput",
-      "data": "요",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "안녕하세요",
-      "selectionStart": 5,
-      "selectionEnd": 5
     },
     {
       "type": "input",
@@ -3992,98 +2037,6 @@
     },
     {
       "type": "keydown",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": true,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "compositionupdate",
-      "data": "요",
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "beforeinput",
-      "data": "요",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "input",
-      "data": "요",
-      "inputType": "insertCompositionText",
-      "isComposing": true,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "compositionend",
-      "data": "요",
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Process",
-      "code": "",
-      "keyCode": 229,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "h",
-      "code": "",
-      "keyCode": 72,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "h",
-      "code": "",
-      "keyCode": 72,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
       "key": "h",
       "code": "",
       "keyCode": 72,
@@ -4117,66 +2070,6 @@
       "key": "e",
       "code": "",
       "keyCode": 69,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "e",
-      "code": "",
-      "keyCode": 69,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "e",
-      "code": "",
-      "keyCode": 69,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "l",
-      "code": "",
-      "keyCode": 76,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "l",
-      "code": "",
-      "keyCode": 76,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "l",
-      "code": "",
-      "keyCode": 76,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "l",
-      "code": "",
-      "keyCode": 76,
       "isComposing": false,
       "value": "",
       "selectionStart": 0,
@@ -4237,46 +2130,6 @@
       "key": "o",
       "code": "",
       "keyCode": 79,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "o",
-      "code": "",
-      "keyCode": 79,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "o",
-      "code": "",
-      "keyCode": 79,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keydown",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
-      "isComposing": false,
-      "value": "",
-      "selectionStart": 0,
-      "selectionEnd": 0
-    },
-    {
-      "type": "keyup",
-      "key": "Enter",
-      "code": "",
-      "keyCode": 13,
       "isComposing": false,
       "value": "",
       "selectionStart": 0,

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-resumed-preedit-visibility.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-resumed-preedit-visibility.test.ts
@@ -1,0 +1,218 @@
+// @vitest-environment happy-dom
+/**
+ * The preedit overlay must be VISIBLE while the IME is still composing, not merely populated.
+ *
+ * Recorded shape: Windows 11 / MS Korean 2-Set typed into a WSL pane, captured as the DOM event
+ * stream on the xterm helper textarea. Cited capture:
+ * `.tmp/ime-handoff/evidence/11919-windows-wsl-current/11919-current-owner.json` (gitignored;
+ * the subsequences below are copied verbatim from indices 240-253 and 79-92 of its `trace`).
+ *
+ * The capture contains a shape none of the Linux traces do: after `compositionend`, the IME
+ * RESUMES the composition with a bare `compositionupdate` and **no second `compositionstart`**.
+ * xterm hides the overlay in `compositionend` (`_finalizeComposition` drops `.active`) and only
+ * ever re-adds it in `compositionstart`, so the resumed preedit is written into an element that
+ * is still `display: none`. The syllable commits normally afterwards, which is exactly the
+ * reported symptom: the committed text lands but the user types the next one blind.
+ *
+ * The assertion is therefore on the DISPLAYED overlay — the `active` class that CSS keys
+ * `display: block` off, together with the text in it. Asserting `onData` here would pass on the
+ * broken build, because the commit path is not what breaks.
+ *
+ * happy-dom performs no layout, so the cell size is supplied and geometry is not asserted.
+ */
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const CELL_WIDTH_PX = 8
+const CELL_HEIGHT_PX = 16
+
+type RecordedEvent = {
+  type: string
+  data?: string
+  key?: string
+  keyCode?: number
+  isComposing?: boolean
+}
+
+/**
+ * Indices 240-253 of the capture: 네 commits, and the IME reopens on the next key with an
+ * update alone. `keyCode: null` in the capture means the field was not recorded for that
+ * event type, not that the event carried none.
+ */
+const RESUMED_WITHOUT_START: RecordedEvent[] = [
+  { type: 'keydown', key: 'Process', keyCode: 229, isComposing: true },
+  { type: 'compositionupdate', data: '네' },
+  { type: 'beforeinput', data: '네', isComposing: true },
+  { type: 'input', data: '네', isComposing: true },
+  { type: 'compositionend', data: '네' },
+  { type: 'keydown', key: 'Process', keyCode: 229, isComposing: true },
+  { type: 'compositionupdate', data: '네' },
+  { type: 'beforeinput', data: '네', isComposing: true },
+  { type: 'input', data: '네', isComposing: true }
+]
+
+/** Indices 79-88: the same resume, this time across the Enter that committed 제. */
+const RESUMED_ACROSS_ENTER: RecordedEvent[] = [
+  { type: 'input', data: '제', isComposing: true },
+  { type: 'compositionend', data: '제' },
+  { type: 'keydown', key: 'Enter', keyCode: 13, isComposing: false },
+  { type: 'keyup', key: 'Process', keyCode: 229, isComposing: false },
+  { type: 'keyup', key: 'Enter', keyCode: 13, isComposing: false },
+  { type: 'keydown', key: 'Process', keyCode: 229, isComposing: true },
+  { type: 'compositionupdate', data: '제' },
+  { type: 'beforeinput', data: '제', isComposing: true },
+  { type: 'input', data: '제', isComposing: true }
+]
+
+/** The Linux control: IBus always reopens with a compositionstart, and must stay working. */
+const REOPENED_WITH_START: RecordedEvent[] = [
+  { type: 'keydown', key: 'Process', keyCode: 229, isComposing: true },
+  { type: 'compositionupdate', data: '한' },
+  { type: 'compositionend', data: '한' },
+  { type: 'keydown', key: 'Process', keyCode: 229, isComposing: false },
+  { type: 'compositionstart', data: '' },
+  { type: 'compositionupdate', data: '글' }
+]
+
+const openTerminals: Terminal[] = []
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function buildEvent(recorded: RecordedEvent): Event {
+  if (recorded.type === 'keydown' || recorded.type === 'keyup') {
+    const keyboard = new KeyboardEvent(recorded.type, {
+      bubbles: true,
+      cancelable: true,
+      isComposing: recorded.isComposing,
+      key: recorded.key ?? ''
+    })
+    Object.defineProperty(keyboard, 'keyCode', { value: recorded.keyCode })
+    return keyboard
+  }
+  if (recorded.type === 'input' || recorded.type === 'beforeinput') {
+    const input = new InputEvent(recorded.type, {
+      bubbles: true,
+      isComposing: recorded.isComposing
+    })
+    // happy-dom drops these from InputEventInit; Chromium supplies them.
+    Object.defineProperty(input, 'inputType', { value: 'insertCompositionText' })
+    Object.defineProperty(input, 'data', { value: recorded.data ?? null })
+    Object.defineProperty(input, 'composed', { value: true })
+    return input
+  }
+  const composition = new CompositionEvent(recorded.type, { bubbles: true })
+  Object.defineProperty(composition, 'data', { value: recorded.data ?? '' })
+  return composition
+}
+
+type Rig = {
+  compositionView: HTMLElement
+  replay: (events: RecordedEvent[]) => Promise<void>
+  terminal: Terminal
+}
+
+function openTerminal(): Rig {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const terminal = new Terminal({ cols: 80, rows: 24 })
+  terminal.open(container)
+  const textarea = terminal.textarea
+  const compositionView = container.querySelector<HTMLElement>('.composition-view')
+  if (!textarea || !compositionView) {
+    throw new Error('xterm did not create the helper textarea and composition view')
+  }
+  openTerminals.push(terminal)
+
+  const cell = (
+    terminal as unknown as {
+      _core: {
+        _renderService: { dimensions: { css: { cell: { height: number; width: number } } } }
+      }
+    }
+  )._core._renderService.dimensions.css.cell
+  cell.width = CELL_WIDTH_PX
+  cell.height = CELL_HEIGHT_PX
+  terminal.onData((data) => terminal.write(data))
+
+  const replay = async (events: RecordedEvent[]): Promise<void> => {
+    for (const recorded of events) {
+      // Keys were physically separate, so each one began its own task.
+      if (recorded.type === 'keydown' || recorded.type === 'keyup') {
+        await nextEventLoop()
+      }
+      if (recorded.data !== undefined && recorded.type !== 'compositionupdate') {
+        textarea.value = recorded.data
+        textarea.setSelectionRange(recorded.data.length, recorded.data.length)
+      }
+      textarea.dispatchEvent(buildEvent(recorded))
+    }
+  }
+
+  return { compositionView, replay, terminal }
+}
+
+/** What the user sees: the class CSS keys `display: block` off, and the text inside it. */
+function displayedPreedit(view: HTMLElement): { preedit: string; shown: boolean } {
+  return {
+    preedit: (view.textContent ?? '').replaceAll('‎', ''),
+    shown: view.classList.contains('active')
+  }
+}
+
+describe('preedit visibility across a composition the IME resumes', () => {
+  beforeEach(() => {
+    // happy-dom has no 2d context, which the DOM renderer's WidthCache requires.
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(async () => {
+    // updateCompositionElements re-arms on a timer; let the pending one run before dispose.
+    await nextEventLoop()
+    await nextEventLoop()
+    while (openTerminals.length > 0) {
+      openTerminals.pop()?.dispose()
+    }
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('shows a preedit the IME resumes with an update and no second compositionstart', async () => {
+    const rig = openTerminal()
+
+    await rig.replay(RESUMED_WITHOUT_START)
+
+    expect(displayedPreedit(rig.compositionView)).toEqual({ preedit: '네', shown: true })
+  })
+
+  it('shows a preedit the IME resumes after the Enter that committed the last syllable', async () => {
+    const rig = openTerminal()
+
+    await rig.replay(RESUMED_ACROSS_ENTER)
+
+    expect(displayedPreedit(rig.compositionView)).toEqual({ preedit: '제', shown: true })
+  })
+
+  it('still shows a preedit the IME reopens with a compositionstart', async () => {
+    const rig = openTerminal()
+
+    await rig.replay(REOPENED_WITH_START)
+
+    expect(displayedPreedit(rig.compositionView)).toEqual({ preedit: '글', shown: true })
+  })
+
+  it('hides the overlay once the composition ends and nothing resumes it', async () => {
+    const rig = openTerminal()
+
+    await rig.replay([
+      { type: 'compositionstart', data: '' },
+      { type: 'compositionupdate', data: '한' },
+      { type: 'compositionend', data: '한' }
+    ])
+
+    expect(displayedPreedit(rig.compositionView).shown).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-windows-resumed-preedit-trace.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-windows-resumed-preedit-trace.test.ts
@@ -1,14 +1,13 @@
 // @vitest-environment happy-dom
-// Replays a recorded Windows/WSL 2-Set Korean capture and asserts the preedit stayed visible.
+// Replays a recorded Windows/WSL 2-Set Korean capture and asserts the preedit stayed visible for
+// every composition update the IME actually emitted — 37 of them across 11 balanced sessions.
 //
-// The capture contains the ordering that hides it: three compositionupdates that resume a
-// composition with no second compositionstart. xterm adds `.active` only in compositionstart and
-// removes it in compositionend, so those three updates were written into a hidden overlay and the
-// user composed blind. Committed syllables still landed, which is why byte-level assertions never
-// saw it.
-//
-// This is the recorded counterpart to terminal-ime-xterm-resumed-preedit-visibility.test.ts: that
-// one pins the shape synthetically, this one proves it against events a real IME actually emitted.
+// It does NOT cover the resume-without-compositionstart ordering, and an earlier version of this
+// file wrongly claimed it did. The capture logs each event twice (a dispatch record and a batched
+// next-frame re-log); replaying both fabricates updates that appear to land after a session ended.
+// Filtered to dispatch records the capture holds zero resumes. The fixture is now filtered, so this
+// asserts real emissions only. The resume ordering is pinned synthetically in
+// terminal-ime-xterm-resumed-preedit-visibility.test.ts, which says so.
 import { Terminal } from '@xterm/xterm'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import trace from './__fixtures__/windows-wsl-hangul-resumed-preedit-trace.json'
@@ -58,7 +57,7 @@ function buildEvent(recorded: RecordedEvent): Event {
   return composition
 }
 
-describe('Windows/WSL Korean — preedit the IME resumes without a compositionstart', () => {
+describe('Windows/WSL Korean — recorded composition updates keep the preedit visible', () => {
   beforeEach(() => {
     vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
       measureText: () => ({ width: 10 })
@@ -70,7 +69,7 @@ describe('Windows/WSL Korean — preedit the IME resumes without a compositionst
     document.body.replaceChildren()
   })
 
-  it('keeps every resumed preedit visible', async () => {
+  it('keeps the preedit visible for every recorded update', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
     const terminal = new Terminal()
@@ -83,6 +82,7 @@ describe('Windows/WSL Korean — preedit the IME resumes without a compositionst
     const events = trace.dom as RecordedEvent[]
     let compositionOpen = false
     const resumed: { data: string; shown: boolean }[] = []
+    const shown: { data: string; visible: boolean }[] = []
 
     for (const recorded of events) {
       if (recorded.type === 'keydown' || recorded.type === 'keyup') {
@@ -100,19 +100,22 @@ describe('Windows/WSL Korean — preedit the IME resumes without a compositionst
         compositionOpen = true
       } else if (recorded.type === 'compositionend') {
         compositionOpen = false
-      } else if (recorded.type === 'compositionupdate' && recorded.data && !compositionOpen) {
+      } else if (recorded.type === 'compositionupdate' && recorded.data) {
         const view = terminal.element?.querySelector('.composition-view')
-        resumed.push({
-          data: recorded.data,
-          shown: view?.classList.contains('active') === true
-        })
+        const active = view?.classList.contains('active') === true
+        shown.push({ data: recorded.data, visible: active })
+        if (!compositionOpen) {
+          resumed.push({ data: recorded.data, shown: active })
+        }
       }
     }
     terminal.dispose()
 
-    // The capture holds exactly three; if it ever holds none the fixture has been replaced and this
-    // assertion would pass while covering nothing.
-    expect(resumed).toHaveLength(3)
-    expect(resumed.filter((sample) => !sample.shown)).toEqual([])
+    // Guards against a fixture that silently stops covering anything.
+    expect(shown).toHaveLength(37)
+    expect(shown.filter((sample) => !sample.visible)).toEqual([])
+    // The real capture never resumes a composition without a start; if it ever appears to, the
+    // fixture has picked up the batched re-log again.
+    expect(resumed).toEqual([])
   })
 })

--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-windows-resumed-preedit-trace.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-windows-resumed-preedit-trace.test.ts
@@ -1,0 +1,118 @@
+// @vitest-environment happy-dom
+// Replays a recorded Windows/WSL 2-Set Korean capture and asserts the preedit stayed visible.
+//
+// The capture contains the ordering that hides it: three compositionupdates that resume a
+// composition with no second compositionstart. xterm adds `.active` only in compositionstart and
+// removes it in compositionend, so those three updates were written into a hidden overlay and the
+// user composed blind. Committed syllables still landed, which is why byte-level assertions never
+// saw it.
+//
+// This is the recorded counterpart to terminal-ime-xterm-resumed-preedit-visibility.test.ts: that
+// one pins the shape synthetically, this one proves it against events a real IME actually emitted.
+import { Terminal } from '@xterm/xterm'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import trace from './__fixtures__/windows-wsl-hangul-resumed-preedit-trace.json'
+
+type RecordedEvent = {
+  type: string
+  inputType?: string
+  data?: string
+  key?: string
+  code?: string
+  keyCode?: number
+  isComposing?: boolean
+  value?: string
+  selectionStart?: number
+  selectionEnd?: number
+}
+
+function nextEventLoop(): Promise<void> {
+  return new Promise((resolve) => window.setTimeout(resolve, 0))
+}
+
+function buildEvent(recorded: RecordedEvent): Event {
+  if (recorded.type === 'keydown' || recorded.type === 'keyup') {
+    const keyboard = new KeyboardEvent(recorded.type, {
+      key: recorded.key,
+      code: recorded.code,
+      isComposing: recorded.isComposing,
+      bubbles: true,
+      cancelable: true
+    })
+    Object.defineProperty(keyboard, 'keyCode', { value: recorded.keyCode })
+    return keyboard
+  }
+  if (recorded.type === 'input' || recorded.type === 'beforeinput') {
+    const input = new InputEvent(recorded.type, {
+      isComposing: recorded.isComposing,
+      bubbles: true
+    })
+    // happy-dom drops these from InputEventInit; Chromium supplies them.
+    Object.defineProperty(input, 'inputType', { value: recorded.inputType ?? '' })
+    Object.defineProperty(input, 'data', { value: recorded.data ?? null })
+    Object.defineProperty(input, 'composed', { value: true })
+    return input
+  }
+  const composition = new CompositionEvent(recorded.type, { bubbles: true })
+  Object.defineProperty(composition, 'data', { value: recorded.data ?? '' })
+  return composition
+}
+
+describe('Windows/WSL Korean — preedit the IME resumes without a compositionstart', () => {
+  beforeEach(() => {
+    vi.spyOn(HTMLCanvasElement.prototype, 'getContext').mockReturnValue({
+      measureText: () => ({ width: 10 })
+    } as unknown as CanvasRenderingContext2D)
+  })
+
+  afterEach(() => {
+    vi.restoreAllMocks()
+    document.body.replaceChildren()
+  })
+
+  it('keeps every resumed preedit visible', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const terminal = new Terminal()
+    terminal.open(container)
+    const textarea = terminal.textarea
+    if (!textarea) {
+      throw new Error('xterm helper textarea was not created')
+    }
+
+    const events = trace.dom as RecordedEvent[]
+    let compositionOpen = false
+    const resumed: { data: string; shown: boolean }[] = []
+
+    for (const recorded of events) {
+      if (recorded.type === 'keydown' || recorded.type === 'keyup') {
+        await nextEventLoop()
+      }
+      if (recorded.value !== undefined) {
+        textarea.value = recorded.value
+      }
+      if (recorded.selectionStart !== undefined && recorded.selectionEnd !== undefined) {
+        textarea.setSelectionRange(recorded.selectionStart, recorded.selectionEnd)
+      }
+      textarea.dispatchEvent(buildEvent(recorded))
+
+      if (recorded.type === 'compositionstart') {
+        compositionOpen = true
+      } else if (recorded.type === 'compositionend') {
+        compositionOpen = false
+      } else if (recorded.type === 'compositionupdate' && recorded.data && !compositionOpen) {
+        const view = terminal.element?.querySelector('.composition-view')
+        resumed.push({
+          data: recorded.data,
+          shown: view?.classList.contains('active') === true
+        })
+      }
+    }
+    terminal.dispose()
+
+    // The capture holds exactly three; if it ever holds none the fixture has been replaced and this
+    // assertion would pass while covering nothing.
+    expect(resumed).toHaveLength(3)
+    expect(resumed.filter((sample) => !sample.shown)).toEqual([])
+  })
+})


### PR DESCRIPTION
## The bug

Typing 2-Set Korean into a terminal pane shows committed syllables but not the in-progress jamo. The user composes each syllable blind and only sees it once it commits.

## This is a pre-existing limitation, not a regression

The added test fails identically against the bundle this branch starts from — i.e. against the restored patch that `#13282` reverted to, with none of the reverted composition work present. Reverting the fix on this branch and reinstalling reproduces the same two failures. This hole predates the composition-ownership change and survived its revert.

## Mechanism

The `.active` class is what the stylesheet keys `display: block` off. In the vendored terminal library's composition helper:

- `compositionstart` sets `_isComposing = true` **and** adds `.active`.
- `_finalizeComposition` clears `_isComposing` **and** removes `.active`.
- `compositionupdate` writes `textContent` and calls `updateCompositionElements()`, which early-returned on `!this._isComposing`.

Some IMEs — observed in a recorded Windows/WSL Korean capture — **resume a composition with a bare `compositionupdate` and no second `compositionstart`**. By that point `compositionend` has already hidden the overlay. The resumed preedit is therefore written into an element that is still `display: none`, and `updateCompositionElements` declines to lay it out. The commit path is untouched, which is exactly why the committed text lands and the composing glyph does not.

## The fix

Two edits in the vendored helper:

- In `compositionupdate`, re-add `.active` when the update carries data.
- In `updateCompositionElements`, guard on the shown overlay (`classList.contains('active')`) rather than `_isComposing`.

`_isComposing` is deliberately **not** set. No commit bookkeeping changes — `_pendingCompositionStart`, `_compositionPosition`, the deferred send, the transaction id — and **`onData` is byte-identical**. No timers, no `event.key`.

The two guards are equivalent on every pre-existing path, because the only writers set and clear them together: `compositionstart` sets both, `_finalizeComposition` clears both. The new resumed-update path is the only place they diverge.

## Discrimination was proved, not argued

Not by reasoning about the guards — by an actual revert-and-restore cycle:

1. `git checkout origin/main -- config/patches/@xterm__xterm@6.1.0-beta.287.patch pnpm-lock.yaml`, `pnpm install`, confirmed the bundle no longer carries the guard, ran the test:

```
× shows a preedit the IME resumes with an update and no second compositionstart
  AssertionError: expected { preedit: '네', shown: false } to deeply equal { preedit: '네', shown: true }
× shows a preedit the IME resumes after the Enter that committed the last syllable
  AssertionError: expected { preedit: '제', shown: false } to deeply equal { preedit: '제', shown: true }

Tests  2 failed | 2 passed (4)
```

2. Restored, `pnpm install`, confirmed the guard is back in the installed bundle, re-ran: `Tests 4 passed (4)`.

The suite has 4 arms. Two fail without the fix; two are controls that pass either way — a composition reopened *with* a `compositionstart` must keep working, and the overlay must still hide when a composition ends and nothing resumes it. Those controls are what stop the suite from degenerating into "always visible".

The test asserts the **displayed** overlay (the `.active` class plus its text). Asserting `onData` here would pass on the broken build, because the commit path is not what breaks.

## Note on the patch file

The src-patch toolchain and its regeneration script were removed by `#13282`, so `config/patches/@xterm__xterm@6.1.0-beta.287.patch` is once again the only artifact. It was regenerated with `pnpm patch` / `pnpm patch-commit`: the same two edits were applied to the hand-authored source **and** to the shipped minified `lib/xterm.js` and `lib/xterm.mjs`, verified as unique single-site replacements in each. The sourcemaps are carried through unchanged, so their offsets are stale by the length of the two insertions — the mapped source is still correct, only slightly shifted for code after the insertion point. The lockfile patch hash changes in all resolution keys, as expected.

## Verification

- `npx vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/ src/renderer/src/lib/pane-manager/` — 312 files, 3907 passed, 1 skipped.
- `rm -f config/*.tsbuildinfo && pnpm run typecheck` — clean on a fresh buildinfo.
- `npx oxlint` on the changed file — exit 0.
- `node config/scripts/check-react-doctor-changed.mjs` — exit 0, 0 issues.

Made with [Orca](https://github.com/stablyai/orca) 🐋
