### PR TITLE
test(e2e): headless IME preedit-geometry coverage for Korean and CJK terminal input [NOT FOR MERGE]

### DIFF
--- a/tests/e2e/fixtures/linux-fcitx5-wayland-hangul-mixed-ascii-dom-trace.json
+++ b/tests/e2e/fixtures/linux-fcitx5-wayland-hangul-mixed-ascii-dom-trace.json
@@ -1,0 +1,1641 @@
+{
+  "recordedFrom": "linux-final/run-30833689965/terminal-ime-native-fcitx5-wayland-evidence/terminal-ime-evidence/native-fcitx5-wayland-boundaries-forwards-the-issue-exact-byte-sequence-without-loss-or-duplication.json",
+  "inputFramework": "fcitx5",
+  "engine": "hangul",
+  "displayServer": "wayland",
+  "note": "Native fcitx5 on Wayland (Sway), same five repetitions. Two properties make this the strongest negative control in the set: the composing keys produce NO keydown at all — not even keyCode 229 — and the literal a/b/c keydowns carry physically wrong `code` values (Digit4/Digit5/Digit6). Any ownership rule that reads 229 or `code` fails here.",
+  "onData": [
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "Digit4",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "Digit5",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "Digit6",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Digit0",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/linux-fcitx5-x11-pinyin-candidate-digit-dom-trace.json
+++ b/tests/e2e/fixtures/linux-fcitx5-x11-pinyin-candidate-digit-dom-trace.json
@@ -1,0 +1,1751 @@
+{
+  "recordedFrom": "linux-final/run-30833689965/terminal-ime-native-fcitx5-evidence/terminal-ime-evidence/native-fcitx5-x11-boundaries-keeps-a-numeric-pinyin-candidate-and-ordinary-digit-exactly-once.json",
+  "inputFramework": "fcitx5",
+  "engine": "libpinyin",
+  "displayServer": "x11",
+  "note": "Native fcitx5/libpinyin on X11: five zhong -> 中 conversions selected with candidate digit 1, then five ordinary digit-1 presses as the negative control. The candidate digit must not reach the shell and the ordinary digit must reach it exactly once; the first repetition emits no digit keydown at all, only an orphan keyup.",
+  "onData": [
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "z",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "z",
+      "code": "KeyZ",
+      "keyCode": 90,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh",
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o",
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o n",
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zhong",
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "beforeinput",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "input",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "z",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "z",
+      "code": "KeyZ",
+      "keyCode": 90,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh",
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o",
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o n",
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zhong",
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "beforeinput",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "input",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "z",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "z",
+      "code": "KeyZ",
+      "keyCode": 90,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh",
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o",
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o n",
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zhong",
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "beforeinput",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "input",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "z",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "z",
+      "code": "KeyZ",
+      "keyCode": 90,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh",
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o",
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o n",
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zhong",
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "beforeinput",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "input",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "z",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "z",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "z",
+      "code": "KeyZ",
+      "keyCode": 90,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh",
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "z",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "zh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o",
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "zh o",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zh o n",
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "zh o n",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "zhong",
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "beforeinput",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zh o n",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "input",
+      "data": "zhong",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "zhong",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/linux-ibus-x11-hangul-mixed-ascii-dom-trace.json
+++ b/tests/e2e/fixtures/linux-ibus-x11-hangul-mixed-ascii-dom-trace.json
@@ -1,0 +1,2611 @@
+{
+  "recordedFrom": "linux-final/run-30833689965/terminal-ime-native-evidence/terminal-ime-evidence/native-ibus-x11-boundaries-forwards-the-issue-exact-byte-sequence-without-loss-or-duplication.json",
+  "inputFramework": "ibus",
+  "engine": "hangul",
+  "displayServer": "x11",
+  "note": "Native IBus/X11 2-Set Korean under Xvfb, five repetitions of 한 + literal abc + 글 + Enter. The commit shape is the discriminating part: compositionend carries EMPTY data and the syllable arrives afterwards as a separate non-composing input event with inputType insertText, so anything reading the commit off compositionend.data drops every syllable.",
+  "onData": [
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "한"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "b"
+    },
+    {
+      "data": "c"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "AltRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "b",
+      "code": "KeyB",
+      "keyCode": 66,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltRight",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertText",
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/linux-ibus-x11-pinyin-candidate-digit-dom-trace.json
+++ b/tests/e2e/fixtures/linux-ibus-x11-pinyin-candidate-digit-dom-trace.json
@@ -1,0 +1,1416 @@
+{
+  "recordedFrom": "linux-final/run-30833689965/terminal-ime-native-evidence/terminal-ime-evidence/native-ibus-x11-boundaries-keeps-a-numeric-pinyin-candidate-and-ordinary-digit-exactly-once.json",
+  "inputFramework": "ibus",
+  "engine": "libpinyin",
+  "displayServer": "x11",
+  "note": "The same Chinese candidate/control scenario under IBus/X11. Kept alongside the fcitx5 copy because the two frameworks disagree on where the candidate digit appears: IBus fires no composition update for the conversion step that fcitx5 does.",
+  "onData": [
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "中"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    },
+    {
+      "data": "1"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "在",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中哦",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "在",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中哦",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "在",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中哦",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "在",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中哦",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyZ",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "在",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "在",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "在",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyO",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中哦",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中哦",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyN",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中哦",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Digit1",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "中",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "中",
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "中",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "1",
+      "code": "Digit1",
+      "keyCode": 49,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/macos-2set-hangul-dom-trace.json
+++ b/tests/e2e/fixtures/macos-2set-hangul-dom-trace.json
@@ -1,0 +1,408 @@
+{
+  "recordedFrom": "macos-current-6a99/native-macos-2set-boundaries-forwards-physical-hangul-input-as-exact-pty-bytes.json",
+  "inputFramework": "macos-ime",
+  "engine": "apple-2set-korean",
+  "displayServer": "macos",
+  "note": "Native macOS 2-Set Korean. Every composing keydown carries keyCode 229 while `key` is still the single translated jamo — the macOS marker the structural predicate is built on, and the reason it reads `key` for length only. 한 closes and 글 opens with no keydown between them, so the syllable boundary is exercised as recorded rather than as imagined.",
+  "onData": [
+    {
+      "data": "한"
+    },
+    {
+      "data": "글"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "ㅎ",
+      "code": "KeyG",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "ㅎ",
+      "code": "KeyG",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "ㅏ",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅎ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "ㅏ",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "ㄴ",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "하",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "ㄴ",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "ㄱ",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "한",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "한",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "ㄱ",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "ㅡ",
+      "code": "KeyM",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "그",
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "그",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "ㅡ",
+      "code": "KeyM",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "ㄹ",
+      "code": "KeyF",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한그",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "ㄹ",
+      "code": "KeyF",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "글",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "글",
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "한글",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/macos-cangjie-cancelled-preedit-dom-trace.json
+++ b/tests/e2e/fixtures/macos-cangjie-cancelled-preedit-dom-trace.json
@@ -1,0 +1,321 @@
+{
+  "recordedFrom": "macos-11951-cangjie-2026-08-06/native-macos-cangjie-removes-cancelled-preedit-without-writing-it-to-the-pty.json",
+  "inputFramework": "macos-ime",
+  "engine": "apple-cangjie",
+  "displayServer": "macos",
+  "note": "Native macOS Cangjie: 尸 composed then backspaced away. Same guarantee as the pinyin capture against a second Chinese input method, and the same `ordinary` tail with the same caveat.",
+  "onData": [
+    {
+      "data": "o"
+    },
+    {
+      "data": "r"
+    },
+    {
+      "data": "d"
+    },
+    {
+      "data": "i"
+    },
+    {
+      "data": "n"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "r"
+    },
+    {
+      "data": "y"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "尸",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "尸",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "尸",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "尸",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "尸",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "尸",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "尸",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "尸",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "尸",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "尸",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 8,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "d",
+      "code": "KeyD",
+      "keyCode": 68,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "KeyD",
+      "keyCode": 68,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "i",
+      "code": "KeyI",
+      "keyCode": 73,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "i",
+      "code": "KeyI",
+      "keyCode": 73,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "y",
+      "code": "KeyY",
+      "keyCode": 89,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "y",
+      "code": "KeyY",
+      "keyCode": 89,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/macos-pinyin-cancelled-preedit-dom-trace.json
+++ b/tests/e2e/fixtures/macos-pinyin-cancelled-preedit-dom-trace.json
@@ -1,0 +1,681 @@
+{
+  "recordedFrom": "native-macos-current-head/pinyin-clean-585d01684ab.json",
+  "inputFramework": "macos-ime",
+  "engine": "apple-pinyin",
+  "displayServer": "macos",
+  "note": "Native macOS pinyin: `ce shi` typed, then backspaced away one frame at a time until the session closes with nothing committed. The abandoned preedit must write nothing to the PTY. The recording continues with a literal `ordinary` typed as bare keydowns — the recorder's own negative control — but that tail carries no `input` events, because the build it was captured on produced the byte from the keydown itself. Replaying it would measure the recorder, not the product, so specs cut the trace where the composition closes.",
+  "onData": [
+    {
+      "data": "o"
+    },
+    {
+      "data": "r"
+    },
+    {
+      "data": "d"
+    },
+    {
+      "data": "i"
+    },
+    {
+      "data": "n"
+    },
+    {
+      "data": "a"
+    },
+    {
+      "data": "r"
+    },
+    {
+      "data": "y"
+    },
+    {
+      "data": "\r"
+    }
+  ],
+  "dom": [
+    {
+      "type": "keydown",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "c",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "c",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "c",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "c",
+      "code": "KeyC",
+      "keyCode": 67,
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "e",
+      "code": "KeyE",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce",
+      "value": "c",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ce",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "e",
+      "code": "KeyE",
+      "keyCode": 69,
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce s",
+      "value": "ce",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce s",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "ce s",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "KeyS",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce sh",
+      "value": "ce s",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce sh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "ce sh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "KeyH",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "i",
+      "code": "KeyI",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce shi",
+      "value": "ce sh",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce shi",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "ce shi",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce shi",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    },
+    {
+      "type": "keyup",
+      "key": "i",
+      "code": "KeyI",
+      "keyCode": 73,
+      "isComposing": true,
+      "value": "ce shi",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    },
+    {
+      "type": "keydown",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce shi",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce sh",
+      "value": "ce shi",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce sh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce shi",
+      "selectionStart": 0,
+      "selectionEnd": 6
+    },
+    {
+      "type": "input",
+      "data": "ce sh",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 8,
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce s",
+      "value": "ce sh",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce s",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce sh",
+      "selectionStart": 0,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "ce s",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 8,
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ce",
+      "value": "ce s",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "ce",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce s",
+      "selectionStart": 0,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "ce",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 8,
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "c",
+      "value": "ce",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "c",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ce",
+      "selectionStart": 0,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "c",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 8,
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "",
+      "value": "c",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "c",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "deleteContentBackward",
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionend",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Backspace",
+      "code": "Backspace",
+      "keyCode": 8,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "KeyO",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "d",
+      "code": "KeyD",
+      "keyCode": 68,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "KeyD",
+      "keyCode": 68,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "i",
+      "code": "KeyI",
+      "keyCode": 73,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "i",
+      "code": "KeyI",
+      "keyCode": 73,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "KeyN",
+      "keyCode": 78,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "KeyA",
+      "keyCode": 65,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "y",
+      "code": "KeyY",
+      "keyCode": 89,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "y",
+      "code": "KeyY",
+      "keyCode": 89,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/fixtures/windows-native-2set-hangul-dom-trace.json
+++ b/tests/e2e/fixtures/windows-native-2set-hangul-dom-trace.json
@@ -1,0 +1,724 @@
+{
+  "recordedFrom": "windows-ko-fidelity-20260805/records-ko.json",
+  "inputFramework": "windows-ime",
+  "engine": "microsoft-korean",
+  "displayServer": "windows",
+  "note": "Windows 11 Microsoft Korean captured with a SendInput injector that transmits real scan codes, so every `code` is the physical key rather than the empty string the earlier keybd_event harness produced. Three 가 + Enter lines; the second and third are committed with Shift held. Enter arrives twice per line — first as Process/229 which closes the composition, then as the real Enter — which is the ordering that decides whether the syllable precedes the newline. No onData was recorded: the capture ran in a standalone recorder isolated from the app, so the expectation is derived from what the user typed rather than replayed.",
+  "dom": [
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "AltLeft",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㄱ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "가",
+      "value": "ㄱ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㄱ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "가",
+      "value": "가",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "가",
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keypress",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertLineBreak",
+      "isComposing": false,
+      "value": "가",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "inputType": "insertLineBreak",
+      "isComposing": false,
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\nㄱ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\nㄱ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "가\nㄱ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\nㄱ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "가",
+      "value": "가\nㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\nㄱ",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "ShiftLeft",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Shift",
+      "code": "ShiftLeft",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "가",
+      "value": "가\n가",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "가",
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keypress",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertLineBreak",
+      "isComposing": false,
+      "value": "가\n가",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "inputType": "insertLineBreak",
+      "isComposing": false,
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Shift",
+      "code": "ShiftLeft",
+      "keyCode": 16,
+      "isComposing": false,
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄱ",
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가\n",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "ㄱ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가\nㄱ",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "KeyR",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가\nㄱ",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "KeyR",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "가\n가\nㄱ",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가\nㄱ",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "가",
+      "value": "가\n가\nㄱ",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가\nㄱ",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "KeyK",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "KeyK",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "ShiftRight",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "가",
+      "value": "가\n가\n가",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "가",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionend",
+      "data": "가",
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keypress",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "inputType": "insertLineBreak",
+      "isComposing": false,
+      "value": "가\n가\n가",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "inputType": "insertLineBreak",
+      "isComposing": false,
+      "value": "가\n가\n가\n",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "Enter",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "가\n가\n가\n",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "Enter",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "가\n가\n가\n",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    },
+    {
+      "type": "keyup",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": false,
+      "value": "가\n가\n가\n",
+      "selectionStart": 6,
+      "selectionEnd": 6
+    }
+  ]
+}

--- a/tests/e2e/fixtures/windows-wsl-2set-hangul-dom-trace.json
+++ b/tests/e2e/fixtures/windows-wsl-2set-hangul-dom-trace.json
@@ -1,0 +1,2279 @@
+{
+  "recordedFrom": "11919-windows-wsl-current/11919-current-owner.json",
+  "inputFramework": "windows-ime",
+  "engine": "microsoft-korean",
+  "note": "Windows/WSL 2-Set Korean, 11 committed syllables. Only the capture's immediate-phase records are kept: the source recorder logged every event twice, once on dispatch and once as a batched next-frame snapshot, so keeping both would replay each event a second time and manufacture orderings the IME never emitted.",
+  "onData": [
+    {
+      "data": "문",
+      "hex": "ebacb8",
+      "now": 2465839,
+      "wallMs": 1785868361391
+    },
+    {
+      "data": "제",
+      "hex": "eca09c",
+      "now": 2466055.2000000477,
+      "wallMs": 1785868361607
+    },
+    {
+      "data": "\r",
+      "hex": "0d",
+      "now": 2466056.2999999523,
+      "wallMs": 1785868361608
+    },
+    {
+      "data": "모",
+      "hex": "ebaaa8",
+      "now": 2466991,
+      "wallMs": 1785868362543
+    },
+    {
+      "data": "르",
+      "hex": "eba5b4",
+      "now": 2467240.4000000954,
+      "wallMs": 1785868362792
+    },
+    {
+      "data": "겠",
+      "hex": "eab2a0",
+      "now": 2467522.5999999046,
+      "wallMs": 1785868363074
+    },
+    {
+      "data": "네",
+      "hex": "eb84a4",
+      "now": 2467761.5999999046,
+      "wallMs": 1785868363313
+    },
+    {
+      "data": "\r",
+      "hex": "0d",
+      "now": 2467761.7999999523,
+      "wallMs": 1785868363314
+    },
+    {
+      "data": "안",
+      "hex": "ec9588",
+      "now": 2468805.4000000954,
+      "wallMs": 1785868364357
+    },
+    {
+      "data": "녕",
+      "hex": "eb8595",
+      "now": 2469178,
+      "wallMs": 1785868364730
+    },
+    {
+      "data": "하",
+      "hex": "ed9598",
+      "now": 2469555.0999999046,
+      "wallMs": 1785868365107
+    },
+    {
+      "data": "세",
+      "hex": "ec84b8",
+      "now": 2469801.7000000477,
+      "wallMs": 1785868365353
+    },
+    {
+      "data": "요",
+      "hex": "ec9a94",
+      "now": 2469916.4000000954,
+      "wallMs": 1785868365468
+    },
+    {
+      "data": "\r",
+      "hex": "0d",
+      "now": 2469916.7000000477,
+      "wallMs": 1785868365468
+    },
+    {
+      "data": "h",
+      "hex": "68",
+      "now": 2471057,
+      "wallMs": 1785868366609
+    },
+    {
+      "data": "e",
+      "hex": "65",
+      "now": 2471177,
+      "wallMs": 1785868366729
+    },
+    {
+      "data": "l",
+      "hex": "6c",
+      "now": 2471302.2999999523,
+      "wallMs": 1785868366854
+    },
+    {
+      "data": "l",
+      "hex": "6c",
+      "now": 2471427.7000000477,
+      "wallMs": 1785868366979
+    },
+    {
+      "data": "o",
+      "hex": "6f",
+      "now": 2471553.2999999523,
+      "wallMs": 1785868367105
+    },
+    {
+      "data": "\r",
+      "hex": "0d",
+      "now": 2471678.7000000477,
+      "wallMs": 1785868367230
+    }
+  ],
+  "dom": [
+    {
+      "type": "keyup",
+      "key": "HangulMode",
+      "code": "",
+      "keyCode": 21,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅁ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "",
+      "keyCode": 65,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "무",
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "무",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "무",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "n",
+      "code": "",
+      "keyCode": 78,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "문",
+      "value": "무",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "무",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "묹",
+      "value": "문",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "묹",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "묹",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "w",
+      "code": "",
+      "keyCode": 87,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "문",
+      "value": "묹",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "묹",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "문",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "문",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "제",
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "제",
+      "value": "문제",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "제",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "제",
+      "value": "문제",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅁ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅁ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "a",
+      "code": "",
+      "keyCode": 65,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "모",
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅁ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "몰",
+      "value": "모",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "몰",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "몰",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "f",
+      "code": "",
+      "keyCode": 70,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "모",
+      "value": "몰",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "몰",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "모",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "모",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "르",
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "m",
+      "code": "",
+      "keyCode": 77,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "륵",
+      "value": "모르",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "륵",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "륵",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "r",
+      "code": "",
+      "keyCode": 82,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "르",
+      "value": "모륵",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모륵",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "르",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "르",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "게",
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "게",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "게",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "겠",
+      "value": "모르게",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르게",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "T",
+      "code": "",
+      "keyCode": 84,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Shift",
+      "code": "",
+      "keyCode": 16,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "겠",
+      "value": "모르겠",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "겠",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "겠",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄴ",
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "네",
+      "value": "모르겠ㄴ",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠ㄴ",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "네",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "네",
+      "value": "모르겠네",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅇ",
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅇ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "input",
+      "data": "ㅇ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "아",
+      "value": "ㅇ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "아",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "ㅇ",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "아",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "안",
+      "value": "아",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "아",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "안",
+      "value": "안",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 0,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "안",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionend",
+      "data": "안",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㄴ",
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안",
+      "selectionStart": 1,
+      "selectionEnd": 1
+    },
+    {
+      "type": "input",
+      "data": "ㄴ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "s",
+      "code": "",
+      "keyCode": 83,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녀",
+      "value": "안ㄴ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녀",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안ㄴ",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녀",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "u",
+      "code": "",
+      "keyCode": 85,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녕",
+      "value": "안녀",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녀",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "녕",
+      "value": "안녕",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 1,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "녕",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionend",
+      "data": "녕",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "compositionupdate",
+      "data": "ㅎ",
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "beforeinput",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕",
+      "selectionStart": 2,
+      "selectionEnd": 2
+    },
+    {
+      "type": "input",
+      "data": "ㅎ",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "g",
+      "code": "",
+      "keyCode": 71,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "안녕ㅎ",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕ㅎ",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "k",
+      "code": "",
+      "keyCode": 75,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "핫",
+      "value": "안녕하",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "핫",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "핫",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keyup",
+      "key": "t",
+      "code": "",
+      "keyCode": 84,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "하",
+      "value": "안녕핫",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕핫",
+      "selectionStart": 2,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "하",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionend",
+      "data": "하",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "compositionupdate",
+      "data": "세",
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "beforeinput",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하",
+      "selectionStart": 3,
+      "selectionEnd": 3
+    },
+    {
+      "type": "input",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "p",
+      "code": "",
+      "keyCode": 80,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "셍",
+      "value": "안녕하세",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "셍",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "셍",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keyup",
+      "key": "d",
+      "code": "",
+      "keyCode": 68,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "세",
+      "value": "안녕하셍",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하셍",
+      "selectionStart": 3,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "세",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionend",
+      "data": "세",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionstart",
+      "data": "",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "compositionupdate",
+      "data": "요",
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "beforeinput",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세",
+      "selectionStart": 4,
+      "selectionEnd": 4
+    },
+    {
+      "type": "input",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keyup",
+      "key": "y",
+      "code": "",
+      "keyCode": 89,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionupdate",
+      "data": "요",
+      "value": "안녕하세요",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "beforeinput",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 4,
+      "selectionEnd": 5
+    },
+    {
+      "type": "input",
+      "data": "요",
+      "inputType": "insertCompositionText",
+      "isComposing": true,
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "compositionend",
+      "data": "요",
+      "value": "안녕하세요",
+      "selectionStart": 5,
+      "selectionEnd": 5
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Process",
+      "code": "",
+      "keyCode": 229,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "h",
+      "code": "",
+      "keyCode": 72,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "e",
+      "code": "",
+      "keyCode": 69,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "e",
+      "code": "",
+      "keyCode": 69,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "l",
+      "code": "",
+      "keyCode": 76,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "o",
+      "code": "",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "o",
+      "code": "",
+      "keyCode": 79,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keydown",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    },
+    {
+      "type": "keyup",
+      "key": "Enter",
+      "code": "",
+      "keyCode": 13,
+      "isComposing": false,
+      "value": "",
+      "selectionStart": 0,
+      "selectionEnd": 0
+    }
+  ]
+}

--- a/tests/e2e/terminal-cjk-ime-committed-text.spec.ts
+++ b/tests/e2e/terminal-cjk-ime-committed-text.spec.ts
@@ -1,0 +1,317 @@
+/**
+ * Headless end-to-end coverage for Japanese and Chinese terminal input.
+ *
+ * Two shapes are covered, and the second is the one the whole suite used to be blind to:
+ *
+ *  1. Phrase-level composition — a Japanese preedit that grows to several characters and converts
+ *     to kanji, asserted on the overlay's real geometry rather than on the bytes it later emits.
+ *  2. Committed text that arrives with **no composition session at all**. Full-width punctuation
+ *     (`，` `。` `、`) and full-width digits are typed as a single keystroke that the input source
+ *     rewrites; there is no compositionstart/update/end around them. Every IME test in the repo
+ *     was composition-session-shaped, so this shape was invisible to the suite by construction —
+ *     which is how `，` reaching the shell as an ASCII `,` shipped to users.
+ *
+ * The assertion for shape 2 is deliberately "the ASCII byte never appears" rather than "the
+ * substitution was applied": the correct design never manufactures the ASCII byte in the first
+ * place, so pinning its absence stays true under a forwarder rewrite as well as under a
+ * structural one.
+ */
+import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  attachTerminalImeBoundaryEvidence,
+  disposeTerminalImeBoundaryProbe,
+  installTerminalImeBoundaryProbe,
+  readTerminalImeBoundaryTrace
+} from './terminal-ime-boundary-probe'
+import {
+  commitImeText,
+  dispatchImeProcessKey,
+  dispatchImeRewrittenPrintableKey,
+  dispatchImeSubstitutedTextKey,
+  dispatchPlainEnter,
+  setImeComposition,
+  type ImeKeyIdentity
+} from './terminal-ime-cdp-composition'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
+import { expectPreeditHidden, expectPreeditRendered } from './terminal-ime-preedit-overlay-probe'
+
+const MAC_IME_POLICY_USER_AGENT =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/146 Safari/537.36'
+
+/** Frames a Japanese IME shows while typing にほんご and converting it to 日本語. */
+const JAPANESE_FRAMES = ['に', 'にほ', 'にほん', 'にほんご', '日本語'] as const
+
+/**
+ * Substitutions an East Asian input source commits from one keystroke, with no composition session
+ * around them. `ascii` is the character the physical key carries in the Latin layout — the byte the
+ * user must never see — and `glyph` is what the input source actually committed.
+ */
+type SubstitutedKeystroke = ImeKeyIdentity & { glyph: string; ascii: string }
+
+const FULL_WIDTH_PUNCTUATION: readonly SubstitutedKeystroke[] = [
+  { key: ',', code: 'Comma', keyCode: 188, glyph: '，', ascii: ',' },
+  { key: '.', code: 'Period', keyCode: 190, glyph: '。', ascii: '.' },
+  { key: ',', code: 'Comma', keyCode: 188, glyph: '、', ascii: ',' }
+]
+
+const FULL_WIDTH_DIGITS: readonly SubstitutedKeystroke[] = [
+  { key: '1', code: 'Digit1', keyCode: 49, glyph: '１', ascii: '1' },
+  { key: '2', code: 'Digit2', keyCode: 50, glyph: '２', ascii: '2' },
+  { key: '3', code: 'Digit3', keyCode: 51, glyph: '３', ascii: '3' }
+]
+
+const SUBSTITUTION_GROUPS = [
+  { label: 'punctuation', keystrokes: FULL_WIDTH_PUNCTUATION },
+  { label: 'digits', keystrokes: FULL_WIDTH_DIGITS }
+] as const
+
+/**
+ * The two ways a substituted keystroke can reach the renderer. Both are real; only the second one
+ * regressed, and only the second one can regress, which is why running both is the point.
+ */
+const SUBSTITUTION_SHAPES: readonly {
+  name: string
+  slug: string
+  knownBroken: boolean
+  knownBrokenReason: string
+  dispatch: (session: CDPSession, keystroke: SubstitutedKeystroke) => Promise<void>
+}[] = [
+  {
+    // Green, and honest about its limits: xterm's own key handler emits `event.key`, so this shape
+    // survives with or without a forwarder and would have passed throughout the regression. It
+    // guards the frameworks that do rewrite `key`; it is not the regression guard.
+    name: 'the keydown already carries the substituted glyph',
+    slug: 'rewritten-keydown',
+    knownBroken: false,
+    knownBrokenReason: '',
+    dispatch: (session, keystroke) =>
+      dispatchImeRewrittenPrintableKey(session, {
+        key: keystroke.glyph,
+        code: keystroke.code,
+        keyCode: keystroke.keyCode
+      })
+  },
+  {
+    // Red on `main`, by design — this is the acceptance criterion, not a flake.
+    //
+    // The keydown carries the plain Latin `,` and the `，` exists only in the following `input`
+    // event, so anything that produces bytes from the keydown emits the ASCII form and destroys
+    // the real one. Today the bypass that would prevent that is gated on the OS reporting an
+    // input source whose id matches a 23-term allowlist. That read returns null on every
+    // non-macOS host and `com.apple.keylayout.*` on a macOS runner with no CJK source selected,
+    // and the preload API surface is frozen so no spec can stub it — meaning correctness here is
+    // not expressible as a test until the gate goes away.
+    //
+    // Closed by the structural rule in the re-land design: bytes for printable characters come
+    // only from the `input` event, decided on the event's own shape with no input-source read.
+    // When that lands, this test starts passing and Playwright fails the run until the
+    // `test.fail()` marker below is deleted.
+    name: 'the keydown still carries the ASCII layout key',
+    slug: 'substituted-insert-text',
+    knownBroken: true,
+    knownBrokenReason:
+      'the keydown-side bypass is gated on a macOS input-source allowlist, so the ASCII form wins on every host that cannot satisfy it',
+    dispatch: (session, keystroke) =>
+      dispatchImeSubstitutedTextKey(session, keystroke, keystroke.glyph)
+  }
+]
+
+/**
+ * The keydown bypass that owns single-keystroke IME commits only installs when the renderer reports
+ * macOS, and the ASCII downgrade is a macOS-only failure mode: Windows and Linux frameworks claim
+ * the same keystroke as VK_PROCESSKEY, so their version of the defect is a drop rather than a
+ * downgrade. Overriding the UA is how the repo already exercises Windows- and Linux-gated IME
+ * policy from any runner, and it is what lets this run on the Linux CI shards.
+ */
+async function reloadWithMacImePolicy(page: Page): Promise<void> {
+  await page.addInitScript((userAgent) => {
+    Object.defineProperty(navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true
+    })
+  }, MAC_IME_POLICY_USER_AGENT)
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(() => Boolean(window.__store), null, {
+    timeout: 30_000
+  })
+}
+
+type CjkTerminalArena = {
+  page: Page
+  session: CDPSession
+  ptyId: string
+}
+
+async function openTerminalArena(page: Page): Promise<{ ptyId: string; session: CDPSession }> {
+  await waitForSessionReady(page)
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  const ptyId = await waitForActivePanePtyId(page)
+  const session = await page.context().newCDPSession(page)
+  return { ptyId, session }
+}
+
+async function teardownTerminalArena(
+  arena: CjkTerminalArena,
+  testInfo: TestInfo,
+  evidenceName: string,
+  interrupt: boolean
+): Promise<void> {
+  await attachTerminalImeBoundaryEvidence(arena.page, testInfo, evidenceName).catch(() => undefined)
+  await disposeTerminalImeBoundaryProbe(arena.page).catch(() => undefined)
+  await arena.session.detach().catch(() => undefined)
+  if (interrupt) {
+    await sendToTerminal(arena.page, arena.ptyId, '\x03').catch(() => undefined)
+  }
+}
+
+test.describe('Terminal CJK IME committed text', () => {
+  test('shows a growing Japanese phrase preedit and commits the converted kanji', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    const { ptyId, session } = await openTerminalArena(orcaPage)
+    const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }
+    const reader = createTerminalImeByteReader(testRepoPath, 1)
+    let completed = false
+    try {
+      await startTerminalImeByteReader(orcaPage, ptyId, reader)
+      await focusActiveTerminalInput(orcaPage)
+      await installTerminalImeBoundaryProbe(orcaPage)
+
+      await expectPreeditHidden(orcaPage, 'before composing')
+      await dispatchImeProcessKey(session, { key: 'Process', code: 'KeyN' })
+
+      const widthByFrame = new Map<string, number>()
+      for (const frame of JAPANESE_FRAMES) {
+        await setImeComposition(session, frame)
+        const sample = await expectPreeditRendered(orcaPage, frame, `composing ${frame}`)
+        widthByFrame.set(frame, sample.rect.width)
+      }
+      // A phrase-level preedit must widen as it grows. An overlay pinned to one cell renders only
+      // the first character, which is a shape every non-geometric assertion reports as correct.
+      expect(widthByFrame.get('にほんご')!).toBeGreaterThan(widthByFrame.get('に')!)
+      expect(widthByFrame.get('日本語')!).toBeGreaterThan(widthByFrame.get('に')!)
+
+      await commitImeText(session, '日本語')
+      await expectPreeditHidden(orcaPage, 'after committing 日本語')
+      await dispatchPlainEnter(session)
+
+      const received = await waitForTerminalImeBytes(orcaPage, reader)
+      expect(received).toEqual([Buffer.from('日本語\n').toString('hex')])
+      completed = true
+    } finally {
+      await teardownTerminalArena(arena, testInfo, 'japanese-phrase-preedit', !completed)
+      removeTerminalImeByteReader(reader)
+    }
+  })
+
+  for (const shape of SUBSTITUTION_SHAPES) {
+    for (const group of SUBSTITUTION_GROUPS) {
+      test(`sends full-width ${group.label} and never their ASCII form when ${shape.name}${shape.knownBroken ? ' @ime-known-broken' : ''}`, async ({
+        orcaPage,
+        testRepoPath
+      }, testInfo) => {
+        test.fail(shape.knownBroken, shape.knownBrokenReason)
+        await reloadWithMacImePolicy(orcaPage)
+        const { ptyId, session } = await openTerminalArena(orcaPage)
+        const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }
+        const reader = createTerminalImeByteReader(testRepoPath, 1)
+        const expected = group.keystrokes.map((keystroke) => keystroke.glyph).join('')
+        let completed = false
+        try {
+          await startTerminalImeByteReader(orcaPage, ptyId, reader)
+          await focusActiveTerminalInput(orcaPage)
+          await installTerminalImeBoundaryProbe(orcaPage)
+
+          for (const keystroke of group.keystrokes) {
+            await shape.dispatch(session, keystroke)
+            await orcaPage.waitForTimeout(60)
+          }
+          await dispatchPlainEnter(session)
+
+          const sent = (await readTerminalImeBoundaryTrace(orcaPage)).onData.join('')
+          for (const keystroke of group.keystrokes) {
+            expect(
+              sent,
+              `${keystroke.glyph} reached the PTY as ASCII ${keystroke.ascii}`
+            ).not.toContain(keystroke.ascii)
+          }
+          expect(sent).toBe(`${expected}\r`)
+
+          const received = await waitForTerminalImeBytes(orcaPage, reader)
+          expect(received).toEqual([Buffer.from(`${expected}\n`).toString('hex')])
+          completed = true
+        } finally {
+          await teardownTerminalArena(
+            arena,
+            testInfo,
+            `full-width-${group.label}-${shape.slug}`,
+            !completed
+          )
+          removeTerminalImeByteReader(reader)
+        }
+      })
+    }
+  }
+
+  test('forwards Chinese pinyin conversions and their trailing full-width stop together', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await reloadWithMacImePolicy(orcaPage)
+    const { ptyId, session } = await openTerminalArena(orcaPage)
+    const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }
+    const reader = createTerminalImeByteReader(testRepoPath, 1)
+    let completed = false
+    try {
+      await startTerminalImeByteReader(orcaPage, ptyId, reader)
+      await focusActiveTerminalInput(orcaPage)
+      await installTerminalImeBoundaryProbe(orcaPage)
+
+      await dispatchImeProcessKey(session, { key: 'Process', code: 'KeyN' })
+      for (const frame of ['n', 'ni', 'niha', 'nihao', '你好']) {
+        await setImeComposition(session, frame)
+        await expectPreeditRendered(orcaPage, frame, `composing ${frame}`)
+      }
+      await commitImeText(session, '你好')
+      await expectPreeditHidden(orcaPage, 'after committing 你好')
+
+      // The distinct risk here is the adjacency, not the substitution: the stop arrives with no
+      // composition session immediately after one closed, so a tracker that still believes a
+      // composition is open swallows it. Dispatched in the glyph-carrying shape so this stays a
+      // test of the transition rather than a second copy of the known-broken case above.
+      await dispatchImeRewrittenPrintableKey(session, {
+        key: '。',
+        code: 'Period',
+        keyCode: 190
+      })
+      await orcaPage.waitForTimeout(60)
+      await dispatchPlainEnter(session)
+
+      const trace = await readTerminalImeBoundaryTrace(orcaPage)
+      expect(trace.onData.join('')).toBe('你好。\r')
+
+      const received = await waitForTerminalImeBytes(orcaPage, reader)
+      expect(received).toEqual([Buffer.from('你好。\n').toString('hex')])
+      completed = true
+    } finally {
+      await teardownTerminalArena(arena, testInfo, 'pinyin-with-full-width-stop', !completed)
+      removeTerminalImeByteReader(reader)
+    }
+  })
+})

--- a/tests/e2e/terminal-cjk-ime-committed-text.spec.ts
+++ b/tests/e2e/terminal-cjk-ime-committed-text.spec.ts
@@ -1,36 +1,29 @@
 /**
  * Headless end-to-end coverage for Japanese and Chinese terminal input.
  *
- * Two shapes are covered, and the second is the one the whole suite used to be blind to:
+ * Three shapes are covered, and the second is the one the whole suite used to be blind to:
  *
  *  1. Phrase-level composition — a Japanese preedit that grows to several characters and converts
- *     to kanji, asserted on the overlay's real geometry rather than on the bytes it later emits.
+ *     to kanji, and a pinyin preedit that spends most of its life as multi-letter romanisation.
+ *     Both are asserted on the overlay's real geometry rather than on the bytes they later emit.
  *  2. Committed text that arrives with **no composition session at all**. Full-width punctuation
  *     (`，` `。` `、`) and full-width digits are typed as a single keystroke that the input source
  *     rewrites; there is no compositionstart/update/end around them. Every IME test in the repo
  *     was composition-session-shaped, so this shape was invisible to the suite by construction —
- *     which is how `，` reaching the shell as an ASCII `,` shipped to users.
+ *     which is how `，` reaching the shell as an ASCII `,` shipped to users. This is the macOS
+ *     shape, and the tests for it pin the macOS ownership policy.
+ *  3. The same full-width punctuation arriving **inside** a composition session, which is how the
+ *     Windows and Linux frameworks deliver it. Same user-facing guarantee, different ordering.
  *
- * The assertion for shape 2 is deliberately "the ASCII byte never appears" rather than "the
+ * The assertion for shapes 2 and 3 is deliberately "the ASCII byte never appears" rather than "the
  * substitution was applied": the correct design never manufactures the ASCII byte in the first
  * place, so pinning its absence stays true under a forwarder rewrite as well as under a
  * structural one.
  */
-import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
+import type { CDPSession } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
-import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
-import {
-  focusActiveTerminalInput,
-  sendToTerminal,
-  waitForActivePanePtyId,
-  waitForActiveTerminalManager
-} from './helpers/terminal'
-import {
-  attachTerminalImeBoundaryEvidence,
-  disposeTerminalImeBoundaryProbe,
-  installTerminalImeBoundaryProbe,
-  readTerminalImeBoundaryTrace
-} from './terminal-ime-boundary-probe'
+import { closeTerminalImePaneArena, openTerminalImePaneArena } from './terminal-ime-pane-arena'
+import { readTerminalImeBoundaryTrace } from './terminal-ime-boundary-probe'
 import {
   commitImeText,
   dispatchImeProcessKey,
@@ -47,9 +40,7 @@ import {
   waitForTerminalImeBytes
 } from './terminal-ime-byte-reader'
 import { expectPreeditHidden, expectPreeditRendered } from './terminal-ime-preedit-overlay-probe'
-
-const MAC_IME_POLICY_USER_AGENT =
-  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/146 Safari/537.36'
+import { applyImePlatformPolicy, type ImePlatformPolicy } from './terminal-ime-platform-policy'
 
 /** Frames a Japanese IME shows while typing にほんご and converting it to 日本語. */
 const JAPANESE_FRAMES = ['に', 'にほ', 'にほん', 'にほんご', '日本語'] as const
@@ -124,75 +115,35 @@ const SUBSTITUTION_SHAPES: readonly {
 ]
 
 /**
- * The keydown bypass that owns single-keystroke IME commits only installs when the renderer reports
- * macOS, and the ASCII downgrade is a macOS-only failure mode: Windows and Linux frameworks claim
- * the same keystroke as VK_PROCESSKEY, so their version of the defect is a drop rather than a
- * downgrade. Overriding the UA is how the repo already exercises Windows- and Linux-gated IME
- * policy from any runner, and it is what lets this run on the Linux CI shards.
+ * The two substitution shapes above are macOS-only, and deliberately so: the keydown bypass that
+ * owns single-keystroke IME commits installs only when the renderer reports macOS, because only
+ * the macOS text system delivers a substituted glyph with the plain layout key still on the
+ * keydown. Windows and Linux frameworks claim the same keystroke as VK_PROCESSKEY and route the
+ * glyph through a composition session instead, which the separate composition-session test below
+ * covers. Running the macOS shapes under a Linux policy would assert a sequence no Linux input
+ * framework produces.
  */
-async function reloadWithMacImePolicy(page: Page): Promise<void> {
-  await page.addInitScript((userAgent) => {
-    Object.defineProperty(navigator, 'userAgent', {
-      get: () => userAgent,
-      configurable: true
-    })
-  }, MAC_IME_POLICY_USER_AGENT)
-  await page.reload({ waitUntil: 'domcontentloaded' })
-  await page.waitForFunction(() => Boolean(window.__store), null, {
-    timeout: 30_000
-  })
-}
-
-type CjkTerminalArena = {
-  page: Page
-  session: CDPSession
-  ptyId: string
-}
-
-async function openTerminalArena(page: Page): Promise<{ ptyId: string; session: CDPSession }> {
-  await waitForSessionReady(page)
-  await waitForActiveWorktree(page)
-  await ensureTerminalVisible(page)
-  await waitForActiveTerminalManager(page, 30_000)
-  const ptyId = await waitForActivePanePtyId(page)
-  const session = await page.context().newCDPSession(page)
-  return { ptyId, session }
-}
-
-async function teardownTerminalArena(
-  arena: CjkTerminalArena,
-  testInfo: TestInfo,
-  evidenceName: string,
-  interrupt: boolean
-): Promise<void> {
-  await attachTerminalImeBoundaryEvidence(arena.page, testInfo, evidenceName).catch(() => undefined)
-  await disposeTerminalImeBoundaryProbe(arena.page).catch(() => undefined)
-  await arena.session.detach().catch(() => undefined)
-  if (interrupt) {
-    await sendToTerminal(arena.page, arena.ptyId, '\x03').catch(() => undefined)
-  }
-}
+const FULL_WIDTH_SESSION_PUNCTUATION = [
+  { key: ',', code: 'Comma', keyCode: 188, glyph: '，', ascii: ',' },
+  { key: '.', code: 'Period', keyCode: 190, glyph: '。', ascii: '.' }
+] as const
 
 test.describe('Terminal CJK IME committed text', () => {
   test('shows a growing Japanese phrase preedit and commits the converted kanji', async ({
     orcaPage,
     testRepoPath
   }, testInfo) => {
-    const { ptyId, session } = await openTerminalArena(orcaPage)
-    const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }
+    const arena = await openTerminalImePaneArena(orcaPage)
     const reader = createTerminalImeByteReader(testRepoPath, 1)
     let completed = false
     try {
-      await startTerminalImeByteReader(orcaPage, ptyId, reader)
-      await focusActiveTerminalInput(orcaPage)
-      await installTerminalImeBoundaryProbe(orcaPage)
-
+      await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
       await expectPreeditHidden(orcaPage, 'before composing')
-      await dispatchImeProcessKey(session, { key: 'Process', code: 'KeyN' })
+      await dispatchImeProcessKey(arena.session, { key: 'Process', code: 'KeyN' })
 
       const widthByFrame = new Map<string, number>()
       for (const frame of JAPANESE_FRAMES) {
-        await setImeComposition(session, frame)
+        await setImeComposition(arena.session, frame)
         const sample = await expectPreeditRendered(orcaPage, frame, `composing ${frame}`)
         widthByFrame.set(frame, sample.rect.width)
       }
@@ -201,15 +152,15 @@ test.describe('Terminal CJK IME committed text', () => {
       expect(widthByFrame.get('にほんご')!).toBeGreaterThan(widthByFrame.get('に')!)
       expect(widthByFrame.get('日本語')!).toBeGreaterThan(widthByFrame.get('に')!)
 
-      await commitImeText(session, '日本語')
+      await commitImeText(arena.session, '日本語')
       await expectPreeditHidden(orcaPage, 'after committing 日本語')
-      await dispatchPlainEnter(session)
+      await dispatchPlainEnter(arena.session)
 
       const received = await waitForTerminalImeBytes(orcaPage, reader)
       expect(received).toEqual([Buffer.from('日本語\n').toString('hex')])
       completed = true
     } finally {
-      await teardownTerminalArena(arena, testInfo, 'japanese-phrase-preedit', !completed)
+      await closeTerminalImePaneArena(arena, testInfo, 'japanese-phrase-preedit', !completed)
       removeTerminalImeByteReader(reader)
     }
   })
@@ -220,22 +171,18 @@ test.describe('Terminal CJK IME committed text', () => {
         orcaPage,
         testRepoPath
       }, testInfo) => {
-        await reloadWithMacImePolicy(orcaPage)
-        const { ptyId, session } = await openTerminalArena(orcaPage)
-        const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }
+        await applyImePlatformPolicy(orcaPage, 'mac')
+        const arena = await openTerminalImePaneArena(orcaPage)
         const reader = createTerminalImeByteReader(testRepoPath, 1)
         const expected = group.keystrokes.map((keystroke) => keystroke.glyph).join('')
         let completed = false
         try {
-          await startTerminalImeByteReader(orcaPage, ptyId, reader)
-          await focusActiveTerminalInput(orcaPage)
-          await installTerminalImeBoundaryProbe(orcaPage)
-
+          await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
           for (const keystroke of group.keystrokes) {
-            await shape.dispatch(session, keystroke)
+            await shape.dispatch(arena.session, keystroke)
             await orcaPage.waitForTimeout(60)
           }
-          await dispatchPlainEnter(session)
+          await dispatchPlainEnter(arena.session)
 
           const sent = (await readTerminalImeBoundaryTrace(orcaPage)).onData.join('')
           for (const keystroke of group.keystrokes) {
@@ -250,7 +197,7 @@ test.describe('Terminal CJK IME committed text', () => {
           expect(received).toEqual([Buffer.from(`${expected}\n`).toString('hex')])
           completed = true
         } finally {
-          await teardownTerminalArena(
+          await closeTerminalImePaneArena(
             arena,
             testInfo,
             `full-width-${group.label}-${shape.slug}`,
@@ -266,35 +213,39 @@ test.describe('Terminal CJK IME committed text', () => {
     orcaPage,
     testRepoPath
   }, testInfo) => {
-    await reloadWithMacImePolicy(orcaPage)
-    const { ptyId, session } = await openTerminalArena(orcaPage)
-    const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }
+    await applyImePlatformPolicy(orcaPage, 'mac')
+    const arena = await openTerminalImePaneArena(orcaPage)
     const reader = createTerminalImeByteReader(testRepoPath, 1)
     let completed = false
     try {
-      await startTerminalImeByteReader(orcaPage, ptyId, reader)
-      await focusActiveTerminalInput(orcaPage)
-      await installTerminalImeBoundaryProbe(orcaPage)
-
-      await dispatchImeProcessKey(session, { key: 'Process', code: 'KeyN' })
+      await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
+      await dispatchImeProcessKey(arena.session, { key: 'Process', code: 'KeyN' })
+      const widthByFrame = new Map<string, number>()
       for (const frame of ['n', 'ni', 'niha', 'nihao', '你好']) {
-        await setImeComposition(session, frame)
-        await expectPreeditRendered(orcaPage, frame, `composing ${frame}`)
+        await setImeComposition(arena.session, frame)
+        const sample = await expectPreeditRendered(orcaPage, frame, `composing ${frame}`)
+        widthByFrame.set(frame, sample.rect.width)
       }
-      await commitImeText(session, '你好')
+      // Pinyin spends most of its life as a multi-letter romanisation before any Chinese appears,
+      // so an overlay pinned to a single cell shows the user only the first letter of what they
+      // typed. Width is the only property that catches that; text content looks correct.
+      expect(widthByFrame.get('nihao')!).toBeGreaterThan(widthByFrame.get('n')!)
+      expect(widthByFrame.get('你好')!).toBeGreaterThan(widthByFrame.get('n')!)
+
+      await commitImeText(arena.session, '你好')
       await expectPreeditHidden(orcaPage, 'after committing 你好')
 
       // The distinct risk here is the adjacency, not the substitution: the stop arrives with no
       // composition session immediately after one closed, so a tracker that still believes a
       // composition is open swallows it. Dispatched in the glyph-carrying shape so this stays a
       // test of the transition rather than a second copy of the known-broken case above.
-      await dispatchImeRewrittenPrintableKey(session, {
+      await dispatchImeRewrittenPrintableKey(arena.session, {
         key: '。',
         code: 'Period',
         keyCode: 190
       })
       await orcaPage.waitForTimeout(60)
-      await dispatchPlainEnter(session)
+      await dispatchPlainEnter(arena.session)
 
       const trace = await readTerminalImeBoundaryTrace(orcaPage)
       expect(trace.onData.join('')).toBe('你好。\r')
@@ -303,8 +254,59 @@ test.describe('Terminal CJK IME committed text', () => {
       expect(received).toEqual([Buffer.from('你好。\n').toString('hex')])
       completed = true
     } finally {
-      await teardownTerminalArena(arena, testInfo, 'pinyin-with-full-width-stop', !completed)
+      await closeTerminalImePaneArena(arena, testInfo, 'pinyin-with-full-width-stop', !completed)
       removeTerminalImeByteReader(reader)
     }
   })
+
+  for (const policy of ['windows', 'linux'] as const satisfies readonly ImePlatformPolicy[]) {
+    test(`sends full-width punctuation committed through a composition session on ${policy}`, async ({
+      orcaPage,
+      testRepoPath
+    }, testInfo) => {
+      // SYNTHESISED, and the reason is worth stating: the recorded corpus contains no Windows or
+      // Linux capture of full-width punctuation, only of Hangul and pinyin. What is not synthesised
+      // is the shape — on these platforms the framework claims the punctuation key as
+      // VK_PROCESSKEY and routes the substituted glyph through a real composition arena.session, which is
+      // what `Input.imeSetComposition` opens, rather than through the macOS insertText path the
+      // tests above cover. The ASCII form is asserted absent rather than the substitution asserted
+      // present, so this stays true of any design that never manufactures the ASCII byte.
+      await applyImePlatformPolicy(orcaPage, policy)
+      const arena = await openTerminalImePaneArena(orcaPage)
+      const reader = createTerminalImeByteReader(testRepoPath, 1)
+      const expected = FULL_WIDTH_SESSION_PUNCTUATION.map((entry) => entry.glyph).join('')
+      let completed = false
+      try {
+        await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
+        for (const entry of FULL_WIDTH_SESSION_PUNCTUATION) {
+          await dispatchImeProcessKey(arena.session, { key: 'Process', code: entry.code })
+          await setImeComposition(arena.session, entry.glyph)
+          await expectPreeditRendered(orcaPage, entry.glyph, `composing ${entry.glyph}`)
+          await commitImeText(arena.session, entry.glyph)
+          await expectPreeditHidden(orcaPage, `after committing ${entry.glyph}`)
+        }
+        await dispatchPlainEnter(arena.session)
+
+        const sent = (await readTerminalImeBoundaryTrace(orcaPage)).onData.join('')
+        for (const entry of FULL_WIDTH_SESSION_PUNCTUATION) {
+          expect(sent, `${entry.glyph} reached the PTY as ASCII ${entry.ascii}`).not.toContain(
+            entry.ascii
+          )
+        }
+        expect(sent).toBe(`${expected}\r`)
+
+        const received = await waitForTerminalImeBytes(orcaPage, reader)
+        expect(received).toEqual([Buffer.from(`${expected}\n`).toString('hex')])
+        completed = true
+      } finally {
+        await closeTerminalImePaneArena(
+          arena,
+          testInfo,
+          `full-width-punctuation-session-${policy}`,
+          !completed
+        )
+        removeTerminalImeByteReader(reader)
+      }
+    })
+  }
 })

--- a/tests/e2e/terminal-cjk-ime-committed-text.spec.ts
+++ b/tests/e2e/terminal-cjk-ime-committed-text.spec.ts
@@ -85,8 +85,6 @@ const SUBSTITUTION_GROUPS = [
 const SUBSTITUTION_SHAPES: readonly {
   name: string
   slug: string
-  knownBroken: boolean
-  knownBrokenReason: string
   dispatch: (session: CDPSession, keystroke: SubstitutedKeystroke) => Promise<void>
 }[] = [
   {
@@ -95,8 +93,6 @@ const SUBSTITUTION_SHAPES: readonly {
     // guards the frameworks that do rewrite `key`; it is not the regression guard.
     name: 'the keydown already carries the substituted glyph',
     slug: 'rewritten-keydown',
-    knownBroken: false,
-    knownBrokenReason: '',
     dispatch: (session, keystroke) =>
       dispatchImeRewrittenPrintableKey(session, {
         key: keystroke.glyph,
@@ -105,7 +101,7 @@ const SUBSTITUTION_SHAPES: readonly {
       })
   },
   {
-    // Red on `main`, by design — this is the acceptance criterion, not a flake.
+    // The regression guard. Red on `main`, green from the structural-forwarder layer down.
     //
     // The keydown carries the plain Latin `,` and the `，` exists only in the following `input`
     // event, so anything that produces bytes from the keydown emits the ASCII form and destroys
@@ -115,15 +111,13 @@ const SUBSTITUTION_SHAPES: readonly {
     // and the preload API surface is frozen so no spec can stub it — meaning correctness here is
     // not expressible as a test until the gate goes away.
     //
-    // Closed by the structural rule in the re-land design: bytes for printable characters come
-    // only from the `input` event, decided on the event's own shape with no input-source read.
-    // When that lands, this test starts passing and Playwright fails the run until the
-    // `test.fail()` marker below is deleted.
+    // Closed by the structural rule one layer below: bytes for printable characters come only from
+    // the `input` event, decided on the event's own shape with no input-source read. Verified on
+    // real macOS hardware — with an Apple pinyin source selected, the pty receives ef bc 8c e3 80 82
+    // (，。) where main sends ASCII. Note main can pass this by luck: an input source whose id
+    // happens to contain an allowlist term, such as Sogou's, satisfies the old gate.
     name: 'the keydown still carries the ASCII layout key',
     slug: 'substituted-insert-text',
-    knownBroken: true,
-    knownBrokenReason:
-      'the keydown-side bypass is gated on a macOS input-source allowlist, so the ASCII form wins on every host that cannot satisfy it',
     dispatch: (session, keystroke) =>
       dispatchImeSubstitutedTextKey(session, keystroke, keystroke.glyph)
   }
@@ -222,11 +216,10 @@ test.describe('Terminal CJK IME committed text', () => {
 
   for (const shape of SUBSTITUTION_SHAPES) {
     for (const group of SUBSTITUTION_GROUPS) {
-      test(`sends full-width ${group.label} and never their ASCII form when ${shape.name}${shape.knownBroken ? ' @ime-known-broken' : ''}`, async ({
+      test(`sends full-width ${group.label} and never their ASCII form when ${shape.name}`, async ({
         orcaPage,
         testRepoPath
       }, testInfo) => {
-        test.fail(shape.knownBroken, shape.knownBrokenReason)
         await reloadWithMacImePolicy(orcaPage)
         const { ptyId, session } = await openTerminalArena(orcaPage)
         const arena: CjkTerminalArena = { page: orcaPage, session, ptyId }

--- a/tests/e2e/terminal-ime-cdp-composition.ts
+++ b/tests/e2e/terminal-ime-cdp-composition.ts
@@ -1,0 +1,176 @@
+import type { CDPSession, Page } from '@stablyai/playwright-test'
+
+/**
+ * Drives real Chromium composition through CDP.
+ *
+ * `Input.imeSetComposition` puts the renderer into a genuine composition session — the same one a
+ * native IME would open — so these specs need no system input source, no accessibility grant and
+ * no visible window. That is what lets the geometry assertions this module feeds run headless in
+ * CI instead of behind a `@headful` + macOS-only gate.
+ */
+export type ImeKeyIdentity = {
+  key: string
+  code: string
+  keyCode: number
+}
+
+export async function setImeComposition(session: CDPSession, text: string): Promise<void> {
+  const length = Array.from(text).length
+  await session.send('Input.imeSetComposition', {
+    text,
+    selectionStart: length,
+    selectionEnd: length
+  })
+}
+
+export async function commitImeText(session: CDPSession, text: string): Promise<void> {
+  await session.send('Input.insertText', { text })
+}
+
+/** IME preedit keystrokes reach the renderer as VK_PROCESSKEY (229) with no text payload. */
+export async function dispatchImeProcessKey(
+  session: CDPSession,
+  identity: Pick<ImeKeyIdentity, 'key' | 'code'>
+): Promise<void> {
+  for (const type of ['rawKeyDown', 'keyUp'] as const) {
+    await session.send('Input.dispatchKeyEvent', {
+      type,
+      key: identity.key,
+      code: identity.code,
+      windowsVirtualKeyCode: 229,
+      nativeVirtualKeyCode: 229,
+      text: '',
+      unmodifiedText: ''
+    })
+  }
+}
+
+/**
+ * A printable keydown whose `key` the IME has already rewritten to the glyph it will commit —
+ * the shape a CJK input source produces for punctuation and full-width digits, which arrive with
+ * no composition session at all.
+ */
+export async function dispatchImeRewrittenPrintableKey(
+  session: CDPSession,
+  identity: ImeKeyIdentity
+): Promise<void> {
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyDown',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode,
+    text: identity.key,
+    unmodifiedText: identity.key
+  })
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode
+  })
+}
+
+/**
+ * A printable keydown that still carries the **ASCII layout key**, followed by the substituted
+ * glyph arriving through the text system.
+ *
+ * This is the macOS shape for full-width punctuation and digits: the input source rewrites the
+ * character inside `insertText:`, not on the keydown, so the keydown Chromium delivers is the
+ * plain `,` from the physical layout and the `，` only ever appears in the `input` event. Anything
+ * that produces terminal bytes from the keydown emits the ASCII form and destroys the real one.
+ */
+export async function dispatchImeSubstitutedTextKey(
+  session: CDPSession,
+  identity: ImeKeyIdentity,
+  committedText: string
+): Promise<void> {
+  // rawKeyDown carries no `text`, so Chromium generates no character of its own and the only
+  // committed text is the one the input source supplies below.
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'rawKeyDown',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode,
+    text: '',
+    unmodifiedText: ''
+  })
+  await session.send('Input.insertText', { text: committedText })
+  await session.send('Input.dispatchKeyEvent', {
+    type: 'keyUp',
+    key: identity.key,
+    code: identity.code,
+    windowsVirtualKeyCode: identity.keyCode,
+    nativeVirtualKeyCode: identity.keyCode
+  })
+}
+
+export async function dispatchPlainEnter(session: CDPSession): Promise<void> {
+  for (const type of ['rawKeyDown', 'keyUp'] as const) {
+    await session.send('Input.dispatchKeyEvent', {
+      type,
+      key: 'Enter',
+      code: 'Enter',
+      windowsVirtualKeyCode: 13,
+      nativeVirtualKeyCode: 13
+    })
+  }
+}
+
+/**
+ * Composes one 2-Set Hangul syllable through its recorded jamo frames.
+ *
+ * `pauseMs = 0` drives the frames back to back with no settle time, which is how a fast typist's
+ * key repeat reaches the renderer.
+ */
+export async function composeHangulSyllable(
+  session: CDPSession,
+  page: Page,
+  frames: readonly { jamoKey: ImeKeyIdentity; preedit: string }[],
+  pauseMs = 60
+): Promise<void> {
+  for (const frame of frames) {
+    await dispatchImeProcessKey(session, frame.jamoKey)
+    await setImeComposition(session, frame.preedit)
+    if (pauseMs > 0) {
+      await page.waitForTimeout(pauseMs)
+    }
+  }
+}
+
+/**
+ * Emits a bare `compositionupdate` with no `compositionstart` ahead of it.
+ *
+ * SYNTHESISED, not replayed, and the reason is worth stating: the recorded Windows/WSL Hangul
+ * capture in `fixtures/windows-wsl-2set-hangul-dom-trace.json` does **not** contain this ordering
+ * — every one of its 37 composition updates sits inside an open start/end pair. The shape is
+ * nevertheless reachable by construction, because xterm adds `.active` to the overlay only in its
+ * `compositionstart` handler and its `compositionupdate` handler writes `textContent` without
+ * ever re-adding it. CDP cannot produce the ordering either: `Input.imeSetComposition` always
+ * opens a session first. So this is dispatched directly.
+ */
+export async function dispatchResumedCompositionUpdate(page: Page, data: string): Promise<void> {
+  await page.evaluate((preedit: string) => {
+    const textarea = document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea:focus')
+    if (!textarea) {
+      throw new Error('xterm helper textarea is not focused')
+    }
+    textarea.dispatchEvent(
+      new CompositionEvent('compositionupdate', {
+        bubbles: true,
+        data: preedit
+      })
+    )
+    textarea.dispatchEvent(
+      new InputEvent('input', {
+        bubbles: true,
+        composed: true,
+        data: preedit,
+        inputType: 'insertCompositionText',
+        isComposing: true
+      })
+    )
+  }, data)
+}

--- a/tests/e2e/terminal-ime-linux-input-frameworks.spec.ts
+++ b/tests/e2e/terminal-ime-linux-input-frameworks.spec.ts
@@ -1,0 +1,149 @@
+/**
+ * Headless end-to-end coverage for the Linux terminal IME shapes, replayed from native captures.
+ *
+ * The Linux failure mode is not the macOS one. macOS downgrades a substituted glyph to its ASCII
+ * layout character; Linux input frameworks claim the keystroke outright, so what breaks there is a
+ * character that never arrives at all. Three recorded orderings make that concrete, and none of
+ * them is something a hand-authored sequence would have produced:
+ *
+ *  - **IBus/X11** ends its composition with an EMPTY `compositionend`, then delivers the syllable
+ *    as a separate non-composing `input` with `inputType: 'insertText'`. Reading the commit off
+ *    `compositionend.data` — the obvious implementation, and the one the recorded Windows capture
+ *    rewards — drops every syllable on this framework.
+ *  - **fcitx5/Wayland** emits no keydown at all for a composing key, not even `keyCode 229`, and
+ *    labels the literal `a`/`b`/`c` keydowns with physically wrong `code` values. Any ownership
+ *    rule reading 229 or `code` is wrong here; 229 is a positive marker only.
+ *  - **Numeric pinyin candidates** (both frameworks) must not reach the shell, while an ordinary
+ *    digit typed outside a composition must reach it exactly once. Those pull in opposite
+ *    directions, so the negative control is load-bearing rather than decorative.
+ *
+ * Each trace replays against a terminal pinned to the Linux ownership policy, and is asserted on
+ * both sides of the boundary: the preedit's real geometry at every frame the user would see, and
+ * the exact bytes the recorded native run put on the PTY.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
+import { applyImePlatformPolicy, expectImePlatformPolicy } from './terminal-ime-platform-policy'
+import { closeTerminalImePaneArena, openTerminalImePaneArena } from './terminal-ime-pane-arena'
+import {
+  replayRecordedImeDomTrace,
+  type RecordedImeDomTrace
+} from './terminal-ime-recorded-dom-trace-replay'
+
+function loadTrace(fixture: string): RecordedImeDomTrace {
+  return JSON.parse(
+    readFileSync(path.join(__dirname, 'fixtures', fixture), 'utf8')
+  ) as RecordedImeDomTrace
+}
+
+type LinuxTraceCase = {
+  slug: string
+  title: string
+  trace: RecordedImeDomTrace
+  /** Composition frames the user would see. Pinned so a truncated fixture cannot pass vacuously. */
+  visibleUpdates: number
+  /** Frames whose commit rides on `compositionend.data`; zero is the IBus shape, not an error. */
+  commitsCarriedByCompositionEnd: number
+}
+
+const LINUX_TRACE_CASES: readonly LinuxTraceCase[] = [
+  {
+    slug: 'ibus-x11-hangul',
+    title: 'IBus on X11 commits Hangul through a post-compositionend insertText',
+    trace: loadTrace('linux-ibus-x11-hangul-mixed-ascii-dom-trace.json'),
+    visibleUpdates: 30,
+    commitsCarriedByCompositionEnd: 0
+  },
+  {
+    slug: 'fcitx5-wayland-hangul',
+    title: 'fcitx5 on Wayland commits Hangul with no keydown and no 229 marker',
+    trace: loadTrace('linux-fcitx5-wayland-hangul-mixed-ascii-dom-trace.json'),
+    visibleUpdates: 40,
+    commitsCarriedByCompositionEnd: 10
+  },
+  {
+    slug: 'fcitx5-x11-pinyin',
+    title: 'fcitx5 on X11 keeps a numeric pinyin candidate and an ordinary digit apart',
+    trace: loadTrace('linux-fcitx5-x11-pinyin-candidate-digit-dom-trace.json'),
+    visibleUpdates: 30,
+    commitsCarriedByCompositionEnd: 5
+  },
+  {
+    slug: 'ibus-x11-pinyin',
+    title: 'IBus on X11 keeps a numeric pinyin candidate and an ordinary digit apart',
+    trace: loadTrace('linux-ibus-x11-pinyin-candidate-digit-dom-trace.json'),
+    visibleUpdates: 25,
+    commitsCarriedByCompositionEnd: 5
+  }
+]
+
+function recordedOnData(trace: RecordedImeDomTrace): string {
+  return (trace.onData ?? []).map((entry) => entry.data).join('')
+}
+
+test.describe('Terminal Linux IME input frameworks', () => {
+  for (const testCase of LINUX_TRACE_CASES) {
+    test(testCase.title, async ({ orcaPage, testRepoPath }, testInfo) => {
+      await applyImePlatformPolicy(orcaPage, 'linux')
+      await expectImePlatformPolicy(orcaPage, 'linux')
+      const expectedOnData = recordedOnData(testCase.trace)
+      const expectedLines = [...expectedOnData].filter((char) => char === '\r').length
+      const arena = await openTerminalImePaneArena(orcaPage)
+      const reader = createTerminalImeByteReader(testRepoPath, expectedLines)
+      let completed = false
+      try {
+        await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
+
+        const replay = await replayRecordedImeDomTrace(orcaPage, testCase.trace)
+
+        const updates = replay.samples.filter(
+          (sample) => sample.type === 'compositionupdate' && sample.data.length > 0
+        )
+        expect(updates.length, 'the recorded trace carries no composition updates').toBe(
+          testCase.visibleUpdates
+        )
+        const invisible = updates.filter(
+          (sample) => sample.overlay.rect.width === 0 || sample.overlay.rect.height === 0
+        )
+        expect(
+          invisible.map((sample) => ({ index: sample.index, data: sample.data })),
+          'these recorded preedit frames were written into an overlay with no size'
+        ).toEqual([])
+
+        // Pins where each framework hides its commit. The IBus figure is zero, and that zero is
+        // the whole reason this file exists.
+        const endsCarryingText = replay.samples.filter(
+          (sample) => sample.type === 'compositionend' && sample.data.length > 0
+        )
+        expect(
+          endsCarryingText.length,
+          'the framework moved its commit onto a different event than the fixture records'
+        ).toBe(testCase.commitsCarriedByCompositionEnd)
+
+        expect(replay.onData, 'the replayed byte stream diverged from the native capture').toBe(
+          expectedOnData
+        )
+
+        const received = await waitForTerminalImeBytes(orcaPage, reader)
+        expect(received.join('')).toBe(
+          expectedOnData
+            .split('\r')
+            .filter((line) => line.length > 0)
+            .map((line) => Buffer.from(`${line}\n`).toString('hex'))
+            .join('')
+        )
+        completed = true
+      } finally {
+        await closeTerminalImePaneArena(arena, testInfo, `linux-${testCase.slug}`, !completed)
+        removeTerminalImeByteReader(reader)
+      }
+    })
+  }
+})

--- a/tests/e2e/terminal-ime-macos-input-framework.spec.ts
+++ b/tests/e2e/terminal-ime-macos-input-framework.spec.ts
@@ -1,0 +1,154 @@
+/**
+ * Headless end-to-end coverage for the macOS terminal IME shape, replayed from native captures.
+ *
+ * The rest of the macOS coverage in this suite drives Chromium composition through CDP, which is
+ * genuine but hand-ordered. These specs replay what the OS actually emitted, and they carry the one
+ * property the synthetic sequences cannot assert: on macOS a composing keydown arrives with
+ * `keyCode 229` while `key` is still the **single translated character** the input source produced
+ * — `ㅎ`, not `Process`. That is exactly the case the ownership rule has to get right, because it
+ * is indistinguishable by length from an ordinary printable key, and it is why `key` is read for
+ * length and never for identity.
+ *
+ * Two guarantees are covered:
+ *
+ *  1. A committed session reaches the PTY intact, including a syllable boundary where one
+ *     composition closes and the next opens with no keydown between them.
+ *  2. An **abandoned** preedit writes nothing at all. This is the third failure mode, alongside the
+ *     macOS downgrade and the Windows/Linux drop: text the user backspaced away leaking to the
+ *     shell. Two Chinese input methods are covered because they cancel differently.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
+import { applyImePlatformPolicy, expectImePlatformPolicy } from './terminal-ime-platform-policy'
+import { closeTerminalImePaneArena, openTerminalImePaneArena } from './terminal-ime-pane-arena'
+import { samplePreeditOverlay } from './terminal-ime-preedit-overlay-probe'
+import {
+  replayRecordedImeDomTrace,
+  type RecordedImeDomTrace
+} from './terminal-ime-recorded-dom-trace-replay'
+
+function loadTrace(fixture: string): RecordedImeDomTrace {
+  return JSON.parse(
+    readFileSync(path.join(__dirname, 'fixtures', fixture), 'utf8')
+  ) as RecordedImeDomTrace
+}
+
+const HANGUL_TRACE = loadTrace('macos-2set-hangul-dom-trace.json')
+
+/**
+ * Both cancellation captures continue past the closed composition with a literal `ordinary` typed
+ * as bare keydowns — the recorder's own negative control. That tail carries no `input` events,
+ * because the build it was captured on produced the byte from the keydown itself, so replaying it
+ * would measure the recorder rather than the product. Cutting at the `compositionend` keeps every
+ * event the cancellation actually consists of and drops only the part that cannot be replayed
+ * faithfully.
+ */
+function upToCompositionEnd(trace: RecordedImeDomTrace): RecordedImeDomTrace {
+  const end = trace.dom.findIndex((event) => event.type === 'compositionend')
+  return { ...trace, dom: trace.dom.slice(0, end + 1) }
+}
+
+const CANCELLED_PREEDIT_CASES = [
+  {
+    slug: 'pinyin',
+    title: 'a pinyin preedit backspaced away writes nothing to the shell',
+    trace: upToCompositionEnd(loadTrace('macos-pinyin-cancelled-preedit-dom-trace.json')),
+    visibleUpdates: 9
+  },
+  {
+    slug: 'cangjie',
+    title: 'a Cangjie preedit backspaced away writes nothing to the shell',
+    trace: upToCompositionEnd(loadTrace('macos-cangjie-cancelled-preedit-dom-trace.json')),
+    visibleUpdates: 1
+  }
+] as const
+
+test.describe('Terminal macOS IME input framework', () => {
+  test('forwards a recorded 2-Set Korean session as its exact bytes', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await applyImePlatformPolicy(orcaPage, 'mac')
+    await expectImePlatformPolicy(orcaPage, 'mac')
+    const arena = await openTerminalImePaneArena(orcaPage)
+    const reader = createTerminalImeByteReader(testRepoPath, 1)
+    let completed = false
+    try {
+      await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
+
+      const replay = await replayRecordedImeDomTrace(orcaPage, HANGUL_TRACE)
+
+      const updates = replay.samples.filter(
+        (sample) => sample.type === 'compositionupdate' && sample.data.length > 0
+      )
+      expect(updates.length, 'the recorded trace carries no composition updates').toBe(8)
+      expect(
+        updates
+          .filter((sample) => sample.overlay.rect.width === 0 || sample.overlay.rect.height === 0)
+          .map((sample) => ({ index: sample.index, data: sample.data })),
+        'these recorded preedit frames were written into an overlay with no size'
+      ).toEqual([])
+
+      expect(replay.onData, 'the replayed byte stream diverged from the native capture').toBe(
+        (HANGUL_TRACE.onData ?? []).map((entry) => entry.data).join('')
+      )
+      expect(replay.onData).toBe('한글\r')
+
+      const received = await waitForTerminalImeBytes(orcaPage, reader)
+      expect(received).toEqual([Buffer.from('한글\n').toString('hex')])
+      completed = true
+    } finally {
+      await closeTerminalImePaneArena(arena, testInfo, 'macos-2set-hangul', !completed)
+      removeTerminalImeByteReader(reader)
+    }
+  })
+
+  for (const testCase of CANCELLED_PREEDIT_CASES) {
+    test(testCase.title, async ({ orcaPage }, testInfo) => {
+      await applyImePlatformPolicy(orcaPage, 'mac')
+      const arena = await openTerminalImePaneArena(orcaPage)
+      let completed = false
+      try {
+        const replay = await replayRecordedImeDomTrace(orcaPage, testCase.trace)
+
+        const updates = replay.samples.filter(
+          (sample) => sample.type === 'compositionupdate' && sample.data.length > 0
+        )
+        expect(updates.length, 'the recorded trace carries no composition updates').toBe(
+          testCase.visibleUpdates
+        )
+        expect(
+          updates
+            .filter((sample) => sample.overlay.rect.width === 0 || sample.overlay.rect.height === 0)
+            .map((sample) => ({ index: sample.index, data: sample.data })),
+          'these recorded preedit frames were written into an overlay with no size'
+        ).toEqual([])
+
+        // The whole point. Not "the right bytes" — no bytes.
+        expect(
+          replay.onData,
+          'text the user backspaced out of the preedit still reached the shell'
+        ).toBe('')
+
+        const overlay = await samplePreeditOverlay(orcaPage)
+        expect(overlay.active, 'the cancelled preedit is still on screen').toBe(false)
+        expect(overlay.rect.width, 'the cancelled preedit still occupies width').toBe(0)
+        completed = true
+      } finally {
+        await closeTerminalImePaneArena(
+          arena,
+          testInfo,
+          `macos-cancelled-preedit-${testCase.slug}`,
+          !completed
+        )
+      }
+    })
+  }
+})

--- a/tests/e2e/terminal-ime-pane-arena.ts
+++ b/tests/e2e/terminal-ime-pane-arena.ts
@@ -1,0 +1,50 @@
+import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  attachTerminalImeBoundaryEvidence,
+  disposeTerminalImeBoundaryProbe,
+  installTerminalImeBoundaryProbe
+} from './terminal-ime-boundary-probe'
+
+/** A focused terminal pane with a CDP session and the boundary probe already attached. */
+export type TerminalImePaneArena = {
+  page: Page
+  session: CDPSession
+  ptyId: string
+}
+
+export async function openTerminalImePaneArena(page: Page): Promise<TerminalImePaneArena> {
+  await waitForSessionReady(page)
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  const ptyId = await waitForActivePanePtyId(page)
+  const session = await page.context().newCDPSession(page)
+  await focusActiveTerminalInput(page)
+  await installTerminalImeBoundaryProbe(page)
+  return { page, session, ptyId }
+}
+
+/**
+ * `interrupt` sends Ctrl+C only when the test did not reach its end, so a spec that failed
+ * mid-composition cannot leave a byte reader holding the pane for the next test in the worker.
+ */
+export async function closeTerminalImePaneArena(
+  arena: TerminalImePaneArena,
+  testInfo: TestInfo,
+  evidenceName: string,
+  interrupt: boolean
+): Promise<void> {
+  await attachTerminalImeBoundaryEvidence(arena.page, testInfo, evidenceName).catch(() => undefined)
+  await disposeTerminalImeBoundaryProbe(arena.page).catch(() => undefined)
+  await arena.session.detach().catch(() => undefined)
+  if (interrupt) {
+    await sendToTerminal(arena.page, arena.ptyId, '\x03').catch(() => undefined)
+  }
+}

--- a/tests/e2e/terminal-ime-platform-policy.ts
+++ b/tests/e2e/terminal-ime-platform-policy.ts
@@ -1,0 +1,51 @@
+import type { Page } from '@stablyai/playwright-test'
+
+/**
+ * Pins the renderer's IME ownership policy to one platform, from any runner.
+ *
+ * Every platform-dependent IME decision in the terminal reads `navigator.userAgent` and nothing
+ * else — the forwarder that owns printable keydowns installs only when the UA reports macOS, the
+ * candidate-key guards only when it reports desktop Linux, and the standalone `keyCode 229`
+ * keydown reaches xterm on macOS and Linux but not on Windows. Overriding the UA is therefore the
+ * whole platform decision, which is what lets the Windows and Linux shapes run headless on the
+ * Linux CI shards instead of needing three runners.
+ *
+ * What it does NOT simulate is the input framework itself. That comes from the recorded traces
+ * replayed against the pinned policy, because the frameworks disagree on ordering in ways no
+ * hand-authored sequence would have predicted.
+ */
+export type ImePlatformPolicy = 'mac' | 'windows' | 'linux'
+
+const USER_AGENT_BY_POLICY: Record<ImePlatformPolicy, string> = {
+  mac: 'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 Chrome/146 Safari/537.36',
+  windows: 'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 Chrome/146 Safari/537.36',
+  // X11 rather than Wayland in the UA string: Chromium reports the same token for both, so the
+  // Wayland traces run under this policy too.
+  linux: 'Mozilla/5.0 (X11; Linux x86_64) AppleWebKit/537.36 Chrome/146 Safari/537.36'
+}
+
+export async function applyImePlatformPolicy(page: Page, policy: ImePlatformPolicy): Promise<void> {
+  await page.addInitScript((userAgent) => {
+    Object.defineProperty(navigator, 'userAgent', {
+      get: () => userAgent,
+      configurable: true
+    })
+  }, USER_AGENT_BY_POLICY[policy])
+  await page.reload({ waitUntil: 'domcontentloaded' })
+  await page.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })
+}
+
+/** Fails loudly if the override did not take, so a policy-scoped spec cannot pass on the wrong one. */
+export async function expectImePlatformPolicy(
+  page: Page,
+  policy: ImePlatformPolicy
+): Promise<void> {
+  const observed = await page.evaluate(() => ({
+    mac: navigator.userAgent.includes('Mac'),
+    windows: navigator.userAgent.includes('Windows'),
+    linux: navigator.userAgent.includes('Linux') && !/Android|CrOS/.test(navigator.userAgent)
+  }))
+  if (!observed[policy] || (policy !== 'mac' && observed.mac)) {
+    throw new Error(`IME platform policy '${policy}' did not take: ${JSON.stringify(observed)}`)
+  }
+}

--- a/tests/e2e/terminal-ime-preedit-overlay-probe.ts
+++ b/tests/e2e/terminal-ime-preedit-overlay-probe.ts
@@ -1,0 +1,102 @@
+import type { Page } from '@stablyai/playwright-test'
+import { expect } from '@stablyai/playwright-test'
+
+/**
+ * Samples the xterm preedit overlay's real geometry.
+ *
+ * Why geometry and not the `active` class: an overlay forced to
+ * `max-width: 0; overflow: hidden` is invisible on screen, yet keeps its class, its
+ * `textContent`, `display: block` and `checkVisibility() === true`. The bounding rect is the
+ * only property that discriminates, and it is also the only one a DOM emulator cannot produce —
+ * happy-dom reports all-zero rects in every state, so a unit-level arm passes over an overlay
+ * that never renders.
+ */
+export type PreeditOverlaySample = {
+  found: boolean
+  active: boolean
+  text: string
+  rect: { width: number; height: number }
+  checkVisibility: boolean | null
+  display: string
+  visibility: string
+  opacity: string
+  maxWidth: string
+  overflow: string
+}
+
+export function readPreeditOverlay(): PreeditOverlaySample {
+  const textarea =
+    document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea:focus') ??
+    document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
+  const view = textarea?.parentElement?.querySelector<HTMLElement>('.composition-view') ?? null
+  if (!view) {
+    return {
+      found: false,
+      active: false,
+      text: '',
+      rect: { width: 0, height: 0 },
+      checkVisibility: null,
+      display: '',
+      visibility: '',
+      opacity: '',
+      maxWidth: '',
+      overflow: ''
+    }
+  }
+  const style = getComputedStyle(view)
+  const rect = view.getBoundingClientRect()
+  return {
+    found: true,
+    active: view.classList.contains('active'),
+    // The overlay wraps its text in LRM marks; strip them so assertions read as the user sees it.
+    text: (view.textContent ?? '').replaceAll('‎', ''),
+    rect: { width: rect.width, height: rect.height },
+    checkVisibility: typeof view.checkVisibility === 'function' ? view.checkVisibility() : null,
+    display: style.display,
+    visibility: style.visibility,
+    opacity: style.opacity,
+    maxWidth: style.maxWidth,
+    overflow: style.overflow
+  }
+}
+
+export async function samplePreeditOverlay(page: Page): Promise<PreeditOverlaySample> {
+  return page.evaluate(readPreeditOverlay)
+}
+
+export async function expectPreeditRendered(
+  page: Page,
+  expectedText: string,
+  message: string
+): Promise<PreeditOverlaySample> {
+  await expect
+    .poll(async () => (await samplePreeditOverlay(page)).text, { message })
+    .toBe(expectedText)
+  const sample = await samplePreeditOverlay(page)
+  assertPreeditRendered(sample, expectedText, message)
+  return sample
+}
+
+export function assertPreeditRendered(
+  sample: PreeditOverlaySample,
+  expectedText: string,
+  message: string
+): void {
+  expect(sample.found, `${message}: no composition overlay exists`).toBe(true)
+  expect(sample.text, `${message}: overlay text`).toBe(expectedText)
+  expect(sample.active, `${message}: overlay is not marked active`).toBe(true)
+  expect(sample.display, `${message}: overlay is display:none`).not.toBe('none')
+  expect(sample.visibility, `${message}: overlay is not visible`).toBe('visible')
+  expect(sample.checkVisibility, `${message}: overlay fails checkVisibility`).not.toBe(false)
+  // The load-bearing pair. Do not weaken these to a class or visibility check.
+  expect(sample.rect.width, `${message}: overlay has zero width`).toBeGreaterThan(0)
+  expect(sample.rect.height, `${message}: overlay has zero height`).toBeGreaterThan(0)
+  expect(sample.maxWidth, `${message}: overlay is clipped to zero width`).not.toBe('0px')
+}
+
+export async function expectPreeditHidden(page: Page, message: string): Promise<void> {
+  await expect.poll(async () => (await samplePreeditOverlay(page)).active, { message }).toBe(false)
+  const sample = await samplePreeditOverlay(page)
+  expect(sample.rect.width, `${message}: overlay still occupies width`).toBe(0)
+  expect(sample.rect.height, `${message}: overlay still occupies height`).toBe(0)
+}

--- a/tests/e2e/terminal-ime-recorded-dom-trace-replay.ts
+++ b/tests/e2e/terminal-ime-recorded-dom-trace-replay.ts
@@ -29,6 +29,8 @@ export type RecordedImeDomTrace = {
   recordedFrom: string
   inputFramework: string
   engine: string
+  /** Present on the Linux captures, where X11 and Wayland emit different orderings. */
+  displayServer?: string
   note: string
   onData?: { data: string }[]
   dom: RecordedImeDomEvent[]
@@ -70,50 +72,89 @@ async function startRecordedTraceOnDataCapture(page: Page): Promise<void> {
   })
 }
 
-async function dispatchRecordedEvent(page: Page, recorded: RecordedImeDomEvent): Promise<void> {
-  await page.evaluate((event: RecordedImeDomEvent) => {
+async function dispatchRecordedEvents(
+  page: Page,
+  recorded: readonly RecordedImeDomEvent[]
+): Promise<void> {
+  await page.evaluate((events: RecordedImeDomEvent[]) => {
     const textarea = document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea:focus')
     if (!textarea) {
       throw new Error('xterm helper textarea is not focused')
     }
-    if (event.type === 'keydown' || event.type === 'keyup') {
-      const keyboard = new KeyboardEvent(event.type, {
-        key: event.key,
-        code: event.code,
-        isComposing: event.isComposing,
-        bubbles: true,
-        cancelable: true
-      })
-      Object.defineProperty(keyboard, 'keyCode', { value: event.keyCode })
-      textarea.dispatchEvent(keyboard)
-    } else if (event.type === 'input' || event.type === 'beforeinput') {
-      textarea.dispatchEvent(
-        new InputEvent(event.type, {
+    for (const event of events) {
+      // The recorded value/selection is what the recorder observed *during* this event, so it has
+      // to be in place before dispatch. xterm reads `textarea.value` inside its own handlers rather
+      // than off the event, so applying it afterwards hands every handler the previous event's
+      // state.
+      if (event.value !== undefined) {
+        textarea.value = event.value
+      }
+      if (event.selectionStart !== undefined && event.selectionEnd !== undefined) {
+        textarea.setSelectionRange(event.selectionStart, event.selectionEnd)
+      }
+      // keypress is recorded on Windows, where the IME lets Enter through to the textarea's own
+      // default action; replaying it as a CompositionEvent would invent an event no IME ever sent.
+      if (event.type === 'keydown' || event.type === 'keyup' || event.type === 'keypress') {
+        const keyboard = new KeyboardEvent(event.type, {
+          key: event.key,
+          code: event.code,
+          isComposing: event.isComposing,
           bubbles: true,
-          cancelable: event.type === 'beforeinput',
-          composed: true,
-          data: event.data ?? null,
-          inputType: event.inputType ?? '',
-          isComposing: event.isComposing
+          cancelable: true
         })
-      )
-    } else {
-      textarea.dispatchEvent(
-        new CompositionEvent(event.type, {
-          bubbles: true,
-          data: event.data ?? ''
-        })
-      )
+        Object.defineProperty(keyboard, 'keyCode', { value: event.keyCode })
+        textarea.dispatchEvent(keyboard)
+      } else if (event.type === 'input' || event.type === 'beforeinput') {
+        textarea.dispatchEvent(
+          new InputEvent(event.type, {
+            bubbles: true,
+            cancelable: event.type === 'beforeinput',
+            composed: true,
+            data: event.data ?? null,
+            inputType: event.inputType ?? '',
+            isComposing: event.isComposing
+          })
+        )
+      } else {
+        textarea.dispatchEvent(
+          new CompositionEvent(event.type, {
+            bubbles: true,
+            data: event.data ?? ''
+          })
+        )
+      }
     }
-    // The recorded value/selection is the state *after* the event, so applying it here leaves the
-    // textarea holding exactly the state the next recorded event was dispatched against.
-    if (event.value !== undefined) {
-      textarea.value = event.value
+  }, recorded as RecordedImeDomEvent[])
+}
+
+/**
+ * Groups a `compositionend` with the `beforeinput`/`input` events that immediately follow it.
+ *
+ * Chromium dispatches a commit's `compositionend` and the `input` carrying the committed text
+ * inside one task. The replay's per-event round-trip inserts a task boundary the IME never
+ * produced, and xterm arms a deferred finalizer on `compositionend` that reads the textarea when it
+ * runs — so a boundary there lets the finalizer settle the commit against a textarea the committed
+ * text has not reached yet. On IBus, whose `compositionend` is empty and whose text arrives only in
+ * the following `insertText`, that swallowed every syllable and made a working build look broken.
+ *
+ * Only the commit tail is fused. Composition updates keep their own round-trip, which is what lets
+ * xterm's deferred overlay positioning run before each geometry sample.
+ */
+function nextRecordedEventGroup(
+  dom: readonly RecordedImeDomEvent[],
+  start: number
+): RecordedImeDomEvent[] {
+  const group = [dom[start]]
+  if (dom[start].type !== 'compositionend') {
+    return group
+  }
+  for (let index = start + 1; index < dom.length; index += 1) {
+    if (dom[index].type !== 'input' && dom[index].type !== 'beforeinput') {
+      break
     }
-    if (event.selectionStart !== undefined && event.selectionEnd !== undefined) {
-      textarea.setSelectionRange(event.selectionStart, event.selectionEnd)
-    }
-  }, recorded)
+    group.push(dom[index])
+  }
+  return group
 }
 
 export async function replayRecordedImeDomTrace(
@@ -125,8 +166,11 @@ export async function replayRecordedImeDomTrace(
   const samples: ReplayedCompositionSample[] = []
   let compositionOpen = false
 
-  for (const [index, recorded] of trace.dom.entries()) {
-    await dispatchRecordedEvent(page, recorded)
+  for (let index = 0; index < trace.dom.length; ) {
+    const group = nextRecordedEventGroup(trace.dom, index)
+    const recorded = group[0]
+    await dispatchRecordedEvents(page, group)
+    index += group.length
     if (!COMPOSITION_EVENT_TYPES.has(recorded.type)) {
       continue
     }
@@ -134,7 +178,7 @@ export async function replayRecordedImeDomTrace(
       compositionOpen = true
     }
     samples.push({
-      index,
+      index: index - group.length,
       type: recorded.type,
       data: recorded.data ?? '',
       compositionOpen,

--- a/tests/e2e/terminal-ime-recorded-dom-trace-replay.ts
+++ b/tests/e2e/terminal-ime-recorded-dom-trace-replay.ts
@@ -1,0 +1,154 @@
+import type { Page } from '@stablyai/playwright-test'
+import {
+  samplePreeditOverlay,
+  type PreeditOverlaySample
+} from './terminal-ime-preedit-overlay-probe'
+
+/**
+ * Replays a recorded IME DOM trace against the live terminal one event at a time, sampling the
+ * preedit overlay after every composition event.
+ *
+ * Each event costs a CDP round-trip. That is deliberate: it lets xterm's deferred composition
+ * timers and the renderer's layout run between events the way they do under a real IME, so a
+ * per-event geometry sample measures an overlay that has actually been positioned.
+ */
+export type RecordedImeDomEvent = {
+  type: string
+  data?: string
+  inputType?: string
+  key?: string
+  code?: string
+  keyCode?: number
+  isComposing?: boolean
+  value?: string
+  selectionStart?: number
+  selectionEnd?: number
+}
+
+export type RecordedImeDomTrace = {
+  recordedFrom: string
+  inputFramework: string
+  engine: string
+  note: string
+  onData?: { data: string }[]
+  dom: RecordedImeDomEvent[]
+}
+
+export type ReplayedCompositionSample = {
+  index: number
+  type: string
+  data: string
+  compositionOpen: boolean
+  overlay: PreeditOverlaySample
+}
+
+export type RecordedTraceReplay = {
+  samples: ReplayedCompositionSample[]
+  onData: string
+}
+
+const COMPOSITION_EVENT_TYPES = new Set(['compositionstart', 'compositionupdate', 'compositionend'])
+
+async function startRecordedTraceOnDataCapture(page: Page): Promise<void> {
+  await page.evaluate(() => {
+    const target = window as unknown as { __recordedTraceOnData: string[] }
+    target.__recordedTraceOnData = []
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    if (!pane) {
+      throw new Error('No active terminal pane for the recorded trace replay')
+    }
+    pane.terminal.onData((data) => target.__recordedTraceOnData.push(data))
+  })
+}
+
+async function dispatchRecordedEvent(page: Page, recorded: RecordedImeDomEvent): Promise<void> {
+  await page.evaluate((event: RecordedImeDomEvent) => {
+    const textarea = document.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea:focus')
+    if (!textarea) {
+      throw new Error('xterm helper textarea is not focused')
+    }
+    if (event.type === 'keydown' || event.type === 'keyup') {
+      const keyboard = new KeyboardEvent(event.type, {
+        key: event.key,
+        code: event.code,
+        isComposing: event.isComposing,
+        bubbles: true,
+        cancelable: true
+      })
+      Object.defineProperty(keyboard, 'keyCode', { value: event.keyCode })
+      textarea.dispatchEvent(keyboard)
+    } else if (event.type === 'input' || event.type === 'beforeinput') {
+      textarea.dispatchEvent(
+        new InputEvent(event.type, {
+          bubbles: true,
+          cancelable: event.type === 'beforeinput',
+          composed: true,
+          data: event.data ?? null,
+          inputType: event.inputType ?? '',
+          isComposing: event.isComposing
+        })
+      )
+    } else {
+      textarea.dispatchEvent(
+        new CompositionEvent(event.type, {
+          bubbles: true,
+          data: event.data ?? ''
+        })
+      )
+    }
+    // The recorded value/selection is the state *after* the event, so applying it here leaves the
+    // textarea holding exactly the state the next recorded event was dispatched against.
+    if (event.value !== undefined) {
+      textarea.value = event.value
+    }
+    if (event.selectionStart !== undefined && event.selectionEnd !== undefined) {
+      textarea.setSelectionRange(event.selectionStart, event.selectionEnd)
+    }
+  }, recorded)
+}
+
+export async function replayRecordedImeDomTrace(
+  page: Page,
+  trace: RecordedImeDomTrace
+): Promise<RecordedTraceReplay> {
+  await startRecordedTraceOnDataCapture(page)
+
+  const samples: ReplayedCompositionSample[] = []
+  let compositionOpen = false
+
+  for (const [index, recorded] of trace.dom.entries()) {
+    await dispatchRecordedEvent(page, recorded)
+    if (!COMPOSITION_EVENT_TYPES.has(recorded.type)) {
+      continue
+    }
+    if (recorded.type === 'compositionstart') {
+      compositionOpen = true
+    }
+    samples.push({
+      index,
+      type: recorded.type,
+      data: recorded.data ?? '',
+      compositionOpen,
+      overlay: await samplePreeditOverlay(page)
+    })
+    if (recorded.type === 'compositionend') {
+      compositionOpen = false
+    }
+  }
+
+  const onData = await page.evaluate(() =>
+    ((window as unknown as { __recordedTraceOnData?: string[] }).__recordedTraceOnData ?? []).join(
+      ''
+    )
+  )
+  return { samples, onData }
+}

--- a/tests/e2e/terminal-ime-windows-input-framework.spec.ts
+++ b/tests/e2e/terminal-ime-windows-input-framework.spec.ts
@@ -1,0 +1,109 @@
+/**
+ * Headless end-to-end coverage for the Windows terminal IME shape, replayed from native captures.
+ *
+ * Windows is the third ownership path and the only one where a standalone `keyCode 229` keydown is
+ * withheld from xterm entirely — macOS and Linux both pass it through so the composition helper can
+ * schedule its textarea diff. That split lives behind a `navigator.userAgent` check, so until now
+ * the Windows-recorded traces in this suite were replayed under whichever policy the runner
+ * happened to report: macOS locally, Linux on the CI shards. Neither is Windows. These specs pin
+ * the policy explicitly.
+ *
+ * The failure mode being guarded is a **dropped** character, not a downgraded one. The Windows
+ * framework claims the keystroke as `key: 'Process'` / `keyCode: 229` and produces the text only
+ * through the composition session, so anything that swallows the claimed keydown without letting
+ * the commit through loses the syllable outright, with nothing on screen to show for it.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import { expect, test } from './helpers/orca-app'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
+import { applyImePlatformPolicy, expectImePlatformPolicy } from './terminal-ime-platform-policy'
+import { closeTerminalImePaneArena, openTerminalImePaneArena } from './terminal-ime-pane-arena'
+import {
+  replayRecordedImeDomTrace,
+  type RecordedImeDomTrace
+} from './terminal-ime-recorded-dom-trace-replay'
+
+const NATIVE_TRACE = JSON.parse(
+  readFileSync(
+    path.join(__dirname, 'fixtures', 'windows-native-2set-hangul-dom-trace.json'),
+    'utf8'
+  )
+) as RecordedImeDomTrace
+
+test.describe('Terminal Windows IME input framework', () => {
+  test('commits each Hangul syllable ahead of its newline through the Windows 229 path', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    await applyImePlatformPolicy(orcaPage, 'windows')
+    await expectImePlatformPolicy(orcaPage, 'windows')
+    const arena = await openTerminalImePaneArena(orcaPage)
+    const reader = createTerminalImeByteReader(testRepoPath, 3)
+    let completed = false
+    try {
+      await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
+
+      const replay = await replayRecordedImeDomTrace(orcaPage, NATIVE_TRACE)
+
+      const updates = replay.samples.filter(
+        (sample) => sample.type === 'compositionupdate' && sample.data.length > 0
+      )
+      expect(updates.length, 'the recorded trace carries no composition updates').toBe(9)
+      expect(
+        updates
+          .filter((sample) => sample.overlay.rect.width === 0 || sample.overlay.rect.height === 0)
+          .map((sample) => ({ index: sample.index, data: sample.data })),
+        'these recorded preedit frames were written into an overlay with no size'
+      ).toEqual([])
+
+      // Enter reaches the renderer twice per line: first as Process/229, which the framework uses
+      // to close the composition, then as the real Enter. If the two ever swap, the newline
+      // overtakes the syllable and the shell runs an empty line — the ordering the user reported.
+      // The capture ran in a recorder isolated from the app so it carries no byte stream of its
+      // own; `가\r` per line is what the recorded keystrokes mean, not a replayed observation.
+      expect(replay.onData).toBe('가\r가\r가\r')
+
+      const received = await waitForTerminalImeBytes(orcaPage, reader)
+      expect(received).toEqual(Array.from({ length: 3 }, () => Buffer.from('가\n').toString('hex')))
+      completed = true
+    } finally {
+      await closeTerminalImePaneArena(arena, testInfo, 'windows-native-2set-hangul', !completed)
+      removeTerminalImeByteReader(reader)
+    }
+  })
+
+  test('holding Shift across the commit neither drops nor duplicates the syllable', async ({
+    orcaPage
+  }, testInfo) => {
+    // The second and third lines of the capture are committed with Shift physically held, and the
+    // framework interleaves `Process`/`Shift` keydowns while it is. Shift stays eligible for text
+    // ownership by design — shifted punctuation still commits substituted text — so a rule that
+    // treated any modifier as disqualifying would silently lose these two lines while the first
+    // kept working, which is the shape of bug that reads as "it only breaks sometimes".
+    await applyImePlatformPolicy(orcaPage, 'windows')
+    const arena = await openTerminalImePaneArena(orcaPage)
+    let completed = false
+    try {
+      // Cut at a line boundary — the `Process` keydown that opens the second composition — so the
+      // replay still starts from a complete keystroke rather than from the middle of one.
+      const secondLineStart =
+        NATIVE_TRACE.dom.reduce<number[]>(
+          (starts, event, index) =>
+            event.type === 'compositionstart' ? [...starts, index] : starts,
+          []
+        )[1] - 1
+      const shiftedTail = { ...NATIVE_TRACE, dom: NATIVE_TRACE.dom.slice(secondLineStart) }
+      const replay = await replayRecordedImeDomTrace(orcaPage, shiftedTail)
+      expect(replay.onData).toBe('가\r가\r')
+      completed = true
+    } finally {
+      await closeTerminalImePaneArena(arena, testInfo, 'windows-shift-held-commit', !completed)
+    }
+  })
+})

--- a/tests/e2e/terminal-korean-preedit-visibility.spec.ts
+++ b/tests/e2e/terminal-korean-preedit-visibility.spec.ts
@@ -148,16 +148,14 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
     }
   })
 
-  test('keeps a preedit the IME resumes without a compositionstart visible @ime-known-broken', async ({
+  test('keeps a preedit the IME resumes without a compositionstart visible', async ({
     orcaPage
   }, testInfo) => {
     // Red on `main`, by design. xterm adds `.active` to the overlay only in its `compositionstart`
     // handler, so a preedit resumed by a bare `compositionupdate` is written into a hidden element
     // and the user composes blind while the committed bytes still land correctly — which is why no
-    // byte-level assertion ever saw it. Pre-existing and broken in every shipped build; the parked
-    // eight-line fix in xterm's own composition helper closes it, and Playwright will fail the run
-    // until the `test.fail()` marker below is deleted.
-    test.fail(true, 'the resumed preedit is written into an overlay xterm never marks active')
+    // byte-level assertion ever saw it. Pre-existing and broken in every shipped build; closed by
+    // the visibility fix in xterm's own composition helper one layer below this one.
     const { ptyId, session } = await openTerminalArena(orcaPage)
     const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
     let completed = false

--- a/tests/e2e/terminal-korean-preedit-visibility.spec.ts
+++ b/tests/e2e/terminal-korean-preedit-visibility.spec.ts
@@ -1,0 +1,256 @@
+/**
+ * Headless end-to-end coverage for 2-Set Korean terminal input, asserting what the user sees.
+ *
+ * Two IME defects shipped past a suite of ~3000 passing IME assertions. Both were invisible to it
+ * for the same reason: every assertion was about bytes reaching the PTY, and a preedit rendered
+ * into a hidden overlay satisfies all of them while the user composes blind. The real-geometry
+ * coverage that would have caught it existed, but was `@headful`, env-gated and macOS-only, so it
+ * never ran in CI.
+ *
+ * This file closes that gap. Composition is driven through CDP `Input.imeSetComposition`, which
+ * opens a genuine Chromium composition session with no native IME, no accessibility grant and no
+ * system input source — so the geometry assertions run in the normal headless CI project.
+ */
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  commitImeText,
+  composeHangulSyllable,
+  dispatchPlainEnter,
+  dispatchResumedCompositionUpdate,
+  type ImeKeyIdentity
+} from './terminal-ime-cdp-composition'
+import {
+  attachTerminalImeBoundaryEvidence,
+  disposeTerminalImeBoundaryProbe,
+  installTerminalImeBoundaryProbe,
+  readTerminalImeBoundaryTrace
+} from './terminal-ime-boundary-probe'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
+import {
+  expectPreeditHidden,
+  expectPreeditRendered,
+  samplePreeditOverlay
+} from './terminal-ime-preedit-overlay-probe'
+import {
+  replayRecordedImeDomTrace,
+  type RecordedImeDomTrace
+} from './terminal-ime-recorded-dom-trace-replay'
+
+/** 2-Set Korean maps each jamo to a QWERTY position; the IME rewrites `key` to the jamo itself. */
+const JAMO: Record<string, ImeKeyIdentity> = {
+  ㅎ: { key: 'ㅎ', code: 'KeyG', keyCode: 71 },
+  ㅏ: { key: 'ㅏ', code: 'KeyK', keyCode: 75 },
+  ㄴ: { key: 'ㄴ', code: 'KeyS', keyCode: 83 },
+  ㄱ: { key: 'ㄱ', code: 'KeyR', keyCode: 82 },
+  ㅡ: { key: 'ㅡ', code: 'KeyM', keyCode: 77 },
+  ㄹ: { key: 'ㄹ', code: 'KeyF', keyCode: 70 }
+}
+
+/** ㅎ → ㅏ → ㄴ assembles 한; the preedit shows the partially assembled syllable at each step. */
+const HAN_FRAMES = [
+  { jamoKey: JAMO['ㅎ'], preedit: 'ㅎ' },
+  { jamoKey: JAMO['ㅏ'], preedit: '하' },
+  { jamoKey: JAMO['ㄴ'], preedit: '한' }
+] as const
+
+/** ㄱ → ㅡ → ㄹ assembles 글. */
+const GEUL_FRAMES = [
+  { jamoKey: JAMO['ㄱ'], preedit: 'ㄱ' },
+  { jamoKey: JAMO['ㅡ'], preedit: '그' },
+  { jamoKey: JAMO['ㄹ'], preedit: '글' }
+] as const
+
+const RECORDED_TRACE = JSON.parse(
+  readFileSync(path.join(__dirname, 'fixtures', 'windows-wsl-2set-hangul-dom-trace.json'), 'utf8')
+) as RecordedImeDomTrace
+
+type KoreanTerminalArena = {
+  page: Page
+  session: CDPSession
+  ptyId: string
+}
+
+async function openTerminalArena(page: Page): Promise<{ ptyId: string; session: CDPSession }> {
+  await waitForSessionReady(page)
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  const ptyId = await waitForActivePanePtyId(page)
+  const session = await page.context().newCDPSession(page)
+  return { ptyId, session }
+}
+
+async function teardownTerminalArena(
+  arena: KoreanTerminalArena,
+  testInfo: TestInfo,
+  evidenceName: string,
+  interrupt: boolean
+): Promise<void> {
+  await attachTerminalImeBoundaryEvidence(arena.page, testInfo, evidenceName).catch(() => undefined)
+  await disposeTerminalImeBoundaryProbe(arena.page).catch(() => undefined)
+  await arena.session.detach().catch(() => undefined)
+  if (interrupt) {
+    await sendToTerminal(arena.page, arena.ptyId, '\x03').catch(() => undefined)
+  }
+}
+
+test.describe('Terminal 2-Set Korean preedit visibility', () => {
+  test('shows every assembling jamo at non-zero size and commits the syllable ahead of the newline', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    const { ptyId, session } = await openTerminalArena(orcaPage)
+    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    const reader = createTerminalImeByteReader(testRepoPath, 1)
+    let completed = false
+    try {
+      await startTerminalImeByteReader(orcaPage, ptyId, reader)
+      await focusActiveTerminalInput(orcaPage)
+      await installTerminalImeBoundaryProbe(orcaPage)
+
+      await expectPreeditHidden(orcaPage, 'before composing')
+
+      for (const frame of HAN_FRAMES) {
+        await composeHangulSyllable(session, orcaPage, [frame])
+        await expectPreeditRendered(orcaPage, frame.preedit, `composing ${frame.preedit}`)
+      }
+
+      await commitImeText(session, '한')
+      await expectPreeditHidden(orcaPage, 'after committing 한')
+
+      await dispatchPlainEnter(session)
+
+      const received = await waitForTerminalImeBytes(orcaPage, reader)
+      expect(received).toEqual([Buffer.from('한\n').toString('hex')])
+
+      const trace = await readTerminalImeBoundaryTrace(orcaPage)
+      // The ordering the user reported as broken: the syllable must precede the newline.
+      expect(trace.onData.join('')).toBe('한\r')
+      completed = true
+    } finally {
+      await teardownTerminalArena(arena, testInfo, 'korean-preedit-visibility', !completed)
+      removeTerminalImeByteReader(reader)
+    }
+  })
+
+  test('keeps a preedit the IME resumes without a compositionstart visible @ime-known-broken', async ({
+    orcaPage
+  }, testInfo) => {
+    // Red on `main`, by design. xterm adds `.active` to the overlay only in its `compositionstart`
+    // handler, so a preedit resumed by a bare `compositionupdate` is written into a hidden element
+    // and the user composes blind while the committed bytes still land correctly — which is why no
+    // byte-level assertion ever saw it. Pre-existing and broken in every shipped build; the parked
+    // eight-line fix in xterm's own composition helper closes it, and Playwright will fail the run
+    // until the `test.fail()` marker below is deleted.
+    test.fail(true, 'the resumed preedit is written into an overlay xterm never marks active')
+    const { ptyId, session } = await openTerminalArena(orcaPage)
+    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    let completed = false
+    try {
+      await focusActiveTerminalInput(orcaPage)
+      await installTerminalImeBoundaryProbe(orcaPage)
+
+      // Synthesised, not replayed — see dispatchResumedCompositionUpdate for why the recorded
+      // corpus cannot supply this ordering and why it is still reachable in production.
+      await dispatchResumedCompositionUpdate(orcaPage, '한')
+
+      const sample = await samplePreeditOverlay(orcaPage)
+      expect(sample.found, 'no composition overlay exists').toBe(true)
+      expect(sample.text, 'the resumed preedit text never reached the overlay').toBe('한')
+      expect(
+        sample.rect.width,
+        'the resumed preedit was written into an overlay with zero width — the user composes blind'
+      ).toBeGreaterThan(0)
+      expect(sample.rect.height, 'the resumed preedit overlay has zero height').toBeGreaterThan(0)
+      completed = true
+    } finally {
+      await teardownTerminalArena(arena, testInfo, 'korean-resumed-preedit', !completed)
+    }
+  })
+
+  test('renders the preedit at every update of a recorded Windows/WSL Hangul session', async ({
+    orcaPage
+  }, testInfo) => {
+    const { ptyId, session } = await openTerminalArena(orcaPage)
+    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    let completed = false
+    try {
+      await focusActiveTerminalInput(orcaPage)
+      await installTerminalImeBoundaryProbe(orcaPage)
+
+      const replay = await replayRecordedImeDomTrace(orcaPage, RECORDED_TRACE)
+      const updates = replay.samples.filter(
+        (sample) => sample.type === 'compositionupdate' && sample.data.length > 0
+      )
+      // If the fixture is ever replaced with one that carries no updates this assertion keeps the
+      // rest of the test from passing vacuously.
+      expect(updates.length, 'the recorded trace carries no composition updates').toBe(37)
+
+      const invisible = updates.filter(
+        (sample) => sample.overlay.rect.width === 0 || sample.overlay.rect.height === 0
+      )
+      expect(
+        invisible.map((sample) => ({ index: sample.index, data: sample.data })),
+        'these recorded preedit frames were written into an overlay with no size'
+      ).toEqual([])
+
+      const committed = replay.samples
+        .filter((sample) => sample.type === 'compositionend' && sample.data.length > 0)
+        .map((sample) => sample.data)
+      expect(committed.join('')).toBe('문제모르겠네안녕하세요')
+      completed = true
+    } finally {
+      await teardownTerminalArena(arena, testInfo, 'korean-recorded-trace-preedit', !completed)
+    }
+  })
+
+  test('loses and duplicates nothing when back-to-back syllables commit at full speed', async ({
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    const { ptyId, session } = await openTerminalArena(orcaPage)
+    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    const reader = createTerminalImeByteReader(testRepoPath, 1)
+    let completed = false
+    try {
+      await startTerminalImeByteReader(orcaPage, ptyId, reader)
+      await focusActiveTerminalInput(orcaPage)
+      await installTerminalImeBoundaryProbe(orcaPage)
+
+      // No settle time between frames or between syllables: the cadence a fast typist produces,
+      // and the one that used to drop or double a syllable at the boundary.
+      for (let repetition = 0; repetition < 4; repetition += 1) {
+        await composeHangulSyllable(session, orcaPage, HAN_FRAMES, 0)
+        await commitImeText(session, '한')
+        await composeHangulSyllable(session, orcaPage, GEUL_FRAMES, 0)
+        await commitImeText(session, '글')
+      }
+      await dispatchPlainEnter(session)
+
+      const received = await waitForTerminalImeBytes(orcaPage, reader)
+      expect(received).toEqual([Buffer.from(`${'한글'.repeat(4)}\n`).toString('hex')])
+
+      const trace = await readTerminalImeBoundaryTrace(orcaPage)
+      expect(trace.onData.join('')).toBe(`${'한글'.repeat(4)}\r`)
+      completed = true
+    } finally {
+      await teardownTerminalArena(arena, testInfo, 'korean-fast-cadence', !completed)
+      removeTerminalImeByteReader(reader)
+    }
+  })
+})

--- a/tests/e2e/terminal-korean-preedit-visibility.spec.ts
+++ b/tests/e2e/terminal-korean-preedit-visibility.spec.ts
@@ -13,15 +13,8 @@
  */
 import { readFileSync } from 'node:fs'
 import path from 'node:path'
-import type { CDPSession, Page, TestInfo } from '@stablyai/playwright-test'
 import { expect, test } from './helpers/orca-app'
-import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
-import {
-  focusActiveTerminalInput,
-  sendToTerminal,
-  waitForActivePanePtyId,
-  waitForActiveTerminalManager
-} from './helpers/terminal'
+import { closeTerminalImePaneArena, openTerminalImePaneArena } from './terminal-ime-pane-arena'
 import {
   commitImeText,
   composeHangulSyllable,
@@ -29,12 +22,7 @@ import {
   dispatchResumedCompositionUpdate,
   type ImeKeyIdentity
 } from './terminal-ime-cdp-composition'
-import {
-  attachTerminalImeBoundaryEvidence,
-  disposeTerminalImeBoundaryProbe,
-  installTerminalImeBoundaryProbe,
-  readTerminalImeBoundaryTrace
-} from './terminal-ime-boundary-probe'
+import { readTerminalImeBoundaryTrace } from './terminal-ime-boundary-probe'
 import {
   createTerminalImeByteReader,
   removeTerminalImeByteReader,
@@ -46,6 +34,7 @@ import {
   expectPreeditRendered,
   samplePreeditOverlay
 } from './terminal-ime-preedit-overlay-probe'
+import { applyImePlatformPolicy } from './terminal-ime-platform-policy'
 import {
   replayRecordedImeDomTrace,
   type RecordedImeDomTrace
@@ -79,61 +68,27 @@ const RECORDED_TRACE = JSON.parse(
   readFileSync(path.join(__dirname, 'fixtures', 'windows-wsl-2set-hangul-dom-trace.json'), 'utf8')
 ) as RecordedImeDomTrace
 
-type KoreanTerminalArena = {
-  page: Page
-  session: CDPSession
-  ptyId: string
-}
-
-async function openTerminalArena(page: Page): Promise<{ ptyId: string; session: CDPSession }> {
-  await waitForSessionReady(page)
-  await waitForActiveWorktree(page)
-  await ensureTerminalVisible(page)
-  await waitForActiveTerminalManager(page, 30_000)
-  const ptyId = await waitForActivePanePtyId(page)
-  const session = await page.context().newCDPSession(page)
-  return { ptyId, session }
-}
-
-async function teardownTerminalArena(
-  arena: KoreanTerminalArena,
-  testInfo: TestInfo,
-  evidenceName: string,
-  interrupt: boolean
-): Promise<void> {
-  await attachTerminalImeBoundaryEvidence(arena.page, testInfo, evidenceName).catch(() => undefined)
-  await disposeTerminalImeBoundaryProbe(arena.page).catch(() => undefined)
-  await arena.session.detach().catch(() => undefined)
-  if (interrupt) {
-    await sendToTerminal(arena.page, arena.ptyId, '\x03').catch(() => undefined)
-  }
-}
-
 test.describe('Terminal 2-Set Korean preedit visibility', () => {
   test('shows every assembling jamo at non-zero size and commits the syllable ahead of the newline', async ({
     orcaPage,
     testRepoPath
   }, testInfo) => {
-    const { ptyId, session } = await openTerminalArena(orcaPage)
-    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    const arena = await openTerminalImePaneArena(orcaPage)
     const reader = createTerminalImeByteReader(testRepoPath, 1)
     let completed = false
     try {
-      await startTerminalImeByteReader(orcaPage, ptyId, reader)
-      await focusActiveTerminalInput(orcaPage)
-      await installTerminalImeBoundaryProbe(orcaPage)
-
+      await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
       await expectPreeditHidden(orcaPage, 'before composing')
 
       for (const frame of HAN_FRAMES) {
-        await composeHangulSyllable(session, orcaPage, [frame])
+        await composeHangulSyllable(arena.session, orcaPage, [frame])
         await expectPreeditRendered(orcaPage, frame.preedit, `composing ${frame.preedit}`)
       }
 
-      await commitImeText(session, '한')
+      await commitImeText(arena.session, '한')
       await expectPreeditHidden(orcaPage, 'after committing 한')
 
-      await dispatchPlainEnter(session)
+      await dispatchPlainEnter(arena.session)
 
       const received = await waitForTerminalImeBytes(orcaPage, reader)
       expect(received).toEqual([Buffer.from('한\n').toString('hex')])
@@ -143,7 +98,7 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
       expect(trace.onData.join('')).toBe('한\r')
       completed = true
     } finally {
-      await teardownTerminalArena(arena, testInfo, 'korean-preedit-visibility', !completed)
+      await closeTerminalImePaneArena(arena, testInfo, 'korean-preedit-visibility', !completed)
       removeTerminalImeByteReader(reader)
     }
   })
@@ -156,13 +111,9 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
     // and the user composes blind while the committed bytes still land correctly — which is why no
     // byte-level assertion ever saw it. Pre-existing and broken in every shipped build; closed by
     // the visibility fix in xterm's own composition helper one layer below this one.
-    const { ptyId, session } = await openTerminalArena(orcaPage)
-    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    const arena = await openTerminalImePaneArena(orcaPage)
     let completed = false
     try {
-      await focusActiveTerminalInput(orcaPage)
-      await installTerminalImeBoundaryProbe(orcaPage)
-
       // Synthesised, not replayed — see dispatchResumedCompositionUpdate for why the recorded
       // corpus cannot supply this ordering and why it is still reachable in production.
       await dispatchResumedCompositionUpdate(orcaPage, '한')
@@ -177,20 +128,20 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
       expect(sample.rect.height, 'the resumed preedit overlay has zero height').toBeGreaterThan(0)
       completed = true
     } finally {
-      await teardownTerminalArena(arena, testInfo, 'korean-resumed-preedit', !completed)
+      await closeTerminalImePaneArena(arena, testInfo, 'korean-resumed-preedit', !completed)
     }
   })
 
   test('renders the preedit at every update of a recorded Windows/WSL Hangul session', async ({
     orcaPage
   }, testInfo) => {
-    const { ptyId, session } = await openTerminalArena(orcaPage)
-    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    // Pinned to the Windows policy because the trace is a Windows recording. Without the pin it
+    // ran under whatever the runner reported — macOS locally, Linux on the CI shards — so the one
+    // platform it was named for was the one platform it never exercised.
+    await applyImePlatformPolicy(orcaPage, 'windows')
+    const arena = await openTerminalImePaneArena(orcaPage)
     let completed = false
     try {
-      await focusActiveTerminalInput(orcaPage)
-      await installTerminalImeBoundaryProbe(orcaPage)
-
       const replay = await replayRecordedImeDomTrace(orcaPage, RECORDED_TRACE)
       const updates = replay.samples.filter(
         (sample) => sample.type === 'compositionupdate' && sample.data.length > 0
@@ -211,9 +162,15 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
         .filter((sample) => sample.type === 'compositionend' && sample.data.length > 0)
         .map((sample) => sample.data)
       expect(committed.join('')).toBe('문제모르겠네안녕하세요')
+
+      // The capture's own byte stream, asserted rather than carried unused: it is the only thing
+      // in this test that would notice a syllable being dropped between the overlay and the PTY,
+      // and the trailing ASCII `hello` pins that a plain word after a Korean session is unharmed.
+      expect(replay.onData).toBe((RECORDED_TRACE.onData ?? []).map((entry) => entry.data).join(''))
+      expect(replay.onData).toBe('문제\r모르겠네\r안녕하세요\rhello\r')
       completed = true
     } finally {
-      await teardownTerminalArena(arena, testInfo, 'korean-recorded-trace-preedit', !completed)
+      await closeTerminalImePaneArena(arena, testInfo, 'korean-recorded-trace-preedit', !completed)
     }
   })
 
@@ -221,24 +178,20 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
     orcaPage,
     testRepoPath
   }, testInfo) => {
-    const { ptyId, session } = await openTerminalArena(orcaPage)
-    const arena: KoreanTerminalArena = { page: orcaPage, session, ptyId }
+    const arena = await openTerminalImePaneArena(orcaPage)
     const reader = createTerminalImeByteReader(testRepoPath, 1)
     let completed = false
     try {
-      await startTerminalImeByteReader(orcaPage, ptyId, reader)
-      await focusActiveTerminalInput(orcaPage)
-      await installTerminalImeBoundaryProbe(orcaPage)
-
+      await startTerminalImeByteReader(orcaPage, arena.ptyId, reader)
       // No settle time between frames or between syllables: the cadence a fast typist produces,
       // and the one that used to drop or double a syllable at the boundary.
       for (let repetition = 0; repetition < 4; repetition += 1) {
-        await composeHangulSyllable(session, orcaPage, HAN_FRAMES, 0)
-        await commitImeText(session, '한')
-        await composeHangulSyllable(session, orcaPage, GEUL_FRAMES, 0)
-        await commitImeText(session, '글')
+        await composeHangulSyllable(arena.session, orcaPage, HAN_FRAMES, 0)
+        await commitImeText(arena.session, '한')
+        await composeHangulSyllable(arena.session, orcaPage, GEUL_FRAMES, 0)
+        await commitImeText(arena.session, '글')
       }
-      await dispatchPlainEnter(session)
+      await dispatchPlainEnter(arena.session)
 
       const received = await waitForTerminalImeBytes(orcaPage, reader)
       expect(received).toEqual([Buffer.from(`${'한글'.repeat(4)}\n`).toString('hex')])
@@ -247,7 +200,7 @@ test.describe('Terminal 2-Set Korean preedit visibility', () => {
       expect(trace.onData.join('')).toBe(`${'한글'.repeat(4)}\r`)
       completed = true
     } finally {
-      await teardownTerminalArena(arena, testInfo, 'korean-fast-cadence', !completed)
+      await closeTerminalImePaneArena(arena, testInfo, 'korean-fast-cadence', !completed)
       removeTerminalImeByteReader(reader)
     }
   })

--- a/tests/e2e/terminal-macos-qingg-punctuation-native.spec.ts
+++ b/tests/e2e/terminal-macos-qingg-punctuation-native.spec.ts
@@ -1,0 +1,288 @@
+/**
+ * Native macOS hardware coverage for a third-party input source outside every allowlist.
+ *
+ * This is the arm no headless spec can express. Qingg (`com.aodaren.inputmethod.Qingg`) matches none
+ * of the terms the pre-structural build enumerated — verified by running those term lists against
+ * the id, not assumed — so on that build the bypass never installs and the character is destroyed
+ * before the input source can commit it.
+ *
+ * **The mechanism, stated precisely, because the obvious wording is wrong.** The old build does not
+ * "discard the substituted character". Pressing `.` there produces `keydown` and `keyup` and
+ * *nothing else* — no `keypress`, no `beforeinput`, no `input`. xterm manufactures the ASCII byte
+ * from the keydown and `preventDefault()` tears down the text pipeline before the input source is
+ * ever asked. Under the structural rule the same key yields `keypress` with `keyCode 12290` (0x3002)
+ * and `beforeinput` carrying `。`.
+ *
+ * **The verdict is mode-independent.** What the input source committed at the DOM boundary must
+ * equal what the PTY received. Nothing here assumes Qingg is in full-width punctuation mode; if it
+ * is in English-punctuation mode it commits `.` and the PTY must receive `.`. That is why the
+ * assertion is an equality between two measurements rather than a comparison against a hardcoded
+ * glyph — and it is what makes the spec survive an operator whose punctuation mode we cannot see.
+ *
+ * **Read `beforeinput`, never `input`.** The forwarder registers `input` in the capture phase on the
+ * pane element and calls `stopImmediatePropagation()` once it has the bytes, so a probe bound to the
+ * descendant helper textarea never observes it — a strict run against a correct build fails for that
+ * reason alone, with the right bytes underneath. `beforeinput` fires first, is never consumed,
+ * carries the same `data`, and means the same thing on both builds.
+ */
+import { execFileSync } from 'node:child_process'
+import type { Page, TestInfo } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import {
+  focusActiveTerminalInput,
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager
+} from './helpers/terminal'
+import {
+  attachTerminalImeBoundaryEvidence,
+  disposeTerminalImeBoundaryProbe,
+  installTerminalImeBoundaryProbe,
+  readTerminalImeBoundaryTrace
+} from './terminal-ime-boundary-probe'
+import {
+  createTerminalImeByteReader,
+  removeTerminalImeByteReader,
+  startTerminalImeByteReader,
+  waitForTerminalImeBytes
+} from './terminal-ime-byte-reader'
+import { samplePreeditOverlay } from './terminal-ime-preedit-overlay-probe'
+
+const QINGG_INPUT_SOURCE_ID =
+  process.env.ORCA_E2E_QINGG_INPUT_SOURCE_ID ?? 'com.aodaren.inputmethod.Qingg'
+const ASCII_INPUT_SOURCE_ID =
+  process.env.ORCA_E2E_ASCII_INPUT_SOURCE_ID ?? 'com.apple.keylayout.ABC'
+/** Optional operator-supplied binary taking one input-source id. Without it the operator selects. */
+const SELECT_INPUT_SOURCE = process.env.ORCA_E2E_NATIVE_INPUT_SOURCE_SELECT ?? ''
+
+const KEY_A = 0
+const KEY_BACKSLASH = 42
+const KEY_COMMA = 43
+const KEY_PERIOD = 47
+const KEY_RETURN = 36
+const KEY_ESCAPE = 53
+
+/** Each probe is one keystroke plus Return, so the byte reader sees exactly one line per probe. */
+const PROBES = [
+  {
+    label: 'backslash',
+    keyCode: KEY_BACKSLASH,
+    ascii: '\\',
+    // The in-session positive control. The pre-structural build kept a narrow `code === 'Backslash'`
+    // bypass, so this key is correct there too. That asymmetry is the point: it proves the input
+    // source really was driving this session, so the other two arms cannot be waved away as
+    // "Qingg was not active". It is asserted, not merely observed — see the skip note below.
+    asciiHex: '5c'
+  },
+  { label: 'period', keyCode: KEY_PERIOD, ascii: '.', asciiHex: '2e' },
+  { label: 'comma', keyCode: KEY_COMMA, ascii: ',', asciiHex: '2c' }
+] as const
+
+type ProbeVerdict = {
+  key: string
+  imeCommitted: string
+  ptyReceived: string
+  ptyHex: string
+  domTypes: string[]
+}
+
+type BoundaryDomEvent = { type: string; data: string | null; inputType: string | null }
+
+function selectInputSource(id: string): boolean {
+  if (!SELECT_INPUT_SOURCE) {
+    return false
+  }
+  execFileSync(SELECT_INPUT_SOURCE, [id])
+  execFileSync('/bin/sleep', ['1.5'])
+  return true
+}
+
+function pressKeyCodes(processId: number, keyCodes: readonly number[], delaySeconds = 0.15): void {
+  execFileSync('osascript', [
+    '-e',
+    `tell application "System Events" to set frontmost of first application process whose unix id is ${processId} to true`,
+    '-e',
+    'tell application "System Events"',
+    '-e',
+    `repeat with currentKeyCode in {${keyCodes.join(', ')}}`,
+    '-e',
+    'key code (currentKeyCode as integer)',
+    '-e',
+    `delay ${delaySeconds}`,
+    '-e',
+    'end repeat',
+    '-e',
+    'end tell'
+  ])
+}
+
+/**
+ * Probes attachment with a **letter**, and never with punctuation.
+ *
+ * Punctuation substitution emits no `compositionstart` and no `keyCode 229` even under a fully
+ * attached input source, so at the keydown it is indistinguishable from having no input source at
+ * all. Only a letter opens a composition, so only a letter can answer "did the IME attach". The
+ * punctuation arms below are judged on PTY bytes alone for the same reason.
+ */
+async function imeAttached(page: Page, processId: number): Promise<boolean> {
+  for (let attempt = 1; attempt <= 6; attempt += 1) {
+    pressKeyCodes(processId, [KEY_A])
+    await page.waitForTimeout(700)
+    if ((await samplePreeditOverlay(page)).active) {
+      pressKeyCodes(processId, [KEY_ESCAPE])
+      await page.waitForTimeout(400)
+      return true
+    }
+  }
+  return false
+}
+
+/** What the input source committed, read at the DOM boundary. See the file header on `beforeinput`. */
+function committedGlyphs(dom: readonly BoundaryDomEvent[]): string {
+  return dom
+    .filter((event) => event.type === 'beforeinput' && event.inputType === 'insertText')
+    .map((event) => event.data ?? '')
+    .join('')
+}
+
+async function measureProbes(
+  page: Page,
+  testInfo: TestInfo,
+  testRepoPath: string,
+  processId: number,
+  evidenceName: string
+): Promise<ProbeVerdict[]> {
+  await waitForSessionReady(page)
+  await waitForActiveWorktree(page)
+  await ensureTerminalVisible(page)
+  await waitForActiveTerminalManager(page, 30_000)
+  const ptyId = await waitForActivePanePtyId(page)
+  const reader = createTerminalImeByteReader(testRepoPath, PROBES.length)
+  try {
+    await focusActiveTerminalInput(page)
+    // Clear anything the attachment probe left on the prompt before the reader starts.
+    await sendToTerminal(page, ptyId, '\x15')
+    await startTerminalImeByteReader(page, ptyId, reader)
+    await focusActiveTerminalInput(page)
+    await installTerminalImeBoundaryProbe(page)
+
+    const domMarks: number[] = []
+    for (const probe of PROBES) {
+      pressKeyCodes(processId, [probe.keyCode, KEY_RETURN])
+      await page.waitForTimeout(900)
+      domMarks.push((await readTerminalImeBoundaryTrace(page)).dom.length)
+    }
+
+    const lines = await waitForTerminalImeBytes(page, reader)
+    const trace = await readTerminalImeBoundaryTrace(page)
+    const verdicts: ProbeVerdict[] = []
+    let start = 0
+    PROBES.forEach((probe, index) => {
+      const dom = trace.dom.slice(start, domMarks[index]) as BoundaryDomEvent[]
+      start = domMarks[index]!
+      const ptyHex = lines[index] ?? ''
+      verdicts.push({
+        key: probe.ascii,
+        imeCommitted: committedGlyphs(dom),
+        ptyReceived: Buffer.from(ptyHex, 'hex').toString('utf8').replace(/\n$/, ''),
+        ptyHex,
+        // Pins the mechanism: on the pre-structural build this is exactly ['keydown','keyup'].
+        domTypes: dom.map((event) => event.type)
+      })
+    })
+    await testInfo.attach(`${evidenceName}-verdicts.json`, {
+      body: JSON.stringify(verdicts, null, 2),
+      contentType: 'application/json'
+    })
+    return verdicts
+  } finally {
+    await attachTerminalImeBoundaryEvidence(page, testInfo, evidenceName).catch(() => undefined)
+    await disposeTerminalImeBoundaryProbe(page).catch(() => undefined)
+    await sendToTerminal(page, ptyId, '\x03').catch(() => undefined)
+    removeTerminalImeByteReader(reader)
+  }
+}
+
+test.describe('Native macOS non-allowlist input source punctuation @headful', () => {
+  test.describe.configure({ mode: 'serial' })
+  test.skip(
+    process.platform !== 'darwin' || process.env.ORCA_E2E_NATIVE_MACOS_QINGG !== '1',
+    'Requires macOS with Qingg installed and Accessibility access; set ORCA_E2E_NATIVE_MACOS_QINGG=1'
+  )
+
+  test('what the input source commits is what the PTY receives', async ({
+    electronApp,
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    selectInputSource(QINGG_INPUT_SOURCE_ID)
+    const processId = electronApp.process().pid!
+    await waitForSessionReady(orcaPage)
+    await waitForActiveWorktree(orcaPage)
+    await ensureTerminalVisible(orcaPage)
+    await waitForActiveTerminalManager(orcaPage, 30_000)
+    await focusActiveTerminalInput(orcaPage)
+
+    // macOS attaches an input method per app instance, and the attach can simply fail: measured
+    // under exclusive host access, 3 of 6 instances never attached, and re-issuing the input-source
+    // selection did not recover one of them across 9 keystrokes and 2 re-selections. It is permanent
+    // for that instance's life, so a non-attached run is a refusal to measure, never a negative
+    // result — skip it rather than failing and rather than gating on a fully green session.
+    test.skip(
+      !(await imeAttached(orcaPage, processId)),
+      'The input method never attached to this app instance (no composition after 6 letter keystrokes). Known macOS per-instance attach failure, not recoverable by retry — rerun the spec for a fresh instance.'
+    )
+
+    const verdicts = await measureProbes(
+      orcaPage,
+      testInfo,
+      testRepoPath,
+      processId,
+      'qingg-punctuation'
+    )
+
+    for (const verdict of verdicts) {
+      // Non-vacuity, and the sharp end of the mechanism: on the pre-structural build the DOM shows
+      // only keydown/keyup, so nothing was committed at all and this fails before the equality does.
+      expect(
+        verdict.imeCommitted,
+        `${verdict.key}: the input source committed nothing — DOM was ${JSON.stringify(verdict.domTypes)}. The keydown produced the byte and preventDefault tore down the text pipeline.`
+      ).not.toBe('')
+      expect(
+        verdict.ptyReceived,
+        `${verdict.key}: the input source committed ${JSON.stringify(verdict.imeCommitted)} but the PTY received ${JSON.stringify(verdict.ptyReceived)}`
+      ).toBe(verdict.imeCommitted)
+    }
+  })
+
+  test('a plain ASCII layout substitutes nothing', async ({
+    electronApp,
+    orcaPage,
+    testRepoPath
+  }, testInfo) => {
+    // Mandatory control. Without it a build that blanket-rewrote every `.` into `。` would pass the
+    // Qingg arm above and be badly wrong. Needs a second input source selected, so it can only run
+    // unattended when the operator supplies a selector binary.
+    test.skip(
+      !selectInputSource(ASCII_INPUT_SOURCE_ID),
+      'Needs to switch input sources; set ORCA_E2E_NATIVE_INPUT_SOURCE_SELECT to a binary taking one input-source id'
+    )
+
+    const verdicts = await measureProbes(
+      orcaPage,
+      testInfo,
+      testRepoPath,
+      electronApp.process().pid!,
+      'ascii-layout-control'
+    )
+
+    PROBES.forEach((probe, index) => {
+      const verdict = verdicts[index]!
+      expect(
+        verdict.ptyHex.replace(/0a$/, ''),
+        `${probe.ascii} was substituted with no input source active — the build rewrites punctuation unconditionally`
+      ).toBe(probe.asciiHex)
+    })
+  })
+})


### PR DESCRIPTION
**Draft — not for merge.** This is coverage-only. It adds no product code and changes no behaviour. It exists to become the acceptance criteria for the IME re-land stack, and three of its tests are red on `main` on purpose.

## Why

Both IME defects that shipped and were reverted walked straight through a suite of ~3000 passing IME assertions. Every one of those assertions was about bytes reaching the PTY, and a preedit rendered into a hidden overlay satisfies all of them while the user composes blind. The one arm that asserted real geometry correctly was `@headful`, env-gated and macOS-only, so it never ran in CI and was deleted with the revert.

## What changed

Composition is driven through CDP `Input.imeSetComposition` rather than a native input source, which removes the accessibility grant, the system input source and the visible window that forced the headful gate. The suite runs in the ordinary `electron-headless` project.

The load-bearing assertion is the composition overlay's real bounding rect. Verified to have teeth: with `.composition-view.active { max-width: 0; overflow: hidden }` injected — invisible on screen — the `active` class, the `textContent`, `display: block` and `checkVisibility() === true` all still pass, and only the rect assertion fails.

New files, all under `tests/e2e/`:

| file | role |
|---|---|
| `terminal-korean-preedit-visibility.spec.ts` | 2-Set Hangul: assembly, geometry, resumed preedit, fast cadence, commit-before-newline |
| `terminal-cjk-ime-committed-text.spec.ts` | Japanese phrase preedit; Chinese pinyin; full-width punctuation and digits |
| `terminal-ime-preedit-overlay-probe.ts` | overlay geometry sampler and its assertions |
| `terminal-ime-cdp-composition.ts` | CDP composition drivers |
| `terminal-ime-recorded-dom-trace-replay.ts` | per-event recorded-trace replay with a geometry sample at every composition event |
| `fixtures/windows-wsl-2set-hangul-dom-trace.json` | derived from the sealed read-only Windows/WSL capture, which is unmodified |

## Results on this commit

10 tests, 55.4s serially on macOS. 7 green, 3 `test.fail()`.

| test | on `main` | closed by |
|---|---|---|
| Hangul jamo assemble, preedit visible, syllable before newline | pass | — |
| Recorded Windows/WSL Hangul session, preedit visible at all 37 updates | pass | — |
| Back-to-back syllables at full cadence, nothing lost or duplicated | pass | — |
| Japanese phrase preedit widens and commits the kanji | pass | — |
| Chinese pinyin conversion plus trailing full-width stop | pass | — |
| Full-width punctuation / digits, keydown already carries the glyph | pass | — |
| **Preedit resumed by a bare `compositionupdate`** | **fail** | the parked resumed-preedit visibility fix |
| **Full-width punctuation, keydown carries the ASCII layout key** | **fail** | the structural forwarder |
| **Full-width digits, keydown carries the ASCII layout key** | **fail** | the structural forwarder |

The three red ones carry `test.fail()` and an `@ime-known-broken` tag, so they run in CI, stay visible in the report, and fail the run the moment their fix lands — which forces the marker to be removed rather than the test to be forgotten.

## Findings worth reading before the re-land

1. **The recorded Windows/WSL capture does not contain the resume-without-`compositionstart` ordering.** The source recorder logged every event twice — once on dispatch, once as a batched next-frame snapshot. Replaying both copies makes a `compositionupdate` follow an already-replayed `compositionend`, which manufactures the shape. Filtering to the dispatch-phase records leaves 11 balanced start/end pairs and all 37 updates inside them: zero resumes. The fixture here keeps only the dispatch phase, and the resumed-preedit test is therefore **synthesised and says so** — the shape is still reachable, because xterm adds `.active` only in its `compositionstart` handler and its `compositionupdate` handler never re-adds it, which this PR reproduces headlessly against a live overlay.

2. **The full-width punctuation regression is not testable while the bypass reads an input source.** The keydown carries the plain Latin `,`; the `，` exists only in the following `input` event. The bypass that would prevent the ASCII byte is gated on the OS reporting an input source id matching a 23-term allowlist. That probe returns `null` on every non-macOS host and `com.apple.keylayout.*` on a macOS runner with no CJK source selected, and the preload API surface is frozen so no spec can stub it. Correctness here is not expressible as a test until the gate goes away — which is an argument for the structural rule independent of the ones already made for it.

3. **`event.key`-rewritten punctuation is not regression coverage.** xterm's own key handler emits `event.key`, so that shape passes with or without a forwarder and would have passed throughout the regression. It is kept, and labelled as such.

## Not covered

- Never executed on Linux. CI runs these on ubuntu under xvfb; font metrics and the UA override should carry over, but that is unverified here.
- No native-IME arm. These specs prove the renderer and PTY path; they do not prove the OS hands Chromium the events assumed.
- The macOS candidate-window anchoring regression is not covered — the OS reads the focused textarea's rect, which is outside what a page-level assertion can see.

Made with [Orca](https://github.com/stablyai/orca) 🐋
