### PR TITLE
fix: keep cross-project dialog actions in bounds

### DIFF
--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -2077,27 +2077,38 @@ export default function SmartWorkspaceNameField({
               {crossRepoSwitchDescriptionSuffix}
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter>
+          <DialogFooter className="sm:flex-wrap">
             <Button variant="outline" onClick={dismissCrossRepoPrompt}>
               {translate(
                 'auto.components.new.workspace.SmartWorkspaceNameField.6859e2896c',
                 'Cancel'
               )}
             </Button>
-            <Button variant="outline" onClick={() => void handleUseCurrentRepo()}>
-              {translate(
-                'auto.components.new.workspace.SmartWorkspaceNameField.eadf877af5',
-                'Keep'
-              )}{' '}
-              {selectedRepo?.displayName ?? crossRepoSwitchFallbackLabel}
+            <Button
+              variant="outline"
+              className="min-w-0 max-w-full"
+              onClick={() => void handleUseCurrentRepo()}
+            >
+              <span className="min-w-0 truncate">
+                {translate(
+                  'auto.components.new.workspace.SmartWorkspaceNameField.eadf877af5',
+                  'Keep'
+                )}{' '}
+                {selectedRepo?.displayName ?? crossRepoSwitchFallbackLabel}
+              </span>
             </Button>
             {crossRepoPrompt?.matchingRepo ? (
-              <Button onClick={() => void acceptGitHubLink(crossRepoPrompt.matchingRepo!)}>
-                {translate(
-                  'auto.components.new.workspace.SmartWorkspaceNameField.a76fcb4fa0',
-                  'Switch to'
-                )}{' '}
-                {crossRepoPrompt.matchingRepo.displayName}
+              <Button
+                className="min-w-0 max-w-full"
+                onClick={() => void acceptGitHubLink(crossRepoPrompt.matchingRepo!)}
+              >
+                <span className="min-w-0 truncate">
+                  {translate(
+                    'auto.components.new.workspace.SmartWorkspaceNameField.a76fcb4fa0',
+                    'Switch to'
+                  )}{' '}
+                  {crossRepoPrompt.matchingRepo.displayName}
+                </span>
               </Button>
             ) : allowCrossRepoProjectAdd ? (
               <Button onClick={() => void handleAddMatchingRepo()}>

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -2065,10 +2065,10 @@ export default function SmartWorkspaceNameField({
         open={crossRepoPrompt !== null}
         onOpenChange={(next) => !next && dismissCrossRepoPrompt()}
       >
-        <DialogContent className="sm:max-w-md">
-          <DialogHeader>
+        <DialogContent className="min-w-0 sm:max-w-md">
+          <DialogHeader className="min-w-0">
             <DialogTitle>{crossRepoSwitchTitle}</DialogTitle>
-            <DialogDescription>
+            <DialogDescription className="break-words">
               {translate(
                 'auto.components.new.workspace.SmartWorkspaceNameField.ad188067ae',
                 'The GitHub URL points to'
@@ -2077,7 +2077,7 @@ export default function SmartWorkspaceNameField({
               {crossRepoSwitchDescriptionSuffix}
             </DialogDescription>
           </DialogHeader>
-          <DialogFooter className="sm:flex-wrap">
+          <DialogFooter className="min-w-0 sm:flex-wrap">
             <Button variant="outline" onClick={dismissCrossRepoPrompt}>
               {translate(
                 'auto.components.new.workspace.SmartWorkspaceNameField.6859e2896c',

--- a/tests/e2e/new-workspace-cross-project-dialog.spec.ts
+++ b/tests/e2e/new-workspace-cross-project-dialog.spec.ts
@@ -5,8 +5,9 @@ import path from 'node:path'
 import { test, expect } from './helpers/orca-app'
 import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
 
-const LONG_REPOSITORY_NAME = 'cross-project-dialog-long-repository-name'
+const LONG_REPOSITORY_NAME = 'cross-project-dialog-long-repository-name'.repeat(3)
 const LONG_REPOSITORY_SLUG = LONG_REPOSITORY_NAME
+const CURRENT_REPOSITORY_NAME = 'current-project-name'.repeat(3)
 
 function runGit(repositoryPath: string, args: string[]): void {
   execFileSync('git', args, { cwd: repositoryPath, stdio: 'pipe' })
@@ -45,6 +46,30 @@ test('keeps long repository names inside the cross-project confirmation dialog',
       }
       return repository.id
     }, secondRepositoryPath)
+
+    const currentRepositoryId = await orcaPage.evaluate(() => {
+      const store = window.__store
+      const activeWorktreeId = store?.getState().activeWorktreeId
+      if (!store || !activeWorktreeId) {
+        throw new Error('active repository is unavailable')
+      }
+      const entry = Object.entries(store.getState().worktreesByRepo).find(([, worktrees]) =>
+        worktrees.some((worktree) => worktree.id === activeWorktreeId)
+      )
+      if (!entry) {
+        throw new Error('active repository could not be resolved')
+      }
+      return entry[0]
+    })
+    await orcaPage.evaluate(
+      async ({ repositoryId, displayName }) => {
+        const store = window.__store
+        if (!store || !(await store.getState().updateRepo(repositoryId, { displayName }))) {
+          throw new Error('failed to update the current repository name')
+        }
+      },
+      { repositoryId: currentRepositoryId, displayName: CURRENT_REPOSITORY_NAME }
+    )
 
     await electronApp.evaluate(
       ({ ipcMain }, { repositoryId, repositorySlug }) => {

--- a/tests/e2e/new-workspace-cross-project-dialog.spec.ts
+++ b/tests/e2e/new-workspace-cross-project-dialog.spec.ts
@@ -1,0 +1,119 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { test, expect } from './helpers/orca-app'
+import { waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+
+const LONG_REPOSITORY_NAME = 'cross-project-dialog-long-repository-name'
+const LONG_REPOSITORY_SLUG = LONG_REPOSITORY_NAME
+
+function runGit(repositoryPath: string, args: string[]): void {
+  execFileSync('git', args, { cwd: repositoryPath, stdio: 'pipe' })
+}
+
+function createGitRepository(repositoryPath: string): void {
+  mkdirSync(repositoryPath, { recursive: true })
+  runGit(repositoryPath, ['init'])
+  runGit(repositoryPath, ['config', 'user.email', 'e2e@test.local'])
+  runGit(repositoryPath, ['config', 'user.name', 'E2E Test'])
+  writeFileSync(path.join(repositoryPath, 'README.md'), '# Cross-project dialog E2E\n')
+  runGit(repositoryPath, ['add', '-A'])
+  runGit(repositoryPath, ['commit', '-m', 'Initial commit'])
+}
+
+test('keeps long repository names inside the cross-project confirmation dialog', async ({
+  electronApp,
+  orcaPage
+}, testInfo) => {
+  await waitForSessionReady(orcaPage)
+  await waitForActiveWorktree(orcaPage)
+
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-cross-project-dialog-'))
+  const secondRepositoryPath = path.join(tempRoot, LONG_REPOSITORY_NAME)
+  createGitRepository(secondRepositoryPath)
+
+  try {
+    const secondRepositoryId = await orcaPage.evaluate(async (repositoryPath) => {
+      const store = window.__store
+      if (!store) {
+        throw new Error('window.__store is not available')
+      }
+      const repository = await store.getState().addRepoPath(repositoryPath)
+      if (!repository) {
+        throw new Error(`Failed to add repository at ${repositoryPath}`)
+      }
+      return repository.id
+    }, secondRepositoryPath)
+
+    await electronApp.evaluate(
+      ({ ipcMain }, { repositoryId, repositorySlug }) => {
+        ipcMain.removeHandler('gh:repoSlug')
+        ipcMain.handle('gh:repoSlug', (_event, args: { repoId?: string }) =>
+          args.repoId === repositoryId
+            ? { owner: 'e2e', repo: repositorySlug }
+            : { owner: 'e2e', repo: 'current-project' }
+        )
+      },
+      { repositoryId: secondRepositoryId, repositorySlug: LONG_REPOSITORY_SLUG }
+    )
+
+    // Why: 640px is the narrowest desktop layout, where the footer switches to a row.
+    await orcaPage.setViewportSize({ width: 640, height: 720 })
+    await orcaPage.getByRole('button', { name: 'New workspace', exact: true }).click()
+
+    const composer = orcaPage.getByRole('dialog', { name: /Create (Workspace|Worktree)/i })
+    await expect(composer).toBeVisible()
+    const nameInput = composer.locator('[data-workspace-name-input="true"]')
+    await expect(nameInput).toBeVisible()
+    await nameInput.fill(`https://github.com/e2e/${LONG_REPOSITORY_SLUG}/issues/42`)
+
+    const confirmation = orcaPage.getByRole('dialog', { name: 'Switch project?' })
+    await expect(confirmation).toBeVisible()
+    await expect(confirmation).toContainText(LONG_REPOSITORY_NAME)
+
+    if (process.env.ORCA_VISUAL_PROOF === '1') {
+      mkdirSync(testInfo.outputDir, { recursive: true })
+      await confirmation.screenshot({ path: testInfo.outputPath('cross-project-dialog.png') })
+    }
+
+    const layout = await confirmation.evaluate((dialog) => {
+      const footer = dialog.querySelector<HTMLElement>('[data-slot="dialog-footer"]')
+      if (!footer) {
+        throw new Error('cross-project dialog footer is missing')
+      }
+      const dialogRect = dialog.getBoundingClientRect()
+      const dialogStyles = getComputedStyle(dialog)
+      const contentLeft = dialogRect.left + Number.parseFloat(dialogStyles.paddingLeft)
+      const contentRight = dialogRect.right - Number.parseFloat(dialogStyles.paddingRight)
+      const footerRect = footer.getBoundingClientRect()
+      const buttons = Array.from(dialog.querySelectorAll<HTMLButtonElement>('[data-slot="button"]'))
+      return {
+        dialogFits: dialog.scrollWidth <= dialog.clientWidth,
+        footerFits:
+          footer.scrollWidth <= footer.clientWidth &&
+          footerRect.left >= contentLeft - 1 &&
+          footerRect.right <= contentRight + 1,
+        buttonsFit: buttons.every((button) => {
+          const rect = button.getBoundingClientRect()
+          return (
+            button.scrollWidth <= button.clientWidth + 1 &&
+            rect.left >= contentLeft - 1 &&
+            rect.right <= contentRight + 1
+          )
+        })
+      }
+    })
+
+    expect(layout).toEqual({ dialogFits: true, footerFits: true, buttonsFit: true })
+  } finally {
+    await orcaPage
+      .evaluate(() => {
+        window.__store?.getState().closeModal()
+      })
+      .catch(() => {
+        /* page may already be torn down */
+      })
+    rmSync(tempRoot, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

Long repository names could push the cross-project confirmation actions outside the dialog. The footer now wraps at the desktop breakpoint, and dynamic repository labels stay constrained with the existing truncation style.

A focused E2E test covers the 640px desktop layout and asserts the dialog, footer, and buttons remain within their content bounds.

## Visual proof

Before:

![before.png](https://github.com/user-attachments/assets/25193365-bffe-4958-a34b-122c459288e0)

After:

![after.png](https://github.com/user-attachments/assets/e33b63a5-8a75-4a2c-9d1d-d4d81d97d96e)

## Verification

- `ORCA_VISUAL_PROOF=1 SKIP_BUILD=1 pnpm exec playwright test tests/e2e/new-workspace-cross-project-dialog.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1`
- `pnpm run typecheck:web`
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/new-workspace/SmartWorkspaceNameField.ime-enter.test.tsx src/renderer/src/components/new-workspace/SmartWorkspaceNameField.jira-accessibility.test.tsx src/renderer/src/components/new-workspace/SmartWorkspaceNameField-source-boundaries.test.ts src/renderer/src/components/new-workspace/SmartWorkspaceNameField-provider-boundaries.test.ts src/renderer/src/components/new-workspace/SmartWorkspaceNameField-repo-slug-routing.test.ts`
- `pnpm run check:code-quality:changed`