### PR TITLE
fix(quick-open): compact Cmd+P file rows

### DIFF
--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -119,6 +119,7 @@ export default function QuickOpen(): React.JSX.Element | null {
         placeholder={translate('auto.components.QuickOpen.1cb6ef47b7', 'Go to file...')}
         value={query}
         onValueChange={setQuery}
+        className="!h-9 !py-2"
       />
       <CommandList className="p-2">
         {loading ? (

--- a/src/renderer/src/components/QuickOpen.tsx
+++ b/src/renderer/src/components/QuickOpen.tsx
@@ -155,13 +155,14 @@ export default function QuickOpen(): React.JSX.Element | null {
                 key={item.path}
                 value={item.path}
                 onSelect={() => handleSelect(item.path)}
-                className="min-w-0 p-0"
+                // Why: CommandDialog's descendant rule otherwise adds 24px of vertical padding.
+                className="min-w-0 !p-0"
               >
                 {/* Why: the trigger is this inner element, not the CommandItem.
                     cmdk sets its own onPointerMove after spreading props, which
                     drops the one Radix needs to open the tooltip. */}
                 <FilePathCursorTooltip path={item.path}>
-                  <div className="flex w-full min-w-0 items-center gap-2 px-3 py-1.5">
+                  <div className="flex w-full min-w-0 items-center gap-2 px-3 py-1">
                     <FileIcon className="size-3.5 shrink-0 text-muted-foreground" />
                     {/* shrink-0 + max-w-full: the directory gives up all of its
                         width before the filename loses a character. */}

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -25,6 +25,9 @@ test('cmd+p quick open prioritizes the filename and reveals the full path on hov
   })
   const dialog = orcaPage.getByRole('dialog', { name: 'Go to file' })
   await expect(dialog).toBeVisible()
+  const inputBox = await dialog.locator('[data-cmdk-input-wrapper]').boundingBox()
+  expect(inputBox).not.toBeNull()
+  expect(inputBox!.height).toBeLessThanOrEqual(45)
   const input = dialog.locator('input[placeholder="Go to file..."]')
   await input.fill('QuickOpenTarget')
 

--- a/tests/e2e/quick-open-file-paths.spec.ts
+++ b/tests/e2e/quick-open-file-paths.spec.ts
@@ -31,6 +31,9 @@ test('cmd+p quick open prioritizes the filename and reveals the full path on hov
   const row = dialog.getByRole('option').filter({ hasText: 'QuickOpenTarget.tsx' }).first()
   await expect(row).toBeVisible()
   await expect(row).toContainText('packages/orca/src/renderer/src/components/navigation/')
+  const rowBox = await row.boundingBox()
+  expect(rowBox).not.toBeNull()
+  expect(rowBox!.height).toBeLessThanOrEqual(29)
   const rowText = await row.textContent()
   expect(rowText?.indexOf('QuickOpenTarget.tsx')).toBeLessThan(
     rowText?.indexOf('packages/orca/src/renderer/src/components/navigation/') ?? -1


### PR DESCRIPTION
## Summary

- Cut Cmd+P Quick Open file rows from about 56px to 28px by removing inherited dialog padding and tightening the row padding.
- Reduce the search-input wrapper from about 56px to 45px while preserving its icon and text spacing.
- Add real-Electron height assertions so both compact dimensions do not regress.

## Screenshots

### Overall density

| Before — 55.6px rows | After — 27.9px rows and 44.9px input |
| --- | --- |
| ![Before: tall Cmd+P file rows](https://github.com/user-attachments/assets/f5ecabcf-bf70-4df7-b52d-80de28dde3ff) | ![After: compact Cmd+P file rows and search input](https://github.com/user-attachments/assets/7451059f-9a56-4189-b61f-a53d72024897) |

### Search input follow-up

| Before — 55.8px input | After — 44.9px input |
| --- | --- |
| ![Before: tall Cmd+P search input](https://github.com/user-attachments/assets/f5dc2768-9adc-4c71-a5d4-71298508c4b6) | ![After: compact Cmd+P search input](https://github.com/user-attachments/assets/7451059f-9a56-4189-b61f-a53d72024897) |

## Testing

- [ ] `pnpm lint` — targeted `oxlint` passed for both changed files
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused real-Electron E2E passed
- [ ] `pnpm build` — `electron-vite build --mode e2e` passed
- [x] Added or updated high-quality tests that would catch regressions

Focused test: `SKIP_BUILD=1 pnpm run test:e2e tests/e2e/quick-open-file-paths.spec.ts`

## AI Review Report

Reviewed the input and item padding cascade, command-item selection behavior, tooltip trigger structure, and the Cmd+P keyboard flow. The dialog's higher-specificity descendant sizing was the source of the oversized controls; both overrides are scoped to Quick Open, leaving other command surfaces unchanged. Verified that the change only affects layout and introduces no macOS, Linux, Windows, SSH, folder-workspace, path, shell, or Electron platform behavior differences.

## Security Audit

UI-only class changes and a DOM measurement assertion. No input handling, command execution, path handling, authentication, secrets, dependencies, IPC, or remote-wire behavior changed.

## Notes

Heights were measured in the real Electron app with ten representative results. All ten fit in the after-state without scrolling.
