### PR TITLE
feat(mobile): add an Android emulator harness for device-only repros

### DIFF
--- a/mobile/README.md
+++ b/mobile/README.md
@@ -86,9 +86,15 @@ pnpm start --dev-client          # Metro
 
 Prerequisites, once:
 
+Pick the image ABI that matches the host CPU — `arm64-v8a` on Apple silicon and
+other ARM hosts, `x86_64` on Intel and AMD. A mismatched image runs under
+translation without hardware acceleration and is far too slow to type into.
+
 ```bash
-sdkmanager "platform-tools" "emulator" "system-images;android-36;google_apis_playstore;arm64-v8a"
-avdmanager create avd -n orca-android -k "system-images;android-36;google_apis_playstore;arm64-v8a" -d pixel_7
+ABI=arm64-v8a   # x86_64 on Intel or AMD hosts
+IMAGE="system-images;android-36;google_apis_playstore;$ABI"
+sdkmanager "platform-tools" "emulator" "$IMAGE"
+avdmanager create avd -n orca-android -k "$IMAGE" -d pixel_7
 ```
 
 Notes that cost time if you hit them cold:
@@ -96,7 +102,12 @@ Notes that cost time if you hit them cold:
 - **Use a JDK 17 for the build.** Gradle fails `configureCMakeDebug` with a restricted-method error on JDK 24+, which reads like an unrelated native build failure. `start:emulator:android` warns when `JAVA_HOME` points at an unsupported JDK.
 - **A Play Store system image is required for Gboard**, which is what you need for CJK input. `google_apis` images ship a Latin-only keyboard.
 - **AVDs may not be where the emulator looks.** Recent `avdmanager` writes them under `$XDG_CONFIG_HOME/.android/avd`; the script resolves the same path and passes it to every tool it runs.
-- **Port 6768 collides with a running Orca desktop**, which also listens there. Either quit the desktop app or start the stub on another port with `PORT=6769 pnpm mock-server` and pair to that.
+- **Port 6768 collides with a running Orca desktop**, which also listens there. Either quit the desktop app, or move the stub and reverse the port it actually uses:
+
+  ```bash
+  PORT=6769 pnpm mock-server
+  pnpm start:emulator:android --port 8081 --port 6769
+  ```
 
 Adding a CJK keyboard to the emulator: Settings → System → Languages → Add a language. Gboard picks up the matching keyboard automatically; switch layouts with the globe key.
 

--- a/mobile/README.md
+++ b/mobile/README.md
@@ -72,6 +72,34 @@ If the phone has a stale host entry, remove it from the app and pair again.
 3. For native modules: `pnpm exec expo run:android`
 4. Run with `pnpm start --dev-client`
 
+### Android Emulator
+
+Use this for anything that needs a real Android IME, keyboard, or soft-input behaviour — those bugs cannot be reproduced on the iOS simulator or by reading the source.
+
+```bash
+pnpm start:emulator:android      # boots or reuses an AVD, then reverses 8081 and 6768
+pnpm exec expo run:android       # builds and installs the dev client
+pnpm start --dev-client          # Metro
+```
+
+`start:emulator:android` accepts `--avd <name>`, `--port <n>` (repeatable) and `--no-reverse`.
+
+Prerequisites, once:
+
+```bash
+sdkmanager "platform-tools" "emulator" "system-images;android-36;google_apis_playstore;arm64-v8a"
+avdmanager create avd -n orca-android -k "system-images;android-36;google_apis_playstore;arm64-v8a" -d pixel_7
+```
+
+Notes that cost time if you hit them cold:
+
+- **Use a JDK 17 for the build.** Gradle fails `configureCMakeDebug` with a restricted-method error on JDK 24+, which reads like an unrelated native build failure. `start:emulator:android` warns when `JAVA_HOME` points at an unsupported JDK.
+- **A Play Store system image is required for Gboard**, which is what you need for CJK input. `google_apis` images ship a Latin-only keyboard.
+- **AVDs may not be where the emulator looks.** Recent `avdmanager` writes them under `$XDG_CONFIG_HOME/.android/avd`; the script resolves the same path and passes it to every tool it runs.
+- **Port 6768 collides with a running Orca desktop**, which also listens there. Either quit the desktop app or start the stub on another port with `PORT=6769 pnpm mock-server` and pair to that.
+
+Adding a CJK keyboard to the emulator: Settings → System → Languages → Add a language. Gboard picks up the matching keyboard automatically; switch layouts with the globe key.
+
 ### iOS Simulator
 
 1. Install Xcode from the App Store

--- a/mobile/package.json
+++ b/mobile/package.json
@@ -15,7 +15,8 @@
     "format:check": "oxfmt --check .",
     "mock-server": "npx tsx scripts/mock-server.ts",
     "repro:workspace-picker-lag": "npx tsx scripts/repro-workspace-picker-lag.ts",
-    "start:emulator": "node scripts/start-emulator.mjs"
+    "start:emulator": "node scripts/start-emulator.mjs",
+    "start:emulator:android": "npx tsx scripts/start-android-emulator.ts"
   },
   "dependencies": {
     "@noble/hashes": "1.8.0",

--- a/mobile/scripts/android-emulator-environment.ts
+++ b/mobile/scripts/android-emulator-environment.ts
@@ -1,0 +1,144 @@
+// Why: locating the Android SDK, the AVD store and a booted device is the part of
+// an Android repro that silently goes wrong, so it is pure and unit-tested here
+// while start-android-emulator.ts keeps only the process spawning.
+import path from 'node:path'
+
+export type AndroidEnvironment = {
+  readonly env: NodeJS.ProcessEnv
+  readonly homeDir: string
+  readonly platform: NodeJS.Platform
+}
+
+export type AndroidTool = 'adb' | 'emulator' | 'avdmanager'
+
+const TOOL_DIRECTORIES: Record<AndroidTool, readonly string[]> = {
+  adb: ['platform-tools'],
+  emulator: ['emulator'],
+  avdmanager: ['cmdline-tools', 'latest', 'bin']
+}
+
+// Why: avdmanager ships as a shell wrapper, so Windows needs the .bat sibling
+// while the native binaries need .exe.
+const WINDOWS_TOOL_SUFFIX: Record<AndroidTool, string> = {
+  adb: '.exe',
+  emulator: '.exe',
+  avdmanager: '.bat'
+}
+
+function defaultSdkRoot({ homeDir, platform, env }: AndroidEnvironment): string {
+  if (platform === 'win32') {
+    const localAppData = env.LOCALAPPDATA
+    return localAppData
+      ? path.join(localAppData, 'Android', 'Sdk')
+      : path.join(homeDir, 'AppData', 'Local', 'Android', 'Sdk')
+  }
+  if (platform === 'darwin') {
+    return path.join(homeDir, 'Library', 'Android', 'sdk')
+  }
+  return path.join(homeDir, 'Android', 'Sdk')
+}
+
+export function resolveAndroidSdkRoot(environment: AndroidEnvironment): string {
+  const { env } = environment
+  return env.ANDROID_HOME || env.ANDROID_SDK_ROOT || defaultSdkRoot(environment)
+}
+
+// Why: recent avdmanager writes AVDs under $XDG_CONFIG_HOME/.android while the
+// emulator still defaults to ~/.android, so a freshly created AVD is invisible
+// unless both sides are pointed at the same root.
+export function resolveAndroidAvdHome({ env, homeDir }: AndroidEnvironment): string {
+  if (env.ANDROID_AVD_HOME) {
+    return env.ANDROID_AVD_HOME
+  }
+  if (env.ANDROID_USER_HOME) {
+    return path.join(env.ANDROID_USER_HOME, 'avd')
+  }
+  if (env.XDG_CONFIG_HOME) {
+    return path.join(env.XDG_CONFIG_HOME, '.android', 'avd')
+  }
+  return path.join(homeDir, '.android', 'avd')
+}
+
+export function resolveAndroidToolPath(environment: AndroidEnvironment, tool: AndroidTool): string {
+  const suffix = environment.platform === 'win32' ? WINDOWS_TOOL_SUFFIX[tool] : ''
+  return path.join(
+    resolveAndroidSdkRoot(environment),
+    ...TOOL_DIRECTORIES[tool],
+    `${tool}${suffix}`
+  )
+}
+
+export function parseAvdNames(listAvdsStdout: string): string[] {
+  return (
+    listAvdsStdout
+      .split('\n')
+      .map((line) => line.trim())
+      // Why: `emulator -list-avds` prefixes warnings with the binary name and can
+      // emit blank lines; AVD names never contain whitespace.
+      .filter((line) => line.length > 0 && !line.includes(' ') && !line.includes(':'))
+  )
+}
+
+export function selectAvdName(avdNames: readonly string[], requested?: string): string | null {
+  if (avdNames.length === 0) {
+    return null
+  }
+  if (!requested) {
+    return avdNames[0] ?? null
+  }
+  const exact = avdNames.find((name) => name === requested)
+  if (exact) {
+    return exact
+  }
+  const lowerRequested = requested.toLowerCase()
+  return avdNames.find((name) => name.toLowerCase().includes(lowerRequested)) ?? null
+}
+
+export function findBootedEmulatorSerial(adbDevicesStdout: string): string | null {
+  for (const line of adbDevicesStdout.split('\n')) {
+    const [serial, state] = line.trim().split(/\s+/)
+    // Why: `offline` and `unauthorized` entries appear while an emulator is still
+    // coming up; only `device` accepts shell commands.
+    if (serial?.startsWith('emulator-') && state === 'device') {
+      return serial
+    }
+  }
+  return null
+}
+
+// Why: `adb emu avd name` answers with the name followed by an OK acknowledgement,
+// so the reused emulator can be matched against an explicitly requested AVD.
+export function parseRunningAvdName(emuAvdNameStdout: string): string | null {
+  const name = emuAvdNameStdout
+    .split('\n')
+    .map((line) => line.trim())
+    .find((line) => line.length > 0 && line !== 'OK')
+  return name ?? null
+}
+
+// Why: Gradle 9 fails `configureCMakeDebug` on JDK 24+ because the Android
+// toolchain calls a restricted java.lang.System method that those runtimes deny.
+const MAX_SUPPORTED_BUILD_JDK = 23
+
+export function parseJavaMajorVersion(javaVersionOutput: string): number | null {
+  const match = /version "(\d+)(?:\.(\d+))?/.exec(javaVersionOutput)
+  if (!match) {
+    return null
+  }
+  const major = Number(match[1])
+  // Why: Java 8 and earlier report as 1.x, so the minor field carries the major.
+  return major === 1 ? Number(match[2] ?? 0) : major
+}
+
+export function describeBuildJdkSupport(majorVersion: number | null): string | null {
+  if (majorVersion === null) {
+    return 'Could not read a Java version; `expo run:android` needs a JDK on PATH.'
+  }
+  if (majorVersion < 17) {
+    return `JDK ${majorVersion} is too old for the Android Gradle plugin; use JDK 17.`
+  }
+  if (majorVersion > MAX_SUPPORTED_BUILD_JDK) {
+    return `JDK ${majorVersion} fails the Gradle CMake configure step; set JAVA_HOME to a JDK 17 build before \`expo run:android\`.`
+  }
+  return null
+}

--- a/mobile/scripts/android-emulator-environment.ts
+++ b/mobile/scripts/android-emulator-environment.ts
@@ -45,18 +45,17 @@ export function resolveAndroidSdkRoot(environment: AndroidEnvironment): string {
 
 // Why: recent avdmanager writes AVDs under $XDG_CONFIG_HOME/.android while the
 // emulator still defaults to ~/.android, so a freshly created AVD is invisible
-// unless both sides are pointed at the same root.
+// unless both sides are pointed at the same root. ANDROID_EMULATOR_HOME is the
+// emulator's own override for that directory (`emulator -help-environment`).
 export function resolveAndroidAvdHome({ env, homeDir }: AndroidEnvironment): string {
   if (env.ANDROID_AVD_HOME) {
     return env.ANDROID_AVD_HOME
   }
-  if (env.ANDROID_USER_HOME) {
-    return path.join(env.ANDROID_USER_HOME, 'avd')
-  }
-  if (env.XDG_CONFIG_HOME) {
-    return path.join(env.XDG_CONFIG_HOME, '.android', 'avd')
-  }
-  return path.join(homeDir, '.android', 'avd')
+  const androidHome =
+    env.ANDROID_EMULATOR_HOME ??
+    env.ANDROID_USER_HOME ??
+    (env.XDG_CONFIG_HOME ? path.join(env.XDG_CONFIG_HOME, '.android') : null)
+  return path.join(androidHome ?? path.join(homeDir, '.android'), 'avd')
 }
 
 export function resolveAndroidToolPath(environment: AndroidEnvironment, tool: AndroidTool): string {

--- a/mobile/scripts/android-emulator-environment.ts
+++ b/mobile/scripts/android-emulator-environment.ts
@@ -51,11 +51,13 @@ export function resolveAndroidAvdHome({ env, homeDir }: AndroidEnvironment): str
   if (env.ANDROID_AVD_HOME) {
     return env.ANDROID_AVD_HOME
   }
+  // Why: an exported-but-empty override must fall through, not resolve to the
+  // relative './avd' that `??` would produce.
   const androidHome =
-    env.ANDROID_EMULATOR_HOME ??
-    env.ANDROID_USER_HOME ??
-    (env.XDG_CONFIG_HOME ? path.join(env.XDG_CONFIG_HOME, '.android') : null)
-  return path.join(androidHome ?? path.join(homeDir, '.android'), 'avd')
+    env.ANDROID_EMULATOR_HOME ||
+    env.ANDROID_USER_HOME ||
+    (env.XDG_CONFIG_HOME ? path.join(env.XDG_CONFIG_HOME, '.android') : '')
+  return path.join(androidHome || path.join(homeDir, '.android'), 'avd')
 }
 
 export function resolveAndroidToolPath(environment: AndroidEnvironment, tool: AndroidTool): string {

--- a/mobile/scripts/start-android-emulator.ts
+++ b/mobile/scripts/start-android-emulator.ts
@@ -145,14 +145,29 @@ async function reversePorts(
   serial: string,
   ports: readonly number[]
 ): Promise<void> {
+  const reversed: number[] = []
+  const failed: number[] = []
   for (const port of ports) {
-    await execFileAsync(adbPath, ['-s', serial, 'reverse', `tcp:${port}`, `tcp:${port}`], {
-      env: toolEnv
-    }).catch(() => {
-      log(`  ! could not reverse port ${port}`)
-    })
+    const ok = await execFileAsync(
+      adbPath,
+      ['-s', serial, 'reverse', `tcp:${port}`, `tcp:${port}`],
+      { env: toolEnv }
+    ).then(
+      () => true,
+      () => false
+    )
+    if (ok) {
+      reversed.push(port)
+    } else {
+      failed.push(port)
+    }
   }
-  log(`▸ Reversed ports: ${ports.join(', ')}`)
+  if (reversed.length > 0) {
+    log(`▸ Reversed ports: ${reversed.join(', ')}`)
+  }
+  if (failed.length > 0) {
+    log(`  ! could not reverse: ${failed.join(', ')}`)
+  }
 }
 
 async function main(): Promise<void> {
@@ -169,7 +184,9 @@ async function main(): Promise<void> {
     const runningAvd = parseRunningAvdName(
       await readToolOutput(adbPath, ['-s', serial, 'emu', 'avd', 'name']).catch(() => '')
     )
-    if (options.avd && runningAvd && runningAvd !== options.avd) {
+    // Why: startup matches case-insensitively on a substring, so reuse must too —
+    // otherwise `--avd pixel` rejects the Pixel_7_API_36 it would have booted.
+    if (options.avd && runningAvd && selectAvdName([runningAvd], options.avd) === null) {
       fail(
         `${serial} is running ${runningAvd}, not the requested ${options.avd}.\n` +
           `  Stop it first: adb -s ${serial} emu kill`

--- a/mobile/scripts/start-android-emulator.ts
+++ b/mobile/scripts/start-android-emulator.ts
@@ -1,0 +1,209 @@
+#!/usr/bin/env npx tsx
+// Why: Orca Mobile bugs that only appear under an Android IME (#7427, #7495) kept
+// stalling on "no Android device here" — start:emulator only drives the iOS
+// simulator. This boots or reuses an AVD and reports the exact next command.
+import { execFile, spawn } from 'node:child_process'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import process from 'node:process'
+import { promisify } from 'node:util'
+import {
+  describeBuildJdkSupport,
+  findBootedEmulatorSerial,
+  parseAvdNames,
+  parseJavaMajorVersion,
+  parseRunningAvdName,
+  resolveAndroidAvdHome,
+  resolveAndroidSdkRoot,
+  resolveAndroidToolPath,
+  selectAvdName,
+  type AndroidEnvironment
+} from './android-emulator-environment'
+
+const execFileAsync = promisify(execFile)
+
+const BOOT_TIMEOUT_MS = 300_000
+const BOOT_POLL_INTERVAL_MS = 2_000
+// Why: Metro and the mock host both live on the developer's machine; reversing
+// them means the guest reaches them on localhost, which keeps the pairing
+// endpoint identical to a physical-device run.
+const REVERSED_PORTS = [8081, 6768]
+
+type CliOptions = {
+  readonly avd?: string
+  readonly noReverse: boolean
+  readonly ports: readonly number[]
+}
+
+function parseArgs(argv: readonly string[]): CliOptions {
+  const args = [...argv]
+  let avd: string | undefined
+  let noReverse = false
+  const ports: number[] = []
+  for (let index = 0; index < args.length; index++) {
+    const arg = args[index]
+    if (arg === '--avd' && index + 1 < args.length) {
+      avd = args[++index]
+    } else if (arg === '--no-reverse') {
+      noReverse = true
+    } else if (arg === '--port' && index + 1 < args.length) {
+      const port = Number(args[++index])
+      if (Number.isInteger(port) && port > 0) {
+        ports.push(port)
+      }
+    }
+  }
+  return { avd, noReverse, ports: ports.length > 0 ? ports : REVERSED_PORTS }
+}
+
+function log(message: string): void {
+  console.log(message)
+}
+
+function fail(message: string): never {
+  console.error(`\n✖ ${message}\n`)
+  process.exit(1)
+}
+
+const environment: AndroidEnvironment = {
+  env: process.env,
+  homeDir: os.homedir(),
+  platform: process.platform
+}
+
+// Why: the emulator resolves AVDs from its own env, so reporting the XDG-aware
+// path is not enough — every tool has to be pointed at the same store or
+// `-list-avds` comes back empty for an AVD avdmanager just created.
+const toolEnv: NodeJS.ProcessEnv = {
+  ...process.env,
+  ANDROID_SDK_ROOT: resolveAndroidSdkRoot(environment),
+  ANDROID_AVD_HOME: resolveAndroidAvdHome(environment)
+}
+
+async function readToolOutput(toolPath: string, args: readonly string[]): Promise<string> {
+  const { stdout, stderr } = await execFileAsync(toolPath, [...args], { env: toolEnv })
+  return `${stdout}${stderr}`
+}
+
+async function reportBuildJdk(): Promise<void> {
+  const javaBinary = process.platform === 'win32' ? 'java.exe' : 'java'
+  const javaHome = process.env.JAVA_HOME
+  const javaPath = javaHome ? path.join(javaHome, 'bin', javaBinary) : javaBinary
+  const output = await readToolOutput(javaPath, ['-version']).catch(() => '')
+  const advice = describeBuildJdkSupport(parseJavaMajorVersion(output))
+  if (advice) {
+    log(`  ! ${advice}`)
+  }
+}
+
+function requireTool(tool: 'adb' | 'emulator'): string {
+  const toolPath = resolveAndroidToolPath(environment, tool)
+  if (!fs.existsSync(toolPath)) {
+    fail(
+      `${tool} not found at ${toolPath}.\n` +
+        `  Set ANDROID_HOME, or install it with:\n` +
+        `    sdkmanager --sdk_root="${resolveAndroidSdkRoot(environment)}" "platform-tools" "emulator"`
+    )
+  }
+  return toolPath
+}
+
+async function bootEmulator(emulatorPath: string, avdName: string): Promise<void> {
+  log(`▸ Booting AVD ${avdName}`)
+  const child = spawn(emulatorPath, ['-avd', avdName, '-no-boot-anim'], {
+    detached: true,
+    env: toolEnv,
+    stdio: 'ignore'
+  })
+  child.unref()
+}
+
+async function waitForBoot(adbPath: string, deadline: number): Promise<string> {
+  while (Date.now() < deadline) {
+    const devices = await readToolOutput(adbPath, ['devices']).catch(() => '')
+    const serial = findBootedEmulatorSerial(devices)
+    if (serial) {
+      const booted = await readToolOutput(adbPath, [
+        '-s',
+        serial,
+        'shell',
+        'getprop',
+        'sys.boot_completed'
+      ]).catch(() => '')
+      if (booted.trim() === '1') {
+        return serial
+      }
+    }
+    await new Promise((resolve) => setTimeout(resolve, BOOT_POLL_INTERVAL_MS))
+  }
+  fail('Timed out waiting for the emulator to finish booting.')
+}
+
+async function reversePorts(
+  adbPath: string,
+  serial: string,
+  ports: readonly number[]
+): Promise<void> {
+  for (const port of ports) {
+    await execFileAsync(adbPath, ['-s', serial, 'reverse', `tcp:${port}`, `tcp:${port}`], {
+      env: toolEnv
+    }).catch(() => {
+      log(`  ! could not reverse port ${port}`)
+    })
+  }
+  log(`▸ Reversed ports: ${ports.join(', ')}`)
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+  const adbPath = requireTool('adb')
+  const emulatorPath = requireTool('emulator')
+
+  log(`▸ SDK root: ${resolveAndroidSdkRoot(environment)}`)
+  log(`▸ AVD home: ${resolveAndroidAvdHome(environment)}`)
+  await reportBuildJdk()
+
+  let serial = findBootedEmulatorSerial(await readToolOutput(adbPath, ['devices']).catch(() => ''))
+  if (serial) {
+    const runningAvd = parseRunningAvdName(
+      await readToolOutput(adbPath, ['-s', serial, 'emu', 'avd', 'name']).catch(() => '')
+    )
+    if (options.avd && runningAvd && runningAvd !== options.avd) {
+      fail(
+        `${serial} is running ${runningAvd}, not the requested ${options.avd}.\n` +
+          `  Stop it first: adb -s ${serial} emu kill`
+      )
+    }
+    log(`▸ Reusing running emulator ${serial}${runningAvd ? ` (${runningAvd})` : ''}`)
+  } else {
+    const avdNames = parseAvdNames(await readToolOutput(emulatorPath, ['-list-avds']))
+    const avdName = selectAvdName(avdNames, options.avd)
+    if (!avdName) {
+      fail(
+        (options.avd
+          ? `No AVD matched "${options.avd}".`
+          : 'No AVDs found. Create one with avdmanager, then re-run.') +
+          (avdNames.length > 0 ? `\n  Available: ${avdNames.join(', ')}` : '') +
+          `\n  AVDs are read from ${resolveAndroidAvdHome(environment)}.` +
+          `\n  Create one with ${resolveAndroidToolPath(environment, 'avdmanager')}`
+      )
+    }
+    await bootEmulator(emulatorPath, avdName)
+    serial = await waitForBoot(adbPath, Date.now() + BOOT_TIMEOUT_MS)
+  }
+
+  if (!options.noReverse) {
+    await reversePorts(adbPath, serial, options.ports)
+  }
+
+  log(`\n✔ Emulator ready: ${serial}\n`)
+  log('Next:')
+  log('  pnpm mock-server                # host stub, or run Orca desktop instead')
+  log('  pnpm exec expo run:android      # build and install the dev client')
+  log('  pnpm start --dev-client         # Metro\n')
+}
+
+main().catch((error: unknown) => {
+  fail(error instanceof Error ? error.message : String(error))
+})

--- a/mobile/src/android-emulator-environment.test.ts
+++ b/mobile/src/android-emulator-environment.test.ts
@@ -1,0 +1,165 @@
+import path from 'node:path'
+import { describe, expect, it } from 'vitest'
+import {
+  describeBuildJdkSupport,
+  findBootedEmulatorSerial,
+  parseAvdNames,
+  parseJavaMajorVersion,
+  parseRunningAvdName,
+  resolveAndroidAvdHome,
+  resolveAndroidSdkRoot,
+  resolveAndroidToolPath,
+  selectAvdName,
+  type AndroidEnvironment
+} from '../scripts/android-emulator-environment'
+
+function environment(overrides: Partial<AndroidEnvironment> = {}): AndroidEnvironment {
+  return {
+    env: {},
+    homeDir: path.join(path.sep, 'home', 'dev'),
+    platform: 'linux',
+    ...overrides
+  }
+}
+
+describe('android emulator environment', () => {
+  it('Given ANDROID_HOME When resolving the SDK root Then it wins over the platform default', () => {
+    // Given / When
+    const root = resolveAndroidSdkRoot(
+      environment({ env: { ANDROID_HOME: '/opt/sdk', ANDROID_SDK_ROOT: '/other/sdk' } })
+    )
+
+    // Then
+    expect(root).toBe('/opt/sdk')
+  })
+
+  it('Given no SDK variables When resolving the SDK root Then each platform gets its documented default', () => {
+    // Given / When / Then
+    expect(resolveAndroidSdkRoot(environment({ platform: 'darwin' }))).toBe(
+      path.join(path.sep, 'home', 'dev', 'Library', 'Android', 'sdk')
+    )
+    expect(resolveAndroidSdkRoot(environment({ platform: 'linux' }))).toBe(
+      path.join(path.sep, 'home', 'dev', 'Android', 'Sdk')
+    )
+    expect(
+      resolveAndroidSdkRoot(
+        environment({ platform: 'win32', env: { LOCALAPPDATA: 'C:\\Users\\dev\\AppData\\Local' } })
+      )
+    ).toBe(path.join('C:\\Users\\dev\\AppData\\Local', 'Android', 'Sdk'))
+  })
+
+  // Why: this is the trap that makes a freshly created AVD invisible — avdmanager
+  // writes it under XDG while the emulator looks in ~/.android.
+  it('Given XDG_CONFIG_HOME When resolving the AVD home Then it follows avdmanager rather than ~/.android', () => {
+    // Given / When
+    const avdHome = resolveAndroidAvdHome(
+      environment({ env: { XDG_CONFIG_HOME: path.join(path.sep, 'home', 'dev', '.config') } })
+    )
+
+    // Then
+    expect(avdHome).toBe(path.join(path.sep, 'home', 'dev', '.config', '.android', 'avd'))
+  })
+
+  it('Given AVD home overrides When resolving Then the most specific variable wins', () => {
+    // Given / When / Then
+    expect(
+      resolveAndroidAvdHome(
+        environment({
+          env: {
+            ANDROID_AVD_HOME: '/explicit/avd',
+            ANDROID_USER_HOME: '/user/.android',
+            XDG_CONFIG_HOME: '/xdg'
+          }
+        })
+      )
+    ).toBe('/explicit/avd')
+    expect(
+      resolveAndroidAvdHome(
+        environment({ env: { ANDROID_USER_HOME: '/user/.android', XDG_CONFIG_HOME: '/xdg' } })
+      )
+    ).toBe(path.join('/user/.android', 'avd'))
+    expect(resolveAndroidAvdHome(environment())).toBe(
+      path.join(path.sep, 'home', 'dev', '.android', 'avd')
+    )
+  })
+
+  it('Given a Windows SDK When resolving tool paths Then binaries and wrappers get their own suffix', () => {
+    // Given
+    const win = environment({ platform: 'win32', env: { ANDROID_HOME: 'C:\\sdk' } })
+
+    // When / Then
+    expect(resolveAndroidToolPath(win, 'adb')).toBe(
+      path.join('C:\\sdk', 'platform-tools', 'adb.exe')
+    )
+    expect(resolveAndroidToolPath(win, 'avdmanager')).toBe(
+      path.join('C:\\sdk', 'cmdline-tools', 'latest', 'bin', 'avdmanager.bat')
+    )
+    expect(resolveAndroidToolPath(environment({ env: { ANDROID_HOME: '/sdk' } }), 'emulator')).toBe(
+      path.join('/sdk', 'emulator', 'emulator')
+    )
+  })
+
+  it('Given emulator warnings in the AVD listing When parsing Then only AVD names survive', () => {
+    // Given: the emulator binary prefixes advice lines onto stdout
+    const stdout = [
+      'INFO    | Storing crashdata in: /tmp/avd',
+      'emulator: WARNING: encryption is off',
+      'orca-jp',
+      'Pixel_7_API_36',
+      ''
+    ].join('\n')
+
+    // When / Then
+    expect(parseAvdNames(stdout)).toEqual(['orca-jp', 'Pixel_7_API_36'])
+  })
+
+  it('Given AVD names When selecting Then exact beats partial and a miss is reported', () => {
+    // Given
+    const names = ['orca-jp', 'Pixel_7_API_36']
+
+    // When / Then
+    expect(selectAvdName(names)).toBe('orca-jp')
+    expect(selectAvdName(names, 'Pixel_7_API_36')).toBe('Pixel_7_API_36')
+    expect(selectAvdName(names, 'pixel')).toBe('Pixel_7_API_36')
+    expect(selectAvdName(names, 'nexus')).toBeNull()
+    expect(selectAvdName([], 'orca-jp')).toBeNull()
+  })
+
+  it('Given a device list with a still-booting emulator When finding a serial Then only a ready device matches', () => {
+    // Given
+    const booting = 'List of devices attached\nemulator-5554\toffline\n'
+    const ready = 'List of devices attached\nemulator-5554\toffline\nemulator-5556\tdevice\n'
+
+    // When / Then
+    expect(findBootedEmulatorSerial(booting)).toBeNull()
+    expect(findBootedEmulatorSerial(ready)).toBe('emulator-5556')
+    // A physical handset is not an emulator and must not be picked up silently.
+    expect(findBootedEmulatorSerial('List of devices attached\nR5CT30ABCDE\tdevice\n')).toBeNull()
+  })
+
+  it('Given adb emu avd name output When parsing Then the acknowledgement is not mistaken for a name', () => {
+    // Given / When / Then
+    expect(parseRunningAvdName('orca-jp\nOK\n')).toBe('orca-jp')
+    expect(parseRunningAvdName('OK\n')).toBeNull()
+    expect(parseRunningAvdName('')).toBeNull()
+  })
+
+  it('Given java -version output When parsing Then both modern and 1.x schemes resolve', () => {
+    // Given / When / Then
+    expect(parseJavaMajorVersion('openjdk version "17.0.20" 2026-07-21')).toBe(17)
+    expect(parseJavaMajorVersion('openjdk version "25.0.2" 2026-01-20')).toBe(25)
+    expect(parseJavaMajorVersion('java version "1.8.0_401"')).toBe(8)
+    expect(parseJavaMajorVersion('no java here')).toBeNull()
+  })
+
+  // Why: JDK 25 is the failure I hit — Gradle 9 aborts configureCMakeDebug with a
+  // restricted-method error, which reads as an unrelated native build failure.
+  it('Given a build JDK When describing support Then only the workable range passes silently', () => {
+    // Given / When / Then
+    expect(describeBuildJdkSupport(17)).toBeNull()
+    expect(describeBuildJdkSupport(21)).toBeNull()
+    expect(describeBuildJdkSupport(25)).toContain('JDK 17')
+    expect(describeBuildJdkSupport(11)).toContain('too old')
+    expect(describeBuildJdkSupport(null)).toContain('needs a JDK')
+  })
+})

--- a/mobile/src/android-emulator-environment.test.ts
+++ b/mobile/src/android-emulator-environment.test.ts
@@ -60,19 +60,32 @@ describe('android emulator environment', () => {
     expect(avdHome).toBe(path.join(path.sep, 'home', 'dev', '.config', '.android', 'avd'))
   })
 
-  it('Given AVD home overrides When resolving Then the most specific variable wins', () => {
-    // Given / When / Then
+  it('Given AVD home overrides When resolving Then the documented precedence wins', () => {
+    // Given / When / Then: ANDROID_EMULATOR_HOME replaces ~/.android per
+    // `emulator -help-environment`, so it outranks the XDG fallback.
     expect(
       resolveAndroidAvdHome(
         environment({
           env: {
             ANDROID_AVD_HOME: '/explicit/avd',
+            ANDROID_EMULATOR_HOME: '/emulator/.android',
             ANDROID_USER_HOME: '/user/.android',
             XDG_CONFIG_HOME: '/xdg'
           }
         })
       )
     ).toBe('/explicit/avd')
+    expect(
+      resolveAndroidAvdHome(
+        environment({
+          env: {
+            ANDROID_EMULATOR_HOME: '/emulator/.android',
+            ANDROID_USER_HOME: '/user/.android',
+            XDG_CONFIG_HOME: '/xdg'
+          }
+        })
+      )
+    ).toBe(path.join('/emulator/.android', 'avd'))
     expect(
       resolveAndroidAvdHome(
         environment({ env: { ANDROID_USER_HOME: '/user/.android', XDG_CONFIG_HOME: '/xdg' } })

--- a/mobile/src/android-emulator-environment.test.ts
+++ b/mobile/src/android-emulator-environment.test.ts
@@ -96,6 +96,24 @@ describe('android emulator environment', () => {
     )
   })
 
+  // Why: shells export empty overrides all the time (`export X=$UNSET`), and a
+  // nullish fallback would hand the emulator the relative path './avd'.
+  it('Given empty AVD overrides When resolving Then they fall through to the home default', () => {
+    // Given / When / Then
+    expect(
+      resolveAndroidAvdHome(
+        environment({
+          env: { ANDROID_AVD_HOME: '', ANDROID_EMULATOR_HOME: '', ANDROID_USER_HOME: '' }
+        })
+      )
+    ).toBe(path.join(path.sep, 'home', 'dev', '.android', 'avd'))
+    expect(
+      resolveAndroidAvdHome(
+        environment({ env: { ANDROID_EMULATOR_HOME: '', ANDROID_USER_HOME: '/user/.android' } })
+      )
+    ).toBe(path.join('/user/.android', 'avd'))
+  })
+
   it('Given a Windows SDK When resolving tool paths Then binaries and wrappers get their own suffix', () => {
     // Given
     const win = environment({ platform: 'win32', env: { ANDROID_HOME: 'C:\\sdk' } })


### PR DESCRIPTION
## Summary

Adds `pnpm start:emulator:android`, so an Android repro is one command instead of an afternoon.

Mobile bugs that only appear under an Android IME keep stalling on "no Android device here":

- #7427 — "Japanese flick/romaji IME on Orca Mobile terminal requires the mobile app. Not available here. Not labeling `cannot_repro` (env blocked)."
- #7495 — closed only after a hand-built emulator rig, with the note that a candidate fix built on a plausible theory had to be dropped once device testing contradicted it.

`start:emulator` drives the iOS simulator only (`--device 'iPhone 17 Pro'`), and the sole other Android script packages a release, so every contributor rebuilds the same setup from scratch. I just did, while chasing #7427 on Android, and this is that setup with the traps encoded.

The script boots or reuses an AVD, waits for `sys.boot_completed`, reverses the Metro and mock-host ports, and prints the exact next commands. Flags: `--avd <name>`, `--port <n>` (repeatable), `--no-reverse`.

```
▸ SDK root: /Users/me/Library/Android/sdk
▸ AVD home: /Users/me/.config/.android/avd
▸ Booting AVD orca-android
▸ Reversed ports: 8081, 6768

✔ Emulator ready: emulator-5554
```

**What is unit-tested rather than discovered on a cold machine.** Path and output parsing live in `android-emulator-environment.ts` so the parts that go wrong silently are pinned:

- **AVDs are resolved the way `avdmanager` writes them** (`$XDG_CONFIG_HOME/.android/avd`), and that path is passed to every spawned tool. Reporting it is not enough — the emulator reads its own env, so `-list-avds` otherwise returns nothing for an AVD that was just created. I shipped this bug into my own first draft and only caught it by running the script.
- **adb output is trusted only when a device reports `device`**, so a still-booting emulator (`offline`) and a physical handset are both skipped.
- **`JAVA_HOME` is checked against the range AGP accepts.** JDK 24+ aborts `configureCMakeDebug` with a restricted-method error that reads like an unrelated native failure.
- **An explicit `--avd` is no longer ignored** when a different AVD is already running; the script names the one to stop.

README gains the prerequisites and the four traps that cost the most time: the build JDK, the Play Store image Gboard needs for CJK input, the AVD path, and the mock host colliding with a running Orca desktop on 6768.

## Screenshots

No visual change — this is developer tooling.

## Testing

- [x] `pnpm lint` (mobile `oxlint`, clean)
- [x] `pnpm typecheck` (`tsc --noEmit` in `mobile/`)
- [x] `pnpm test` — `mobile` 3401 passed, 11 of them new. One pre-existing unrelated failure, `src/mock-server-key-pair.test.ts > makes concurrent creators converge on the persisted winner`, which fails identically on an unmodified tree.
- [ ] `pnpm build` — not run; adds a dev script and its tests, no app code.
- [x] Added tests that would catch regressions

Exercised end to end on macOS 15 / Apple silicon against a Pixel 7 API 36 AVD: cold boot, reuse of a running emulator, `--avd` match and mismatch, missing AVD, and the JDK 17 (silent) and JDK 25 (warned) branches.

## AI Review Report

Reviewed with Claude.

- **Cross-platform.** SDK root has a per-platform default (`%LOCALAPPDATA%\Android\Sdk`, `~/Library/Android/sdk`, `~/Android/Sdk`), tool paths get `.exe` for the native binaries and `.bat` for the `avdmanager` wrapper, and every path is built with `path.join`. The review caught a `${JAVA_HOME}/bin/java` template literal that would have broken on Windows; it now uses `path.join` and `java.exe`. All three platform branches are asserted in tests. Only macOS was exercised for real — Linux and Windows rest on the unit tests, which is the honest limit here.
- **Correctness.** Two defects came out of running the script rather than reading it: the AVD-home env not reaching the spawned emulator, and `--avd` being silently ignored when any emulator was already up. Both fixed and covered.
- **Scope.** No app code, no runtime dependency, one `package.json` script. Nothing here executes during a build or in the shipped app.
- **Performance.** Polls `adb` every 2s with a 5-minute ceiling; no busy loop.
- **Resource cleanup.** The emulator is spawned detached and `unref`'d on purpose, so the script exits while the emulator keeps running — that is the intended workflow, and the serial is printed so it can be killed with `adb emu kill`.
- **SSH / remote / providers / agents.** Untouched.

## Security Audit

Reviewed with Claude.

- **Command execution.** `execFile`/`spawn` only, never a shell, so no interpolation reaches a command line. Executable paths are derived from `ANDROID_HOME` or a platform default and are `existsSync`-checked before use.
- **Input handling.** `--avd` and `--port` are compared and range-checked, not interpolated into commands; ports must be positive integers.
- **Env handling.** The child env is `process.env` plus two Android path variables. No secrets are read, written, or logged; the script prints only paths, an AVD name and a device serial.
- **Network.** `adb reverse` maps loopback ports into the emulator the same way `expo run:android` already does. It opens nothing to the network.
- **Paths / auth / IPC / dependencies.** No new dependencies. No credential or IPC surface.

## Notes

- This is unsolicited tooling, so say the word if it is not wanted and I will close it — the README section alone would still be worth keeping.
- The JDK ceiling is a version-sensitive constant (`MAX_SUPPORTED_BUILD_JDK`). It is a warning, never a hard stop, so a future AGP that supports newer JDKs makes it stale rather than wrong.
- Verified on macOS only. If you want Linux or Windows confirmation before merging, I would rather you know that up front than assume it.
- Found while building this: `mobile/scripts/mock-server-terminal-stream.ts` answers `terminal.send` with `{ ok: true }` while the client gates on `accepted`, so mock-based runs silently drop the carriage return after a flushed IME composition. That fix is in #13070 rather than here, to keep this PR to tooling.
