### PR TITLE
fix(folder-workspace): stop silently deleting workspaces of groups without a parentPath on load

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -91,7 +91,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical test blobs in oracle tree ff317d5b1df769bdc83cf8db587a1c9ac42bda7c failed five focused tests and the headed row assertion on base eacb9a9fa447cfe05558c50dba258c80f4f5c96e via overlay 0b33561fa9f1f3d75d96fbb970415dc1e2325363. Rebased published logic 972804c60eef936474ef78019fba9ce9b8dbfe77 passed persistence but failed the headed row because its referenced sidebar fix was not in the PR. Candidate 38b68404c020e3db6f64b3b74d9f95096fabca12 passed 120 focused tests and the headed restart; disabled 0cf63935ad4dcebe4aba60ae4ff017ea7edbf5cd failed the same five focused tests."
+        "evidence": "The byte-identical test blobs in oracle tree a32abda1166fa53c68ef3f12d096afcc2e64fed2 failed five focused tests and the headed row assertion on base bbcf89e221ad5e759b1933bbd4b04b07f770f379 via overlay 2c00c6ec070239528faab270cecd9db697f6ea9c. Rebased published logic 4e6d6ae1fd88dc204f525ea394999037d9107dd5 passed 119 focused tests but failed the sidebar-row contract and headed restart via overlay c2e8319833768eeab0851c896e4a4751f8f7a8c1. Candidate 97fb69b2f95df6e35c894913d4ba9901e766bb89 passed all 120 focused tests and the headed restart; disabled ade2403a2f7630a38a3c6c403044acabbc5edb88 failed the same five focused tests."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "updatedAt": "2026-08-09",
+  "updatedAt": "2026-08-10",
   "policy": {
     "maturityLevels": ["experimental", "soak", "blocking", "accepted-gap", "deprecated"],
     "blockingPromotion": {
@@ -10,6 +10,105 @@
     }
   },
   "gates": [
+    {
+      "id": "folder-workspace.manual-group-restart-survival",
+      "title": "Manual-group folder workspaces survive restart and remain reachable",
+      "maturity": "experimental",
+      "protection": "partial",
+      "owner": "startup-persistence",
+      "layer": "main-store-renderer-restart",
+      "surfaces": [
+        "folder workspace persistence load",
+        "workspace session terminal ownership",
+        "project-group sidebar rows"
+      ],
+      "platforms": ["macos", "linux", "windows"],
+      "providers": ["local", "ssh", "paired-runtime"],
+      "coveredPlatforms": ["macos"],
+      "coveredProviders": ["local", "ssh"],
+      "coverageNotes": "Production Store restart tests cover runtime-created local workspaces, seeded local and SSH legacy shapes, explicit null provenance, POSIX and Windows-style paths, malformed entries, folder-scan fallback, terminal wiring, durable rewrite, and group-delete cleanup. A headed macOS Electron test proves the row is visible before and after restart; live SSH, paired-runtime, Linux, and Windows launches remain gaps.",
+      "motivatingLinks": ["https://github.com/stablyai/orca/pull/13344"],
+      "invariant": "A folder workspace with an existing project group and its own non-empty folderPath must survive persistence load regardless of whether the group has parentPath, preserve host provenance and session ownership, and remain reachable in the sidebar; only missing groups or unresolvable paths may be dropped.",
+      "oracle": "Create a real folder workspace in a manual group through the production Store, attach a terminal tab, flush, restart, flush again, and require the workspace plus tab wiring to remain durable before proving explicit group deletion cleans both. Seed local, SSH, Windows-path, folder-scan fallback, duplicate, orphaned, and malformed legacy records and require exact salvage. Launch headed Orca twice against the same seeded profile and require the manual-group workspace row on both launches.",
+      "commands": [
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/folder-workspace-persistence-load.test.ts src/shared/folder-workspaces.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts --reporter=dot",
+        "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/folder-workspace-manual-group-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1"
+      ],
+      "testFiles": [
+        "src/main/folder-workspace-persistence-load.test.ts",
+        "src/shared/folder-workspaces.test.ts",
+        "src/renderer/src/components/sidebar/worktree-list-groups.test.ts",
+        "tests/e2e/folder-workspace-manual-group-restart.spec.ts"
+      ],
+      "assertionRefs": [
+        {
+          "file": "src/main/folder-workspace-persistence-load.test.ts",
+          "assertions": [
+            "runtime-created manual-group workspace and terminal wiring survive restart and the following durable save",
+            "local, SSH, Windows-path, and folder-scan fallback records survive while duplicates, orphans, missing paths, and malformed values drop",
+            "explicit project-group deletion removes the retained workspace and its scoped terminal state"
+          ]
+        },
+        {
+          "file": "src/renderer/src/components/sidebar/worktree-list-groups.test.ts",
+          "assertions": [
+            "manual groups render their owned folder-workspace rows",
+            "folder workspaces with missing project groups stay hidden"
+          ]
+        },
+        {
+          "file": "tests/e2e/folder-workspace-manual-group-restart.spec.ts",
+          "assertions": ["headed Orca renders the exact folder-workspace row on both launches"]
+        }
+      ],
+      "evidenceRuns": [
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/folder-workspace-persistence-load.test.ts src/shared/folder-workspaces.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 2,
+          "summary": "Three deterministic files passed production Store restart, normalization, cleanup, scale, and sidebar-row contracts."
+        },
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/folder-workspace-manual-group-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
+          "result": "passed",
+          "durationSeconds": 7,
+          "summary": "One isolated-profile headed Electron test passed two launches and rendered the exact manual-group folder-workspace row both times."
+        }
+      ],
+      "runtimeBudget": {
+        "p95Seconds": 15,
+        "scope": "focused Store, normalizer, sidebar-row, and headed restart contracts on a local development runner"
+      },
+      "flakeHistory": {
+        "status": "unknown",
+        "evidence": "One deterministic and one headed local run are recorded; CI and soak history have not started."
+      },
+      "redGreenEvidence": {
+        "status": "complete",
+        "evidence": "The byte-identical oracle tree 4fec40a5ed24fd5239b3cfd1fe5c5225c59a619d failed four focused tests and the headed row assertion on base eacb9a9fa447cfe05558c50dba258c80f4f5c96e via overlay 12251816415a6a52da22b462c959b242f315b09e. Rebased published logic 972804c60eef936474ef78019fba9ce9b8dbfe77 passed persistence but failed the headed row because its referenced sidebar fix was not in the PR. Correction 7431072a484ce161e0f7d5ece5afb0d9375e71f8 passed both; disabled 87f1052a368e517bede3ecadcdd6479e7eca4598 has the exact red baseline tree."
+      },
+      "performanceBudget": {
+        "required": true,
+        "evidence": "Normalization performs one project-group index build, one workspace pass, and the existing result sort: O(groups + workspaces log workspaces), with no filesystem, provider, RPC, retry, polling, subprocess, or listener work. A 20,000-group/20,000-workspace contract guards indexed lookup; sidebar grouping remains one group index plus one workspace pass and existing per-group sorting."
+      },
+      "promotionCriteria": [
+        "Collect stable CI and headed macOS soak history.",
+        "Run the restart oracle against a real direct-SSH folder workspace.",
+        "Collect Linux or Windows headed coverage and paired-runtime inventory parity."
+      ],
+      "knownGaps": [
+        "The headed profile is seeded rather than created through a live runtime RPC.",
+        "No live SSH, paired-runtime, Linux, Windows, WSL, or headless serve restart was run.",
+        "The provider-independent path strings are covered, but remote filesystem availability is owned by the existing activation path-status gate."
+      ],
+      "demotionRule": "Demote or quarantine if restart can drop a resolvable workspace, retain an orphan, lose session wiring, hide the retained row, leak cleanup state, or make catalog normalization superlinear before its existing sort."
+    },
     {
       "id": "editor.restored-sibling-owner-reparent",
       "title": "Restored sibling tabs migrate filesystem authority before becoming editable",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -91,7 +91,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical oracle tree 4fec40a5ed24fd5239b3cfd1fe5c5225c59a619d failed four focused tests and the headed row assertion on base eacb9a9fa447cfe05558c50dba258c80f4f5c96e via overlay 12251816415a6a52da22b462c959b242f315b09e. Rebased published logic 972804c60eef936474ef78019fba9ce9b8dbfe77 passed persistence but failed the headed row because its referenced sidebar fix was not in the PR. Correction 7431072a484ce161e0f7d5ece5afb0d9375e71f8 passed both; disabled 87f1052a368e517bede3ecadcdd6479e7eca4598 has the exact red baseline tree."
+        "evidence": "The byte-identical test blobs in oracle tree ff317d5b1df769bdc83cf8db587a1c9ac42bda7c failed five focused tests and the headed row assertion on base eacb9a9fa447cfe05558c50dba258c80f4f5c96e via overlay 0b33561fa9f1f3d75d96fbb970415dc1e2325363. Rebased published logic 972804c60eef936474ef78019fba9ce9b8dbfe77 passed persistence but failed the headed row because its referenced sidebar fix was not in the PR. Candidate 38b68404c020e3db6f64b3b74d9f95096fabca12 passed 120 focused tests and the headed restart; disabled 0cf63935ad4dcebe4aba60ae4ff017ea7edbf5cd failed the same five focused tests."
       },
       "performanceBudget": {
         "required": true,

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -16,26 +16,29 @@
       "maturity": "experimental",
       "protection": "partial",
       "owner": "startup-persistence",
-      "layer": "main-store-renderer-restart",
+      "layer": "main-store-renderer-runtime-mobile-restart",
       "surfaces": [
         "folder workspace persistence load",
         "workspace session terminal ownership",
-        "project-group sidebar rows"
+        "project-group sidebar rows",
+        "runtime/mobile workspace inventory"
       ],
       "platforms": ["macos", "linux", "windows"],
       "providers": ["local", "ssh", "paired-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": ["local", "ssh"],
-      "coverageNotes": "Production Store restart tests cover runtime-created local workspaces, seeded local and SSH legacy shapes, explicit null provenance, POSIX and Windows-style paths, malformed entries, folder-scan fallback, terminal wiring, durable rewrite, and group-delete cleanup. A headed macOS Electron test proves the row is visible before and after restart; live SSH, paired-runtime, Linux, and Windows launches remain gaps.",
+      "coverageNotes": "Production Store restart tests cover runtime-created local workspaces, seeded local and SSH legacy shapes, explicit null provenance, POSIX and Windows-style paths, malformed entries, folder-scan fallback, terminal wiring, durable rewrite, and group-delete cleanup. Deterministic runtime coverage proves worktree.ps includes an explicit-path workspace whose existing manual group has null parentPath. A headed macOS Electron test proves the desktop row is visible before and after restart; live SSH, paired-runtime, Linux, and Windows launches remain gaps.",
       "motivatingLinks": ["https://github.com/stablyai/orca/pull/13344"],
       "invariant": "A folder workspace with an existing project group and its own non-empty folderPath must survive persistence load regardless of whether the group has parentPath, preserve host provenance and session ownership, and remain reachable in the sidebar; only missing groups or unresolvable paths may be dropped.",
-      "oracle": "Create a real folder workspace in a manual group through the production Store, attach a terminal tab, flush, restart, flush again, and require the workspace plus tab wiring to remain durable before proving explicit group deletion cleans both. Seed local, SSH, Windows-path, folder-scan fallback, duplicate, orphaned, and malformed legacy records and require exact salvage. Launch headed Orca twice against the same seeded profile and require the manual-group workspace row on both launches.",
+      "oracle": "Create a real folder workspace in a manual group through the production Store, attach a terminal tab, flush, restart, flush again, and require the workspace plus tab wiring to remain durable before proving explicit group deletion cleans both. Seed local, SSH, Windows-path, folder-scan fallback, duplicate, orphaned, and malformed legacy records and require exact salvage. Request worktree.ps and require the manual-group workspace in runtime/mobile inventory. Launch headed Orca twice against the same seeded profile and require the desktop row on both launches.",
       "commands": [
         "pnpm exec vitest run --config config/vitest.config.ts src/main/folder-workspace-persistence-load.test.ts src/shared/folder-workspaces.test.ts src/renderer/src/components/sidebar/worktree-list-groups.test.ts --reporter=dot",
+        "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --reporter=dot",
         "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/folder-workspace-manual-group-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1"
       ],
       "testFiles": [
         "src/main/folder-workspace-persistence-load.test.ts",
+        "src/main/runtime/orca-runtime.test.ts",
         "src/shared/folder-workspaces.test.ts",
         "src/renderer/src/components/sidebar/worktree-list-groups.test.ts",
         "tests/e2e/folder-workspace-manual-group-restart.spec.ts"
@@ -47,6 +50,12 @@
             "runtime-created manual-group workspace and terminal wiring survive restart and the following durable save",
             "local, SSH, Windows-path, and folder-scan fallback records survive while duplicates, orphans, missing paths, and malformed values drop",
             "explicit project-group deletion removes the retained workspace and its scoped terminal state"
+          ]
+        },
+        {
+          "file": "src/main/runtime/orca-runtime.test.ts",
+          "assertions": [
+            "worktree.ps includes an explicit-path folder workspace when its existing manual project group has null parentPath and excludes one whose group is missing"
           ]
         },
         {
@@ -75,6 +84,15 @@
           "date": "2026-08-10",
           "runner": "local",
           "platform": "macos",
+          "command": "pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/orca-runtime.test.ts --reporter=dot",
+          "result": "passed",
+          "durationSeconds": 18,
+          "summary": "The full runtime file passed 1,077 tests with one existing skip, including manual-group mobile inventory, host routing, authorization, and deletion paths."
+        },
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
           "command": "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/folder-workspace-manual-group-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
           "result": "passed",
           "durationSeconds": 7,
@@ -82,8 +100,8 @@
         }
       ],
       "runtimeBudget": {
-        "p95Seconds": 15,
-        "scope": "focused Store, normalizer, sidebar-row, and headed restart contracts on a local development runner"
+        "p95Seconds": 30,
+        "scope": "focused Store, normalizer, sidebar-row and headed restart contracts plus the full OrcaRuntimeService test file on a local development runner"
       },
       "flakeHistory": {
         "status": "unknown",
@@ -95,7 +113,7 @@
       },
       "performanceBudget": {
         "required": true,
-        "evidence": "Normalization performs one project-group index build, one workspace pass, and the existing result sort: O(groups + workspaces log workspaces), with no filesystem, provider, RPC, retry, polling, subprocess, or listener work. A 20,000-group/20,000-workspace contract guards indexed lookup; sidebar grouping remains one group index plus one workspace pass and existing per-group sorting."
+        "evidence": "Normalization performs one project-group index build, one workspace pass, and the existing result sort: O(groups + workspaces log workspaces), with no filesystem, provider, RPC, retry, polling, subprocess, or listener work. The 20,000-group/20,000-workspace contract covers only normalization's indexed lookup; renderer grouping and runtime/mobile inventory have focused functional coverage but no scale oracle."
       },
       "promotionCriteria": [
         "Collect stable CI and headed macOS soak history.",

--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -95,8 +95,8 @@
           "platform": "macos",
           "command": "pnpm exec electron-vite build --mode e2e && SKIP_BUILD=1 pnpm exec playwright test tests/e2e/folder-workspace-manual-group-restart.spec.ts --config tests/playwright.config.ts --project electron-headful --workers=1",
           "result": "passed",
-          "durationSeconds": 7,
-          "summary": "One isolated-profile headed Electron test passed two launches and rendered the exact manual-group folder-workspace row both times."
+          "durationSeconds": 8,
+          "summary": "Corrected oracle 8fa16033cf6a278f92a9e59d0ffc535e14e43644 passed two isolated-profile headed Electron launches and rendered the exact manual-group folder-workspace row both times."
         }
       ],
       "runtimeBudget": {
@@ -109,7 +109,7 @@
       },
       "redGreenEvidence": {
         "status": "complete",
-        "evidence": "The byte-identical test blobs in oracle tree a32abda1166fa53c68ef3f12d096afcc2e64fed2 failed five focused tests and the headed row assertion on base bbcf89e221ad5e759b1933bbd4b04b07f770f379 via overlay 2c00c6ec070239528faab270cecd9db697f6ea9c. Rebased published logic 4e6d6ae1fd88dc204f525ea394999037d9107dd5 passed 119 focused tests but failed the sidebar-row contract and headed restart via overlay c2e8319833768eeab0851c896e4a4751f8f7a8c1. Candidate 97fb69b2f95df6e35c894913d4ba9901e766bb89 passed all 120 focused tests and the headed restart; disabled ade2403a2f7630a38a3c6c403044acabbc5edb88 failed the same five focused tests."
+        "evidence": "Five test blobs are byte-identical across all four roles. Review base bbcf89e221ad5e759b1933bbd4b04b07f770f379 via oracle 791f5ef1f9c23ae3627a80e2c9dc6127ca9c5306 failed 5/120 persistence/renderer assertions, the runtime/mobile assertion, and the headed row. Public head 9911ba78729c7a81188dc628ce5985d6ca437b67 rebased as 4e6d6ae1fd88dc204f525ea394999037d9107dd5 via oracle 09bf9de2dce179807379dcf3141bcf26c471eeeb failed 1/120 renderer assertions, the runtime/mobile assertion, and the headed row. Corrected 8fa16033cf6a278f92a9e59d0ffc535e14e43644 passed 120/120 focused assertions, the runtime/mobile assertion, and both headed launches. Disabled 1102339d0767c5f069421f46a2d759b3aba2bb88 restores exactly the three production predicates and failed the same six deterministic assertions plus the headed row."
       },
       "performanceBudget": {
         "required": true,

--- a/src/main/folder-workspace-persistence-load.test.ts
+++ b/src/main/folder-workspace-persistence-load.test.ts
@@ -1,0 +1,222 @@
+import { mkdtempSync, mkdirSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultPersistedState, getDefaultWorkspaceSession } from '../shared/constants'
+import type { FolderWorkspace, ProjectGroup, TerminalTab } from '../shared/types'
+import { folderWorkspaceKey } from '../shared/workspace-scope'
+
+const testState = { dir: '' }
+
+vi.mock('electron', () => ({
+  app: { getPath: () => testState.dir },
+  safeStorage: {
+    isEncryptionAvailable: () => true,
+    encryptString: (value: string) => Buffer.from(`encrypted:${value}`, 'utf-8'),
+    decryptString: (value: Buffer) => value.toString('utf-8').replace(/^encrypted:/, '')
+  }
+}))
+
+vi.mock('./ssh/ssh-config-parser', () => ({
+  loadUserSshConfig: vi.fn(() => []),
+  sshConfigHostsToTargets: vi.fn(() => [])
+}))
+
+vi.mock('./telemetry/client', () => ({ track: vi.fn() }))
+vi.mock('./telemetry/cohort-classifier', () => ({ getCohortAtEmit: vi.fn() }))
+
+const stores: { flushOrThrow(): void }[] = []
+
+async function createStore(dataFile = join(testState.dir, 'orca-data.json')) {
+  const { Store, initDataPath } = await import('./persistence')
+  initDataPath()
+  const store = new Store({ dataFile })
+  stores.push(store)
+  return store
+}
+
+function projectGroup(overrides: Partial<ProjectGroup>): ProjectGroup {
+  return {
+    id: 'manual-local',
+    name: 'Manual local',
+    parentPath: null,
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  }
+}
+
+function folderWorkspace(overrides: Partial<FolderWorkspace>): FolderWorkspace {
+  return {
+    id: 'manual-local-workspace',
+    projectGroupId: 'manual-local',
+    name: 'Manual local workspace',
+    folderPath: join(testState.dir, 'local-folder'),
+    connectionId: null,
+    linkedTask: null,
+    linkedTaskSourceContext: null,
+    comment: 'preserve me',
+    isArchived: false,
+    isUnread: true,
+    isPinned: true,
+    sortOrder: 10,
+    lastActivityAt: 9,
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides
+  }
+}
+
+function terminalTab(id: string, worktreeId: string): TerminalTab {
+  return {
+    id,
+    ptyId: null,
+    worktreeId,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+}
+
+describe('folder workspace persistence load', () => {
+  beforeEach(() => {
+    testState.dir = mkdtempSync(join(tmpdir(), 'orca-folder-workspace-load-'))
+    stores.length = 0
+  })
+
+  afterEach(() => {
+    for (const store of stores) {
+      store.flushOrThrow()
+    }
+    rmSync(testState.dir, { recursive: true, force: true })
+  })
+
+  it('round-trips a real manual-group workspace and its terminal wiring across restart', async () => {
+    const folderPath = join(testState.dir, 'real-folder')
+    mkdirSync(folderPath)
+    const initial = await createStore()
+    const group = initial.createProjectGroup({
+      name: 'Manual',
+      parentPath: null,
+      createdFrom: 'manual'
+    })
+    const workspace = initial.createFolderWorkspace({
+      projectGroupId: group.id,
+      name: 'Manual workspace',
+      folderPath,
+      connectionId: null
+    })
+    const workspaceKey = folderWorkspaceKey(workspace.id)
+    const tab = terminalTab('manual-tab', workspaceKey)
+    initial.setWorkspaceSession({
+      ...getDefaultWorkspaceSession(),
+      activeWorkspaceKey: workspaceKey,
+      activeWorktreeId: workspaceKey,
+      activeTabId: tab.id,
+      tabsByWorktree: { [workspaceKey]: [tab] },
+      terminalLayoutsByTabId: {
+        [tab.id]: { root: null, activeLeafId: null, expandedLeafId: null }
+      }
+    })
+    initial.flushOrThrow()
+
+    const restarted = await createStore()
+    expect(restarted.getFolderWorkspaces()).toContainEqual(
+      expect.objectContaining({
+        id: workspace.id,
+        projectGroupId: group.id,
+        folderPath,
+        connectionId: null
+      })
+    )
+    expect(restarted.getWorkspaceSession().tabsByWorktree[workspaceKey]).toEqual([tab])
+
+    restarted.flushOrThrow()
+    const persisted = JSON.parse(readFileSync(join(testState.dir, 'orca-data.json'), 'utf-8')) as {
+      folderWorkspaces: FolderWorkspace[]
+    }
+    expect(persisted.folderWorkspaces.map((entry) => entry.id)).toContain(workspace.id)
+
+    expect(restarted.deleteProjectGroup(group.id)).toBe(true)
+    restarted.flushOrThrow()
+    const cleaned = await createStore()
+    expect(cleaned.getFolderWorkspaces()).toEqual([])
+    expect(cleaned.getWorkspaceSession().tabsByWorktree[workspaceKey]).toBeUndefined()
+  })
+
+  it('salvages valid local and SSH shapes while dropping only unresolvable records', async () => {
+    const dataFile = join(testState.dir, 'legacy-orca-data.json')
+    const localPath = join(testState.dir, 'manual-local-folder')
+    const remotePath = '/srv/manual-ssh-folder'
+    const windowsPath = 'C:\\workspace\\manual-folder'
+    const groups = [
+      projectGroup({ id: 'manual-local' }),
+      projectGroup({ id: 'manual-ssh', name: 'Manual SSH', connectionId: 'ssh-1', tabOrder: 1 }),
+      projectGroup({
+        id: 'folder-scan',
+        name: 'Folder scan',
+        parentPath: '/srv/folder-scan',
+        createdFrom: 'folder-scan',
+        tabOrder: 2
+      })
+    ]
+    const valid = [
+      folderWorkspace({ id: 'manual-local-workspace', folderPath: localPath }),
+      folderWorkspace({
+        id: 'manual-ssh-workspace',
+        projectGroupId: 'manual-ssh',
+        folderPath: remotePath,
+        connectionId: undefined
+      }),
+      folderWorkspace({ id: 'manual-windows-workspace', folderPath: windowsPath }),
+      folderWorkspace({
+        id: 'legacy-fallback-workspace',
+        projectGroupId: 'folder-scan',
+        folderPath: ''
+      })
+    ]
+    const invalid = [
+      folderWorkspace({ id: 'missing-group-workspace', projectGroupId: 'missing' }),
+      folderWorkspace({ id: 'missing-path-workspace', folderPath: '' }),
+      folderWorkspace({ id: 'manual-local-workspace', name: 'duplicate' }),
+      { ...folderWorkspace({ id: 'invalid-project-group' }), projectGroupId: 42 },
+      { ...folderWorkspace({ id: 'empty-id' }), id: '' },
+      null,
+      42
+    ]
+    const defaults = getDefaultPersistedState(testState.dir)
+    writeFileSync(
+      dataFile,
+      JSON.stringify({
+        ...defaults,
+        projectGroups: groups,
+        folderWorkspaces: [...valid, ...invalid]
+      }),
+      'utf-8'
+    )
+
+    const store = await createStore(dataFile)
+    expect(store.getFolderWorkspaces()).toEqual([
+      expect.objectContaining({ id: 'manual-local-workspace', folderPath: localPath }),
+      expect.objectContaining({
+        id: 'manual-ssh-workspace',
+        folderPath: remotePath,
+        connectionId: 'ssh-1'
+      }),
+      expect.objectContaining({ id: 'manual-windows-workspace', folderPath: windowsPath }),
+      expect.objectContaining({
+        id: 'legacy-fallback-workspace',
+        folderPath: '/srv/folder-scan'
+      })
+    ])
+    expect(store.getFolderWorkspaces()[0]?.connectionId).toBeNull()
+  })
+})

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -35104,6 +35104,38 @@ describe('OrcaRuntimeService', () => {
     })
   })
 
+  it('uses project-group existence for folder workspaces in mobile inventory', async () => {
+    const folderWorkspace = makeFolderWorkspace({ folderPath: '/tmp/manual-folder' })
+    const orphanWorkspace = makeFolderWorkspace({
+      id: 'orphan-folder-workspace',
+      projectGroupId: 'missing-group',
+      folderPath: '/tmp/orphan-folder'
+    })
+    const projectGroup = makeFolderProjectGroup({
+      name: 'Manual',
+      parentPath: null,
+      createdFrom: 'manual'
+    })
+    const runtime = new OrcaRuntimeService({
+      ...createFolderWorkspaceRuntimeStore(folderWorkspace, projectGroup),
+      getFolderWorkspaces: () => [folderWorkspace, orphanWorkspace]
+    } as never)
+
+    const { worktrees } = await runtime.getWorktreePs()
+
+    expect(worktrees).toContainEqual(
+      expect.objectContaining({
+        workspaceKind: 'folder-workspace',
+        worktreeId: TEST_FOLDER_WORKSPACE_KEY,
+        repo: 'Manual',
+        path: '/tmp/manual-folder'
+      })
+    )
+    expect(
+      worktrees.some((worktree) => worktree.worktreeId === 'folder:orphan-folder-workspace')
+    ).toBe(false)
+  })
+
   it('attaches inline agent rows from the latest OSC 9999 status', async () => {
     const runtime = new OrcaRuntimeService(store)
     const leafId = '22222222-2222-4222-8222-222222222222'

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -17550,7 +17550,7 @@ export class OrcaRuntimeService {
     )
     for (const folderWorkspace of this.store?.getFolderWorkspaces?.() ?? []) {
       const projectGroup = projectGroupById.get(folderWorkspace.projectGroupId)
-      if (!projectGroup?.parentPath) {
+      if (!projectGroup) {
         continue
       }
       const worktree = folderWorkspaceToWorktree(folderWorkspace)

--- a/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.test.ts
@@ -3302,7 +3302,7 @@ describe('project groups', () => {
     ])
   })
 
-  it('does not render folder workspaces under non-folder Project Groups', () => {
+  it('renders folder workspaces under manual Project Groups', () => {
     const group: ProjectGroup = {
       id: 'group-manual',
       name: 'Manual',
@@ -3318,7 +3318,7 @@ describe('project groups', () => {
     const folderWorkspace: FolderWorkspace = {
       id: 'folder-workspace-1',
       projectGroupId: group.id,
-      name: 'Hidden',
+      name: 'Terminals',
       folderPath: '/monorepo',
       linkedTask: null,
       comment: '',
@@ -3357,9 +3357,55 @@ describe('project groups', () => {
       {
         type: 'header',
         key: 'project-group:group-manual',
-        count: 0
+        count: 1
+      },
+      {
+        type: 'folder-workspace',
+        folderWorkspace: { id: folderWorkspace.id },
+        projectGroup: { id: group.id }
       }
     ])
+  })
+
+  it('does not render folder workspaces whose Project Group is missing', () => {
+    const folderWorkspace: FolderWorkspace = {
+      id: 'orphan-folder-workspace',
+      projectGroupId: 'missing-group',
+      name: 'Orphan',
+      folderPath: '/missing',
+      linkedTask: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 10,
+      lastActivityAt: 0,
+      createdAt: 1,
+      updatedAt: 1
+    }
+
+    const rows = buildRows(
+      'repo',
+      [],
+      new Map(),
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      undefined,
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      undefined,
+      [folderWorkspace]
+    )
+
     expect(rows.some((row) => row.type === 'folder-workspace')).toBe(false)
   })
 

--- a/src/renderer/src/components/sidebar/worktree-list-groups.ts
+++ b/src/renderer/src/components/sidebar/worktree-list-groups.ts
@@ -1398,7 +1398,7 @@ export function buildRows(
   const folderWorkspacesByProjectGroupId = new Map<string, FolderWorkspace[]>()
   for (const workspace of folderWorkspaces) {
     const group = projectGroupsById.get(workspace.projectGroupId)
-    if (!group?.parentPath) {
+    if (!group) {
       continue
     }
     const list = folderWorkspacesByProjectGroupId.get(workspace.projectGroupId) ?? []

--- a/src/shared/folder-workspaces.test.ts
+++ b/src/shared/folder-workspaces.test.ts
@@ -67,4 +67,24 @@ describe('normalizeFolderWorkspaces', () => {
     const result = normalizeFolderWorkspaces([workspace({ connectionId: null })], groups)
     expect(result[0]?.connectionId).toBeNull()
   })
+
+  it('indexes large manual-group catalogs without dropping workspaces', () => {
+    const count = 20_000
+    const groups = Array.from({ length: count }, (_, index) =>
+      group({ id: `group-${index}`, parentPath: null })
+    )
+    const workspaces = Array.from({ length: count }, (_, index) =>
+      workspace({
+        id: `workspace-${index}`,
+        projectGroupId: `group-${index}`,
+        folderPath: `/tmp/project-${index}`,
+        sortOrder: index
+      })
+    )
+
+    const result = normalizeFolderWorkspaces(workspaces, groups)
+
+    expect(result).toHaveLength(count)
+    expect(new Set(result.map((entry) => entry.id)).size).toBe(count)
+  })
 })

--- a/src/shared/folder-workspaces.test.ts
+++ b/src/shared/folder-workspaces.test.ts
@@ -1,0 +1,70 @@
+import { describe, expect, it } from 'vitest'
+import { normalizeFolderWorkspaces } from './folder-workspaces'
+import type { ProjectGroup } from './types'
+
+function group(overrides: Partial<ProjectGroup>): ProjectGroup {
+  return {
+    id: 'group-1',
+    name: 'Group',
+    parentPath: null,
+    connectionId: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    ...overrides
+  } as ProjectGroup
+}
+
+function workspace(overrides: Record<string, unknown>): Record<string, unknown> {
+  return {
+    id: 'workspace-1',
+    projectGroupId: 'group-1',
+    name: 'Terminals',
+    folderPath: '/tmp/project',
+    connectionId: null,
+    sortOrder: 10,
+    lastActivityAt: 5,
+    createdAt: 1,
+    updatedAt: 2,
+    ...overrides
+  }
+}
+
+describe('normalizeFolderWorkspaces', () => {
+  it('keeps a workspace with its own folderPath in a manual group without parentPath', () => {
+    const groups = [group({ id: 'group-1', parentPath: null })]
+    const result = normalizeFolderWorkspaces([workspace({})], groups)
+    expect(result.map((entry) => entry.id)).toEqual(['workspace-1'])
+    expect(result[0].folderPath).toBe('/tmp/project')
+  })
+
+  it('drops a workspace whose group does not exist', () => {
+    const result = normalizeFolderWorkspaces(
+      [workspace({ projectGroupId: 'missing-group' })],
+      [group({ id: 'group-1' })]
+    )
+    expect(result).toEqual([])
+  })
+
+  it('drops a workspace with no folderPath when the group has no parentPath', () => {
+    const groups = [group({ id: 'group-1', parentPath: null })]
+    const result = normalizeFolderWorkspaces([workspace({ folderPath: '' })], groups)
+    expect(result).toEqual([])
+  })
+
+  it('falls back to the group parentPath when the workspace has no folderPath', () => {
+    const groups = [group({ id: 'group-1', parentPath: '/tmp/parent' })]
+    const result = normalizeFolderWorkspaces([workspace({ folderPath: undefined })], groups)
+    expect(result[0]?.folderPath).toBe('/tmp/parent')
+  })
+
+  it('preserves an explicit null connectionId instead of inheriting from the group', () => {
+    const groups = [group({ id: 'group-1', parentPath: '/tmp/parent', connectionId: 'ssh-remote' })]
+    const result = normalizeFolderWorkspaces([workspace({ connectionId: null })], groups)
+    expect(result[0]?.connectionId).toBeNull()
+  })
+})

--- a/src/shared/folder-workspaces.ts
+++ b/src/shared/folder-workspaces.ts
@@ -19,11 +19,11 @@ export function normalizeFolderWorkspaces(
   if (!Array.isArray(value)) {
     return []
   }
-  const folderGroups = new Map<string, ProjectGroup>()
+  // Groups without a parentPath (manual groups) still own workspaces that carry
+  // their own folderPath; requiring parentPath here silently deleted them on load.
+  const groupsById = new Map<string, ProjectGroup>()
   for (const group of projectGroups) {
-    if (group.parentPath) {
-      folderGroups.set(group.id, group)
-    }
+    groupsById.set(group.id, group)
   }
 
   const workspaces: FolderWorkspace[] = []
@@ -38,11 +38,11 @@ export function normalizeFolderWorkspaces(
       raw.id.trim().length === 0 ||
       seen.has(raw.id) ||
       typeof raw.projectGroupId !== 'string' ||
-      !folderGroups.has(raw.projectGroupId)
+      !groupsById.has(raw.projectGroupId)
     ) {
       continue
     }
-    const group = folderGroups.get(raw.projectGroupId)
+    const group = groupsById.get(raw.projectGroupId)
     const folderPath =
       typeof raw.folderPath === 'string' && raw.folderPath.trim().length > 0
         ? raw.folderPath

--- a/src/shared/folder-workspaces.ts
+++ b/src/shared/folder-workspaces.ts
@@ -19,12 +19,7 @@ export function normalizeFolderWorkspaces(
   if (!Array.isArray(value)) {
     return []
   }
-  // Groups without a parentPath (manual groups) still own workspaces that carry
-  // their own folderPath; requiring parentPath here silently deleted them on load.
-  const groupsById = new Map<string, ProjectGroup>()
-  for (const group of projectGroups) {
-    groupsById.set(group.id, group)
-  }
+  const groupsById = new Map(projectGroups.map((group) => [group.id, group]))
 
   const workspaces: FolderWorkspace[] = []
   const seen = new Set<string>()

--- a/tests/e2e/folder-workspace-manual-group-restart.spec.ts
+++ b/tests/e2e/folder-workspace-manual-group-restart.spec.ts
@@ -1,0 +1,81 @@
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import type { ElectronApplication } from '@stablyai/playwright-test'
+import { expect, test } from './helpers/orca-app'
+import { createRestartSession } from './helpers/orca-restart'
+import { waitForSessionReady } from './helpers/store'
+
+test('manual-group folder workspace remains visible across a headed restart @headful', async (// oxlint-disable-next-line no-empty-pattern -- This restart test owns its Electron launches.
+{}, testInfo) => {
+  test.setTimeout(300_000)
+  const session = createRestartSession(testInfo)
+  const dataFile = path.join(session.userDataDir, 'orca-data.json')
+  const folderPath = path.join(session.userDataDir, 'manual-folder')
+  const groupId = 'manual-folder-group'
+  const workspaceId = 'manual-folder-workspace'
+  const workspaceName = 'Persisted manual folder'
+  mkdirSync(folderPath)
+  const state = JSON.parse(readFileSync(dataFile, 'utf-8')) as Record<string, unknown>
+  const now = Date.now()
+  state.projectGroups = [
+    {
+      id: groupId,
+      name: 'Manual folder group',
+      parentPath: null,
+      connectionId: null,
+      parentGroupId: null,
+      createdFrom: 'manual',
+      tabOrder: 0,
+      isCollapsed: false,
+      color: null,
+      createdAt: now,
+      updatedAt: now
+    }
+  ]
+  state.folderWorkspaces = [
+    {
+      id: workspaceId,
+      projectGroupId: groupId,
+      name: workspaceName,
+      folderPath,
+      connectionId: null,
+      linkedTask: null,
+      linkedTaskSourceContext: null,
+      comment: '',
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: now,
+      lastActivityAt: now,
+      createdAt: now,
+      updatedAt: now
+    }
+  ]
+  writeFileSync(dataFile, `${JSON.stringify(state, null, 2)}\n`, 'utf-8')
+
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+  const workspaceRow = (page: Awaited<ReturnType<typeof session.launch>>['page']) =>
+    page.locator(`[data-worktree-id="folder:${workspaceId}"]`)
+  try {
+    const first = await session.launch()
+    firstApp = first.app
+    await waitForSessionReady(first.page)
+    await expect(workspaceRow(first.page)).toContainText(workspaceName)
+
+    await session.close(firstApp)
+    firstApp = null
+
+    const second = await session.launch()
+    secondApp = second.app
+    await waitForSessionReady(second.page)
+    await expect(workspaceRow(second.page)).toContainText(workspaceName)
+  } finally {
+    for (const app of [secondApp, firstApp]) {
+      if (app) {
+        await session.close(app)
+      }
+    }
+    await session.dispose()
+  }
+})


### PR DESCRIPTION
## Summary

`normalizeFolderWorkspaces` (src/shared/folder-workspaces.ts) only accepts persisted folder workspaces whose project group has a `parentPath`. A workspace created in a **manual group** (no `parentPath`) — reachable today via the `folderWorkspace.create` runtime RPC, which accepts any `projectGroupId` and an explicit `folderPath` — is silently dropped on the next app launch, and the prune **persists on the following save: real data loss**, including the workspace's tabs/terminal session wiring.

The invariant dates from when the only creation path was the "+" button of a folder-scan group, where the workspace inherited the group's path. A workspace that carries its own `folderPath` doesn't need the group to have one.

This bit me in practice: two workspaces created via RPC in manual groups survived for days (the loader only runs at launch) and vanished after the next app update relaunched it. The objects were still referenced by the persisted session state — only the `folderWorkspaces` entries were gone.

## Fix

Normalization now keeps a workspace when its group **exists**, and only falls back to the group's `parentPath` when the workspace has no `folderPath` of its own. Still dropped: workspaces whose group is missing, and workspaces with no path from either source.

## Tests

New `src/shared/folder-workspaces.test.ts` covering: own-path workspace in a manual group survives, missing group still drops, no-path-anywhere still drops, group `parentPath` fallback, and explicit `connectionId: null` preservation.

🤖 Generated with [Claude Code](https://claude.com/claude-code)