### PR TITLE
fix(editor): match WSL UNC paths across forward-slash and backslash forms

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -258,4 +258,20 @@ describe('getOpenFilesForExternalFileChange', () => {
       }).map((file) => file.id)
     ).toEqual(['runtime-edit', 'runtime-diff'])
   })
+  it('matches WSL edit tabs opened from a forward-slash UNC terminal link', () => {
+    // Why: terminal links use //wsl.localhost/Distro/... while file watchers emit \\wsl.localhost\Distro\...
+    const terminalLinkTab = makeOpenFile({
+      id: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
+      filePath: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
+      worktreeId: 'wt-wsl'
+    })
+
+    expect(
+      getOpenFilesForExternalFileChange([terminalLinkTab], {
+        worktreeId: 'wt-wsl',
+        worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
+        relativePath: 'file.ts'
+      }).map((file) => file.id)
+    ).toEqual(['//wsl.localhost/Ubuntu/workspace/repo/file.ts'])
+  })
 })

--- a/src/renderer/src/components/editor/editor-autosave.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave.test.ts
@@ -258,20 +258,26 @@ describe('getOpenFilesForExternalFileChange', () => {
       }).map((file) => file.id)
     ).toEqual(['runtime-edit', 'runtime-diff'])
   })
-  it('matches WSL edit tabs opened from a forward-slash UNC terminal link', () => {
-    // Why: terminal links use //wsl.localhost/Distro/... while file watchers emit \\wsl.localhost\Distro\...
-    const terminalLinkTab = makeOpenFile({
-      id: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
-      filePath: '//wsl.localhost/Ubuntu/workspace/repo/file.ts',
-      worktreeId: 'wt-wsl'
-    })
+  it('matches WSL editor tabs opened from a forward-slash UNC terminal link', () => {
+    const terminalLinkPath = '//wsl.localhost/Ubuntu/workspace/repo/file.ts'
+    const terminalLinkTabs = [
+      makeOpenFile({ id: terminalLinkPath, filePath: terminalLinkPath, worktreeId: 'wt-wsl' }),
+      makeOpenFile({
+        id: `markdown-preview::${terminalLinkPath}`,
+        filePath: terminalLinkPath,
+        worktreeId: 'wt-wsl',
+        mode: 'markdown-preview',
+        language: 'markdown',
+        markdownPreviewSourceFileId: terminalLinkPath
+      })
+    ]
 
     expect(
-      getOpenFilesForExternalFileChange([terminalLinkTab], {
+      getOpenFilesForExternalFileChange(terminalLinkTabs, {
         worktreeId: 'wt-wsl',
         worktreePath: '\\\\wsl.localhost\\Ubuntu\\workspace\\repo',
         relativePath: 'file.ts'
       }).map((file) => file.id)
-    ).toEqual(['//wsl.localhost/Ubuntu/workspace/repo/file.ts'])
+    ).toEqual([terminalLinkPath, `markdown-preview::${terminalLinkPath}`])
   })
 })

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -122,6 +122,7 @@ export function getOpenFilesForExternalFileChange(
   target: EditorPathMutationTarget
 ): OpenFile[] {
   const absolutePath = joinPath(target.worktreePath, target.relativePath)
+  const absolutePathKey = normalizeRuntimePathForComparison(absolutePath)
   const hasRuntimeOwnerFilter = Object.prototype.hasOwnProperty.call(target, 'runtimeEnvironmentId')
   const targetRuntimeOwner = target.runtimeEnvironmentId?.trim() || null
   return openFiles.filter((file) => {
@@ -135,9 +136,7 @@ export function getOpenFilesForExternalFileChange(
       return false
     }
     if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-      // Why: WSL UNC paths from terminal links (//wsl.localhost/...) and file
-      // watchers (\\wsl.localhost\...) must fold to the same form before comparing.
-      return normalizeRuntimePathForComparison(file.filePath) === normalizeRuntimePathForComparison(absolutePath)
+      return normalizeRuntimePathForComparison(file.filePath) === absolutePathKey
     }
     if (file.mode === 'diff') {
       return (

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -1,5 +1,6 @@
 import { joinPath } from '@/lib/path'
 import type { OpenFile } from '@/store/slices/editor'
+import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
 import {
   DEFAULT_EDITOR_AUTO_SAVE_DELAY_MS,
   MAX_EDITOR_AUTO_SAVE_DELAY_MS,
@@ -134,7 +135,9 @@ export function getOpenFilesForExternalFileChange(
       return false
     }
     if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-      return file.filePath === absolutePath
+      // Why: WSL UNC paths from terminal links (//wsl.localhost/...) and file
+      // watchers (\\wsl.localhost\...) must fold to the same form before comparing.
+      return normalizeRuntimePathForComparison(file.filePath) === normalizeRuntimePathForComparison(absolutePath)
     }
     if (file.mode === 'diff') {
       return (


### PR DESCRIPTION
﻿## Summary

WSL files opened from terminal links use the forward-slash UNC form (`//wsl.localhost/Ubuntu/...`), but file watcher events emit the backslash form (`\\wsl.localhost\Ubuntu\...`). The raw string equality in `getOpenFilesForExternalFileChange` never matched, so the editor tab stayed stale after external edits. This PR folds both sides through `normalizeRuntimePathForComparison`, which already handles separator style, the `wsl.localhost`/`wsl$` alias, and distro case folding.

Closes #13349.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Added a regression test in `editor-autosave.test.ts` that matches a forward-slash UNC tab (`//wsl.localhost/Ubuntu/...`) against a backslash watcher path (`\\wsl.localhost\Ubuntu\...`) and asserts the tab is included in the reload set.

## AI Review Report

The change adds one import and replaces a raw `===` comparison with a call to an existing, well-tested normalization function. The main risk reviewed was non-idempotency of `normalizeRuntimePathForComparison` for WSL UNC paths — the function is documented as not safe to re-normalize an already-normalized value. The fix calls it on both raw values independently (never on an already-normalized value), so this trap does not apply.

Cross-platform compatibility was checked for macOS, Linux, and Windows: `normalizeRuntimePathForComparison` only folds separators and lowercases for Windows drive letters and WSL UNC aliases; POSIX paths are returned with NFC normalization and forward-slash folding only, so macOS/Linux behavior is unchanged.

## Security Audit

No new command execution, IPC, network access, authentication, secrets, or filesystem path handling beyond passing existing strings through an existing pure comparison-normalization function. No dependency changes.

## Notes

The non-idempotency caveat in `cross-platform-path.ts` applies to storing canonical forms; this PR only compares, so it is not affected.