### PR TITLE
fix(terminal-links): detect non-Latin file paths

### DIFF
--- a/src/renderer/src/lib/terminal-links-redos.test.ts
+++ b/src/renderer/src/lib/terminal-links-redos.test.ts
@@ -9,7 +9,10 @@ import { extractTerminalFileLinks, extractTerminalFileLinkCandidates } from './t
 describe('terminal-links ReDoS guard (#5970)', () => {
   const cases: [string, string][] = [
     ['separator + space padding', `a/${' '.repeat(30_000)}`],
-    ['advertised url + space padding', `Web Interface http://127.0.0.1:4040${' '.repeat(30_000)}`]
+    ['advertised url + space padding', `Web Interface http://127.0.0.1:4040${' '.repeat(30_000)}`],
+    // The local-path class accepts Unicode letters/marks; keep that scan linear too.
+    ['non-latin separator + space padding', `한/${' '.repeat(30_000)}`],
+    ['non-latin run + space padding', `${'한글'.repeat(15_000)}/${' '.repeat(30_000)}`]
   ]
 
   for (const [name, line] of cases) {

--- a/src/renderer/src/lib/terminal-links.test.ts
+++ b/src/renderer/src/lib/terminal-links.test.ts
@@ -215,6 +215,45 @@ describe('terminal path helpers', () => {
       expect(links).toHaveLength(20_000)
       expect(links[0].pathText).toBe('/tmp/Foo Bar/file')
     }, 5_000)
+
+    // An ASCII-only character class truncated these at the first non-Latin
+    // character, so only the ASCII prefix was linkified and the filename sat
+    // outside every link range.
+    it.each([
+      ['Korean', '/Users/me/docs/한글폴더/파일.md'],
+      ['Japanese', '/Users/me/docs/日本語/ファイル.md'],
+      ['Chinese', '/Users/me/docs/中文目录/文件.md'],
+      ['Cyrillic', '/Users/me/docs/Документы/файл.md'],
+      ['Greek', '/Users/me/docs/έγγραφα/αρχείο.md']
+    ])('detects unspaced %s paths end to end', (_script, path) => {
+      const links = extractTerminalFileLinks(path)
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: path, displayText: path })
+    })
+
+    it('detects relative paths that start with a non-Latin segment', () => {
+      const links = extractTerminalFileLinks('한글폴더/파일.md')
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: '한글폴더/파일.md' })
+    })
+
+    it('keeps line and column suffixes on non-Latin paths', () => {
+      const links = extractTerminalFileLinks('/Users/me/docs/한글폴더/파일.ts:42:7')
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({
+        pathText: '/Users/me/docs/한글폴더/파일.ts',
+        line: 42,
+        column: 7
+      })
+    })
+
+    // macOS stores many names decomposed, while terminal output is composed.
+    it('detects NFD-decomposed non-Latin paths', () => {
+      const path = `/Users/me/docs/${'한글폴더'.normalize('NFD')}/${'파일.md'.normalize('NFD')}`
+      const links = extractTerminalFileLinks(path)
+      expect(links).toHaveLength(1)
+      expect(links[0]).toMatchObject({ pathText: path })
+    })
   })
 
   it('supports Windows cwd resolution for terminal file links', () => {

--- a/src/renderer/src/lib/terminal-links.ts
+++ b/src/renderer/src/lib/terminal-links.ts
@@ -33,8 +33,11 @@ export type ResolvedTerminalFileLink = Pick<ParsedTerminalFileLink, 'line' | 'co
 // `:line` and `:col` suffixes (e.g. `src/foo.ts:12:3`, `./bin`, `/abs/path`).
 // Why: framework route files commonly use punctuation segments like
 // `app/(shop)/products/[id]/page.tsx`; keep those links whole.
+// Why \p{L}\p{M}\p{N}: an ASCII-only class truncated the match at the first
+// non-Latin character, so CJK paths linkified only their ASCII prefix and the
+// filename was left outside every link range. \p{M} keeps macOS NFD names whole.
 const LOCAL_PATH_REGEX =
-  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[A-Za-z0-9._-]+[\\/])[A-Za-z0-9._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/g
+  /(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/]|[\p{L}\p{M}\p{N}._-]+[\\/])[\p{L}\p{M}\p{N}._~\-/%+@\\()[\]]*(?::\d+)?(?::\d+)?/gu
 
 // Matches separator paths whose file or folder names include spaces. This runs
 // before LOCAL_PATH_REGEX so `/Users/A/Foo Bar/file.ts` is claimed as one link


### PR DESCRIPTION
## Summary

Fixes #13396.
Related to #13397 (found while reducing this one; not addressed here).

Terminal file links were truncated at the first non-Latin character, so Cmd/Ctrl+clicking a Korean, Japanese, Chinese, Cyrillic, or Greek path did nothing.

`LOCAL_PATH_REGEX` used an ASCII-only character class. For `/Users/me/docs/한글폴더/파일.md` the match stopped at `/Users/me/docs/`, leaving the filename outside every link range — hovering it showed no underline and the click was a no-op.

Paths containing a space happened to work, because `SPACED_LOCAL_PATH_REGEXES` uses a negated class that already accepted those characters. But those regexes only fire when the candidate contains whitespace, so a space was accidentally rescuing non-Latin paths:

| Path | Before | After |
| --- | --- | --- |
| `/Users/me/docs/folder/file.md` | linkified | linkified |
| `/Users/me/docs/한글폴더/파일.md` | **cut at `docs/`** | linkified |
| `/Users/me/docs/한글 폴더/파일.md` | linkified | linkified |

The fix allows `\p{L}\p{M}\p{N}` in both the relative-prefix and body classes and adds the `u` flag. `\p{M}` also keeps macOS NFD (decomposed) names whole, which matters because terminal output is composed while many macOS directory names on disk are not.

## Screenshots

No visual change to any UI surface. The only visible difference is that non-Latin paths in the terminal now underline on hover across their full length instead of stopping partway.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added to `terminal-links.test.ts`:

- unspaced Korean / Japanese / Chinese / Cyrillic / Greek paths match end to end
- a relative path starting with a non-Latin segment (`한글폴더/파일.md`)
- `:line:col` suffixes still parse on a non-Latin path
- an NFD-decomposed path matches whole

Added to `terminal-links-redos.test.ts`: two non-Latin padding cases, so the widened class stays under the existing linear-time guard.

Note on the full suite: 9 tests fail on my machine, all in `src/main/updater.test.ts` (`linux root package install recovery`), `src/main/local-downloaded-folder-promotion.test.ts`, `src/main/startup/run-electron-vite-dev.test.ts`, and `tests/e2e/cross-version-wire/`. I confirmed these are pre-existing by stashing my change and re-running the same files on a clean tree, where they fail identically. None of them touch terminal link parsing. Some also passed when run in isolation but failed under full-suite parallelism, so they look partly flaky and partly environment-dependent (Linux-specific paths running on macOS).

## AI Review Report

Reviewed with Claude Code. Focus areas and outcomes:

**Cross-platform.** The change is a character-class widening, with no platform branching. Verified that the Windows drive-letter alternative (`[A-Za-z]:[\\/]`) is untouched, and that `C:\Users\me\file.txt` and backslash separators still match, since `\\` remains in the body class. `\p{N}` preserves the digits the old class allowed, so drive-relative and numeric segments are unaffected. Existing Windows-path tests (`isPathInsideWorktree`, `toWorktreeRelativePath`, UNC forward-slash cases) pass unchanged.

**Regression surface.** Confirmed the previously-supported shapes still match: framework route segments (`app/(shop)/products/[productId]/page.tsx:42:7`), `~/`-prefixed POSIX paths, `./bin`, `src/foo.ts:12:3`, and spaced paths handled by the separate spaced regexes. The `u` flag required no escaping changes to the existing literal.

**Performance.** This was the main risk, given the `#5970` ReDoS guard. The widened classes still exclude `:` and all whitespace, so they cannot overlap the `(?::\d+)?` suffixes or the space padding that caused the original backtracking. The scan stays a single linear character-class repetition. I added non-Latin padding cases to the ReDoS test rather than relying on the ASCII ones.

**SSH / remote.** No change. Detection runs on terminal text before any local/remote routing decision, and `openHttpLink` / `openDetectedFilePath` ownership checks are untouched.

**Scope flagged but not changed.** `BARE_FILENAME_PATTERN` in `detectBareFilenameLinks` is also ASCII-only, so a bare `파일.md` token with no separator still is not linkified. I left it alone deliberately: that path resolves tokens against the cwd and is intentionally conservative, and widening it would raise false positives in non-Latin prose. Happy to do it separately if you want it.

## Security Audit

**Path handling.** This widens what text is *recognized* as a path candidate, not what the app is allowed to open. Every downstream gate is unchanged: `parseExplicitFileLinkTarget` still rejects trailing separators and non-positive line/column values, `openDetectedFilePath` still routes through `authorizeExternalPath` and `statRuntimePath`, and `resolveAuthorizedPath` in `src/main/ipc/filesystem-auth.ts` still enforces the allowed-roots boundary. A path that was previously unlinkable is now clickable, but opening it goes through exactly the same authorization as any ASCII path.

**Traversal.** `\p{L}\p{M}\p{N}` adds no separator, `.`, `:`, or whitespace characters, so it introduces no new way to express `..` or to smuggle a drive/UNC prefix. `isDescendantOrEqual` remains the containment check.

**Command execution / IPC / secrets / dependencies.** None touched. No new IPC channel, no shell invocation, no dependency change.

**Follow-up.** While reducing this I found a separate macOS bug where NFD-normalized directories are detected but never open — filed as #13397. It is not addressed here.

## Notes

- macOS-motivated but not macOS-specific; the bug affected every platform with non-Latin path names.
- No migration or setting involved.
