### PR TITLE
[Perf-LH] Stop re-probing ordinary workspace folders every poll

### DIFF
--- a/config/scripts/worktree-base-pending-marker-benchmark.mjs
+++ b/config/scripts/worktree-base-pending-marker-benchmark.mjs
@@ -1,0 +1,117 @@
+#!/usr/bin/env node
+// Run with: node config/scripts/worktree-base-pending-marker-benchmark.mjs
+import fs from 'node:fs'
+import { mkdir, mkdtemp, rm } from 'node:fs/promises'
+import { syncBuiltinESMExports } from 'node:module'
+import os from 'node:os'
+import { join } from 'node:path'
+import { performance } from 'node:perf_hooks'
+import { createJiti } from 'jiti'
+
+const CANDIDATE_COUNT = Number(process.env.ORCA_PENDING_MARKER_BENCH_CANDIDATES ?? '64')
+const TOTAL_TICKS = Number(process.env.ORCA_PENDING_MARKER_BENCH_TICKS ?? '900')
+const STEADY_TICKS = Number(process.env.ORCA_PENDING_MARKER_BENCH_STEADY_TICKS ?? '300')
+
+for (const [name, value] of [
+  ['ORCA_PENDING_MARKER_BENCH_CANDIDATES', CANDIDATE_COUNT],
+  ['ORCA_PENDING_MARKER_BENCH_TICKS', TOTAL_TICKS],
+  ['ORCA_PENDING_MARKER_BENCH_STEADY_TICKS', STEADY_TICKS]
+]) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+if (STEADY_TICKS >= TOTAL_TICKS) {
+  throw new Error('ORCA_PENDING_MARKER_BENCH_STEADY_TICKS must be smaller than total ticks')
+}
+
+const root = await mkdtemp(join(os.tmpdir(), 'orca-pending-marker-bench-'))
+const markerPaths = new Set()
+for (let index = 0; index < CANDIDATE_COUNT; index += 1) {
+  const candidate = join(root, `ordinary-folder-${index}`)
+  await mkdir(candidate)
+  markerPaths.add(join(candidate, '.git'))
+}
+
+const originalStat = fs.promises.stat
+let visibleTick = 0
+const markerStatTicks = []
+fs.promises.stat = async (path, ...args) => {
+  if (markerPaths.has(String(path))) {
+    markerStatTicks.push(visibleTick)
+  }
+  return originalStat(path, ...args)
+}
+syncBuiltinESMExports()
+
+let poller
+let timeout
+try {
+  const jiti = createJiti(import.meta.url)
+  const { startWorktreeBaseDirectoryPoller } = await jiti.import(
+    '../../src/main/ipc/worktree-base-directory-poller.ts'
+  )
+  const repo = { repoId: 'repo-1', repoName: 'repo', nestWorkspaces: false }
+  const target = {
+    key: `base:local:${root}`,
+    kind: 'base',
+    path: root,
+    repos: new Map([[repo.repoId, repo]])
+  }
+  let finish
+  let fail
+  const completed = new Promise((resolve, reject) => {
+    finish = resolve
+    fail = reject
+  })
+  timeout = setTimeout(() => fail(new Error('poller benchmark timed out')), 30_000)
+  const startedAt = performance.now()
+  poller = await startWorktreeBaseDirectoryPoller(
+    target,
+    () => target.repos,
+    () => {},
+    {
+      pollIntervalMs: 0,
+      visibility: {
+        isWindowVisible: () => {
+          visibleTick += 1
+          if (visibleTick > TOTAL_TICKS) {
+            finish()
+            return false
+          }
+          return true
+        },
+        onWindowBecameVisible: () => () => {}
+      }
+    }
+  )
+  await completed
+  clearTimeout(timeout)
+  await poller.unsubscribe()
+  poller = undefined
+
+  const steadyStartTick = TOTAL_TICKS - STEADY_TICKS
+  const steadyMarkerStats = markerStatTicks.filter((tick) => tick > steadyStartTick).length
+  const totalMarkerStats = markerStatTicks.length
+  const statsPerCandidateTick = steadyMarkerStats / CANDIDATE_COUNT / STEADY_TICKS
+  const elapsedMs = performance.now() - startedAt
+
+  console.log('Worktree-base marker cooldown benchmark. Lower is better.')
+  console.log(
+    JSON.stringify({
+      candidates: CANDIDATE_COUNT,
+      totalTicks: TOTAL_TICKS,
+      steadyTicks: STEADY_TICKS,
+      totalMarkerStats,
+      steadyMarkerStats,
+      statsPerCandidateTick: Number(statsPerCandidateTick.toFixed(4)),
+      elapsedMs: Number(elapsedMs.toFixed(1))
+    })
+  )
+} finally {
+  clearTimeout(timeout)
+  await poller?.unsubscribe()
+  fs.promises.stat = originalStat
+  syncBuiltinESMExports()
+  await rm(root, { recursive: true, force: true })
+}

--- a/src/main/ipc/worktree-base-directory-poller.test.ts
+++ b/src/main/ipc/worktree-base-directory-poller.test.ts
@@ -1,10 +1,12 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { writeFileSync } from 'node:fs'
 import { mkdtemp, mkdir, realpath, rm, writeFile } from 'node:fs/promises'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import {
   createWorktreePollerWindowVisibility,
   startWorktreeBaseDirectoryPoller,
+  WORKTREE_BASE_BACKSTOP_TICKS,
   type WorktreeBasePollEvent,
   type WorktreePollerWindowVisibility
 } from './worktree-base-directory-poller'
@@ -202,6 +204,65 @@ describe('worktree base directory poller', () => {
       )
     )
     expect(fullScans.length).toBeGreaterThan(0)
+  })
+
+  it('retires stale marker probes while preserving backstop detection and path reuse', async () => {
+    const root = await makeRoot()
+    const ordinaryFolder = join(root, 'ordinary-folder')
+    const markerPath = join(ordinaryFolder, '.git')
+    await mkdir(ordinaryFolder)
+
+    const received: WorktreeBasePollEvent[][] = []
+    const target = makeTarget('base', root)
+    let fullScans = 0
+    let pendingMarkerProbes = 0
+    let writeMarkerOnNextProbe = false
+    const pendingMarkerMaxTicks = WORKTREE_BASE_BACKSTOP_TICKS * 2
+    const markerCreationTick = pendingMarkerMaxTicks * 2 + WORKTREE_BASE_BACKSTOP_TICKS * 4
+    const poller = await startWorktreeBaseDirectoryPoller(
+      target,
+      () => target.repos,
+      (events) => received.push(events),
+      {
+        pollIntervalMs: 0,
+        pendingMarkerMaxTicks,
+        onFullScan: () => {
+          fullScans += 1
+          if (fullScans * WORKTREE_BASE_BACKSTOP_TICKS === markerCreationTick) {
+            writeFileSync(markerPath, 'gitdir: elsewhere')
+          }
+        },
+        onPendingMarkerProbe: (path) => {
+          pendingMarkerProbes += 1
+          if (writeMarkerOnNextProbe && path === markerPath) {
+            writeMarkerOnNextProbe = false
+            writeFileSync(markerPath, 'gitdir: elsewhere')
+          }
+        }
+      }
+    )
+    cleanups.push(() => poller.unsubscribe())
+
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'create' && event.path === markerPath)
+    )
+
+    await rm(ordinaryFolder, { recursive: true })
+    await waitForEvents(received, (flat) =>
+      flat.some((event) => event.type === 'delete' && event.path === ordinaryFolder)
+    )
+    writeMarkerOnNextProbe = true
+    await mkdir(ordinaryFolder)
+    const events = await waitForEvents(
+      received,
+      (flat) =>
+        flat.filter((event) => event.type === 'create' && event.path === markerPath).length === 2
+    )
+
+    expect(pendingMarkerProbes).toBeLessThanOrEqual(pendingMarkerMaxTicks)
+    expect(
+      events.filter((event) => event.type === 'create' && event.path === markerPath)
+    ).toHaveLength(2)
   })
 
   it('parks base scans while hidden and losslessly detects changes on resume', async () => {

--- a/src/main/ipc/worktree-base-directory-poller.ts
+++ b/src/main/ipc/worktree-base-directory-poller.ts
@@ -63,6 +63,10 @@ export type WorktreeBasePollerOptions = {
   onWatchError?: (error: Error) => void
   /** Test hook: called whenever a full snapshot scan runs (vs. a gated skip). */
   onFullScan?: () => void
+  /** Test hook: called before a pending `.git` marker stat. */
+  onPendingMarkerProbe?: (path: string) => void
+  /** Test hook: overrides the fast-probe window. */
+  pendingMarkerMaxTicks?: number
 }
 
 // Why: these targets used to be recursive FSEvents subscriptions spanning the
@@ -193,7 +197,7 @@ async function startBasePoller(
   onEvents: (events: WorktreeBasePollEvent[]) => void,
   pollIntervalMs: number,
   visibility: WorktreePollerWindowVisibility,
-  onFullScan?: () => void
+  options: WorktreeBasePollerOptions
 ): Promise<WorktreeBaseSubscription> {
   let disposed = false
   let ticking = false
@@ -202,16 +206,17 @@ async function startBasePoller(
   let gateSignatures = await Promise.all(snapshot.gateDirs.map(dirSignature))
   let timer: ReturnType<typeof setTimeout> | null = null
   let parkedWhileHidden = false
-  // dir → tick when first seen without a `.git` marker
-  const pendingMarkers = new Map<string, number>()
+  const pendingMarkerMaxTicks = options.pendingMarkerMaxTicks ?? PENDING_MARKER_MAX_TICKS
+  // dir → first probe tick; null means backstop scans only
+  const markerProbeStartedAt = new Map<string, number | null>()
   for (const [dir, marker] of snapshot.markers) {
     if (!marker) {
-      pendingMarkers.set(dir, 0)
+      markerProbeStartedAt.set(dir, 0)
     }
   }
 
   const fullScan = async (): Promise<void> => {
-    onFullScan?.()
+    options.onFullScan?.()
     const next = await snapshotBase(target.path, getRepos())
     const nextSignatures = await Promise.all(next.gateDirs.map(dirSignature))
     if (disposed) {
@@ -220,14 +225,14 @@ async function startBasePoller(
     const events = diffBase(snapshot, next)
     for (const [dir, marker] of next.markers) {
       if (marker) {
-        pendingMarkers.delete(dir)
-      } else if (!pendingMarkers.has(dir)) {
-        pendingMarkers.set(dir, tickCount)
+        markerProbeStartedAt.delete(dir)
+      } else if (!markerProbeStartedAt.has(dir)) {
+        markerProbeStartedAt.set(dir, tickCount)
       }
     }
-    for (const [dir, firstSeenTick] of pendingMarkers) {
-      if (!next.markers.has(dir) || tickCount - firstSeenTick > PENDING_MARKER_MAX_TICKS) {
-        pendingMarkers.delete(dir)
+    for (const dir of markerProbeStartedAt.keys()) {
+      if (!next.markers.has(dir)) {
+        markerProbeStartedAt.delete(dir)
       }
     }
     snapshot = next
@@ -239,9 +244,17 @@ async function startBasePoller(
 
   const checkPendingMarkers = async (): Promise<void> => {
     const events: WorktreeBasePollEvent[] = []
-    for (const dir of pendingMarkers.keys()) {
+    for (const [dir, firstSeenTick] of markerProbeStartedAt) {
+      if (firstSeenTick === null) {
+        continue
+      }
+      if (tickCount - firstSeenTick > pendingMarkerMaxTicks) {
+        markerProbeStartedAt.set(dir, null)
+        continue
+      }
+      options.onPendingMarkerProbe?.(join(dir, '.git'))
       if (await hasGitMarker(dir)) {
-        pendingMarkers.delete(dir)
+        markerProbeStartedAt.delete(dir)
         snapshot.markers.set(dir, true)
         events.push({ type: 'create', path: join(dir, '.git') })
       }
@@ -267,7 +280,7 @@ async function startBasePoller(
       await fullScan()
       return
     }
-    if (pendingMarkers.size > 0) {
+    if (markerProbeStartedAt.size > 0) {
       await checkPendingMarkers()
     }
   }
@@ -356,5 +369,5 @@ export async function startWorktreeBaseDirectoryPoller(
       options.onWatchError
     )
   }
-  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options.onFullScan)
+  return startBasePoller(target, getRepos, onEvents, pollIntervalMs, visibility, options)
 }


### PR DESCRIPTION
## Summary

This PR stops Orca from repeatedly asking the operating system whether long-lived ordinary workspace folders contain a `.git` marker.

A `.git` marker is the file or directory Git puts at the root of a repository or worktree. Orca watches for that marker so it can notice worktrees created outside the app.

The poller already had two intended modes:

1. **Fast window:** check a newly seen marker-less directory every visible poll cycle for up to 300 cycles. At the production two-second interval, that is about ten minutes.
2. **Backstop:** after the fast window, rely on the existing full scan every 15 visible poll cycles, or about every 30 seconds.

The bug was that each full scan forgot which directories had already exhausted the fast window. It removed an expired directory from the pending map, then a later full scan saw the same marker-less directory and added it back as “new.” In steady state, ordinary folders therefore received `.git` filesystem probes on 95.33% of visible poll cycles.

### New state transitions

| What Orca observes | State kept by the poller | What happens next |
| --- | --- | --- |
| A new directory without `.git` | First fast-probe tick | Probe `<directory>/.git` on non-backstop cycles |
| The directory exceeds the fast window | `null` (“backstop only”) | Stop individual probes; periodic full scans still inspect it |
| A full scan finds `.git` | No marker-probe state | Emit the same worktree-create event as before |
| A full scan observes that the directory disappeared | No marker-probe state | A later directory at the same path gets a fresh fast window |

The implementation uses one map instead of a pending map plus a second collection. A numeric value means “still in the fast window”; `null` means “only inspect this path during a full backstop scan.”

The regression test covers all three important behaviors:

- stale probes actually stop;
- a `.git` marker created much later is still detected by a backstop scan;
- after an expired path is deleted and recreated, it gets fast probes again.

## Benchmark

Harness:

`node config/scripts/worktree-base-pending-marker-benchmark.mjs`

The harness imports the real production poller, creates 64 ordinary directories with no `.git` marker, accelerates the poll interval to zero, and records real calls to `fs.promises.stat` for those 64 marker paths. It runs 900 visible poll cycles and treats the final 300 as the steady-state window.

Both arms used the same harness and fixture. The only switched input was the poller implementation:

- Before: base commit `f3ea376b6b26`, poller blob `2f65e0fc28219488aeeb385f49532f4475553b3b`
- After: this PR, poller blob `b5076c2ed7ffe326a5286af327c4a960e0b24ecf`

| Metric (lower is better) | Before | After | Reduction |
| --- | ---: | ---: | ---: |
| Total `.git` marker stats across 900 cycles | 55,872 | 21,824 | 60.9% |
| Steady-state marker stats across final 300 cycles | 18,304 | 1,280 | **93.0%** |
| Steady stats per candidate per cycle | 0.9533 | 0.0667 | **93.0%** |

The after value, 0.0667, is the expected backstop floor: one full scan every 15 cycles. The total-run reduction is smaller because the benchmark intentionally includes the initial fast-probe window.

The benchmark also prints elapsed wall time as a diagnostic, but this PR does not claim a wall-time speedup from that number. A zero-delay timer is useful for reproducing syscall counts quickly, but its scheduling overhead is not representative of the production two-second cadence. The deterministic filesystem-operation count is the performance claim.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint was not run; `pnpm run check:code-quality:changed` passed with 0 new standard, type-aware, or React Doctor findings across all 3 changed files.
- [ ] `pnpm typecheck` — the affected Node target passed with `pnpm run typecheck:node`; CLI and web targets are untouched.
- [ ] `pnpm test` — the complete repository suite was not run; the detected-worktree reliability group passed 177/177 tests across 7 files.
- [ ] `pnpm build` — not run; this does not change packaging, native modules, renderer code, or build configuration.
- [x] Added a regression test that fails if expired paths resume fast probing, if late marker discovery is lost, or if delete/recreate path reuse stays in cooldown.

Additional checks:

- Focused poller suite: 22/22 passed.
- New cooldown test: passed five repeated runs during independent review.
- `pnpm run check:max-lines-ratchet`: passed with no new bypasses.
- `pnpm run check:reliability-gates`: reliability manifest passed for all 73 gates.
- `git diff --check`: passed.
- Benchmark reruns reproduced exactly 21,824 total stats, 1,280 steady stats, and 0.0667 steady stats per candidate per cycle.

## AI Review Report

The final review traced each marker state from initial discovery through expiry, periodic scanning, marker creation, deletion, recreation, hidden-window parking, and unsubscribe cleanup.

The first review found that the initial two-collection implementation pushed the production file over the repository’s 300-line limit. No lint disable or limit increase was added. The implementation was simplified to one nullable map, and the max-lines gate now passes.

The review also flagged that a test using the production 300-cycle cooldown would need roughly 660 zero-delay timer turns and could be slower on heavily loaded Windows CI. The test now uses an explicit test-only 30-cycle window while production keeps the unchanged 300-cycle value. It exercises the same expiry and backstop boundaries in fewer timer turns.

A final independent review found no remaining actionable issues. It explicitly checked:

- expiry at the exact tick boundary;
- full scans not reactivating expired entries;
- late `.git` discovery;
- observed delete/recreate state reset;
- stale state and partial filesystem failures;
- overlapping poll prevention and unsubscribe cleanup;
- macOS, Linux, and Windows path handling;
- local, SSH, WSL UNC, and folder-workspace routing;
- remote-wire and Git-command compatibility.

No keyboard shortcut, shortcut label, shell invocation, or Electron platform-specific behavior changed. Existing `path.join` handling remains the only path construction used for marker paths.

## Security Audit

This is a reduction in existing filesystem reads and does not add a new authority boundary.

- **Input handling:** no new user-controlled input is parsed. The new options are test hooks used by the regression suite.
- **Filesystem access:** the code checks the same `<candidate>/.git` paths as before, using the existing `path.join` and `stat` functions. It performs fewer checks after cooldown.
- **Commands and shells:** no commands, shell arguments, or Git invocations were added or changed.
- **IPC and remote wire:** no RPC parameter, event, stream opcode, serialization, or persisted format changed.
- **Authentication and secrets:** untouched.
- **Dependencies:** no dependency or lockfile change.
- **Failure behavior:** filesystem misses and transient stat failures retain the existing retry/backstop behavior.

No security follow-up is required.

## Notes

The deliberate tradeoff is narrow: if a directory has remained marker-less beyond the roughly ten-minute fast window and someone later adds `.git` inside that same still-existing directory, detection can take until the next full scan—up to roughly 30 seconds while the window is visible—instead of the next two-second fast poll. Normal worktree creation is unaffected because Git creates the marker during directory creation, well inside the fast window. If the old directory is observed disappearing first, recreating that path starts a fresh fast window.

Scope is intentionally limited:

- local non-folder repository base targets use this poller;
- SSH targets continue to use `provider.watch`;
- WSL UNC roots continue to be skipped;
- folder workspaces continue to be skipped;
- `git-common` targets continue to use their separate watcher;
- no GitHub-, GitLab-, or other review-provider behavior changed.