### PR TITLE
fix(sidebar): surface host context labels on pinned worktree rows

### DIFF
--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.test.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.test.ts
@@ -3,6 +3,7 @@ import { fileURLToPath } from 'node:url'
 import { describe, expect, it } from 'vitest'
 import { buildRows } from './build-rows'
 import { ALL_GROUP_META, getPRGroupKey, PINNED_GROUP_KEY } from './group-keys'
+import type { Row } from './row-types'
 import { getGroupKeyForWorktree } from './worktree-group-keys'
 import {
   REPO_HEADER_ACTION_BUTTON_CLASS,
@@ -11,6 +12,7 @@ import {
 import { repo, worktree, repoMap } from '../../worktree-list-groups-test-fixtures'
 import type { Repo } from '../../../../../../shared/repo-types'
 import type { Worktree } from '../../../../../../shared/worktree/types'
+import { LOCAL_EXECUTION_HOST_ID } from '../../../../../../shared/execution-host'
 
 function readWorktreeListSource(): string {
   return readFileSync(fileURLToPath(new URL('../../WorktreeList.tsx', import.meta.url)), 'utf8')
@@ -136,6 +138,52 @@ describe('buildRows with pinned worktrees', () => {
     expect(pinnedHeader.type === 'header' ? pinnedHeader.hostWorktreeCounts : undefined).toEqual(
       new Map([['runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3', 1]])
     )
+  })
+
+  it('labels pinned rows when the pinned section mixes hosts', () => {
+    const runtimeHostId = 'runtime:03ef704c-b180-4b10-998d-e28fbd5de9a3' as const
+    const runtimePinned = {
+      ...pinned,
+      id: 'wt-runtime-pinned',
+      hostId: runtimeHostId
+    }
+    const rows = buildRows(
+      'none',
+      [pinned, runtimePinned],
+      repoMap,
+      null,
+      new Set(),
+      undefined,
+      undefined,
+      undefined,
+      {},
+      new Map([
+        [pinned.id, pinned],
+        [runtimePinned.id, runtimePinned]
+      ]),
+      false,
+      undefined,
+      [],
+      new Set(),
+      new Map(),
+      new Map(),
+      [],
+      undefined,
+      [],
+      new Map([
+        [LOCAL_EXECUTION_HOST_ID, 'Local'],
+        [runtimeHostId, 'Builder']
+      ])
+    )
+    const pinnedRows = rows.filter(
+      (row): row is Extract<Row, { type: 'item' }> =>
+        row.type === 'item' && row.sectionKey === PINNED_GROUP_KEY
+    )
+
+    expect(pinnedRows.map((row) => [row.worktree.id, row.hostContextLabel])).toEqual([
+      ['wt-pinned', 'Local'],
+      ['wt-runtime-pinned', 'Builder']
+    ])
   })
 
   it('groups all worktrees under All in groupBy none', () => {

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts
@@ -128,6 +128,7 @@ export function buildRows(
     renderedNaturalAnchorRepoIds,
     importedWorktreesByRepo,
     groupBy !== 'repo',
+    hostLabelById,
     result,
     lineageById,
     worktreeMap,

--- a/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
+++ b/src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts
@@ -4,6 +4,7 @@ import type { Worktree } from '../../../../../../shared/worktree/types'
 import { getWorktreeExecutionHostId } from '../../../../../../shared/execution-host'
 import type { ExecutionHostId } from '../../../../../../shared/execution-host'
 import { PINNED_GROUP_KEY, PINNED_GROUP_META } from './group-keys'
+import { getMixedWorktreeHostContextLabels } from './host-labels'
 import { appendWorktreeRows, buildImportedWorktreesCardRow } from './row-builders'
 import type { ImportedWorktreesCardCandidate, Row } from './row-types'
 
@@ -21,6 +22,7 @@ export function emitPinnedGroup(
   renderedNaturalAnchorRepoIds: ReadonlySet<string>,
   importedWorktreesByRepo: ReadonlyMap<string, ImportedWorktreesCardCandidate>,
   allowImportedFallback: boolean,
+  hostLabelById: ReadonlyMap<string, string> | undefined,
   result: Row[],
   lineageById: Record<string, WorktreeLineage>,
   worktreeMap: Map<string, Worktree>,
@@ -68,11 +70,20 @@ export function emitPinnedGroup(
   }
 
   const firstItemIndex = result.length
+  // Why: pinned rows sit under a generic header, so mixed-host sections need
+  // per-row host context.
+  const pinnedHostLabels = getMixedWorktreeHostContextLabels(
+    pinnedSectionWorktrees,
+    repoMap,
+    hostLabelById,
+    defaultHostId
+  )
   appendWorktreeRows(result, pinnedSectionWorktrees, repoMap, lineageById, worktreeMap, {
     nestLineage,
     collapsedGroups,
     groupDepth: 0,
     sectionKey: PINNED_GROUP_KEY,
+    hostContextLabelByWorktreeIdentity: pinnedHostLabels,
     cyclicLineageIds
   })
   if (!allowImportedFallback) {


### PR DESCRIPTION
## ELI5

Pinned worktrees are shown under a generic "Pinned" section. If you pin worktrees from multiple hosts, the row itself needs to say which host it belongs to, otherwise different machines can look indistinguishable.

## What Changed

- Migrated the original pinned-host-label fix onto the current split sidebar grouping files.
- Pass `hostLabelById` into pinned group row emission.
- Reuse `getMixedWorktreeHostContextLabels` for pinned rows, matching the natural-group behavior.
- Added a `buildRows` regression test that verifies mixed-host pinned rows receive their host context labels.

## Why

The old PR changed `worktree-list-groups.ts`, but main has since split that file into `worktree-list/grouping/*`. This keeps the intended behavior while fitting the current architecture.

## Linked Issue

Closes #13353.

## Visual Proof

N/A — this is a row-model plumbing fix for mixed-host sidebar state. The visible label is rendered by the existing `WorktreeCard` host-context path; the new regression test verifies pinned rows now receive that field.

## Testing

- [x] `pnpm run typecheck:web`
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.test.ts`
- [x] `pnpm exec oxlint src/renderer/src/components/sidebar/worktree-list/grouping/pinned-group-rows.ts src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.ts src/renderer/src/components/sidebar/worktree-list/grouping/build-rows.test.ts`
- [x] Rebased onto latest `origin/main` on Windows and resolved conflicts.
- [ ] Full `pnpm lint`, full `pnpm test`, and `pnpm build` were not run locally in this repair pass; CI should cover the full matrix.

## AI Disclosure

This repair pass was assisted by OpenAI Codex for conflict resolution, test update, and PR body cleanup.

## Review

Self-reviewed for the current sidebar grouping architecture:

- Pinned group rows use the same host-label helper as natural group rows.
- The label map is keyed by host-qualified worktree identity, preserving same-id worktrees on different hosts.
- Single-host pinned sections still suppress labels to avoid noise.

## Agent skill upstream boundary

- [x] Not applicable, or this change follows `docs/reference/agent-skill-sharing-upstream-boundary.md` and copies or mechanically translates no upstream skill-installer source, tests, fixtures, registry entries, path tables, comments, or documentation.

## Notes

- No new IPC, network access, command execution, dependencies, or persisted state.
- Cross-platform/SSH behavior follows existing execution-host metadata and host-qualified worktree identity handling.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] `pnpm lint`, `pnpm typecheck`, `pnpm test`, and `pnpm build` pass (or CI will cover; local preferred)

## Author

- X / Twitter: N/A
