### PR TITLE
fix(terminal): release retained output slice parents

### DIFF
--- a/config/vitest.config.ts
+++ b/config/vitest.config.ts
@@ -16,7 +16,8 @@ export default defineConfig({
   test: {
     environment: 'node',
     // Why: Node 26's undefined Web Storage globals prevent Vitest from installing happy-dom's.
-    execArgv: ['--no-experimental-webstorage'],
+    // Why --expose-gc: retention tests need a deterministic collection point to measure what a queue really holds.
+    execArgv: ['--no-experimental-webstorage', '--expose-gc'],
     // Why: happy-dom drops MutationObserver callbacks on GC; keep them alive like a browser does.
     setupFiles: [resolve('config/scripts/happy-dom-mutation-observer-retention.ts')],
     include: [

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -333,6 +333,7 @@ import {
 } from './renderer-owned-agent-status-registry'
 import type { DirectSshPaneRetryAttempt } from '@/store/slices/direct-ssh-terminal-recovery'
 import { directSshAuthoritiesEqual } from '@/store/slices/direct-ssh-terminal-authority-ledger'
+import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -6870,7 +6871,9 @@ export function connectPanePty(
       if (rawLength !== chunk.data.length) {
         return null
       }
-      return chunk.data.slice(offset)
+      // Why flatten: this tail outlives the chunk it was cut from once queued, and a raw slice
+      // would pin the whole original chunk in the output queue (STA-3567).
+      return flattenRetainedSlice(chunk.data.slice(offset))
     }
 
     type RestoredSnapshotReconciliation =
@@ -6920,7 +6923,9 @@ export function connectPanePty(
         // Why: renderer-only OSC stripping makes raw seq offsets unmappable onto cleaned text; refetch instead of risking duplicate output.
         return { action: 'force-fresh-restore' }
       }
-      const sliced = data.slice(restoredSnapshotBaselineSeq - startSeq)
+      // Why flatten: same as above - the trimmed tail is handed to the output queue, and a raw
+      // slice would keep the entire pre-trim payload alive behind it (STA-3567).
+      const sliced = flattenRetainedSlice(data.slice(restoredSnapshotBaselineSeq - startSeq))
       return {
         action: 'write',
         data: sliced,

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -333,7 +333,6 @@ import {
 } from './renderer-owned-agent-status-registry'
 import type { DirectSshPaneRetryAttempt } from '@/store/slices/direct-ssh-terminal-recovery'
 import { directSshAuthoritiesEqual } from '@/store/slices/direct-ssh-terminal-authority-ledger'
-import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 
 const pendingSpawnByPaneKey = new Map<string, Promise<string | null>>()
 const SSH_SESSION_EXPIRED_ERROR = 'SSH_SESSION_EXPIRED'
@@ -6871,9 +6870,7 @@ export function connectPanePty(
       if (rawLength !== chunk.data.length) {
         return null
       }
-      // Why flatten: this tail outlives the chunk it was cut from once queued, and a raw slice
-      // would pin the whole original chunk in the output queue (STA-3567).
-      return flattenRetainedSlice(chunk.data.slice(offset))
+      return chunk.data.slice(offset)
     }
 
     type RestoredSnapshotReconciliation =
@@ -6923,9 +6920,7 @@ export function connectPanePty(
         // Why: renderer-only OSC stripping makes raw seq offsets unmappable onto cleaned text; refetch instead of risking duplicate output.
         return { action: 'force-fresh-restore' }
       }
-      // Why flatten: same as above - the trimmed tail is handed to the output queue, and a raw
-      // slice would keep the entire pre-trim payload alive behind it (STA-3567).
-      const sliced = flattenRetainedSlice(data.slice(restoredSnapshotBaselineSeq - startSeq))
+      const sliced = data.slice(restoredSnapshotBaselineSeq - startSeq)
       return {
         action: 'write',
         data: sliced,

--- a/src/renderer/src/lib/flatten-retained-slice.test.ts
+++ b/src/renderer/src/lib/flatten-retained-slice.test.ts
@@ -1,0 +1,57 @@
+import { describe, expect, it } from 'vitest'
+
+import { flattenRetainedSlice } from './flatten-retained-slice'
+
+// Why 1 MB: comfortably above V8's SlicedString threshold, so a raw slice really does keep the
+// parent alive and the difference between flattened and not is unmistakable in heapUsed.
+const PARENT_CHARS = 1024 * 1024
+const TAIL_CHARS = 512
+const PARENTS = 8
+
+function collect(): number {
+  const gc = (globalThis as { gc?: () => void }).gc
+  if (!gc) {
+    throw new Error('global.gc unavailable - config/vitest.config.ts must pass --expose-gc')
+  }
+  gc()
+  gc()
+  return process.memoryUsage().heapUsed
+}
+
+// Distinct leading chars stop V8 sharing one backing store across the parents.
+function makeParent(index: number, filler: string): string {
+  return String.fromCharCode(0x41 + index) + filler.repeat(PARENT_CHARS - 1)
+}
+
+function retainedBytesForTails(filler: string, transform: (value: string) => string): number {
+  const parents = Array.from({ length: PARENTS }, (_unused, index) => makeParent(index, filler))
+  const baseline = collect()
+  const tails = parents.map((parent) => transform(parent.slice(parent.length - TAIL_CHARS)))
+  // Drop the parents; only the tails stay reachable.
+  parents.length = 0
+  const retained = collect() - baseline
+  expect(tails).toHaveLength(PARENTS)
+  expect(tails.every((tail) => tail.length === TAIL_CHARS)).toBe(true)
+  return retained
+}
+
+describe('flattenRetainedSlice', () => {
+  it('preserves content exactly', () => {
+    expect(flattenRetainedSlice('')).toBe('')
+    expect(flattenRetainedSlice('a')).toBe('a')
+    const source = 'hello world, 漢字, [0m, \u{1f600}'
+    expect(flattenRetainedSlice(source.slice(3))).toBe(source.slice(3))
+  })
+
+  it.each([
+    ['one-byte', 'a'],
+    ['two-byte', '漢']
+  ])('drops the %s parent a raw slice would pin', (_label, filler) => {
+    const raw = retainedBytesForTails(filler, (value) => value)
+    const flattened = retainedBytesForTails(filler, flattenRetainedSlice)
+
+    // A raw slice pins all 8 parents; flattening must keep only the tails.
+    expect(raw).toBeGreaterThan(PARENTS * PARENT_CHARS * 0.5)
+    expect(flattened).toBeLessThan(PARENTS * PARENT_CHARS * 0.05)
+  })
+})

--- a/src/renderer/src/lib/flatten-retained-slice.ts
+++ b/src/renderer/src/lib/flatten-retained-slice.ts
@@ -1,0 +1,11 @@
+/**
+ * V8 backs `String.prototype.slice` with a SlicedString that points at the whole parent, so a
+ * short tail of a large chunk keeps that whole chunk alive. Concatenating forces a ConsString
+ * whose flattening allocates a fresh sequential string of just this length, dropping the parent.
+ *
+ * Use this whenever a slice outlives the value it was cut from — a queued remainder, or an
+ * overlap-trimmed payload handed to a component that will hold it.
+ */
+export function flattenRetainedSlice(value: string): string {
+  return value.length === 0 ? value : `${value} `.slice(0, -1)
+}

--- a/src/renderer/src/lib/flatten-retained-slice.ts
+++ b/src/renderer/src/lib/flatten-retained-slice.ts
@@ -1,11 +1,4 @@
-/**
- * V8 backs `String.prototype.slice` with a SlicedString that points at the whole parent, so a
- * short tail of a large chunk keeps that whole chunk alive. Concatenating forces a ConsString
- * whose flattening allocates a fresh sequential string of just this length, dropping the parent.
- *
- * Use this whenever a slice outlives the value it was cut from — a queued remainder, or an
- * overlap-trimmed payload handed to a component that will hold it.
- */
+// V8 slices can retain their full parent; force a standalone copy for values that outlive it.
 export function flattenRetainedSlice(value: string): string {
   return value.length === 0 ? value : `${value} `.slice(0, -1)
 }

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1737,6 +1737,34 @@ describe('pane terminal output scheduler', () => {
       return process.memoryUsage().heapUsed
     }
 
+    it('does not pin the parent when a producer enqueues a slice', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput } = await loadScheduler()
+
+      // Why a slice: agent-status-osc.ts and the restore-overlap trims hand the scheduler
+      // strings cut from a much larger buffer. The queue must own its copy rather than
+      // trusting every producer to flatten first (STA-3567 review round 2).
+      const KEEP_CHARS = 64 * 1024
+      const sinks = Array.from({ length: TERMINALS }, () => ({
+        write: (_data: string, callback?: () => void) => callback?.()
+      }))
+
+      const baseline = collect()
+
+      for (const [index, sink] of sinks.entries()) {
+        const parent = String.fromCharCode(65 + index) + 'q'.repeat(CHUNK_CHARS - 1)
+        writeTerminalOutput(sink, parent.slice(parent.length - KEEP_CHARS), {
+          foreground: false,
+          latencySensitive: false
+        })
+      }
+
+      const retainedBytes = collect() - baseline
+
+      // 8 x 64 KB of real payload must not keep 8 x 2 MB of parents alive.
+      expect(retainedBytes).toBeLessThan(4 * 1024 * 1024)
+    })
+
     it('drops the parent chunk once only a small tail is still queued', async () => {
       vi.useFakeTimers()
       const { writeTerminalOutput } = await loadScheduler()

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1721,4 +1721,79 @@ describe('pane terminal output scheduler', () => {
     vi.advanceTimersByTime(100)
     expect(throwing.write).toHaveBeenCalledTimes(1)
   })
+
+  describe('queue memory retention (STA-3567)', () => {
+    // Why 2 MB: comfortably above BACKGROUND_CHUNK_CHARS (16 K), so every drain leaves a residual slice.
+    const CHUNK_CHARS = 2 * 1024 * 1024
+    const TERMINALS = 8
+
+    function collect(): number {
+      const gc = (globalThis as { gc?: () => void }).gc
+      if (!gc) {
+        throw new Error('global.gc unavailable - config/vitest.config.ts must pass --expose-gc')
+      }
+      gc()
+      gc()
+      return process.memoryUsage().heapUsed
+    }
+
+    it('drops the parent chunk once only a small tail is still queued', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput } = await loadScheduler()
+
+      // Why a hand-rolled write: vi.fn() retains every argument in mock.calls, which would
+      // dominate the measurement with the very bytes the queue is supposed to have released.
+      let writtenChars = 0
+      const makeSink = (): { write: (data: string, callback?: () => void) => void } => ({
+        write: (data: string, callback?: () => void) => {
+          writtenChars += data.length
+          callback?.()
+        }
+      })
+
+      // Distinct leading chars keep V8 from sharing any backing store between terminals.
+      const terminals = Array.from({ length: TERMINALS }, (_unused, index) => {
+        const terminal = makeSink()
+        writeTerminalOutput(
+          terminal,
+          String.fromCharCode(65 + index) + 'q'.repeat(CHUNK_CHARS - 1),
+          { foreground: false, latencySensitive: false }
+        )
+        return terminal
+      })
+
+      const debug = (
+        globalThis as {
+          __terminalOutputSchedulerDebug?: { snapshot: () => { queuedChars: number } }
+        }
+      ).__terminalOutputSchedulerDebug
+      if (!debug) {
+        throw new Error('scheduler debug API unavailable')
+      }
+
+      const baseline = collect()
+
+      // Why stop early: the leak is what a PARTIALLY drained queue pins. Draining to empty
+      // frees the chunks either way, so a full drain cannot observe the defect.
+      const TAIL_CHARS = 64 * 1024
+      let ticks = 0
+      while (debug.snapshot().queuedChars > TAIL_CHARS && ticks < 20000) {
+        vi.advanceTimersByTime(4)
+        ticks += 1
+      }
+
+      const queuedChars = debug.snapshot().queuedChars
+      const retainedBytes = collect() - baseline
+
+      // Sanity: nearly everything drained, but a real tail is still queued - otherwise
+      // there is no residual slice to hold a parent chunk and the measurement is meaningless.
+      expect(writtenChars).toBeGreaterThan(TERMINALS * CHUNK_CHARS * 0.9)
+      expect(queuedChars).toBeGreaterThan(0)
+      expect(queuedChars).toBeLessThanOrEqual(TAIL_CHARS)
+
+      // The defect: those few queued KB pinned 8 x 2 MB of parent chunks (~16 MB).
+      expect(retainedBytes).toBeLessThan(4 * 1024 * 1024)
+      expect(terminals).toHaveLength(TERMINALS)
+    })
+  })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts
@@ -1737,6 +1737,66 @@ describe('pane terminal output scheduler', () => {
       return process.memoryUsage().heapUsed
     }
 
+    it('releases chunks it has already drained past', async () => {
+      vi.useFakeTimers()
+      const { writeTerminalOutput } = await loadScheduler()
+
+      // Why many medium chunks: compactConsumedChunks only splices once chunkIndex reaches 64,
+      // so below that the drained slots stay in the array and must be cleared individually.
+      const CHUNKS_PER_TERMINAL = 40
+      const CHUNK = 48 * 1024
+      const SINKS = 4
+
+      let writtenChars = 0
+      const terminals = Array.from({ length: SINKS }, () => ({
+        write: (data: string, callback?: () => void) => {
+          writtenChars += data.length
+          callback?.()
+        }
+      }))
+
+      const baseline = collect()
+
+      for (const [index, terminal] of terminals.entries()) {
+        for (let chunk = 0; chunk < CHUNKS_PER_TERMINAL; chunk += 1) {
+          writeTerminalOutput(
+            terminal,
+            String.fromCharCode(65 + index) +
+              String.fromCharCode(48 + (chunk % 10)) +
+              'q'.repeat(CHUNK - 2),
+            { foreground: false, latencySensitive: false }
+          )
+        }
+      }
+
+      const debug = (
+        globalThis as {
+          __terminalOutputSchedulerDebug?: { snapshot: () => { queuedChars: number } }
+        }
+      ).__terminalOutputSchedulerDebug
+      if (!debug) {
+        throw new Error('scheduler debug API unavailable')
+      }
+
+      const TAIL_CHARS = 64 * 1024
+      let ticks = 0
+      while (debug.snapshot().queuedChars > TAIL_CHARS && ticks < 40000) {
+        vi.advanceTimersByTime(4)
+        ticks += 1
+      }
+
+      const queuedChars = debug.snapshot().queuedChars
+      const retainedBytes = collect() - baseline
+
+      // Sanity: the queues really drained down, and none hit the backlog cap.
+      expect(writtenChars).toBeGreaterThan(SINKS * CHUNKS_PER_TERMINAL * CHUNK * 0.9)
+      expect(queuedChars).toBeGreaterThan(0)
+      expect(queuedChars).toBeLessThanOrEqual(TAIL_CHARS)
+
+      // The defect: ~39 drained-past slots per terminal kept their strings alive uncharged.
+      expect(retainedBytes).toBeLessThan(2 * 1024 * 1024)
+    })
+
     it('does not pin the parent when a producer enqueues a slice', async () => {
       vi.useFakeTimers()
       const { writeTerminalOutput } = await loadScheduler()
@@ -1778,17 +1838,21 @@ describe('pane terminal output scheduler', () => {
           callback?.()
         }
       })
+      const terminals = Array.from({ length: TERMINALS }, makeSink)
 
-      // Distinct leading chars keep V8 from sharing any backing store between terminals.
-      const terminals = Array.from({ length: TERMINALS }, (_unused, index) => {
-        const terminal = makeSink()
+      // Why baseline BEFORE enqueueing: the queue owns a copy of every chunk, so a baseline
+      // taken after enqueue already contains the parents this test must prove get released,
+      // and the assertion would hold even with residual flattening disabled.
+      const baseline = collect()
+
+      for (const [index, terminal] of terminals.entries()) {
+        // Built and dropped inline so only the queue's own copy stays reachable.
         writeTerminalOutput(
           terminal,
           String.fromCharCode(65 + index) + 'q'.repeat(CHUNK_CHARS - 1),
           { foreground: false, latencySensitive: false }
         )
-        return terminal
-      })
+      }
 
       const debug = (
         globalThis as {
@@ -1798,8 +1862,6 @@ describe('pane terminal output scheduler', () => {
       if (!debug) {
         throw new Error('scheduler debug API unavailable')
       }
-
-      const baseline = collect()
 
       // Why stop early: the leak is what a PARTIALLY drained queue pins. Draining to empty
       // frees the chunks either way, so a full drain cannot observe the defect.
@@ -1819,9 +1881,8 @@ describe('pane terminal output scheduler', () => {
       expect(queuedChars).toBeGreaterThan(0)
       expect(queuedChars).toBeLessThanOrEqual(TAIL_CHARS)
 
-      // The defect: those few queued KB pinned 8 x 2 MB of parent chunks (~16 MB).
+      // The defect: those few queued KB pinned 8 x 2 MB of chunks (~16 MB).
       expect(retainedBytes).toBeLessThan(4 * 1024 * 1024)
-      expect(terminals).toHaveLength(TERMINALS)
     })
   })
 })

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -49,6 +49,8 @@ type WriteTerminalOutputOptions = {
 
 type QueueChunk = {
   data: string
+  // Why: `data` may be a V8 SlicedString pinning a much larger parent; this is what the queue really holds alive.
+  retainedChars: number
   foreground: boolean
   forceForegroundRefresh: boolean
   followupForegroundRefresh: boolean
@@ -582,6 +584,11 @@ function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
   )
 }
 
+// Why: V8 backs `slice` with a SlicedString that points at the whole parent, so a small tail keeps a huge chunk alive. Concatenating forces a ConsString whose flattening allocates a fresh sequential string of just this length.
+function flattenRetainedSlice(value: string): string {
+  return value.length === 0 ? value : `${value} `.slice(0, -1)
+}
+
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
   let remaining = limit
   let data = ''
@@ -631,6 +638,18 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
       data += chunk.data
       remaining -= chunk.data.length
       entry.queuedChars -= chunk.data.length
+      // Why: compaction only splices every 64 chunks, so without this a fully consumed chunk keeps
+      // its (possibly parent-pinning) string and callbacks alive while charging nothing. Nothing
+      // reads below chunkIndex, so the drained slot only has to stay type-shaped.
+      entry.chunks[entry.chunkIndex] = {
+        data: '',
+        retainedChars: 0,
+        foreground: chunk.foreground,
+        forceForegroundRefresh: false,
+        followupForegroundRefresh: false,
+        shouldRefreshForegroundSynchronously: ALWAYS_REFRESH_FOREGROUND_SYNCHRONOUSLY,
+        stripTransientCursorShows: false
+      }
       entry.chunkIndex += 1
       if (chunk.onParsed) {
         parsedCallbacks.push(chunk.onParsed)
@@ -642,9 +661,13 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
     }
 
     data += chunk.data.slice(0, remaining)
+    const residual = chunk.data.slice(remaining)
+    // Why: the residual is a SlicedString still pinning `retainedChars`; copy it flat once it pins 2x its own length so a drained 2MB chunk stops holding 2MB to serve a 1KB tail. Halving keeps total copying linear in the original chunk.
+    const flatten = residual.length * 2 <= chunk.retainedChars
     entry.chunks[entry.chunkIndex] = {
       ...chunk,
-      data: chunk.data.slice(remaining)
+      data: flatten ? flattenRetainedSlice(residual) : residual,
+      retainedChars: flatten ? residual.length : chunk.retainedChars
     }
     entry.queuedChars -= remaining
     remaining = 0
@@ -721,6 +744,7 @@ function enqueueChunk(
 ): void {
   entry.chunks.push({
     data,
+    retainedChars: data.length,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,
     followupForegroundRefresh: options?.followupForegroundRefresh === true,
@@ -783,6 +807,7 @@ function replaceBacklogWithWarning(
   entry.chunks = [
     {
       data: warning,
+      retainedChars: warning.length,
       foreground: false,
       forceForegroundRefresh: false,
       followupForegroundRefresh: false,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -7,6 +7,7 @@ import {
 } from './pane-terminal-foreground-render-settle'
 import { runGuardedWriteCompletionStep } from './xterm-write-callback-guard'
 import { recordRendererCrashBreadcrumb } from '@/lib/crash-breadcrumb-recorder'
+import { flattenRetainedSlice } from '@/lib/flatten-retained-slice'
 import {
   discardInFlightTerminalOutputAckCredits,
   registerTerminalOutputAckCredits
@@ -584,11 +585,6 @@ function coalescedQueuedDataNeedsCursorRestore(entry: QueueEntry): boolean {
   )
 }
 
-// Why: V8 backs `slice` with a SlicedString that points at the whole parent, so a small tail keeps a huge chunk alive. Concatenating forces a ConsString whose flattening allocates a fresh sequential string of just this length.
-function flattenRetainedSlice(value: string): string {
-  return value.length === 0 ? value : `${value} `.slice(0, -1)
-}
-
 function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
   let remaining = limit
   let data = ''
@@ -744,6 +740,9 @@ function enqueueChunk(
 ): void {
   entry.chunks.push({
     data,
+    // Why data.length is the truth here: callers must hand the queue a string that owns its own
+    // storage. A caller passing a slice of a much larger buffer would understate what the queue
+    // pins, so producers flatten overlap-trimmed payloads before they reach the scheduler.
     retainedChars: data.length,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -50,7 +50,7 @@ type WriteTerminalOutputOptions = {
 
 type QueueChunk = {
   data: string
-  // Why: `data` may be a V8 SlicedString pinning a much larger parent; this is what the queue really holds alive.
+  // Tracks the backing data still reachable through this queue slot.
   retainedChars: number
   foreground: boolean
   forceForegroundRefresh: boolean
@@ -634,9 +634,7 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
       data += chunk.data
       remaining -= chunk.data.length
       entry.queuedChars -= chunk.data.length
-      // Why: compaction only splices every 64 chunks, so without this a fully consumed chunk keeps
-      // its (possibly parent-pinning) string and callbacks alive while charging nothing. Nothing
-      // reads below chunkIndex, so the drained slot only has to stay type-shaped.
+      // Clear drained slots before the 64-chunk compaction can release them.
       entry.chunks[entry.chunkIndex] = {
         data: '',
         retainedChars: 0,
@@ -658,7 +656,7 @@ function takeQueuedChunk(entry: QueueEntry, limit: number): QueuedWrite | null {
 
     data += chunk.data.slice(0, remaining)
     const residual = chunk.data.slice(remaining)
-    // Why: the residual is a SlicedString still pinning `retainedChars`; copy it flat once it pins 2x its own length so a drained 2MB chunk stops holding 2MB to serve a 1KB tail. Halving keeps total copying linear in the original chunk.
+    // Geometric flattening bounds retained parents while keeping total copy work linear.
     const flatten = residual.length * 2 <= chunk.retainedChars
     entry.chunks[entry.chunkIndex] = {
       ...chunk,
@@ -738,10 +736,7 @@ function enqueueChunk(
     ackCredit?: () => void
   }
 ): void {
-  // Why copy at the boundary: producers hand us slices and concatenations that pin far more than
-  // they measure - restore-overlap trims and OSC status stripping both do - and the queue holds
-  // this string long after the parent is otherwise dead. Owning our copy is what makes
-  // retainedChars true, and it costs ~0.1ms per 512KB against a ~30MB/s sustained drain.
+  // Own queued data so producer slices cannot pin larger PTY or restore buffers.
   const owned = flattenRetainedSlice(data)
   entry.chunks.push({
     data: owned,

--- a/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
+++ b/src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.ts
@@ -738,12 +738,14 @@ function enqueueChunk(
     ackCredit?: () => void
   }
 ): void {
+  // Why copy at the boundary: producers hand us slices and concatenations that pin far more than
+  // they measure - restore-overlap trims and OSC status stripping both do - and the queue holds
+  // this string long after the parent is otherwise dead. Owning our copy is what makes
+  // retainedChars true, and it costs ~0.1ms per 512KB against a ~30MB/s sustained drain.
+  const owned = flattenRetainedSlice(data)
   entry.chunks.push({
-    data,
-    // Why data.length is the truth here: callers must hand the queue a string that owns its own
-    // storage. A caller passing a slice of a much larger buffer would understate what the queue
-    // pins, so producers flatten overlap-trimmed payloads before they reach the scheduler.
-    retainedChars: data.length,
+    data: owned,
+    retainedChars: owned.length,
     foreground: options?.foreground === true,
     forceForegroundRefresh: options?.forceForegroundRefresh === true,
     followupForegroundRefresh: options?.followupForegroundRefresh === true,


### PR DESCRIPTION
## Summary

Orca buffers terminal text briefly before drawing it. A JavaScript string quirk let tiny queued leftovers keep much larger, already-consumed strings alive in memory. Repeating that pattern could grow the renderer heap toward its roughly 4 GiB limit and crash the app.

This change makes the terminal-output queue own the strings it stores, releases fully consumed chunks immediately, and copies small leftovers away from large parent strings. Terminal contents and ordering do not change; only how long the underlying memory stays reachable changes.

The crash sweep found the same high-heap signature in 38 reports: 20 macOS/Linux renderer crashes and 18 Windows renderer OOMs. Their heaps reached 2.95–4.02 GB while visible terminal buffers and serialized app state were orders of magnitude smaller.

## Start here: the system in one minute

A shell can produce text faster or in larger bursts than xterm should draw at once, so Orca puts that text in a scheduler queue and drains it in controlled batches. The source can be local, WSL, SSH, or a remote runtime; they all eventually use this queue.

```mermaid
flowchart LR
    A["Local shell, WSL, SSH,<br/>or remote runtime"] --> B["Terminal-output scheduler<br/>buffers text bursts"]
    B --> C["xterm<br/>draws the text"]
    B -. "Bug was here:<br/>small queued strings could retain<br/>much larger consumed strings" .-> D["Renderer heap grows<br/>even though little output remains queued"]
```

The important V8 behavior is that taking a slice of a string does not always copy the selected characters. The slice can act like a window into the original string's storage. If the queue keeps that small window, garbage collection must keep the entire original string too.

In this PR, a **parent string** means that larger original allocation. It is not a terminal-process relationship.

## The bug and fix in one picture

```mermaid
flowchart TB
    subgraph BEFORE["Before"]
        direction LR
        A1["2 MiB output chunk"] -->|"drain most of it"| B1["64 KiB tail remains queued"]
        B1 -->|"tail is a view into the parent"| C1["All 2 MiB stay alive"]
    end

    subgraph AFTER["After"]
        direction LR
        A2["2 MiB output chunk"] -->|"drain most of it"| B2["Copy the 64 KiB tail"]
        B2 --> C2["64 KiB stays queued"]
        B2 --> D2["Original 2 MiB can be collected"]
    end
```

That mismatch was the core problem: the scheduler could report only a few queued KiB while V8 still had to retain many MiB. Repeated terminal output accumulated those hidden parents until the renderer ran out of heap.

There were three ways this happened, so the fix has three matching defenses:

```mermaid
flowchart TD
    A["String enters the queue"] --> B["1. Make a queue-owned copy<br/>Producer slices cannot pin larger buffers"]
    B --> C{"How is the chunk drained?"}
    C -->|"Fully consumed"| D["2. Clear its queue slot immediately"]
    C -->|"Partially consumed"| E{"Tail is at most half of<br/>the storage it retains?"}
    E -->|"Yes"| F["3. Copy only the remaining tail<br/>and release the larger parent"]
    E -->|"No"| G["Keep draining without another copy"]
    F --> G
    D --> H["Same terminal bytes, order,<br/>callbacks, and ACK behavior"]
    G --> H
```

The partial-tail copy happens geometrically—only after the remainder has shrunk to at most half of what it retains. That bounds hidden retained memory while keeping total copy work linear instead of copying on every small drain.

### Tiny glossary

- **Chunk:** one string of terminal output held by the scheduler.
- **Tail/residual:** the part of a chunk not drawn yet.
- **Parent/backing store:** the larger string memory a V8 slice can still reference.
- **Flatten/copy:** create a standalone string containing only the characters still needed.

## What changed

- Consumed queue slots are cleared immediately instead of retaining drained strings until 64-slot compaction.
- Every enqueued string is copied at the queue boundary, so slices from any producer cannot pin larger PTY, restore, SSH, or remote buffers.
- Partial drains track the storage still retained and flatten a residual tail when it shrinks to half that size.
- Garbage-collection-aware regression tests cover all three retention paths and verify the copied text is byte-for-byte identical.

## Clear, undeniable fix evidence

The evidence proves the retention mechanism and its removal. It does not claim that a test recreated every field condition behind all 38 reports.

| Proof | Before | After |
| --- | ---: | ---: |
| Field-shaped ABBA counter: 64 × 2 MiB parents, 64 KiB tails, 10 trials/arm | 128.01 MiB retained | 6.01 MiB retained |
| Eight partial queued chunks drained to 8 KiB tails | 16.075 MiB retained | 0.067 MiB retained |
| Eight 64 KiB producer slices from 8 MiB parents | 64.002 MiB retained | 0.509 MiB retained |

A safe implementation mutation made all three new scheduler guards fail:

- drained slots: 7,968,312 retained bytes, over the 2,097,152-byte limit;
- producer slices: 16,773,640 retained bytes, over the 4,194,304-byte limit;
- residual tails: 8,492,824 retained bytes, over the 4,194,304-byte limit.

Restoring this patch makes the same suite pass: 77/77 focused tests. Production Electron 43 / V8 15 independently retained 8.38 MiB and 16.77 MiB for raw one-byte/two-byte tails and approximately zero after flattening.

The latest [Windows v1.4.177 report `9fefe31f-804d-4ea2-9530-57bbbda7fc50`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786326278472139) climbed from 2,752 to 3,984 MiB used heap against a 4,192 MiB limit while measured store state was about 11.9 MiB and estimated terminal buffers were 366 KiB. In a fresh `awin` worktree, the fixed head passed 77/77; the three-guard pre-fix mutation failed 3/77 at 7,978,256 retained bytes (2,097,152 limit), 16,784,016 bytes (4,194,304 limit), and 8,504,520 bytes (4,194,304 limit); restoration returned 77/77 with a clean worktree. This proves the mechanism on Windows, not a complete replay of that field session.

The new [Windows v1.4.176 report `c447338a-3bf9-4b72-88f3-7d30108e3200`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786346531992759) reached about 3,920 MiB used heap against a 4,192 MiB limit after roughly 12.57 hours. Serialized store state was about 1.8 MiB, the two estimated terminal buffers totaled about 93 KiB, and no webviews were present. That is a strong mechanism match for this queue-retention fix, but it is not a complete replay of the field session.

The new [Windows v1.4.175 report `101c94ca-843d-46d5-9b01-ace5879f02b5`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786347457280699) rose to 2,938 MiB after 2 hours 39 minutes, 3,364 MiB after 4 hours 48 minutes, and 3,975 MiB around 6 hours 11 minutes before OOM at 6 hours 38 minutes. Serialized store state was only 638–754 KiB, estimated terminal buffers were 889–1,647 KiB, and no webviews were present. A recovery rendered about 205 ms later, and its replacement independently regrew past 3,443 MiB. This matches the high-heap retention cluster; it is not a complete field-session replay.

The new [macOS v1.4.177 report `1fc38983-d1ff-415e-8f7e-265158057de4`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786347615685259) reached 3,060 MiB after about 5 hours, 3,384 MiB after 7 hours 19 minutes, and 3,999 MiB in the final minute before exit 5 at 8 hours 30 minutes. Serialized store state stayed near 488 KiB, estimated terminal buffers were 127–253 KiB, and no webviews were present. The exact fixed head still passes 77/77 focused tests. This is another strong mechanism match, not proof that exit code 5 has no other contributor.

The late [macOS v1.4.177 report `4f113705-938f-4946-b212-d410f1a12ebd`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786327530709709) rose from 14 to 2,600 to 3,452 to 3,987 MiB used heap against the same 4,192 MiB limit while measured store state stayed at 1.0–1.2 MiB and estimated terminal buffers stayed at 0.7–2.8 MiB. On the exact fixed head, the suite passed 77/77; the same safe mutation failed 3/77 at 7,962,456 retained bytes, 16,773,840 bytes, and 8,492,032 bytes, then restoration returned 77/77 with a clean worktree. This independently reproduces the mechanism on macOS, not the complete field session or exclusion of every WebGL/browser contributor.

The late [Windows v1.4.177 report `5761eba2-42a3-4c95-b4e6-5570b9891bc9`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786329529689839) recorded two renderer OOMs in one main-process lifetime. The first renderer rose from 1,675 to 3,632 MiB in 39 minutes (~50.2 MiB/min); after recovery reload, the fresh 14 MiB renderer rose to 3,658 MiB in 71 minutes (~51.3 MiB/min). Across all high-water samples, serialized store state stayed at 5,076 KiB and the sole estimated terminal buffer stayed at 177 KiB. On the exact fixed head, 77/77 passed; the safe pre-fix mutation failed exactly three guards at 7,981,160 retained bytes (2,097,152 limit), 16,783,840 bytes (4,194,304 limit), and 8,504,552 bytes (4,194,304 limit), then restoration returned 77/77 with a clean worktree. This independently reproduces the mechanism on Windows, not the complete field session or heap-snapshot attribution.


The newest [Windows v1.4.177 report `04f32f4e-5f04-4151-a880-ec74e45f10a5`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786349295299789) supplies two independent renderer lifetimes in one diagnostic bundle. The first rose from 14 to 3,965 MiB over 15.93 hours before OOM; its recovery restarted at 14 MiB and independently reached 2,722 MiB within 5.63 hours. At the high-water marks, serialized store state was only 1.1–1.7 MiB, estimated terminal buffers were 12.7–13.9 MiB, and no webviews were present. The exact fixed head still passes 77/77 focused tests. This is another strong mechanism match, not a complete field-session replay or heap-snapshot attribution.

The delayed [macOS v1.4.176 report `9405cc38-88e9-462d-a374-9417ffafd463`](https://stablygroup.slack.com/archives/C0B4PDCMPPT/p1786353046052569) rose through 2,523, 3,368, and 4,014 of 4,192 MiB before exit 5. Serialized store state remained 1,575 KiB, estimated terminal buffers remained about 4,536 KiB across 23 panes, and no webviews were present. The v1.4.178 label belongs to the later upload bundle, not the original crash. Reversibly restoring the three exact pre-fix scheduler behaviors made exactly three of 77 retention tests fail at 7,998,416, 16,736,096, and 8,519,648 retained bytes; restoring the fixed head returned 77/77 with no tracked diff. This proves the retained-string mechanism, not the complete 52.98-hour field session.

## ELI5

Cutting a tiny piece from a huge V8 string can behave like keeping a bookmark inside the original book: the tiny piece keeps the whole book on the shelf. The terminal queue accumulated those bookmarks. This change photocopies only the pages the queue still needs and throws away the finished books.

## Trade-offs and negative behavior changes

- Every non-empty chunk entering the scheduled queue gets one owned copy. Measured cost is 0.130–0.152 ms/MiB, plus 0.115 ms/MiB for geometric residual flattening. At the scheduler's ~30 MiB/s ceiling this is about 8 ms CPU/s, under 1% of one core.
- Latency-sensitive foreground echo bypasses this queue and pays no new copy.
- Retention tests add `--expose-gc` to Vitest worker processes. Current CI uses process forks; a future `worker_threads` pool would need a different configuration because V8 rejects that flag in worker-thread `execArgv`.
- No UI, terminal-output, ordering, ACK-credit, SSH, remote, or folder-workspace behavior intentionally changes.

## Adversarial review

**Loops until clean: 1. Result: clean.**

The fresh reviewer checked callback and ACK-credit behavior, ordering, discard/reentrancy/failure cleanup, Electron 43 / V8 15 string behavior, test stability, and macOS/Linux/Windows/SSH/folder/remote assumptions. No implementation findings remained. The reviewer called out one evidence limitation: there is no end-to-end recreation of a full 4 GB field crash, so this PR is worded as fixing a demonstrated mechanism consistent with the cluster.

## Performance review

Fresh `/perf` protocol review: **clean**.

- 117.6 MiB/s simulated foreground ceiling; 1.9 MiB/s background ceiling.
- 79 focused tests/bench passed.
- 77 retention/scheduler tests passed in 5/5 repeated runs.
- `terminal-performance.output-backpressure-budget` slice passed 463/463 tests.
- No new polling, timers, scans, provider fanout, or unbounded work.

The remaining measurement gap is a packaged Electron live input-latency soak across Windows/WSL/SSH; the existing experimental gate already records that gap.

## Verification

```text
pnpm exec vitest run --config config/vitest.config.ts \
  src/renderer/src/lib/pane-manager/pane-terminal-output-scheduler.test.ts \
  src/renderer/src/lib/flatten-retained-slice.test.ts
# 77 passed

pnpm typecheck
pnpm lint
pnpm exec oxfmt --check <five changed files>
git diff --check origin/main...HEAD
```

All passed after rebasing onto current `origin/main`. The lint output contains only the pre-existing `WorktreeJumpPalette.tsx` exhaustive-deps warnings.

GitHub CI is complete: **44 checks passed, 1 path-gated E2E job skipped, 0 failed**.

## Screenshots

Not applicable: this is a non-UI memory-lifetime change. The Mermaid diagrams above illustrate the data flow and before/after behavior.

## Security audit

No new permissions, persistence, external inputs, network paths, or execution behavior. Terminal bytes follow the same path and produce the same output; the queue only changes string ownership and release timing.

## Related work

Neil-authored PRs #11038 and #11333 address the same V8 sliced-string mechanism at other long-lived terminal-value boundaries; they do not cover this scheduler queue. PR #12939, authored by Jinwoo, is the direct scheduler predecessor. This PR supersedes #12939 because it also detaches producer slices, clears fully drained queue slots immediately, and geometrically flattens residual tails; the two scheduler PRs should not both merge.

