### PR TITLE
test(i18n): match Japanese agent search label

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx
@@ -370,7 +370,7 @@ describe('AgentKanbanBoard', () => {
     renderBoard([card({ bucket: 'done' })])
 
     expect(screen.getByText('完了')).toBeInTheDocument()
-    expect(screen.getByLabelText('エージェントを検索')).toBeInTheDocument()
+    expect(screen.getByLabelText('Agent を検索')).toBeInTheDocument()
     expect(screen.getByRole('button', { name: /^フィルター/ })).toBeInTheDocument()
   })
 


### PR DESCRIPTION
## Summary

- update the dashboard localization assertion to match the current Japanese catalog
- preserve the catalog policy of keeping “Agent” in Latin script
- unblock Node 24/26 shard 3/16 failures affecting PR checks

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard-popout/AgentKanbanBoard.test.tsx` — 23 passed
- exact CI shard `3/16` under Node 26 — 285 files passed, 3,034 tests passed, 4 skipped
- `git diff --check`

This is intentionally separate from #13377 so that performance PR remains scoped to AI Vault.