### PR TITLE
[Perf-SS] Keep relay writer drains linear under deep backlogs

### DIFF
--- a/src/relay/dispatcher-writer-admission.test.ts
+++ b/src/relay/dispatcher-writer-admission.test.ts
@@ -110,8 +110,8 @@ describe('DispatcherWriterAdmission', () => {
     const replacement = createEntry('liveness', 3)
 
     admitOrThrow(admission, first)
-    expect(shiftOrThrow(admission, 'liveness')).toBe(first)
     admitOrThrow(admission, queued)
+    expect(shiftOrThrow(admission, 'liveness')).toBe(first)
     expect(admission.admit(replacement, Number.MAX_SAFE_INTEGER)).toEqual({
       accepted: true,
       replaced: queued

--- a/src/relay/dispatcher-writer-admission.test.ts
+++ b/src/relay/dispatcher-writer-admission.test.ts
@@ -1,0 +1,203 @@
+import { describe, expect, it } from 'vitest'
+import {
+  DEFAULT_PRODUCER_QUEUE_MAX_BYTES,
+  DISPATCHER_CONTROL_QUEUE_MAX_FRAMES,
+  DispatcherWriterAdmission,
+  type DispatcherWriterEntry,
+  type DispatcherWriterLane
+} from './dispatcher-writer-admission'
+
+function createEntry(
+  lane: DispatcherWriterLane,
+  id: number,
+  estimatedBytes = 1
+): DispatcherWriterEntry {
+  return {
+    lane,
+    encode: () => Buffer.from(String(id)),
+    estimatedBytes,
+    onSettled: () => undefined,
+    settled: false
+  }
+}
+
+function admitOrThrow(admission: DispatcherWriterAdmission, entry: DispatcherWriterEntry): void {
+  const result = admission.admit(entry, Number.MAX_SAFE_INTEGER)
+  if (!result.accepted) {
+    throw new Error(`entry rejected from ${entry.lane}`)
+  }
+}
+
+function shiftOrThrow(
+  admission: DispatcherWriterAdmission,
+  lane: DispatcherWriterLane
+): DispatcherWriterEntry {
+  const entry = admission.shift(lane)
+  if (!entry) {
+    throw new Error(`missing queued entry from ${lane}`)
+  }
+  return entry
+}
+
+describe('DispatcherWriterAdmission', () => {
+  it('drains a release-scale lane in FIFO order across compactions', () => {
+    const entryCount = 30_000
+    const admission = new DispatcherWriterAdmission(DEFAULT_PRODUCER_QUEUE_MAX_BYTES)
+    const entries = Array.from({ length: entryCount }, (_, index) =>
+      createEntry('ordinary', index, 64)
+    )
+
+    for (const entry of entries) {
+      admitOrThrow(admission, entry)
+    }
+    expect(admission.queuedEntries).toBe(entryCount)
+    expect(admission.retainedProducerBytes).toBe(entryCount * 64)
+    expect(admission.peek('ordinary')).toBe(entries[0])
+
+    for (let index = 0; index < entries.length; index++) {
+      const shifted = shiftOrThrow(admission, 'ordinary')
+      if (shifted !== entries[index]) {
+        throw new Error(`FIFO mismatch at ${index}`)
+      }
+      admission.release(shifted)
+      if (index === 0 || index === Math.floor(entryCount / 2)) {
+        expect(admission.peek('ordinary')).toBe(entries[index + 1])
+      }
+    }
+
+    expect(admission.shift('ordinary')).toBeUndefined()
+    expect(admission.queuedEntries).toBe(0)
+    expect(admission.retainedProducerBytes).toBe(0)
+  })
+
+  it('keeps accounting retained until shifted entries are released', () => {
+    const producerAdmission = new DispatcherWriterAdmission(4)
+    const producerEntries = Array.from({ length: 4 }, (_, index) => createEntry('ordinary', index))
+    for (const entry of producerEntries) {
+      admitOrThrow(producerAdmission, entry)
+      expect(shiftOrThrow(producerAdmission, 'ordinary')).toBe(entry)
+    }
+    expect(producerAdmission.queuedEntries).toBe(0)
+    expect(producerAdmission.retainedProducerBytes).toBe(4)
+    expect(producerAdmission.canAdmitProducer(1, 1)).toBe(false)
+    producerAdmission.release(producerEntries[0])
+    expect(producerAdmission.canAdmitProducer(1, 1)).toBe(true)
+    for (const entry of producerEntries.slice(1)) {
+      producerAdmission.release(entry)
+    }
+
+    const controlAdmission = new DispatcherWriterAdmission(1)
+    const controlEntries = Array.from({ length: DISPATCHER_CONTROL_QUEUE_MAX_FRAMES }, (_, index) =>
+      createEntry('control', index)
+    )
+    for (const entry of controlEntries) {
+      admitOrThrow(controlAdmission, entry)
+      expect(shiftOrThrow(controlAdmission, 'control')).toBe(entry)
+    }
+    expect(controlAdmission.queuedEntries).toBe(0)
+    expect(controlAdmission.canAdmitControl(1)).toBe(false)
+    controlAdmission.release(controlEntries[0])
+    expect(controlAdmission.canAdmitControl(1)).toBe(true)
+    for (const entry of controlEntries.slice(1)) {
+      controlAdmission.release(entry)
+    }
+  })
+
+  it('replaces only the live liveness tail after a consumed prefix', () => {
+    const admission = new DispatcherWriterAdmission(1)
+    const first = createEntry('liveness', 1)
+    const queued = createEntry('liveness', 2)
+    const replacement = createEntry('liveness', 3)
+
+    admitOrThrow(admission, first)
+    expect(shiftOrThrow(admission, 'liveness')).toBe(first)
+    admitOrThrow(admission, queued)
+    expect(admission.admit(replacement, Number.MAX_SAFE_INTEGER)).toEqual({
+      accepted: true,
+      replaced: queued
+    })
+    expect(shiftOrThrow(admission, 'liveness')).toBe(replacement)
+    expect(admission.queuedEntries).toBe(0)
+    expect(admission.admit(createEntry('liveness', 4), Number.MAX_SAFE_INTEGER)).toEqual({
+      accepted: false
+    })
+
+    admission.release(first)
+    admission.release(replacement)
+    const afterRelease = createEntry('liveness', 5)
+    admitOrThrow(admission, afterRelease)
+    expect(shiftOrThrow(admission, 'liveness')).toBe(afterRelease)
+    admission.release(afterRelease)
+  })
+
+  it('takes only the live suffix after deep partial drains and refills', () => {
+    const admission = new DispatcherWriterAdmission(10_000)
+    const initial = Array.from({ length: 4_096 }, (_, index) => createEntry('ordinary', index))
+    for (const entry of initial) {
+      admitOrThrow(admission, entry)
+    }
+    for (let index = 0; index < 3_000; index++) {
+      const shifted = shiftOrThrow(admission, 'ordinary')
+      expect(shifted).toBe(initial[index])
+      admission.release(shifted)
+    }
+    const refill = Array.from({ length: 2_048 }, (_, index) =>
+      createEntry('ordinary', initial.length + index)
+    )
+    for (const entry of refill) {
+      admitOrThrow(admission, entry)
+    }
+
+    const expected = [...initial.slice(3_000), ...refill]
+    const queued = admission.takeQueued()
+    expect(queued).toEqual(expected)
+    expect(admission.queuedEntries).toBe(0)
+    expect(admission.retainedProducerBytes).toBe(expected.length)
+    for (const entry of queued) {
+      admission.release(entry)
+    }
+    expect(admission.retainedProducerBytes).toBe(0)
+  })
+
+  it('preserves close-time lane and per-lane FIFO order', () => {
+    const admission = new DispatcherWriterAdmission(1_024)
+    const fixedBulk = createEntry('fixed-bulk', 1)
+    const liveness = createEntry('liveness', 2)
+    const control = createEntry('control', 3)
+    const legacy = createEntry('legacy-response', 4)
+    const interactive = createEntry('interactive', 5)
+    const ordinaryOne = createEntry('ordinary', 6)
+    const ordinaryTwo = createEntry('ordinary', 7)
+    const bulk = createEntry('bulk', 8)
+    for (const entry of [
+      fixedBulk,
+      liveness,
+      control,
+      legacy,
+      interactive,
+      ordinaryOne,
+      ordinaryTwo,
+      bulk
+    ]) {
+      admitOrThrow(admission, entry)
+    }
+
+    const queued = admission.takeQueued()
+    expect(queued).toEqual([
+      liveness,
+      control,
+      legacy,
+      interactive,
+      ordinaryOne,
+      ordinaryTwo,
+      fixedBulk,
+      bulk
+    ])
+    for (const entry of queued) {
+      admission.release(entry)
+    }
+    expect(admission.queuedEntries).toBe(0)
+    expect(admission.retainedProducerBytes).toBe(0)
+    expect(admission.canAdmitControl(1)).toBe(true)
+  })
+})

--- a/src/relay/dispatcher-writer-admission.ts
+++ b/src/relay/dispatcher-writer-admission.ts
@@ -50,15 +50,84 @@ export function relayWriterControlReserve(highWaterMark: number): number {
   return Math.min(64 * 1024, Math.max(1024, Math.floor(highWaterMark / 4)))
 }
 
+const LANE_QUEUE_COMPACTION_HEAD_THRESHOLD = 64
+
+class DispatcherWriterLaneQueue {
+  private entries: (DispatcherWriterEntry | undefined)[] = []
+  private head = 0
+
+  get length(): number {
+    return this.entries.length - this.head
+  }
+
+  push(entry: DispatcherWriterEntry): void {
+    this.entries.push(entry)
+  }
+
+  peek(): DispatcherWriterEntry | undefined {
+    return this.entries[this.head]
+  }
+
+  shift(): DispatcherWriterEntry | undefined {
+    const entry = this.entries[this.head]
+    if (!entry) {
+      return undefined
+    }
+    this.entries[this.head] = undefined
+    this.head++
+    this.compact()
+    return entry
+  }
+
+  pop(): DispatcherWriterEntry | undefined {
+    if (this.length === 0) {
+      return undefined
+    }
+    const entry = this.entries.pop()
+    if (this.entries.length === this.head) {
+      this.reset()
+    }
+    return entry
+  }
+
+  takeAll(): DispatcherWriterEntry[] {
+    const queued: DispatcherWriterEntry[] = []
+    for (let index = this.head; index < this.entries.length; index++) {
+      const entry = this.entries[index]
+      if (entry) {
+        queued.push(entry)
+      }
+    }
+    this.reset()
+    return queued
+  }
+
+  private compact(): void {
+    if (this.head === this.entries.length) {
+      this.reset()
+      return
+    }
+    if (this.head >= LANE_QUEUE_COMPACTION_HEAD_THRESHOLD && this.head * 2 >= this.entries.length) {
+      this.entries = this.entries.slice(this.head)
+      this.head = 0
+    }
+  }
+
+  private reset(): void {
+    this.entries.length = 0
+    this.head = 0
+  }
+}
+
 export class DispatcherWriterAdmission {
-  private readonly queues: Record<DispatcherWriterLane, DispatcherWriterEntry[]> = {
-    liveness: [],
-    control: [],
-    'legacy-response': [],
-    interactive: [],
-    ordinary: [],
-    'fixed-bulk': [],
-    bulk: []
+  private readonly queues: Record<DispatcherWriterLane, DispatcherWriterLaneQueue> = {
+    liveness: new DispatcherWriterLaneQueue(),
+    control: new DispatcherWriterLaneQueue(),
+    'legacy-response': new DispatcherWriterLaneQueue(),
+    interactive: new DispatcherWriterLaneQueue(),
+    ordinary: new DispatcherWriterLaneQueue(),
+    'fixed-bulk': new DispatcherWriterLaneQueue(),
+    bulk: new DispatcherWriterLaneQueue()
   }
   private controlBytes = 0
   private controlFrames = 0
@@ -115,7 +184,7 @@ export class DispatcherWriterAdmission {
   }
 
   peek(lane: DispatcherWriterLane): DispatcherWriterEntry | undefined {
-    return this.queues[lane][0]
+    return this.queues[lane].peek()
   }
 
   shift(lane: DispatcherWriterLane): DispatcherWriterEntry | undefined {
@@ -123,7 +192,7 @@ export class DispatcherWriterAdmission {
   }
 
   takeQueued(): DispatcherWriterEntry[] {
-    return Object.values(this.queues).flatMap((queue) => queue.splice(0))
+    return Object.values(this.queues).flatMap((queue) => queue.takeAll())
   }
 
   release(entry: DispatcherWriterEntry): void {


### PR DESCRIPTION
## Summary

ELI5: a relay writer keeps separate checkout lines for different kinds of outgoing frames. Removing the first frame used to make JavaScript slide every remaining frame forward. Under a deep backlog that repeated copying grew quadratically and crossed a sharp V8 performance cliff. Each lane now keeps a logical front cursor, clears consumed references immediately, and occasionally compacts in one amortized pass.

This keeps relay writer drains approximately linear under release-scale backlogs while preserving the same admission limits, lane priority, FIFO/wire order, liveness coalescing, accounting, settlement, and close behavior.

## Queue visualization

```mermaid
flowchart LR
  subgraph Before["Before — repeated Array.shift()"]
    B0["[A, B, C, …]"] -->|"dequeue A"| B1["copy B…N one slot left"]
    B1 -->|"repeat for N frames"| B2["Θ(N²) total drain work"]
  end

  subgraph After["After — cursor-backed lane queue"]
    A0["[A, B, C, …], head = 0"] -->|"dequeue A"| A1["[∅, B, C, …], head = 1"]
    A1 --> A2{"head ≥ 64 and dead prefix ≥ 50%?"}
    A2 -->|No| A3["continue with O(1) dequeue"]
    A2 -->|Yes| A4["copy live suffix once; reset head"]
    A3 --> A5["Θ(N) total drain work"]
    A4 --> A5
  end
```

The compaction copy is charged to at least as many preceding dequeues: at compaction, consumed `H ≥ live L`. The backing array therefore stays below `2 × live entries + 63`, while each consumed reference is cleared immediately.

## Performance proof

The benchmark imports the actual `DispatcherWriterAdmission`. It fills the queue and forces GC outside the timed region, runs 8 warmup rounds, then takes 11 interleaved before/after samples while timing only repeated `shift("ordinary")` calls. Values below are medians from the same host and workload; lower is better.

| Runtime / backlog | Before | After | Improvement |
| --- | ---: | ---: | ---: |
| Node 18, production-shaped 2 MiB cap: 16,384 × 128-byte frames | 10.922792 ms | 0.049208 ms | 221.97× / 99.55% lower |
| Node 18, 20,000 frames | 18.675167 ms | 0.049167 ms | 379.83× |
| Node 18, 40,000 frames | 95.413250 ms | 0.113500 ms | 840.65× |
| Node 18, 60,000 frames | 222.860833 ms | 0.167125 ms | 1,333.50× |
| Node 24, 20,000 frames | 18.641000 ms | 0.066625 ms | 279.79× |
| Node 24, 40,000 frames | 95.273000 ms | 0.141708 ms | 672.32× |
| Node 24, 60,000 frames | 223.065000 ms | 0.216250 ms | 1,031.51× |

The before-change implementation jumps from 1.458 ms at 15,044 entries to 9.349 ms at 15,045. The cursor-backed queue removes that cliff on both Node 18 and Node 24, and after-change drain time scales approximately linearly through 60,000 entries.

An independent Node 24 reproduction also observed the 15,045-entry cliff and linear post-change scaling. At depth 1, the new representation added about 5 ns per queue operation; that cost is dominated by frame encoding and socket writes, while depths of 8 and above were faster.

## No-regression proof

- FIFO and wire order: release-scale tests drain 30,000 entries across multiple compactions and compare every entry by identity. Close-time tests verify both lane order and within-lane order.
- Admission accounting: tests prove shifted entries remain charged until `release`, for both producer bytes and control-frame limits.
- Liveness: tests cover replacing the queued tail after a physically consumed prefix and rejecting a third outstanding frame when two are already in flight/admitted.
- Cleanup and memory: each shifted slot is cleared immediately; empty queues reset; compaction requires at least 64 consumed slots and a half-consumed backing array. Deep partial drain/refill plus `takeQueued()` verifies that only the live suffix is returned.
- Behavioral equivalence: independent model reviews passed 2,000,000 and 4,000,000 randomized admit/peek/shift/take/release operations against the previous array behavior.
- Scheduling and lifecycle: the lane scheduler, writer pump, saturation, release, reconnect, and settlement code are untouched. The full relay suite passes.
- Remote compatibility: this is host-local storage only. It changes no opcode, capability, payload, frame content, sequence assignment, drop policy, or ordering, so mixed client/host versions remain compatible.
- Platform/remoting parity: the implementation is platform-neutral TypeScript and the relay build passes for Linux, macOS, and Windows on x64/arm64 plus the WSL hook. Local, SSH, folder-workspace, and relay routing are unchanged.

## Reliability readiness

- **Invariant:** `terminal-performance.output-backpressure-budget` — each lane remains FIFO, lane priority and wire order are unchanged, admitted entries stay charged until settlement, liveness stays bounded to two outstanding frames, and close settles every queued/in-flight entry once.
- **Failure source:** repeated `Array.shift()` copies made a deep relay backlog quadratic and crossed a sharp V8 cliff at 15,045 entries, delaying remote output drains.
- **Oracle:** identity-based 30,000-entry FIFO drain, consumed-prefix liveness replacement, retained-byte/control-frame accounting, deep partial drain/refill, close-time lane order, randomized old/new model parity, and the measured drain benchmark.
- **Gate:** existing `terminal-performance.output-backpressure-budget` reliability gate, with the focused admission test as its representation-level oracle. The full relay suite and required CI run it on every PR.
- **Performance budget:** no polling, timers, retries, subprocesses, wake loops, or network calls were added. Total drain work changes from Θ(N²) to amortized Θ(N), consumed references clear immediately, and backing storage remains bounded relative to the live suffix.
- **Diagnostics:** the deterministic tests report the first FIFO identity mismatch and exact accounting mismatch; existing relay close/error diagnostics are unchanged because no runtime failure path was added.
- **Residual gap:** no deployed half-open TCP or real Windows/Linux network-drop run was repeated for this representation-only change. Connection, generation, reconnect, and transport code is unchanged; deterministic writer/relay gates cover the affected semantics.

| Provider / platform | Readiness result |
| --- | --- |
| SSH / remote relay | Covered: internal queue representation only, including disconnect-close cleanup |
| Mobile / relay | Mobile-facing internals touched; wire/content remains compatible with old iOS/Android clients |
| macOS / Linux / Windows hosted relay | Covered by platform-neutral TypeScript plus all packaged relay builds |
| WSL hook relay | Unaffected; the hook does not import this dispatcher |
| Local / daemon PTY | Unaffected |
| Folder workspaces / Git providers | Unaffected |

## Screenshots

No visual product change.

## Testing

- [x] Targeted native and type-aware oxlint passed with zero findings
- [x] `pnpm typecheck:node`
- [x] Full relay suite: 109/109 files, 1,278/1,278 tests
- [x] `pnpm build:relay` for Linux, macOS, and Windows on x64/arm64 plus the WSL hook
- [x] Added or updated high-quality tests that would catch regressions

Additional gates:

- Focused admission/writer tests: 19/19 passed after the review fix.
- `pnpm check:max-lines-ratchet`, formatting, and `git diff --check` passed.
- Two independent randomized equivalence reviews passed.

## AI Review Report

Four adversarial review tracks traced queue operations through admission, lane scheduling, writer saturation, liveness bypass/replacement, close, in-flight release, reconnect, and idle notification. They explicitly checked all seven readiness areas: SSH/network failure, crash/cast/retry/unbounded growth, security/supply chain, performance/resources, functional correctness, backward compatibility/data loss, and cross-platform/remoting.

The first pass found one P2 test-quality gap: the liveness test reset an empty backing array before replacement, so it did not actually exercise replacement after a consumed cursor. Commit `2d78cd7` reorders the setup to create `[undefined, queued]` with `head = 1` before replacement. Independent second-pass review and focused tests are clean. No P0, P1, or P2 issue remains.

## Security Audit

The change adds no dependency, install hook, network sink, command execution, path handling, auth flow, secret, IPC/RPC field, parser, deserialization, or user-controlled allocation limit. Review found no malware, obfuscation, exfiltration, shell/eval, supply-chain, signing, or updater surface. Existing bounded admission limits remain authoritative, consumed object references are released earlier, and no follow-up is required.

## Notes

- Mobile-facing relay internals are touched; there is no mobile RPC, E2EE, framing, payload, version, pairing, or persisted-contract change.
- No persistence, migration, UI, telemetry, or Git-provider surface is touched.
- X: @nwparker_
