### PR TITLE
feat(jira): saved and custom JQL filters in the Tasks panel

### DIFF
--- a/src/main/ipc/jira.ts
+++ b/src/main/ipc/jira.ts
@@ -19,6 +19,7 @@ import {
   searchIssues,
   updateIssue
 } from '../jira/issues'
+import { listSavedFilters } from '../jira/saved-filters'
 import type {
   JiraConnectArgs,
   JiraCreateIssueArgs,
@@ -246,6 +247,10 @@ export function registerJiraHandlers(): void {
 
   ipcMain.handle('jira:listProjects', async (_event, args?: { siteId?: JiraSiteSelection }) => {
     return listProjects(normalizeSiteSelection(args?.siteId))
+  })
+
+  ipcMain.handle('jira:listSavedFilters', async (_event, args?: { siteId?: JiraSiteSelection }) => {
+    return listSavedFilters(normalizeSiteSelection(args?.siteId))
   })
 
   ipcMain.handle(

--- a/src/main/jira/issues.ts
+++ b/src/main/jira/issues.ts
@@ -169,7 +169,7 @@ function toIssueSearchFailureError(error: unknown): unknown {
   return new Error(`Error ${status}: ${error.message}`)
 }
 
-function shouldSurfaceSiteFailure(
+export function shouldSurfaceSiteFailure(
   selection: JiraSiteSelection | null | undefined,
   entryCount: number
 ): boolean {

--- a/src/main/jira/saved-filters.test.ts
+++ b/src/main/jira/saved-filters.test.ts
@@ -1,0 +1,186 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { JiraClientForSite } from './client'
+
+const {
+  clearTokenMock,
+  getClientsMock,
+  isAuthErrorMock,
+  jiraRequestMock,
+  acquireMock,
+  releaseMock
+} = vi.hoisted(() => ({
+  clearTokenMock: vi.fn(),
+  getClientsMock: vi.fn(),
+  isAuthErrorMock: vi.fn(),
+  jiraRequestMock: vi.fn(),
+  acquireMock: vi.fn().mockResolvedValue(undefined),
+  releaseMock: vi.fn()
+}))
+
+vi.mock('./client', () => ({
+  acquire: (...args: unknown[]) => acquireMock(...args),
+  release: (...args: unknown[]) => releaseMock(...args),
+  apiBasePath: (site: { authType?: string }) =>
+    site.authType === 'server' ? '/rest/api/2' : '/rest/api/3',
+  clearToken: (...args: unknown[]) => clearTokenMock(...args),
+  getClients: (...args: unknown[]) => getClientsMock(...args),
+  isAuthError: (...args: unknown[]) => isAuthErrorMock(...args),
+  jiraRequest: (...args: unknown[]) => jiraRequestMock(...args)
+}))
+
+function makeEntry(id = 'site-1'): JiraClientForSite {
+  return {
+    site: {
+      id,
+      siteUrl: 'https://example.atlassian.net',
+      email: 'ada@example.com',
+      displayName: 'Example Jira',
+      accountId: 'account-1'
+    },
+    authorization: 'Basic token'
+  }
+}
+
+function makeServerEntry(id = 'server-1'): JiraClientForSite {
+  return {
+    site: {
+      id,
+      siteUrl: 'https://jira.example.com',
+      email: '',
+      displayName: 'Self-hosted Jira',
+      accountId: 'wquintal',
+      authType: 'server'
+    },
+    authorization: 'Bearer pat-token'
+  }
+}
+
+describe('listSavedFilters', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    isAuthErrorMock.mockReturnValue(false)
+    getClientsMock.mockReturnValue([makeEntry()])
+    acquireMock.mockResolvedValue(undefined)
+  })
+
+  it('fetches Cloud filters from /filter/my with favourites and JQL expanded', async () => {
+    jiraRequestMock.mockResolvedValueOnce([
+      { id: '10001', name: 'Team backlog', jql: 'project = ALP ORDER BY rank', favourite: true },
+      { id: 10002, name: 'API cleanup', jql: 'labels = api' }
+    ])
+    const { listSavedFilters } = await import('./saved-filters')
+
+    const filters = await listSavedFilters('site-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ site: expect.objectContaining({ id: 'site-1' }) }),
+      '/rest/api/3/filter/my?expand=jql&includeFavourites=true'
+    )
+    expect(filters).toEqual([
+      {
+        id: '10002',
+        name: 'API cleanup',
+        jql: 'labels = api',
+        siteId: 'site-1',
+        siteName: 'Example Jira',
+        favourite: undefined
+      },
+      {
+        id: '10001',
+        name: 'Team backlog',
+        jql: 'project = ALP ORDER BY rank',
+        siteId: 'site-1',
+        siteName: 'Example Jira',
+        favourite: true
+      }
+    ])
+  })
+
+  it('fetches Server/DC filters from the REST v2 favourite resource', async () => {
+    getClientsMock.mockReturnValue([makeServerEntry()])
+    jiraRequestMock.mockResolvedValueOnce([
+      { id: '9001', name: 'My sprint', jql: 'sprint in openSprints()' }
+    ])
+    const { listSavedFilters } = await import('./saved-filters')
+
+    const filters = await listSavedFilters('server-1')
+
+    expect(jiraRequestMock).toHaveBeenCalledWith(
+      expect.objectContaining({ site: expect.objectContaining({ authType: 'server' }) }),
+      '/rest/api/2/filter/favourite?expand=jql'
+    )
+    expect(filters).toEqual([
+      {
+        id: '9001',
+        name: 'My sprint',
+        jql: 'sprint in openSprints()',
+        siteId: 'server-1',
+        siteName: 'Self-hosted Jira',
+        favourite: undefined
+      }
+    ])
+  })
+
+  it('drops filters without executable JQL and non-array payloads', async () => {
+    jiraRequestMock.mockResolvedValueOnce([
+      { id: '1', name: 'No JQL exposed' },
+      { id: '2', name: '  ', jql: 'labels = api' },
+      { id: '3', name: 'Blank JQL', jql: '   ' },
+      { id: '4', name: 'Valid', jql: 'assignee = currentUser()' }
+    ])
+    const { listSavedFilters } = await import('./saved-filters')
+
+    const filters = await listSavedFilters('site-1')
+
+    expect(filters.map((filter) => filter.id)).toEqual(['4'])
+  })
+
+  it('clears the token and rethrows on auth failure for an explicit single site', async () => {
+    const error = new Error('Unauthorized')
+    isAuthErrorMock.mockReturnValue(true)
+    jiraRequestMock.mockRejectedValueOnce(error)
+    const { listSavedFilters } = await import('./saved-filters')
+
+    await expect(listSavedFilters('site-1')).rejects.toThrow('Unauthorized')
+    expect(clearTokenMock).toHaveBeenCalledWith('site-1')
+    expect(releaseMock).toHaveBeenCalled()
+  })
+
+  it("keeps healthy sites' filters when one site fails under an 'all' fan-out", async () => {
+    const warnSpy = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      getClientsMock.mockReturnValue([makeEntry('site-1'), makeEntry('site-2')])
+      jiraRequestMock
+        .mockRejectedValueOnce(new Error('boom'))
+        .mockResolvedValueOnce([{ id: '7', name: 'Alive', jql: 'project = OK' }])
+      const { listSavedFilters } = await import('./saved-filters')
+
+      const filters = await listSavedFilters('all')
+
+      expect(filters.map((filter) => filter.id)).toEqual(['7'])
+      expect(warnSpy).toHaveBeenCalled()
+    } finally {
+      warnSpy.mockRestore()
+    }
+  })
+
+  it('dedupes filters by site and id across owned + favourite overlap', async () => {
+    jiraRequestMock.mockResolvedValueOnce([
+      { id: '10001', name: 'Team backlog', jql: 'project = ALP', favourite: true },
+      { id: '10001', name: 'Team backlog', jql: 'project = ALP', favourite: true }
+    ])
+    const { listSavedFilters } = await import('./saved-filters')
+
+    const filters = await listSavedFilters('site-1')
+
+    expect(filters).toHaveLength(1)
+  })
+
+  it('returns an empty list when no site is connected', async () => {
+    getClientsMock.mockReturnValue([])
+    const { listSavedFilters } = await import('./saved-filters')
+
+    await expect(listSavedFilters()).resolves.toEqual([])
+    expect(jiraRequestMock).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/jira/saved-filters.ts
+++ b/src/main/jira/saved-filters.ts
@@ -1,0 +1,89 @@
+import type { JiraSavedFilter, JiraSite, JiraSiteSelection } from '../../shared/types'
+import {
+  acquire,
+  apiBasePath,
+  clearToken,
+  getClients,
+  isAuthError,
+  jiraRequest,
+  release
+} from './client'
+import { shouldSurfaceSiteFailure } from './issues'
+
+type JiraRecord = Record<string, unknown>
+
+function mapSavedFilter(site: JiraSite, raw: JiraRecord): JiraSavedFilter | null {
+  const id =
+    typeof raw.id === 'string'
+      ? raw.id
+      : typeof raw.id === 'number' && Number.isFinite(raw.id)
+        ? String(raw.id)
+        : ''
+  const name = typeof raw.name === 'string' ? raw.name : ''
+  const jql = typeof raw.jql === 'string' ? raw.jql : ''
+  // A filter without JQL cannot be executed (expand missing or restricted) — drop it.
+  if (!id || !name.trim() || !jql.trim()) {
+    return null
+  }
+  return {
+    id,
+    name,
+    jql,
+    siteId: site.id,
+    siteName: site.displayName,
+    favourite: raw.favourite === true ? true : undefined
+  }
+}
+
+/**
+ * Lists the user's saved Jira filters (owned and favourites) with their JQL,
+ * so the Tasks panel can run them through the regular issue-search path.
+ */
+export async function listSavedFilters(
+  siteId?: JiraSiteSelection | null
+): Promise<JiraSavedFilter[]> {
+  const entries = getClients(siteId)
+  if (entries.length === 0) {
+    return []
+  }
+  const results = await Promise.all(
+    entries.map(async (entry) => {
+      await acquire()
+      try {
+        // Server/DC has no /filter/my; /filter/favourite covers owned + starred filters.
+        const path =
+          entry.site.authType === 'server'
+            ? `${apiBasePath(entry.site)}/filter/favourite?expand=jql`
+            : '/rest/api/3/filter/my?expand=jql&includeFavourites=true'
+        const records = await jiraRequest<JiraRecord[]>(entry, path)
+        return (Array.isArray(records) ? records : [])
+          .map((record) => mapSavedFilter(entry.site, record))
+          .filter((filter): filter is JiraSavedFilter => filter !== null)
+      } catch (error) {
+        if (isAuthError(error)) {
+          clearToken(entry.site.id)
+          if (shouldSurfaceSiteFailure(siteId, entries.length)) {
+            throw error
+          }
+        } else {
+          console.warn('[jira] listSavedFilters failed:', error)
+        }
+        return []
+      } finally {
+        release()
+      }
+    })
+  )
+  const seen = new Set<string>()
+  return results
+    .flat()
+    .filter((filter) => {
+      const key = `${filter.siteId}:${filter.id}`
+      if (seen.has(key)) {
+        return false
+      }
+      seen.add(key)
+      return true
+    })
+    .sort((a, b) => a.name.localeCompare(b.name))
+}

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -790,6 +790,7 @@ import {
   searchIssues as searchJiraIssues,
   updateIssue as updateJiraIssue
 } from '../jira/issues'
+import { listSavedFilters as listJiraSavedFilters } from '../jira/saved-filters'
 import {
   clearProjectItemFieldValue,
   getProjectViewTable,
@@ -34662,6 +34663,10 @@ export class OrcaRuntimeService {
 
   jiraListProjects(siteId?: JiraSiteSelection): ReturnType<typeof listJiraProjects> {
     return listJiraProjects(siteId)
+  }
+
+  jiraListSavedFilters(siteId?: JiraSiteSelection): ReturnType<typeof listJiraSavedFilters> {
+    return listJiraSavedFilters(siteId)
   }
 
   jiraListIssueTypes(

--- a/src/main/runtime/rpc/methods/jira.test.ts
+++ b/src/main/runtime/rpc/methods/jira.test.ts
@@ -172,6 +172,7 @@ describe('jira RPC methods', () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       jiraListProjects: vi.fn().mockResolvedValue([{ id: 'project-1' }]),
+      jiraListSavedFilters: vi.fn().mockResolvedValue([{ id: 'filter-1' }]),
       jiraListIssueTypes: vi.fn().mockResolvedValue([{ id: 'type-1' }]),
       jiraListCreateFields: vi.fn().mockResolvedValue([{ key: 'customfield_10010' }]),
       jiraListPriorities: vi.fn().mockResolvedValue([{ id: 'priority-1' }]),
@@ -184,6 +185,7 @@ describe('jira RPC methods', () => {
     const dispatcher = new RpcDispatcher({ runtime, methods: JIRA_METHODS })
 
     await dispatcher.dispatch(makeRequest('jira.listProjects', { siteId: 'all' }))
+    await dispatcher.dispatch(makeRequest('jira.listSavedFilters', { siteId: 'site-1' }))
     await dispatcher.dispatch(
       makeRequest('jira.listIssueTypes', { projectIdOrKey: 'project-1', siteId: 'site-1' })
     )
@@ -210,6 +212,7 @@ describe('jira RPC methods', () => {
     )
 
     expect(runtime.jiraListProjects).toHaveBeenCalledWith('all')
+    expect(runtime.jiraListSavedFilters).toHaveBeenCalledWith('site-1')
     expect(runtime.jiraListIssueTypes).toHaveBeenCalledWith('project-1', 'site-1')
     expect(runtime.jiraListCreateFields).toHaveBeenCalledWith('project-1', 'type-1', 'site-1')
     expect(runtime.jiraListPriorities).toHaveBeenCalledWith('site-1')

--- a/src/main/runtime/rpc/methods/jira.ts
+++ b/src/main/runtime/rpc/methods/jira.ts
@@ -227,6 +227,11 @@ export const JIRA_METHODS: RpcAnyMethod[] = [
     handler: async (params, { runtime }) => runtime.jiraListProjects(params?.siteId)
   }),
   defineMethod({
+    name: 'jira.listSavedFilters',
+    params: SiteSelection,
+    handler: async (params, { runtime }) => runtime.jiraListSavedFilters(params?.siteId)
+  }),
+  defineMethod({
     name: 'jira.listIssueTypes',
     params: ProjectIssueTypes,
     handler: async (params, { runtime }) =>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -204,6 +204,7 @@ import type {
   JiraIssueUpdate,
   JiraPriority,
   JiraProject,
+  JiraSavedFilter,
   JiraSiteSelection,
   JiraTransition,
   JiraUser,
@@ -2340,6 +2341,7 @@ export type PreloadApi = {
     }) => Promise<{ ok: true; id: string } | { ok: false; error: string }>
     issueComments: (args: { key: string; siteId?: string }) => Promise<JiraComment[]>
     listProjects: (args?: { siteId?: JiraSiteSelection }) => Promise<JiraProject[]>
+    listSavedFilters: (args?: { siteId?: JiraSiteSelection }) => Promise<JiraSavedFilter[]>
     listIssueTypes: (args: { projectIdOrKey: string; siteId?: string }) => Promise<JiraIssueType[]>
     listCreateFields: (args: {
       projectIdOrKey: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -1919,6 +1919,9 @@ const api = {
     listProjects: (args?: { siteId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('jira:listProjects', args),
 
+    listSavedFilters: (args?: { siteId?: string }): Promise<unknown[]> =>
+      ipcRenderer.invoke('jira:listSavedFilters', args),
+
     listIssueTypes: (args: { projectIdOrKey: string; siteId?: string }): Promise<unknown[]> =>
       ipcRenderer.invoke('jira:listIssueTypes', args),
 

--- a/src/renderer/src/components/TaskPage.tsx
+++ b/src/renderer/src/components/TaskPage.tsx
@@ -366,6 +366,7 @@ import type {
   JiraProject,
   JiraProjectStatusOrder,
   JiraPriority,
+  JiraSavedFilter,
   LinearIssue,
   LinearProjectDetail,
   LinearProjectSummary,
@@ -406,8 +407,17 @@ import {
   jiraListCreateFields,
   jiraListIssueTypes,
   jiraListProjects,
-  jiraListPriorities
+  jiraListPriorities,
+  jiraListSavedFilters
 } from '@/runtime/runtime-jira-client'
+import { TaskPageJiraFilterMenu } from './task-page-jira-filter-menu'
+import { loadJiraFilterViewState, saveJiraFilterViewState } from './jira-custom-filters-storage'
+import {
+  MAX_JIRA_CUSTOM_FILTERS,
+  resolveActiveJiraFilterJql,
+  type ActiveJiraFilterRef,
+  type JiraCustomFilter
+} from '../../../shared/jira-custom-filters'
 import {
   sortJiraIssues,
   type JiraIssueSortColumn,
@@ -4608,6 +4618,10 @@ export default function TaskPage(): React.JSX.Element {
   const [appliedJiraSearch, setAppliedJiraSearch] = useState('')
   const [activeJiraPreset, setActiveJiraPreset] = useState<JiraPresetId>('assigned')
   const [jiraRefreshNonce, setJiraRefreshNonce] = useState(0)
+  const [jiraSavedFilters, setJiraSavedFilters] = useState<JiraSavedFilter[]>([])
+  const [jiraSavedFiltersLoading, setJiraSavedFiltersLoading] = useState(false)
+  const [jiraCustomFilters, setJiraCustomFilters] = useState<JiraCustomFilter[]>([])
+  const [activeJiraFilter, setActiveJiraFilter] = useState<ActiveJiraFilterRef | null>(null)
   const [jiraProjectStatusOrder, setJiraProjectStatusOrder] = useState<{
     order: JiraProjectStatusOrder
     scopeKey: string
@@ -4673,6 +4687,64 @@ export default function TaskPage(): React.JSX.Element {
     [jiraOrderBy]
   )
 
+  const handleSelectJiraSavedFilter = useCallback(
+    (filter: JiraSavedFilter) => {
+      setJiraSearchInput('')
+      setAppliedJiraSearch('')
+      // Snapshot name/jql so the filter can run before the next list refresh.
+      setActiveJiraFilter({
+        source: 'saved',
+        siteId: filter.siteId,
+        filterId: filter.id,
+        name: filter.name,
+        jql: filter.jql
+      })
+      setTaskResumeState({ jiraQuery: '' })
+    },
+    [setTaskResumeState]
+  )
+
+  const handleSelectJiraCustomFilter = useCallback(
+    (filter: JiraCustomFilter) => {
+      setJiraSearchInput('')
+      setAppliedJiraSearch('')
+      setActiveJiraFilter({ source: 'custom', id: filter.id })
+      setTaskResumeState({ jiraQuery: '' })
+    },
+    [setTaskResumeState]
+  )
+
+  const handleCreateJiraCustomFilter = useCallback(
+    (draft: { name: string; jql: string }) => {
+      if (jiraCustomFilters.length >= MAX_JIRA_CUSTOM_FILTERS) {
+        return
+      }
+      const id = crypto.randomUUID()
+      setJiraCustomFilters((current) => [...current, { id, ...draft }])
+      setJiraSearchInput('')
+      setAppliedJiraSearch('')
+      setActiveJiraFilter({ source: 'custom', id })
+      setTaskResumeState({ jiraQuery: '' })
+    },
+    [jiraCustomFilters.length, setTaskResumeState]
+  )
+
+  const handleUpdateJiraCustomFilter = useCallback(
+    (id: string, draft: { name: string; jql: string }) => {
+      setJiraCustomFilters((current) =>
+        current.map((filter) => (filter.id === id ? { ...filter, ...draft } : filter))
+      )
+    },
+    []
+  )
+
+  const handleDeleteJiraCustomFilter = useCallback((id: string) => {
+    setJiraCustomFilters((current) => current.filter((filter) => filter.id !== id))
+    setActiveJiraFilter((current) =>
+      current?.source === 'custom' && current.id === id ? null : current
+    )
+  }, [])
+
   useEffect(() => {
     if (taskResumeAppliedRef.current || !persistedUIReady || !settings) {
       return
@@ -4721,6 +4793,10 @@ export default function TaskPage(): React.JSX.Element {
     setActiveJiraPreset(jiraPreset)
     setJiraSearchInput(jiraQuery)
     setAppliedJiraSearch(jiraQuery)
+
+    const jiraFilterView = loadJiraFilterViewState()
+    setJiraCustomFilters(jiraFilterView.customFilters)
+    setActiveJiraFilter(jiraFilterView.activeFilter ?? null)
 
     // Why: settings/UI hydrate async; apply the restored Tasks context exactly once so later source/filter clicks stay local.
     taskResumeAppliedRef.current = true
@@ -8603,12 +8679,76 @@ export default function TaskPage(): React.JSX.Element {
     if (!taskResumeApplied) {
       return
     }
+    saveJiraFilterViewState({
+      customFilters: jiraCustomFilters,
+      activeFilter: activeJiraFilter ?? undefined
+    })
+  }, [activeJiraFilter, jiraCustomFilters, taskResumeApplied])
+
+  useEffect(() => {
+    if (!taskResumeApplied) {
+      return
+    }
     if (!jiraSearchPersistReadyRef.current) {
       jiraSearchPersistReadyRef.current = true
       return
     }
     setTaskResumeState({ jiraQuery: appliedJiraSearch.trim() })
   }, [appliedJiraSearch, setTaskResumeState, taskResumeApplied])
+
+  useEffect(() => {
+    if (!taskResumeApplied || taskSource !== 'jira' || !jiraConnected) {
+      return
+    }
+    let cancelled = false
+    setJiraSavedFiltersLoading(true)
+    jiraListSavedFilters(jiraTaskSourceContext ?? settings, selectedJiraSiteId)
+      .then((filters) => {
+        if (cancelled) {
+          return
+        }
+        setJiraSavedFilters(filters)
+        // Reconcile the active saved filter: pick up renames/JQL edits, and fall
+        // back to presets when the filter was deleted in Jira or is out of scope.
+        setActiveJiraFilter((current) => {
+          if (current?.source !== 'saved') {
+            return current
+          }
+          const match = filters.find(
+            (filter) => filter.siteId === current.siteId && filter.id === current.filterId
+          )
+          if (!match) {
+            return null
+          }
+          return match.name !== current.name || match.jql !== current.jql
+            ? { ...current, name: match.name, jql: match.jql }
+            : current
+        })
+      })
+      .catch((error) => {
+        if (!cancelled) {
+          // Keep the panel usable without saved filters (e.g. older remote hosts).
+          setJiraSavedFilters([])
+          console.warn('[jira] saved filters load failed:', error)
+        }
+      })
+      .finally(() => {
+        if (!cancelled) {
+          setJiraSavedFiltersLoading(false)
+        }
+      })
+    return () => {
+      cancelled = true
+    }
+  }, [
+    taskSource,
+    jiraConnected,
+    selectedJiraSiteId,
+    jiraRefreshNonce,
+    taskResumeApplied,
+    jiraTaskSourceContext,
+    settings
+  ])
 
   useEffect(() => {
     if (!taskResumeApplied) {
@@ -8627,12 +8767,18 @@ export default function TaskPage(): React.JSX.Element {
     setJiraErrorDetailsOpen(false)
 
     const trimmed = appliedJiraSearch.trim()
+    const activeFilterJql =
+      trimmed.length === 0 ? resolveActiveJiraFilterJql(activeJiraFilter, jiraCustomFilters) : null
     const request =
       trimmed.length > 0
         ? searchJiraIssues(trimmed, JIRA_ITEM_LIMIT, { sourceContext: jiraTaskSourceContext })
-        : listJiraIssues(activeJiraPreset, JIRA_ITEM_LIMIT, {
-            sourceContext: jiraTaskSourceContext
-          })
+        : activeFilterJql
+          ? searchJiraIssues(activeFilterJql, JIRA_ITEM_LIMIT, {
+              sourceContext: jiraTaskSourceContext
+            })
+          : listJiraIssues(activeJiraPreset, JIRA_ITEM_LIMIT, {
+              sourceContext: jiraTaskSourceContext
+            })
 
     void request
       .then((issues) => {
@@ -8682,6 +8828,8 @@ export default function TaskPage(): React.JSX.Element {
     selectedJiraSiteId,
     appliedJiraSearch,
     activeJiraPreset,
+    activeJiraFilter,
+    jiraCustomFilters,
     jiraRefreshNonce,
     taskResumeApplied,
     jiraTaskSourceContext,
@@ -9698,7 +9846,8 @@ export default function TaskPage(): React.JSX.Element {
                     <div className="flex flex-wrap items-center justify-between gap-3">
                       <div className="flex flex-wrap gap-2">
                         {jiraPresets.map((preset) => {
-                          const active = !jiraSearchInput && activeJiraPreset === preset.id
+                          const active =
+                            !jiraSearchInput && !activeJiraFilter && activeJiraPreset === preset.id
                           return (
                             <button
                               key={preset.id}
@@ -9707,6 +9856,7 @@ export default function TaskPage(): React.JSX.Element {
                                 setJiraSearchInput('')
                                 setAppliedJiraSearch('')
                                 setActiveJiraPreset(preset.id)
+                                setActiveJiraFilter(null)
                                 setTaskResumeState({ jiraPreset: preset.id, jiraQuery: '' })
                                 setJiraRefreshNonce((n) => n + 1)
                               }}
@@ -9721,6 +9871,19 @@ export default function TaskPage(): React.JSX.Element {
                             </button>
                           )
                         })}
+                        <TaskPageJiraFilterMenu
+                          savedFilters={jiraSavedFilters}
+                          savedFiltersLoading={jiraSavedFiltersLoading}
+                          customFilters={jiraCustomFilters}
+                          activeFilter={jiraSearchInput ? null : activeJiraFilter}
+                          showSiteName={selectedJiraSiteId === 'all'}
+                          initialJql={jiraSearchInput.trim()}
+                          onSelectSaved={handleSelectJiraSavedFilter}
+                          onSelectCustom={handleSelectJiraCustomFilter}
+                          onCreateCustom={handleCreateJiraCustomFilter}
+                          onUpdateCustom={handleUpdateJiraCustomFilter}
+                          onDeleteCustom={handleDeleteJiraCustomFilter}
+                        />
                       </div>
                       <div className="flex shrink-0 items-center gap-2">
                         <Tooltip>

--- a/src/renderer/src/components/jira-custom-filters-storage.test.ts
+++ b/src/renderer/src/components/jira-custom-filters-storage.test.ts
@@ -1,0 +1,49 @@
+// @vitest-environment happy-dom
+import { beforeEach, describe, expect, it } from 'vitest'
+import { loadJiraFilterViewState, saveJiraFilterViewState } from './jira-custom-filters-storage'
+
+const STORAGE_KEY = 'orca.jira.custom-filters.v1'
+
+describe('Jira custom filters local storage', () => {
+  beforeEach(() => {
+    localStorage.clear()
+  })
+
+  it('falls back to an empty state when nothing is stored or the payload is corrupt', () => {
+    expect(loadJiraFilterViewState()).toEqual({ customFilters: [] })
+
+    localStorage.setItem(STORAGE_KEY, '{not json')
+    expect(loadJiraFilterViewState()).toEqual({ customFilters: [] })
+  })
+
+  it('round-trips custom filters and the active selection', () => {
+    const state = {
+      customFilters: [{ id: 'a', name: 'My bugs', jql: 'type = Bug' }],
+      activeFilter: { source: 'custom' as const, id: 'a' }
+    }
+
+    saveJiraFilterViewState(state)
+
+    expect(loadJiraFilterViewState()).toEqual(state)
+  })
+
+  it('clears the key when the state becomes empty', () => {
+    saveJiraFilterViewState({ customFilters: [{ id: 'a', name: 'My bugs', jql: 'type = Bug' }] })
+
+    saveJiraFilterViewState({ customFilters: [] })
+
+    expect(localStorage.getItem(STORAGE_KEY)).toBeNull()
+    expect(loadJiraFilterViewState()).toEqual({ customFilters: [] })
+  })
+
+  it('drops an active ref pointing at a deleted custom filter on save', () => {
+    saveJiraFilterViewState({
+      customFilters: [{ id: 'a', name: 'My bugs', jql: 'type = Bug' }],
+      activeFilter: { source: 'custom', id: 'deleted' }
+    })
+
+    expect(loadJiraFilterViewState()).toEqual({
+      customFilters: [{ id: 'a', name: 'My bugs', jql: 'type = Bug' }]
+    })
+  })
+})

--- a/src/renderer/src/components/jira-custom-filters-storage.ts
+++ b/src/renderer/src/components/jira-custom-filters-storage.ts
@@ -1,0 +1,31 @@
+import {
+  resolveJiraFilterViewState,
+  type JiraFilterViewState
+} from '../../../shared/jira-custom-filters'
+
+// Why: custom filters are a per-device preference, not host state. Routing them
+// through `ui.set` would nest them in taskResumeState's strict schema, where a
+// host that predates the field silently discards the WHOLE resume state.
+const STORAGE_KEY = 'orca.jira.custom-filters.v1'
+
+export function loadJiraFilterViewState(): JiraFilterViewState {
+  try {
+    const raw = localStorage.getItem(STORAGE_KEY)
+    return resolveJiraFilterViewState(raw ? (JSON.parse(raw) as unknown) : undefined)
+  } catch {
+    return resolveJiraFilterViewState(undefined)
+  }
+}
+
+export function saveJiraFilterViewState(state: JiraFilterViewState): void {
+  try {
+    const normalized = resolveJiraFilterViewState(state)
+    if (normalized.customFilters.length === 0 && !normalized.activeFilter) {
+      localStorage.removeItem(STORAGE_KEY)
+      return
+    }
+    localStorage.setItem(STORAGE_KEY, JSON.stringify(normalized))
+  } catch {
+    // The live view stays usable when browser storage is unavailable or full.
+  }
+}

--- a/src/renderer/src/components/task-page-jira-filter-menu.test.tsx
+++ b/src/renderer/src/components/task-page-jira-filter-menu.test.tsx
@@ -1,0 +1,177 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import type { ReactNode } from 'react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+
+import type { JiraSavedFilter } from '../../../shared/types'
+import type { ActiveJiraFilterRef, JiraCustomFilter } from '../../../shared/jira-custom-filters'
+import { TaskPageJiraFilterMenu } from './task-page-jira-filter-menu'
+
+// Radix menus/dialogs need real pointer events; render their content inline so
+// the menu behavior stays testable in happy-dom (same approach as other menu tests).
+vi.mock('@/components/ui/dropdown-menu', () => ({
+  DropdownMenu: ({ children }: { children: ReactNode }) => <>{children}</>,
+  DropdownMenuContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuItem: ({
+    children,
+    onSelect
+  }: {
+    children: ReactNode
+    onSelect?: (event: Event) => void
+  }) => (
+    <div role="menuitem" tabIndex={0} onClick={() => onSelect?.(new Event('menu.itemSelect'))}>
+      {children}
+    </div>
+  ),
+  DropdownMenuLabel: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DropdownMenuSeparator: () => <hr />,
+  DropdownMenuTrigger: ({ children }: { children: ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ open, children }: { open: boolean; children: ReactNode }) =>
+    open ? <div role="dialog">{children}</div> : null,
+  DialogContent: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: ReactNode }) => <p>{children}</p>,
+  DialogFooter: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogHeader: ({ children }: { children: ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: ReactNode }) => <h2>{children}</h2>
+}))
+
+afterEach(cleanup)
+
+const savedFilter: JiraSavedFilter = {
+  id: '10001',
+  name: 'Team backlog',
+  jql: 'project = ALP ORDER BY rank',
+  siteId: 'site-1',
+  siteName: 'Example Jira'
+}
+
+const customFilter: JiraCustomFilter = {
+  id: 'custom-1',
+  name: 'My open bugs',
+  jql: 'type = Bug AND resolution = Unresolved'
+}
+
+type MenuProps = Parameters<typeof TaskPageJiraFilterMenu>[0]
+
+function renderMenu(overrides: Partial<MenuProps> = {}): MenuProps {
+  const props: MenuProps = {
+    savedFilters: [savedFilter],
+    savedFiltersLoading: false,
+    customFilters: [customFilter],
+    activeFilter: null,
+    showSiteName: false,
+    onSelectSaved: vi.fn(),
+    onSelectCustom: vi.fn(),
+    onCreateCustom: vi.fn(),
+    onUpdateCustom: vi.fn(),
+    onDeleteCustom: vi.fn(),
+    ...overrides
+  }
+  render(<TaskPageJiraFilterMenu {...props} />)
+  return props
+}
+
+describe('TaskPage Jira filter menu', () => {
+  it('lists saved and custom filters and reports selections', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+
+    await user.click(screen.getByText('Team backlog'))
+    expect(props.onSelectSaved).toHaveBeenCalledWith(savedFilter)
+
+    await user.click(screen.getByText('My open bugs'))
+    expect(props.onSelectCustom).toHaveBeenCalledWith(customFilter)
+  })
+
+  it('shows the active filter name on the trigger', () => {
+    const activeFilter: ActiveJiraFilterRef = {
+      source: 'saved',
+      siteId: savedFilter.siteId,
+      filterId: savedFilter.id,
+      name: savedFilter.name,
+      jql: savedFilter.jql
+    }
+    renderMenu({ activeFilter })
+    expect(screen.getAllByText('Team backlog').length).toBeGreaterThan(1)
+    expect(screen.queryByText('Filters')).not.toBeInTheDocument()
+  })
+
+  it('shows site names only for the all-sites selection', () => {
+    renderMenu({ showSiteName: true })
+    expect(screen.getByText('Example Jira')).toBeInTheDocument()
+
+    cleanup()
+    renderMenu({ showSiteName: false })
+    expect(screen.queryByText('Example Jira')).not.toBeInTheDocument()
+  })
+
+  it('shows an empty state when Jira has no saved filters', () => {
+    renderMenu({ savedFilters: [] })
+    expect(screen.getByText('No saved filters')).toBeInTheDocument()
+
+    cleanup()
+    renderMenu({ savedFilters: [], savedFiltersLoading: true })
+    expect(screen.getByText('Loading…')).toBeInTheDocument()
+  })
+
+  it('creates a custom filter through the dialog', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+
+    await user.click(screen.getByText('New custom filter…'))
+    const saveButton = screen.getByRole('button', { name: 'Save' })
+    expect(saveButton).toBeDisabled()
+
+    await user.type(screen.getByLabelText('Name'), '  Blocked issues ')
+    await user.type(screen.getByLabelText('JQL'), ' status = Blocked ')
+    await user.click(saveButton)
+
+    expect(props.onCreateCustom).toHaveBeenCalledWith({
+      name: 'Blocked issues',
+      jql: 'status = Blocked'
+    })
+  })
+
+  it('prefills the new-filter JQL from the current search', async () => {
+    const user = userEvent.setup()
+    renderMenu({ initialJql: 'project = ALP' })
+
+    await user.click(screen.getByText('New custom filter…'))
+    expect(screen.getByLabelText('JQL')).toHaveValue('project = ALP')
+  })
+
+  it('edits a custom filter without selecting it', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+
+    await user.click(screen.getByRole('button', { name: 'Edit filter “My open bugs”' }))
+    expect(props.onSelectCustom).not.toHaveBeenCalled()
+
+    const nameInput = screen.getByLabelText('Name')
+    expect(nameInput).toHaveValue('My open bugs')
+    await user.clear(nameInput)
+    await user.type(nameInput, 'Renamed')
+    await user.click(screen.getByRole('button', { name: 'Save' }))
+
+    expect(props.onUpdateCustom).toHaveBeenCalledWith('custom-1', {
+      name: 'Renamed',
+      jql: customFilter.jql
+    })
+  })
+
+  it('deletes a custom filter without selecting it', async () => {
+    const user = userEvent.setup()
+    const props = renderMenu()
+
+    await user.click(screen.getByRole('button', { name: 'Delete filter “My open bugs”' }))
+    expect(props.onDeleteCustom).toHaveBeenCalledWith('custom-1')
+    expect(props.onSelectCustom).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/task-page-jira-filter-menu.tsx
+++ b/src/renderer/src/components/task-page-jira-filter-menu.tsx
@@ -1,0 +1,277 @@
+import { useLayoutEffect, useState } from 'react'
+import { Check, ChevronDown, ListFilter, Pencil, Plus, Trash2 } from 'lucide-react'
+import { Button } from '@/components/ui/button'
+import {
+  Dialog,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle
+} from '@/components/ui/dialog'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '@/components/ui/dropdown-menu'
+import { Input } from '@/components/ui/input'
+import { Label } from '@/components/ui/label'
+import { cn } from '@/lib/utils'
+import { translate } from '@/i18n/i18n'
+import type { JiraSavedFilter } from '../../../shared/types'
+import type { ActiveJiraFilterRef, JiraCustomFilter } from '../../../shared/jira-custom-filters'
+
+export type JiraCustomFilterDraft = { name: string; jql: string }
+
+type TaskPageJiraFilterMenuProps = {
+  savedFilters: JiraSavedFilter[]
+  savedFiltersLoading: boolean
+  customFilters: JiraCustomFilter[]
+  activeFilter: ActiveJiraFilterRef | null
+  showSiteName: boolean
+  /** Prefills the JQL field of a new custom filter (e.g. the current search). */
+  initialJql?: string
+  onSelectSaved: (filter: JiraSavedFilter) => void
+  onSelectCustom: (filter: JiraCustomFilter) => void
+  onCreateCustom: (draft: JiraCustomFilterDraft) => void
+  onUpdateCustom: (id: string, draft: JiraCustomFilterDraft) => void
+  onDeleteCustom: (id: string) => void
+}
+
+type FilterDialogState = { mode: 'create' } | { mode: 'edit'; filter: JiraCustomFilter }
+
+function isActiveSaved(active: ActiveJiraFilterRef | null, filter: JiraSavedFilter): boolean {
+  return (
+    active?.source === 'saved' && active.siteId === filter.siteId && active.filterId === filter.id
+  )
+}
+
+export function TaskPageJiraFilterMenu({
+  savedFilters,
+  savedFiltersLoading,
+  customFilters,
+  activeFilter,
+  showSiteName,
+  initialJql,
+  onSelectSaved,
+  onSelectCustom,
+  onCreateCustom,
+  onUpdateCustom,
+  onDeleteCustom
+}: TaskPageJiraFilterMenuProps): React.JSX.Element {
+  const [dialogState, setDialogState] = useState<FilterDialogState | null>(null)
+  const [draftName, setDraftName] = useState('')
+  const [draftJql, setDraftJql] = useState('')
+
+  // Reset the draft before paint on every open so a stale draft never flashes.
+  useLayoutEffect(() => {
+    if (!dialogState) {
+      return
+    }
+    if (dialogState.mode === 'edit') {
+      setDraftName(dialogState.filter.name)
+      setDraftJql(dialogState.filter.jql)
+    } else {
+      setDraftName('')
+      setDraftJql(initialJql ?? '')
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [dialogState])
+
+  const activeCustomFilter =
+    activeFilter?.source === 'custom'
+      ? customFilters.find((filter) => filter.id === activeFilter.id)
+      : undefined
+  const activeLabel =
+    activeFilter?.source === 'saved' ? activeFilter.name : activeCustomFilter?.name
+  const canSaveDraft = draftName.trim().length > 0 && draftJql.trim().length > 0
+
+  const submitDraft = (): void => {
+    if (!canSaveDraft || !dialogState) {
+      return
+    }
+    const draft = { name: draftName.trim(), jql: draftJql.trim() }
+    if (dialogState.mode === 'edit') {
+      onUpdateCustom(dialogState.filter.id, draft)
+    } else {
+      onCreateCustom(draft)
+    }
+    setDialogState(null)
+  }
+
+  return (
+    <>
+      <DropdownMenu>
+        <DropdownMenuTrigger asChild>
+          <button
+            type="button"
+            className={cn(
+              'flex max-w-56 items-center gap-1 rounded-md border px-2 py-1 text-xs transition',
+              activeLabel
+                ? 'border-border/50 bg-foreground/90 text-background backdrop-blur-md'
+                : 'border-border/50 bg-transparent text-foreground hover:bg-muted/50'
+            )}
+          >
+            <ListFilter className="size-3.5 shrink-0" />
+            <span className="truncate">
+              {activeLabel ?? translate('auto.components.TaskPage.jiraFiltersMenuLabel', 'Filters')}
+            </span>
+            <ChevronDown className="size-3 shrink-0 opacity-70" />
+          </button>
+        </DropdownMenuTrigger>
+        <DropdownMenuContent
+          align="start"
+          className="max-h-96 w-72 overflow-y-auto scrollbar-sleek"
+        >
+          <DropdownMenuLabel className="text-muted-foreground">
+            {translate('auto.components.TaskPage.jiraFiltersSavedHeading', 'Saved in Jira')}
+          </DropdownMenuLabel>
+          {savedFilters.map((filter) => (
+            <DropdownMenuItem
+              key={`${filter.siteId}:${filter.id}`}
+              onSelect={() => onSelectSaved(filter)}
+            >
+              <Check
+                className={cn(
+                  'size-3.5',
+                  isActiveSaved(activeFilter, filter) ? 'opacity-100' : 'opacity-0'
+                )}
+              />
+              <span className="min-w-0 flex-1 truncate">{filter.name}</span>
+              {showSiteName && filter.siteName ? (
+                <span className="max-w-24 shrink-0 truncate text-[11px] text-muted-foreground">
+                  {filter.siteName}
+                </span>
+              ) : null}
+            </DropdownMenuItem>
+          ))}
+          {savedFilters.length === 0 ? (
+            <div className="px-2 py-1 text-[12px] text-muted-foreground">
+              {savedFiltersLoading
+                ? translate('auto.components.TaskPage.jiraFiltersLoadingSaved', 'Loading…')
+                : translate('auto.components.TaskPage.jiraFiltersSavedEmpty', 'No saved filters')}
+            </div>
+          ) : null}
+          <DropdownMenuSeparator />
+          <DropdownMenuLabel className="text-muted-foreground">
+            {translate('auto.components.TaskPage.jiraFiltersCustomHeading', 'My filters')}
+          </DropdownMenuLabel>
+          {customFilters.map((filter) => {
+            const active = activeFilter?.source === 'custom' && activeFilter.id === filter.id
+            return (
+              <DropdownMenuItem key={filter.id} onSelect={() => onSelectCustom(filter)}>
+                <Check className={cn('size-3.5', active ? 'opacity-100' : 'opacity-0')} />
+                <span className="min-w-0 flex-1 truncate">{filter.name}</span>
+                <span className="flex shrink-0 items-center gap-0.5">
+                  <button
+                    type="button"
+                    aria-label={translate(
+                      'auto.components.TaskPage.jiraFiltersEditAria',
+                      'Edit filter “{{name}}”',
+                      { name: filter.name }
+                    )}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      setDialogState({ mode: 'edit', filter })
+                    }}
+                    className="rounded p-1 text-muted-foreground transition hover:bg-accent hover:text-foreground"
+                  >
+                    <Pencil className="size-3" />
+                  </button>
+                  <button
+                    type="button"
+                    aria-label={translate(
+                      'auto.components.TaskPage.jiraFiltersDeleteAria',
+                      'Delete filter “{{name}}”',
+                      { name: filter.name }
+                    )}
+                    onPointerDown={(event) => event.stopPropagation()}
+                    onClick={(event) => {
+                      event.stopPropagation()
+                      onDeleteCustom(filter.id)
+                    }}
+                    className="rounded p-1 text-muted-foreground transition hover:bg-destructive/10 hover:text-destructive"
+                  >
+                    <Trash2 className="size-3" />
+                  </button>
+                </span>
+              </DropdownMenuItem>
+            )
+          })}
+          <DropdownMenuItem onSelect={() => setDialogState({ mode: 'create' })}>
+            <Plus className="size-3.5" />
+            {translate('auto.components.TaskPage.jiraFiltersNewCustom', 'New custom filter…')}
+          </DropdownMenuItem>
+        </DropdownMenuContent>
+      </DropdownMenu>
+
+      <Dialog open={dialogState !== null} onOpenChange={(open) => !open && setDialogState(null)}>
+        <DialogContent className="sm:max-w-md">
+          <DialogHeader>
+            <DialogTitle>
+              {dialogState?.mode === 'edit'
+                ? translate('auto.components.TaskPage.jiraFiltersDialogTitleEdit', 'Edit filter')
+                : translate('auto.components.TaskPage.jiraFiltersDialogTitleNew', 'New filter')}
+            </DialogTitle>
+            <DialogDescription>
+              {translate(
+                'auto.components.TaskPage.jiraFiltersDialogDescription',
+                'Saved on this device. The JQL runs against your connected Jira sites.'
+              )}
+            </DialogDescription>
+          </DialogHeader>
+          <div className="flex flex-col gap-3">
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="jira-filter-name">
+                {translate('auto.components.TaskPage.jiraFiltersNameLabel', 'Name')}
+              </Label>
+              <Input
+                id="jira-filter-name"
+                value={draftName}
+                onChange={(event) => setDraftName(event.target.value)}
+                placeholder={translate(
+                  'auto.components.TaskPage.jiraFiltersNamePlaceholder',
+                  'e.g. My open bugs'
+                )}
+                autoFocus
+              />
+            </div>
+            <div className="flex flex-col gap-1.5">
+              <Label htmlFor="jira-filter-jql">
+                {translate('auto.components.TaskPage.jiraFiltersJqlLabel', 'JQL')}
+              </Label>
+              <Input
+                id="jira-filter-jql"
+                value={draftJql}
+                onChange={(event) => setDraftJql(event.target.value)}
+                onKeyDown={(event) => {
+                  if (event.key === 'Enter') {
+                    event.preventDefault()
+                    submitDraft()
+                  }
+                }}
+                placeholder={translate(
+                  'auto.components.TaskPage.99c2755218',
+                  'Jira JQL, e.g. project = ABC AND statusCategory != Done'
+                )}
+                className="font-mono"
+              />
+            </div>
+          </div>
+          <DialogFooter>
+            <Button variant="outline" onClick={() => setDialogState(null)}>
+              {translate('auto.components.TaskPage.ff69a30681', 'Cancel')}
+            </Button>
+            <Button onClick={submitDraft} disabled={!canSaveDraft}>
+              {translate('auto.components.TaskPage.jiraFiltersSave', 'Save')}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
+    </>
+  )
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -1983,7 +1983,22 @@
         "linearModeHasWorktreeTooltip": "Linear tickets linked to an Orca workspace",
         "linearEmptyHasWorktree": "No Linear tickets are linked to an Orca workspace yet. Start work from a Linear issue to see it here.",
         "linearOpenAttachedWorkspace": "Open workspace attached to {{value0}}",
-        "linearWorktreesColumn": "Workspaces"
+        "linearWorktreesColumn": "Workspaces",
+        "jiraFiltersMenuLabel": "Filters",
+        "jiraFiltersSavedHeading": "Saved in Jira",
+        "jiraFiltersCustomHeading": "My filters",
+        "jiraFiltersLoadingSaved": "Loading…",
+        "jiraFiltersSavedEmpty": "No saved filters",
+        "jiraFiltersNewCustom": "New custom filter…",
+        "jiraFiltersEditAria": "Edit filter “{{name}}”",
+        "jiraFiltersDeleteAria": "Delete filter “{{name}}”",
+        "jiraFiltersDialogTitleEdit": "Edit filter",
+        "jiraFiltersDialogTitleNew": "New filter",
+        "jiraFiltersDialogDescription": "Saved on this device. The JQL runs against your connected Jira sites.",
+        "jiraFiltersNameLabel": "Name",
+        "jiraFiltersNamePlaceholder": "e.g. My open bugs",
+        "jiraFiltersJqlLabel": "JQL",
+        "jiraFiltersSave": "Save"
       },
       "Terminal": {
         "73768427cf": "Close",

--- a/src/renderer/src/i18n/locales/es.json
+++ b/src/renderer/src/i18n/locales/es.json
@@ -1895,7 +1895,22 @@
         "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
         "loadPageUnreachable": "La página {{value0}} está más allá de lo que la búsqueda de GitHub puede devolver.",
         "loadPageFailed": "No se pudo cargar la página {{value0}} desde GitHub.",
-        "loadPageNoMoreResults": "No hay más resultados en la página {{value0}}."
+        "loadPageNoMoreResults": "No hay más resultados en la página {{value0}}.",
+        "jiraFiltersMenuLabel": "Filtros",
+        "jiraFiltersSavedHeading": "Guardados en Jira",
+        "jiraFiltersCustomHeading": "Mis filtros",
+        "jiraFiltersLoadingSaved": "Cargando…",
+        "jiraFiltersSavedEmpty": "No hay filtros guardados",
+        "jiraFiltersNewCustom": "Nuevo filtro personalizado…",
+        "jiraFiltersEditAria": "Editar el filtro “{{name}}”",
+        "jiraFiltersDeleteAria": "Eliminar el filtro “{{name}}”",
+        "jiraFiltersDialogTitleEdit": "Editar filtro",
+        "jiraFiltersDialogTitleNew": "Nuevo filtro",
+        "jiraFiltersDialogDescription": "Se guarda en este dispositivo. El JQL se ejecuta en tus sitios de Jira conectados.",
+        "jiraFiltersNameLabel": "Nombre",
+        "jiraFiltersNamePlaceholder": "p. ej., Mis bugs abiertos",
+        "jiraFiltersJqlLabel": "JQL",
+        "jiraFiltersSave": "Guardar"
       },
       "Terminal": {
         "73768427cf": "Cerrar",

--- a/src/renderer/src/i18n/locales/ja.json
+++ b/src/renderer/src/i18n/locales/ja.json
@@ -1895,7 +1895,22 @@
         "jiraLinkSourceUnavailable": "この Jira Issue をリンクできませんでした。Jira に再接続するか該当するサイトを選択してから、もう一度お試しください。",
         "loadPageUnreachable": "ページ {{value0}} は GitHub 検索が返せる範囲を超えています。",
         "loadPageFailed": "GitHub からページ {{value0}} を読み込めませんでした。",
-        "loadPageNoMoreResults": "ページ {{value0}} にはこれ以上結果がありません。"
+        "loadPageNoMoreResults": "ページ {{value0}} にはこれ以上結果がありません。",
+        "jiraFiltersMenuLabel": "フィルター",
+        "jiraFiltersSavedHeading": "Jira に保存済み",
+        "jiraFiltersCustomHeading": "マイフィルター",
+        "jiraFiltersLoadingSaved": "読み込み中…",
+        "jiraFiltersSavedEmpty": "保存済みフィルターはありません",
+        "jiraFiltersNewCustom": "新しいカスタムフィルター…",
+        "jiraFiltersEditAria": "フィルター「{{name}}」を編集",
+        "jiraFiltersDeleteAria": "フィルター「{{name}}」を削除",
+        "jiraFiltersDialogTitleEdit": "フィルターを編集",
+        "jiraFiltersDialogTitleNew": "新しいフィルター",
+        "jiraFiltersDialogDescription": "このデバイスに保存されます。JQL は接続済みの Jira サイトに対して実行されます。",
+        "jiraFiltersNameLabel": "名前",
+        "jiraFiltersNamePlaceholder": "例: 自分の未解決バグ",
+        "jiraFiltersJqlLabel": "JQL",
+        "jiraFiltersSave": "保存"
       },
       "Terminal": {
         "73768427cf": "閉じる",

--- a/src/renderer/src/i18n/locales/ko.json
+++ b/src/renderer/src/i18n/locales/ko.json
@@ -1895,7 +1895,22 @@
         "jiraLinkSourceUnavailable": "Couldn’t link this Jira issue. Reconnect Jira or pick the matching site, then try again.",
         "loadPageUnreachable": "{{value0}} 페이지는 GitHub 검색이 반환할 수 있는 범위를 벗어났습니다.",
         "loadPageFailed": "GitHub에서 {{value0}} 페이지를 불러오지 못했습니다.",
-        "loadPageNoMoreResults": "{{value0}} 페이지에 더 이상 결과가 없습니다."
+        "loadPageNoMoreResults": "{{value0}} 페이지에 더 이상 결과가 없습니다.",
+        "jiraFiltersMenuLabel": "필터",
+        "jiraFiltersSavedHeading": "Jira에 저장됨",
+        "jiraFiltersCustomHeading": "내 필터",
+        "jiraFiltersLoadingSaved": "불러오는 중…",
+        "jiraFiltersSavedEmpty": "저장된 필터가 없습니다",
+        "jiraFiltersNewCustom": "새 사용자 지정 필터…",
+        "jiraFiltersEditAria": "필터 “{{name}}” 편집",
+        "jiraFiltersDeleteAria": "필터 “{{name}}” 삭제",
+        "jiraFiltersDialogTitleEdit": "필터 편집",
+        "jiraFiltersDialogTitleNew": "새 필터",
+        "jiraFiltersDialogDescription": "이 기기에 저장됩니다. JQL은 연결된 Jira 사이트에서 실행됩니다.",
+        "jiraFiltersNameLabel": "이름",
+        "jiraFiltersNamePlaceholder": "예: 내 미해결 버그",
+        "jiraFiltersJqlLabel": "JQL",
+        "jiraFiltersSave": "저장"
       },
       "Terminal": {
         "73768427cf": "닫기",

--- a/src/renderer/src/i18n/locales/zh.json
+++ b/src/renderer/src/i18n/locales/zh.json
@@ -1895,7 +1895,22 @@
         "jiraLinkSourceUnavailable": "无法关联此 Jira 议题。请重新连接 Jira 或选择匹配的站点，然后重试。",
         "loadPageUnreachable": "第 {{value0}} 页超出了 GitHub 搜索可返回的范围。",
         "loadPageFailed": "无法从 GitHub 加载第 {{value0}} 页。",
-        "loadPageNoMoreResults": "第 {{value0}} 页没有更多结果。"
+        "loadPageNoMoreResults": "第 {{value0}} 页没有更多结果。",
+        "jiraFiltersMenuLabel": "筛选器",
+        "jiraFiltersSavedHeading": "已保存在 Jira",
+        "jiraFiltersCustomHeading": "我的筛选器",
+        "jiraFiltersLoadingSaved": "加载中…",
+        "jiraFiltersSavedEmpty": "没有已保存的筛选器",
+        "jiraFiltersNewCustom": "新建自定义筛选器…",
+        "jiraFiltersEditAria": "编辑筛选器“{{name}}”",
+        "jiraFiltersDeleteAria": "删除筛选器“{{name}}”",
+        "jiraFiltersDialogTitleEdit": "编辑筛选器",
+        "jiraFiltersDialogTitleNew": "新建筛选器",
+        "jiraFiltersDialogDescription": "保存在此设备上。JQL 将在你连接的 Jira 站点上运行。",
+        "jiraFiltersNameLabel": "名称",
+        "jiraFiltersNamePlaceholder": "例如:我的未解决缺陷",
+        "jiraFiltersJqlLabel": "JQL",
+        "jiraFiltersSave": "保存"
       },
       "Terminal": {
         "73768427cf": "关闭",

--- a/src/renderer/src/runtime/runtime-jira-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-client.ts
@@ -25,6 +25,7 @@ import { readRuntimeJiraPayload } from './runtime-jira-payload-stream'
 import { getJiraRuntimeTarget, type RuntimeJiraSettings } from './runtime-jira-target'
 
 export { jiraLookupIssueSummary, jiraReadStatus } from './runtime-jira-summary-client'
+export { jiraListSavedFilters } from './runtime-jira-saved-filters-client'
 export type { RuntimeJiraSettings } from './runtime-jira-target'
 
 export type JiraConnectResult = { ok: true; viewer: JiraViewer } | { ok: false; error: string }

--- a/src/renderer/src/runtime/runtime-jira-saved-filters-client.test.ts
+++ b/src/renderer/src/runtime/runtime-jira-saved-filters-client.test.ts
@@ -1,0 +1,104 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { jiraListSavedFilters } from './runtime-jira-saved-filters-client'
+import { clearRuntimeCompatibilityCacheForTests } from './runtime-rpc-client'
+import { createCompatibleRuntimeStatusResponse } from './runtime-compatibility-test-fixture'
+
+const listSavedFiltersLocal = vi.fn()
+const runtimeCall = vi.fn()
+const runtimeSubscribe = vi.fn()
+
+const localContext = {
+  kind: 'task-source' as const,
+  provider: 'jira' as const,
+  projectId: 'project-1',
+  hostId: 'local' as const
+}
+
+const runtimeContext = {
+  ...localContext,
+  hostId: 'runtime:env-1' as const
+}
+
+const savedFilter = {
+  id: '10001',
+  name: 'Team backlog',
+  jql: 'project = ALP',
+  siteId: 'site-1'
+}
+
+function mockRuntimeCall(listResponse: { ok: boolean; result?: unknown; error?: unknown }): void {
+  runtimeCall.mockImplementation(async (args: { method: string }) => {
+    if (args.method === 'status.get') {
+      return createCompatibleRuntimeStatusResponse()
+    }
+    return { id: 'rpc-1', ...listResponse, _meta: { runtimeId: 'remote-runtime' } }
+  })
+}
+
+beforeEach(() => {
+  clearRuntimeCompatibilityCacheForTests()
+  listSavedFiltersLocal.mockReset()
+  runtimeCall.mockReset()
+  runtimeSubscribe.mockReset()
+  vi.stubGlobal('window', {
+    api: {
+      jira: {
+        listSavedFilters: listSavedFiltersLocal
+      },
+      runtimeEnvironments: {
+        call: runtimeCall,
+        subscribe: runtimeSubscribe
+      }
+    }
+  })
+})
+
+afterEach(() => {
+  vi.unstubAllGlobals()
+})
+
+describe('runtime Jira saved-filters client', () => {
+  it('reads local saved filters through the preload bridge', async () => {
+    listSavedFiltersLocal.mockResolvedValue([savedFilter])
+
+    await expect(jiraListSavedFilters(localContext, 'site-1')).resolves.toEqual([savedFilter])
+
+    expect(listSavedFiltersLocal).toHaveBeenCalledWith({ siteId: 'site-1' })
+    expect(runtimeCall).not.toHaveBeenCalled()
+  })
+
+  it('routes paired-runtime reads through jira.listSavedFilters RPC', async () => {
+    mockRuntimeCall({ ok: true, result: [savedFilter] })
+
+    await expect(jiraListSavedFilters(runtimeContext, 'site-1')).resolves.toEqual([savedFilter])
+
+    expect(runtimeCall).toHaveBeenCalledWith(
+      expect.objectContaining({
+        method: 'jira.listSavedFilters',
+        params: { siteId: 'site-1' },
+        selector: 'env-1'
+      })
+    )
+    expect(listSavedFiltersLocal).not.toHaveBeenCalled()
+  })
+
+  it('degrades to an empty list when the remote host predates saved filters', async () => {
+    mockRuntimeCall({
+      ok: false,
+      error: { code: 'method_not_found', message: 'Unknown method: jira.listSavedFilters' }
+    })
+
+    await expect(jiraListSavedFilters(runtimeContext)).resolves.toEqual([])
+  })
+
+  it('propagates other remote failures so the caller can report them', async () => {
+    mockRuntimeCall({
+      ok: false,
+      error: { code: 'internal_error', message: 'boom' }
+    })
+
+    await expect(jiraListSavedFilters(runtimeContext)).rejects.toThrow('boom')
+  })
+})

--- a/src/renderer/src/runtime/runtime-jira-saved-filters-client.ts
+++ b/src/renderer/src/runtime/runtime-jira-saved-filters-client.ts
@@ -1,0 +1,27 @@
+import type { JiraSavedFilter, JiraSiteSelection } from '../../../shared/types'
+import { callRuntimeRpc, RuntimeRpcCallError } from './runtime-rpc-client'
+import { getJiraRuntimeTarget, type RuntimeJiraSettings } from './runtime-jira-target'
+
+export async function jiraListSavedFilters(
+  settings: RuntimeJiraSettings,
+  siteId?: JiraSiteSelection | null
+): Promise<JiraSavedFilter[]> {
+  const target = getJiraRuntimeTarget(settings)
+  if (target.kind !== 'environment') {
+    return window.api.jira.listSavedFilters(siteId ? { siteId } : undefined)
+  }
+  try {
+    return await callRuntimeRpc<JiraSavedFilter[]>(
+      target,
+      'jira.listSavedFilters',
+      siteId ? { siteId } : undefined,
+      { timeoutMs: 30_000 }
+    )
+  } catch (error) {
+    // Older remote hosts predate saved filters; hide them instead of failing the panel.
+    if (error instanceof RuntimeRpcCallError && error.code === 'method_not_found') {
+      return []
+    }
+    throw error
+  }
+}

--- a/src/shared/jira-custom-filters.test.ts
+++ b/src/shared/jira-custom-filters.test.ts
@@ -1,0 +1,95 @@
+import { describe, expect, it } from 'vitest'
+import {
+  MAX_JIRA_CUSTOM_FILTERS,
+  normalizeJiraCustomFilters,
+  resolveActiveJiraFilterJql,
+  resolveJiraFilterViewState,
+  type JiraCustomFilter
+} from './jira-custom-filters'
+
+function makeFilter(id: string): JiraCustomFilter {
+  return { id, name: `Filter ${id}`, jql: `labels = ${id}` }
+}
+
+describe('normalizeJiraCustomFilters', () => {
+  it('keeps well-formed filters and trims fields', () => {
+    expect(
+      normalizeJiraCustomFilters([{ id: ' a ', name: ' My bugs ', jql: ' project = ALP ' }])
+    ).toEqual([{ id: 'a', name: 'My bugs', jql: 'project = ALP' }])
+  })
+
+  it('drops malformed entries, blank fields, and duplicate ids', () => {
+    expect(
+      normalizeJiraCustomFilters([
+        null,
+        'nope',
+        { id: 'a', name: '', jql: 'x' },
+        { id: 'a', name: 'No JQL' },
+        { id: '', name: 'No id', jql: 'x' },
+        { id: 'a', name: 'First', jql: 'x' },
+        { id: 'a', name: 'Duplicate', jql: 'y' }
+      ])
+    ).toEqual([{ id: 'a', name: 'First', jql: 'x' }])
+  })
+
+  it('caps the list and tolerates non-array input', () => {
+    const oversized = Array.from({ length: MAX_JIRA_CUSTOM_FILTERS + 5 }, (_, index) =>
+      makeFilter(String(index))
+    )
+    expect(normalizeJiraCustomFilters(oversized)).toHaveLength(MAX_JIRA_CUSTOM_FILTERS)
+    expect(normalizeJiraCustomFilters({ not: 'a list' })).toEqual([])
+  })
+})
+
+describe('resolveJiraFilterViewState', () => {
+  it('drops an active custom ref whose filter no longer exists', () => {
+    expect(
+      resolveJiraFilterViewState({
+        customFilters: [makeFilter('a')],
+        activeFilter: { source: 'custom', id: 'missing' }
+      })
+    ).toEqual({ customFilters: [makeFilter('a')] })
+  })
+
+  it('keeps an active saved ref with its snapshot', () => {
+    const activeFilter = {
+      source: 'saved',
+      siteId: 'site-1',
+      filterId: '10001',
+      name: 'Team backlog',
+      jql: 'project = ALP'
+    }
+    expect(resolveJiraFilterViewState({ customFilters: [], activeFilter })).toEqual({
+      customFilters: [],
+      activeFilter
+    })
+  })
+
+  it('rejects saved refs missing their executable snapshot and garbage input', () => {
+    expect(
+      resolveJiraFilterViewState({
+        activeFilter: { source: 'saved', siteId: 'site-1', filterId: '10001', name: 'x', jql: '' }
+      })
+    ).toEqual({ customFilters: [] })
+    expect(resolveJiraFilterViewState('garbage')).toEqual({ customFilters: [] })
+    expect(resolveJiraFilterViewState(undefined)).toEqual({ customFilters: [] })
+  })
+})
+
+describe('resolveActiveJiraFilterJql', () => {
+  it('returns the snapshot JQL for saved filters', () => {
+    expect(
+      resolveActiveJiraFilterJql(
+        { source: 'saved', siteId: 's', filterId: 'f', name: 'n', jql: 'project = ALP' },
+        []
+      )
+    ).toBe('project = ALP')
+  })
+
+  it('resolves custom filters by id and degrades to null when deleted', () => {
+    const filters = [makeFilter('a')]
+    expect(resolveActiveJiraFilterJql({ source: 'custom', id: 'a' }, filters)).toBe('labels = a')
+    expect(resolveActiveJiraFilterJql({ source: 'custom', id: 'gone' }, filters)).toBeNull()
+    expect(resolveActiveJiraFilterJql(null, filters)).toBeNull()
+  })
+})

--- a/src/shared/jira-custom-filters.ts
+++ b/src/shared/jira-custom-filters.ts
@@ -1,0 +1,93 @@
+// User-defined Jira filters (name + JQL) stored on this device, plus which
+// saved/custom filter is active in the Tasks panel. Saved-filter selections
+// snapshot name/jql so they can run before the remote list has loaded.
+export type JiraCustomFilter = { id: string; name: string; jql: string }
+
+export type ActiveJiraFilterRef =
+  | { source: 'custom'; id: string }
+  | { source: 'saved'; siteId: string; filterId: string; name: string; jql: string }
+
+export type JiraFilterViewState = {
+  customFilters: JiraCustomFilter[]
+  activeFilter?: ActiveJiraFilterRef
+}
+
+export const MAX_JIRA_CUSTOM_FILTERS = 50
+
+function asTrimmedString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+export function normalizeJiraCustomFilters(value: unknown): JiraCustomFilter[] {
+  if (!Array.isArray(value)) {
+    return []
+  }
+  const filters: JiraCustomFilter[] = []
+  const seen = new Set<string>()
+  for (const entry of value) {
+    if (filters.length >= MAX_JIRA_CUSTOM_FILTERS) {
+      break
+    }
+    if (!entry || typeof entry !== 'object') {
+      continue
+    }
+    const record = entry as Record<string, unknown>
+    const id = asTrimmedString(record.id)
+    const name = asTrimmedString(record.name)
+    const jql = asTrimmedString(record.jql)
+    if (!id || !name || !jql || seen.has(id)) {
+      continue
+    }
+    seen.add(id)
+    filters.push({ id, name, jql })
+  }
+  return filters
+}
+
+function normalizeActiveJiraFilter(
+  value: unknown,
+  customFilters: JiraCustomFilter[]
+): ActiveJiraFilterRef | undefined {
+  if (!value || typeof value !== 'object') {
+    return undefined
+  }
+  const record = value as Record<string, unknown>
+  if (record.source === 'custom') {
+    const id = asTrimmedString(record.id)
+    return id && customFilters.some((filter) => filter.id === id)
+      ? { source: 'custom', id }
+      : undefined
+  }
+  if (record.source === 'saved') {
+    const siteId = asTrimmedString(record.siteId)
+    const filterId = asTrimmedString(record.filterId)
+    const name = asTrimmedString(record.name)
+    const jql = asTrimmedString(record.jql)
+    return siteId && filterId && name && jql
+      ? { source: 'saved', siteId, filterId, name, jql }
+      : undefined
+  }
+  return undefined
+}
+
+export function resolveJiraFilterViewState(value: unknown): JiraFilterViewState {
+  const record = value && typeof value === 'object' ? (value as Record<string, unknown>) : {}
+  const customFilters = normalizeJiraCustomFilters(record.customFilters)
+  const activeFilter = normalizeActiveJiraFilter(record.activeFilter, customFilters)
+  return activeFilter ? { customFilters, activeFilter } : { customFilters }
+}
+
+/** JQL to run for the active filter, or null when it no longer resolves (fall back to presets). */
+export function resolveActiveJiraFilterJql(
+  active: ActiveJiraFilterRef | null | undefined,
+  customFilters: JiraCustomFilter[]
+): string | null {
+  if (!active) {
+    return null
+  }
+  if (active.source === 'saved') {
+    return active.jql
+  }
+  const match = customFilters.find((filter) => filter.id === active.id)
+  return match ? match.jql : null
+}

--- a/src/shared/jira-types.ts
+++ b/src/shared/jira-types.ts
@@ -134,6 +134,16 @@ export type JiraIssueUpdate = {
 
 export type JiraIssueFilter = 'assigned' | 'reported' | 'all' | 'done'
 
+/** A saved filter fetched from Jira (owned or favourite), with its JQL expanded. */
+export type JiraSavedFilter = {
+  id: string
+  name: string
+  jql: string
+  siteId: string
+  siteName?: string
+  favourite?: boolean
+}
+
 export type JiraConnectArgs = {
   siteUrl: string
   // Ignored for 'server' auth: self-hosted PATs authenticate via Bearer

--- a/src/shared/types.ts
+++ b/src/shared/types.ts
@@ -2015,6 +2015,7 @@ export type {
   JiraPriority,
   JiraProject,
   JiraProjectStatusOrder,
+  JiraSavedFilter,
   JiraSite,
   JiraSiteSelection,
   JiraStatus,


### PR DESCRIPTION
Brings Jira's saved filters into the Tasks panel, and lets users define local custom JQL filters, next to the existing Assigned/Reported/All Open/Done presets.

## What it does

**Saved Jira filters** — a new "Filters" menu lists the user's saved filters with their JQL expanded: Cloud via `GET /rest/api/3/filter/my?expand=jql&includeFavourites=true`, Server/DC via `GET /rest/api/2/filter/favourite?expand=jql`, respecting the existing `apiBasePath` v2/v3 duality. With "All sites" selected it fans out per site with the same policy as `listProjects`, labeling each entry with its site.

**Local custom filters** — name + JQL pairs created, renamed, and deleted from the same menu through a minimal shadcn dialog; the JQL field pre-fills from the current search when one is active. Both kinds execute through the existing `searchIssues(jql)` path — no new execution surface, only a listing method.

## Design notes

- **Local persistence lives in `localStorage`** (`orca.jira.custom-filters.v1`), not `taskResumeState`: that object's `.strict()` schema makes an old remote host drop the *entire* resume state on an unknown key — the same failure that moved the Linear view to localStorage (#13391).
- **Wire compatibility**: `jira.listSavedFilters` is a new RPC method; the renderer client treats `method_not_found` from older hosts as "no saved filters" instead of breaking the panel. Nothing existing changed shape.
- **Degradation**: invalid JQL lands in the panel's existing load-failure state; a filter deleted on Jira's side reconciles on refresh and falls back to the default preset.

## Verification

- New tests: Cloud and Server/DC fetch, single-site auth error vs `all` fan-out, dedupe, storage normalizer, menu CRUD + selection via RTL, and the remote client's `method_not_found` degradation. ~576 tests passing across affected and adjacent suites.
- Full `pnpm lint` (oxlint + audits + reliability gates + localization checks) and full typecheck (node/cli/web) green. New strings localized in en/es/ja/ko/zh.

🤖 Generated with [Claude Code](https://claude.com/claude-code)