### PR TITLE
test(terminal): assert preedit visibility across the recorded IME traces

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ime-xterm-linux-native-trace-replay.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ime-xterm-linux-native-trace-replay.test.ts
@@ -98,8 +98,13 @@ function replayEvent(textarea: HTMLTextAreaElement, recorded: RecordedEvent): vo
   textarea.dispatchEvent(buildEvent(recorded))
 }
 
-async function replayTrace(trace: RecordedTrace): Promise<string> {
+type PreeditSample = { data: string; shown: boolean }
+
+async function replayTrace(
+  trace: RecordedTrace
+): Promise<{ stream: string; preedits: PreeditSample[] }> {
   const { emitted, terminal, textarea } = openTerminal()
+  const preedits: PreeditSample[] = []
   for (const recorded of trace.dom) {
     // Keys were driven 20 ms apart, so every physical key event began its own task; the composition
     // and input events the IME derived from one key stay in that key's task, which is what lets
@@ -108,12 +113,16 @@ async function replayTrace(trace: RecordedTrace): Promise<string> {
       await nextEventLoop()
     }
     replayEvent(textarea, recorded)
+    if (recorded.type === 'compositionupdate' && recorded.data) {
+      const view = terminal.element?.querySelector('.composition-view')
+      preedits.push({ data: recorded.data, shown: view?.classList.contains('active') === true })
+    }
   }
   // Two turns: the commit's deferred send, then the late-native-commit window it opens.
   await nextEventLoop()
   await nextEventLoop()
   terminal.dispose()
-  return emitted.join('')
+  return { stream: emitted.join(''), preedits }
 }
 
 describe.each([
@@ -132,11 +141,11 @@ describe.each([
   })
 
   it('reproduces the recorded onData stream exactly', async () => {
-    expect(await replayTrace(trace)).toBe(trace.onData.join(''))
+    expect((await replayTrace(trace)).stream).toBe(trace.onData.join(''))
   })
 
   it('sends each committed syllable once per repetition', async () => {
-    const stream = await replayTrace(trace)
+    const { stream } = await replayTrace(trace)
     expect(stream.match(/한/g)).toHaveLength(trace.repetitions)
     expect(stream.match(/글/g)).toHaveLength(trace.repetitions)
     // The ASCII typed between the two commits is the part a mis-scoped commit swallows.
@@ -144,9 +153,18 @@ describe.each([
   })
 
   it('matches the bytes the PTY received on the recorded run', async () => {
-    const stream = await replayTrace(trace)
+    const { stream } = await replayTrace(trace)
     // The tty turned each CR into LF, so compare against the recorded lines plus that conversion.
     const lines = Buffer.from(trace.receivedBytes.join(''), 'hex').toString('utf8')
     expect(stream.replaceAll('\r', '\n')).toBe(lines)
+  })
+
+  // Why: bytes reaching the PTY say nothing about whether the user could SEE what they were
+  // composing. A preedit written into a hidden overlay types blind and still passes every
+  // onData assertion above, which is how that class of defect has shipped before.
+  it('keeps the preedit visible for every recorded composition update', async () => {
+    const { preedits } = await replayTrace(trace)
+    expect(preedits.length).toBeGreaterThan(0)
+    expect(preedits.filter((sample) => !sample.shown)).toEqual([])
   })
 })


### PR DESCRIPTION
Two IME defects shipped past this suite in the last day. This closes the gap that let them.

**The gap.** Every assertion in this file was about bytes reaching the PTY — exact `onData`, exactly-once counts, and the recorded PTY bytes. All three are correct and all three are blind to whether the user could *see* what they were composing. A preedit written into a hidden overlay types blind and satisfies every one of them.

That is not hypothetical. A sibling investigation found a preedit-overlay test that asserts `overlayActive === true` — the exact property that broke in a real report — and passed anyway, because its helper hand-authored an event ordering in which the overlay is active by construction. The environment was never the limitation; the event corpus was.

**The change.** Sample the composition overlay at each recorded `compositionupdate` and require it to be shown. The traces here are real captures against live input frameworks, so this turns an existing corpus into visibility coverage rather than adding new fixtures.

**It discriminates**, proved by breaking it rather than by reasoning: pointing the selector at a non-existent element (simulating an overlay that never activates) fails both framework arms with `keeps the preedit visible for every recorded composition update`; restoring it returns 8/8. The `preedits.length > 0` guard prevents the filter from passing vacuously on an empty sample set.

Verified: 8 tests pass (up from 6), typecheck clean across all three configs with `config/*.tsbuildinfo` cleared first, oxlint clean, and `check-react-doctor-changed` exits 0 — that last gate failed a PR earlier today while every local suite was green.

Tests only, no production change.

Worth noting for whoever extends this: the recorded Linux traces do not contain the Windows/WSL shape where an IME resumes a composition with a bare `compositionupdate` and no second `compositionstart`. Adding that capture as a third fixture would extend this assertion to the platform ordering that is currently unguarded.

Made with [Orca](https://github.com/stablyai/orca) 🐋
