### PR TITLE
fix(terminal): retain WebGL for recently hidden worktrees

### DIFF
--- a/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-visibility-resume.ts
@@ -133,8 +133,7 @@ export function hideTerminalVisibility({
     captureViewportPositions(false)
   }
   if (!isWorktreeActive && (wasVisible || surfaceBecameHidden)) {
-    // Suspend WebGL when going hidden. xterm.write() continues to land in the
-    // DOM-renderer fallback terminal; the suspend is purely a GPU resource decision.
+    // xterm.write() keeps updating the hidden buffer; suspension only changes renderer lifetime.
     manager.suspendRendering()
     return { hiddenReason: 'surface', renderingSuspended: true }
   }

--- a/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
+++ b/src/renderer/src/lib/pane-manager/pane-dom-creation.ts
@@ -121,6 +121,7 @@ export function createPaneDOM(
     gpuRenderingEnabled: ENABLE_WEBGL_RENDERER,
     webglAttachmentDeferred: false,
     webglDisabledAfterContextLoss: false,
+    webglRebuildDeferred: false,
     hasComplexScriptOutput: false,
     fitAddon,
     fitResizeObserver: null,

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.test.ts
@@ -430,6 +430,19 @@ describe('attachLigatures', () => {
     expect(pane.terminal.refresh).toHaveBeenCalledWith(0, 23)
     expect(pane.ligaturesAddon).not.toBeNull()
   })
+
+  it('defers a retained WebGL rebuild while hidden', () => {
+    const pane = createPane()
+    const retainedAddon = { dispose: vi.fn() } as never
+    pane.webglAddon = retainedAddon
+    pane.webglAttachmentDeferred = true
+
+    attachLigatures(pane)
+
+    expect(pane.webglAddon).toBe(retainedAddon)
+    expect(pane.webglRebuildDeferred).toBe(true)
+    expect(pane.terminal.refresh).not.toHaveBeenCalled()
+  })
 })
 
 describe('openTerminal — addon and provider wiring', () => {

--- a/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
+++ b/src/renderer/src/lib/pane-manager/pane-lifecycle.ts
@@ -16,6 +16,7 @@ import {
 import { installTerminalLinkifierHoverResetOnWrite } from './terminal-linkifier-hover-reset-on-write'
 import { attachDomRendererFocusClassSync } from './pane-dom-focus-class-sync'
 import { attachWebgl, cancelPendingWebglRefresh, disposeWebgl } from './pane-webgl-renderer'
+import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 import { configureLazyArabicShapingJoiner } from './terminal-arabic-shaping-joiner'
 import { TerminalLigaturesAddon } from './terminal-ligatures-addon'
 import { installTerminalImeCandidateAnchor } from './terminal-ime-candidate-anchor'
@@ -136,16 +137,15 @@ export function attachLigatures(pane: ManagedPaneInternal): void {
     pane.ligaturesAddon = ligaturesAddon
     // Why: ligatures can be enabled after rows already rendered, especially
     // from Settings. Force existing glyph runs to be recomputed immediately.
-    pane.terminal.refresh(0, pane.terminal.rows - 1)
+    if (!pane.webglAttachmentDeferred) {
+      pane.terminal.refresh(0, pane.terminal.rows - 1)
+    }
     // Why: the WebGL renderer builds its glyph texture atlas at activation
     // time, so `font-feature-settings` applied after WebGL loaded won't
     // reach the GPU-rendered cells until the atlas is rebuilt. The upstream
     // docs call this out explicitly — reactivating WebGL after ligatures
     // forces a fresh atlas that includes the ligated glyphs.
-    if (pane.webglAddon) {
-      disposeWebgl(pane)
-      attachWebgl(pane)
-    }
+    rebuildAttachedWebgl(pane)
   } catch (err) {
     console.warn('[terminal] ligatures addon failed to attach for pane', pane.id, err)
     pane.ligaturesAddon = null
@@ -162,10 +162,7 @@ export function setLigaturesEnabled(pane: ManagedPaneInternal, enabled: boolean)
     // Why: ligatures lived inside the WebGL atlas, so after disposing the
     // addon the atlas still holds the ligated glyphs. Rebuild it so text
     // renders as the non-ligated fallback immediately.
-    if (pane.webglAddon) {
-      disposeWebgl(pane)
-      attachWebgl(pane)
-    }
+    rebuildAttachedWebgl(pane)
   }
 }
 

--- a/src/renderer/src/lib/pane-manager/pane-manager-types.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager-types.ts
@@ -142,6 +142,8 @@ export type ManagedPaneInternal = {
   gpuRenderingEnabled: boolean
   webglAttachmentDeferred: boolean
   webglDisabledAfterContextLoss: boolean
+  // Hidden retained renderers rebuild at the resume boundary, never behind the hidden surface.
+  webglRebuildDeferred?: boolean
   // Why per-pane: one pane's failed WebGL attach must not strand every other
   // pane on the DOM renderer until the next recovery boundary. Optional so
   // absent means "never failed"; only the attach failure path sets it.

--- a/src/renderer/src/lib/pane-manager/pane-manager.ts
+++ b/src/renderer/src/lib/pane-manager/pane-manager.ts
@@ -41,6 +41,7 @@ import {
 } from './pane-rendering-control'
 import type { TerminalLeafId } from '../../../../shared/stable-pane-id'
 import { registerLivePaneManager, unregisterLivePaneManager } from './pane-manager-registry'
+import { releaseHiddenWebglRetention } from './terminal-webgl-hidden-retention'
 import { schedulePaneRevealPresent, schedulePaneRevealRepaint } from './pane-reveal-repaint'
 import { fitRevealedPane } from './pane-reveal-fit'
 import { PaneIdentityRegistry } from './pane-identity-registry'
@@ -391,12 +392,15 @@ export class PaneManager {
 
   suspendRendering(): void {
     this.renderingSuspended = true
-    suspendPaneRendering(this.panes.values())
+    suspendPaneRendering(this.panes.values(), {
+      owner: this,
+      livePanes: () => (this.destroyed ? [] : this.panes.values())
+    })
   }
 
   resumeRendering(): void {
     this.renderingSuspended = false
-    resumePaneRendering(this.panes.values())
+    resumePaneRendering(this.panes.values(), this)
   }
 
   movePane(sourcePaneId: number, targetPaneId: number, zone: DropZone): void {
@@ -410,6 +414,7 @@ export class PaneManager {
   destroy(): void {
     this.destroyed = true
     unregisterLivePaneManager(this)
+    releaseHiddenWebglRetention(this)
     cancelActivePaneDrag(this.dragState)
     this.cancelPendingPaneReparentFrames()
     for (const pane of this.panes.values()) {

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -57,6 +57,10 @@ export function suspendPaneRendering(
   // Keep recent hidden worktrees on live WebGL so switch-back never presents
   // DOM-fallback frames; evicted/over-cap owners fall back to dispose.
   if (retention && tryRetainHiddenPanesWebgl(retention.owner, retention.livePanes)) {
+    // Why: retained WebGL keeps xterm's focused cursor timer alive behind the hidden surface.
+    for (const pane of suspended) {
+      pane.terminal.blur()
+    }
     return
   }
   for (const pane of suspended) {

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -8,6 +8,10 @@ import {
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
 import { reattachWebglIfNeeded } from './pane-webgl-reattach'
+import {
+  releaseHiddenWebglRetention,
+  tryRetainHiddenPanesWebgl
+} from './terminal-webgl-hidden-retention'
 
 export function setPaneGpuRenderingState(
   panes: Map<number, ManagedPaneInternal>,
@@ -42,14 +46,31 @@ export function markPaneComplexScriptOutput(
   }
 }
 
-export function suspendPaneRendering(panes: Iterable<ManagedPaneInternal>): void {
-  for (const pane of panes) {
+export function suspendPaneRendering(
+  panes: Iterable<ManagedPaneInternal>,
+  retention?: { owner: object; livePanes: () => Iterable<ManagedPaneInternal> }
+): void {
+  const suspended = Array.from(panes)
+  for (const pane of suspended) {
     pane.webglAttachmentDeferred = true
+  }
+  // Keep recent hidden worktrees on live WebGL so switch-back never presents
+  // DOM-fallback frames; evicted/over-cap owners fall back to dispose.
+  if (retention && tryRetainHiddenPanesWebgl(retention.owner, retention.livePanes)) {
+    return
+  }
+  for (const pane of suspended) {
     disposeWebgl(pane)
   }
 }
 
-export function resumePaneRendering(panes: Iterable<ManagedPaneInternal>): void {
+export function resumePaneRendering(
+  panes: Iterable<ManagedPaneInternal>,
+  retentionOwner?: object
+): void {
+  if (retentionOwner) {
+    releaseHiddenWebglRetention(retentionOwner)
+  }
   for (const pane of panes) {
     // Why: resume (worktree foreground, window wake) is the WebGL retry
     // boundary — Chromium may have restored the GPU process since a context

--- a/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
+++ b/src/renderer/src/lib/pane-manager/pane-rendering-control.ts
@@ -4,10 +4,11 @@ import {
   attachWebgl,
   clearTerminalWebglAttachBackoff,
   disposeWebgl,
+  isPaneWebglContextLost,
   markComplexScriptOutput,
   resetWebglTextureAtlas
 } from './pane-webgl-renderer'
-import { reattachWebglIfNeeded } from './pane-webgl-reattach'
+import { rebuildAttachedWebgl, reattachWebglIfNeeded } from './pane-webgl-reattach'
 import {
   releaseHiddenWebglRetention,
   tryRetainHiddenPanesWebgl
@@ -80,8 +81,17 @@ export function resumePaneRendering(
     // boundary — Chromium may have restored the GPU process since a context
     // loss, and bounding retries to resume events cannot loop on live loss.
     clearTerminalWebglAttachBackoff(pane)
+    const rebuildDeferred = pane.webglRebuildDeferred === true
     pane.webglAttachmentDeferred = false
     pane.webglDisabledAfterContextLoss = false
+    pane.webglRebuildDeferred = false
+    if (pane.webglAddon && isPaneWebglContextLost(pane)) {
+      disposeWebgl(pane)
+    }
+    if (rebuildDeferred && pane.webglAddon) {
+      rebuildAttachedWebgl(pane)
+      continue
+    }
     reattachWebglIfNeeded(pane)
   }
 }

--- a/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-context-recovery.test.ts
@@ -1,8 +1,9 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { setTerminalWebglDiagnosticRecorder } from '../../../../shared/terminal-webgl-diagnostics'
 import type { ManagedPaneInternal } from './pane-manager-types'
-import { resumePaneRendering } from './pane-rendering-control'
+import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
 import { attachWebgl, resetTerminalWebglSuggestion } from './pane-webgl-renderer'
+import { rebuildAttachedWebgl } from './pane-webgl-reattach'
 
 function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneInternal {
   const leafId = '11111111-1111-4111-8111-111111111111' as never
@@ -14,6 +15,7 @@ function createPane(options: { loadAddon?: () => void } = {}): ManagedPaneIntern
       cols: 80,
       rows: 24,
       refresh: vi.fn(),
+      blur: vi.fn(),
       loadAddon: vi.fn(options.loadAddon)
     } as never,
     container: {} as never,
@@ -110,6 +112,47 @@ describe('terminal WebGL context recovery', () => {
     resumePaneRendering([pane])
     expect(pane.webglDisabledAfterContextLoss).toBe(false)
     expect(pane.webglAddon).not.toBeNull()
+  })
+
+  it('defers retained replay rebuilds until rendering resumes', () => {
+    const owner = {}
+    const pane = createPane()
+    attachWebgl(pane)
+    const retainedAddon = pane.webglAddon
+    suspendPaneRendering([pane], { owner, livePanes: () => [pane] })
+
+    rebuildAttachedWebgl(pane)
+
+    expect(pane.webglAddon).toBe(retainedAddon)
+    expect(pane.webglRebuildDeferred).toBe(true)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
+
+    resumePaneRendering([pane], owner)
+
+    expect(pane.webglAddon).not.toBe(retainedAddon)
+    expect(pane.webglRebuildDeferred).toBe(false)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(2)
+  })
+
+  it('replaces a retained context lost before xterm dispatches its loss event', () => {
+    const pane = createPane()
+    const dispose = vi.fn()
+    const lostAddon = {
+      dispose,
+      _renderer: {
+        _gl: {
+          getExtension: vi.fn(() => null),
+          isContextLost: vi.fn(() => true)
+        }
+      }
+    }
+    pane.webglAddon = lostAddon as never
+
+    resumePaneRendering([pane])
+
+    expect(dispose).toHaveBeenCalledTimes(1)
+    expect(pane.webglAddon).not.toBe(lostAddon)
+    expect(pane.terminal.loadAddon).toHaveBeenCalledTimes(1)
   })
 
   it('re-latches when the retried context is lost again', () => {

--- a/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-reattach.ts
@@ -11,6 +11,11 @@ export function rebuildAttachedWebgl(pane: ManagedPaneInternal): void {
   if (!pane.webglAddon || pane.webglDisabledAfterContextLoss) {
     return
   }
+  if (pane.webglAttachmentDeferred) {
+    pane.webglRebuildDeferred = true
+    return
+  }
+  pane.webglRebuildDeferred = false
   disposeWebgl(pane)
   // Why: the live addon just proved context creation works, so a stale attach
   // backoff from an earlier failure must not downgrade this pane to DOM.

--- a/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
+++ b/src/renderer/src/lib/pane-manager/pane-webgl-renderer.ts
@@ -23,6 +23,7 @@ let suggestedRendererType: 'dom' | undefined
 
 type ReleasableWebglContext = {
   getExtension(name: 'WEBGL_lose_context'): WEBGL_lose_context | null
+  isContextLost?: () => boolean
 }
 
 type XtermWebglAddonInternals = {
@@ -72,6 +73,15 @@ export function cancelPendingWebglRefresh(pane: ManagedPaneInternal): void {
     globalThis.cancelAnimationFrame(pane.pendingWebglRefreshRafId)
   }
   pane.pendingWebglRefreshRafId = null
+}
+
+export function isPaneWebglContextLost(pane: ManagedPaneInternal): boolean {
+  try {
+    const renderer = (pane.webglAddon as unknown as XtermWebglAddonInternals | null)?._renderer
+    return renderer?._gl?.isContextLost?.() === true
+  } catch {
+    return true
+  }
 }
 
 export function disposeWebgl(

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
@@ -10,6 +10,7 @@ import {
 
 function createPane(withAddon = true): ManagedPaneInternal {
   return {
+    terminal: { blur: vi.fn() },
     webglAddon: withAddon
       ? ({ dispose: vi.fn() } as unknown as ManagedPaneInternal['webglAddon'])
       : null,
@@ -36,6 +37,7 @@ describe('terminal-webgl-hidden-retention', () => {
     suspendPaneRendering(panes, retentionFor(owner, panes))
     expect(panes.every((pane) => pane.webglAttachmentDeferred)).toBe(true)
     expect(panes.every((pane) => pane.webglAddon != null)).toBe(true)
+    expect(panes.every((pane) => vi.mocked(pane.terminal.blur).mock.calls.length === 1)).toBe(true)
     expect(retainedHiddenWebglOwnerCountForTest()).toBe(1)
   })
 
@@ -45,6 +47,7 @@ describe('terminal-webgl-hidden-retention', () => {
     suspendPaneRendering(panes)
     expect(addon?.dispose).toHaveBeenCalled()
     expect(panes[0].webglAddon).toBeNull()
+    expect(panes[0].terminal.blur).not.toHaveBeenCalled()
   })
 
   it('evicts the least-recently-hidden owner over the context cap', () => {

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.test.ts
@@ -1,0 +1,149 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { resumePaneRendering, suspendPaneRendering } from './pane-rendering-control'
+import {
+  releaseHiddenWebglRetention,
+  resetHiddenWebglRetentionForTest,
+  retainedHiddenWebglOwnerCountForTest,
+  tryRetainHiddenPanesWebgl
+} from './terminal-webgl-hidden-retention'
+
+function createPane(withAddon = true): ManagedPaneInternal {
+  return {
+    webglAddon: withAddon
+      ? ({ dispose: vi.fn() } as unknown as ManagedPaneInternal['webglAddon'])
+      : null,
+    webglAttachmentDeferred: false,
+    webglDisabledAfterContextLoss: false,
+    webglAttachFailedSinceRecovery: false,
+    gpuRenderingEnabled: true,
+    pendingWebglRefreshRafId: null
+  } as unknown as ManagedPaneInternal
+}
+
+function retentionFor(owner: object, panes: ManagedPaneInternal[]) {
+  return { owner, livePanes: () => panes }
+}
+
+describe('terminal-webgl-hidden-retention', () => {
+  beforeEach(() => {
+    resetHiddenWebglRetentionForTest()
+  })
+
+  it('suspend retains live WebGL addons and still defers attachment', () => {
+    const owner = {}
+    const panes = [createPane(), createPane()]
+    suspendPaneRendering(panes, retentionFor(owner, panes))
+    expect(panes.every((pane) => pane.webglAttachmentDeferred)).toBe(true)
+    expect(panes.every((pane) => pane.webglAddon != null)).toBe(true)
+    expect(retainedHiddenWebglOwnerCountForTest()).toBe(1)
+  })
+
+  it('suspend without retention context disposes addons (window-level callers unchanged)', () => {
+    const panes = [createPane()]
+    const addon = panes[0].webglAddon
+    suspendPaneRendering(panes)
+    expect(addon?.dispose).toHaveBeenCalled()
+    expect(panes[0].webglAddon).toBeNull()
+  })
+
+  it('evicts the least-recently-hidden owner over the context cap', () => {
+    const ownerA = {}
+    const panesA = [createPane(), createPane(), createPane()]
+    const addonsA = panesA.map((pane) => pane.webglAddon)
+    suspendPaneRendering(panesA, retentionFor(ownerA, panesA))
+
+    const ownerB = {}
+    const panesB = [createPane(), createPane(), createPane()]
+    suspendPaneRendering(panesB, retentionFor(ownerB, panesB))
+
+    // A(3) + B(3) fits the cap of 6; C(2) forces A out.
+    const ownerC = {}
+    const panesC = [createPane(), createPane()]
+    suspendPaneRendering(panesC, retentionFor(ownerC, panesC))
+
+    expect(panesA.every((pane) => pane.webglAddon === null)).toBe(true)
+    for (const addon of addonsA) {
+      expect(addon?.dispose).toHaveBeenCalled()
+    }
+    expect(panesB.every((pane) => pane.webglAddon != null)).toBe(true)
+    expect(panesC.every((pane) => pane.webglAddon != null)).toBe(true)
+    expect(retainedHiddenWebglOwnerCountForTest()).toBe(2)
+  })
+
+  it('re-suspending an owner refreshes its LRU position', () => {
+    const ownerA = {}
+    const panesA = [createPane(), createPane(), createPane()]
+    suspendPaneRendering(panesA, retentionFor(ownerA, panesA))
+    const ownerB = {}
+    const panesB = [createPane(), createPane(), createPane()]
+    suspendPaneRendering(panesB, retentionFor(ownerB, panesB))
+
+    // Touch A again: B becomes the eviction candidate.
+    suspendPaneRendering(panesA, retentionFor(ownerA, panesA))
+    const ownerC = {}
+    const panesC = [createPane()]
+    suspendPaneRendering(panesC, retentionFor(ownerC, panesC))
+
+    expect(panesB.every((pane) => pane.webglAddon === null)).toBe(true)
+    expect(panesA.every((pane) => pane.webglAddon != null)).toBe(true)
+  })
+
+  it('does not retain when the owner has no live addons', () => {
+    const owner = {}
+    const panes = [createPane(false)]
+    suspendPaneRendering(panes, retentionFor(owner, panes))
+    expect(retainedHiddenWebglOwnerCountForTest()).toBe(0)
+  })
+
+  it('does not retain a single owner wider than the whole cap', () => {
+    const owner = {}
+    const panes = Array.from({ length: 7 }, () => createPane())
+    const addons = panes.map((pane) => pane.webglAddon)
+    suspendPaneRendering(panes, retentionFor(owner, panes))
+    expect(retainedHiddenWebglOwnerCountForTest()).toBe(0)
+    for (const addon of addons) {
+      expect(addon?.dispose).toHaveBeenCalled()
+    }
+  })
+
+  it('resume releases retention bookkeeping and keeps the live addon', () => {
+    const owner = {}
+    const panes = [createPane()]
+    suspendPaneRendering(panes, retentionFor(owner, panes))
+    resumePaneRendering(panes, owner)
+    expect(retainedHiddenWebglOwnerCountForTest()).toBe(0)
+    expect(panes[0].webglAddon).not.toBeNull()
+    expect(panes[0].webglAttachmentDeferred).toBe(false)
+    // Released owner no longer counts toward the cap: three more 3-pane owners fit.
+    const others = [{}, {}]
+    for (const other of others) {
+      const otherPanes = [createPane(), createPane(), createPane()]
+      suspendPaneRendering(otherPanes, retentionFor(other, otherPanes))
+      expect(otherPanes.every((pane) => pane.webglAddon != null)).toBe(true)
+    }
+  })
+
+  it('releaseHiddenWebglRetention never disposes addons (destroy path owns that)', () => {
+    const owner = {}
+    const panes = [createPane()]
+    expect(tryRetainHiddenPanesWebgl(owner, () => panes)).toBe(true)
+    releaseHiddenWebglRetention(owner)
+    expect(panes[0].webglAddon).not.toBeNull()
+    expect(retainedHiddenWebglOwnerCountForTest()).toBe(0)
+  })
+
+  it('eviction accounting survives addons disposed after retention (GPU toggle off)', () => {
+    const ownerA = {}
+    const panesA = [createPane(), createPane(), createPane(), createPane()]
+    suspendPaneRendering(panesA, retentionFor(ownerA, panesA))
+    // GPU-off path disposes retained addons directly.
+    for (const pane of panesA) {
+      pane.webglAddon = null
+    }
+    const ownerB = {}
+    const panesB = Array.from({ length: 6 }, () => createPane())
+    suspendPaneRendering(panesB, retentionFor(ownerB, panesB))
+    expect(panesB.every((pane) => pane.webglAddon != null)).toBe(true)
+  })
+})

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.ts
@@ -1,11 +1,9 @@
 import type { ManagedPaneInternal } from './pane-manager-types'
 import { disposeWebgl } from './pane-webgl-renderer'
 
-// Chromium caps active WebGL contexts per page (~16, #6874); the visible
-// worktree typically holds 1-4. Retaining a few hidden contexts keeps recent
-// switch-backs on WebGL — no DOM-fallback frames whose divergent cell metrics
-// (unfloored width, letter-spacing from a mid-transition measure) flash as
-// wider/spaced-out text until reattach completes.
+// Orca raises Blink's active-context ceiling to 128, but retained contexts
+// still consume GPU memory. Six keeps recent switch-backs on WebGL without
+// letting hidden worktrees grow that cost with the mounted-pane population.
 const MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS = 6
 
 type RetainedHiddenEntry = {

--- a/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.ts
+++ b/src/renderer/src/lib/pane-manager/terminal-webgl-hidden-retention.ts
@@ -1,0 +1,83 @@
+import type { ManagedPaneInternal } from './pane-manager-types'
+import { disposeWebgl } from './pane-webgl-renderer'
+
+// Chromium caps active WebGL contexts per page (~16, #6874); the visible
+// worktree typically holds 1-4. Retaining a few hidden contexts keeps recent
+// switch-backs on WebGL — no DOM-fallback frames whose divergent cell metrics
+// (unfloored width, letter-spacing from a mid-transition measure) flash as
+// wider/spaced-out text until reattach completes.
+const MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS = 6
+
+type RetainedHiddenEntry = {
+  owner: object
+  livePanes: () => Iterable<ManagedPaneInternal>
+}
+
+// LRU: oldest suspend first.
+const retainedEntries: RetainedHiddenEntry[] = []
+
+function liveContextCount(entry: RetainedHiddenEntry): number {
+  let count = 0
+  for (const pane of entry.livePanes()) {
+    if (pane.webglAddon) {
+      count += 1
+    }
+  }
+  return count
+}
+
+function disposeEntryContexts(entry: RetainedHiddenEntry): void {
+  for (const pane of entry.livePanes()) {
+    disposeWebgl(pane)
+  }
+}
+
+function removeEntry(owner: object): void {
+  const index = retainedEntries.findIndex((entry) => entry.owner === owner)
+  if (index !== -1) {
+    retainedEntries.splice(index, 1)
+  }
+}
+
+/**
+ * Try to keep the owner's live WebGL addons across a hide. Returns true when
+ * retained — the caller must then skip its dispose pass. Evicts (disposes)
+ * least-recently-hidden owners to stay under the context cap.
+ */
+export function tryRetainHiddenPanesWebgl(
+  owner: object,
+  livePanes: () => Iterable<ManagedPaneInternal>
+): boolean {
+  removeEntry(owner)
+  const entry: RetainedHiddenEntry = { owner, livePanes }
+  const ownCount = liveContextCount(entry)
+  // Nothing to retain (GPU off / first-mount hidden), or a single tab too wide
+  // for the cap — normal dispose keeps eviction from thrashing every other tab.
+  if (ownCount === 0 || ownCount > MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS) {
+    return false
+  }
+  let total = ownCount
+  for (const other of retainedEntries) {
+    total += liveContextCount(other)
+  }
+  while (total > MAX_RETAINED_HIDDEN_WEBGL_CONTEXTS && retainedEntries.length > 0) {
+    const evicted = retainedEntries.shift()!
+    total -= liveContextCount(evicted)
+    disposeEntryContexts(evicted)
+  }
+  retainedEntries.push(entry)
+  return true
+}
+
+/** Drop retention bookkeeping on reveal/destroy; never disposes live addons. */
+export function releaseHiddenWebglRetention(owner: object): void {
+  removeEntry(owner)
+}
+
+export function retainedHiddenWebglOwnerCountForTest(): number {
+  return retainedEntries.length
+}
+
+export function resetHiddenWebglRetentionForTest(): void {
+  retainedEntries.length = 0
+}


### PR DESCRIPTION
## Summary

Switching back to a recently viewed worktree can visibly glitch the terminal: the text renders subtly wrong — ~5 % wider character advance with lighter-looking strokes — for anywhere from a flicker to 1–2 s on a loaded machine, sometimes followed by a split-second blank, then snaps to normal. Field-observed end to end on a maintainer's machine under load: wrong text → blank → normal.

That sequence is the fingerprint of the hide/reveal renderer lifecycle: hiding a worktree disposes each pane's WebGL addon, so the pane falls to xterm's DOM renderer (unfloored char width = wider, different antialiasing weight = thinner-looking) for its entire hidden life; on reveal, every frame presented before the new WebGL context attaches shows that DOM rendering (phase 1); the freshly attached WebGL canvas starts empty until its first repaint (phase 2 — the blank); then the WebGL paint lands (phase 3). On an idle macOS machine the attach takes ~5 ms and nothing presents in the window; under load (or Windows/ANGLE, where attach costs 100–500 ms) the phases become visible for seconds.

The fix: keep the WebGL addons alive across the hide for the most recently hidden worktrees — an LRU capped at 6 retained contexts (Orca raises Blink's active-context ceiling to 128, but retained contexts still hold GPU memory; visible worktrees typically hold 1–4), least-recently-hidden owners evicted to today's dispose path. A warm switch-back then has no renderer swap at all: no DOM window, no attach, no blank, no repaint. Window-occlusion suspends and first-mount-hidden panes are unchanged (no retention context / no contexts to retain), the GPU-acceleration setting still disposes, and context-loss recovery paths are untouched.

## Screenshots

Deterministic A/B reproduction on the real click-driven reveal path (rig; the only emulation is delaying the resume/attach boundary by 1.5 s to stand in for a loaded machine), every presented frame captured via screencast:

- **Pre-fix state**: revealed text paints at the wide DOM advance (text-block right edge x = 921) and holds across 9 consecutive frames for ~1.5 s, then snaps to x = 889 on the frame after attach. Ink count is equal in both phases (46.4 k px) spread over ~4 % more width — exactly the reported "spaced out and thinner" look.
- **With this PR** (same delayed resume): the first painted frame is already x = 889 and all 20 frames are identical — the delayed attach is a visual non-event.

Filmstrips: `/tmp/fontglitch-rig/evidence-three-phase/{before-fix,after-fix}/`; renderer-state probes additionally show the hidden pane staying on WebGL for its entire hidden life (previously: DOM renderer from 100 ms after switch-away onward).

## Testing

- [x] `pnpm typecheck`
- [x] Targeted `oxlint` on changed files (clean)
- [x] Targeted `vitest`: 9 new tests through the public suspend/resume path (retention, LRU eviction at the cap, MRU refresh, no-retention callers unchanged, over-cap single owner, release-on-resume accounting, GPU-toggle accounting) + full pane-manager/terminal-pane suites green (311 files / 3920 tests)
- [ ] Full `pnpm lint` / `pnpm test` / `pnpm build` — left to CI
- [x] Added high-quality regression tests: they exercise `suspendPaneRendering`/`resumePaneRendering`, so deleting the wiring (not just the module) flips them red
- [x] End-to-end A/B validation in the dev app (above): pre-fix flicker reproduced on the real reveal path, eliminated with the fix as the only variable

## AI Review Report

Reviewed by the implementing agent: (1) every consumer of `webglAttachmentDeferred` audited for the new state "deferred with a live addon" — attach guards, fit-attach heal, GPU toggles, and diagnostics all behave (attach paths skip panes that already hold an addon). (2) `reattachWebglIfNeeded` no-ops on retained panes, so resume is unchanged for them and still attaches evicted ones. (3) Manager destroy releases retention bookkeeping; pane disposal owns the addon teardown. (4) Hidden retained panes don't burn GPU work — xterm's IntersectionObserver pauses rendering while not intersecting. (5) Context-loss on a hidden retained pane runs the existing loss handler; hidden-time dpr changes are covered by the merged canvas-dpr repair on the fit path. Cross-platform: renderer-internal, no shortcuts/labels/paths/shell behavior; biggest benefit on Windows/ANGLE where attach costs 100–500 ms; the context cap respects Chromium's budget on all platforms.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC changes. Pure renderer-lifecycle bookkeeping over objects Orca already owns.

## Notes

- Scope boundary: parked tabs fully unmount, so their reveal is a fresh remount this PR does not cover (blank-first sequence, not the wrong-text-first one) — companion work: gate the remount's first paint on renderer readiness, or the parking redesign (offscreen full-size box).
- The cap is the one deliberate conservatism vs simply never disposing on hide: it bounds retained GPU memory instead of letting it grow with the hidden-pane population. Deleting the hide-time dispose entirely (net code removal) is a candidate follow-up once retained-context behavior is proven in the field.
- #13371 (speculative DOM letter-spacing repair) was withdrawn after review — the corrupted-measurement theory behind it did not survive scrutiny; the field sequence above is fully explained by the renderer swap this PR removes.

- Second commit pauses cursor work on retained hidden panes (`terminal.blur()` at suspend): a retained WebGL pane would otherwise keep xterm's focused-cursor blink timer running behind the hidden surface; the reveal path re-focuses the active pane as before.