### PR TITLE
feat(shared): declarative PR watch-rules evaluator + forge-aware history backtest (prototype for #13066)

### DIFF
--- a/.github/scripts/pr-test-loc-table.mjs
+++ b/.github/scripts/pr-test-loc-table.mjs
@@ -39,6 +39,7 @@ export function sumChangedFiles(files) {
 const COLOR_ADDED = '#1a7f37'
 const COLOR_DELETED = '#cf222e'
 
+// Added/Deleted keep the diffstat convention: the colour marks direction, not merit.
 function diffCell(count) {
   if (count === 0) {
     return '0'
@@ -49,10 +50,21 @@ function diffCell(count) {
   return `$\\color{${COLOR_DELETED}}{\\Huge{\\mathbf{−}}}$\u200b${Math.abs(count)}`
 }
 
+// Why uncoloured: Net is a derived judgement, and red-on-negative scored deletion as a
+// defect — backwards, since removal is usually the cheaper change. Green-on-positive is
+// no better: growth is not merit either. Sign shows direction; no colour scores it.
+function netCell(count) {
+  if (count === 0) {
+    return '0'
+  }
+  const sign = count > 0 ? '+' : '−'
+  return `$\\Huge{\\mathbf{${sign}}}$\u200b${Math.abs(count)}`
+}
+
 function locTableRow(label, bucket) {
   const added = bucket.added ?? 0
   const deleted = bucket.deleted ?? 0
-  return `| ${label} | ${bucket.files ?? 0} | ${diffCell(added)} | ${diffCell(-deleted)} | ${diffCell(added - deleted)} |`
+  return `| ${label} | ${bucket.files ?? 0} | ${diffCell(added)} | ${diffCell(-deleted)} | ${netCell(added - deleted)} |`
 }
 
 export function formatLocTable({ test, nonTest }) {

--- a/config/pr-watch-rules.example.yaml
+++ b/config/pr-watch-rules.example.yaml
@@ -8,11 +8,11 @@ pr_watch:
     note: 9 reverts in 4 months — WebGL/repaint changes are hard to test
 
   - name: Remote wire
-    when: { paths: ["src/shared/rpc/**", "src/main/runtime/rpc/**"] }
+    when: { paths: ['src/shared/rpc/**', 'src/main/runtime/rpc/**'] }
     note: New stream opcodes must be capability-negotiated — decoders drop unknown ones silently
 
   - name: Windows setup shell
-    when: { paths: ["src/main/**/wsl*", "docs/reference/windows-setup-shell.md"] }
+    when: { paths: ['src/main/**/wsl*', 'docs/reference/windows-setup-shell.md'] }
     note: .cmd runner rules — never derive from terminal-shell preference (AGENTS.md)
 
 review_queue:
@@ -21,11 +21,12 @@ review_queue:
       when: { any: [{ draft: true }, { mergeable: conflicting }] }
       action: bounce
     - name: Deep review
-      when: { any: [{ files: ">=p90" }, { churn: ">=p90" }, { scope: terminal }] }
+      # Sized on additions, not additions+deletions: a large removal is not a large read.
+      when: { any: [{ files: '>=p90' }, { additions: '>=p90' }, { scope: terminal }] }
       slot: deep
     - name: New contributor
-      when: { authorMergedPRs: "==0" }
+      when: { authorMergedPRs: '==0' }
       note: First PR — calibration review; check workflows/CI files
     - name: Fast track
-      when: { files: "<=p50", churn: "<=p50", type: [fix, test, docs] }
+      when: { files: '<=p50', additions: '<=p50', type: [fix, test, docs] }
       batchBy: author

--- a/config/pr-watch-rules.example.yaml
+++ b/config/pr-watch-rules.example.yaml
@@ -12,7 +12,7 @@ pr_watch:
     note: New stream opcodes must be capability-negotiated — decoders drop unknown ones silently
 
   - name: Windows setup shell
-    when: { paths: ["src/main/wsl*", "docs/reference/windows-setup-shell.md"] }
+    when: { paths: ["src/main/**/wsl*", "docs/reference/windows-setup-shell.md"] }
     note: .cmd runner rules — never derive from terminal-shell preference (AGENTS.md)
 
 review_queue:

--- a/config/pr-watch-rules.example.yaml
+++ b/config/pr-watch-rules.example.yaml
@@ -1,0 +1,31 @@
+# Example PR watch rules + review-queue tiers for the backtest harness.
+# Replay against history: node config/scripts/pr-watch-backtest.mjs
+# See docs/superpowers/specs/2026-08-07-pr-watch-rules-design.md.
+
+pr_watch:
+  - name: Terminal rendering
+    when: { scope: terminal }
+    note: 9 reverts in 4 months — WebGL/repaint changes are hard to test
+
+  - name: Remote wire
+    when: { paths: ["src/shared/rpc/**", "src/main/runtime/rpc/**"] }
+    note: New stream opcodes must be capability-negotiated — decoders drop unknown ones silently
+
+  - name: Windows setup shell
+    when: { paths: ["src/main/wsl*", "docs/reference/windows-setup-shell.md"] }
+    note: .cmd runner rules — never derive from terminal-shell preference (AGENTS.md)
+
+review_queue:
+  tiers:
+    - name: Not reviewable
+      when: { any: [{ draft: true }, { mergeable: conflicting }] }
+      action: bounce
+    - name: Deep review
+      when: { any: [{ files: ">=p90" }, { churn: ">=p90" }, { scope: terminal }] }
+      slot: deep
+    - name: New contributor
+      when: { authorMergedPRs: "==0" }
+      note: First PR — calibration review; check workflows/CI files
+    - name: Fast track
+      when: { files: "<=p50", churn: "<=p50", type: [fix, test, docs] }
+      batchBy: author

--- a/config/scripts/pr-review-residual.mjs
+++ b/config/scripts/pr-review-residual.mjs
@@ -115,9 +115,11 @@ const designRow = (pr) => [
   pr.files > 0 ? pr.testFiles / pr.files : 0
 ]
 
-// Why: an LLM review bot reviews nearly everything here, so treating it as "the reviewer"
-// would define away the human judgement the metric claims to instrument.
-const BOT_REVIEWER_RE = /\[bot\]$|^(coderabbitai|github-actions|dependabot|copilot)/i
+// Why: AI review bots review nearly everything here, and none of them carry a [bot] suffix
+// on their login. Treating one as "the reviewer" would define away the human judgement the
+// metric claims to instrument.
+const BOT_REVIEWER_RE =
+  /\[bot\]$|^(coderabbitai|greptile|pullfrog|github-actions|dependabot|copilot)/i
 
 export const humanReviewersOf = (review) =>
   (review.reviewers ?? []).filter((login) => !BOT_REVIEWER_RE.test(login))

--- a/config/scripts/pr-review-residual.mjs
+++ b/config/scripts/pr-review-residual.mjs
@@ -1,0 +1,348 @@
+// Review-time residual conditional on PR size: fit review effort from structural size only,
+// then ask whether the *excess* predicts downstream rework. Offline — reads the backtest
+// export and the cached review timeline, never the network.
+// Usage: node config/scripts/pr-review-residual.mjs --prs <export.json> --reviews <cache.jsonl>
+//        [--effort rounds|reviewers|threads] [--null-rounds 200]
+import { readFileSync } from 'node:fs'
+import { mean, meanWithError } from './pr-rework-metrics.mjs'
+import { groupEffectLines, pct, pp, quintileLines } from './pr-rework-report.mjs'
+
+const log1p = (x) => Math.log(1 + Math.max(0, x))
+
+/** Solve (X'X)b = X'y by Gaussian elimination with partial pivoting. */
+export function olsFit(rows, y) {
+  const k = rows[0].length
+  const xtx = Array.from({ length: k }, () => new Float64Array(k + 1))
+  for (let i = 0; i < rows.length; i += 1) {
+    const xi = rows[i]
+    for (let a = 0; a < k; a += 1) {
+      for (let b = 0; b < k; b += 1) {
+        xtx[a][b] += xi[a] * xi[b]
+      }
+      xtx[a][k] += xi[a] * y[i]
+    }
+  }
+  for (let col = 0; col < k; col += 1) {
+    let pivot = col
+    for (let r = col + 1; r < k; r += 1) {
+      if (Math.abs(xtx[r][col]) > Math.abs(xtx[pivot][col])) {
+        pivot = r
+      }
+    }
+    ;[xtx[col], xtx[pivot]] = [xtx[pivot], xtx[col]]
+    const d = xtx[col][col]
+    if (Math.abs(d) < 1e-12) {
+      continue
+    }
+    for (let c = col; c <= k; c += 1) {
+      xtx[col][c] /= d
+    }
+    for (let r = 0; r < k; r += 1) {
+      if (r === col) {
+        continue
+      }
+      const f = xtx[r][col]
+      for (let c = col; c <= k; c += 1) {
+        xtx[r][c] -= f * xtx[col][c]
+      }
+    }
+  }
+  return Array.from({ length: k }, (_, i) => xtx[i][k])
+}
+
+export const predict = (x, beta) => x.reduce((a, v, i) => a + v * beta[i], 0)
+
+export function rSquared(rows, y, beta) {
+  const ybar = mean(y)
+  let ssRes = 0
+  let ssTot = 0
+  for (let i = 0; i < rows.length; i += 1) {
+    ssRes += (y[i] - predict(rows[i], beta)) ** 2
+    ssTot += (y[i] - ybar) ** 2
+  }
+  return ssTot === 0 ? 0 : 1 - ssRes / ssTot
+}
+
+const rankOf = (values) => {
+  const idx = values.map((v, i) => [v, i]).sort((a, b) => a[0] - b[0])
+  const ranks = Array.from({ length: values.length })
+  let i = 0
+  while (i < idx.length) {
+    let j = i
+    while (j + 1 < idx.length && idx[j + 1][0] === idx[i][0]) {
+      j += 1
+    }
+    const r = (i + j) / 2 + 1
+    for (let k = i; k <= j; k += 1) {
+      ranks[idx[k][1]] = r
+    }
+    i = j + 1
+  }
+  return ranks
+}
+
+export function spearman(xs, ys) {
+  const rx = rankOf(xs)
+  const ry = rankOf(ys)
+  const mx = mean(rx)
+  const my = mean(ry)
+  let num = 0
+  let dx = 0
+  let dy = 0
+  for (let i = 0; i < rx.length; i += 1) {
+    num += (rx[i] - mx) * (ry[i] - my)
+    dx += (rx[i] - mx) ** 2
+    dy += (ry[i] - my) ** 2
+  }
+  return dx === 0 || dy === 0 ? 0 : num / Math.sqrt(dx * dy)
+}
+
+const FEATURES = [
+  'const',
+  'log(1+files)',
+  'log(1+additions)',
+  'log(1+deletions)',
+  'breadth',
+  'testRatio'
+]
+
+const designRow = (pr) => [
+  1,
+  log1p(pr.files),
+  log1p(pr.additions),
+  log1p(pr.deletions),
+  pr.breadth,
+  pr.files > 0 ? pr.testFiles / pr.files : 0
+]
+
+// Why: an LLM review bot reviews nearly everything here, so treating it as "the reviewer"
+// would define away the human judgement the metric claims to instrument.
+const BOT_REVIEWER_RE = /\[bot\]$|^(coderabbitai|github-actions|dependabot|copilot)/i
+
+export const humanReviewersOf = (review) =>
+  (review.reviewers ?? []).filter((login) => !BOT_REVIEWER_RE.test(login))
+
+export function effortValue(review, key) {
+  if (key === 'reviewers') {
+    return humanReviewersOf(review).length
+  }
+  if (key === 'threads') {
+    return review.threads
+  }
+  if (key === 'reviews') {
+    return review.reviews
+  }
+  return review.rounds
+}
+
+/**
+ * Subtract each primary reviewer's mean residual — a reviewer fixed effect.
+ *
+ * Why: reviewer identity is the largest confound. Without it, "this PR consumed excess
+ * review" is partly "this reviewer always asks for changes".
+ */
+export function reviewerDemean(rows, { minPRs = 10 } = {}) {
+  const counts = new Map()
+  for (const r of rows) {
+    counts.set(r.reviewer, (counts.get(r.reviewer) ?? 0) + 1)
+  }
+  const cellOf = (r) => (counts.get(r.reviewer) >= minPRs ? r.reviewer : '(other)')
+  const sums = new Map()
+  for (const r of rows) {
+    const key = cellOf(r)
+    const acc = sums.get(key) ?? { n: 0, total: 0 }
+    acc.n += 1
+    acc.total += r.residual
+    sums.set(key, acc)
+  }
+  return rows.map((r) => {
+    const acc = sums.get(cellOf(r))
+    return { ...r, reviewerCell: cellOf(r), eps: r.residual - acc.total / acc.n }
+  })
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const argOf = (flag, fallback) => {
+    const i = args.indexOf(flag)
+    return i === -1 ? fallback : args[i + 1]
+  }
+  const prsPath = argOf('--prs', null)
+  const reviewsPath = argOf('--reviews', null)
+  if (!prsPath || !reviewsPath) {
+    console.error('--prs <export.json> and --reviews <cache.jsonl> are required')
+    process.exit(2)
+  }
+  const effortKey = argOf('--effort', 'rounds')
+  const nullRounds = Number(argOf('--null-rounds', '200'))
+  // Disclosed post-hoc variant: an LLM bot reviews most PRs here, so the claim "a human
+  // slowed down on this diff" can only be tested on the PRs a human actually reviewed.
+  const humanOnly = args.includes('--human-only')
+
+  const exported = JSON.parse(readFileSync(prsPath, 'utf8'))
+  const reviews = new Map()
+  for (const line of readFileSync(reviewsPath, 'utf8').split('\n')) {
+    if (line.trim()) {
+      const r = JSON.parse(line)
+      reviews.set(r.number, r)
+    }
+  }
+  const [h1, h2] = exported.horizons
+  console.log(
+    `export: ${exported.prs.length} PRs, horizons ${h1}d/${h2}d, baseline ${exported.baseline ?? 'span'} · review cache: ${reviews.size} PRs`
+  )
+
+  const joined = exported.prs.filter((p) => reviews.has(p.n))
+  console.log(
+    `join: ${joined.length}/${exported.prs.length} matched (${pct(joined.length, exported.prs.length)})`
+  )
+  const byType = new Map()
+  for (const p of exported.prs) {
+    const acc = byType.get(p.authorType) ?? { n: 0, matched: 0 }
+    acc.n += 1
+    acc.matched += reviews.has(p.n) ? 1 : 0
+    byType.set(p.authorType, acc)
+  }
+  console.log('  join coverage by author type (differential-coverage check):')
+  for (const [type, acc] of byType) {
+    console.log(
+      `    ${type.padEnd(10)} ${String(acc.n).padStart(5)} PRs   matched ${pct(acc.matched, acc.n)}`
+    )
+  }
+
+  // Pre-registered exclusions: censored, empty, and never-reviewed PRs.
+  const scored = joined.filter((p) => !p.metrics[h1].censored && p.files > 0)
+  const reviewed = scored.filter((p) => {
+    const r = reviews.get(p.n)
+    if (humanOnly) {
+      return humanReviewersOf(r).length > 0
+    }
+    return r.reviews > 0 || r.threads > 0
+  })
+  const unreviewed = scored.length - reviewed.length
+  console.log(
+    `analysed ${reviewed.length} PRs${humanOnly ? ' (human-reviewed only)' : ''} · excluded ${unreviewed} without ${humanOnly ? 'a human review' : 'any review'} (${pct(unreviewed, scored.length)}) as censored · ${joined.length - scored.length} censored/empty`
+  )
+
+  // Why: the pre-registered preference order only holds if the chosen measure actually
+  // varies. A constant effort measure produces quintiles that are pure sort order.
+  console.log('\n=== review effort measures (choose the first with real spread) ===')
+  for (const key of ['rounds', 'reviewers', 'threads', 'reviews']) {
+    const values = reviewed.map((p) => effortValue(reviews.get(p.n), key))
+    const s = meanWithError(values)
+    const sd = Math.sqrt(s.se ** 2 * s.n)
+    const zero = values.filter((v) => v === 0).length
+    console.log(
+      `  ${key.padEnd(10)} mean ${s.mean.toFixed(2)}  sd ${sd.toFixed(2)}  zero ${pct(zero, values.length)}  max ${Math.max(...values)}`
+    )
+  }
+  const humanReviewed = reviewed.filter((p) => humanReviewersOf(reviews.get(p.n)).length > 0)
+  console.log(
+    `  human-reviewed: ${humanReviewed.length}/${reviewed.length} (${pct(humanReviewed.length, reviewed.length)}) — the rest are bot-only reviews`
+  )
+
+  const effortOf = (r) => effortValue(r, effortKey)
+  const design = reviewed.map(designRow)
+  const y = reviewed.map((p) => log1p(effortOf(reviews.get(p.n))))
+  const beta = olsFit(design, y)
+  console.log(`\n=== null model: log(1+${effortKey}) ~ structural size only ===`)
+  FEATURES.forEach((name, i) => console.log(`  ${name.padEnd(20)} ${beta[i].toFixed(4)}`))
+  console.log(`  R² = ${rSquared(design, y, beta).toFixed(4)}   n = ${reviewed.length}`)
+  console.log(
+    `  spearman(files, ${effortKey}) = ${spearman(
+      reviewed.map((p) => p.files),
+      reviewed.map((p) => effortOf(reviews.get(p.n)))
+    ).toFixed(3)} · spearman(additions, ${effortKey}) = ${spearman(
+      reviewed.map((p) => p.additions),
+      reviewed.map((p) => effortOf(reviews.get(p.n)))
+    ).toFixed(3)}`
+  )
+
+  const withResidual = reviewed.map((p, i) => {
+    const r = reviews.get(p.n)
+    return {
+      pr: p,
+      reviewer: humanReviewersOf(r)[0] ?? r.reviewers[0] ?? '(none)',
+      residual: y[i] - predict(design[i], beta)
+    }
+  })
+  const rows = reviewerDemean(withResidual)
+
+  // Reviewer-assignment independence: if agent PRs route to different reviewers, the
+  // residual carries the treatment and the metric manufactures an effect.
+  for (const line of groupEffectLines(
+    'agent share by primary reviewer (assignment independence)',
+    rows
+      .filter((r) => r.reviewerCell !== '(other)')
+      .map((r) => ({
+        group: r.reviewerCell,
+        value: r.pr.authorType === 'agent' ? 1 : 0,
+        stratum: r.pr.metrics[h1].expected,
+        cell: r.pr.date.slice(0, 7)
+      })),
+    { rounds: nullRounds, minPRs: 20 }
+  )) {
+    console.log(line)
+  }
+
+  for (const h of [h1, h2]) {
+    const usable = rows.filter((r) => !r.pr.metrics[h].censored)
+    const table = usable.map((r) => ({
+      predictor: r.eps,
+      value: r.pr.metrics[h].lift,
+      stratum: r.pr.metrics[h].expected,
+      cell: r.pr.date.slice(0, 7)
+    }))
+    for (const line of quintileLines(
+      `rework lift@${h}d by excess-review-friction quintile (n=${usable.length}, effort=${effortKey})`,
+      table,
+      { rounds: nullRounds, minPRs: 20 }
+    )) {
+      console.log(line)
+    }
+    // Second shuffle variant from the pre-registration: hold the reviewer fixed too.
+    for (const line of quintileLines(
+      `  … same, shuffled within (reviewer × file-heat) cells`,
+      usable.map((r, i) => ({ ...table[i], cell: r.reviewerCell })),
+      { rounds: nullRounds, minPRs: 20 }
+    )) {
+      console.log(line)
+    }
+    console.log(
+      `  spearman(eps, lift@${h}d) = ${spearman(
+        usable.map((r) => r.eps),
+        usable.map((r) => r.pr.metrics[h].lift)
+      ).toFixed(3)}`
+    )
+  }
+
+  const epsByType = new Map()
+  for (const r of rows) {
+    const acc = epsByType.get(r.pr.authorType) ?? []
+    acc.push(r.eps)
+    epsByType.set(r.pr.authorType, acc)
+  }
+  console.log('\n=== excess review friction by author type (descriptive, never a predictor) ===')
+  for (const [type, values] of epsByType) {
+    const s = meanWithError(values)
+    console.log(
+      `  ${type.padEnd(10)} n=${String(s.n).padStart(5)}  eps ${s.mean.toFixed(4)} ± ${s.se.toFixed(4)}`
+    )
+  }
+  console.log(
+    `\nunreviewed (censored, reported separately): ${unreviewed} PRs · mean lift@${h1}d ${pp(
+      mean(
+        scored
+          .filter((p) => {
+            const r = reviews.get(p.n)
+            return r.reviews === 0 && r.threads === 0
+          })
+          .map((p) => p.metrics[h1].lift)
+      )
+    )}`
+  )
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/config/scripts/pr-review-residual.test.mjs
+++ b/config/scripts/pr-review-residual.test.mjs
@@ -1,5 +1,12 @@
 import { describe, expect, it } from 'vitest'
-import { olsFit, predict, rSquared, reviewerDemean, spearman } from './pr-review-residual.mjs'
+import {
+  humanReviewersOf,
+  olsFit,
+  predict,
+  rSquared,
+  reviewerDemean,
+  spearman
+} from './pr-review-residual.mjs'
 import { summarizeReviews } from './pr-review-timeline.mjs'
 
 describe('olsFit', () => {
@@ -55,6 +62,29 @@ describe('reviewerDemean', () => {
     expect(out[10].eps).toBeCloseTo(0, 10)
     expect(out.at(-1).reviewerCell).toBe('(other)')
     expect(out.at(-2).eps).toBeCloseTo(0.5, 10)
+  })
+})
+
+describe('humanReviewersOf', () => {
+  // Why: none of the AI reviewers in this repo carry a [bot] login suffix.
+  it('treats every AI reviewer as non-human regardless of login suffix', () => {
+    expect(
+      humanReviewersOf({
+        reviewers: [
+          'coderabbitai',
+          'greptile-apps',
+          'pullfrog',
+          'copilot-pull-request-reviewer',
+          'dependabot[bot]',
+          'nwparker'
+        ]
+      })
+    ).toEqual(['nwparker'])
+  })
+
+  it('reports no human reviewer for a bot-only review', () => {
+    expect(humanReviewersOf({ reviewers: ['coderabbitai'] })).toEqual([])
+    expect(humanReviewersOf({})).toEqual([])
   })
 })
 

--- a/config/scripts/pr-review-residual.test.mjs
+++ b/config/scripts/pr-review-residual.test.mjs
@@ -1,0 +1,117 @@
+import { describe, expect, it } from 'vitest'
+import { olsFit, predict, rSquared, reviewerDemean, spearman } from './pr-review-residual.mjs'
+import { summarizeReviews } from './pr-review-timeline.mjs'
+
+describe('olsFit', () => {
+  it('recovers the generating coefficients of a noiseless fit', () => {
+    const rows = Array.from({ length: 40 }, (_, i) => [1, i, (i % 7) - 3])
+    const y = rows.map(([, a, b]) => 2 + 0.5 * a - 1.25 * b)
+    const beta = olsFit(rows, y)
+
+    expect(beta[0]).toBeCloseTo(2, 6)
+    expect(beta[1]).toBeCloseTo(0.5, 6)
+    expect(beta[2]).toBeCloseTo(-1.25, 6)
+    expect(rSquared(rows, y, beta)).toBeCloseTo(1, 10)
+  })
+
+  it('leaves the unexplained part in the residual', () => {
+    const rows = Array.from({ length: 30 }, (_, i) => [1, i])
+    const y = rows.map(([, a], i) => a + (i === 0 ? 10 : 0))
+    const beta = olsFit(rows, y)
+
+    expect(y[0] - predict(rows[0], beta)).toBeGreaterThan(5)
+    expect(rSquared(rows, y, beta)).toBeLessThan(1)
+  })
+})
+
+describe('spearman', () => {
+  it('is 1 for a monotone but non-linear relation', () => {
+    const xs = [1, 2, 3, 4, 5]
+    expect(
+      spearman(
+        xs,
+        xs.map((x) => x ** 3)
+      )
+    ).toBeCloseTo(1, 10)
+  })
+
+  it('is negative when the ranks invert', () => {
+    expect(spearman([1, 2, 3, 4], [4, 3, 2, 1])).toBeCloseTo(-1, 10)
+  })
+})
+
+describe('reviewerDemean', () => {
+  // Why: without this, "excess friction" is partly "this reviewer always asks for changes".
+  it('removes a strict reviewer offset and pools rare reviewers', () => {
+    const rows = [
+      ...Array.from({ length: 10 }, () => ({ reviewer: 'strict', residual: 1 })),
+      ...Array.from({ length: 10 }, () => ({ reviewer: 'lenient', residual: -1 })),
+      { reviewer: 'rare1', residual: 0.5 },
+      { reviewer: 'rare2', residual: -0.5 }
+    ]
+    const out = reviewerDemean(rows, { minPRs: 10 })
+
+    expect(out[0].eps).toBeCloseTo(0, 10)
+    expect(out[10].eps).toBeCloseTo(0, 10)
+    expect(out.at(-1).reviewerCell).toBe('(other)')
+    expect(out.at(-2).eps).toBeCloseTo(0.5, 10)
+  })
+})
+
+describe('summarizeReviews', () => {
+  it('counts a round per changes-requested review and collects distinct reviewers', () => {
+    const summary = summarizeReviews({
+      number: 7,
+      createdAt: '2026-05-01T00:00:00Z',
+      mergedAt: '2026-05-01T06:00:00Z',
+      changedFiles: 3,
+      additions: 10,
+      deletions: 2,
+      author: { login: 'alice' },
+      reviews: {
+        totalCount: 3,
+        nodes: [
+          {
+            state: 'CHANGES_REQUESTED',
+            submittedAt: '2026-05-01T02:00:00Z',
+            author: { login: 'bob' }
+          },
+          {
+            state: 'CHANGES_REQUESTED',
+            submittedAt: '2026-05-01T03:00:00Z',
+            author: { login: 'bob' }
+          },
+          { state: 'APPROVED', submittedAt: '2026-05-01T05:00:00Z', author: { login: 'carol' } }
+        ]
+      },
+      reviewThreads: { totalCount: 9 },
+      comments: { totalCount: 2 },
+      commits: { totalCount: 4 }
+    })
+
+    expect(summary).toMatchObject({
+      rounds: 3,
+      changesRequested: 2,
+      approvals: 1,
+      reviewers: ['bob', 'carol'],
+      threads: 9,
+      hoursOpen: 6
+    })
+    expect(summary.firstReviewAt).toBe('2026-05-01T02:00:00Z')
+  })
+
+  it('reports a never-reviewed PR as zero rounds of evidence', () => {
+    const summary = summarizeReviews({
+      number: 8,
+      createdAt: '2026-05-01T00:00:00Z',
+      mergedAt: '2026-05-01T00:10:00Z',
+      reviews: { totalCount: 0, nodes: [] },
+      reviewThreads: { totalCount: 0 },
+      comments: { totalCount: 0 },
+      commits: { totalCount: 1 }
+    })
+
+    expect(summary).toMatchObject({ reviews: 0, threads: 0, reviewers: [], rounds: 1 })
+    expect(summary.author).toBeNull()
+  })
+})

--- a/config/scripts/pr-review-timeline.mjs
+++ b/config/scripts/pr-review-timeline.mjs
@@ -1,0 +1,141 @@
+// Fetches review-timeline counts for merged PRs over the backtest window and caches them as
+// JSONL. The backtest itself stays offline and zero-API-call; this is the one script that
+// talks to the forge, it is resumable, and the residual analysis reads only its cache.
+// Usage: node config/scripts/pr-review-timeline.mjs --out <file.jsonl> [--since YYYY-MM-DD]
+//        [--repo owner/name] [--page-size 50] [--max-pages 400]
+import { execFileSync } from 'node:child_process'
+import { appendFileSync, existsSync, readFileSync, writeFileSync } from 'node:fs'
+
+const QUERY = `query($owner:String!,$name:String!,$size:Int!,$after:String){
+  repository(owner:$owner,name:$name){
+    pullRequests(states:MERGED,first:$size,after:$after,orderBy:{field:CREATED_AT,direction:DESC}){
+      pageInfo{ hasNextPage endCursor }
+      nodes{
+        number createdAt mergedAt changedFiles additions deletions
+        author{ login }
+        reviews(first:50){ totalCount nodes{ state submittedAt author{ login } } }
+        reviewThreads(first:1){ totalCount }
+        comments(first:1){ totalCount }
+        commits(first:1){ totalCount }
+      }
+    }
+  }
+}`
+
+/** Collapse one PR's review nodes into the counts the residual model needs. */
+export function summarizeReviews(pr) {
+  const nodes = pr.reviews?.nodes ?? []
+  const reviewers = new Set()
+  let changesRequested = 0
+  let approvals = 0
+  let firstReviewAt = null
+  for (const r of nodes) {
+    if (r.author?.login) {
+      reviewers.add(r.author.login)
+    }
+    if (r.state === 'CHANGES_REQUESTED') {
+      changesRequested += 1
+    }
+    if (r.state === 'APPROVED') {
+      approvals += 1
+    }
+    if (r.submittedAt && (firstReviewAt === null || r.submittedAt < firstReviewAt)) {
+      firstReviewAt = r.submittedAt
+    }
+  }
+  // Why 1 + changes-requested: a round is one pass over the diff, and every
+  // changes-requested review forces another. Robust to calendar noise in a way hours-open
+  // is not; the fetched review and thread counts let the alternates be checked.
+  return {
+    number: pr.number,
+    createdAt: pr.createdAt,
+    mergedAt: pr.mergedAt,
+    author: pr.author?.login ?? null,
+    changedFiles: pr.changedFiles,
+    additions: pr.additions,
+    deletions: pr.deletions,
+    commits: pr.commits?.totalCount ?? 0,
+    reviews: pr.reviews?.totalCount ?? 0,
+    reviewNodes: nodes.length,
+    changesRequested,
+    approvals,
+    rounds: 1 + changesRequested,
+    reviewers: [...reviewers],
+    threads: pr.reviewThreads?.totalCount ?? 0,
+    comments: pr.comments?.totalCount ?? 0,
+    firstReviewAt,
+    hoursOpen:
+      pr.mergedAt && pr.createdAt
+        ? (Date.parse(pr.mergedAt) - Date.parse(pr.createdAt)) / 3600_000
+        : null
+  }
+}
+
+function graphql({ owner, name, size, after }) {
+  const args = [
+    'api',
+    'graphql',
+    '-f',
+    `query=${QUERY}`,
+    '-F',
+    `owner=${owner}`,
+    '-F',
+    `name=${name}`,
+    '-F',
+    `size=${size}`
+  ]
+  if (after) {
+    args.push('-F', `after=${after}`)
+  }
+  const raw = execFileSync('gh', args, { encoding: 'utf8', maxBuffer: 1 << 26 })
+  const parsed = JSON.parse(raw)
+  if (parsed.errors) {
+    throw new Error(`GraphQL: ${parsed.errors.map((e) => e.message).join('; ')}`)
+  }
+  return parsed.data.repository.pullRequests
+}
+
+function main() {
+  const args = process.argv.slice(2)
+  const argOf = (flag, fallback) => {
+    const i = args.indexOf(flag)
+    return i === -1 ? fallback : args[i + 1]
+  }
+  const out = argOf('--out', null)
+  if (!out) {
+    console.error('--out <file.jsonl> is required')
+    process.exit(2)
+  }
+  const [owner, name] = argOf('--repo', 'stablyai/orca').split('/')
+  const since = argOf('--since', '2026-04-01')
+  const size = Number(argOf('--page-size', '50'))
+  const maxPages = Number(argOf('--max-pages', '400'))
+  const statePath = `${out}.state.json`
+
+  let after = existsSync(statePath) ? JSON.parse(readFileSync(statePath, 'utf8')).cursor : null
+  let fetched = existsSync(out) ? readFileSync(out, 'utf8').split('\n').filter(Boolean).length : 0
+  if (!existsSync(out)) {
+    writeFileSync(out, '')
+  }
+  console.log(`${owner}/${name}: paging merged PRs created since ${since} (resume=${!!after})`)
+
+  for (let page = 0; page < maxPages; page += 1) {
+    const result = graphql({ owner, name, size, after })
+    const rows = result.nodes.map(summarizeReviews)
+    appendFileSync(out, rows.map((r) => `${JSON.stringify(r)}\n`).join(''))
+    fetched += rows.length
+    const oldest = rows.at(-1)?.createdAt ?? ''
+    after = result.pageInfo.endCursor
+    writeFileSync(statePath, JSON.stringify({ cursor: after, oldest, fetched }))
+    console.log(`  page ${page + 1}: ${fetched} PRs, oldest createdAt ${oldest.slice(0, 10)}`)
+    if (!result.pageInfo.hasNextPage || oldest.slice(0, 10) < since) {
+      console.log(`done: ${fetched} PRs cached in ${out}`)
+      return
+    }
+  }
+  console.log(`stopped at --max-pages; ${fetched} PRs cached. Re-run to resume.`)
+}
+
+if (import.meta.main) {
+  main()
+}

--- a/config/scripts/pr-rework-metrics.mjs
+++ b/config/scripts/pr-rework-metrics.mjs
@@ -1,0 +1,406 @@
+// Label-free rework/lift metric: "did a later PR change this PR's code", scored against
+// each file's own baseline rate. Pure functions over records the backtest already holds;
+// no git pass, no API call. See docs/pr-metric-improvements-brief.md.
+
+export const DAY_MS = 86_400_000
+const LN2 = Math.LN2
+
+export const mean = (xs) => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length)
+
+/** Standard error of the mean — every reported effect needs its uncertainty next to it. */
+export function meanWithError(xs) {
+  const n = xs.length
+  if (n === 0) {
+    return { n: 0, mean: 0, se: 0 }
+  }
+  const m = mean(xs)
+  if (n === 1) {
+    return { n, mean: m, se: 0 }
+  }
+  const variance = xs.reduce((a, x) => a + (x - m) ** 2, 0) / (n - 1)
+  return { n, mean: m, se: Math.sqrt(variance / n) }
+}
+
+// Why: -M/-C rewrite renames as "a/{b => c}/d.ts" or "a => b"; both name one file, and
+// leaving them raw splits a renamed file's history into two never-rejoined buckets.
+export function normalizeNumstatPath(raw) {
+  const brace = /^(.*)\{(.*?)\s*=>\s*(.*?)\}(.*)$/.exec(raw)
+  if (brace) {
+    return `${brace[1]}${brace[3]}${brace[4]}`.replace(/\/{2,}/g, '/').replace(/^\//, '')
+  }
+  const arrow = /^(.+?)\s+=>\s+(.+)$/.exec(raw)
+  return (arrow ? arrow[2] : raw).trim()
+}
+
+// Why: a same-file edit six hours later is overwhelmingly a repair; at ninety days it is
+// ordinary evolution. Halving weight per half-life is the label-free stand-in for "was it a fix".
+export function timeDecayWeight(deltaMs, halfLifeMs) {
+  if (deltaMs <= 0) {
+    return 1
+  }
+  return 2 ** (-deltaMs / halfLifeMs)
+}
+
+/**
+ * Expected decay weight of the *first* follow-up under a Poisson file rate.
+ *
+ * Why closed form: the decay-weighted rate needs the same per-file baseline the binary rate
+ * gets, or it re-reads file heat. First-event time is Exp(lambda) truncated at the horizon, so
+ * E[2^(-t/H)] = lambda/(lambda+k) * (1 - e^-(lambda+k)T) with k = ln2/H. No simulation.
+ */
+export function expectedDecayWeight(lambdaPerDay, horizonDays, halfLifeDays) {
+  if (lambdaPerDay <= 0 || horizonDays <= 0) {
+    return 0
+  }
+  const k = LN2 / halfLifeDays
+  const rate = lambdaPerDay + k
+  return (lambdaPerDay / rate) * (1 - Math.exp(-rate * horizonDays))
+}
+
+export const DEFAULT_STACK_WINDOW_HOURS = 72
+
+/**
+ * Is `later` rework of `pr`, or the same work continuing?
+ *
+ * Why a window and not a blanket same-author exclusion: excluding an author's own follow-ups
+ * forever removes a larger share of candidate reworkers for prolific authors than for rare
+ * ones — measurement error aligned with the author comparison. Stacked PRs land within days,
+ * so a short window covers the continuation case without that bias. Ticket lineage is the
+ * branch-lineage proxy available in squash history and is excluded at any distance.
+ */
+export function isRework(pr, later, stackWindowMs = DEFAULT_STACK_WINDOW_HOURS * 3600_000) {
+  if (pr.ticket && later.ticket && pr.ticket === later.ticket) {
+    return false
+  }
+  return !(later.author === pr.author && Math.abs(later.t - pr.t) <= stackWindowMs)
+}
+
+export const ticketOf = (subject) => /\b(STA-\d+)\b/i.exec(subject)?.[1]?.toUpperCase() ?? null
+
+export const hasConventionalPrefix = (subject) =>
+  /^\s*(feat|fix|perf|refactor|chore|docs|test|style|build|ci|revert)\s*(\([^)]*\))?\s*!?:/i.test(
+    subject
+  )
+
+export const isFixSubject = (subject) => /^\s*fix\s*(\([^)]*\))?\s*!?:/i.test(subject)
+
+export const scopeOf = (subject) =>
+  /^\s*[a-z]+\(([a-z0-9/._-]+)\)!?\s*:/i.exec(subject)?.[1]?.toLowerCase() ?? null
+
+const AREA_PREFIXES = ['src/renderer/src/', 'src/', 'config/', '.github/']
+
+/** Label-free counterpart to the title scope: the two directory levels that carry meaning. */
+export function areaOfPath(path) {
+  const prefix = AREA_PREFIXES.find((p) => path.startsWith(p))
+  const rest = prefix ? path.slice(prefix.length) : path
+  const parts = rest.split('/')
+  if (parts.length <= 1) {
+    return prefix ? prefix.replace(/\/$/, '') : '(root)'
+  }
+  return parts.slice(0, 2).join('/')
+}
+
+/** Modal area over a PR's files: where the change actually lives, no title needed. */
+export function dominantArea(paths) {
+  const counts = new Map()
+  for (const path of paths) {
+    const area = areaOfPath(path)
+    counts.set(area, (counts.get(area) ?? 0) + 1)
+  }
+  let best = null
+  let bestN = 0
+  for (const [area, n] of counts) {
+    if (n > bestN) {
+      best = area
+      bestN = n
+    }
+  }
+  return best ?? '(none)'
+}
+
+// Why: agents are declared by a co-author trailer, not by the git author, so the treatment
+// variable is trailer-present vs absent. Absence is not proof of a human — that asymmetry is
+// exactly why coverage is reported next to every author-type split.
+const AGENT_TRAILER_RE =
+  /co-authored-by:\s*(orca|claude|codex|cursor|devin|copilot|gemini|openai|chatgpt)/i
+
+export const authorTypeOf = (body) => (AGENT_TRAILER_RE.test(body ?? '') ? 'agent' : 'untagged')
+
+// Why: one pass over the PRs keyed by file, so every horizon is a lookup rather than a rescan.
+export function buildFileTimeline(prs) {
+  const timeline = new Map()
+  for (const pr of prs) {
+    for (const path of new Set(pr.paths)) {
+      let entries = timeline.get(path)
+      if (!entries) {
+        entries = []
+        timeline.set(path, entries)
+      }
+      entries.push(pr)
+    }
+  }
+  for (const entries of timeline.values()) {
+    entries.sort((a, b) => a.t - b.t)
+  }
+  return timeline
+}
+
+const churnOf = (pr) => (Number.isFinite(pr.churn) ? pr.churn : 0)
+
+/**
+ * Repair signature of one follow-up, label-free.
+ *
+ * containment: share of the follow-up's files that this PR had touched. 1.0 = surgical return
+ * to exactly this code; low = a sweep that happened to include it.
+ * asymmetry: this PR's size as a share of the pair. High = a small follow-up to a big change,
+ * which is what a repair looks like; ~0.5 = two comparable changes, i.e. evolution.
+ */
+export function repairSignature(pr, later) {
+  const laterPaths = new Set(later.paths)
+  let shared = 0
+  for (const path of laterPaths) {
+    if (pr.pathSet.has(path)) {
+      shared += 1
+    }
+  }
+  const total = churnOf(pr) + churnOf(later)
+  return {
+    containment: laterPaths.size === 0 ? 0 : shared / laterPaths.size,
+    asymmetry: total === 0 ? 0.5 : churnOf(pr) / total
+  }
+}
+
+const emptyMetrics = (censored) => ({
+  censored,
+  reworkRate: 0,
+  expected: 0,
+  lift: 0,
+  decay: 0,
+  decayExpected: 0,
+  decayLift: 0,
+  containment: 0,
+  asymmetry: 0,
+  events: 0,
+  fixShare: 0
+})
+
+/**
+ * Per-PR rework over a horizon, with a per-file baseline subtracted.
+ *
+ * Why lift, not the raw rate: hot files churn regardless of authorship, so an unnormalized
+ * rate just rediscovers which files are hot (#13066's own warning about thin signal). Both the
+ * binary rate and the decay-weighted rate get their own closed-form baseline.
+ *
+ * baseline: 'span' divides each file's touch count by the whole window, which understates the
+ * rate of files that only appear late and so inflates their lift. 'exposure' divides by the
+ * days since the file was first seen. 'span' is the default because it is the specification
+ * the metric shipped with; 'exposure' is the declared sensitivity check.
+ */
+export function computeReworkMetrics(
+  prs,
+  {
+    horizonDays,
+    halfLifeHours,
+    spanDays,
+    latestT,
+    stackWindowHours = DEFAULT_STACK_WINDOW_HOURS,
+    baseline = 'span'
+  }
+) {
+  const horizonMs = horizonDays * DAY_MS
+  const halfLifeMs = halfLifeHours * 3600_000
+  const halfLifeDays = halfLifeHours / 24
+  const stackWindowMs = stackWindowHours * 3600_000
+  const timeline = buildFileTimeline(prs)
+  const exposureDays = new Map()
+  for (const [path, entries] of timeline) {
+    const observed = (latestT - entries[0].t) / DAY_MS
+    exposureDays.set(path, Math.max(1, Math.min(spanDays, observed)))
+  }
+  for (const pr of prs) {
+    pr.pathSet = new Set(pr.paths)
+  }
+  // Why: PRs merged inside the trailing horizon have not had time to be reworked; scoring
+  // them as clean would bias every rate downward exactly where the data is freshest.
+  const censorBefore = latestT - horizonMs
+  const out = new Map()
+  for (const pr of prs) {
+    if (pr.t > censorBefore) {
+      out.set(pr, emptyMetrics(true))
+      continue
+    }
+    const paths = [...pr.pathSet]
+    if (paths.length === 0) {
+      out.set(pr, emptyMetrics(false))
+      continue
+    }
+    let touched = 0
+    let expectedSum = 0
+    let decaySum = 0
+    let decayExpectedSum = 0
+    let containmentSum = 0
+    let asymmetrySum = 0
+    let fixTouched = 0
+    for (const path of paths) {
+      const entries = timeline.get(path) ?? []
+      let first = null
+      let othersEver = 0
+      for (const other of entries) {
+        if (other === pr || !isRework(pr, other, stackWindowMs)) {
+          continue
+        }
+        othersEver += 1
+        if (other.t > pr.t && other.t - pr.t <= horizonMs && first === null) {
+          first = other
+        }
+      }
+      // Why: baseline is P(this file is touched at least once by another author in a window
+      // of the horizon), Poisson from the file's own rate. A linear rate*horizon pegs at 1.0
+      // for any file touched >4x in the span, which flattens lift to noise on a busy repo.
+      const denomDays = baseline === 'exposure' ? exposureDays.get(path) : spanDays
+      const lambdaPerDay = denomDays > 0 ? othersEver / denomDays : 0
+      expectedSum += 1 - Math.exp(-lambdaPerDay * horizonDays)
+      decayExpectedSum += expectedDecayWeight(lambdaPerDay, horizonDays, halfLifeDays)
+      if (first) {
+        touched += 1
+        decaySum += timeDecayWeight(first.t - pr.t, halfLifeMs)
+        const sig = repairSignature(pr, first)
+        containmentSum += sig.containment
+        asymmetrySum += sig.asymmetry
+        if (isFixSubject(first.subject)) {
+          fixTouched += 1
+        }
+      }
+    }
+    const n = paths.length
+    const reworkRate = touched / n
+    const expected = expectedSum / n
+    const decay = decaySum / n
+    const decayExpected = decayExpectedSum / n
+    out.set(pr, {
+      censored: false,
+      reworkRate,
+      expected,
+      lift: reworkRate - expected,
+      decay,
+      decayExpected,
+      decayLift: decay - decayExpected,
+      containment: touched === 0 ? 0 : containmentSum / touched,
+      asymmetry: touched === 0 ? 0 : asymmetrySum / touched,
+      events: touched,
+      fixShare: touched === 0 ? 0 : fixTouched / touched
+    })
+  }
+  return out
+}
+
+// Why: deterministic shuffles keep the null test reproducible across runs and machines.
+export function mulberry32(seed) {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+export const shuffleInPlace = (xs, rand) => {
+  for (let i = xs.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[xs[i], xs[j]] = [xs[j], xs[i]]
+  }
+  return xs
+}
+
+/**
+ * Split rows into shuffle cells: equal-count strata of a continuous key, nested inside the
+ * categorical `cell` when rows carry one.
+ *
+ * Why nest: file heat is not the only thing that moves with a group label. Agent share rises
+ * over the window, and so does repo-wide follow-up rate, so a heat-only shuffle would let
+ * calendar drift masquerade as an authorship effect.
+ */
+export function strataOf(rows, keyOf, count) {
+  const byCell = new Map()
+  for (const row of rows) {
+    const key = row.cell ?? ''
+    let bucket = byCell.get(key)
+    if (!bucket) {
+      bucket = []
+      byCell.set(key, bucket)
+    }
+    bucket.push(row)
+  }
+  const buckets = []
+  for (const cell of byCell.values()) {
+    const sorted = [...cell].sort((a, b) => keyOf(a) - keyOf(b))
+    const per = Math.max(1, Math.ceil(sorted.length / count))
+    for (let i = 0; i < sorted.length; i += per) {
+      buckets.push(sorted.slice(i, i + per))
+    }
+  }
+  return buckets
+}
+
+// Why: weighted between-group spread of lift is the thing a "some authors ship reworkable
+// code" claim rests on; if a label shuffle reproduces it, the metric is reading file heat.
+export function betweenGroupSpread(rows, minPRs) {
+  const byGroup = new Map()
+  for (const r of rows) {
+    let bucket = byGroup.get(r.group)
+    if (!bucket) {
+      bucket = []
+      byGroup.set(r.group, bucket)
+    }
+    bucket.push(r.value)
+  }
+  const kept = [...byGroup.values()].filter((v) => v.length >= minPRs)
+  if (kept.length < 2) {
+    return { spread: 0, groups: kept.length }
+  }
+  const means = kept.map((v) => mean(v))
+  const grand = mean(means)
+  return { spread: Math.sqrt(mean(means.map((m) => (m - grand) ** 2))), groups: kept.length }
+}
+
+const percentileOf = (sorted, p) =>
+  sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))]
+
+/**
+ * Group-label shuffle null test.
+ *
+ * Why: the live null hypothesis is "rework reflects file heat and feature area, not
+ * authorship". Shuffling labels *within* file-heat strata holds heat fixed, so anything left
+ * is the label. Labels are permuted over fixed values — the standard permutation test; it does
+ * not re-derive the stacked-PR exclusion, which is stated in the report.
+ */
+export function groupShuffleNull(rows, { rounds = 200, strata = 4, minPRs = 20, seed = 20260816 }) {
+  const observed = betweenGroupSpread(rows, minPRs)
+  if (observed.groups < 2 || rows.length === 0 || rounds <= 0) {
+    return { ...observed, nullMean: 0, nullP95: 0, pValue: 1, rounds: 0 }
+  }
+  const buckets = strataOf(rows, (r) => r.stratum, strata)
+  const rand = mulberry32(seed)
+  const nulls = []
+  for (let r = 0; r < rounds; r += 1) {
+    const shuffled = []
+    for (const bucket of buckets) {
+      const groups = shuffleInPlace(
+        bucket.map((x) => x.group),
+        rand
+      )
+      bucket.forEach((row, i) => shuffled.push({ group: groups[i], value: row.value }))
+    }
+    nulls.push(betweenGroupSpread(shuffled, minPRs).spread)
+  }
+  nulls.sort((a, b) => a - b)
+  const atOrAbove = nulls.filter((v) => v >= observed.spread).length
+  return {
+    ...observed,
+    nullMean: mean(nulls),
+    nullP95: percentileOf(nulls, 0.95),
+    pValue: (atOrAbove + 1) / (rounds + 1),
+    rounds
+  }
+}

--- a/config/scripts/pr-rework-metrics.test.mjs
+++ b/config/scripts/pr-rework-metrics.test.mjs
@@ -1,0 +1,394 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DAY_MS,
+  areaOfPath,
+  authorTypeOf,
+  betweenGroupSpread,
+  buildFileTimeline,
+  computeReworkMetrics,
+  dominantArea,
+  expectedDecayWeight,
+  groupShuffleNull,
+  hasConventionalPrefix,
+  isFixSubject,
+  isRework,
+  meanWithError,
+  mulberry32,
+  normalizeNumstatPath,
+  repairSignature,
+  scopeOf,
+  ticketOf,
+  timeDecayWeight
+} from './pr-rework-metrics.mjs'
+
+const HOUR_MS = 3600_000
+const base = Date.parse('2026-01-01T00:00:00Z')
+
+function pr(overrides) {
+  return {
+    author: 'alice',
+    subject: 'feat(x): thing',
+    ticket: null,
+    paths: ['a.ts'],
+    churn: 100,
+    t: base,
+    ...overrides
+  }
+}
+
+// Baseline span/latest chosen so nothing is right-censored unless a test wants it.
+const opts = (extra = {}) => ({
+  horizonDays: 30,
+  halfLifeHours: 48,
+  spanDays: 365,
+  latestT: base + 400 * DAY_MS,
+  ...extra
+})
+
+describe('normalizeNumstatPath', () => {
+  it('collapses a braced rename to the new path', () => {
+    expect(normalizeNumstatPath('src/{old => new}/file.ts')).toBe('src/new/file.ts')
+  })
+
+  it('collapses an arrow rename to the new path', () => {
+    expect(normalizeNumstatPath('old/file.ts => new/file.ts')).toBe('new/file.ts')
+  })
+
+  it('drops an emptied brace segment without leaving a double slash', () => {
+    expect(normalizeNumstatPath('src/{legacy => }/file.ts')).toBe('src/file.ts')
+  })
+
+  it('leaves an ordinary path untouched', () => {
+    expect(normalizeNumstatPath('src/main/index.ts')).toBe('src/main/index.ts')
+  })
+})
+
+describe('timeDecayWeight', () => {
+  it('weights a same-hour repair far above a months-later edit', () => {
+    const soon = timeDecayWeight(6 * HOUR_MS, 48 * HOUR_MS)
+    const later = timeDecayWeight(90 * DAY_MS, 48 * HOUR_MS)
+    expect(soon).toBeGreaterThan(0.9)
+    expect(later).toBeLessThan(0.01)
+    expect(soon).toBeGreaterThan(later * 50)
+  })
+
+  it('halves at exactly one half-life', () => {
+    expect(timeDecayWeight(48 * HOUR_MS, 48 * HOUR_MS)).toBeCloseTo(0.5, 10)
+  })
+})
+
+describe('expectedDecayWeight', () => {
+  it('is zero for a file nobody else touches', () => {
+    expect(expectedDecayWeight(0, 30, 2)).toBe(0)
+  })
+
+  // Why: the closed form replaces a simulation, so it must match one.
+  it('matches a Monte Carlo draw of the first follow-up', () => {
+    const lambda = 0.25
+    const horizon = 30
+    const halfLife = 2
+    const rand = mulberry32(7)
+    let total = 0
+    const draws = 200_000
+    for (let i = 0; i < draws; i += 1) {
+      const t = -Math.log(1 - rand()) / lambda
+      total += t <= horizon ? 2 ** (-t / halfLife) : 0
+    }
+    expect(expectedDecayWeight(lambda, horizon, halfLife)).toBeCloseTo(total / draws, 2)
+  })
+
+  it('rises with file heat', () => {
+    expect(expectedDecayWeight(1, 30, 2)).toBeGreaterThan(expectedDecayWeight(0.05, 30, 2))
+  })
+})
+
+describe('isRework', () => {
+  it('excludes a same-author follow-up inside the stacking window', () => {
+    expect(isRework(pr(), pr({ t: base + DAY_MS }))).toBe(false)
+  })
+
+  // Why: a blanket same-author exclusion removes more candidate reworkers from prolific
+  // authors than from rare ones, which is measurement error aligned with the comparison.
+  it('counts a same-author follow-up long after the stacking window', () => {
+    expect(isRework(pr(), pr({ t: base + 20 * DAY_MS }))).toBe(true)
+  })
+
+  it('excludes a different author on the same ticket at any distance', () => {
+    const first = pr({ ticket: 'STA-1' })
+    const later = pr({ author: 'bob', ticket: 'STA-1', t: base + 40 * DAY_MS })
+    expect(isRework(first, later)).toBe(false)
+  })
+
+  it('counts a different author with no shared ticket', () => {
+    expect(isRework(pr(), pr({ author: 'bob', t: base + DAY_MS }))).toBe(true)
+  })
+})
+
+describe('repairSignature', () => {
+  it('reads a surgical return to the same code as contained and asymmetric', () => {
+    const first = { pathSet: new Set(['a.ts', 'b.ts', 'c.ts']), churn: 400 }
+    const later = { paths: ['a.ts'], churn: 3 }
+    const sig = repairSignature(first, later)
+    expect(sig.containment).toBe(1)
+    expect(sig.asymmetry).toBeGreaterThan(0.98)
+  })
+
+  it('reads a repo-wide sweep as uncontained and symmetric', () => {
+    const first = { pathSet: new Set(['a.ts']), churn: 100 }
+    const later = { paths: ['a.ts', 'x.ts', 'y.ts', 'z.ts'], churn: 100 }
+    const sig = repairSignature(first, later)
+    expect(sig.containment).toBe(0.25)
+    expect(sig.asymmetry).toBe(0.5)
+  })
+})
+
+describe('area and label helpers', () => {
+  it('derives a two-level area under the known source roots', () => {
+    expect(areaOfPath('src/main/terminal/pty.ts')).toBe('main/terminal')
+    expect(areaOfPath('src/renderer/src/components/Task.tsx')).toBe('components/Task.tsx')
+    expect(areaOfPath('README.md')).toBe('(root)')
+  })
+
+  it('takes the modal area of a PR', () => {
+    expect(dominantArea(['src/main/git/a.ts', 'src/main/git/b.ts', 'src/shared/c.ts'])).toBe(
+      'main/git'
+    )
+  })
+
+  it('marks an agent co-author trailer and does not claim the rest are human', () => {
+    expect(authorTypeOf('Co-authored-by: Orca <help@stably.ai>')).toBe('agent')
+    expect(authorTypeOf('Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>')).toBe('agent')
+    expect(authorTypeOf('Reviewed-by: Someone')).toBe('untagged')
+    expect(authorTypeOf(undefined)).toBe('untagged')
+  })
+
+  it('recognises conventional prefixes, fix: and scopes', () => {
+    expect(hasConventionalPrefix('fix: thing')).toBe(true)
+    expect(hasConventionalPrefix('feat(terminal)!: thing')).toBe(true)
+    expect(hasConventionalPrefix('Remove worktree deletion toasts')).toBe(false)
+    expect(isFixSubject('fix(ssh): thing')).toBe(true)
+    expect(isFixSubject('feat(ssh): thing')).toBe(false)
+    expect(scopeOf('feat(Terminal)!: x')).toBe('terminal')
+    expect(scopeOf('chore: x')).toBeNull()
+  })
+
+  it('extracts an STA ticket case-insensitively', () => {
+    expect(ticketOf('fix(x): thing (STA-4276)')).toBe('STA-4276')
+    expect(ticketOf('fix(x): sta-99 lowercase')).toBe('STA-99')
+    expect(ticketOf('fix(x): no ticket')).toBeNull()
+  })
+})
+
+describe('buildFileTimeline', () => {
+  it('indexes each path once per PR and orders entries by time', () => {
+    const late = pr({ t: base + 2 * DAY_MS, paths: ['a.ts'] })
+    const early = pr({ t: base, paths: ['a.ts', 'a.ts', 'b.ts'] })
+    const timeline = buildFileTimeline([late, early])
+    expect(timeline.get('a.ts')).toEqual([early, late])
+    expect(timeline.get('b.ts')).toEqual([early])
+  })
+})
+
+describe('computeReworkMetrics', () => {
+  it('counts a later different-author touch as rework', () => {
+    const first = pr()
+    const second = pr({ author: 'bob', t: base + 3 * DAY_MS })
+    const m = computeReworkMetrics([first, second], opts()).get(first)
+    expect(m.reworkRate).toBe(1)
+    expect(m.censored).toBe(false)
+  })
+
+  it('does not count a touch beyond the horizon', () => {
+    const first = pr()
+    const second = pr({ author: 'bob', t: base + 45 * DAY_MS })
+    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0)
+  })
+
+  it('does not count the PR stacked behind it', () => {
+    const first = pr()
+    const second = pr({ t: base + DAY_MS })
+    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0)
+  })
+
+  // Why: the whole point of lift — a hot file must not score as rework just for being hot.
+  it('subtracts a hot file baseline so lift stays near zero', () => {
+    const others = Array.from({ length: 60 }, (_, i) =>
+      pr({ author: `dev${i}`, t: base + (i + 1) * 6 * DAY_MS })
+    )
+    const first = pr()
+    const m = computeReworkMetrics([first, ...others], opts({ spanDays: 360 })).get(first)
+    expect(m.reworkRate).toBe(1)
+    expect(m.expected).toBeGreaterThan(0.9)
+    expect(Math.abs(m.lift)).toBeLessThan(0.1)
+  })
+
+  // Why: the binary rate saturates on a busy repo; the decay-weighted rate must not, and it
+  // needs the same baseline subtraction or it just re-reads heat.
+  it('separates a fast repair from slow evolution after baseline subtraction', () => {
+    const fast = pr({ paths: ['fast.ts'] })
+    const slow = pr({ paths: ['slow.ts'] })
+    const metrics = computeReworkMetrics(
+      [
+        fast,
+        slow,
+        pr({ author: 'bob', paths: ['fast.ts'], t: base + 2 * HOUR_MS }),
+        pr({ author: 'bob', paths: ['slow.ts'], t: base + 25 * DAY_MS })
+      ],
+      opts()
+    )
+    expect(metrics.get(fast).reworkRate).toBe(metrics.get(slow).reworkRate)
+    expect(metrics.get(fast).decayLift).toBeGreaterThan(0.9)
+    expect(metrics.get(slow).decayLift).toBeLessThan(0.05)
+  })
+
+  it('scores containment and asymmetry of the first follow-up', () => {
+    const first = pr({ paths: ['a.ts', 'b.ts'], churn: 400 })
+    const surgical = pr({ author: 'bob', paths: ['a.ts'], churn: 4, t: base + HOUR_MS })
+    const sweep = pr({
+      author: 'carol',
+      paths: ['b.ts', 'x.ts', 'y.ts', 'z.ts'],
+      churn: 400,
+      t: base + HOUR_MS
+    })
+    const m = computeReworkMetrics([first, surgical, sweep], opts()).get(first)
+    expect(m.events).toBe(2)
+    expect(m.containment).toBeCloseTo((1 + 0.25) / 2, 10)
+    expect(m.asymmetry).toBeCloseTo((400 / 404 + 0.5) / 2, 10)
+  })
+
+  it('censors PRs merged inside the trailing horizon instead of scoring them clean', () => {
+    const recent = pr({ t: base + 395 * DAY_MS })
+    const m = computeReworkMetrics([recent], opts()).get(recent)
+    expect(m.censored).toBe(true)
+    expect(m.lift).toBe(0)
+  })
+
+  it('averages partial rework across a multi-file PR', () => {
+    const first = pr({ paths: ['a.ts', 'b.ts'] })
+    const second = pr({ author: 'bob', paths: ['a.ts'], t: base + DAY_MS })
+    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0.5)
+  })
+
+  it('reports the fix: share of rework events without letting it drive lift', () => {
+    const first = pr({ paths: ['a.ts', 'b.ts'] })
+    const fixer = pr({
+      author: 'bob',
+      subject: 'fix(a): repair',
+      paths: ['a.ts'],
+      t: base + DAY_MS
+    })
+    const featurer = pr({
+      author: 'carol',
+      subject: 'feat(b): extend',
+      paths: ['b.ts'],
+      t: base + DAY_MS
+    })
+    const m = computeReworkMetrics([first, fixer, featurer], opts()).get(first)
+    expect(m.reworkRate).toBe(1)
+    expect(m.fixShare).toBe(0.5)
+  })
+})
+
+describe('meanWithError', () => {
+  it('reports the standard error of the mean', () => {
+    const s = meanWithError([1, 2, 3, 4])
+    expect(s.mean).toBe(2.5)
+    expect(s.se).toBeCloseTo(Math.sqrt(5 / 3 / 4), 10)
+  })
+
+  it('has no error to report for a single observation', () => {
+    expect(meanWithError([7])).toEqual({ n: 1, mean: 7, se: 0 })
+  })
+})
+
+describe('betweenGroupSpread', () => {
+  it('ignores groups below the minimum sample', () => {
+    const rows = [
+      ...Array.from({ length: 25 }, () => ({ group: 'alice', value: 0.4 })),
+      { group: 'bob', value: -0.4 }
+    ]
+    expect(betweenGroupSpread(rows, 20).groups).toBe(1)
+    expect(betweenGroupSpread(rows, 20).spread).toBe(0)
+  })
+
+  it('grows as group means diverge', () => {
+    const tight = [
+      ...Array.from({ length: 25 }, () => ({ group: 'alice', value: 0.1 })),
+      ...Array.from({ length: 25 }, () => ({ group: 'bob', value: 0.1 }))
+    ]
+    const wide = [
+      ...Array.from({ length: 25 }, () => ({ group: 'alice', value: 0.5 })),
+      ...Array.from({ length: 25 }, () => ({ group: 'bob', value: -0.5 }))
+    ]
+    expect(betweenGroupSpread(tight, 20).spread).toBeCloseTo(0, 10)
+    expect(betweenGroupSpread(wide, 20).spread).toBeGreaterThan(0.4)
+  })
+})
+
+describe('mulberry32', () => {
+  it('is deterministic for a given seed', () => {
+    const a = mulberry32(42)
+    const b = mulberry32(42)
+    expect([a(), a(), a()]).toEqual([b(), b(), b()])
+  })
+})
+
+describe('groupShuffleNull', () => {
+  // Why: the live null is "this is file heat, not authorship" — a heat-driven effect must not survive.
+  it('fails to reject when the value tracks file heat rather than the group', () => {
+    const rows = []
+    for (let i = 0; i < 60; i += 1) {
+      const heat = i / 60
+      rows.push({ group: i % 2 === 0 ? 'alice' : 'bob', value: heat, stratum: heat })
+    }
+    const result = groupShuffleNull(rows, { rounds: 200, minPRs: 20 })
+    expect(result.groups).toBe(2)
+    expect(result.pValue).toBeGreaterThan(0.05)
+  })
+
+  it('rejects when one group carries higher lift at equal file heat', () => {
+    const rows = []
+    for (let i = 0; i < 60; i += 1) {
+      const alice = i % 2 === 0
+      rows.push({ group: alice ? 'alice' : 'bob', value: alice ? 0.5 : -0.5, stratum: 0.5 })
+    }
+    expect(groupShuffleNull(rows, { rounds: 200, minPRs: 20 }).pValue).toBeLessThanOrEqual(0.05)
+  })
+
+  it('reports UNEVALUABLE shape when only one group clears the minimum', () => {
+    const rows = Array.from({ length: 30 }, () => ({ group: 'alice', value: 0.2, stratum: 0.2 }))
+    const result = groupShuffleNull(rows, { rounds: 50, minPRs: 20 })
+    expect(result.groups).toBe(1)
+    expect(result.pValue).toBe(1)
+  })
+
+  it('reports zero rounds when the shuffle is switched off', () => {
+    const rows = Array.from({ length: 60 }, (_, i) => ({
+      group: i % 2 ? 'a' : 'b',
+      value: i / 60,
+      stratum: i / 60
+    }))
+    expect(groupShuffleNull(rows, { rounds: 0, minPRs: 20 }).rounds).toBe(0)
+  })
+})
+
+describe('exposure-adjusted baseline', () => {
+  // Why: a file first seen late in the window has its rate divided by the whole span, which
+  // understates it and inflates the lift of every PR that touches a young file.
+  it('raises the baseline for a file that only exists late in the window', () => {
+    const young = pr({ paths: ['young.ts'], t: base + 300 * DAY_MS })
+    const follow = pr({ author: 'bob', paths: ['young.ts'], t: base + 310 * DAY_MS })
+    const args = { ...opts(), spanDays: 365 }
+    const span = computeReworkMetrics([young, follow], args).get(young)
+    const exposure = computeReworkMetrics([young, follow], {
+      ...args,
+      baseline: 'exposure'
+    }).get(young)
+
+    expect(span.reworkRate).toBe(exposure.reworkRate)
+    // 1 touch over the file's 100 observed days, not over the 365-day window.
+    expect(exposure.expected).toBeCloseTo(1 - Math.exp(-0.3), 6)
+    expect(span.expected).toBeCloseTo(1 - Math.exp(-30 / 365), 6)
+    expect(exposure.lift).toBeLessThan(span.lift)
+  })
+})

--- a/config/scripts/pr-rework-report.mjs
+++ b/config/scripts/pr-rework-report.mjs
@@ -99,6 +99,15 @@ export function quintileLines(title, rows, { rounds = 200, strata = 4, minPRs = 
     lines.push('  UNEVALUABLE: fewer than 5 rows')
     return lines
   }
+  // Why: a predictor with no spread still sorts into five buckets, and the resulting table
+  // looks like a finding when it is only the tie-break order of the sort.
+  const spread = sorted.at(-1).predictor - sorted[0].predictor
+  if (!(spread > 1e-9)) {
+    lines.push(
+      `  UNEVALUABLE: the predictor is constant (range ${spread.toExponential(2)}) — no quintiles exist`
+    )
+    return lines
+  }
   const cuts = [0.2, 0.4, 0.6, 0.8].map((p) =>
     percentileOf(
       sorted.map((r) => r.predictor),

--- a/config/scripts/pr-rework-report.mjs
+++ b/config/scripts/pr-rework-report.mjs
@@ -1,0 +1,145 @@
+// Report formatting for the rework/lift metric. Pure: every function returns lines so the
+// tables are unit-testable and every effect is printed next to its shuffle control.
+
+import { groupShuffleNull, mean, meanWithError } from './pr-rework-metrics.mjs'
+
+export const pct = (x, n) => (n === 0 ? '—' : `${((x / n) * 100).toFixed(2)}%`)
+export const pp = (x) => `${x >= 0 ? '+' : ''}${(x * 100).toFixed(1)}pp`
+
+export const percentileOf = (sorted, p) =>
+  sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))]
+
+export const dist = (values) => {
+  const s = [...values].sort((a, b) => a - b)
+  return {
+    p50: percentileOf(s, 0.5),
+    p75: percentileOf(s, 0.75),
+    p90: percentileOf(s, 0.9),
+    p95: percentileOf(s, 0.95)
+  }
+}
+
+const groupBy = (rows) => {
+  const byGroup = new Map()
+  for (const r of rows) {
+    let bucket = byGroup.get(r.group)
+    if (!bucket) {
+      bucket = []
+      byGroup.set(r.group, bucket)
+    }
+    bucket.push(r.value)
+  }
+  return byGroup
+}
+
+/**
+ * One effect table plus the shuffle control that decides whether to believe it.
+ *
+ * The shuffle permutes group labels within file-heat strata, so a surviving spread cannot be
+ * explained by "these groups touch hotter files". Groups below minPRs are listed but excluded
+ * from the spread — the same min-n discipline the revert column uses.
+ */
+export function groupEffectLines(
+  title,
+  rows,
+  { rounds = 200, minPRs = 20, strata = 4, limit = 12 } = {}
+) {
+  const lines = [`\n=== ${title} ===`]
+  const byGroup = groupBy(rows)
+  const ordered = [...byGroup.entries()].sort((a, b) => b[1].length - a[1].length)
+  lines.push(`  ${'group'.padEnd(26)}${'n'.padStart(7)}${'mean'.padStart(10)}${'±se'.padStart(9)}`)
+  for (const [group, values] of ordered.slice(0, limit)) {
+    const s = meanWithError(values)
+    const flag = s.n < minPRs ? '  (n<min, excluded from spread)' : ''
+    lines.push(
+      `  ${String(group).slice(0, 25).padEnd(26)}${String(s.n).padStart(7)}${pp(s.mean).padStart(10)}${pp(s.se).padStart(9)}${flag}`
+    )
+  }
+  if (ordered.length > limit) {
+    const rest = ordered.slice(limit)
+    const restRows = rest.reduce((a, [, v]) => a + v.length, 0)
+    lines.push(`  … ${rest.length} smaller groups (${restRows} PRs) not shown`)
+  }
+  const kept = ordered.filter(([, v]) => v.length >= minPRs)
+  if (kept.length === 2) {
+    const [a, b] = kept
+    const sa = meanWithError(a[1])
+    const sb = meanWithError(b[1])
+    const diff = sa.mean - sb.mean
+    const se = Math.sqrt(sa.se ** 2 + sb.se ** 2)
+    lines.push(
+      `  difference ${a[0]} − ${b[0]}: ${pp(diff)} ± ${pp(se)} (95% CI ${pp(diff - 1.96 * se)} … ${pp(diff + 1.96 * se)})`
+    )
+  }
+  const nul = groupShuffleNull(rows, { rounds, minPRs, strata })
+  if (nul.groups < 2) {
+    lines.push(`  UNEVALUABLE: fewer than 2 groups with >=${minPRs} scored PRs`)
+    return lines
+  }
+  lines.push(
+    `  between-group spread: observed ${pp(nul.spread)} · shuffle null mean ${pp(nul.nullMean)} · null p95 ${pp(nul.nullP95)} · p=${nul.pValue.toFixed(3)} (${nul.rounds} rounds)`
+  )
+  lines.push(
+    nul.pValue <= 0.05
+      ? '  SURVIVES the within-stratum shuffle: the grouping still separates with file heat held fixed'
+      : '  NULL NOT REJECTED: the shuffle reproduces this spread — it is file heat and feature area, not the grouping'
+  )
+  return lines
+}
+
+/**
+ * Quintile table of `value` against a continuous predictor, with the shuffle control.
+ *
+ * Cut points come from the predictor's own distribution, fixed before any value is read.
+ */
+export function quintileLines(title, rows, { rounds = 200, strata = 4, minPRs = 20 } = {}) {
+  const sorted = [...rows].sort((a, b) => a.predictor - b.predictor)
+  const lines = [`\n=== ${title} ===`]
+  if (sorted.length < 5) {
+    lines.push('  UNEVALUABLE: fewer than 5 rows')
+    return lines
+  }
+  const cuts = [0.2, 0.4, 0.6, 0.8].map((p) =>
+    percentileOf(
+      sorted.map((r) => r.predictor),
+      p
+    )
+  )
+  const quintileOf = (x) => {
+    let q = 0
+    while (q < 4 && x > cuts[q]) {
+      q += 1
+    }
+    return q + 1
+  }
+  const labelled = sorted.map((r) => ({ ...r, group: `Q${quintileOf(r.predictor)}` }))
+  lines.push(`  cut points (predictor): ${cuts.map((c) => c.toFixed(3)).join(' | ')}`)
+  lines.push(
+    `  ${'quintile'.padEnd(10)}${'n'.padStart(7)}${'predictor'.padStart(12)}${'mean'.padStart(10)}${'±se'.padStart(9)}`
+  )
+  for (let q = 1; q <= 5; q += 1) {
+    const bucket = labelled.filter((r) => r.group === `Q${q}`)
+    const s = meanWithError(bucket.map((r) => r.value))
+    const p = mean(bucket.map((r) => r.predictor))
+    lines.push(
+      `  ${`Q${q}`.padEnd(10)}${String(s.n).padStart(7)}${p.toFixed(3).padStart(12)}${pp(s.mean).padStart(10)}${pp(s.se).padStart(9)}`
+    )
+  }
+  const q1 = meanWithError(labelled.filter((r) => r.group === 'Q1').map((r) => r.value))
+  const q5 = meanWithError(labelled.filter((r) => r.group === 'Q5').map((r) => r.value))
+  const diff = q5.mean - q1.mean
+  const se = Math.sqrt(q1.se ** 2 + q5.se ** 2)
+  lines.push(
+    `  Q5 − Q1: ${pp(diff)} ± ${pp(se)} (95% CI ${pp(diff - 1.96 * se)} … ${pp(diff + 1.96 * se)})`
+  )
+  const nul = groupShuffleNull(labelled, { rounds, minPRs, strata })
+  lines.push(
+    `  between-quintile spread: observed ${pp(nul.spread)} · shuffle null mean ${pp(nul.nullMean)} · null p95 ${pp(nul.nullP95)} · p=${nul.pValue.toFixed(3)} (${nul.rounds} rounds)`
+  )
+  lines.push(
+    nul.pValue <= 0.05
+      ? '  SURVIVES the within-stratum shuffle'
+      : '  NULL NOT REJECTED: the quintile ordering carries no information the shuffle cannot reproduce'
+  )
+  return lines
+}

--- a/config/scripts/pr-test-loc-summary.test.mjs
+++ b/config/scripts/pr-test-loc-summary.test.mjs
@@ -156,17 +156,17 @@ describe('PR test LoC summary', () => {
     expect(requests[2].options.method).toBe('PATCH')
   })
 
-  it('colors added cells green and deleted or negative-net cells red', () => {
+  it('colors added and deleted cells but leaves the net judgement uncolored', () => {
     const block = renderLocBlock({
       test: { files: 1, added: 2, deleted: 5 },
       nonTest: { files: 1, added: 0, deleted: 4 }
     })
 
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b5 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b3 |'
+      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b5 | $\\Huge{\\mathbf{−}}$\u200b3 |'
     )
     expect(block).toContain(
-      '| Prod | 1 | 0 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b4 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b4 |'
+      '| Prod | 1 | 0 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b4 | $\\Huge{\\mathbf{−}}$\u200b4 |'
     )
   })
 
@@ -179,10 +179,10 @@ describe('PR test LoC summary', () => {
 
     expect(block).toContain(LOC_HANDS_OFF_COMMENT)
     expect(block).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b1 |'
+      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b1 | $\\Huge{\\mathbf{+}}$\u200b1 |'
     )
     expect(block).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b4 | 0 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b4 |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b4 | 0 | $\\Huge{\\mathbf{+}}$\u200b4 |'
     )
     expect(block).not.toContain('| Total |')
     expect(mergeLocBlock('## ELI5\n\nHello\n', totals)).toBe(`${block}\n\n## ELI5\n\nHello\n`)
@@ -215,10 +215,10 @@ describe('PR test LoC summary', () => {
     expect(result.stdout.startsWith('<!-- orca-pr-loc -->')).toBe(true)
     expect(result.stdout).toContain(LOC_HANDS_OFF_COMMENT)
     expect(result.stdout).toContain(
-      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b6 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b5 |'
+      '| Test | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b6 | $\\color{#cf222e}{\\Huge{\\mathbf{−}}}$\u200b1 | $\\Huge{\\mathbf{+}}$\u200b5 |'
     )
     expect(result.stdout).toContain(
-      '| Prod | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | 0 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 |'
+      '| Prod | 1 | $\\color{#1a7f37}{\\Huge{\\mathbf{+}}}$\u200b2 | 0 | $\\Huge{\\mathbf{+}}$\u200b2 |'
     )
     expect(result.stdout).not.toContain('| Total |')
     expect(result.stdout).toContain('## ELI5\n\nHello\n')

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -1,0 +1,202 @@
+// Replays a PR watch-rules / review-queue config over local git history so a rule
+// can be judged before it is trusted. Offline: git log is the only data source.
+// Usage: node config/scripts/pr-watch-backtest.mjs [--rules <file.yaml>] [--window <commits>]
+import { execFileSync } from 'node:child_process'
+import { readFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { pathToFileURL } from 'node:url'
+import { parse as parseYaml } from 'yaml'
+
+const repoRoot = join(import.meta.dirname, '..', '..')
+// Node >=23 strips erasable types, letting the backtest share the real evaluator.
+// pathToFileURL: Windows absolute paths are not valid ESM specifiers.
+const { evaluateWatchRules, classifyReviewQueueTier, validateWatchRules, validateTierRules } =
+  await import(pathToFileURL(join(repoRoot, 'src', 'shared', 'pr-watch-rules.ts')).href)
+
+const args = process.argv.slice(2)
+const argOf = (flag, fallback) => {
+  const i = args.indexOf(flag)
+  return i >= 0 ? args[i + 1] : fallback
+}
+const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
+const windowSize = Number(argOf('--window', '8000'))
+
+const config = parseYaml(readFileSync(rulesPath, 'utf8'))
+const chipRules = config?.pr_watch ? validateWatchRules(config.pr_watch) : []
+const tierRules = config?.review_queue?.tiers ? validateTierRules(config.review_queue.tiers) : []
+if (chipRules.length === 0 && tierRules.length === 0) {
+  console.error(`${rulesPath}: no pr_watch rules or review_queue.tiers found`)
+  process.exit(1)
+}
+
+// --- history: one merged-PR record per squash-merge commit, plus revert labels ---
+const log = execFileSync(
+  'git',
+  ['-C', repoRoot, 'log', `-${windowSize}`, '--numstat', '--date=short', '--format=@@@%an|%ad|%s'],
+  { encoding: 'utf8', maxBuffer: 1 << 28 }
+)
+
+const commits = []
+let cur = null
+for (const line of log.split('\n')) {
+  if (line.startsWith('@@@')) {
+    if (cur) {
+      commits.push(cur)
+    }
+    const [author, date, ...rest] = line.slice(3).split('|')
+    cur = { author, date, subject: rest.join('|'), paths: [], churn: 0 }
+    continue
+  }
+  const m = cur && /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line)
+  if (!m) {
+    continue
+  }
+  cur.paths.push(m[3])
+  if (m[1] !== '-') {
+    cur.churn += Number(m[1])
+  }
+  if (m[2] !== '-') {
+    cur.churn += Number(m[2])
+  }
+}
+if (cur) {
+  commits.push(cur)
+}
+
+const trailingPR = (s) => Number(/\(#(\d+)\)\s*$/.exec(s)?.[1] ?? Number.NaN)
+const norm = (s) =>
+  s
+    .replace(/\s*\(#\d+\)\s*$/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+
+// Revert-target extraction: quoted-number, unquoted-number, and quoted-title forms.
+const byTitle = new Map()
+for (const c of commits) {
+  const n = trailingPR(c.subject)
+  if (!Number.isNaN(n) && !/^revert\b/i.test(c.subject)) {
+    byTitle.set(norm(c.subject), n)
+  }
+}
+const revertTargets = new Set()
+for (const c of commits) {
+  if (!/^revert\b/i.test(c.subject)) {
+    continue
+  }
+  const quoted = /"([^"]+)"/.exec(c.subject)?.[1]
+  const inQuote = quoted ? [...quoted.matchAll(/#(\d+)/g)].map((m) => Number(m[1])) : []
+  if (inQuote.length) {
+    inQuote.forEach((t) => revertTargets.add(t))
+    continue
+  }
+  const own = trailingPR(c.subject)
+  const rest = [...c.subject.matchAll(/#(\d+)/g)].map((m) => Number(m[1])).filter((x) => x !== own)
+  if (rest.length) {
+    rest.forEach((t) => revertTargets.add(t))
+  } else if (quoted && byTitle.has(norm(quoted))) {
+    revertTargets.add(byTitle.get(norm(quoted)))
+  }
+}
+
+const authorMerged = new Map()
+const prs = []
+for (const c of commits.toReversed()) {
+  const n = trailingPR(c.subject)
+  if (Number.isNaN(n) || /^revert\b/i.test(c.subject)) {
+    continue
+  }
+  const prior = authorMerged.get(c.author) ?? 0
+  authorMerged.set(c.author, prior + 1)
+  prs.push({
+    n,
+    date: c.date,
+    subject: c.subject,
+    reverted: revertTargets.has(n),
+    input: {
+      title: c.subject,
+      author: c.author,
+      paths: c.paths,
+      files: c.paths.length,
+      churn: c.churn,
+      draft: false, // merged history: never draft, never conflicting
+      mergeable: 'mergeable',
+      authorMergedPRs: prior
+    }
+  })
+}
+
+const pct = (x, n) => `${((x / n) * 100).toFixed(2)}%`
+const percentileOf = (sorted, p) =>
+  sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))]
+const dist = (values) => {
+  const s = [...values].sort((a, b) => a - b)
+  return {
+    p50: percentileOf(s, 0.5),
+    p75: percentileOf(s, 0.75),
+    p90: percentileOf(s, 0.9),
+    p95: percentileOf(s, 0.95)
+  }
+}
+const percentiles = {
+  files: dist(prs.map((p) => p.input.files)),
+  churn: dist(prs.map((p) => p.input.churn))
+}
+
+const totalReverts = prs.filter((p) => p.reverted).length
+const months = ((new Date(prs.at(-1).date) - new Date(prs[0].date)) / 2.63e9).toFixed(1)
+console.log(
+  `history: ${prs.length} merged PRs over ${months} months (window ${windowSize} commits)`
+)
+console.log(
+  `calibration: files p50=${percentiles.files.p50} p90=${percentiles.files.p90} · churn p50=${percentiles.churn.p50} p90=${percentiles.churn.p90}`
+)
+const showReverts = totalReverts >= 20
+console.log(
+  showReverts
+    ? `revert labels: ${totalReverts}`
+    : `revert labels: ${totalReverts} — below min-n 20, correlation column suppressed`
+)
+
+if (chipRules.length) {
+  console.log(`\n=== pr_watch rules ===`)
+  const header = `${'rule'.padEnd(24)}${'fires'.padStart(7)}   % of PRs${showReverts ? '   reverts caught' : ''}`
+  console.log(`${header}\n${'-'.repeat(header.length + 4)}`)
+  for (const rule of chipRules) {
+    const hits = prs.filter((p) =>
+      evaluateWatchRules([rule], p.input, { percentiles }).some((m) => !m.pending)
+    )
+    const caught = hits.filter((p) => p.reverted).length
+    let line = `${rule.name.slice(0, 23).padEnd(24)}${String(hits.length).padStart(7)}${pct(hits.length, prs.length).padStart(11)}`
+    if (showReverts) {
+      line += `   ${caught} / ${totalReverts}`
+    }
+    console.log(line)
+    if (hits.length === 0) {
+      console.log(
+        prs.length >= 200
+          ? '    DEAD: matched nothing across a large history — delete or fix it'
+          : `    0 matches across ${prs.length} PRs / ${months} months — may just be a quiet area`
+      )
+    } else {
+      if (hits.length >= 10 && hits.length / prs.length > 0.2) {
+        console.log('    BROAD: matches over 20% of PRs — too wide to direct attention')
+      }
+      console.log(`    sample: ${hits.at(-1).subject.slice(0, 76)}`)
+    }
+  }
+}
+
+if (tierRules.length) {
+  console.log(`\n=== review_queue tiers (first-match) ===`)
+  const counts = new Map()
+  for (const p of prs) {
+    const { tier, pending } = classifyReviewQueueTier(tierRules, p.input, { percentiles })
+    const key = (tier ?? '(catch-all)') + (pending ? ' [pending]' : '')
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  for (const [name, n] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
+    console.log(`  ${name.padEnd(26)} ${String(n).padStart(6)}  ${pct(n, prs.length).padStart(8)}`)
+  }
+  console.log('  (drafts/conflicts never appear in merged history — T0 tiers only fire live)')
+}

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -1,34 +1,33 @@
 // Replays a PR watch-rules / review-queue config over local git history so a rule
 // can be judged before it is trusted. Offline: git log is the only data source.
 // Usage: node config/scripts/pr-watch-backtest.mjs [--rules <file.yaml>] [--window <commits>] [--repo <path>]
-//        [--horizon <days>] [--horizon2 <days>] [--half-life <hours>] [--null-rounds <n>]
+//        [--horizon <days>] [--horizon2 <days>] [--half-life <hours>] [--stack-window <hours>]
+//        [--null-rounds <n>] [--export <file.json>]
 import { execFileSync } from 'node:child_process'
-import { readFileSync } from 'node:fs'
+import { readFileSync, writeFileSync } from 'node:fs'
 import { join } from 'node:path'
 import { pathToFileURL } from 'node:url'
 import { parse as parseYaml } from 'yaml'
+import { isTestPath } from '../../.github/scripts/pr-test-loc-table.mjs'
+import {
+  DAY_MS,
+  DEFAULT_STACK_WINDOW_HOURS,
+  areaOfPath,
+  authorTypeOf,
+  computeReworkMetrics,
+  dominantArea,
+  hasConventionalPrefix,
+  mean,
+  normalizeNumstatPath,
+  scopeOf,
+  ticketOf
+} from './pr-rework-metrics.mjs'
+import { dist, groupEffectLines, pct, pp } from './pr-rework-report.mjs'
 
 const repoRoot = join(import.meta.dirname, '..', '..')
 // Node >=23 strips erasable types, letting the backtest share the real evaluator.
 // pathToFileURL: Windows absolute paths are not valid ESM specifiers.
 const sharedUrl = (name) => pathToFileURL(join(repoRoot, 'src', 'shared', name)).href
-
-export const DAY_MS = 86_400_000
-
-const pct = (x, n) => `${((x / n) * 100).toFixed(2)}%`
-const percentileOf = (sorted, p) =>
-  sorted[Math.min(sorted.length - 1, Math.floor(sorted.length * p))]
-const dist = (values) => {
-  const s = [...values].sort((a, b) => a - b)
-  return {
-    p50: percentileOf(s, 0.5),
-    p75: percentileOf(s, 0.75),
-    p90: percentileOf(s, 0.9),
-    p95: percentileOf(s, 0.95)
-  }
-}
-const mean = (xs) => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length)
-const pp = (x) => `${x >= 0 ? '+' : ''}${(x * 100).toFixed(1)}pp`
 
 export const norm = (s) =>
   s
@@ -37,314 +36,32 @@ export const norm = (s) =>
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
 
-// Why: -M/-C rewrite renames as "a/{b => c}/d.ts" or "a => b"; both name one file, and
-// leaving them raw splits a renamed file's history into two never-rejoined buckets.
-export function normalizeNumstatPath(raw) {
-  const brace = /^(.*)\{(.*?)\s*=>\s*(.*?)\}(.*)$/.exec(raw)
-  if (brace) {
-    return `${brace[1]}${brace[3]}${brace[4]}`.replace(/\/{2,}/g, '/').replace(/^\//, '')
-  }
-  const arrow = /^(.+?)\s+=>\s+(.+)$/.exec(raw)
-  return (arrow ? arrow[2] : raw).trim()
-}
-
-// Why: a same-file edit six hours later is overwhelmingly a repair; at ninety days it is
-// ordinary evolution. Halving weight per half-life is the label-free stand-in for "was it a fix".
-export function timeDecayWeight(deltaMs, halfLifeMs) {
-  if (deltaMs <= 0) {
-    return 1
-  }
-  return 2 ** (-deltaMs / halfLifeMs)
-}
-
-// Why: stacked PRs legitimately revisit their own lines, so same-author and same-ticket
-// follow-ups are continuation, not rework, and must not count against the first PR.
-export function isRework(pr, later) {
-  if (later.author === pr.author) {
-    return false
-  }
-  return !(pr.ticket && later.ticket && pr.ticket === later.ticket)
-}
-
-export const ticketOf = (subject) => /\b(STA-\d+)\b/i.exec(subject)?.[1]?.toUpperCase() ?? null
-
-export const hasConventionalPrefix = (subject) =>
-  /^\s*(feat|fix|perf|refactor|chore|docs|test|style|build|ci|revert)\s*(\([^)]*\))?\s*!?:/i.test(
-    subject
-  )
-
-export const isFixSubject = (subject) => /^\s*fix\s*(\([^)]*\))?\s*!?:/i.test(subject)
-
-// Why: one pass over the PRs keyed by file, so every horizon is a lookup rather than a rescan.
-export function buildFileTimeline(prs) {
-  const timeline = new Map()
-  for (const pr of prs) {
-    for (const path of new Set(pr.paths)) {
-      let entries = timeline.get(path)
-      if (!entries) {
-        entries = []
-        timeline.set(path, entries)
-      }
-      entries.push(pr)
-    }
-  }
-  for (const entries of timeline.values()) {
-    entries.sort((a, b) => a.t - b.t)
-  }
-  return timeline
-}
-
-/**
- * Per-PR rework over a horizon, with a per-file baseline subtracted.
- *
- * Why lift, not the raw rate: hot files churn regardless of authorship, so an unnormalized
- * rate just rediscovers which files are hot (#13066's own warning about thin signal).
- */
-export function computeReworkMetrics(prs, { horizonDays, halfLifeHours, spanDays, latestT }) {
-  const horizonMs = horizonDays * DAY_MS
-  const halfLifeMs = halfLifeHours * 3600_000
-  const timeline = buildFileTimeline(prs)
-  // Why: PRs merged inside the trailing horizon have not had time to be reworked; scoring
-  // them as clean would bias every rate downward exactly where the data is freshest.
-  const censorBefore = latestT - horizonMs
-  const out = new Map()
-  for (const pr of prs) {
-    if (pr.t > censorBefore) {
-      out.set(pr, { censored: true, reworkRate: 0, expected: 0, lift: 0, decay: 0, fixShare: 0 })
-      continue
-    }
-    const paths = [...new Set(pr.paths)]
-    if (paths.length === 0) {
-      out.set(pr, { censored: false, reworkRate: 0, expected: 0, lift: 0, decay: 0, fixShare: 0 })
-      continue
-    }
-    let touched = 0
-    let expectedSum = 0
-    let decaySum = 0
-    let fixTouched = 0
-    for (const path of paths) {
-      const entries = timeline.get(path) ?? []
-      let first = null
-      let othersEver = 0
-      for (const other of entries) {
-        if (other === pr || !isRework(pr, other)) {
-          continue
-        }
-        othersEver += 1
-        if (other.t > pr.t && other.t - pr.t <= horizonMs && first === null) {
-          first = other
-        }
-      }
-      // Why: baseline is P(this file is touched at least once by another author in a window
-      // of the horizon), Poisson from the file's own rate. A linear rate*horizon pegs at 1.0
-      // for any file touched >4x in the span, which flattens lift to noise on a busy repo.
-      const lambdaPerDay = spanDays > 0 ? othersEver / spanDays : 0
-      expectedSum += 1 - Math.exp(-lambdaPerDay * horizonDays)
-      if (first) {
-        touched += 1
-        decaySum += timeDecayWeight(first.t - pr.t, halfLifeMs)
-        if (isFixSubject(first.subject)) {
-          fixTouched += 1
-        }
-      }
-    }
-    const reworkRate = touched / paths.length
-    const expected = expectedSum / paths.length
-    out.set(pr, {
-      censored: false,
-      reworkRate,
-      expected,
-      lift: reworkRate - expected,
-      decay: decaySum / paths.length,
-      fixShare: touched === 0 ? 0 : fixTouched / touched
-    })
-  }
-  return out
-}
-
-// Why: deterministic shuffles keep the null test reproducible across runs and machines.
-export function mulberry32(seed) {
-  let a = seed >>> 0
-  return () => {
-    a = (a + 0x6d2b79f5) >>> 0
-    let t = Math.imul(a ^ (a >>> 15), 1 | a)
-    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
-    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
-  }
-}
-
-const shuffleInPlace = (xs, rand) => {
-  for (let i = xs.length - 1; i > 0; i -= 1) {
-    const j = Math.floor(rand() * (i + 1))
-    ;[xs[i], xs[j]] = [xs[j], xs[i]]
-  }
-  return xs
-}
-
-// Why: weighted between-author spread of lift is the thing a "some authors ship reworkable
-// code" claim rests on; if a label shuffle reproduces it, the metric is reading file heat.
-export function betweenAuthorSpread(rows, minPRs) {
-  const byAuthor = new Map()
-  for (const r of rows) {
-    let bucket = byAuthor.get(r.author)
-    if (!bucket) {
-      bucket = []
-      byAuthor.set(r.author, bucket)
-    }
-    bucket.push(r.lift)
-  }
-  const kept = [...byAuthor.values()].filter((v) => v.length >= minPRs)
-  if (kept.length < 2) {
-    return { spread: 0, authors: kept.length }
-  }
-  const means = kept.map((v) => mean(v))
-  const grand = mean(means)
-  const spread = Math.sqrt(mean(means.map((m) => (m - grand) ** 2)))
-  return { spread, authors: kept.length }
-}
-
-/**
- * Author-shuffle null test.
- *
- * Why: the live null hypothesis is "rework reflects file heat and feature area, not
- * authorship". Shuffling authors *within* file-heat strata holds heat fixed, so anything
- * left is authorship. Labels are permuted over fixed lift values — the standard permutation
- * test; it does not re-derive the same-author exclusion, which is stated in the report.
- */
-export function authorShuffleNull(
-  rows,
-  { rounds = 200, strata = 4, minPRs = 20, seed = 20260816 }
-) {
-  const observed = betweenAuthorSpread(rows, minPRs)
-  if (observed.authors < 2 || rows.length === 0) {
-    return { ...observed, nullMean: 0, nullP95: 0, pValue: 1, rounds: 0 }
-  }
-  const sorted = [...rows].sort((a, b) => a.expected - b.expected)
-  const perStratum = Math.max(1, Math.ceil(sorted.length / strata))
-  const buckets = []
-  for (let i = 0; i < sorted.length; i += perStratum) {
-    buckets.push(sorted.slice(i, i + perStratum))
-  }
-  const rand = mulberry32(seed)
-  const nulls = []
-  for (let r = 0; r < rounds; r += 1) {
-    const shuffled = []
-    for (const bucket of buckets) {
-      const authors = shuffleInPlace(
-        bucket.map((x) => x.author),
-        rand
-      )
-      bucket.forEach((row, i) => shuffled.push({ author: authors[i], lift: row.lift }))
-    }
-    nulls.push(betweenAuthorSpread(shuffled, minPRs).spread)
-  }
-  nulls.sort((a, b) => a - b)
-  const atOrAbove = nulls.filter((v) => v >= observed.spread).length
-  return {
-    ...observed,
-    nullMean: mean(nulls),
-    nullP95: percentileOf(nulls, 0.95),
-    pValue: (atOrAbove + 1) / (rounds + 1),
-    rounds
-  }
-}
-
-async function main() {
-  const args = process.argv.slice(2)
-  const argOf = (flag, fallback) => {
-    const i = args.indexOf(flag)
-    if (i === -1) {
-      return fallback
-    }
-    const value = args[i + 1]
-    if (value === undefined || value.startsWith('--')) {
-      console.error(`${flag} requires a value`)
-      process.exit(1)
-    }
-    return value
-  }
-  const positiveNumber = (flag, fallback) => {
-    const value = Number(argOf(flag, fallback))
-    if (!Number.isFinite(value) || value <= 0) {
-      console.error(`${flag} must be a positive number`)
-      process.exit(1)
-    }
-    return value
-  }
-  const { evaluateWatchRules, classifyReviewQueueTier, validateWatchRules, validateTierRules } =
-    await import(sharedUrl('pr-watch-rules.ts'))
-  const { identifyMergedPR, extractRevertTargets } = await import(
-    sharedUrl('forge-merge-subject.ts')
-  )
-
-  const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
-  const windowSize = Number(argOf('--window', '8000'))
-  if (!Number.isInteger(windowSize) || windowSize <= 0) {
-    console.error('--window must be a positive integer')
-    process.exit(1)
-  }
-  const historyRepo = argOf('--repo', repoRoot)
-  const horizonDays = positiveNumber('--horizon', '30')
-  const horizon2Days = positiveNumber('--horizon2', '90')
-  const halfLifeHours = positiveNumber('--half-life', '48')
-  const nullRounds = positiveNumber('--null-rounds', '200')
-
-  const config = parseYaml(readFileSync(rulesPath, 'utf8'))
-  const chipRules = config?.pr_watch ? validateWatchRules(config.pr_watch) : []
-  const tierRules = config?.review_queue?.tiers ? validateTierRules(config.review_queue.tiers) : []
-  if (chipRules.length === 0 && tierRules.length === 0) {
-    console.error(`${rulesPath}: no pr_watch rules or review_queue.tiers found`)
-    process.exit(1)
-  }
-
-  // --- history: one record per first-parent commit, sized against first parent so
-  // merge-commit forges (Bitbucket, GitLab merge style) aggregate a whole PR. `-m`
-  // keeps numstat on merges; squash repos are unaffected. Bodies are captured for
-  // GitLab's "See merge request !N" trailers.
-  // Why -w -M -C: whitespace-only churn and renames are not rework, and counting them
-  // as such is the noisiest way to inflate the metric.
-  const log = execFileSync(
-    'git',
-    [
-      '-C',
-      historyRepo,
-      'log',
-      `-${windowSize}`,
-      '--first-parent',
-      '-m',
-      '--numstat',
-      '-w',
-      '-M',
-      '-C',
-      '--date=short',
-      // %aI alongside %ad: the decay term needs hour resolution, the report wants a date.
-      // %b on its own lines: the record parser folds any non-numstat line into the
-      // body, which is where GitLab's "See merge request !N" trailer lives.
-      '--format=@@@%H|%an|%ad|%aI|%s%n%b'
-    ],
-    { encoding: 'utf8', maxBuffer: 1 << 28 }
-  )
-
+/** One record per first-parent commit, with additions and deletions kept apart. */
+export function parseNumstatLog(log) {
   const NUMSTAT_RE = /^(\d+|-)\t(\d+|-)\t(.+)$/
   const commits = []
   let cur = null
+  // Repeat sections belong to a merge's later parents: skip their numstat *and* body, or the
+  // first-parent record absorbs a second diff of the same commit.
+  let skipping = false
   for (const line of log.split('\n')) {
     if (line.startsWith('@@@')) {
       const [hash, author, date, iso, ...rest] = line.slice(3).split('|')
       const subject = rest.join('|')
       // Under -m git emits one diff section per merge parent (repeating the header);
-      // --first-parent limits the walk, and the mainline diff is always first. Fold
-      // repeat headers by commit hash, keeping that first (first-parent) section.
+      // --first-parent limits the walk, and the mainline diff is always first.
       if (cur && cur.hash === hash) {
+        skipping = true
         continue
       }
       if (cur) {
         commits.push(cur)
       }
+      skipping = false
       cur = { hash, author, date, iso, subject, body: [], paths: [], additions: 0, deletions: 0 }
       continue
     }
-    if (!cur) {
+    if (!cur || skipping) {
       continue
     }
     const m = NUMSTAT_RE.exec(line)
@@ -365,6 +82,97 @@ async function main() {
   if (cur) {
     commits.push(cur)
   }
+  return commits
+}
+
+function readHistory(historyRepo, windowSize) {
+  // --- history: one record per first-parent commit, sized against first parent so
+  // merge-commit forges (Bitbucket, GitLab merge style) aggregate a whole PR. `-m`
+  // keeps numstat on merges; squash repos are unaffected. Bodies are captured for
+  // GitLab's "See merge request !N" trailers and for agent co-author trailers.
+  // Why -w -M -C: whitespace-only churn and renames are not rework, and counting them
+  // as such is the noisiest way to inflate the metric.
+  return execFileSync(
+    'git',
+    [
+      '-C',
+      historyRepo,
+      'log',
+      `-${windowSize}`,
+      '--first-parent',
+      '-m',
+      '--numstat',
+      '-w',
+      '-M',
+      '-C',
+      '--date=short',
+      // %aI alongside %ad: the decay term needs hour resolution, the report wants a date.
+      // %b on its own lines: the record parser folds any non-numstat line into the
+      // body, which is where GitLab's "See merge request !N" trailer lives.
+      '--format=@@@%H|%an|%ad|%aI|%s%n%b'
+    ],
+    { encoding: 'utf8', maxBuffer: 1 << 28 }
+  )
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const argOf = (flag, fallback) => {
+    const i = args.indexOf(flag)
+    if (i === -1) {
+      return fallback
+    }
+    const value = args[i + 1]
+    if (value === undefined || value.startsWith('--')) {
+      console.error(`${flag} requires a value`)
+      process.exit(1)
+    }
+    return value
+  }
+  const number = (flag, fallback, { allowZero = false } = {}) => {
+    const value = Number(argOf(flag, fallback))
+    if (!Number.isFinite(value) || value < 0 || (!allowZero && value === 0)) {
+      console.error(`${flag} must be a ${allowZero ? 'non-negative' : 'positive'} number`)
+      process.exit(1)
+    }
+    return value
+  }
+  const { evaluateWatchRules, classifyReviewQueueTier, validateWatchRules, validateTierRules } =
+    await import(sharedUrl('pr-watch-rules.ts'))
+  const { identifyMergedPR, extractRevertTargets } = await import(
+    sharedUrl('forge-merge-subject.ts')
+  )
+
+  const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
+  const windowSize = Number(argOf('--window', '8000'))
+  if (!Number.isInteger(windowSize) || windowSize <= 0) {
+    console.error('--window must be a positive integer')
+    process.exit(1)
+  }
+  const historyRepo = argOf('--repo', repoRoot)
+  const horizonDays = number('--horizon', '30')
+  const horizon2Days = number('--horizon2', '90')
+  const halfLifeHours = number('--half-life', '48')
+  const stackWindowHours = number('--stack-window', String(DEFAULT_STACK_WINDOW_HOURS), {
+    allowZero: true
+  })
+  const nullRounds = number('--null-rounds', '200', { allowZero: true })
+  const exportPath = argOf('--export', null)
+  const baseline = argOf('--baseline', 'span')
+  if (baseline !== 'span' && baseline !== 'exposure') {
+    console.error('--baseline must be span or exposure')
+    process.exit(1)
+  }
+
+  const config = parseYaml(readFileSync(rulesPath, 'utf8'))
+  const chipRules = config?.pr_watch ? validateWatchRules(config.pr_watch) : []
+  const tierRules = config?.review_queue?.tiers ? validateTierRules(config.review_queue.tiers) : []
+  if (chipRules.length === 0 && tierRules.length === 0) {
+    console.error(`${rulesPath}: no pr_watch rules or review_queue.tiers found`)
+    process.exit(1)
+  }
+
+  const commits = parseNumstatLog(readHistory(historyRepo, windowSize))
 
   // PR identity + revert labels via the shared forge-aware parser.
   const byTitle = new Map()
@@ -404,9 +212,15 @@ async function main() {
       date: c.date,
       t: Date.parse(c.iso),
       author: c.author,
+      authorType: authorTypeOf(c.body),
       subject: c.subject,
+      scope: scopeOf(c.subject),
+      area: dominantArea(c.paths),
       ticket: ticketOf(c.subject),
       paths: c.paths,
+      churn: c.additions + c.deletions,
+      testFiles: c.paths.filter(isTestPath).length,
+      breadth: new Set(c.paths.map(areaOfPath)).size,
       reverted: revertTargets.has(c.pr.number),
       input: {
         title: c.subject,
@@ -443,7 +257,7 @@ async function main() {
   const months = ((new Date(prs.at(-1).date) - new Date(prs[0].date)) / 2.63e9).toFixed(1)
   const forgeSummary = [...forgeCounts.entries()].map(([f, n]) => `${f}:${n}`).join(' ')
   console.log(
-    `history: ${prs.length} merged PRs over ${months} months (window ${windowSize} commits)`
+    `history: ${prs.length} merged PRs over ${months} months (window ${windowSize} commits) · ${prs[0].date} … ${prs.at(-1).date}`
   )
   console.log(
     `merge subjects: ${forgeSummary || 'none identified'}${unidentified ? ` · unattributable merges excluded: ${unidentified}` : ''}`
@@ -462,14 +276,10 @@ async function main() {
   const times = prs.map((p) => p.t).filter((t) => Number.isFinite(t))
   const latestT = Math.max(...times)
   const spanDays = Math.max(1, (latestT - Math.min(...times)) / DAY_MS)
+  const metricOpts = { halfLifeHours, spanDays, latestT, stackWindowHours, baseline }
   const metricsBy = {
-    [horizonDays]: computeReworkMetrics(prs, { horizonDays, halfLifeHours, spanDays, latestT }),
-    [horizon2Days]: computeReworkMetrics(prs, {
-      horizonDays: horizon2Days,
-      halfLifeHours,
-      spanDays,
-      latestT
-    })
+    [horizonDays]: computeReworkMetrics(prs, { horizonDays, ...metricOpts }),
+    [horizon2Days]: computeReworkMetrics(prs, { horizonDays: horizon2Days, ...metricOpts })
   }
   const primary = metricsBy[horizonDays]
   const scored = prs.filter((p) => !primary.get(p).censored)
@@ -478,47 +288,51 @@ async function main() {
     rework: mean(subset.map((p) => metrics.get(p).reworkRate)),
     expected: mean(subset.map((p) => metrics.get(p).expected)),
     lift: mean(subset.map((p) => metrics.get(p).lift)),
-    decay: mean(subset.map((p) => metrics.get(p).decay))
+    decay: mean(subset.map((p) => metrics.get(p).decay)),
+    decayLift: mean(subset.map((p) => metrics.get(p).decayLift)),
+    containment: mean(subset.map((p) => metrics.get(p).containment)),
+    asymmetry: mean(subset.map((p) => metrics.get(p).asymmetry))
   })
   console.log(`\n=== rework / lift (label-free) ===`)
   console.log(
-    `scored ${scored.length} PRs · right-censored ${censored} merged inside the trailing ${horizonDays}d · baseline span ${spanDays.toFixed(0)}d`
+    `scored ${scored.length} PRs · right-censored ${censored} merged inside the trailing ${horizonDays}d · baseline ${baseline} (span ${spanDays.toFixed(0)}d) · stacked-PR window ${stackWindowHours}h`
   )
   for (const h of [horizonDays, horizon2Days]) {
     const sub = prs.filter((p) => !metricsBy[h].get(p).censored)
     const o = overall(metricsBy[h], sub)
     console.log(
-      `  @${String(h).padStart(3)}d  n=${String(sub.length).padStart(5)}  rework ${(o.rework * 100).toFixed(1)}%  expected ${(o.expected * 100).toFixed(1)}%  lift ${pp(o.lift)}  decay ${o.decay.toFixed(3)}`
+      `  @${String(h).padStart(3)}d  n=${String(sub.length).padStart(5)}  rework ${(o.rework * 100).toFixed(1)}%  expected ${(o.expected * 100).toFixed(1)}%  lift ${pp(o.lift)}  decay ${o.decay.toFixed(3)}  decay-lift ${pp(o.decayLift)}  containment ${o.containment.toFixed(3)}  asymmetry ${o.asymmetry.toFixed(3)}`
     )
   }
 
   // Why: a fix:-weighted view is only meaningful next to how often the label exists at all,
-  // and coverage that varies by author is differential error aligned with the comparison.
+  // and coverage that varies by author type is differential error aligned with the comparison.
   const covered = prs.filter((p) => hasConventionalPrefix(p.subject)).length
   const coverage = covered / prs.length
   console.log(
     `label coverage: ${covered}/${prs.length} conventional-commit subjects (${pct(covered, prs.length)})`
   )
-  const byAuthorCoverage = new Map()
+  const byType = new Map()
   for (const p of prs) {
-    const row = byAuthorCoverage.get(p.author) ?? { n: 0, ok: 0 }
+    const row = byType.get(p.authorType) ?? { n: 0, ok: 0, scored: 0 }
     row.n += 1
     row.ok += hasConventionalPrefix(p.subject) ? 1 : 0
-    byAuthorCoverage.set(p.author, row)
+    row.scored += primary.get(p).censored ? 0 : 1
+    byType.set(p.authorType, row)
   }
-  const topAuthors = [...byAuthorCoverage.entries()]
-    .filter(([, r]) => r.n >= 20)
-    .sort((a, b) => b[1].n - a[1].n)
-    .slice(0, 8)
-  if (topAuthors.length) {
-    console.log('  coverage by author (n>=20; spread here means the fix: column is biased):')
-    for (const [author, r] of topAuthors) {
-      console.log(
-        `    ${author.slice(0, 22).padEnd(24)} ${String(r.n).padStart(5)} PRs   ${pct(r.ok, r.n).padStart(8)}`
-      )
-    }
+  console.log('  coverage by author type (agent = co-author trailer; untagged is not "human"):')
+  for (const [type, r] of [...byType.entries()].sort((a, b) => b[1].n - a[1].n)) {
+    console.log(
+      `    ${type.padEnd(12)} ${String(r.n).padStart(5)} PRs   conventional ${pct(r.ok, r.n).padStart(8)}   scored ${String(r.scored).padStart(5)}`
+    )
   }
-  const showFixWeighted = coverage >= 0.6 && scored.length >= 20
+  const types = [...byType.values()]
+  const coverageGap =
+    types.length < 2 ? 0 : Math.abs(types[0].ok / types[0].n - types[1].ok / types[1].n)
+  console.log(
+    `  differential-discipline gap: ${(coverageGap * 100).toFixed(1)}pp between author types`
+  )
+  const showFixWeighted = coverage >= 0.6 && scored.length >= 20 && coverageGap <= 0.1
   if (showFixWeighted) {
     const fixShare = mean(scored.map((p) => primary.get(p).fixShare))
     console.log(
@@ -526,29 +340,47 @@ async function main() {
     )
   } else {
     console.log(
-      `  secondary (label-dependent): suppressed — coverage ${pct(covered, prs.length)} below min 60% or n<20`
+      `  secondary (label-dependent): SUPPRESSED — coverage ${pct(covered, prs.length)} (min 60%), n=${scored.length} (min 20), author-type gap ${(coverageGap * 100).toFixed(1)}pp (max 10.0pp)`
     )
   }
 
-  // --- required null test
-  const rows = scored.map((p) => ({
-    author: p.author,
-    lift: primary.get(p).lift,
-    expected: primary.get(p).expected
-  }))
-  const nul = authorShuffleNull(rows, { rounds: nullRounds })
-  console.log(`\n=== author-shuffle null test (${nul.rounds} rounds, within file-heat strata) ===`)
-  if (nul.authors < 2) {
-    console.log('  UNEVALUABLE: fewer than 2 authors with >=20 scored PRs')
-  } else {
-    console.log(
-      `  between-author lift spread: observed ${pp(nul.spread)} · null mean ${pp(nul.nullMean)} · null p95 ${pp(nul.nullP95)} · p=${nul.pValue.toFixed(3)}`
-    )
-    console.log(
-      nul.pValue <= 0.05
-        ? '  SURVIVES: authorship still separates after holding file heat fixed'
-        : '  NULL NOT REJECTED: this is measuring hot files and feature area, not authorship — report it as such'
-    )
+  // --- required null tests: every effect prints beside its shuffle control. Cells are
+  // (merge month x file-heat quartile): agent share and repo-wide follow-up rate both rise
+  // over the window, so a heat-only shuffle would let calendar drift look like authorship.
+  const effectRows = (keyOf, metrics = primary) =>
+    prs
+      .filter((p) => !metrics.get(p).censored)
+      .map((p) => ({
+        group: keyOf(p),
+        value: metrics.get(p).lift,
+        stratum: metrics.get(p).expected,
+        cell: p.date.slice(0, 7)
+      }))
+  const nullOpts = { rounds: nullRounds, minPRs: 20, strata: 4 }
+  const effects = [
+    [`by merge month (drift check)`, (p) => p.date.slice(0, 7), { ...nullOpts, cells: false }],
+    [`by author`, (p) => p.author, nullOpts],
+    [`by author type`, (p) => p.authorType, nullOpts],
+    [
+      `by title scope (label-dependent — ${pct(prs.filter((p) => p.scope).length, prs.length)} coverage)`,
+      (p) => p.scope ?? '(none)',
+      nullOpts
+    ],
+    [`by path area (label-free)`, (p) => p.area, nullOpts]
+  ]
+  for (const [label, keyOf, opts] of effects) {
+    // Month cannot be its own shuffle cell: that would shuffle the effect away by construction.
+    const rows = effectRows(keyOf).map((r) => (opts.cells === false ? { ...r, cell: '' } : r))
+    for (const line of groupEffectLines(`lift@${horizonDays}d ${label}`, rows, opts)) {
+      console.log(line)
+    }
+  }
+  for (const line of groupEffectLines(
+    `lift@${horizon2Days}d by author type`,
+    effectRows((p) => p.authorType, metricsBy[horizon2Days]),
+    nullOpts
+  )) {
+    console.log(line)
   }
 
   if (chipRules.length) {
@@ -594,12 +426,15 @@ async function main() {
     }
   }
 
+  const tierOf = (p) => {
+    const { tier, pending } = classifyReviewQueueTier(tierRules, p.input, { percentiles })
+    return (tier ?? '(catch-all)') + (pending ? ' [pending]' : '')
+  }
   if (tierRules.length) {
     console.log(`\n=== review_queue tiers (first-match) ===`)
     const counts = new Map()
     for (const p of prs) {
-      const { tier, pending } = classifyReviewQueueTier(tierRules, p.input, { percentiles })
-      const key = (tier ?? '(catch-all)') + (pending ? ' [pending]' : '')
+      const key = tierOf(p)
       counts.set(key, (counts.get(key) ?? 0) + 1)
     }
     for (const [name, n] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
@@ -609,9 +444,50 @@ async function main() {
     }
     console.log('  (drafts/conflicts never appear in merged history — T0 tiers only fire live)')
   }
+
+  if (exportPath) {
+    // Why export rather than re-parse: the review-residual analysis must join against exactly
+    // the records scored here, or the two halves of the study drift apart.
+    const rows = prs.map((p) => ({
+      n: p.n,
+      date: p.date,
+      t: p.t,
+      author: p.author,
+      authorType: p.authorType,
+      subject: p.subject,
+      scope: p.scope,
+      area: p.area,
+      tier: tierRules.length ? tierOf(p) : null,
+      files: p.input.files,
+      additions: p.input.additions,
+      deletions: p.input.deletions,
+      testFiles: p.testFiles,
+      breadth: p.breadth,
+      reverted: p.reverted,
+      metrics: Object.fromEntries([horizonDays, horizon2Days].map((h) => [h, metricsBy[h].get(p)]))
+    }))
+    writeFileSync(
+      exportPath,
+      JSON.stringify(
+        {
+          generatedAt: new Date().toISOString(),
+          windowSize,
+          horizons: [horizonDays, horizon2Days],
+          halfLifeHours,
+          stackWindowHours,
+          spanDays,
+          prs: rows
+        },
+        null,
+        1
+      )
+    )
+    console.log(`\nexported ${rows.length} PR records to ${exportPath}`)
+  }
 }
 
-// Why: the metric helpers above are unit-tested, so importing this file must not shell out to git.
+// Why: the metric helpers live in pr-rework-metrics.mjs, so importing this file must not
+// shell out to git.
 if (import.meta.main) {
   await main()
 }

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -1,6 +1,6 @@
 // Replays a PR watch-rules / review-queue config over local git history so a rule
 // can be judged before it is trusted. Offline: git log is the only data source.
-// Usage: node config/scripts/pr-watch-backtest.mjs [--rules <file.yaml>] [--window <commits>]
+// Usage: node config/scripts/pr-watch-backtest.mjs [--rules <file.yaml>] [--window <commits>] [--repo <path>]
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -10,8 +10,10 @@ import { parse as parseYaml } from 'yaml'
 const repoRoot = join(import.meta.dirname, '..', '..')
 // Node >=23 strips erasable types, letting the backtest share the real evaluator.
 // pathToFileURL: Windows absolute paths are not valid ESM specifiers.
+const sharedUrl = (name) => pathToFileURL(join(repoRoot, 'src', 'shared', name)).href
 const { evaluateWatchRules, classifyReviewQueueTier, validateWatchRules, validateTierRules } =
-  await import(pathToFileURL(join(repoRoot, 'src', 'shared', 'pr-watch-rules.ts')).href)
+  await import(sharedUrl('pr-watch-rules.ts'))
+const { identifyMergedPR, extractRevertTargets } = await import(sharedUrl('forge-merge-subject.ts'))
 
 const args = process.argv.slice(2)
 const argOf = (flag, fallback) => {
@@ -20,6 +22,7 @@ const argOf = (flag, fallback) => {
 }
 const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
 const windowSize = Number(argOf('--window', '8000'))
+const historyRepo = argOf('--repo', repoRoot)
 
 const config = parseYaml(readFileSync(rulesPath, 'utf8'))
 const chipRules = config?.pr_watch ? validateWatchRules(config.pr_watch) : []
@@ -29,26 +32,54 @@ if (chipRules.length === 0 && tierRules.length === 0) {
   process.exit(1)
 }
 
-// --- history: one merged-PR record per squash-merge commit, plus revert labels ---
+// --- history: one record per first-parent commit, sized against first parent so
+// merge-commit forges (Bitbucket, GitLab merge style) aggregate a whole PR. `-m`
+// keeps numstat on merges; squash repos are unaffected. Bodies are captured for
+// GitLab's "See merge request !N" trailers.
 const log = execFileSync(
   'git',
-  ['-C', repoRoot, 'log', `-${windowSize}`, '--numstat', '--date=short', '--format=@@@%an|%ad|%s'],
+  [
+    '-C',
+    historyRepo,
+    'log',
+    `-${windowSize}`,
+    '--first-parent',
+    '-m',
+    '--numstat',
+    '--date=short',
+    // %b on its own lines: the record parser folds any non-numstat line into the
+    // body, which is where GitLab's "See merge request !N" trailer lives.
+    '--format=@@@%an|%ad|%s%n%b'
+  ],
   { encoding: 'utf8', maxBuffer: 1 << 28 }
 )
 
+const NUMSTAT_RE = /^(\d+|-)\t(\d+|-)\t(.+)$/
 const commits = []
 let cur = null
 for (const line of log.split('\n')) {
   if (line.startsWith('@@@')) {
+    const [author, date, ...rest] = line.slice(3).split('|')
+    const subject = rest.join('|')
+    // Old git can emit one header per merge parent under -m; keep the
+    // first-parent record and fold duplicates.
+    if (cur && cur.author === author && cur.date === date && cur.subject === subject) {
+      continue
+    }
     if (cur) {
       commits.push(cur)
     }
-    const [author, date, ...rest] = line.slice(3).split('|')
-    cur = { author, date, subject: rest.join('|'), paths: [], churn: 0 }
+    cur = { author, date, subject, body: [], paths: [], churn: 0 }
     continue
   }
-  const m = cur && /^(\d+|-)\t(\d+|-)\t(.+)$/.exec(line)
+  if (!cur) {
+    continue
+  }
+  const m = NUMSTAT_RE.exec(line)
   if (!m) {
+    if (line.trim()) {
+      cur.body.push(line.trim())
+    }
     continue
   }
   cur.paths.push(m[3])
@@ -63,56 +94,51 @@ if (cur) {
   commits.push(cur)
 }
 
-const trailingPR = (s) => Number(/\(#(\d+)\)\s*$/.exec(s)?.[1] ?? Number.NaN)
 const norm = (s) =>
   s
-    .replace(/\s*\(#\d+\)\s*$/, '')
+    .replace(/\s*\([#!]\d+\)\s*$/, '')
     .toLowerCase()
     .replace(/[^a-z0-9]+/g, ' ')
     .trim()
 
-// Revert-target extraction: quoted-number, unquoted-number, and quoted-title forms.
+// PR identity + revert labels via the shared forge-aware parser.
 const byTitle = new Map()
 for (const c of commits) {
-  const n = trailingPR(c.subject)
-  if (!Number.isNaN(n) && !/^revert\b/i.test(c.subject)) {
-    byTitle.set(norm(c.subject), n)
+  c.body = c.body.join('\n')
+  c.pr = identifyMergedPR(c.subject, c.body)
+  if (c.pr.number !== null && !/^revert\b/i.test(c.subject)) {
+    byTitle.set(norm(c.subject), c.pr.number)
   }
 }
 const revertTargets = new Set()
 for (const c of commits) {
-  if (!/^revert\b/i.test(c.subject)) {
-    continue
-  }
-  const quoted = /"([^"]+)"/.exec(c.subject)?.[1]
-  const inQuote = quoted ? [...quoted.matchAll(/#(\d+)/g)].map((m) => Number(m[1])) : []
-  if (inQuote.length) {
-    inQuote.forEach((t) => revertTargets.add(t))
-    continue
-  }
-  const own = trailingPR(c.subject)
-  const rest = [...c.subject.matchAll(/#(\d+)/g)].map((m) => Number(m[1])).filter((x) => x !== own)
-  if (rest.length) {
-    rest.forEach((t) => revertTargets.add(t))
-  } else if (quoted && byTitle.has(norm(quoted))) {
-    revertTargets.add(byTitle.get(norm(quoted)))
+  const { targets, quotedTitle } = extractRevertTargets(c.subject, c.body)
+  targets.forEach((t) => revertTargets.add(t))
+  if (targets.length === 0 && quotedTitle && byTitle.has(norm(quotedTitle))) {
+    revertTargets.add(byTitle.get(norm(quotedTitle)))
   }
 }
 
 const authorMerged = new Map()
 const prs = []
+const forgeCounts = new Map()
+let unidentified = 0
 for (const c of commits.toReversed()) {
-  const n = trailingPR(c.subject)
-  if (Number.isNaN(n) || /^revert\b/i.test(c.subject)) {
+  if (/^revert\b/i.test(c.subject)) {
     continue
   }
+  if (c.pr.number === null) {
+    unidentified += 1
+    continue
+  }
+  forgeCounts.set(c.pr.forge, (forgeCounts.get(c.pr.forge) ?? 0) + 1)
   const prior = authorMerged.get(c.author) ?? 0
   authorMerged.set(c.author, prior + 1)
   prs.push({
-    n,
+    n: c.pr.number,
     date: c.date,
     subject: c.subject,
-    reverted: revertTargets.has(n),
+    reverted: revertTargets.has(c.pr.number),
     input: {
       title: c.subject,
       author: c.author,
@@ -145,8 +171,12 @@ const percentiles = {
 
 const totalReverts = prs.filter((p) => p.reverted).length
 const months = ((new Date(prs.at(-1).date) - new Date(prs[0].date)) / 2.63e9).toFixed(1)
+const forgeSummary = [...forgeCounts.entries()].map(([f, n]) => `${f}:${n}`).join(' ')
 console.log(
   `history: ${prs.length} merged PRs over ${months} months (window ${windowSize} commits)`
+)
+console.log(
+  `merge subjects: ${forgeSummary || 'none identified'}${unidentified ? ` · unattributable merges excluded: ${unidentified}` : ''}`
 )
 console.log(
   `calibration: files p50=${percentiles.files.p50} p90=${percentiles.files.p90} · churn p50=${percentiles.churn.p50} p90=${percentiles.churn.p90}`

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -1,6 +1,7 @@
 // Replays a PR watch-rules / review-queue config over local git history so a rule
 // can be judged before it is trusted. Offline: git log is the only data source.
 // Usage: node config/scripts/pr-watch-backtest.mjs [--rules <file.yaml>] [--window <commits>] [--repo <path>]
+//        [--horizon <days>] [--horizon2 <days>] [--half-life <hours>] [--null-rounds <n>]
 import { execFileSync } from 'node:child_process'
 import { readFileSync } from 'node:fs'
 import { join } from 'node:path'
@@ -11,159 +12,8 @@ const repoRoot = join(import.meta.dirname, '..', '..')
 // Node >=23 strips erasable types, letting the backtest share the real evaluator.
 // pathToFileURL: Windows absolute paths are not valid ESM specifiers.
 const sharedUrl = (name) => pathToFileURL(join(repoRoot, 'src', 'shared', name)).href
-const { evaluateWatchRules, classifyReviewQueueTier, validateWatchRules, validateTierRules } =
-  await import(sharedUrl('pr-watch-rules.ts'))
-const { identifyMergedPR, extractRevertTargets } = await import(sharedUrl('forge-merge-subject.ts'))
 
-const args = process.argv.slice(2)
-const argOf = (flag, fallback) => {
-  const i = args.indexOf(flag)
-  if (i < 0) {
-    return fallback
-  }
-  const value = args[i + 1]
-  if (value === undefined || value.startsWith('--')) {
-    console.error(`${flag} requires a value`)
-    process.exit(1)
-  }
-  return value
-}
-const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
-const windowSize = Number(argOf('--window', '8000'))
-if (!Number.isInteger(windowSize) || windowSize <= 0) {
-  console.error('--window must be a positive integer')
-  process.exit(1)
-}
-const historyRepo = argOf('--repo', repoRoot)
-
-const config = parseYaml(readFileSync(rulesPath, 'utf8'))
-const chipRules = config?.pr_watch ? validateWatchRules(config.pr_watch) : []
-const tierRules = config?.review_queue?.tiers ? validateTierRules(config.review_queue.tiers) : []
-if (chipRules.length === 0 && tierRules.length === 0) {
-  console.error(`${rulesPath}: no pr_watch rules or review_queue.tiers found`)
-  process.exit(1)
-}
-
-// --- history: one record per first-parent commit, sized against first parent so
-// merge-commit forges (Bitbucket, GitLab merge style) aggregate a whole PR. `-m`
-// keeps numstat on merges; squash repos are unaffected. Bodies are captured for
-// GitLab's "See merge request !N" trailers.
-const log = execFileSync(
-  'git',
-  [
-    '-C',
-    historyRepo,
-    'log',
-    `-${windowSize}`,
-    '--first-parent',
-    '-m',
-    '--numstat',
-    '--date=short',
-    // %b on its own lines: the record parser folds any non-numstat line into the
-    // body, which is where GitLab's "See merge request !N" trailer lives.
-    '--format=@@@%H|%an|%ad|%s%n%b'
-  ],
-  { encoding: 'utf8', maxBuffer: 1 << 28 }
-)
-
-const NUMSTAT_RE = /^(\d+|-)\t(\d+|-)\t(.+)$/
-const commits = []
-let cur = null
-for (const line of log.split('\n')) {
-  if (line.startsWith('@@@')) {
-    const [hash, author, date, ...rest] = line.slice(3).split('|')
-    const subject = rest.join('|')
-    // Under -m git emits one diff section per merge parent (repeating the header);
-    // --first-parent limits the walk, and the mainline diff is always first. Fold
-    // repeat headers by commit hash, keeping that first (first-parent) section.
-    if (cur && cur.hash === hash) {
-      continue
-    }
-    if (cur) {
-      commits.push(cur)
-    }
-    cur = { hash, author, date, subject, body: [], paths: [], churn: 0 }
-    continue
-  }
-  if (!cur) {
-    continue
-  }
-  const m = NUMSTAT_RE.exec(line)
-  if (!m) {
-    if (line.trim()) {
-      cur.body.push(line.trim())
-    }
-    continue
-  }
-  cur.paths.push(m[3])
-  if (m[1] !== '-') {
-    cur.churn += Number(m[1])
-  }
-  if (m[2] !== '-') {
-    cur.churn += Number(m[2])
-  }
-}
-if (cur) {
-  commits.push(cur)
-}
-
-const norm = (s) =>
-  s
-    .replace(/\s*\([#!]\d+\)\s*$/, '')
-    .toLowerCase()
-    .replace(/[^a-z0-9]+/g, ' ')
-    .trim()
-
-// PR identity + revert labels via the shared forge-aware parser.
-const byTitle = new Map()
-for (const c of commits) {
-  c.body = c.body.join('\n')
-  c.pr = identifyMergedPR(c.subject, c.body)
-  if (c.pr.number !== null && !/^revert\b/i.test(c.subject)) {
-    byTitle.set(norm(c.subject), c.pr.number)
-  }
-}
-const revertTargets = new Set()
-for (const c of commits) {
-  const { targets, quotedTitle } = extractRevertTargets(c.subject, c.body)
-  targets.forEach((t) => revertTargets.add(t))
-  if (targets.length === 0 && quotedTitle && byTitle.has(norm(quotedTitle))) {
-    revertTargets.add(byTitle.get(norm(quotedTitle)))
-  }
-}
-
-const authorMerged = new Map()
-const prs = []
-const forgeCounts = new Map()
-let unidentified = 0
-for (const c of commits.toReversed()) {
-  if (/^revert\b/i.test(c.subject)) {
-    continue
-  }
-  if (c.pr.number === null) {
-    unidentified += 1
-    continue
-  }
-  forgeCounts.set(c.pr.forge, (forgeCounts.get(c.pr.forge) ?? 0) + 1)
-  const prior = authorMerged.get(c.author) ?? 0
-  authorMerged.set(c.author, prior + 1)
-  prs.push({
-    n: c.pr.number,
-    date: c.date,
-    subject: c.subject,
-    reverted: revertTargets.has(c.pr.number),
-    input: {
-      title: c.subject,
-      author: c.author,
-      paths: c.paths,
-      files: c.paths.length,
-      churn: c.churn,
-      draft: false, // merged history: never draft, never conflicting
-      mergeable: 'mergeable',
-      authorMergedPRs: prior
-    }
-  })
-}
+export const DAY_MS = 86_400_000
 
 const pct = (x, n) => `${((x / n) * 100).toFixed(2)}%`
 const percentileOf = (sorted, p) =>
@@ -177,80 +27,585 @@ const dist = (values) => {
     p95: percentileOf(s, 0.95)
   }
 }
-const percentiles = {
-  files: dist(prs.map((p) => p.input.files)),
-  churn: dist(prs.map((p) => p.input.churn)),
-  authorMergedPRs: dist(prs.map((p) => p.input.authorMergedPRs))
+const mean = (xs) => (xs.length === 0 ? 0 : xs.reduce((a, b) => a + b, 0) / xs.length)
+const pp = (x) => `${x >= 0 ? '+' : ''}${(x * 100).toFixed(1)}pp`
+
+export const norm = (s) =>
+  s
+    .replace(/\s*\([#!]\d+\)\s*$/, '')
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, ' ')
+    .trim()
+
+// Why: -M/-C rewrite renames as "a/{b => c}/d.ts" or "a => b"; both name one file, and
+// leaving them raw splits a renamed file's history into two never-rejoined buckets.
+export function normalizeNumstatPath(raw) {
+  const brace = /^(.*)\{(.*?)\s*=>\s*(.*?)\}(.*)$/.exec(raw)
+  if (brace) {
+    return `${brace[1]}${brace[3]}${brace[4]}`.replace(/\/{2,}/g, '/').replace(/^\//, '')
+  }
+  const arrow = /^(.+?)\s+=>\s+(.+)$/.exec(raw)
+  return (arrow ? arrow[2] : raw).trim()
 }
 
-if (prs.length === 0) {
-  console.error(
-    `no merged PRs identified in the last ${windowSize} commits (unattributable merges: ${unidentified})`
+// Why: a same-file edit six hours later is overwhelmingly a repair; at ninety days it is
+// ordinary evolution. Halving weight per half-life is the label-free stand-in for "was it a fix".
+export function timeDecayWeight(deltaMs, halfLifeMs) {
+  if (deltaMs <= 0) {
+    return 1
+  }
+  return 2 ** (-deltaMs / halfLifeMs)
+}
+
+// Why: stacked PRs legitimately revisit their own lines, so same-author and same-ticket
+// follow-ups are continuation, not rework, and must not count against the first PR.
+export function isRework(pr, later) {
+  if (later.author === pr.author) {
+    return false
+  }
+  return !(pr.ticket && later.ticket && pr.ticket === later.ticket)
+}
+
+export const ticketOf = (subject) => /\b(STA-\d+)\b/i.exec(subject)?.[1]?.toUpperCase() ?? null
+
+export const hasConventionalPrefix = (subject) =>
+  /^\s*(feat|fix|perf|refactor|chore|docs|test|style|build|ci|revert)\s*(\([^)]*\))?\s*!?:/i.test(
+    subject
   )
-  process.exit(1)
-}
-const totalReverts = prs.filter((p) => p.reverted).length
-const months = ((new Date(prs.at(-1).date) - new Date(prs[0].date)) / 2.63e9).toFixed(1)
-const forgeSummary = [...forgeCounts.entries()].map(([f, n]) => `${f}:${n}`).join(' ')
-console.log(
-  `history: ${prs.length} merged PRs over ${months} months (window ${windowSize} commits)`
-)
-console.log(
-  `merge subjects: ${forgeSummary || 'none identified'}${unidentified ? ` · unattributable merges excluded: ${unidentified}` : ''}`
-)
-console.log(
-  `calibration: files p50=${percentiles.files.p50} p90=${percentiles.files.p90} · churn p50=${percentiles.churn.p50} p90=${percentiles.churn.p90}`
-)
-const showReverts = totalReverts >= 20
-console.log(
-  showReverts
-    ? `revert labels: ${totalReverts}`
-    : `revert labels: ${totalReverts} — below min-n 20, correlation column suppressed`
-)
 
-if (chipRules.length) {
-  console.log(`\n=== pr_watch rules ===`)
-  const header = `${'rule'.padEnd(24)}${'fires'.padStart(7)}   % of PRs${showReverts ? '   reverts caught' : ''}`
-  console.log(`${header}\n${'-'.repeat(header.length + 4)}`)
-  for (const rule of chipRules) {
-    const verdicts = prs.map((p) => evaluateWatchRules([rule], p.input, { percentiles })[0])
-    const hits = prs.filter((_, i) => verdicts[i] && !verdicts[i].pending)
-    const pendingCount = verdicts.filter((v) => v?.pending).length
-    const caught = hits.filter((p) => p.reverted).length
-    let line = `${rule.name.slice(0, 23).padEnd(24)}${String(hits.length).padStart(7)}${pct(hits.length, prs.length).padStart(11)}`
-    if (showReverts) {
-      line += `   ${caught} / ${totalReverts}`
+export const isFixSubject = (subject) => /^\s*fix\s*(\([^)]*\))?\s*!?:/i.test(subject)
+
+// Why: one pass over the PRs keyed by file, so every horizon is a lookup rather than a rescan.
+export function buildFileTimeline(prs) {
+  const timeline = new Map()
+  for (const pr of prs) {
+    for (const path of new Set(pr.paths)) {
+      let entries = timeline.get(path)
+      if (!entries) {
+        entries = []
+        timeline.set(path, entries)
+      }
+      entries.push(pr)
     }
-    console.log(line)
-    if (hits.length === 0) {
-      if (pendingCount === prs.length) {
-        console.log('    UNEVALUABLE: needs data the backtest does not collect (labels/branch)')
+  }
+  for (const entries of timeline.values()) {
+    entries.sort((a, b) => a.t - b.t)
+  }
+  return timeline
+}
+
+/**
+ * Per-PR rework over a horizon, with a per-file baseline subtracted.
+ *
+ * Why lift, not the raw rate: hot files churn regardless of authorship, so an unnormalized
+ * rate just rediscovers which files are hot (#13066's own warning about thin signal).
+ */
+export function computeReworkMetrics(prs, { horizonDays, halfLifeHours, spanDays, latestT }) {
+  const horizonMs = horizonDays * DAY_MS
+  const halfLifeMs = halfLifeHours * 3600_000
+  const timeline = buildFileTimeline(prs)
+  // Why: PRs merged inside the trailing horizon have not had time to be reworked; scoring
+  // them as clean would bias every rate downward exactly where the data is freshest.
+  const censorBefore = latestT - horizonMs
+  const out = new Map()
+  for (const pr of prs) {
+    if (pr.t > censorBefore) {
+      out.set(pr, { censored: true, reworkRate: 0, expected: 0, lift: 0, decay: 0, fixShare: 0 })
+      continue
+    }
+    const paths = [...new Set(pr.paths)]
+    if (paths.length === 0) {
+      out.set(pr, { censored: false, reworkRate: 0, expected: 0, lift: 0, decay: 0, fixShare: 0 })
+      continue
+    }
+    let touched = 0
+    let expectedSum = 0
+    let decaySum = 0
+    let fixTouched = 0
+    for (const path of paths) {
+      const entries = timeline.get(path) ?? []
+      let first = null
+      let othersEver = 0
+      for (const other of entries) {
+        if (other === pr || !isRework(pr, other)) {
+          continue
+        }
+        othersEver += 1
+        if (other.t > pr.t && other.t - pr.t <= horizonMs && first === null) {
+          first = other
+        }
+      }
+      // Why: baseline is P(this file is touched at least once by another author in a window
+      // of the horizon), Poisson from the file's own rate. A linear rate*horizon pegs at 1.0
+      // for any file touched >4x in the span, which flattens lift to noise on a busy repo.
+      const lambdaPerDay = spanDays > 0 ? othersEver / spanDays : 0
+      expectedSum += 1 - Math.exp(-lambdaPerDay * horizonDays)
+      if (first) {
+        touched += 1
+        decaySum += timeDecayWeight(first.t - pr.t, halfLifeMs)
+        if (isFixSubject(first.subject)) {
+          fixTouched += 1
+        }
+      }
+    }
+    const reworkRate = touched / paths.length
+    const expected = expectedSum / paths.length
+    out.set(pr, {
+      censored: false,
+      reworkRate,
+      expected,
+      lift: reworkRate - expected,
+      decay: decaySum / paths.length,
+      fixShare: touched === 0 ? 0 : fixTouched / touched
+    })
+  }
+  return out
+}
+
+// Why: deterministic shuffles keep the null test reproducible across runs and machines.
+export function mulberry32(seed) {
+  let a = seed >>> 0
+  return () => {
+    a = (a + 0x6d2b79f5) >>> 0
+    let t = Math.imul(a ^ (a >>> 15), 1 | a)
+    t = (t + Math.imul(t ^ (t >>> 7), 61 | t)) ^ t
+    return ((t ^ (t >>> 14)) >>> 0) / 4294967296
+  }
+}
+
+const shuffleInPlace = (xs, rand) => {
+  for (let i = xs.length - 1; i > 0; i -= 1) {
+    const j = Math.floor(rand() * (i + 1))
+    ;[xs[i], xs[j]] = [xs[j], xs[i]]
+  }
+  return xs
+}
+
+// Why: weighted between-author spread of lift is the thing a "some authors ship reworkable
+// code" claim rests on; if a label shuffle reproduces it, the metric is reading file heat.
+export function betweenAuthorSpread(rows, minPRs) {
+  const byAuthor = new Map()
+  for (const r of rows) {
+    let bucket = byAuthor.get(r.author)
+    if (!bucket) {
+      bucket = []
+      byAuthor.set(r.author, bucket)
+    }
+    bucket.push(r.lift)
+  }
+  const kept = [...byAuthor.values()].filter((v) => v.length >= minPRs)
+  if (kept.length < 2) {
+    return { spread: 0, authors: kept.length }
+  }
+  const means = kept.map((v) => mean(v))
+  const grand = mean(means)
+  const spread = Math.sqrt(mean(means.map((m) => (m - grand) ** 2)))
+  return { spread, authors: kept.length }
+}
+
+/**
+ * Author-shuffle null test.
+ *
+ * Why: the live null hypothesis is "rework reflects file heat and feature area, not
+ * authorship". Shuffling authors *within* file-heat strata holds heat fixed, so anything
+ * left is authorship. Labels are permuted over fixed lift values — the standard permutation
+ * test; it does not re-derive the same-author exclusion, which is stated in the report.
+ */
+export function authorShuffleNull(
+  rows,
+  { rounds = 200, strata = 4, minPRs = 20, seed = 20260816 }
+) {
+  const observed = betweenAuthorSpread(rows, minPRs)
+  if (observed.authors < 2 || rows.length === 0) {
+    return { ...observed, nullMean: 0, nullP95: 0, pValue: 1, rounds: 0 }
+  }
+  const sorted = [...rows].sort((a, b) => a.expected - b.expected)
+  const perStratum = Math.max(1, Math.ceil(sorted.length / strata))
+  const buckets = []
+  for (let i = 0; i < sorted.length; i += perStratum) {
+    buckets.push(sorted.slice(i, i + perStratum))
+  }
+  const rand = mulberry32(seed)
+  const nulls = []
+  for (let r = 0; r < rounds; r += 1) {
+    const shuffled = []
+    for (const bucket of buckets) {
+      const authors = shuffleInPlace(
+        bucket.map((x) => x.author),
+        rand
+      )
+      bucket.forEach((row, i) => shuffled.push({ author: authors[i], lift: row.lift }))
+    }
+    nulls.push(betweenAuthorSpread(shuffled, minPRs).spread)
+  }
+  nulls.sort((a, b) => a - b)
+  const atOrAbove = nulls.filter((v) => v >= observed.spread).length
+  return {
+    ...observed,
+    nullMean: mean(nulls),
+    nullP95: percentileOf(nulls, 0.95),
+    pValue: (atOrAbove + 1) / (rounds + 1),
+    rounds
+  }
+}
+
+async function main() {
+  const args = process.argv.slice(2)
+  const argOf = (flag, fallback) => {
+    const i = args.indexOf(flag)
+    if (i === -1) {
+      return fallback
+    }
+    const value = args[i + 1]
+    if (value === undefined || value.startsWith('--')) {
+      console.error(`${flag} requires a value`)
+      process.exit(1)
+    }
+    return value
+  }
+  const positiveNumber = (flag, fallback) => {
+    const value = Number(argOf(flag, fallback))
+    if (!Number.isFinite(value) || value <= 0) {
+      console.error(`${flag} must be a positive number`)
+      process.exit(1)
+    }
+    return value
+  }
+  const { evaluateWatchRules, classifyReviewQueueTier, validateWatchRules, validateTierRules } =
+    await import(sharedUrl('pr-watch-rules.ts'))
+  const { identifyMergedPR, extractRevertTargets } = await import(
+    sharedUrl('forge-merge-subject.ts')
+  )
+
+  const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
+  const windowSize = Number(argOf('--window', '8000'))
+  if (!Number.isInteger(windowSize) || windowSize <= 0) {
+    console.error('--window must be a positive integer')
+    process.exit(1)
+  }
+  const historyRepo = argOf('--repo', repoRoot)
+  const horizonDays = positiveNumber('--horizon', '30')
+  const horizon2Days = positiveNumber('--horizon2', '90')
+  const halfLifeHours = positiveNumber('--half-life', '48')
+  const nullRounds = positiveNumber('--null-rounds', '200')
+
+  const config = parseYaml(readFileSync(rulesPath, 'utf8'))
+  const chipRules = config?.pr_watch ? validateWatchRules(config.pr_watch) : []
+  const tierRules = config?.review_queue?.tiers ? validateTierRules(config.review_queue.tiers) : []
+  if (chipRules.length === 0 && tierRules.length === 0) {
+    console.error(`${rulesPath}: no pr_watch rules or review_queue.tiers found`)
+    process.exit(1)
+  }
+
+  // --- history: one record per first-parent commit, sized against first parent so
+  // merge-commit forges (Bitbucket, GitLab merge style) aggregate a whole PR. `-m`
+  // keeps numstat on merges; squash repos are unaffected. Bodies are captured for
+  // GitLab's "See merge request !N" trailers.
+  // Why -w -M -C: whitespace-only churn and renames are not rework, and counting them
+  // as such is the noisiest way to inflate the metric.
+  const log = execFileSync(
+    'git',
+    [
+      '-C',
+      historyRepo,
+      'log',
+      `-${windowSize}`,
+      '--first-parent',
+      '-m',
+      '--numstat',
+      '-w',
+      '-M',
+      '-C',
+      '--date=short',
+      // %aI alongside %ad: the decay term needs hour resolution, the report wants a date.
+      // %b on its own lines: the record parser folds any non-numstat line into the
+      // body, which is where GitLab's "See merge request !N" trailer lives.
+      '--format=@@@%H|%an|%ad|%aI|%s%n%b'
+    ],
+    { encoding: 'utf8', maxBuffer: 1 << 28 }
+  )
+
+  const NUMSTAT_RE = /^(\d+|-)\t(\d+|-)\t(.+)$/
+  const commits = []
+  let cur = null
+  for (const line of log.split('\n')) {
+    if (line.startsWith('@@@')) {
+      const [hash, author, date, iso, ...rest] = line.slice(3).split('|')
+      const subject = rest.join('|')
+      // Under -m git emits one diff section per merge parent (repeating the header);
+      // --first-parent limits the walk, and the mainline diff is always first. Fold
+      // repeat headers by commit hash, keeping that first (first-parent) section.
+      if (cur && cur.hash === hash) {
         continue
       }
-      console.log(
-        prs.length >= 200
-          ? '    DEAD: matched nothing across a large history — delete or fix it'
-          : `    0 matches across ${prs.length} PRs / ${months} months — may just be a quiet area`
-      )
-    } else {
-      if (hits.length >= 10 && hits.length / prs.length > 0.2) {
-        console.log('    BROAD: matches over 20% of PRs — too wide to direct attention')
+      if (cur) {
+        commits.push(cur)
       }
-      console.log(`    sample: ${hits.at(-1).subject.slice(0, 76)}`)
+      cur = { hash, author, date, iso, subject, body: [], paths: [], churn: 0 }
+      continue
     }
+    if (!cur) {
+      continue
+    }
+    const m = NUMSTAT_RE.exec(line)
+    if (!m) {
+      if (line.trim()) {
+        cur.body.push(line.trim())
+      }
+      continue
+    }
+    cur.paths.push(normalizeNumstatPath(m[3]))
+    if (m[1] !== '-') {
+      cur.churn += Number(m[1])
+    }
+    if (m[2] !== '-') {
+      cur.churn += Number(m[2])
+    }
+  }
+  if (cur) {
+    commits.push(cur)
+  }
+
+  // PR identity + revert labels via the shared forge-aware parser.
+  const byTitle = new Map()
+  for (const c of commits) {
+    c.body = c.body.join('\n')
+    c.pr = identifyMergedPR(c.subject, c.body)
+    if (c.pr.number !== null && !/^revert\b/i.test(c.subject)) {
+      byTitle.set(norm(c.subject), c.pr.number)
+    }
+  }
+  const revertTargets = new Set()
+  for (const c of commits) {
+    const { targets, quotedTitle } = extractRevertTargets(c.subject, c.body)
+    targets.forEach((t) => revertTargets.add(t))
+    if (targets.length === 0 && quotedTitle && byTitle.has(norm(quotedTitle))) {
+      revertTargets.add(byTitle.get(norm(quotedTitle)))
+    }
+  }
+
+  const authorMerged = new Map()
+  const prs = []
+  const forgeCounts = new Map()
+  let unidentified = 0
+  for (const c of commits.toReversed()) {
+    if (/^revert\b/i.test(c.subject)) {
+      continue
+    }
+    if (c.pr.number === null) {
+      unidentified += 1
+      continue
+    }
+    forgeCounts.set(c.pr.forge, (forgeCounts.get(c.pr.forge) ?? 0) + 1)
+    const prior = authorMerged.get(c.author) ?? 0
+    authorMerged.set(c.author, prior + 1)
+    prs.push({
+      n: c.pr.number,
+      date: c.date,
+      t: Date.parse(c.iso),
+      author: c.author,
+      subject: c.subject,
+      ticket: ticketOf(c.subject),
+      paths: c.paths,
+      reverted: revertTargets.has(c.pr.number),
+      input: {
+        title: c.subject,
+        author: c.author,
+        paths: c.paths,
+        files: c.paths.length,
+        churn: c.churn,
+        draft: false, // merged history: never draft, never conflicting
+        mergeable: 'mergeable',
+        authorMergedPRs: prior
+      }
+    })
+  }
+
+  const percentiles = {
+    files: dist(prs.map((p) => p.input.files)),
+    churn: dist(prs.map((p) => p.input.churn)),
+    authorMergedPRs: dist(prs.map((p) => p.input.authorMergedPRs))
+  }
+
+  if (prs.length === 0) {
+    console.error(
+      `no merged PRs identified in the last ${windowSize} commits (unattributable merges: ${unidentified})`
+    )
+    process.exit(1)
+  }
+  const totalReverts = prs.filter((p) => p.reverted).length
+  const months = ((new Date(prs.at(-1).date) - new Date(prs[0].date)) / 2.63e9).toFixed(1)
+  const forgeSummary = [...forgeCounts.entries()].map(([f, n]) => `${f}:${n}`).join(' ')
+  console.log(
+    `history: ${prs.length} merged PRs over ${months} months (window ${windowSize} commits)`
+  )
+  console.log(
+    `merge subjects: ${forgeSummary || 'none identified'}${unidentified ? ` · unattributable merges excluded: ${unidentified}` : ''}`
+  )
+  console.log(
+    `calibration: files p50=${percentiles.files.p50} p90=${percentiles.files.p90} · churn p50=${percentiles.churn.p50} p90=${percentiles.churn.p90}`
+  )
+  const showReverts = totalReverts >= 20
+  console.log(
+    showReverts
+      ? `revert labels: ${totalReverts}`
+      : `revert labels: ${totalReverts} — below min-n 20, correlation column suppressed`
+  )
+
+  // --- label-free rework/lift, joined over the records already in memory (no second git pass)
+  const times = prs.map((p) => p.t).filter((t) => Number.isFinite(t))
+  const latestT = Math.max(...times)
+  const spanDays = Math.max(1, (latestT - Math.min(...times)) / DAY_MS)
+  const metricsBy = {
+    [horizonDays]: computeReworkMetrics(prs, { horizonDays, halfLifeHours, spanDays, latestT }),
+    [horizon2Days]: computeReworkMetrics(prs, {
+      horizonDays: horizon2Days,
+      halfLifeHours,
+      spanDays,
+      latestT
+    })
+  }
+  const primary = metricsBy[horizonDays]
+  const scored = prs.filter((p) => !primary.get(p).censored)
+  const censored = prs.length - scored.length
+  const overall = (metrics, subset) => ({
+    rework: mean(subset.map((p) => metrics.get(p).reworkRate)),
+    expected: mean(subset.map((p) => metrics.get(p).expected)),
+    lift: mean(subset.map((p) => metrics.get(p).lift)),
+    decay: mean(subset.map((p) => metrics.get(p).decay))
+  })
+  console.log(`\n=== rework / lift (label-free) ===`)
+  console.log(
+    `scored ${scored.length} PRs · right-censored ${censored} merged inside the trailing ${horizonDays}d · baseline span ${spanDays.toFixed(0)}d`
+  )
+  for (const h of [horizonDays, horizon2Days]) {
+    const sub = prs.filter((p) => !metricsBy[h].get(p).censored)
+    const o = overall(metricsBy[h], sub)
+    console.log(
+      `  @${String(h).padStart(3)}d  n=${String(sub.length).padStart(5)}  rework ${(o.rework * 100).toFixed(1)}%  expected ${(o.expected * 100).toFixed(1)}%  lift ${pp(o.lift)}  decay ${o.decay.toFixed(3)}`
+    )
+  }
+
+  // Why: a fix:-weighted view is only meaningful next to how often the label exists at all,
+  // and coverage that varies by author is differential error aligned with the comparison.
+  const covered = prs.filter((p) => hasConventionalPrefix(p.subject)).length
+  const coverage = covered / prs.length
+  console.log(
+    `label coverage: ${covered}/${prs.length} conventional-commit subjects (${pct(covered, prs.length)})`
+  )
+  const byAuthorCoverage = new Map()
+  for (const p of prs) {
+    const row = byAuthorCoverage.get(p.author) ?? { n: 0, ok: 0 }
+    row.n += 1
+    row.ok += hasConventionalPrefix(p.subject) ? 1 : 0
+    byAuthorCoverage.set(p.author, row)
+  }
+  const topAuthors = [...byAuthorCoverage.entries()]
+    .filter(([, r]) => r.n >= 20)
+    .sort((a, b) => b[1].n - a[1].n)
+    .slice(0, 8)
+  if (topAuthors.length) {
+    console.log('  coverage by author (n>=20; spread here means the fix: column is biased):')
+    for (const [author, r] of topAuthors) {
+      console.log(
+        `    ${author.slice(0, 22).padEnd(24)} ${String(r.n).padStart(5)} PRs   ${pct(r.ok, r.n).padStart(8)}`
+      )
+    }
+  }
+  const showFixWeighted = coverage >= 0.6 && scored.length >= 20
+  if (showFixWeighted) {
+    const fixShare = mean(scored.map((p) => primary.get(p).fixShare))
+    console.log(
+      `  secondary (label-dependent): ${(fixShare * 100).toFixed(1)}% of rework events are fix: subjects — coverage ${pct(covered, prs.length)}`
+    )
+  } else {
+    console.log(
+      `  secondary (label-dependent): suppressed — coverage ${pct(covered, prs.length)} below min 60% or n<20`
+    )
+  }
+
+  // --- required null test
+  const rows = scored.map((p) => ({
+    author: p.author,
+    lift: primary.get(p).lift,
+    expected: primary.get(p).expected
+  }))
+  const nul = authorShuffleNull(rows, { rounds: nullRounds })
+  console.log(`\n=== author-shuffle null test (${nul.rounds} rounds, within file-heat strata) ===`)
+  if (nul.authors < 2) {
+    console.log('  UNEVALUABLE: fewer than 2 authors with >=20 scored PRs')
+  } else {
+    console.log(
+      `  between-author lift spread: observed ${pp(nul.spread)} · null mean ${pp(nul.nullMean)} · null p95 ${pp(nul.nullP95)} · p=${nul.pValue.toFixed(3)}`
+    )
+    console.log(
+      nul.pValue <= 0.05
+        ? '  SURVIVES: authorship still separates after holding file heat fixed'
+        : '  NULL NOT REJECTED: this is measuring hot files and feature area, not authorship — report it as such'
+    )
+  }
+
+  if (chipRules.length) {
+    console.log(`\n=== pr_watch rules ===`)
+    const header = `${'rule'.padEnd(24)}${'fires'.padStart(7)}   % of PRs${showReverts ? '   reverts caught' : ''}   rework@${horizonDays}d      lift`
+    console.log(`${header}\n${'-'.repeat(header.length + 4)}`)
+    for (const rule of chipRules) {
+      const verdicts = prs.map((p) => evaluateWatchRules([rule], p.input, { percentiles })[0])
+      const hits = prs.filter((_, i) => verdicts[i] && !verdicts[i].pending)
+      const pendingCount = verdicts.filter((v) => v?.pending).length
+      const caught = hits.filter((p) => p.reverted).length
+      const scoredHits = hits.filter((p) => !primary.get(p).censored)
+      let line = `${rule.name.slice(0, 23).padEnd(24)}${String(hits.length).padStart(7)}${pct(hits.length, prs.length).padStart(11)}`
+      if (showReverts) {
+        line += `   ${caught} / ${totalReverts}`
+      }
+      if (scoredHits.length >= 20) {
+        const o = overall(primary, scoredHits)
+        const reworkCell = `   ${(o.rework * 100).toFixed(0)}%`.padStart(13)
+        const liftCell = `   ${pp(o.lift)}`.padStart(10)
+        line += `${reworkCell}${liftCell}`
+      } else {
+        // Why: same min-n discipline as the revert column — small samples manufacture signal.
+        line += `${'   n<20'.padStart(13)}        —`
+      }
+      console.log(line)
+      if (hits.length === 0) {
+        if (pendingCount === prs.length) {
+          console.log('    UNEVALUABLE: needs data the backtest does not collect (labels/branch)')
+          continue
+        }
+        console.log(
+          prs.length >= 200
+            ? '    DEAD: matched nothing across a large history — delete or fix it'
+            : `    0 matches across ${prs.length} PRs / ${months} months — may just be a quiet area`
+        )
+      } else {
+        if (hits.length >= 10 && hits.length / prs.length > 0.2) {
+          console.log('    BROAD: matches over 20% of PRs — too wide to direct attention')
+        }
+        console.log(`    sample: ${hits.at(-1).subject.slice(0, 76)}`)
+      }
+    }
+  }
+
+  if (tierRules.length) {
+    console.log(`\n=== review_queue tiers (first-match) ===`)
+    const counts = new Map()
+    for (const p of prs) {
+      const { tier, pending } = classifyReviewQueueTier(tierRules, p.input, { percentiles })
+      const key = (tier ?? '(catch-all)') + (pending ? ' [pending]' : '')
+      counts.set(key, (counts.get(key) ?? 0) + 1)
+    }
+    for (const [name, n] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
+      console.log(
+        `  ${name.padEnd(26)} ${String(n).padStart(6)}  ${pct(n, prs.length).padStart(8)}`
+      )
+    }
+    console.log('  (drafts/conflicts never appear in merged history — T0 tiers only fire live)')
   }
 }
 
-if (tierRules.length) {
-  console.log(`\n=== review_queue tiers (first-match) ===`)
-  const counts = new Map()
-  for (const p of prs) {
-    const { tier, pending } = classifyReviewQueueTier(tierRules, p.input, { percentiles })
-    const key = (tier ?? '(catch-all)') + (pending ? ' [pending]' : '')
-    counts.set(key, (counts.get(key) ?? 0) + 1)
-  }
-  for (const [name, n] of [...counts.entries()].sort((a, b) => b[1] - a[1])) {
-    console.log(`  ${name.padEnd(26)} ${String(n).padStart(6)}  ${pct(n, prs.length).padStart(8)}`)
-  }
-  console.log('  (drafts/conflicts never appear in merged history — T0 tiers only fire live)')
+// Why: the metric helpers above are unit-tested, so importing this file must not shell out to git.
+if (import.meta.main) {
+  await main()
 }

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -341,7 +341,7 @@ async function main() {
       if (cur) {
         commits.push(cur)
       }
-      cur = { hash, author, date, iso, subject, body: [], paths: [], churn: 0 }
+      cur = { hash, author, date, iso, subject, body: [], paths: [], additions: 0, deletions: 0 }
       continue
     }
     if (!cur) {
@@ -356,10 +356,10 @@ async function main() {
     }
     cur.paths.push(normalizeNumstatPath(m[3]))
     if (m[1] !== '-') {
-      cur.churn += Number(m[1])
+      cur.additions += Number(m[1])
     }
     if (m[2] !== '-') {
-      cur.churn += Number(m[2])
+      cur.deletions += Number(m[2])
     }
   }
   if (cur) {
@@ -413,7 +413,11 @@ async function main() {
         author: c.author,
         paths: c.paths,
         files: c.paths.length,
-        churn: c.churn,
+        additions: c.additions,
+        deletions: c.deletions,
+        // Why keep churn: rules that genuinely want one magnitude still resolve, but the
+        // split lets a deletion-heavy simplification stop sizing like an equal-sized rewrite.
+        churn: c.additions + c.deletions,
         draft: false, // merged history: never draft, never conflicting
         mergeable: 'mergeable',
         authorMergedPRs: prior
@@ -423,6 +427,8 @@ async function main() {
 
   const percentiles = {
     files: dist(prs.map((p) => p.input.files)),
+    additions: dist(prs.map((p) => p.input.additions)),
+    deletions: dist(prs.map((p) => p.input.deletions)),
     churn: dist(prs.map((p) => p.input.churn)),
     authorMergedPRs: dist(prs.map((p) => p.input.authorMergedPRs))
   }
@@ -443,7 +449,7 @@ async function main() {
     `merge subjects: ${forgeSummary || 'none identified'}${unidentified ? ` · unattributable merges excluded: ${unidentified}` : ''}`
   )
   console.log(
-    `calibration: files p50=${percentiles.files.p50} p90=${percentiles.files.p90} · churn p50=${percentiles.churn.p50} p90=${percentiles.churn.p90}`
+    `calibration: files p50=${percentiles.files.p50} p90=${percentiles.files.p90} · additions p50=${percentiles.additions.p50} p90=${percentiles.additions.p90} · deletions p50=${percentiles.deletions.p50} p90=${percentiles.deletions.p90} · churn p50=${percentiles.churn.p50} p90=${percentiles.churn.p90}`
   )
   const showReverts = totalReverts >= 20
   console.log(

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -475,6 +475,7 @@ async function main() {
           horizons: [horizonDays, horizon2Days],
           halfLifeHours,
           stackWindowHours,
+          baseline,
           spanDays,
           prs: rows
         },

--- a/config/scripts/pr-watch-backtest.mjs
+++ b/config/scripts/pr-watch-backtest.mjs
@@ -18,10 +18,22 @@ const { identifyMergedPR, extractRevertTargets } = await import(sharedUrl('forge
 const args = process.argv.slice(2)
 const argOf = (flag, fallback) => {
   const i = args.indexOf(flag)
-  return i >= 0 ? args[i + 1] : fallback
+  if (i < 0) {
+    return fallback
+  }
+  const value = args[i + 1]
+  if (value === undefined || value.startsWith('--')) {
+    console.error(`${flag} requires a value`)
+    process.exit(1)
+  }
+  return value
 }
 const rulesPath = argOf('--rules', join(repoRoot, 'config', 'pr-watch-rules.example.yaml'))
 const windowSize = Number(argOf('--window', '8000'))
+if (!Number.isInteger(windowSize) || windowSize <= 0) {
+  console.error('--window must be a positive integer')
+  process.exit(1)
+}
 const historyRepo = argOf('--repo', repoRoot)
 
 const config = parseYaml(readFileSync(rulesPath, 'utf8'))
@@ -49,7 +61,7 @@ const log = execFileSync(
     '--date=short',
     // %b on its own lines: the record parser folds any non-numstat line into the
     // body, which is where GitLab's "See merge request !N" trailer lives.
-    '--format=@@@%an|%ad|%s%n%b'
+    '--format=@@@%H|%an|%ad|%s%n%b'
   ],
   { encoding: 'utf8', maxBuffer: 1 << 28 }
 )
@@ -59,17 +71,18 @@ const commits = []
 let cur = null
 for (const line of log.split('\n')) {
   if (line.startsWith('@@@')) {
-    const [author, date, ...rest] = line.slice(3).split('|')
+    const [hash, author, date, ...rest] = line.slice(3).split('|')
     const subject = rest.join('|')
-    // Old git can emit one header per merge parent under -m; keep the
-    // first-parent record and fold duplicates.
-    if (cur && cur.author === author && cur.date === date && cur.subject === subject) {
+    // Under -m git emits one diff section per merge parent (repeating the header);
+    // --first-parent limits the walk, and the mainline diff is always first. Fold
+    // repeat headers by commit hash, keeping that first (first-parent) section.
+    if (cur && cur.hash === hash) {
       continue
     }
     if (cur) {
       commits.push(cur)
     }
-    cur = { author, date, subject, body: [], paths: [], churn: 0 }
+    cur = { hash, author, date, subject, body: [], paths: [], churn: 0 }
     continue
   }
   if (!cur) {
@@ -166,9 +179,16 @@ const dist = (values) => {
 }
 const percentiles = {
   files: dist(prs.map((p) => p.input.files)),
-  churn: dist(prs.map((p) => p.input.churn))
+  churn: dist(prs.map((p) => p.input.churn)),
+  authorMergedPRs: dist(prs.map((p) => p.input.authorMergedPRs))
 }
 
+if (prs.length === 0) {
+  console.error(
+    `no merged PRs identified in the last ${windowSize} commits (unattributable merges: ${unidentified})`
+  )
+  process.exit(1)
+}
 const totalReverts = prs.filter((p) => p.reverted).length
 const months = ((new Date(prs.at(-1).date) - new Date(prs[0].date)) / 2.63e9).toFixed(1)
 const forgeSummary = [...forgeCounts.entries()].map(([f, n]) => `${f}:${n}`).join(' ')
@@ -193,9 +213,9 @@ if (chipRules.length) {
   const header = `${'rule'.padEnd(24)}${'fires'.padStart(7)}   % of PRs${showReverts ? '   reverts caught' : ''}`
   console.log(`${header}\n${'-'.repeat(header.length + 4)}`)
   for (const rule of chipRules) {
-    const hits = prs.filter((p) =>
-      evaluateWatchRules([rule], p.input, { percentiles }).some((m) => !m.pending)
-    )
+    const verdicts = prs.map((p) => evaluateWatchRules([rule], p.input, { percentiles })[0])
+    const hits = prs.filter((_, i) => verdicts[i] && !verdicts[i].pending)
+    const pendingCount = verdicts.filter((v) => v?.pending).length
     const caught = hits.filter((p) => p.reverted).length
     let line = `${rule.name.slice(0, 23).padEnd(24)}${String(hits.length).padStart(7)}${pct(hits.length, prs.length).padStart(11)}`
     if (showReverts) {
@@ -203,6 +223,10 @@ if (chipRules.length) {
     }
     console.log(line)
     if (hits.length === 0) {
+      if (pendingCount === prs.length) {
+        console.log('    UNEVALUABLE: needs data the backtest does not collect (labels/branch)')
+        continue
+      }
       console.log(
         prs.length >= 200
           ? '    DEAD: matched nothing across a large history — delete or fix it'

--- a/config/scripts/pr-watch-backtest.test.mjs
+++ b/config/scripts/pr-watch-backtest.test.mjs
@@ -1,0 +1,252 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DAY_MS,
+  authorShuffleNull,
+  betweenAuthorSpread,
+  buildFileTimeline,
+  computeReworkMetrics,
+  hasConventionalPrefix,
+  isFixSubject,
+  isRework,
+  mulberry32,
+  normalizeNumstatPath,
+  ticketOf,
+  timeDecayWeight
+} from './pr-watch-backtest.mjs'
+
+const HOUR_MS = 3600_000
+const base = Date.parse('2026-01-01T00:00:00Z')
+
+function pr(overrides) {
+  return {
+    author: 'alice',
+    subject: 'feat(x): thing',
+    ticket: null,
+    paths: ['a.ts'],
+    t: base,
+    ...overrides
+  }
+}
+
+// Baseline span/latest chosen so nothing is right-censored unless a test wants it.
+const opts = (extra = {}) => ({
+  horizonDays: 30,
+  halfLifeHours: 48,
+  spanDays: 365,
+  latestT: base + 400 * DAY_MS,
+  ...extra
+})
+
+describe('normalizeNumstatPath', () => {
+  it('collapses a braced rename to the new path', () => {
+    expect(normalizeNumstatPath('src/{old => new}/file.ts')).toBe('src/new/file.ts')
+  })
+
+  it('collapses an arrow rename to the new path', () => {
+    expect(normalizeNumstatPath('old/file.ts => new/file.ts')).toBe('new/file.ts')
+  })
+
+  it('drops an emptied brace segment without leaving a double slash', () => {
+    expect(normalizeNumstatPath('src/{legacy => }/file.ts')).toBe('src/file.ts')
+  })
+
+  it('leaves an ordinary path untouched', () => {
+    expect(normalizeNumstatPath('src/main/index.ts')).toBe('src/main/index.ts')
+  })
+})
+
+describe('timeDecayWeight', () => {
+  it('weights a same-hour repair far above a months-later edit', () => {
+    const soon = timeDecayWeight(6 * HOUR_MS, 48 * HOUR_MS)
+    const later = timeDecayWeight(90 * DAY_MS, 48 * HOUR_MS)
+    expect(soon).toBeGreaterThan(0.9)
+    expect(later).toBeLessThan(0.01)
+    expect(soon).toBeGreaterThan(later * 50)
+  })
+
+  it('halves at exactly one half-life', () => {
+    expect(timeDecayWeight(48 * HOUR_MS, 48 * HOUR_MS)).toBeCloseTo(0.5, 10)
+  })
+})
+
+describe('isRework', () => {
+  it('excludes a same-author follow-up as stacked work', () => {
+    expect(isRework(pr(), pr({ t: base + DAY_MS }))).toBe(false)
+  })
+
+  it('excludes a different author on the same ticket', () => {
+    const first = pr({ ticket: 'STA-1' })
+    const later = pr({ author: 'bob', ticket: 'STA-1', t: base + DAY_MS })
+    expect(isRework(first, later)).toBe(false)
+  })
+
+  it('counts a different author with no shared ticket', () => {
+    expect(isRework(pr(), pr({ author: 'bob', t: base + DAY_MS }))).toBe(true)
+  })
+})
+
+describe('subject label helpers', () => {
+  it('recognises conventional prefixes with and without scope', () => {
+    expect(hasConventionalPrefix('fix: thing')).toBe(true)
+    expect(hasConventionalPrefix('feat(terminal)!: thing')).toBe(true)
+    expect(hasConventionalPrefix('Remove worktree deletion toasts')).toBe(false)
+  })
+
+  it('separates fix: from other conventional kinds', () => {
+    expect(isFixSubject('fix(ssh): thing')).toBe(true)
+    expect(isFixSubject('feat(ssh): thing')).toBe(false)
+  })
+
+  it('extracts an STA ticket case-insensitively', () => {
+    expect(ticketOf('fix(x): thing (STA-4276)')).toBe('STA-4276')
+    expect(ticketOf('fix(x): sta-99 lowercase')).toBe('STA-99')
+    expect(ticketOf('fix(x): no ticket')).toBeNull()
+  })
+})
+
+describe('buildFileTimeline', () => {
+  it('indexes each path once per PR and orders entries by time', () => {
+    const late = pr({ t: base + 2 * DAY_MS, paths: ['a.ts'] })
+    const early = pr({ t: base, paths: ['a.ts', 'a.ts', 'b.ts'] })
+    const timeline = buildFileTimeline([late, early])
+    expect(timeline.get('a.ts')).toEqual([early, late])
+    expect(timeline.get('b.ts')).toEqual([early])
+  })
+})
+
+describe('computeReworkMetrics', () => {
+  it('counts a later different-author touch as rework', () => {
+    const first = pr()
+    const second = pr({ author: 'bob', t: base + 3 * DAY_MS })
+    const m = computeReworkMetrics([first, second], opts()).get(first)
+    expect(m.reworkRate).toBe(1)
+    expect(m.censored).toBe(false)
+  })
+
+  it('does not count a touch beyond the horizon', () => {
+    const first = pr()
+    const second = pr({ author: 'bob', t: base + 45 * DAY_MS })
+    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0)
+  })
+
+  it('does not count the PR stacked behind it', () => {
+    const first = pr()
+    const second = pr({ t: base + DAY_MS })
+    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0)
+  })
+
+  // Why: the whole point of lift — a hot file must not score as rework just for being hot.
+  it('subtracts a hot file baseline so lift stays near zero', () => {
+    const others = Array.from({ length: 60 }, (_, i) =>
+      pr({ author: `dev${i}`, t: base + (i + 1) * 6 * DAY_MS })
+    )
+    const first = pr()
+    const m = computeReworkMetrics([first, ...others], opts({ spanDays: 360 })).get(first)
+    expect(m.reworkRate).toBe(1)
+    expect(m.expected).toBeGreaterThan(0.9)
+    expect(Math.abs(m.lift)).toBeLessThan(0.1)
+  })
+
+  it('scores lift high when a cold file is reworked immediately', () => {
+    const first = pr({ paths: ['cold.ts'] })
+    const second = pr({ author: 'bob', paths: ['cold.ts'], t: base + 2 * HOUR_MS })
+    const m = computeReworkMetrics([first, second], opts()).get(first)
+    expect(m.lift).toBeGreaterThan(0.9)
+    expect(m.decay).toBeGreaterThan(0.9)
+  })
+
+  it('censors PRs merged inside the trailing horizon instead of scoring them clean', () => {
+    const recent = pr({ t: base + 395 * DAY_MS })
+    const m = computeReworkMetrics([recent], opts()).get(recent)
+    expect(m.censored).toBe(true)
+    expect(m.lift).toBe(0)
+  })
+
+  it('averages partial rework across a multi-file PR', () => {
+    const first = pr({ paths: ['a.ts', 'b.ts'] })
+    const second = pr({ author: 'bob', paths: ['a.ts'], t: base + DAY_MS })
+    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0.5)
+  })
+
+  it('reports the fix: share of rework events without letting it drive lift', () => {
+    const first = pr({ paths: ['a.ts', 'b.ts'] })
+    const fixer = pr({
+      author: 'bob',
+      subject: 'fix(a): repair',
+      paths: ['a.ts'],
+      t: base + DAY_MS
+    })
+    const featurer = pr({
+      author: 'carol',
+      subject: 'feat(b): extend',
+      paths: ['b.ts'],
+      t: base + DAY_MS
+    })
+    const m = computeReworkMetrics([first, fixer, featurer], opts()).get(first)
+    expect(m.reworkRate).toBe(1)
+    expect(m.fixShare).toBe(0.5)
+  })
+})
+
+describe('betweenAuthorSpread', () => {
+  it('ignores authors below the minimum sample', () => {
+    const rows = [
+      ...Array.from({ length: 25 }, () => ({ author: 'alice', lift: 0.4 })),
+      { author: 'bob', lift: -0.4 }
+    ]
+    expect(betweenAuthorSpread(rows, 20).authors).toBe(1)
+    expect(betweenAuthorSpread(rows, 20).spread).toBe(0)
+  })
+
+  it('grows as author means diverge', () => {
+    const tight = [
+      ...Array.from({ length: 25 }, () => ({ author: 'alice', lift: 0.1 })),
+      ...Array.from({ length: 25 }, () => ({ author: 'bob', lift: 0.1 }))
+    ]
+    const wide = [
+      ...Array.from({ length: 25 }, () => ({ author: 'alice', lift: 0.5 })),
+      ...Array.from({ length: 25 }, () => ({ author: 'bob', lift: -0.5 }))
+    ]
+    expect(betweenAuthorSpread(tight, 20).spread).toBeCloseTo(0, 10)
+    expect(betweenAuthorSpread(wide, 20).spread).toBeGreaterThan(0.4)
+  })
+})
+
+describe('mulberry32', () => {
+  it('is deterministic for a given seed', () => {
+    const a = mulberry32(42)
+    const b = mulberry32(42)
+    expect([a(), a(), a()]).toEqual([b(), b(), b()])
+  })
+})
+
+describe('authorShuffleNull', () => {
+  // Why: the live null is "this is file heat, not authorship" — a heat-driven effect must not survive.
+  it('fails to reject when lift tracks file heat rather than author', () => {
+    const rows = []
+    for (let i = 0; i < 60; i += 1) {
+      const heat = i / 60
+      rows.push({ author: i % 2 === 0 ? 'alice' : 'bob', lift: heat, expected: heat })
+    }
+    const result = authorShuffleNull(rows, { rounds: 200, minPRs: 20 })
+    expect(result.authors).toBe(2)
+    expect(result.pValue).toBeGreaterThan(0.05)
+  })
+
+  it('rejects when one author carries higher lift at equal file heat', () => {
+    const rows = []
+    for (let i = 0; i < 60; i += 1) {
+      const alice = i % 2 === 0
+      rows.push({ author: alice ? 'alice' : 'bob', lift: alice ? 0.5 : -0.5, expected: 0.5 })
+    }
+    const result = authorShuffleNull(rows, { rounds: 200, minPRs: 20 })
+    expect(result.pValue).toBeLessThanOrEqual(0.05)
+  })
+
+  it('reports UNEVALUABLE shape when only one author clears the minimum', () => {
+    const rows = Array.from({ length: 30 }, () => ({ author: 'alice', lift: 0.2, expected: 0.2 }))
+    const result = authorShuffleNull(rows, { rounds: 50, minPRs: 20 })
+    expect(result.authors).toBe(1)
+    expect(result.pValue).toBe(1)
+  })
+})

--- a/config/scripts/pr-watch-backtest.test.mjs
+++ b/config/scripts/pr-watch-backtest.test.mjs
@@ -1,252 +1,55 @@
 import { describe, expect, it } from 'vitest'
-import {
-  DAY_MS,
-  authorShuffleNull,
-  betweenAuthorSpread,
-  buildFileTimeline,
-  computeReworkMetrics,
-  hasConventionalPrefix,
-  isFixSubject,
-  isRework,
-  mulberry32,
-  normalizeNumstatPath,
-  ticketOf,
-  timeDecayWeight
-} from './pr-watch-backtest.mjs'
+import { norm, parseNumstatLog } from './pr-watch-backtest.mjs'
 
-const HOUR_MS = 3600_000
-const base = Date.parse('2026-01-01T00:00:00Z')
+const log = [
+  '@@@abc|Alice|2026-01-02|2026-01-02T10:00:00Z|feat(x): add a thing (#10)',
+  'Co-authored-by: Orca <help@stably.ai>',
+  '12\t3\tsrc/main/a.ts',
+  '0\t40\tsrc/main/b.ts',
+  '-\t-\tassets/logo.png',
+  '@@@def|Bob|2026-01-03|2026-01-03T10:00:00Z|fix(y): repair (#11)',
+  '4\t4\tsrc/{old => new}/c.ts',
+  ''
+].join('\n')
 
-function pr(overrides) {
-  return {
-    author: 'alice',
-    subject: 'feat(x): thing',
-    ticket: null,
-    paths: ['a.ts'],
-    t: base,
-    ...overrides
-  }
-}
+describe('parseNumstatLog', () => {
+  it('keeps additions and deletions apart and folds the body', () => {
+    const [first, second] = parseNumstatLog(log)
 
-// Baseline span/latest chosen so nothing is right-censored unless a test wants it.
-const opts = (extra = {}) => ({
-  horizonDays: 30,
-  halfLifeHours: 48,
-  spanDays: 365,
-  latestT: base + 400 * DAY_MS,
-  ...extra
-})
-
-describe('normalizeNumstatPath', () => {
-  it('collapses a braced rename to the new path', () => {
-    expect(normalizeNumstatPath('src/{old => new}/file.ts')).toBe('src/new/file.ts')
-  })
-
-  it('collapses an arrow rename to the new path', () => {
-    expect(normalizeNumstatPath('old/file.ts => new/file.ts')).toBe('new/file.ts')
-  })
-
-  it('drops an emptied brace segment without leaving a double slash', () => {
-    expect(normalizeNumstatPath('src/{legacy => }/file.ts')).toBe('src/file.ts')
-  })
-
-  it('leaves an ordinary path untouched', () => {
-    expect(normalizeNumstatPath('src/main/index.ts')).toBe('src/main/index.ts')
-  })
-})
-
-describe('timeDecayWeight', () => {
-  it('weights a same-hour repair far above a months-later edit', () => {
-    const soon = timeDecayWeight(6 * HOUR_MS, 48 * HOUR_MS)
-    const later = timeDecayWeight(90 * DAY_MS, 48 * HOUR_MS)
-    expect(soon).toBeGreaterThan(0.9)
-    expect(later).toBeLessThan(0.01)
-    expect(soon).toBeGreaterThan(later * 50)
-  })
-
-  it('halves at exactly one half-life', () => {
-    expect(timeDecayWeight(48 * HOUR_MS, 48 * HOUR_MS)).toBeCloseTo(0.5, 10)
-  })
-})
-
-describe('isRework', () => {
-  it('excludes a same-author follow-up as stacked work', () => {
-    expect(isRework(pr(), pr({ t: base + DAY_MS }))).toBe(false)
-  })
-
-  it('excludes a different author on the same ticket', () => {
-    const first = pr({ ticket: 'STA-1' })
-    const later = pr({ author: 'bob', ticket: 'STA-1', t: base + DAY_MS })
-    expect(isRework(first, later)).toBe(false)
-  })
-
-  it('counts a different author with no shared ticket', () => {
-    expect(isRework(pr(), pr({ author: 'bob', t: base + DAY_MS }))).toBe(true)
-  })
-})
-
-describe('subject label helpers', () => {
-  it('recognises conventional prefixes with and without scope', () => {
-    expect(hasConventionalPrefix('fix: thing')).toBe(true)
-    expect(hasConventionalPrefix('feat(terminal)!: thing')).toBe(true)
-    expect(hasConventionalPrefix('Remove worktree deletion toasts')).toBe(false)
-  })
-
-  it('separates fix: from other conventional kinds', () => {
-    expect(isFixSubject('fix(ssh): thing')).toBe(true)
-    expect(isFixSubject('feat(ssh): thing')).toBe(false)
-  })
-
-  it('extracts an STA ticket case-insensitively', () => {
-    expect(ticketOf('fix(x): thing (STA-4276)')).toBe('STA-4276')
-    expect(ticketOf('fix(x): sta-99 lowercase')).toBe('STA-99')
-    expect(ticketOf('fix(x): no ticket')).toBeNull()
-  })
-})
-
-describe('buildFileTimeline', () => {
-  it('indexes each path once per PR and orders entries by time', () => {
-    const late = pr({ t: base + 2 * DAY_MS, paths: ['a.ts'] })
-    const early = pr({ t: base, paths: ['a.ts', 'a.ts', 'b.ts'] })
-    const timeline = buildFileTimeline([late, early])
-    expect(timeline.get('a.ts')).toEqual([early, late])
-    expect(timeline.get('b.ts')).toEqual([early])
-  })
-})
-
-describe('computeReworkMetrics', () => {
-  it('counts a later different-author touch as rework', () => {
-    const first = pr()
-    const second = pr({ author: 'bob', t: base + 3 * DAY_MS })
-    const m = computeReworkMetrics([first, second], opts()).get(first)
-    expect(m.reworkRate).toBe(1)
-    expect(m.censored).toBe(false)
-  })
-
-  it('does not count a touch beyond the horizon', () => {
-    const first = pr()
-    const second = pr({ author: 'bob', t: base + 45 * DAY_MS })
-    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0)
-  })
-
-  it('does not count the PR stacked behind it', () => {
-    const first = pr()
-    const second = pr({ t: base + DAY_MS })
-    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0)
-  })
-
-  // Why: the whole point of lift — a hot file must not score as rework just for being hot.
-  it('subtracts a hot file baseline so lift stays near zero', () => {
-    const others = Array.from({ length: 60 }, (_, i) =>
-      pr({ author: `dev${i}`, t: base + (i + 1) * 6 * DAY_MS })
-    )
-    const first = pr()
-    const m = computeReworkMetrics([first, ...others], opts({ spanDays: 360 })).get(first)
-    expect(m.reworkRate).toBe(1)
-    expect(m.expected).toBeGreaterThan(0.9)
-    expect(Math.abs(m.lift)).toBeLessThan(0.1)
-  })
-
-  it('scores lift high when a cold file is reworked immediately', () => {
-    const first = pr({ paths: ['cold.ts'] })
-    const second = pr({ author: 'bob', paths: ['cold.ts'], t: base + 2 * HOUR_MS })
-    const m = computeReworkMetrics([first, second], opts()).get(first)
-    expect(m.lift).toBeGreaterThan(0.9)
-    expect(m.decay).toBeGreaterThan(0.9)
-  })
-
-  it('censors PRs merged inside the trailing horizon instead of scoring them clean', () => {
-    const recent = pr({ t: base + 395 * DAY_MS })
-    const m = computeReworkMetrics([recent], opts()).get(recent)
-    expect(m.censored).toBe(true)
-    expect(m.lift).toBe(0)
-  })
-
-  it('averages partial rework across a multi-file PR', () => {
-    const first = pr({ paths: ['a.ts', 'b.ts'] })
-    const second = pr({ author: 'bob', paths: ['a.ts'], t: base + DAY_MS })
-    expect(computeReworkMetrics([first, second], opts()).get(first).reworkRate).toBe(0.5)
-  })
-
-  it('reports the fix: share of rework events without letting it drive lift', () => {
-    const first = pr({ paths: ['a.ts', 'b.ts'] })
-    const fixer = pr({
-      author: 'bob',
-      subject: 'fix(a): repair',
-      paths: ['a.ts'],
-      t: base + DAY_MS
+    expect(first).toMatchObject({
+      hash: 'abc',
+      author: 'Alice',
+      subject: 'feat(x): add a thing (#10)',
+      additions: 12,
+      deletions: 43,
+      paths: ['src/main/a.ts', 'src/main/b.ts', 'assets/logo.png']
     })
-    const featurer = pr({
-      author: 'carol',
-      subject: 'feat(b): extend',
-      paths: ['b.ts'],
-      t: base + DAY_MS
-    })
-    const m = computeReworkMetrics([first, fixer, featurer], opts()).get(first)
-    expect(m.reworkRate).toBe(1)
-    expect(m.fixShare).toBe(0.5)
+    expect(first.body).toEqual(['Co-authored-by: Orca <help@stably.ai>'])
+    expect(second).toMatchObject({ hash: 'def', additions: 4, deletions: 4 })
+  })
+
+  it('normalises renames so a file keeps one history', () => {
+    expect(parseNumstatLog(log)[1].paths).toEqual(['src/new/c.ts'])
+  })
+
+  // Why: -m repeats the header per merge parent; only the first-parent section may count.
+  it('folds repeated headers for the same commit', () => {
+    const repeated = [
+      '@@@abc|Alice|2026-01-02|2026-01-02T10:00:00Z|feat: x (#10)',
+      '5\t1\ta.ts',
+      '@@@abc|Alice|2026-01-02|2026-01-02T10:00:00Z|feat: x (#10)',
+      '900\t900\tb.ts'
+    ].join('\n')
+    const commits = parseNumstatLog(repeated)
+
+    expect(commits).toHaveLength(1)
+    expect(commits[0]).toMatchObject({ additions: 5, deletions: 1, paths: ['a.ts'] })
   })
 })
 
-describe('betweenAuthorSpread', () => {
-  it('ignores authors below the minimum sample', () => {
-    const rows = [
-      ...Array.from({ length: 25 }, () => ({ author: 'alice', lift: 0.4 })),
-      { author: 'bob', lift: -0.4 }
-    ]
-    expect(betweenAuthorSpread(rows, 20).authors).toBe(1)
-    expect(betweenAuthorSpread(rows, 20).spread).toBe(0)
-  })
-
-  it('grows as author means diverge', () => {
-    const tight = [
-      ...Array.from({ length: 25 }, () => ({ author: 'alice', lift: 0.1 })),
-      ...Array.from({ length: 25 }, () => ({ author: 'bob', lift: 0.1 }))
-    ]
-    const wide = [
-      ...Array.from({ length: 25 }, () => ({ author: 'alice', lift: 0.5 })),
-      ...Array.from({ length: 25 }, () => ({ author: 'bob', lift: -0.5 }))
-    ]
-    expect(betweenAuthorSpread(tight, 20).spread).toBeCloseTo(0, 10)
-    expect(betweenAuthorSpread(wide, 20).spread).toBeGreaterThan(0.4)
-  })
-})
-
-describe('mulberry32', () => {
-  it('is deterministic for a given seed', () => {
-    const a = mulberry32(42)
-    const b = mulberry32(42)
-    expect([a(), a(), a()]).toEqual([b(), b(), b()])
-  })
-})
-
-describe('authorShuffleNull', () => {
-  // Why: the live null is "this is file heat, not authorship" — a heat-driven effect must not survive.
-  it('fails to reject when lift tracks file heat rather than author', () => {
-    const rows = []
-    for (let i = 0; i < 60; i += 1) {
-      const heat = i / 60
-      rows.push({ author: i % 2 === 0 ? 'alice' : 'bob', lift: heat, expected: heat })
-    }
-    const result = authorShuffleNull(rows, { rounds: 200, minPRs: 20 })
-    expect(result.authors).toBe(2)
-    expect(result.pValue).toBeGreaterThan(0.05)
-  })
-
-  it('rejects when one author carries higher lift at equal file heat', () => {
-    const rows = []
-    for (let i = 0; i < 60; i += 1) {
-      const alice = i % 2 === 0
-      rows.push({ author: alice ? 'alice' : 'bob', lift: alice ? 0.5 : -0.5, expected: 0.5 })
-    }
-    const result = authorShuffleNull(rows, { rounds: 200, minPRs: 20 })
-    expect(result.pValue).toBeLessThanOrEqual(0.05)
-  })
-
-  it('reports UNEVALUABLE shape when only one author clears the minimum', () => {
-    const rows = Array.from({ length: 30 }, () => ({ author: 'alice', lift: 0.2, expected: 0.2 }))
-    const result = authorShuffleNull(rows, { rounds: 50, minPRs: 20 })
-    expect(result.authors).toBe(1)
-    expect(result.pValue).toBe(1)
+describe('norm', () => {
+  it('strips the forge suffix so a revert can be matched to its subject', () => {
+    expect(norm('fix(terminal): stop flicker (#14982)')).toBe('fix terminal stop flicker')
+    expect(norm('fix(terminal): stop flicker (!42)')).toBe('fix terminal stop flicker')
   })
 })

--- a/src/shared/forge-merge-subject.test.ts
+++ b/src/shared/forge-merge-subject.test.ts
@@ -72,6 +72,13 @@ describe('extractRevertTargets', () => {
     ).toEqual({ targets: [456], quotedTitle: 'Resolve login bug' })
   })
 
+  it('extracts GitHub revert targets from the PR-UI body trailer', () => {
+    expect(extractRevertTargets('Revert "feat: x" (#456)', 'Reverts stablyai/orca#123')).toEqual({
+      targets: [123],
+      quotedTitle: 'feat: x'
+    })
+  })
+
   it('returns the quoted title alone when no number is recoverable', () => {
     expect(extractRevertTargets('Revert "Improve startup timing"')).toEqual({
       targets: [],

--- a/src/shared/forge-merge-subject.test.ts
+++ b/src/shared/forge-merge-subject.test.ts
@@ -1,0 +1,85 @@
+import { describe, expect, it } from 'vitest'
+import { extractRevertTargets, identifyMergedPR } from './forge-merge-subject'
+
+describe('identifyMergedPR', () => {
+  it('identifies GitHub squash subjects', () => {
+    expect(identifyMergedPR('fix(terminal): repaint (#12345)')).toEqual({
+      number: 12345,
+      forge: 'github'
+    })
+  })
+
+  it('identifies GitHub merge-commit subjects', () => {
+    expect(identifyMergedPR('Merge pull request #77 from org/branch')).toEqual({
+      number: 77,
+      forge: 'github'
+    })
+  })
+
+  it('identifies Bitbucket merge subjects and does not misread them as GitHub', () => {
+    expect(identifyMergedPR('Merged in feature/x (pull request #88)')).toEqual({
+      number: 88,
+      forge: 'bitbucket'
+    })
+  })
+
+  it('identifies GitLab squash subjects with a trailing MR reference', () => {
+    expect(identifyMergedPR('Resolve login bug (!42)')).toEqual({ number: 42, forge: 'gitlab' })
+  })
+
+  it('identifies GitLab merge commits via the see-merge-request body trailer', () => {
+    expect(
+      identifyMergedPR(
+        "Merge branch 'fix' into 'main'",
+        'Fix it\n\nSee merge request group/proj!907'
+      )
+    ).toEqual({ number: 907, forge: 'gitlab' })
+  })
+
+  it('returns null for unattributable merges', () => {
+    expect(identifyMergedPR("Merge branch 'develop'")).toEqual({ number: null, forge: null })
+    expect(identifyMergedPR('plain commit with no reference')).toEqual({
+      number: null,
+      forge: null
+    })
+  })
+})
+
+describe('extractRevertTargets', () => {
+  it('extracts targets quoted inside GitHub revert subjects', () => {
+    expect(extractRevertTargets('Revert "feat: x (#123)" (#200)')).toEqual({
+      targets: [123],
+      quotedTitle: 'feat: x (#123)'
+    })
+  })
+
+  it('extracts unquoted targets, excluding the revert PR itself', () => {
+    expect(extractRevertTargets('Revert #12658: show PR status (#12825)')).toEqual({
+      targets: [12658],
+      quotedTitle: null
+    })
+  })
+
+  it('extracts multiple targets from one revert', () => {
+    expect(
+      extractRevertTargets('Revert terminal changes from #10692 and #10794 (#11338)').targets
+    ).toEqual([10692, 10794])
+  })
+
+  it('extracts GitLab revert targets from the body trailer', () => {
+    expect(
+      extractRevertTargets('Revert "Resolve login bug"', 'This reverts merge request !456')
+    ).toEqual({ targets: [456], quotedTitle: 'Resolve login bug' })
+  })
+
+  it('returns the quoted title alone when no number is recoverable', () => {
+    expect(extractRevertTargets('Revert "Improve startup timing"')).toEqual({
+      targets: [],
+      quotedTitle: 'Improve startup timing'
+    })
+  })
+
+  it('returns nothing for non-revert subjects', () => {
+    expect(extractRevertTargets('fix(a): b (#9)')).toEqual({ targets: [], quotedTitle: null })
+  })
+})

--- a/src/shared/forge-merge-subject.ts
+++ b/src/shared/forge-merge-subject.ts
@@ -20,6 +20,8 @@ const SUBJECT_FORMS: { re: RegExp; forge: MergedPRIdentity['forge'] }[] = [
 ]
 const GITLAB_BODY_RE = /See merge request (?:[\w./-]+)?!(\d+)/i
 const GITLAB_REVERT_BODY_RE = /This reverts merge request !(\d+)/i
+// GitHub PR-UI reverts carry `Reverts owner/repo#123` in the body, no subject number.
+const GITHUB_REVERT_BODY_RE = /Reverts\s+[\w.-]+\/[\w.-]+#(\d+)/i
 
 export function identifyMergedPR(subject: string, body?: string): MergedPRIdentity {
   for (const { re, forge } of SUBJECT_FORMS) {
@@ -64,6 +66,8 @@ export function extractRevertTargets(subject: string, body?: string): RevertTarg
     return { targets: unquoted, quotedTitle }
   }
 
-  const fromBody = body ? GITLAB_REVERT_BODY_RE.exec(body) : null
+  const fromBody = body
+    ? (GITLAB_REVERT_BODY_RE.exec(body) ?? GITHUB_REVERT_BODY_RE.exec(body))
+    : null
   return { targets: fromBody ? [Number(fromBody[1])] : [], quotedTitle }
 }

--- a/src/shared/forge-merge-subject.ts
+++ b/src/shared/forge-merge-subject.ts
@@ -1,0 +1,69 @@
+/**
+ * Forge-aware parsing of merge-commit subjects: which PR/MR a merged commit
+ * belongs to, and which PR/MR a revert commit undoes. Titles are the one
+ * artifact every forge shares, so this is the portability seam for anything
+ * that replays PR history from a bare clone (see the backtest harness).
+ */
+
+export type MergedPRIdentity = {
+  number: number | null
+  forge: 'github' | 'gitlab' | 'bitbucket' | null
+}
+
+// Order matters: Bitbucket's `(pull request #N)` must win before a bare
+// trailing `#N)` could be misread, and explicit references beat body trailers.
+const SUBJECT_FORMS: { re: RegExp; forge: MergedPRIdentity['forge'] }[] = [
+  { re: /\(!(\d+)\)\s*$/, forge: 'gitlab' },
+  { re: /\(pull request #(\d+)\)\s*$/i, forge: 'bitbucket' },
+  { re: /\(#(\d+)\)\s*$/, forge: 'github' },
+  { re: /^Merge pull request #(\d+)/i, forge: 'github' }
+]
+const GITLAB_BODY_RE = /See merge request (?:[\w./-]+)?!(\d+)/i
+const GITLAB_REVERT_BODY_RE = /This reverts merge request !(\d+)/i
+
+export function identifyMergedPR(subject: string, body?: string): MergedPRIdentity {
+  for (const { re, forge } of SUBJECT_FORMS) {
+    const m = re.exec(subject)
+    if (m) {
+      return { number: Number(m[1]), forge }
+    }
+  }
+  const fromBody = body ? GITLAB_BODY_RE.exec(body) : null
+  if (fromBody) {
+    return { number: Number(fromBody[1]), forge: 'gitlab' }
+  }
+  return { number: null, forge: null }
+}
+
+export type RevertTargets = {
+  targets: number[]
+  /** The quoted original title, for callers that resolve paraphrased reverts by title match. */
+  quotedTitle: string | null
+}
+
+export function extractRevertTargets(subject: string, body?: string): RevertTargets {
+  if (!/^revert\b/i.test(subject)) {
+    return { targets: [], quotedTitle: null }
+  }
+  const quotedTitle = /"([^"]+)"/.exec(subject)?.[1] ?? null
+
+  // Numbers inside the quotes name the reverted PR; the revert's own trailing
+  // number must never count as a target.
+  const inQuote = quotedTitle
+    ? [...quotedTitle.matchAll(/[#!](\d+)/g)].map((m) => Number(m[1]))
+    : []
+  if (inQuote.length) {
+    return { targets: inQuote, quotedTitle }
+  }
+
+  const own = identifyMergedPR(subject).number
+  const unquoted = [...subject.matchAll(/[#!](\d+)/g)]
+    .map((m) => Number(m[1]))
+    .filter((n) => n !== own)
+  if (unquoted.length) {
+    return { targets: unquoted, quotedTitle }
+  }
+
+  const fromBody = body ? GITLAB_REVERT_BODY_RE.exec(body) : null
+  return { targets: fromBody ? [Number(fromBody[1])] : [], quotedTitle }
+}

--- a/src/shared/pr-watch-rules-types.ts
+++ b/src/shared/pr-watch-rules-types.ts
@@ -14,6 +14,10 @@ export type PRWatchInput = {
   draft?: boolean
   mergeable?: 'conflicting' | 'mergeable' | 'unknown'
   files?: number
+  /** Split so a deletion-heavy simplification is not sized like an equal-sized rewrite. */
+  additions?: number
+  deletions?: number
+  /** additions + deletions; only for rules that genuinely want one magnitude. */
   churn?: number
   /** undefined = not loaded; 0 = loaded, author has no merged PRs */
   authorMergedPRs?: number
@@ -30,6 +34,8 @@ export type PRWatchConditions = {
   draft?: boolean
   mergeable?: 'conflicting' | 'mergeable' | 'unknown'
   files?: string
+  additions?: string
+  deletions?: string
   churn?: string
   authorMergedPRs?: string
   /** ORed condition groups, ANDed with any sibling conditions. */
@@ -45,11 +51,9 @@ export type PRWatchTierRule = PRWatchRule & {
 
 export type PRWatchMatch = { rule: string; note?: string; pending: boolean }
 
+export type NumericConditionKey = 'files' | 'additions' | 'deletions' | 'churn' | 'authorMergedPRs'
 export type PercentileDistribution = Partial<
-  Record<
-    'files' | 'churn' | 'authorMergedPRs',
-    Partial<Record<'p50' | 'p75' | 'p90' | 'p95', number>>
-  >
+  Record<NumericConditionKey, Partial<Record<'p50' | 'p75' | 'p90' | 'p95', number>>>
 >
 export type EvaluateOptions = { percentiles?: PercentileDistribution }
 

--- a/src/shared/pr-watch-rules-types.ts
+++ b/src/shared/pr-watch-rules-types.ts
@@ -1,0 +1,56 @@
+/**
+ * Shared types for the PR watch-rules evaluator and its load-time validator.
+ * Split out so both modules import these via `import type` (erased at runtime),
+ * keeping each source file under its line budget with no cross-module value import.
+ */
+
+export type PRWatchInput = {
+  title: string
+  labels?: string[]
+  author?: string | null
+  branchName?: string
+  /** undefined = not fetched yet; [] = fetched and genuinely empty */
+  paths?: string[]
+  draft?: boolean
+  mergeable?: 'conflicting' | 'mergeable' | 'unknown'
+  files?: number
+  churn?: number
+  /** undefined = not loaded; 0 = loaded, author has no merged PRs */
+  authorMergedPRs?: number
+}
+
+export type PRWatchConditions = {
+  scope?: string | string[]
+  type?: string | string[]
+  title?: string
+  labels?: string[]
+  author?: string[]
+  branch?: string
+  paths?: string[]
+  draft?: boolean
+  mergeable?: 'conflicting' | 'mergeable' | 'unknown'
+  files?: string
+  churn?: string
+  authorMergedPRs?: string
+  /** ORed condition groups, ANDed with any sibling conditions. */
+  any?: PRWatchConditions[]
+}
+
+export type PRWatchRule = { name: string; when: PRWatchConditions; note?: string }
+export type PRWatchTierRule = PRWatchRule & {
+  action?: 'bounce'
+  slot?: 'deep'
+  batchBy?: 'author'
+}
+
+export type PRWatchMatch = { rule: string; note?: string; pending: boolean }
+
+export type PercentileDistribution = Partial<
+  Record<
+    'files' | 'churn' | 'authorMergedPRs',
+    Partial<Record<'p50' | 'p75' | 'p90' | 'p95', number>>
+  >
+>
+export type EvaluateOptions = { percentiles?: PercentileDistribution }
+
+export type TierResult = { tier: string | null; pending: boolean }

--- a/src/shared/pr-watch-rules.test.ts
+++ b/src/shared/pr-watch-rules.test.ts
@@ -54,6 +54,24 @@ describe('evaluateWatchRules (chip mode)', () => {
     ).toEqual(['Big fix'])
   })
 
+  it('sizes a deletion-heavy PR by additions, not by additions plus deletions', () => {
+    const r = validateWatchRules([
+      { name: 'Deep', when: { additions: '>=p90' } },
+      { name: 'Pruning', when: { deletions: '>=500' } }
+    ])
+    const percentiles = { additions: { p90: 1183 }, churn: { p90: 1405 } }
+    const simplification = input({ additions: 20, deletions: 1400, churn: 1420 })
+
+    expect(evaluateWatchRules(r, simplification, { percentiles }).map((m) => m.rule)).toEqual([
+      'Pruning'
+    ])
+    expect(
+      evaluateWatchRules(r, input({ additions: 1200, deletions: 10, churn: 1210 }), {
+        percentiles
+      }).map((m) => m.rule)
+    ).toEqual(['Deep'])
+  })
+
   it('matches scope, type, labels, and author case-insensitively', () => {
     const r = validateWatchRules([
       { name: 'L', when: { labels: ['Needs-QA'] } },

--- a/src/shared/pr-watch-rules.test.ts
+++ b/src/shared/pr-watch-rules.test.ts
@@ -18,6 +18,8 @@ describe('parseConventionalTitle', () => {
     expect(parseConventionalTitle('Feat(SSH): y')).toEqual({ type: 'feat', scope: 'ssh' })
     expect(parseConventionalTitle('docs: z')).toEqual({ type: 'docs', scope: null })
     expect(parseConventionalTitle('Add a thing')).toEqual({ type: null, scope: null })
+    expect(parseConventionalTitle('feat(api)!: drop v1')).toEqual({ type: 'feat', scope: 'api' })
+    expect(parseConventionalTitle('feat!: drop v1')).toEqual({ type: 'feat', scope: null })
   })
 })
 
@@ -120,6 +122,14 @@ describe('evaluateWatchRules (chip mode)', () => {
       { rule: 'New', note: undefined, pending: true }
     ])
   })
+
+  it('treats a null author as a definite miss, not pending', () => {
+    const r = validateWatchRules([{ name: 'A', when: { author: ['nwparker'] } }])
+    expect(evaluateWatchRules(r, input({ author: null }))).toEqual([])
+    expect(evaluateWatchRules(r, input({}))).toEqual([
+      { rule: 'A', note: undefined, pending: true }
+    ])
+  })
 })
 
 describe('validateWatchRules', () => {
@@ -134,6 +144,35 @@ describe('validateWatchRules', () => {
     expect(() => validateWatchRules([{ name: 'X', when: {} }])).toThrow(/condition/i)
     expect(() => validateWatchRules([{ name: 'X', when: { title: '(' } }])).toThrow(/regex/i)
     expect(() => validateWatchRules([{ name: 'X', when: { files: 'p90' } }])).toThrow(/comparison/i)
+  })
+
+  it('rejects malformed condition value shapes', () => {
+    expect(() => validateWatchRules([{ name: 'X', when: { labels: 'bug' } }])).toThrow(
+      /array of strings/
+    )
+    expect(() => validateWatchRules([{ name: 'X', when: { paths: 'src/**' } }])).toThrow(
+      /array of strings/
+    )
+    expect(() => validateWatchRules([{ name: 'X', when: { scope: [1] } }])).toThrow(
+      /string or an array/
+    )
+    expect(() => validateWatchRules([{ name: 'X', when: { draft: 'yes' } }])).toThrow(
+      /true or false/
+    )
+    expect(() => validateWatchRules([{ name: 'X', when: { mergeable: 'conflict' } }])).toThrow(
+      /conflicting/
+    )
+  })
+
+  it('validates nested any groups and rejects mode-specific keys', () => {
+    expect(() => validateWatchRules([{ name: 'X', when: { any: [] } }])).toThrow(/non-empty/)
+    expect(() => validateWatchRules([{ name: 'X', when: { any: [{ bogus: 1 }] } }])).toThrow(
+      /bogus/
+    )
+    expect(() => validateWatchRules([{ name: 'X', when: { scope: 'a' }, slot: 'deep' }])).toThrow(
+      /unknown key/
+    )
+    expect(validateTierRules([{ name: 'X', when: { scope: 'a' }, slot: 'deep' }])).toHaveLength(1)
   })
 })
 

--- a/src/shared/pr-watch-rules.test.ts
+++ b/src/shared/pr-watch-rules.test.ts
@@ -164,6 +164,16 @@ describe('validateWatchRules', () => {
     )
   })
 
+  it('rejects non-string regex conditions instead of coercing them', () => {
+    for (const key of ['title', 'branch'] as const) {
+      for (const bad of [42, null, {}, ['a']]) {
+        expect(() => validateWatchRules([{ name: 'X', when: { [key]: bad } }])).toThrow(
+          /must be a string/
+        )
+      }
+    }
+  })
+
   it('validates nested any groups and rejects mode-specific keys', () => {
     expect(() => validateWatchRules([{ name: 'X', when: { any: [] } }])).toThrow(/non-empty/)
     expect(() => validateWatchRules([{ name: 'X', when: { any: [{ bogus: 1 }] } }])).toThrow(

--- a/src/shared/pr-watch-rules.test.ts
+++ b/src/shared/pr-watch-rules.test.ts
@@ -1,0 +1,222 @@
+import { describe, expect, it } from 'vitest'
+import {
+  classifyReviewQueueTier,
+  evaluateWatchRules,
+  parseConventionalTitle,
+  validateTierRules,
+  validateWatchRules
+} from './pr-watch-rules'
+
+const input = (over: Partial<Parameters<typeof evaluateWatchRules>[1]> = {}) => ({
+  title: 'fix(terminal): stop repaint flicker',
+  ...over
+})
+
+describe('parseConventionalTitle', () => {
+  it('parses scoped, bare, and unprefixed titles', () => {
+    expect(parseConventionalTitle('fix(terminal): x')).toEqual({ type: 'fix', scope: 'terminal' })
+    expect(parseConventionalTitle('Feat(SSH): y')).toEqual({ type: 'feat', scope: 'ssh' })
+    expect(parseConventionalTitle('docs: z')).toEqual({ type: 'docs', scope: null })
+    expect(parseConventionalTitle('Add a thing')).toEqual({ type: null, scope: null })
+  })
+})
+
+describe('evaluateWatchRules (chip mode)', () => {
+  const rules = validateWatchRules([
+    { name: 'Terminal', when: { scope: 'terminal' }, note: 'fragile' },
+    { name: 'Wire', when: { paths: ['src/shared/rpc/**'] } },
+    { name: 'Big fix', when: { type: ['fix', 'perf'], churn: '>=500' } }
+  ])
+
+  it('reports every matching rule, not just the first', () => {
+    const matches = evaluateWatchRules(rules, input({ churn: 900 }))
+    expect(matches.filter((m) => !m.pending).map((m) => m.rule)).toEqual(['Terminal', 'Big fix'])
+  })
+
+  it('carries the note through', () => {
+    expect(evaluateWatchRules(rules, input())[0]).toMatchObject({
+      rule: 'Terminal',
+      note: 'fragile'
+    })
+  })
+
+  it('ANDs conditions within a rule and ORs values within a list', () => {
+    expect(
+      evaluateWatchRules(rules, input({ title: 'perf(git): faster status', churn: 499, paths: [] }))
+    ).toEqual([])
+    expect(
+      evaluateWatchRules(
+        rules,
+        input({ title: 'perf(git): faster status', churn: 500, paths: [] })
+      ).map((m) => m.rule)
+    ).toEqual(['Big fix'])
+  })
+
+  it('matches scope, type, labels, and author case-insensitively', () => {
+    const r = validateWatchRules([
+      { name: 'L', when: { labels: ['Needs-QA'] } },
+      { name: 'A', when: { author: ['NWParker'] } }
+    ])
+    expect(
+      evaluateWatchRules(r, input({ labels: ['needs-qa'], author: 'nwparker' })).map((m) => m.rule)
+    ).toEqual(['L', 'A'])
+  })
+
+  it('is pending, not unmatched, when a paths rule sees paths undefined', () => {
+    const m = evaluateWatchRules(rules, input({ title: 'feat(rpc): add opcode' }))
+    expect(m).toEqual([{ rule: 'Wire', note: undefined, pending: true }])
+  })
+
+  it('does not match when paths were fetched and are empty', () => {
+    expect(evaluateWatchRules(rules, input({ title: 'feat(rpc): add opcode', paths: [] }))).toEqual(
+      []
+    )
+  })
+
+  it('matches globs including ** and directory anchors', () => {
+    const r = validateWatchRules([
+      { name: 'G', when: { paths: ['src/main/**/*.test.ts', 'docs/*.md'] } }
+    ])
+    const hit = (p: string) =>
+      evaluateWatchRules(r, input({ paths: [p] })).some((m) => m.rule === 'G' && !m.pending)
+    expect(hit('src/main/git/status.test.ts')).toBe(true)
+    expect(hit('docs/readme.md')).toBe(true)
+    expect(hit('docs/nested/readme.md')).toBe(false)
+    expect(hit('src/main.ts')).toBe(false)
+  })
+
+  it('matches title and branch by regex', () => {
+    const r = validateWatchRules([
+      { name: 'T', when: { title: 'revert|rollback' } },
+      { name: 'B', when: { branch: '^release/' } }
+    ])
+    expect(
+      evaluateWatchRules(r, input({ title: 'Rollback the cache', branchName: 'release/1.5' })).map(
+        (m) => m.rule
+      )
+    ).toEqual(['T', 'B'])
+  })
+
+  it('resolves percentile tokens against an injected distribution', () => {
+    const r = validateWatchRules([{ name: 'P', when: { files: '>=p90' } }])
+    const dist = { files: { p50: 7, p75: 18, p90: 33 }, churn: { p50: 180, p75: 620, p90: 1500 } }
+    expect(
+      evaluateWatchRules(r, input({ files: 40 }), { percentiles: dist }).map((m) => m.rule)
+    ).toEqual(['P'])
+    expect(evaluateWatchRules(r, input({ files: 20 }), { percentiles: dist })).toEqual([])
+  })
+
+  it('is pending when a percentile token has no distribution to resolve against', () => {
+    const r = validateWatchRules([{ name: 'P', when: { files: '>=p90' } }])
+    expect(evaluateWatchRules(r, input({ files: 40 }))).toEqual([
+      { rule: 'P', note: undefined, pending: true }
+    ])
+  })
+
+  it('treats authorMergedPRs 0 as loaded-and-zero, undefined as pending', () => {
+    const r = validateWatchRules([{ name: 'New', when: { authorMergedPRs: '==0' } }])
+    expect(evaluateWatchRules(r, input({ authorMergedPRs: 0 })).map((m) => m.rule)).toEqual(['New'])
+    expect(evaluateWatchRules(r, input({}))).toEqual([
+      { rule: 'New', note: undefined, pending: true }
+    ])
+  })
+})
+
+describe('validateWatchRules', () => {
+  it('rejects unknown keys, duplicate names, empty when, bad globs, bad regexes', () => {
+    expect(() => validateWatchRules([{ name: 'X', when: { bogus: 1 } }])).toThrow(/bogus/)
+    expect(() =>
+      validateWatchRules([
+        { name: 'X', when: { scope: 'a' } },
+        { name: 'X', when: { scope: 'b' } }
+      ])
+    ).toThrow(/duplicate/i)
+    expect(() => validateWatchRules([{ name: 'X', when: {} }])).toThrow(/condition/i)
+    expect(() => validateWatchRules([{ name: 'X', when: { title: '(' } }])).toThrow(/regex/i)
+    expect(() => validateWatchRules([{ name: 'X', when: { files: 'p90' } }])).toThrow(/comparison/i)
+  })
+})
+
+describe('classifyReviewQueueTier (first-match mode)', () => {
+  const tiers = validateTierRules([
+    { name: 'Not reviewable', when: { any: [{ draft: true }, { mergeable: 'conflicting' }] } },
+    {
+      name: 'Deep',
+      when: { any: [{ files: '>=19' }, { churn: '>=1500' }, { scope: 'terminal' }] }
+    },
+    { name: 'New contributor', when: { authorMergedPRs: '==0' } },
+    { name: 'Fast', when: { files: '<=7', churn: '<=400', type: ['fix', 'test', 'docs'] } }
+  ])
+
+  it('takes the first matching tier and stops', () => {
+    expect(classifyReviewQueueTier(tiers, input({ draft: true, files: 50, churn: 9000 }))).toEqual({
+      tier: 'Not reviewable',
+      pending: false
+    })
+  })
+
+  it('ORs any: groups', () => {
+    expect(
+      classifyReviewQueueTier(
+        tiers,
+        input({
+          title: 'feat(git): x',
+          files: 3,
+          churn: 2000,
+          authorMergedPRs: 5,
+          draft: false,
+          mergeable: 'mergeable'
+        })
+      )
+    ).toEqual({ tier: 'Deep', pending: false })
+  })
+
+  it('falls through to the implicit catch-all', () => {
+    expect(
+      classifyReviewQueueTier(
+        tiers,
+        input({
+          title: 'feat(git): x',
+          files: 10,
+          churn: 600,
+          authorMergedPRs: 12,
+          draft: false,
+          mergeable: 'mergeable'
+        })
+      )
+    ).toEqual({ tier: null, pending: false })
+  })
+
+  it('stops at a pending rule instead of unsafely falling past it', () => {
+    // files unknown: the Deep tier cannot be ruled out, so classification is
+    // tentatively Deep with pending — never silently Fast.
+    expect(
+      classifyReviewQueueTier(
+        tiers,
+        input({
+          title: 'fix(git): x',
+          churn: 120,
+          authorMergedPRs: 3,
+          draft: false,
+          mergeable: 'mergeable'
+        })
+      )
+    ).toEqual({ tier: 'Deep', pending: true })
+  })
+
+  it('classifies the fast tier for a small scoped fix from a known author', () => {
+    expect(
+      classifyReviewQueueTier(
+        tiers,
+        input({
+          title: 'fix(git): x',
+          files: 3,
+          churn: 120,
+          authorMergedPRs: 3,
+          draft: false,
+          mergeable: 'mergeable'
+        })
+      )
+    ).toEqual({ tier: 'Fast', pending: false })
+  })
+})

--- a/src/shared/pr-watch-rules.ts
+++ b/src/shared/pr-watch-rules.ts
@@ -244,12 +244,18 @@ function validateConditions(when: unknown, where: string): asserts when is PRWat
     }
   }
   for (const key of ['title', 'branch'] as const) {
-    if (rec[key] !== undefined) {
-      try {
-        new RegExp(rec[key] as string)
-      } catch {
-        throw new Error(`${where}: "${key}" is not a valid regex`)
-      }
+    const value = rec[key]
+    if (value === undefined) {
+      continue
+    }
+    // RegExp coerces: `title: 42` would silently compile as /42/ instead of failing.
+    if (typeof value !== 'string') {
+      throw new Error(`${where}: "${key}" must be a string`)
+    }
+    try {
+      new RegExp(value)
+    } catch {
+      throw new Error(`${where}: "${key}" is not a valid regex`)
     }
   }
   for (const key of ['labels', 'author', 'paths'] as const) {

--- a/src/shared/pr-watch-rules.ts
+++ b/src/shared/pr-watch-rules.ts
@@ -4,61 +4,33 @@
  * docs/superpowers/specs/2026-08-07-pr-watch-rules-design.md.
  */
 
-export type PRWatchInput = {
-  title: string
-  labels?: string[]
-  author?: string | null
-  branchName?: string
-  /** undefined = not fetched yet; [] = fetched and genuinely empty */
-  paths?: string[]
-  draft?: boolean
-  mergeable?: 'conflicting' | 'mergeable' | 'unknown'
-  files?: number
-  churn?: number
-  /** undefined = not loaded; 0 = loaded, author has no merged PRs */
-  authorMergedPRs?: number
-}
-
-export type PRWatchConditions = {
-  scope?: string | string[]
-  type?: string | string[]
-  title?: string
-  labels?: string[]
-  author?: string[]
-  branch?: string
-  paths?: string[]
-  draft?: boolean
-  mergeable?: 'conflicting' | 'mergeable' | 'unknown'
-  files?: string
-  churn?: string
-  authorMergedPRs?: string
-  /** ORed condition groups, ANDed with any sibling conditions. */
-  any?: PRWatchConditions[]
-}
-
-export type PRWatchRule = { name: string; when: PRWatchConditions; note?: string }
-export type PRWatchTierRule = PRWatchRule & {
-  action?: 'bounce'
-  slot?: 'deep'
-  batchBy?: 'author'
-}
-
-export type PRWatchMatch = { rule: string; note?: string; pending: boolean }
-
-export type PercentileDistribution = Partial<
-  Record<
-    'files' | 'churn' | 'authorMergedPRs',
-    Partial<Record<'p50' | 'p75' | 'p90' | 'p95', number>>
-  >
->
-export type EvaluateOptions = { percentiles?: PercentileDistribution }
+import type {
+  EvaluateOptions,
+  PRWatchConditions,
+  PRWatchInput,
+  PRWatchMatch,
+  PRWatchRule,
+  PRWatchTierRule,
+  TierResult
+} from './pr-watch-rules-types'
 
 // 'no' beats 'pending' under AND (a definite miss can't become a match);
 // 'match' beats 'pending' under OR.
 type Verdict = 'match' | 'no' | 'pending'
 
 const COMPARISON_RE = /^(>=|<=|>|<|==)\s*(p50|p75|p90|p95|\d+)$/
-const CONVENTIONAL_RE = /^([a-z]+)(?:\(([a-z0-9/._-]+)\))?\s*:/i
+const CONVENTIONAL_RE = /^([a-z]+)(?:\(([a-z0-9/._-]+)\))?!?\s*:/i
+
+// Rule regexes/globs are recompiled per PR by the backtest; memoize by source.
+const regexCache = new Map<string, RegExp>()
+const regexFor = (pattern: string): RegExp => {
+  let re = regexCache.get(pattern)
+  if (re === undefined) {
+    re = new RegExp(pattern, 'i')
+    regexCache.set(pattern, re)
+  }
+  return re
+}
 
 export function parseConventionalTitle(title: string): {
   type: string | null
@@ -68,7 +40,12 @@ export function parseConventionalTitle(title: string): {
   return { type: m?.[1]?.toLowerCase() ?? null, scope: m?.[2]?.toLowerCase() ?? null }
 }
 
+const globCache = new Map<string, RegExp>()
 function globToRegExp(glob: string): RegExp {
+  const cached = globCache.get(glob)
+  if (cached !== undefined) {
+    return cached
+  }
   let out = '^'
   for (let i = 0; i < glob.length; i++) {
     const c = glob[i]
@@ -83,10 +60,12 @@ function globToRegExp(glob: string): RegExp {
     } else if (c === '?') {
       out += '[^/]'
     } else {
-      out += /[a-zA-Z0-9/_-]/.test(c) ? c : `\\${c}`
+      out += /[.*+?^${}()|[\]\\]/.test(c) ? `\\${c}` : c
     }
   }
-  return new RegExp(`${out}$`)
+  const re = new RegExp(`${out}$`)
+  globCache.set(glob, re)
+  return re
 }
 
 const eqFold = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
@@ -147,10 +126,10 @@ function evaluateConditions(
     )
   }
   if (when.title !== undefined) {
-    verdicts.push(bool(new RegExp(when.title, 'i').test(input.title)))
+    verdicts.push(bool(regexFor(when.title).test(input.title)))
   }
   if (when.branch !== undefined) {
-    verdicts.push(known(input.branchName, (b) => bool(new RegExp(when.branch!, 'i').test(b))))
+    verdicts.push(known(input.branchName, (b) => bool(regexFor(when.branch!).test(b))))
   }
   if (when.labels !== undefined) {
     verdicts.push(
@@ -158,8 +137,11 @@ function evaluateConditions(
     )
   }
   if (when.author !== undefined) {
+    // null = no author (deleted account): a definite miss, not pending.
     verdicts.push(
-      known(input.author ?? undefined, (a) => bool(when.author!.some((w) => eqFold(w, a))))
+      input.author === null
+        ? 'no'
+        : known(input.author, (a) => bool(when.author!.some((w) => eqFold(w, a))))
     )
   }
   if (when.paths !== undefined) {
@@ -208,8 +190,6 @@ export function evaluateWatchRules(
   return out
 }
 
-export type TierResult = { tier: string | null; pending: boolean }
-
 /**
  * Tier mode: ordered, first-match-wins, implicit catch-all (tier: null). A pending
  * rule stops the walk with a tentative assignment — absence of data must never let
@@ -231,6 +211,8 @@ export function classifyReviewQueueTier(
 
 const RULE_KEYS = new Set(['name', 'when', 'note'])
 const TIER_KEYS = new Set(['name', 'when', 'note', 'action', 'slot', 'batchBy'])
+// Untrusted YAML keys: Set membership avoids the prototype-chain hits a plain
+// object would report as valid (e.g. `constructor`, `toString`).
 const CONDITION_KEYS = new Set([
   'scope',
   'type',
@@ -270,6 +252,33 @@ function validateConditions(when: unknown, where: string): asserts when is PRWat
       }
     }
   }
+  for (const key of ['labels', 'author', 'paths'] as const) {
+    const v = rec[key]
+    if (v !== undefined && !(Array.isArray(v) && v.every((e) => typeof e === 'string'))) {
+      throw new Error(`${where}: "${key}" must be an array of strings`)
+    }
+  }
+  for (const key of ['scope', 'type'] as const) {
+    const v = rec[key]
+    if (
+      v !== undefined &&
+      typeof v !== 'string' &&
+      !(Array.isArray(v) && v.every((e) => typeof e === 'string'))
+    ) {
+      throw new Error(`${where}: "${key}" must be a string or an array of strings`)
+    }
+  }
+  if (rec.draft !== undefined && typeof rec.draft !== 'boolean') {
+    throw new Error(`${where}: "draft" must be true or false`)
+  }
+  if (
+    rec.mergeable !== undefined &&
+    rec.mergeable !== 'conflicting' &&
+    rec.mergeable !== 'mergeable' &&
+    rec.mergeable !== 'unknown'
+  ) {
+    throw new Error(`${where}: "mergeable" must be conflicting, mergeable, or unknown`)
+  }
   for (const key of ['files', 'churn', 'authorMergedPRs'] as const) {
     if (rec[key] !== undefined && !COMPARISON_RE.test(String(rec[key]))) {
       throw new Error(`${where}: "${key}" must be a comparison like ">=19" or ">=p90"`)
@@ -288,16 +297,13 @@ function validateRuleList(raw: unknown, allowedKeys: Set<string>, label: string)
     throw new Error(`${label} must be an array of rules`)
   }
   const seen = new Set<string>()
-  for (const [i, rule] of raw.entries()) {
+  for (let i = 0; i < raw.length; i++) {
+    const rule: unknown = raw[i]
     const where = `${label}[${i}]`
-    if (
-      !rule ||
-      typeof rule !== 'object' ||
-      typeof (rule as { name?: unknown }).name !== 'string'
-    ) {
+    if (!rule || typeof rule !== 'object' || !('name' in rule) || typeof rule.name !== 'string') {
       throw new Error(`${where}: every rule needs a string "name"`)
     }
-    const name = (rule as { name: string }).name
+    const name = rule.name
     if (seen.has(name)) {
       throw new Error(`${label}: duplicate rule name "${name}"`)
     }
@@ -307,7 +313,7 @@ function validateRuleList(raw: unknown, allowedKeys: Set<string>, label: string)
         throw new Error(`${where} ("${name}"): unknown key "${key}"`)
       }
     }
-    validateConditions((rule as { when?: unknown }).when, `${where} ("${name}")`)
+    validateConditions('when' in rule ? rule.when : undefined, `${where} ("${name}")`)
   }
 }
 

--- a/src/shared/pr-watch-rules.ts
+++ b/src/shared/pr-watch-rules.ts
@@ -6,6 +6,7 @@
 
 import type {
   EvaluateOptions,
+  NumericConditionKey,
   PRWatchConditions,
   PRWatchInput,
   PRWatchMatch,
@@ -19,6 +20,8 @@ import type {
 type Verdict = 'match' | 'no' | 'pending'
 
 const COMPARISON_RE = /^(>=|<=|>|<|==)\s*(p50|p75|p90|p95|\d+)$/
+// Superset of NumericConditionKey is caught by compare()'s parameter type.
+const NUMERIC_KEYS = ['files', 'additions', 'deletions', 'churn', 'authorMergedPRs'] as const
 const CONVENTIONAL_RE = /^([a-z]+)(?:\(([a-z0-9/._-]+)\))?!?\s*:/i
 
 // Rule regexes/globs are recompiled per PR by the backtest; memoize by source.
@@ -74,7 +77,7 @@ const anyOf = (v: string | string[]): string[] => (Array.isArray(v) ? v : [v])
 function compare(
   spec: string,
   value: number | undefined,
-  key: 'files' | 'churn' | 'authorMergedPRs',
+  key: NumericConditionKey,
   opts: EvaluateOptions
 ): Verdict {
   if (value === undefined) {
@@ -158,7 +161,7 @@ function evaluateConditions(
   if (when.mergeable !== undefined) {
     verdicts.push(known(input.mergeable, (s) => bool(s === when.mergeable)))
   }
-  for (const key of ['files', 'churn', 'authorMergedPRs'] as const) {
+  for (const key of NUMERIC_KEYS) {
     if (when[key] !== undefined) {
       verdicts.push(compare(when[key]!, input[key], key, opts))
     }
@@ -213,7 +216,7 @@ const RULE_KEYS = new Set(['name', 'when', 'note'])
 const TIER_KEYS = new Set(['name', 'when', 'note', 'action', 'slot', 'batchBy'])
 // Untrusted YAML keys: Set membership avoids the prototype-chain hits a plain
 // object would report as valid (e.g. `constructor`, `toString`).
-const CONDITION_KEYS = new Set([
+const CONDITION_KEYS = new Set<string>([
   'scope',
   'type',
   'title',
@@ -223,10 +226,8 @@ const CONDITION_KEYS = new Set([
   'paths',
   'draft',
   'mergeable',
-  'files',
-  'churn',
-  'authorMergedPRs',
-  'any'
+  'any',
+  ...NUMERIC_KEYS
 ])
 
 function validateConditions(when: unknown, where: string): asserts when is PRWatchConditions {
@@ -285,7 +286,7 @@ function validateConditions(when: unknown, where: string): asserts when is PRWat
   ) {
     throw new Error(`${where}: "mergeable" must be conflicting, mergeable, or unknown`)
   }
-  for (const key of ['files', 'churn', 'authorMergedPRs'] as const) {
+  for (const key of NUMERIC_KEYS) {
     if (rec[key] !== undefined && !COMPARISON_RE.test(String(rec[key]))) {
       throw new Error(`${where}: "${key}" must be a comparison like ">=19" or ">=p90"`)
     }

--- a/src/shared/pr-watch-rules.ts
+++ b/src/shared/pr-watch-rules.ts
@@ -1,0 +1,322 @@
+/**
+ * Declarative PR watch rules + review-queue tier cascade (one evaluator, two modes).
+ * Pure: percentile distributions are injected, never read from disk. See
+ * docs/superpowers/specs/2026-08-07-pr-watch-rules-design.md.
+ */
+
+export type PRWatchInput = {
+  title: string
+  labels?: string[]
+  author?: string | null
+  branchName?: string
+  /** undefined = not fetched yet; [] = fetched and genuinely empty */
+  paths?: string[]
+  draft?: boolean
+  mergeable?: 'conflicting' | 'mergeable' | 'unknown'
+  files?: number
+  churn?: number
+  /** undefined = not loaded; 0 = loaded, author has no merged PRs */
+  authorMergedPRs?: number
+}
+
+export type PRWatchConditions = {
+  scope?: string | string[]
+  type?: string | string[]
+  title?: string
+  labels?: string[]
+  author?: string[]
+  branch?: string
+  paths?: string[]
+  draft?: boolean
+  mergeable?: 'conflicting' | 'mergeable' | 'unknown'
+  files?: string
+  churn?: string
+  authorMergedPRs?: string
+  /** ORed condition groups, ANDed with any sibling conditions. */
+  any?: PRWatchConditions[]
+}
+
+export type PRWatchRule = { name: string; when: PRWatchConditions; note?: string }
+export type PRWatchTierRule = PRWatchRule & {
+  action?: 'bounce'
+  slot?: 'deep'
+  batchBy?: 'author'
+}
+
+export type PRWatchMatch = { rule: string; note?: string; pending: boolean }
+
+export type PercentileDistribution = Partial<
+  Record<
+    'files' | 'churn' | 'authorMergedPRs',
+    Partial<Record<'p50' | 'p75' | 'p90' | 'p95', number>>
+  >
+>
+export type EvaluateOptions = { percentiles?: PercentileDistribution }
+
+// 'no' beats 'pending' under AND (a definite miss can't become a match);
+// 'match' beats 'pending' under OR.
+type Verdict = 'match' | 'no' | 'pending'
+
+const COMPARISON_RE = /^(>=|<=|>|<|==)\s*(p50|p75|p90|p95|\d+)$/
+const CONVENTIONAL_RE = /^([a-z]+)(?:\(([a-z0-9/._-]+)\))?\s*:/i
+
+export function parseConventionalTitle(title: string): {
+  type: string | null
+  scope: string | null
+} {
+  const m = CONVENTIONAL_RE.exec(title)
+  return { type: m?.[1]?.toLowerCase() ?? null, scope: m?.[2]?.toLowerCase() ?? null }
+}
+
+function globToRegExp(glob: string): RegExp {
+  let out = '^'
+  for (let i = 0; i < glob.length; i++) {
+    const c = glob[i]
+    if (c === '*') {
+      if (glob[i + 1] === '*') {
+        // `**/` also matches zero directories, so src/**/*.ts covers src/a.ts
+        out += glob[i + 2] === '/' ? '(?:.*/)?' : '.*'
+        i += glob[i + 2] === '/' ? 2 : 1
+      } else {
+        out += '[^/]*'
+      }
+    } else if (c === '?') {
+      out += '[^/]'
+    } else {
+      out += /[a-zA-Z0-9/_-]/.test(c) ? c : `\\${c}`
+    }
+  }
+  return new RegExp(`${out}$`)
+}
+
+const eqFold = (a: string, b: string): boolean => a.toLowerCase() === b.toLowerCase()
+const anyOf = (v: string | string[]): string[] => (Array.isArray(v) ? v : [v])
+
+function compare(
+  spec: string,
+  value: number | undefined,
+  key: 'files' | 'churn' | 'authorMergedPRs',
+  opts: EvaluateOptions
+): Verdict {
+  if (value === undefined) {
+    return 'pending'
+  }
+  const m = COMPARISON_RE.exec(spec)!
+  let bound: number
+  if (m[2].startsWith('p')) {
+    const resolved = opts.percentiles?.[key]?.[m[2] as 'p50']
+    if (resolved === undefined) {
+      return 'pending'
+    }
+    bound = resolved
+  } else {
+    bound = Number(m[2])
+  }
+  const ok =
+    m[1] === '>='
+      ? value >= bound
+      : m[1] === '<='
+        ? value <= bound
+        : m[1] === '>'
+          ? value > bound
+          : m[1] === '<'
+            ? value < bound
+            : value === bound
+  return ok ? 'match' : 'no'
+}
+
+function evaluateConditions(
+  when: PRWatchConditions,
+  input: PRWatchInput,
+  opts: EvaluateOptions
+): Verdict {
+  const parsed = parseConventionalTitle(input.title)
+  const verdicts: Verdict[] = []
+  const bool = (ok: boolean): Verdict => (ok ? 'match' : 'no')
+  const known = <T>(value: T | undefined, judge: (v: T) => Verdict): Verdict =>
+    value === undefined ? 'pending' : judge(value)
+
+  if (when.scope !== undefined) {
+    verdicts.push(
+      bool(parsed.scope !== null && anyOf(when.scope).some((s) => eqFold(s, parsed.scope!)))
+    )
+  }
+  if (when.type !== undefined) {
+    verdicts.push(
+      bool(parsed.type !== null && anyOf(when.type).some((t) => eqFold(t, parsed.type!)))
+    )
+  }
+  if (when.title !== undefined) {
+    verdicts.push(bool(new RegExp(when.title, 'i').test(input.title)))
+  }
+  if (when.branch !== undefined) {
+    verdicts.push(known(input.branchName, (b) => bool(new RegExp(when.branch!, 'i').test(b))))
+  }
+  if (when.labels !== undefined) {
+    verdicts.push(
+      known(input.labels, (ls) => bool(when.labels!.some((w) => ls.some((l) => eqFold(l, w)))))
+    )
+  }
+  if (when.author !== undefined) {
+    verdicts.push(
+      known(input.author ?? undefined, (a) => bool(when.author!.some((w) => eqFold(w, a))))
+    )
+  }
+  if (when.paths !== undefined) {
+    verdicts.push(
+      known(input.paths, (ps) => {
+        const regexes = when.paths!.map(globToRegExp)
+        return bool(ps.some((p) => regexes.some((re) => re.test(p))))
+      })
+    )
+  }
+  if (when.draft !== undefined) {
+    verdicts.push(known(input.draft, (d) => bool(d === when.draft)))
+  }
+  if (when.mergeable !== undefined) {
+    verdicts.push(known(input.mergeable, (s) => bool(s === when.mergeable)))
+  }
+  for (const key of ['files', 'churn', 'authorMergedPRs'] as const) {
+    if (when[key] !== undefined) {
+      verdicts.push(compare(when[key]!, input[key], key, opts))
+    }
+  }
+  if (when.any !== undefined) {
+    const sub = when.any.map((group) => evaluateConditions(group, input, opts))
+    verdicts.push(sub.includes('match') ? 'match' : sub.includes('pending') ? 'pending' : 'no')
+  }
+
+  if (verdicts.includes('no')) {
+    return 'no'
+  }
+  return verdicts.includes('pending') ? 'pending' : 'match'
+}
+
+/** Chip mode: every rule reports independently. */
+export function evaluateWatchRules(
+  rules: readonly PRWatchRule[],
+  input: PRWatchInput,
+  opts: EvaluateOptions = {}
+): PRWatchMatch[] {
+  const out: PRWatchMatch[] = []
+  for (const rule of rules) {
+    const verdict = evaluateConditions(rule.when, input, opts)
+    if (verdict !== 'no') {
+      out.push({ rule: rule.name, note: rule.note, pending: verdict === 'pending' })
+    }
+  }
+  return out
+}
+
+export type TierResult = { tier: string | null; pending: boolean }
+
+/**
+ * Tier mode: ordered, first-match-wins, implicit catch-all (tier: null). A pending
+ * rule stops the walk with a tentative assignment — absence of data must never let
+ * an item fall through to a cheaper tier.
+ */
+export function classifyReviewQueueTier(
+  tiers: readonly PRWatchTierRule[],
+  input: PRWatchInput,
+  opts: EvaluateOptions = {}
+): TierResult {
+  for (const tier of tiers) {
+    const verdict = evaluateConditions(tier.when, input, opts)
+    if (verdict !== 'no') {
+      return { tier: tier.name, pending: verdict === 'pending' }
+    }
+  }
+  return { tier: null, pending: false }
+}
+
+const RULE_KEYS = new Set(['name', 'when', 'note'])
+const TIER_KEYS = new Set(['name', 'when', 'note', 'action', 'slot', 'batchBy'])
+const CONDITION_KEYS = new Set([
+  'scope',
+  'type',
+  'title',
+  'labels',
+  'author',
+  'branch',
+  'paths',
+  'draft',
+  'mergeable',
+  'files',
+  'churn',
+  'authorMergedPRs',
+  'any'
+])
+
+function validateConditions(when: unknown, where: string): asserts when is PRWatchConditions {
+  if (!when || typeof when !== 'object' || Array.isArray(when)) {
+    throw new Error(`${where}: "when" must be an object with at least one condition`)
+  }
+  const rec = when as Record<string, unknown>
+  const keys = Object.keys(rec)
+  if (keys.length === 0) {
+    throw new Error(`${where}: "when" has no conditions; an empty rule is not match-everything`)
+  }
+  for (const key of keys) {
+    if (!CONDITION_KEYS.has(key)) {
+      throw new Error(`${where}: unknown condition "${key}"`)
+    }
+  }
+  for (const key of ['title', 'branch'] as const) {
+    if (rec[key] !== undefined) {
+      try {
+        new RegExp(rec[key] as string)
+      } catch {
+        throw new Error(`${where}: "${key}" is not a valid regex`)
+      }
+    }
+  }
+  for (const key of ['files', 'churn', 'authorMergedPRs'] as const) {
+    if (rec[key] !== undefined && !COMPARISON_RE.test(String(rec[key]))) {
+      throw new Error(`${where}: "${key}" must be a comparison like ">=19" or ">=p90"`)
+    }
+  }
+  if (rec.any !== undefined) {
+    if (!Array.isArray(rec.any) || rec.any.length === 0) {
+      throw new Error(`${where}: "any" must be a non-empty array of condition groups`)
+    }
+    rec.any.forEach((group, i) => validateConditions(group, `${where}.any[${i}]`))
+  }
+}
+
+function validateRuleList(raw: unknown, allowedKeys: Set<string>, label: string): void {
+  if (!Array.isArray(raw)) {
+    throw new Error(`${label} must be an array of rules`)
+  }
+  const seen = new Set<string>()
+  for (const [i, rule] of raw.entries()) {
+    const where = `${label}[${i}]`
+    if (
+      !rule ||
+      typeof rule !== 'object' ||
+      typeof (rule as { name?: unknown }).name !== 'string'
+    ) {
+      throw new Error(`${where}: every rule needs a string "name"`)
+    }
+    const name = (rule as { name: string }).name
+    if (seen.has(name)) {
+      throw new Error(`${label}: duplicate rule name "${name}"`)
+    }
+    seen.add(name)
+    for (const key of Object.keys(rule)) {
+      if (!allowedKeys.has(key)) {
+        throw new Error(`${where} ("${name}"): unknown key "${key}"`)
+      }
+    }
+    validateConditions((rule as { when?: unknown }).when, `${where} ("${name}")`)
+  }
+}
+
+export function validateWatchRules(raw: unknown): PRWatchRule[] {
+  validateRuleList(raw, RULE_KEYS, 'pr_watch')
+  return raw as PRWatchRule[]
+}
+
+export function validateTierRules(raw: unknown): PRWatchTierRule[] {
+  validateRuleList(raw, TIER_KEYS, 'review_queue.tiers')
+  return raw as PRWatchTierRule[]
+}


### PR DESCRIPTION
## Summary

Prototype of the direction proposed in #13066: instead of a computed merge-risk score (measured unpredictive there — best signal AUC 0.62, ~40 false alarms per true one), let a repo *declare* which PRs deserve attention, and validate any rule against real history before trusting it.

Two pieces, no app integration yet — nothing is wired into the UI, `orca.yaml`, or any fetch path, so the review surface is the evaluator contract and the harness:

**`src/shared/pr-watch-rules.ts`** — pure evaluator, two modes over one condition grammar:

- *Chip mode* (`evaluateWatchRules`): every matching rule reports, carrying the rule author's `note` — the "why this PR needs a closer look" a numeric badge can't express.
- *Tier mode* (`classifyReviewQueueTier`): ordered first-match cascade for review-queue triage (draft/conflicting → deep/new-contributor/fast-track), with numeric thresholds accepting literals (`">=19"`) or percentile tokens (`">=p90"`) resolved against an injected distribution — the same config self-calibrates across repos of different velocity.
- Tri-state semantics throughout: a condition on unfetched data is **pending**, never silently unmatched, and a pending tier rule stops the cascade with a tentative assignment so missing data can never demote a PR to a cheaper tier. Definitive-no beats pending under AND; match beats pending under OR.
- `validateWatchRules`/`validateTierRules` reject unknown keys, duplicate names, empty `when`, invalid regexes/comparisons at load, so a typo cannot silently disable a rule.

**`config/scripts/pr-watch-backtest.mjs`** — replays a YAML rule file over local `git log` (offline, zero API calls) so rules are judged before they're trusted. Imports the real evaluator via Node ≥23 type-stripping — no duplicated matching logic to drift. Self-calibrates percentiles from the window; flags dead and over-broad rules; suppresses the revert-correlation column below 20 labels so small samples can't manufacture signal.

**Forge-aware** (`src/shared/forge-merge-subject.ts`): merged-PR identity and revert targets parse GitHub squash/merge subjects, GitLab `(!N)` + `See merge request !N` trailers, and Bitbucket `Merged in … (pull request #N)`; the harness walks `--first-parent -m --numstat` so merge-commit PRs are sized as one unit. Unattributable merges are counted, not guessed.

Replaying the example rules over this repo's history reproduces the #13066 hand analysis exactly:

```
history: 6481 merged PRs over 4.5 months
merge subjects: github:6481 · unattributable merges excluded: 1424
calibration: files p50=4 p90=20 · churn p50=188 p90=1355

Terminal rendering    253   3.90%   9 / 62 reverts
Remote wire           376   5.80%   2 / 62   ← already showing drift: broader than intended
Windows setup shell    17   0.26%   0 / 62
```

The "Remote wire" line is the harness doing its job — that rule is drifting broad and would be flagged for tightening, which is exactly the feedback loop this exists to provide.

## Screenshots

No visual change — no UI in this PR. The backtest output above is the user-visible surface.

## Testing

- [x] `pnpm lint` — passes for all new files (oxlint + react-doctor + type-aware audit + max-lines ratchet). The full lint chain's `verify:skill-bundle-manifest` step fails identically on an untouched `main` checkout (stale generated skill artifacts — pre-existing, unrelated).
- [x] `pnpm typecheck` — clean (full three-project run)
- [x] `pnpm test` — targeted: 30/30 across both new test files, written test-first (each watched fail before implementation). No existing tests touched.
- [ ] `pnpm build` — not run; nothing here is imported by the app yet, so the build surface is unchanged. Happy to run if wanted.
- [x] Tests added: 18 for the evaluator (AND/OR semantics, pending discipline, glob anchors, percentile resolution, first-match tiering, validation rejections), 12 for forge subject parsing.

## AI Review Report

Built and reviewed with Claude (Fable 5), TDD throughout. Main risks checked:

- **Pending vs no-match soundness** — the property that absence of data can never look like safety. Covered by dedicated tests (`paths: undefined` vs `paths: []`, `authorMergedPRs: 0` vs unloaded, percentile token with no distribution, tier cascade stopping at a pending rule instead of falling through to a cheaper tier).
- **Backtest/evaluator drift** — the harness imports the real TS module rather than duplicating matching logic; the regression check is that the replay reproduces the independent hand analysis (terminal 253 fires / 9 of 62 reverts, identical before and after the forge rework).
- **Small-sample overreach** — min-n guards verified on a synthetic 4-PR history: correlation column suppressed, no dead-rule verdicts on thin data.
- **Glob semantics** — `**` vs `*` anchoring tested (`docs/*.md` must not match nested paths; `src/**/*.test.ts` must match zero-directory expansions).

**Cross-platform (macOS / Linux / Windows):** explicitly checked. The evaluator is pure string/number logic. The harness was developed and verified on Windows — the one platform issue found (Windows absolute paths are invalid ESM specifiers) is fixed via `pathToFileURL` with a comment. `execFileSync('git', …)` avoids shell quoting differences; no path separators assumed (git output is always `/`).

**Forge compatibility (per AGENTS.md):** verified on a scripted synthetic history mixing GitLab squash, GitLab merge-commit + body trailer, and Bitbucket merge subjects — all identified, merge-commit MR sized across its branch, GitLab-style revert labeled. Known limit stated in code and spec: a GitLab squash template that omits the MR reference leaves commits unattributable (reported, not guessed).

## Security Audit

- **Input handling:** rule files are user-authored YAML parsed with the existing `yaml` dependency; validation rejects unknown keys/shapes before evaluation. Rule-supplied regexes (`title`, `branch`) are compiled at validation time; globs are converted by a converter that escapes everything outside `[a-zA-Z0-9/_-]`, so glob input cannot inject regex metacharacters. No rule input reaches a shell.
- **Command execution:** the harness runs `git log` only, via `execFileSync` with an argument array (no shell interpolation). `--repo` accepts a path but only ever passes it to `git -C`.
- **ReDoS surface:** rule regexes are user-authored and run against short PR titles/branch names in a local dev script — bounded input, local trust domain. The built-in patterns use no nested quantifiers.
- **Secrets / auth / IPC / wire:** none touched. No network calls anywhere in this PR; no IPC channels; no remote-wire impact (nothing a client and host exchange changes).
- **Follow-up:** if/when rules load from repo-level `orca.yaml` in the app process, re-review regex compilation as untrusted-repo input (a hostile repo could ship a pathological regex); the validation seam is where a complexity guard would go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
