### PR TITLE
feat(browser): open clicked links in the pane to the side

### DIFF
--- a/src/renderer/src/components/settings/BrowserLinkSidePaneSetting.tsx
+++ b/src/renderer/src/components/settings/BrowserLinkSidePaneSetting.tsx
@@ -1,0 +1,52 @@
+import type { GlobalSettings } from '../../../../shared/global-settings-types'
+import { SearchableSetting } from './SearchableSetting'
+import { SettingsSwitchRow } from './SettingsFormControls'
+import { translate } from '@/i18n/i18n'
+
+type BrowserLinkSidePaneSettingProps = {
+  settings: Pick<GlobalSettings, 'openLinksInApp' | 'openLinksInSidePane'>
+  updateSettings: (updates: Partial<GlobalSettings>) => void
+}
+
+export function BrowserLinkSidePaneSetting({
+  settings,
+  updateSettings
+}: BrowserLinkSidePaneSettingProps): React.JSX.Element {
+  // Why: placement only exists for links Orca opens itself — with Link Routing
+  // off they leave for the system browser, so the switch would do nothing.
+  const openLinksInApp = settings.openLinksInApp === true
+  const title = translate(
+    'auto.components.settings.BrowserLinkSidePaneSetting.7f3c1a9e5d',
+    'Open Links Beside'
+  )
+  const description = openLinksInApp
+    ? translate(
+        'auto.components.settings.BrowserLinkSidePaneSetting.2b8d4f6c01',
+        'Open in-app links in the pane beside the one you clicked from, splitting to the right when there is no pane there yet. Off opens another tab in the current pane.'
+      )
+    : translate(
+        'auto.components.settings.BrowserLinkSidePaneSetting.3c5e7a9b1d',
+        'Turn on Link Routing to open links in Orca before choosing where they land.'
+      )
+
+  return (
+    <SearchableSetting
+      title={title}
+      description={description}
+      keywords={['browser', 'links', 'routing', 'pane', 'split', 'side', 'beside', 'tab']}
+    >
+      {/* Nested under Link Routing: only meaningful once links open in Orca. */}
+      <div className="ml-4 border-l border-border pl-4">
+        <SettingsSwitchRow
+          label={title}
+          description={description}
+          checked={settings.openLinksInSidePane === true}
+          disabled={!openLinksInApp}
+          onChange={() =>
+            updateSettings({ openLinksInSidePane: settings.openLinksInSidePane !== true })
+          }
+        />
+      </div>
+    </SearchableSetting>
+  )
+}

--- a/src/renderer/src/components/settings/BrowserPane.tsx
+++ b/src/renderer/src/components/settings/BrowserPane.tsx
@@ -13,6 +13,7 @@ import { BrowserSearchEngineSetting } from './BrowserSearchEngineSetting'
 import { BrowserLinkRoutingSetting } from './BrowserLinkRoutingSetting'
 import { BrowserLinkRoutingModifierSetting } from './BrowserLinkRoutingModifierSetting'
 import { BrowserTerminalLinkActionsSetting } from './BrowserTerminalLinkActionsSetting'
+import { BrowserLinkSidePaneSetting } from './BrowserLinkSidePaneSetting'
 import { BrowserLocalhostWorktreeLabelsSetting } from './BrowserLocalhostWorktreeLabelsSetting'
 import { BrowserClientHostedRemoteSetting } from './BrowserClientHostedRemoteSetting'
 import { BrowserSshWorkspaceRoutingSetting } from './BrowserSshWorkspaceRoutingSetting'
@@ -119,6 +120,7 @@ export function BrowserPane({
   const showSshWorkspaceRouting = matchesSettingsSearch(searchQuery, [
     getBrowserPaneSearchEntries()[9]
   ])
+  const showLinkSidePane = matchesSettingsSearch(searchQuery, [getBrowserPaneSearchEntries()[10]])
   const showBrowserUse = matchesSettingsSearch(searchQuery, getBrowserUsePaneSearchEntries())
   const isMac = isMacUserAgent()
   const linkRoutingDescription = getBrowserLinkRoutingDescription(
@@ -273,6 +275,10 @@ export function BrowserPane({
           isMac={isMac}
           updateSettings={updateSettings}
         />
+      ) : null}
+
+      {showLinkSidePane ? (
+        <BrowserLinkSidePaneSetting settings={settings} updateSettings={updateSettings} />
       ) : null}
 
       {showLocalhostLabels ? (

--- a/src/renderer/src/components/settings/browser-search.test.ts
+++ b/src/renderer/src/components/settings/browser-search.test.ts
@@ -106,7 +106,9 @@ describe('browser link routing modifier copy', () => {
       'Localhost Worktree Labels',
       'Session & Cookies',
       'Remote server workspaces',
-      'SSH workspaces'
+      'SSH workspaces',
+      // Appended, never inserted: earlier indices are load-bearing.
+      'Open Links Beside'
     ])
   })
 

--- a/src/renderer/src/components/settings/browser-search.ts
+++ b/src/renderer/src/components/settings/browser-search.ts
@@ -287,6 +287,21 @@ export function getBrowserPaneSearchEntries(
           'network'
         )
       ]
+    },
+    {
+      title: translate('auto.components.settings.browser.search.7f3c1a9e5d', 'Open Links Beside'),
+      description: translate(
+        'auto.components.settings.browser.search.2b8d4f6c01',
+        'Open in-app links in the pane beside the one you clicked from, splitting to the right when there is no pane there yet.'
+      ),
+      keywords: [
+        ...translateSearchKeyword('auto.components.settings.browser.search.2d2d995c58', 'browser'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.6f1b2c3d4e', 'links'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.8c2d1e4b5a', 'pane'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.5a9b3c7d2e', 'split'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.4e8f2a1c6b', 'side'),
+        ...translateSearchKeyword('auto.components.settings.browser.search.9d3e5f7a8c', 'beside')
+      ]
     }
   ]
 }

--- a/src/renderer/src/hooks/ipc-events/browser-state-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/browser-state-ipc-bridge.ts
@@ -3,6 +3,7 @@ import { getRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner
 import { redactKagiSessionToken } from '../../../../shared/browser-url'
 import { useAppStore } from '../../store'
 import { acquireBrowserAutomationBootstrapLease } from './browser-automation-bootstrap-lease'
+import { resolveLinkTargetGroupId } from '@/lib/link-target-group'
 
 /**
  * A client-hosted page is a local Electron webview on this desktop that happens to belong to a
@@ -97,6 +98,7 @@ export function registerBrowserStateIpcBridge(
       store.createBrowserTab(sourcePage.worktreeId, url, {
         title: url,
         activate: activate ?? true,
+        targetGroupId: resolveLinkTargetGroupId(store, sourcePage) ?? undefined,
         ...(sourceTab
           ? {
               sessionProfileId: sourceTab.sessionProfileId,

--- a/src/renderer/src/i18n/en-runtime-required.json
+++ b/src/renderer/src/i18n/en-runtime-required.json
@@ -1125,7 +1125,7 @@
           "ebb942a2ec": "fix-login-flow"
         },
         "BrowserPane": {
-          "4af9a17947": "kagi"
+          "4af9a17947": "Kagi"
         },
         "BrowserProfileRow": {
           "7df818977e": "From",

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -6742,7 +6742,7 @@
           "64898ecdab": "Create",
           "7b649a578a": "Creating…",
           "4399c77caa": "Default",
-          "4af9a17947": "kagi"
+          "4af9a17947": "Kagi"
         },
         "BrowserProfileRow": {
           "8e636cae25": "Profile \"{{value0}}\" removed.",
@@ -9237,7 +9237,9 @@
               "tunnel": "tunnel",
               "routing": "routing",
               "network": "network"
-            }
+            },
+            "7f3c1a9e5d": "Open Links Beside",
+            "2b8d4f6c01": "Open in-app links in the pane beside the one you clicked from, splitting to the right when there is no pane there yet."
           },
           "use": {
             "search": {
@@ -11841,6 +11843,11 @@
           "targetDescription": "Higher values increase contrast where possible. Background colors stay unchanged.",
           "subtle": "Subtle",
           "strong": "Strong"
+        },
+        "BrowserLinkSidePaneSetting": {
+          "7f3c1a9e5d": "Open Links Beside",
+          "2b8d4f6c01": "Open in-app links in the pane beside the one you clicked from, splitting to the right when there is no pane there yet. Off opens another tab in the current pane.",
+          "3c5e7a9b1d": "Turn on Link Routing to open links in Orca before choosing where they land."
         }
       },
       "right": {

--- a/src/renderer/src/lib/file-preview.ts
+++ b/src/renderer/src/lib/file-preview.ts
@@ -12,6 +12,7 @@ import { translate } from '@/i18n/i18n'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 import { findSiblingGroupId } from '@/store/slices/tabs'
+import { resolveSourceGroupId } from '@/lib/side-group-placement'
 import { browserPageDocLocationsEqual } from '../../../shared/browser-page-doc-location'
 import type { BrowserPageDocLocation } from '../../../shared/browser-workspace-types'
 import { findPage } from '@/store/slices/browser-page-records'
@@ -325,14 +326,11 @@ export function openFilePreviewToSide(params: {
     return
   }
 
-  // Resolve the group this action originated from. Prefer the caller-supplied
-  // id (the tab's own group under split-pane layouts), fall back to the
-  // worktree's active group.
-  const sourceGroupId =
-    params.sourceGroupId ??
-    state.activeGroupIdByWorktree[worktreeId] ??
-    state.groupsByWorktree[worktreeId]?.[0]?.id ??
-    null
+  const sourceGroupId = resolveSourceGroupId({
+    requestedGroupId: params.sourceGroupId,
+    activeGroupId: state.activeGroupIdByWorktree?.[worktreeId] ?? null,
+    fallbackGroupId: state.groupsByWorktree[worktreeId]?.[0]?.id ?? null
+  })
   if (!sourceGroupId) {
     return
   }

--- a/src/renderer/src/lib/link-target-group.test.ts
+++ b/src/renderer/src/lib/link-target-group.test.ts
@@ -1,0 +1,73 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroupLayoutNode } from '../../../shared/tab-types'
+import { resolveLinkTargetGroupPlan } from './link-target-group'
+
+const leaf = (groupId: string): TabGroupLayoutNode => ({ type: 'leaf', groupId })
+const split = (first: TabGroupLayoutNode, second: TabGroupLayoutNode): TabGroupLayoutNode => ({
+  type: 'split',
+  direction: 'horizontal',
+  first,
+  second,
+  ratio: 0.5
+})
+
+const base = {
+  enabled: true,
+  workspaceId: 'ws-1',
+  tabs: [{ entityId: 'ws-1', groupId: 'left' }],
+  activeGroupId: 'left',
+  firstGroupId: 'left',
+  layout: split(leaf('left'), leaf('right'))
+}
+
+describe('resolveLinkTargetGroupPlan', () => {
+  it('keeps default tab behavior when the setting is off', () => {
+    expect(resolveLinkTargetGroupPlan({ ...base, enabled: false })).toEqual({
+      kind: 'active-group'
+    })
+  })
+
+  it('targets the sibling pane of the clicked page, not the active pane', () => {
+    // Click originates in 'left' while 'right' is focused: still goes to the
+    // clicked page's sibling, which is 'right'.
+    expect(resolveLinkTargetGroupPlan({ ...base, activeGroupId: 'right' })).toEqual({
+      kind: 'existing',
+      groupId: 'right'
+    })
+  })
+
+  it('targets the sibling when the clicked page lives in the second pane', () => {
+    expect(
+      resolveLinkTargetGroupPlan({
+        ...base,
+        tabs: [{ entityId: 'ws-1', groupId: 'right' }]
+      })
+    ).toEqual({ kind: 'existing', groupId: 'left' })
+  })
+
+  it('asks for a right split when the worktree has only one pane', () => {
+    expect(resolveLinkTargetGroupPlan({ ...base, layout: leaf('left') })).toEqual({
+      kind: 'split-right',
+      sourceGroupId: 'left'
+    })
+  })
+
+  it('falls back to the active group when the clicked page has no tab yet', () => {
+    expect(resolveLinkTargetGroupPlan({ ...base, tabs: [] })).toEqual({
+      kind: 'existing',
+      groupId: 'right'
+    })
+  })
+
+  it('keeps default behavior when no group can be resolved at all', () => {
+    expect(
+      resolveLinkTargetGroupPlan({
+        ...base,
+        tabs: [],
+        activeGroupId: null,
+        firstGroupId: null,
+        layout: null
+      })
+    ).toEqual({ kind: 'active-group' })
+  })
+})

--- a/src/renderer/src/lib/link-target-group.ts
+++ b/src/renderer/src/lib/link-target-group.ts
@@ -1,0 +1,89 @@
+import type { TabGroupLayoutNode } from '../../../shared/tab-types'
+import { resolveSideGroupPlacement, resolveSourceGroupId } from './side-group-placement'
+
+/**
+ * Where a clicked in-app link should open. `active-group` keeps the historical
+ * behavior (another tab in the worktree's active group); the other two place it
+ * beside the pane the click came from.
+ */
+export type LinkTargetGroupPlan =
+  | { kind: 'active-group' }
+  | { kind: 'existing'; groupId: string }
+  | { kind: 'split-right'; sourceGroupId: string }
+
+/**
+ * Pure resolution so the placement rules are testable without a store. The
+ * source group is the clicked page's own group rather than the focused one —
+ * a link clicked in an unfocused pane still opens next to itself.
+ */
+export function resolveLinkTargetGroupPlan(args: {
+  enabled: boolean
+  workspaceId: string
+  tabs: readonly { entityId: string; groupId: string }[]
+  activeGroupId: string | null
+  firstGroupId: string | null
+  layout: TabGroupLayoutNode | null
+}): LinkTargetGroupPlan {
+  if (!args.enabled) {
+    return { kind: 'active-group' }
+  }
+  const sourceGroupId = resolveSourceGroupId({
+    requestedGroupId: args.tabs.find((tab) => tab.entityId === args.workspaceId)?.groupId ?? null,
+    activeGroupId: args.activeGroupId,
+    fallbackGroupId: args.firstGroupId
+  })
+  if (!sourceGroupId) {
+    return { kind: 'active-group' }
+  }
+  const placement = resolveSideGroupPlacement({ layout: args.layout, sourceGroupId })
+  return placement.kind === 'existing'
+    ? { kind: 'existing', groupId: placement.groupId }
+    : { kind: 'split-right', sourceGroupId }
+}
+
+type LinkTargetStore = {
+  // Settings hydrate asynchronously; a null store means the setting is not on yet.
+  settings: { openLinksInSidePane?: boolean } | null
+  unifiedTabsByWorktree: Record<string, { entityId: string; groupId: string }[] | undefined>
+  activeGroupIdByWorktree: Record<string, string | undefined>
+  groupsByWorktree: Record<string, { id: string }[] | undefined>
+  layoutByWorktree: Record<string, TabGroupLayoutNode | undefined>
+  createEmptySplitGroup: (
+    worktreeId: string,
+    sourceGroupId: string,
+    direction: 'right'
+  ) => string | null
+}
+
+/**
+ * Resolve the group a clicked link should open in, creating the right-hand
+ * split when the setting is on and the source pane has no sibling. Returns null
+ * to mean "let createBrowserTab use the active group" — including when a split
+ * cannot be created, so link-opening degrades to a tab rather than failing.
+ */
+export function resolveLinkTargetGroupId(
+  store: LinkTargetStore,
+  sourcePage: { worktreeId: string; workspaceId: string }
+): string | null {
+  // Why: when the setting is off, degrade to the active group without touching
+  // per-worktree layout maps — the opener may fire before they are populated.
+  if (store.settings?.openLinksInSidePane !== true) {
+    return null
+  }
+  const { worktreeId, workspaceId } = sourcePage
+  const plan = resolveLinkTargetGroupPlan({
+    enabled: true,
+    workspaceId,
+    tabs: store.unifiedTabsByWorktree[worktreeId] ?? [],
+    activeGroupId: store.activeGroupIdByWorktree[worktreeId] ?? null,
+    firstGroupId: store.groupsByWorktree[worktreeId]?.[0]?.id ?? null,
+    layout: store.layoutByWorktree[worktreeId] ?? null
+  })
+  if (plan.kind === 'active-group') {
+    return null
+  }
+  if (plan.kind === 'existing') {
+    return plan.groupId
+  }
+  return store.createEmptySplitGroup(worktreeId, plan.sourceGroupId, 'right')
+}

--- a/src/renderer/src/lib/side-group-placement.test.ts
+++ b/src/renderer/src/lib/side-group-placement.test.ts
@@ -1,0 +1,101 @@
+import { describe, expect, it } from 'vitest'
+import type { TabGroupLayoutNode } from '../../../shared/tab-types'
+import { resolveSideGroupPlacement, resolveSourceGroupId } from './side-group-placement'
+
+const leaf = (groupId: string): TabGroupLayoutNode => ({ type: 'leaf', groupId })
+const split = (
+  first: TabGroupLayoutNode,
+  second: TabGroupLayoutNode,
+  direction: 'horizontal' | 'vertical' = 'horizontal'
+): TabGroupLayoutNode => ({ type: 'split', direction, first, second, ratio: 0.5 })
+
+describe('resolveSourceGroupId', () => {
+  it('prefers the caller-supplied group over the active group', () => {
+    expect(
+      resolveSourceGroupId({
+        requestedGroupId: 'g-req',
+        activeGroupId: 'g-act',
+        fallbackGroupId: 'g-first'
+      })
+    ).toBe('g-req')
+  })
+
+  it('falls back to the active group, then the first group', () => {
+    expect(
+      resolveSourceGroupId({
+        requestedGroupId: null,
+        activeGroupId: 'g-act',
+        fallbackGroupId: 'g-first'
+      })
+    ).toBe('g-act')
+    expect(
+      resolveSourceGroupId({
+        requestedGroupId: null,
+        activeGroupId: null,
+        fallbackGroupId: 'g-first'
+      })
+    ).toBe('g-first')
+  })
+
+  it('returns null when no group can be resolved', () => {
+    expect(
+      resolveSourceGroupId({ requestedGroupId: null, activeGroupId: null, fallbackGroupId: null })
+    ).toBeNull()
+  })
+})
+
+describe('resolveSideGroupPlacement', () => {
+  it('reuses the existing sibling group when the layout is already split', () => {
+    expect(
+      resolveSideGroupPlacement({
+        layout: split(leaf('left'), leaf('right')),
+        sourceGroupId: 'left'
+      })
+    ).toEqual({ kind: 'existing', groupId: 'right' })
+  })
+
+  it('reuses the sibling when the source is the second pane', () => {
+    expect(
+      resolveSideGroupPlacement({
+        layout: split(leaf('left'), leaf('right')),
+        sourceGroupId: 'right'
+      })
+    ).toEqual({ kind: 'existing', groupId: 'left' })
+  })
+
+  it('asks for a right split when the worktree has a single pane', () => {
+    expect(resolveSideGroupPlacement({ layout: leaf('only'), sourceGroupId: 'only' })).toEqual({
+      kind: 'split-right'
+    })
+  })
+
+  it('asks for a right split when no layout has been persisted yet', () => {
+    expect(resolveSideGroupPlacement({ layout: null, sourceGroupId: 'only' })).toEqual({
+      kind: 'split-right'
+    })
+  })
+
+  it('resolves the nearest layout sibling under nested splits', () => {
+    // (a | (b | c)) — b's sibling is c, not a.
+    const layout = split(leaf('a'), split(leaf('b'), leaf('c')))
+    expect(resolveSideGroupPlacement({ layout, sourceGroupId: 'b' })).toEqual({
+      kind: 'existing',
+      groupId: 'c'
+    })
+  })
+
+  it('treats a subtree sibling as reusable rather than forcing a new split', () => {
+    // a's sibling subtree is (b | c); reuse its first leaf instead of splitting again.
+    const layout = split(leaf('a'), split(leaf('b'), leaf('c')))
+    expect(resolveSideGroupPlacement({ layout, sourceGroupId: 'a' })).toEqual({
+      kind: 'existing',
+      groupId: 'b'
+    })
+  })
+
+  it('asks for a right split when the source group is absent from the layout', () => {
+    expect(
+      resolveSideGroupPlacement({ layout: split(leaf('x'), leaf('y')), sourceGroupId: 'missing' })
+    ).toEqual({ kind: 'split-right' })
+  })
+})

--- a/src/renderer/src/lib/side-group-placement.ts
+++ b/src/renderer/src/lib/side-group-placement.ts
@@ -1,0 +1,31 @@
+import type { TabGroupLayoutNode } from '../../../shared/tab-types'
+import { findSiblingGroupId } from '@/store/slices/tabs'
+
+/**
+ * Where a "to the side" action should place its content: reuse the layout
+ * sibling when the pane is already split, otherwise ask for a right split.
+ * Shared by Open Preview to the Side and clicked-link routing; kept pure so
+ * the resolution is testable without a store.
+ */
+export type SideGroupPlacement = { kind: 'existing'; groupId: string } | { kind: 'split-right' }
+
+/**
+ * Resolve which group an action originated from. The caller-supplied id wins
+ * (the tab's own group under split-pane layouts, which is not necessarily the
+ * focused one), then the worktree's active group, then its first group.
+ */
+export function resolveSourceGroupId(args: {
+  requestedGroupId: string | null
+  activeGroupId: string | null
+  fallbackGroupId: string | null
+}): string | null {
+  return args.requestedGroupId ?? args.activeGroupId ?? args.fallbackGroupId ?? null
+}
+
+export function resolveSideGroupPlacement(args: {
+  layout: TabGroupLayoutNode | null
+  sourceGroupId: string
+}): SideGroupPlacement {
+  const sibling = args.layout ? findSiblingGroupId(args.layout, args.sourceGroupId) : null
+  return sibling ? { kind: 'existing', groupId: sibling } : { kind: 'split-right' }
+}

--- a/src/shared/global-settings-types.ts
+++ b/src/shared/global-settings-types.ts
@@ -208,6 +208,8 @@ export type GlobalSettings = {
   openLinksInAppModifierInverts?: boolean
   /** Show link actions on plain click in the terminal and chat; off restores modifier-click-only terminal links. */
   terminalLinkActionPopoverEnabled?: boolean
+  /** Opt-in: in-app links open beside the source pane (splitting right when there is no sibling) instead of as another tab in the active group. */
+  openLinksInSidePane?: boolean
   /** Opt-in: open new coding-agent tabs in native chat instead of the raw terminal; optional for legacy settings. */
   openAgentTabsInChatByDefault?: boolean
   /** Experimental native chat surface for Claude/Codex sessions; off by default. */


### PR DESCRIPTION
## Summary

Closes #13390.

Clicking an in-app link always opened another tab in the worktree's **active group**, even with a browser pane sitting right beside the source — the handler passed no group at all:

```ts
store.createBrowserTab(sourcePage.worktreeId, url, { title: url })
```

This adds an opt-in setting (**Settings → Browser → Open Links Beside**, nested under Link Routing) that instead reuses the source pane's layout sibling, or splits right when there is no sibling yet. That is the behavior *Open Preview to the Side* already provides for previews; this PR makes it available for links and has both paths share one implementation.

**Default is off**, so nobody's current behavior changes silently.

### Shape

- **`src/renderer/src/lib/side-group-placement.ts`** — the placement primitive, lifted out of `file-preview.ts` now that it has two callers: resolve the source group (requested → active → first), then reuse the layout sibling or ask for a right split. Pure, so the rules are testable without a store.
- **`src/renderer/src/lib/link-target-group.ts`** — link-specific policy: a pure planner plus a thin store adapter that performs the split.
- **`file-preview.ts`** now delegates to the shared helper; `openFilePreviewToSide` behavior is unchanged.

Two decisions worth calling out, both pinned by tests:

1. **The source group is the clicked page's own group, not the focused one.** A link clicked in an unfocused pane opens beside *itself*, which is what makes the behavior predictable under split layouts.
2. **Every failure path degrades to the previous behavior rather than failing to open** — setting off, no resolvable group, or `createEmptySplitGroup` returning null all fall back to a new tab in the active group.

The existing remote/SSH early return (`getRuntimeEnvironmentIdForWorktree`) is untouched.

## Screenshots

No new UI surface beyond one settings switch; the behavior change is *where* an existing tab appears. With `Agent | Browser` split and a link clicked in the left pane, the page now opens in the right pane instead of as another left-pane tab. With a single pane, a right split is created and the link opens there.

## Testing

- [x] `pnpm lint` — oxlint, type-aware audit, react-doctor, max-lines ratchet, reliability gates, and all three localization gates (catalog / extraction / coverage) pass individually for these changes. New user-facing strings were added via `pnpm run sync:localization-catalog`. The full chain's `verify:skill-bundle-manifest` step fails identically on an untouched `main` checkout (stale generated skill artifacts — pre-existing, unrelated).
- [x] `pnpm typecheck` — clean (all three projects)
- [x] `pnpm test` — **3,839 passed / 1 skipped** across the full `src/renderer/src/lib` suite, which includes the existing `file-preview` tests exercising the refactor. 16 of those are new.
- [ ] `pnpm build` — not run.
- [x] Added 16 tests, written test-first: source-group precedence, sibling reuse from either pane, nested-split sibling resolution, subtree siblings, split-right when single-pane or when the source group is missing from the layout, setting-off passthrough, and the unfocused-pane case.

**Not manually verified in a running app.** The logic is unit-tested and the store calls are the same ones `openFilePreviewToSide` already uses in production, but I have not watched a click land in the right pane. Worth a manual check before merge.

## AI Review Report

Reviewed with Claude (Opus 5), TDD throughout — each test watched fail before implementation.

Risks checked:

- **Silent behavior change for existing users** — mitigated by defaulting the setting off; the passthrough case is a test.
- **Regressing "Open Preview to the Side"** — the refactor is behavior-preserving, and the full existing lib suite (3,839 tests) passes unchanged.
- **Broken opens on failure paths** — audited every path that can fail to produce a group; all return null and fall back to the historical behavior rather than dropping the link.
- **Wrong pane under nested splits** — "to the side" resolves as the *layout sibling* via the existing `findSiblingGroupId`; tested with `(a | (b | c))` for both the nearest-sibling and subtree cases. This is deliberate but is not always the visually rightmost pane.
- **Index-coupled settings search entries** — `BrowserPane` selects search entries positionally, so the new entry is **appended** rather than inserted, with a comment recording why. Inserting would have silently mis-mapped every later setting's visibility.

**Cross-platform (macOS / Linux / Windows):** checked. No shortcuts, accelerators, shortcut labels, path handling, or shell invocation are touched. The change is layout-state logic plus one settings switch; nothing platform-conditional. Developed and tested on Windows.

**Forge/provider and remote considerations:** no source-control provider surface touched. No wire-format change — the placement decision is made entirely in the renderer from local layout state, so there is no client/host contract impact per `docs/reference/remote-wire-compatibility.md`. Remote/SSH worktrees keep their existing early return and are unaffected.

## Security Audit

- **Input handling:** the URL path is unchanged — main still validates and normalizes before sending, and this PR only adds a destination group id resolved from local layout state. No rule, URL, or guest-supplied content influences the placement decision.
- **Command execution / path handling / IPC:** none added. No new IPC channels; the existing `browser:open-link-in-orca-tab` payload is unchanged.
- **Secrets / auth:** untouched.
- **Settings surface:** one boolean, defaulting off, persisted through the existing `GlobalSettings` path.
- **Follow-up:** none identified.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
