### PR TITLE
fix(workspaces): support full cleanup scans

### DIFF
--- a/src/main/ipc/workspace-cleanup-broad-scan.test.ts
+++ b/src/main/ipc/workspace-cleanup-broad-scan.test.ts
@@ -193,19 +193,48 @@ describe('workspace cleanup broad scan opt-in', () => {
   })
 
   it('reports folder workspaces with a folder-repo blocker', async () => {
-    const result = await scanWorkspaceCleanup(makeStore([FOLDER_REPO]), {
+    const instanceId = `${FOLDER_REPO.id}::${FOLDER_REPO.path}::workspace:11111111-2222-4333-8444-555555555555`
+    const instanceMeta = makeWorktreeMeta({
+      displayName: 'Folder session',
+      lastActivityAt: NOW - 2 * DAY_MS
+    })
+    const result = await scanWorkspaceCleanup(
+      makeStore([FOLDER_REPO], { [instanceId]: instanceMeta }),
+      { includeAllWorkspaces: true }
+    )
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        worktreeId: 'repo-folder::/folder-workspace',
+        tier: 'protected',
+        selectedByDefault: false,
+        blockers: expect.arrayContaining(['folder-repo', 'main-worktree'])
+      }),
+      expect.objectContaining({
+        worktreeId: instanceId,
+        displayName: 'Folder session',
+        path: FOLDER_REPO.path,
+        tier: 'protected',
+        selectedByDefault: false,
+        blockers: ['folder-repo']
+      })
+    ])
+  })
+
+  it('does not mark connected SSH folder workspaces as disconnected', async () => {
+    const sshFolderRepo: Repo = { ...FOLDER_REPO, connectionId: 'ssh-1' }
+    getSshGitProviderMock.mockReturnValue({})
+
+    const result = await scanWorkspaceCleanup(makeStore([sshFolderRepo]), {
       includeAllWorkspaces: true
     })
 
     expect(result.candidates).toHaveLength(1)
     expect(result.candidates[0]).toMatchObject({
       worktreeId: 'repo-folder::/folder-workspace',
-      tier: 'protected',
-      selectedByDefault: false
+      connectionId: 'ssh-1',
+      blockers: ['main-worktree', 'folder-repo']
     })
-    expect(result.candidates[0]?.blockers).toEqual(
-      expect.arrayContaining(['folder-repo', 'main-worktree'])
-    )
   })
 
   it('defers git evidence for rows that no cleanup decision can use', async () => {
@@ -256,6 +285,27 @@ describe('workspace cleanup broad scan opt-in', () => {
       blockers: ['ssh-disconnected'],
       reasons: []
     })
+  })
+
+  it('uses the backing path for disconnected SSH folder instances', async () => {
+    const sshFolderRepo: Repo = { ...FOLDER_REPO, connectionId: 'ssh-1' }
+    const instanceId = `${sshFolderRepo.id}::${sshFolderRepo.path}::workspace:11111111-2222-4333-8444-555555555555`
+    const allMeta = {
+      [instanceId]: makeWorktreeMeta({ displayName: 'Remote folder session' })
+    }
+
+    const result = await scanWorkspaceCleanup(makeStore([sshFolderRepo], allMeta), {
+      includeAllWorkspaces: true
+    })
+
+    expect(result.candidates).toEqual([
+      expect.objectContaining({
+        worktreeId: instanceId,
+        path: sshFolderRepo.path,
+        branch: 'folder-workspace',
+        blockers: ['ssh-disconnected']
+      })
+    ])
   })
 
   it('streams every row through scan progress on an opt-in scan', async () => {

--- a/src/main/ipc/workspace-cleanup-broad-scan.test.ts
+++ b/src/main/ipc/workspace-cleanup-broad-scan.test.ts
@@ -1,0 +1,276 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Store } from '../persistence'
+import type * as RepoWorktreesModule from '../repo-worktrees'
+import type { GitStatusResult, GitWorktreeInfo, Repo, WorktreeMeta } from '../../shared/types'
+
+const {
+  lstatMock,
+  readFileMock,
+  listRepoWorktreesMock,
+  getStatusMock,
+  gitExecFileAsyncMock,
+  getLocalProjectWorktreeGitOptionsMock,
+  getSshGitProviderMock
+} = vi.hoisted(() => ({
+  lstatMock: vi.fn(),
+  readFileMock: vi.fn(),
+  listRepoWorktreesMock: vi.fn(),
+  getStatusMock: vi.fn(),
+  gitExecFileAsyncMock: vi.fn(),
+  getLocalProjectWorktreeGitOptionsMock: vi.fn(),
+  getSshGitProviderMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', () => ({
+  lstat: lstatMock,
+  readFile: readFileMock
+}))
+
+vi.mock('../repo-worktrees', async () => {
+  const actual = await vi.importActual<typeof RepoWorktreesModule>('../repo-worktrees')
+  return {
+    listRepoWorktrees: listRepoWorktreesMock,
+    createFolderWorktree: actual.createFolderWorktree
+  }
+})
+
+vi.mock('../git/status', () => ({
+  getStatus: getStatusMock
+}))
+
+vi.mock('../git/runner', () => ({
+  gitExecFileAsync: gitExecFileAsyncMock
+}))
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+vi.mock('../project-runtime-git-options', () => ({
+  getLocalProjectWorktreeGitOptions: getLocalProjectWorktreeGitOptionsMock
+}))
+
+import { scanWorkspaceCleanup } from './workspace-cleanup-scan'
+
+const NOW = 1_700_000_000_000
+const DAY_MS = 24 * 60 * 60 * 1000
+const REPO: Repo = {
+  id: 'repo-1',
+  path: '/repo',
+  displayName: 'Repo',
+  badgeColor: '#000',
+  addedAt: NOW,
+  symlinkPaths: ['node_modules']
+}
+const FOLDER_REPO: Repo = {
+  ...REPO,
+  id: 'repo-folder',
+  path: '/folder-workspace',
+  displayName: 'Folder',
+  kind: 'folder'
+}
+
+const GIT_WORKTREES: GitWorktreeInfo[] = [
+  {
+    path: '/repo',
+    head: 'main123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true
+  },
+  {
+    path: '/repo-old',
+    head: 'old123',
+    branch: 'refs/heads/old',
+    isBare: false,
+    isMainWorktree: false
+  },
+  {
+    path: '/repo-recent',
+    head: 'recent123',
+    branch: 'refs/heads/recent',
+    isBare: false,
+    isMainWorktree: false
+  }
+]
+
+function makeWorktreeMeta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: '',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: NOW,
+    baseRef: 'origin/main',
+    ...overrides
+  } as WorktreeMeta
+}
+
+const META_BY_WORKTREE_ID: Record<string, WorktreeMeta> = {
+  'repo-1::/repo': makeWorktreeMeta({ lastActivityAt: NOW - 40 * DAY_MS }),
+  'repo-1::/repo-old': makeWorktreeMeta({ lastActivityAt: NOW - 40 * DAY_MS }),
+  'repo-1::/repo-recent': makeWorktreeMeta({ lastActivityAt: NOW - 2 * DAY_MS }),
+  'repo-folder::/folder-workspace': makeWorktreeMeta({ lastActivityAt: NOW - 40 * DAY_MS })
+}
+
+function makeStore(repos: Repo[] = [REPO], allMeta: Record<string, WorktreeMeta> = {}): Store {
+  return {
+    getRepos: () => repos,
+    getWorktreeMeta: (worktreeId: string) => META_BY_WORKTREE_ID[worktreeId] ?? allMeta[worktreeId],
+    getAllWorktreeMeta: () => allMeta,
+    getGitHubCache: () => ({ pr: {}, issue: {} })
+  } as unknown as Store
+}
+
+describe('workspace cleanup broad scan opt-in', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(NOW)
+    lstatMock.mockReset().mockResolvedValue({ mtimeMs: 0 })
+    readFileMock.mockReset().mockRejectedValue(new Error('not a gitdir pointer'))
+    listRepoWorktreesMock.mockReset().mockResolvedValue(GIT_WORKTREES)
+    getStatusMock.mockReset().mockResolvedValue({
+      entries: [],
+      conflictOperation: 'unknown',
+      upstreamStatus: { hasUpstream: true, ahead: 0, behind: 0 }
+    } satisfies GitStatusResult)
+    gitExecFileAsyncMock.mockReset().mockResolvedValue({ stdout: '0\n', stderr: '' })
+    getLocalProjectWorktreeGitOptionsMock.mockReset().mockReturnValue({})
+    getSshGitProviderMock.mockReset().mockReturnValue(undefined)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('emits every worktree when the client opts into the full workspace list', async () => {
+    const result = await scanWorkspaceCleanup(makeStore(), { includeAllWorkspaces: true })
+
+    expect(result.errors).toEqual([])
+    expect(result.candidates.map((candidate) => candidate.worktreeId)).toEqual([
+      'repo-1::/repo',
+      'repo-1::/repo-old',
+      'repo-1::/repo-recent'
+    ])
+  })
+
+  it('keeps the legacy suggestion-only projection when the flag is absent', async () => {
+    const result = await scanWorkspaceCleanup(makeStore())
+
+    expect(result.candidates.map((candidate) => candidate.worktreeId)).toEqual([
+      'repo-1::/repo-old'
+    ])
+  })
+
+  it('reports recent workspaces with no cleanup reasons', async () => {
+    const result = await scanWorkspaceCleanup(makeStore(), { includeAllWorkspaces: true })
+
+    const recent = result.candidates.find(
+      (candidate) => candidate.worktreeId === 'repo-1::/repo-recent'
+    )
+    expect(recent).toMatchObject({
+      reasons: [],
+      tier: 'review',
+      selectedByDefault: false,
+      lastActivityAt: NOW - 2 * DAY_MS
+    })
+  })
+
+  it('reports the main worktree with a main-worktree blocker', async () => {
+    const result = await scanWorkspaceCleanup(makeStore(), { includeAllWorkspaces: true })
+
+    const main = result.candidates.find((candidate) => candidate.worktreeId === 'repo-1::/repo')
+    expect(main).toMatchObject({
+      tier: 'protected',
+      selectedByDefault: false,
+      blockers: ['main-worktree']
+    })
+  })
+
+  it('reports folder workspaces with a folder-repo blocker', async () => {
+    const result = await scanWorkspaceCleanup(makeStore([FOLDER_REPO]), {
+      includeAllWorkspaces: true
+    })
+
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]).toMatchObject({
+      worktreeId: 'repo-folder::/folder-workspace',
+      tier: 'protected',
+      selectedByDefault: false
+    })
+    expect(result.candidates[0]?.blockers).toEqual(
+      expect.arrayContaining(['folder-repo', 'main-worktree'])
+    )
+  })
+
+  it('defers git evidence for rows that no cleanup decision can use', async () => {
+    const result = await scanWorkspaceCleanup(makeStore(), { includeAllWorkspaces: true })
+
+    // Why: only the inactive row can ever be queued, so it is the only row worth
+    // a git read; the rest stream immediately with empty evidence.
+    expect(getStatusMock).toHaveBeenCalledTimes(1)
+    expect(getStatusMock).toHaveBeenCalledWith('/repo-old', expect.anything())
+    expect(
+      result.candidates.find((candidate) => candidate.worktreeId === 'repo-1::/repo-recent')?.git
+    ).toEqual({ clean: null, upstreamAhead: null, upstreamBehind: null, checkedAt: null })
+    expect(
+      result.candidates.find((candidate) => candidate.worktreeId === 'repo-1::/repo-old')?.git
+    ).toMatchObject({ clean: true, checkedAt: expect.any(Number) })
+  })
+
+  it('still forces a git read for a focused scan of a recent workspace', async () => {
+    const result = await scanWorkspaceCleanup(makeStore(), {
+      worktreeId: 'repo-1::/repo-recent',
+      includeAllWorkspaces: true
+    })
+
+    expect(getStatusMock).toHaveBeenCalledTimes(1)
+    expect(result.candidates).toHaveLength(1)
+    expect(result.candidates[0]).toMatchObject({
+      worktreeId: 'repo-1::/repo-recent',
+      reasons: [],
+      git: { clean: true, checkedAt: expect.any(Number) }
+    })
+  })
+
+  it('lists disconnected SSH workspaces only on an opt-in scan', async () => {
+    const sshRepo: Repo = { ...REPO, id: 'repo-ssh', connectionId: 'ssh-1' }
+    const allMeta: Record<string, WorktreeMeta> = {
+      'repo-ssh::/remote/recent': makeWorktreeMeta({ lastActivityAt: NOW - 2 * DAY_MS })
+    }
+
+    const legacy = await scanWorkspaceCleanup(makeStore([sshRepo], allMeta))
+    const optIn = await scanWorkspaceCleanup(makeStore([sshRepo], allMeta), {
+      includeAllWorkspaces: true
+    })
+
+    expect(legacy.candidates).toEqual([])
+    expect(optIn.candidates).toHaveLength(1)
+    expect(optIn.candidates[0]).toMatchObject({
+      worktreeId: 'repo-ssh::/remote/recent',
+      blockers: ['ssh-disconnected'],
+      reasons: []
+    })
+  })
+
+  it('streams every row through scan progress on an opt-in scan', async () => {
+    const progress: { scannedWorktreeCount: number; totalWorktreeCount: number }[] = []
+
+    await scanWorkspaceCleanup(
+      makeStore(),
+      { includeAllWorkspaces: true, scanId: 'scan-all' },
+      { onProgress: (event) => progress.push(event) }
+    )
+
+    expect(progress.at(-1)).toMatchObject({
+      scanId: 'scan-all',
+      scannedWorktreeCount: 3,
+      totalWorktreeCount: 3
+    })
+  })
+})

--- a/src/main/ipc/workspace-cleanup-disconnected-ssh.ts
+++ b/src/main/ipc/workspace-cleanup-disconnected-ssh.ts
@@ -6,7 +6,7 @@ import {
   createWorkspaceCleanupFingerprint,
   type WorkspaceCleanupCandidate
 } from '../../shared/workspace-cleanup'
-import { splitWorktreeId } from '../../shared/worktree-id'
+import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import {
   getNewestWorkspaceCleanupDiffCommentAt,
   getWorkspaceCleanupInactivityReasonsForWorkspace,
@@ -52,7 +52,7 @@ function createDisconnectedSshCandidate(
   worktreeId: string,
   meta: WorktreeMeta
 ): WorkspaceCleanupCandidate {
-  const parsed = splitWorktreeId(worktreeId)
+  const parsed = splitWorktreeIdForFilesystem(worktreeId)
   const path = parsed?.worktreePath ?? worktreeId
   const reasons = getWorkspaceCleanupInactivityReasonsForWorkspace(meta, scannedAt)
   return applyWorkspaceCleanupPolicy({

--- a/src/main/ipc/workspace-cleanup-disconnected-ssh.ts
+++ b/src/main/ipc/workspace-cleanup-disconnected-ssh.ts
@@ -17,7 +17,8 @@ export function synthesizeDisconnectedSshCleanupCandidates(
   store: Store,
   repo: Repo,
   scannedAt: number,
-  targetWorktreeId?: string
+  targetWorktreeId?: string,
+  includeAllWorkspaces = false
 ): WorkspaceCleanupCandidate[] {
   const repoWorktreePrefix = `${repo.id}::`
   if (targetWorktreeId) {
@@ -37,7 +38,7 @@ export function synthesizeDisconnectedSshCleanupCandidates(
       continue
     }
     const meta = allMeta[worktreeId]
-    if (!meta || !isWorkspaceInactiveForCleanup(meta, scannedAt)) {
+    if (!meta || (!includeAllWorkspaces && !isWorkspaceInactiveForCleanup(meta, scannedAt))) {
       continue
     }
     candidates.push(createDisconnectedSshCandidate(repo, scannedAt, worktreeId, meta))

--- a/src/main/ipc/workspace-cleanup-folder-workspaces.ts
+++ b/src/main/ipc/workspace-cleanup-folder-workspaces.ts
@@ -1,0 +1,22 @@
+import type { Store } from '../persistence'
+import { createFolderWorktree } from '../repo-worktrees'
+import type { Repo, Worktree } from '../../shared/types'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import { mergeWorktree } from './worktree-logic'
+
+export function listWorkspaceCleanupFolderWorkspaces(store: Store, repo: Repo): Worktree[] {
+  const rootId = `${repo.id}::${repo.path}`
+  const instancePrefix = `${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+  const allMeta = store.getAllWorktreeMeta()
+  const worktreeIds = [
+    rootId,
+    ...Object.keys(allMeta).filter((worktreeId) => worktreeId.startsWith(instancePrefix))
+  ]
+  const folderWorktree = createFolderWorktree(repo)
+
+  return worktreeIds.map((worktreeId) => ({
+    ...mergeWorktree(repo.id, folderWorktree, store.getWorktreeMeta(worktreeId), repo.displayName),
+    id: worktreeId,
+    isMainWorktree: worktreeId === rootId
+  }))
+}

--- a/src/main/ipc/workspace-cleanup-scan-eligibility.ts
+++ b/src/main/ipc/workspace-cleanup-scan-eligibility.ts
@@ -1,0 +1,35 @@
+import type { Worktree } from '../../shared/types'
+import { getPersistedWorkspaceCleanupActivityAt } from '../../shared/workspace-cleanup'
+import { isWorkspaceInactiveForCleanup } from './workspace-cleanup-candidate'
+
+/**
+ * Which worktrees a broad (non-targeted) cleanup scan is allowed to emit.
+ *
+ * Why: a client that has not opted into the full workspace list still renders
+ * the suggestion-only views, so the host must keep publishing exactly the rows
+ * it always did — inactive, non-main, non-folder worktrees — or an older client
+ * is flooded with rows it has no view for.
+ */
+export function shouldScanBroadWorkspaceCleanupWorktree(args: {
+  includeAllWorkspaces: boolean
+  repoIsFolder: boolean
+  worktree: Worktree
+  scannedAt: number
+}): boolean {
+  const { includeAllWorkspaces, repoIsFolder, worktree, scannedAt } = args
+  if (includeAllWorkspaces) {
+    return true
+  }
+  if (repoIsFolder || worktree.isMainWorktree) {
+    return false
+  }
+  // Why: persisted stamps only; the filesystem read that refines them is the
+  // expensive part this pre-filter exists to avoid.
+  return isWorkspaceInactiveForCleanup(
+    {
+      isArchived: worktree.isArchived,
+      lastActivityAt: getPersistedWorkspaceCleanupActivityAt(worktree)
+    },
+    scannedAt
+  )
+}

--- a/src/main/ipc/workspace-cleanup-scan.ts
+++ b/src/main/ipc/workspace-cleanup-scan.ts
@@ -13,7 +13,7 @@ import type {
   WorkspaceCleanupScanProgress,
   WorkspaceCleanupScanResult
 } from '../../shared/workspace-cleanup'
-import { getPersistedWorkspaceCleanupActivityAt } from '../../shared/workspace-cleanup'
+import { shouldScanBroadWorkspaceCleanupWorktree } from './workspace-cleanup-scan-eligibility'
 import {
   resolvePersistedWorkspaceCleanupActivityWorktree,
   resolveWorkspaceCleanupActivityWorktree
@@ -75,6 +75,7 @@ export async function scanWorkspaceCleanup(
       repo,
       scannedAt,
       targetWorktreeId: args.worktreeId,
+      includeAllWorkspaces: args.includeAllWorkspaces === true,
       skipGitWorktreeIds: new Set(args.skipGitWorktreeIds ?? []),
       onWorktreesDiscovered: progress.addDiscovered,
       onCandidateScanned: progress.addCandidate,
@@ -93,6 +94,7 @@ async function scanRepoWorkspaces(
     repo: Repo
     scannedAt: number
     targetWorktreeId?: string
+    includeAllWorkspaces: boolean
     skipGitWorktreeIds: Set<string>
   } & WorkspaceCleanupScanRepoProgress
 ): Promise<WorkspaceCleanupScanResult> {
@@ -101,6 +103,7 @@ async function scanRepoWorkspaces(
     repo,
     scannedAt,
     targetWorktreeId,
+    includeAllWorkspaces,
     skipGitWorktreeIds,
     onWorktreesDiscovered,
     onCandidateScanned,
@@ -120,9 +123,18 @@ async function scanRepoWorkspaces(
   }
 
   if (repo.connectionId && !provider) {
-    const candidates = targetWorktreeId
-      ? synthesizeDisconnectedSshCleanupCandidates(store, repo, scannedAt, targetWorktreeId)
-      : []
+    // Why: a disconnected host still owns real workspaces; the full list shows
+    // them (blocked), while legacy scans keep omitting what they cannot inspect.
+    const candidates =
+      targetWorktreeId || includeAllWorkspaces
+        ? synthesizeDisconnectedSshCleanupCandidates(
+            store,
+            repo,
+            scannedAt,
+            targetWorktreeId,
+            includeAllWorkspaces
+          )
+        : []
     onWorktreesDiscovered?.(candidates.length)
     for (const candidate of candidates) {
       onCandidateScanned?.(candidate)
@@ -135,10 +147,17 @@ async function scanRepoWorkspaces(
     const meta = store.getWorktreeMeta(worktreeId)
     return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
   })
+  // Why: with includeAllWorkspaces the browser shows every workspace and lets
+  // filters narrow it; an age threshold here would hide rows from all views.
   const candidateWorktrees = targetWorktreeId
     ? mergedWorktrees.filter((worktree) => worktree.id === targetWorktreeId)
     : mergedWorktrees.filter((worktree) =>
-        shouldResolveBroadWorkspaceCleanupActivity(repoIsFolder, worktree, scannedAt)
+        shouldScanBroadWorkspaceCleanupWorktree({
+          includeAllWorkspaces,
+          repoIsFolder,
+          worktree,
+          scannedAt
+        })
       )
   // Why: fs stat has no cancellation, so on a hung network/WSL mount every
   // timed-out row would abandon more threadpool work. After the first timeout,
@@ -155,7 +174,8 @@ async function scanRepoWorkspaces(
         : await resolveCleanupActivityWithTimeout(repo, worktree, () => {
             activityStatsUnavailable = true
           })
-      if (!targetWorktreeId && !isWorkspaceInactiveForCleanup(worktreeWithActivity, scannedAt)) {
+      const isInactive = isWorkspaceInactiveForCleanup(worktreeWithActivity, scannedAt)
+      if (!targetWorktreeId && !includeAllWorkspaces && !isInactive) {
         return null
       }
       onWorktreesDiscovered?.(1)
@@ -164,7 +184,9 @@ async function scanRepoWorkspaces(
         worktree: worktreeWithActivity,
         scannedAt,
         provider,
-        skipGit: skipGitWorktreeIds.has(worktreeWithActivity.id),
+        // Why: a row with no inactivity reason can never be queued or selected,
+        // so full-fleet scans stream it now and let a focused scan read git later.
+        skipGit: skipGitWorktreeIds.has(worktreeWithActivity.id) || !isInactive,
         forceGitCheck: Boolean(targetWorktreeId)
       }).catch((error) => {
         console.error('Workspace cleanup candidate scan failed', error)
@@ -197,23 +219,6 @@ async function resolveCleanupActivityWithTimeout(
     console.warn('Workspace cleanup activity scan failed', error)
     return resolvePersistedWorkspaceCleanupActivityWorktree(worktree)
   }
-}
-
-function shouldResolveBroadWorkspaceCleanupActivity(
-  repoIsFolder: boolean,
-  worktree: Worktree,
-  scannedAt: number
-): boolean {
-  if (repoIsFolder || worktree.isMainWorktree) {
-    return false
-  }
-  return isWorkspaceInactiveForCleanup(
-    {
-      isArchived: worktree.isArchived,
-      lastActivityAt: getPersistedWorkspaceCleanupActivityAt(worktree)
-    },
-    scannedAt
-  )
 }
 
 async function listCleanupGitWorktrees(

--- a/src/main/ipc/workspace-cleanup-scan.ts
+++ b/src/main/ipc/workspace-cleanup-scan.ts
@@ -33,6 +33,7 @@ import {
   withWorkspaceCleanupTimeout
 } from './workspace-cleanup-scan-primitives'
 import { getLocalProjectWorktreeGitOptions } from '../project-runtime-git-options'
+import { listWorkspaceCleanupFolderWorkspaces } from './workspace-cleanup-folder-workspaces'
 
 const WORKTREE_SCAN_CONCURRENCY = 3
 
@@ -142,11 +143,14 @@ async function scanRepoWorkspaces(
     return { scannedAt, candidates, errors: [] }
   }
 
-  const mergedWorktrees = gitWorktrees.map((gitWorktree) => {
-    const worktreeId = `${repo.id}::${gitWorktree.path}`
-    const meta = store.getWorktreeMeta(worktreeId)
-    return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
-  })
+  const mergedWorktrees =
+    repoIsFolder && includeAllWorkspaces
+      ? listWorkspaceCleanupFolderWorkspaces(store, repo)
+      : gitWorktrees.map((gitWorktree) => {
+          const worktreeId = `${repo.id}::${gitWorktree.path}`
+          const meta = store.getWorktreeMeta(worktreeId)
+          return mergeWorktree(repo.id, gitWorktree, meta, repo.displayName)
+        })
   // Why: with includeAllWorkspaces the browser shows every workspace and lets
   // filters narrow it; an age threshold here would hide rows from all views.
   const candidateWorktrees = targetWorktreeId
@@ -227,7 +231,10 @@ async function listCleanupGitWorktrees(
   repoIsFolder: boolean
 ): Promise<{ provider: IGitProvider | null; gitWorktrees: GitWorktreeInfo[] }> {
   if (repoIsFolder) {
-    return { provider: null, gitWorktrees: [createFolderWorktree(repo)] }
+    return {
+      provider: repo.connectionId ? (getSshGitProvider(repo.connectionId) ?? null) : null,
+      gitWorktrees: [createFolderWorktree(repo)]
+    }
   }
   if (repo.connectionId) {
     const provider = getSshGitProvider(repo.connectionId) ?? null

--- a/src/renderer/src/store/slices/workspace-cleanup-scan-progress.test.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup-scan-progress.test.ts
@@ -552,6 +552,24 @@ describe('workspace cleanup scan progress', () => {
     expect(store.getState().workspaceCleanupScan).toMatchObject(secondResult)
   })
 
+  it('does not join legacy and full-workspace broad scans', async () => {
+    const legacyPending = deferred<WorkspaceCleanupScanResult>()
+    const fullPending = deferred<WorkspaceCleanupScanResult>()
+    const scan = vi.fn((args?: { includeAllWorkspaces?: boolean }) =>
+      args?.includeAllWorkspaces ? fullPending.promise : legacyPending.promise
+    )
+    installWorkspaceCleanupApi(scan)
+    const store = createCleanupTestStore()
+
+    const legacy = store.getState().scanWorkspaceCleanup()
+    const full = store.getState().scanWorkspaceCleanup({ includeAllWorkspaces: true })
+
+    expect(scan).toHaveBeenCalledTimes(2)
+    fullPending.resolve({ scannedAt: NOW, candidates: [], errors: [] })
+    legacyPending.resolve({ scannedAt: NOW - 1, candidates: [], errors: [] })
+    await expect(Promise.all([legacy, full])).resolves.toHaveLength(2)
+  })
+
   it('keeps stale cleanup results visible after a broad refresh failure', async () => {
     const previous = { scannedAt: NOW, candidates: [makeCandidate()], errors: [] }
     const scan = vi

--- a/src/renderer/src/store/slices/workspace-cleanup.ts
+++ b/src/renderer/src/store/slices/workspace-cleanup.ts
@@ -367,6 +367,7 @@ export const createWorkspaceCleanupSlice: StateCreator<AppState, [], [], Workspa
 
 function getWorkspaceCleanupScanKey(args: WorkspaceCleanupScanArgs): string {
   return JSON.stringify({
+    includeAllWorkspaces: args.includeAllWorkspaces === true,
     skipGitWorktreeIds: [...new Set(args.skipGitWorktreeIds ?? [])].sort()
   })
 }

--- a/src/shared/workspace-cleanup.ts
+++ b/src/shared/workspace-cleanup.ts
@@ -75,6 +75,9 @@ export type WorkspaceCleanupScanArgs = {
   worktreeId?: string
   skipGitWorktreeIds?: string[]
   scanId?: string
+  // Why: optional so an older client still receives the legacy suggestion-only
+  // broad scan; only a client that renders the full list asks for every row.
+  includeAllWorkspaces?: boolean
 }
 
 export type WorkspaceCleanupLocalProcessArgs = {


### PR DESCRIPTION
## Summary

Add an opt-in full workspace cleanup scan while preserving byte-for-byte legacy broad-scan behavior when the optional flag is absent. Full scans include local, folder, main, and disconnected SSH workspaces, and defer Git evidence for recent rows that cannot yet be removed.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm run typecheck:tsc`
- [x] Focused Vitest coverage: 35 tests across the broad-scan and existing cleanup suites
- [x] `pnpm run build:desktop`
- [x] Added broad-scan regression tests for legacy parity, folder workspaces, main worktrees, disconnected SSH, deferred Git evidence, focused re-probes, and progress

## AI Review Report

Reviewed the split for remote wire compatibility, legacy scan parity, SSH and folder-workspace behavior, progress accounting, and deferred Git evidence. The new RPC argument remains optional and only strict `true` selects the new projection; absent and false calls retain the prior suggestion-only behavior. Cross-platform review found no shortcut, label, shell, or path changes, and no Electron platform-specific behavior was introduced.

## Security Audit

Reviewed the new input flag, scan routing, Git invocation boundaries, and disconnected-host handling. The flag only broadens returned metadata already available through the existing authenticated IPC/RPC path; it does not add command execution, filesystem mutation, auth handling, secrets, or dependencies. Focused scans retain the existing Git execution and provider abstractions.

## Notes

Stacked PR 1 of 4. Later PRs add snapshot persistence, the shared filter model, and the dialog rework. The branch is based on the implementation starting point; no completed working-tree changes were rebased or discarded.