### PR TITLE
fix(activity): derive unread badges from the Agents page thread build

### DIFF
--- a/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.test.ts
@@ -17,12 +17,11 @@ import {
   isActivityFilterFocusShortcut,
   shouldIgnoreActivityFilterFocusShortcutTarget,
   buildActivityThreadGroups,
-  buildActivityEvents,
-  buildAgentPaneThreads,
   getActivityThreadGroup,
   groupActivityThreadsByStatus,
   isActivitySearchQueryTooLarge
 } from './ActivityPrototypePage'
+import { buildActivityEvents, buildAgentPaneThreads } from './agent-pane-threads'
 import { makePaneKey } from '../../../../shared/stable-pane-id'
 
 const LEAF_ID = '11111111-1111-4111-8111-111111111111'

--- a/src/renderer/src/components/activity/ActivityPrototypePage.tsx
+++ b/src/renderer/src/components/activity/ActivityPrototypePage.tsx
@@ -13,15 +13,10 @@ import {
 
 import { AgentStateDot, agentStateLabel } from '@/components/AgentStateDot'
 import { AgentIcon } from '@/lib/agent-catalog'
-import {
-  agentTypeToIconAgent,
-  formatAgentTypeLabel,
-  isExplicitAgentStatusFresh
-} from '@/lib/agent-status'
+import { agentTypeToIconAgent, formatAgentTypeLabel } from '@/lib/agent-status'
 import { activateTabAndFocusPane } from '@/lib/activate-tab-and-focus-pane'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
 import { useAppStore } from '@/store'
-import type { RetainedAgentEntry } from '@/store/slices/agent-status'
 import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import { useSidebarResize } from '@/hooks/useSidebarResize'
 import { Button } from '@/components/ui/button'
@@ -61,75 +56,20 @@ import {
   type ActivityPortalReadinessLatch,
   type ActivityPortalReadinessStatus
 } from './activity-portal-readiness-oscillation'
-import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
-import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
-import {
-  AGENT_STATUS_STALE_AFTER_MS,
-  type AgentStateHistoryEntry,
-  type AgentStatusEntry,
-  type AgentStatusState,
-  type AgentType,
-  type MigrationUnsupportedPtyEntry
-} from '../../../../shared/agent-status-types'
+import type { Repo } from '../../../../shared/types'
+import type { AgentStatusState } from '../../../../shared/agent-status-types'
 import { parsePaneKey } from '../../../../shared/stable-pane-id'
 import { isClipboardTextByteLengthOverLimit } from '../../../../shared/clipboard-text'
-import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { translate } from '@/i18n/i18n'
 import { formatUiRelativeTime } from '@/i18n/relative-time-format'
-import {
-  getActivityThreadTaskTitle,
-  getActivityThreadWorkspaceTitle,
-  resolveActivityThreadStatusPreview
-} from '@/lib/activity-thread-display'
+import { getActivityThreadWorkspaceTitle } from '@/lib/activity-thread-display'
 import { getAgentRowPrimaryText } from '@/lib/agent-row-primary-text'
+import type { ActivityEvent, AgentPaneThread } from './activity-events'
+import { buildActivityEvents, buildAgentPaneThreads } from './agent-pane-threads'
 
 type ThreadReadFilter = 'all' | 'unread'
 type ActivityGroupBy = 'status' | 'project' | 'worktree' | 'agent'
-type ActivityEventState = Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
-type ActivityLiveAgentState = Extract<AgentStatusState, 'working' | 'blocked' | 'waiting'>
 type ActivityStatusGroupId = 'working' | 'blocked' | 'waiting' | 'done' | 'interrupted'
-
-type ActivityEvent = {
-  id: string
-  state: ActivityEventState
-  timestamp: number
-  worktree: Worktree
-  repo: Repo | null
-  entry: AgentStatusEntry
-  tab: TerminalTab
-  agentType: AgentType
-  agentAlive: boolean
-  migrationUnsupportedPtyId?: string
-  unread: boolean
-}
-
-type ActivityLiveAgentSnapshot = {
-  state: ActivityLiveAgentState
-  timestamp: number
-  worktree: Worktree
-  repo: Repo | null
-  entry: AgentStatusEntry
-  tab: TerminalTab
-  agentType: AgentType
-}
-
-// Why: keyed per agent pane (tab + leaf id), not per workspace, so the list shows one row per agent; paneKey is `${tabId}:${leafId}`.
-type AgentPaneThread = {
-  paneKey: string
-  paneTitle: string
-  worktree: Worktree
-  repo: Repo | null
-  tab: TerminalTab
-  agentType: AgentType
-  currentAgentState: ActivityLiveAgentState | null
-  currentAgentEntry: AgentStatusEntry | null
-  responsePreview: string
-  latestTimestamp: number
-  latestEvent: ActivityEvent | null
-  events: ActivityEvent[]
-  migrationUnsupportedPtyId?: string
-  unread: boolean
-}
 
 type ActivityThreadGroup = {
   key: string
@@ -161,7 +101,17 @@ const ACTIVITY_STATUS_GROUP_ORDER: ActivityStatusGroupId[] = [
   'done',
   'interrupted'
 ]
-const STANDALONE_ACTIVITY_WORKTREE_REPO_ID = '__activity_standalone__'
+const ACTIVITY_READ_FILTER_STORAGE_KEY = 'orca.activity.read-filter'
+
+function readStoredActivityReadFilter(): ThreadReadFilter {
+  try {
+    return window.localStorage.getItem(ACTIVITY_READ_FILTER_STORAGE_KEY) === 'unread'
+      ? 'unread'
+      : 'all'
+  } catch {
+    return 'all'
+  }
+}
 
 const absoluteDateFormatter = new Intl.DateTimeFormat(undefined, {
   year: 'numeric',
@@ -445,411 +395,6 @@ function agentMeta(event: ActivityEvent): string {
     return event.entry.interrupted ? `${agent} interrupted` : `${agent} completed`
   }
   return event.state === 'waiting' ? `${agent} waiting` : `${agent} blocked`
-}
-
-// Why: rows need a stable task identity across follow-up turns; the live turn prompt ("yes", "ok proceed") must not replace the task title.
-function paneTitleForEntry(
-  entry: AgentStatusEntry,
-  tab: TerminalTab,
-  generatedTitlesEnabled: boolean
-): string {
-  return getActivityThreadTaskTitle({ entry, tab, generatedTitlesEnabled })
-}
-
-function paneTitleForEvent(event: ActivityEvent, generatedTitlesEnabled: boolean): string {
-  return paneTitleForEntry(event.entry, event.tab, generatedTitlesEnabled)
-}
-
-function statusPreviewForEntry(
-  entry: AgentStatusEntry,
-  agentState?: AgentStatusState | null,
-  previousPreview?: string
-): string {
-  return resolveActivityThreadStatusPreview(entry, agentState, previousPreview)
-}
-
-function isActivityEventState(state: AgentStatusState): state is ActivityEventState {
-  return state === 'done' || state === 'blocked' || state === 'waiting'
-}
-
-function isActivityLiveAgentState(state: AgentStatusState): state is ActivityLiveAgentState {
-  return state === 'working' || state === 'blocked' || state === 'waiting'
-}
-
-function freshActivityLiveAgentState(
-  entry: AgentStatusEntry,
-  now: number
-): ActivityLiveAgentState | null {
-  if (!isActivityLiveAgentState(entry.state)) {
-    return null
-  }
-  return isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS) ? entry.state : null
-}
-
-function standaloneActivityWorktree(worktreeId: string): Worktree {
-  const displayName =
-    worktreeId === FLOATING_TERMINAL_WORKTREE_ID ? 'Floating terminal' : 'Standalone terminal'
-  return {
-    id: worktreeId,
-    repoId: STANDALONE_ACTIVITY_WORKTREE_REPO_ID,
-    path: '',
-    head: '',
-    branch: displayName,
-    isBare: false,
-    isMainWorktree: false,
-    displayName,
-    comment: '',
-    linkedIssue: null,
-    linkedPR: null,
-    linkedLinearIssue: null,
-    isArchived: false,
-    isUnread: false,
-    isPinned: false,
-    sortOrder: 0,
-    lastActivityAt: 0
-  }
-}
-
-// Why: per-pane cap guarantees each agent appears in the left list even when one pane has a long history.
-const EVENTS_PER_PANE_CAP = 5
-
-function historyEntrySnapshot(
-  entry: AgentStatusEntry,
-  history: AgentStateHistoryEntry
-): AgentStatusEntry {
-  return {
-    ...entry,
-    state: history.state,
-    prompt: history.prompt,
-    updatedAt: history.startedAt,
-    stateStartedAt: history.startedAt,
-    stateHistory: [],
-    toolName: undefined,
-    toolInput: undefined,
-    lastAssistantMessage: undefined,
-    interrupted: history.interrupted
-  }
-}
-
-function appendActivityEvent(args: {
-  events: ActivityEvent[]
-  seenEventIds: Set<string>
-  state: ActivityEventState
-  timestamp: number
-  worktree: Worktree
-  repo: Repo | null
-  entry: AgentStatusEntry
-  tab: TerminalTab
-  agentType: AgentType
-  agentAlive: boolean
-  acknowledgedAt: number
-  migrationUnsupportedPtyId?: string
-}): void {
-  const id = `agent:${args.entry.paneKey}:${args.state}:${args.timestamp}`
-  if (args.seenEventIds.has(id)) {
-    return
-  }
-  args.seenEventIds.add(id)
-  args.events.push({
-    id,
-    state: args.state,
-    timestamp: args.timestamp,
-    worktree: args.worktree,
-    repo: args.repo,
-    entry: args.entry,
-    tab: args.tab,
-    agentType: args.agentType,
-    agentAlive: args.agentAlive,
-    migrationUnsupportedPtyId: args.migrationUnsupportedPtyId,
-    unread: args.acknowledgedAt < args.timestamp
-  })
-}
-
-function appendActivityEventsForEntry(args: {
-  events: ActivityEvent[]
-  seenEventIds: Set<string>
-  entry: AgentStatusEntry
-  worktree: Worktree
-  repo: Repo | null
-  tab: TerminalTab
-  agentType: AgentType
-  agentAlive: boolean
-  acknowledgedAt: number
-  migrationUnsupportedPtyId?: string
-}): void {
-  // Why: Activity is append-only; when a pane continues (done→working), stateHistory is the only record of the previous done/blocking event.
-  for (const history of args.entry.stateHistory) {
-    if (!isActivityEventState(history.state)) {
-      continue
-    }
-    appendActivityEvent({
-      ...args,
-      state: history.state,
-      timestamp: history.startedAt,
-      entry: historyEntrySnapshot(args.entry, history)
-    })
-  }
-
-  // Why: SessionStart creates an idle row, not an "Agent finished" activity event (STA-3386).
-  if (!isActivityEventState(args.entry.state) || args.entry.sessionBoundary === true) {
-    return
-  }
-  appendActivityEvent({
-    ...args,
-    state: args.entry.state,
-    timestamp: args.entry.stateStartedAt
-  })
-}
-
-export function buildActivityEvents(args: {
-  agentStatusByPaneKey: Record<string, AgentStatusEntry>
-  migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>
-  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
-  tabsByWorktree: Record<string, TerminalTab[]>
-  worktreeMap: Map<string, Worktree>
-  repoMap: Map<string, Repo>
-  acknowledgedAgentsByPaneKey: Record<string, number>
-  now: number
-}): {
-  events: ActivityEvent[]
-  liveAgentByPaneKey: Record<string, ActivityLiveAgentSnapshot>
-} {
-  const events: ActivityEvent[] = []
-  const seenEventIds = new Set<string>()
-  const tabContext = new Map<string, { worktree: Worktree; tab: TerminalTab }>()
-  const liveAgentByPaneKey: Record<string, ActivityLiveAgentSnapshot> = {}
-
-  for (const [worktreeId, tabs] of Object.entries(args.tabsByWorktree)) {
-    const worktree = args.worktreeMap.get(worktreeId) ?? standaloneActivityWorktree(worktreeId)
-    for (const tab of tabs) {
-      tabContext.set(tab.id, { worktree, tab })
-    }
-  }
-
-  for (const [paneKey, entry] of Object.entries(args.agentStatusByPaneKey)) {
-    const parsed = parsePaneKey(paneKey)
-    if (!parsed) {
-      continue
-    }
-    const context = tabContext.get(parsed.tabId)
-    if (!context) {
-      continue
-    }
-    const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
-    // Why: live status is separate from history; a fresh working turn updates the thread without counting as an unread done/blocked/waiting event.
-    const liveState = freshActivityLiveAgentState(entry, args.now)
-    if (liveState) {
-      liveAgentByPaneKey[paneKey] = {
-        state: liveState,
-        timestamp: entry.stateStartedAt,
-        worktree: context.worktree,
-        repo: args.repoMap.get(context.worktree.repoId) ?? null,
-        entry,
-        tab: context.tab,
-        agentType: entry.agentType ?? 'unknown'
-      }
-    }
-    appendActivityEventsForEntry({
-      events,
-      seenEventIds,
-      worktree: context.worktree,
-      repo: args.repoMap.get(context.worktree.repoId) ?? null,
-      entry,
-      tab: context.tab,
-      agentType: entry.agentType ?? 'unknown',
-      agentAlive: true,
-      acknowledgedAt: ackAt
-    })
-  }
-
-  for (const unsupported of Object.values(args.migrationUnsupportedByPtyId ?? {})) {
-    const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
-    if (!entry) {
-      continue
-    }
-    const parsed = parsePaneKey(entry.paneKey)
-    if (!parsed) {
-      continue
-    }
-    const context = tabContext.get(parsed.tabId)
-    if (!context) {
-      continue
-    }
-    const ackAt = args.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0
-    liveAgentByPaneKey[entry.paneKey] = {
-      state: 'blocked',
-      timestamp: entry.stateStartedAt,
-      worktree: context.worktree,
-      repo: args.repoMap.get(context.worktree.repoId) ?? null,
-      entry,
-      tab: context.tab,
-      agentType: entry.agentType ?? 'unknown'
-    }
-    appendActivityEventsForEntry({
-      events,
-      seenEventIds,
-      worktree: context.worktree,
-      repo: args.repoMap.get(context.worktree.repoId) ?? null,
-      entry,
-      tab: context.tab,
-      agentType: entry.agentType ?? 'unknown',
-      agentAlive: false,
-      acknowledgedAt: ackAt,
-      migrationUnsupportedPtyId: unsupported.ptyId
-    })
-  }
-
-  for (const [paneKey, retained] of Object.entries(args.retainedAgentsByPaneKey)) {
-    if (!parsePaneKey(paneKey)) {
-      continue
-    }
-    const worktree =
-      args.worktreeMap.get(retained.worktreeId) ??
-      (args.tabsByWorktree[retained.worktreeId]
-        ? standaloneActivityWorktree(retained.worktreeId)
-        : null)
-    if (!worktree) {
-      continue
-    }
-    const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
-    appendActivityEventsForEntry({
-      events,
-      seenEventIds,
-      worktree,
-      repo: args.repoMap.get(worktree.repoId) ?? null,
-      entry: retained.entry,
-      tab: retained.tab,
-      agentType: retained.agentType,
-      agentAlive: false,
-      acknowledgedAt: ackAt
-    })
-  }
-
-  const sorted = events.sort((a, b) => b.timestamp - a.timestamp)
-  const perPaneCount = new Map<string, number>()
-  const includedEventIds = new Set<string>()
-  const capped: ActivityEvent[] = []
-  // Why: reserve each pane's newest event before the global 80-event cap so the validator's >16 panes × ≥5 events can't push a pane out of the window and hide it.
-  for (const event of sorted) {
-    const paneKey = event.entry.paneKey
-    if (perPaneCount.has(paneKey)) {
-      continue
-    }
-    if (capped.length >= 80) {
-      break
-    }
-    perPaneCount.set(paneKey, 1)
-    includedEventIds.add(event.id)
-    capped.push(event)
-  }
-  for (const event of sorted) {
-    if (includedEventIds.has(event.id)) {
-      continue
-    }
-    if (capped.length >= 80) {
-      break
-    }
-    const paneKey = event.entry.paneKey
-    const count = perPaneCount.get(paneKey) ?? 0
-    if (count >= EVENTS_PER_PANE_CAP) {
-      continue
-    }
-    perPaneCount.set(paneKey, count + 1)
-    includedEventIds.add(event.id)
-    capped.push(event)
-  }
-  return { events: capped.sort((a, b) => b.timestamp - a.timestamp), liveAgentByPaneKey }
-}
-
-export function buildAgentPaneThreads(args: {
-  events: ActivityEvent[]
-  liveAgentByPaneKey: Record<string, ActivityLiveAgentSnapshot>
-  generatedTitlesEnabled?: boolean
-}): AgentPaneThread[] {
-  const generatedTitlesEnabled = args.generatedTitlesEnabled === true
-  const byPaneKey = new Map<string, AgentPaneThread>()
-  for (const event of args.events) {
-    const paneKey = event.entry.paneKey
-    const existing = byPaneKey.get(paneKey)
-    if (!existing) {
-      byPaneKey.set(paneKey, {
-        paneKey,
-        paneTitle: paneTitleForEvent(event, generatedTitlesEnabled),
-        worktree: event.worktree,
-        repo: event.repo,
-        tab: event.tab,
-        agentType: event.agentType,
-        currentAgentState: null,
-        currentAgentEntry: null,
-        responsePreview: statusPreviewForEntry(event.entry, event.state),
-        latestTimestamp: event.timestamp,
-        latestEvent: event,
-        events: [event],
-        migrationUnsupportedPtyId: event.migrationUnsupportedPtyId,
-        unread: event.unread
-      })
-      continue
-    }
-    existing.events.push(event)
-    existing.unread = existing.unread || event.unread
-    existing.migrationUnsupportedPtyId =
-      existing.migrationUnsupportedPtyId ?? event.migrationUnsupportedPtyId
-    if (!existing.latestEvent || event.timestamp > existing.latestEvent.timestamp) {
-      existing.latestEvent = event
-      existing.paneTitle = paneTitleForEvent(event, generatedTitlesEnabled)
-      existing.agentType = event.agentType
-      existing.tab = event.tab
-      existing.responsePreview = statusPreviewForEntry(
-        event.entry,
-        event.state,
-        existing.responsePreview
-      )
-      existing.latestTimestamp = event.timestamp
-    }
-  }
-
-  for (const [paneKey, liveAgent] of Object.entries(args.liveAgentByPaneKey)) {
-    const existing = byPaneKey.get(paneKey)
-    if (!existing) {
-      byPaneKey.set(paneKey, {
-        paneKey,
-        paneTitle: paneTitleForEntry(liveAgent.entry, liveAgent.tab, generatedTitlesEnabled),
-        worktree: liveAgent.worktree,
-        repo: liveAgent.repo,
-        tab: liveAgent.tab,
-        agentType: liveAgent.agentType,
-        currentAgentState: liveAgent.state,
-        currentAgentEntry: liveAgent.entry,
-        responsePreview: statusPreviewForEntry(liveAgent.entry, liveAgent.state),
-        latestTimestamp: liveAgent.timestamp,
-        latestEvent: null,
-        events: [],
-        unread: false
-      })
-      continue
-    }
-    // Why: row title/time/target must follow the active turn (not historical events) so a running agent never shows the previous prompt as primary.
-    existing.paneTitle = paneTitleForEntry(liveAgent.entry, liveAgent.tab, generatedTitlesEnabled)
-    existing.worktree = liveAgent.worktree
-    existing.repo = liveAgent.repo
-    existing.tab = liveAgent.tab
-    existing.agentType = liveAgent.agentType
-    existing.currentAgentState = liveAgent.state
-    existing.currentAgentEntry = liveAgent.entry
-    existing.responsePreview = statusPreviewForEntry(
-      liveAgent.entry,
-      liveAgent.state,
-      existing.responsePreview
-    )
-    existing.latestTimestamp = liveAgent.timestamp
-  }
-
-  return Array.from(byPaneKey.values())
-    .map((thread) => ({
-      ...thread,
-      events: [...thread.events].sort((a, b) => b.timestamp - a.timestamp)
-    }))
-    .sort((a, b) => b.latestTimestamp - a.latestTimestamp)
 }
 
 function EventTime({ timestamp }: { timestamp: number }): React.JSX.Element {
@@ -1403,7 +948,8 @@ function ThreadRow({
 }
 
 export default function ActivityPrototypePage(): React.JSX.Element {
-  const [readFilter, setReadFilter] = useState<ThreadReadFilter>('all')
+  // Why: the unread-only toggle is a sticky viewing mode, not a per-visit query — restore it across page opens.
+  const [readFilter, setReadFilter] = useState<ThreadReadFilter>(readStoredActivityReadFilter)
   const [groupBy, setGroupBy] = useState<ActivityGroupBy>('status')
   const [query, setQuery] = useState('')
   const activityFilterInputRef = useRef<HTMLInputElement | null>(null)
@@ -1738,6 +1284,15 @@ export default function ActivityPrototypePage(): React.JSX.Element {
     activateAndRevealWorktree(thread.worktree.id)
   }
 
+  const updateReadFilter = (next: ThreadReadFilter): void => {
+    setReadFilter(next)
+    try {
+      window.localStorage.setItem(ACTIVITY_READ_FILTER_STORAGE_KEY, next)
+    } catch {
+      // Best-effort; the filter falls back to 'all' next mount if storage is unavailable.
+    }
+  }
+
   const hasUnreadThreads = allThreads.some((thread) => thread.unread)
 
   const markAllThreadsRead = (): void => {
@@ -1817,7 +1372,7 @@ export default function ActivityPrototypePage(): React.JSX.Element {
                 <TooltipTrigger asChild>
                   <Toggle
                     pressed={readFilter === 'unread'}
-                    onPressedChange={(pressed) => setReadFilter(pressed ? 'unread' : 'all')}
+                    onPressedChange={(pressed) => updateReadFilter(pressed ? 'unread' : 'all')}
                     variant="outline"
                     size="sm"
                     className={cn(

--- a/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
+++ b/src/renderer/src/components/activity/ActivityTitlebarControls.tsx
@@ -8,7 +8,7 @@ import { useActivityUnreadCount } from './useActivityUnreadCount'
 import { translate } from '@/i18n/i18n'
 
 export function ActivityTitlebarControls(): React.JSX.Element {
-  const unreadCount = useActivityUnreadCount(true, 'agent-events')
+  const unreadCount = useActivityUnreadCount(true)
   const closeActivityPage = useAppStore((s) => s.closeActivityPage)
 
   return (

--- a/src/renderer/src/components/activity/activity-events.ts
+++ b/src/renderer/src/components/activity/activity-events.ts
@@ -1,0 +1,215 @@
+import { isExplicitAgentStatusFresh } from '@/lib/agent-status'
+import {
+  getActivityThreadTaskTitle,
+  resolveActivityThreadStatusPreview
+} from '@/lib/activity-thread-display'
+import {
+  AGENT_STATUS_STALE_AFTER_MS,
+  type AgentStateHistoryEntry,
+  type AgentStatusEntry,
+  type AgentStatusState,
+  type AgentType
+} from '../../../../shared/agent-status-types'
+import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../../shared/constants'
+import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
+
+export type ActivityEventState = Extract<AgentStatusState, 'done' | 'blocked' | 'waiting'>
+export type ActivityLiveAgentState = Extract<AgentStatusState, 'working' | 'blocked' | 'waiting'>
+
+export type ActivityEvent = {
+  id: string
+  state: ActivityEventState
+  timestamp: number
+  worktree: Worktree
+  repo: Repo | null
+  entry: AgentStatusEntry
+  tab: TerminalTab
+  agentType: AgentType
+  agentAlive: boolean
+  migrationUnsupportedPtyId?: string
+  unread: boolean
+}
+
+export type ActivityLiveAgentSnapshot = {
+  state: ActivityLiveAgentState
+  timestamp: number
+  worktree: Worktree
+  repo: Repo | null
+  entry: AgentStatusEntry
+  tab: TerminalTab
+  agentType: AgentType
+}
+
+// Why: keyed per agent pane (tab + leaf id), not per workspace, so the list shows one row per agent; paneKey is `${tabId}:${leafId}`.
+export type AgentPaneThread = {
+  paneKey: string
+  paneTitle: string
+  worktree: Worktree
+  repo: Repo | null
+  tab: TerminalTab
+  agentType: AgentType
+  currentAgentState: ActivityLiveAgentState | null
+  currentAgentEntry: AgentStatusEntry | null
+  responsePreview: string
+  latestTimestamp: number
+  latestEvent: ActivityEvent | null
+  events: ActivityEvent[]
+  migrationUnsupportedPtyId?: string
+  unread: boolean
+}
+
+const STANDALONE_ACTIVITY_WORKTREE_REPO_ID = '__activity_standalone__'
+
+// Why: rows need a stable task identity across follow-up turns; the live turn prompt ("yes", "ok proceed") must not replace the task title.
+export function paneTitleForEntry(
+  entry: AgentStatusEntry,
+  tab: TerminalTab,
+  generatedTitlesEnabled: boolean
+): string {
+  return getActivityThreadTaskTitle({ entry, tab, generatedTitlesEnabled })
+}
+
+export function paneTitleForEvent(event: ActivityEvent, generatedTitlesEnabled: boolean): string {
+  return paneTitleForEntry(event.entry, event.tab, generatedTitlesEnabled)
+}
+
+export function statusPreviewForEntry(
+  entry: AgentStatusEntry,
+  agentState?: AgentStatusState | null,
+  previousPreview?: string
+): string {
+  return resolveActivityThreadStatusPreview(entry, agentState, previousPreview)
+}
+
+function isActivityEventState(state: AgentStatusState): state is ActivityEventState {
+  return state === 'done' || state === 'blocked' || state === 'waiting'
+}
+
+function isActivityLiveAgentState(state: AgentStatusState): state is ActivityLiveAgentState {
+  return state === 'working' || state === 'blocked' || state === 'waiting'
+}
+
+export function freshActivityLiveAgentState(
+  entry: AgentStatusEntry,
+  now: number
+): ActivityLiveAgentState | null {
+  if (!isActivityLiveAgentState(entry.state)) {
+    return null
+  }
+  return isExplicitAgentStatusFresh(entry, now, AGENT_STATUS_STALE_AFTER_MS) ? entry.state : null
+}
+
+export function standaloneActivityWorktree(worktreeId: string): Worktree {
+  const displayName =
+    worktreeId === FLOATING_TERMINAL_WORKTREE_ID ? 'Floating terminal' : 'Standalone terminal'
+  return {
+    id: worktreeId,
+    repoId: STANDALONE_ACTIVITY_WORKTREE_REPO_ID,
+    path: '',
+    head: '',
+    branch: displayName,
+    isBare: false,
+    isMainWorktree: false,
+    displayName,
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0
+  }
+}
+
+// Why: per-pane cap guarantees each agent appears in the left list even when one pane has a long history.
+export const EVENTS_PER_PANE_CAP = 5
+
+function historyEntrySnapshot(
+  entry: AgentStatusEntry,
+  history: AgentStateHistoryEntry
+): AgentStatusEntry {
+  return {
+    ...entry,
+    state: history.state,
+    prompt: history.prompt,
+    updatedAt: history.startedAt,
+    stateStartedAt: history.startedAt,
+    stateHistory: [],
+    toolName: undefined,
+    toolInput: undefined,
+    lastAssistantMessage: undefined,
+    interrupted: history.interrupted
+  }
+}
+
+function appendActivityEvent(args: {
+  events: ActivityEvent[]
+  seenEventIds: Set<string>
+  state: ActivityEventState
+  timestamp: number
+  worktree: Worktree
+  repo: Repo | null
+  entry: AgentStatusEntry
+  tab: TerminalTab
+  agentType: AgentType
+  agentAlive: boolean
+  acknowledgedAt: number
+  migrationUnsupportedPtyId?: string
+}): void {
+  const id = `agent:${args.entry.paneKey}:${args.state}:${args.timestamp}`
+  if (args.seenEventIds.has(id)) {
+    return
+  }
+  args.seenEventIds.add(id)
+  args.events.push({
+    id,
+    state: args.state,
+    timestamp: args.timestamp,
+    worktree: args.worktree,
+    repo: args.repo,
+    entry: args.entry,
+    tab: args.tab,
+    agentType: args.agentType,
+    agentAlive: args.agentAlive,
+    migrationUnsupportedPtyId: args.migrationUnsupportedPtyId,
+    unread: args.acknowledgedAt < args.timestamp
+  })
+}
+
+export function appendActivityEventsForEntry(args: {
+  events: ActivityEvent[]
+  seenEventIds: Set<string>
+  entry: AgentStatusEntry
+  worktree: Worktree
+  repo: Repo | null
+  tab: TerminalTab
+  agentType: AgentType
+  agentAlive: boolean
+  acknowledgedAt: number
+  migrationUnsupportedPtyId?: string
+}): void {
+  // Why: Activity is append-only; when a pane continues (done→working), stateHistory is the only record of the previous done/blocking event.
+  for (const history of args.entry.stateHistory) {
+    if (!isActivityEventState(history.state)) {
+      continue
+    }
+    appendActivityEvent({
+      ...args,
+      state: history.state,
+      timestamp: history.startedAt,
+      entry: historyEntrySnapshot(args.entry, history)
+    })
+  }
+
+  // Why: SessionStart creates an idle row, not an "Agent finished" activity event (STA-3386).
+  if (!isActivityEventState(args.entry.state) || args.entry.sessionBoundary === true) {
+    return
+  }
+  appendActivityEvent({
+    ...args,
+    state: args.entry.state,
+    timestamp: args.entry.stateStartedAt
+  })
+}

--- a/src/renderer/src/components/activity/agent-pane-threads.ts
+++ b/src/renderer/src/components/activity/agent-pane-threads.ts
@@ -1,0 +1,285 @@
+import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import type {
+  AgentStatusEntry,
+  MigrationUnsupportedPtyEntry
+} from '../../../../shared/agent-status-types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import type { Repo, TerminalTab, Worktree } from '../../../../shared/types'
+import {
+  EVENTS_PER_PANE_CAP,
+  appendActivityEventsForEntry,
+  freshActivityLiveAgentState,
+  paneTitleForEntry,
+  paneTitleForEvent,
+  standaloneActivityWorktree,
+  statusPreviewForEntry,
+  type ActivityEvent,
+  type ActivityLiveAgentSnapshot,
+  type AgentPaneThread
+} from './activity-events'
+
+export function buildActivityEvents(args: {
+  agentStatusByPaneKey: Record<string, AgentStatusEntry>
+  migrationUnsupportedByPtyId?: Record<string, MigrationUnsupportedPtyEntry>
+  retainedAgentsByPaneKey: Record<string, RetainedAgentEntry>
+  tabsByWorktree: Record<string, TerminalTab[]>
+  worktreeMap: Map<string, Worktree>
+  repoMap: Map<string, Repo>
+  acknowledgedAgentsByPaneKey: Record<string, number>
+  now: number
+}): {
+  events: ActivityEvent[]
+  liveAgentByPaneKey: Record<string, ActivityLiveAgentSnapshot>
+} {
+  const events: ActivityEvent[] = []
+  const seenEventIds = new Set<string>()
+  const tabContext = new Map<string, { worktree: Worktree; tab: TerminalTab }>()
+  const liveAgentByPaneKey: Record<string, ActivityLiveAgentSnapshot> = {}
+
+  for (const [worktreeId, tabs] of Object.entries(args.tabsByWorktree)) {
+    const worktree = args.worktreeMap.get(worktreeId) ?? standaloneActivityWorktree(worktreeId)
+    for (const tab of tabs) {
+      tabContext.set(tab.id, { worktree, tab })
+    }
+  }
+
+  for (const [paneKey, entry] of Object.entries(args.agentStatusByPaneKey)) {
+    const parsed = parsePaneKey(paneKey)
+    if (!parsed) {
+      continue
+    }
+    const context = tabContext.get(parsed.tabId)
+    if (!context) {
+      continue
+    }
+    const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
+    // Why: live status is separate from history; a fresh working turn updates the thread without counting as an unread done/blocked/waiting event.
+    const liveState = freshActivityLiveAgentState(entry, args.now)
+    if (liveState) {
+      liveAgentByPaneKey[paneKey] = {
+        state: liveState,
+        timestamp: entry.stateStartedAt,
+        worktree: context.worktree,
+        repo: args.repoMap.get(context.worktree.repoId) ?? null,
+        entry,
+        tab: context.tab,
+        agentType: entry.agentType ?? 'unknown'
+      }
+    }
+    appendActivityEventsForEntry({
+      events,
+      seenEventIds,
+      worktree: context.worktree,
+      repo: args.repoMap.get(context.worktree.repoId) ?? null,
+      entry,
+      tab: context.tab,
+      agentType: entry.agentType ?? 'unknown',
+      agentAlive: true,
+      acknowledgedAt: ackAt
+    })
+  }
+
+  for (const unsupported of Object.values(args.migrationUnsupportedByPtyId ?? {})) {
+    const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
+    if (!entry) {
+      continue
+    }
+    const parsed = parsePaneKey(entry.paneKey)
+    if (!parsed) {
+      continue
+    }
+    const context = tabContext.get(parsed.tabId)
+    if (!context) {
+      continue
+    }
+    const ackAt = args.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0
+    liveAgentByPaneKey[entry.paneKey] = {
+      state: 'blocked',
+      timestamp: entry.stateStartedAt,
+      worktree: context.worktree,
+      repo: args.repoMap.get(context.worktree.repoId) ?? null,
+      entry,
+      tab: context.tab,
+      agentType: entry.agentType ?? 'unknown'
+    }
+    appendActivityEventsForEntry({
+      events,
+      seenEventIds,
+      worktree: context.worktree,
+      repo: args.repoMap.get(context.worktree.repoId) ?? null,
+      entry,
+      tab: context.tab,
+      agentType: entry.agentType ?? 'unknown',
+      agentAlive: false,
+      acknowledgedAt: ackAt,
+      migrationUnsupportedPtyId: unsupported.ptyId
+    })
+  }
+
+  for (const [paneKey, retained] of Object.entries(args.retainedAgentsByPaneKey)) {
+    if (!parsePaneKey(paneKey)) {
+      continue
+    }
+    const worktree =
+      args.worktreeMap.get(retained.worktreeId) ??
+      (args.tabsByWorktree[retained.worktreeId]
+        ? standaloneActivityWorktree(retained.worktreeId)
+        : null)
+    if (!worktree) {
+      continue
+    }
+    const ackAt = args.acknowledgedAgentsByPaneKey[paneKey] ?? 0
+    appendActivityEventsForEntry({
+      events,
+      seenEventIds,
+      worktree,
+      repo: args.repoMap.get(worktree.repoId) ?? null,
+      entry: retained.entry,
+      tab: retained.tab,
+      agentType: retained.agentType,
+      agentAlive: false,
+      acknowledgedAt: ackAt
+    })
+  }
+
+  const sorted = events.sort((a, b) => b.timestamp - a.timestamp)
+  const perPaneCount = new Map<string, number>()
+  const includedEventIds = new Set<string>()
+  const capped: ActivityEvent[] = []
+  // Why: reserve each pane's newest event before the global 80-event cap so the validator's >16 panes × ≥5 events can't push a pane out of the window and hide it.
+  for (const event of sorted) {
+    const paneKey = event.entry.paneKey
+    if (perPaneCount.has(paneKey)) {
+      continue
+    }
+    if (capped.length >= 80) {
+      break
+    }
+    perPaneCount.set(paneKey, 1)
+    includedEventIds.add(event.id)
+    capped.push(event)
+  }
+  for (const event of sorted) {
+    if (includedEventIds.has(event.id)) {
+      continue
+    }
+    if (capped.length >= 80) {
+      break
+    }
+    const paneKey = event.entry.paneKey
+    const count = perPaneCount.get(paneKey) ?? 0
+    if (count >= EVENTS_PER_PANE_CAP) {
+      continue
+    }
+    perPaneCount.set(paneKey, count + 1)
+    includedEventIds.add(event.id)
+    capped.push(event)
+  }
+  return { events: capped.sort((a, b) => b.timestamp - a.timestamp), liveAgentByPaneKey }
+}
+
+export function buildAgentPaneThreads(args: {
+  events: ActivityEvent[]
+  liveAgentByPaneKey: Record<string, ActivityLiveAgentSnapshot>
+  generatedTitlesEnabled?: boolean
+}): AgentPaneThread[] {
+  const generatedTitlesEnabled = args.generatedTitlesEnabled === true
+  const byPaneKey = new Map<string, AgentPaneThread>()
+  for (const event of args.events) {
+    const paneKey = event.entry.paneKey
+    const existing = byPaneKey.get(paneKey)
+    if (!existing) {
+      byPaneKey.set(paneKey, {
+        paneKey,
+        paneTitle: paneTitleForEvent(event, generatedTitlesEnabled),
+        worktree: event.worktree,
+        repo: event.repo,
+        tab: event.tab,
+        agentType: event.agentType,
+        currentAgentState: null,
+        currentAgentEntry: null,
+        responsePreview: statusPreviewForEntry(event.entry, event.state),
+        latestTimestamp: event.timestamp,
+        latestEvent: event,
+        events: [event],
+        migrationUnsupportedPtyId: event.migrationUnsupportedPtyId,
+        unread: event.unread
+      })
+      continue
+    }
+    existing.events.push(event)
+    existing.unread = existing.unread || event.unread
+    existing.migrationUnsupportedPtyId =
+      existing.migrationUnsupportedPtyId ?? event.migrationUnsupportedPtyId
+    if (!existing.latestEvent || event.timestamp > existing.latestEvent.timestamp) {
+      existing.latestEvent = event
+      existing.paneTitle = paneTitleForEvent(event, generatedTitlesEnabled)
+      existing.agentType = event.agentType
+      existing.tab = event.tab
+      existing.responsePreview = statusPreviewForEntry(
+        event.entry,
+        event.state,
+        existing.responsePreview
+      )
+      existing.latestTimestamp = event.timestamp
+    }
+  }
+
+  for (const [paneKey, liveAgent] of Object.entries(args.liveAgentByPaneKey)) {
+    const existing = byPaneKey.get(paneKey)
+    if (!existing) {
+      byPaneKey.set(paneKey, {
+        paneKey,
+        paneTitle: paneTitleForEntry(liveAgent.entry, liveAgent.tab, generatedTitlesEnabled),
+        worktree: liveAgent.worktree,
+        repo: liveAgent.repo,
+        tab: liveAgent.tab,
+        agentType: liveAgent.agentType,
+        currentAgentState: liveAgent.state,
+        currentAgentEntry: liveAgent.entry,
+        responsePreview: statusPreviewForEntry(liveAgent.entry, liveAgent.state),
+        latestTimestamp: liveAgent.timestamp,
+        latestEvent: null,
+        events: [],
+        unread: false
+      })
+      continue
+    }
+    // Why: row title/time/target must follow the active turn (not historical events) so a running agent never shows the previous prompt as primary.
+    existing.paneTitle = paneTitleForEntry(liveAgent.entry, liveAgent.tab, generatedTitlesEnabled)
+    existing.worktree = liveAgent.worktree
+    existing.repo = liveAgent.repo
+    existing.tab = liveAgent.tab
+    existing.agentType = liveAgent.agentType
+    existing.currentAgentState = liveAgent.state
+    existing.currentAgentEntry = liveAgent.entry
+    existing.responsePreview = statusPreviewForEntry(
+      liveAgent.entry,
+      liveAgent.state,
+      existing.responsePreview
+    )
+    existing.latestTimestamp = liveAgent.timestamp
+  }
+
+  return Array.from(byPaneKey.values())
+    .map((thread) => ({
+      ...thread,
+      events: [...thread.events].sort((a, b) => b.timestamp - a.timestamp)
+    }))
+    .sort((a, b) => b.latestTimestamp - a.latestTimestamp)
+}
+
+// Why: badges must equal the unread rows the Agents page renders (and that "Mark all read" acks) — derive both from the same thread build.
+export function countUnreadAgentPaneThreads(
+  args: Parameters<typeof buildActivityEvents>[0]
+): number {
+  const { events, liveAgentByPaneKey } = buildActivityEvents(args)
+  let count = 0
+  for (const thread of buildAgentPaneThreads({ events, liveAgentByPaneKey })) {
+    if (thread.unread) {
+      count += 1
+    }
+  }
+  return count
+}

--- a/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.test.ts
@@ -1,13 +1,29 @@
 import { describe, expect, it } from 'vitest'
 import type { AgentStatusEntry } from '../../../../shared/agent-status-types'
-import { countActivityUnread } from './useActivityUnreadCount'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TerminalTab } from '../../../../shared/types'
+import type { RetainedAgentEntry } from '@/store/slices/agent-status'
+import { countUnreadAgentPaneThreads } from './agent-pane-threads'
 
-const PANE = 'tab-1:11111111-1111-4111-8111-111111111111'
+const PANE = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+
+function makeTab(): TerminalTab {
+  return {
+    id: 'tab-1',
+    ptyId: 'pty-1',
+    worktreeId: 'wt-1',
+    title: 'Claude',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
 
 function makeEntry(overrides: Partial<AgentStatusEntry>): AgentStatusEntry {
   return {
     state: 'done',
-    prompt: '',
+    prompt: 'fix bug',
     updatedAt: 2_000,
     stateStartedAt: 2_000,
     paneKey: PANE,
@@ -17,50 +33,88 @@ function makeEntry(overrides: Partial<AgentStatusEntry>): AgentStatusEntry {
   }
 }
 
-function makeSource(entry: AgentStatusEntry, ackAt = 0) {
+function makeSource(args: {
+  entry?: AgentStatusEntry
+  retained?: Record<string, RetainedAgentEntry>
+  ackAt?: number
+  withTab?: boolean
+}): Parameters<typeof countUnreadAgentPaneThreads>[0] {
   return {
-    acknowledgedAgentsByPaneKey: { [PANE]: ackAt },
-    agentStatusByPaneKey: { [PANE]: entry },
+    agentStatusByPaneKey: args.entry ? { [PANE]: args.entry } : {},
     migrationUnsupportedByPtyId: {},
-    retainedAgentsByPaneKey: {},
-    worktreesByRepo: {}
+    retainedAgentsByPaneKey: args.retained ?? {},
+    tabsByWorktree: args.withTab === false ? {} : { 'wt-1': [makeTab()] },
+    worktreeMap: new Map(),
+    repoMap: new Map(),
+    acknowledgedAgentsByPaneKey: { [PANE]: args.ackAt ?? 0 },
+    now: 2_000
   }
 }
 
-describe('countActivityUnread session-boundary rows (STA-3386)', () => {
-  it('does not count a session-boundary done as unread in either mode', () => {
-    const source = makeSource(makeEntry({ sessionBoundary: true }))
-    expect(countActivityUnread(source, 'sidebar-badge')).toBe(0)
-    expect(countActivityUnread(source, 'agent-events')).toBe(0)
+describe('countUnreadAgentPaneThreads', () => {
+  it('counts an unacknowledged done as one unread thread', () => {
+    expect(countUnreadAgentPaneThreads(makeSource({ entry: makeEntry({}) }))).toBe(1)
+  })
+
+  it('drops to zero once the pane is acknowledged, mirroring "Mark all read"', () => {
+    expect(countUnreadAgentPaneThreads(makeSource({ entry: makeEntry({}), ackAt: 2_500 }))).toBe(0)
+  })
+
+  it('counts one thread per pane even with multiple unread events', () => {
+    const entry = makeEntry({
+      stateHistory: [
+        { state: 'done', prompt: 'first', startedAt: 1_000 },
+        { state: 'blocked', prompt: 'second', startedAt: 1_500 }
+      ]
+    })
+    expect(countUnreadAgentPaneThreads(makeSource({ entry }))).toBe(1)
+  })
+
+  // Why: the Agents page cannot list a pane without tab context, so the badge must not count it either.
+  it('ignores panes whose tab is gone from tabsByWorktree', () => {
+    expect(countUnreadAgentPaneThreads(makeSource({ entry: makeEntry({}), withTab: false }))).toBe(
+      0
+    )
+  })
+
+  it('counts retained non-done agents that the Agents page lists as unread', () => {
+    const retained: RetainedAgentEntry = {
+      entry: makeEntry({ state: 'blocked' }),
+      worktreeId: 'wt-1',
+      tab: makeTab(),
+      agentType: 'claude',
+      startedAt: 1_000
+    }
+    expect(countUnreadAgentPaneThreads(makeSource({ retained: { [PANE]: retained } }))).toBe(1)
+  })
+})
+
+describe('countUnreadAgentPaneThreads session-boundary rows (STA-3386)', () => {
+  it('does not count a session-boundary done as unread', () => {
+    const source = makeSource({ entry: makeEntry({ sessionBoundary: true }) })
+    expect(countUnreadAgentPaneThreads(source)).toBe(0)
   })
 
   it('keeps counting a real completion displaced into history by a session boundary', () => {
     // Why: agent finished (unacknowledged), then the user resumed the session — the
-    // boundary row replaces the live done but the finish must stay unread in both badges.
-    const source = makeSource(
-      makeEntry({
+    // boundary row replaces the live done but the finish must stay unread in the badge.
+    const source = makeSource({
+      entry: makeEntry({
         sessionBoundary: true,
         stateHistory: [{ state: 'done', prompt: 'fix bug', startedAt: 1_000 }]
       })
-    )
-    expect(countActivityUnread(source, 'sidebar-badge')).toBe(1)
-    expect(countActivityUnread(source, 'agent-events')).toBe(1)
+    })
+    expect(countUnreadAgentPaneThreads(source)).toBe(1)
   })
 
   it('stops counting the displaced completion once acknowledged', () => {
-    const source = makeSource(
-      makeEntry({
+    const source = makeSource({
+      entry: makeEntry({
         sessionBoundary: true,
         stateHistory: [{ state: 'done', prompt: 'fix bug', startedAt: 1_000 }]
       }),
-      1_500
-    )
-    expect(countActivityUnread(source, 'sidebar-badge')).toBe(0)
-    expect(countActivityUnread(source, 'agent-events')).toBe(0)
-  })
-
-  it('still counts an ordinary unacknowledged done in sidebar-badge mode', () => {
-    const source = makeSource(makeEntry({}))
-    expect(countActivityUnread(source, 'sidebar-badge')).toBe(1)
+      ackAt: 1_500
+    })
+    expect(countUnreadAgentPaneThreads(source)).toBe(0)
   })
 })

--- a/src/renderer/src/components/activity/useActivityUnreadCount.ts
+++ b/src/renderer/src/components/activity/useActivityUnreadCount.ts
@@ -1,107 +1,37 @@
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
 
-import { migrationUnsupportedToAgentStatusEntry } from '@/lib/migration-unsupported-agent-entry'
 import { useAppStore } from '@/store'
+import { getRepoMapFromState, getWorktreeMapFromState } from '@/store/selectors'
 import type { AppState } from '@/store/types'
-import type { AgentStatusEntry, AgentStatusState } from '../../../../shared/agent-status-types'
+import { countUnreadAgentPaneThreads } from './agent-pane-threads'
 
-type ActivityUnreadCountSource = Pick<
-  AppState,
-  | 'acknowledgedAgentsByPaneKey'
-  | 'agentStatusByPaneKey'
-  | 'migrationUnsupportedByPtyId'
-  | 'retainedAgentsByPaneKey'
-  | 'worktreesByRepo'
->
-
-type ActivityUnreadCountMode = 'agent-events' | 'sidebar-badge'
-
-const EMPTY_WORKTREES_BY_REPO: AppState['worktreesByRepo'] = {}
+const EMPTY_TABS_BY_WORKTREE: AppState['tabsByWorktree'] = {}
+const EMPTY_WORKTREE_MAP: ReturnType<typeof getWorktreeMapFromState> = new Map()
+const EMPTY_REPO_MAP: ReturnType<typeof getRepoMapFromState> = new Map()
 const EMPTY_MIGRATION_UNSUPPORTED: AppState['migrationUnsupportedByPtyId'] = {}
 const EMPTY_RETAINED_AGENTS: AppState['retainedAgentsByPaneKey'] = {}
 const EMPTY_ACKNOWLEDGED_AGENTS: AppState['acknowledgedAgentsByPaneKey'] = {}
 
 const DISABLED_ACTIVITY_UNREAD_INPUTS = {
   sortEpoch: 0,
-  worktreesByRepo: EMPTY_WORKTREES_BY_REPO,
+  tabsByWorktree: EMPTY_TABS_BY_WORKTREE,
+  worktreeMap: EMPTY_WORKTREE_MAP,
+  repoMap: EMPTY_REPO_MAP,
   migrationUnsupportedByPtyId: EMPTY_MIGRATION_UNSUPPORTED,
   retainedAgentsByPaneKey: EMPTY_RETAINED_AGENTS,
   acknowledgedAgentsByPaneKey: EMPTY_ACKNOWLEDGED_AGENTS
 }
 
-function isUnreadAgentState(state: AgentStatusState): boolean {
-  return state === 'done' || state === 'blocked' || state === 'waiting'
-}
-
-export function countActivityUnread(
-  source: ActivityUnreadCountSource,
-  mode: ActivityUnreadCountMode
-): number {
-  let count = 0
-
-  if (mode === 'sidebar-badge') {
-    for (const worktrees of Object.values(source.worktreesByRepo)) {
-      for (const worktree of worktrees) {
-        if (worktree.createdAt && worktree.isUnread) {
-          count += 1
-        }
-      }
-    }
-  }
-
-  const countEntry = (entry: AgentStatusEntry, ackAt: number): void => {
-    if (mode === 'agent-events') {
-      // Why: Activity feed surfaces historical done/blocked/waiting events
-      // from stateHistory, so the titlebar badge must mirror that event count.
-      for (const history of entry.stateHistory) {
-        if (isUnreadAgentState(history.state) && ackAt < history.startedAt) {
-          count += 1
-        }
-      }
-    }
-    // Why: a session-boundary done is an idle connect (STA-3386), not an event to read.
-    // History never contains a boundary, but it DOES keep the real completion a boundary
-    // displaced (the slice pushes it on done→done), so sidebar-badge mode — which skips the
-    // history loop above — must still count that displaced completion or the badge silently
-    // drops an unacknowledged finish the moment its session is resumed.
-    if (
-      isUnreadAgentState(entry.state) &&
-      entry.sessionBoundary !== true &&
-      ackAt < entry.stateStartedAt
-    ) {
-      count += 1
-    } else if (mode === 'sidebar-badge' && entry.state === 'done' && entry.sessionBoundary) {
-      const displaced = entry.stateHistory.at(-1)
-      if (displaced && isUnreadAgentState(displaced.state) && ackAt < displaced.startedAt) {
-        count += 1
-      }
-    }
-  }
-
-  for (const [paneKey, entry] of Object.entries(source.agentStatusByPaneKey)) {
-    countEntry(entry, source.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
-  }
-  for (const [paneKey, retained] of Object.entries(source.retainedAgentsByPaneKey)) {
-    if (mode === 'sidebar-badge' && retained.entry.state !== 'done') {
-      continue
-    }
-    countEntry(retained.entry, source.acknowledgedAgentsByPaneKey[paneKey] ?? 0)
-  }
-  for (const unsupported of Object.values(source.migrationUnsupportedByPtyId)) {
-    const entry = migrationUnsupportedToAgentStatusEntry(unsupported)
-    if (entry) {
-      countEntry(entry, source.acknowledgedAgentsByPaneKey[entry.paneKey] ?? 0)
-    }
-  }
-
-  return count
-}
-
-export function useActivityUnreadCount(enabled: boolean, mode: ActivityUnreadCountMode): number {
+// Why: the sidebar pill and Agents titlebar badge must equal the unread rows the
+// Agents page lists (and that "Mark all read" acknowledges), so the count derives
+// from the same thread build instead of a parallel per-entry tally.
+export function useActivityUnreadCount(enabled: boolean): number {
   const {
     sortEpoch,
-    worktreesByRepo,
+    tabsByWorktree,
+    worktreeMap,
+    repoMap,
     migrationUnsupportedByPtyId,
     retainedAgentsByPaneKey,
     acknowledgedAgentsByPaneKey
@@ -115,7 +45,9 @@ export function useActivityUnreadCount(enabled: boolean, mode: ActivityUnreadCou
         // cannot change unread count unless a sort-relevant state transition
         // or removal occurred. sortEpoch is the cheap invalidation signal.
         sortEpoch: state.sortEpoch,
-        worktreesByRepo: state.worktreesByRepo,
+        tabsByWorktree: state.tabsByWorktree,
+        worktreeMap: getWorktreeMapFromState(state),
+        repoMap: getRepoMapFromState(state),
         migrationUnsupportedByPtyId: state.migrationUnsupportedByPtyId,
         retainedAgentsByPaneKey: state.retainedAgentsByPaneKey,
         acknowledgedAgentsByPaneKey: state.acknowledgedAgentsByPaneKey
@@ -128,23 +60,24 @@ export function useActivityUnreadCount(enabled: boolean, mode: ActivityUnreadCou
       return 0
     }
     void sortEpoch
-    return countActivityUnread(
-      {
-        agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
-        migrationUnsupportedByPtyId,
-        retainedAgentsByPaneKey,
-        worktreesByRepo,
-        acknowledgedAgentsByPaneKey
-      },
-      mode
-    )
+    return countUnreadAgentPaneThreads({
+      agentStatusByPaneKey: useAppStore.getState().agentStatusByPaneKey,
+      migrationUnsupportedByPtyId,
+      retainedAgentsByPaneKey,
+      tabsByWorktree,
+      worktreeMap,
+      repoMap,
+      acknowledgedAgentsByPaneKey,
+      now: Date.now()
+    })
   }, [
     acknowledgedAgentsByPaneKey,
     enabled,
     migrationUnsupportedByPtyId,
-    mode,
+    repoMap,
     retainedAgentsByPaneKey,
     sortEpoch,
-    worktreesByRepo
+    tabsByWorktree,
+    worktreeMap
   ])
 }

--- a/src/renderer/src/components/sidebar/SidebarNav.tsx
+++ b/src/renderer/src/components/sidebar/SidebarNav.tsx
@@ -77,7 +77,7 @@ const SidebarNav = React.memo(function SidebarNav() {
   const activityActive = activeView === 'activity'
   const mobileActive = activeView === 'mobile'
   const artifactsActive = activeView === 'artifacts'
-  const activityUnreadCount = useActivityUnreadCount(showAgentsButton, 'sidebar-badge')
+  const activityUnreadCount = useActivityUnreadCount(showAgentsButton)
   const mobileOnboardingBadge = useMobileSidebarOnboardingBadge(showMobileButton)
   const hideAutomationsButton = React.useCallback(() => {
     void updateSettings({ showAutomationsButton: false })


### PR DESCRIPTION
## Problem

The sidebar **Agents** pill and the Agents detail view computed "unread" from two different code paths, so they drifted apart: after **Mark all read**, the detail view was empty while the pill still showed a count. The pill counted things the page never lists (and therefore can never acknowledge):

- workspace cards manually flagged unread (`worktree.isUnread`), which agent-level ack can never clear
- agent panes whose tab context is gone (the page drops these)
- retained/event-cap asymmetries (retained non-`done` agents, events past the per-pane/global caps)

Separately, the "show unread only" toggle in the detail view reset to the full list on every visit.

## Fix

- Extract the event/thread builders out of `ActivityPrototypePage.tsx` into `activity-events.ts` + `agent-pane-threads.ts`. The page is lazy-loaded, so the always-mounted sidebar could not share its logic before.
- `useActivityUnreadCount` now counts unread threads via `countUnreadAgentPaneThreads` from that same build, for both the sidebar pill and the Agents titlebar badge — the badges always equal the unread rows the page renders, and **Mark all read** zeroes everything. Behavior change: a workspace card marked unread by hand no longer inflates the Agents pill (the card keeps its own indicator).
- Persist the unread-only toggle to `localStorage` (`orca.activity.read-filter`, same pattern as other local view prefs) and restore it on mount.

## Testing

- `tsc` renderer typecheck, `oxlint`, full `pnpm lint` (incl. max-lines ratchet) pass
- Activity suite: 63 tests pass; unread-count tests rewritten around the shared counter, preserving the STA-3386 session-boundary cases and adding coverage for ack-mirrors-mark-all-read, one-thread-per-pane counting, gone-tab exclusion, and retained non-done agents
- SidebarNav: 23 tests pass