### PR TITLE
fix(terminal): avoid garbled TUI frame after app restart

### DIFF
--- a/config/reliability-gates.jsonc
+++ b/config/reliability-gates.jsonc
@@ -3477,7 +3477,7 @@
       "providers": ["local", "daemon", "ssh", "remote-runtime"],
       "coveredPlatforms": ["macos"],
       "coveredProviders": [],
-      "coverageNotes": "Local macOS evidence on main@1282f5c2d, including #7192's runtime-mirror geometry authority slice. Deterministic provider-contract coverage now includes settled window-wake reassertion and SSH relay applied-size readback. Live shell-visible SSH/remote geometry and Windows ConPTY readback remain non-blocking gaps.",
+      "coverageNotes": "Local macOS evidence on main@1282f5c2d, including #7192's runtime-mirror geometry authority slice. Deterministic provider-contract coverage includes settled window-wake reassertion and SSH relay applied-size readback. A live daemon-backed restart test now covers a wide alternate-screen capture reattaching to a narrow pane. Live shell-visible SSH/remote geometry and Windows ConPTY readback remain non-blocking gaps.",
       "motivatingLinks": [
         "https://github.com/stablyai/orca/pull/6644",
         "https://github.com/stablyai/orca/pull/6649",
@@ -3488,9 +3488,10 @@
         "https://github.com/stablyai/orca/pull/7192"
       ],
       "invariant": "A visible desktop-owned terminal cannot trust 0x0, stale requested size, or renderer-only size; xterm, fit/proposed size, applied PTY size, shell-visible size, and the runtime mirror's parse dimensions must converge or enter explicit degraded state, and mirror resize reflow must stay ordered with queued output writes.",
-      "oracle": "The current executable slice uses deterministic frame schedulers and fake providers to force 0x0 first fit, delayed layout settle, dropped resize/readback drift, hidden-to-visible activation, and window wake. It asserts the renderer forwards a usable size, pty:getSize reports applied rather than merely requested size where available, visibility resume reasserts real drift without hot listSessions, one settled wake produces one geometry-only readback, and SSH relay readback is authoritative with bounded fallback. Shell-visible stty/echo-wrap convergence remains a live-gate follow-up.",
+      "oracle": "The provider-contract slice forces 0x0 first fit, delayed layout settle, dropped resize/readback drift, hidden-to-visible activation, and window wake. The Electron slice restarts Orca around a live daemon-backed alternate-screen fixture, proves daemon and PTY identity survive, narrows the pane, observes the live resize repaint, and rejects any retained wide-frame rows. Shell-visible SSH/remote convergence remains a live-gate follow-up.",
       "commands": [
-        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts src/renderer/src/components/terminal-pane/pty-size-reassertion.test.ts src/renderer/src/components/terminal-pane/split-right-white-screen.test.ts src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.test.ts src/main/ipc/pty.test.ts src/main/providers/ssh-pty-provider.test.ts src/main/runtime/orca-runtime.test.ts src/relay/pty-handler.test.ts"
+        "pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts src/renderer/src/components/terminal-pane/pty-size-reassertion.test.ts src/renderer/src/components/terminal-pane/split-right-white-screen.test.ts src/renderer/src/components/terminal-pane/use-terminal-window-wake-recovery.test.ts src/main/ipc/pty.test.ts src/main/providers/ssh-pty-provider.test.ts src/main/runtime/orca-runtime.test.ts src/relay/pty-handler.test.ts",
+        "pnpm exec playwright test tests/e2e/terminal-active-restart-alt-frame-width.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1"
       ],
       "testFiles": [
         "src/renderer/src/components/terminal-pane/pty-size-reconcile.test.ts",
@@ -3500,7 +3501,8 @@
         "src/main/ipc/pty.test.ts",
         "src/main/providers/ssh-pty-provider.test.ts",
         "src/main/runtime/orca-runtime.test.ts",
-        "src/relay/pty-handler.test.ts"
+        "src/relay/pty-handler.test.ts",
+        "tests/e2e/terminal-active-restart-alt-frame-width.spec.ts"
       ],
       "assertionRefs": [
         {
@@ -3561,6 +3563,14 @@
             "relay readback reports the grid actually applied by node-pty",
             "missing relay PTYs return an unverified null size"
           ]
+        },
+        {
+          "file": "tests/e2e/terminal-active-restart-alt-frame-width.spec.ts",
+          "assertions": [
+            "the daemon and exact PTY survive restart while the pane narrows",
+            "the live fixture receives the new grid and visibly repaints",
+            "no row from the wider captured alternate frame remains"
+          ]
         }
       ],
       "evidenceRuns": [
@@ -3572,6 +3582,15 @@
           "result": "passed",
           "durationSeconds": 18.54,
           "summary": "8 test files passed, 1,272 tests passed on the PR branch."
+        },
+        {
+          "date": "2026-08-10",
+          "runner": "local",
+          "platform": "macos",
+          "command": "pnpm exec playwright test tests/e2e/terminal-active-restart-alt-frame-width.spec.ts --config tests/playwright.config.ts --project electron-headless --workers=1",
+          "result": "passed",
+          "durationSeconds": 16.0,
+          "summary": "5 live daemon restart repetitions passed; three forced-headful repetitions also passed."
         }
       ],
       "runtimeBudget": {
@@ -3584,7 +3603,7 @@
       },
       "redGreenEvidence": {
         "status": "partial",
-        "evidence": "#7192 proved the mirror slice red before its fix (snapshot stayed 80x24, queued write parsed at the wrong width). The renderer 0x0/settle slices do not have recorded red runs."
+        "evidence": "#7192 proved the mirror slice red before its fix. The restart slice retained 16 stale frame rows on current main and under an intentional bypass, then passed after restoring the frame-boundary selection. The renderer 0x0/settle slices do not have recorded red runs."
       },
       "performanceBudget": {
         "required": true,

--- a/src/main/daemon/daemon-pty-adapter.test.ts
+++ b/src/main/daemon/daemon-pty-adapter.test.ts
@@ -1485,6 +1485,7 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(second.launchAgent).toBe('droid')
       expect(second.snapshot).toBeDefined()
       expect(second.snapshot).toContain('hello from shell')
+      expect(second.snapshotFrameStart).toBeUndefined()
       expect(second.providerSequence).toEqual({
         value: 'hello from shell\r\n'.length,
         generation: 'continued'
@@ -1504,6 +1505,21 @@ describe('DaemonPtyAdapter (IPtyProvider)', () => {
       expect(result.isReattach).toBe(true)
       expect(result.snapshot).toContain('\x1b[?2004h')
       expect(result.snapshot).toContain('prompt$')
+    })
+
+    it('marks the alternate-screen frame boundary in the merged snapshot', async () => {
+      const sessionId = 'alt-frame-boundary-test'
+      await adapter.spawn({ cols: 100, rows: 30, sessionId })
+      lastSubprocess._simulateData('\x1b[?1049h\x1b[2J\x1b[HALT-FRAME-BODY')
+      await new Promise((resolve) => setTimeout(resolve, 50))
+
+      const result = await adapter.spawn({ cols: 100, rows: 30, sessionId })
+      const boundary = result.snapshotFrameStart
+
+      expect(result.isAlternateScreen).toBe(true)
+      expect(boundary).toEqual(expect.any(Number))
+      expect(result.snapshot?.slice(0, boundary)).toContain('\x1b[?1049h')
+      expect(result.snapshot?.slice(boundary)).toContain('ALT-FRAME-BODY')
     })
 
     it('returns the preserved sequence from attach-only adoption', async () => {

--- a/src/main/daemon/daemon-pty-adapter.ts
+++ b/src/main/daemon/daemon-pty-adapter.ts
@@ -831,10 +831,8 @@ export class DaemonPtyAdapter implements IPtyProvider {
     }
 
     const isAltScreen = result.snapshot.modes.alternateScreen
-    const snapshotPayload =
-      result.snapshot.scrollbackAnsi +
-      result.snapshot.rehydrateSequences +
-      result.snapshot.snapshotAnsi
+    const snapshotPrefix = result.snapshot.scrollbackAnsi + result.snapshot.rehydrateSequences
+    const snapshotPayload = snapshotPrefix + result.snapshot.snapshotAnsi
     // Why kitty flags ride beside the payload, not inside it: the snapshot reaches renderer xterms where POST_REPLAY_REATTACH_RESET's kitty reset must win (terminal-query-authority.md §kitty).
     const kittyKeyboardFlags = result.snapshot.modes.kittyKeyboardFlags
     return {
@@ -847,6 +845,9 @@ export class DaemonPtyAdapter implements IPtyProvider {
       snapshot: snapshotPayload,
       snapshotCols: result.snapshot.cols,
       snapshotRows: result.snapshot.rows,
+      ...(isAltScreen && result.snapshot.snapshotAnsi
+        ? { snapshotFrameStart: snapshotPrefix.length }
+        : {}),
       ...(providerSequence ? { providerSequence } : {}),
       ...(typeof kittyKeyboardFlags === 'number' && kittyKeyboardFlags > 0
         ? { snapshotKittyKeyboardFlags: kittyKeyboardFlags }

--- a/src/main/providers/pty-spawn-result.ts
+++ b/src/main/providers/pty-spawn-result.ts
@@ -32,6 +32,9 @@ export type PtySpawnResult = {
    *  writing the snapshot so ANSI cursor positions land correctly. */
   snapshotCols?: number
   snapshotRows?: number
+  /** Start of the alternate-screen frame within `snapshot`. Optional so older
+   *  clients keep consuming the merged snapshot unchanged. */
+  snapshotFrameStart?: number
   /** Provider sequence at the attach boundary. `reset` starts a new provider
    *  generation; `continued` resumes the existing absolute domain. */
   providerSequence?: {

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -1564,6 +1564,7 @@ export type PreloadApi = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
+      snapshotFrameStart?: number
       isReattach?: boolean
       isAlternateScreen?: boolean
       replay?: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -961,6 +961,7 @@ const api = {
       snapshot?: string
       snapshotCols?: number
       snapshotRows?: number
+      snapshotFrameStart?: number
       isReattach?: boolean
       isAlternateScreen?: boolean
       replay?: string

--- a/src/renderer/src/components/terminal-pane/pty-connection.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.test.ts
@@ -8677,6 +8677,44 @@ describe('connectPanePty', () => {
     )
   })
 
+  it('drops a wider live daemon alt frame while preserving its replay prefix', async () => {
+    const { connectPanePty } = await import('./pty-connection')
+    const transport = createMockTransport('tab-pty')
+    const prefix = '\x1b[?1049hPREFIX-SCROLLBACK'
+    const frame = 'STALE-ALT-FRAME'
+    transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) =>
+      sessionId
+        ? {
+            id: sessionId,
+            snapshot: prefix + frame,
+            snapshotFrameStart: prefix.length,
+            snapshotCols: 200,
+            snapshotRows: 50,
+            isAlternateScreen: true
+          }
+        : null
+    )
+    transportFactoryQueue.push(transport)
+    mockStoreState = {
+      ...mockStoreState,
+      tabsByWorktree: { 'wt-1': [{ id: 'tab-1', ptyId: 'tab-pty' }] }
+    } as StoreState
+    const pane = createPane(1)
+    pane.fitAddon.proposeDimensions = vi.fn(() => ({ cols: 120, rows: 40 })) as never
+    const deps = createDeps({
+      restoredLeafId: LEAF_1,
+      restoredPtyIdByLeafId: { [LEAF_1]: 'tab-pty' }
+    })
+
+    connectPanePty(pane as never, createManager(1) as never, deps as never)
+    await flushAsyncTicks(20)
+
+    const writes = pane.terminal.write.mock.calls.map(([data]) => data).join('')
+    expect(writes).toContain(prefix)
+    expect(writes).not.toContain(frame)
+    expect(pane.terminal.resize).toHaveBeenCalledWith(200, 50)
+  })
+
   it('resizes the pane to the snapshot grid before replaying daemon snapshot bytes (bug #7279)', async () => {
     // Why: the daemon serializes soft-wrapped lines flat, so reattach must resize xterm to the snapshot grid before writing, or rows rewrap wrong.
     const { connectPanePty } = await import('./pty-connection')

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -260,7 +260,9 @@ import { resolveHiddenRestoreScrollbackRows } from './terminal-hidden-restore-sc
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
-  resolvePositiveTerminalDimensions
+  readProposedTerminalCols,
+  resolvePositiveTerminalDimensions,
+  selectDaemonSnapshotReplayData
 } from './terminal-snapshot-replay-paint'
 import {
   decideSshReattachPaintSource,
@@ -8322,6 +8324,14 @@ export function connectPanePty(
         }
         if (connectResult?.snapshot) {
           rememberReattachPayloadAgentSignal(connectResult.snapshot, { fullScreenReplay: true })
+          const snapshotReplayData = selectDaemonSnapshotReplayData({
+            snapshot: connectResult.snapshot,
+            snapshotFrameStart: connectResult.snapshotFrameStart,
+            snapshotCols: connectResult.snapshotCols,
+            targetCols: readProposedTerminalCols(pane),
+            isAlternateScreen: connectResult.isAlternateScreen,
+            coldRestore: Boolean(connectResult.coldRestore)
+          })
           // Why: replay at the snapshot's own dimensions to avoid rewrapping soft-wrapped rows at a different column count (#7279); suppress the PTY forward so this layout-only resize doesn't SIGWINCH the remote TUI.
           const snapshotDimensions = resolvePositiveTerminalDimensions(
             connectResult.snapshotCols,
@@ -8342,7 +8352,7 @@ export function connectPanePty(
           writeReplayData('\x1b[2J\x1b[3J\x1b[H')
           // Why: re-arm the kitty keyboard mirror from the snapshot preamble so Option chords keep their encoding after a window reload.
           kittyKeyboardModes.scanReplay(connectResult.snapshot)
-          writeReplayData(connectResult.snapshot)
+          writeReplayData(snapshotReplayData)
           // Snapshot reattach keeps a live session, so drop only renderer-owned state instead of the broader mode reset — unless this is a cold restore, whose owner is gone.
           writeReplayData(
             reattachReplayResetSequence(

--- a/src/renderer/src/components/terminal-pane/pty-transport-types.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport-types.ts
@@ -59,6 +59,8 @@ export type PtyConnectResult = {
   snapshot?: string
   snapshotCols?: number
   snapshotRows?: number
+  /** Start of an alternate-screen frame within the merged snapshot. */
+  snapshotFrameStart?: number
   isAlternateScreen?: boolean
   sessionExpired?: boolean
   coldRestore?: { scrollback: string; cwd: string; cols?: number; rows?: number }

--- a/src/renderer/src/components/terminal-pane/pty-transport.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.test.ts
@@ -1717,7 +1717,8 @@ describe('createIpcPtyTransport', () => {
       launchAgent: 'droid',
       snapshot: 'snapshot data',
       snapshotCols: 132,
-      snapshotRows: 43
+      snapshotRows: 43,
+      snapshotFrameStart: 17
     })
 
     ;(globalThis as { window: typeof window }).window = {
@@ -1757,6 +1758,7 @@ describe('createIpcPtyTransport', () => {
       snapshot: 'snapshot data',
       snapshotCols: 132,
       snapshotRows: 43,
+      snapshotFrameStart: 17,
       isAlternateScreen: undefined,
       coldRestore: undefined,
       replay: undefined,
@@ -1781,6 +1783,7 @@ describe('createIpcPtyTransport', () => {
       snapshot: undefined,
       snapshotCols: undefined,
       snapshotRows: undefined,
+      snapshotFrameStart: undefined,
       isAlternateScreen: undefined,
       sessionExpired: undefined,
       coldRestore: undefined,

--- a/src/renderer/src/components/terminal-pane/pty-transport.ts
+++ b/src/renderer/src/components/terminal-pane/pty-transport.ts
@@ -887,6 +887,7 @@ export function createIpcPtyTransport(opts: IpcPtyTransportOptions = {}): PtyTra
             snapshot: spawnResult.snapshot,
             snapshotCols: spawnResult.snapshotCols,
             snapshotRows: spawnResult.snapshotRows,
+            snapshotFrameStart: spawnResult.snapshotFrameStart,
             isAlternateScreen: spawnResult.isAlternateScreen,
             sessionExpired: spawnResult.sessionExpired,
             coldRestore: spawnResult.coldRestore,

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.test.ts
@@ -2,7 +2,9 @@ import { describe, expect, it } from 'vitest'
 import {
   buildMainModelSnapshotReplayWrites,
   hasPositiveTerminalDimensions,
-  resolvePositiveTerminalDimensions
+  readProposedTerminalCols,
+  resolvePositiveTerminalDimensions,
+  selectDaemonSnapshotReplayData
 } from './terminal-snapshot-replay-paint'
 
 describe('hasPositiveTerminalDimensions', () => {
@@ -30,6 +32,66 @@ describe('resolvePositiveTerminalDimensions', () => {
     expect(resolvePositiveTerminalDimensions(80, 24)).toEqual({ cols: 80, rows: 24 })
     expect(resolvePositiveTerminalDimensions(Infinity, 24)).toBeNull()
     expect(resolvePositiveTerminalDimensions(undefined, undefined)).toBeNull()
+  })
+})
+
+describe('readProposedTerminalCols', () => {
+  it('returns a measurable proposed width and degrades safely', () => {
+    expect(
+      readProposedTerminalCols({ fitAddon: { proposeDimensions: () => ({ cols: 90, rows: 30 }) } })
+    ).toBe(90)
+    expect(readProposedTerminalCols({ fitAddon: { proposeDimensions: () => undefined } })).toBe(
+      undefined
+    )
+    expect(
+      readProposedTerminalCols({
+        fitAddon: {
+          proposeDimensions: () => {
+            throw new Error('unmeasurable')
+          }
+        }
+      })
+    ).toBe(undefined)
+  })
+})
+
+describe('selectDaemonSnapshotReplayData', () => {
+  const snapshot = 'PREFIX-ALT-FRAME'
+  const base = {
+    snapshot,
+    snapshotFrameStart: 7,
+    snapshotCols: 140,
+    targetCols: 80,
+    isAlternateScreen: true
+  }
+
+  it('drops only a wider live alternate-screen frame', () => {
+    expect(selectDaemonSnapshotReplayData(base)).toBe('PREFIX-')
+  })
+
+  it('keeps equal, narrower, normal-screen, and cold-restore frames', () => {
+    expect(selectDaemonSnapshotReplayData({ ...base, targetCols: 140 })).toBe(snapshot)
+    expect(selectDaemonSnapshotReplayData({ ...base, targetCols: 160 })).toBe(snapshot)
+    expect(selectDaemonSnapshotReplayData({ ...base, isAlternateScreen: false })).toBe(snapshot)
+    expect(selectDaemonSnapshotReplayData({ ...base, coldRestore: true })).toBe(snapshot)
+  })
+
+  it.each([undefined, -1, 0, 7.5, snapshot.length, snapshot.length + 1])(
+    'keeps the merged snapshot for boundary %s',
+    (snapshotFrameStart) => {
+      expect(selectDaemonSnapshotReplayData({ ...base, snapshotFrameStart })).toBe(snapshot)
+    }
+  )
+
+  it.each([
+    { snapshotCols: undefined, targetCols: 80 },
+    { snapshotCols: 140, targetCols: undefined },
+    { snapshotCols: Number.NaN, targetCols: 80 },
+    { snapshotCols: 140, targetCols: Number.POSITIVE_INFINITY },
+    { snapshotCols: 0, targetCols: 80 },
+    { snapshotCols: 140, targetCols: 0 }
+  ])('keeps the merged snapshot for invalid widths %#', (widths) => {
+    expect(selectDaemonSnapshotReplayData({ ...base, ...widths })).toBe(snapshot)
   })
 })
 

--- a/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-snapshot-replay-paint.ts
@@ -28,6 +28,47 @@ export function resolvePositiveTerminalDimensions(
     : null
 }
 
+export function readProposedTerminalCols(pane: {
+  fitAddon?: { proposeDimensions?: () => { cols: number; rows: number } | undefined }
+}): number | undefined {
+  try {
+    return pane.fitAddon?.proposeDimensions?.()?.cols
+  } catch {
+    return undefined
+  }
+}
+
+export function selectDaemonSnapshotReplayData(input: {
+  snapshot: string
+  snapshotFrameStart?: number
+  snapshotCols?: number
+  targetCols?: number
+  isAlternateScreen?: boolean
+  coldRestore?: boolean
+}): string {
+  const { snapshot, snapshotFrameStart, snapshotCols, targetCols } = input
+  const hasNarrowerTarget =
+    typeof snapshotCols === 'number' &&
+    typeof targetCols === 'number' &&
+    Number.isFinite(snapshotCols) &&
+    Number.isFinite(targetCols) &&
+    snapshotCols > 0 &&
+    targetCols > 0 &&
+    snapshotCols > targetCols
+  const hasFrameBoundary =
+    typeof snapshotFrameStart === 'number' &&
+    Number.isInteger(snapshotFrameStart) &&
+    snapshotFrameStart > 0 &&
+    snapshotFrameStart < snapshot.length
+
+  if (!input.isAlternateScreen || input.coldRestore || !hasNarrowerTarget || !hasFrameBoundary) {
+    return snapshot
+  }
+
+  // The live owner repaints its absolute frame after the post-replay SIGWINCH.
+  return snapshot.slice(0, snapshotFrameStart)
+}
+
 /**
  * Ordered replay writes for a main-model snapshot, including the alt-screen
  * choreography: main strips the `?1049h` marker when splitting scrollbackAnsi

--- a/tests/e2e/fixtures/restart-alt-frame-width-fixture.cjs
+++ b/tests/e2e/fixtures/restart-alt-frame-width-fixture.cjs
@@ -1,0 +1,73 @@
+const fs = require('node:fs')
+
+const logPath = process.argv[2]
+let armed = false
+let pendingInput = ''
+
+function log(message) {
+  fs.appendFileSync(logPath, `${message}\n`)
+}
+
+function write(data) {
+  process.stdout.write(data)
+}
+
+function paintCapturedFrame() {
+  const cols = Math.max(40, process.stdout.columns || 80)
+  const rows = Math.max(12, process.stdout.rows || 24)
+  const frameRows = Math.min(18, rows - 2)
+  let frame = '\x1b[?2026h\x1b[?1049h\x1b[2J\x1b[H\x1b[?25l'
+  for (let row = 0; row < frameRows; row += 1) {
+    const label = `STALE_FRAME_ROW_${String(row).padStart(2, '0')}`
+    frame += `\x1b[48;5;240m${label.padEnd(cols, ' ')}\x1b[0m`
+    if (row + 1 < frameRows) {
+      frame += '\r\n'
+    }
+  }
+  frame += '\x1b[?2026l'
+  write(frame)
+  log(`READY pid=${process.pid} cols=${cols} rows=${rows}`)
+}
+
+function paintPartialResize() {
+  const cols = Math.max(1, process.stdout.columns || 0)
+  const rows = Math.max(1, process.stdout.rows || 0)
+  write(`\x1b[?2026h\x1b[H\x1b[2KREPAINT_AFTER_RESIZE cols=${cols} rows=${rows}\x1b[?2026l`)
+  log(`RESIZE cols=${cols} rows=${rows}`)
+}
+
+function cleanup() {
+  write('\x1b[?25h\x1b[?1049l')
+  process.exit(0)
+}
+
+process.stdin.setEncoding('utf8')
+if (process.stdin.isTTY) {
+  process.stdin.setRawMode(true)
+}
+process.stdin.resume()
+
+process.stdin.on('data', (chunk) => {
+  const input = String(chunk)
+  if (input.includes('\x03') || input.includes('q')) {
+    cleanup()
+    return
+  }
+  pendingInput += input
+  if (pendingInput.includes('ARM_REPAINT')) {
+    armed = true
+    pendingInput = ''
+    log('ARMED')
+  } else {
+    pendingInput = pendingInput.slice(-32)
+  }
+})
+
+process.on('SIGWINCH', () => {
+  if (armed) {
+    paintPartialResize()
+  }
+})
+process.on('SIGINT', cleanup)
+
+paintCapturedFrame()

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -44,6 +44,8 @@ type LaunchOptions = {
   onStderr?: (chunk: string) => void
   /** Merged into this launch only (not baked into the session's shared env). */
   extraEnv?: Record<string, string>
+  /** Applied before renderer readiness so restore-time terminal fitting observes this grid. */
+  windowSize?: { width: number; height: number }
 }
 
 type RestartSession = {
@@ -195,6 +197,15 @@ export function createRestartSession(
       throw error
     }
     const page = await app.firstWindow({ timeout: 120_000 })
+    if (options?.windowSize) {
+      await app.evaluate(({ BrowserWindow }, size) => {
+        const window = BrowserWindow.getAllWindows()[0]
+        if (!window) {
+          throw new Error('Restart fixture could not find the first BrowserWindow')
+        }
+        window.setSize(size.width, size.height)
+      }, options.windowSize)
+    }
     await page.waitForLoadState('domcontentloaded')
     await page.waitForFunction(() => Boolean(window.__store), null, { timeout: 30_000 })
     return { app, page }

--- a/tests/e2e/terminal-active-restart-alt-frame-width.spec.ts
+++ b/tests/e2e/terminal-active-restart-alt-frame-width.spec.ts
@@ -1,0 +1,212 @@
+/**
+ * Reliability contract: a live daemon-backed alternate-screen TUI cannot retain
+ * rows from a wider capture after the active pane reattaches at a narrower grid.
+ *
+ * Oracle: the same daemon, PTY, and fixture process survive the restart; the
+ * fixture records and visibly paints its resize response; no captured-frame row
+ * remains in xterm afterward. Current main retains those rows by reflowing the
+ * daemon snapshot before the live partial repaint.
+ *
+ * Maturity: experimental until repeated CI history supports promotion.
+ */
+
+import { execFileSync } from 'node:child_process'
+import { existsSync, mkdtempSync, readFileSync, realpathSync, rmSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import type { ElectronApplication, Page } from '@stablyai/playwright-test'
+import { test, expect } from './helpers/orca-app'
+import {
+  sendToTerminal,
+  waitForActivePanePtyId,
+  waitForActiveTerminalManager,
+  waitForPaneCount
+} from './helpers/terminal'
+import { ensureTerminalVisible, waitForActiveWorktree, waitForSessionReady } from './helpers/store'
+import { attachRepoAndOpenTerminal, createRestartSession } from './helpers/orca-restart'
+import { PROTOCOL_VERSION } from '../../src/main/daemon/types'
+
+const FIXTURE_PATH = path.join(
+  process.cwd(),
+  'tests/e2e/fixtures/restart-alt-frame-width-fixture.cjs'
+)
+
+type TerminalProbe = {
+  ptyId: string
+  cols: number
+  rows: number
+  proposedCols: number | null
+  visibleText: string
+  staleFrameRows: string[]
+}
+
+function createProofRepo(): string {
+  const repoDir = realpathSync(mkdtempSync(path.join(os.tmpdir(), 'orca-alt-frame-restart-')))
+  const git = (...args: string[]): void => {
+    execFileSync('git', args, { cwd: repoDir, stdio: 'pipe' })
+  }
+  git('init', '-q')
+  git('config', 'user.email', 'e2e@test.local')
+  git('config', 'user.name', 'E2E Test')
+  writeFileSync(path.join(repoDir, 'README.md'), '# Alternate-frame restart proof\n')
+  git('add', '-A')
+  git('commit', '-q', '-m', 'Seed alternate-frame restart proof')
+  return repoDir
+}
+
+function readDaemonPid(userDataDir: string): number {
+  return Number(
+    readFileSync(path.join(userDataDir, 'daemon', `daemon-v${PROTOCOL_VERSION}.pid`), 'utf8').trim()
+  )
+}
+
+async function readActiveTerminal(page: Page): Promise<TerminalProbe | null> {
+  return page.evaluate(async () => {
+    const state = window.__store?.getState()
+    const worktreeId = state?.activeWorktreeId
+    const tabId =
+      state?.activeTabType === 'terminal'
+        ? state.activeTabId
+        : worktreeId
+          ? (state?.activeTabIdByWorktree?.[worktreeId] ?? null)
+          : null
+    const manager = tabId ? window.__paneManagers?.get(tabId) : null
+    const pane = manager?.getActivePane?.() ?? manager?.getPanes?.()[0] ?? null
+    const ptyId = pane?.container.dataset.ptyId
+    if (!pane || !ptyId) {
+      return null
+    }
+    await new Promise<void>((resolve) => pane.terminal.write('', resolve))
+    const lines: string[] = []
+    const staleFrameRows: string[] = []
+    const buffer = pane.terminal.buffer.active
+    for (let row = 0; row < pane.terminal.rows; row += 1) {
+      const text = buffer.getLine(buffer.viewportY + row)?.translateToString(true) ?? ''
+      lines.push(text)
+      if (text.includes('STALE_FRAME_ROW_')) {
+        staleFrameRows.push(text)
+      }
+    }
+    let proposedCols: number | null = null
+    try {
+      proposedCols = pane.fitAddon.proposeDimensions()?.cols ?? null
+    } catch {
+      proposedCols = null
+    }
+    return {
+      ptyId,
+      cols: pane.terminal.cols,
+      rows: pane.terminal.rows,
+      proposedCols,
+      visibleText: lines.join('\n'),
+      staleFrameRows
+    }
+  })
+}
+
+async function waitForTerminal(
+  page: Page,
+  predicate: (probe: TerminalProbe) => boolean,
+  message: string
+): Promise<TerminalProbe> {
+  await expect
+    .poll(
+      async () => {
+        const probe = await readActiveTerminal(page)
+        return probe !== null && predicate(probe)
+      },
+      { timeout: 30_000, message }
+    )
+    .toBe(true)
+  const probe = await readActiveTerminal(page)
+  if (!probe) {
+    throw new Error(`${message}: terminal disappeared after settling`)
+  }
+  return probe
+}
+
+test.describe.configure({ mode: 'serial' })
+
+test('active live TUI drops a wider daemon frame when restart restores a narrower pane', async (// oxlint-disable-next-line no-empty-pattern -- This restart test owns both launches.
+{}, testInfo) => {
+  test.setTimeout(240_000)
+  test.skip(process.platform === 'win32', 'The deterministic fixture observes POSIX SIGWINCH')
+
+  const repoPath = createProofRepo()
+  const logPath = testInfo.outputPath('restart-alt-frame-width.log')
+  const session = createRestartSession(testInfo)
+  let firstApp: ElectronApplication | null = null
+  let secondApp: ElectronApplication | null = null
+
+  try {
+    const first = await session.launch({ windowSize: { width: 1500, height: 900 } })
+    firstApp = first.app
+    await attachRepoAndOpenTerminal(first.page, repoPath)
+    await waitForSessionReady(first.page)
+    await waitForActiveWorktree(first.page)
+    await ensureTerminalVisible(first.page)
+    await waitForActiveTerminalManager(first.page, 30_000)
+    await waitForPaneCount(first.page, 1, 30_000)
+
+    const firstPtyId = await waitForActivePanePtyId(first.page)
+    await sendToTerminal(
+      first.page,
+      firstPtyId,
+      `node ${JSON.stringify(FIXTURE_PATH)} ${JSON.stringify(logPath)}\r`
+    )
+    const beforeRestart = await waitForTerminal(
+      first.page,
+      (probe) => probe.staleFrameRows.length >= 8,
+      'Wide alternate-screen fixture did not paint before restart'
+    )
+    await sendToTerminal(first.page, firstPtyId, 'ARM_REPAINT')
+    await expect
+      .poll(() => (existsSync(logPath) ? readFileSync(logPath, 'utf8') : ''), {
+        timeout: 10_000,
+        message: 'Fixture did not arm its resize-only repaint'
+      })
+      .toContain('ARMED')
+
+    const daemonPid = readDaemonPid(session.userDataDir)
+    await session.close(firstApp)
+    firstApp = null
+
+    const second = await session.launch({ windowSize: { width: 820, height: 700 } })
+    secondApp = second.app
+    await waitForSessionReady(second.page)
+    await waitForActiveWorktree(second.page)
+    await ensureTerminalVisible(second.page)
+    await waitForActiveTerminalManager(second.page, 30_000)
+    await waitForPaneCount(second.page, 1, 30_000)
+
+    const afterRestart = await waitForTerminal(
+      second.page,
+      (probe) => probe.visibleText.includes('REPAINT_AFTER_RESIZE'),
+      'Live TUI did not visibly repaint after the narrower warm reattach'
+    )
+    const proofPath = testInfo.outputPath('after-narrow-restart.png')
+    await second.page.screenshot({ path: proofPath })
+    await testInfo.attach('after-narrow-restart', { path: proofPath, contentType: 'image/png' })
+
+    expect(readDaemonPid(session.userDataDir), 'daemon must survive the app restart').toBe(
+      daemonPid
+    )
+    expect(afterRestart.ptyId, 'the restored pane must keep the exact daemon PTY').toBe(firstPtyId)
+    expect(afterRestart.proposedCols).toBe(afterRestart.cols)
+    expect(afterRestart.cols).toBeLessThan(beforeRestart.cols)
+    expect(readFileSync(logPath, 'utf8')).toContain(`RESIZE cols=${afterRestart.cols}`)
+    expect(
+      afterRestart.staleFrameRows,
+      `wider captured rows remained after live repaint:\n${afterRestart.visibleText}`
+    ).toEqual([])
+  } finally {
+    if (secondApp) {
+      await session.close(secondApp)
+    }
+    if (firstApp) {
+      await session.close(firstApp)
+    }
+    await session.dispose()
+    rmSync(repoPath, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary

- Prevent a live alternate-screen TUI from restoring a frame captured at a wider grid and then having xterm reflow it into detached rows when Orca restarts into a narrower window.
- Keep the legacy merged snapshot intact and add one optional frame-boundary index. New renderers skip only the too-wide live frame; old readers and malformed or absent boundaries fall back to the full snapshot.
- Preserve normal-buffer history, mode rehydration, agent/mode scanning, and cold-restore behavior. The live TUI repaints the clean alternate screen on the existing post-reattach resize.
- Add a real two-launch Electron regression that proves the daemon and exact PTY survive restart, observes the narrower live repaint, and rejects every retained captured-frame row.

This intentionally fixes the high-frequency update/restart case. It does not claim to eliminate every rarer source of terminal rendering corruption.

Credit to Brennan Benson for the earlier width-mismatch investigation and candidate branch. This version uses a single offset instead of duplicate snapshot strings and explicitly tests the IPC transport mapping that the earlier branch bypassed.

## Screenshots

| Before: current main / intentional bypass | After: fixed replay |
| --- | --- |
| ![Before: stale wide frame rows reflowed into gray bands](https://github.com/user-attachments/assets/cd3eba24-48b8-4326-9f9a-ba8c091a9a31) | ![After: only the live resize repaint remains](https://github.com/user-attachments/assets/1274e27d-988a-43cc-aa11-ca8cba2f62c0) |

The red run retained `STALE_FRAME_ROW_02` through `_17` after the fixture visibly handled the resize. The green run retained zero captured rows.

## Testing

- [ ] `pnpm lint` — full repo lint left to CI; changed-code quality, React Doctor, reliability-manifest validation, formatting, and max-lines ratchet pass locally.
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full repo suite left to CI; 848 focused daemon/transport/replay/renderer/cross-version tests pass.
- [ ] `pnpm build` — native/release packaging left to CI; `pnpm run build:electron-vite` and the E2E build pass.
- [x] Added high-quality regression coverage.

Additional evidence:

- Exact Electron restart oracle: red on current main with 16 stale rows; red again when only the new final replay selection was intentionally bypassed; green after restoration.
- Repetition: 5/5 headless and 3/3 forced-headful restart runs passed, plus a final post-rebase run.
- `terminal-geometry.visible-convergence`: 1,779 passed, 1 skipped.
- `terminal-output.scrollback-restore`: 561 passed as part of the focused renderer suite.
- Cross-version terminal wire: 4 passed.
- Production Electron build passed.

## AI Review Report

The review traced the value across daemon result, preload contract, IPC transport mapping, and renderer replay. It found that the prior candidate branch added fields at the endpoints but did not forward them through `pty-transport`; its mocked pane tests therefore could pass while the real restart path still replayed the full frame. This PR forwards the offset through that choke point and pins it with a transport test plus the real Electron journey.

Compatibility checks covered macOS, Linux, Windows, WSL, SSH/remote, folder workspaces, mobile hydration, and mixed-version behavior:

- The selection itself is platform-independent. Live macOS is covered; Linux shares the POSIX fixture path. The live Windows test is skipped because its deterministic fixture observes POSIX `SIGWINCH`, while unit/provider coverage exercises the platform-neutral decision and fallback.
- WSL daemon reattach can consume the optional offset. SSH and remote-runtime results without it retain the full snapshot.
- No path, shortcut, label, shell-launch, or workspace-type behavior changed.
- No remote stream opcode or RPC payload changed. The optional app IPC field preserves the merged legacy snapshot in both version directions.
- Main/mobile hydration continues to receive the full snapshot.

The performance review found one integer added to an existing reattach result and one bounded string slice only on a qualifying restart. There are no new timers, polling loops, subprocesses, scans, retries, or unbounded retention.

## Security Audit

The renderer validates the optional boundary as an in-range integer and validates both widths before slicing; absent or malformed data fails closed to the existing full replay. The change does not add dependencies, network access, auth, secrets, filesystem access, or command execution. The E2E quotes fixture paths through JSON string encoding and removes its isolated temporary repository.

## Notes

- A qualifying narrow restart may show a clean/blank alternate frame briefly until the surviving TUI handles the already-existing resize signal. A TUI that ignores resize can remain blank until its next repaint; cold restores never skip because no live owner exists to repaint.
- Equal-width, wider-destination, normal-screen, unmeasurable, malformed, legacy, and cold-restore cases retain the full snapshot.
- The new reliability test remains experimental until it accumulates CI history, especially on Linux and Windows/ConPTY.
