### PR TITLE
[leas code] Deduplicate repository search entries

### DIFF
--- a/src/renderer/src/components/settings/RepositoryPane.test.ts
+++ b/src/renderer/src/components/settings/RepositoryPane.test.ts
@@ -104,6 +104,13 @@ describe('RepositoryPane search entries', () => {
     expect(matchesSettingsSearch('worktree path', entries)).toBe(true)
   })
 
+  it('includes each project search section once', () => {
+    const entries = getRepositoryPaneSearchEntries(repo)
+
+    expect(entries.filter(({ title }) => title === 'Project Icon')).toHaveLength(1)
+    expect(entries.filter(({ title }) => title === 'Default Worktree Base')).toHaveLength(1)
+  })
+
   it('omits project runtime search for remote or unsupported repos', () => {
     expect(matchesSettingsSearch('project runtime', getRepositoryPaneSearchEntries(repo))).toBe(
       false

--- a/src/renderer/src/components/settings/repository-search.ts
+++ b/src/renderer/src/components/settings/repository-search.ts
@@ -185,41 +185,6 @@ export function getRepositoryPaneSearchEntries(
         )
       ]
     },
-    {
-      title: translate('auto.components.settings.repository.search.b24f00294a', 'Project Icon'),
-      description: translate(
-        'auto.components.settings.repository.search.a1f3a2bd47',
-        'Project icon and color used in the sidebar and tabs.'
-      ),
-      keywords: [
-        repo.displayName,
-        ...translateSearchKeyword(
-          'auto.components.settings.repository.search.6438a94c63',
-          'project icon'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.repository.search.b2546efab5',
-          'repository icon'
-        ),
-        ...translateSearchKeyword('auto.components.settings.repository.search.8d045419b1', 'color'),
-        ...translateSearchKeyword('auto.components.settings.repository.search.6d8de2f090', 'hex'),
-        ...translateSearchKeyword('auto.components.settings.repository.search.c1075178cf', 'badge'),
-        ...translateSearchKeyword(
-          'auto.components.settings.repository.search.cb4b4de666',
-          'avatar'
-        ),
-        ...translateSearchKeyword(
-          'auto.components.settings.repository.search.9dc60d7f6d',
-          'github'
-        ),
-        ...translateSearchKeyword('auto.components.settings.repository.search.1e73e840ff', 'emoji'),
-        ...translateSearchKeyword(
-          'auto.components.settings.repository.search.27733eb6c1',
-          'favicon'
-        )
-      ]
-    },
-    ...(isFolder ? [] : getRepositoryGitWorktreeSearchEntries(repo)),
     ...(isFolder
       ? []
       : [...getRepositoryGitAuthorSearchEntries(repo), ...getRepositoryGitHooksSearchEntries(repo)])


### PR DESCRIPTION
## Summary

Remove the second copy of the Project Icon search metadata and the repeated worktree search metadata from repository settings. Each section now contributes one search result instead of two, for a net reduction of 28 lines.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/settings/RepositoryPane.test.ts` (6 tests)
- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/hooks/useSettingsNavigationMetadata.test.ts src/renderer/src/hooks/useSettingsNavigationMetadata.language-switch.test.tsx src/renderer/src/hooks/useSettingsNavigationMetadata.capability-owner.test.tsx` (25 tests)
- `pnpm run typecheck:web`
- Targeted oxlint and oxfmt checks
- `pnpm run check:code-quality:changed`
- `pnpm run check:react-doctor:changed`

## AI Review Report

The review traced both duplicated array contributions, checked their translation keys and keywords for exact equivalence, and verified that the retained entries still cover repository identity, worktree, hooks, and author searches. A focused regression assertion now requires one Project Icon and one Default Worktree Base entry. The change was reviewed for macOS, Linux, and Windows; it contains no shortcut, label, path, shell, Electron, SSH, or folder-workspace behavior changes.

## Security Audit

No command execution, path mutation, authentication, secrets, dependencies, IPC, or external input handling changed. The patch only removes duplicate in-memory search metadata.

## Notes

Independent cleanup PR based on `main`; no platform-specific behavior or follow-up risk identified.