### PR TITLE
Fix Ctrl+Z in Windows and Linux terminals

### DIFF
--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -266,14 +266,16 @@ describe('registerAppMenu', () => {
       registerAppMenu(buildMenuOptions())
 
       const editSubmenu = getSubmenu(getTemplate(), 'Edit')
-      const expectedAccelerator = platform === 'darwin' ? undefined : ''
+      const expectedRegistration = platform === 'darwin' ? undefined : false
+      const undoItem = editSubmenu.find((item) => item.role === 'undo')
+      const redoItem = editSubmenu.find((item) => item.role === 'redo')
 
-      expect(editSubmenu.find((item) => item.role === 'undo')?.accelerator).toBe(
-        expectedAccelerator
-      )
-      expect(editSubmenu.find((item) => item.role === 'redo')?.accelerator).toBe(
-        expectedAccelerator
-      )
+      expect(undoItem?.accelerator).toBeUndefined()
+      expect(redoItem?.accelerator).toBeUndefined()
+      expect(undoItem && 'registerAccelerator' in undoItem).toBe(platform !== 'darwin')
+      expect(redoItem && 'registerAccelerator' in redoItem).toBe(platform !== 'darwin')
+      expect(undoItem?.registerAccelerator).toBe(expectedRegistration)
+      expect(redoItem?.registerAccelerator).toBe(expectedRegistration)
     }
   )
 

--- a/src/main/menu/register-app-menu.test.ts
+++ b/src/main/menu/register-app-menu.test.ts
@@ -259,6 +259,24 @@ describe('registerAppMenu', () => {
     }
   )
 
+  it.each(['darwin', 'linux', 'win32'] as const)(
+    'preserves terminal undo and redo chords on %s',
+    (platform) => {
+      vi.spyOn(process, 'platform', 'get').mockReturnValue(platform)
+      registerAppMenu(buildMenuOptions())
+
+      const editSubmenu = getSubmenu(getTemplate(), 'Edit')
+      const expectedAccelerator = platform === 'darwin' ? undefined : ''
+
+      expect(editSubmenu.find((item) => item.role === 'undo')?.accelerator).toBe(
+        expectedAccelerator
+      )
+      expect(editSubmenu.find((item) => item.role === 'redo')?.accelerator).toBe(
+        expectedAccelerator
+      )
+    }
+  )
+
   it('keeps selection actions native in a focused guest webview', () => {
     const send = vi.fn()
     const guestContents = { copy: vi.fn(), selectAll: vi.fn() }

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -167,11 +167,13 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     ]
   }
 
+  // Why: non-macOS Ctrl+Z/Ctrl+Y belong to terminal apps; focused DOM editors undo without menu accelerators.
+  const undoRedoAccelerator = isMac ? undefined : ''
   const editMenu: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.edit', 'Edit'),
     submenu: [
-      { role: 'undo' },
-      { role: 'redo' },
+      { role: 'undo', accelerator: undoRedoAccelerator },
+      { role: 'redo', accelerator: undoRedoAccelerator },
       { type: 'separator' },
       { role: 'cut' },
       createAppMenuSelectionItem({

--- a/src/main/menu/register-app-menu.ts
+++ b/src/main/menu/register-app-menu.ts
@@ -167,13 +167,15 @@ function buildAndApplyMenu(options: RegisterAppMenuOptions): void {
     ]
   }
 
-  // Why: non-macOS Ctrl+Z/Ctrl+Y belong to terminal apps; focused DOM editors undo without menu accelerators.
-  const undoRedoAccelerator = isMac ? undefined : ''
+  // Why: keep native menu hints while letting non-macOS Ctrl+Z/Ctrl+Y reach the focused terminal or DOM control.
+  const undoRedoOptions: Electron.MenuItemConstructorOptions = isMac
+    ? {}
+    : { registerAccelerator: false }
   const editMenu: Electron.MenuItemConstructorOptions = {
     label: translateMain('menu.edit', 'Edit'),
     submenu: [
-      { role: 'undo', accelerator: undoRedoAccelerator },
-      { role: 'redo', accelerator: undoRedoAccelerator },
+      { role: 'undo', ...undoRedoOptions },
+      { role: 'redo', ...undoRedoOptions },
       { type: 'separator' },
       { role: 'cut' },
       createAppMenuSelectionItem({


### PR DESCRIPTION
## Summary

- Keep Electron Undo/Redo menu roles visible on Windows and Linux without registering their accelerators globally.
- Let Ctrl+Z and Ctrl+Y reach the focused terminal while preserving DOM-native editing and macOS menu behavior.
- Add platform-pinned regression coverage for macOS, Linux, and Windows.

## Electron evidence

Ctrl+Z sent through Electron/CDP reached the raw terminal as the expected `0x1A` control byte:

![ctrl-z-control-byte.png](https://github.com/user-attachments/assets/c00bbdc2-8c89-4eac-848f-315059d0a025)

## Testing

- `pnpm exec vitest run src/main/menu/register-app-menu.test.ts` — 27 passed, 1 skipped
- `pnpm run typecheck:node`
- Focused Oxlint and Oxfmt checks
- Electron/CDP terminal transport validation
- Senior AI review: clean after replacing an undocumented empty accelerator with `registerAccelerator: false`

The configured low-spec Windows runtime disconnected during worktree creation and remained unavailable, so Windows end-to-end Electron validation could not be completed.

Partially addresses #12354 (Ctrl+Z/Ctrl+Y only; the other reported behaviors remain open).
