### PR TITLE
fix(ssh): one bind producer, so the superseded-pane fence is live on reattach (STA-3077 F)

### DIFF
--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -15,6 +15,7 @@ export { getBashShellReadyRcfileContent } from '../providers/local-pty-shell-rea
 import type { OrcaRuntimeService } from '../runtime/orca-runtime'
 import type { Store } from '../persistence'
 import { retireTerminalSurfaceFromPersistence } from '../runtime/mobile-session-terminal-persistence-retirement'
+import { findTerminalTabIdForLeaf } from '../runtime/workspace-session-terminal-membership-authority'
 import type { GlobalSettings, TuiAgent } from '../../shared/types'
 import { normalizeRuntimePathForComparison } from '../../shared/cross-platform-path'
 import { terminalOutputBacklogCapChars } from '../../shared/terminal-scrollback-policy'
@@ -521,6 +522,45 @@ function rememberPaneKeyForPty(ptyId: string, paneKey: unknown): string | null {
   ptyPaneKey.set(ptyId, normalizedPaneKey)
   paneKeyPtyId.set(normalizedPaneKey, ptyId)
   return normalizedPaneKey
+}
+
+/**
+ * The one producer of a pane -> shell binding: durable record and fence maps together, keyed by the
+ * tab holding the leaf *now* (a stored tabId names the tab a moved pane left). Splitting these let
+ * the superseded-PTY fence sit inert on reattach, the path it was built for.
+ *
+ * Returns false when a durable pane refuses. A throw is unknown rather than a refusal, so it
+ * propagates — only the caller that created the shell should clean it up.
+ */
+export function bindPaneShell(args: {
+  store: Pick<Store, 'persistPtyBinding' | 'getWorkspaceSession'> | undefined
+  worktreeId: string
+  tabId: string
+  leafId: string
+  ptyId: string
+  incarnationId?: string
+  startupCwd?: string
+  mayCreate?: boolean
+}): boolean {
+  const session =
+    typeof args.store?.getWorkspaceSession === 'function'
+      ? args.store.getWorkspaceSession()
+      : undefined
+  const tabId = findTerminalTabIdForLeaf(session, args.leafId) ?? args.tabId
+  const bound = args.store?.persistPtyBinding({
+    worktreeId: args.worktreeId,
+    tabId,
+    leafId: args.leafId,
+    ptyId: args.ptyId,
+    ...(args.incarnationId ? { incarnationId: args.incarnationId } : {}),
+    ...(args.startupCwd ? { startupCwd: args.startupCwd } : {}),
+    ...(args.mayCreate === false ? { mayCreate: false } : {})
+  })
+  if (bound === false) {
+    return false
+  }
+  rememberPaneKeyForPty(args.ptyId, makePaneKey(tabId, args.leafId))
+  return true
 }
 
 function cleanupPendingPaneSerializersForSender(ownerWebContentsId: number): void {
@@ -5125,15 +5165,15 @@ export function registerPtyHandlers(
         })
         if (hostSessionBinding && !stablePaneBindingPersisted) {
           try {
-            const binding = {
+            bindPaneShell({
+              store: hostSessionBinding.store,
               worktreeId: hostSessionBinding.worktreeId,
               tabId: hostSessionBinding.tabId,
               leafId: hostSessionBinding.leafId,
               ptyId: result.id,
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
               ...(cwd ? { startupCwd: cwd } : {})
-            }
-            hostSessionBinding.store.persistPtyBinding(binding)
+            })
           } catch (err) {
             console.error('[pty] failed to persist runtime PTY binding after spawn:', err)
             if (!result.isReattach) {
@@ -6497,15 +6537,15 @@ export function registerPtyHandlers(
           !stablePaneBindingPersisted
         ) {
           try {
-            const binding = {
+            bindPaneShell({
+              store,
               worktreeId: args.worktreeId,
               tabId: args.tabId,
               leafId: validatedLeafId,
               ptyId: result.id,
               ...(result.incarnationId ? { incarnationId: result.incarnationId } : {}),
               ...(cwd ? { startupCwd: cwd } : {})
-            }
-            store.persistPtyBinding(binding)
+            })
           } catch (err) {
             console.error('[pty] failed to persist PTY binding after spawn:', err)
             if (!result.isReattach) {

--- a/src/main/runtime/workspace-session-terminal-membership-authority.ts
+++ b/src/main/runtime/workspace-session-terminal-membership-authority.ts
@@ -161,6 +161,24 @@ export function advanceTerminalTopologyRevision(
   }
 }
 
+/**
+ * The tab whose live layout holds this leaf. Only the leaf half of a pane key is stable — breaking
+ * a pane out into its own tab moves the leaf and leaves any stored tabId naming the tab it left.
+ */
+export function findTerminalTabIdForLeaf(
+  session: WorkspaceSessionState | undefined,
+  leafId: string
+): string | undefined {
+  for (const [tabId, layout] of Object.entries(session?.terminalLayoutsByTabId ?? {})) {
+    const leafIds = new Set<string>()
+    collectLeafIds(layout.root, leafIds)
+    if (leafIds.has(leafId)) {
+      return tabId
+    }
+  }
+  return undefined
+}
+
 export function hasHostAuthoritativeTerminalMembership(
   session: WorkspaceSessionState | undefined,
   worktreeId: string

--- a/src/main/ssh-pane-binding-partition.test.ts
+++ b/src/main/ssh-pane-binding-partition.test.ts
@@ -257,17 +257,27 @@ describe('STA-3077 step P: every production caller names that one home', () => {
   // A guard that behaves correctly is not evidence that both writers reach it,
   // and the defect IS that they disagree — so pin the call sites too.
   it('has no SSH pane binding write that selects the ssh partition', () => {
-    const writers = ['src/main/ipc/pty.ts', 'src/main/ssh/ssh-relay-session.ts']
+    const file = 'src/main/ipc/pty.ts'
+    const calls = callArgumentsIn(readFileSync(file, 'utf-8'), 'persistPtyBinding')
+    expect(calls.length, `${file} no longer writes pane bindings`).toBeGreaterThan(0)
 
-    const partitioned = writers.flatMap((file) => {
-      const calls = callArgumentsIn(readFileSync(file, 'utf-8'), 'persistPtyBinding')
-      expect(calls.length, `${file} no longer writes pane bindings`).toBeGreaterThan(0)
-      return calls
-        .filter((call) => call.includes('toSshExecutionHostId'))
-        .map((call) => `${file}: ${summarize(call)}`)
-    })
+    const partitioned = calls
+      .filter((call) => call.includes('toSshExecutionHostId'))
+      .map((call) => `${file}: ${summarize(call)}`)
 
     expect(partitioned).toEqual([])
+  })
+
+  // STRENGTHENED, not relaxed. This clause used to require the relay to hold a `persistPtyBinding`
+  // call of its own and merely forbid an ssh-partition argument on it. Step F removed that call:
+  // the relay binds through the one `bindPaneShell` producer, which is what makes the superseded-
+  // pane fence live on reattach. Requiring ZERO direct writes here is the stronger property — a
+  // second bind producer is exactly the defect that let spawn and reattach disagree.
+  it('has no pane binding write in the relay that bypasses the one bind producer', () => {
+    const source = readFileSync('src/main/ssh/ssh-relay-session.ts', 'utf-8')
+
+    expect(callArgumentsIn(source, 'persistPtyBinding').map(summarize)).toEqual([])
+    expect(source).toContain('bindPaneShell(')
   })
 
   // The readers must land in the same place; one that still consults

--- a/src/main/ssh-reattach-pane-cardinality.test.ts
+++ b/src/main/ssh-reattach-pane-cardinality.test.ts
@@ -282,6 +282,8 @@ describe('STA-3077: the reattach path actually refuses to create', () => {
   // This is the oracle the store-level tests could not provide: `mayCreate`
   // existed and was correct, but no production caller passed it, so reattach
   // still grafted panes. Pin the wiring, not just the capability.
+  // The reattach bind now goes through the one `bindPaneShell` producer, and it
+  // still refuses to create.
   it('passes mayCreate:false from the SSH reattach binding write', async () => {
     const { readFileSync } = await import('node:fs')
     const source = readFileSync('src/main/ssh/ssh-relay-session.ts', 'utf-8')
@@ -289,16 +291,24 @@ describe('STA-3077: the reattach path actually refuses to create', () => {
       source.indexOf('restoreReattachedPtyRuntime'),
       source.indexOf('private async attachPtyWithRetry')
     )
-    expect(bindCall).toContain('persistPtyBinding')
+    expect(bindCall).toContain('bindPaneShell')
     expect(bindCall).toContain('mayCreate: false')
   })
 
+  // Strengthened, not relaxed: counting guards against calls went vacuous once
+  // the direct store calls disappeared, so pin both halves instead.
   it('has no production persistPtyBinding caller that can create during reattach', async () => {
     const { readFileSync } = await import('node:fs')
     const source = readFileSync('src/main/ssh/ssh-relay-session.ts', 'utf-8')
     // Every bind in the relay session is a reattach; none may grow topology.
-    const calls = source.split('persistPtyBinding(').length - 1
-    const guarded = source.split('mayCreate: false').length - 1
-    expect(guarded).toBeGreaterThanOrEqual(calls)
+    expect(source.split('persistPtyBinding(').length - 1).toBe(0)
+    const binds = source.split('bindPaneShell(').length - 1
+    expect(binds).toBeGreaterThan(0)
+    // Each `bindPaneShell(` call site must carry its own `mayCreate: false`.
+    const guardedBinds = source
+      .split('bindPaneShell(')
+      .slice(1)
+      .filter((tail) => tail.slice(0, tail.indexOf('})')).includes('mayCreate: false')).length
+    expect(guardedBinds).toBe(binds)
   })
 })

--- a/src/main/ssh/ssh-relay-session-reattach-pane-fence.test.ts
+++ b/src/main/ssh/ssh-relay-session-reattach-pane-fence.test.ts
@@ -151,8 +151,18 @@ function makeMainWindow() {
   return { isDestroyed: () => false, isVisible: () => true, isMinimized: () => false, webContents }
 }
 
-function makeStore(leases: unknown[]) {
+/** A live layout in which `leafId` sits in `tabId` — the tab the pane is in RIGHT NOW. */
+function sessionWithLeafInTab(tabId: string, leafId: string) {
   return {
+    terminalLayoutsByTabId: {
+      [tabId]: { root: { type: 'leaf' as const, leafId }, ptyIdsByLeafId: {} }
+    }
+  }
+}
+
+function makeStore(leases: unknown[], session?: ReturnType<typeof sessionWithLeafInTab>) {
+  return {
+    ...(session ? { getWorkspaceSession: vi.fn(() => session) } : {}),
     getRepos: vi.fn().mockReturnValue([]),
     getSshPtyConsumerRecovery: vi.fn().mockReturnValue(null),
     upsertSshPtyConsumerRecovery: vi.fn(),
@@ -173,12 +183,15 @@ function makeStore(leases: unknown[]) {
  * One pane: spawned over SSH, then rebound by a reconnect whose durable lease
  * names a different remote PTY — the STA-3077 shape.
  */
-async function spawnThenReattachPane(leafId: string) {
+async function spawnThenReattachPane(leafId: string, currentTabId?: string) {
   const mainWindow = makeMainWindow()
   const predecessorPtyId = `ssh:${TARGET}@@pty-old-${leafId.slice(0, 4)}`
   const reattachedRelayPtyId = `pty-new-${leafId.slice(0, 4)}`
   const leases: unknown[] = []
-  const store = makeStore(leases)
+  const store = makeStore(
+    leases,
+    currentTabId ? sessionWithLeafInTab(currentTabId, leafId) : undefined
+  )
   const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }
   const session = new SshRelaySession(
     TARGET,
@@ -226,7 +239,7 @@ async function spawnThenReattachPane(leafId: string) {
     listeners.get('pty:write')!({ sender: mainWindow.webContents }, { id, data: 'x' })
   }
   return {
-    paneKey: makePaneKey(TAB_ID, leafId),
+    paneKey: makePaneKey(currentTabId ?? TAB_ID, leafId),
     predecessorPtyId,
     reattachedPtyId: `ssh:${TARGET}@@${reattachedRelayPtyId}`,
     provider,
@@ -278,6 +291,20 @@ describe('a relay reattach binds the pane through the same producer as spawn', (
     cleanup = pane.dispose
 
     expect(getPtyIdForPaneKey(pane.paneKey)).toBe(pane.reattachedPtyId)
+  })
+
+  // The lease's tabId is frozen at write time, but `detachTerminalPaneToTab` moves a live pane
+  // into a new tab without killing its PTY. A producer that forwarded `lease.tabId` would key the
+  // fence to the tab the pane LEFT — and every other clause here uses one tab on both sides, so
+  // nothing else in this file would notice.
+  it('keys the pane to the tab the leaf is in now, not the one its lease was written in', async () => {
+    const leafId = '44444444-4444-4444-8444-444444444444'
+    const pane = await spawnThenReattachPane(leafId, 'tab-moved-to')
+    cleanup = pane.dispose
+
+    expect(pane.paneKey).toBe(makePaneKey('tab-moved-to', leafId))
+    expect(getPtyIdForPaneKey(pane.paneKey)).toBe(pane.reattachedPtyId)
+    expect(getPtyIdForPaneKey(makePaneKey(TAB_ID, leafId))).not.toBe(pane.reattachedPtyId)
   })
 
   // Guards the clause above from a fence that simply refuses everything.

--- a/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
+++ b/src/main/ssh/ssh-relay-session-reconnect-incarnation.test.ts
@@ -101,6 +101,8 @@ vi.mock('../providers/ssh-git-provider', () => ({
   SshGitProvider: class MockSshGitProvider {}
 }))
 vi.mock('../ipc/pty', () => ({
+  // Step F: the single pane->shell bind producer the relay now calls.
+  bindPaneShell: vi.fn(() => true),
   registerSshPtyProvider: vi.fn(),
   unregisterSshPtyProvider: vi.fn(),
   getSshPtyProvider: vi.fn(),
@@ -124,6 +126,7 @@ vi.mock('../providers/ssh-git-dispatch', () => ({
 }))
 
 const {
+  bindPaneShell,
   registerSshPtyProvider,
   getSshPtyProvider,
   getPtyIdsForConnection,
@@ -435,8 +438,11 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId
     })
     expect(runtime.onPtySpawned).not.toHaveBeenCalled()
-    // mayCreate:false — reattach binds an existing pane and never grafts one back.
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith({
+    // Step F moved the observation point to the one bind producer; the intent is
+    // unchanged — exact incarnation proof, and mayCreate:false so reattach binds
+    // an existing pane and never grafts one back.
+    expect(bindPaneShell).toHaveBeenCalledWith({
+      store: expect.anything(),
       worktreeId: 'worktree-1',
       tabId: 'tab-1',
       leafId: INCARNATION_LEAF_ID,
@@ -444,7 +450,7 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId,
       mayCreate: false
     })
-    expect(vi.mocked(mockStore.persistPtyBinding).mock.invocationCallOrder[0]).toBeLessThan(
+    expect(vi.mocked(bindPaneShell).mock.invocationCallOrder[0]).toBeLessThan(
       vi.mocked(mockStore.markSshRemotePtyLeasesAttachedAsync).mock.invocationCallOrder[0]!
     )
   })
@@ -491,7 +497,8 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     expect(runtime.registerPty).not.toHaveBeenCalled()
     expect(restorePtyIncarnation).toHaveBeenCalledWith(APP_PTY_ID, incarnationId)
     expect(setPtyOwnership).not.toHaveBeenCalled()
-    expect(mockStore.persistPtyBinding).not.toHaveBeenCalled()
+    // Step F: observed at the one bind producer, else this negative is vacuous.
+    expect(bindPaneShell).not.toHaveBeenCalled()
     expect(sourceActivationLease.rollback).toHaveBeenCalledOnce()
     expect(sourceActivationLease.commit).not.toHaveBeenCalled()
     expect(mockStore.markSshRemotePtyLease).toHaveBeenCalledWith(
@@ -550,8 +557,14 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
       incarnationId: currentIncarnationId
     })
     expect(setPtyOwnership).toHaveBeenCalledWith(APP_PTY_ID, 'target-1')
-    expect(mockStore.persistPtyBinding).toHaveBeenCalledWith(
-      expect.objectContaining({ ptyId: APP_PTY_ID, incarnationId: currentIncarnationId })
+    // Step F moved the observation point to the one bind producer; the asserted
+    // intent — exact incarnation proof, mayCreate:false — is unchanged.
+    expect(bindPaneShell).toHaveBeenCalledWith(
+      expect.objectContaining({
+        ptyId: APP_PTY_ID,
+        incarnationId: currentIncarnationId,
+        mayCreate: false
+      })
     )
     expect(mockWindow.webContents.send).toHaveBeenCalledWith('pty:replay', {
       id: APP_PTY_ID,
@@ -569,7 +582,9 @@ describe('SshRelaySession reconnect incarnation ordering', () => {
     vi.mocked(mockStore.getSshRemotePtyLeases).mockReturnValue([detachedLease()] as ReturnType<
       typeof mockStore.getSshRemotePtyLeases
     >)
-    vi.mocked(mockStore.persistPtyBinding).mockImplementationOnce(() => {
+    // Step F: the durable write now happens inside the bind producer, so that is
+    // where the failure has to be injected.
+    vi.mocked(bindPaneShell).mockImplementationOnce(() => {
       throw new Error('disk full')
     })
     const runtime = { onPtySpawned: vi.fn(), registerPty: vi.fn() }

--- a/src/main/ssh/ssh-relay-session.ts
+++ b/src/main/ssh/ssh-relay-session.ts
@@ -32,6 +32,7 @@ import {
 import { _internals as openCodeInternals } from '../opencode/hook-service'
 import { getPiAgentStatusExtensionSource } from '../pi/agent-status-extension-source'
 import {
+  bindPaneShell,
   registerSshPtyProvider,
   unregisterSshPtyProvider,
   getSshPtyProvider,
@@ -2462,7 +2463,8 @@ export class SshRelaySession {
       // A thrown write is unknown, not a refusal, so it must not detach anything.
       let bound: boolean | null = null
       try {
-        bound = this.store.persistPtyBinding({
+        bound = bindPaneShell({
+          store: this.store,
           worktreeId: lease.worktreeId,
           tabId: lease.tabId,
           leafId: lease.leafId,


### PR DESCRIPTION
Design step **F**. Goalpost **S5**. Closes a defect in already-shipped work.

> Stacked on the P PR.

## The defect

The superseded-PTY fence refuses a keystroke queued for a shell whose pane has since bound a different one. It works by comparing `ptyPaneKey` against `paneKeyPtyId` — and **only spawn ever wrote those maps.**

The relay's reattach bound the pane through `runtime.registerPty` instead, so the maps never learned the successor. `isSupersededPtyId` returned `false` by construction, and the fence sat inert on **the one path it was built for**: a keystroke queued before a reconnect still reached the shell the pane no longer owns.

This is the second of three guards this program has shipped inert while passing their tests.

## The change

One `bindPaneShell` producer writes the durable record and the fence maps together. All three binding paths call it: the relay reattach and both spawn handlers.

Error policy stays at the call sites because it **genuinely differs** — a caller that just created a shell must clean it up on a failed durable write; a caller that merely reattached must not detach anything. Folding that into the producer would have collapsed two different meanings into one.

The paneKey is composed from the tab holding the leaf **now**, resolved from the live layout, not from the tabId frozen in the lease. Only the leaf half of a pane key is remint-stable; `detachTerminalPaneToTab` moves a live pane and its PTY into a new tab, so a stored tabId names the tab the pane left.

## Evidence

Oracle `src/main/ssh/ssh-relay-session-reattach-pane-fence.test.ts` — 4 clauses green.

**Mutation proof, both sub-guards isolated:**

| mutation | result |
| --- | --- |
| drop the `rememberPaneKeyForPty` call | 3 clauses redden |
| prefer the stored `tabId` over the live layout | 1 clause reddens |

**That second clause is new in this PR, and it matters.** Every pre-existing clause used one `tabId` on both sides — so a producer that simply forwarded `lease.tabId` would have gone green and shipped the moved-pane bug unnoticed.

## Two source-text clauses strengthened, not relaxed

They previously required the relay to hold a `persistPtyBinding` call of its own and merely forbade an ssh-partition argument on it. The relay now has none, so they assert **zero** direct binding writes there plus a `bindPaneShell` call. A second bind producer is exactly the defect this removes, so requiring zero is the stronger property.

## A latent false green, repaired

The "persistence fails" case in `ssh-relay-session-reconnect-incarnation` was passing because a missing mock made the call throw a `TypeError` that happened to emit the `console.error` it asserted. The failure is now injected at the producer, so it is a real oracle for "a thrown durable write must not detach the PTY".

## Line count — this one grows

**+60 production lines**, and that is reported rather than smoothed over.

One producer replacing three call sites only shrinks code if those sites duplicated the whole bind. They did not — each did *part* of it differently, which **is** the defect. The producer is net-new; the call sites shrank by 7 lines. Collapsing the two spawn handlers' surrounding logic as well would buy the difference back, but it reorders side effects that existing ordering assertions pin, so it was left alone.

## Compatibility

Client-local in-memory fence maps and the durable binding. No wire change, no relay redeploy.

Made with [Orca](https://github.com/stablyai/orca) 🐋
