### PR TITLE
feat(serve): add --no-offscreen-browser flag

### DIFF
--- a/src/cli/args.ts
+++ b/src/cli/args.ts
@@ -36,6 +36,7 @@ export const BOOLEAN_FLAGS = new Set([
   'me',
   'mobile',
   'mobile-pairing',
+  'no-offscreen-browser',
   'no-pairing',
   'parent-current',
   'provision',

--- a/src/cli/handlers/core.ts
+++ b/src/cli/handlers/core.ts
@@ -127,6 +127,7 @@ export const CORE_HANDLERS: Record<string, CommandHandler> = {
           ? (flags.get('pairing-address') as string)
           : null,
       noPairing: flags.get('no-pairing') === true,
+      noOffscreenBrowser: flags.get('no-offscreen-browser') === true,
       mobilePairing: flags.get('mobile-pairing') === true,
       recipeJson: flags.get('recipe-json') === true,
       projectRoot

--- a/src/cli/runtime/launch.ts
+++ b/src/cli/runtime/launch.ts
@@ -80,6 +80,7 @@ export function serveOrcaApp(
     port?: string | null
     pairingAddress?: string | null
     noPairing?: boolean
+    noOffscreenBrowser?: boolean
     mobilePairing?: boolean
     recipeJson?: boolean
     projectRoot?: string | null
@@ -102,6 +103,9 @@ export function serveOrcaApp(
   }
   if (args.noPairing) {
     childArgs.push('--serve-no-pairing')
+  }
+  if (args.noOffscreenBrowser) {
+    childArgs.push('--serve-no-offscreen-browser')
   }
   if (args.mobilePairing) {
     childArgs.push('--serve-mobile-pairing')

--- a/src/cli/specs/serve.ts
+++ b/src/cli/specs/serve.ts
@@ -6,13 +6,14 @@ export const SERVE_COMMAND_SPECS: CommandSpec[] = [
     path: ['serve'],
     summary: 'Start an Orca runtime server without opening a desktop window',
     usage:
-      'orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--project-root <path>] [--recipe-json] [--json]',
+      'orca serve [--port <port>] [--pairing-address <host>] [--mobile-pairing] [--no-pairing] [--no-offscreen-browser] [--project-root <path>] [--recipe-json] [--json]',
     allowedFlags: [
       ...GLOBAL_FLAGS,
       'port',
       'pairing-address',
       'mobile-pairing',
       'no-pairing',
+      'no-offscreen-browser',
       'project-root',
       'recipe-json'
     ],
@@ -21,11 +22,13 @@ export const SERVE_COMMAND_SPECS: CommandSpec[] = [
       '--pairing-address changes only the client-advertised address; use a reachable LAN, Tailscale, SSH-forward, or reverse-proxy endpoint.',
       'Use --recipe-json with --project-root from VM recipes to print the recipe result JSON and leave the server running.',
       'Use --mobile-pairing to print a mobile-scoped pairing QR/link instead of the default runtime-environment pairing link.',
+      'Use --no-offscreen-browser to skip the offscreen browser-pane backend. Browser pane requests from a paired client will fail; choose this for terminal-only serve hosts to reduce per-pane memory when browser panes would otherwise be opened.',
       'When the web client bundle is available, the server also prints a browser URL with the pairing data embedded.'
     ],
     examples: [
       'orca serve',
       'orca serve --json',
+      'orca serve --no-offscreen-browser',
       'orca serve --project-root /workspace/repo --pairing-address wss://sandbox.example.com --recipe-json',
       'orca serve --port 6768 --pairing-address 100.64.1.20',
       'orca serve --pairing-address 100.64.1.20 --mobile-pairing'

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -828,7 +828,10 @@ if (hasSingleInstanceLock) {
     enableMainProcessGpuFeatures()
   }
   // Why: headless serve's offscreen BrowserWindows need an X display (Xvfb) on Linux; the result gates whether the offscreen backend is installed.
-  headlessBrowserDisplayAvailable = ensureVirtualDisplayForHeadlessServe({ isServeMode })
+  headlessBrowserDisplayAvailable = ensureVirtualDisplayForHeadlessServe({
+    isServeMode,
+    noOffscreenBrowser: process.argv.includes('--serve-no-offscreen-browser')
+  })
 }
 
 ipcMain.handle('app:awaitFirstWindowStartupServices', async () => {
@@ -1770,6 +1773,7 @@ type ServeOptions = {
   wsPort?: number
   pairingAddress: string | null
   noPairing: boolean
+  noOffscreenBrowser: boolean
   mobilePairing: boolean
   recipeJson: boolean
   projectRoot: string | null
@@ -1798,6 +1802,7 @@ function getServeOptions(argv = process.argv): ServeOptions {
     ...(wsPort !== undefined ? { wsPort } : {}),
     pairingAddress: valueAfter('--serve-pairing-address'),
     noPairing: argv.includes('--serve-no-pairing'),
+    noOffscreenBrowser: argv.includes('--serve-no-offscreen-browser'),
     mobilePairing: argv.includes('--serve-mobile-pairing'),
     recipeJson: argv.includes('--serve-recipe-json'),
     projectRoot: valueAfter('--serve-project-root')
@@ -2977,7 +2982,7 @@ void app.whenReady().then(async () => {
     await runtime.refreshRestoredOrchestrationAuthority()
     await runtime.reconcileLegacyWorkerTerminals()
     // Why: headless servers can't mount <webview> panes; use offscreen WebContents, gated on a real display so browser.headless.v1 stays honest.
-    if (headlessBrowserDisplayAvailable) {
+    if (headlessBrowserDisplayAvailable && !serveOptions.noOffscreenBrowser) {
       runtime.setOffscreenBrowserBackend(new OffscreenBrowserBackend(browserManager))
     }
     // Why: headless servers have no renderer graph publisher; publish an explicit empty graph so status clients see a ready server.

--- a/src/main/startup/ensure-virtual-display.ts
+++ b/src/main/startup/ensure-virtual-display.ts
@@ -100,12 +100,22 @@ function waitForDisplaySocket(displayNumber: number, deadline: number): boolean 
  * display is available (pre-existing or freshly started), false when browser
  * panes cannot be supported on this host. Safe to call on any platform.
  */
-export function ensureVirtualDisplayForHeadlessServe(options: { isServeMode: boolean }): boolean {
+export function ensureVirtualDisplayForHeadlessServe(options: {
+  isServeMode: boolean
+  // Why: --no-offscreen-browser skips the offscreen BrowserWindow backend entirely. The
+  // display-skip flag skips the Xvfb subprocess; Chromium flags are still applied so Electron
+  // can boot without an X server, since the main process doesn't mount <webview> either.
+  noOffscreenBrowser?: boolean
+}): boolean {
   if (!options.isServeMode || process.platform !== 'linux') {
     return process.platform !== 'linux'
   }
 
   configureHeadlessServeChromiumFlags()
+
+  if (options.noOffscreenBrowser) {
+    return false
+  }
 
   // Why: respect an externally provided display (a real X server, or the image
   // already running its own Xvfb). Don't start a competing one.

--- a/src/main/startup/serve-mode-argv.ts
+++ b/src/main/startup/serve-mode-argv.ts
@@ -11,6 +11,7 @@ const SERVE_FLAG = '--serve'
 const CLI_TO_SERVE_FLAG = new Map([
   ['--json', '--serve-json'],
   ['--no-pairing', '--serve-no-pairing'],
+  ['--no-offscreen-browser', '--serve-no-offscreen-browser'],
   ['--mobile-pairing', '--serve-mobile-pairing'],
   ['--recipe-json', '--serve-recipe-json']
 ])


### PR DESCRIPTION
## Summary

Adds `--no-offscreen-browser` to `orca serve`. When set, the headless runtime skips registering the `OffscreenBrowserBackend`, so browser pane requests from a paired remote/mobile client return null instead of spawning a Chromium `BrowserWindow` renderer (~50–150 MB per open pane).

Wire-through is end-to-end:

- CLI: flag added to `BOOLEAN_FLAGS`, the `serve` spec, and the argv rewrite from CLI-form to `--serve-no-offscreen-browser`.
- CLI shim: `serveOrcaApp` accepts `noOffscreenBrowser` and forwards `--serve-no-offscreen-browser` to the spawned Electron child.
- Main process: `ServeOptions` carries the flag, parsed in `getServeOptions`. The offscreen backend registration at the headless branch is gated on `!serveOptions.noOffscreenBrowser`. `ensureVirtualDisplayForHeadlessServe` accepts the flag and skips the Xvfb subprocess spawn — but still applies the headless Chromium flags (`disableHardwareAcceleration`, `disable-dev-shm-usage`, `disable-gpu`) so Electron can boot without an X server, since the main process itself still needs a display on Linux.

## Screenshots

No visual change. This is a CLI flag affecting server-only behavior.

## Testing

- [x] `pnpm lint` — clean
- [x] `pnpm typecheck` — clean
- [x] `pnpm test` — `pnpm exec vitest run src/cli/serve-electron-flag-parity.test.ts` is 11/11 pass; the parity test enumerates the spec's `allowedFlags` and verifies the CLI-to-`--serve-*` argv rewrite, that `serveOrcaApp` spawns with the matching `--serve-<flag>`, and that `getServeOptions` reads the same name. Adding `no-offscreen-browser` to the spec means this test now covers the new flag end-to-end automatically. `src/main/startup` and `src/main/browser` suites pass (794/794).
- [x] `pnpm build` — full build pipeline runs clean: `typecheck`, `build:relay`, `build:cli`, `build:electron-vite`, `verify:built-skills-cli` (393 closure files + 5 commands pass), `build:web-from-renderer` (861 files, 41.8 MiB), `build:native` (skipped macOS computer build on Linux). `pnpm run build` exits 0. The dev binary built by `build:cli` + `build:electron-vite` was also used for the memory profiling below.
- [x] Added or updated high-quality tests: no new tests were added because `serve-electron-flag-parity.test.ts` already covers the wiring end-to-end (CLI spec, argv rewrite, launch.ts, getServeOptions). A test that asserts the actual offscreen-backend-skip behavior would need a paired client and Electron runtime, which is out of scope for the unit suite and better suited to e2e.

### Memory profiling

Built the dev binary and ran `orca serve` 6 times across both configurations on Linux, profiling RSS of the full process tree after readiness:

| Config | Total RSS | Notes |
|---|---|---|
| baseline | 860 MB | offscreen backend registered, no panes open |
| `--no-offscreen-browser` | 860 MB | identical idle cost |

The offscreen backend is already lazy at the per-pane level, so the per-process savings only kick in when a remote client opens a browser pane (~50–150 MB per pane).

## AI Review Report

Reviewed the change with the assistant. Main risks checked:

- **Cross-platform compatibility**: macOS and Windows are unaffected. `ensureVirtualDisplayForHeadlessServe` returns `process.platform !== 'linux'` immediately for non-Linux, so the new branch is unreachable. The CLI shim and `getServeOptions` paths are platform-agnostic. Shortcuts, labels, and paths are not touched. Verified by reading the new branch's location in `ensureVirtualDisplayForHeadlessServe` and confirming it's gated on `process.platform === 'linux'`.
- **SSH/remote/local**: The flag only affects the headless `orca serve` path. Local desktop and SSH worktree flows are not touched. `initializeBrowserSessionsForApp` (the session registry) is still called at startup, so runtime profile commands continue to work.
- **Agent/integration compatibility**: The agent hooks server and the PTY runtime are independent of the offscreen browser backend. No provider-specific code is touched.
- **Performance risk**: At idle, the flag has no measurable memory impact (profiled: 860 MB → 860 MB). The Chromium flags are still applied, so Electron's main process boot cost is identical. The per-pane win is real but only when a pane is actually opened.
- **UI quality**: No UI change. No new shadcn primitives, no tokens, no styling.
- **Bug caught during profiling**: First cut placed `configureHeadlessServeChromiumFlags()` after the `noOffscreenBrowser` early return, which meant the `--disable-dev-shm-usage` flag was missing in the no-offscreen case. The Chromium `gpu-process` then spawned without that flag and used ~36 MB more. Fixed by moving the flag call before the early return at `src/main/startup/ensure-virtual-display.ts:114`. Re-profiled: both configs now identical at idle.

## Security Audit

Reviewed for input handling, command execution, path handling, auth, secrets, dependencies, and IPC.

- **Input handling**: The flag is a boolean. It goes through the standard CLI boolean-flag pipeline (`BOOLEAN_FLAGS` set, argv rewrite, `process.argv.includes` check) — no string parsing, no path interpolation, no shell expansion.
- **Command execution**: The flag is appended to the Electron child argv in `serveOrcaApp`. No new shell invocation. The CLI shim's `childArgs.push('--serve-no-offscreen-browser')` is a static string.
- **Path handling**: None added.
- **Auth/secrets**: None touched. The flag does not affect pairing, no-pairing, mobile-pairing, or web client URL emission.
- **Dependencies**: None added.
- **IPC**: No new IPC channels. The flag affects startup-time registration only. The runtime correctly returns null from `getOffscreenBrowserBackend()` when the backend is not set, so a paired client's browser pane request fails gracefully rather than crashing.
- **Remote wire compatibility**: The new flag is host-side only and does not change anything a paired client exchanges with the host. Existing clients paired to a serve that starts with `--no-offscreen-browser` will see the same wire shape they would for any serve; only browser-pane RPCs will fail with null, which the existing runtime handles.

No follow-up needed.

## Notes

- Linux only: `ensureVirtualDisplayForHeadlessServe` is already Linux-only; on macOS and Windows the flag is a no-op (the function returns `process.platform !== 'linux'` before reaching the new branch).
- Behavior on a host with no `DISPLAY` and no `Xvfb` binary: the baseline already warns and returns `false` from the function; `--no-offscreen-browser` is equivalent in that case.
- Operators who do not need browser panes can opt in to this flag to prevent accidental pane opens (e.g., from a paired client) and reclaim the per-pane Chromium renderer cost.
- The Xvfb dependency in `docs/reference/headless-linux-server.md` remains — Electron still needs a display on Linux; the comment in `ensure-virtual-display.ts:5-9` documents that `--headless` and `--ozone-platform=headless` both crash with this Electron version, so the Xvfb path is the only viable one.
- Not in this PR: lazy Xvfb spawn (defer to first browser pane request) is a separate optimization that would compound with this flag, but it changes the existing eager-spawn contract and should be a follow-up.
