### PR TITLE
fix(orchestration): refuse unknown bare terminal send targets

### DIFF
--- a/src/main/runtime/rpc/errors.ts
+++ b/src/main/runtime/rpc/errors.ts
@@ -69,6 +69,7 @@ const STRUCTURED_RUNTIME_PASSTHROUGH_CODES: ReadonlySet<string> = new Set([
   'task_not_found',
   'task_not_startable',
   'dispatch_not_found',
+  'terminal_not_found',
   'dispatch_run_mismatch',
   'dispatch_inactive',
   'worker_identity_changed',

--- a/src/main/runtime/rpc/methods/orchestration.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration.test.ts
@@ -375,6 +375,34 @@ describe('orchestration RPC methods', () => {
       ).rejects.toMatchObject({ code: 'invalid_argument' })
     })
 
+    it('rejects unknown bare terminal handles instead of storing unread mail', async () => {
+      setup()
+      await expect(
+        call('orchestration.send', {
+          from: 'term_coord',
+          to: 'term_00000000-0000-0000-0000-000000000000',
+          subject: 'gone'
+        })
+      ).rejects.toMatchObject({ code: 'terminal_not_found' })
+      expect(db.getUnreadMessages('term_00000000-0000-0000-0000-000000000000')).toHaveLength(0)
+    })
+
+    it('still delivers bare-handle mail to an active Dispatch assignee without a pane key', async () => {
+      setup()
+      const task = db.createTask({ spec: 'in-flight work' })
+      db.createDispatchContext(task.id, 'term_worker')
+      vi.spyOn(runtime, 'deliverPendingMessagesForHandle').mockImplementation(() => {})
+
+      const result = (await call('orchestration.send', {
+        from: 'term_coord',
+        to: 'term_worker',
+        subject: 'how is it going?',
+        type: 'status'
+      })) as { message: { to_handle: string } }
+
+      expect(result.message.to_handle).toBe('term_worker')
+    })
+
     it('stores the runtime-observed sender pane key on the message row', async () => {
       setup()
       vi.spyOn(runtime, 'getTerminalPaneKey').mockReturnValue('tab_runtime:leaf_runtime')

--- a/src/main/runtime/rpc/methods/orchestration.ts
+++ b/src/main/runtime/rpc/methods/orchestration.ts
@@ -511,6 +511,21 @@ export const ORCHESTRATION_METHODS: RpcMethod[] = [
         )
       }
 
+      // Why: bare terminal handles used to accept unknown UUIDs with ok:true and
+      // store mail nobody can read; refuse like run:/dispatch: (#13363).
+      if (
+        !isGroupAddress(to) &&
+        !to.startsWith('run:') &&
+        !to.startsWith('dispatch:') &&
+        !to.startsWith('task:')
+      ) {
+        const livePaneKey = runtime.getTerminalPaneKey(to)
+        const activeAssignee = db.getActiveDispatchForTerminal(to)
+        if (!livePaneKey && !activeAssignee) {
+          throw new OrchestrationError('terminal_not_found', `Terminal ${to} was not found.`)
+        }
+      }
+
       if (!isGroupAddress(to)) {
         const federatedDispatchId = routing.dispatchId
         const federatedTarget =


### PR DESCRIPTION
## Summary
- `orchestration send --to` already refuses unknown `run:` / `dispatch:` addresses but accepted bare terminal handles that do not exist, returning `ok: true` and storing unreachable mail (#13363).
- Refuse those handles with `terminal_not_found` when there is no live pane key **and** no active Dispatch assignee (so in-flight workers without a momentarily resolvable pane still receive status mail).
- Cover the dead-handle and active-assignee paths in unit tests.

## Test plan
- [x] `vitest run src/main/runtime/rpc/methods/orchestration.test.ts -t orchestration.send` (39 passed)
- [ ] Manual: `orca orchestration send --to term_00000000-0000-0000-0000-000000000000 --subject x --body y --json` → `terminal_not_found`

Fixes #13363