### PR TITLE
fix(agent-hooks): guard copilot and kimi Windows hooks before they own stdin

### DIFF
--- a/src/main/agent-hooks/hook-stdin-contract.ts
+++ b/src/main/agent-hooks/hook-stdin-contract.ts
@@ -29,9 +29,12 @@ export const WINDOWS_HOOK_STDIN_READER = '"%SystemRoot%\\System32\\more.com"'
 export const WINDOWS_HOOK_STDIN_DRAIN_COMMAND = `${WINDOWS_HOOK_STDIN_READER} >nul 2>nul`
 
 // Why (#11549): missing Orca context means the hook ran outside an Orca pane, where the caller
-// may abandon stdin rather than close it — more.com then drains forever and strands a visible
-// cmd.exe per hook event. Batch can exit instead because it streams to curl rather than
-// capturing, so unlike the POSIX/PowerShell hooks it loses no payload by giving up stdin.
+// may abandon stdin rather than close it — a read-to-EOF then blocks forever and strands a
+// visible window per hook event. The Windows rule: a hook must check the Orca env before it
+// owns stdin, and exit without reading when the env is missing — the payload is discarded on
+// that path anyway. This applies to .cmd, the copilot .ps1, and the Git Bash kimi .sh alike.
+// POSIX hooks keep capture-first: their callers close stdin, and exiting mid-write there
+// surfaces as EPIPE the agent can see (#8110).
 export function buildWindowsHookEnvironmentGuardLines(): string[] {
   return [
     'if "%ORCA_AGENT_HOOK_PORT%"=="" exit /b 0',

--- a/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
+++ b/src/main/agent-hooks/managed-hook-stdin-lifecycle.test.ts
@@ -296,13 +296,17 @@ describe('Windows managed hook stdin structure', () => {
         claude.indexOf('if not "%DEVIN_PROJECT_DIR%"=="" goto :orca_agent_hook_drain_stdin')
       )
 
+      // Why (#11549 class): every Windows-local hook now guards before owning stdin —
+      // the caller may abandon the pipe, and the payload is discarded on this path anyway.
       const copilot = readFileSync(join(hooksDir, 'copilot-hook.ps1'), 'utf8')
-      expect(copilot.indexOf('[Console]::In.ReadToEnd()')).toBeLessThan(
-        copilot.indexOf('if (-not $env:ORCA_AGENT_HOOK_PORT')
+      expect(copilot.indexOf('if (-not $env:ORCA_AGENT_HOOK_PORT')).toBeGreaterThan(-1)
+      expect(copilot.indexOf('if (-not $env:ORCA_AGENT_HOOK_PORT')).toBeLessThan(
+        copilot.indexOf('[Console]::In.ReadToEnd()')
       )
       const kimi = readFileSync(join(hooksDir, 'kimi-hook.sh'), 'utf8')
-      expect(kimi.indexOf(`payload=$(${POSIX_HOOK_STDIN_READER})`)).toBeLessThan(
-        kimi.indexOf('exit 0')
+      expect(kimi.indexOf('if [ -z "$ORCA_AGENT_HOOK_PORT" ]')).toBeGreaterThan(-1)
+      expect(kimi.indexOf('if [ -z "$ORCA_AGENT_HOOK_PORT" ]')).toBeLessThan(
+        kimi.indexOf(`payload=$(${POSIX_HOOK_STDIN_READER})`)
       )
     } finally {
       homedirMock.mockImplementation(() => process.env.HOME ?? tmpdir())
@@ -321,7 +325,7 @@ describe('Windows managed hook stdin structure', () => {
   })
 
   it.skipIf(process.platform !== 'win32')(
-    'exits 0 for every local script and missing-script launcher, and only .cmd drops stdin',
+    'exits 0 for every local script and missing-script launcher, dropping stdin only without Orca env',
     async () => {
       const home = mkdtempSync(join(tmpdir(), 'orca-hook-stdin-windows-live-'))
       homedirMock.mockReturnValue(home)
@@ -359,16 +363,13 @@ describe('Windows managed hook stdin structure', () => {
               : [scriptPath]
           const result = await runHookProcess(executable, args, hookEnvironment())
           expect(result.exitCode, `${fileName} exit code`).toBe(0)
-          if (fileName.endsWith('.cmd')) {
-            // Why (#11549): these guards exit rather than own stdin, so the writer breaks —
-            // EPIPE, or ECONNRESET when Windows tears the pipe down first. hookEnvironment()
-            // strips every ORCA_* var, so the relaxation only ever covers the missing-env
-            // path — a happy-path case added to this loop must not reuse it.
-            for (const error of result.stdinErrors) {
-              expect(['EPIPE', 'ECONNRESET'], `${fileName} stdin error`).toContain(error.code)
-            }
-          } else {
-            expect(result.stdinErrors, `${fileName} stdin errors`).toHaveLength(0)
+          // Why (#11549 class): every Windows-local hook exits before owning stdin when the
+          // Orca env is missing, so the writer may break — EPIPE, or ECONNRESET when Windows
+          // tears the pipe down first. hookEnvironment() strips every ORCA_* var, so this
+          // relaxation only ever covers the missing-env path — a happy-path case added to
+          // this loop must not reuse it.
+          for (const error of result.stdinErrors) {
+            expect(['EPIPE', 'ECONNRESET'], `${fileName} stdin error`).toContain(error.code)
           }
         }
 

--- a/src/main/copilot/hook-service.ts
+++ b/src/main/copilot/hook-service.ts
@@ -117,7 +117,6 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
   if (target === 'local' && process.platform === 'win32') {
     return [
       "Write-Output '{}'",
-      '$inputData = [Console]::In.ReadToEnd()',
       // Why: endpoint.cmd is cmd syntax, not PowerShell. Parse its `set KEY=...`
       // lines so surviving PTYs can refresh to the current Orca server.
       'if ($env:ORCA_AGENT_HOOK_ENDPOINT -and (Test-Path -LiteralPath $env:ORCA_AGENT_HOOK_ENDPOINT)) {',
@@ -129,7 +128,11 @@ function getManagedScript(target: 'local' | 'posix' = 'local'): string {
       '    }',
       '  } catch {}',
       '}',
+      // Why (#11549 class): missing Orca context means a user-wide hook fired outside an
+      // Orca pane. ReadToEnd blocks forever if that caller abandons the pipe, so the guard
+      // must run before the hook owns stdin; the payload would be discarded anyway.
       'if (-not $env:ORCA_AGENT_HOOK_PORT -or -not $env:ORCA_AGENT_HOOK_TOKEN -or -not $env:ORCA_PANE_KEY) { exit 0 }',
+      '$inputData = [Console]::In.ReadToEnd()',
       'if ([string]::IsNullOrWhiteSpace($inputData)) { exit 0 }',
       'try {',
       '  $payload = $inputData | ConvertFrom-Json',

--- a/src/main/kimi/hook-service.ts
+++ b/src/main/kimi/hook-service.ts
@@ -57,10 +57,12 @@ function getManagedCommand(scriptPath: string): string {
   return wrapPosixHookCommand(posixPath)
 }
 
-function getManagedScript(): string {
-  return [
-    '#!/bin/sh',
-    ...buildPosixHookPayloadCapture(),
+function getManagedScript(target: 'local' | 'posix' = 'local'): string {
+  // Why (#11549 class): on Windows this .sh runs under Git Bash but the caller is a
+  // Windows process that can abandon the pipe, so the missing-env guard must run before
+  // the capture owns stdin. POSIX callers close stdin (#8110), so posix keeps capture-first.
+  const windowsLocal = target === 'local' && process.platform === 'win32'
+  const endpointRefreshAndGuard = [
     // Why: refresh PORT/TOKEN/ENV/VERSION from the current Orca install so a PTY
     // that survived an Orca restart still reaches the live listener. See
     // claude/hook-service.ts for the full rationale.
@@ -69,7 +71,13 @@ function getManagedScript(): string {
     'fi',
     'if [ -z "$ORCA_AGENT_HOOK_PORT" ] || [ -z "$ORCA_AGENT_HOOK_TOKEN" ] || [ -z "$ORCA_PANE_KEY" ]; then',
     '  exit 0',
-    'fi',
+    'fi'
+  ]
+  return [
+    '#!/bin/sh',
+    ...(windowsLocal
+      ? [...endpointRefreshAndGuard, ...buildPosixHookPayloadCapture()]
+      : [...buildPosixHookPayloadCapture(), ...endpointRefreshAndGuard]),
     // Why: worktreeId embeds a filesystem path, so hand-building JSON in POSIX
     // shell is not safe once a path contains quotes or newlines. Post the raw
     // hook payload plus metadata as form fields and let the receiver parse it.
@@ -207,7 +215,7 @@ export class KimiHookService {
       const text = (await readTextFileRemote(sftp, remoteConfigPath)) ?? ''
       const command = wrapPosixHookCommand(remoteScriptPath)
       // Write the script first so config.toml never points at a missing script.
-      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript())
+      await writeManagedScriptRemote(sftp, remoteScriptPath, getManagedScript('posix'))
       await writeTextFileRemoteAtomic(sftp, remoteConfigPath, applyManagedKimiHooks(text, command))
       return {
         agent: 'kimi',


### PR DESCRIPTION
## Summary

Follow-up to #11568 / #11549 — the same hang class in the two Windows hooks that PR left open. `copilot-hook.ps1` ran `[Console]::In.ReadToEnd()` and `kimi-hook.sh` (Git Bash) captured stdin **before** checking the Orca env, so a user-wide hook fired outside an Orca pane blocked forever when the caller abandoned the pipe — one stranded `powershell.exe`/`bash.exe` per hook event.

The env guard (after the endpoint refresh, which can supply PORT/TOKEN for restart-surviving PTYs) now runs **before** the read on the Windows-local variants. The payload is discarded on the missing-env path anyway; the broken writer is the trade #11568 established. POSIX variants keep capture-first — those callers close stdin, and exiting mid-write there surfaces as EPIPE the agent can see (#8110). Kimi's remote install now requests the posix variant explicitly.

## Screenshots

No visual change. Real-Windows-host process evidence in the Testing section.

## Testing

- [x] `pnpm exec oxlint` on touched files, clean
- [x] `pnpm typecheck` (node project), clean
- [x] `pnpm exec vitest run` on `src/main/agent-hooks/` + copilot + kimi suites: 41 files, 613 tests green
- [x] Structural assertions flipped to pin guard-before-read for both scripts; revert-check confirms reverting the source fails the suite
- [x] Validated on a real Windows host (PowerShell child processes with redirected pipes, ORCA_* stripped):
  - pre-fix copilot + abandoning caller: never exits (the bug)
  - post-fix copilot and kimi + abandoning caller: exit 0 immediately
  - post-fix copilot with full Orca env: consumes stdin (no writer error) and its POST arrives at a local listener with paneKey + payload
  - control: trivial exit-0 scripts under both hosts exit fine with an abandoned pipe, ruling out host-level stdin confounds
- [ ] `pnpm build` (not run locally; CI packages)

## AI Review Report

Reviewed adversarially. Ordering verified against the generated scripts: copilot still emits its required `{}` stdout first, then endpoint refresh, then guard, then read; the endpoint file supplies only PORT/TOKEN/ENV/VERSION and `ORCA_PANE_KEY` is launch-context env, so no later step could populate missing context after the early exit — every skipped payload is one Orca could not route or authenticate anyway. Kimi forks guard-first only for `local` + `win32`; POSIX local, SSH/remote, and the posix lifecycle tests keep capture-first. The accepted risk is the same as #11568's: a parent mid-write sees a broken pipe on the missing-env path while the hook still exits 0; not Copilot/Kimi-specific.

## Security Audit

No new input handling, command execution, or network surface — the change reorders existing lines in generated scripts. The guard reduces exposure: outside-Orca payloads are no longer read into hook process memory at all on the missing-env path. Token/port handling, curl/Invoke-WebRequest targets, and remote install content are unchanged.

## Notes

- Windows-only behavior change; POSIX and SSH/remote script content is byte-identical.
- With this, every Windows-local managed hook (.cmd, .ps1, Git Bash .sh) follows the same rule: missing Orca env never owns stdin. The statusline script's drain remains intentionally different — its caller demonstrably closes stdin, and its read is the payload capture.
