### PR TITLE
[leas code] Centralize UTF-8 byte and chunk boundaries

### DIFF
--- a/src/main/browser/browser-text-insertion.ts
+++ b/src/main/browser/browser-text-insertion.ts
@@ -1,21 +1,9 @@
 import { measureClipboardTextByteLength } from '../../shared/clipboard-text'
 import { yieldToEventLoop } from '../../shared/event-loop-yield'
+import { getUtf8ChunkEndIndex } from '../../shared/utf8-byte-limits'
 import type { CdpCommandSender } from './snapshot-engine'
 
 export const BROWSER_TEXT_INSERT_CHUNK_BYTES = 64 * 1024
-
-function getUtf8ByteLengthForCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
 
 export function splitBrowserTextInsertionChunks(
   text: string,
@@ -38,24 +26,11 @@ export function* iterateBrowserTextInsertionChunks(
     return
   }
 
-  let currentStart = 0
-  let currentBytes = 0
-  let index = 0
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextIndex = index + codeUnitLength
-    const characterBytes = getUtf8ByteLengthForCodePoint(codePoint)
-    if (currentBytes > 0 && currentBytes + characterBytes > normalizedMax) {
-      yield text.slice(currentStart, index)
-      currentStart = index
-      currentBytes = 0
-    }
-    currentBytes += characterBytes
-    index = nextIndex
-  }
-  if (currentStart < text.length) {
-    yield text.slice(currentStart)
+  let startIndex = 0
+  while (startIndex < text.length) {
+    const endIndex = getUtf8ChunkEndIndex(text, startIndex, normalizedMax)
+    yield text.slice(startIndex, endIndex)
+    startIndex = endIndex
   }
 }
 
@@ -68,8 +43,7 @@ export async function insertTextThroughCdp(
   let chunk = chunks.next()
   while (!chunk.done) {
     await sender('Input.insertText', { text: chunk.value })
-    // Why: browser automation text can be paste-sized; yielding keeps the main
-    // process responsive between bounded CDP payloads.
+    // Keep paste-sized insertion from monopolizing the main process.
     chunk = chunks.next()
     if (options?.yieldBetweenChunks !== false && !chunk.done) {
       await yieldToEventLoop()

--- a/src/renderer/src/components/dictation/dictation-insertion-target.test.ts
+++ b/src/renderer/src/components/dictation/dictation-insertion-target.test.ts
@@ -1,12 +1,12 @@
 // @vitest-environment happy-dom
 
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 
 import {
   TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES,
   TEXT_CONTROL_PASTE_DIRECT_MAX_BYTES,
-  TEXT_CONTROL_PASTE_MAX_BYTES,
-  getTextControlPasteByteLength
+  TEXT_CONTROL_PASTE_MAX_BYTES
 } from '@/lib/text-control-paste'
 import { insertText } from './dictation-insertion-target'
 
@@ -98,8 +98,7 @@ describe('dictation insertion target', () => {
     expect(execCommand.mock.calls.length).toBeGreaterThan(1)
     expect(
       execCommand.mock.calls.every(
-        (call) =>
-          getTextControlPasteByteLength(String(call[2] ?? '')) <= TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES
+        (call) => getUtf8ByteLength(String(call[2] ?? '')) <= TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES
       )
     ).toBe(true)
     expect(beforeInputEvents).toHaveLength(execCommand.mock.calls.length)

--- a/src/renderer/src/components/dictation/dictation-insertion-target.ts
+++ b/src/renderer/src/components/dictation/dictation-insertion-target.ts
@@ -1,9 +1,9 @@
 import { yieldToEventLoop } from '../../../../shared/event-loop-yield'
+import { getUtf8ChunkEndIndex } from '../../../../shared/utf8-byte-limits'
 import {
   TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES,
   TEXT_CONTROL_PASTE_DIRECT_MAX_BYTES,
   TEXT_CONTROL_PASTE_MAX_BYTES,
-  getTextControlPasteByteLength,
   measureTextControlPasteByteLength,
   measureTextControlPasteByteLengthWithYield,
   pasteTextIntoTextControl
@@ -108,11 +108,7 @@ async function insertTextIntoContentEditableTarget(
     if (!isContentEditableDictationTargetCurrent(element)) {
       return
     }
-    const nextIndex = getNextDictationChunkBoundary(
-      text,
-      textIndex,
-      TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES
-    )
+    const nextIndex = getUtf8ChunkEndIndex(text, textIndex, TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES)
     if (
       !insertContentEditableDictationChunk(element, editorElement, text.slice(textIndex, nextIndex))
     ) {
@@ -161,23 +157,4 @@ function insertContentEditableDictationChunk(
 
 function isContentEditableDictationTargetCurrent(element: HTMLElement): boolean {
   return element.isConnected && element.contains(element.ownerDocument.activeElement)
-}
-
-function getNextDictationChunkBoundary(text: string, startIndex: number, maxBytes: number): number {
-  let byteLength = 0
-  let index = startIndex
-
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextByteLength = getTextControlPasteByteLength(text.slice(index, index + codeUnitLength))
-
-    if (byteLength > 0 && byteLength + nextByteLength > maxBytes) {
-      break
-    }
-    byteLength += nextByteLength
-    index += codeUnitLength
-  }
-
-  return index
 }

--- a/src/renderer/src/components/editor/monaco-large-text-paste.ts
+++ b/src/renderer/src/components/editor/monaco-large-text-paste.ts
@@ -1,5 +1,6 @@
 import type { editor } from 'monaco-editor'
 import { yieldToEventLoop } from '../../../../shared/event-loop-yield'
+import { getUtf8ChunkEndIndex } from '../../../../shared/utf8-byte-limits'
 import {
   measureTextControlPasteByteLength,
   measureTextControlPasteByteLengthWithYield
@@ -71,39 +72,6 @@ type Position = {
 
 function getPlainTextFromPasteEvent(event: ClipboardEvent): string {
   return event.clipboardData?.getData('text/plain') ?? ''
-}
-
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
-
-function getNextChunkBoundary(text: string, startIndex: number, maxBytes: number): number {
-  let byteLength = 0
-  let index = startIndex
-
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextByteLength = getCodePointUtf8ByteLength(codePoint)
-
-    if (byteLength > 0 && byteLength + nextByteLength > maxBytes) {
-      break
-    }
-
-    byteLength += nextByteLength
-    index += codeUnitLength
-  }
-
-  return index
 }
 
 function getEndPositionAfterInsert(start: Position, text: string): Position {
@@ -187,7 +155,7 @@ async function insertMonacoTextInChunks(
       return { status: 'cancelled', reason: 'target-unavailable', byteLength, chunksWritten }
     }
 
-    const nextIndex = getNextChunkBoundary(text, textIndex, chunkMaxBytes)
+    const nextIndex = getUtf8ChunkEndIndex(text, textIndex, chunkMaxBytes)
     const chunk = text.slice(textIndex, nextIndex)
     const endPosition = getEndPositionAfterInsert(
       { lineNumber: selection.startLineNumber, column: selection.startColumn },

--- a/src/renderer/src/components/editor/rich-markdown-large-text-paste.ts
+++ b/src/renderer/src/components/editor/rich-markdown-large-text-paste.ts
@@ -2,6 +2,10 @@ import type { Editor } from '@tiptap/react'
 import { toast } from 'sonner'
 import { yieldToEventLoop } from '../../../../shared/event-loop-yield'
 import {
+  getUtf8ChunkEndIndex,
+  isUtf8ByteLengthWithinLimit
+} from '../../../../shared/utf8-byte-limits'
+import {
   measureTextControlPasteByteLength,
   measureTextControlPasteByteLengthWithYield
 } from '@/lib/text-control-paste'
@@ -32,61 +36,6 @@ export type RichMarkdownLargeTextPasteResult =
       byteLength: number
       chunksWritten: number
     }
-
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
-
-function isTextByteLengthOverLimit(text: string, maxBytes: number): boolean {
-  if (text.length === 0) {
-    return false
-  }
-  if (text.length > maxBytes) {
-    return true
-  }
-
-  let byteLength = 0
-  for (let index = 0; index < text.length; index += 1) {
-    const codePoint = text.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return true
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return false
-}
-
-function getNextChunkBoundary(text: string, startIndex: number, maxBytes: number): number {
-  let byteLength = 0
-  let index = startIndex
-
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextByteLength = getCodePointUtf8ByteLength(codePoint)
-
-    if (byteLength > 0 && byteLength + nextByteLength > maxBytes) {
-      break
-    }
-
-    byteLength += nextByteLength
-    index += codeUnitLength
-  }
-
-  return index
-}
 
 function isEditorAvailable(
   editor: Editor,
@@ -126,7 +75,7 @@ function shouldHandleLargeRichMarkdownPaste({
   if (plainTextExceededLimit || plainTextByteLength > maxDirect) {
     return true
   }
-  return isTextByteLengthOverLimit(htmlText, maxDirect)
+  return !isUtf8ByteLengthWithinLimit(htmlText, maxDirect)
 }
 
 async function insertRichMarkdownTextInChunks(
@@ -144,7 +93,7 @@ async function insertRichMarkdownTextInChunks(
       return { status: 'cancelled', reason: 'target-unavailable', byteLength, chunksWritten }
     }
 
-    const nextIndex = getNextChunkBoundary(text, textIndex, chunkMaxBytes)
+    const nextIndex = getUtf8ChunkEndIndex(text, textIndex, chunkMaxBytes)
     const chunk = text.slice(textIndex, nextIndex)
     editor.view.dispatch(editor.state.tr.insertText(chunk))
     textIndex = nextIndex

--- a/src/renderer/src/components/editor/rich-markdown-source-owning-slice.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-owning-slice.ts
@@ -1,4 +1,5 @@
 import type { Slice } from '@tiptap/pm/model'
+import { getUtf8ByteLengthForCodePoint } from '../../../../shared/utf8-byte-limits'
 import {
   getRichMarkdownLeafVisibleText,
   isRichMarkdownVisibleBlockStart
@@ -90,7 +91,7 @@ function addUtf8BytesWithinLimit(
   let byteLength = current
   for (let index = 0; index < value.length; index += 1) {
     const codePoint = value.codePointAt(index) ?? 0
-    byteLength += codePoint <= 0x7f ? 1 : codePoint <= 0x7ff ? 2 : codePoint <= 0xffff ? 3 : 4
+    byteLength += getUtf8ByteLengthForCodePoint(codePoint)
     if (byteLength > limit) {
       return { byteLength, exceeded: true }
     }

--- a/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
+++ b/src/renderer/src/components/editor/rich-markdown-source-reconcile.ts
@@ -5,6 +5,7 @@ import {
   makeDiff,
   makePatches
 } from '@sanity/diff-match-patch'
+import { getUtf8ByteLengthForCodePoint } from '../../../../shared/utf8-byte-limits'
 
 // Why: cap document size in UTF-16 code units (`.length`) since re-parse cost scales with length — the per-commit throwaway TipTap safety re-parse (~50-67ms here) must stay under the 300ms serialize debounce so it can't stall the main thread on slow/SSH hosts.
 const RECONCILE_SIZE_CAP_CODE_UNITS = 50_000
@@ -150,25 +151,12 @@ function getUtf8OffsetsAtCodeUnitIndices(
       if (codePoint === undefined) {
         break
       }
-      byteOffset += utf8CodePointLength(codePoint)
+      byteOffset += getUtf8ByteLengthForCodePoint(codePoint)
       codeUnitIndex += codePoint > 0xffff ? 2 : 1
     }
     offsets.set(target, byteOffset)
   }
   return offsets
-}
-
-function utf8CodePointLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }
 
 function hasRepeatedHalfMatchSeed(textA: string, textB: string): boolean {

--- a/src/renderer/src/components/github/pr-file-content-size.test.ts
+++ b/src/renderer/src/components/github/pr-file-content-size.test.ts
@@ -1,0 +1,16 @@
+import { describe, expect, it } from 'vitest'
+import type { GitHubPRFileContents } from '../../../../shared/types'
+import { getPRFileContentsCacheByteCount } from './pr-file-content-size'
+
+describe('PR file content size', () => {
+  it('counts astral characters and lone surrogates as UTF-8 bytes', () => {
+    const contents: GitHubPRFileContents = {
+      original: '😀\ud800',
+      modified: '\udc00é',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    }
+
+    expect(getPRFileContentsCacheByteCount(contents)).toBe(12)
+  })
+})

--- a/src/renderer/src/components/github/pr-file-content-size.ts
+++ b/src/renderer/src/components/github/pr-file-content-size.ts
@@ -1,33 +1,11 @@
 import { MAX_RENDERED_DIFF_COMBINED_CHARACTERS } from '@/components/editor/large-diff-render-limit'
 import type { GitHubPRFile, GitHubPRFileContents } from '../../../../shared/types'
+import { getUtf8ByteLength } from '../../../../shared/utf8-byte-limits'
 
 export const PR_FILE_CONTENT_CACHE_MAX_BYTES = MAX_RENDERED_DIFF_COMBINED_CHARACTERS * 4
 
 export function isPRFileViewed(file: GitHubPRFile): boolean {
   return file.viewerViewedState === 'VIEWED'
-}
-
-export function getUtf8ByteCount(value: string): number {
-  let byteCount = 0
-  for (let index = 0; index < value.length; index += 1) {
-    const code = value.charCodeAt(index)
-    if (code < 0x80) {
-      byteCount += 1
-    } else if (code < 0x800) {
-      byteCount += 2
-    } else if (code >= 0xd800 && code <= 0xdbff && index + 1 < value.length) {
-      const next = value.charCodeAt(index + 1)
-      if (next >= 0xdc00 && next <= 0xdfff) {
-        byteCount += 4
-        index += 1
-      } else {
-        byteCount += 3
-      }
-    } else {
-      byteCount += 3
-    }
-  }
-  return byteCount
 }
 
 export function isPRFileContentsTooLargeSentinel(contents: GitHubPRFileContents): boolean {
@@ -38,7 +16,7 @@ export function getPRFileContentsCacheByteCount(contents: GitHubPRFileContents):
   if (isPRFileContentsTooLargeSentinel(contents)) {
     return 0
   }
-  return getUtf8ByteCount(contents.original) + getUtf8ByteCount(contents.modified)
+  return getUtf8ByteLength(contents.original) + getUtf8ByteLength(contents.modified)
 }
 
 export function getRetainedPRFileContentsByteCount(contents: GitHubPRFileContents): number | null {

--- a/src/renderer/src/components/terminal-pane/terminal-paste-chunks.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-paste-chunks.ts
@@ -1,6 +1,7 @@
 import { BRACKETED_PASTE_END, BRACKETED_PASTE_START } from './terminal-bracketed-paste'
 import { TERMINAL_PASTE_CHUNK_MAX_BYTES } from './terminal-paste-limits'
 import type { TerminalPastePlan } from './terminal-paste-coordinator'
+import { getUtf8ByteLengthForCodePoint } from '../../../../shared/utf8-byte-limits'
 
 const TERMINAL_PASTE_ESCAPE_CODE_POINT = 0x1b
 const TERMINAL_PASTE_INERT_ESCAPE_CODE_POINT = 0x241b
@@ -58,7 +59,7 @@ function* iterateTextByUtf8Bytes(
       : normalizedCodePoint === codePoint
         ? text.slice(index, index + codeUnitLength)
         : '\r'
-    const nextBytes = utf8BytesForCodePoint(
+    const nextBytes = getUtf8ByteLengthForCodePoint(
       sanitizedEscape ? TERMINAL_PASTE_INERT_ESCAPE_CODE_POINT : normalizedCodePoint
     )
     if (chunk && chunkBytes + nextBytes > maxBytes) {
@@ -79,17 +80,4 @@ function* iterateTextByUtf8Bytes(
   if (chunk) {
     yield chunk
   }
-}
-
-function utf8BytesForCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }

--- a/src/renderer/src/lib/agent-draft-paste-content.ts
+++ b/src/renderer/src/lib/agent-draft-paste-content.ts
@@ -1,5 +1,6 @@
 import { yieldToEventLoop } from '../../../shared/event-loop-yield'
 import type { GlobalSettings } from '../../../shared/types'
+import { getUtf8ByteLengthForCodePoint } from '../../../shared/utf8-byte-limits'
 import {
   BRACKETED_PASTE_END,
   BRACKETED_PASTE_START,
@@ -187,19 +188,6 @@ function getSanitizedUtf8ByteLengthForCodePoint(codePoint: number): number {
       ? AGENT_DRAFT_PASTE_INERT_ESCAPE_CODE_POINT
       : codePoint
   )
-}
-
-function getUtf8ByteLengthForCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }
 
 async function writeAgentDraftPtyInput(

--- a/src/renderer/src/lib/comment-body-submit-state.ts
+++ b/src/renderer/src/lib/comment-body-submit-state.ts
@@ -1,3 +1,5 @@
+import { getUtf8ByteLengthForCodePoint } from '../../../shared/utf8-byte-limits'
+
 export const COMMENT_BODY_NONBLANK_SCAN_MAX_BYTES = 64 * 1024
 
 export type CommentBodySubmitState =
@@ -6,19 +8,6 @@ export type CommentBodySubmitState =
   | { status: 'ready'; body: string }
 
 type CommentBodyPresence = 'empty' | 'present' | 'too-large-leading-whitespace'
-
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
 
 function getCommentBodyPresence(
   body: string,
@@ -29,7 +18,7 @@ function getCommentBodyPresence(
   for (let index = 0; index < body.length; index += 1) {
     const codePoint = body.codePointAt(index) ?? 0
     const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    scannedBytes += getCodePointUtf8ByteLength(codePoint)
+    scannedBytes += getUtf8ByteLengthForCodePoint(codePoint)
     if (scannedBytes > maxScanBytes) {
       return 'too-large-leading-whitespace'
     }

--- a/src/renderer/src/lib/paste-payload-metadata.ts
+++ b/src/renderer/src/lib/paste-payload-metadata.ts
@@ -1,4 +1,5 @@
 import { yieldToEventLoop } from '../../../shared/event-loop-yield'
+import { getUtf8ByteLengthForCodePoint } from '../../../shared/utf8-byte-limits'
 
 export type PastePayloadMetadata = {
   byteLength: number
@@ -137,17 +138,4 @@ function isPasteControlSequenceCodePoint(codePoint: number): boolean {
     (codePoint >= 0x0e && codePoint <= 0x1f) ||
     codePoint === 0x7f
   )
-}
-
-function getUtf8ByteLengthForCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }

--- a/src/renderer/src/lib/primary-selection-paste.ts
+++ b/src/renderer/src/lib/primary-selection-paste.ts
@@ -1,4 +1,5 @@
 import { yieldToEventLoop } from '../../../shared/event-loop-yield'
+import { getUtf8ChunkEndIndex } from '../../../shared/utf8-byte-limits'
 import { isPrimarySelectionTextControl } from './primary-selection-capture'
 import {
   TEXT_CONTROL_PASTE_CHUNK_MAX_BYTES,
@@ -101,39 +102,6 @@ function isContentEditablePasteTargetAvailable(
   return target.isConnected && target.isContentEditable && (canContinue?.(target) ?? true)
 }
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
-
-function getNextChunkBoundary(text: string, startIndex: number, maxBytes: number): number {
-  let byteLength = 0
-  let index = startIndex
-
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextByteLength = getCodePointUtf8ByteLength(codePoint)
-
-    if (byteLength > 0 && byteLength + nextByteLength > maxBytes) {
-      break
-    }
-
-    byteLength += nextByteLength
-    index += codeUnitLength
-  }
-
-  return index
-}
-
 function getContentEditableInsertionRange(target: HTMLElement): Range | null {
   const selection = target.ownerDocument.getSelection()
   if (!selection || selection.rangeCount === 0) {
@@ -180,7 +148,7 @@ async function pasteLargeTextIntoContentEditable(
       }
       return false
     }
-    const nextIndex = getNextChunkBoundary(text, textIndex, chunkMaxBytes)
+    const nextIndex = getUtf8ChunkEndIndex(text, textIndex, chunkMaxBytes)
     range = insertContentEditableChunk(target, range, text.slice(textIndex, nextIndex))
     textIndex = nextIndex
     if (textIndex < text.length) {

--- a/src/renderer/src/lib/text-control-paste.test.ts
+++ b/src/renderer/src/lib/text-control-paste.test.ts
@@ -3,7 +3,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { PASTE_PAYLOAD_CORPUS } from './paste-payload-corpus'
 import {
-  getTextControlPasteByteLength,
   measureTextControlPasteByteLength,
   pasteTextIntoTextControl,
   shouldHandleTextControlPaste
@@ -251,7 +250,7 @@ describe('text control paste', () => {
   })
 
   it('uses utf-8 byte thresholds for non-ascii text', () => {
-    expect(getTextControlPasteByteLength('a😀é')).toBe(7)
+    expect(measureTextControlPasteByteLength('a😀é').byteLength).toBe(7)
     expect(shouldHandleTextControlPaste('😀😀', { directMaxBytes: 7 })).toBe(true)
     expect(shouldHandleTextControlPaste('abc', { directMaxBytes: 7 })).toBe(false)
     expect(shouldHandleTextControlPaste('', { directMaxBytes: 0 })).toBe(false)
@@ -263,6 +262,8 @@ describe('text control paste', () => {
     })
 
     expect(measurement).toEqual({ byteLength: 8, exceededLimit: true })
-    expect(measurement.byteLength).toBeLessThan(getTextControlPasteByteLength('😀'.repeat(100)))
+    expect(measurement.byteLength).toBeLessThan(
+      measureTextControlPasteByteLength('😀'.repeat(100)).byteLength
+    )
   })
 })

--- a/src/renderer/src/lib/text-control-paste.ts
+++ b/src/renderer/src/lib/text-control-paste.ts
@@ -1,4 +1,5 @@
 import { yieldToEventLoop } from '../../../shared/event-loop-yield'
+import { getUtf8ChunkEndIndex } from '../../../shared/utf8-byte-limits'
 import {
   createTextControlCancelledResult,
   createTextControlPastedResult,
@@ -34,29 +35,12 @@ export type {
   TextControlPasteSource
 } from './text-control-paste-model'
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
-
 export function measureTextControlPasteByteLength(
   text: string,
   options: { stopAfterBytes?: number } = {}
 ): TextControlPasteByteLengthMeasurement {
   const { byteLength, exceededLimit } = measurePastePayloadMetadata(text, options)
   return { byteLength, exceededLimit }
-}
-
-export function getTextControlPasteByteLength(text: string): number {
-  return measureTextControlPasteByteLength(text).byteLength
 }
 
 export async function measureTextControlPasteByteLengthWithYield(
@@ -127,26 +111,6 @@ export function shouldHandleTextControlPaste(
         }
   const directMaxBytes = options.directMaxBytes ?? TEXT_CONTROL_PASTE_DIRECT_MAX_BYTES
   return measurement.exceededLimit || measurement.byteLength > directMaxBytes
-}
-
-function getNextChunkBoundary(text: string, startIndex: number, maxBytes: number): number {
-  let byteLength = 0
-  let index = startIndex
-
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextByteLength = getCodePointUtf8ByteLength(codePoint)
-
-    if (byteLength > 0 && byteLength + nextByteLength > maxBytes) {
-      break
-    }
-
-    byteLength += nextByteLength
-    index += codeUnitLength
-  }
-
-  return index
 }
 
 function dispatchTextControlInputEvent(
@@ -283,7 +247,7 @@ export async function pasteTextIntoTextControl(
         })
       }
 
-      const nextIndex = getNextChunkBoundary(text, textIndex, chunkMaxBytes)
+      const nextIndex = getUtf8ChunkEndIndex(text, textIndex, chunkMaxBytes)
       const chunk = text.slice(textIndex, nextIndex)
       const caret = target.selectionStart ?? target.value.length
       target.setRangeText(chunk, caret, caret, 'end')

--- a/src/renderer/src/runtime/runtime-file-search-bounds.ts
+++ b/src/renderer/src/runtime/runtime-file-search-bounds.ts
@@ -1,4 +1,5 @@
 import type { SearchOptions, SearchResult } from '../../../shared/types'
+import { isUtf8ByteLengthWithinLimit } from '../../../shared/utf8-byte-limits'
 
 export const RUNTIME_FILE_SEARCH_TEXT_MAX_BYTES = 8 * 1024
 
@@ -8,35 +9,11 @@ export function createEmptyRuntimeFileSearchResult(): SearchResult {
   return { files: [], totalMatches: 0, truncated: false }
 }
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
-
 export function isRuntimeFileSearchTextWithinLimit(
   text: string,
   maxBytes = RUNTIME_FILE_SEARCH_TEXT_MAX_BYTES
 ): boolean {
-  let byteLength = 0
-  for (let index = 0; index < text.length; index += 1) {
-    const codePoint = text.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return false
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return true
+  return isUtf8ByteLengthWithinLimit(text, maxBytes)
 }
 
 export function getRuntimeFileSearchRejectedField(

--- a/src/renderer/src/runtime/runtime-provider-search-bounds.ts
+++ b/src/renderer/src/runtime/runtime-provider-search-bounds.ts
@@ -1,17 +1,6 @@
-export const RUNTIME_PROVIDER_SEARCH_QUERY_MAX_BYTES = 8 * 1024
+import { isUtf8ByteLengthWithinLimit } from '../../../shared/utf8-byte-limits'
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
+export const RUNTIME_PROVIDER_SEARCH_QUERY_MAX_BYTES = 8 * 1024
 
 export function isRuntimeProviderSearchQueryWithinLimit(
   query: string | null | undefined,
@@ -20,16 +9,5 @@ export function isRuntimeProviderSearchQueryWithinLimit(
   if (query === null || query === undefined) {
     return true
   }
-  let byteLength = 0
-  for (let index = 0; index < query.length; index += 1) {
-    const codePoint = query.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return false
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return true
+  return isUtf8ByteLengthWithinLimit(query, maxBytes)
 }

--- a/src/renderer/src/runtime/runtime-repo-search-bounds.ts
+++ b/src/renderer/src/runtime/runtime-repo-search-bounds.ts
@@ -1,32 +1,10 @@
-export const RUNTIME_REPO_REF_SEARCH_QUERY_MAX_BYTES = 2 * 1024
+import { isUtf8ByteLengthWithinLimit } from '../../../shared/utf8-byte-limits'
 
-function getCodePointUtf8ByteLength(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
-}
+export const RUNTIME_REPO_REF_SEARCH_QUERY_MAX_BYTES = 2 * 1024
 
 export function isRuntimeRepoRefSearchQueryWithinLimit(
   query: string,
   maxBytes = RUNTIME_REPO_REF_SEARCH_QUERY_MAX_BYTES
 ): boolean {
-  let byteLength = 0
-  for (let index = 0; index < query.length; index += 1) {
-    const codePoint = query.codePointAt(index) ?? 0
-    byteLength += getCodePointUtf8ByteLength(codePoint)
-    if (byteLength > maxBytes) {
-      return false
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return true
+  return isUtf8ByteLengthWithinLimit(query, maxBytes)
 }

--- a/src/shared/check-job-log-tail-slice.ts
+++ b/src/shared/check-job-log-tail-slice.ts
@@ -1,3 +1,5 @@
+import { clampUtf8TextTail, getUtf8ByteLength } from './utf8-byte-limits'
+
 export const PR_CHECK_LOG_TAIL_LINES = 200
 export const PR_CHECK_LOG_TAIL_RECENT_LINES = 100
 export const PR_CHECK_LOG_TAIL_BYTES = 16 * 1024
@@ -10,47 +12,23 @@ export const PR_CHECK_LOG_TAIL_EARLIER_SEPARATOR = '… earlier errors …'
 const ERROR_LINE_PATTERN =
   /(?:##\[error\]|::error::|::error\b|\berror:|FAILED|exit code|ENOENT|EACCES|panic:|AssertionError)/i
 
-// Why: this slicer runs in main (GitHub/GitLab log fetches) and in the renderer
-// (defensive re-slice of traces from older remote runtimes), so no Buffer.
-function utf8ByteLength(text: string): number {
-  let bytes = 0
-  for (const character of text) {
-    const codePoint = character.codePointAt(0) ?? 0
-    bytes += codePoint < 0x80 ? 1 : codePoint < 0x800 ? 2 : codePoint < 0x10000 ? 3 : 4
-  }
-  return bytes
-}
-
 function applyLogTailByteCap(text: string): string {
-  if (utf8ByteLength(text) <= PR_CHECK_LOG_TAIL_BYTES) {
+  if (getUtf8ByteLength(text) <= PR_CHECK_LOG_TAIL_BYTES) {
     return text
   }
-  return sliceTrailingTextByUtf8Bytes(text, PR_CHECK_LOG_TAIL_BYTES)
-}
-
-function sliceTrailingTextByUtf8Bytes(text: string, byteLimit: number): string {
-  let byteLength = 0
-  const characters = Array.from(text)
-  for (let index = characters.length - 1; index >= 0; index -= 1) {
-    const characterByteLength = utf8ByteLength(characters[index] ?? '')
-    if (byteLength + characterByteLength > byteLimit) {
-      return characters.slice(index + 1).join('')
-    }
-    byteLength += characterByteLength
-  }
-  return text
+  return clampUtf8TextTail(text, PR_CHECK_LOG_TAIL_BYTES).text
 }
 
 function joinLogExcerptWithByteCap(prefixLines: string[], recentLines: string[]): string {
   const prefix = prefixLines.join('\n')
-  const prefixByteLength = utf8ByteLength(prefix)
+  const prefixByteLength = getUtf8ByteLength(prefix)
   if (prefixByteLength >= PR_CHECK_LOG_TAIL_BYTES) {
-    return sliceTrailingTextByUtf8Bytes(prefix, PR_CHECK_LOG_TAIL_BYTES)
+    return clampUtf8TextTail(prefix, PR_CHECK_LOG_TAIL_BYTES).text
   }
 
   const separator = prefix.length > 0 && recentLines.length > 0 ? '\n' : ''
-  const recentBudget = PR_CHECK_LOG_TAIL_BYTES - prefixByteLength - utf8ByteLength(separator)
-  const recentTail = sliceTrailingTextByUtf8Bytes(recentLines.join('\n'), recentBudget)
+  const recentBudget = PR_CHECK_LOG_TAIL_BYTES - prefixByteLength - getUtf8ByteLength(separator)
+  const recentTail = clampUtf8TextTail(recentLines.join('\n'), recentBudget).text
   return `${prefix}${separator}${recentTail}`
 }
 

--- a/src/shared/clipboard-text.ts
+++ b/src/shared/clipboard-text.ts
@@ -1,4 +1,9 @@
 import { yieldToEventLoop } from './event-loop-yield'
+import {
+  getUtf8ByteLengthForCodePoint,
+  measureUtf8ByteLength,
+  type Utf8ByteLengthMeasurement
+} from './utf8-byte-limits'
 
 export const CLIPBOARD_TEXT_READ_MAX_BYTES = 16 * 1024 * 1024
 export const CLIPBOARD_TEXT_WRITE_MAX_BYTES = 16 * 1024 * 1024
@@ -14,28 +19,13 @@ export type WriteClipboardTextOptions = {
   maxBytes?: number
 }
 
-export type ClipboardTextByteLengthMeasurement = {
-  byteLength: number
-  exceededLimit: boolean
-}
+export type ClipboardTextByteLengthMeasurement = Utf8ByteLengthMeasurement
 
 export function measureClipboardTextByteLength(
   text: string,
   options: { stopAfterBytes?: number } = {}
 ): ClipboardTextByteLengthMeasurement {
-  const stopAfterBytes = options.stopAfterBytes
-  let byteLength = 0
-  for (let index = 0; index < text.length; index += 1) {
-    const codePoint = text.codePointAt(index) ?? 0
-    byteLength += getUtf8ByteLengthForCodePoint(codePoint)
-    if (Number.isFinite(stopAfterBytes) && byteLength > (stopAfterBytes ?? 0)) {
-      return { byteLength, exceededLimit: true }
-    }
-    if (codePoint > 0xffff) {
-      index += 1
-    }
-  }
-  return { byteLength, exceededLimit: false }
+  return measureUtf8ByteLength(text, options)
 }
 
 export function getClipboardTextByteLength(text: string): number {
@@ -171,17 +161,4 @@ export function isClipboardTextTooLargeError(error: unknown): boolean {
 
 export function isClipboardTextWriteTooLargeError(error: unknown): boolean {
   return error instanceof Error && error.message.includes(CLIPBOARD_TEXT_WRITE_TOO_LARGE_ERROR)
-}
-
-function getUtf8ByteLengthForCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }

--- a/src/shared/terminal-input.ts
+++ b/src/shared/terminal-input.ts
@@ -3,6 +3,7 @@ import {
   isClipboardTextByteLengthOverLimitWithYield,
   measureClipboardTextByteLength
 } from './clipboard-text'
+import { getUtf8ChunkEndIndex } from './utf8-byte-limits'
 
 export const TERMINAL_INPUT_CHUNK_MAX_BYTES = 16 * 1024
 export const TERMINAL_INPUT_MAX_BYTES = 16 * 1024 * 1024
@@ -11,19 +12,6 @@ export const TERMINAL_INPUT_TOO_LARGE_ERROR =
 
 export function getTerminalInputByteLength(text: string): number {
   return measureClipboardTextByteLength(text).byteLength
-}
-
-function getUtf8ByteLengthForCodePoint(codePoint: number): number {
-  if (codePoint <= 0x7f) {
-    return 1
-  }
-  if (codePoint <= 0x7ff) {
-    return 2
-  }
-  if (codePoint <= 0xffff) {
-    return 3
-  }
-  return 4
 }
 
 export function assertTerminalInputWithinLimit(
@@ -87,23 +75,10 @@ export function* iterateTerminalInputChunks(
     return
   }
 
-  let currentStart = 0
-  let currentBytes = 0
-  let index = 0
-  while (index < text.length) {
-    const codePoint = text.codePointAt(index) ?? 0
-    const codeUnitLength = codePoint > 0xffff ? 2 : 1
-    const nextIndex = index + codeUnitLength
-    const characterBytes = getUtf8ByteLengthForCodePoint(codePoint)
-    if (currentBytes > 0 && currentBytes + characterBytes > normalizedMax) {
-      yield text.slice(currentStart, index)
-      currentStart = index
-      currentBytes = 0
-    }
-    currentBytes += characterBytes
-    index = nextIndex
-  }
-  if (currentStart < text.length) {
-    yield text.slice(currentStart)
+  let startIndex = 0
+  while (startIndex < text.length) {
+    const endIndex = getUtf8ChunkEndIndex(text, startIndex, normalizedMax)
+    yield text.slice(startIndex, endIndex)
+    startIndex = endIndex
   }
 }

--- a/src/shared/utf8-byte-limits.test.ts
+++ b/src/shared/utf8-byte-limits.test.ts
@@ -1,0 +1,59 @@
+import { describe, expect, it } from 'vitest'
+import { getUtf8ChunkEndIndex, isUtf8ByteLengthWithinLimit } from './utf8-byte-limits'
+
+describe('getUtf8ChunkEndIndex', () => {
+  it.each([
+    { name: 'ASCII', text: 'abcdef', maxBytes: 3, endIndex: 3 },
+    { name: 'multibyte characters', text: 'aé中z', maxBytes: 6, endIndex: 3 }
+  ])('respects the byte budget for $name', ({ text, maxBytes, endIndex }) => {
+    expect(getUtf8ChunkEndIndex(text, 0, maxBytes)).toBe(endIndex)
+  })
+
+  it('never splits valid surrogate pairs', () => {
+    expect(getUtf8ChunkEndIndex('a😀b', 0, 4)).toBe(1)
+    expect(getUtf8ChunkEndIndex('a😀b', 1, 4)).toBe(3)
+  })
+
+  it.each(['\ud800a', '\udc00a'])('counts a lone surrogate as three bytes', (text) => {
+    expect(getUtf8ChunkEndIndex(text, 0, 3)).toBe(1)
+  })
+
+  it('starts measuring at the requested offset', () => {
+    expect(getUtf8ChunkEndIndex('skipé中tail', 4, 5)).toBe(6)
+  })
+
+  it('returns the starting index when no text remains', () => {
+    expect(getUtf8ChunkEndIndex('', 0, 1)).toBe(0)
+    expect(getUtf8ChunkEndIndex('abc', 3, 1)).toBe(3)
+  })
+
+  it.each([0, -1])('consumes one code point when the %s-byte budget is exceeded', (maxBytes) => {
+    expect(getUtf8ChunkEndIndex('😀a', 0, maxBytes)).toBe(2)
+  })
+
+  it('preserves raw non-finite budget comparisons', () => {
+    expect(getUtf8ChunkEndIndex('abc', 0, Number.NaN)).toBe(3)
+    expect(getUtf8ChunkEndIndex('abc', 0, Number.POSITIVE_INFINITY)).toBe(3)
+    expect(getUtf8ChunkEndIndex('abc', 0, Number.NEGATIVE_INFINITY)).toBe(1)
+  })
+})
+
+describe('isUtf8ByteLengthWithinLimit', () => {
+  it.each([
+    { name: 'ASCII at a finite limit', text: 'abc', maxBytes: 3, expected: true },
+    { name: 'ASCII over a finite limit', text: 'abcd', maxBytes: 3, expected: false },
+    { name: 'multibyte text at its limit', text: 'é中', maxBytes: 5, expected: true },
+    { name: 'multibyte text over its limit', text: 'é中', maxBytes: 4, expected: false },
+    { name: 'empty text with a negative limit', text: '', maxBytes: -1, expected: true },
+    {
+      name: 'nonempty text with negative infinity',
+      text: 'a',
+      maxBytes: -Infinity,
+      expected: false
+    },
+    { name: 'text with a NaN limit', text: '😀', maxBytes: Number.NaN, expected: true },
+    { name: 'text with positive infinity', text: '😀', maxBytes: Infinity, expected: true }
+  ])('$name', ({ text, maxBytes, expected }) => {
+    expect(isUtf8ByteLengthWithinLimit(text, maxBytes)).toBe(expected)
+  })
+})

--- a/src/shared/utf8-byte-limits.ts
+++ b/src/shared/utf8-byte-limits.ts
@@ -31,6 +31,16 @@ export function getUtf8ByteLength(text: string): number {
   return measureUtf8ByteLength(text).byteLength
 }
 
+export function isUtf8ByteLengthWithinLimit(text: string, maxBytes: number): boolean {
+  if (text.length === 0) {
+    return true
+  }
+  if (text.length > maxBytes) {
+    return false
+  }
+  return !measureUtf8ByteLength(text, { stopAfterBytes: maxBytes }).exceededLimit
+}
+
 export function clampUtf8TextTail(text: string, maxBytes: number): Utf8TextTail {
   if (!text || maxBytes <= 0) {
     return { text: '', bytes: 0 }
@@ -68,6 +78,21 @@ export function clampUtf8TextPrefix(text: string, maxBytes: number): string {
     end += codePoint > 0xffff ? 2 : 1
   }
   return end === text.length ? text : text.slice(0, end)
+}
+
+export function getUtf8ChunkEndIndex(text: string, startIndex: number, maxBytes: number): number {
+  let bytes = 0
+  let endIndex = startIndex
+  while (endIndex < text.length) {
+    const codePoint = text.codePointAt(endIndex) ?? 0
+    const codePointBytes = getUtf8ByteLengthForCodePoint(codePoint)
+    if (bytes > 0 && bytes + codePointBytes > maxBytes) {
+      break
+    }
+    bytes += codePointBytes
+    endIndex += codePoint > 0xffff ? 2 : 1
+  }
+  return endIndex
 }
 
 export function getUtf8ByteLengthForCodePoint(codePoint: number): number {


### PR DESCRIPTION
## Summary

- Centralize UTF-8 code-point sizing, byte-limit checks, and chunk boundaries in the shared byte-limits module.
- Replace duplicate scanners across browser insertion, editor and dictation paste, terminal input, runtime search bounds, clipboard measurement, check-log tails, and PR-file cache accounting.
- Remove dead byte-count exports and 317 net lines while preserving existing behavior.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint not run; the staged-file lint hook and changed-code native, type-aware, and React Doctor gates passed with zero findings.
- [ ] `pnpm typecheck` — node and web typechecks passed; CLI typecheck was not run because CLI code is untouched.
- [ ] `pnpm test` — 24 focused suites / 255 tests passed; the full repository suite was not run.
- [ ] `pnpm build` — not run; no build configuration or dependency changes.
- [x] Added high-quality shared boundary tests plus direct PR-file astral and lone-surrogate byte-accounting coverage.

Additional verification:

- `pnpm exec oxfmt --check` passed for all 24 changed files.
- `git diff --check` passed.
- Randomized differential checks matched the replaced implementations across chunking, counters, tail slicing, finite and fractional limits, `NaN`, infinities, valid surrogate pairs, and lone surrogates.

## AI Review Report

Two independent read-only AI reviews reported no findings. They checked semantic equivalence, dead-export consumers, raw non-finite limit behavior, malformed UTF-16 handling, terminal sanitization and newline behavior, editor yields and target guards, API compatibility, allocation and early-exit performance, and caller-specific behavior. The review identified the remaining runtime search scans and missing PR-file caller coverage; this PR now centralizes those scans and adds the regression test.

Cross-platform review confirmed the changes are pure JavaScript string accounting and behave identically on macOS, Linux, and Windows. No shortcuts, labels, paths, shell behavior, native modules, or Electron platform branches are changed. SSH, remote, local, git-worktree, and folder-workspace behavior is unchanged because no filesystem or workspace assumptions are involved. No RPC parameters, stream opcodes, or published remote payloads change.

## Security Audit

No new input source, command execution, path handling, authentication, secrets, dependency, IPC, or network behavior is introduced. Existing text-size limits, early exits, terminal control-character sanitization, and caller admission checks remain intact. The consolidation reduces duplicate security-sensitive bounds logic; no follow-up is required.

## Notes

- The removed exports had no in-tree, barrel, or public-package consumers.
- GitHub and GitLab check-log behavior remains provider-neutral and unchanged.
- This PR is independent and does not depend on another open cleanup PR.