### PR TITLE
fix(agent-status): mint the Claude turn-complete edge from the turn's own end time

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
@@ -1,0 +1,55 @@
+import { describe, expect, it, vi } from 'vitest'
+import { createAgentCompletionCoordinator } from './agent-completion-coordinator'
+import {
+  HOOK_DONE_QUIET_MS,
+  useAgentCompletionCoordinatorLifecycle
+} from './agent-completion-coordinator-test-harness'
+
+describe('agent completion coordinator', () => {
+  useAgentCompletionCoordinatorLifecycle()
+
+  it('pairs a background all-clear with the turn it announced even after a working title blip', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000
+    })
+    // Why: Claude's lead Stop ended the turn while a background subagent kept the pane `working`.
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    // Why: a working spinner in the title resets the pane's completion-identity record, so the
+    // all-clear below can only be recognized by the turn end time it repeats — not by the pane's
+    // pinned stateStartedAt, which moved when the row finally reported `done` (#13245).
+    vi.advanceTimersByTime(2_000)
+    coordinator.observeTitleWorking()
+
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_050_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
@@ -8,7 +8,7 @@ import {
 describe('agent completion coordinator', () => {
   useAgentCompletionCoordinatorLifecycle()
 
-  it('pairs a background all-clear with the turn it announced even after a working title blip', () => {
+  it('ignores a turn end time that cannot name a turn', () => {
     const dispatchCompletion = vi.fn()
     const coordinator = createAgentCompletionCoordinator({
       paneKey: 'tab-1:leaf-1',
@@ -16,6 +16,63 @@ describe('agent completion coordinator', () => {
       getSettings: () => null,
       inspectProcess: vi.fn(),
       dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000
+    })
+    // Why: NaN/Infinity identify nothing, so a `working` row carrying one is just a working row —
+    // announcing on it would raise a banner for a turn that has not ended.
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000,
+      turnCompletedAt: Number.NaN
+    })
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('does not announce a gated Stop for a turn it never saw start', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    // Why: a stamped `working` row replays on activation and worktree switches. Without a
+    // `working` of its own first, this coordinator has no evidence the turn ran here at all, so
+    // the stamp alone must not mint a banner (#13245).
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+
+    expect(dispatchCompletion).not.toHaveBeenCalled()
+  })
+
+  it('pairs a background all-clear with the turn it announced even after a working title blip', () => {
+    const dispatchCompletion = vi.fn()
+    const dispatchHookLifecycle = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      dispatchHookLifecycle,
       isLive: () => true
     })
 
@@ -35,9 +92,10 @@ describe('agent completion coordinator', () => {
     })
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
 
-    // Why: a working spinner in the title resets the pane's completion-identity record, so the
-    // all-clear below can only be recognized by the turn end time it repeats — not by the pane's
-    // pinned stateStartedAt, which moved when the row finally reported `done` (#13245).
+    // Why: a working spinner in the title drops the pane-scoped record, so the only thing left
+    // that can pair the all-clear with the turn already announced is the coordinator's own
+    // identity for it — which is built from the turn end time the all-clear repeats, not from the
+    // pane's pinned stateStartedAt, which moved when the row finally reported `done` (#13245).
     vi.advanceTimersByTime(2_000)
     coordinator.observeTitleWorking()
 
@@ -51,5 +109,122 @@ describe('agent completion coordinator', () => {
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    // Why: recognizing the all-clear must not cost the pane its `done` lifecycle — the turn is
+    // over, and cursor/cache release still has to run.
+    expect(dispatchHookLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'done', turnCompletedAt: 1_700_000_005_000 })
+    )
+  })
+
+  it('pairs a background all-clear with the turn it announced across a coordinator remount', () => {
+    const dispatchCompletion = vi.fn()
+    const firstCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    firstCoordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000
+    })
+    firstCoordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    firstCoordinator.dispose()
+
+    // Why: a worktree switch rebuilds the coordinator while the hook stream stays live, so the
+    // fresh one holds no identity of its own. Only the pane-scoped turn end time can tell it the
+    // `done` below is the tail of a turn already announced (#13245).
+    const dispatchHookLifecycle = vi.fn()
+    const remountedCoordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      dispatchHookLifecycle,
+      isLive: () => true
+    })
+
+    vi.advanceTimersByTime(30_000)
+    remountedCoordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'review the PR',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_050_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+    // Why: the fresh coordinator can only reach the lifecycle-only drain through the pane-scoped
+    // turn end time; the identity dedupe alone would swallow the `done` and the pane would never
+    // leave `working`.
+    expect(dispatchHookLifecycle).toHaveBeenCalledWith(
+      expect.objectContaining({ state: 'done', turnCompletedAt: 1_700_000_005_000 })
+    )
+  })
+
+  it('still announces a background turn whose gated Stop lost to an earlier title completion', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    // Why: a title-driven turn first, so the pane's completion record names the same agent from a
+    // different source. That record vetoes the gated Stop below without announcing anything.
+    coordinator.observeTitle('⠋ claude')
+    vi.advanceTimersByTime(2_000)
+    coordinator.observeTitle('claude done')
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(2_000)
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the build',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000
+    })
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the build',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    vi.advanceTimersByTime(2_000)
+    coordinator.observeTitleWorking()
+
+    // Why: the gated Stop never reached the user, so the turn is still unannounced and its
+    // all-clear has to raise the banner. A completion mirrored locally before the dispatch
+    // committed would make this `done` read as that turn's tail and the turn would go silent.
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the build',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_050_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
 })

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
@@ -227,4 +227,54 @@ describe('agent completion coordinator', () => {
 
     expect(dispatchCompletion).toHaveBeenCalledTimes(2)
   })
+
+  it('recognizes a gated row replayed after the all-clear that announced its turn', () => {
+    const dispatchCompletion = vi.fn()
+    const coordinator = createAgentCompletionCoordinator({
+      paneKey: 'tab-1:leaf-1',
+      getPtyId: () => 'pty-1',
+      getSettings: () => null,
+      inspectProcess: vi.fn(),
+      dispatchCompletion,
+      isLive: () => true
+    })
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the build',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000
+    })
+    // Why: this coordinator never saw the turn's gated Stop, so the turn is still unannounced and
+    // its all-clear raises the banner itself.
+    coordinator.observeHookStatus({
+      state: 'done',
+      prompt: 'run the build',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_050_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'now lint',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_060_000
+    })
+
+    // Why: activation replays that turn's gated row. What the pane recorded for the completion is
+    // the turn's end time, not the `done` row's stateStartedAt, so the replay reads as the banner
+    // already shown rather than a second one (#13245).
+    coordinator.observeHookStatus({
+      state: 'working',
+      prompt: 'run the build',
+      agentType: 'claude',
+      stateStartedAt: 1_700_000_000_000,
+      turnCompletedAt: 1_700_000_005_000
+    })
+
+    expect(dispatchCompletion).toHaveBeenCalledTimes(1)
+  })
 })

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator-background-turn-identity.test.ts
@@ -25,8 +25,8 @@ describe('agent completion coordinator', () => {
       agentType: 'claude',
       stateStartedAt: 1_700_000_000_000
     })
-    // Why: NaN/Infinity identify nothing, so a `working` row carrying one is just a working row —
-    // announcing on it would raise a banner for a turn that has not ended.
+    // Why: NaN identifies no turn, so this stays an ordinary `working` row — announcing on it
+    // would raise a banner for a turn that has not ended.
     coordinator.observeHookStatus({
       state: 'working',
       prompt: 'review the PR',

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -285,6 +285,7 @@ export function createAgentCompletionCoordinator(
     )
   }
 
+  /** Run one completion's side effects; false when a guard vetoed it and nothing was announced. */
   function dispatchCompletion(
     source: CompletionSource,
     title: string,
@@ -297,23 +298,23 @@ export function createAgentCompletionCoordinator(
        *  inventory), so the synthetic `done` must not run pane lifecycle side effects. */
       notifyWithoutLifecycle?: boolean
     } = {}
-  ): void {
+  ): boolean {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
-      return
+      return false
     }
     if (requiresFreshWorking || lastCompletedTurn === currentTurn) {
-      return
+      return false
     }
     if (!options.isLive() || !hasAgentRunEvidence) {
-      return
+      return false
     }
     const now = Date.now()
     const token = completionToken(source)
     if (token === lastCompletionToken && now - lastCompletionAt < COMPLETION_REPLAY_GUARD_MS) {
-      return
+      return false
     }
     if (completionIdentityAlreadyNotified(optionsOverride.completionIdentity)) {
-      return
+      return false
     }
     lastCompletionToken = token
     lastCompletionAt = now
@@ -350,6 +351,7 @@ export function createAgentCompletionCoordinator(
     } else {
       options.dispatchCompletion(title)
     }
+    return true
   }
 
   function dispatchAttentionNotification(payload: AgentCompletionStatusSnapshot): void {
@@ -816,14 +818,16 @@ export function createAgentCompletionCoordinator(
     }
   }
 
-  /** True when this pane already announced the turn that ended at this timestamp. */
+  /** True when this pane already announced the turn that ended at this timestamp. Read from both
+   *  records that can hold it: the pane-scoped one outlives a remount, and the coordinator-local
+   *  one outlives a working title, which drops the pane-scoped one. */
   function turnCompletedAtAlreadyNotified(turnCompletedAt: number | undefined): boolean {
     if (!isFiniteTurnCompletedAt(turnCompletedAt)) {
       return false
     }
     return (
       lastCompletionIdentityByPaneKey.get(options.paneKey)?.lastTurnCompletedAtNotified ===
-      turnCompletedAt
+        turnCompletedAt || lastCompletionIdentity?.lastTurnCompletedAtNotified === turnCompletedAt
     )
   }
 
@@ -851,17 +855,24 @@ export function createAgentCompletionCoordinator(
         // working-run must not collapse onto a single banner.
         stateStartedAt: turnCompletedAt
       }
-      lastCompletionIdentity = {
+      const announcedIdentity: LastCompletionIdentity = {
         source: 'hook',
         identity: completionIdentityFor('done', payload.agentType, turnCompletedAt),
         agentIdentity: hookCompletionAgentIdentity(payload),
         lastTurnCompletedAtNotified: turnCompletedAt
       }
-      dispatchCompletion('hook', payload.agentType ?? options.paneKey, {
+      const announced = dispatchCompletion('hook', payload.agentType ?? options.paneKey, {
         agentStatus: completionPayload,
-        completionIdentity: lastCompletionIdentity,
+        completionIdentity: announcedIdentity,
         notifyWithoutLifecycle: true
       })
+      // Why: a vetoed dispatch (pane not live, or an earlier completion for this agent already
+      // recorded) announces nothing and writes no pane record. Mirroring the identity anyway
+      // would make this turn's all-clear `done` read as the tail of an announcement the user
+      // never saw, and the turn would go silent entirely (#13245).
+      if (announced) {
+        lastCompletionIdentity = announcedIdentity
+      }
     }
     options.dispatchHookLifecycle?.(payload)
   }

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -33,10 +33,9 @@ type LastCompletionIdentity = {
   agentIdentity: string | null
   /** End time of the Claude lead turn already announced from a pane that stayed `working` for
    *  its background inventory (#13245); absent for every other completion. That turn's all-clear
-   *  `done` arrives carrying the same value and must not raise a second banner. Held here —
-   *  not in a coordinator-local flag — so the suppression is keyed by turn (a turn whose
-   *  all-clear never arrives cannot swallow the next turn) and survives the live remount this
-   *  map already outlives. */
+   *  `done` arrives carrying the same value and must not raise a second banner. Keyed by turn
+   *  rather than a boolean flag, so a turn whose all-clear never arrives cannot swallow the next
+   *  one; pane-scoped so it survives the live remount this map already outlives. */
   lastTurnCompletedAtNotified?: number | null
 }
 

--- a/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
+++ b/src/renderer/src/components/terminal-pane/agent-completion-coordinator.ts
@@ -31,6 +31,13 @@ type LastCompletionIdentity = {
   source: CompletionIdentitySource
   identity: string
   agentIdentity: string | null
+  /** End time of the Claude lead turn already announced from a pane that stayed `working` for
+   *  its background inventory (#13245); absent for every other completion. That turn's all-clear
+   *  `done` arrives carrying the same value and must not raise a second banner. Held here —
+   *  not in a coordinator-local flag — so the suppression is keyed by turn (a turn whose
+   *  all-clear never arrives cannot swallow the next turn) and survives the live remount this
+   *  map already outlives. */
+  lastTurnCompletedAtNotified?: number | null
 }
 
 // Why: worktree switches remount a pane while the PTY/hook stream stays live, so stale completion replays must outlive one coordinator.
@@ -57,6 +64,11 @@ const POLL_TIER_INTERVAL_MS: Record<PollCadenceTier, number> = {
   idle: IDLE_POLL_INTERVAL_MS,
   hidden: HIDDEN_POLL_INTERVAL_MS,
   'no-evidence': NO_EVIDENCE_POLL_INTERVAL_MS
+}
+
+/** Narrow an optional turn end time to one that can identify a turn; NaN and Infinity cannot. */
+function isFiniteTurnCompletedAt(value: number | undefined): value is number {
+  return typeof value === 'number' && Number.isFinite(value)
 }
 
 function isCompletionHookState(state: ParsedAgentStatusPayload['state']): boolean {
@@ -169,15 +181,27 @@ export function createAgentCompletionCoordinator(
     return `${source}:${currentTurn}:${processSession}`
   }
 
+  /** Dedupe key for one completion: the state, the agent, and the timestamp that names the turn. */
+  function completionIdentityFor(
+    state: string,
+    agentType: string | undefined,
+    timestamp: number
+  ): string {
+    return [state, agentType ?? '', String(Math.trunc(timestamp))].join(':')
+  }
+
   function hookCompletionIdentity(payload: AgentCompletionStatusSnapshot): string | null {
-    if (typeof payload.stateStartedAt !== 'number' || !Number.isFinite(payload.stateStartedAt)) {
+    // Why: `stateStartedAt` is pinned for as long as the reported state does not change, so on a
+    // pane held at `working` by Claude's background inventory every turn in the run would share
+    // one identity and only the first would notify. The turn's own end time is the per-turn
+    // identity there; everywhere else stateStartedAt still is (#13245).
+    const timestamp = isFiniteTurnCompletedAt(payload.turnCompletedAt)
+      ? payload.turnCompletedAt
+      : payload.stateStartedAt
+    if (typeof timestamp !== 'number' || !Number.isFinite(timestamp)) {
       return null
     }
-    return [
-      payload.state,
-      payload.agentType ?? '',
-      String(Math.trunc(payload.stateStartedAt))
-    ].join(':')
+    return completionIdentityFor(payload.state, payload.agentType, timestamp)
   }
 
   function hookCompletionAgentIdentity(payload: AgentCompletionStatusSnapshot): string | null {
@@ -269,6 +293,9 @@ export function createAgentCompletionCoordinator(
       terminalIdleConfirmed?: boolean
       agentStatus?: AgentCompletionStatusSnapshot
       completionIdentity?: LastCompletionIdentity | null
+      /** Announce only. The pane is legitimately still `working` (Claude background
+       *  inventory), so the synthetic `done` must not run pane lifecycle side effects. */
+      notifyWithoutLifecycle?: boolean
     } = {}
   ): void {
     if (source !== 'hook' && pendingHookDoneTimer !== null) {
@@ -298,10 +325,21 @@ export function createAgentCompletionCoordinator(
     if (optionsOverride.completionIdentity) {
       lastCompletionIdentityByPaneKey.set(options.paneKey, optionsOverride.completionIdentity)
     }
-    if (source === 'hook' && optionsOverride.agentStatus) {
+    if (
+      source === 'hook' &&
+      optionsOverride.agentStatus &&
+      optionsOverride.notifyWithoutLifecycle !== true
+    ) {
       options.dispatchHookLifecycle?.(optionsOverride.agentStatus)
     }
-    if (optionsOverride.quietedHookDone === true || source === 'process-exit') {
+    if (
+      optionsOverride.quietedHookDone === true ||
+      source === 'process-exit' ||
+      // Why: this completion has no matching store row to read the finished turn from — the pane
+      // row stays `working` — so its own `done` snapshot must ride along or the banner reads the
+      // previous turn. Scoped to that one path so every other agent's dispatch shape is unchanged.
+      optionsOverride.notifyWithoutLifecycle === true
+    ) {
       // Why: confirmed process death is independent completion evidence; keep its provenance so stale hook rows can't veto it later.
       options.dispatchCompletion(title, {
         source,
@@ -778,6 +816,56 @@ export function createAgentCompletionCoordinator(
     }
   }
 
+  /** True when this pane already announced the turn that ended at this timestamp. */
+  function turnCompletedAtAlreadyNotified(turnCompletedAt: number | undefined): boolean {
+    if (!isFiniteTurnCompletedAt(turnCompletedAt)) {
+      return false
+    }
+    return (
+      lastCompletionIdentityByPaneKey.get(options.paneKey)?.lastTurnCompletedAtNotified ===
+      turnCompletedAt
+    )
+  }
+
+  /** Claude's lead Stop already ended this turn; the pane only reports `working` because its
+   *  background subagents/shells/crons are still registered. Mint the completion edge now —
+   *  deferring it means silence for the whole background lifetime, and for a background shell
+   *  the edge never arrives at all (#13245). Banner only: the pane really is still working, so
+   *  pane lifecycle keeps following the reported `working` state. */
+  function observeTurnCompletedWhileBackgroundWorking(
+    payload: AgentCompletionStatusSnapshot,
+    turnCompletedAt: number
+  ): void {
+    if (
+      workingStatusObserved &&
+      !requiresFreshWorking &&
+      !turnCompletedAtAlreadyNotified(turnCompletedAt)
+    ) {
+      clearPendingHookDone()
+      clearPendingCodexAttention()
+      const completionPayload: AgentCompletionStatusSnapshot = {
+        ...payload,
+        state: 'done',
+        // Why: the turn's real end time, not an offset fabricated from the pinned working
+        // stateStartedAt — the notification id is built from this, so consecutive turns in one
+        // working-run must not collapse onto a single banner.
+        stateStartedAt: turnCompletedAt
+      }
+      lastCompletionIdentity = {
+        source: 'hook',
+        identity: completionIdentityFor('done', payload.agentType, turnCompletedAt),
+        agentIdentity: hookCompletionAgentIdentity(payload),
+        lastTurnCompletedAtNotified: turnCompletedAt
+      }
+      dispatchCompletion('hook', payload.agentType ?? options.paneKey, {
+        agentStatus: completionPayload,
+        completionIdentity: lastCompletionIdentity,
+        notifyWithoutLifecycle: true
+      })
+    }
+    options.dispatchHookLifecycle?.(payload)
+  }
+
   function observeHookStatus(payload: AgentCompletionStatusSnapshot): void {
     recordPaneActivity()
     if (options.shouldSuppressHookCompletion?.(payload)) {
@@ -792,6 +880,10 @@ export function createAgentCompletionCoordinator(
       establishAgentEvidence()
     }
     if (payload.state === 'working') {
+      if (isFiniteTurnCompletedAt(payload.turnCompletedAt)) {
+        observeTurnCompletedWhileBackgroundWorking(payload, payload.turnCompletedAt)
+        return
+      }
       clearPendingHookDone()
       // Why: resumed work cancels the debounced attention so a self-resolving pause never notifies.
       clearPendingCodexAttention()
@@ -822,6 +914,21 @@ export function createAgentCompletionCoordinator(
       clearPendingCodexAttention()
       if (isRecognizedAgentType(payload.agentType)) {
         establishAgentEvidence()
+      }
+      if (turnCompletedAtAlreadyNotified(payload.turnCompletedAt)) {
+        // Why: this `done` is the all-clear tail of a turn whose completion was already
+        // announced from the gated Stop; drain it for pane lifecycle only (#13245).
+        clearPendingHookDone()
+        const allClearIdentity = hookCompletionIdentity(payload)
+        if (allClearIdentity) {
+          lastCompletionIdentity = {
+            source: 'hook',
+            identity: allClearIdentity,
+            agentIdentity: hookCompletionAgentIdentity(payload)
+          }
+        }
+        options.dispatchHookLifecycle?.(payload)
+        return
       }
       const hookIdentity = hookCompletionIdentity(payload)
       if (

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -190,6 +190,38 @@ describe('dispatchTerminalNotification', () => {
     expect(mockState.markTerminalPaneUnread).toHaveBeenCalledWith(paneKey)
   })
 
+  it('builds the notification id from a completion snapshot, not the pinned working row', () => {
+    // Why: a Claude pane held at `working` by background work keeps one stateStartedAt for
+    // every turn in the run, so reading the id from the stored row collapses consecutive
+    // banners onto one id and each new banner closes the previous one (#13245).
+    const pinnedWorkingStartedAt = Date.now() - 60_000
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      stateStartedAt: pinnedWorkingStartedAt
+    })
+    const turnCompletedAt = Date.now()
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'done',
+        prompt: 'codex-hook-notify',
+        agentType: 'codex',
+        stateStartedAt: turnCompletedAt
+      }
+    })
+
+    expect(getLastNotificationDispatchArg()?.notificationId).toBe(
+      buildAgentNotificationId({
+        worktreeId: 'wt-primary',
+        paneKey,
+        stateStartedAt: turnCompletedAt
+      })
+    )
+  })
+
   it('uses a live pane key when inactive worktree tab membership is not hydrated', () => {
     mockState.tabsByWorktree = {}
 

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.test.ts
@@ -222,6 +222,36 @@ describe('dispatchTerminalNotification', () => {
     )
   })
 
+  it('keeps the stored row for the notification id when the snapshot is not a completion', () => {
+    // Why: only a `done` snapshot names a finished turn, so a mid-turn one must not outrank the
+    // stored row's timing.
+    const storedStartedAt = Date.now() - 60_000
+    mockState.agentStatusByPaneKey[paneKey] = makeAgentStatus(paneKey, {
+      state: 'working',
+      stateStartedAt: storedStartedAt
+    })
+
+    dispatchTerminalNotification('wt-primary', {
+      source: 'agent-task-complete',
+      terminalTitle: 'codex',
+      paneKey,
+      agentStatusSnapshot: {
+        state: 'working',
+        prompt: 'codex-hook-notify',
+        agentType: 'codex',
+        stateStartedAt: Date.now()
+      }
+    })
+
+    expect(getLastNotificationDispatchArg()?.notificationId).toBe(
+      buildAgentNotificationId({
+        worktreeId: 'wt-primary',
+        paneKey,
+        stateStartedAt: storedStartedAt
+      })
+    )
+  })
+
   it('uses a live pane key when inactive worktree tab membership is not hydrated', () => {
     mockState.tabsByWorktree = {}
 

--- a/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
+++ b/src/renderer/src/components/terminal-pane/use-notification-dispatch.ts
@@ -120,8 +120,16 @@ export function dispatchTerminalNotification(
   ) {
     return
   }
+  // Why: the stored row's stateStartedAt is pinned while its state does not change, so a pane
+  // that stays `working` across several finished turns (Claude background inventory) would build
+  // the same notification id every time and main would close the previous banner as a repaint.
+  // A completion snapshot carries that turn's own end time, so it is the authority here (#13245).
   const agentNotificationStateStartedAt =
-    freshStoredAgentStatus?.stateStartedAt ?? eventAgentStatusSnapshot?.stateStartedAt
+    (eventAgentStatusSnapshot?.state === 'done'
+      ? eventAgentStatusSnapshot.stateStartedAt
+      : undefined) ??
+    freshStoredAgentStatus?.stateStartedAt ??
+    eventAgentStatusSnapshot?.stateStartedAt
   // Why: main-process hook IPC can update inactive/unmounted worktrees before
   // the renderer's live-PTY map catches up. A fresh accepted hook snapshot is
   // authoritative for agent completion; title/BEL-only paths still need PTY liveness.

--- a/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
@@ -38,7 +38,6 @@ const WORKTREE_ID = 'wt-1'
 const HOOK_DONE_QUIET_MS = 1_500
 
 const RUNNING_SHELL = { id: 'shell-1', type: 'shell', status: 'running' }
-const FINISHED_SHELL = { id: 'shell-1', type: 'shell', status: 'completed' }
 
 /** Replays Claude hook events through the real listener and the real completion coordinator,
  *  stamping `stateStartedAt` the way the hook server does: pinned for as long as the reported
@@ -171,13 +170,14 @@ describe('claude turn completions while background work keeps the pane working',
     await replay.emit({
       hook_event_name: 'Stop',
       last_assistant_message: 'Lint is queued.',
-      background_tasks: [FINISHED_SHELL]
+      background_tasks: [RUNNING_SHELL]
     })
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
     // Why: a turn that ended while a background shell ran must not silence the next one (#13245).
     expect(completionBodies()).toEqual(['Build started in the background.', 'Lint is queued.'])
-    // Why: two bodies are only two banners if they also build two notification ids.
+    // Why: the pane never left `working`, so both ids come from the turns' own end times; equal
+    // ids would make main close the first banner as a repaint of the second.
     expect(new Set(completionStateStartedAts()).size).toBe(2)
   })
 

--- a/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
@@ -94,9 +94,9 @@ function createClaudeHookReplay(): {
   }
 }
 
-/** Every completion banner, including one dispatched without a snapshot — an extra banner must
- *  never hide behind a missing snapshot. A `waiting`/`blocked` snapshot rides the same channel to
- *  raise "needs input" attention, which is a separate signal and not a turn completion. */
+/** Completion banners; a snapshot-less dispatch counts too, so an extra banner cannot hide behind
+ *  a missing snapshot. A `waiting`/`blocked` snapshot rides the same channel to raise "needs
+ *  input" attention, which is a separate signal and not a turn completion. */
 function completionSnapshots(): (
   | { lastAssistantMessage?: string; stateStartedAt?: number }
   | undefined
@@ -175,12 +175,9 @@ describe('claude turn completions while background work keeps the pane working',
     })
     vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
 
-    // Why: the first turn's completion must not be able to swallow the next turn's — the
-    // background shell never produces an all-clear of its own, so a one-shot suppression flag
-    // would survive into turn N+1 and silence it (#13245).
+    // Why: a turn that ended while a background shell ran must not silence the next one (#13245).
     expect(completionBodies()).toEqual(['Build started in the background.', 'Lint is queued.'])
-    // Why: two bodies are only two banners if they also build two notification ids; the pane
-    // never left `working`, so both would otherwise be minted from the same pinned timestamp.
+    // Why: two bodies are only two banners if they also build two notification ids.
     expect(new Set(completionStateStartedAts()).size).toBe(2)
   })
 

--- a/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
@@ -1,0 +1,267 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createHookListenerState, normalizeHookPayload } from '../../../shared/agent-hook-listener'
+import type { AgentStatusEntry } from '../../../shared/agent-status-types'
+
+const dispatchTerminalNotification = vi.fn()
+const dispatchAgentHookTerminalLifecycle = vi.fn()
+
+type MockStoreState = {
+  settings: {
+    experimentalTerminalAttention: boolean
+    notifications: { enabled: boolean; agentTaskComplete: boolean }
+  }
+  ptyIdsByTabId: Record<string, string[]>
+  suppressedPtyExitIds: Record<string, boolean>
+  tabsByWorktree: Record<string, { id: string; ptyId?: string | null }[]>
+  terminalLayoutsByTabId: Record<string, never>
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+}
+
+let mockStoreState: MockStoreState
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState
+  }
+}))
+
+vi.mock('@/components/terminal-pane/use-notification-dispatch', () => ({
+  dispatchTerminalNotification
+}))
+
+vi.mock('@/components/terminal-pane/agent-hook-terminal-lifecycle', () => ({
+  dispatchAgentHookTerminalLifecycle
+}))
+
+const PANE_KEY = 'tab-1:11111111-1111-4111-8111-111111111111'
+const WORKTREE_ID = 'wt-1'
+const HOOK_DONE_QUIET_MS = 1_500
+
+const RUNNING_SHELL = { id: 'shell-1', type: 'shell', status: 'running' }
+const FINISHED_SHELL = { id: 'shell-1', type: 'shell', status: 'completed' }
+
+/** Replays Claude hook events through the real listener and the real completion coordinator,
+ *  stamping `stateStartedAt` the way the hook server does: pinned for as long as the reported
+ *  state does not change (src/main/agent-hooks/server.ts). That pinning is the reason a turn
+ *  needs its own end time to be identified at all (#13245). */
+function createClaudeHookReplay(): {
+  emit: (payload: Record<string, unknown>) => Promise<void>
+  remountCoordinator: () => Promise<void>
+} {
+  const listenerState = createHookListenerState()
+  let pinnedState: string | null = null
+  let pinnedStateStartedAt = 0
+
+  return {
+    emit: async (hookPayload) => {
+      const { observeAgentHookCompletionForNotification } =
+        await import('./agent-hook-completion-notifications')
+      const event = normalizeHookPayload(
+        listenerState,
+        'claude',
+        { paneKey: PANE_KEY, tabId: 'tab-1', worktreeId: WORKTREE_ID, payload: hookPayload },
+        'production'
+      )
+      if (!event) {
+        return
+      }
+      if (pinnedState !== event.payload.state) {
+        pinnedState = event.payload.state
+        pinnedStateStartedAt = Date.now()
+      }
+      mockStoreState.agentStatusByPaneKey[PANE_KEY] = {
+        state: event.payload.state,
+        prompt: event.payload.prompt,
+        paneKey: PANE_KEY,
+        updatedAt: Date.now(),
+        stateStartedAt: pinnedStateStartedAt,
+        agentType: event.payload.agentType,
+        stateHistory: []
+      }
+      observeAgentHookCompletionForNotification({
+        paneKey: PANE_KEY,
+        worktreeId: WORKTREE_ID,
+        payload: { ...event.payload, stateStartedAt: pinnedStateStartedAt }
+      })
+    },
+    remountCoordinator: async () => {
+      const { resetAgentHookCompletionNotificationCoordinators } =
+        await import('./agent-hook-completion-notifications')
+      // Why: a worktree switch tears the pane's coordinator down while the pane stays live and
+      // the hook stream keeps running; the next event builds a fresh coordinator.
+      resetAgentHookCompletionNotificationCoordinators()
+    }
+  }
+}
+
+/** Every completion banner, including one dispatched without a snapshot — an extra banner must
+ *  never hide behind a missing snapshot. A `waiting`/`blocked` snapshot rides the same channel to
+ *  raise "needs input" attention, which is a separate signal and not a turn completion. */
+function completionSnapshots(): (
+  | { lastAssistantMessage?: string; stateStartedAt?: number }
+  | undefined
+)[] {
+  return dispatchTerminalNotification.mock.calls
+    .map(([, event]) => event.agentStatusSnapshot)
+    .filter((snapshot) => snapshot === undefined || snapshot.state === 'done')
+}
+
+function completionBodies(): (string | undefined)[] {
+  return completionSnapshots().map((snapshot) => snapshot?.lastAssistantMessage)
+}
+
+function completionStateStartedAts(): (number | undefined)[] {
+  return completionSnapshots().map((snapshot) => snapshot?.stateStartedAt)
+}
+
+describe('claude turn completions while background work keeps the pane working', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-01-01T00:00:00.000Z'))
+    dispatchTerminalNotification.mockClear()
+    dispatchAgentHookTerminalLifecycle.mockClear()
+    mockStoreState = {
+      settings: {
+        experimentalTerminalAttention: false,
+        notifications: { enabled: true, agentTaskComplete: true }
+      },
+      ptyIdsByTabId: { 'tab-1': ['pty-1'] },
+      suppressedPtyExitIds: {},
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'pty-1' }] },
+      terminalLayoutsByTabId: {},
+      agentStatusByPaneKey: {}
+    }
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('still notifies the turn after one that ended while a background shell ran', async () => {
+    const replay = createClaudeHookReplay()
+
+    await replay.emit({ hook_event_name: 'UserPromptSubmit', prompt: 'run the build' })
+    vi.advanceTimersByTime(1_000)
+    await replay.emit({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Build started in the background.',
+      background_tasks: [RUNNING_SHELL]
+    })
+
+    // Why: the pane's stored row still says `working`, so the banner has nothing to read the
+    // finished turn from unless this completion's own `done` snapshot rides with it.
+    expect(dispatchTerminalNotification).toHaveBeenCalledWith(
+      'wt-1',
+      expect.objectContaining({
+        source: 'agent-task-complete',
+        paneKey: PANE_KEY,
+        agentStatusSnapshot: expect.objectContaining({
+          state: 'done',
+          agentType: 'claude',
+          prompt: 'run the build',
+          lastAssistantMessage: 'Build started in the background.'
+        })
+      })
+    )
+
+    vi.advanceTimersByTime(5_000)
+    await replay.emit({ hook_event_name: 'UserPromptSubmit', prompt: 'now lint' })
+    vi.advanceTimersByTime(1_000)
+    await replay.emit({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Lint is queued.',
+      background_tasks: [FINISHED_SHELL]
+    })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    // Why: the first turn's completion must not be able to swallow the next turn's — the
+    // background shell never produces an all-clear of its own, so a one-shot suppression flag
+    // would survive into turn N+1 and silence it (#13245).
+    expect(completionBodies()).toEqual(['Build started in the background.', 'Lint is queued.'])
+  })
+
+  it('notifies every turn taken while a session cron keeps the pane working', async () => {
+    const replay = createClaudeHookReplay()
+
+    for (const turn of [1, 2, 3]) {
+      await replay.emit({ hook_event_name: 'UserPromptSubmit', prompt: `turn ${turn}` })
+      vi.advanceTimersByTime(1_000)
+      await replay.emit({
+        hook_event_name: 'Stop',
+        last_assistant_message: `Turn ${turn} done.`,
+        session_crons: [{ id: 'cron-1' }]
+      })
+      vi.advanceTimersByTime(5_000)
+    }
+
+    expect(completionBodies()).toEqual(['Turn 1 done.', 'Turn 2 done.', 'Turn 3 done.'])
+    // Why: the pane never leaves `working`, so its stateStartedAt is pinned for the whole run.
+    // Each completion must carry its own turn's end time or the built notification ids collide
+    // and each banner closes the previous one.
+    expect(new Set(completionStateStartedAts()).size).toBe(3)
+  })
+
+  it('does not re-announce a turn whose all-clear arrives after a child question', async () => {
+    const replay = createClaudeHookReplay()
+
+    await replay.emit({ hook_event_name: 'UserPromptSubmit', prompt: 'go' })
+    await replay.emit({ hook_event_name: 'SubagentStart', agent_id: 'a1', agent_type: 'probe' })
+    vi.advanceTimersByTime(1_000)
+    await replay.emit({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Kicked off the probe.',
+      background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+    })
+
+    expect(completionBodies()).toEqual(['Kicked off the probe.'])
+
+    // Why: a background child pausing for a human answer displaces the finished lead turn; the
+    // turn end time has to survive that stash or the drain below reads as a second completion.
+    await replay.emit({
+      hook_event_name: 'PreToolUse',
+      tool_name: 'AskUserQuestion',
+      agent_id: 'a1',
+      tool_input: { questions: [{ question: 'Continue?' }] }
+    })
+    await replay.emit({ hook_event_name: 'PostToolUse', tool_name: 'Read', agent_id: 'a1' })
+    vi.advanceTimersByTime(2_000)
+    await replay.emit({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    expect(completionBodies()).toEqual(['Kicked off the probe.'])
+  })
+
+  it('does not double-fire when the coordinator remounts before the all-clear arrives', async () => {
+    const replay = createClaudeHookReplay()
+
+    await replay.emit({ hook_event_name: 'UserPromptSubmit', prompt: 'review the PR' })
+    await replay.emit({
+      hook_event_name: 'SubagentStart',
+      agent_id: 'a1',
+      agent_type: 'general-purpose'
+    })
+    vi.advanceTimersByTime(1_000)
+    await replay.emit({
+      hook_event_name: 'Stop',
+      last_assistant_message: 'Which branch should I target?',
+      background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+    })
+
+    expect(completionBodies()).toEqual(['Which branch should I target?'])
+
+    await replay.remountCoordinator()
+
+    vi.advanceTimersByTime(49_000)
+    await replay.emit({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+    vi.advanceTimersByTime(HOOK_DONE_QUIET_MS)
+
+    // Why: the all-clear carries the same turn end time as the banner already shown, so the
+    // fresh coordinator recognizes it as that turn's tail rather than a new completion.
+    expect(completionBodies()).toEqual(['Which branch should I target?'])
+    expect(dispatchAgentHookTerminalLifecycle).toHaveBeenCalledWith(
+      PANE_KEY,
+      expect.objectContaining({ state: 'done', agentType: 'claude' })
+    )
+  })
+})

--- a/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
+++ b/src/renderer/src/hooks/agent-hook-completion-background-turn-notifications.test.ts
@@ -179,6 +179,9 @@ describe('claude turn completions while background work keeps the pane working',
     // background shell never produces an all-clear of its own, so a one-shot suppression flag
     // would survive into turn N+1 and silence it (#13245).
     expect(completionBodies()).toEqual(['Build started in the background.', 'Lint is queued.'])
+    // Why: two bodies are only two banners if they also build two notification ids; the pane
+    // never left `working`, so both would otherwise be minted from the same pinned timestamp.
+    expect(new Set(completionStateStartedAts()).size).toBe(2)
   })
 
   it('notifies every turn taken while a session cron keeps the pane working', async () => {

--- a/src/renderer/src/hooks/ipc-events-agent-status-store-test-fixtures.ts
+++ b/src/renderer/src/hooks/ipc-events-agent-status-store-test-fixtures.ts
@@ -31,6 +31,7 @@ export type AgentStatusSetData = {
   lastAssistantMessage?: string
   interrupted?: boolean
   sessionBoundary?: boolean
+  turnCompletedAt?: number
   terminalHandle?: string
   launchToken?: string
   providerSession?: { key: 'session_id'; id: string }

--- a/src/renderer/src/hooks/useIpcEvents-agent-status-pane-teardown.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-agent-status-pane-teardown.test.ts
@@ -94,6 +94,74 @@ describe('useIpcEvents agent status snapshot integration', () => {
     expect(observeAgentHookCompletionForNotification).not.toHaveBeenCalled()
   })
 
+  it('carries turnCompletedAt through to the completion coordinator', async () => {
+    const setAgentStatus = vi.fn()
+    const observeAgentHookCompletionForNotification = vi.fn()
+    const onSetListenerRef: { current: ((data: AgentStatusSetData) => void) | null } = {
+      current: null
+    }
+
+    const storeState: StoreLike = buildStoreState({
+      setAgentStatus,
+      workspaceSessionReady: true,
+      settings: { terminalFontSize: 13, notifications: { enabled: true, agentTaskComplete: true } },
+      tabsByWorktree: {
+        'wt-1': [{ id: 'tab-future', ptyId: 'pty-1', worktreeId: 'wt-1', title: 'Claude' }]
+      },
+      terminalLayoutsByTabId: {}
+    })
+
+    stubReactSyncEffect()
+    vi.doMock('../store', () => ({
+      useAppStore: {
+        subscribe: vi.fn(() => () => {}),
+        getState: () => storeState
+      }
+    }))
+    vi.doMock('./agent-hook-completion-notifications', () => ({
+      observeAgentHookCompletionForNotification,
+      resetAgentHookCompletionNotificationCoordinators: vi.fn(),
+      syncAgentHookCompletionNotificationsForStoreUpdate: vi.fn()
+    }))
+    stubAuxiliaryModules()
+    vi.stubGlobal(
+      'window',
+      buildWindowApi({
+        onSet: (cb) => {
+          onSetListenerRef.current = cb
+          return () => {}
+        }
+      })
+    )
+
+    const { useIpcEvents } = await import('./useIpcEvents')
+    useIpcEvents()
+    await Promise.resolve()
+
+    if (typeof onSetListenerRef.current !== 'function') {
+      throw new Error('Expected agentStatus.onSet listener to be registered')
+    }
+    onSetListenerRef.current({
+      paneKey: FUTURE_PANE_KEY,
+      tabId: 'tab-future',
+      worktreeId: 'wt-1',
+      state: 'working',
+      prompt: 'run the build',
+      agentType: 'claude',
+      turnCompletedAt: 1_700_000_000_400,
+      receivedAt: 1_700_000_000_500,
+      stateStartedAt: 1_700_000_000_100
+    })
+
+    // Why: this rebuild is a field whitelist, so an omitted field never reaches the
+    // coordinator and the turn-complete-while-background edge is lost on the live IPC path.
+    expect(observeAgentHookCompletionForNotification).toHaveBeenCalledWith(
+      expect.objectContaining({
+        payload: expect.objectContaining({ turnCompletedAt: 1_700_000_000_400 })
+      })
+    )
+  })
+
   it('keeps auto-approved Codex done statuses on the completion path', async () => {
     const setAgentStatus = vi.fn()
     const observeAgentHookCompletionForNotification = vi.fn()

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -3182,6 +3182,9 @@ export function useIpcEvents(): void {
         lastAssistantMessage: data.lastAssistantMessage,
         interrupted: data.interrupted,
         sessionBoundary: data.sessionBoundary,
+        // Why: same trap as interactivePrompt — this rebuild is a field whitelist, so the
+        // completion coordinator never sees the turn's end time if omitted (#13245).
+        turnCompletedAt: data.turnCompletedAt,
         // Why: same trap as interactivePrompt — this rebuild is a field whitelist, so subagent child rows vanish if omitted.
         subagents: data.subagents
       })

--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -98,6 +98,48 @@ describe('shared agent-hook-listener', () => {
       expect(finalStop?.payload.subagents).toBeUndefined()
     })
 
+    it('stamps the turn end time on a Stop gated up by background work, and on its all-clear', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'review the PR' })
+      claudeEvent({ hook_event_name: 'SubagentStart', agent_id: 'a1' })
+      const stop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+      })
+      expect(stop?.payload.state).toBe('working')
+      expect(stop?.payload.turnCompletedAt).toEqual(expect.any(Number))
+
+      // Why: the child lifecycle that drains the last background work IS this turn's all-clear,
+      // so it must repeat the same end time — that pairing is what lets a consumer tell the tail
+      // of an announced turn from a new completion (#13245).
+      const allClear = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
+      expect(allClear?.payload.state).toBe('done')
+      expect(allClear?.payload.turnCompletedAt).toBe(stop?.payload.turnCompletedAt)
+    })
+
+    it('does not stamp a turn end time on a Stop that already resolves to done', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'ship it' })
+      const stop = claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
+      expect(stop?.payload.state).toBe('done')
+      expect(stop?.payload.turnCompletedAt).toBeUndefined()
+    })
+
+    it('drops the previous turn end time once the next turn starts', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'run the build' })
+      const gated = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+      })
+      expect(gated?.payload.turnCompletedAt).toEqual(expect.any(Number))
+
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'now lint' })
+      const nextStop = claudeEvent({
+        hook_event_name: 'Stop',
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'completed' }]
+      })
+      expect(nextStop?.payload.state).toBe('done')
+      expect(nextStop?.payload.turnCompletedAt).toBeUndefined()
+    })
+
     it('emits a status refresh with the lead state on subagent lifecycle events', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'kick off reviewers' })
       claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })
@@ -632,10 +674,18 @@ describe('shared agent-hook-listener', () => {
       // Why: the lead already finished; the answer resumes the child, so the
       // emitted state is gated up to working only while that child still runs.
       expect(clearClaudeAnsweredQuestionWait(state, PANE_KEY)).toEqual({ state: 'working' })
-      expect(state.claudeLeadStateByPaneKey.get(PANE_KEY)).toEqual({ state: 'done' })
+      // Why: the restored record also keeps the end time stamped on the gated Stop, so the
+      // drained all-clear below is recognizable as this same turn's tail (#13245).
+      expect(state.claudeLeadStateByPaneKey.get(PANE_KEY)).toEqual({
+        state: 'done',
+        turnCompletedAt: expect.any(Number)
+      })
 
       const drained = claudeEvent({ hook_event_name: 'SubagentStop', agent_id: 'a1' })
       expect(drained?.payload.state).toBe('done')
+      expect(drained?.payload.turnCompletedAt).toBe(
+        state.claudeLeadStateByPaneKey.get(PANE_KEY)?.turnCompletedAt
+      )
     })
 
     it('falls back to working when no lead record exists', () => {

--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -11,7 +11,12 @@ import {
 import { clearGrokSessionPathLookupCacheForTests } from './grok-session-paths'
 import { AGENT_STATUS_MAX_SUBAGENTS } from './agent-status-types'
 import { makePaneKey } from './stable-pane-id'
-import { PANE_KEY } from './agent-hook-listener-test-harness'
+import {
+  CLAUDE_PREVIOUS_PROMPT_ID,
+  CLAUDE_PROMPT_ID,
+  normalizeAndAccept,
+  PANE_KEY
+} from './agent-hook-listener-test-harness'
 
 describe('shared agent-hook-listener', () => {
   let state: HookListenerState
@@ -147,12 +152,44 @@ describe('shared agent-hook-listener', () => {
       expect(gated?.payload.turnCompletedAt).toEqual(expect.any(Number))
 
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'now lint' })
+      // Why: the emitted payload computes its stamp fresh, so only the lead record proves the
+      // previous turn's end time was dropped rather than carried into the new turn.
+      expect(state.claudeLeadStateByPaneKey.get(PANE_KEY)?.turnCompletedAt).toBeUndefined()
+
       const nextStop = claudeEvent({
         hook_event_name: 'Stop',
         background_tasks: [{ id: 'shell-1', type: 'shell', status: 'completed' }]
       })
       expect(nextStop?.payload.state).toBe('done')
       expect(nextStop?.payload.turnCompletedAt).toBeUndefined()
+    })
+
+    it('does not stamp a turn end time on a manual PostCompact', () => {
+      normalizeAndAccept(state, 'claude', {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'compact then keep going',
+        prompt_id: CLAUDE_PREVIOUS_PROMPT_ID,
+        session_id: 'session-a'
+      })
+      normalizeAndAccept(state, 'claude', {
+        hook_event_name: 'PreCompact',
+        trigger: 'manual',
+        prompt_id: CLAUDE_PROMPT_ID,
+        session_id: 'session-a'
+      })
+
+      // Why: a manual PostCompact reports 'done' without being a turn boundary, and the running
+      // shell gates it up to 'working' — every other conjunct of the stamp holds. No turn ended
+      // here, so it must carry no turn end time.
+      const compacted = normalizeAndAccept(state, 'claude', {
+        hook_event_name: 'PostCompact',
+        trigger: 'manual',
+        prompt_id: CLAUDE_PROMPT_ID,
+        session_id: 'session-a',
+        background_tasks: [{ id: 'shell-1', type: 'shell', status: 'running' }]
+      })
+      expect(compacted?.payload.state).toBe('working')
+      expect(compacted?.payload.turnCompletedAt).toBeUndefined()
     })
 
     it('emits a status refresh with the lead state on subagent lifecycle events', () => {
@@ -425,10 +462,11 @@ describe('shared agent-hook-listener', () => {
         agent_id: 'a1',
         agent_type: 'general-purpose'
       })
-      claudeEvent({
+      const gated = claudeEvent({
         hook_event_name: 'Stop',
         background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
       })
+      expect(gated?.payload.turnCompletedAt).toEqual(expect.any(Number))
 
       const blocked = claudeEvent({
         hook_event_name: 'PermissionRequest',
@@ -445,6 +483,9 @@ describe('shared agent-hook-listener', () => {
         tool_input: { command: 'rm -rf build' }
       })
       expect(approved?.payload.state).toBe('working')
+      // Why: this row restores the stashed lead, so it re-emits the same turn's end time — a
+      // consumer must read it as that announced turn, not as a fresh one.
+      expect(approved?.payload.turnCompletedAt).toBe(gated?.payload.turnCompletedAt)
 
       // Why: the lead already stopped before the wait; draining the child
       // must resolve to done, not pin the pane on an invented 'working'.

--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -116,6 +116,21 @@ describe('shared agent-hook-listener', () => {
       expect(allClear?.payload.turnCompletedAt).toBe(stop?.payload.turnCompletedAt)
     })
 
+    it('does not stamp a turn end time on an interrupted Stop', () => {
+      claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'review the PR' })
+      claudeEvent({ hook_event_name: 'SubagentStart', agent_id: 'a1' })
+      // Why: a running child still gates the pane up to `working`, but the lead turn was cut
+      // short rather than finished — stamping it would announce a completion for work the user
+      // interrupted (#13245).
+      const stop = claudeEvent({
+        hook_event_name: 'Stop',
+        is_interrupt: true,
+        background_tasks: [{ id: 'a1', type: 'subagent', status: 'running' }]
+      })
+      expect(stop?.payload.state).toBe('working')
+      expect(stop?.payload.turnCompletedAt).toBeUndefined()
+    })
+
     it('does not stamp a turn end time on a Stop that already resolves to done', () => {
       claudeEvent({ hook_event_name: 'UserPromptSubmit', prompt: 'ship it' })
       const stop = claudeEvent({ hook_event_name: 'Stop', background_tasks: [] })

--- a/src/shared/agent-hook-listener-claude-subagents.test.ts
+++ b/src/shared/agent-hook-listener-claude-subagents.test.ts
@@ -689,8 +689,8 @@ describe('shared agent-hook-listener', () => {
       // Why: the lead already finished; the answer resumes the child, so the
       // emitted state is gated up to working only while that child still runs.
       expect(clearClaudeAnsweredQuestionWait(state, PANE_KEY)).toEqual({ state: 'working' })
-      // Why: the restored record also keeps the end time stamped on the gated Stop, so the
-      // drained all-clear below is recognizable as this same turn's tail (#13245).
+      // Why: the restored record still carries a turn end time, and the drain below repeats it —
+      // that pairing marks the all-clear as a turn's tail rather than a completion (#13245).
       expect(state.claudeLeadStateByPaneKey.get(PANE_KEY)).toEqual({
         state: 'done',
         turnCompletedAt: expect.any(Number)

--- a/src/shared/agent-hook-listener.ts
+++ b/src/shared/agent-hook-listener.ts
@@ -156,8 +156,12 @@ export type ClaudeLeadTurnState = {
   waitingAgentId?: string
   /** Tool call that owns the wait; late completions from parallel sibling tools must not dismiss its card. */
   waitingToolUseId?: string
+  /** End time of the lead turn this record closed while the background inventory kept the pane
+   *  gated to 'working'. Held here so the pane's later all-clear 'done' can carry the same value
+   *  and consumers can pair the two halves of one turn (#13245). Cleared by the next lead event. */
+  turnCompletedAt?: number
   /** Lead state a child-induced wait displaced, restored when the wait clears; can't invent 'working' since the done-gate only downgrades done→working, never back. */
-  stateBeforeWait?: Pick<ClaudeLeadTurnState, 'state' | 'interrupted'>
+  stateBeforeWait?: Pick<ClaudeLeadTurnState, 'state' | 'interrupted' | 'turnCompletedAt'>
 }
 
 type CodexLeadTurnState = {
@@ -2802,7 +2806,11 @@ function buildClaudeCachedLeadStatusPayload(
       interrupted: lead?.interrupted
     }),
     updateToolSnapshot: false,
-    interrupted: lead?.interrupted
+    interrupted: lead?.interrupted,
+    // Why: the child lifecycle that drains the last background work IS this turn's all-clear;
+    // carrying the lead's stamp lets a consumer see it is the tail of a turn it already
+    // announced rather than a second completion (#13245).
+    turnCompletedAt: lead?.turnCompletedAt
   })
 }
 
@@ -2969,7 +2977,8 @@ function normalizeClaudeEvent(
     return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
       stateName: resolveClaudePaneState(state, paneKey, restored),
       updateToolSnapshot: true,
-      interrupted: restored.interrupted
+      interrupted: restored.interrupted,
+      turnCompletedAt: restored.turnCompletedAt
     })
   }
 
@@ -3001,17 +3010,16 @@ function normalizeClaudeEvent(
         ? previousLead.stateBeforeWait
         : {
             state: previousLead.state,
-            ...(previousLead.interrupted ? { interrupted: true as const } : {})
+            ...(previousLead.interrupted ? { interrupted: true as const } : {}),
+            // Why: a background child's permission pause displaces an already-finished lead turn;
+            // keep its end time so the eventual all-clear still pairs with the completion that
+            // was announced for that turn instead of announcing a second one (#13245).
+            ...(previousLead.turnCompletedAt !== undefined
+              ? { turnCompletedAt: previousLead.turnCompletedAt }
+              : {})
           }
       : undefined
   const waitingToolUseId = eventToolUseId ?? previousLead?.waitingToolUseId
-  state.claudeLeadStateByPaneKey.set(paneKey, {
-    state: reportedStateName,
-    ...(interrupted ? { interrupted } : {}),
-    ...(isWaitingInducing && eventAgentId ? { waitingAgentId: eventAgentId } : {}),
-    ...(isAskUserQuestionWait && waitingToolUseId !== undefined ? { waitingToolUseId } : {}),
-    ...(stateBeforeWait ? { stateBeforeWait } : {})
-  })
 
   if (interrupted && eventAgentId === undefined) {
     state.claudeRunningNonAgentTaskPaneKeys.delete(paneKey)
@@ -3035,11 +3043,33 @@ function normalizeClaudeEvent(
     // Why: a legacy or partial Stop confirms the lead boundary, not a child restored from disk; keep the child-only gate eligible for reconciliation.
     state.claudeUnconfirmedRestoredStatusPaneKeys.add(paneKey)
   }
+  // Why: the lead already ended the turn — the pane only stays 'working' because the background
+  // inventory is still registered, which is exactly the case where 'stateStartedAt' is pinned and
+  // cannot tell two turns apart. Stamp this turn's own end time so a completion consumer gets one
+  // identity per turn, and so the later all-clear can be recognized as the same turn (#13245).
+  const turnCompletedAt =
+    eventAgentId === undefined &&
+    isTurnBoundary &&
+    reportedStateName === 'done' &&
+    effectiveState === 'working' &&
+    interrupted !== true
+      ? Date.now()
+      : undefined
+
+  state.claudeLeadStateByPaneKey.set(paneKey, {
+    state: reportedStateName,
+    ...(interrupted ? { interrupted } : {}),
+    ...(turnCompletedAt !== undefined ? { turnCompletedAt } : {}),
+    ...(isWaitingInducing && eventAgentId ? { waitingAgentId: eventAgentId } : {}),
+    ...(isAskUserQuestionWait && waitingToolUseId !== undefined ? { waitingToolUseId } : {}),
+    ...(stateBeforeWait ? { stateBeforeWait } : {})
+  })
 
   return buildClaudeStatusPayload(state, eventName, promptText, paneKey, hookPayload, {
     stateName: effectiveState,
     updateToolSnapshot: true,
-    interrupted
+    interrupted,
+    turnCompletedAt
   })
 }
 
@@ -3054,6 +3084,7 @@ function buildClaudeStatusPayload(
     updateToolSnapshot: boolean
     interrupted?: boolean
     sessionBoundary?: boolean
+    turnCompletedAt?: number
   }
 ): ParsedAgentStatusPayload | null {
   // Why: child-driven refreshes are roster bookkeeping, not lead tool activity; read the cached snapshot without merging so they can't clear a live AskUserQuestion card or clobber the tool preview.
@@ -3078,6 +3109,7 @@ function buildClaudeStatusPayload(
     lastAssistantMessage: snapshot.lastAssistantMessage,
     interrupted: options.interrupted,
     sessionBoundary: options.sessionBoundary,
+    turnCompletedAt: options.turnCompletedAt,
     subagents: claudeRosterToSnapshots(state.claudeSubagentRosterByPaneKey.get(paneKey))
   })
 }

--- a/src/shared/agent-status-field-normalization.ts
+++ b/src/shared/agent-status-field-normalization.ts
@@ -211,3 +211,13 @@ export function normalizeOptionalMultilineField(
   const normalized = normalizeMultilineField(value, maxLength)
   return normalized.length > 0 ? normalized : undefined
 }
+
+/** Keep a lead turn's end time only on the two rows that describe that turn: the `working` row a
+ *  background inventory gated it up to, and that turn's later all-clear `done` (#13245). On any
+ *  other state it would be truth about a turn the event does not describe. */
+export function normalizeTurnCompletedAtField(value: unknown, state: string): number | undefined {
+  if (typeof value !== 'number' || !Number.isFinite(value)) {
+    return undefined
+  }
+  return state === 'working' || state === 'done' ? value : undefined
+}

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -4,6 +4,7 @@ import {
   isFreshNonDoneAgentStatus,
   parseAgentStatusPayload,
   normalizeAgentStatusPayload,
+  pickParsedAgentStatusPayload,
   AGENT_STATUS_JSON_STRUCTURE_LIMITS,
   AGENT_STATUS_MAX_FIELD_LENGTH,
   AGENT_STATUS_MAX_SUBAGENTS,
@@ -433,6 +434,38 @@ Fix dispatch fallback preview for normalized status prompts`
     expect(
       parseAgentStatusPayload('{"state":"done","sessionBoundary":"true"}')!.sessionBoundary
     ).toBeUndefined()
+  })
+
+  it('keeps turnCompletedAt on the gated working row and its all-clear done, nowhere else', () => {
+    for (const state of ['working', 'done'] as const) {
+      expect(
+        parseAgentStatusPayload(`{"state":"${state}","turnCompletedAt":1767225601000}`)!
+          .turnCompletedAt
+      ).toBe(1767225601000)
+    }
+    // Why: a paused turn is not a finished one; carrying the stamp there would announce a
+    // completion for a turn that is still live.
+    for (const state of ['blocked', 'waiting'] as const) {
+      expect(
+        parseAgentStatusPayload(`{"state":"${state}","turnCompletedAt":1767225601000}`)!
+          .turnCompletedAt
+      ).toBeUndefined()
+    }
+    for (const raw of ['"1767225601000"', 'null', 'true']) {
+      expect(
+        parseAgentStatusPayload(`{"state":"done","turnCompletedAt":${raw}}`)!.turnCompletedAt
+      ).toBeUndefined()
+    }
+  })
+
+  it('carries turnCompletedAt through the client-visible payload projection', () => {
+    expect(
+      pickParsedAgentStatusPayload({
+        state: 'working',
+        prompt: 'run the build',
+        turnCompletedAt: 1767225601000
+      }).turnCompletedAt
+    ).toBe(1767225601000)
   })
 
   it('requires strict boolean true for interrupted (rejects truthy non-boolean)', () => {

--- a/src/shared/agent-status-types.test.ts
+++ b/src/shared/agent-status-types.test.ts
@@ -456,6 +456,13 @@ Fix dispatch fallback preview for normalized status prompts`
         parseAgentStatusPayload(`{"state":"done","turnCompletedAt":${raw}}`)!.turnCompletedAt
       ).toBeUndefined()
     }
+    // Why: the object entry point is not fed by JSON.parse, so it can carry values JSON cannot.
+    // A non-finite stamp names no turn and must not reach a completion consumer.
+    for (const value of [Number.NaN, Number.POSITIVE_INFINITY]) {
+      expect(
+        normalizeAgentStatusPayload({ state: 'done', turnCompletedAt: value })!.turnCompletedAt
+      ).toBeUndefined()
+    }
   })
 
   it('carries turnCompletedAt through the client-visible payload projection', () => {

--- a/src/shared/agent-status-types.ts
+++ b/src/shared/agent-status-types.ts
@@ -7,7 +7,8 @@ import {
   normalizeInteractivePromptField,
   normalizeOptionalField,
   normalizeOptionalMultilineField,
-  normalizePromptField
+  normalizePromptField,
+  normalizeTurnCompletedAtField
 } from './agent-status-field-normalization'
 import { assertJsonTextStructureWithinLimits } from './json-text-structure-limit'
 
@@ -184,6 +185,17 @@ export type AgentStatusPayload = {
    *  completions (notifications, automation runs, unread badges, finished timestamps)
    *  must ignore it. Only meaningful on `done`. */
   sessionBoundary?: boolean
+  /** Wall-clock ms at which the lead turn actually ended, stamped when Claude's background
+   *  inventory (subagents/background shells/session crons) gates the pane up to `working`
+   *  even though the lead Stop/StopFailure already finished the turn (#13245).
+   *
+   *  Why it exists: the pane's `stateStartedAt` is pinned for as long as the reported state
+   *  does not change, and this situation is precisely "the pane never leaves `working`", so
+   *  `stateStartedAt` cannot identify which turn ended. This field is the turn's own end
+   *  time. It rides the gated `working` row AND that turn's later all-clear `done`, so a
+   *  consumer that announced the first can recognize the second by equality. Never written
+   *  to the stored status entry — it identifies an event, not pane state. */
+  turnCompletedAt?: number
   /** Live in-process children of the reporting session. See AgentStatusEntry. */
   subagents?: AgentSubagentSnapshot[]
 }
@@ -217,6 +229,7 @@ export function pickParsedAgentStatusPayload(
       : {}),
     ...(row.interrupted !== undefined ? { interrupted: row.interrupted } : {}),
     ...(row.sessionBoundary !== undefined ? { sessionBoundary: row.sessionBoundary } : {}),
+    ...(row.turnCompletedAt !== undefined ? { turnCompletedAt: row.turnCompletedAt } : {}),
     ...(row.subagents !== undefined ? { subagents: row.subagents } : {})
   }
 }
@@ -417,6 +430,7 @@ function normalizeAgentStatusObject(parsed: unknown): ParsedAgentStatusPayload |
     // Why: only meaningful on `done`; coerce to undefined elsewhere so it can't leak stale truth across transitions.
     interrupted: obj.interrupted === true && state === 'done' ? true : undefined,
     sessionBoundary: obj.sessionBoundary === true && state === 'done' ? true : undefined,
+    turnCompletedAt: normalizeTurnCompletedAtField(obj.turnCompletedAt, state),
     subagents: normalizeSubagentsField(obj.subagents)
   }
 }


### PR DESCRIPTION
## Summary

Fixes #13245.

Also reported independently on Windows as #14253 (v1.4.180, long-lived `npm run dev` background shell) — same `SubagentStop` / `state: working` shape, confirmed as the same defect in #13245.

When a Claude lead turn ends while unrelated background work is still registered — a subagent, a
background shell, a session cron — `resolveClaudePaneState` gates the pane up to `working`. That is
right for the sidebar (work really is still running), but it also erases the `working → done` edge
that mints the completion banner. A turn that ends by asking the user a question therefore stays
silent for the whole background lifetime, and for a background shell (which emits no all-clear of
its own) the edge is lost outright.

This teaches the lead turn to carry its own end time.

- `normalizeClaudeEvent` stamps `turnCompletedAt` on a lead `Stop`/`StopFailure` that the background
  inventory gates up to `working`, holds it on the lead-turn record, and repeats it on that turn's
  later all-clear `done`. The two rows pair by equality.
- The completion coordinator announces the turn as soon as the stamped row arrives, and recognizes
  the all-clear as that same turn's tail rather than a second completion. The pane's own lifecycle
  keeps following the reported `working` state, so the sidebar still shows live background work.
- Completion identity and the OS notification id now come from `turnCompletedAt` when present. This
  matters because the hook server pins `stateStartedAt` for as long as the reported state does not
  change, and this bug is precisely "the pane never leaves `working`" — every turn in one working-run
  would otherwise share a single identity, so turns 2..N would be dropped as replays and their
  banners would close each other in `notifications.ts`.

Measured end to end through the real `normalizeHookPayload` → `observeAgentHookCompletionForNotification`
path (completion banners; time is measured from the start of the sequence, and the turn ends at 1.0 s):

| scenario | main | this branch |
|---|---|---|
| subagent, one turn | 1 banner at 51.5 s — 50.5 s after the turn ended | 1 banner at 1.0 s, carrying that turn's own text |
| background shell, turn N then N+1 | 1 banner (turn N+1 only; turn N never notifies) | 2 banners, one per turn, distinct notification ids |
| persistent session cron, 3 turns | 0 banners | 3 banners, three distinct notification ids |

Relationship to #13251: that PR takes the same seam and fixes the subagent case (1 immediate banner
with fresh text). The measured gaps are the other two rows — it produces 1 banner for the
background-shell case and 1 for the three-turn cron case. Its suppression marker is a bare boolean
cleared only by a later `done`, so where no such `done` ever arrives for turn N it survives into turn
N+1 and swallows it; and its synthetic identity is derived from `stateStartedAt + 1`, which is the
pinned value, so every turn in one working-run collapses onto one identity. This branch keys both the
suppression and the identity on the turn's own end time instead, which removes both. It is also
scoped to Claude: the meta-carrying dispatch branch is gated to this one path, so no other agent's
behaviour or existing tests change.

## Screenshots

No visual change. The sidebar keeps showing `working` for the whole background lifetime exactly as
before; only the completion notification timing changes.

## Testing

- [x] `pnpm lint` — `oxlint` 0 errors / 9 warnings (all pre-existing, `WorktreeJumpPalette.tsx`);
      `audit:code-quality:native`, `audit:code-quality:type-aware`, `check:reliability-gates` (73
      gates), `check:max-lines-ratchet` (352 grandfathered, no new bypasses),
      `check:zustand-selector-fanout`, and the three `verify:localization-*` gates all pass.
      `check:code-quality:changed` and `check:react-doctor:changed` against the PR base report 0 new
      findings across the changed files. `oxfmt --check` clean on every touched file.
- [x] `pnpm typecheck` (node + cli + web)
- [x] `pnpm test` — full vitest run: 4521 files / 48465 tests pass. The only failures are 5 tests in
      `config/scripts/check-root-directory-entries.test.mjs` and `src/relay/agent-exec-handler.test.ts`,
      which fail identically on the PR base in this environment (they assert on the sandbox's
      root-directory listing and inherited `GIT_CONFIG_*` env).
- [ ] `pnpm build` — not run; this change is pure renderer/shared logic with no packaging surface.
- [x] Added tests

New suite `agent-hook-completion-background-turn-notifications.test.ts` replays real Claude hook
sequences through the real listener and the real coordinator, stamping `stateStartedAt` the way the
hook server does (pinned across same-state events), and pins:

- a turn taken after a background-shell turn still notifies, and the first banner carries its own
  `done` snapshot (the pane row still says `working`, so nothing else can supply the turn's text);
- three turns under a persistent session cron produce three banners with three distinct
  `stateStartedAt` values, so their notification ids cannot collide;
- an all-clear that arrives after a background child paused for a human answer does not re-announce
  the turn;
- a live coordinator remount between the gated `Stop` and the all-clear does not double-fire.

Plus unit pins: the listener stamps only on a gated turn boundary and drops the stamp when the next
turn starts; the coordinator pairs an all-clear with the turn it announced even after a working-title
blip resets the pane's identity record; the field is clamped to `working`/`done` and survives the
client payload projection; the IPC field whitelist forwards it; and the notification id is built from
the completion snapshot rather than the pinned working row.

Every production change was reverted in turn and the corresponding test confirmed failing (11
mutations, each one caught, on a 413-test baseline).

One existing assertion moved: `restores the stashed lead state for an answered child question` now
expects the restored lead record to keep `turnCompletedAt`. That carry is deliberate — a background
child pausing for a human answer displaces the finished lead turn, and without it the drain that
follows reads as a second completion. The test's original intent (the lead restores to `done`, not
`working`) is unchanged, and the case is now covered by a behavioural test too.

## AI Review Report

Reviewed for: turn-identity correctness across pinned `stateStartedAt`; suppression lifetime (does a
turn whose all-clear never arrives silence the next turn?); coordinator remount and the module-scoped
identity map's eviction rules; blast radius onto non-Claude agents; and whether the new field can
leak into persisted pane state.

Flagged and addressed:

- The suppression must be keyed by turn, not by a boolean — it now lives in the existing per-pane
  identity map as `lastTurnCompletedAtNotified` and only matches an exact `turnCompletedAt`, so a
  stale mark cannot swallow a later turn. Living in that map is also what makes the remount case
  work, since `dispose()` already preserves it while the pane is live.
- A background child's permission pause displaces the finished lead turn through `stateBeforeWait`;
  the stamp is carried through that stash, otherwise the later drain double-fires. Covered by a test.
- The review also caught two tests that were too weak to see a regression: the completion counter
  was ignoring banners dispatched without a snapshot (so a duplicate could hide), and the identity
  derivation had no failing case. Both are now pinned, verified by mutation.
- The synthetic `done` must not run pane lifecycle effects while the pane is genuinely still working;
  it is dispatched with `notifyWithoutLifecycle`, and the lifecycle keeps following the reported
  `working` row.
- `turnCompletedAt` is clamped to `working`/`done` on parse and is never written into
  `AgentStatusEntry` (that entry is built field-by-field), so nothing reaches `last-status.json`.

Cross-platform: the change is platform-agnostic — no shell invocation, no path handling, no
keyboard/shortcut or label surface, no Electron platform branches. The only platform-adjacent
behaviour is OS notification identity, which flows through the existing shared
`buildAgentNotificationId` and the existing `notifications.ts` replacement rule on all three
platforms; the change makes those ids more distinct, never less.

## Security Audit

- Input handling: `turnCompletedAt` arrives from an agent hook payload, so it is treated as
  untrusted. It is accepted only as a finite `number` and only on `working`/`done`; every other type
  or state normalizes to `undefined`, matching how `interrupted`/`sessionBoundary` are clamped. It is
  never parsed, formatted into a path, or interpolated into a command.
- IPC: the field is added to the same explicit whitelist the other status fields already pass
  through; no widening of the IPC surface, no new channel, no new privilege.
- The value only affects notification identity and a per-pane in-memory dedupe key. A hostile value
  could at worst change grouping of that pane's own notifications; it cannot cross panes (the map is
  keyed by `paneKey`) and cannot suppress another agent's notifications.
- No command execution, path handling, auth, secrets, or dependency changes. No follow-up needed.

## Notes

- Claude-only by construction: only `normalizeClaudeEvent` emits the field, so every other agent
  takes byte-identical paths.
- Not verified without running the app: the on-screen banner and Dock/tray presentation. The tests
  cover the dispatch decision, the snapshot carried, and the id inputs, but not the OS presentation
  itself.

