### PR TITLE
fix(agents): keep OpenCode identity through Claude hooks

### DIFF
--- a/src/main/agent-hooks/server-opencode-inherited-hook.test.ts
+++ b/src/main/agent-hooks/server-opencode-inherited-hook.test.ts
@@ -1,0 +1,121 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { AgentHookServer } from './server'
+import { makePaneKey } from '../../shared/stable-pane-id'
+
+const PANE_KEY = makePaneKey('tab-1', '11111111-1111-4111-8111-111111111111')
+const servers: AgentHookServer[] = []
+
+function createServer(): AgentHookServer {
+  const server = new AgentHookServer()
+  servers.push(server)
+  return server
+}
+
+async function postClaudeHook(
+  server: AgentHookServer,
+  payload: Record<string, unknown>
+): Promise<Response> {
+  const env = server.buildPtyEnv()
+  return fetch(`http://127.0.0.1:${env.ORCA_AGENT_HOOK_PORT}/hook/claude`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Orca-Agent-Hook-Token': env.ORCA_AGENT_HOOK_TOKEN
+    },
+    body: JSON.stringify({
+      paneKey: PANE_KEY,
+      tabId: 'tab-1',
+      worktreeId: 'worktree-1',
+      launchToken: 'opencode-launch-token',
+      env: 'production',
+      payload
+    })
+  })
+}
+
+afterEach(() => {
+  for (const server of servers.splice(0)) {
+    server.stop()
+  }
+})
+
+describe('AgentHookServer inherited OpenCode hook identity', () => {
+  it('persists the corroborated OpenCode identity without Claude session metadata', async () => {
+    const server = createServer()
+    const resolver = vi.fn(async () => 'opencode' as const)
+    server.setLocalStatusIdentityResolver(resolver)
+    await server.start({ env: 'production' })
+
+    await expect(
+      postClaudeHook(server, {
+        hook_event_name: 'UserPromptSubmit',
+        prompt: 'Continue weighted SLO scheduling work',
+        session_id: 'inherited-claude-session',
+        model: 'claude-sonnet'
+      })
+    ).resolves.toMatchObject({ status: 204 })
+    await expect(
+      postClaudeHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'inherited-claude-session',
+        model: 'claude-sonnet'
+      })
+    ).resolves.toMatchObject({ status: 204 })
+
+    expect(resolver).toHaveBeenCalledOnce()
+    expect(server.getStatusSnapshot()).toEqual([
+      expect.objectContaining({
+        paneKey: PANE_KEY,
+        state: 'working',
+        prompt: 'Continue weighted SLO scheduling work',
+        agentType: 'opencode'
+      })
+    ])
+    expect(server.getStatusSnapshot()[0]).not.toHaveProperty('model')
+    expect(server.getStatusSnapshot()[0]).not.toHaveProperty('providerSession')
+  })
+
+  it('suppresses a first inherited Claude completion while OpenCode is foreground', async () => {
+    const server = createServer()
+    server.setLocalStatusIdentityResolver(async () => 'opencode')
+    await server.start({ env: 'production' })
+
+    await expect(
+      postClaudeHook(server, {
+        hook_event_name: 'Stop',
+        session_id: 'inherited-claude-session',
+        model: 'claude-sonnet'
+      })
+    ).resolves.toMatchObject({ status: 204 })
+
+    expect(server.getStatusSnapshot()).toEqual([])
+  })
+
+  it('does not consult local foreground identity for remote hook ingestion', () => {
+    const server = createServer()
+    const resolver = vi.fn(async () => 'opencode' as const)
+    server.setLocalStatusIdentityResolver(resolver)
+
+    server.ingestRemote(
+      {
+        paneKey: PANE_KEY,
+        tabId: 'tab-1',
+        worktreeId: 'worktree-1',
+        payload: {
+          state: 'working',
+          prompt: 'remote work',
+          agentType: 'claude',
+          model: 'claude-sonnet'
+        }
+      },
+      'ssh-connection-1'
+    )
+
+    expect(resolver).not.toHaveBeenCalled()
+    expect(server.getStatusSnapshot()[0]).toMatchObject({
+      connectionId: 'ssh-connection-1',
+      agentType: 'claude',
+      model: 'claude-sonnet'
+    })
+  })
+})

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -76,7 +76,7 @@ import {
   type AgentQuestionAnsweredInferenceRequest
 } from '../../shared/agent-question-answered-intent'
 import { parseLegacyNumericPaneKey, parsePaneKey } from '../../shared/stable-pane-id'
-import type { LegacyPaneKeyAliasEntry } from '../../shared/types'
+import type { LegacyPaneKeyAliasEntry, TuiAgent } from '../../shared/types'
 import {
   getAgentResumeArgv,
   normalizeAgentProviderSession,
@@ -154,6 +154,10 @@ type PaneKeyAliasEntry = {
   updatedAt: number
   authorityVerified: boolean
 }
+
+type LocalStatusIdentityResolver = (
+  event: Readonly<AgentHookEventPayload>
+) => Promise<TuiAgent | null>
 
 // Why: co-located with the endpoint file in userData/agent-hooks/ so hook-server cross-restart artifacts stay together.
 const LAST_STATUS_FILE_NAME = 'last-status.json'
@@ -634,6 +638,7 @@ export class AgentHookServer {
   private closedAgentStatusTabIds = new Set<string>()
   private closedAgentStatusPaneKeys = new Set<string>()
   private connectionTimestampWatermarkById = new Map<string, number>()
+  private localStatusIdentityResolver: LocalStatusIdentityResolver | null = null
   // Why: skip disk writes when the JSON exactly matches the last write; guards against re-firing trailing timers when nothing changed.
   private lastWrittenJson: string | null = null
 
@@ -651,6 +656,10 @@ export class AgentHookServer {
         console.error('[agent-hooks] replay listener threw', err)
       }
     }
+  }
+
+  setLocalStatusIdentityResolver(resolver: LocalStatusIdentityResolver | null): void {
+    this.localStatusIdentityResolver = resolver
   }
 
   // Why: statusline posts carry live Claude usage windows, not agent status; they feed RateLimitService directly.
@@ -1136,7 +1145,8 @@ export class AgentHookServer {
 
   private applyNormalizedStatus(
     payload: AgentHookEventPayload,
-    onAccepted?: () => void
+    onAccepted?: () => void,
+    corroboratedForegroundAgent?: TuiAgent | null
   ): EnrichedAgentHookEventPayload {
     const previous = this.state.lastStatusByPaneKey.get(payload.paneKey) as
       | EnrichedAgentHookEventPayload
@@ -1204,14 +1214,20 @@ export class AgentHookServer {
           }
         : stateReconciledPayload
     const identity = resolveAgentStatusIdentity({
-      existing: previous
+      existing: corroboratedForegroundAgent
         ? {
-            agentType: previous.payload.agentType,
-            state: previous.payload.state,
-            updatedAt: previous.receivedAt,
-            restoredUnconfirmed: previous.restoredUnconfirmed
+            agentType: corroboratedForegroundAgent,
+            state: 'working',
+            updatedAt: now
           }
-        : undefined,
+        : previous
+          ? {
+              agentType: previous.payload.agentType,
+              state: previous.payload.state,
+              updatedAt: previous.receivedAt,
+              restoredUnconfirmed: previous.restoredUnconfirmed
+            }
+          : undefined,
       incoming: rootContextPreservingPayload.payload.agentType,
       now
     })
@@ -1224,16 +1240,63 @@ export class AgentHookServer {
     ) {
       return previous
     }
-    const identityResolvedPayload =
-      identity.agentType === rootContextPreservingPayload.payload.agentType
-        ? rootContextPreservingPayload
-        : {
-            ...rootContextPreservingPayload,
-            payload: {
-              ...rootContextPreservingPayload.payload,
-              agentType: identity.agentType
-            }
-          }
+    const inheritedDifferentAgent =
+      identity.inheritedFromActivePane &&
+      identity.agentType !== rootContextPreservingPayload.payload.agentType
+    const parentContext = previous?.payload.agentType === identity.agentType ? previous : undefined
+    let identityResolvedPayload = rootContextPreservingPayload
+    if (inheritedDifferentAgent) {
+      const {
+        providerSession: _providerSession,
+        providerPromptId: _providerPromptId,
+        compactTrigger: _compactTrigger,
+        toolUseId: _toolUseId,
+        toolAgentId: _toolAgentId,
+        toolAgentType: _toolAgentType,
+        claudeRunningNonAgentTask: _claudeRunningNonAgentTask,
+        ...identityNeutralEnvelope
+      } = rootContextPreservingPayload
+      const {
+        model: _model,
+        subagents: _subagents,
+        ...identityNeutralStatus
+      } = rootContextPreservingPayload.payload
+      identityResolvedPayload = {
+        ...identityNeutralEnvelope,
+        ...(parentContext?.providerSession
+          ? { providerSession: parentContext.providerSession }
+          : {}),
+        ...(parentContext?.providerPromptId
+          ? { providerPromptId: parentContext.providerPromptId }
+          : {}),
+        ...(parentContext?.compactTrigger ? { compactTrigger: parentContext.compactTrigger } : {}),
+        payload: {
+          ...identityNeutralStatus,
+          agentType: identity.agentType,
+          ...(parentContext?.payload.model ? { model: parentContext.payload.model } : {}),
+          ...(parentContext?.payload.subagents
+            ? { subagents: parentContext.payload.subagents }
+            : {})
+        }
+      }
+      if (
+        rootContextPreservingPayload.payload.agentType === 'claude' &&
+        identity.agentType !== 'claude'
+      ) {
+        this.state.claudeSubagentRosterByPaneKey.delete(payload.paneKey)
+        this.state.claudeLeadStateByPaneKey.delete(payload.paneKey)
+        this.state.claudeRunningNonAgentTaskPaneKeys.delete(payload.paneKey)
+        this.state.claudeActiveSessionCronPaneKeys.delete(payload.paneKey)
+      }
+    } else if (identity.agentType !== rootContextPreservingPayload.payload.agentType) {
+      identityResolvedPayload = {
+        ...rootContextPreservingPayload,
+        payload: {
+          ...rootContextPreservingPayload.payload,
+          agentType: identity.agentType
+        }
+      }
+    }
     const effectivePayload = attachClaudePermissionToolUseId(previous, identityResolvedPayload)
     if (previous && shouldKeepClaudePermissionVisible(previous, effectivePayload)) {
       return previous
@@ -1268,7 +1331,9 @@ export class AgentHookServer {
     ) {
       this.clearAssistantMessageRetry(effectivePayload.paneKey)
     }
-    onAccepted?.()
+    if (!inheritedDifferentAgent) {
+      onAccepted?.()
+    }
     if (!identity.inheritedFromActivePane) {
       this.maybeTrackAgentPromptSent(effectivePayload, previous)
     }
@@ -2158,9 +2223,57 @@ export class AgentHookServer {
               ? { ...normalized.event, launchToken: undefined }
               : normalized.event
           this.recordCurrentAuthorityObservation(event)
-          const enriched = this.applyNormalizedStatus(event, normalized.onAccepted)
-          this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
-          this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
+          let corroboratedForegroundAgent: TuiAgent | null = null
+          const currentStatus = this.state.lastStatusByPaneKey.get(event.paneKey) as
+            | EnrichedAgentHookEventPayload
+            | undefined
+          const currentIdentityAlreadyProtectsPane = currentStatus
+            ? resolveAgentStatusIdentity({
+                existing: {
+                  agentType: currentStatus.payload.agentType,
+                  state: currentStatus.payload.state,
+                  updatedAt: currentStatus.receivedAt,
+                  restoredUnconfirmed: currentStatus.restoredUnconfirmed
+                },
+                incoming: event.payload.agentType,
+                now: Date.now()
+              }).inheritedFromActivePane
+            : false
+          if (
+            !currentIdentityAlreadyProtectsPane &&
+            event.connectionId === null &&
+            event.isReplay !== true
+          ) {
+            try {
+              corroboratedForegroundAgent =
+                (await this.localStatusIdentityResolver?.(event)) ?? null
+            } catch {
+              // Why: foreground inspection is advisory; a failed probe must not block the agent hook.
+            }
+          }
+          const incomingAgent =
+            event.payload.agentType && event.payload.agentType !== 'unknown'
+              ? event.payload.agentType
+              : null
+          const inheritedFromCorroboratedForeground =
+            corroboratedForegroundAgent !== null &&
+            incomingAgent !== null &&
+            incomingAgent !== corroboratedForegroundAgent
+          const firstInheritedCompletion =
+            inheritedFromCorroboratedForeground &&
+            event.payload.state === 'done' &&
+            !this.state.lastStatusByPaneKey.has(event.paneKey)
+          const inheritedProviderIdentityOnly =
+            inheritedFromCorroboratedForeground && event.providerSessionOnly === true
+          if (!firstInheritedCompletion && !inheritedProviderIdentityOnly) {
+            const enriched = this.applyNormalizedStatus(
+              event,
+              normalized.onAccepted,
+              corroboratedForegroundAgent
+            )
+            this.scheduleAssistantMessageRetry(source, aliasedBody, enriched)
+            this.scheduleCodexSubagentPoll(source, aliasedBody, enriched)
+          }
         }
 
         res.writeHead(204)
@@ -2233,6 +2346,7 @@ export class AgentHookServer {
     this.closedAgentStatusTabIds.clear()
     this.closedAgentStatusPaneKeys.clear()
     this.connectionTimestampWatermarkById.clear()
+    this.localStatusIdentityResolver = null
     this.legacyPaneKeyAliases.clear()
     clearAllListenerCaches(this.state)
     this.notifyStatusChangeListeners()

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -2467,6 +2467,9 @@ void app.whenReady().then(async () => {
       isAgentStatusHooksEnabled(store?.getSettings()) ? agentHookServer.buildPtyEnv() : {},
     orchestrationEnvironmentTransport
   })
+  agentHookServer.setLocalStatusIdentityResolver((event) =>
+    runtimeService.resolveCorroboratedLocalHookAgent(event)
+  )
   runtime = runtimeService
   runtimeService.prepareLegacyWorkerTerminalRecovery()
   publishProviderSessionChanges(agentHookServer.getProviderSessionIdentities())

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -23969,6 +23969,60 @@ describe('OrcaRuntimeService', () => {
     )
   })
 
+  it('corroborates a conflicting local hook from the exact OpenCode PTY', async () => {
+    const getForegroundProcess = vi.fn(async () => 'opencode')
+    const runtime = new OrcaRuntimeService(store)
+    runtime.setPtyController({
+      spawn: vi.fn().mockResolvedValue({ id: 'pty-opencode' }),
+      write: () => true,
+      kill: () => true,
+      getForegroundProcess
+    })
+    runtime.attachWindow(1)
+    await runtime.createTerminal(`path:${TEST_WORKTREE_PATH}`, {
+      tabId: 'opencode-tab',
+      leafId: HEADLESS_LEAF_ID,
+      command: 'opencode',
+      launchAgent: 'opencode',
+      launchConfig: { agentCommand: 'opencode', agentArgs: '', agentEnv: {} },
+      launchToken: 'opencode-launch-token',
+      title: 'OpenCode',
+      activate: true
+    })
+    runtime.onPtyData(
+      'pty-opencode',
+      '\x1b]0;OC | Continue weighted SLO scheduling work\x07working\n',
+      100
+    )
+
+    const event = {
+      paneKey: makePaneKey('opencode-tab', HEADLESS_LEAF_ID),
+      tabId: 'opencode-tab',
+      worktreeId: TEST_WORKTREE_ID,
+      launchToken: 'opencode-launch-token',
+      connectionId: null,
+      payload: {
+        state: 'working' as const,
+        prompt: 'Continue weighted SLO scheduling work',
+        agentType: 'claude'
+      }
+    }
+    await expect(runtime.resolveCorroboratedLocalHookAgent(event)).resolves.toBe('opencode')
+    await expect(
+      runtime.resolveCorroboratedLocalHookAgent({
+        ...event,
+        launchToken: 'different-launch-token'
+      })
+    ).resolves.toBeNull()
+    await expect(
+      runtime.resolveCorroboratedLocalHookAgent({
+        ...event,
+        connectionId: 'ssh-connection-1'
+      })
+    ).resolves.toBeNull()
+    expect(getForegroundProcess).toHaveBeenCalledOnce()
+  })
+
   it('skips the foreground-process probe when the PTY launch agent is already known', async () => {
     // Why: foregroundAgent is only a fallback when launchAgent is unknown, so probing a launched agent burns a relay round-trip without changing the resolved owner.
     const getForegroundProcess = vi.fn(async () => 'omp')

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -47,6 +47,9 @@ import {
   type AgentStatusOrchestrationContext,
   type AgentStatusEntry
 } from '../../shared/agent-status-types'
+import type { AgentHookEventPayload } from '../../shared/agent-hook-listener'
+import { resolveCorroboratedForegroundAgent } from '../../shared/agent-status-identity'
+import { resolveExplicitTerminalTitleAgentType } from '../../shared/terminal-title-agent-type'
 import { indexAgentStatusRowsByPaneKey } from '../agent-hooks/agent-status-pane-index'
 import type { AgentHookAuthorityAttestation } from '../agent-hooks/server'
 import type {
@@ -1762,6 +1765,7 @@ const MOBILE_TERMINAL_CREATE_RESULT_TTL_MS = 60_000
 const WORKTREE_CREATE_RESULT_TTL_MS = 60_000
 const FOREGROUND_AGENT_WRAPPER_RETRY_INTERVAL_MS = 150
 const FOREGROUND_AGENT_WRAPPER_RETRY_TIMEOUT_MS = 6_500
+const LOCAL_HOOK_FOREGROUND_PROCESS_TIMEOUT_MS = 1_000
 const BRACKETED_PASTE_BEGIN = '\x1b[200~'
 const BRACKETED_PASTE_END = '\x1b[201~'
 const BRACKETED_PASTE_QUIET_MS = 1500
@@ -16372,6 +16376,70 @@ export class OrcaRuntimeService {
     const parsed = parsePaneKey(paneKey)
     const leaf = parsed ? this.leaves.get(this.getLeafKey(parsed.tabId, parsed.leafId)) : null
     return leaf?.worktreeId ?? this.getPtyRecordForPaneKey(paneKey)?.worktreeId ?? null
+  }
+
+  async resolveCorroboratedLocalHookAgent(
+    event: Readonly<AgentHookEventPayload>
+  ): Promise<TuiAgent | null> {
+    const launchToken = event.launchToken?.trim()
+    const eventPane = parsePaneKey(event.paneKey)
+    if (event.connectionId !== null || !launchToken || !eventPane) {
+      return null
+    }
+    const pty = this.getPtyRecordForPaneKey(event.paneKey)
+    const ptyPane = parsePaneKey(pty?.paneKey ?? '')
+    if (
+      !pty?.connected ||
+      pty.connectionId !== null ||
+      pty.launchToken !== launchToken ||
+      !ptyPane ||
+      ptyPane.leafId !== eventPane.leafId ||
+      (event.tabId !== undefined && event.tabId !== eventPane.tabId) ||
+      (event.worktreeId !== undefined && event.worktreeId !== pty.worktreeId)
+    ) {
+      return null
+    }
+    const title = getLatestPtyTitle(pty) ?? ''
+    const titleAgent = resolveCompatibleAgentTypeForOwner(
+      resolveExplicitTerminalTitleAgentType(title),
+      pty.launchAgent
+    )
+    const incomingAgent = resolveCompatibleAgentTypeForOwner(
+      event.payload.agentType,
+      pty.launchAgent
+    )
+    if (!titleAgent || !incomingAgent || titleAgent === incomingAgent) {
+      return null
+    }
+    const controller = this.ptyController
+    const foregroundRead = this.readPtyForegroundProcessFromController(
+      pty.ptyId,
+      pty.lastOscTitleAt ?? 0
+    )
+    if (!controller || !foregroundRead) {
+      return null
+    }
+    const result = await withTimeout(foregroundRead, LOCAL_HOOK_FOREGROUND_PROCESS_TIMEOUT_MS, {
+      controller,
+      process: null,
+      available: false
+    })
+    const current = this.getPtyRecordForPaneKey(event.paneKey)
+    if (
+      current !== pty ||
+      !current.connected ||
+      current.connectionId !== null ||
+      current.launchToken !== launchToken ||
+      result.controller !== this.ptyController ||
+      !result.available
+    ) {
+      return null
+    }
+    return resolveCorroboratedForegroundAgent({
+      processAgent: recognizeAgentProcess(result.process)?.agent ?? null,
+      title: getLatestPtyTitle(current) ?? '',
+      ownerAgent: current.launchAgent
+    })
   }
 
   /** Read-only context of the worktree the user is focused on, for plugin

--- a/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
+++ b/src/renderer/src/lib/use-tab-agent-opencode-native-title.test.ts
@@ -274,6 +274,42 @@ describe('OpenCode native title tab identity', () => {
     }
   })
 
+  it('keeps OpenCode identity when its process and native title contradict a Claude hook', () => {
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'OC | Continue weighted SLO scheduling work',
+        hookAgent: 'claude',
+        processAgent: 'opencode',
+        processAgentTrusted: true,
+        launchAgent: 'opencode'
+      })
+    ).toBe('opencode')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'OC | Continue weighted SLO scheduling work',
+        hookAgent: 'claude',
+        processAgent: 'opencode',
+        launchAgent: 'opencode'
+      })
+    ).toBe('claude')
+    expect(
+      resolveTabAgentFromSignals({
+        hasObservedAgentSignal: true,
+        isRemote: false,
+        title: 'OC | Continue weighted SLO scheduling work',
+        hookAgent: 'claude',
+        processAgent: 'opencode',
+        processAgentTrusted: true,
+        processShellForeground: true,
+        launchAgent: 'opencode'
+      })
+    ).toBe('claude')
+  })
+
   it('updates a mounted inactive/restored split without provider probes', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)

--- a/src/renderer/src/lib/use-tab-agent.ts
+++ b/src/renderer/src/lib/use-tab-agent.ts
@@ -79,6 +79,7 @@ export function resolveTabAgentFromSignals(args: {
   focusedCompletedHookAgent?: TuiAgent | null
   siblingCompletedHookAgent?: TuiAgent | null
   processAgent?: TuiAgent | null
+  processAgentTrusted?: boolean
   processShellForeground?: boolean
   sleepingSessionAgent?: TuiAgent | null
   launchAgent?: TuiAgent
@@ -155,8 +156,12 @@ export function resolveTabAgentFromSignals(args: {
   const activeLaunchAgent = launchedAgentExited ? null : launchAgent
   // Why: re-own the foreground process within its title-identity group so OMP's nested pi (shell → omp → pi) can't flip an OMP-owned tab's icon.
   const processAgent = resolveSignalAgentForLaunchOwner(args.processAgent, owner)
-  // Identity-first precedence (see JSDoc): live hook > process > title > completed > sleeping > launch > sibling.
+  const processCanCorroborate =
+    !args.isRemote && Boolean(args.processAgentTrusted) && !processProvesShell
+  const corroboratedForegroundAgent =
+    processCanCorroborate && explicitTitleAgent === processAgent ? processAgent : null
   return (
+    corroboratedForegroundAgent ??
     liveFocusedIdentity ??
     processAgent ??
     titleAgent ??
@@ -174,13 +179,11 @@ export function resolveTabAgentFromSignals(args: {
  * already-computed state as the sidebar rows — no foreground probing.
  * Identity-first precedence:
  *
- * 1. Live focused hook — ground truth while the agent works; never title-overridden.
- * 2. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
- * 3. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
- * 4. Idle focused identity — the pane's completed hook or sidebar-retained completion; suppressed locally once OSC 133;D proves exit.
- * 5. Sleeping session identity — current provider-session ownership.
- * 6. launchAgent — bootstrap before any hook/process signal; cleared once exit evidence shows it left.
- * 7. Sibling-pane identity (live, then completed/retained) — split-tab fallback.
+ * 1. Corroborated local foreground identity — process and explicit title agree, so an inherited compatibility hook cannot re-own the pane.
+ * 2. Live focused hook — ground truth while the agent works.
+ * 3. Process identity — recognized foreground process (local only); re-owned within its title-identity group so OMP's nested `pi` (shell → omp → pi) can't flip the icon.
+ * 4. Title — only a reuse override or legacy standalone identity; native OpenCode titles cannot displace durable ownership.
+ * 5. Durable fallbacks — focused completion, sleeping session, launch intent, then sibling-pane identity.
  */
 export function useTabAgent(tab: TerminalTab): TuiAgent | null {
   const focusedHookAgent = useAppStore((s) =>
@@ -221,14 +224,12 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     const activeLeafId = s.terminalLayoutsByTabId[tab.id]?.activeLeafId
     return activeLeafId && isTerminalLeafId(activeLeafId) ? makePaneKey(tab.id, activeLeafId) : null
   })
-  const processAgent = useAppStore((s) =>
-    focusedPaneKey ? (s.paneForegroundAgentByPaneKey[focusedPaneKey]?.agent ?? null) : null
+  const foregroundProcess = useAppStore((s) =>
+    focusedPaneKey ? s.paneForegroundAgentByPaneKey[focusedPaneKey] : undefined
   )
-  const processShellForeground = useAppStore((s) =>
-    focusedPaneKey
-      ? Boolean(s.paneForegroundAgentByPaneKey[focusedPaneKey]?.shellForeground)
-      : false
-  )
+  const processAgent = foregroundProcess?.agent ?? null
+  const processAgentTrusted = foregroundProcess?.routingTrusted === true
+  const processShellForeground = Boolean(foregroundProcess?.shellForeground)
   // Why: a hibernated pane's session record is the freshest identity once PTY, hook, and process signals are all gone.
   const sleepingSessionAgent = useAppStore((s) =>
     focusedPaneKey ? (s.sleepingAgentSessionsByPaneKey[focusedPaneKey]?.agent ?? null) : null
@@ -342,6 +343,7 @@ export function useTabAgent(tab: TerminalTab): TuiAgent | null {
     focusedCompletedHookAgent,
     siblingCompletedHookAgent,
     processAgent,
+    processAgentTrusted,
     processShellForeground,
     sleepingSessionAgent,
     launchAgent: tab.launchAgent

--- a/src/renderer/src/store/slices/agent-status-agent-identity.test.ts
+++ b/src/renderer/src/store/slices/agent-status-agent-identity.test.ts
@@ -1,0 +1,208 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { AppState } from '../types'
+import { createTestStore, makeTab } from './store-test-helpers'
+
+const LEAF_ID = '11111111-1111-4111-8111-111111111111'
+const PANE_KEY = `tab-1:${LEAF_ID}`
+const SIBLING_LEAF_ID = '22222222-2222-4222-8222-222222222222'
+type TestStore = ReturnType<typeof createTestStore>
+
+function createOpenCodePaneStore(
+  foreground: AppState['paneForegroundAgentByPaneKey'][string]
+): TestStore {
+  const store = createTestStore()
+  store.setState({
+    tabsByWorktree: {
+      'worktree-1': [
+        makeTab({
+          id: 'tab-1',
+          worktreeId: 'worktree-1',
+          title: 'OC | Continue weighted SLO scheduling work',
+          launchAgent: 'opencode'
+        })
+      ]
+    },
+    paneForegroundAgentByPaneKey: { [PANE_KEY]: foreground }
+  } as Partial<AppState>)
+  return store
+}
+
+function sendInheritedClaudeStatus(
+  store: TestStore,
+  connectionId?: string | null,
+  state: 'working' | 'done' = 'working',
+  terminalTitle?: string
+): void {
+  store.getState().setAgentStatus(
+    PANE_KEY,
+    {
+      state,
+      prompt: 'Continue weighted SLO scheduling work',
+      agentType: 'claude',
+      model: 'claude-sonnet',
+      restoredUnconfirmed: true
+    },
+    terminalTitle,
+    undefined,
+    connectionId === undefined
+      ? undefined
+      : { tabId: 'tab-1', worktreeId: 'worktree-1', connectionId },
+    {
+      providerSession: {
+        key: 'session_id',
+        id: 'inherited-claude-session',
+        transcriptPath: '/tmp/inherited-claude-session.jsonl'
+      }
+    }
+  )
+}
+
+describe('agent status foreground identity', () => {
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('keeps OpenCode identity when its process and native title contradict a Claude hook', () => {
+    vi.useFakeTimers()
+    const store = createOpenCodePaneStore({
+      agent: 'opencode',
+      routingTrusted: true,
+      shellForeground: false
+    })
+    sendInheritedClaudeStatus(store)
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]).toMatchObject({
+      agentType: 'opencode',
+      terminalTitle: 'OC | Continue weighted SLO scheduling work'
+    })
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY].model).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY].providerSession).toBeUndefined()
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY].restoredUnconfirmed).toBeUndefined()
+  })
+
+  it('uses the addressed pane title instead of the focused sibling title', () => {
+    vi.useFakeTimers()
+    const store = createOpenCodePaneStore({
+      agent: 'opencode',
+      routingTrusted: true,
+      shellForeground: false
+    })
+    store.setState({
+      tabsByWorktree: {
+        'worktree-1': [
+          makeTab({
+            id: 'tab-1',
+            worktreeId: 'worktree-1',
+            title: 'zsh',
+            launchAgent: 'opencode'
+          })
+        ]
+      },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: {
+            type: 'split',
+            direction: 'vertical',
+            first: { type: 'leaf', leafId: '11111111-1111-4111-8111-111111111111' },
+            second: { type: 'leaf', leafId: SIBLING_LEAF_ID }
+          },
+          activeLeafId: SIBLING_LEAF_ID,
+          expandedLeafId: null,
+          titlesByLeafId: {
+            '11111111-1111-4111-8111-111111111111': 'OC | Continue weighted SLO scheduling work',
+            [SIBLING_LEAF_ID]: 'zsh'
+          }
+        }
+      }
+    } as Partial<AppState>)
+
+    sendInheritedClaudeStatus(
+      store,
+      undefined,
+      'working',
+      'OC | Continue weighted SLO scheduling work'
+    )
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]).toMatchObject({
+      agentType: 'opencode',
+      terminalTitle: 'OC | Continue weighted SLO scheduling work'
+    })
+  })
+
+  it('suppresses a first inherited child completion instead of completing OpenCode', () => {
+    vi.useFakeTimers()
+    const store = createOpenCodePaneStore({
+      agent: 'opencode',
+      routingTrusted: true,
+      shellForeground: false
+    })
+
+    sendInheritedClaudeStatus(store, undefined, 'done')
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]).toBeUndefined()
+  })
+
+  it('keeps the hook identity for a remote-runtime pane', () => {
+    vi.useFakeTimers()
+    const store = createOpenCodePaneStore({
+      agent: 'opencode',
+      routingTrusted: true,
+      shellForeground: false
+    })
+    const ptyId = 'remote:runtime-environment@@terminal-handle'
+    store.setState({
+      ptyIdsByTabId: { 'tab-1': [ptyId] },
+      terminalLayoutsByTabId: {
+        'tab-1': {
+          root: { type: 'leaf', leafId: LEAF_ID },
+          activeLeafId: LEAF_ID,
+          expandedLeafId: null,
+          ptyIdsByLeafId: { [LEAF_ID]: ptyId }
+        }
+      }
+    } as Partial<AppState>)
+
+    sendInheritedClaudeStatus(store, null)
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]).toMatchObject({
+      agentType: 'claude',
+      model: 'claude-sonnet',
+      restoredUnconfirmed: true
+    })
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY].providerSession).toMatchObject({
+      id: 'inherited-claude-session'
+    })
+  })
+
+  it.each([
+    ['launch-only hint', { agent: 'opencode', shellForeground: false }, undefined],
+    [
+      'shell foreground',
+      { agent: 'opencode', routingTrusted: true, shellForeground: true },
+      undefined
+    ],
+    [
+      'remote route',
+      { agent: 'opencode', routingTrusted: true, shellForeground: false },
+      'ssh-connection-1'
+    ],
+    [
+      'mismatched process',
+      { agent: 'codex', routingTrusted: true, shellForeground: false },
+      undefined
+    ]
+  ] as const)('keeps the hook identity for a %s', (_label, foreground, connectionId) => {
+    vi.useFakeTimers()
+    const store = createOpenCodePaneStore(foreground)
+    sendInheritedClaudeStatus(store, connectionId)
+
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY]).toMatchObject({
+      agentType: 'claude',
+      model: 'claude-sonnet',
+      restoredUnconfirmed: true
+    })
+    expect(store.getState().agentStatusByPaneKey[PANE_KEY].providerSession).toMatchObject({
+      id: 'inherited-claude-session'
+    })
+  })
+})

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -22,11 +22,15 @@ import {
   type SleepingAgentSessionRecord
 } from '../../../../shared/agent-session-resume'
 import {
+  resolveCorroboratedForegroundAgent,
   resolveAgentStatusIdentity,
   shouldSuppressInheritedTerminalStatus
 } from '../../../../shared/agent-status-identity'
 import { isCommandCodeNewTurnWhileWorking } from '../../../../shared/command-code-turn-boundary'
 import type { TerminalPaneLayoutNode, TerminalTab } from '../../../../shared/types'
+import { parsePaneKey } from '../../../../shared/stable-pane-id'
+import { getConnectionIdFromState } from '@/lib/connection-owner-resolution'
+import { parseRemoteRuntimePtyId } from '@/runtime/runtime-terminal-stream'
 import {
   getRepoExecutionHostId,
   getWorktreeExecutionHostId
@@ -1733,9 +1737,68 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         if (existing && updatedAt < existing.updatedAt) {
           return s
         }
+        const statusTabId =
+          routing?.tabId ?? existing?.tabId ?? getTabIdFromPaneKey(paneKey) ?? undefined
+        const statusWorktreeId =
+          routing?.worktreeId ??
+          existing?.worktreeId ??
+          findAgentPaneWorktreeId(s, paneKey) ??
+          undefined
+        const statusTab =
+          statusTabId && statusWorktreeId
+            ? s.tabsByWorktree[statusWorktreeId]?.find((tab) => tab.id === statusTabId)
+            : undefined
+        const statusPane = parsePaneKey(paneKey)
+        const statusLayout = statusTabId ? s.terminalLayoutsByTabId[statusTabId] : undefined
+        const addressedPtyId = statusPane
+          ? statusLayout?.ptyIdsByLeafId?.[statusPane.leafId]
+          : undefined
+        const hasRemoteRuntimePty = addressedPtyId
+          ? parseRemoteRuntimePtyId(addressedPtyId) !== null
+          : (statusTabId ? (s.ptyIdsByTabId[statusTabId] ?? []) : []).some(
+              (ptyId) => parseRemoteRuntimePtyId(ptyId) !== null
+            )
+        const paneLocalTitle =
+          terminalTitle ??
+          (statusPane ? statusLayout?.titlesByLeafId?.[statusPane.leafId] : undefined) ??
+          existing?.terminalTitle
+        const tabTitleBelongsToPane =
+          !statusPane ||
+          !statusLayout?.activeLeafId ||
+          statusLayout.activeLeafId === statusPane.leafId
+        const corroboratingTitle =
+          paneLocalTitle ?? (tabTitleBelongsToPane ? statusTab?.title : undefined) ?? ''
+        const foreground = s.paneForegroundAgentByPaneKey[paneKey]
+        const statusConnectionId =
+          routing?.connectionId !== undefined
+            ? routing.connectionId
+            : existing?.connectionId !== undefined
+              ? existing.connectionId
+              : getConnectionIdFromState(s, statusWorktreeId ?? null)
+        const hasTrustedLocalForeground =
+          foreground?.routingTrusted === true &&
+          !foreground.shellForeground &&
+          !hasRemoteRuntimePty &&
+          (statusConnectionId === null || statusConnectionId === undefined)
+        const corroboratedForegroundAgent = hasTrustedLocalForeground
+          ? resolveCorroboratedForegroundAgent({
+              processAgent: foreground?.agent,
+              title: corroboratingTitle,
+              ownerAgent: statusTab?.launchAgent
+            })
+          : null
+        const foregroundOverridesHookIdentity =
+          corroboratedForegroundAgent !== null &&
+          payload.agentType !== undefined &&
+          payload.agentType !== 'unknown' &&
+          payload.agentType !== corroboratedForegroundAgent
+        const incomingModel = foregroundOverridesHookIdentity ? undefined : payload.model
+        const incomingRestoredUnconfirmed =
+          !foregroundOverridesHookIdentity && payload.restoredUnconfirmed
         // Why: terminalTitle labels the pane itself, not the turn, so a missing title means "no update" —
         // preserve the prior value to avoid flicker (unlike tool/prompt fields, which clear on a fresh turn).
-        const effectiveTitle = terminalTitle ?? existing?.terminalTitle
+        const effectiveTitle =
+          (corroboratedForegroundAgent ? corroboratingTitle : undefined) ?? paneLocalTitle
 
         // Rolling log of state transitions for the dashboard's activity blocks; push only on
         // real state changes to avoid dupes from prompt-only pings within the same state.
@@ -1772,14 +1835,20 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         }
 
         const identity = resolveAgentStatusIdentity({
-          existing: existing
+          existing: corroboratedForegroundAgent
             ? {
-                agentType: existing.agentType,
-                state: existing.state,
-                updatedAt: existing.updatedAt,
-                restoredUnconfirmed: existing.restoredUnconfirmed
+                agentType: corroboratedForegroundAgent,
+                state: 'working',
+                updatedAt
               }
-            : undefined,
+            : existing
+              ? {
+                  agentType: existing.agentType,
+                  state: existing.state,
+                  updatedAt: existing.updatedAt,
+                  restoredUnconfirmed: existing.restoredUnconfirmed
+                }
+              : undefined,
           incoming: payload.agentType,
           now: updatedAt
         })
@@ -1808,7 +1877,6 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
               ? existing.stateStartedAt
               : updatedAt)
         if (
-          existing &&
           shouldSuppressInheritedTerminalStatus({
             inheritedFromActivePane: identity.inheritedFromActivePane,
             incomingState: payload.state
@@ -1844,21 +1912,22 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
         const canReuseExistingProviderSession =
           existing?.agentType === identity.agentType &&
           (existing.state !== 'done' || payload.state === 'done')
+        const incomingProviderSession = foregroundOverridesHookIdentity
+          ? undefined
+          : metadata?.providerSession
         const providerSession =
-          metadata?.providerSession ??
+          incomingProviderSession ??
           (canReuseExistingProviderSession ? existing.providerSession : undefined)
         const existingProviderSession = canReuseExistingProviderSession
           ? existing.providerSession
           : undefined
         const providerSessionChanged =
-          Boolean(metadata?.providerSession && existingProviderSession) &&
+          Boolean(incomingProviderSession && existingProviderSession) &&
           !agentProviderSessionsEqual(
             identity.agentType,
-            metadata?.providerSession,
+            incomingProviderSession,
             existingProviderSession
           )
-        const statusTabId =
-          routing?.tabId ?? existing?.tabId ?? getTabIdFromPaneKey(paneKey) ?? undefined
         const statusTerminalHandle = routing?.terminalHandle ?? existing?.terminalHandle
         const registryEntry = s.agentLaunchConfigByPaneKey[paneKey]
         const matchedRegistryLaunchConfig = registryEntryMatchesStatus({
@@ -1898,7 +1967,10 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             : undefined
         // Why: on a reused pane key, once the provider session changes the old launch registry must not bleed options into the new session.
         const launchConfigSource =
-          (payload.state !== 'done' && !providerSessionChanged && metadata?.launchToken
+          (payload.state !== 'done' &&
+          !foregroundOverridesHookIdentity &&
+          !providerSessionChanged &&
+          metadata?.launchToken
             ? metadata?.launchConfig
             : undefined) ??
           matchedRegistryLaunchConfig ??
@@ -1910,15 +1982,11 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           stateStartedAt,
           agentType: identity.agentType,
           model:
-            payload.model ??
+            incomingModel ??
             (existing?.agentType === identity.agentType ? existing.model : undefined),
           paneKey,
           terminalHandle: statusTerminalHandle,
-          worktreeId:
-            routing?.worktreeId ??
-            existing?.worktreeId ??
-            findAgentPaneWorktreeId(s, paneKey) ??
-            undefined,
+          worktreeId: statusWorktreeId,
           ...(routing?.connectionId !== undefined
             ? { connectionId: routing.connectionId }
             : existing?.connectionId !== undefined
@@ -1942,7 +2010,7 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
             : payload.subagents,
           ...(providerSession ? { providerSession } : {}),
           ...(promptInteractionKey ? { promptInteractionKey } : {}),
-          ...(payload.restoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
+          ...(incomingRestoredUnconfirmed ? { restoredUnconfirmed: true } : {}),
           // Why: `interrupted` is done-only; parseAgentStatusPayload already clamps it for non-done states, so write it through directly.
           interrupted: payload.interrupted,
           // Why: done→done repaints (OSC 9999, reconnect snapshot replays) re-deliver a

--- a/src/shared/agent-status-identity.ts
+++ b/src/shared/agent-status-identity.ts
@@ -4,6 +4,9 @@ import {
   type AgentStatusState,
   type AgentType
 } from './agent-status-types'
+import { resolveCompatibleAgentTypeForOwner } from './agent-title-owner'
+import { resolveExplicitTerminalTitleAgentType } from './terminal-title-agent-type'
+import type { TuiAgent } from './types'
 
 type ExistingAgentIdentity = {
   agentType?: AgentType
@@ -15,6 +18,21 @@ type ExistingAgentIdentity = {
 type AgentIdentityResolution = {
   agentType: AgentType
   inheritedFromActivePane: boolean
+}
+
+export function resolveCorroboratedForegroundAgent(args: {
+  processAgent?: TuiAgent | null
+  title: string
+  ownerAgent?: TuiAgent | null
+}): TuiAgent | null {
+  const processAgent = resolveCompatibleAgentTypeForOwner(args.processAgent, args.ownerAgent) as
+    | TuiAgent
+    | undefined
+  const titleAgent = resolveCompatibleAgentTypeForOwner(
+    resolveExplicitTerminalTitleAgentType(args.title),
+    args.ownerAgent
+  ) as TuiAgent | undefined
+  return processAgent && processAgent === titleAgent ? processAgent : null
 }
 
 export function shouldSuppressInheritedTerminalStatus(args: {


### PR DESCRIPTION
## Summary

- Keep an OpenCode pane identified as OpenCode when its exact live local foreground process and explicit native `OC | ...` title agree, even if Claude-compatible tooling posts an inherited Claude hook for the same pane.
- Resolve the identity before main-process retention so renderer replay, sidebar/tab status, `worktree.ps`, headless, and mobile consumers receive the same corrected agent, while incompatible Claude session/model/tool metadata is removed.
- Preserve hook precedence for shell foreground, missing or mismatched process evidence, launch-only hints, SSH panes, and remote-runtime PTYs; preserve launch-owner normalization for Pi/oh-my-pi and similar wrappers.
- Suppress inherited child completion/provider-only events so a nested Claude-compatible hook cannot complete or attach a Claude session to the active OpenCode turn.

Related context: #8940, #12466, and the nested-hook precedence established in #3990. This fixes the residual inherited Claude-compatible hook path rather than the already-fixed generic title path.

## Screenshots

No visual layout change. A fresh headed Electron run on the rebased commit verified that the tab and sidebar remain OpenCode after a real Claude-form hook reaches a renderer-created OpenCode PTY.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck` (node, CLI, and web typechecks run through `pnpm run build:desktop`)
- [ ] `pnpm test` (the pre-rebase identical patch ran 48,668 passing and 155 skipped tests with 6 unrelated baseline/environment failures; focused affected tests were rerun after rebase and GitHub CI owns the new full-suite run)
- [x] `pnpm build` (`pnpm run build:desktop`)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Exact-SHA validation on rebased commit `f54840c939998f38437e4d7aaa0e3980352ee43c`:

- independent QA matrix: 1,452 passed, 1 skipped across 17 files
- core identity/runtime selection: 1,100 passed, 1 skipped across 4 files under Node 24
- rebase-adjacent Prime Agent/process-recognition and canonical PTY hydration suites: 35/35 passed
- lint, reliability, type-aware, max-lines, skill, and localization gates: passed
- desktop build and node/CLI/web typechecks: passed
- `git diff --check`: clean
- fresh headed Electron QA: renderer store, main `worktree.ps`, tab, and sidebar all stayed OpenCode; Claude model/provider metadata was absent

The regression matrix covers local positive identity correction, exact launch-token/live-PTY binding, stale launch hints, shell return, process/title mismatch, first inherited `Stop`, inactive split-pane titles, SSH, remote-runtime PTYs, replay/remote ingestion, metadata filtering, Pi/oh-my-pi owner normalization, Prime Agent coexistence, and canonical PTY hydration.

## AI Review Report

Five independent review lanes plus a debugging runtime audit reviewed exact rebased SHA `f54840c939998f38437e4d7aaa0e3980352ee43c`: goal verification, code quality, security, history/context, and QA all passed with no blockers. An earlier review found that connection IDs alone did not identify remote-runtime PTYs; the final patch adds an addressed-PTY remote-runtime guard and negative regression. Every lane was rerun after the main rebase.

The review explicitly checked macOS, Linux, and Windows compatibility. This PR changes no shortcuts, labels, filesystem paths, shell commands, or platform-specific process APIs; it uses the existing cross-platform PTY controller and shared agent/title normalization. It also checked local, SSH, and remote-runtime routing; supported-agent wrapper ownership; Prime Agent coexistence; canonical PTY hydration; split-pane behavior; main/renderer/headless/mobile consistency; performance; and UI quality. The only new process query is bounded and occurs only for a conflicting non-replay local hook without an already-protected parent identity.

## Security Audit

The correction is classification, not authorization. Main-process corroboration requires the runtime-owned local hook endpoint, exact nonempty launch token, exact pane/leaf/tab/worktree binding, a connected local PTY, the current controller, and a bounded foreground-process result; those bindings are rechecked after the async probe. Replay and remote ingestion bypass the resolver, and renderer fallback excludes SSH and remote-runtime PTYs.

No dependency, wire contract, IPC surface, command execution, filesystem path, credential, or secret-handling change was introduced. Conflicting Claude provider-session/transcript/model/tool/subagent metadata is stripped before persistence and publication. Residual low risk: a process and title are controlled by the same local user and can spoof presentation classification, but no reviewed authorization consumer trusts this identity.

## Notes

- Rebasing onto upstream `bf406720a059029cadaaeb56c79e6b8cc49d5dec` preserved the stable patch ID exactly. Six later upstream commits contain four IME/key-remap changes, a release marker, and manual artifact sharing. The artifact commit adds unrelated imports and service methods in `orca-runtime.ts`, far from the PTY identity resolver; `git merge-tree` confirms the current PR and live `main` integrate without conflict.
- Linux hosted manual QA was completed; platform-neutral controller behavior and macOS/Linux/Windows non-regression were reviewed statically and through mocked controller tests.
- Open PRs #9135 and #10066 overlap conceptually but do not implement this inherited-hook/full-chain correction.
- X/Twitter handle: not provided (none is configured on the contributor's GitHub profile).
