### PR TITLE
fix(mobile-ios): require external TestFlight distribution

### DIFF
--- a/.github/workflows/mobile-ios-release.yml
+++ b/.github/workflows/mobile-ios-release.yml
@@ -30,9 +30,11 @@ jobs:
     # (@MainActor isolation). Xcode 16.x (macos-15) can't even parse it
     # ("unknown attribute 'MainActor'"), so we need Xcode 26.x → macos-26.
     runs-on: macos-26
-    # Archive + upload is ~30–40m when healthy; 90m leaves margin without
-    # sitting multi-hour on ASC processing polls (see Fastfile pilot wait).
+    # Archive + upload is ~30–40m when healthy; 90m leaves margin for setup.
     timeout-minutes: 90
+    outputs:
+      release_version: ${{ steps.release_metadata.outputs.version }}
+      build_number: ${{ steps.release_metadata.outputs.build_number }}
 
     defaults:
       run:
@@ -79,6 +81,10 @@ jobs:
           FASTLANE_HIDE_CHANGELOG: '1'
         run: bundle exec fastlane ios prepare_release_version version:"$MOBILE_IOS_RELEASE_VERSION" bump_patch:"$MOBILE_IOS_BUMP_PATCH_VERSION"
 
+      - name: Capture release metadata
+        id: release_metadata
+        run: node -e 'const fs = require("node:fs"); const { expo } = require("./app.json"); fs.appendFileSync(process.env.GITHUB_OUTPUT, `version=${expo.version}\nbuild_number=${expo.ios.buildNumber}\n`)'
+
       - name: Expo prebuild
         run: npx expo prebuild --platform ios --no-install
 
@@ -122,11 +128,10 @@ jobs:
           ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
           ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
           APPLE_TEAM_ID: ${{ secrets.APPLE_TEAM_ID }}
-          TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.testflight_changelog }}
           # Keep fastlane non-interactive and quiet about analytics in CI.
           FASTLANE_SKIP_UPDATE_CHECK: '1'
           FASTLANE_HIDE_CHANGELOG: '1'
-        run: bundle exec fastlane ios release
+        run: bundle exec fastlane ios build_and_upload
 
       - name: Upload .ipa artifact
         if: always()
@@ -135,3 +140,44 @@ jobs:
           name: orca-mobile-ipa
           path: mobile/build/*.ipa
           if-no-files-found: ignore
+
+  ios-distribute:
+    name: Distribute to external TestFlight testers
+    needs: ios-build
+    runs-on: ubuntu-latest
+    # Fastlane's processing wait fails after 20m; this outer bound leaves setup
+    # margin without allowing App Store Connect polling to hang for hours.
+    timeout-minutes: 30
+
+    defaults:
+      run:
+        working-directory: mobile
+
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v6
+
+      - name: Setup Ruby and fastlane
+        uses: ruby/setup-ruby@v1
+        with:
+          ruby-version: '3.3'
+          bundler-cache: true
+          working-directory: mobile
+
+      - name: Wait for processing and distribute to peeps
+        env:
+          ASC_KEY_ID: ${{ secrets.ASC_KEY_ID }}
+          ASC_ISSUER_ID: ${{ secrets.ASC_ISSUER_ID }}
+          ASC_API_KEY_P8: ${{ secrets.ASC_API_KEY_P8 }}
+          TESTFLIGHT_CHANGELOG: ${{ github.event.inputs.testflight_changelog }}
+          MOBILE_IOS_RELEASE_VERSION: ${{ needs.ios-build.outputs.release_version }}
+          MOBILE_IOS_BUILD_NUMBER: ${{ needs.ios-build.outputs.build_number }}
+          FASTLANE_SKIP_UPDATE_CHECK: '1'
+          FASTLANE_HIDE_CHANGELOG: '1'
+        run: |
+          if ! bundle exec fastlane ios distribute_testflight \
+            version:"$MOBILE_IOS_RELEASE_VERSION" \
+            build_number:"$MOBILE_IOS_BUILD_NUMBER"; then
+            echo "::error::TestFlight $MOBILE_IOS_RELEASE_VERSION ($MOBILE_IOS_BUILD_NUMBER) was uploaded but not distributed to peeps. If App Store Connect is still processing it, rerun only this failed job after the build becomes Ready; otherwise inspect the Fastlane error above."
+            exit 1
+          fi

--- a/mobile/fastlane/Fastfile
+++ b/mobile/fastlane/Fastfile
@@ -2,8 +2,9 @@
 #
 # Builds the prebuilt iOS workspace, signs it with the distribution identity
 # imported into the CI keychain plus an explicit App Store provisioning profile
-# fetched via the App Store Connect API key, then uploads the .ipa to
-# TestFlight. All Apple credentials come from CI env vars
+# fetched via the App Store Connect API key, uploads the .ipa, then distributes
+# the processed build to external TestFlight testers. Credentials come from CI
+# env vars
 # (see .github/workflows/mobile-ios-release.yml) so nothing secret lives in the
 # repo.
 #
@@ -28,6 +29,9 @@ WORKSPACE = File.join(MOBILE_ROOT, "ios", "Orca.xcworkspace")
 BUILD_OUTPUT_DIRECTORY = File.join(MOBILE_ROOT, "build")
 SCHEME = "Orca"
 BUNDLE_ID = "com.stably.orca.mobile"
+TESTFLIGHT_GROUPS = ["peeps"].freeze
+DEFAULT_TESTFLIGHT_CHANGELOG = "Latest Orca Mobile updates and fixes.".freeze
+TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS = 20 * 60
 
 # App Store version states in which the version "train" is terminally closed to
 # new TestFlight build uploads (altool rejects with 90186 "train ... is
@@ -70,6 +74,11 @@ end
 
 def current_mobile_version(config)
   config.fetch("expo").fetch("version")
+end
+
+def testflight_changelog
+  changelog = ENV.fetch("TESTFLIGHT_CHANGELOG", "").strip
+  changelog.empty? ? DEFAULT_TESTFLIGHT_CHANGELOG : changelog
 end
 
 # True when either state field reports a terminally closed train. `respond_to?`
@@ -172,7 +181,7 @@ platform :ios do
   end
 
   desc "Build, sign, and upload Orca Mobile to App Store Connect / TestFlight"
-  lane :release do
+  lane :build_and_upload do
     api_key = app_store_connect_api_key_from_env
 
     team_id = ENV.fetch("APPLE_TEAM_ID")
@@ -214,13 +223,56 @@ platform :ios do
 
     upload_to_testflight(
       api_key: api_key,
-      # Why: ASC processing wait hung for hours (0.0.42 builds 1–2) with no Ready
-      # build and no email. Exit after upload acceptance. Do not pass changelog —
-      # Pilot only fully skips waiting when changelog is nil (otherwise it still
-      # polls until the build appears). External distribute (e.g. peeps) from ASC
-      # or a follow-up lane once Ready.
+      # Distribution runs separately so a processing timeout can be retried
+      # against this exact build without uploading another binary.
       skip_waiting_for_build_processing: true,
       distribute_external: false,
+    )
+  end
+
+  desc "Wait for and distribute an uploaded build to external TestFlight testers"
+  lane :distribute_testflight do |options|
+    version = options[:version].to_s.strip
+    build_number = options[:build_number].to_s.strip
+    UI.user_error!("version is required") if version.empty?
+    UI.user_error!("build_number is required") if build_number.empty?
+
+    api_key = app_store_connect_api_key_from_env
+    app = Spaceship::ConnectAPI::App.find(BUNDLE_ID)
+    UI.user_error!("Could not find App Store Connect app #{BUNDLE_ID}") unless app
+
+    available_groups = app.get_beta_groups.map(&:name)
+    missing_groups = TESTFLIGHT_GROUPS - available_groups
+    unless missing_groups.empty?
+      UI.user_error!(
+        "Missing TestFlight group(s): #{missing_groups.join(', ')}. " \
+        "Create them in App Store Connect or update TESTFLIGHT_GROUPS.",
+      )
+    end
+
+    upload_to_testflight(
+      api_key: api_key,
+      app_identifier: BUNDLE_ID,
+      app_version: version,
+      build_number: build_number,
+      distribute_only: true,
+      skip_waiting_for_build_processing: false,
+      wait_processing_timeout_duration: TESTFLIGHT_PROCESSING_TIMEOUT_SECONDS,
+      distribute_external: true,
+      groups: TESTFLIGHT_GROUPS,
+      notify_external_testers: true,
+      changelog: testflight_changelog,
+    )
+  end
+
+  desc "Build, upload, and distribute Orca Mobile to external TestFlight testers"
+  lane :release do
+    build_and_upload
+
+    config = load_mobile_app_config
+    distribute_testflight(
+      version: current_mobile_version(config),
+      build_number: config.fetch("expo").fetch("ios").fetch("buildNumber"),
     )
   end
 end


### PR DESCRIPTION
## Summary

- Split the iOS release into an honestly named build/upload job and a required external TestFlight distribution job.
- Pass the exact uploaded marketing version and build number to a retryable `distribute_only` lane.
- Bound App Store Connect processing polling to 20 minutes and fail with recovery guidance instead of hanging for hours.
- Restore the external changelog/default, assign `peeps`, enable tester notifications, and fail if that group does not exist.

Follow-up to P1-3 / #12961.

## Operator path

1. Trigger **Mobile iOS Release** as before. The first job builds and uploads; the second job waits for that exact build and distributes it to `peeps`.
2. If App Store Connect is not Ready within 20 minutes, the workflow stays red even though the binary was uploaded. Wait for that version/build to become Ready, then choose **Re-run failed jobs** in GitHub Actions. The successful build job is retained, so the distribution job retries the same build without rebuilding or uploading another one.
3. If the failure reports a missing `peeps` group, restore/rename the group in App Store Connect or update `TESTFLIGHT_GROUPS`, then rerun the failed job.

A green workflow means Fastlane successfully ran the external group-assignment/submission path with notifications enabled. Apple beta review may still delay when testers receive the notification.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (full suite not run; no JavaScript/TypeScript changed)
- [ ] `pnpm typecheck` (not applicable to workflow/Ruby-only changes)
- [ ] `pnpm test` (full suite not run)
- [ ] `pnpm build` (not applicable to workflow/Ruby-only changes)
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- [x] `ruby -c mobile/fastlane/Fastfile`
- [x] `ruby mobile/fastlane/ios_release_version_test.rb` (11 runs, 23 assertions)
- [x] `pnpm exec oxfmt --check .github/workflows/mobile-ios-release.yml`
- [x] `pnpm run check:max-lines-ratchet`
- [x] Loaded `fastlane lanes` with Fastlane 2.237.0 and confirmed all four iOS lanes register

No App Store Connect mutation was performed locally; the release lane requires production credentials and a real uploaded build. The focused syntax, formatting, existing Ruby tests, and Fastlane DSL load checks cover this configuration-only change.

## AI Review Report

Reviewed the release state transition end to end. The main risks checked were selecting the wrong TestFlight build, an unbounded processing poll, a silently missing tester group, empty changelogs on tag triggers, false-green lane/job naming, and recovery after a processing timeout. The review led to exact version/build outputs, a separate retryable job, a native 20-minute Fastlane timeout plus a 30-minute job bound, and an explicit group-existence preflight.

Cross-platform review covered macOS, Linux, and Windows. The archive remains isolated to the required macOS runner; the API-only distribution lane is safe on Linux and does not require Xcode. No product shortcuts, labels, paths, shell launch behavior, Electron behavior, SSH behavior, folder-workspace behavior, or Windows runtime code changed.

## Security Audit

Apple credentials remain GitHub secrets passed only through environment variables. The workflow does not print them or persist them as outputs. Version/build outputs come from the generated app config and are shell-quoted; the operator changelog is passed as environment data rather than interpolated into a command. No dependency, IPC, filesystem, or application auth surface changed. The new App Store Connect calls use the existing scoped API key.

## Notes

- Fastlane can submit a build for external beta review and assign the group, but Apple controls approval and notification timing.
- On timeout, the uploaded binary remains in App Store Connect; only external distribution is unconfirmed and the workflow remains red.
