### PR TITLE
fix(ssh): give an SSH pane binding one home — the 2→19→20 mechanism (STA-3077 P)

### DIFF
--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -5205,15 +5205,16 @@ describe('registerPtyHandlers', () => {
             state: 'attached'
           })
         )
-        expect(store.persistPtyBinding).toHaveBeenCalledWith(
-          {
-            worktreeId: 'wt-1',
-            tabId: 'tab-1',
-            leafId,
-            ptyId: 'ssh-pty'
-          },
-          'ssh:ssh-1'
-        )
+        // STA-3077 step P inverted this: SSH pane bindings no longer go to a
+        // per-target `ssh:<target>` partition. One home (`local`) only, so the
+        // hostId argument is gone — pin its absence, not its old value.
+        expect(store.persistPtyBinding).toHaveBeenCalledWith({
+          worktreeId: 'wt-1',
+          tabId: 'tab-1',
+          leafId,
+          ptyId: 'ssh-pty'
+        })
+        expect(store.persistPtyBinding.mock.calls.at(-1)).toHaveLength(1)
 
         store.upsertSshRemotePtyLease.mockClear()
         store.persistPtyBinding.mockClear()
@@ -9391,6 +9392,9 @@ describe('registerPtyHandlers', () => {
     )
     expect(runtime.noteTerminalSpawnCommand).not.toHaveBeenCalled()
     expect(store.persistPtyBinding).toHaveBeenCalledOnce()
+    // STA-3077 step P inverted this: the reattach writer no longer passes a
+    // hostId slot at all (it used to pass `undefined` here for the local case),
+    // so the call is now strictly single-argument.
     expect(store.persistPtyBinding).toHaveBeenCalledWith(
       expect.objectContaining({
         worktreeId,
@@ -9402,9 +9406,9 @@ describe('registerPtyHandlers', () => {
           ptyId: 'pty-persisted-owner',
           incarnationId: 'inc-stale-owner'
         }
-      }),
-      undefined
+      })
     )
+    expect(store.persistPtyBinding.mock.calls[0]!).toHaveLength(1)
     expect(
       mainWindow.webContents.send.mock.calls.filter(([channel]) => channel === 'pty:spawned')
     ).toHaveLength(1)
@@ -10103,9 +10107,8 @@ describe('registerPtyHandlers', () => {
     expect(runtime.onPtyExit).toHaveBeenCalledWith('pty-already-retired-owner', 0, undefined)
   })
 
-  it('retires a dead owner from the exact SSH host session before fresh recovery', async () => {
+  it('retires a dead owner from the local session — the one pane-binding home — before fresh recovery', async () => {
     const connectionId = 'ssh-dead-stable-pane'
-    const hostId = `ssh:${connectionId}`
     const tabId = 'tab-dead-ssh-owner'
     const leafId = '34343434-3434-4434-8434-343434343434'
     const paneKey = makePaneKey(tabId, leafId)
@@ -10154,12 +10157,16 @@ describe('registerPtyHandlers', () => {
       terminalPtyIncarnationsByPaneKey: { [paneKey]: 'inc-dead-ssh-owner' }
     }
     const store = {
+      // STA-3077 step P inverted these: the reader/retirer used to target the
+      // per-target `ssh:<connectionId>` partition while the renderer published
+      // pane membership to `local` — two homes, so supersession no-opped. Both
+      // sides now address the single default (local) partition, i.e. no hostId.
       getWorkspaceSession: vi.fn((requestedHostId?: string) => {
-        expect(requestedHostId).toBe(hostId)
+        expect(requestedHostId).toBeUndefined()
         return session
       }),
       setWorkspaceSession: vi.fn((next, requestedHostId?: string) => {
-        expect(requestedHostId).toBe(hostId)
+        expect(requestedHostId).toBeUndefined()
         session = next
       }),
       flushOrThrow: vi.fn(),
@@ -10222,16 +10229,25 @@ describe('registerPtyHandlers', () => {
       expect(remoteSpawn.mock.calls[1]?.[0]).toMatchObject({
         command: 'codex resume exact-dead-ssh-provider-session'
       })
-      expect(store.setWorkspaceSession).toHaveBeenCalledWith(expect.anything(), hostId)
+      // STA-3077 step P inverted these: the retirement write and the fresh
+      // binding write both land in the single default (local) partition now, so
+      // no hostId is passed. The dead owner must still actually be retired.
+      expect(store.setWorkspaceSession).toHaveBeenCalledOnce()
+      expect(store.setWorkspaceSession.mock.calls[0]!).toHaveLength(1)
+      expect(
+        store.setWorkspaceSession.mock.calls[0]![0].terminalLayoutsByTabId[tabId]?.ptyIdsByLeafId?.[
+          leafId
+        ]
+      ).not.toBe(deadPtyId)
       expect(store.persistPtyBinding).toHaveBeenCalledWith(
         expect.objectContaining({
           worktreeId,
           tabId,
           leafId,
           ptyId: freshPtyId
-        }),
-        hostId
+        })
       )
+      expect(store.persistPtyBinding.mock.calls.at(-1)!).toHaveLength(1)
     } finally {
       unregisterSshPtyProvider(connectionId)
     }
@@ -10577,15 +10593,15 @@ describe('registerPtyHandlers', () => {
         state: 'attached'
       })
     )
-    expect(store.persistPtyBinding).toHaveBeenCalledWith(
-      {
-        worktreeId: 'wt-remote',
-        tabId: 'tab-remote',
-        leafId,
-        ptyId: 'ssh:ssh-1@@relay-pty'
-      },
-      'ssh:ssh-1'
-    )
+    // STA-3077 step P inverted this: the headless binding writer no longer
+    // targets `ssh:<target>`; one home (`local`) only, so no hostId argument.
+    expect(store.persistPtyBinding).toHaveBeenCalledWith({
+      worktreeId: 'wt-remote',
+      tabId: 'tab-remote',
+      leafId,
+      ptyId: 'ssh:ssh-1@@relay-pty'
+    })
+    expect(store.persistPtyBinding.mock.calls[0]!).toHaveLength(1)
     expect(store.persistPtyBinding.mock.invocationCallOrder[0]!).toBeLessThan(
       store.upsertSshRemotePtyLease.mock.invocationCallOrder[0]!
     )
@@ -10729,15 +10745,15 @@ describe('registerPtyHandlers', () => {
         persistHostSessionBinding: true
       })
 
-      expect(store.persistPtyBinding).toHaveBeenCalledWith(
-        {
-          worktreeId: 'wt-remote',
-          tabId: 'tab-remote',
-          leafId,
-          ptyId: 'ssh:ssh-reattach-ok@@relay-pty'
-        },
-        'ssh:ssh-reattach-ok'
-      )
+      // STA-3077 step P inverted this: the reattach binding refresh writes to the
+      // single default (local) partition, so the `ssh:<target>` hostId is gone.
+      expect(store.persistPtyBinding).toHaveBeenCalledWith({
+        worktreeId: 'wt-remote',
+        tabId: 'tab-remote',
+        leafId,
+        ptyId: 'ssh:ssh-reattach-ok@@relay-pty'
+      })
+      expect(store.persistPtyBinding.mock.calls.at(-1)!).toHaveLength(1)
       expect(store.upsertSshRemotePtyLease).toHaveBeenCalledWith(
         expect.objectContaining({
           targetId: 'ssh-reattach-ok',

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -16,7 +16,6 @@ import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { Store } from '../persistence'
 import { retireTerminalSurfaceFromPersistence } from '../runtime/mobile-session-terminal-persistence-retirement'
 import type { GlobalSettings, TuiAgent } from '../../shared/types'
-import { toSshExecutionHostId } from '../../shared/execution-host'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { terminalOutputBacklogCapChars } from '../../shared/terminal-scrollback-policy'
 import type {
@@ -660,11 +659,13 @@ type StablePaneAdoption = {
 } | null
 const stablePaneAdoptionsByOwnerKey = new Map<string, Promise<StablePaneAdoption>>()
 
+// Pane bindings have one home: the local partition. An SSH pane is not partitioned out — the
+// renderer publishes its membership to `local` and `mayCreate: false` is evaluated there — so
+// selecting `ssh:<target>` here read a partition no live writer maintains (STA-3077 step P).
 function resolvePersistedStablePaneOwner(
   store: Store | undefined,
   paneKey: string,
-  worktreeId: string,
-  connectionId: string | null | undefined
+  worktreeId: string
 ): Pick<StablePaneOwner, 'tabId' | 'leafId' | 'ptyId' | 'incarnationId'> | null {
   if (!store || typeof store.getWorkspaceSession !== 'function') {
     return null
@@ -673,9 +674,7 @@ function resolvePersistedStablePaneOwner(
   if (!parsed) {
     return null
   }
-  const session = store.getWorkspaceSession(
-    connectionId ? toSshExecutionHostId(connectionId) : undefined
-  )
+  const session = store.getWorkspaceSession()
   const tab = session.tabsByWorktree?.[worktreeId]?.find(
     (candidate) => candidate.id === parsed.tabId && candidate.worktreeId === worktreeId
   )
@@ -715,7 +714,7 @@ function resolveStablePaneOwner(
       }
     }
   }
-  const persisted = resolvePersistedStablePaneOwner(store, paneKey, worktreeId, connectionId)
+  const persisted = resolvePersistedStablePaneOwner(store, paneKey, worktreeId)
   if (resolved?.ptyId && persisted && resolved.ptyId !== persisted.ptyId) {
     throw new Error('terminal_pane_owner_conflict')
   }
@@ -751,15 +750,13 @@ function resolveStablePaneOwner(
 function retirePersistedStablePaneOwner(
   store: Store | undefined,
   owner: StablePaneOwner,
-  worktreeId: string,
-  connectionId: string | null | undefined
+  worktreeId: string
 ): boolean {
   if (!store) {
     return false
   }
   const paneKey = makePaneKey(owner.tabId, owner.leafId)
-  const hostId = connectionId ? toSshExecutionHostId(connectionId) : undefined
-  const current = resolvePersistedStablePaneOwner(store, paneKey, worktreeId, connectionId)
+  const current = resolvePersistedStablePaneOwner(store, paneKey, worktreeId)
   if (!current) {
     // Why: persistence already dropped this pane binding (an earlier stop retired it while the
     // runtime kept history), so there is nothing left to clear — that is a completed retirement,
@@ -769,7 +766,7 @@ function retirePersistedStablePaneOwner(
   if (current.ptyId !== owner.ptyId || current.incarnationId !== owner.persistedIncarnationId) {
     return false
   }
-  const session = store.getWorkspaceSession(hostId)
+  const session = store.getWorkspaceSession()
   const retired = retireTerminalSurfaceFromPersistence(session, {
     worktreeId,
     parentTabId: owner.tabId,
@@ -780,7 +777,7 @@ function retirePersistedStablePaneOwner(
   if (retired === session) {
     return false
   }
-  store.setWorkspaceSession(retired, hostId)
+  store.setWorkspaceSession(retired)
   store.flushOrThrow()
   return true
 }
@@ -814,24 +811,20 @@ function persistAdmittedStablePaneBinding(args: {
   result: PtySpawnResult
   worktreeId: string | undefined
   startupCwd: string | undefined
-  connectionId: string | null | undefined
 }): boolean {
   const expectedBinding = stablePanePersistenceFence(args.owner)
   if (!args.store || !args.owner || !args.worktreeId || !expectedBinding) {
     return false
   }
-  const persisted = args.store.persistPtyBinding(
-    {
-      worktreeId: args.worktreeId,
-      tabId: args.owner.tabId,
-      leafId: args.owner.leafId,
-      ptyId: args.result.id,
-      ...(args.result.incarnationId ? { incarnationId: args.result.incarnationId } : {}),
-      ...(args.startupCwd ? { startupCwd: args.startupCwd } : {}),
-      expectedBinding
-    },
-    args.connectionId ? toSshExecutionHostId(args.connectionId) : undefined
-  )
+  const persisted = args.store.persistPtyBinding({
+    worktreeId: args.worktreeId,
+    tabId: args.owner.tabId,
+    leafId: args.owner.leafId,
+    ptyId: args.result.id,
+    ...(args.result.incarnationId ? { incarnationId: args.result.incarnationId } : {}),
+    ...(args.startupCwd ? { startupCwd: args.startupCwd } : {}),
+    expectedBinding
+  })
   if (persisted === false) {
     throw new Error('terminal_pane_owner_changed')
   }
@@ -880,10 +873,7 @@ async function attachStablePaneOwner(
     runtime?.onPtyExit(owner.ptyId, 0, owner.incarnationId)
     clearProviderPtyState(owner.ptyId)
     ptyOwnership.delete(owner.ptyId)
-    if (
-      args.worktreeId &&
-      !retirePersistedStablePaneOwner(args.store, owner, args.worktreeId, args.connectionId)
-    ) {
+    if (args.worktreeId && !retirePersistedStablePaneOwner(args.store, owner, args.worktreeId)) {
       throw new Error('terminal_pane_owner_changed')
     }
     if (args.resolveOwner?.()) {
@@ -5045,8 +5035,7 @@ export function registerPtyHandlers(
             owner: stablePaneOwner,
             result,
             worktreeId: hostSessionBinding?.worktreeId,
-            startupCwd: cwd,
-            connectionId: args.connectionId
+            startupCwd: cwd
           })
         } catch (error) {
           if (error instanceof Error && error.message === 'terminal_pane_owner_changed') {
@@ -5144,14 +5133,7 @@ export function registerPtyHandlers(
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
               ...(cwd ? { startupCwd: cwd } : {})
             }
-            if (args.connectionId) {
-              hostSessionBinding.store.persistPtyBinding(
-                binding,
-                toSshExecutionHostId(args.connectionId)
-              )
-            } else {
-              hostSessionBinding.store.persistPtyBinding(binding)
-            }
+            hostSessionBinding.store.persistPtyBinding(binding)
           } catch (err) {
             console.error('[pty] failed to persist runtime PTY binding after spawn:', err)
             if (!result.isReattach) {
@@ -6442,8 +6424,7 @@ export function registerPtyHandlers(
             owner: stablePaneOwner,
             result,
             worktreeId: args.worktreeId,
-            startupCwd: cwd,
-            connectionId: args.connectionId
+            startupCwd: cwd
           })
         } catch (error) {
           if (error instanceof Error && error.message === 'terminal_pane_owner_changed') {
@@ -6524,11 +6505,7 @@ export function registerPtyHandlers(
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
               ...(cwd ? { startupCwd: cwd } : {})
             }
-            if (args.connectionId) {
-              store.persistPtyBinding(binding, toSshExecutionHostId(args.connectionId))
-            } else {
-              store.persistPtyBinding(binding)
-            }
+            store.persistPtyBinding(binding)
           } catch (err) {
             console.error('[pty] failed to persist PTY binding after spawn:', err)
             if (!result.isReattach) {

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -2834,6 +2834,8 @@ export class Store {
     const loaded = this.load()
     const normalized = normalizePersistedPaneIdentityState(loaded)
     this.state = normalized.state
+    // After the leaf remap, so every folded binding keys on a UUID.
+    const foldedSshPaneBindings = this.foldSshPaneBindingsIntoLocalPartition()
     // Why: activeView is a frequent, tiny preference; keeping it beside the
     // profile avoids serializing the multi-MB recovery store on navigation.
     this.activeViewPreference = new ActiveViewPreference(this.dataFile, this.state.ui?.activeView)
@@ -2852,7 +2854,7 @@ export class Store {
       this.state.legacyPaneKeyAliasEntries = entries
       this.scheduleSave()
     })
-    if (normalized.changed || this.loadNeedsSave || adaptedProjectGroups) {
+    if (normalized.changed || this.loadNeedsSave || adaptedProjectGroups || foldedSshPaneBindings) {
       // Why: rewrite legacy pane:1 leaves so older renderer writes can't revive them; other migrations also set loadNeedsSave.
       this.scheduleSave()
     }
@@ -7260,22 +7262,49 @@ export class Store {
    *
    * Returns the number of leases retired, for logging.
    */
-  /** The PTY a pane is durably bound to, across the target and local partitions. */
+  /**
+   * One-time fold: SSH pane bindings written to an `ssh:<target>` partition by an older build move
+   * into `local`, the partition the renderer has always published pane membership to. Two homes is
+   * the STA-3077 defect itself — the reattach writer updated one and supersession read the other.
+   * `local` wins on conflict because it is the live publisher; the loser is dropped rather than
+   * demoted to an orphan candidate, since relay pty ids recycle and cannot identify a shell alone.
+   */
+  private foldSshPaneBindingsIntoLocalPartition(): boolean {
+    const partitions = this.state.workspaceSessionsByHostId ?? {}
+    const local = (this.state.workspaceSession ??= getDefaultWorkspaceSession())
+    let changed = false
+    for (const hostId of Object.keys(partitions)) {
+      if (parseExecutionHostId(hostId)?.kind !== 'ssh') {
+        continue
+      }
+      const host: WorkspaceSessionState | undefined = partitions[hostId]
+      for (const [tabId, layout] of Object.entries(host?.terminalLayoutsByTabId ?? {})) {
+        const bindings = layout.ptyIdsByLeafId
+        if (!bindings || Object.keys(bindings).length === 0) {
+          continue
+        }
+        const localLayout = local.terminalLayoutsByTabId?.[tabId]
+        if (localLayout) {
+          localLayout.ptyIdsByLeafId = { ...bindings, ...localLayout.ptyIdsByLeafId }
+        }
+        layout.ptyIdsByLeafId = {}
+        changed = true
+      }
+    }
+    return changed
+  }
+
+  /** The PTY a pane is durably bound to. SSH pane bindings live in the local partition only —
+   *  see `foldSshPaneBindingsIntoLocalPartition`. Hedging across two partitions is what let a
+   *  stale `ssh:<target>` copy outvote the live binding and no-op supersession (STA-3077). */
   private durablyBoundPtyIdForPane(
     targetId: string,
     tabId: string,
     leafId: string
   ): string | undefined {
-    for (const session of [
-      this.state.workspaceSessionsByHostId?.[toSshExecutionHostId(targetId)],
-      this.state.workspaceSession
-    ]) {
-      const boundPtyId = session?.terminalLayoutsByTabId?.[tabId]?.ptyIdsByLeafId?.[leafId]
-      if (boundPtyId) {
-        return this.getRelayPtyIdForSshLeaseComparison(targetId, boundPtyId)
-      }
-    }
-    return undefined
+    const boundPtyId =
+      this.state.workspaceSession?.terminalLayoutsByTabId?.[tabId]?.ptyIdsByLeafId?.[leafId]
+    return boundPtyId ? this.getRelayPtyIdForSshLeaseComparison(targetId, boundPtyId) : undefined
   }
 
   /**

--- a/src/main/ssh-pane-binding-partition.test.ts
+++ b/src/main/ssh-pane-binding-partition.test.ts
@@ -91,6 +91,12 @@ function rendererPublishesPane(store: TestStore, relayPtyId: string): void {
   store.setWorkspaceSession(paneSession(relayPtyId) as never, LOCAL_EXECUTION_HOST_ID)
 }
 
+/** A mid-session write into `ssh:<target>` — orphan adoption still targets that partition, so the
+ *  one-time load fold cannot be the only thing keeping the two homes from reappearing. */
+function somethingRewritesTheSshPartition(store: TestStore, relayPtyId: string): void {
+  store.setWorkspaceSession(paneSession(relayPtyId) as never, SSH_PARTITION)
+}
+
 /** ssh-relay-session.ts:2504 — the reattach bind. No hostId, refuses to create. */
 function relayReattachBindsPane(store: TestStore, relayPtyId: string): boolean | null {
   return store.persistPtyBinding({
@@ -199,6 +205,21 @@ describe('STA-3077 step P: one pane, one live claim across partitions', () => {
     expect(relayReattachBindsPane(store, 'pty-2')).toBe(true)
 
     store.supersedeDuplicatePaneLeases(TARGET)
+
+    expect(liveLeaseIdsForPane(store)).toEqual(['pty-2'])
+  })
+
+  // Isolates the reader from the one-time load fold. Without this clause the fold masks the
+  // partition preference — it deletes the divergent copy at boot, so restoring the ssh-first
+  // hedge stays green and the reader guard ships unproven. Anything that writes `ssh:<target>`
+  // after load (orphan adoption still does) would then revive the defect inside one session.
+  it('supersedes the predecessor when the ssh partition is rewritten mid-session', async () => {
+    const store = await createStore(diskAfterEarlierSession('pty-1'))
+    sshSpawnUpsertsLease(store, 'pty-1')
+    expect(relayReattachBindsPane(store, 'pty-2')).toBe(true)
+    somethingRewritesTheSshPartition(store, 'pty-1')
+
+    sshSpawnUpsertsLease(store, 'pty-2')
 
     expect(liveLeaseIdsForPane(store)).toEqual(['pty-2'])
   })


### PR DESCRIPTION
Design step **P**. Goalpost **S4**. **This is the mechanism behind the reported 2 → 19 → 20.**

> Second of a 4-PR stack; base is the E-0 PR.

## The defect

An SSH pane's durable binding lived in **two** persisted partitions:

| writer | partition |
| --- | --- |
| main's spawn | `ssh:<target>` |
| the relay's reattach write (no hostId → `resolveHostId(undefined)`) | `local` |
| the renderer's session publish (SSH worktrees are deliberately not partitioned out) | `local` |

`durablyBoundPtyIdForPane` hedged **ssh-first-then-local**, so supersession asked "what is this pane bound to?" and read the partition no live writer maintained. It saw a stale pty id, concluded the arriving lease was not the bound one, and bailed.

Supersession silently no-opped. Every reconnect legitimately minted a new PTY id and left the predecessor live. Ten reconnects, ten live leases, ten panes.

## The change

`local` wins: it is the only publisher of pane membership and where `mayCreate:false` is evaluated. Every reader and writer now names it, plus a one-time load fold for existing state.

**+9 production lines** — the call sites shrank; the fold is new state repair.

## Side effect worth naming

The renderer never hydrated the `ssh:*` partition at all (`listKnownRuntimeHostIds` filters to `runtime:*`). So the Issue #217 force-quit binding protection — the reason `persistPtyBinding` exists — **had never worked for SSH panes.** It does now.

## Evidence

Oracle `src/main/ssh-pane-binding-partition.test.ts` — 10 clauses green, including one holding live-claim count flat across **ten** reconnects, and an E2E spec driving three real reconnects against a Docker relay (in the last PR of this stack).

**Mutation proof, run as a 2×2 because the two edits mask each other:**

| reader | load fold | result |
| --- | --- | --- |
| hedge (original) | off | 6 red — baseline |
| local-only | off | 1 red — the reader carries 3 clauses |
| hedge | **on** | **all green** ← the fold masks the reader |

That third row is why this PR **adds a clause**: with the fold shipping, it erases the divergent copy at boot, so the reader guard was correct and would have shipped *unproven* — precisely the failure mode that produced three inert guards in this codebase already. The new clause rewrites `ssh:<target>` **mid-session** and reddens when the hedge is restored.

## Two fold defects found by later review, fixed in the last PR of this stack

Listed here because they belong to this change conceptually:
- the fold moved the binding but not the **incarnation** that fences it, so the CAS compared `undefined` to `undefined`;
- it **destroyed bindings it could not move** — with no local layout to fold into it cleared the source anyway.

## Tests inverted, not patched

Five clauses in `ipc/pty.test.ts` pinned the two-partition shape and are inverted to the single home, each keeping an arity check so a re-added partition argument fails loudly.

## Compatibility

Client-local persistence only. No wire change, no relay redeploy.

Made with [Orca](https://github.com/stablyai/orca) 🐋
