### PR TITLE
fix(workspace): stabilize smart entry keyboard flow

### DIFF
--- a/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.test.tsx
@@ -330,6 +330,26 @@ describe('NewWorkspaceComposerCard folder task source mode', () => {
     vi.clearAllMocks()
   })
 
+  it('keeps the Advanced focus highlight inside the composer edge', () => {
+    current = renderCard()
+
+    const advancedButton = [...current.container.querySelectorAll('button')].find((button) =>
+      button.textContent?.includes('Advanced')
+    )
+
+    expect(advancedButton?.className).toContain('focus-visible:ring-inset')
+  })
+
+  it('removes collapsed Advanced controls from the Tab order', () => {
+    current = renderCard({ advancedOpen: false, branchesEnabled: true })
+
+    const advancedPanel = [...current.container.querySelectorAll('[aria-hidden="true"]')].find(
+      (element) => element.querySelector('textarea[placeholder="Write a note"]') !== null
+    )
+
+    expect(advancedPanel?.hasAttribute('inert')).toBe(true)
+  })
+
   it('passes folder child repos into the create-from field without a source trigger', () => {
     current = renderCard({
       repoBackedSearchRepos: sourceRepos as never

--- a/src/renderer/src/components/NewWorkspaceComposerCard.tsx
+++ b/src/renderer/src/components/NewWorkspaceComposerCard.tsx
@@ -918,7 +918,7 @@ export default function NewWorkspaceComposerCard({
             variant="ghost"
             size="sm"
             onClick={onToggleAdvanced}
-            className="-ml-2 text-xs"
+            className="-ml-2 text-xs focus-visible:ring-inset"
           >
             {translate('auto.components.NewWorkspaceComposerCard.f0470c7383', 'Advanced')}
             <ChevronDown
@@ -934,6 +934,7 @@ export default function NewWorkspaceComposerCard({
             advancedOpen ? 'grid-rows-[1fr]' : 'grid-rows-[0fr]'
           )}
           aria-hidden={!advancedOpen}
+          inert={!advancedOpen}
         >
           <div className="min-h-0">
             {/* Why: px-1 gives the Note textarea's 3px outset focus ring breathing room so the overflow-hidden drawer doesn't clip it. */}

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.jira-accessibility.test.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.jira-accessibility.test.tsx
@@ -4,7 +4,9 @@ import React, { act } from 'react'
 import { cleanup, createEvent, fireEvent, render, screen } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import type { JiraIssue } from '../../../../shared/types'
-import SmartWorkspaceNameField from './SmartWorkspaceNameField'
+import SmartWorkspaceNameField, {
+  type SmartWorkspaceNameSelection
+} from './SmartWorkspaceNameField'
 
 const jiraMock = vi.hoisted(() => ({
   retry: vi.fn(),
@@ -31,6 +33,7 @@ const jiraMock = vi.hoisted(() => ({
     errorKind: 'disconnected' | 'site-not-connected' | 'read-failed' | 'update-runtime' | null
   }
 }))
+const shellMock = vi.hoisted(() => ({ openUrl: vi.fn() }))
 const popoverMock = vi.hoisted(() => ({ contentMounted: true }))
 const jiraSearchMock = vi.hoisted(() => vi.fn(async (): Promise<JiraIssue[]> => []))
 const jiraConnectionMock = vi.hoisted(() => ({
@@ -40,6 +43,7 @@ const jiraConnectionMock = vi.hoisted(() => ({
     sites: []
   }
 }))
+const originalWindowApi = window.api
 
 vi.mock('./use-jira-url-source', () => ({
   useJiraUrlSource: () => ({
@@ -161,7 +165,9 @@ function renderField(
     onPlainEnter?: () => void
     onOpenJiraSettings?: () => void
     onValueChange?: (value: string) => void
+    onClearSelectedSource?: () => void
     value?: string
+    selectedSource?: SmartWorkspaceNameSelection | null
   } = {}
 ) {
   return render(
@@ -174,8 +180,8 @@ function renderField(
       onGitHubItemSelect={vi.fn()}
       onBranchSelect={vi.fn()}
       onLinearIssueSelect={vi.fn()}
-      selectedSource={null}
-      onClearSelectedSource={vi.fn()}
+      selectedSource={overrides.selectedSource ?? null}
+      onClearSelectedSource={overrides.onClearSelectedSource ?? vi.fn()}
       jiraSourceContext={
         overrides.jiraSourceContext
           ? ({
@@ -199,6 +205,10 @@ function renderField(
 describe('SmartWorkspaceNameField Jira accessibility', () => {
   beforeEach(() => {
     vi.clearAllMocks()
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { shell: shellMock }
+    })
     jiraSearchMock.mockResolvedValue([])
     Object.assign(jiraMock.state, {
       intent: true,
@@ -218,6 +228,14 @@ describe('SmartWorkspaceNameField Jira accessibility', () => {
 
   afterEach(() => {
     cleanup()
+    if (originalWindowApi === undefined) {
+      Reflect.deleteProperty(window, 'api')
+    } else {
+      Object.defineProperty(window, 'api', {
+        configurable: true,
+        value: originalWindowApi
+      })
+    }
   })
 
   it('associates loading status with the busy input and blocks plain Enter', () => {
@@ -234,6 +252,33 @@ describe('SmartWorkspaceNameField Jira accessibility', () => {
     act(() => {
       fireEvent.keyDown(input, { key: 'Enter' })
     })
+    expect(onPlainEnter).not.toHaveBeenCalled()
+  })
+
+  it('keeps selected-source actions out of Tab order with keyboard fallbacks', () => {
+    const onClearSelectedSource = vi.fn()
+    const onPlainEnter = vi.fn()
+    renderField({
+      onClearSelectedSource,
+      onPlainEnter,
+      selectedSource: {
+        kind: 'github-issue',
+        label: 'Issue #123',
+        url: 'https://github.com/orca/ide/issues/123'
+      }
+    })
+
+    expect(screen.getByRole('button', { name: 'Open link in browser' }).tabIndex).toBe(-1)
+    expect(screen.getByRole('button', { name: 'Clear selected source' }).tabIndex).toBe(-1)
+
+    const pill = document.querySelector<HTMLElement>('[data-workspace-source-pill="true"]')
+    expect(pill?.getAttribute('aria-keyshortcuts')).toBe('Alt+Enter Backspace Delete')
+
+    fireEvent.keyDown(pill as HTMLElement, { key: 'Backspace' })
+    expect(onClearSelectedSource).toHaveBeenCalledOnce()
+
+    fireEvent.keyDown(pill as HTMLElement, { key: 'Enter', altKey: true })
+    expect(shellMock.openUrl).toHaveBeenCalledWith('https://github.com/orca/ide/issues/123')
     expect(onPlainEnter).not.toHaveBeenCalled()
   })
 

--- a/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
+++ b/src/renderer/src/components/new-workspace/SmartWorkspaceNameField.tsx
@@ -1306,14 +1306,14 @@ export default function SmartWorkspaceNameField({
     isQueryStale,
     sourceIntent
   })
-  // Why: while isQueryStale, cmdk onValueChange is ignored; re-sync the stored arm
-  // when the query settles so commandValue cannot lag resolvedCommandValue.
+  // Why: while isQueryStale, cmdk onValueChange is ignored; keep the stored arm
+  // aligned too so a stale provider cannot reappear when the query settles.
   useEffect(() => {
-    if (isQueryStale || commandValue === resolvedCommandValue) {
+    if (commandValue === resolvedCommandValue) {
       return
     }
     setCommandValue(resolvedCommandValue)
-  }, [commandValue, isQueryStale, resolvedCommandValue])
+  }, [commandValue, resolvedCommandValue])
   const activeEmojiShortcode = useMemo(
     () => getActiveWorkspaceEmojiShortcode(value, emojiCursor),
     [emojiCursor, value]
@@ -1409,6 +1409,12 @@ export default function SmartWorkspaceNameField({
       selectJiraAccount
     ]
   )
+
+  const openSelectedSource = useCallback((): void => {
+    if (selectedSource?.url) {
+      void window.api.shell.openUrl(selectedSource.url)
+    }
+  }, [selectedSource?.url])
 
   const applyEmojiReplacement = useCallback(
     (replacement: WorkspaceEmojiReplacement): void => {
@@ -1681,9 +1687,42 @@ export default function SmartWorkspaceNameField({
                   ref={setSelectedSourceNode}
                   data-workspace-source-pill="true"
                   tabIndex={0}
+                  aria-keyshortcuts={
+                    selectedSource.url ? 'Alt+Enter Backspace Delete' : 'Backspace Delete'
+                  }
                   onKeyDown={(event) => {
+                    if (event.currentTarget !== event.target) {
+                      return
+                    }
                     if (
-                      event.currentTarget !== event.target ||
+                      (event.key === 'Backspace' || event.key === 'Delete') &&
+                      !event.metaKey &&
+                      !event.ctrlKey &&
+                      !event.shiftKey &&
+                      !event.altKey
+                    ) {
+                      event.preventDefault()
+                      onClearSelectedSource()
+                      cancelLocalInputFocusFrame()
+                      localInputFocusFrameRef.current = requestAnimationFrame(() => {
+                        localInputFocusFrameRef.current = null
+                        localInputRef.current?.focus({ preventScroll: true })
+                      })
+                      return
+                    }
+                    if (
+                      event.key === 'Enter' &&
+                      event.altKey &&
+                      !event.metaKey &&
+                      !event.ctrlKey &&
+                      !event.shiftKey &&
+                      selectedSource.url
+                    ) {
+                      event.preventDefault()
+                      openSelectedSource()
+                      return
+                    }
+                    if (
                       event.key !== 'Enter' ||
                       event.metaKey ||
                       event.ctrlKey ||
@@ -1708,7 +1747,8 @@ export default function SmartWorkspaceNameField({
                           type="button"
                           variant="ghost"
                           size="icon-xs"
-                          onClick={() => void window.api.shell.openUrl(selectedSource.url!)}
+                          tabIndex={-1}
+                          onClick={openSelectedSource}
                           className="size-6 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
                           aria-label={translate(
                             'auto.components.new.workspace.SmartWorkspaceNameField.2c69728c2a',
@@ -1732,6 +1772,7 @@ export default function SmartWorkspaceNameField({
                         type="button"
                         variant="ghost"
                         size="icon-xs"
+                        tabIndex={-1}
                         onClick={onClearSelectedSource}
                         className="size-6 shrink-0 rounded-sm text-muted-foreground hover:text-foreground"
                         aria-label={translate(

--- a/src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
+++ b/src/renderer/src/components/new-workspace/smart-workspace-command-value.test.ts
@@ -31,7 +31,7 @@ describe('resolveSmartWorkspaceCommandValue', () => {
     ).toBe('use-name')
   })
 
-  it('freezes the current arm while the query is ahead of debounced search', () => {
+  it('keeps typed text armed while the query is ahead of debounced search', () => {
     expect(
       resolveSmartWorkspaceCommandValue({
         currentValue: 'github-12',
@@ -39,7 +39,7 @@ describe('resolveSmartWorkspaceCommandValue', () => {
         isQueryStale: true,
         sourceIntent: null
       })
-    ).toBe('github-12')
+    ).toBe('use-name')
   })
 
   it('falls back to typed-text when a frozen arm is no longer rendered', () => {
@@ -48,6 +48,25 @@ describe('resolveSmartWorkspaceCommandValue', () => {
         currentValue: 'github-12',
         rows: [row('use-name', 'use-name'), row('github', 'github-99')],
         isQueryStale: true,
+        sourceIntent: null
+      })
+    ).toBe('use-name')
+  })
+
+  it('does not resurrect a provider arm when the stale query settles', () => {
+    const rows = [row('use-name', 'use-name'), row('github', 'github-12')]
+    const typedTextArm = resolveSmartWorkspaceCommandValue({
+      currentValue: 'github-12',
+      rows,
+      isQueryStale: true,
+      sourceIntent: null
+    })
+
+    expect(
+      resolveSmartWorkspaceCommandValue({
+        currentValue: typedTextArm,
+        rows,
+        isQueryStale: false,
         sourceIntent: null
       })
     ).toBe('use-name')

--- a/src/shared/new-workspace/smart-workspace-command-value.ts
+++ b/src/shared/new-workspace/smart-workspace-command-value.ts
@@ -33,11 +33,11 @@ export function resolveSmartWorkspaceCommandValue({
   // Why: freeze the arm while the live input is ahead of debounced search so the
   // highlight does not thrash to use-name / empty / first-row on every keystroke.
   if (isQueryStale) {
-    if (rows.some((row) => row.value === currentValue)) {
-      return currentValue
-    }
     const typedTextRow = rows.find((row) => row.kind === 'use-name' || row.kind === 'create-branch')
-    return typedTextRow?.value ?? rows[0]?.value ?? ''
+    if (typedTextRow) {
+      return typedTextRow.value
+    }
+    return rows.some((row) => row.value === currentValue) ? currentValue : (rows[0]?.value ?? '')
   }
 
   if (sourceIntent === 'github') {


### PR DESCRIPTION
Fixes Create Worktree smart-entry keyboard behavior. Keeps typed text highlighted while debounced provider results are stale, lets fresh source matches take over, and keeps selected-source actions out of the main Tab path so focus advances to Agent. Adds keyboard fallbacks for clearing/opening a selected source, contains the Advanced focus ring, and skips collapsed Advanced controls with inert.\n\nValidation: 41 focused Vitest tests, targeted oxlint, web typecheck, oxfmt, source-result tests, and git diff checks.