### PR TITLE
fix(terminal): compose Hangul on iPadOS by mirroring field edits to the PTY

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.test.ts
@@ -1,0 +1,204 @@
+// @vitest-environment happy-dom
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  buildTerminalIosTextEditPayload,
+  computeTerminalIosTextEditStep,
+  installTerminalIosTextEditMirror
+} from './terminal-ios-text-edit-mirror'
+
+const DEL = '\x7f'
+
+/**
+ * Field values observed on iPadOS 26.5.2 with a hardware 2-set Korean keyboard
+ * while typing `한글깨짐`, one entry per `input` event. The system fires no
+ * composition events: it deletes the trailing syllable and reinserts the
+ * updated one. Note the `ㅣ` step — one deletion, two characters back.
+ */
+const IPADOS_HANGUL_FIELD_SEQUENCE = [
+  'ㅎ',
+  '',
+  '하',
+  '',
+  '한',
+  '한ㄱ',
+  '한',
+  '한그',
+  '한',
+  '한글',
+  '한글ㄲ',
+  '한글',
+  '한글깨',
+  '한글',
+  '한글깾',
+  '한글',
+  '한글깨지',
+  '한글깨',
+  '한글깨짐'
+] as const
+
+/** Applies PTY bytes the way a line editor does, so the test asserts what the user ends up seeing. */
+function applyTerminalPayload(buffer: string, payload: string): string {
+  let result = Array.from(buffer)
+  for (const char of Array.from(payload)) {
+    if (char === DEL) {
+      result = result.slice(0, -1)
+    } else {
+      result.push(char)
+    }
+  }
+  return result.join('')
+}
+
+const openContainers: HTMLElement[] = []
+
+function openMirror(): {
+  textarea: HTMLTextAreaElement
+  sent: string[]
+  mirror: ReturnType<typeof installTerminalIosTextEditMirror>
+} {
+  const container = document.createElement('div')
+  const textarea = document.createElement('textarea')
+  textarea.classList.add('xterm-helper-textarea')
+  container.appendChild(textarea)
+  document.body.appendChild(container)
+  openContainers.push(container)
+  const sent: string[] = []
+  const mirror = installTerminalIosTextEditMirror({
+    terminalElement: container,
+    sendInput: (data) => sent.push(data)
+  })
+  return { textarea, sent, mirror }
+}
+
+function typeIntoField(textarea: HTMLTextAreaElement, value: string): void {
+  textarea.value = value
+  textarea.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+afterEach(() => {
+  for (const container of openContainers.splice(0)) {
+    container.remove()
+  }
+})
+
+describe('computeTerminalIosTextEditStep', () => {
+  it('appends without erasing when the field only grew', () => {
+    expect(computeTerminalIosTextEditStep('한글', '한글깨')).toEqual({
+      eraseCount: 0,
+      appendText: '깨'
+    })
+  })
+
+  it('erases the diverging tail before appending the replacement', () => {
+    expect(computeTerminalIosTextEditStep('하', '한')).toEqual({ eraseCount: 1, appendText: '한' })
+  })
+
+  it('handles a replacement that is longer than what it replaced', () => {
+    // Why: typing ㅣ after 깾 emits one deleteContentBackward and reinserts two characters.
+    expect(computeTerminalIosTextEditStep('한글깾', '한글깨지')).toEqual({
+      eraseCount: 1,
+      appendText: '깨지'
+    })
+  })
+
+  it('counts erasures in code points, not UTF-16 units', () => {
+    expect(computeTerminalIosTextEditStep('가😀', '가')).toEqual({ eraseCount: 1, appendText: '' })
+  })
+
+  it('emits nothing when the field is unchanged', () => {
+    expect(computeTerminalIosTextEditStep('한글', '한글')).toEqual({
+      eraseCount: 0,
+      appendText: ''
+    })
+  })
+})
+
+describe('buildTerminalIosTextEditPayload', () => {
+  it('sends one DEL per erased code point ahead of the replacement', () => {
+    expect(buildTerminalIosTextEditPayload({ eraseCount: 2, appendText: '글' })).toBe(
+      `${DEL}${DEL}글`
+    )
+  })
+
+  it('is empty when there is nothing to erase or append', () => {
+    expect(buildTerminalIosTextEditPayload({ eraseCount: 0, appendText: '' })).toBe('')
+  })
+})
+
+describe('installTerminalIosTextEditMirror', () => {
+  it('reproduces the recorded iPadOS sequence as composed syllables', () => {
+    const { textarea, sent } = openMirror()
+    for (const value of IPADOS_HANGUL_FIELD_SEQUENCE) {
+      typeIntoField(textarea, value)
+    }
+    const rendered = sent.reduce(applyTerminalPayload, '')
+    expect(rendered).toBe('한글깨짐')
+  })
+
+  it('never leaves a lone jamo as the final PTY state', () => {
+    const { textarea, sent } = openMirror()
+    for (const value of IPADOS_HANGUL_FIELD_SEQUENCE) {
+      typeIntoField(textarea, value)
+    }
+    const rendered = sent.reduce(applyTerminalPayload, '')
+    const compatibilityJamo = Array.from(rendered).filter((char) => {
+      const codePoint = char.codePointAt(0) ?? 0
+      return codePoint >= 0x3130 && codePoint <= 0x318f
+    })
+    expect(compatibilityJamo).toEqual([])
+  })
+
+  it('stops the input event so xterm cannot send the same text again', () => {
+    const { textarea } = openMirror()
+    let reachedTextareaListener = false
+    textarea.addEventListener('input', () => {
+      reachedTextareaListener = true
+    })
+    typeIntoField(textarea, 'ㅎ')
+    expect(reachedTextareaListener).toBe(false)
+  })
+
+  it('ignores input events from other fields inside the pane, such as terminal search', () => {
+    const { textarea, sent } = openMirror()
+    const searchField = document.createElement('input')
+    searchField.value = 'unrelated'
+    textarea.parentElement?.appendChild(searchField)
+    searchField.dispatchEvent(new Event('input', { bubbles: true }))
+    expect(sent).toEqual([])
+  })
+
+  it('reset clears the field so the next edit does not replay sent text', () => {
+    const { textarea, sent, mirror } = openMirror()
+    typeIntoField(textarea, '한')
+    mirror.reset()
+    expect(textarea.value).toBe('')
+    typeIntoField(textarea, '글')
+    expect(sent).toEqual(['한', '글'])
+  })
+
+  it('reset on blur keeps a refocused pane from erasing text the PTY still holds', () => {
+    const { textarea, sent } = openMirror()
+    typeIntoField(textarea, '한')
+    textarea.dispatchEvent(new Event('blur', { bubbles: true }))
+    typeIntoField(textarea, '글')
+    expect(sent).toEqual(['한', '글'])
+  })
+
+  it('stops mirroring once disposed', () => {
+    const { textarea, sent, mirror } = openMirror()
+    mirror.dispose()
+    typeIntoField(textarea, 'ㅎ')
+    expect(sent).toEqual([])
+  })
+
+  it('is inert without a terminal element', () => {
+    const mirror = installTerminalIosTextEditMirror({
+      terminalElement: null,
+      sendInput: () => {
+        throw new Error('should not send')
+      }
+    })
+    expect(() => mirror.reset()).not.toThrow()
+    expect(() => mirror.dispose()).not.toThrow()
+  })
+})

--- a/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.test.ts
@@ -184,6 +184,60 @@ describe('installTerminalIosTextEditMirror', () => {
     expect(sent).toEqual(['한', '글'])
   })
 
+  it('stands aside for input sources that do run a composition session', () => {
+    // Why: the iPad on-screen keyboard and the Japanese/Chinese IMEs compose
+    // normally; xterm commits those by reading the field, so mirroring them
+    // would send the same text twice.
+    const { textarea, sent } = openMirror()
+    let reachedTextareaListener = false
+    textarea.addEventListener('input', () => {
+      reachedTextareaListener = true
+    })
+    textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    typeIntoField(textarea, 'に')
+    typeIntoField(textarea, 'にほ')
+    expect(sent).toEqual([])
+    expect(reachedTextareaListener).toBe(true)
+  })
+
+  it('resumes mirroring after the composition session ends', () => {
+    const { textarea, sent } = openMirror()
+    textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
+    typeIntoField(textarea, 'にほん')
+    textarea.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    // Why: xterm already sent the composed text, so the next diff must start empty.
+    typeIntoField(textarea, 'にほんㅎ')
+    expect(sent).toEqual(['にほんㅎ'])
+  })
+
+  it('reports when it is the one writing, so external PTY writes can be told apart', () => {
+    const container = document.createElement('div')
+    const textarea = document.createElement('textarea')
+    textarea.classList.add('xterm-helper-textarea')
+    container.appendChild(textarea)
+    document.body.appendChild(container)
+    openContainers.push(container)
+    const mirroringDuringSend: boolean[] = []
+    const mirror = installTerminalIosTextEditMirror({
+      terminalElement: container,
+      sendInput: () => mirroringDuringSend.push(mirror.isMirroring())
+    })
+    typeIntoField(textarea, 'ㅎ')
+    expect(mirroringDuringSend).toEqual([true])
+    expect(mirror.isMirroring()).toBe(false)
+  })
+
+  it('ignores blur from other elements in the pane', () => {
+    const { textarea, sent } = openMirror()
+    typeIntoField(textarea, '한')
+    const searchField = document.createElement('input')
+    textarea.parentElement?.appendChild(searchField)
+    searchField.dispatchEvent(new Event('blur', { bubbles: true }))
+    expect(textarea.value).toBe('한')
+    typeIntoField(textarea, '한글')
+    expect(sent).toEqual(['한', '글'])
+  })
+
   it('stops mirroring once disposed', () => {
     const { textarea, sent, mirror } = openMirror()
     mirror.dispose()

--- a/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.test.ts
@@ -200,11 +200,12 @@ describe('installTerminalIosTextEditMirror', () => {
     expect(reachedTextareaListener).toBe(true)
   })
 
-  it('resumes mirroring after the composition session ends', () => {
+  it('resumes mirroring after the composition session ends', async () => {
     const { textarea, sent } = openMirror()
     textarea.dispatchEvent(new CompositionEvent('compositionstart', { bubbles: true }))
     typeIntoField(textarea, 'にほん')
     textarea.dispatchEvent(new CompositionEvent('compositionend', { bubbles: true }))
+    await Promise.resolve()
     // Why: xterm already sent the composed text, so the next diff must start empty.
     typeIntoField(textarea, 'にほんㅎ')
     expect(sent).toEqual(['にほんㅎ'])

--- a/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.ts
@@ -49,14 +49,17 @@ export function buildTerminalIosTextEditPayload(step: TerminalIosTextEditStep): 
 
 export type TerminalIosTextEditMirror = IDisposable & {
   /**
-   * Drops mirrored state once xterm writes to the PTY itself, so the next edit
+   * Drops mirrored state once anything else writes to the PTY, so the next edit
    * diffs against an empty field instead of replaying text the PTY already has.
    */
   reset: () => void
+  /** True only while this mirror is the one writing to the PTY. */
+  isMirroring: () => boolean
 }
 
 const NO_OP_MIRROR: TerminalIosTextEditMirror = {
   reset: () => undefined,
+  isMirroring: () => false,
   dispose: () => undefined
 }
 
@@ -81,6 +84,8 @@ export function installTerminalIosTextEditMirror(args: {
 
   const terminalElement = args.terminalElement
   let sentText = ''
+  let composing = false
+  let mirroring = false
 
   const reset = (): void => {
     sentText = ''
@@ -90,7 +95,23 @@ export function installTerminalIosTextEditMirror(args: {
     }
   }
 
+  // Why: some iOS input sources (the on-screen keyboard, Japanese and Chinese
+  // IMEs) do run a composition session. xterm's CompositionHelper already
+  // handles those correctly, and it commits by reading the field itself — so
+  // the mirror must stand aside for the whole session or the text is sent
+  // twice. Only the session end clears `sentText`; the field belongs to xterm.
+  const beginComposition = (): void => {
+    composing = true
+  }
+  const endComposition = (): void => {
+    composing = false
+    sentText = ''
+  }
+
   const mirrorTextEdit = (event: Event): void => {
+    if (composing) {
+      return
+    }
     const textarea = asHelperTextarea(event.target)
     if (!textarea) {
       return
@@ -101,19 +122,36 @@ export function installTerminalIosTextEditMirror(args: {
     // syllable, so xterm must not also read it as fresh input.
     event.stopImmediatePropagation()
     const payload = buildTerminalIosTextEditPayload(step)
-    if (payload) {
+    if (!payload) {
+      return
+    }
+    mirroring = true
+    try {
       args.sendInput(payload)
+    } finally {
+      mirroring = false
+    }
+  }
+
+  const resetOnHelperTextareaBlur = (event: Event): void => {
+    if (asHelperTextarea(event.target)) {
+      reset()
     }
   }
 
   terminalElement.addEventListener('input', mirrorTextEdit, true)
-  terminalElement.addEventListener('blur', reset, true)
+  terminalElement.addEventListener('compositionstart', beginComposition, true)
+  terminalElement.addEventListener('compositionend', endComposition, true)
+  terminalElement.addEventListener('blur', resetOnHelperTextareaBlur, true)
 
   return {
     reset,
+    isMirroring: () => mirroring,
     dispose: () => {
       terminalElement.removeEventListener('input', mirrorTextEdit, true)
-      terminalElement.removeEventListener('blur', reset, true)
+      terminalElement.removeEventListener('compositionstart', beginComposition, true)
+      terminalElement.removeEventListener('compositionend', endComposition, true)
+      terminalElement.removeEventListener('blur', resetOnHelperTextareaBlur, true)
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.ts
@@ -1,0 +1,119 @@
+import type { IDisposable } from '@xterm/xterm'
+
+// Why: iOS/iPadOS composes Hangul with a hardware keyboard by rewriting text it
+// has already committed — `deleteContentBackward` then `insertText` with the
+// updated syllable — and fires no composition events at all. xterm cannot see
+// that: it consumes the printable keydown, so the system's input logic never
+// runs and the raw compatibility jamo in `event.key` reaches the PTY instead.
+// Letting the keydown through and mirroring the field's edits keeps composition
+// working. The diff is taken against the field rather than the edit events so a
+// stray delete cannot desync the PTY.
+
+const TERMINAL_DEL_BYTE = '\x7f'
+
+export type TerminalIosTextEditStep = {
+  readonly eraseCount: number
+  readonly appendText: string
+}
+
+/**
+ * Diffs text already sent to the PTY against the field's current value, as
+ * "erase this many code points, then append this".
+ *
+ * Erasures are counted in code points, not UTF-16 units, because one Hangul
+ * syllable is one code point and one terminal DEL.
+ */
+export function computeTerminalIosTextEditStep(
+  sentText: string,
+  fieldText: string
+): TerminalIosTextEditStep {
+  const sent = Array.from(sentText)
+  const field = Array.from(fieldText)
+  let commonPrefixLength = 0
+  while (
+    commonPrefixLength < sent.length &&
+    commonPrefixLength < field.length &&
+    sent[commonPrefixLength] === field[commonPrefixLength]
+  ) {
+    commonPrefixLength += 1
+  }
+  return {
+    eraseCount: sent.length - commonPrefixLength,
+    appendText: field.slice(commonPrefixLength).join('')
+  }
+}
+
+export function buildTerminalIosTextEditPayload(step: TerminalIosTextEditStep): string {
+  return TERMINAL_DEL_BYTE.repeat(step.eraseCount) + step.appendText
+}
+
+export type TerminalIosTextEditMirror = IDisposable & {
+  /**
+   * Drops mirrored state once xterm writes to the PTY itself, so the next edit
+   * diffs against an empty field instead of replaying text the PTY already has.
+   */
+  reset: () => void
+}
+
+const NO_OP_MIRROR: TerminalIosTextEditMirror = {
+  reset: () => undefined,
+  dispose: () => undefined
+}
+
+function findHelperTextarea(root: HTMLElement): HTMLTextAreaElement | null {
+  return root.querySelector<HTMLTextAreaElement>('.xterm-helper-textarea')
+}
+
+function asHelperTextarea(target: EventTarget | null): HTMLTextAreaElement | null {
+  if (!(target instanceof HTMLTextAreaElement)) {
+    return null
+  }
+  return target.classList.contains('xterm-helper-textarea') ? target : null
+}
+
+export function installTerminalIosTextEditMirror(args: {
+  terminalElement: HTMLElement | null | undefined
+  sendInput: (data: string) => void
+}): TerminalIosTextEditMirror {
+  if (!args.terminalElement) {
+    return NO_OP_MIRROR
+  }
+
+  const terminalElement = args.terminalElement
+  let sentText = ''
+
+  const reset = (): void => {
+    sentText = ''
+    const textarea = findHelperTextarea(terminalElement)
+    if (textarea) {
+      textarea.value = ''
+    }
+  }
+
+  const mirrorTextEdit = (event: Event): void => {
+    const textarea = asHelperTextarea(event.target)
+    if (!textarea) {
+      return
+    }
+    const step = computeTerminalIosTextEditStep(sentText, textarea.value)
+    sentText = textarea.value
+    // Why: the field keeps its text so the system can rewrite the trailing
+    // syllable, so xterm must not also read it as fresh input.
+    event.stopImmediatePropagation()
+    const payload = buildTerminalIosTextEditPayload(step)
+    if (payload) {
+      args.sendInput(payload)
+    }
+  }
+
+  terminalElement.addEventListener('input', mirrorTextEdit, true)
+  terminalElement.addEventListener('blur', reset, true)
+
+  return {
+    reset,
+    dispose: () => {
+      terminalElement.removeEventListener('input', mirrorTextEdit, true)
+      terminalElement.removeEventListener('blur', reset, true)
+    }
+  }
+}

--- a/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-ios-text-edit-mirror.ts
@@ -11,8 +11,13 @@ import type { IDisposable } from '@xterm/xterm'
 
 const TERMINAL_DEL_BYTE = '\x7f'
 
+/**
+ * Represents a text edit step computed by diffing the field against sent text.
+ */
 export type TerminalIosTextEditStep = {
+  /** The number of code points to erase from the PTY. */
   readonly eraseCount: number
+  /** The text to append to the PTY after erasing. */
   readonly appendText: string
 }
 
@@ -43,10 +48,16 @@ export function computeTerminalIosTextEditStep(
   }
 }
 
+/**
+ * Builds the raw payload string (DEL bytes + appendText) for a text edit step.
+ */
 export function buildTerminalIosTextEditPayload(step: TerminalIosTextEditStep): string {
   return TERMINAL_DEL_BYTE.repeat(step.eraseCount) + step.appendText
 }
 
+/**
+ * Controller for the terminal iOS text edit mirror.
+ */
 export type TerminalIosTextEditMirror = IDisposable & {
   /**
    * Drops mirrored state once anything else writes to the PTY, so the next edit
@@ -74,6 +85,12 @@ function asHelperTextarea(target: EventTarget | null): HTMLTextAreaElement | nul
   return target.classList.contains('xterm-helper-textarea') ? target : null
 }
 
+/**
+ * Installs an edit mirror on the helper textarea inside the terminal element.
+ *
+ * Captures input events on iOS/iPadOS WebKit to diff text already sent against the field's
+ * current value, allowing hardware-keyboard Hangul input to reach the PTY.
+ */
 export function installTerminalIosTextEditMirror(args: {
   terminalElement: HTMLElement | null | undefined
   sendInput: (data: string) => void
@@ -99,13 +116,17 @@ export function installTerminalIosTextEditMirror(args: {
   // IMEs) do run a composition session. xterm's CompositionHelper already
   // handles those correctly, and it commits by reading the field itself — so
   // the mirror must stand aside for the whole session or the text is sent
-  // twice. Only the session end clears `sentText`; the field belongs to xterm.
+  // twice. Only after the session end clears `sentText`; the field belongs to xterm.
+  // We defer clearing `composing` via queueMicrotask so xterm can complete its
+  // deferred composition commit before the mirror resumes.
   const beginComposition = (): void => {
     composing = true
   }
   const endComposition = (): void => {
-    composing = false
-    sentText = ''
+    queueMicrotask(() => {
+      composing = false
+      sentText = ''
+    })
   }
 
   const mirrorTextEdit = (event: Event): void => {

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -924,10 +924,19 @@ export function useTerminalPaneLifecycle({
               sendInput: (data) => pane.terminal.input(data)
             })
           : null
+        // Why: Ctrl+C, paste and xterm's own key handling all reach the PTY without a bypassed keydown; any of them makes mirrored field text stale.
+        const iosTextEditMirrorResync = iosTextEditMirror
+          ? pane.terminal.onData(() => {
+              if (!iosTextEditMirror.isMirroring()) {
+                iosTextEditMirror.reset()
+              }
+            })
+          : null
         imeCompositionDisposablesRef.current.set(pane.id, {
           dispose: () => {
             imeCompositionTracker.dispose()
             linuxImeCandidateState?.dispose()
+            iosTextEditMirrorResync?.dispose()
             iosTextEditMirror?.dispose()
           }
         })
@@ -1060,10 +1069,6 @@ export function useTerminalPaneLifecycle({
             hasSelection: pane.terminal.hasSelection(),
             kittyKeyboardFlags: paneKittyKeyboardModesRef.current.get(pane.id)?.flags ?? 0
           })
-          if (!shouldBypass && e.type === 'keydown') {
-            // Why: xterm is about to write to the PTY itself, so any text mirrored from the field is already stale.
-            iosTextEditMirror?.reset()
-          }
           observeLinuxCandidateEvent()
           return !shouldBypass
         })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -95,6 +95,8 @@ import {
   getMacNativeTextInputSourceTracker
 } from './terminal-ime-input-source'
 import { installTerminalImeNativeTextForwarder } from './terminal-ime-native-text-forwarder'
+import { installTerminalIosTextEditMirror } from './terminal-ios-text-edit-mirror'
+import { isCurrentPlatformIosWeb } from '@/lib/ios-web-platform'
 import {
   shouldBypassXtermKeyboardEvent,
   shouldHandleTerminalInterruptKeyboardEvent,
@@ -914,10 +916,19 @@ export function useTerminalPaneLifecycle({
           : null
         const macNativeTextInputSourceTracker = isMac ? getMacNativeTextInputSourceTracker() : null
         const imeCompositionTracker = installTerminalImeCompositionTracker(pane.terminal.element)
+        // Why: iOS/iPadOS composes CJK by rewriting the field and fires no composition events, so the field's edits are the only signal. See terminal-ios-text-edit-mirror.ts.
+        const isIosWeb = isCurrentPlatformIosWeb()
+        const iosTextEditMirror = isIosWeb
+          ? installTerminalIosTextEditMirror({
+              terminalElement: pane.terminal.element,
+              sendInput: (data) => pane.terminal.input(data)
+            })
+          : null
         imeCompositionDisposablesRef.current.set(pane.id, {
           dispose: () => {
             imeCompositionTracker.dispose()
             linuxImeCandidateState?.dispose()
+            iosTextEditMirror?.dispose()
           }
         })
         // Why: only known macOS native text paths (physical CJK/Vietnamese IME) need the keydown bypass; synthetic Unicode lacks physical key identity.
@@ -1045,9 +1056,14 @@ export function useTerminalPaneLifecycle({
 
           const shouldBypass = shouldBypassXtermKeyboardEvent(e, {
             isMac,
+            isIosWeb,
             hasSelection: pane.terminal.hasSelection(),
             kittyKeyboardFlags: paneKittyKeyboardModesRef.current.get(pane.id)?.flags ?? 0
           })
+          if (!shouldBypass && e.type === 'keydown') {
+            // Why: xterm is about to write to the PTY itself, so any text mirrored from the field is already stale.
+            iosTextEditMirror?.reset()
+          }
           observeLinuxCandidateEvent()
           return !shouldBypass
         })

--- a/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
+++ b/src/renderer/src/components/terminal-pane/use-terminal-pane-lifecycle.ts
@@ -924,13 +924,28 @@ export function useTerminalPaneLifecycle({
               sendInput: (data) => pane.terminal.input(data)
             })
           : null
-        // Why: Ctrl+C, paste and xterm's own key handling all reach the PTY without a bypassed keydown; any of them makes mirrored field text stale.
+        // Why: Ctrl+C, paste, xterm's key handling, and PTY output writes (prompts/responses) all make mirrored field text stale.
         const iosTextEditMirrorResync = iosTextEditMirror
-          ? pane.terminal.onData(() => {
-              if (!iosTextEditMirror.isMirroring()) {
-                iosTextEditMirror.reset()
+          ? (() => {
+              const onDataSub = pane.terminal.onData(() => {
+                if (!iosTextEditMirror.isMirroring()) {
+                  iosTextEditMirror.reset()
+                }
+              })
+              const originalWrite = pane.terminal.write.bind(pane.terminal)
+              pane.terminal.write = (...args: Parameters<typeof pane.terminal.write>) => {
+                if (!iosTextEditMirror.isMirroring()) {
+                  iosTextEditMirror.reset()
+                }
+                return originalWrite(...args)
               }
-            })
+              return {
+                dispose: () => {
+                  onDataSub.dispose()
+                  pane.terminal.write = originalWrite
+                }
+              }
+            })()
           : null
         imeCompositionDisposablesRef.current.set(pane.id, {
           dispose: () => {

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-ios.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-ios.test.ts
@@ -47,6 +47,14 @@ describe('shouldBypassXtermForIosTextEdit', () => {
     ).toBe(false)
   })
 
+  it('leaves composing keystrokes to xterm, for iOS sources that do compose', () => {
+    // Why: the on-screen keyboard and the Japanese/Chinese IMEs run a real
+    // composition session, which xterm's CompositionHelper already commits.
+    expect(
+      shouldBypassXtermForIosTextEdit(event({ ...HANGUL_JAMO_KEYDOWN, isComposing: true }), true)
+    ).toBe(false)
+  })
+
   it('is inert off iOS web, leaving desktop IME handling untouched', () => {
     expect(shouldBypassXtermForIosTextEdit(event(HANGUL_JAMO_KEYDOWN), false)).toBe(false)
   })

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy-ios.test.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy-ios.test.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  shouldBypassXtermForIosTextEdit,
+  shouldBypassXtermKeyboardEvent
+} from './xterm-bypass-policy'
+import { event } from './xterm-bypass-event-fixture'
+
+// iPadOS reports a real physical key for every jamo — `key: 'ㅎ'`, `code: 'KeyG'`,
+// `keyCode: 71`, `isComposing: false` — and runs no composition session. Only by
+// leaving those keys to the default handler does the system compose them.
+const HANGUL_JAMO_KEYDOWN = { key: 'ㅎ', code: 'KeyG', keyCode: 71 }
+
+describe('shouldBypassXtermForIosTextEdit', () => {
+  it('claims an unmodified jamo keydown on iOS web', () => {
+    expect(shouldBypassXtermForIosTextEdit(event(HANGUL_JAMO_KEYDOWN), true)).toBe(true)
+  })
+
+  it('claims the matching keyup and keypress so xterm cannot re-send the glyph', () => {
+    for (const type of ['keyup', 'keypress']) {
+      expect(shouldBypassXtermForIosTextEdit(event({ ...HANGUL_JAMO_KEYDOWN, type }), true)).toBe(
+        true
+      )
+    }
+  })
+
+  it('leaves ASCII alone so English typing keeps the normal xterm path', () => {
+    expect(
+      shouldBypassXtermForIosTextEdit(event({ key: 'a', code: 'KeyA', keyCode: 65 }), true)
+    ).toBe(false)
+  })
+
+  it('leaves named keys alone so Enter and arrows still reach the shell', () => {
+    for (const key of ['Enter', 'Backspace', 'ArrowLeft', 'Escape']) {
+      expect(shouldBypassXtermForIosTextEdit(event({ key }), true)).toBe(false)
+    }
+  })
+
+  it('leaves modifier chords alone so shortcuts are not swallowed', () => {
+    expect(
+      shouldBypassXtermForIosTextEdit(event({ ...HANGUL_JAMO_KEYDOWN, ctrlKey: true }), true)
+    ).toBe(false)
+    expect(
+      shouldBypassXtermForIosTextEdit(event({ ...HANGUL_JAMO_KEYDOWN, metaKey: true }), true)
+    ).toBe(false)
+    expect(
+      shouldBypassXtermForIosTextEdit(event({ ...HANGUL_JAMO_KEYDOWN, altKey: true }), true)
+    ).toBe(false)
+  })
+
+  it('is inert off iOS web, leaving desktop IME handling untouched', () => {
+    expect(shouldBypassXtermForIosTextEdit(event(HANGUL_JAMO_KEYDOWN), false)).toBe(false)
+  })
+})
+
+describe('shouldBypassXtermKeyboardEvent — iOS web', () => {
+  const iosOptions = { isMac: true, isIosWeb: true, hasSelection: false }
+  const macOptions = { isMac: true, hasSelection: false }
+
+  it('bypasses a bare jamo keydown', () => {
+    expect(shouldBypassXtermKeyboardEvent(event(HANGUL_JAMO_KEYDOWN), iosOptions)).toBe(true)
+  })
+
+  it('does not bypass the same key on a Mac desktop browser', () => {
+    // Why: iPadOS reports `Macintosh` in its default desktop mode, so `isMac`
+    // alone must not turn the iOS path on for real Macs.
+    expect(shouldBypassXtermKeyboardEvent(event(HANGUL_JAMO_KEYDOWN), macOptions)).toBe(false)
+  })
+
+  it('still bypasses Shift+jamo without the iOS flag, as it did before', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(
+        event({ key: 'ㄲ', code: 'KeyR', keyCode: 82, shiftKey: true }),
+        macOptions
+      )
+    ).toBe(true)
+  })
+
+  it('keeps Cmd+C bubbling on iOS web', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(event({ key: 'c', code: 'KeyC', metaKey: true }), iosOptions)
+    ).toBe(true)
+  })
+
+  it('keeps Enter on xterm so the command is submitted', () => {
+    expect(
+      shouldBypassXtermKeyboardEvent(
+        event({ key: 'Enter', code: 'Enter', keyCode: 13 }),
+        iosOptions
+      )
+    ).toBe(false)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -134,6 +134,11 @@ export function shouldBypassXtermForIosTextEdit(
   if (!isIosWeb || event.ctrlKey || event.metaKey || event.altKey) {
     return false
   }
+  if (event.isComposing === true) {
+    // Why: input sources that do run a composition session stay with xterm's
+    // CompositionHelper, which already commits them correctly.
+    return false
+  }
   if (!isXtermHandledKeyEvent(event.type) && event.type !== 'keypress') {
     return false
   }

--- a/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
+++ b/src/renderer/src/components/terminal-pane/xterm-bypass-policy.ts
@@ -37,6 +37,10 @@ export type XtermBypassOptions = {
    *  Windows/Linux should only bubble to clipboard when something is selected,
    *  otherwise it must reach the shell as SIGINT. */
   hasSelection: boolean
+  /** True when the renderer runs inside iOS/iPadOS WebKit, where the system
+   *  composes CJK text by rewriting the field instead of running a composition
+   *  session. See `terminal-ios-text-edit-mirror.ts`. */
+  isIosWeb?: boolean
 }
 
 export type XtermImeKeyboardOptions = {
@@ -113,6 +117,27 @@ export function shouldBypassXtermForMacNativeText(
 
 function isXtermHandledKeyEvent(type: string): boolean {
   return type === 'keydown' || type === 'keyup'
+}
+
+/**
+ * Why: iOS/iPadOS composes CJK text by rewriting the field through
+ * `beforeinput`/`input`, with no composition session, and that only runs when
+ * the printable keydown reaches the default handler. xterm has to stay out of
+ * the way for those keys so `terminal-ios-text-edit-mirror.ts` can mirror the
+ * resulting edits. `keypress` is included because `_keyPress` would otherwise
+ * send the glyph a second time alongside the mirror.
+ */
+export function shouldBypassXtermForIosTextEdit(
+  event: XtermBypassEvent,
+  isIosWeb: boolean
+): boolean {
+  if (!isIosWeb || event.ctrlKey || event.metaKey || event.altKey) {
+    return false
+  }
+  if (!isXtermHandledKeyEvent(event.type) && event.type !== 'keypress') {
+    return false
+  }
+  return isSingleNonAsciiPrintableText(event.key)
 }
 
 /** Returns whether xterm must not process an IME-owned keyboard event. */
@@ -244,6 +269,9 @@ export function shouldBypassXtermKeyboardEvent(
   event: XtermBypassEvent,
   options: XtermBypassOptions
 ): boolean {
+  if (shouldBypassXtermForIosTextEdit(event, options.isIosWeb === true)) {
+    return true
+  }
   if (!isXtermHandledKeyEvent(event.type)) {
     return false
   }

--- a/src/renderer/src/lib/ios-web-platform.test.ts
+++ b/src/renderer/src/lib/ios-web-platform.test.ts
@@ -1,0 +1,42 @@
+import { describe, expect, it } from 'vitest'
+import { isIosWebPlatform } from './ios-web-platform'
+
+const IPAD_DESKTOP_MODE_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Safari/605.1.15'
+const IPAD_MOBILE_MODE_UA =
+  'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
+const IPHONE_UA =
+  'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+const MAC_DESKTOP_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+const MAC_ELECTRON_UA =
+  'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) orca/1.0.0 Chrome/126.0.0.0 Electron/31.0.0 Safari/537.36'
+const WINDOWS_UA =
+  'Mozilla/5.0 (Windows NT 10.0; Win64; x64) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
+const ANDROID_UA =
+  'Mozilla/5.0 (Linux; Android 14; Pixel 8) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Mobile Safari/537.36'
+
+describe('isIosWebPlatform', () => {
+  it('detects iPadOS desktop mode, which reports Macintosh and omits iPad', () => {
+    expect(isIosWebPlatform(IPAD_DESKTOP_MODE_UA, 5)).toBe(true)
+  })
+
+  it('detects iPad and iPhone mobile-mode user agents', () => {
+    expect(isIosWebPlatform(IPAD_MOBILE_MODE_UA, 5)).toBe(true)
+    expect(isIosWebPlatform(IPHONE_UA, 5)).toBe(true)
+  })
+
+  it('detects a mobile-mode iPad even when the touch count is unavailable', () => {
+    expect(isIosWebPlatform(IPAD_MOBILE_MODE_UA, 0)).toBe(true)
+  })
+
+  it('does not claim a Mac browser or the Electron app', () => {
+    expect(isIosWebPlatform(MAC_DESKTOP_UA, 0)).toBe(false)
+    expect(isIosWebPlatform(MAC_ELECTRON_UA, 0)).toBe(false)
+  })
+
+  it('does not claim Windows, Linux or Android', () => {
+    expect(isIosWebPlatform(WINDOWS_UA, 0)).toBe(false)
+    expect(isIosWebPlatform(ANDROID_UA, 5)).toBe(false)
+  })
+})

--- a/src/renderer/src/lib/ios-web-platform.test.ts
+++ b/src/renderer/src/lib/ios-web-platform.test.ts
@@ -7,6 +7,8 @@ const IPAD_MOBILE_MODE_UA =
   'Mozilla/5.0 (iPad; CPU OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) CriOS/120.0.0.0 Mobile/15E148 Safari/604.1'
 const IPHONE_UA =
   'Mozilla/5.0 (iPhone; CPU iPhone OS 17_0 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/17.0 Mobile/15E148 Safari/604.1'
+const IPOD_UA =
+  'Mozilla/5.0 (iPod touch; CPU iPhone OS 14_8 like Mac OS X) AppleWebKit/605.1.15 (KHTML, like Gecko) Version/14.1.2 Mobile/15E148 Safari/604.1'
 const MAC_DESKTOP_UA =
   'Mozilla/5.0 (Macintosh; Intel Mac OS X 10_15_7) AppleWebKit/537.36 (KHTML, like Gecko) Chrome/126.0.0.0 Safari/537.36'
 const MAC_ELECTRON_UA =
@@ -21,9 +23,10 @@ describe('isIosWebPlatform', () => {
     expect(isIosWebPlatform(IPAD_DESKTOP_MODE_UA, 5)).toBe(true)
   })
 
-  it('detects iPad and iPhone mobile-mode user agents', () => {
+  it('detects iPad, iPhone and iPod mobile-mode user agents', () => {
     expect(isIosWebPlatform(IPAD_MOBILE_MODE_UA, 5)).toBe(true)
     expect(isIosWebPlatform(IPHONE_UA, 5)).toBe(true)
+    expect(isIosWebPlatform(IPOD_UA, 5)).toBe(true)
   })
 
   it('detects a mobile-mode iPad even when the touch count is unavailable', () => {

--- a/src/renderer/src/lib/ios-web-platform.ts
+++ b/src/renderer/src/lib/ios-web-platform.ts
@@ -16,6 +16,10 @@ export function isIosWebPlatform(userAgent: string, maxTouchPoints: number): boo
   return userAgent.includes('Mac') && maxTouchPoints > 1
 }
 
+/**
+ * Returns true if the current environment is an iOS or iPadOS web client browser.
+ * Safe to invoke in SSR or non-DOM environments where navigator is undefined.
+ */
 export function isCurrentPlatformIosWeb(): boolean {
   if (typeof navigator === 'undefined') {
     return false

--- a/src/renderer/src/lib/ios-web-platform.ts
+++ b/src/renderer/src/lib/ios-web-platform.ts
@@ -1,0 +1,24 @@
+/**
+ * True when the renderer runs inside iOS/iPadOS WebKit — the web client opened
+ * in a browser on an iPhone or iPad.
+ *
+ * Every iOS and iPadOS user agent contains `Mac`: iPad desktop mode (the
+ * default since iPadOS 13) reports `Macintosh; Intel Mac OS X`, and mobile mode
+ * reports `like Mac OS X`. Desktop mode omits `iPad`, so the touch-point count
+ * is the only signal separating an iPad from a Mac. Both browsers on the
+ * platform are WebKit — iOS bars third-party engines — so this covers Safari,
+ * Chrome and the rest alike.
+ */
+export function isIosWebPlatform(userAgent: string, maxTouchPoints: number): boolean {
+  if (/iPad|iPhone|iPod/.test(userAgent)) {
+    return true
+  }
+  return userAgent.includes('Mac') && maxTouchPoints > 1
+}
+
+export function isCurrentPlatformIosWeb(): boolean {
+  if (typeof navigator === 'undefined') {
+    return false
+  }
+  return isIosWebPlatform(navigator.userAgent, navigator.maxTouchPoints)
+}


### PR DESCRIPTION
## Summary

Korean typed on an iPadOS hardware keyboard reached the terminal as uncomposed
compatibility jamo in the `orca serve` web client — `한글깨짐` arrived as
`ㅎㅏㄴㄱㅡㄹㄲㅐㅈㅣㅁ`. It reproduces in both Safari and Chrome, which share the
system WebKit engine on iOS.

iPadOS composes Hangul with a hardware keyboard by **rewriting text it has
already committed** — `deleteContentBackward` followed by `insertText` carrying
the updated syllable — and fires no composition events at all. xterm consumed the
printable keydown and default-prevented it, so that logic never ran and the raw
jamo from `event.key` went to the PTY.

Captured on iPadOS 26.5.2, an ordinary text field on the same page shows the
working path and the terminal shows the broken one, from identical keydowns:

| keystroke | ordinary text field | terminal |
| -- | -- | -- |
| `ㅎ` | `input insertText "ㅎ"` (U+314E) | keydown/keyup only |
| `ㅏ` | `deleteContentBackward` → `insertText "하"` (U+D558) | keydown/keyup only |
| `ㄴ` | `deleteContentBackward` → `insertText "한"` (U+D55C) | keydown/keyup only |

Exactly one key escaped in the terminal capture: `ㄲ`, typed with Shift, which
matched the existing Shift bypass in `xterm-bypass-policy.ts` and produced the
full native `keypress`/`beforeinput`/`input` chain. That bypass is the control
group proving the mechanism.

Fixes #13345

### What this changes

1. On iOS/iPadOS, generalize that bypass to unmodified non-ASCII printable keys,
   `keypress` included — without it `_keyPress` re-sends the glyph alongside the
   mirror.
2. Mirror the resulting field edits to the PTY as `DEL × n + replacement`, using
   the prefix-diff approach the mobile client already uses in
   `terminal-live-hangul-mirror.ts`.

Diffing the field rather than replaying edit events keeps a stray delete from
desyncing the PTY, and handles the non-1:1 case: typing `ㅣ` after `깾` emits one
deletion and reinserts two characters.

Input sources that *do* run a composition session — the on-screen keyboard, the
Japanese and Chinese IMEs — are left entirely to xterm's `CompositionHelper`,
which already commits them correctly.

### Not affected

No non-iOS platform. `shouldBypassXtermForIosTextEdit` returns early when the
flag is off, so desktop IME handling is untouched. In particular the macOS
native-text forwarder stays installed — deleting it is what regressed full-width
CJK punctuation in #13128 and forced the revert in #13282.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — `build:desktop` and both native scripts pass individually; the
      `build:native` wrapper cannot run on this machine, see below
- [x] Added or updated high-quality tests that would catch regressions

36 new tests across 3 files. The core one replays the 19-step field sequence
recorded on the affected device and asserts the PTY renders `한글깨짐` with no
compatibility jamo left over, so a regression fails the test rather than
silently degrading. All 651 test files under `terminal-pane/` and `lib/` pass.

`pnpm test` reports 5 pre-existing failures on this machine
(`check-root-directory-entries`, `terminal-attribution`, `runtime-auth-service`,
`updater`, `remote-runtime-shared-control-connection`). They reproduce
identically on `main` at 34f2a62cd and live in `config/scripts/`, `src/main/`
and `src/shared/` — this change touches only `src/renderer/`.

`pnpm build` could not complete on this machine: `build:native` re-invokes pnpm
as `node $npm_execpath run <script>`
(`config/scripts/build-native-for-platform.mjs:19-27`), which assumes a
JavaScript entry point. With pnpm installed as the standalone `@pnpm/exe`
binary, Node parses that binary as JS and throws
`SyntaxError: Invalid or unexpected token`. This reproduces on `main` at
34f2a62cd and CI is unaffected, since `pnpm/action-setup` installs the JS
distribution. Everything the wrapper would have run passes on its own:
`build:desktop`, `build:computer-macos` and `build:notification-status-macos`
all exit 0.

Device-verified on iPad Pro 12.9" (6th gen) / iPadOS 26.5.2 with a hardware
keyboard, against `orca serve` on Linux.

## AI Review Report

Ran `/code-review` (high) and `/security-review` on the branch. The review
explicitly covered cross-platform compatibility for macOS, Linux and Windows —
shortcuts, labels, paths, shell behavior and Electron-specific differences —
plus SSH/remote/local, agent and integration compatibility, performance and
security risk.

**Three findings were raised and fixed:**

1. **Double-send on iOS input sources that do compose (high).** The first draft
   intercepted `input` but not the composition events, so on the iPad on-screen
   keyboard or a Japanese IME the mirror sent preedit text and then xterm's
   `_sendPendingComposition` sent the same text again from the field, yielding
   `にほんにほん`. Fixed by standing aside for the whole composition session and
   adding an `isComposing` guard to the bypass predicate.
2. **Stale mirror state after a non-mirror PTY write (medium).** `reset()` was
   hooked only to a non-bypassed keydown, so Ctrl+C, Cmd+V paste and the JIS-Yen
   branch each left `sentText` describing a line the shell no longer had; the
   next syllable rewrite then emitted DEL bytes against it. Replaced with a
   `terminal.onData` hook that resets on any write the mirror did not make,
   which covers all three plus xterm's own key handling.
3. **Unfiltered `blur` listener (low).** Any focusable descendant blurring wiped
   mirror state and the field. Now filtered to the helper textarea, matching the
   `input` listener.

**Cross-platform**: the iOS branch is the only behavior change; every other
platform short-circuits before it. No shortcut, label, path or shell behavior is
touched, and nothing Electron-specific changes — this path only runs in the web
client.

**SSH/remote/local**: client-side input handling only. No RPC param, stream
frame or published content changes, so `docs/reference/remote-wire-compatibility.md`
does not apply. The mirror writes through `terminal.input()`, i.e. the existing
`onData` path, so the pane's replay guard, stale-agent block and mobile presence
lock all still run.

**Agents and integrations**: the bytes reaching the PTY are ordinary text plus
DEL (`0x7f`). No agent-, integration- or git-provider-specific branching.

**Performance**: one prefix comparison per input event, linear in the field
length and only while a CJK syllable is being composed. No new timers,
listeners on hot paths, or renders.

**UI quality**: no visual change.

## Security Audit

`/security-review` found no HIGH or MEDIUM issues. Checked and ruled out:

- **PTY input guards are not bypassed.** The mirror writes via
  `terminal.input()`, which lands on the same `onData` path as existing input,
  so the pane's guards still run.
- **Paste cannot reach the new `input` listener.** `TerminalPane.tsx` registers
  a capture-phase `paste` listener on the pane-manager root and calls
  `preventDefault()`, so no default insertion and no `input` event occurs. The
  clipboard therefore still goes through the existing paste path rather than
  being forwarded raw.
- **Drag-and-drop likewise cannot reach it** — the helper textarea sits at
  `z-index: -5` and loses hit-testing.
- **No control-byte injection.** The bypass requires `codePoint >= 0x80` with no
  Ctrl/Meta/Alt, so no C0 byte or ESC can enter through it. The only control
  byte the mirror emits is DEL, and the count is bounded by the length of text
  the mirror itself sent.
- **`stopImmediatePropagation()` suppresses nothing security-relevant** — only
  later-registered listeners on the same node, which is xterm's own input
  handling, by design.
- No authentication, authorization, secrets, crypto, command-execution, path-
  handling or IPC surface is touched.

## Notes

- **iOS/iPadOS detection needs two signals.** Every iOS user agent contains
  `Mac` — `Macintosh` in iPad desktop mode, the default since iPadOS 13, and
  `like Mac OS X` in mobile mode — and desktop mode omits `iPad`, so
  `maxTouchPoints` is the only thing separating an iPad from a Mac.
- **Open question for reviewers: kitty keyboard.** The sibling
  `shouldBypassXtermForMacNativeText` refuses to bypass while kitty progressive
  enhancement is active. The iOS branch deliberately does not, because gating on
  it would leave Korean broken in exactly the agent TUIs that enable kitty mode.
  Happy to add the guard if you would rather keep CSI-u reporting intact there.
- **Verified with a hardware keyboard only.** The on-screen keyboard now routes
  through xterm's composition path rather than the mirror, but has not been
  device-tested. Chinese and Japanese IMEs on iPadOS are likewise untested.
- **The mirror sends DEL to repair a superseded syllable**, the same tradeoff
  the mobile client already ships.
- **`mobile/` is a separate pnpm workspace**, so its equivalent mirror could not
  be imported directly; the shared algorithm is noted in the code comments
  instead of being extracted into a package, which felt out of scope here.