### PR TITLE
fix(agent-hooks): refresh existing Orca launchers when agent CLIs are unavailable

### DIFF
--- a/config/tsconfig.cli.json
+++ b/config/tsconfig.cli.json
@@ -12,6 +12,7 @@
     "../src/main/agent-hooks/local-agent-cli-presence.ts",
     "../src/main/agent-hooks/managed-agent-hook-controls.ts",
     "../src/main/agent-hooks/managed-agent-hook-registry.ts",
+    "../src/main/agent-hooks/managed-hook-script-refresh.ts",
     "../src/main/amp/hook-service.ts",
     "../src/main/antigravity/hook-service.ts",
     "../src/main/claude/hook-settings.ts",

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -259,18 +259,6 @@ export function hookDefinitionHasManagedCommand(
   )
 }
 
-// Why: a CLI that falls off PATH freezes its last-installed script while the agent's
-// user-wide config keeps invoking it (#11549 aftermath). The script file is Orca-owned,
-// so an existing one is proof of a prior install and safe to bring current; a missing one
-// stays missing — creating it is install()'s job, behind the CLI presence gate.
-export function refreshManagedScriptIfPresent(scriptPath: string, content: string): boolean {
-  if (!existsSync(scriptPath)) {
-    return false
-  }
-  writeManagedScript(scriptPath, content)
-  return true
-}
-
 // Why: temp+rename so concurrent writers can't leave a torn script for an in-flight /bin/sh to source.
 export function writeManagedScript(scriptPath: string, content: string): void {
   const dir = dirname(scriptPath)

--- a/src/main/agent-hooks/installer-utils.ts
+++ b/src/main/agent-hooks/installer-utils.ts
@@ -259,6 +259,18 @@ export function hookDefinitionHasManagedCommand(
   )
 }
 
+// Why: a CLI that falls off PATH freezes its last-installed script while the agent's
+// user-wide config keeps invoking it (#11549 aftermath). The script file is Orca-owned,
+// so an existing one is proof of a prior install and safe to bring current; a missing one
+// stays missing — creating it is install()'s job, behind the CLI presence gate.
+export function refreshManagedScriptIfPresent(scriptPath: string, content: string): boolean {
+  if (!existsSync(scriptPath)) {
+    return false
+  }
+  writeManagedScript(scriptPath, content)
+  return true
+}
+
 // Why: temp+rename so concurrent writers can't leave a torn script for an in-flight /bin/sh to source.
 export function writeManagedScript(scriptPath: string, content: string): void {
   const dir = dirname(scriptPath)

--- a/src/main/agent-hooks/managed-agent-hook-controls.test.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.test.ts
@@ -7,7 +7,9 @@ const mocks = vi.hoisted(() => ({
   removeClaude: vi.fn(),
   removeCodex: vi.fn(),
   statusClaude: vi.fn(),
-  statusCodex: vi.fn()
+  statusCodex: vi.fn(),
+  refreshClaude: vi.fn(),
+  refreshCodex: vi.fn()
 }))
 
 vi.mock('./local-agent-cli-presence', () => ({
@@ -26,6 +28,10 @@ vi.mock('./managed-agent-hook-registry', () => ({
   MANAGED_AGENT_HOOK_STATUS_READERS: [
     ['claude', mocks.statusClaude],
     ['codex', mocks.statusCodex]
+  ],
+  MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS: [
+    ['claude', mocks.refreshClaude],
+    ['codex', mocks.refreshCodex]
   ]
 }))
 
@@ -71,6 +77,58 @@ describe('managed agent hook controls', () => {
       }),
       expect.objectContaining({ agent: 'codex', state: 'installed' })
     ])
+  })
+
+  it('refreshes existing scripts for agents whose CLI is no longer detected', async () => {
+    mocks.detect.mockResolvedValue({
+      claude: { state: 'missing' },
+      codex: { state: 'found' }
+    })
+
+    await installManagedAgentHooks({ agentCmdOverrides: {} })
+
+    // Why (#11549 aftermath): the skipped agent's user-wide config still invokes the
+    // script, so a stale (leaking) script must not be frozen by the presence gate.
+    expect(mocks.refreshClaude).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshCodex).toHaveBeenCalledTimes(1)
+    expect(mocks.installClaude).not.toHaveBeenCalled()
+  })
+
+  it('refreshes existing scripts even when CLI detection rejects', async () => {
+    mocks.detect.mockRejectedValue(new Error('detection unavailable'))
+
+    await installManagedAgentHooks({ agentCmdOverrides: {} })
+
+    expect(mocks.refreshClaude).toHaveBeenCalledTimes(1)
+    expect(mocks.refreshCodex).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps installing when a script refresh throws', async () => {
+    mocks.refreshClaude.mockImplementation(() => {
+      throw new Error('disk full')
+    })
+    mocks.detect.mockResolvedValue({
+      claude: { state: 'found' },
+      codex: { state: 'found' }
+    })
+
+    const results = await installManagedAgentHooks({ agentCmdOverrides: {} })
+
+    expect(mocks.installClaude).toHaveBeenCalledTimes(1)
+    expect(mocks.installCodex).toHaveBeenCalledTimes(1)
+    expect(results).toEqual([
+      expect.objectContaining({ agent: 'claude', state: 'installed' }),
+      expect.objectContaining({ agent: 'codex', state: 'installed' })
+    ])
+  })
+
+  it('only refreshes scripts for the selected agents', async () => {
+    mocks.detect.mockResolvedValue({ codex: { state: 'found' } })
+
+    await installManagedAgentHooks({ agentCmdOverrides: {} }, { agents: ['codex'] })
+
+    expect(mocks.refreshClaude).not.toHaveBeenCalled()
+    expect(mocks.refreshCodex).toHaveBeenCalledTimes(1)
   })
 
   it('fails closed when CLI detection rejects', async () => {

--- a/src/main/agent-hooks/managed-agent-hook-controls.test.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.test.ts
@@ -57,6 +57,8 @@ describe('managed agent hook controls', () => {
     mocks.installCodex.mockReturnValue(status('codex', 'installed'))
     mocks.removeClaude.mockReturnValue(status('claude', 'not_installed'))
     mocks.removeCodex.mockReturnValue(status('codex', 'not_installed'))
+    mocks.refreshClaude.mockResolvedValue(undefined)
+    mocks.refreshCodex.mockResolvedValue(undefined)
   })
 
   it('installs only agents with positively detected CLIs', async () => {
@@ -103,10 +105,30 @@ describe('managed agent hook controls', () => {
     expect(mocks.refreshCodex).toHaveBeenCalledTimes(1)
   })
 
-  it('keeps installing when a script refresh throws', async () => {
-    mocks.refreshClaude.mockImplementation(() => {
-      throw new Error('disk full')
+  it('awaits each script refresh before probing for CLIs', async () => {
+    let releaseRefresh: (() => void) | undefined
+    mocks.refreshClaude.mockImplementation(
+      () =>
+        new Promise<void>((resolve) => {
+          releaseRefresh = resolve
+        })
+    )
+    mocks.detect.mockResolvedValue({
+      claude: { state: 'missing' },
+      codex: { state: 'missing' }
     })
+
+    const install = installManagedAgentHooks({ agentCmdOverrides: {} })
+    await Promise.resolve()
+
+    expect(mocks.detect).not.toHaveBeenCalled()
+    releaseRefresh?.()
+    await install
+    expect(mocks.detect).toHaveBeenCalledTimes(1)
+  })
+
+  it('keeps installing when a script refresh throws', async () => {
+    mocks.refreshClaude.mockRejectedValue(new Error('disk full'))
     mocks.detect.mockResolvedValue({
       claude: { state: 'found' },
       codex: { state: 'found' }

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -92,14 +92,14 @@ function runInstaller(
 // Orca's script, but the presence gate below then skips install() forever, freezing the
 // script at whatever Orca generated last. Existing scripts are Orca-owned, so bring them
 // current before any gating; creating new ones remains install()'s presence-gated job.
-function refreshExistingManagedScripts(options: InstallOptions): void {
+async function refreshExistingManagedScripts(options: InstallOptions): Promise<void> {
   const allowed = options.agents ? new Set(options.agents) : null
   for (const [agent, refresh] of MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS) {
     if (allowed !== null && !allowed.has(agent)) {
       continue
     }
     try {
-      refresh()
+      await refresh()
     } catch (error) {
       console.error(`[agent-hooks] Failed to refresh ${agent} managed script:`, error)
     }
@@ -110,7 +110,7 @@ export async function installManagedAgentHooks(
   settings: ManagedHookSettings = null,
   options: InstallOptions = {}
 ): Promise<AgentHookInstallStatus[]> {
-  refreshExistingManagedScripts(options)
+  await refreshExistingManagedScripts(options)
   const installers = selectedInstallers(options)
   const disabled = new Set(normalizeDisabledTuiAgents(settings?.disabledTuiAgents))
   const enabledInstallers = installers.filter(([agent]) => !disabled.has(agent))

--- a/src/main/agent-hooks/managed-agent-hook-controls.ts
+++ b/src/main/agent-hooks/managed-agent-hook-controls.ts
@@ -9,6 +9,7 @@ import { detectLocalManagedAgentCliPresence } from './local-agent-cli-presence'
 import {
   MANAGED_AGENT_HOOK_INSTALLERS,
   MANAGED_AGENT_HOOK_REMOVERS,
+  MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS,
   MANAGED_AGENT_HOOK_STATUS_READERS,
   type ManagedAgentHookInstaller
 } from './managed-agent-hook-registry'
@@ -87,10 +88,29 @@ function runInstaller(
   }
 }
 
+// Why (#11549 aftermath): a CLI that falls off PATH keeps its user-wide config invoking
+// Orca's script, but the presence gate below then skips install() forever, freezing the
+// script at whatever Orca generated last. Existing scripts are Orca-owned, so bring them
+// current before any gating; creating new ones remains install()'s presence-gated job.
+function refreshExistingManagedScripts(options: InstallOptions): void {
+  const allowed = options.agents ? new Set(options.agents) : null
+  for (const [agent, refresh] of MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS) {
+    if (allowed !== null && !allowed.has(agent)) {
+      continue
+    }
+    try {
+      refresh()
+    } catch (error) {
+      console.error(`[agent-hooks] Failed to refresh ${agent} managed script:`, error)
+    }
+  }
+}
+
 export async function installManagedAgentHooks(
   settings: ManagedHookSettings = null,
   options: InstallOptions = {}
 ): Promise<AgentHookInstallStatus[]> {
+  refreshExistingManagedScripts(options)
   const installers = selectedInstallers(options)
   const disabled = new Set(normalizeDisabledTuiAgents(settings?.disabledTuiAgents))
   const enabledInstallers = installers.filter(([agent]) => !disabled.has(agent))

--- a/src/main/agent-hooks/managed-agent-hook-registry.ts
+++ b/src/main/agent-hooks/managed-agent-hook-registry.ts
@@ -16,6 +16,7 @@ import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type ManagedAgentHookInstaller = readonly [HookInstallAgent, () => AgentHookInstallStatus]
+export type ManagedAgentHookScriptRefresher = readonly [HookInstallAgent, () => void]
 export type ManagedAgentHookRemover = readonly [HookInstallAgent, () => AgentHookInstallStatus]
 export type ManagedAgentHookStatusReader = readonly [HookInstallAgent, () => AgentHookInstallStatus]
 
@@ -34,6 +35,27 @@ export const MANAGED_AGENT_HOOK_INSTALLERS: readonly ManagedAgentHookInstaller[]
   ['hermes', () => hermesHookService.install()],
   ['devin', () => devinHookService.install()],
   ['kimi', () => kimiHookService.install()]
+]
+
+// Why: covers the shared launcher/statusline scripts under ~/.orca/agent-hooks — the files a
+// user-wide agent config keeps invoking after the CLI falls off PATH. Amp and Hermes write
+// provider-native plugin code into their own config dirs with their own install lifecycles,
+// not shared launchers, so they are deliberately absent. Enforced by the coverage test in
+// managed-hook-script-refresh.test.ts: a new installer that writes a launcher without adding
+// a refresher here fails that test.
+export const MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS: readonly ManagedAgentHookScriptRefresher[] = [
+  ['claude', () => claudeHookService.refreshManagedScripts()],
+  ['openclaude', () => openClaudeHookService.refreshManagedScripts()],
+  ['codex', () => codexHookService.refreshManagedScripts()],
+  ['gemini', () => geminiHookService.refreshManagedScripts()],
+  ['antigravity', () => antigravityHookService.refreshManagedScripts()],
+  ['cursor', () => cursorHookService.refreshManagedScripts()],
+  ['droid', () => droidHookService.refreshManagedScripts()],
+  ['command-code', () => commandCodeHookService.refreshManagedScripts()],
+  ['grok', () => grokHookService.refreshManagedScripts()],
+  ['copilot', () => copilotHookService.refreshManagedScripts()],
+  ['devin', () => devinHookService.refreshManagedScripts()],
+  ['kimi', () => kimiHookService.refreshManagedScripts()]
 ]
 
 export const MANAGED_AGENT_HOOK_REMOVERS: readonly ManagedAgentHookRemover[] = [

--- a/src/main/agent-hooks/managed-agent-hook-registry.ts
+++ b/src/main/agent-hooks/managed-agent-hook-registry.ts
@@ -16,7 +16,7 @@ import { kimiHookService } from '../kimi/hook-service'
 import { openClaudeHookService } from '../openclaude/hook-service'
 
 export type ManagedAgentHookInstaller = readonly [HookInstallAgent, () => AgentHookInstallStatus]
-export type ManagedAgentHookScriptRefresher = readonly [HookInstallAgent, () => void]
+export type ManagedAgentHookScriptRefresher = readonly [HookInstallAgent, () => Promise<void>]
 export type ManagedAgentHookRemover = readonly [HookInstallAgent, () => AgentHookInstallStatus]
 export type ManagedAgentHookStatusReader = readonly [HookInstallAgent, () => AgentHookInstallStatus]
 

--- a/src/main/agent-hooks/managed-hook-script-refresh-main-thread.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh-main-thread.test.ts
@@ -1,0 +1,101 @@
+import type * as NodeFsModule from 'node:fs'
+import { mkdir, mkdtemp, rm, writeFile } from 'node:fs/promises'
+import type * as NodeFsPromisesModule from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import type * as NodeOsModule from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const state = vi.hoisted(() => ({
+  home: '',
+  syncCalls: [] as { name: string; target: string }[],
+  blockAsyncReads: false
+}))
+
+vi.mock('node:fs', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsModule>()
+  const wrapped: Record<string, unknown> = { ...actual }
+  for (const [name, value] of Object.entries(actual)) {
+    if (!name.endsWith('Sync') || typeof value !== 'function') {
+      continue
+    }
+    const original = value as ((...args: unknown[]) => unknown) & Record<string, unknown>
+    const recorder = (...args: unknown[]): unknown => {
+      state.syncCalls.push({ name, target: typeof args[0] === 'string' ? args[0] : '' })
+      return original(...args)
+    }
+    Object.assign(recorder, original)
+    wrapped[name] = recorder
+  }
+  return { ...wrapped, default: wrapped }
+})
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromisesModule>()
+  return {
+    ...actual,
+    default: actual,
+    readFile: (...args: Parameters<typeof actual.readFile>) =>
+      state.blockAsyncReads && String(args[0]).startsWith(state.home)
+        ? new Promise<never>(() => {})
+        : actual.readFile(...args)
+  }
+})
+
+vi.mock('node:os', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeOsModule>()
+  return { ...actual, default: actual, homedir: () => state.home }
+})
+
+vi.mock('electron', () => ({ app: { getPath: () => '/tmp/orca-user-data' } }))
+
+import { MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS } from './managed-agent-hook-registry'
+
+function syncCallsUnderHome(): string[] {
+  return state.syncCalls
+    .filter((call) => call.target.startsWith(state.home))
+    .map((call) => `${call.name}(${call.target})`)
+}
+
+describe('managed hook script refresh stays off the main thread', () => {
+  beforeEach(async () => {
+    state.home = await mkdtemp(join(tmpdir(), 'orca-hook-refresh-main-thread-'))
+    state.syncCalls = []
+    state.blockAsyncReads = false
+  })
+
+  afterEach(async () => {
+    state.blockAsyncReads = false
+    await rm(state.home, { recursive: true, force: true })
+  })
+
+  it('uses no synchronous HOME filesystem calls for missing or stale scripts', async () => {
+    const hooksDir = join(state.home, '.orca', 'agent-hooks')
+    const claudeScript = join(
+      hooksDir,
+      process.platform === 'win32' ? 'claude-hook.cmd' : 'claude-hook.sh'
+    )
+    await mkdir(hooksDir, { recursive: true })
+    await writeFile(claudeScript, 'stale', 'utf-8')
+    state.syncCalls = []
+
+    for (const [, refresh] of MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS) {
+      await refresh()
+    }
+
+    expect(syncCallsUnderHome()).toEqual([])
+  })
+
+  it('keeps the event loop responsive while a HOME read is stalled', async () => {
+    state.blockAsyncReads = true
+    const refresh = MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS[0][1]()
+    let settled = false
+    void refresh.then(() => {
+      settled = true
+    })
+
+    await new Promise<void>((resolve) => setTimeout(resolve, 5))
+
+    expect(settled).toBe(false)
+  })
+})

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -92,12 +92,16 @@ describe('refreshManagedScriptIfPresent', () => {
       expect(await refreshManagedScriptIfPresent(present, 'fresh')).toBe(true)
       expect(readFileSync(present, 'utf8')).toBe('fresh')
 
-      chmodSync(present, 0o600)
+      if (process.platform !== 'win32') {
+        chmodSync(present, 0o600)
+      }
       const fixedTime = new Date(1_000)
       utimesSync(present, fixedTime, fixedTime)
       expect(await refreshManagedScriptIfPresent(present, 'fresh')).toBe(true)
       expect(statSync(present).mtimeMs).toBe(fixedTime.getTime())
-      expect(statSync(present).mode & 0o777).toBe(0o755)
+      if (process.platform !== 'win32') {
+        expect(statSync(present).mode & 0o777).toBe(0o755)
+      }
 
       const missing = join(dir, 'missing.cmd')
       expect(await refreshManagedScriptIfPresent(missing, 'fresh')).toBe(false)

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -4,11 +4,14 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   existsSync,
+  chmodSync,
   mkdirSync,
   mkdtempSync,
   readdirSync,
   readFileSync,
   rmSync,
+  statSync,
+  utimesSync,
   writeFileSync
 } from 'node:fs'
 import { tmpdir } from 'node:os'
@@ -51,18 +54,18 @@ vi.mock('os', async (importOriginal) => {
   }
 })
 
-import { refreshManagedScriptIfPresent } from './installer-utils'
+import { refreshManagedScriptIfPresent } from './managed-hook-script-refresh'
 import {
   MANAGED_AGENT_HOOK_INSTALLERS,
   MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS
 } from './managed-agent-hook-registry'
 import { ClaudeHookService } from '../claude/hook-service'
 
-function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+async function withPlatform<T>(platform: NodeJS.Platform, run: () => T | Promise<T>): Promise<T> {
   const original = Object.getOwnPropertyDescriptor(process, 'platform')
   Object.defineProperty(process, 'platform', { configurable: true, value: platform })
   try {
-    return run()
+    return await run()
   } finally {
     if (original) {
       Object.defineProperty(process, 'platform', original)
@@ -81,16 +84,23 @@ const STALE_WINDOWS_HOOK = [
 ].join('\r\n')
 
 describe('refreshManagedScriptIfPresent', () => {
-  it('rewrites an existing script and refuses to create a missing one', () => {
+  it('rewrites an existing script and refuses to create a missing one', async () => {
     const dir = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-unit-'))
     try {
       const present = join(dir, 'present.cmd')
       writeFileSync(present, 'stale')
-      expect(refreshManagedScriptIfPresent(present, 'fresh')).toBe(true)
+      expect(await refreshManagedScriptIfPresent(present, 'fresh')).toBe(true)
       expect(readFileSync(present, 'utf8')).toBe('fresh')
 
+      chmodSync(present, 0o600)
+      const fixedTime = new Date(1_000)
+      utimesSync(present, fixedTime, fixedTime)
+      expect(await refreshManagedScriptIfPresent(present, 'fresh')).toBe(true)
+      expect(statSync(present).mtimeMs).toBe(fixedTime.getTime())
+      expect(statSync(present).mode & 0o777).toBe(0o755)
+
       const missing = join(dir, 'missing.cmd')
-      expect(refreshManagedScriptIfPresent(missing, 'fresh')).toBe(false)
+      expect(await refreshManagedScriptIfPresent(missing, 'fresh')).toBe(false)
       expect(existsSync(missing)).toBe(false)
     } finally {
       rmSync(dir, { recursive: true, force: true })
@@ -99,7 +109,7 @@ describe('refreshManagedScriptIfPresent', () => {
 })
 
 describe('managed hook script refresh', () => {
-  it('brings a stale leaking script current without touching agent config', () => {
+  it('brings a stale leaking script current without touching agent config', async () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-'))
     homedirMock.mockReturnValue(home)
     try {
@@ -109,7 +119,7 @@ describe('managed hook script refresh', () => {
       mkdirSync(hooksDir, { recursive: true })
       writeFileSync(join(hooksDir, 'claude-hook.cmd'), STALE_WINDOWS_HOOK)
 
-      withPlatform('win32', () => new ClaudeHookService().refreshManagedScripts())
+      await withPlatform('win32', () => new ClaudeHookService().refreshManagedScripts())
 
       const refreshed = readFileSync(join(hooksDir, 'claude-hook.cmd'), 'utf8')
       expect(refreshed).toContain('if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0')
@@ -124,7 +134,7 @@ describe('managed hook script refresh', () => {
     }
   })
 
-  it('covers every shared launcher script with a refresher', () => {
+  it('covers every shared launcher script with a refresher', async () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-coverage-'))
     homedirMock.mockReturnValue(home)
     const previousGrokHome = process.env.GROK_HOME
@@ -132,7 +142,7 @@ describe('managed hook script refresh', () => {
     delete process.env.GROK_HOME
     delete process.env.KIMI_CODE_HOME
     try {
-      withPlatform('win32', () => {
+      await withPlatform('win32', () => {
         for (const [, install] of MANAGED_AGENT_HOOK_INSTALLERS) {
           install()
         }
@@ -173,13 +183,13 @@ describe('managed hook script refresh', () => {
     }
   })
 
-  it('creates nothing anywhere when no managed scripts exist', () => {
+  it('creates nothing anywhere when no managed scripts exist', async () => {
     const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-empty-'))
     homedirMock.mockReturnValue(home)
     try {
-      withPlatform('win32', () => {
+      await withPlatform('win32', async () => {
         for (const [agent, refresh] of MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS) {
-          expect(() => refresh(), `${agent} refresh on empty home`).not.toThrow()
+          await expect(refresh(), `${agent} refresh on empty home`).resolves.toBeUndefined()
         }
       })
       // Why: a refresh pass on a machine with no prior installs must be a strict no-op.

--- a/src/main/agent-hooks/managed-hook-script-refresh.test.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.test.ts
@@ -1,0 +1,192 @@
+// Why (#11549 aftermath): a CLI that falls off PATH keeps its user-wide config invoking
+// Orca's script while the presence gate skips install() forever. These tests pin the
+// repair — existing scripts come current, missing ones are never created.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  existsSync,
+  mkdirSync,
+  mkdtempSync,
+  readdirSync,
+  readFileSync,
+  rmSync,
+  writeFileSync
+} from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import type * as osModule from 'node:os'
+
+let isolatedUserDataDir = ''
+let previousUserDataPath: string | undefined
+
+beforeEach(() => {
+  previousUserDataPath = process.env.ORCA_USER_DATA_PATH
+  isolatedUserDataDir = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-user-data-'))
+  process.env.ORCA_USER_DATA_PATH = isolatedUserDataDir
+})
+
+afterEach(() => {
+  if (previousUserDataPath === undefined) {
+    delete process.env.ORCA_USER_DATA_PATH
+  } else {
+    process.env.ORCA_USER_DATA_PATH = previousUserDataPath
+  }
+  rmSync(isolatedUserDataDir, { recursive: true, force: true })
+})
+
+const { homedirMock } = vi.hoisted(() => ({
+  homedirMock: vi.fn<() => string>()
+}))
+
+vi.mock('electron', () => ({
+  app: {
+    getPath: () => '/tmp/orca-user-data'
+  }
+}))
+
+vi.mock('os', async (importOriginal) => {
+  const actual = await importOriginal<typeof osModule>()
+  return {
+    ...actual,
+    homedir: homedirMock.mockImplementation(actual.homedir)
+  }
+})
+
+import { refreshManagedScriptIfPresent } from './installer-utils'
+import {
+  MANAGED_AGENT_HOOK_INSTALLERS,
+  MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS
+} from './managed-agent-hook-registry'
+import { ClaudeHookService } from '../claude/hook-service'
+
+function withPlatform<T>(platform: NodeJS.Platform, run: () => T): T {
+  const original = Object.getOwnPropertyDescriptor(process, 'platform')
+  Object.defineProperty(process, 'platform', { configurable: true, value: platform })
+  try {
+    return run()
+  } finally {
+    if (original) {
+      Object.defineProperty(process, 'platform', original)
+    }
+  }
+}
+
+const STALE_WINDOWS_HOOK = [
+  '@echo off',
+  'setlocal',
+  'if "%ORCA_AGENT_HOOK_PORT%"=="" goto :orca_agent_hook_drain_stdin',
+  ':orca_agent_hook_drain_stdin',
+  '"%SystemRoot%\\System32\\more.com" >nul 2>nul',
+  'exit /b 0',
+  ''
+].join('\r\n')
+
+describe('refreshManagedScriptIfPresent', () => {
+  it('rewrites an existing script and refuses to create a missing one', () => {
+    const dir = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-unit-'))
+    try {
+      const present = join(dir, 'present.cmd')
+      writeFileSync(present, 'stale')
+      expect(refreshManagedScriptIfPresent(present, 'fresh')).toBe(true)
+      expect(readFileSync(present, 'utf8')).toBe('fresh')
+
+      const missing = join(dir, 'missing.cmd')
+      expect(refreshManagedScriptIfPresent(missing, 'fresh')).toBe(false)
+      expect(existsSync(missing)).toBe(false)
+    } finally {
+      rmSync(dir, { recursive: true, force: true })
+    }
+  })
+})
+
+describe('managed hook script refresh', () => {
+  it('brings a stale leaking script current without touching agent config', () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-'))
+    homedirMock.mockReturnValue(home)
+    try {
+      // Why: the bug population has a script (from a past install) but no reachable
+      // CLI — and possibly no config dir Orca may create. Seed only the script.
+      const hooksDir = join(home, '.orca', 'agent-hooks')
+      mkdirSync(hooksDir, { recursive: true })
+      writeFileSync(join(hooksDir, 'claude-hook.cmd'), STALE_WINDOWS_HOOK)
+
+      withPlatform('win32', () => new ClaudeHookService().refreshManagedScripts())
+
+      const refreshed = readFileSync(join(hooksDir, 'claude-hook.cmd'), 'utf8')
+      expect(refreshed).toContain('if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0')
+      expect(refreshed).not.toContain('if "%ORCA_AGENT_HOOK_PORT%"=="" goto')
+      // Why: refresh must not resurrect config for a CLI the user may have removed.
+      expect(existsSync(join(home, '.claude'))).toBe(false)
+      // Why: the statusline script was never installed here, so it must not appear.
+      expect(existsSync(join(hooksDir, 'claude-statusline.cmd'))).toBe(false)
+    } finally {
+      homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('covers every shared launcher script with a refresher', () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-coverage-'))
+    homedirMock.mockReturnValue(home)
+    const previousGrokHome = process.env.GROK_HOME
+    const previousKimiHome = process.env.KIMI_CODE_HOME
+    delete process.env.GROK_HOME
+    delete process.env.KIMI_CODE_HOME
+    try {
+      withPlatform('win32', () => {
+        for (const [, install] of MANAGED_AGENT_HOOK_INSTALLERS) {
+          install()
+        }
+      })
+      const hooksDir = join(home, '.orca', 'agent-hooks')
+      const files = readdirSync(hooksDir)
+      expect(files.length).toBeGreaterThan(0)
+      const refresherAgents = MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS.map(([agent]) => agent)
+      // Why: an installer that writes a shared launcher but skips the refresher list would
+      // recreate the frozen-stale-script class this suite exists to prevent.
+      for (const file of files) {
+        expect(
+          refresherAgents.some((agent) => file.startsWith(`${agent}-`)),
+          `${file} is written to ~/.orca/agent-hooks but no refresher owns it`
+        ).toBe(true)
+      }
+      // Why: the reverse direction — a refresher naming an agent that writes nothing is a
+      // stale registry entry, likely a renamed script file.
+      for (const agent of refresherAgents) {
+        expect(
+          files.some((file) => file.startsWith(`${agent}-`)),
+          `refresher for ${agent} matches no installed script`
+        ).toBe(true)
+      }
+    } finally {
+      homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+      if (previousGrokHome === undefined) {
+        delete process.env.GROK_HOME
+      } else {
+        process.env.GROK_HOME = previousGrokHome
+      }
+      if (previousKimiHome === undefined) {
+        delete process.env.KIMI_CODE_HOME
+      } else {
+        process.env.KIMI_CODE_HOME = previousKimiHome
+      }
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+
+  it('creates nothing anywhere when no managed scripts exist', () => {
+    const home = mkdtempSync(join(tmpdir(), 'orca-hook-refresh-empty-'))
+    homedirMock.mockReturnValue(home)
+    try {
+      withPlatform('win32', () => {
+        for (const [agent, refresh] of MANAGED_AGENT_HOOK_SCRIPT_REFRESHERS) {
+          expect(() => refresh(), `${agent} refresh on empty home`).not.toThrow()
+        }
+      })
+      // Why: a refresh pass on a machine with no prior installs must be a strict no-op.
+      expect(readdirSync(home)).toEqual([])
+    } finally {
+      homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
+      rmSync(home, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/main/agent-hooks/managed-hook-script-refresh.ts
+++ b/src/main/agent-hooks/managed-hook-script-refresh.ts
@@ -1,0 +1,90 @@
+import { randomUUID } from 'node:crypto'
+import { chmod, readFile, rename, rm, stat, writeFile } from 'node:fs/promises'
+import { dirname, join } from 'node:path'
+import { grantDirAclAsync, isPermissionError } from '../win32-utils'
+
+type ExistingScript = { exists: false } | { exists: true; content: string | null }
+
+function isMissingPathError(error: unknown): boolean {
+  return error instanceof Error && 'code' in error && error.code === 'ENOENT'
+}
+
+async function readExistingScript(scriptPath: string): Promise<ExistingScript> {
+  try {
+    return { exists: true, content: await readFile(scriptPath, 'utf-8') }
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return { exists: false }
+    }
+    try {
+      await stat(scriptPath)
+      return { exists: true, content: null }
+    } catch (statError) {
+      if (isMissingPathError(statError)) {
+        return { exists: false }
+      }
+      throw error
+    }
+  }
+}
+
+async function scriptStillExists(scriptPath: string): Promise<boolean> {
+  try {
+    await stat(scriptPath)
+    return true
+  } catch (error) {
+    if (isMissingPathError(error)) {
+      return false
+    }
+    throw error
+  }
+}
+
+async function writeScriptWithAclRetry(scriptPath: string, content: string): Promise<void> {
+  try {
+    await writeFile(scriptPath, content, 'utf-8')
+  } catch (error) {
+    if (isPermissionError(error) && process.platform === 'win32') {
+      try {
+        await grantDirAclAsync(dirname(scriptPath))
+        await writeFile(scriptPath, content, 'utf-8')
+        return
+      } catch {
+        // Re-throw the original permission error.
+      }
+    }
+    throw error
+  }
+}
+
+// Why: refresh must not block Electron's main thread or create state for an absent CLI.
+export async function refreshManagedScriptIfPresent(
+  scriptPath: string,
+  content: string
+): Promise<boolean> {
+  const existing = await readExistingScript(scriptPath)
+  if (!existing.exists) {
+    return false
+  }
+  if (existing.content === content) {
+    if (process.platform !== 'win32') {
+      await chmod(scriptPath, 0o755)
+    }
+    return true
+  }
+
+  const tmpPath = join(dirname(scriptPath), `.${Date.now()}-${randomUUID()}.tmp`)
+  try {
+    await writeScriptWithAclRetry(tmpPath, content)
+    if (process.platform !== 'win32') {
+      await chmod(tmpPath, 0o755)
+    }
+    if (!(await scriptStillExists(scriptPath))) {
+      return false
+    }
+    await rename(tmpPath, scriptPath)
+    return true
+  } finally {
+    await rm(tmpPath, { force: true }).catch(() => undefined)
+  }
+}

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -16,7 +16,6 @@ import {
   wrapPosixHookCommand,
   wrapWindowsCmdHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition,
   type HooksConfig
@@ -26,6 +25,7 @@ import {
   writeHooksJsonRemote,
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
@@ -297,11 +297,11 @@ function removeInstalledConfig(config: HooksConfig): void {
 }
 
 export class AntigravityHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
     if (process.platform === 'win32') {
       for (const event of ANTIGRAVITY_EVENTS) {
-        refreshManagedScriptIfPresent(
+        await refreshManagedScriptIfPresent(
           getWindowsWrapperScriptPath(event),
           getWindowsWrapperScript(event.eventName)
         )

--- a/src/main/antigravity/hook-service.ts
+++ b/src/main/antigravity/hook-service.ts
@@ -16,6 +16,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsCmdHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition,
   type HooksConfig
@@ -296,6 +297,18 @@ function removeInstalledConfig(config: HooksConfig): void {
 }
 
 export class AntigravityHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+    if (process.platform === 'win32') {
+      for (const event of ANTIGRAVITY_EVENTS) {
+        refreshManagedScriptIfPresent(
+          getWindowsWrapperScriptPath(event),
+          getWindowsWrapperScript(event.eventName)
+        )
+      }
+    }
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -4,7 +4,6 @@ import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared
 import {
   buildWindowsAgentHookCurlPostCommand,
   readHooksJson,
-  refreshManagedScriptIfPresent,
   writeHooksJson,
   writeManagedScript,
   type HooksConfig
@@ -14,6 +13,7 @@ import {
   writeHooksJsonRemote,
   writeManagedScriptRemote
 } from '../agent-hooks/installer-utils-remote'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   buildPosixHookPayloadCapture,
   buildWindowsHookEnvironmentGuardLines,
@@ -172,13 +172,13 @@ export class ClaudeHookService {
     return { agent: this.options.agent, state, configPath, managedHooksPresent, detail }
   }
 
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(
       getManagedScriptPath(this.options.settings),
       getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
     )
     // Why: no agent gate — the statusline script only ever exists for claude, so presence is the gate.
-    refreshManagedScriptIfPresent(
+    await refreshManagedScriptIfPresent(
       getStatusLineScriptPath(this.options.settings),
       getManagedStatusLineScript('local')
     )

--- a/src/main/claude/hook-service.ts
+++ b/src/main/claude/hook-service.ts
@@ -4,6 +4,7 @@ import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared
 import {
   buildWindowsAgentHookCurlPostCommand,
   readHooksJson,
+  refreshManagedScriptIfPresent,
   writeHooksJson,
   writeManagedScript,
   type HooksConfig
@@ -169,6 +170,18 @@ export class ClaudeHookService {
       detail = `Managed hook missing for events: ${missing.join(', ')}`
     }
     return { agent: this.options.agent, state, configPath, managedHooksPresent, detail }
+  }
+
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(
+      getManagedScriptPath(this.options.settings),
+      getManagedScript('local', { skipWhenDevinImportsClaude: this.options.agent === 'claude' })
+    )
+    // Why: no agent gate — the statusline script only ever exists for claude, so presence is the gate.
+    refreshManagedScriptIfPresent(
+      getStatusLineScriptPath(this.options.settings),
+      getManagedStatusLineScript('local')
+    )
   }
 
   install(): AgentHookInstallStatus {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -16,6 +16,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsCmdHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
@@ -1021,6 +1022,10 @@ function getWslReconciliationKey(runtimeHomePath: string): string {
 }
 
 export class CodexHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   private readonly wslReconciliationGeneration = new Map<string, number>()
 
   private supersedeWslReconciliation(runtimeHomePath: string | null | undefined): number {

--- a/src/main/codex/hook-service.ts
+++ b/src/main/codex/hook-service.ts
@@ -16,10 +16,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsCmdHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import { resolveHooksJsonWritePath } from '../agent-hooks/hook-config-write-path'
 import { writeFileAtomically } from '../codex-accounts/fs-utils'
 import {
@@ -1022,8 +1022,8 @@ function getWslReconciliationKey(runtimeHomePath: string): string {
 }
 
 export class CodexHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   private readonly wslReconciliationGeneration = new Map<string, number>()

--- a/src/main/command-code/hook-service.ts
+++ b/src/main/command-code/hook-service.ts
@@ -11,6 +11,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
@@ -88,6 +89,10 @@ function buildInstalledConfig(
 }
 
 export class CommandCodeHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), buildCommandCodeManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/command-code/hook-service.ts
+++ b/src/main/command-code/hook-service.ts
@@ -11,10 +11,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
@@ -89,8 +89,8 @@ function buildInstalledConfig(
 }
 
 export class CommandCodeHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), buildCommandCodeManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), buildCommandCodeManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/copilot/hook-service.ts
+++ b/src/main/copilot/hook-service.ts
@@ -14,6 +14,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
@@ -183,6 +184,10 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class CopilotHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/copilot/hook-service.ts
+++ b/src/main/copilot/hook-service.ts
@@ -14,10 +14,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
@@ -184,8 +184,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class CopilotHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -12,10 +12,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
@@ -102,8 +102,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class CursorHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/cursor/hook-service.ts
+++ b/src/main/cursor/hook-service.ts
@@ -12,6 +12,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
@@ -101,6 +102,10 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class CursorHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/devin/hook-service.ts
+++ b/src/main/devin/hook-service.ts
@@ -3,9 +3,9 @@ import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared
 import {
   buildWindowsAgentHookPostCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readTextFileRemote,
   writeHooksJsonRemote,
@@ -80,8 +80,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class DevinHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getDevinManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getDevinManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/devin/hook-service.ts
+++ b/src/main/devin/hook-service.ts
@@ -3,6 +3,7 @@ import type { AgentHookInstallState, AgentHookInstallStatus } from '../../shared
 import {
   buildWindowsAgentHookPostCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript
 } from '../agent-hooks/installer-utils'
 import {
@@ -79,6 +80,10 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class DevinHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getDevinManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getDevinConfigPath()
     const scriptPath = getDevinManagedScriptPath()

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -12,6 +12,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition,
   type HooksConfig
@@ -159,6 +160,10 @@ function buildInstalledDroidConfig(
 }
 
 export class DroidHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/droid/hook-service.ts
+++ b/src/main/droid/hook-service.ts
@@ -12,11 +12,11 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition,
   type HooksConfig
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
@@ -160,8 +160,8 @@ function buildInstalledDroidConfig(
 }
 
 export class DroidHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -13,6 +13,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
@@ -97,6 +98,10 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class GeminiHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/gemini/hook-service.ts
+++ b/src/main/gemini/hook-service.ts
@@ -13,10 +13,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
@@ -98,8 +98,8 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
 }
 
 export class GeminiHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -11,10 +11,10 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
-  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readHooksJsonRemote,
   writeHooksJsonRemote,
@@ -183,8 +183,8 @@ function buildInstalledConfig(
 }
 
 export class GrokHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/grok/hook-service.ts
+++ b/src/main/grok/hook-service.ts
@@ -11,6 +11,7 @@ import {
   wrapPosixHookCommand,
   wrapWindowsHookCommand,
   writeHooksJson,
+  refreshManagedScriptIfPresent,
   writeManagedScript,
   type HookDefinition
 } from '../agent-hooks/installer-utils'
@@ -182,6 +183,10 @@ function buildInstalledConfig(
 }
 
 export class GrokHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const scriptPath = getManagedScriptPath()

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -16,9 +16,9 @@ import {
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
   wrapPosixHookCommand,
-  refreshManagedScriptIfPresent,
   writeManagedScript
 } from '../agent-hooks/installer-utils'
+import { refreshManagedScriptIfPresent } from '../agent-hooks/managed-hook-script-refresh'
 import {
   readTextFileRemote,
   writeManagedScriptRemote,
@@ -156,8 +156,8 @@ function buildStatus(present: Set<string>, configPath: string): AgentHookInstall
 }
 
 export class KimiHookService {
-  refreshManagedScripts(): void {
-    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  async refreshManagedScripts(): Promise<void> {
+    await refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
   }
 
   getStatus(): AgentHookInstallStatus {

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -16,6 +16,7 @@ import {
   createManagedCommandMatcher,
   getSharedManagedScriptPath,
   wrapPosixHookCommand,
+  refreshManagedScriptIfPresent,
   writeManagedScript
 } from '../agent-hooks/installer-utils'
 import {
@@ -155,6 +156,10 @@ function buildStatus(present: Set<string>, configPath: string): AgentHookInstall
 }
 
 export class KimiHookService {
+  refreshManagedScripts(): void {
+    refreshManagedScriptIfPresent(getManagedScriptPath(), getManagedScript())
+  }
+
   getStatus(): AgentHookInstallStatus {
     const configPath = getConfigPath()
     const text = readConfigToml(configPath)


### PR DESCRIPTION
## Summary

Follow-up to #11568 / #11549. If an agent CLI falls off PATH (for example, after an npm-prefix or shim relocation), the presence gate skips `install()` with no removal, while the agent's user-wide config can keep invoking its existing launcher under `~/.orca/agent-hooks`. That left the launcher frozen at its previous generated version; on Windows, it could preserve the pre-#11568 `more.com` leak indefinitely.

This adds a reconcile pass before presence detection: every **already-existing** shared launcher/statusline script is rewritten to the current template. Creation remains presence-gated, so an absent script or missing agent config is not created. Amp and Hermes remain excluded because they install provider-native plugin code through a different lifecycle rather than shared launchers.

The refresh path is asynchronous and sequential. It short-circuits identical content, publishes changed content with a same-directory temp file plus rename, preserves POSIX executable mode, and applies the existing Windows ACL recovery behavior without blocking Electron's main thread or fanning work across the thread pool.

## User path

1. A user installs an agent CLI and Orca writes both the agent's user-wide hook config and an Orca-managed launcher.
2. The CLI later becomes temporarily undetectable to Orca because its PATH entry or shim moved.
3. The agent config can still point at the existing launcher, but the CLI-presence gate correctly refuses to create or mutate agent-owned configuration.
4. On Orca's next managed-hook reconciliation, this PR updates only that existing Orca launcher to the current safe template. If the launcher never existed, nothing is created.
5. If the CLI is installed or detected again later, the normal presence-gated installer reconciles its configuration as before.

## Decision rationale

The lifecycle boundary is deliberate: **automatically maintain artifacts Orca already owns; require positive CLI detection before creating integrations or mutating agent-owned configuration.**

- An existing file under `~/.orca/agent-hooks` proves Orca previously created that launcher, and the agent's user-wide config may still invoke it while the CLI is temporarily missing from Orca's PATH.
- CLI detection has legitimate false negatives across GUI/login-shell PATH differences, package-manager prefix changes, shims, and temporary relocations. Deleting on `cli_not_found` could therefore break a still-referenced hook target.
- Explicit reinstall/setup was rejected because Orca has no user-managed hook-version workflow, and the affected CLI is undetectable by definition. Requiring user action would leave old launchers—and the #11549 Windows process leak—deployed indefinitely.
- Full unconditional reinstall was also rejected: it would undo #11442's safety boundary by creating agent homes or mutating agent configuration without evidence that the agent is installed.
- Comparable terminal-agent integrations converge on the same ownership principle: generated product-owned artifacts need a self-healing update path, while first-time creation and agent-owned configuration remain explicit or presence-gated. Existing-only automatic repair and outdated-install detection are common ways to avoid stranding stale hooks without broad mutation.

This makes the refresh pass the narrowest repair that reaches the affected population: it updates only existing Orca-owned launchers, creates nothing for never-configured agents, and leaves agent configuration untouched until the CLI is positively detected.

## Screenshots

No product UI changes. Exact-head Windows Electron validation and screenshots: https://github.com/stablyai/orca/pull/13378#issuecomment-5234640774

## Testing

- [x] Same-model clean review loop at `0646b42075`: 53 files, 703 passed, 27 skipped
- [x] Focused exact-head refresh/Windows suite: 4 files, 21 passed
- [x] Unit and end-to-end coverage for existing-script refresh, missing-script/config preservation, identical-content no-op, ACL/mode behavior, atomic publication, concurrent refreshes, and stale pre-#11568 Windows launchers
- [x] Main-thread regression coverage proves no synchronous HOME filesystem calls and keeps the event loop responsive while a refresh read is stalled
- [x] Bidirectional coverage gate fails if a shared launcher is added without a refresher or a refresher has no installed launcher
- [x] Node and CLI typechecks; native, type-aware, and standard lint; reliability gates; `git diff --check`
- [x] CI: Node 18 managed hooks, Node 24/26 test matrices, Git/wire compatibility, static analysis, and macOS/Linux/Windows packaging

## AI Review Report

Reviewed adversarially from the user-visible failure back through presence detection and installer history. Before #11442, managed-hook reconciliation invoked installers unconditionally, which refreshed launchers; #11442 correctly added CLI-presence gating but thereby froze an existing launcher when a CLI became undetectable. #11568 fixed the leaking Windows template and explicitly left existing-launcher refresh as this follow-up.

Alternatives considered and rejected: deleting on `cli_not_found` turns a false-negative PATH probe into a broken hook target; treating launcher existence as CLI presence would resume mutating agent configuration without proof the CLI is installed; versioned filenames require config rewrites. SSH/relay installers are separate and unchanged, and the local path does not assume a git worktree, so SSH/WSL and folder-workspace behavior are unaffected.

## Security Audit

Refresh touches only files that already exist under Orca's fixed `~/.orca/agent-hooks` namespace and uses the same trusted in-repo generators as installation. It creates no launcher directories, missing scripts, or agent configuration. Best-effort failures are logged per agent and preserve a complete old script rather than publishing partial content.

## Notes

- Windows is the motivating population, but using each service's existing platform-specific generator keeps refresh behavior platform-uniform.
- Amp and Hermes provider-native plugins may have a similar staleness class, but their refresh belongs to their own install lifecycle and is deliberately outside this PR.
- The only theoretical residual is an external deletion in the tiny existence-check-to-rename window. Orca has no product path that deletes these launcher files, and Node does not expose a portable atomic replace-if-present primitive that also preserves complete-file publication.
