### PR TITLE
fix(agent-hooks): accept BOM-prefixed hook configs

### DIFF
--- a/src/main/agent-hooks/hooks-json-read.ts
+++ b/src/main/agent-hooks/hooks-json-read.ts
@@ -11,6 +11,17 @@ export type HooksJsonSnapshot = {
   config: HooksConfig | null
 }
 
+export function parseHooksJsonText(raw: string): HooksConfig | null {
+  // Why: JSON.parse rejects a decoded UTF-8 BOM; strip only the leading marker.
+  const content = raw.charCodeAt(0) === 0xfeff ? raw.slice(1) : raw
+  try {
+    const parsed = JSON.parse(content)
+    return isPlainObject(parsed) ? parsed : null
+  } catch {
+    return null
+  }
+}
+
 // Why: generation guards abort a mutation when the file no longer matches the
 // bytes it was derived from; the raw snapshot and the parse must come from one
 // read or a concurrent save can slip between them unnoticed.
@@ -24,12 +35,7 @@ export function readHooksJsonWithRaw(configPath: string): HooksJsonSnapshot {
   } catch {
     return { raw: null, config: null }
   }
-  try {
-    const parsed = JSON.parse(raw)
-    return { raw, config: isPlainObject(parsed) ? parsed : null }
-  } catch {
-    return { raw, config: null }
-  }
+  return { raw, config: parseHooksJsonText(raw) }
 }
 
 export function readHooksJson(configPath: string): HooksConfig | null {

--- a/src/main/agent-hooks/installer-utils-remote.test.ts
+++ b/src/main/agent-hooks/installer-utils-remote.test.ts
@@ -151,6 +151,15 @@ describe('installer-utils-remote', () => {
     expect(result).toBeNull()
   })
 
+  it('parses settings.json with one leading BOM', async () => {
+    const { sftp, fs } = createFakeSftp()
+    fs.files.set('/home/u/.cursor/hooks.json', '\uFEFF{"version":1,"hooks":{}}')
+
+    const result = await readHooksJsonRemote(sftp, '/home/u/.cursor/hooks.json')
+
+    expect(result).toEqual({ version: 1, hooks: {} })
+  })
+
   it('rethrows non-ENOENT read errors so callers can distinguish I/O failures from parse failures', async () => {
     const sftp = {
       readFile: (_path: string, _enc: string, cb: (err: unknown) => void): void => {

--- a/src/main/agent-hooks/installer-utils-remote.ts
+++ b/src/main/agent-hooks/installer-utils-remote.ts
@@ -14,7 +14,8 @@
 import { randomUUID } from 'node:crypto'
 import type { SFTPWrapper, FileEntryWithStats } from 'ssh2'
 
-import { isPlainObject, type HooksConfig } from './installer-utils'
+import type { HooksConfig } from './installer-utils'
+import { parseHooksJsonText } from './hooks-json-read'
 
 const DEFAULT_REMOTE_CONFIG_MODE = 0o600
 const REMOTE_SFTP_OPERATION_TIMEOUT_MS = 10_000
@@ -38,12 +39,7 @@ export async function readHooksJsonRemote(
     }
     throw err
   }
-  try {
-    const parsed = JSON.parse(body)
-    return isPlainObject(parsed) ? parsed : null
-  } catch {
-    return null
-  }
+  return parseHooksJsonText(body)
 }
 
 /** Atomically write a JSON config to the remote — write to a tmp path then

--- a/src/main/agent-hooks/installer-utils.test.ts
+++ b/src/main/agent-hooks/installer-utils.test.ts
@@ -56,6 +56,25 @@ describe('readHooksJsonWithRaw', () => {
     })
   })
 
+  it('parses one leading BOM while preserving the exact raw contents', () => {
+    const contents = '\uFEFF{"hooks": {"Stop": []}, "custom": 1}\n'
+    writeFileSync(configPath, contents, 'utf-8')
+
+    expect(readHooksJsonWithRaw(configPath)).toEqual({
+      raw: contents,
+      config: { hooks: { Stop: [] }, custom: 1 }
+    })
+  })
+
+  it('rejects multiple or misplaced BOM characters', () => {
+    const body = '{"hooks": {"Stop": []}}'
+    for (const contents of [`\uFEFF\uFEFF${body}`, ` \uFEFF${body}`, `{\uFEFF"hooks": {}}`]) {
+      writeFileSync(configPath, contents, 'utf-8')
+
+      expect(readHooksJsonWithRaw(configPath)).toEqual({ raw: contents, config: null })
+    }
+  })
+
   it('reports a missing file as an empty config with no raw bytes', () => {
     expect(readHooksJsonWithRaw(configPath)).toEqual({ raw: null, config: {} })
   })


### PR DESCRIPTION
## Summary

Accept exactly one leading UTF-8 BOM when reading agent hook configuration JSON locally or over SFTP.

The local reader still returns the original raw contents for generation guards; only the copy passed to `JSON.parse` is normalized. This follows the hook-payload boundary fix in #12652 without broad trimming or relaxed malformed-JSON handling.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

Focused validation:

- [x] Local and remote config-reader tests: 63 passed, 2 skipped
- [x] `pnpm run typecheck:node`
- [x] Affected-file Oxlint, type-aware, and React Doctor scans
- [x] `pnpm run check:max-lines-ratchet`
- [x] `pnpm run check:reliability-gates`

The changed-code wrapper itself is blocked locally because the Node 26 engine warning is included in the JSON it parses; the equivalent underlying scans pass. CI runs the supported Node version.

## AI Review Report

Reviewed the local config snapshot invariant, SFTP/SSH reader parity, malformed-input behavior, and all call sites. The review caught that SSH uses a separate SFTP reader, so both paths now share one parser. Tests verify that one leading BOM parses, the local raw contents remain exact, and multiple or misplaced BOM characters remain invalid.

The change is platform-neutral TypeScript. It adds no shortcuts, labels, paths, shell behavior, wire fields, or Electron-specific behavior. macOS, Linux, Windows, folder workspaces, git worktrees, and SSH retain their existing paths; only decoded JSON input normalization changes.

## Security Audit

The parser removes only one leading U+FEFF before `JSON.parse`. It does not trim other input or accept malformed JSON, arrays, or primitives as hook configs. Local raw snapshots remain unchanged for concurrent-mutation guards, and remote non-ENOENT I/O failures still propagate distinctly from parse failures.

No commands, dependencies, authentication, secrets, IPC, or wire formats are added or changed.

## Notes

A successfully rewritten config is emitted as standard JSON without a BOM while preserving its existing keys and managed-hook merge behavior.
