### PR TITLE
fix(grok): carry reasoning effort for models outside the seed catalog

### DIFF
--- a/src/shared/agent-session-option-catalog-grok.test.ts
+++ b/src/shared/agent-session-option-catalog-grok.test.ts
@@ -45,6 +45,10 @@ describe('grok session option catalog', () => {
     }
   })
 
+  it('gives unknown model ids the same effort menu launch reads from the seed', () => {
+    expect(GROK_SESSION_OPTION_CATALOG.unknownModelOptions?.map(({ id }) => id)).toEqual(['effort'])
+  })
+
   it('treats a successful discovery as authoritative, unlike the other agents', () => {
     expect(GROK_SESSION_OPTION_CATALOG.discoveredModelsAreAuthoritative).toBe(true)
     for (const agent of ['claude', 'codex', 'gemini', 'cursor'] as const) {
@@ -86,6 +90,39 @@ describe('grok launch args', () => {
       args: ['-m', 'grok-build'],
       appliedValues: { model: 'grok-build' }
     })
+  })
+
+  it('carries a picked effort onto a discovered model the seed never listed', () => {
+    // Regression: launch reads options off the static seed, so a discovered id
+    // resolved to no options and dropped `--reasoning-effort` from the argv.
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-build', effort: 'low' })).toEqual(
+      {
+        args: ['-m', 'grok-build', '--reasoning-effort', 'low'],
+        appliedValues: { model: 'grok-build', effort: 'low' }
+      }
+    )
+  })
+
+  it('drops an effort value the menu does not offer on an unseeded model', () => {
+    expect(
+      resolveAgentSessionOptionLaunch('grok', { model: 'grok-build', effort: 'none' })
+    ).toEqual({ args: ['-m', 'grok-build'], appliedValues: { model: 'grok-build' } })
+  })
+
+  it('honors a user effort flag over the picker on an unseeded model too', () => {
+    expect(
+      resolveAgentSessionOptionLaunch('grok', { model: 'grok-build', effort: 'low' }, [
+        '--reasoning-effort=high'
+      ]).appliedValues
+    ).toEqual({ model: 'grok-build' })
+  })
+
+  it('still adds no effort default for a model the seed does not carry', () => {
+    // An unseeded id has no verified menu, so only an explicit pick may reach argv.
+    expect(resolveAgentSessionOptionLaunch('grok', { model: 'grok-build' }).args).toEqual([
+      '-m',
+      'grok-build'
+    ])
   })
 
   it('spawns vanilla when no model was ever picked', () => {

--- a/src/shared/agent-session-option-catalog-grok.ts
+++ b/src/shared/agent-session-option-catalog-grok.ts
@@ -55,6 +55,10 @@ export const GROK_SESSION_OPTION_CATALOG: AgentSessionOptionCatalog = {
     // agent picker…" and never persist a model, so `-m` would never be emitted.
     midSession: { kind: 'command', build: (value) => `/model ${String(value)}` }
   },
+  // Why: `--reasoning-effort` is a global grok flag, not a per-model capability, and
+  // launch resolves against this static seed. Without this, a discovered id the seed
+  // does not carry shows the effort menu but launches with the flag dropped.
+  unknownModelOptions: [GROK_EFFORT],
   // Why: grok's selectable ids retire between releases, so a stale seed entry
   // must be droppable — picking one is a fatal launch, not a warning.
   discoveredModelsAreAuthoritative: true,


### PR DESCRIPTION
## Problem

When grok discovers a model at runtime that isn't in the static seed catalog, the `--reasoning-effort` flag was dropped on launch even if the user had selected an effort level, because the launch resolver only consulted the static seed for available options.

## Solution

Add `unknownModelOptions: [GROK_EFFORT]` to ensure effort remains available for any model, carrying user selections through to launch args whether seeded or discovered.

## Summary

Ensures reasoning effort is preserved when launching Grok with discovered models.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build`
- [x] Added high-quality tests catching regression: four cases covering effort carry-through, unsupported value filtering, user flag override, and unseeded model defaults

## AI Review Report

TODO — run `/code-review` before merge

## Security Audit

No security-sensitive changes (internal option catalog configuration).

## Notes

The `--reasoning-effort` flag is a global Grok capability, not model-specific, so it must be available consistently across all models.