### PR TITLE
fix(terminal): keep a deliberately slept workspace from respawning its PTY

### DIFF
--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts
@@ -101,13 +101,26 @@ describe('runSleepWorktree', () => {
     await runSleepWorktree('wt-1')
 
     expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
-    expect(mocks.clearWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
     const markCall = mocks.markWorktreeSleepIntent.mock.invocationCallOrder[0]
     const activeClear = mocks.state.setActiveWorktree.mock.invocationCallOrder[0]
-    const terminalShutdown = mocks.state.shutdownWorktreeTerminals.mock.invocationCallOrder[0]
-    const clearCall = mocks.clearWorktreeSleepIntent.mock.invocationCallOrder[0]
     expect(markCall).toBeLessThan(activeClear)
-    expect(terminalShutdown).toBeLessThan(clearCall)
+  })
+
+  it('keeps the sleep intent after a successful sleep so mounted panes stay cold', async () => {
+    mocks.state.activeWorktreeId = 'wt-1'
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.clearWorktreeSleepIntent).not.toHaveBeenCalled()
+  })
+
+  it('releases the sleep intent when teardown fails so the workspace stays usable', async () => {
+    mocks.state.activeWorktreeId = 'wt-1'
+    mocks.state.shutdownWorktreeTerminals.mockRejectedValueOnce(new Error('kill failed'))
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.clearWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
   })
 
   it('preserves active row position through section-scoped sidebar row ids', async () => {
@@ -188,7 +201,14 @@ describe('runSleepWorktree', () => {
 
     expect(mocks.state.setActiveWorktree).not.toHaveBeenCalled()
     expect(mocks.state.suppressPtyExit).not.toHaveBeenCalled()
-    expect(mocks.markWorktreeSleepIntent).not.toHaveBeenCalled()
+  })
+
+  it('marks sleep intent for a background worktree so its mounted panes stay cold', async () => {
+    mocks.state.activeWorktreeId = 'wt-other'
+
+    await runSleepWorktree('wt-1')
+
+    expect(mocks.markWorktreeSleepIntent).toHaveBeenCalledWith('wt-1')
   })
 
   it('surfaces a toast and skips terminals when browsers throws', async () => {

--- a/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/sleep-worktree-flow.ts
@@ -142,6 +142,12 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
     shutdownWorktreeTerminals
   } = useAppStore.getState()
   let activeSleepIntentWorktreeId: string | null = null
+  // Why: every slept workspace is marked, not just the focused one — a background
+  // sleep is exactly the case whose mounted panes get respawned by an unrelated
+  // activation (#10205).
+  for (const worktreeId of worktreeIds) {
+    markWorktreeSleepIntent(worktreeId)
+  }
   if (activeWorktreeId && worktreeIds.includes(activeWorktreeId)) {
     const restoreSidebarPosition = preserveSidebarWorktreePosition(activeWorktreeId)
     // Why: clearing the active workspace can unmount TerminalPanes before
@@ -192,12 +198,14 @@ export async function runSleepWorktrees(worktreeIds: readonly string[]): Promise
       }
     }
   } finally {
-    if (activeSleepIntentWorktreeId) {
-      clearWorktreeSleepIntent(activeSleepIntentWorktreeId)
-      if (failedWorktreeIds.has(activeSleepIntentWorktreeId)) {
-        // Why: any failed sleep step must leave the workspace visible and retryable.
-        setActiveWorktree(activeSleepIntentWorktreeId)
-      }
+    // Why: a failed sleep leaves the workspace awake, so its mark must go — otherwise
+    // its panes would be refused the respawn they still need.
+    for (const worktreeId of failedWorktreeIds) {
+      clearWorktreeSleepIntent(worktreeId)
+    }
+    if (activeSleepIntentWorktreeId && failedWorktreeIds.has(activeSleepIntentWorktreeId)) {
+      // Why: any failed sleep step must leave the workspace visible and retryable.
+      setActiveWorktree(activeSleepIntentWorktreeId)
     }
   }
   if (errors.length > 0) {

--- a/src/renderer/src/components/terminal-pane/deliberate-sleep-cold-start.test.ts
+++ b/src/renderer/src/components/terminal-pane/deliberate-sleep-cold-start.test.ts
@@ -1,0 +1,52 @@
+import { describe, expect, it } from 'vitest'
+import { shouldStayColdForDeliberateSleep } from './deliberate-sleep-cold-start'
+
+const SLEPT = 'repo-1::/work/slept'
+const OTHER = 'repo-1::/work/other'
+
+function args(overrides: Partial<Parameters<typeof shouldStayColdForDeliberateSleep>[0]> = {}) {
+  return {
+    hasQueuedStartup: false,
+    isPaneVisible: false,
+    hasSleepIntent: true,
+    activeWorktreeId: OTHER,
+    worktreeId: SLEPT,
+    ...overrides
+  }
+}
+
+describe('shouldStayColdForDeliberateSleep', () => {
+  it('keeps a slept workspace cold when an unrelated workspace is activated', () => {
+    // The #10205 defect: this spawn is what flipped the slept workspace back to awake.
+    expect(shouldStayColdForDeliberateSleep(args())).toBe(true)
+  })
+
+  it('keeps a slept workspace cold when nothing is active', () => {
+    // Sleeping the focused workspace sets activeWorktreeId to null first.
+    expect(shouldStayColdForDeliberateSleep(args({ activeWorktreeId: null }))).toBe(true)
+  })
+
+  it('allows the spawn once the slept workspace is itself activated', () => {
+    expect(shouldStayColdForDeliberateSleep(args({ activeWorktreeId: SLEPT }))).toBe(false)
+  })
+
+  it('allows the spawn for a visible pane', () => {
+    expect(shouldStayColdForDeliberateSleep(args({ isPaneVisible: true }))).toBe(false)
+  })
+
+  it('allows the spawn when a startup command targets the pane', () => {
+    // Covers the agent-resume and background-launch paths, which queue a startup.
+    expect(shouldStayColdForDeliberateSleep(args({ hasQueuedStartup: true }))).toBe(false)
+  })
+
+  it('does not interfere with a workspace that was never slept', () => {
+    // A hidden tab that simply has no PTY yet must still be able to spawn.
+    expect(shouldStayColdForDeliberateSleep(args({ hasSleepIntent: false }))).toBe(false)
+  })
+
+  it('allows the spawn after an explicit wake clears the intent', () => {
+    expect(
+      shouldStayColdForDeliberateSleep(args({ hasSleepIntent: false, activeWorktreeId: OTHER }))
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/deliberate-sleep-cold-start.ts
+++ b/src/renderer/src/components/terminal-pane/deliberate-sleep-cold-start.ts
@@ -1,0 +1,27 @@
+/**
+ * Decides whether a pane that found nothing to attach to must stay cold instead of
+ * spawning a PTY.
+ *
+ * Why: sleeping a workspace kills its PTYs but leaves its panes mounted, so their
+ * deferred connect still runs on later render passes — including ones caused by
+ * activating an unrelated workspace. Spawning there re-creates the PTY and silently
+ * wakes the workspace the user just slept (#10205).
+ */
+export function shouldStayColdForDeliberateSleep(args: {
+  /** A startup command targeted at this pane is an explicit request to launch. */
+  hasQueuedStartup: boolean
+  /** A visible pane must have a PTY, whatever the workspace's sleep state. */
+  isPaneVisible: boolean
+  /** Cleared by activation and by an explicit background wake. */
+  hasSleepIntent: boolean
+  activeWorktreeId: string | null
+  worktreeId: string
+}): boolean {
+  if (args.hasQueuedStartup || args.isPaneVisible) {
+    return false
+  }
+  if (!args.hasSleepIntent) {
+    return false
+  }
+  return args.activeWorktreeId !== args.worktreeId
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
@@ -292,6 +292,53 @@ describe('connectPanePty', () => {
     expect(transport.connect).toHaveBeenCalled()
   })
 
+  it('retires a fresh PTY whose spawn loses a race with deliberate sleep', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { markWorktreeSleepIntent, clearWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transport.getPtyId.mockReturnValue('pty-late-sleep')
+    transportFactoryQueue.push(transport)
+    let resolveSpawn!: (ptyId: string) => void
+    transport.connect.mockImplementation(
+      () =>
+        new Promise<string>((resolve) => {
+          resolveSpawn = resolve
+        })
+    )
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-2',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-late-sleep', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-late-sleep': [] }
+    }
+
+    try {
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({
+          tabId: 'tab-late-sleep',
+          isVisibleRef: { current: false },
+          isActiveRef: { current: false }
+        }) as never
+      )
+      await flushAsyncTicks()
+      markWorktreeSleepIntent('wt-1')
+      const onPtySpawn = createdTransportOptions[0]?.onPtySpawn as
+        | ((ptyId: string) => void)
+        | undefined
+      onPtySpawn?.('pty-late-sleep')
+      await flushAsyncTicks()
+
+      expect(transport.disconnect).toHaveBeenCalledOnce()
+    } finally {
+      resolveSpawn('pty-late-sleep')
+      clearWorktreeSleepIntent('wt-1')
+      await flushAsyncTicks()
+    }
+  })
+
   // Why: a doomed pane (or a child pane whose parent worktree is being removed,
   // which startFreshSpawn's own-worktree skip cannot see) can still race a spawn
   // that main fences. reportError must swallow that fence so the tab never flashes

--- a/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts
@@ -234,6 +234,64 @@ describe('connectPanePty', () => {
     expect(transport.connect).toHaveBeenCalled()
   })
 
+  it('does not spawn a PTY for a deliberately slept workspace while another is active', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const { markWorktreeSleepIntent, clearWorktreeSleepIntent } =
+      await import('@/lib/worktree-sleep-intent')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-2',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-sleep-skip-spawn', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-sleep-skip-spawn': [] }
+    }
+    markWorktreeSleepIntent('wt-1')
+
+    try {
+      connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        createDeps({
+          tabId: 'tab-sleep-skip-spawn',
+          isVisibleRef: { current: false },
+          isActiveRef: { current: false }
+        }) as never
+      )
+      await flushAsyncTicks()
+
+      // The #10205 respawn: this connect is what woke the workspace the user slept.
+      expect(transport.connect).not.toHaveBeenCalled()
+    } finally {
+      clearWorktreeSleepIntent('wt-1')
+    }
+  })
+
+  it('spawns a PTY for a hidden pane whose workspace was never slept', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport()
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      activeWorktreeId: 'wt-2',
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-sleep-control-spawn', ptyId: null }] },
+      ptyIdsByTabId: { 'tab-sleep-control-spawn': [] }
+    }
+
+    connectPanePty(
+      createPane(1) as never,
+      createManager(1) as never,
+      createDeps({
+        tabId: 'tab-sleep-control-spawn',
+        isVisibleRef: { current: false },
+        isActiveRef: { current: false }
+      }) as never
+    )
+    await flushAsyncTicks()
+
+    expect(transport.connect).toHaveBeenCalled()
+  })
+
   // Why: a doomed pane (or a child pane whose parent worktree is being removed,
   // which startFreshSpawn's own-worktree skip cannot see) can still race a spawn
   // that main fences. reportError must swallow that fence so the tab never flashes

--- a/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-choice.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/deferred-session-reattach-choice.ts
@@ -1,7 +1,9 @@
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
+import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { isWebTerminalSurfaceTabId } from '@/runtime/web-terminal-surface-id'
 import { getEagerPtyBufferHandle } from '../pty-dispatcher'
+import { shouldStayColdForDeliberateSleep } from '../deliberate-sleep-cold-start'
 
 import {
   pendingSpawnByPaneKey,
@@ -216,6 +218,19 @@ export function runDeferredSessionReattachChoice(session: ConnectPanePtySession)
         .catch((err) => {
           session.reportError(err instanceof Error ? err.message : String(err))
         })
+    } else if (
+      shouldStayColdForDeliberateSleep({
+        hasQueuedStartup: session.paneStartup !== null,
+        isPaneVisible: session.deps.isVisibleRef.current === true,
+        hasSleepIntent: hasWorktreeSleepIntent(session.deps.worktreeId),
+        activeWorktreeId: storeSnapshot.activeWorktreeId,
+        worktreeId: session.deps.worktreeId
+      })
+    ) {
+      // Why: an ambient remount must not restart a workspace the user deliberately slept.
+      recordPtyConnectDiagnostic(
+        `pane=${session.pane.id} -> SKIP SPAWN (deliberate sleep)`
+      )
     } else {
       recordPtyConnectDiagnostic(`pane=${session.pane.id} -> FRESH SPAWN`)
       if (sleptRemoteColdRestoreStartup || hasSleepingAgentSession) {

--- a/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/fresh-spawn-start.ts
@@ -1,10 +1,12 @@
 import { useAppStore } from '@/store'
+import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { hasPtySerializer } from '../pty-buffer-serializer'
 import { writeTerminalOutput } from '@/lib/pane-manager/pane-terminal-output-scheduler'
 
 import { STARTUP_CWD_FALLBACK_NOTICE } from './startup-cwd-fallback-notice'
 import { pendingSpawnByPaneKey, pendingSpawnGenerationByPaneKey } from './pty-connect-limits'
 import { shouldWritePtyOutputForeground } from './foreground-output-scan'
+import { shouldStayColdForDeliberateSleep } from '../deliberate-sleep-cold-start'
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 import { toProcessExitStartup } from './process-exit-startup'
 import type {
@@ -21,6 +23,17 @@ export function bindStartFreshSpawn(session: ConnectPanePtySession): void {
     startupOverride?: PendingStartupCommand | null,
     options: FreshSpawnOptions = {}
   ): Promise<string | null> => {
+    if (
+      shouldStayColdForDeliberateSleep({
+        hasQueuedStartup: session.paneStartup !== null,
+        isPaneVisible: session.deps.isVisibleRef.current === true,
+        hasSleepIntent: hasWorktreeSleepIntent(session.deps.worktreeId),
+        activeWorktreeId: useAppStore.getState().activeWorktreeId,
+        worktreeId: session.deps.worktreeId
+      })
+    ) {
+      return Promise.resolve(null)
+    }
     if (session.isLegacyWorkerAutomaticResumeBlocked()) {
       return Promise.resolve(null)
     }

--- a/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-visibility-bind.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection/pane-pty-visibility-bind.ts
@@ -1,5 +1,7 @@
 import { scheduleRuntimeGraphSync } from '@/runtime/sync-runtime-graph'
 import { useAppStore } from '@/store'
+import { hasWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
+import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 // Why: a restored pane's stale-account prompt can only be raised once a PTY is
 // actually attached — nothing is inspectable while the session hydrates.
 import { notifyCodexPaneBoundForStaleSweep } from '@/lib/codex-stale-pane-sweep'
@@ -14,6 +16,7 @@ import {
 import { isRemoteRuntimePtyId } from './paired-parked-terminal-restore'
 
 import type { ConnectPanePtySession } from './connect-pane-pty-session'
+import { shouldStayColdForDeliberateSleep } from '../deliberate-sleep-cold-start'
 
 /** PTY visibility reporting, active-PTY binding, and the spawn/rebind/bell handlers that follow it. */
 export function installPanePtyVisibilityBind(session: ConnectPanePtySession): void {
@@ -104,6 +107,39 @@ export function installPanePtyVisibilityBind(session: ConnectPanePtySession): vo
   }
 
   session.onPtySpawn = (ptyId: string): void => {
+    if (
+      shouldStayColdForDeliberateSleep({
+        hasQueuedStartup: session.paneStartup !== null,
+        isPaneVisible: session.deps.isVisibleRef.current === true,
+        hasSleepIntent: hasWorktreeSleepIntent(session.deps.worktreeId),
+        activeWorktreeId: useAppStore.getState().activeWorktreeId,
+        worktreeId: session.deps.worktreeId
+      })
+    ) {
+      // Why: sleep can win after connect starts but before the host publishes its PTY.
+      queueMicrotask(() => {
+        const remotePty = parseRemoteRuntimePtyId(ptyId)
+        if (remotePty) {
+          void useAppStore
+            .getState()
+            .shutdownWorktreeTerminals(session.deps.worktreeId, {
+              keepIdentifiers: true,
+              expectedRuntimePtyIds: [remotePty.handle]
+            })
+            .catch((error) => {
+              console.error('[sleep-worktree] late remote PTY shutdown failed', {
+                worktreeId: session.deps.worktreeId,
+                ptyId,
+                error
+              })
+            })
+          session.transport.disconnect()
+        } else if (session.transport.getPtyId() === ptyId) {
+          session.transport.disconnect()
+        }
+      })
+      return
+    }
     if (!session.claimCapturedDirectSshRetryPty(ptyId)) {
       // Why: this callback proves a fresh process was created, so rejecting its obsolete lease must also retire it.
       queueMicrotask(() => {

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts
@@ -35,6 +35,8 @@ vi.mock('./sleeping-agent-pane-ownership', () => ({
 
 let sleepingRecords: Record<string, { worktreeId: string; paneKey: string; tabId?: string }> = {}
 let terminalTabsByWorktree: Record<string, { id: string }[]> = {}
+let activeTerminalTabIdsByWorktree: Record<string, string | null> = {}
+const remountTerminalTabForRecovery = vi.fn(() => true)
 const clearSleepingAgentSessionsByPaneKey = vi.fn((paneKeys: readonly string[]) => {
   for (const paneKey of paneKeys) {
     delete sleepingRecords[paneKey]
@@ -45,6 +47,8 @@ vi.mock('@/store', () => ({
     getState: () => ({
       sleepingAgentSessionsByPaneKey: sleepingRecords,
       tabsByWorktree: terminalTabsByWorktree,
+      activeTabIdByWorktree: activeTerminalTabIdsByWorktree,
+      remountTerminalTabForRecovery,
       clearSleepingAgentSessionsByPaneKey
     })
   }
@@ -92,6 +96,8 @@ function recordEvents(): RecordedEvents {
 beforeEach(() => {
   sleepingRecords = {}
   terminalTabsByWorktree = {}
+  activeTerminalTabIdsByWorktree = {}
+  remountTerminalTabForRecovery.mockClear()
   clearSleepingAgentSessionsByPaneKey.mockClear()
   isPassiveSpy.mockReset()
   resumeSpy.mockReset()
@@ -135,19 +141,25 @@ describe('createBackgroundSleepingAgentWakeDispatcher', () => {
 })
 
 describe('wakeSleepingAgentsForWorktreeInBackground', () => {
-  it('clears sleep intent for a slept workspace that has no sleeping-agent record', async () => {
+  it('remounts the selected tab for a slept workspace that has no sleeping-agent record', async () => {
     // Why: a workspace slept with only plain shells has no record, so the no-work
     // return is reached — but the mark still has to go, or its panes stay cold and
     // the client's open gesture becomes a permanent no-op.
     const { hasWorktreeSleepIntent, markWorktreeSleepIntent, clearWorktreeSleepIntent } =
       await import('./worktree-sleep-intent')
     sleepingRecords = {}
+    terminalTabsByWorktree = { 'wt-1': [{ id: 'tab-shell' }] }
+    activeTerminalTabIdsByWorktree = { 'wt-1': 'tab-shell' }
+    const rec = recordEvents()
     markWorktreeSleepIntent('wt-1')
     try {
       wakeSleepingAgentsForWorktreeInBackground('wt-1')
 
       expect(hasWorktreeSleepIntent('wt-1')).toBe(false)
+      expect(remountTerminalTabForRecovery).toHaveBeenCalledWith('tab-shell')
+      expect(rec.mountDetails).toEqual([{ worktreeId: 'wt-1', tabIds: ['tab-shell'] }])
     } finally {
+      rec.stop()
       clearWorktreeSleepIntent('wt-1')
     }
   })

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts
@@ -135,6 +135,23 @@ describe('createBackgroundSleepingAgentWakeDispatcher', () => {
 })
 
 describe('wakeSleepingAgentsForWorktreeInBackground', () => {
+  it('clears sleep intent for a slept workspace that has no sleeping-agent record', async () => {
+    // Why: a workspace slept with only plain shells has no record, so the no-work
+    // return is reached — but the mark still has to go, or its panes stay cold and
+    // the client's open gesture becomes a permanent no-op.
+    const { hasWorktreeSleepIntent, markWorktreeSleepIntent, clearWorktreeSleepIntent } =
+      await import('./worktree-sleep-intent')
+    sleepingRecords = {}
+    markWorktreeSleepIntent('wt-1')
+    try {
+      wakeSleepingAgentsForWorktreeInBackground('wt-1')
+
+      expect(hasWorktreeSleepIntent('wt-1')).toBe(false)
+    } finally {
+      clearWorktreeSleepIntent('wt-1')
+    }
+  })
+
   it('fires wake, targeted background-mount, then resume when a passive record exists', () => {
     sleepingRecords = { k1: { worktreeId: 'wt-1', paneKey: 'tab-a:leaf-1', tabId: 'tab-a' } }
     isPassiveSpy.mockReturnValue(true)

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
@@ -166,6 +166,11 @@ function getCanonicalPassiveWakeRecords(
  * spawn is awaited.
  */
 export function wakeSleepingAgentsForWorktreeInBackground(worktreeId: string): void {
+  // Why: a client opening the workspace is an explicit wake, so it releases the
+  // deliberate-sleep mark its panes are otherwise held cold by (#10205). This runs
+  // before the no-records return: a workspace slept with only plain shells has no
+  // sleeping-agent record, and leaving it marked would keep its panes cold forever.
+  clearWorktreeSleepIntent(worktreeId)
   const worktreeRecords = Object.values(
     useAppStore.getState().sleepingAgentSessionsByPaneKey
   ).filter((record) => record.worktreeId === worktreeId)
@@ -176,9 +181,6 @@ export function wakeSleepingAgentsForWorktreeInBackground(worktreeId: string): v
     return
   }
 
-  // Why: a client opening the workspace is an explicit wake, so it releases the
-  // deliberate-sleep mark its panes are otherwise held cold by (#10205).
-  clearWorktreeSleepIntent(worktreeId)
   const wokenClaimKeys = new Set<string>()
   window.dispatchEvent(
     new CustomEvent<WakeHibernatedAgentsWorktreeDetail>(WAKE_HIBERNATED_AGENTS_WORKTREE_EVENT, {

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
@@ -7,7 +7,7 @@ import { useAppStore } from '@/store'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
-import { clearWorktreeSleepIntent } from './worktree-sleep-intent'
+import { clearWorktreeSleepIntent, hasWorktreeSleepIntent } from './worktree-sleep-intent'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
@@ -166,18 +166,29 @@ function getCanonicalPassiveWakeRecords(
  * spawn is awaited.
  */
 export function wakeSleepingAgentsForWorktreeInBackground(worktreeId: string): void {
+  const hadSleepIntent = hasWorktreeSleepIntent(worktreeId)
   // Why: a client opening the workspace is an explicit wake, so it releases the
   // deliberate-sleep mark its panes are otherwise held cold by (#10205). This runs
   // before the no-records return: a workspace slept with only plain shells has no
   // sleeping-agent record, and leaving it marked would keep its panes cold forever.
   clearWorktreeSleepIntent(worktreeId)
-  const worktreeRecords = Object.values(
-    useAppStore.getState().sleepingAgentSessionsByPaneKey
-  ).filter((record) => record.worktreeId === worktreeId)
-  // Why: nothing is slept here, so there is no wake work. Skipping is what keeps
-  // a phone browsing many worktrees from permanently background-mounting each one
-  // (and reattaching its PTYs) on the desktop host it is paired to.
+  const state = useAppStore.getState()
+  const worktreeRecords = Object.values(state.sleepingAgentSessionsByPaneKey).filter(
+    (record) => record.worktreeId === worktreeId
+  )
+  // Why: only a deliberate sleep needs a plain-shell remount. Ordinary phone
+  // browsing still avoids permanently mounting every workspace on the host.
   if (worktreeRecords.length === 0) {
+    if (hadSleepIntent) {
+      const tabId =
+        state.activeTabIdByWorktree[worktreeId] ?? state.tabsByWorktree[worktreeId]?.[0]?.id
+      if (tabId) {
+        // Why: the sleep marker is intentionally non-reactive; remount the selected
+        // plain-shell tab so this explicit wake actually starts its PTY.
+        state.remountTerminalTabForRecovery(tabId)
+        requestBackgroundTerminalWorktreeMount({ worktreeId, tabIds: [tabId] })
+      }
+    }
     return
   }
 

--- a/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
+++ b/src/renderer/src/lib/wake-sleeping-agents-in-background.ts
@@ -7,6 +7,7 @@ import { useAppStore } from '@/store'
 import type { SleepingAgentSessionRecord } from '../../../shared/agent-session-resume'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../../shared/stable-pane-id'
 import { resumeSleepingAgentSessionsForWorktree } from './resume-sleeping-agent-session'
+import { clearWorktreeSleepIntent } from './worktree-sleep-intent'
 import {
   getProviderSessionClaimKey,
   isPassiveCompletedHibernationEvidence,
@@ -175,6 +176,9 @@ export function wakeSleepingAgentsForWorktreeInBackground(worktreeId: string): v
     return
   }
 
+  // Why: a client opening the workspace is an explicit wake, so it releases the
+  // deliberate-sleep mark its panes are otherwise held cold by (#10205).
+  clearWorktreeSleepIntent(worktreeId)
   const wokenClaimKeys = new Set<string>()
   window.dispatchEvent(
     new CustomEvent<WakeHibernatedAgentsWorktreeDetail>(WAKE_HIBERNATED_AGENTS_WORKTREE_EVENT, {

--- a/src/renderer/src/lib/worktree-activation.ts
+++ b/src/renderer/src/lib/worktree-activation.ts
@@ -15,6 +15,7 @@ import {
   setWorktreeNavViewActivator
 } from '@/store/slices/worktree-nav-history'
 import { resumeSleepingAgentSessionsForWorktree } from '@/lib/resume-sleeping-agent-session'
+import { clearWorktreeSleepIntent } from '@/lib/worktree-sleep-intent'
 import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import { folderWorkspaceKey, parseWorkspaceKey } from '../../../shared/workspace-scope'
 import {
@@ -120,6 +121,8 @@ export function activateAndRevealFolderWorkspace(
   if (!state.isNavigatingHistory) {
     state.recordWorktreeVisit(workspaceKey)
   }
+  // Why: an explicit activation is the user asking for this workspace back (#10205).
+  clearWorktreeSleepIntent(workspaceKey)
   resumeSleepingAgentSessionsForWorktree(workspaceKey)
   const primaryTabId = ensureFolderWorkspaceInitialTerminal(
     folderWorkspace,
@@ -208,6 +211,8 @@ export function activateAndRevealWorktree(
   // Why: sleeping destroys the local PTY but preserves the provider session id, so waking should restore those CLI sessions automatically.
   // Ordering is load-bearing: resuming synchronously creates the session's tab first, so the
   // seeding below sees a renderable surface and doesn't add a bare shell next to it.
+  // Why: an explicit activation is the user asking for this workspace back (#10205).
+  clearWorktreeSleepIntent(worktreeId)
   resumeSleepingAgentSessionsForWorktree(worktreeId)
 
   // 4. Ensure a focusable surface exists for externally-created worktrees

--- a/src/renderer/src/lib/worktree-sleep-intent.ts
+++ b/src/renderer/src/lib/worktree-sleep-intent.ts
@@ -1,3 +1,7 @@
+// Why: a slept workspace keeps its panes mounted, so an ambient deferred connect can
+// respawn its PTY and silently wake it (#10205). The mark outlives the sleep teardown
+// and is cleared only by an explicit activation or background wake, which is what tells
+// a deliberate sleep apart from a tab that simply has no PTY yet.
 const sleepingWorktreeIds = new Set<string>()
 
 export function markWorktreeSleepIntent(worktreeId: string): void {

--- a/tests/e2e/terminal-sleep-wake-restore.spec.ts
+++ b/tests/e2e/terminal-sleep-wake-restore.spec.ts
@@ -37,18 +37,6 @@ type RemoteSleepOracle = {
   worktreePsHasAttachedPty: boolean
 }
 
-async function sleepWorktreeTerminals(page: Page, worktreeId: string): Promise<void> {
-  await page.evaluate(async (id) => {
-    const store = window.__store
-    if (!store) {
-      throw new Error('store unavailable')
-    }
-    const state = store.getState()
-    await state.shutdownWorktreeBrowsers(id)
-    await state.shutdownWorktreeTerminals(id, { keepIdentifiers: true })
-  }, worktreeId)
-}
-
 async function readLivePtyCountForWorktree(page: Page, worktreeId: string): Promise<number> {
   return page.evaluate((id) => {
     const store = window.__store
@@ -182,11 +170,12 @@ function writeSleepWakePayloadScript(scriptPath: string, payload: string): void 
 }
 
 test.describe('Terminal sleep wake restore', () => {
-  test('restores slept terminal output and accepts fresh input after wake', async ({
+  test('keeps a context-menu slept workspace cold until explicit wake @headful', async ({
     orcaPage,
     testRepoPath
-  }) => {
+  }, testInfo) => {
     await waitForSessionReady(orcaPage)
+    await orcaPage.evaluate(() => window.__store?.getState().setShowSleepingWorkspaces(true))
     const firstWorktreeId = await waitForActiveWorktree(orcaPage)
     const secondWorktreeId = (await getAllWorktreeIds(orcaPage)).find(
       (id) => id !== firstWorktreeId
@@ -213,9 +202,16 @@ test.describe('Terminal sleep wake restore', () => {
       for (const marker of expectedMarkers) {
         expect(await mainSnapshotContains(orcaPage, ptyId, marker)).toBe(true)
       }
+      await orcaPage.screenshot({
+        path: testInfo.outputPath('pr-13343-before-sleep.png'),
+        fullPage: true
+      })
 
-      await switchToWorktree(orcaPage, firstWorktreeId)
-      await sleepWorktreeTerminals(orcaPage, secondWorktreeId)
+      const sleptWorktreeRow = orcaPage
+        .locator(`[role="option"][data-worktree-id=${JSON.stringify(secondWorktreeId)}]`)
+        .first()
+      await sleptWorktreeRow.click({ button: 'right' })
+      await orcaPage.getByRole('menuitem', { name: 'Sleep', exact: true }).click()
       const afterSleepDebug = await readSleepWakeTerminalDebug(orcaPage, secondWorktreeId)
       await expect
         .poll(() => readLivePtyCountForWorktree(orcaPage, secondWorktreeId), {
@@ -234,7 +230,27 @@ test.describe('Terminal sleep wake restore', () => {
           worktreePsHasAttachedPty: false
         })
 
-      await switchToWorktree(orcaPage, secondWorktreeId)
+      // Activating another workspace caused the ambient deferred connect in #10205.
+      await orcaPage
+        .locator(`[role="option"][data-worktree-id=${JSON.stringify(firstWorktreeId)}]`)
+        .first()
+        .click()
+      await expect
+        .poll(() => readRemoteSleepOracle(orcaPage, secondWorktreeId), {
+          timeout: 10_000,
+          message: 'activating an unrelated workspace respawned the slept PTY'
+        })
+        .toEqual({
+          terminalListTotalCount: 0,
+          worktreePsLiveTerminalCount: 0,
+          worktreePsHasAttachedPty: false
+        })
+      await orcaPage.screenshot({
+        path: testInfo.outputPath('pr-13343-sleep-sticks.png'),
+        fullPage: true
+      })
+
+      await sleptWorktreeRow.click()
       await ensureTerminalVisible(orcaPage)
       await waitForActiveTerminalManager(orcaPage, 30_000)
       const awakePtyId = await waitForActivePanePtyId(orcaPage)
@@ -262,6 +278,10 @@ test.describe('Terminal sleep wake restore', () => {
       await waitForTerminalOutput(orcaPage, restoreMarker, 15_000, 20_000)
       await sendToTerminal(orcaPage, awakePtyId, `printf '\\n${freshMarker}\\n'\r`)
       await waitForTerminalOutput(orcaPage, freshMarker, 10_000, 20_000)
+      await orcaPage.screenshot({
+        path: testInfo.outputPath('pr-13343-explicit-wake.png'),
+        fullPage: true
+      })
     } finally {
       rmSync(scriptPath, { force: true })
     }


### PR DESCRIPTION
## ELI5

Putting a workspace to sleep could briefly stop its terminals and then silently restart them during unrelated background work. Sleeping now sticks until the workspace is explicitly opened or woken, and explicit wakes reliably bring plain-shell workspaces back.

## What Changed

- Keep an in-memory sleep-intent marker after successful workspace teardown; clear it on failed sleep or explicit activation/wake.
- Keep hidden panes in inactive, deliberately slept workspaces cold instead of fresh-spawning a PTY.
- Preserve visible panes and queued startup commands, including agent resume and background launches.
- On a mobile/background wake with no sleeping-agent record, remount only the selected plain-shell tab and request its targeted background mount.
- Recheck sleep intent immediately before spawn. If sleep wins an in-flight spawn race, retire the late local/direct-SSH PTY through its owning transport; paired-runtime PTYs use exact host-owned shutdown with the raw runtime handle.

## Why

A slept workspace leaves mounted panes behind. Their deferred connect path could later run because another workspace changed, find no PTY to attach, and create a new one. The same race could complete a spawn after sleep teardown had begun. Both paths recreated terminals without an explicit wake.

The marker is intentionally in-memory: renderer restart also resets mounted workspace state, while persistence would reintroduce the stale-sleep-state approach previously reverted for #10205.

## Linked Issue

Fixes #10205

## Visual Proof

No styling change; these captures show the interaction behavior in the headed Electron regression test.

1. Before Sleep: ![before Sleep](https://github.com/user-attachments/assets/45fbde24-af0b-4a02-8240-9e7df20e8aa0)
2. After Sleep and activating an unrelated workspace; renderer and host PTY oracles remain zero: ![Sleep sticks](https://github.com/user-attachments/assets/04149763-5b31-4bb5-a2c7-40b0e7880a87)
3. Explicit activation recreates the PTY and accepts input: ![explicit wake](https://github.com/user-attachments/assets/85e31685-d60a-47ba-8a07-64111f613c95)

## Testing

- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/sleep-worktree-flow.test.ts src/renderer/src/components/terminal-pane/deliberate-sleep-cold-start.test.ts src/renderer/src/components/terminal-pane/pty-connection-fresh-spawn-guards.test.ts src/renderer/src/lib/wake-sleeping-agents-in-background.test.ts` — 4 files, 50/50 passed after rebasing onto current `main`
- [x] `pnpm typecheck`
- [x] `pnpm lint`
- [x] `pnpm build`
- [x] Headed Electron regression — 1/1 passed on macOS; Sleep reaches zero PTYs, unrelated activation keeps it cold, and explicit activation recreates a working PTY
- [ ] Full `pnpm test` was not rerun after the latest rebase; changed-surface tests are green and CI will cover the full suite

## AI Disclosure

AI-assisted implementation and review were used. All changed-surface tests, typecheck, lint, and build were run after the final rebase.

## Review

- **Correctness:** covers the ambient deferred-connect path, explicit plain-shell background wake, failed sleep recovery, and the in-flight spawn race.
- **Cross-platform:** renderer state logic only; no platform-specific paths, shells, shortcuts, accelerators, or native APIs changed.
- **SSH/remote/local:** local and direct-SSH cleanup stays on the existing owning transport. Paired-runtime cleanup uses exact host-owned shutdown. No local fallback or process-liveness inference was added.
- **Folder workspaces:** activation clears intent for folder workspaces and git worktrees.
- **Remote compatibility:** no RPC shape, terminal stream frame, opcode, or published-content contract changed.
- **Agents/integrations/providers:** queued startup remains an explicit escape, preserving agent resume and background launch flows. No source-control or Git-provider behavior changed.
- **Performance:** constant-time `Set`/store reads on the spawn path and one targeted tab mount on explicit plain-shell background wake.
- **Security:** no dependencies, input parsing, credentials, commands, paths, auth, or IPC surface changed; the patch narrows unintended process creation.

## Agent skill upstream boundary

- [x] Not applicable.

## Notes

- This is separate from #12672 / STA-3465, which guarded mobile tab activation in the runtime. This bug is in the renderer pane-connect path.
- The marker remains in-memory by design and does not attempt to persist sleep intent through application restart.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why
- [x] Before/after proof attached
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, folder-workspace, and compatibility impact considered
- [x] `pnpm lint`, `pnpm typecheck`, targeted tests, and `pnpm build` pass; CI will cover the full test suite
