### PR TITLE
fix(browser): make viewport presets scrollable when larger than the pane

### DIFF
--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -2469,10 +2469,13 @@ function BrowserPagePane({
     isMobileDriven
   })
   const pageViewport = ensureBrowserPageViewport(browserTab.id, workspaceId)
+  // Why: render-scoped identities so effects keyed on them rebind after a shell rebuild.
+  const viewportContainer = pageViewport?.container ?? null
+  const viewportScroller = pageViewport?.scroller ?? null
   const containerRef = useRef<HTMLDivElement | null>(null)
-  containerRef.current = pageViewport?.container ?? null
+  containerRef.current = viewportContainer
   const scrollerRef = useRef<HTMLDivElement | null>(null)
-  scrollerRef.current = pageViewport?.scroller ?? null
+  scrollerRef.current = viewportScroller
   const chromeHeaderRef = useRef<HTMLDivElement | null>(null)
   const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -2875,23 +2878,28 @@ function BrowserPagePane({
     const bumpOverlayViewportVersion = (): void => {
       setBrowserOverlayViewport((current) => ({ ...current, version: current.version + 1 }))
     }
-    const observedContainer = containerRef.current
+    // Why: keyed on the element identities so a shell rebuild rebinds both observers.
     const resizeObserver =
-      typeof ResizeObserver === 'undefined' || !observedContainer
+      typeof ResizeObserver === 'undefined' || !viewportContainer
         ? null
         : new ResizeObserver(bumpOverlayViewportVersion)
-    if (resizeObserver && observedContainer) {
-      resizeObserver.observe(observedContainer)
+    if (resizeObserver && viewportContainer) {
+      resizeObserver.observe(viewportContainer)
     }
     // Why: panning a viewport preset moves the webview under container-pinned anchors.
-    const scroller = scrollerRef.current
-    scroller?.addEventListener('scroll', bumpOverlayViewportVersion, { passive: true })
+    viewportScroller?.addEventListener('scroll', bumpOverlayViewportVersion, { passive: true })
 
     return () => {
       resizeObserver?.disconnect()
-      scroller?.removeEventListener('scroll', bumpOverlayViewportVersion)
+      viewportScroller?.removeEventListener('scroll', bumpOverlayViewportVersion)
     }
-  }, [browserAnnotations.length, isActive, pendingAnnotationPayload])
+  }, [
+    browserAnnotations.length,
+    isActive,
+    pendingAnnotationPayload,
+    viewportContainer,
+    viewportScroller
+  ])
 
   useEffect(() => {
     initialBrowserUrlRef.current = browserTab.url

--- a/src/renderer/src/components/browser-pane/BrowserPane.tsx
+++ b/src/renderer/src/components/browser-pane/BrowserPane.tsx
@@ -103,6 +103,7 @@ import {
   ensureBrowserPageViewport,
   getBrowserOverlaySlotViewport,
   parkBrowserPageViewport,
+  setBrowserPageViewportPresetSize,
   subscribeBrowserOverlaySlotViewport,
   syncBrowserPageChromeInset
 } from './browser-page-viewport'
@@ -2470,6 +2471,8 @@ function BrowserPagePane({
   const pageViewport = ensureBrowserPageViewport(browserTab.id, workspaceId)
   const containerRef = useRef<HTMLDivElement | null>(null)
   containerRef.current = pageViewport?.container ?? null
+  const scrollerRef = useRef<HTMLDivElement | null>(null)
+  scrollerRef.current = pageViewport?.scroller ?? null
   const chromeHeaderRef = useRef<HTMLDivElement | null>(null)
   const grabToastTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
   const annotationCopyTimerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
@@ -2547,6 +2550,15 @@ function BrowserPagePane({
   // Why: CDP viewport emulation doesn't survive renderer process swaps, so reapply the preset from this ref on every dom-ready.
   const viewportPresetIdRef = useRef(browserTab.viewportPresetId ?? null)
   viewportPresetIdRef.current = browserTab.viewportPresetId ?? null
+  // Sole size writer: covers menu picks, mount, session rehydrate, and web-session sync
+  // (which sets viewportPresetId without going through the toolbar menu).
+  useLayoutEffect(() => {
+    const preset = getBrowserViewportPreset(browserTab.viewportPresetId ?? null)
+    setBrowserPageViewportPresetSize(
+      browserTab.id,
+      preset ? { width: preset.width, height: preset.height } : null
+    )
+  }, [browserTab.id, browserTab.viewportPresetId])
   const trackNextLoadingEventRef = useRef(false)
   // Most-recent observed webview URL; URL sync checks it to avoid force-navigating to an intermediate redirect (which would loop the redirect chain).
   const lastKnownWebviewUrlRef = useRef<string | null>(null)
@@ -2630,11 +2642,12 @@ function BrowserPagePane({
   const markup = useMarkupMode({
     getCaptureContext: useCallback((): MarkupCaptureContext | null => {
       const webview = webviewRef.current
-      const container = containerRef.current
-      if (!webview || !container) {
+      if (!webview) {
         return null
       }
-      const rect = container.getBoundingClientRect()
+      // Why: capturePage() frames the webview, which under a viewport preset is larger
+      // than the pane — measuring the container here would distort the composite.
+      const rect = webview.getBoundingClientRect()
       if (rect.width <= 0 || rect.height <= 0) {
         return null
       }
@@ -2859,19 +2872,24 @@ function BrowserPagePane({
       return
     }
 
+    const bumpOverlayViewportVersion = (): void => {
+      setBrowserOverlayViewport((current) => ({ ...current, version: current.version + 1 }))
+    }
     const observedContainer = containerRef.current
     const resizeObserver =
       typeof ResizeObserver === 'undefined' || !observedContainer
         ? null
-        : new ResizeObserver(() => {
-            setBrowserOverlayViewport((current) => ({ ...current, version: current.version + 1 }))
-          })
+        : new ResizeObserver(bumpOverlayViewportVersion)
     if (resizeObserver && observedContainer) {
       resizeObserver.observe(observedContainer)
     }
+    // Why: panning a viewport preset moves the webview under container-pinned anchors.
+    const scroller = scrollerRef.current
+    scroller?.addEventListener('scroll', bumpOverlayViewportVersion, { passive: true })
 
     return () => {
       resizeObserver?.disconnect()
+      scroller?.removeEventListener('scroll', bumpOverlayViewportVersion)
     }
   }, [browserAnnotations.length, isActive, pendingAnnotationPayload])
 
@@ -3422,23 +3440,28 @@ function BrowserPagePane({
   // Why: browserTab.url excluded from deps (changes every navigation → would destroy/recreate the webview); URL logic reads browserTabUrlRef.
   // eslint-disable-next-line react-hooks/exhaustive-deps -- see comment above
   useEffect(() => {
-    let container = ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
-    if (!container) {
+    const content = ensureBrowserPageViewport(browserTab.id, workspaceId)?.content ?? null
+    if (!content) {
       return
     }
 
+    // Why: the webview mounts in the preset-sized content host so the pane can scroll
+    // the emulated viewport; pane-pinned overlays and drag/drop stay on the container.
     const ensuredWebview = ensureBrowserPageWebview({
       browserTabId: browserTab.id,
-      container,
+      container: content,
       inputLocked: inputLockedRef.current,
       webviewPartition,
-      resolveContainer: () =>
-        ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
+      resolveContainer: () => ensureBrowserPageViewport(browserTab.id, workspaceId)?.content ?? null
     })
     if (!ensuredWebview) {
       return
     }
-    container = ensuredWebview.container
+    // Why: re-resolve rather than reuse — drift repair inside ensure may have rebuilt the shell.
+    const container = ensureBrowserPageViewport(browserTab.id, workspaceId)?.container ?? null
+    if (!container) {
+      return
+    }
     const webview = ensuredWebview.webview
     const needsInitialNavigation = ensuredWebview.created
 
@@ -5368,17 +5391,22 @@ function BrowserPagePane({
           </div>
         ) : null}
       </div>
+      {pageViewport?.content && markup.isActive && markup.baseImage
+        ? createPortal(
+            // Why: the content host matches the capture box exactly (preset-sized under
+            // emulation) and scrolls with the page, so drawn shapes stay aligned.
+            <MarkupOverlay
+              baseImage={markup.baseImage}
+              busy={markup.state === 'composing'}
+              onComplete={(input) => void markup.complete(input)}
+              onCancel={markup.cancel}
+            />,
+            pageViewport.content
+          )
+        : null}
       {pageViewport?.container
         ? createPortal(
             <>
-              {markup.isActive && markup.baseImage ? (
-                <MarkupOverlay
-                  baseImage={markup.baseImage}
-                  busy={markup.state === 'composing'}
-                  onComplete={(input) => void markup.complete(input)}
-                  onCancel={markup.cancel}
-                />
-              ) : null}
               <div
                 role="status"
                 aria-live="polite"

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.test.ts
@@ -8,6 +8,7 @@ import {
   parkBrowserPageViewport,
   registerBrowserOverlaySlotViewport,
   removeBrowserPageViewport,
+  setBrowserPageViewportPresetSize,
   syncBrowserPageChromeInset
 } from './browser-page-viewport'
 
@@ -22,6 +23,7 @@ function mountSlotViewport(workspaceTabId: string): HTMLDivElement {
 afterEach(() => {
   for (const id of ['page-1', 'page-2']) {
     removeBrowserPageViewport(id)
+    setBrowserPageViewportPresetSize(id, null)
   }
   for (const id of ['workspace-1']) {
     getBrowserOverlaySlotViewport(id)?.remove()
@@ -141,6 +143,65 @@ describe('syncBrowserPageChromeInset', () => {
     const viewport = ensureBrowserPageViewport('page-2', 'workspace-1')!
 
     expect(viewport.chromeInset.style.height).toBe('40px')
+  })
+})
+
+describe('setBrowserPageViewportPresetSize', () => {
+  it('builds a scroller and content host between the container and the webview slot', () => {
+    mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    expect(viewport.scroller.parentElement).toBe(viewport.container)
+    expect(viewport.content.parentElement).toBe(viewport.scroller)
+    expect(viewport.scroller.className).toContain('scrollbar-sleek')
+    expect(viewport.scroller.className).toContain('min-w-0')
+    expect(viewport.scroller.className).toContain('overflow-hidden')
+    expect(viewport.content.className).toContain('relative')
+    expect(viewport.content.className).toContain('mx-auto')
+    expect(viewport.content.style.width).toBe('100%')
+    expect(viewport.content.style.height).toBe('100%')
+  })
+
+  it('sizes the content host to the preset and lets the scroller pan it', () => {
+    mountSlotViewport('workspace-1')
+    const viewport = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    setBrowserPageViewportPresetSize('page-1', { width: 1920, height: 1080 })
+
+    expect(viewport.content.style.width).toBe('1920px')
+    expect(viewport.content.style.height).toBe('1080px')
+    expect(viewport.scroller.style.overflow).toBe('auto')
+
+    setBrowserPageViewportPresetSize('page-1', null)
+
+    expect(viewport.content.style.width).toBe('100%')
+    expect(viewport.content.style.height).toBe('100%')
+    expect(viewport.scroller.style.overflow).toBe('')
+  })
+
+  it('restores the preset size when guest recovery rebuilds the shell', () => {
+    mountSlotViewport('workspace-1')
+    ensureBrowserPageViewport('page-1', 'workspace-1')
+    setBrowserPageViewportPresetSize('page-1', { width: 1024, height: 768 })
+    // Guest replacement tears the shell down; the recovery re-render rebuilds it.
+    removeBrowserPageViewport('page-1')
+
+    const rebuilt = ensureBrowserPageViewport('page-1', 'workspace-1')!
+
+    expect(rebuilt.content.style.width).toBe('1024px')
+    expect(rebuilt.content.style.height).toBe('768px')
+    expect(rebuilt.scroller.style.overflow).toBe('auto')
+  })
+
+  it('applies a preset size recorded before the shell existed', () => {
+    setBrowserPageViewportPresetSize('page-2', { width: 375, height: 667 })
+    mountSlotViewport('workspace-1')
+
+    const viewport = ensureBrowserPageViewport('page-2', 'workspace-1')!
+
+    expect(viewport.content.style.width).toBe('375px')
+    expect(viewport.content.style.height).toBe('667px')
+    expect(viewport.scroller.style.overflow).toBe('auto')
   })
 })
 

--- a/src/renderer/src/components/browser-pane/browser-page-viewport.ts
+++ b/src/renderer/src/components/browser-pane/browser-page-viewport.ts
@@ -10,6 +10,8 @@ type BrowserPageViewport = {
   shell: HTMLDivElement
   chromeInset: HTMLDivElement
   container: HTMLDivElement
+  scroller: HTMLDivElement
+  content: HTMLDivElement
 }
 
 const browserPageViewports = new Map<string, BrowserPageViewport>()
@@ -18,6 +20,9 @@ const browserPageViewports = new Map<string, BrowserPageViewport>()
 // re-measure (guest recovery/replacement, profile switch, slot remount). Remembering
 // the inset keeps geometry a property of attaching a guest, not of the first mount.
 const browserPageChromeInsetHeights = new Map<string, number>()
+
+// Why: like the chrome inset, the emulated-viewport size must survive shell rebuilds.
+const browserPageViewportPresetSizes = new Map<string, { width: number; height: number }>()
 
 const slotRootListeners = new Map<string, Set<() => void>>()
 
@@ -102,12 +107,54 @@ export function ensureBrowserPageViewport(
   container.dataset.browserPageContainer = ''
   container.className = 'relative flex min-h-0 flex-1 overflow-hidden bg-background'
 
+  // Why: the scroller pans the emulated viewport while overlays portaled into the
+  // container stay pinned to the pane. min-w-0 so oversized content scrolls instead
+  // of widening the pane; block layout so mx-auto centers a narrower preset and
+  // degrades to margin 0 (reachable scroll origin) when the preset is wider.
+  const scroller = document.createElement('div')
+  scroller.dataset.browserPageScroller = ''
+  scroller.className = 'scrollbar-sleek relative min-h-0 min-w-0 flex-1 overflow-hidden'
+
+  const content = document.createElement('div')
+  content.dataset.browserPageContent = ''
+  content.className = 'relative mx-auto'
+
+  scroller.appendChild(content)
+  container.appendChild(scroller)
   shell.append(chromeInset, container)
   root.appendChild(shell)
 
-  const viewport = { shell, chromeInset, container }
+  const viewport = { shell, chromeInset, container, scroller, content }
   browserPageViewports.set(browserPageId, viewport)
+  applyViewportPresetSizeStyles(viewport, browserPageViewportPresetSizes.get(browserPageId) ?? null)
   return viewport
+}
+
+function applyViewportPresetSizeStyles(
+  viewport: BrowserPageViewport,
+  size: { width: number; height: number } | null
+): void {
+  viewport.content.style.width = size ? `${size.width}px` : '100%'
+  viewport.content.style.height = size ? `${size.height}px` : '100%'
+  // Why: inline 'auto' beats the overflow-hidden class only while a preset is active.
+  viewport.scroller.style.overflow = size ? 'auto' : ''
+}
+
+// Why: the CDP override pins the guest layout viewport to the preset; sizing the
+// content host to match lets the pane scroll to all of it (the webview stays 100%).
+export function setBrowserPageViewportPresetSize(
+  browserPageId: string,
+  size: { width: number; height: number } | null
+): void {
+  if (size) {
+    browserPageViewportPresetSizes.set(browserPageId, size)
+  } else {
+    browserPageViewportPresetSizes.delete(browserPageId)
+  }
+  const viewport = browserPageViewports.get(browserPageId)
+  if (viewport) {
+    applyViewportPresetSizeStyles(viewport, size)
+  }
 }
 
 export function removeBrowserPageViewport(browserPageId: string): void {


### PR DESCRIPTION
## Summary

When a Viewport Size preset (e.g. Laptop L — 1440 × 900) is larger than the browser pane, the page is clipped at the pane edge with no way to scroll to the hidden part:

- The preset is applied purely via CDP `Emulation.setDeviceMetricsOverride` (#1369), so the guest believes its viewport really is that wide — no overflow on its side, so it never grows a scrollbar.
- The host side keeps the `<webview>` at 100% × 100% of an `overflow-hidden` container, so it clips silently.

Neither layer owns the overflow. This PR gives it to the host, like DevTools responsive mode at 100% zoom:

- `browser-page-viewport.ts` now builds `container → scroller → content → <webview>`. The `content` host is sized to the active preset (`100%` when none); the `scroller` becomes `overflow: auto` only while a preset is active. Presets smaller than the pane render top-centered (`mx-auto`); wider presets keep a reachable scroll origin (auto margins collapse to 0). The preset size is remembered in a module map (mirroring the chrome-inset idiom) so shell rebuilds and guest recovery re-apply it, and the webview element itself stays untouched at 100% — recreation needs no style reapply.
- Every pane overlay (find bar, zoom badge, load-failure overlay, annotation cards/tray, grab menus) stays portaled into the non-scrolling container, pinned to the pane.
- Markup (annotate mode) captures the webview but measured the container for its css dims — the two were only equal by construction. The capture context now measures the webview, and `MarkupOverlay` portals into the `content` host so the frozen image matches the capture box exactly and scrolls with the page.
- Panning under active annotations bumps the existing `browserOverlayViewport.version` re-anchor mechanism via a passive scroll listener on the scroller.

Deliberately excluded:

- **Guest HTML fullscreen handling.** CDP pins the guest layout viewport at the preset regardless of element size, so forcing the element back to pane size during fullscreen would re-clip it with no scroll escape. With this fix, fullscreen fills the preset-sized element and pans via the scroller — strictly better than today's clip. No fullscreen code needed.
- **Scale-to-fit** (CDP `scale`, DevTools device-toolbar style) — planned as a separate follow-up enhancement on top of this.

Fixes #13293

## Screenshots

**Before** — Laptop L (1440 × 900) preset in a half-width window. The page is clipped at the pane edge — note the bottom of the pane: there is no horizontal scrollbar, so the hidden right side is unreachable.

<img width="420" alt="before" src="https://github.com/user-attachments/assets/712d4627-0e31-44d1-959e-5b3a513f4dfb" />

**After** — same window and preset. Note the horizontal scrollbar along the bottom edge of the pane — the full 1440px-wide page can now be panned.

<img width="420" alt="after" src="https://github.com/user-attachments/assets/4a3f0b3d-81b5-446e-b74d-ce9a75cd7a88" />

No visual change when no preset is active — the default path keeps `100%` sizing and `overflow-hidden`, byte-identical behavior.

## Testing

- [x] `pnpm lint` — oxlint, code-quality audits, reliability gates, max-lines ratchet, bundled-skill-guides, and all three localization verifiers pass. `verify:skill-bundle-manifest` fails identically on a clean tree (verified by stashing this change), so it is a pre-existing local-environment issue, not caused by this PR.
- [x] `pnpm typecheck`
- [x] `pnpm test` — ran the full suite twice: both runs produced the identical result (74 files / 217 tests failed, 47,652 passed), all failures outside the changed area (main-process git/ssh/pty/relay/vault and a few unrelated renderer suites; e.g. `spawn /bin/sh ENOENT` on Windows). The browser-pane directory — the changed area — passes 43 files / 339 tests. Local environment runs Node 22 while the repo pins Node 24 (engine warning), the likely cause.
- [x] `pnpm build`
- [x] Added high-quality tests that would catch regressions: four cases in `browser-page-viewport.test.ts` (scroller/content structure contract, preset apply/clear, size survives a shell rebuild, size recorded before the shell exists). **Verified they catch the regression:** with the style applier neutered, exactly these four fail and nothing else (`4 failed | 11 passed`); restored, all 15 pass.
- Manual verification on Windows (dev build): both axes scroll to every page edge under Laptop L/Desktop presets; Mobile M renders top-centered with a letterbox and touch emulation still active; Responsive is unchanged; the preset survives navigation, reload, and app restart; find bar/zoom badge/failure overlay stay pinned while panning; markup shapes land where drawn; annotations re-anchor on pan.

## AI Review Report

Reviewed with Claude Code. Checks performed:

- **Cross-platform (macOS, Linux, Windows).** Renderer-only DOM/CSS; no platform branches, shortcuts, file paths, or Electron platform APIs. Chromium is the same on all three platforms, so `overflow: auto` / `margin: 0 auto` / flex behave identically. The only OS-visible difference is scrollbar chrome (overlay on macOS, classic on Windows/Linux), delegated to the app-wide `.scrollbar-sleek` class that sidebars and lists already use. Verified by hand on Windows.
- **SSH / remote / local.** Remote panes render through a disjoint component (`RemoteBrowserPagePane`, streamed frames into an `<img>`) that never constructs a `<webview>`; the Viewport Size submenu is not offered there, and `setViewportOverride` is not a runtime RPC. No RPC params, stream frames, or host-published content change, so `docs/reference/remote-wire-compatibility.md` is not triggered. Web-client stubs are untouched.
- **Folder workspaces.** The browser pane is workspace-type-agnostic; no git assumptions.
- **Agents / integrations / git providers.** Not involved — no provider-specific behavior.
- **Performance.** Static inline styles applied on preset change; one passive scroll listener gated on active annotations; no new observers or hot-path work. Pane resize no longer re-lays-out the guest while a preset is active (the element size is fixed), which removes resize churn rather than adding it.
- **UI quality.** Existing tokens only — the letterbox shows the container's `bg-background`; scrollbars use the documented `.scrollbar-sleek` class (`docs/STYLEGUIDE.md` § Scrollbars); smaller presets center like the DevTools device toolbar. Checked in light and dark mode.
- **Code budget.** New logic lives in `browser-page-viewport.ts` (well under the 300-line cap); no new `max-lines` suppressions.

Flagged during review and resolved: the webview's drag/drop listeners stay on the container (re-resolved after `ensureBrowserPageWebview`, since drift repair can rebuild the shell) so letterbox drops keep producing the existing guidance notice instead of silently landing on the content host.

## Security Audit

- No IPC handlers, schemas, or preload surfaces change; the CDP path (`setViewportOverride`) is untouched.
- Renderer-only DOM/CSS with no new parsing of page-controlled input; the scroll listener is passive and content-agnostic.
- No new dependencies.

## Notes

- Wheel over the page scrolls the guest (unchanged); panning the oversized viewport uses the pane scrollbars — same interaction as DevTools at 100%.
- Switching tabs parks the shell with `display: none`, which resets the host pan to 0,0; the guest's own scroll position is preserved (the one that matters).
- Grab-menu position staleness while panning matches the pre-existing staleness under guest scroll — not a regression.
- Markup's bottom toolbar sits at the bottom of the preset-sized surface, so for presets taller than the pane it is reached by scrolling; the scale-to-fit follow-up owns that polish.

