### PR TITLE
feat(workspaces): persist cleanup snapshots

### DIFF
--- a/src/main/ipc/workspace-cleanup-candidate.ts
+++ b/src/main/ipc/workspace-cleanup-candidate.ts
@@ -1,6 +1,7 @@
 import type { IGitProvider } from '../providers/types'
 import { isFolderRepo } from '../../shared/repo-kind'
 import type { Repo, Worktree } from '../../shared/types'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import {
   applyWorkspaceCleanupPolicy,
   createWorkspaceCleanupFingerprint,
@@ -58,6 +59,7 @@ export async function buildWorkspaceCleanupCandidate(args: {
     repoId: repo.id,
     repoName: repo.displayName,
     connectionId: repo.connectionId ?? null,
+    executionHostId: getRepoExecutionHostId(repo),
     displayName: worktree.displayName,
     branch: shortWorkspaceCleanupBranchName(worktree.branch),
     path: worktree.path,
@@ -102,6 +104,7 @@ export function buildWorkspaceCleanupCandidateFromError(
     repoId: repo.id,
     repoName: repo.displayName,
     connectionId: repo.connectionId ?? null,
+    executionHostId: getRepoExecutionHostId(repo),
     displayName: worktree.displayName,
     branch: shortWorkspaceCleanupBranchName(worktree.branch),
     path: worktree.path,

--- a/src/main/ipc/workspace-cleanup-disconnected-ssh.ts
+++ b/src/main/ipc/workspace-cleanup-disconnected-ssh.ts
@@ -1,4 +1,5 @@
 import { basename } from 'node:path'
+import { getRepoExecutionHostId } from '../../shared/execution-host'
 import type { Store } from '../persistence'
 import type { Repo, WorktreeMeta } from '../../shared/types'
 import {
@@ -60,6 +61,7 @@ function createDisconnectedSshCandidate(
     repoId: repo.id,
     repoName: repo.displayName,
     connectionId: repo.connectionId ?? null,
+    executionHostId: getRepoExecutionHostId(repo),
     displayName: meta.displayName || basename(path),
     branch: basename(path),
     path,

--- a/src/main/ipc/workspace-cleanup-process-preflight.test.ts
+++ b/src/main/ipc/workspace-cleanup-process-preflight.test.ts
@@ -30,6 +30,7 @@ import { registerWorkspaceCleanupHandlers } from './workspace-cleanup'
 
 function makeEmptyStore(): Store {
   return {
+    getProfileStorageDirectory: () => '/profile-a',
     getRepos: () => [],
     getWorktreeMeta: () => ({}),
     getAllWorktreeMeta: () => ({}),

--- a/src/main/ipc/workspace-cleanup-process-preflight.test.ts
+++ b/src/main/ipc/workspace-cleanup-process-preflight.test.ts
@@ -1,0 +1,105 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+
+const { getSshPtyProviderMock } = vi.hoisted(() => ({
+  getSshPtyProviderMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn()
+  }
+}))
+
+vi.mock('./pty', () => ({
+  getSshPtyProvider: getSshPtyProviderMock
+}))
+
+vi.mock('../memory/pty-registry', () => ({
+  listRegisteredPtys: vi.fn(() => [])
+}))
+
+vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  persistWorkspaceCleanupScanResult: vi.fn(async () => undefined),
+  readWorkspaceCleanupScanSnapshot: vi.fn(async () => null)
+}))
+
+import { registerWorkspaceCleanupHandlers } from './workspace-cleanup'
+
+function makeEmptyStore(): Store {
+  return {
+    getRepos: () => [],
+    getWorktreeMeta: () => ({}),
+    getAllWorktreeMeta: () => ({}),
+    getGitHubCache: () => ({ pr: {}, issue: {} })
+  } as unknown as Store
+}
+
+function getPreflightHandler(): ((...args: never[]) => unknown) | undefined {
+  return vi
+    .mocked(ipcMain.handle)
+    .mock.calls.find(([channel]) => channel === 'workspaceCleanup:hasKillableLocalProcesses')?.[1]
+}
+
+describe('workspace cleanup process preflight', () => {
+  beforeEach(() => {
+    vi.mocked(ipcMain.handle).mockReset()
+    getSshPtyProviderMock.mockReset()
+  })
+
+  it('reports local processes that workspace deletion would kill', async () => {
+    const localProvider = {
+      listProcesses: vi.fn().mockResolvedValue([
+        {
+          id: 'repo-1::/repo-feature@@session-1',
+          cwd: '/repo-feature',
+          title: 'zsh'
+        }
+      ])
+    }
+    registerWorkspaceCleanupHandlers(makeEmptyStore(), {
+      runtime: {
+        hasTerminalsForWorktree: vi.fn().mockResolvedValue(false)
+      } as never,
+      getLocalPtyProvider: () => localProvider as never
+    })
+
+    await expect(
+      getPreflightHandler()?.({} as never, { worktreeId: 'repo-1::/repo-feature' } as never)
+    ).resolves.toEqual({
+      hasKillableProcesses: true
+    })
+  })
+
+  it('reports SSH processes inside the remote workspace path', async () => {
+    getSshPtyProviderMock.mockReturnValue({
+      listProcesses: vi.fn().mockResolvedValue([
+        {
+          id: 'remote-session-1',
+          cwd: '/remote/repo-feature/subdir',
+          title: 'codex'
+        }
+      ])
+    })
+    registerWorkspaceCleanupHandlers(makeEmptyStore(), {
+      runtime: {
+        hasTerminalsForWorktree: vi.fn().mockResolvedValue(false)
+      } as never
+    })
+
+    await expect(
+      getPreflightHandler()?.(
+        {} as never,
+        {
+          worktreeId: 'repo-ssh::/remote/repo-feature',
+          connectionId: 'ssh-1',
+          worktreePath: '/remote/repo-feature'
+        } as never
+      )
+    ).resolves.toEqual({
+      hasKillableProcesses: true
+    })
+  })
+})

--- a/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
+++ b/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
@@ -25,6 +25,7 @@ const NOW = 1_700_000_000_000
 
 function makeEmptyStore(): Store {
   return {
+    getProfileStorageDirectory: () => '/profile-a',
     getRepos: () => [],
     getWorktreeMeta: () => ({}),
     getAllWorktreeMeta: () => ({}),
@@ -48,7 +49,7 @@ describe('workspace cleanup snapshot IPC', () => {
     const args = { includeAllWorkspaces: true }
     const result = await handler?.({ sender: { send: vi.fn() } } as never, args)
 
-    expect(persistScanResultMock).toHaveBeenCalledWith(args, result)
+    expect(persistScanResultMock).toHaveBeenCalledWith('/profile-a', args, result)
   })
 
   it('serves the cached scan snapshot through getCachedScan', async () => {
@@ -60,6 +61,7 @@ describe('workspace cleanup snapshot IPC', () => {
       .mock.calls.find(([channel]) => channel === 'workspaceCleanup:getCachedScan')?.[1]
 
     await expect(handler?.({} as never)).resolves.toBe(snapshot)
+    expect(readScanSnapshotMock).toHaveBeenCalledWith('/profile-a')
     expect(vi.mocked(ipcMain.removeHandler)).toHaveBeenCalledWith('workspaceCleanup:getCachedScan')
   })
 })

--- a/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
+++ b/src/main/ipc/workspace-cleanup-snapshot-ipc.test.ts
@@ -1,0 +1,65 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { ipcMain } from 'electron'
+import type { Store } from '../persistence'
+
+const { persistScanResultMock, readScanSnapshotMock } = vi.hoisted(() => ({
+  persistScanResultMock: vi.fn(),
+  readScanSnapshotMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  ipcMain: {
+    handle: vi.fn(),
+    removeHandler: vi.fn()
+  }
+}))
+
+vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  persistWorkspaceCleanupScanResult: persistScanResultMock,
+  readWorkspaceCleanupScanSnapshot: readScanSnapshotMock
+}))
+
+import { registerWorkspaceCleanupHandlers } from './workspace-cleanup'
+
+const NOW = 1_700_000_000_000
+
+function makeEmptyStore(): Store {
+  return {
+    getRepos: () => [],
+    getWorktreeMeta: () => ({}),
+    getAllWorktreeMeta: () => ({}),
+    getGitHubCache: () => ({ pr: {}, issue: {} })
+  } as unknown as Store
+}
+
+describe('workspace cleanup snapshot IPC', () => {
+  beforeEach(() => {
+    vi.mocked(ipcMain.handle).mockClear()
+    persistScanResultMock.mockReset().mockResolvedValue(undefined)
+    readScanSnapshotMock.mockReset()
+  })
+
+  it('persists the completed scan result after replying', async () => {
+    registerWorkspaceCleanupHandlers(makeEmptyStore())
+    const handler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:scan')?.[1]
+
+    const args = { includeAllWorkspaces: true }
+    const result = await handler?.({ sender: { send: vi.fn() } } as never, args)
+
+    expect(persistScanResultMock).toHaveBeenCalledWith(args, result)
+  })
+
+  it('serves the cached scan snapshot through getCachedScan', async () => {
+    const snapshot = { scannedAt: NOW, candidates: [], errors: [] }
+    readScanSnapshotMock.mockResolvedValue(snapshot)
+    registerWorkspaceCleanupHandlers(makeEmptyStore())
+    const handler = vi
+      .mocked(ipcMain.handle)
+      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:getCachedScan')?.[1]
+
+    await expect(handler?.({} as never)).resolves.toBe(snapshot)
+    expect(vi.mocked(ipcMain.removeHandler)).toHaveBeenCalledWith('workspaceCleanup:getCachedScan')
+  })
+})

--- a/src/main/ipc/workspace-cleanup.test.ts
+++ b/src/main/ipc/workspace-cleanup.test.ts
@@ -19,7 +19,6 @@ const {
   gitExecFileAsyncMock,
   getLocalProjectWorktreeGitOptionsMock,
   getSshGitProviderMock,
-  getSshPtyProviderMock,
   listRegisteredPtysMock
 } = vi.hoisted(() => ({
   lstatMock: vi.fn(),
@@ -29,7 +28,6 @@ const {
   gitExecFileAsyncMock: vi.fn(),
   getLocalProjectWorktreeGitOptionsMock: vi.fn(),
   getSshGitProviderMock: vi.fn(),
-  getSshPtyProviderMock: vi.fn(),
   listRegisteredPtysMock: vi.fn()
 }))
 
@@ -71,10 +69,16 @@ vi.mock('../memory/pty-registry', () => ({
 }))
 
 vi.mock('./pty', () => ({
-  getSshPtyProvider: getSshPtyProviderMock
+  getSshPtyProvider: vi.fn()
 }))
 
-import { registerWorkspaceCleanupHandlers, scanWorkspaceCleanup } from './workspace-cleanup'
+// Why: snapshot persistence does real file I/O; covered in workspace-cleanup-snapshot-ipc.test.ts.
+vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  persistWorkspaceCleanupScanResult: vi.fn(async () => undefined),
+  readWorkspaceCleanupScanSnapshot: vi.fn(async () => null)
+}))
+
+import { scanWorkspaceCleanup } from './workspace-cleanup'
 
 const NOW = 1_700_000_000_000
 const REPO: Repo = {
@@ -163,7 +167,6 @@ describe('workspace cleanup scan', () => {
     gitExecFileAsyncMock.mockReset()
     getLocalProjectWorktreeGitOptionsMock.mockReset().mockReturnValue({})
     getSshGitProviderMock.mockReset()
-    getSshPtyProviderMock.mockReset()
     listRegisteredPtysMock.mockReset()
     listRegisteredPtysMock.mockReturnValue([])
     lstatMock.mockResolvedValue({ mtimeMs: 0 })
@@ -830,62 +833,5 @@ describe('workspace cleanup scan', () => {
       reasons: ['idle-clean']
     })
     expect(result.candidates[0]).not.toHaveProperty('linkedPR')
-  })
-
-  it('reports local processes that workspace deletion would kill', async () => {
-    const localProvider = {
-      listProcesses: vi.fn().mockResolvedValue([
-        {
-          id: 'repo-1::/repo-feature@@session-1',
-          cwd: '/repo-feature',
-          title: 'zsh'
-        }
-      ])
-    }
-    registerWorkspaceCleanupHandlers(makeStore(), {
-      runtime: {
-        hasTerminalsForWorktree: vi.fn().mockResolvedValue(false)
-      } as never,
-      getLocalPtyProvider: () => localProvider as never
-    })
-
-    const handler = vi
-      .mocked(ipcMain.handle)
-      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:hasKillableLocalProcesses')?.[1]
-
-    await expect(handler?.({} as never, { worktreeId: 'repo-1::/repo-feature' })).resolves.toEqual({
-      hasKillableProcesses: true
-    })
-  })
-
-  it('reports SSH processes inside the remote workspace path', async () => {
-    getSshPtyProviderMock.mockReturnValue({
-      listProcesses: vi.fn().mockResolvedValue([
-        {
-          id: 'remote-session-1',
-          cwd: '/remote/repo-feature/subdir',
-          title: 'codex'
-        }
-      ])
-    })
-    registerWorkspaceCleanupHandlers(makeStore(), {
-      runtime: {
-        hasTerminalsForWorktree: vi.fn().mockResolvedValue(false)
-      } as never
-    })
-
-    const handler = vi
-      .mocked(ipcMain.handle)
-      .mock.calls.find(([channel]) => channel === 'workspaceCleanup:hasKillableLocalProcesses')?.[1]
-
-    await expect(
-      handler?.({} as never, {
-        worktreeId: 'repo-ssh::/remote/repo-feature',
-        connectionId: 'ssh-1',
-        worktreePath: '/remote/repo-feature'
-      })
-    ).resolves.toEqual({
-      hasKillableProcesses: true
-    })
   })
 })

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -13,6 +13,10 @@ import {
   type WorkspaceCleanupScanResult
 } from '../../shared/workspace-cleanup'
 import { scanWorkspaceCleanup } from './workspace-cleanup-scan'
+import {
+  persistWorkspaceCleanupScanResult,
+  readWorkspaceCleanupScanSnapshot
+} from '../workspace-cleanup-scan-snapshot'
 
 export { scanWorkspaceCleanup }
 
@@ -26,18 +30,28 @@ export function registerWorkspaceCleanupHandlers(
   deps: WorkspaceCleanupHandlerDeps = {}
 ): void {
   ipcMain.removeHandler('workspaceCleanup:scan')
+  ipcMain.removeHandler('workspaceCleanup:getCachedScan')
   ipcMain.removeHandler('workspaceCleanup:dismiss')
   ipcMain.removeHandler('workspaceCleanup:clearDismissals')
   ipcMain.removeHandler('workspaceCleanup:hasKillableLocalProcesses')
 
   ipcMain.handle(
     'workspaceCleanup:scan',
-    (event, args?: WorkspaceCleanupScanArgs): Promise<WorkspaceCleanupScanResult> =>
-      scanWorkspaceCleanup(store, args ?? {}, {
+    async (event, args?: WorkspaceCleanupScanArgs): Promise<WorkspaceCleanupScanResult> => {
+      const result = await scanWorkspaceCleanup(store, args ?? {}, {
         onProgress: args?.scanId
           ? (progress) => event.sender.send('workspaceCleanup:scanProgress', progress)
           : undefined
       })
+      // Fire-and-forget: snapshot persistence must never delay or fail the scan reply.
+      void persistWorkspaceCleanupScanResult(args ?? {}, result)
+      return result
+    }
+  )
+
+  ipcMain.handle(
+    'workspaceCleanup:getCachedScan',
+    (): Promise<WorkspaceCleanupScanResult | null> => readWorkspaceCleanupScanSnapshot()
   )
 
   ipcMain.handle('workspaceCleanup:dismiss', (_event, args: WorkspaceCleanupDismissArgs) => {

--- a/src/main/ipc/workspace-cleanup.ts
+++ b/src/main/ipc/workspace-cleanup.ts
@@ -29,6 +29,7 @@ export function registerWorkspaceCleanupHandlers(
   store: Store,
   deps: WorkspaceCleanupHandlerDeps = {}
 ): void {
+  const snapshotDirectory = store.getProfileStorageDirectory()
   ipcMain.removeHandler('workspaceCleanup:scan')
   ipcMain.removeHandler('workspaceCleanup:getCachedScan')
   ipcMain.removeHandler('workspaceCleanup:dismiss')
@@ -44,14 +45,15 @@ export function registerWorkspaceCleanupHandlers(
           : undefined
       })
       // Fire-and-forget: snapshot persistence must never delay or fail the scan reply.
-      void persistWorkspaceCleanupScanResult(args ?? {}, result)
+      void persistWorkspaceCleanupScanResult(snapshotDirectory, args ?? {}, result)
       return result
     }
   )
 
   ipcMain.handle(
     'workspaceCleanup:getCachedScan',
-    (): Promise<WorkspaceCleanupScanResult | null> => readWorkspaceCleanupScanSnapshot()
+    (): Promise<WorkspaceCleanupScanResult | null> =>
+      readWorkspaceCleanupScanSnapshot(snapshotDirectory)
   )
 
   ipcMain.handle('workspaceCleanup:dismiss', (_event, args: WorkspaceCleanupDismissArgs) => {

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -74,6 +74,10 @@ function createEvent() {
   }
 }
 
+function createStore(): Store {
+  return { getProfileStorageDirectory: () => '/profile-a' } as Store
+}
+
 describe('registerWorkspaceSpaceHandlers', () => {
   beforeEach(() => {
     analyzeWorkspaceSpaceMock.mockReset()
@@ -82,7 +86,7 @@ describe('registerWorkspaceSpaceHandlers', () => {
   })
 
   it('shares an in-flight analysis request', async () => {
-    const store = {} as Store
+    const store = createStore()
     let resolveFirstScan: (analysis: WorkspaceSpaceAnalysis) => void = () => {}
     const firstScan = new Promise<WorkspaceSpaceAnalysis>((resolve) => {
       resolveFirstScan = resolve
@@ -120,7 +124,7 @@ describe('registerWorkspaceSpaceHandlers', () => {
   })
 
   it('forwards scan progress to the requesting renderer', async () => {
-    const store = {} as Store
+    const store = createStore()
     let onProgress: ((progress: WorkspaceSpaceScanProgress) => void) | undefined
     analyzeWorkspaceSpaceMock.mockImplementationOnce((_store, options) => {
       onProgress = options.onProgress
@@ -150,7 +154,7 @@ describe('registerWorkspaceSpaceHandlers', () => {
   })
 
   it('cancels the in-flight scan', async () => {
-    const store = {} as Store
+    const store = createStore()
     let signal: AbortSignal | undefined
     analyzeWorkspaceSpaceMock.mockImplementationOnce((_store, options) => {
       signal = options.signal
@@ -168,7 +172,7 @@ describe('registerWorkspaceSpaceHandlers', () => {
   })
 
   it('returns a normal cancelled result instead of rejecting expected cancellation', async () => {
-    const store = {} as Store
+    const store = createStore()
     analyzeWorkspaceSpaceMock.mockRejectedValueOnce(new WorkspaceSpaceScanCancelledErrorMock())
 
     registerWorkspaceSpaceHandlers(store)
@@ -182,21 +186,22 @@ describe('registerWorkspaceSpaceHandlers', () => {
     const analysis = createAnalysis(7)
     analyzeWorkspaceSpaceMock.mockResolvedValueOnce(analysis)
 
-    registerWorkspaceSpaceHandlers({} as Store)
+    registerWorkspaceSpaceHandlers(createStore())
     const analyzeHandler = handlers.get('workspaceSpace:analyze')
 
     await expect(analyzeHandler!(createEvent())).resolves.toEqual({ ok: true, analysis })
-    expect(persistAnalysisSnapshotMock).toHaveBeenCalledWith(analysis)
+    expect(persistAnalysisSnapshotMock).toHaveBeenCalledWith('/profile-a', analysis)
   })
 
   it('serves the cached analysis through getCachedAnalysis', async () => {
     const cached = createAnalysis(3)
     readAnalysisSnapshotMock.mockResolvedValue(cached)
 
-    registerWorkspaceSpaceHandlers({} as Store)
+    registerWorkspaceSpaceHandlers(createStore())
     expect(removeHandlerMock).toHaveBeenCalledWith('workspaceSpace:getCachedAnalysis')
     const cachedHandler = handlers.get('workspaceSpace:getCachedAnalysis')
 
     await expect(cachedHandler!()).resolves.toBe(cached)
+    expect(readAnalysisSnapshotMock).toHaveBeenCalledWith('/profile-a')
   })
 })

--- a/src/main/ipc/workspace-space.test.ts
+++ b/src/main/ipc/workspace-space.test.ts
@@ -11,6 +11,8 @@ const {
   analyzeWorkspaceSpaceMock,
   removeHandlerMock,
   handleMock,
+  persistAnalysisSnapshotMock,
+  readAnalysisSnapshotMock,
   WorkspaceSpaceScanCancelledErrorMock
 } = vi.hoisted(() => {
   const handlers = new Map<string, (...args: unknown[]) => Promise<unknown>>()
@@ -21,6 +23,8 @@ const {
     handleMock: vi.fn((channel: string, handler: (...args: unknown[]) => Promise<unknown>) => {
       handlers.set(channel, handler)
     }),
+    persistAnalysisSnapshotMock: vi.fn(),
+    readAnalysisSnapshotMock: vi.fn(),
     WorkspaceSpaceScanCancelledErrorMock: class WorkspaceSpaceScanCancelledError extends Error {}
   }
 })
@@ -35,6 +39,11 @@ vi.mock('electron', () => ({
 vi.mock('../workspace-space-analysis', () => ({
   WorkspaceSpaceScanCancelledError: WorkspaceSpaceScanCancelledErrorMock,
   analyzeWorkspaceSpace: analyzeWorkspaceSpaceMock
+}))
+
+vi.mock('../workspace-space-analysis-snapshot', () => ({
+  persistWorkspaceSpaceAnalysisSnapshot: persistAnalysisSnapshotMock,
+  readWorkspaceSpaceAnalysisSnapshot: readAnalysisSnapshotMock
 }))
 
 import { registerWorkspaceSpaceHandlers } from './workspace-space'
@@ -68,6 +77,8 @@ function createEvent() {
 describe('registerWorkspaceSpaceHandlers', () => {
   beforeEach(() => {
     analyzeWorkspaceSpaceMock.mockReset()
+    persistAnalysisSnapshotMock.mockReset().mockResolvedValue(undefined)
+    readAnalysisSnapshotMock.mockReset().mockResolvedValue(null)
   })
 
   it('shares an in-flight analysis request', async () => {
@@ -164,5 +175,28 @@ describe('registerWorkspaceSpaceHandlers', () => {
     const analyzeHandler = handlers.get('workspaceSpace:analyze')
 
     await expect(analyzeHandler!(createEvent())).resolves.toEqual({ ok: false, cancelled: true })
+    expect(persistAnalysisSnapshotMock).not.toHaveBeenCalled()
+  })
+
+  it('persists the completed analysis snapshot', async () => {
+    const analysis = createAnalysis(7)
+    analyzeWorkspaceSpaceMock.mockResolvedValueOnce(analysis)
+
+    registerWorkspaceSpaceHandlers({} as Store)
+    const analyzeHandler = handlers.get('workspaceSpace:analyze')
+
+    await expect(analyzeHandler!(createEvent())).resolves.toEqual({ ok: true, analysis })
+    expect(persistAnalysisSnapshotMock).toHaveBeenCalledWith(analysis)
+  })
+
+  it('serves the cached analysis through getCachedAnalysis', async () => {
+    const cached = createAnalysis(3)
+    readAnalysisSnapshotMock.mockResolvedValue(cached)
+
+    registerWorkspaceSpaceHandlers({} as Store)
+    expect(removeHandlerMock).toHaveBeenCalledWith('workspaceSpace:getCachedAnalysis')
+    const cachedHandler = handlers.get('workspaceSpace:getCachedAnalysis')
+
+    await expect(cachedHandler!()).resolves.toBe(cached)
   })
 })

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -1,6 +1,7 @@
 import { ipcMain } from 'electron'
 import type { Store } from '../persistence'
 import type {
+  WorkspaceSpaceAnalysis,
   WorkspaceSpaceAnalyzeResult,
   WorkspaceSpaceScanProgress
 } from '../../shared/workspace-space-types'
@@ -8,6 +9,10 @@ import {
   analyzeWorkspaceSpace,
   WorkspaceSpaceScanCancelledError
 } from '../workspace-space-analysis'
+import {
+  persistWorkspaceSpaceAnalysisSnapshot,
+  readWorkspaceSpaceAnalysisSnapshot
+} from '../workspace-space-analysis-snapshot'
 
 const PROGRESS_EMIT_INTERVAL_MS = 100
 
@@ -22,6 +27,7 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
   let inFlightScan: InFlightWorkspaceSpaceScan | null = null
   ipcMain.removeHandler('workspaceSpace:cancel')
   ipcMain.removeHandler('workspaceSpace:analyze')
+  ipcMain.removeHandler('workspaceSpace:getCachedAnalysis')
   ipcMain.handle('workspaceSpace:analyze', async (event): Promise<WorkspaceSpaceAnalyzeResult> => {
     if (!inFlightScan) {
       const controller = new AbortController()
@@ -78,7 +84,12 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
           sendProgress(progress)
         }
       })
-        .then((analysis): WorkspaceSpaceAnalyzeResult => ({ ok: true, analysis }))
+        .then((analysis): WorkspaceSpaceAnalyzeResult => {
+          // Fire-and-forget: a ~6-minute cold analysis must survive reload/restart, but
+          // persistence must never delay or fail the reply.
+          void persistWorkspaceSpaceAnalysisSnapshot(analysis)
+          return { ok: true, analysis }
+        })
         .catch((error: unknown): WorkspaceSpaceAnalyzeResult => {
           if (error instanceof WorkspaceSpaceScanCancelledError) {
             return { ok: false, cancelled: true }
@@ -91,6 +102,11 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
     }
     return inFlightScan.promise
   })
+
+  ipcMain.handle(
+    'workspaceSpace:getCachedAnalysis',
+    (): Promise<WorkspaceSpaceAnalysis | null> => readWorkspaceSpaceAnalysisSnapshot()
+  )
 
   ipcMain.handle('workspaceSpace:cancel', async (): Promise<boolean> => {
     if (!inFlightScan || inFlightScan.controller.signal.aborted) {

--- a/src/main/ipc/workspace-space.ts
+++ b/src/main/ipc/workspace-space.ts
@@ -24,6 +24,7 @@ type InFlightWorkspaceSpaceScan = {
 }
 
 export function registerWorkspaceSpaceHandlers(store: Store): void {
+  const snapshotDirectory = store.getProfileStorageDirectory()
   let inFlightScan: InFlightWorkspaceSpaceScan | null = null
   ipcMain.removeHandler('workspaceSpace:cancel')
   ipcMain.removeHandler('workspaceSpace:analyze')
@@ -87,7 +88,7 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
         .then((analysis): WorkspaceSpaceAnalyzeResult => {
           // Fire-and-forget: a ~6-minute cold analysis must survive reload/restart, but
           // persistence must never delay or fail the reply.
-          void persistWorkspaceSpaceAnalysisSnapshot(analysis)
+          void persistWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, analysis)
           return { ok: true, analysis }
         })
         .catch((error: unknown): WorkspaceSpaceAnalyzeResult => {
@@ -105,7 +106,8 @@ export function registerWorkspaceSpaceHandlers(store: Store): void {
 
   ipcMain.handle(
     'workspaceSpace:getCachedAnalysis',
-    (): Promise<WorkspaceSpaceAnalysis | null> => readWorkspaceSpaceAnalysisSnapshot()
+    (): Promise<WorkspaceSpaceAnalysis | null> =>
+      readWorkspaceSpaceAnalysisSnapshot(snapshotDirectory)
   )
 
   ipcMain.handle('workspaceSpace:cancel', async (): Promise<boolean> => {

--- a/src/main/ipc/worktrees-windows.test.ts
+++ b/src/main/ipc/worktrees-windows.test.ts
@@ -151,6 +151,7 @@ describe('registerWorktreeHandlers – Windows path handling', () => {
     }
   }
   const store = {
+    getProfileStorageDirectory: vi.fn(() => '/profile-a'),
     getRepos: vi.fn(),
     getRepo: vi.fn(),
     getProjects: vi.fn(),

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -234,6 +234,19 @@ vi.mock('../ports/advertised-url-watcher', () => ({
   }
 }))
 
+const { pruneCleanupScanSnapshotMock, pruneSpaceAnalysisSnapshotMock } = vi.hoisted(() => ({
+  pruneCleanupScanSnapshotMock: vi.fn().mockResolvedValue(undefined),
+  pruneSpaceAnalysisSnapshotMock: vi.fn().mockResolvedValue(undefined)
+}))
+
+vi.mock('../workspace-cleanup-scan-snapshot', () => ({
+  pruneWorkspaceCleanupScanSnapshot: pruneCleanupScanSnapshotMock
+}))
+
+vi.mock('../workspace-space-analysis-snapshot', () => ({
+  pruneWorkspaceSpaceAnalysisSnapshot: pruneSpaceAnalysisSnapshotMock
+}))
+
 const {
   killAllProcessesForWorktreeMock,
   clearProviderPtyStateMock,
@@ -8279,6 +8292,18 @@ describe('registerWorktreeHandlers', () => {
     expect(mainWindow.webContents.send).toHaveBeenCalledWith('worktrees:changed', {
       repoId: 'repo-1'
     })
+  })
+
+  it('prunes the persisted cleanup and space snapshots on removal', async () => {
+    mockKnownFeatureWorktree()
+    getEffectiveHooksMock.mockReturnValue(null)
+    removeWorktreeMock.mockResolvedValue({})
+
+    await handlers['worktrees:remove'](null, { worktreeId: 'repo-1::/workspace/feature-wt' })
+
+    // A removed workspace must never resurrect from the cached scan snapshots.
+    expect(pruneCleanupScanSnapshotMock).toHaveBeenCalledWith('repo-1::/workspace/feature-wt')
+    expect(pruneSpaceAnalysisSnapshotMock).toHaveBeenCalledWith('repo-1::/workspace/feature-wt')
   })
 
   it('traces the removal as worktree.remove with a stage sub-span tree', async () => {

--- a/src/main/ipc/worktrees.test.ts
+++ b/src/main/ipc/worktrees.test.ts
@@ -314,6 +314,7 @@ describe('registerWorktreeHandlers', () => {
   }
   const ipcEvent = { sender: { id: 1 } }
   const store = {
+    getProfileStorageDirectory: vi.fn(() => '/profile-a'),
     getRepos: vi.fn(),
     getRepo: vi.fn(),
     getProjects: vi.fn(),
@@ -8302,8 +8303,16 @@ describe('registerWorktreeHandlers', () => {
     await handlers['worktrees:remove'](null, { worktreeId: 'repo-1::/workspace/feature-wt' })
 
     // A removed workspace must never resurrect from the cached scan snapshots.
-    expect(pruneCleanupScanSnapshotMock).toHaveBeenCalledWith('repo-1::/workspace/feature-wt')
-    expect(pruneSpaceAnalysisSnapshotMock).toHaveBeenCalledWith('repo-1::/workspace/feature-wt')
+    expect(pruneCleanupScanSnapshotMock).toHaveBeenCalledWith(
+      '/profile-a',
+      'repo-1::/workspace/feature-wt',
+      'local'
+    )
+    expect(pruneSpaceAnalysisSnapshotMock).toHaveBeenCalledWith(
+      '/profile-a',
+      'repo-1::/workspace/feature-wt',
+      'local'
+    )
   })
 
   it('traces the removal as worktree.remove with a stage sub-span tree', async () => {

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -339,8 +339,9 @@ function removeWorktreeMetadataAndTransientState(
   // Why: release the removed worktree's PR-refresh aliases so coalesced queue entries don't retain it all session (memory creep).
   pruneWorktreePRRefreshAliases(worktreeId)
   // Why: removed workspaces must never resurrect from the persisted cleanup/space scan snapshots.
-  void pruneWorkspaceCleanupScanSnapshot(worktreeId)
-  void pruneWorkspaceSpaceAnalysisSnapshot(worktreeId)
+  const snapshotDirectory = store.getProfileStorageDirectory()
+  void pruneWorkspaceCleanupScanSnapshot(snapshotDirectory, worktreeId, hostId)
+  void pruneWorkspaceSpaceAnalysisSnapshot(snapshotDirectory, worktreeId, hostId)
 }
 
 function getProjectHostSetupMetaUpdates(

--- a/src/main/ipc/worktrees.ts
+++ b/src/main/ipc/worktrees.ts
@@ -19,6 +19,8 @@ import { getProjectGroupSubtreeIds } from '../../shared/project-groups'
 import { projectResolvedWorktreeLineage } from '../../shared/resolved-worktree-lineage'
 import { isPathInsideOrEqual, isWindowsAbsolutePathLike } from '../../shared/cross-platform-path'
 import { deleteWorktreeHistoryDir } from '../terminal-history-deletion'
+import { pruneWorkspaceCleanupScanSnapshot } from '../workspace-cleanup-scan-snapshot'
+import { pruneWorkspaceSpaceAnalysisSnapshot } from '../workspace-space-analysis-snapshot'
 import type {
   AutomationWorkspaceProvenance,
   CliWorkspaceProvenance,
@@ -336,6 +338,9 @@ function removeWorktreeMetadataAndTransientState(
   deleteWorktreeHistoryDir(worktreeId)
   // Why: release the removed worktree's PR-refresh aliases so coalesced queue entries don't retain it all session (memory creep).
   pruneWorktreePRRefreshAliases(worktreeId)
+  // Why: removed workspaces must never resurrect from the persisted cleanup/space scan snapshots.
+  void pruneWorkspaceCleanupScanSnapshot(worktreeId)
+  void pruneWorkspaceSpaceAnalysisSnapshot(worktreeId)
 }
 
 function getProjectHostSetupMetaUpdates(

--- a/src/main/persistence.ts
+++ b/src/main/persistence.ts
@@ -4179,6 +4179,10 @@ export class Store {
 
   // ── Repos ──────────────────────────────────────────────────────────
 
+  getProfileStorageDirectory(): string {
+    return dirname(this.dataFile)
+  }
+
   getRepos(): Repo[] {
     return this.state.repos.map((repo) => this.hydrateRepo(repo))
   }

--- a/src/main/sidecar-snapshot-file.ts
+++ b/src/main/sidecar-snapshot-file.ts
@@ -1,0 +1,41 @@
+// Why a sidecar next to orca-data.json: scan snapshots rewrite wholesale and can reach hundreds
+// of KB; folding them into orca-data.json would rewrite the whole state file per scan (the
+// githubCache sidecar precedent). Best-effort by design: a lost snapshot only costs a rescan.
+import { readFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { durableWriteTempPath, writeFileDurable } from './durable-file-write'
+import { getCanonicalUserDataPath } from './persistence'
+
+const queues = new Map<string, Promise<unknown>>()
+
+export function sidecarSnapshotFile(fileName: string): string {
+  return join(getCanonicalUserDataPath(), fileName)
+}
+
+/** Serialize tasks per sidecar so read-modify-write patch/prune cycles cannot interleave. */
+export function withSidecarSnapshotQueue<T>(fileName: string, task: () => Promise<T>): Promise<T> {
+  const previous = queues.get(fileName) ?? Promise.resolve()
+  const run = previous.then(task, task)
+  queues.set(
+    fileName,
+    run.then(
+      () => undefined,
+      () => undefined
+    )
+  )
+  return run
+}
+
+/** Parsed sidecar contents, or null when the file is missing or not valid JSON. */
+export async function readSidecarSnapshot(fileName: string): Promise<unknown> {
+  try {
+    return JSON.parse(await readFile(sidecarSnapshotFile(fileName), 'utf-8')) as unknown
+  } catch {
+    return null
+  }
+}
+
+export async function writeSidecarSnapshot(fileName: string, payload: unknown): Promise<void> {
+  const file = sidecarSnapshotFile(fileName)
+  await writeFileDurable(durableWriteTempPath(file), file, JSON.stringify(payload))
+}

--- a/src/main/sidecar-snapshot-file.ts
+++ b/src/main/sidecar-snapshot-file.ts
@@ -3,21 +3,26 @@
 // githubCache sidecar precedent). Best-effort by design: a lost snapshot only costs a rescan.
 import { readFile } from 'node:fs/promises'
 import { join } from 'node:path'
-import { durableWriteTempPath, writeFileDurable } from './durable-file-write'
-import { getCanonicalUserDataPath } from './persistence'
+import {
+  durableWriteTempPath,
+  removeStaleDurableWriteTempFiles,
+  writeFileDurable
+} from './durable-file-write'
 
 const queues = new Map<string, Promise<unknown>>()
+const staleTempCleanups = new Map<string, Promise<void>>()
+const STALE_TEMP_AGE_MS = 24 * 60 * 60 * 1000
 
-export function sidecarSnapshotFile(fileName: string): string {
-  return join(getCanonicalUserDataPath(), fileName)
+export function sidecarSnapshotFile(snapshotDirectory: string, fileName: string): string {
+  return join(snapshotDirectory, fileName)
 }
 
 /** Serialize tasks per sidecar so read-modify-write patch/prune cycles cannot interleave. */
-export function withSidecarSnapshotQueue<T>(fileName: string, task: () => Promise<T>): Promise<T> {
-  const previous = queues.get(fileName) ?? Promise.resolve()
+export function withSidecarSnapshotQueue<T>(file: string, task: () => Promise<T>): Promise<T> {
+  const previous = queues.get(file) ?? Promise.resolve()
   const run = previous.then(task, task)
   queues.set(
-    fileName,
+    file,
     run.then(
       () => undefined,
       () => undefined
@@ -27,15 +32,20 @@ export function withSidecarSnapshotQueue<T>(fileName: string, task: () => Promis
 }
 
 /** Parsed sidecar contents, or null when the file is missing or not valid JSON. */
-export async function readSidecarSnapshot(fileName: string): Promise<unknown> {
+export async function readSidecarSnapshot(file: string): Promise<unknown> {
   try {
-    return JSON.parse(await readFile(sidecarSnapshotFile(fileName), 'utf-8')) as unknown
+    return JSON.parse(await readFile(file, 'utf-8')) as unknown
   } catch {
     return null
   }
 }
 
-export async function writeSidecarSnapshot(fileName: string, payload: unknown): Promise<void> {
-  const file = sidecarSnapshotFile(fileName)
+export async function writeSidecarSnapshot(file: string, payload: unknown): Promise<void> {
+  let cleanup = staleTempCleanups.get(file)
+  if (!cleanup) {
+    cleanup = removeStaleDurableWriteTempFiles(file, { minimumAgeMs: STALE_TEMP_AGE_MS })
+    staleTempCleanups.set(file, cleanup)
+  }
+  await cleanup
   await writeFileDurable(durableWriteTempPath(file), file, JSON.stringify(payload))
 }

--- a/src/main/window/attach-main-window-services.test.ts
+++ b/src/main/window/attach-main-window-services.test.ts
@@ -165,8 +165,9 @@ function createMainWindow(
 
 function createStore(): Store & { flushPendingAsync: MockFn } {
   return {
+    getProfileStorageDirectory: vi.fn(() => '/profile-a'),
     flushPendingAsync: vi.fn(() => Promise.resolve())
-  } as Store & { flushPendingAsync: MockFn }
+  } as unknown as Store & { flushPendingAsync: MockFn }
 }
 
 function createRuntime(): RuntimeStub {

--- a/src/main/workspace-cleanup-scan-snapshot.test.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.test.ts
@@ -9,10 +9,6 @@ import type {
 
 const { userDataDirHolder } = vi.hoisted(() => ({ userDataDirHolder: { dir: '' } }))
 
-vi.mock('./persistence', () => ({
-  getCanonicalUserDataPath: () => userDataDirHolder.dir
-}))
-
 import {
   persistWorkspaceCleanupScanResult,
   pruneWorkspaceCleanupScanSnapshot,
@@ -31,6 +27,7 @@ function makeCandidate(
     repoId: 'repo-1',
     repoName: 'Repo',
     connectionId: null,
+    executionHostId: 'local',
     displayName: 'Feature',
     branch: 'feature',
     path: '/repo-feature',
@@ -71,62 +68,67 @@ describe('workspace cleanup scan snapshot', () => {
       worktreeId: 'repo-ssh::/remote/repo-feature',
       repoId: 'repo-ssh',
       connectionId: 'ssh-1',
+      executionHostId: 'ssh:ssh-1',
       path: '/remote/repo-feature',
       blockers: ['ssh-disconnected'],
       git: { clean: null, upstreamAhead: null, upstreamBehind: null, checkedAt: null }
     })
     const result = makeBroadResult([makeCandidate(), sshCandidate])
 
-    await persistWorkspaceCleanupScanResult({ includeAllWorkspaces: true }, result)
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      result
+    )
 
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toEqual(result)
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toEqual(result)
   })
 
   it('returns null when no snapshot has been persisted', async () => {
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
   })
 
   it('degrades corrupt persisted blobs to null instead of throwing', async () => {
     const file = join(userDataDirHolder.dir, SNAPSHOT_FILE)
 
     await writeFile(file, 'not json{', 'utf-8')
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
 
     await writeFile(
       file,
       JSON.stringify({
-        version: 1,
+        version: 2,
         argsFingerprint: workspaceCleanupScanSnapshotFingerprint(),
         result: { scannedAt: NOW, candidates: 'nope', errors: [] }
       }),
       'utf-8'
     )
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
 
     await writeFile(
       file,
       JSON.stringify({
-        version: 1,
+        version: 2,
         argsFingerprint: workspaceCleanupScanSnapshotFingerprint(),
         result: { scannedAt: NOW, candidates: [{ worktreeId: 42 }], errors: [] }
       }),
       'utf-8'
     )
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
   })
 
   it('treats a snapshot from another classifier version as absent', async () => {
     await writeFile(
       join(userDataDirHolder.dir, SNAPSHOT_FILE),
       JSON.stringify({
-        version: 1,
+        version: 2,
         argsFingerprint: 'classifier:1|includeAllWorkspaces',
         result: makeBroadResult([makeCandidate()])
       }),
       'utf-8'
     )
 
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
   })
 
   it('patches targeted rescans into the snapshot without touching other rows', async () => {
@@ -137,17 +139,19 @@ describe('workspace cleanup scan snapshot', () => {
       branch: 'other'
     })
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([stale, other])
     )
 
     const rescanned = makeCandidate({ tier: 'protected', blockers: ['dirty-files'] })
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       { worktreeId: stale.worktreeId },
       { scannedAt: NOW + 60_000, candidates: [rescanned], errors: [] }
     )
 
-    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    const snapshot = await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)
     expect(snapshot?.candidates).toEqual([rescanned, other])
     // Snapshot freshness stays anchored to the last FULL scan.
     expect(snapshot?.scannedAt).toBe(NOW)
@@ -155,17 +159,19 @@ describe('workspace cleanup scan snapshot', () => {
 
   it('appends targeted rows the snapshot has not seen yet', async () => {
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([makeCandidate()])
     )
 
     const created = makeCandidate({ worktreeId: 'repo-1::/repo-new', path: '/repo-new' })
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       { worktreeId: created.worktreeId },
       { scannedAt: NOW + 1, candidates: [created], errors: [] }
     )
 
-    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    const snapshot = await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)
     expect(snapshot?.candidates.map((candidate) => candidate.worktreeId)).toEqual([
       'repo-1::/repo-feature',
       'repo-1::/repo-new'
@@ -174,11 +180,12 @@ describe('workspace cleanup scan snapshot', () => {
 
   it('does not create a snapshot from a targeted scan alone', async () => {
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       { worktreeId: 'repo-1::/repo-feature' },
       makeBroadResult([makeCandidate()])
     )
 
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
     await expect(readFile(join(userDataDirHolder.dir, SNAPSHOT_FILE))).rejects.toMatchObject({
       code: 'ENOENT'
     })
@@ -189,15 +196,20 @@ describe('workspace cleanup scan snapshot', () => {
       makeCandidate(),
       makeCandidate({ worktreeId: 'repo-1::/b', path: '/b' })
     ])
-    await persistWorkspaceCleanupScanResult({ includeAllWorkspaces: true }, broad)
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      broad
+    )
 
     const legacyRow = makeCandidate({ tier: 'review', selectedByDefault: false })
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       {},
       { scannedAt: NOW + 1, candidates: [legacyRow], errors: [] }
     )
 
-    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    const snapshot = await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)
     expect(snapshot?.candidates).toHaveLength(2)
     expect(snapshot?.candidates[0]).toEqual(legacyRow)
   })
@@ -205,17 +217,92 @@ describe('workspace cleanup scan snapshot', () => {
   it('prunes a removed worktree so it cannot resurrect from cache', async () => {
     const kept = makeCandidate({ worktreeId: 'repo-1::/repo-kept', path: '/repo-kept' })
     await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
       { includeAllWorkspaces: true },
       makeBroadResult([makeCandidate(), kept])
     )
 
-    await pruneWorkspaceCleanupScanSnapshot('repo-1::/repo-feature')
+    await pruneWorkspaceCleanupScanSnapshot(userDataDirHolder.dir, 'repo-1::/repo-feature', 'local')
 
-    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    const snapshot = await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)
     expect(snapshot?.candidates).toEqual([kept])
 
     // Unknown ids are a no-op.
-    await pruneWorkspaceCleanupScanSnapshot('repo-1::/never-existed')
-    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toEqual(snapshot)
+    await pruneWorkspaceCleanupScanSnapshot(userDataDirHolder.dir, 'repo-1::/never-existed')
+    await expect(readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir)).resolves.toEqual(snapshot)
+  })
+
+  it('keeps profile snapshots isolated', async () => {
+    const otherProfile = await mkdtemp(join(tmpdir(), 'orca-cleanup-snapshot-other-'))
+    try {
+      await persistWorkspaceCleanupScanResult(
+        userDataDirHolder.dir,
+        { includeAllWorkspaces: true },
+        makeBroadResult([makeCandidate()])
+      )
+
+      await expect(readWorkspaceCleanupScanSnapshot(otherProfile)).resolves.toBeNull()
+    } finally {
+      await rm(otherProfile, { recursive: true, force: true })
+    }
+  })
+
+  it('does not let a scan started before removal restore the pruned row', async () => {
+    const staleResult = {
+      ...makeBroadResult([makeCandidate()]),
+      scannedAt: Date.now() - 1
+    }
+    await pruneWorkspaceCleanupScanSnapshot(userDataDirHolder.dir, 'repo-1::/repo-feature', 'local')
+
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      staleResult
+    )
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([])
+
+    const recreated = { ...staleResult, scannedAt: Date.now() + 1 }
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      recreated
+    )
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
+      makeCandidate()
+    ])
+  })
+
+  it('patches and prunes host-colliding workspace ids independently', async () => {
+    const local = makeCandidate()
+    const remote = makeCandidate({
+      connectionId: 'ssh-1',
+      executionHostId: 'ssh:ssh-1',
+      repoName: 'Remote repo'
+    })
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { includeAllWorkspaces: true },
+      makeBroadResult([local, remote])
+    )
+
+    const rescannedRemote = makeCandidate({
+      ...remote,
+      tier: 'protected',
+      blockers: ['dirty-files']
+    })
+    await persistWorkspaceCleanupScanResult(
+      userDataDirHolder.dir,
+      { worktreeId: remote.worktreeId },
+      { scannedAt: NOW + 1, candidates: [rescannedRemote], errors: [] }
+    )
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
+      local,
+      rescannedRemote
+    ])
+
+    await pruneWorkspaceCleanupScanSnapshot(userDataDirHolder.dir, remote.worktreeId, 'ssh:ssh-1')
+    expect((await readWorkspaceCleanupScanSnapshot(userDataDirHolder.dir))?.candidates).toEqual([
+      local
+    ])
   })
 })

--- a/src/main/workspace-cleanup-scan-snapshot.test.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.test.ts
@@ -1,0 +1,221 @@
+import { mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  WorkspaceCleanupCandidate,
+  WorkspaceCleanupScanResult
+} from '../shared/workspace-cleanup'
+
+const { userDataDirHolder } = vi.hoisted(() => ({ userDataDirHolder: { dir: '' } }))
+
+vi.mock('./persistence', () => ({
+  getCanonicalUserDataPath: () => userDataDirHolder.dir
+}))
+
+import {
+  persistWorkspaceCleanupScanResult,
+  pruneWorkspaceCleanupScanSnapshot,
+  readWorkspaceCleanupScanSnapshot,
+  workspaceCleanupScanSnapshotFingerprint
+} from './workspace-cleanup-scan-snapshot'
+
+const SNAPSHOT_FILE = 'orca-workspace-cleanup-scan.json'
+const NOW = 1_700_000_000_000
+
+function makeCandidate(
+  overrides: Partial<WorkspaceCleanupCandidate> = {}
+): WorkspaceCleanupCandidate {
+  return {
+    worktreeId: 'repo-1::/repo-feature',
+    repoId: 'repo-1',
+    repoName: 'Repo',
+    connectionId: null,
+    displayName: 'Feature',
+    branch: 'feature',
+    path: '/repo-feature',
+    tier: 'ready',
+    selectedByDefault: true,
+    reasons: ['idle-clean'],
+    blockers: [],
+    lastActivityAt: NOW - 40 * 24 * 60 * 60 * 1000,
+    localContext: {
+      terminalTabCount: 0,
+      cleanEditorTabCount: 0,
+      browserTabCount: 0,
+      diffCommentCount: 0,
+      newestDiffCommentAt: null,
+      retainedDoneAgentCount: 0
+    },
+    git: { clean: true, upstreamAhead: 0, upstreamBehind: 0, checkedAt: NOW },
+    fingerprint: '2|feature|abc123|clean|19675',
+    ...overrides
+  }
+}
+
+function makeBroadResult(candidates: WorkspaceCleanupCandidate[]): WorkspaceCleanupScanResult {
+  return { scannedAt: NOW, candidates, errors: [] }
+}
+
+describe('workspace cleanup scan snapshot', () => {
+  beforeEach(async () => {
+    userDataDirHolder.dir = await mkdtemp(join(tmpdir(), 'orca-cleanup-snapshot-'))
+  })
+
+  afterEach(async () => {
+    await rm(userDataDirHolder.dir, { recursive: true, force: true })
+  })
+
+  it('round-trips a broad scan snapshot, including SSH connectionId rows', async () => {
+    const sshCandidate = makeCandidate({
+      worktreeId: 'repo-ssh::/remote/repo-feature',
+      repoId: 'repo-ssh',
+      connectionId: 'ssh-1',
+      path: '/remote/repo-feature',
+      blockers: ['ssh-disconnected'],
+      git: { clean: null, upstreamAhead: null, upstreamBehind: null, checkedAt: null }
+    })
+    const result = makeBroadResult([makeCandidate(), sshCandidate])
+
+    await persistWorkspaceCleanupScanResult({ includeAllWorkspaces: true }, result)
+
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toEqual(result)
+  })
+
+  it('returns null when no snapshot has been persisted', async () => {
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+  })
+
+  it('degrades corrupt persisted blobs to null instead of throwing', async () => {
+    const file = join(userDataDirHolder.dir, SNAPSHOT_FILE)
+
+    await writeFile(file, 'not json{', 'utf-8')
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+
+    await writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        argsFingerprint: workspaceCleanupScanSnapshotFingerprint(),
+        result: { scannedAt: NOW, candidates: 'nope', errors: [] }
+      }),
+      'utf-8'
+    )
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+
+    await writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        argsFingerprint: workspaceCleanupScanSnapshotFingerprint(),
+        result: { scannedAt: NOW, candidates: [{ worktreeId: 42 }], errors: [] }
+      }),
+      'utf-8'
+    )
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+  })
+
+  it('treats a snapshot from another classifier version as absent', async () => {
+    await writeFile(
+      join(userDataDirHolder.dir, SNAPSHOT_FILE),
+      JSON.stringify({
+        version: 1,
+        argsFingerprint: 'classifier:1|includeAllWorkspaces',
+        result: makeBroadResult([makeCandidate()])
+      }),
+      'utf-8'
+    )
+
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+  })
+
+  it('patches targeted rescans into the snapshot without touching other rows', async () => {
+    const stale = makeCandidate({ git: { ...makeCandidate().git, clean: null, checkedAt: null } })
+    const other = makeCandidate({
+      worktreeId: 'repo-1::/repo-other',
+      path: '/repo-other',
+      branch: 'other'
+    })
+    await persistWorkspaceCleanupScanResult(
+      { includeAllWorkspaces: true },
+      makeBroadResult([stale, other])
+    )
+
+    const rescanned = makeCandidate({ tier: 'protected', blockers: ['dirty-files'] })
+    await persistWorkspaceCleanupScanResult(
+      { worktreeId: stale.worktreeId },
+      { scannedAt: NOW + 60_000, candidates: [rescanned], errors: [] }
+    )
+
+    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    expect(snapshot?.candidates).toEqual([rescanned, other])
+    // Snapshot freshness stays anchored to the last FULL scan.
+    expect(snapshot?.scannedAt).toBe(NOW)
+  })
+
+  it('appends targeted rows the snapshot has not seen yet', async () => {
+    await persistWorkspaceCleanupScanResult(
+      { includeAllWorkspaces: true },
+      makeBroadResult([makeCandidate()])
+    )
+
+    const created = makeCandidate({ worktreeId: 'repo-1::/repo-new', path: '/repo-new' })
+    await persistWorkspaceCleanupScanResult(
+      { worktreeId: created.worktreeId },
+      { scannedAt: NOW + 1, candidates: [created], errors: [] }
+    )
+
+    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    expect(snapshot?.candidates.map((candidate) => candidate.worktreeId)).toEqual([
+      'repo-1::/repo-feature',
+      'repo-1::/repo-new'
+    ])
+  })
+
+  it('does not create a snapshot from a targeted scan alone', async () => {
+    await persistWorkspaceCleanupScanResult(
+      { worktreeId: 'repo-1::/repo-feature' },
+      makeBroadResult([makeCandidate()])
+    )
+
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toBeNull()
+    await expect(readFile(join(userDataDirHolder.dir, SNAPSHOT_FILE))).rejects.toMatchObject({
+      code: 'ENOENT'
+    })
+  })
+
+  it('keeps the broad snapshot when a legacy suggestion-only scan completes', async () => {
+    const broad = makeBroadResult([
+      makeCandidate(),
+      makeCandidate({ worktreeId: 'repo-1::/b', path: '/b' })
+    ])
+    await persistWorkspaceCleanupScanResult({ includeAllWorkspaces: true }, broad)
+
+    const legacyRow = makeCandidate({ tier: 'review', selectedByDefault: false })
+    await persistWorkspaceCleanupScanResult(
+      {},
+      { scannedAt: NOW + 1, candidates: [legacyRow], errors: [] }
+    )
+
+    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    expect(snapshot?.candidates).toHaveLength(2)
+    expect(snapshot?.candidates[0]).toEqual(legacyRow)
+  })
+
+  it('prunes a removed worktree so it cannot resurrect from cache', async () => {
+    const kept = makeCandidate({ worktreeId: 'repo-1::/repo-kept', path: '/repo-kept' })
+    await persistWorkspaceCleanupScanResult(
+      { includeAllWorkspaces: true },
+      makeBroadResult([makeCandidate(), kept])
+    )
+
+    await pruneWorkspaceCleanupScanSnapshot('repo-1::/repo-feature')
+
+    const snapshot = await readWorkspaceCleanupScanSnapshot()
+    expect(snapshot?.candidates).toEqual([kept])
+
+    // Unknown ids are a no-op.
+    await pruneWorkspaceCleanupScanSnapshot('repo-1::/never-existed')
+    await expect(readWorkspaceCleanupScanSnapshot()).resolves.toEqual(snapshot)
+  })
+})

--- a/src/main/workspace-cleanup-scan-snapshot.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.ts
@@ -1,0 +1,152 @@
+import {
+  WORKSPACE_CLEANUP_CLASSIFIER_VERSION,
+  type WorkspaceCleanupCandidate,
+  type WorkspaceCleanupScanArgs,
+  type WorkspaceCleanupScanResult
+} from '../shared/workspace-cleanup'
+import {
+  readSidecarSnapshot,
+  withSidecarSnapshotQueue,
+  writeSidecarSnapshot
+} from './sidecar-snapshot-file'
+
+const SNAPSHOT_FILE_NAME = 'orca-workspace-cleanup-scan.json'
+const SNAPSHOT_VERSION = 1
+
+type PersistedWorkspaceCleanupScanSnapshot = {
+  version: number
+  argsFingerprint: string
+  result: WorkspaceCleanupScanResult
+}
+
+/** Why a fingerprint: a classifier bump reshuffles tiers/blockers wholesale, so an older snapshot must read as absent, not stale-but-plausible. */
+export function workspaceCleanupScanSnapshotFingerprint(): string {
+  return `classifier:${WORKSPACE_CLEANUP_CLASSIFIER_VERSION}|includeAllWorkspaces`
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPersistableCandidate(value: unknown): value is WorkspaceCleanupCandidate {
+  if (!isRecord(value)) {
+    return false
+  }
+  return (
+    typeof value.worktreeId === 'string' &&
+    typeof value.repoId === 'string' &&
+    typeof value.fingerprint === 'string' &&
+    (value.connectionId === null || typeof value.connectionId === 'string') &&
+    Array.isArray(value.reasons) &&
+    Array.isArray(value.blockers) &&
+    isRecord(value.git) &&
+    isRecord(value.localContext)
+  )
+}
+
+/** Shape guard so a corrupt persisted blob degrades to null instead of throwing at startup. */
+function parseSnapshot(parsed: unknown): WorkspaceCleanupScanResult | null {
+  if (!isRecord(parsed)) {
+    return null
+  }
+  if (parsed.version !== SNAPSHOT_VERSION) {
+    return null
+  }
+  if (parsed.argsFingerprint !== workspaceCleanupScanSnapshotFingerprint()) {
+    return null
+  }
+  const result = parsed.result
+  if (!isRecord(result)) {
+    return null
+  }
+  if (
+    typeof result.scannedAt !== 'number' ||
+    !Array.isArray(result.candidates) ||
+    !Array.isArray(result.errors) ||
+    !result.candidates.every(isPersistableCandidate)
+  ) {
+    return null
+  }
+  return result as unknown as WorkspaceCleanupScanResult
+}
+
+export async function readWorkspaceCleanupScanSnapshot(): Promise<WorkspaceCleanupScanResult | null> {
+  try {
+    return parseSnapshot(await readSidecarSnapshot(SNAPSHOT_FILE_NAME))
+  } catch {
+    return null
+  }
+}
+
+async function writeSnapshot(result: WorkspaceCleanupScanResult): Promise<void> {
+  await writeSidecarSnapshot(SNAPSHOT_FILE_NAME, {
+    version: SNAPSHOT_VERSION,
+    argsFingerprint: workspaceCleanupScanSnapshotFingerprint(),
+    result
+  } satisfies PersistedWorkspaceCleanupScanSnapshot)
+}
+
+function patchCandidates(
+  existing: WorkspaceCleanupScanResult,
+  fresh: WorkspaceCleanupCandidate[]
+): WorkspaceCleanupScanResult {
+  const freshById = new Map(fresh.map((candidate) => [candidate.worktreeId, candidate]))
+  const candidates = existing.candidates.map((candidate) => {
+    const replacement = freshById.get(candidate.worktreeId)
+    freshById.delete(candidate.worktreeId)
+    return replacement ?? candidate
+  })
+  candidates.push(...freshById.values())
+  // Why keep scannedAt: it marks the last FULL scan; a focused rescan must not advertise fleet-wide freshness.
+  return { ...existing, candidates }
+}
+
+/**
+ * Persist a completed scan: a broad (includeAllWorkspaces) scan replaces the snapshot, anything
+ * narrower patches matching rows into it. Never throws — the snapshot is a refetchable cache.
+ */
+export async function persistWorkspaceCleanupScanResult(
+  args: WorkspaceCleanupScanArgs,
+  result: WorkspaceCleanupScanResult
+): Promise<void> {
+  try {
+    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, async () => {
+      if (!args.worktreeId && args.includeAllWorkspaces === true) {
+        await writeSnapshot(result)
+        return
+      }
+      if (result.candidates.length === 0) {
+        return
+      }
+      const existing = await readWorkspaceCleanupScanSnapshot()
+      // Why: a focused/legacy scan is a subset; without a broad baseline it is not a fleet snapshot.
+      if (!existing) {
+        return
+      }
+      await writeSnapshot(patchCandidates(existing, result.candidates))
+    })
+  } catch (error) {
+    console.warn('[workspace-cleanup] failed to persist scan snapshot:', error)
+  }
+}
+
+/** Drop a removed workspace so it never resurrects from cache. Never throws. */
+export async function pruneWorkspaceCleanupScanSnapshot(worktreeId: string): Promise<void> {
+  try {
+    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, async () => {
+      const existing = await readWorkspaceCleanupScanSnapshot()
+      if (!existing) {
+        return
+      }
+      const candidates = existing.candidates.filter(
+        (candidate) => candidate.worktreeId !== worktreeId
+      )
+      if (candidates.length === existing.candidates.length) {
+        return
+      }
+      await writeSnapshot({ ...existing, candidates })
+    })
+  } catch (error) {
+    console.warn('[workspace-cleanup] failed to prune scan snapshot:', error)
+  }
+}

--- a/src/main/workspace-cleanup-scan-snapshot.ts
+++ b/src/main/workspace-cleanup-scan-snapshot.ts
@@ -6,12 +6,22 @@ import {
 } from '../shared/workspace-cleanup'
 import {
   readSidecarSnapshot,
+  sidecarSnapshotFile,
   withSidecarSnapshotQueue,
   writeSidecarSnapshot
 } from './sidecar-snapshot-file'
+import type { ExecutionHostId } from '../shared/execution-host'
 
 const SNAPSHOT_FILE_NAME = 'orca-workspace-cleanup-scan.json'
-const SNAPSHOT_VERSION = 1
+const SNAPSHOT_VERSION = 2
+
+type PrunedWorkspace = {
+  worktreeId: string
+  executionHostId?: ExecutionHostId
+  prunedAt: number
+}
+
+const prunedWorkspacesByFile = new Map<string, Map<string, PrunedWorkspace>>()
 
 type PersistedWorkspaceCleanupScanSnapshot = {
   version: number
@@ -37,6 +47,7 @@ function isPersistableCandidate(value: unknown): value is WorkspaceCleanupCandid
     typeof value.repoId === 'string' &&
     typeof value.fingerprint === 'string' &&
     (value.connectionId === null || typeof value.connectionId === 'string') &&
+    typeof value.executionHostId === 'string' &&
     Array.isArray(value.reasons) &&
     Array.isArray(value.blockers) &&
     isRecord(value.git) &&
@@ -70,16 +81,20 @@ function parseSnapshot(parsed: unknown): WorkspaceCleanupScanResult | null {
   return result as unknown as WorkspaceCleanupScanResult
 }
 
-export async function readWorkspaceCleanupScanSnapshot(): Promise<WorkspaceCleanupScanResult | null> {
+export async function readWorkspaceCleanupScanSnapshot(
+  snapshotDirectory: string
+): Promise<WorkspaceCleanupScanResult | null> {
   try {
-    return parseSnapshot(await readSidecarSnapshot(SNAPSHOT_FILE_NAME))
+    return parseSnapshot(
+      await readSidecarSnapshot(sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME))
+    )
   } catch {
     return null
   }
 }
 
-async function writeSnapshot(result: WorkspaceCleanupScanResult): Promise<void> {
-  await writeSidecarSnapshot(SNAPSHOT_FILE_NAME, {
+async function writeSnapshot(file: string, result: WorkspaceCleanupScanResult): Promise<void> {
+  await writeSidecarSnapshot(file, {
     version: SNAPSHOT_VERSION,
     argsFingerprint: workspaceCleanupScanSnapshotFingerprint(),
     result
@@ -90,10 +105,11 @@ function patchCandidates(
   existing: WorkspaceCleanupScanResult,
   fresh: WorkspaceCleanupCandidate[]
 ): WorkspaceCleanupScanResult {
-  const freshById = new Map(fresh.map((candidate) => [candidate.worktreeId, candidate]))
+  const freshById = new Map(fresh.map((candidate) => [candidateSnapshotKey(candidate), candidate]))
   const candidates = existing.candidates.map((candidate) => {
-    const replacement = freshById.get(candidate.worktreeId)
-    freshById.delete(candidate.worktreeId)
+    const key = candidateSnapshotKey(candidate)
+    const replacement = freshById.get(key)
+    freshById.delete(key)
     return replacement ?? candidate
   })
   candidates.push(...freshById.values())
@@ -101,29 +117,94 @@ function patchCandidates(
   return { ...existing, candidates }
 }
 
+function candidateSnapshotKey(
+  candidate: Pick<WorkspaceCleanupCandidate, 'executionHostId' | 'worktreeId'>
+): string {
+  return `${candidate.executionHostId ?? 'local'}\0${candidate.worktreeId}`
+}
+
+function prunedWorkspaceKey(worktreeId: string, executionHostId?: ExecutionHostId): string {
+  return `${executionHostId ?? '*'}\0${worktreeId}`
+}
+
+function matchesPrunedWorkspace(
+  candidate: WorkspaceCleanupCandidate,
+  pruned: PrunedWorkspace
+): boolean {
+  return (
+    candidate.worktreeId === pruned.worktreeId &&
+    (!pruned.executionHostId || candidate.executionHostId === pruned.executionHostId)
+  )
+}
+
+function excludeRowsPrunedDuringScan(
+  file: string,
+  result: WorkspaceCleanupScanResult
+): WorkspaceCleanupScanResult {
+  const pruned = [...(prunedWorkspacesByFile.get(file)?.values() ?? [])]
+  if (pruned.length === 0) {
+    return result
+  }
+  const candidates = result.candidates.filter(
+    (candidate) =>
+      !pruned.some(
+        (entry) => entry.prunedAt >= result.scannedAt && matchesPrunedWorkspace(candidate, entry)
+      )
+  )
+  return candidates.length === result.candidates.length ? result : { ...result, candidates }
+}
+
+function clearSupersededPrunes(
+  file: string,
+  result: WorkspaceCleanupScanResult,
+  broad: boolean
+): void {
+  const pruned = prunedWorkspacesByFile.get(file)
+  if (!pruned) {
+    return
+  }
+  for (const [key, entry] of pruned) {
+    if (
+      entry.prunedAt < result.scannedAt &&
+      (broad || result.candidates.some((candidate) => matchesPrunedWorkspace(candidate, entry)))
+    ) {
+      pruned.delete(key)
+    }
+  }
+  if (pruned.size === 0) {
+    prunedWorkspacesByFile.delete(file)
+  }
+}
+
 /**
  * Persist a completed scan: a broad (includeAllWorkspaces) scan replaces the snapshot, anything
  * narrower patches matching rows into it. Never throws — the snapshot is a refetchable cache.
  */
 export async function persistWorkspaceCleanupScanResult(
+  snapshotDirectory: string,
   args: WorkspaceCleanupScanArgs,
   result: WorkspaceCleanupScanResult
 ): Promise<void> {
+  const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
   try {
-    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, async () => {
-      if (!args.worktreeId && args.includeAllWorkspaces === true) {
-        await writeSnapshot(result)
+    await withSidecarSnapshotQueue(file, async () => {
+      const filteredResult = excludeRowsPrunedDuringScan(file, result)
+      const broad = !args.worktreeId && args.includeAllWorkspaces === true
+      if (broad) {
+        await writeSnapshot(file, filteredResult)
+        clearSupersededPrunes(file, result, true)
         return
       }
-      if (result.candidates.length === 0) {
+      if (filteredResult.candidates.length === 0) {
         return
       }
-      const existing = await readWorkspaceCleanupScanSnapshot()
+      const existing = await readWorkspaceCleanupScanSnapshot(snapshotDirectory)
       // Why: a focused/legacy scan is a subset; without a broad baseline it is not a fleet snapshot.
       if (!existing) {
         return
       }
-      await writeSnapshot(patchCandidates(existing, result.candidates))
+      await writeSnapshot(file, patchCandidates(existing, filteredResult.candidates))
+      clearSupersededPrunes(file, result, false)
     })
   } catch (error) {
     console.warn('[workspace-cleanup] failed to persist scan snapshot:', error)
@@ -131,20 +212,34 @@ export async function persistWorkspaceCleanupScanResult(
 }
 
 /** Drop a removed workspace so it never resurrects from cache. Never throws. */
-export async function pruneWorkspaceCleanupScanSnapshot(worktreeId: string): Promise<void> {
+export async function pruneWorkspaceCleanupScanSnapshot(
+  snapshotDirectory: string,
+  worktreeId: string,
+  executionHostId?: ExecutionHostId
+): Promise<void> {
+  const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
+  const pruned = prunedWorkspacesByFile.get(file) ?? new Map<string, PrunedWorkspace>()
+  pruned.set(prunedWorkspaceKey(worktreeId, executionHostId), {
+    worktreeId,
+    ...(executionHostId ? { executionHostId } : {}),
+    prunedAt: Date.now()
+  })
+  prunedWorkspacesByFile.set(file, pruned)
   try {
-    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, async () => {
-      const existing = await readWorkspaceCleanupScanSnapshot()
+    await withSidecarSnapshotQueue(file, async () => {
+      const existing = await readWorkspaceCleanupScanSnapshot(snapshotDirectory)
       if (!existing) {
         return
       }
       const candidates = existing.candidates.filter(
-        (candidate) => candidate.worktreeId !== worktreeId
+        (candidate) =>
+          candidate.worktreeId !== worktreeId ||
+          (executionHostId !== undefined && candidate.executionHostId !== executionHostId)
       )
       if (candidates.length === existing.candidates.length) {
         return
       }
-      await writeSnapshot({ ...existing, candidates })
+      await writeSnapshot(file, { ...existing, candidates })
     })
   } catch (error) {
     console.warn('[workspace-cleanup] failed to prune scan snapshot:', error)

--- a/src/main/workspace-space-analysis-snapshot.test.ts
+++ b/src/main/workspace-space-analysis-snapshot.test.ts
@@ -1,0 +1,182 @@
+import { mkdtemp, rm, writeFile } from 'node:fs/promises'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type {
+  WorkspaceSpaceAnalysis,
+  WorkspaceSpaceWorktree
+} from '../shared/workspace-space-types'
+
+const { userDataDirHolder } = vi.hoisted(() => ({ userDataDirHolder: { dir: '' } }))
+
+vi.mock('./persistence', () => ({
+  getCanonicalUserDataPath: () => userDataDirHolder.dir
+}))
+
+import {
+  persistWorkspaceSpaceAnalysisSnapshot,
+  pruneWorkspaceSpaceAnalysisSnapshot,
+  readWorkspaceSpaceAnalysisSnapshot
+} from './workspace-space-analysis-snapshot'
+
+const SNAPSHOT_FILE = 'orca-workspace-space-analysis.json'
+const NOW = 1_700_000_000_000
+
+function makeWorktreeRow(overrides: Partial<WorkspaceSpaceWorktree> = {}): WorkspaceSpaceWorktree {
+  return {
+    worktreeId: 'repo-1::/repo-feature',
+    repoId: 'repo-1',
+    repoDisplayName: 'Repo',
+    repoPath: '/repo',
+    displayName: 'Feature',
+    path: '/repo-feature',
+    branch: 'feature',
+    isMainWorktree: false,
+    isRemote: false,
+    isSparse: false,
+    canDelete: true,
+    lastActivityAt: NOW - 1000,
+    status: 'ok',
+    error: null,
+    scannedAt: NOW,
+    sizeBytes: 1000,
+    reclaimableBytes: 1000,
+    skippedEntryCount: 0,
+    topLevelItems: [],
+    omittedTopLevelItemCount: 0,
+    omittedTopLevelSizeBytes: 0,
+    ...overrides
+  }
+}
+
+function makeAnalysis(worktrees: WorkspaceSpaceWorktree[]): WorkspaceSpaceAnalysis {
+  const okRows = worktrees.filter((row) => row.status === 'ok')
+  return {
+    scannedAt: NOW,
+    totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
+    reclaimableBytes: worktrees.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+    worktreeCount: worktrees.length,
+    scannedWorktreeCount: okRows.length,
+    unavailableWorktreeCount: worktrees.length - okRows.length,
+    repos: [
+      {
+        repoId: 'repo-1',
+        displayName: 'Repo',
+        path: '/repo',
+        isRemote: false,
+        worktreeCount: worktrees.length,
+        scannedWorktreeCount: okRows.length,
+        unavailableWorktreeCount: worktrees.length - okRows.length,
+        totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
+        reclaimableBytes: worktrees.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+        error: null
+      }
+    ],
+    worktrees
+  }
+}
+
+describe('workspace space analysis snapshot', () => {
+  beforeEach(async () => {
+    userDataDirHolder.dir = await mkdtemp(join(tmpdir(), 'orca-space-snapshot-'))
+  })
+
+  afterEach(async () => {
+    await rm(userDataDirHolder.dir, { recursive: true, force: true })
+  })
+
+  it('round-trips a completed analysis', async () => {
+    const analysis = makeAnalysis([makeWorktreeRow()])
+
+    await persistWorkspaceSpaceAnalysisSnapshot(analysis)
+
+    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toEqual(analysis)
+  })
+
+  it('prunes topLevelItems into the omitted counters to bound the payload', async () => {
+    const row = makeWorktreeRow({
+      sizeBytes: 5000,
+      topLevelItems: [
+        {
+          name: 'node_modules',
+          path: '/repo-feature/node_modules',
+          kind: 'directory',
+          sizeBytes: 3000
+        },
+        { name: 'src', path: '/repo-feature/src', kind: 'directory', sizeBytes: 1000 }
+      ],
+      omittedTopLevelItemCount: 2,
+      omittedTopLevelSizeBytes: 500
+    })
+
+    await persistWorkspaceSpaceAnalysisSnapshot(makeAnalysis([row]))
+
+    const cached = await readWorkspaceSpaceAnalysisSnapshot()
+    expect(cached?.worktrees[0]).toMatchObject({
+      sizeBytes: 5000,
+      topLevelItems: [],
+      omittedTopLevelItemCount: 4,
+      omittedTopLevelSizeBytes: 4500
+    })
+  })
+
+  it('returns null when missing or corrupt instead of throwing', async () => {
+    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+
+    const file = join(userDataDirHolder.dir, SNAPSHOT_FILE)
+    await writeFile(file, '{"version":1,"analysis":', 'utf-8')
+    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+
+    await writeFile(
+      file,
+      JSON.stringify({
+        version: 1,
+        analysis: { scannedAt: 'yesterday', repos: [], worktrees: [] }
+      }),
+      'utf-8'
+    )
+    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+
+    await writeFile(
+      file,
+      JSON.stringify({ version: 99, analysis: makeAnalysis([makeWorktreeRow()]) }),
+      'utf-8'
+    )
+    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+  })
+
+  it('prunes a removed worktree row and rebalances totals', async () => {
+    const removed = makeWorktreeRow({ sizeBytes: 3000, reclaimableBytes: 3000 })
+    const kept = makeWorktreeRow({
+      worktreeId: 'repo-1::/repo-kept',
+      path: '/repo-kept',
+      status: 'missing',
+      sizeBytes: 1000,
+      reclaimableBytes: 0
+    })
+    await persistWorkspaceSpaceAnalysisSnapshot(makeAnalysis([removed, kept]))
+
+    await pruneWorkspaceSpaceAnalysisSnapshot(removed.worktreeId)
+
+    const cached = await readWorkspaceSpaceAnalysisSnapshot()
+    expect(cached?.worktrees.map((row) => row.worktreeId)).toEqual(['repo-1::/repo-kept'])
+    expect(cached).toMatchObject({
+      worktreeCount: 1,
+      scannedWorktreeCount: 0,
+      unavailableWorktreeCount: 1,
+      totalSizeBytes: 1000,
+      reclaimableBytes: 0
+    })
+    expect(cached?.repos[0]).toMatchObject({
+      worktreeCount: 1,
+      scannedWorktreeCount: 0,
+      unavailableWorktreeCount: 1,
+      totalSizeBytes: 1000,
+      reclaimableBytes: 0
+    })
+
+    // Unknown ids are a no-op.
+    await pruneWorkspaceSpaceAnalysisSnapshot('repo-1::/never-existed')
+    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toEqual(cached)
+  })
+})

--- a/src/main/workspace-space-analysis-snapshot.test.ts
+++ b/src/main/workspace-space-analysis-snapshot.test.ts
@@ -9,10 +9,6 @@ import type {
 
 const { userDataDirHolder } = vi.hoisted(() => ({ userDataDirHolder: { dir: '' } }))
 
-vi.mock('./persistence', () => ({
-  getCanonicalUserDataPath: () => userDataDirHolder.dir
-}))
-
 import {
   persistWorkspaceSpaceAnalysisSnapshot,
   pruneWorkspaceSpaceAnalysisSnapshot,
@@ -26,6 +22,7 @@ function makeWorktreeRow(overrides: Partial<WorkspaceSpaceWorktree> = {}): Works
   return {
     worktreeId: 'repo-1::/repo-feature',
     repoId: 'repo-1',
+    executionHostId: 'local',
     repoDisplayName: 'Repo',
     repoPath: '/repo',
     displayName: 'Feature',
@@ -51,6 +48,7 @@ function makeWorktreeRow(overrides: Partial<WorkspaceSpaceWorktree> = {}): Works
 
 function makeAnalysis(worktrees: WorkspaceSpaceWorktree[]): WorkspaceSpaceAnalysis {
   const okRows = worktrees.filter((row) => row.status === 'ok')
+  const rowsByHost = Map.groupBy(worktrees, (row) => row.executionHostId ?? 'local')
   return {
     scannedAt: NOW,
     totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
@@ -58,20 +56,22 @@ function makeAnalysis(worktrees: WorkspaceSpaceWorktree[]): WorkspaceSpaceAnalys
     worktreeCount: worktrees.length,
     scannedWorktreeCount: okRows.length,
     unavailableWorktreeCount: worktrees.length - okRows.length,
-    repos: [
-      {
+    repos: [...rowsByHost.entries()].map(([executionHostId, rows]) => {
+      const scanned = rows.filter((row) => row.status === 'ok')
+      return {
         repoId: 'repo-1',
+        executionHostId,
         displayName: 'Repo',
         path: '/repo',
-        isRemote: false,
-        worktreeCount: worktrees.length,
-        scannedWorktreeCount: okRows.length,
-        unavailableWorktreeCount: worktrees.length - okRows.length,
-        totalSizeBytes: worktrees.reduce((sum, row) => sum + row.sizeBytes, 0),
-        reclaimableBytes: worktrees.reduce((sum, row) => sum + row.reclaimableBytes, 0),
+        isRemote: executionHostId !== 'local',
+        worktreeCount: rows.length,
+        scannedWorktreeCount: scanned.length,
+        unavailableWorktreeCount: rows.length - scanned.length,
+        totalSizeBytes: rows.reduce((sum, row) => sum + row.sizeBytes, 0),
+        reclaimableBytes: rows.reduce((sum, row) => sum + row.reclaimableBytes, 0),
         error: null
       }
-    ],
+    }),
     worktrees
   }
 }
@@ -88,9 +88,11 @@ describe('workspace space analysis snapshot', () => {
   it('round-trips a completed analysis', async () => {
     const analysis = makeAnalysis([makeWorktreeRow()])
 
-    await persistWorkspaceSpaceAnalysisSnapshot(analysis)
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, analysis)
 
-    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toEqual(analysis)
+    await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toEqual(
+      analysis
+    )
   })
 
   it('prunes topLevelItems into the omitted counters to bound the payload', async () => {
@@ -109,9 +111,9 @@ describe('workspace space analysis snapshot', () => {
       omittedTopLevelSizeBytes: 500
     })
 
-    await persistWorkspaceSpaceAnalysisSnapshot(makeAnalysis([row]))
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, makeAnalysis([row]))
 
-    const cached = await readWorkspaceSpaceAnalysisSnapshot()
+    const cached = await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)
     expect(cached?.worktrees[0]).toMatchObject({
       sizeBytes: 5000,
       topLevelItems: [],
@@ -121,28 +123,28 @@ describe('workspace space analysis snapshot', () => {
   })
 
   it('returns null when missing or corrupt instead of throwing', async () => {
-    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
 
     const file = join(userDataDirHolder.dir, SNAPSHOT_FILE)
     await writeFile(file, '{"version":1,"analysis":', 'utf-8')
-    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
 
     await writeFile(
       file,
       JSON.stringify({
-        version: 1,
+        version: 2,
         analysis: { scannedAt: 'yesterday', repos: [], worktrees: [] }
       }),
       'utf-8'
     )
-    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
 
     await writeFile(
       file,
       JSON.stringify({ version: 99, analysis: makeAnalysis([makeWorktreeRow()]) }),
       'utf-8'
     )
-    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toBeNull()
+    await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toBeNull()
   })
 
   it('prunes a removed worktree row and rebalances totals', async () => {
@@ -154,11 +156,14 @@ describe('workspace space analysis snapshot', () => {
       sizeBytes: 1000,
       reclaimableBytes: 0
     })
-    await persistWorkspaceSpaceAnalysisSnapshot(makeAnalysis([removed, kept]))
+    await persistWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      makeAnalysis([removed, kept])
+    )
 
-    await pruneWorkspaceSpaceAnalysisSnapshot(removed.worktreeId)
+    await pruneWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, removed.worktreeId, 'local')
 
-    const cached = await readWorkspaceSpaceAnalysisSnapshot()
+    const cached = await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)
     expect(cached?.worktrees.map((row) => row.worktreeId)).toEqual(['repo-1::/repo-kept'])
     expect(cached).toMatchObject({
       worktreeCount: 1,
@@ -176,7 +181,79 @@ describe('workspace space analysis snapshot', () => {
     })
 
     // Unknown ids are a no-op.
-    await pruneWorkspaceSpaceAnalysisSnapshot('repo-1::/never-existed')
-    await expect(readWorkspaceSpaceAnalysisSnapshot()).resolves.toEqual(cached)
+    await pruneWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, 'repo-1::/never-existed')
+    await expect(readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)).resolves.toEqual(cached)
+  })
+
+  it('keeps profile snapshots isolated', async () => {
+    const otherProfile = await mkdtemp(join(tmpdir(), 'orca-space-snapshot-other-'))
+    try {
+      await persistWorkspaceSpaceAnalysisSnapshot(
+        userDataDirHolder.dir,
+        makeAnalysis([makeWorktreeRow()])
+      )
+
+      await expect(readWorkspaceSpaceAnalysisSnapshot(otherProfile)).resolves.toBeNull()
+    } finally {
+      await rm(otherProfile, { recursive: true, force: true })
+    }
+  })
+
+  it('does not let an analysis started before removal restore the pruned row', async () => {
+    const staleAnalysis = {
+      ...makeAnalysis([makeWorktreeRow()]),
+      scannedAt: Date.now() - 1
+    }
+    await pruneWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      'repo-1::/repo-feature',
+      'local'
+    )
+
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, staleAnalysis)
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([])
+
+    const recreated = { ...staleAnalysis, scannedAt: Date.now() + 1 }
+    await persistWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, recreated)
+    expect((await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir))?.worktrees).toEqual([
+      makeWorktreeRow()
+    ])
+  })
+
+  it('prunes host-colliding workspace ids without corrupting surviving totals', async () => {
+    const local = makeWorktreeRow({ sizeBytes: 1000, reclaimableBytes: 1000 })
+    const remote = makeWorktreeRow({
+      executionHostId: 'ssh:ssh-1',
+      isRemote: true,
+      sizeBytes: 3000,
+      reclaimableBytes: 3000
+    })
+    await persistWorkspaceSpaceAnalysisSnapshot(
+      userDataDirHolder.dir,
+      makeAnalysis([local, remote])
+    )
+
+    await pruneWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir, remote.worktreeId, 'ssh:ssh-1')
+
+    const cached = await readWorkspaceSpaceAnalysisSnapshot(userDataDirHolder.dir)
+    expect(cached?.worktrees).toEqual([local])
+    expect(cached).toMatchObject({
+      worktreeCount: 1,
+      scannedWorktreeCount: 1,
+      totalSizeBytes: 1000,
+      reclaimableBytes: 1000
+    })
+    expect(cached?.repos).toEqual([
+      expect.objectContaining({
+        executionHostId: 'local',
+        worktreeCount: 1,
+        totalSizeBytes: 1000
+      }),
+      expect.objectContaining({
+        executionHostId: 'ssh:ssh-1',
+        worktreeCount: 0,
+        totalSizeBytes: 0
+      })
+    ])
   })
 })

--- a/src/main/workspace-space-analysis-snapshot.ts
+++ b/src/main/workspace-space-analysis-snapshot.ts
@@ -4,12 +4,22 @@ import type {
 } from '../shared/workspace-space-types'
 import {
   readSidecarSnapshot,
+  sidecarSnapshotFile,
   withSidecarSnapshotQueue,
   writeSidecarSnapshot
 } from './sidecar-snapshot-file'
+import type { ExecutionHostId } from '../shared/execution-host'
 
 const SNAPSHOT_FILE_NAME = 'orca-workspace-space-analysis.json'
-const SNAPSHOT_VERSION = 1
+const SNAPSHOT_VERSION = 2
+
+type PrunedWorkspace = {
+  worktreeId: string
+  executionHostId?: ExecutionHostId
+  prunedAt: number
+}
+
+const prunedWorkspacesByFile = new Map<string, Map<string, PrunedWorkspace>>()
 
 type PersistedWorkspaceSpaceAnalysisSnapshot = {
   version: number
@@ -27,6 +37,7 @@ function isPersistableWorktreeRow(value: unknown): value is WorkspaceSpaceWorktr
   return (
     typeof value.worktreeId === 'string' &&
     typeof value.repoId === 'string' &&
+    typeof value.executionHostId === 'string' &&
     typeof value.status === 'string' &&
     typeof value.sizeBytes === 'number' &&
     typeof value.reclaimableBytes === 'number' &&
@@ -71,16 +82,20 @@ function stripTopLevelItems(analysis: WorkspaceSpaceAnalysis): WorkspaceSpaceAna
   }
 }
 
-export async function readWorkspaceSpaceAnalysisSnapshot(): Promise<WorkspaceSpaceAnalysis | null> {
+export async function readWorkspaceSpaceAnalysisSnapshot(
+  snapshotDirectory: string
+): Promise<WorkspaceSpaceAnalysis | null> {
   try {
-    return parseSnapshot(await readSidecarSnapshot(SNAPSHOT_FILE_NAME))
+    return parseSnapshot(
+      await readSidecarSnapshot(sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME))
+    )
   } catch {
     return null
   }
 }
 
-async function writeSnapshot(analysis: WorkspaceSpaceAnalysis): Promise<void> {
-  await writeSidecarSnapshot(SNAPSHOT_FILE_NAME, {
+async function writeSnapshot(file: string, analysis: WorkspaceSpaceAnalysis): Promise<void> {
+  await writeSidecarSnapshot(file, {
     version: SNAPSHOT_VERSION,
     analysis
   } satisfies PersistedWorkspaceSpaceAnalysisSnapshot)
@@ -88,12 +103,15 @@ async function writeSnapshot(analysis: WorkspaceSpaceAnalysis): Promise<void> {
 
 /** Persist a completed analysis. Never throws — the snapshot is a refetchable cache. */
 export async function persistWorkspaceSpaceAnalysisSnapshot(
+  snapshotDirectory: string,
   analysis: WorkspaceSpaceAnalysis
 ): Promise<void> {
+  const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
   try {
-    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, () =>
-      writeSnapshot(stripTopLevelItems(analysis))
-    )
+    await withSidecarSnapshotQueue(file, async () => {
+      await writeSnapshot(file, stripTopLevelItems(excludeRowsPrunedDuringScan(file, analysis)))
+      clearSupersededPrunes(file, analysis)
+    })
   } catch (error) {
     console.warn('[workspace-space] failed to persist analysis snapshot:', error)
   }
@@ -107,14 +125,14 @@ function withoutWorktreeRow(
   const unavailableDelta = removed.status === 'ok' ? 0 : 1
   return {
     ...analysis,
-    worktrees: analysis.worktrees.filter((row) => row.worktreeId !== removed.worktreeId),
+    worktrees: analysis.worktrees.filter((row) => !isSameWorkspace(row, removed)),
     worktreeCount: Math.max(0, analysis.worktreeCount - 1),
     scannedWorktreeCount: Math.max(0, analysis.scannedWorktreeCount - scannedDelta),
     unavailableWorktreeCount: Math.max(0, analysis.unavailableWorktreeCount - unavailableDelta),
     totalSizeBytes: Math.max(0, analysis.totalSizeBytes - removed.sizeBytes),
     reclaimableBytes: Math.max(0, analysis.reclaimableBytes - removed.reclaimableBytes),
     repos: analysis.repos.map((repo) =>
-      repo.repoId === removed.repoId
+      repo.repoId === removed.repoId && repo.executionHostId === removed.executionHostId
         ? {
             ...repo,
             worktreeCount: Math.max(0, repo.worktreeCount - 1),
@@ -128,16 +146,81 @@ function withoutWorktreeRow(
   }
 }
 
+function isSameWorkspace(
+  left: Pick<WorkspaceSpaceWorktree, 'executionHostId' | 'worktreeId'>,
+  right: Pick<WorkspaceSpaceWorktree, 'executionHostId' | 'worktreeId'>
+): boolean {
+  return left.worktreeId === right.worktreeId && left.executionHostId === right.executionHostId
+}
+
+function prunedWorkspaceKey(worktreeId: string, executionHostId?: ExecutionHostId): string {
+  return `${executionHostId ?? '*'}\0${worktreeId}`
+}
+
+function matchesPrunedWorkspace(row: WorkspaceSpaceWorktree, pruned: PrunedWorkspace): boolean {
+  return (
+    row.worktreeId === pruned.worktreeId &&
+    (!pruned.executionHostId || row.executionHostId === pruned.executionHostId)
+  )
+}
+
+function excludeRowsPrunedDuringScan(
+  file: string,
+  analysis: WorkspaceSpaceAnalysis
+): WorkspaceSpaceAnalysis {
+  const pruned = [...(prunedWorkspacesByFile.get(file)?.values() ?? [])]
+  return analysis.worktrees.reduce(
+    (current, row) =>
+      pruned.some(
+        (entry) => entry.prunedAt >= analysis.scannedAt && matchesPrunedWorkspace(row, entry)
+      )
+        ? withoutWorktreeRow(current, row)
+        : current,
+    analysis
+  )
+}
+
+function clearSupersededPrunes(file: string, analysis: WorkspaceSpaceAnalysis): void {
+  const pruned = prunedWorkspacesByFile.get(file)
+  if (!pruned) {
+    return
+  }
+  for (const [key, entry] of pruned) {
+    if (entry.prunedAt < analysis.scannedAt) {
+      pruned.delete(key)
+    }
+  }
+  if (pruned.size === 0) {
+    prunedWorkspacesByFile.delete(file)
+  }
+}
+
 /** Drop a removed workspace's row and rebalance the totals it contributed. Never throws. */
-export async function pruneWorkspaceSpaceAnalysisSnapshot(worktreeId: string): Promise<void> {
+export async function pruneWorkspaceSpaceAnalysisSnapshot(
+  snapshotDirectory: string,
+  worktreeId: string,
+  executionHostId?: ExecutionHostId
+): Promise<void> {
+  const file = sidecarSnapshotFile(snapshotDirectory, SNAPSHOT_FILE_NAME)
+  const pruned = prunedWorkspacesByFile.get(file) ?? new Map<string, PrunedWorkspace>()
+  pruned.set(prunedWorkspaceKey(worktreeId, executionHostId), {
+    worktreeId,
+    ...(executionHostId ? { executionHostId } : {}),
+    prunedAt: Date.now()
+  })
+  prunedWorkspacesByFile.set(file, pruned)
   try {
-    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, async () => {
-      const existing = await readWorkspaceSpaceAnalysisSnapshot()
-      const removed = existing?.worktrees.find((row) => row.worktreeId === worktreeId)
+    await withSidecarSnapshotQueue(file, async () => {
+      const existing = await readWorkspaceSpaceAnalysisSnapshot(snapshotDirectory)
+      const removed = existing?.worktrees.find(
+        (row) =>
+          row.worktreeId === worktreeId &&
+          (executionHostId === undefined || row.executionHostId === executionHostId)
+      )
       if (!existing || !removed) {
         return
       }
-      await writeSnapshot(withoutWorktreeRow(existing, removed))
+      await writeSnapshot(file, withoutWorktreeRow(existing, removed))
     })
   } catch (error) {
     console.warn('[workspace-space] failed to prune analysis snapshot:', error)

--- a/src/main/workspace-space-analysis-snapshot.ts
+++ b/src/main/workspace-space-analysis-snapshot.ts
@@ -1,0 +1,145 @@
+import type {
+  WorkspaceSpaceAnalysis,
+  WorkspaceSpaceWorktree
+} from '../shared/workspace-space-types'
+import {
+  readSidecarSnapshot,
+  withSidecarSnapshotQueue,
+  writeSidecarSnapshot
+} from './sidecar-snapshot-file'
+
+const SNAPSHOT_FILE_NAME = 'orca-workspace-space-analysis.json'
+const SNAPSHOT_VERSION = 1
+
+type PersistedWorkspaceSpaceAnalysisSnapshot = {
+  version: number
+  analysis: WorkspaceSpaceAnalysis
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function isPersistableWorktreeRow(value: unknown): value is WorkspaceSpaceWorktree {
+  if (!isRecord(value)) {
+    return false
+  }
+  return (
+    typeof value.worktreeId === 'string' &&
+    typeof value.repoId === 'string' &&
+    typeof value.status === 'string' &&
+    typeof value.sizeBytes === 'number' &&
+    typeof value.reclaimableBytes === 'number' &&
+    Array.isArray(value.topLevelItems)
+  )
+}
+
+/** Shape guard so a corrupt persisted blob degrades to null instead of throwing at startup. */
+function parseSnapshot(parsed: unknown): WorkspaceSpaceAnalysis | null {
+  if (!isRecord(parsed) || parsed.version !== SNAPSHOT_VERSION) {
+    return null
+  }
+  const analysis = parsed.analysis
+  if (!isRecord(analysis)) {
+    return null
+  }
+  if (
+    typeof analysis.scannedAt !== 'number' ||
+    typeof analysis.totalSizeBytes !== 'number' ||
+    !Array.isArray(analysis.repos) ||
+    !Array.isArray(analysis.worktrees) ||
+    !analysis.worktrees.every(isPersistableWorktreeRow)
+  ) {
+    return null
+  }
+  return analysis as unknown as WorkspaceSpaceAnalysis
+}
+
+// Why strip topLevelItems: 500+ worktrees x 48 items is a multi-MB blob, and the cached view only
+// needs per-worktree totals. Fold the items into the omitted counters so each row stays consistent.
+function stripTopLevelItems(analysis: WorkspaceSpaceAnalysis): WorkspaceSpaceAnalysis {
+  return {
+    ...analysis,
+    worktrees: analysis.worktrees.map((row) => ({
+      ...row,
+      topLevelItems: [],
+      omittedTopLevelItemCount: row.omittedTopLevelItemCount + row.topLevelItems.length,
+      omittedTopLevelSizeBytes:
+        row.omittedTopLevelSizeBytes +
+        row.topLevelItems.reduce((sum, item) => sum + item.sizeBytes, 0)
+    }))
+  }
+}
+
+export async function readWorkspaceSpaceAnalysisSnapshot(): Promise<WorkspaceSpaceAnalysis | null> {
+  try {
+    return parseSnapshot(await readSidecarSnapshot(SNAPSHOT_FILE_NAME))
+  } catch {
+    return null
+  }
+}
+
+async function writeSnapshot(analysis: WorkspaceSpaceAnalysis): Promise<void> {
+  await writeSidecarSnapshot(SNAPSHOT_FILE_NAME, {
+    version: SNAPSHOT_VERSION,
+    analysis
+  } satisfies PersistedWorkspaceSpaceAnalysisSnapshot)
+}
+
+/** Persist a completed analysis. Never throws — the snapshot is a refetchable cache. */
+export async function persistWorkspaceSpaceAnalysisSnapshot(
+  analysis: WorkspaceSpaceAnalysis
+): Promise<void> {
+  try {
+    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, () =>
+      writeSnapshot(stripTopLevelItems(analysis))
+    )
+  } catch (error) {
+    console.warn('[workspace-space] failed to persist analysis snapshot:', error)
+  }
+}
+
+function withoutWorktreeRow(
+  analysis: WorkspaceSpaceAnalysis,
+  removed: WorkspaceSpaceWorktree
+): WorkspaceSpaceAnalysis {
+  const scannedDelta = removed.status === 'ok' ? 1 : 0
+  const unavailableDelta = removed.status === 'ok' ? 0 : 1
+  return {
+    ...analysis,
+    worktrees: analysis.worktrees.filter((row) => row.worktreeId !== removed.worktreeId),
+    worktreeCount: Math.max(0, analysis.worktreeCount - 1),
+    scannedWorktreeCount: Math.max(0, analysis.scannedWorktreeCount - scannedDelta),
+    unavailableWorktreeCount: Math.max(0, analysis.unavailableWorktreeCount - unavailableDelta),
+    totalSizeBytes: Math.max(0, analysis.totalSizeBytes - removed.sizeBytes),
+    reclaimableBytes: Math.max(0, analysis.reclaimableBytes - removed.reclaimableBytes),
+    repos: analysis.repos.map((repo) =>
+      repo.repoId === removed.repoId
+        ? {
+            ...repo,
+            worktreeCount: Math.max(0, repo.worktreeCount - 1),
+            scannedWorktreeCount: Math.max(0, repo.scannedWorktreeCount - scannedDelta),
+            unavailableWorktreeCount: Math.max(0, repo.unavailableWorktreeCount - unavailableDelta),
+            totalSizeBytes: Math.max(0, repo.totalSizeBytes - removed.sizeBytes),
+            reclaimableBytes: Math.max(0, repo.reclaimableBytes - removed.reclaimableBytes)
+          }
+        : repo
+    )
+  }
+}
+
+/** Drop a removed workspace's row and rebalance the totals it contributed. Never throws. */
+export async function pruneWorkspaceSpaceAnalysisSnapshot(worktreeId: string): Promise<void> {
+  try {
+    await withSidecarSnapshotQueue(SNAPSHOT_FILE_NAME, async () => {
+      const existing = await readWorkspaceSpaceAnalysisSnapshot()
+      const removed = existing?.worktrees.find((row) => row.worktreeId === worktreeId)
+      if (!existing || !removed) {
+        return
+      }
+      await writeSnapshot(withoutWorktreeRow(existing, removed))
+    })
+  } catch (error) {
+    console.warn('[workspace-space] failed to prune analysis snapshot:', error)
+  }
+}

--- a/src/main/workspace-space-analysis.ts
+++ b/src/main/workspace-space-analysis.ts
@@ -34,6 +34,7 @@ import { getSshGitProvider } from './providers/ssh-git-dispatch'
 import { createFolderWorktree, listRepoWorktrees } from './repo-worktrees'
 import { mergeWorktree } from './ipc/worktree-logic'
 import { getLocalProjectWorktreeGitOptions } from './project-runtime-git-options'
+import { getRepoExecutionHostId } from '../shared/execution-host'
 
 const REPO_SCAN_CONCURRENCY = 2
 const WORKTREE_SCAN_CONCURRENCY = 3
@@ -309,6 +310,7 @@ function createBaseWorktreeRow(
   return {
     worktreeId: worktree.id,
     repoId: repo.id,
+    executionHostId: getRepoExecutionHostId(repo),
     repoDisplayName: repo.displayName,
     repoPath: repo.path,
     displayName: worktree.displayName,
@@ -733,6 +735,7 @@ async function scanRepo(
       worktrees: [],
       summary: {
         repoId: repo.id,
+        executionHostId: getRepoExecutionHostId(repo),
         displayName: repo.displayName,
         path: repo.path,
         isRemote: Boolean(repo.connectionId),
@@ -809,6 +812,7 @@ async function scanRepo(
     worktrees: rows,
     summary: {
       repoId: repo.id,
+      executionHostId: getRepoExecutionHostId(repo),
       displayName: repo.displayName,
       path: repo.path,
       isRemote: Boolean(repo.connectionId),

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -466,6 +466,7 @@ import type {
   SpeechTranscriptEvent
 } from '../shared/speech-types'
 import type {
+  WorkspaceSpaceAnalysis,
   WorkspaceSpaceAnalyzeResult,
   WorkspaceSpaceScanProgress
 } from '../shared/workspace-space-types'
@@ -1506,6 +1507,8 @@ export type PreloadApi = {
       args?: WorkspaceCleanupScanArgs,
       onProgress?: (progress: WorkspaceCleanupScanProgress) => void
     ) => Promise<WorkspaceCleanupScanResult>
+    /** Last persisted broad-scan snapshot; null until one completes or when the cache is stale/corrupt. */
+    getCachedScan: () => Promise<WorkspaceCleanupScanResult | null>
     dismiss: (args: WorkspaceCleanupDismissArgs) => Promise<void>
     clearDismissals: () => Promise<void>
     hasKillableLocalProcesses: (
@@ -1514,6 +1517,8 @@ export type PreloadApi = {
   }
   workspaceSpace: {
     analyze: () => Promise<WorkspaceSpaceAnalyzeResult>
+    /** Last persisted analysis (topLevelItems pruned to bound the payload); null until one completes. */
+    getCachedAnalysis: () => Promise<WorkspaceSpaceAnalysis | null>
     cancel: () => Promise<boolean>
     onProgress: (callback: (progress: WorkspaceSpaceScanProgress) => void) => () => void
   }

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -895,6 +895,7 @@ const api = {
         .invoke('workspaceCleanup:scan', { ...args, scanId })
         .finally(() => ipcRenderer.removeListener('workspaceCleanup:scanProgress', listener))
     },
+    getCachedScan: () => ipcRenderer.invoke('workspaceCleanup:getCachedScan'),
     dismiss: (args) => ipcRenderer.invoke('workspaceCleanup:dismiss', args),
     clearDismissals: () => ipcRenderer.invoke('workspaceCleanup:clearDismissals'),
     hasKillableLocalProcesses: (args) =>
@@ -903,6 +904,7 @@ const api = {
 
   workspaceSpace: {
     analyze: () => ipcRenderer.invoke('workspaceSpace:analyze'),
+    getCachedAnalysis: () => ipcRenderer.invoke('workspaceSpace:getCachedAnalysis'),
     cancel: () => ipcRenderer.invoke('workspaceSpace:cancel'),
     onProgress: (callback) => {
       const listener = (

--- a/src/shared/workspace-cleanup.ts
+++ b/src/shared/workspace-cleanup.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from './execution-host'
+
 export const WORKSPACE_CLEANUP_CLASSIFIER_VERSION = 2
 export const WORKSPACE_CLEANUP_ARCHIVED_IDLE_MS = 7 * 24 * 60 * 60 * 1000
 export const WORKSPACE_CLEANUP_IDLE_MS = 30 * 24 * 60 * 60 * 1000
@@ -45,6 +47,7 @@ export type WorkspaceCleanupCandidate = {
   repoId: string
   repoName: string
   connectionId: string | null
+  executionHostId?: ExecutionHostId
   displayName: string
   branch: string
   path: string

--- a/src/shared/workspace-space-types.ts
+++ b/src/shared/workspace-space-types.ts
@@ -1,3 +1,5 @@
+import type { ExecutionHostId } from './execution-host'
+
 export type WorkspaceSpaceScanStatus =
   | 'ok'
   | 'missing'
@@ -17,6 +19,7 @@ export type WorkspaceSpaceItem = {
 export type WorkspaceSpaceWorktree = {
   worktreeId: string
   repoId: string
+  executionHostId?: ExecutionHostId
   repoDisplayName: string
   repoPath: string
   displayName: string
@@ -40,6 +43,7 @@ export type WorkspaceSpaceWorktree = {
 
 export type WorkspaceSpaceRepoSummary = {
   repoId: string
+  executionHostId?: ExecutionHostId
   displayName: string
   path: string
   isRemote: boolean


### PR DESCRIPTION
## Summary

Persist completed workspace cleanup scans and space analyses in bounded sidecar snapshots. Add cache-read IPC/preload APIs, reconcile targeted cleanup rescans into the broad snapshot, and prune removed workspaces from both files so stale rows cannot reappear.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm run typecheck:tsc`
- [x] Focused Vitest coverage: 294 tests across 7 IPC, snapshot, removal, and existing cleanup suites
- [x] `pnpm run build:desktop`
- [x] Added regression coverage for round trips, corrupt/stale files, bounded payloads, targeted reconciliation, legacy scans, SSH rows, cancellation, cache IPC, and removal pruning

## AI Review Report

Reviewed the split for durable-write ordering, queue serialization, corrupt and stale cache recovery, scan-result semantics, bounded space payloads, removal races, SSH row identity, folder-workspace identity, and preload type parity. Cross-platform review confirmed sidecar paths use Node path joining and the existing canonical user-data directory; no shortcuts, labels, shell behavior, or Electron platform-specific branches changed.

## Security Audit

Reviewed persisted input validation, path construction, atomic writes, untrusted/corrupt JSON handling, IPC exposure, and payload bounds. Snapshot filenames are fixed, writes use the existing durable-file primitive, reads validate versioned shapes and degrade to null, and space details are pruned before persistence. No user-supplied command execution, auth, secrets, or dependencies were added.

## Notes

Stacked PR 2 of 4. Base PR: #13403. Cache consumption and stale-while-revalidate rendering arrive in PR4.