### PR TITLE
[leas code] Reuse renderer control paths

### DIFF
--- a/src/renderer/src/components/browser-pane/useGrabMode.ts
+++ b/src/renderer/src/components/browser-pane/useGrabMode.ts
@@ -183,34 +183,6 @@ export function useGrabMode(browserPageId: string): GrabModeHook {
     }
   }, [mountedRef])
 
-  const toggle = useCallback(() => {
-    if ((state === 'idle' || state === 'error') && grabTabIdRef.current === null) {
-      setError(null)
-      setPayload(null)
-      setContextMenu(false)
-      void armAndAwait()
-    } else {
-      // Disable grab mode
-      const targetTabId = grabTabIdRef.current ?? browserTabIdRef.current
-      armGenerationRef.current += 1
-      void window.api.browser.setGrabMode({
-        browserPageId: targetTabId,
-        enabled: false
-      })
-      if (activeOpIdRef.current) {
-        void window.api.browser.cancelGrab({
-          browserPageId: targetTabId
-        })
-        activeOpIdRef.current = null
-      }
-      grabTabIdRef.current = null
-      setState('idle')
-      setPayload(null)
-      setError(null)
-      setContextMenu(false)
-    }
-  }, [state, armAndAwait])
-
   const cancel = useCallback(() => {
     const targetTabId = grabTabIdRef.current ?? browserTabIdRef.current
     armGenerationRef.current += 1
@@ -230,6 +202,17 @@ export function useGrabMode(browserPageId: string): GrabModeHook {
     setError(null)
     setContextMenu(false)
   }, [])
+
+  const toggle = useCallback(() => {
+    if ((state === 'idle' || state === 'error') && grabTabIdRef.current === null) {
+      setError(null)
+      setPayload(null)
+      setContextMenu(false)
+      void armAndAwait()
+    } else {
+      cancel()
+    }
+  }, [state, armAndAwait, cancel])
 
   // Why: Copy re-arms so the user can quickly pick another element without
   // re-clicking the toolbar button. Attach to AI exits because the user's

--- a/src/renderer/src/lib/setup-script-prompt.ts
+++ b/src/renderer/src/lib/setup-script-prompt.ts
@@ -4,6 +4,7 @@ import type { SetupScriptImportCandidate } from '../../../shared/setup-script-im
 import type { Repo, RepoHookSettings } from '../../../shared/types'
 import type { HookCheckResult } from '@/runtime/runtime-hooks-client'
 import { isRuntimeScopeForbiddenError } from '@/runtime/runtime-rpc-client'
+import { hasEffectiveSetupCommand } from './setup-script-status'
 
 const SETUP_SCRIPT_PROMPT_DISMISSAL_PREFIX = 'generation-v1:'
 
@@ -67,25 +68,6 @@ export async function inspectSetupScriptPromptState({
     console.warn('[setup-script-prompt] Failed to inspect setup scripts:', error)
     return { status: 'error', repoId: repo.id }
   }
-}
-
-export function hasEffectiveSetupCommand(repo: Repo, hooksResult: HookCheckResult): boolean {
-  const localSetup = repo.hookSettings?.scripts?.setup?.trim()
-  const sharedSetup = hooksResult.hooks?.scripts?.setup?.trim()
-  const rawPolicy = repo.hookSettings?.commandSourcePolicy
-  const sourcePolicy = resolveHookCommandSourcePolicy(rawPolicy, {
-    hasLocalScript: Boolean(localSetup)
-  })
-
-  if (sourcePolicy === 'local-only') {
-    return Boolean(localSetup)
-  }
-
-  if (sourcePolicy === 'run-both') {
-    return Boolean(sharedSetup || localSetup)
-  }
-
-  return Boolean(sharedSetup)
 }
 
 export function ignoresSharedSetupScripts(repo: Pick<Repo, 'hookSettings'>): boolean {


### PR DESCRIPTION
## Summary

Remove two exact renderer control-flow duplicates:

- Setup-script prompt inspection now uses the existing setup status predicate already used by the setup guide.
- Browser grab-mode toggle now calls the existing cancel path when turning grab mode off.

The two changes remove 35 net lines while keeping their public behavior and ownership boundaries unchanged.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/browser-pane/useGrabMode.test.ts src/renderer/src/lib/setup-script-prompt.test.ts src/renderer/src/components/setup-guide/use-setup-guide-progress.test.ts` (3 files, 35 tests)
- `pnpm run typecheck:web`
- Targeted oxlint and oxfmt checks
- `pnpm run check:code-quality:changed`
- `pnpm run check:react-doctor:changed`
- `git diff --check`

## AI Review Report

The review compared both duplicated branches statement by statement. For setup inspection it checked local-only, shared-only, run-both, empty command, error, forbidden runtime, and SSH inspection behavior through the retained predicate. For browser grab mode it checked the target tab, arm generation, disable IPC, conditional cancel IPC, stale operation cleanup, state reset, second-toggle cancellation, direct cancellation, and page-switch tests. The change was reviewed for macOS, Linux, and Windows and alters no shortcuts, labels, paths, shell commands, Electron platform checks, folder-workspace assumptions, Git behavior, or wire formats.

## Security Audit

No authentication, secrets, dependencies, command execution, path handling, or input validation changed. Existing browser IPC calls occur in the same order with the same payloads, and setup-hook inspection still uses the same command-source policy.

## Notes

Independent cleanup PR. The initial focused test retry required deleting this worktree’s gitignored generated `out/` directory after the host disk filled; the directory is rebuildable and unrelated to the patch.