### PR TITLE
[Perf-SS] Keep automation output snapshots linear under long runs

### DIFF
--- a/src/renderer/src/components/automations/automation-run-output-snapshot-equivalence.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot-equivalence.test.ts
@@ -1,0 +1,106 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import {
+  stripAnsiEscapeSequences,
+  TERMINAL_CONTROL_CHARACTER_PATTERN
+} from '../../../../shared/ansi-escape-sequences'
+import {
+  type AutomationRunOutputSnapshotBuffer,
+  createAutomationRunOutputSnapshotBuffer,
+  createAutomationRunOutputSnapshotFromText
+} from './automation-run-output-snapshot'
+
+const MAX_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
+
+function createShiftReferenceBuffer(): AutomationRunOutputSnapshotBuffer {
+  const chunks: string[] = []
+  let totalChars = 0
+  let truncated = false
+
+  return {
+    append(chunk) {
+      if (!chunk) {
+        return
+      }
+      chunks.push(chunk)
+      totalChars += chunk.length
+      let overflowChars = totalChars - MAX_OUTPUT_SNAPSHOT_CHARS
+      while (overflowChars > 0 && chunks.length > 0) {
+        const firstChunk = chunks[0]
+        if (firstChunk.length <= overflowChars) {
+          chunks.shift()
+          totalChars -= firstChunk.length
+          overflowChars -= firstChunk.length
+          truncated = true
+          continue
+        }
+        chunks[0] = firstChunk.slice(overflowChars)
+        totalChars -= overflowChars
+        truncated = true
+        overflowChars = 0
+      }
+    },
+    snapshot() {
+      const content = stripAnsiEscapeSequences(chunks.join(''))
+        .replace(/\r\n/g, '\n')
+        .replace(/\r/g, '\n')
+        .replace(TERMINAL_CONTROL_CHARACTER_PATTERN, '')
+        .trim()
+      return createAutomationRunOutputSnapshotFromText(content, truncated)
+    }
+  }
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state * 1_664_525 + 1_013_904_223) % 4_294_967_296
+    return state
+  }
+}
+
+describe('automation run output snapshot queue equivalence', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-09T12:00:00Z'))
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('matches the shift reference across seeded chunk and control-sequence boundaries', () => {
+    const random = createSeededRandom(0xc0ffee)
+    const tokens = [
+      'plain-output-',
+      '\u001b[31mred\u001b[0m',
+      '\u001b]0;title\u001b\\',
+      '\r\n',
+      '\ud83d\ude00',
+      '\ud83d',
+      '\ude00',
+      '\u0007',
+      '   '
+    ]
+    let source = ''
+    for (let index = 0; index < 80_000; index += 1) {
+      source += tokens[random() % tokens.length]
+    }
+
+    const reference = createShiftReferenceBuffer()
+    const candidate = createAutomationRunOutputSnapshotBuffer()
+    let chunkCount = 0
+    for (let offset = 0; offset < source.length; ) {
+      const chunkLength = 1 + (random() % 73)
+      const chunk = source.slice(offset, offset + chunkLength)
+      reference.append(chunk)
+      candidate.append(chunk)
+      offset += chunkLength
+      chunkCount += 1
+      if (chunkCount % 2_048 === 0) {
+        expect(candidate.snapshot()).toEqual(reference.snapshot())
+      }
+    }
+
+    expect(candidate.snapshot()).toEqual(reference.snapshot())
+  })
+})

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
@@ -86,6 +86,52 @@ describe('automation run output snapshot buffer', () => {
     expect(snapshot?.truncated).toBe(true)
   })
 
+  it('preserves FIFO content through compaction and later partial trimming', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+    const chunkCount = (256 * 1024) / 16
+    const replacementChunks = Array.from({ length: chunkCount }, (_, index) =>
+      index.toString(36).padStart(4, '0').repeat(4)
+    )
+
+    for (let index = 0; index < chunkCount; index += 1) {
+      buffer.append('A'.repeat(16))
+    }
+    for (const chunk of replacementChunks) {
+      buffer.append(chunk)
+    }
+
+    const replacedContent = replacementChunks.join('')
+    expect(buffer.snapshot()).toMatchObject({ content: replacedContent, truncated: true })
+
+    buffer.append('TAIL')
+    expect(buffer.snapshot()).toMatchObject({
+      content: `${replacedContent.slice(4)}TAIL`,
+      truncated: true
+    })
+  })
+
+  it('strips escape sequences joined across chunk boundaries', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+
+    buffer.append('Before\u001b]0;hidden')
+    buffer.append('\u001b\\After')
+
+    expect(buffer.snapshot()).toMatchObject({ content: 'BeforeAfter', truncated: false })
+  })
+
+  it('retains the same UTF-16 tail when overflow splits a surrogate pair', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+    const initial = '\ud83d\ude00'.repeat((256 * 1024) / 2)
+
+    buffer.append(initial)
+    buffer.append('x')
+
+    expect(buffer.snapshot()).toMatchObject({
+      content: `${initial.slice(1)}x`,
+      truncated: true
+    })
+  })
+
   it('creates a saved snapshot from agent transcript text', () => {
     expect(createAutomationRunOutputSnapshotFromText('\nFinal summary.\n')).toEqual({
       format: 'plain_text',

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.ts
@@ -5,6 +5,7 @@ import {
 } from '../../../../shared/ansi-escape-sequences'
 
 const MAX_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
+const OUTPUT_SNAPSHOT_COMPACTION_HEAD_THRESHOLD = 64
 
 export type AutomationRunOutputSnapshotBuffer = {
   append: (chunk: string) => void
@@ -45,6 +46,7 @@ function stripTerminalControls(value: string): string {
 
 export function createAutomationRunOutputSnapshotBuffer(): AutomationRunOutputSnapshotBuffer {
   const chunks: string[] = []
+  let firstChunkIndex = 0
   let totalChars = 0
   let truncated = false
 
@@ -56,19 +58,28 @@ export function createAutomationRunOutputSnapshotBuffer(): AutomationRunOutputSn
       chunks.push(chunk)
       totalChars += chunk.length
       let overflowChars = totalChars - MAX_OUTPUT_SNAPSHOT_CHARS
-      while (overflowChars > 0 && chunks.length > 0) {
-        const firstChunk = chunks[0]
+      while (overflowChars > 0 && firstChunkIndex < chunks.length) {
+        const firstChunk = chunks[firstChunkIndex]
         if (firstChunk.length <= overflowChars) {
-          chunks.shift()
+          chunks[firstChunkIndex] = ''
+          firstChunkIndex += 1
           totalChars -= firstChunk.length
           overflowChars -= firstChunk.length
           truncated = true
           continue
         }
-        chunks[0] = firstChunk.slice(overflowChars)
+        chunks[firstChunkIndex] = firstChunk.slice(overflowChars)
         totalChars -= overflowChars
         truncated = true
         overflowChars = 0
+      }
+      // Why: amortize front removal while bounding dead backing-array slots.
+      if (
+        firstChunkIndex >= OUTPUT_SNAPSHOT_COMPACTION_HEAD_THRESHOLD &&
+        firstChunkIndex * 2 >= chunks.length
+      ) {
+        chunks.splice(0, firstChunkIndex)
+        firstChunkIndex = 0
       }
     },
     snapshot() {


### PR DESCRIPTION
## Summary

### Start here: what does this PR do?

**Bottom line:** automation output stays the same; maintaining the in-memory tail becomes much cheaper during long, noisy runs.

Orca receives terminal output as many small strings while an automation runs. It keeps only the newest **262,144 JavaScript string units** (the existing 256 Ki-unit cap) so run history cannot grow without bound. Before this PR, once that cap was full, each new chunk could make JavaScript move thousands of array entries. This PR replaces that repeated moving with a cursor and occasional cleanup.

| Question | Answer |
| --- | --- |
| What can a user observe? | The same saved automation output, truncation flag, and timestamp semantics. Long fragmented runs spend much less renderer time maintaining the buffer. |
| What production code changes? | One private, per-run, in-memory queue implementation. |
| What does **not** change? | Terminal capture, text cleanup, transcript precedence, snapshot schema, persistence, UI, IPC/RPC, remote wire behavior, and headless dispatch. |
| Review conclusion | No correctness, security, or compatibility finding remains. Risk is low and concentrated in the queue bookkeeping covered by differential and boundary tests. |

### Zero-context picture: where this code sits

An **output snapshot** is the text saved with a completed automation run so the result remains readable later.

```mermaid
flowchart LR
    A["Agent process"] -->|"many small text chunks"| B["Terminal / PTY callback"]
    B --> C["Per-run tail buffer<br/>keeps newest 262,144 UTF-16 code units"]
    C -->|"completion or exit"| D["Join chunks and clean terminal controls"]
    D --> E{"Assistant transcript available?"}
    E -->|"yes"| F["Save assistant transcript"]
    E -->|"no"| G["Save cleaned terminal tail"]
    F --> H["Existing persistence"]
    G --> H
    H --> I["Automation run history UI"]
```

Only the inside of the tail-buffer box changes.

## The problem

The old buffer stored chunks in a normal array. When the buffer overflowed, it called `shift()` to remove the oldest complete chunk. Removing index 0 requires the remaining array entries to be reindexed.

```mermaid
sequenceDiagram
    participant PTY as Terminal stream
    participant Buffer as Full output buffer
    participant JS as JavaScript array
    loop Every small append after the cap is full
        PTY->>Buffer: append(new chunk)
        Buffer->>JS: push(new chunk)
        Buffer->>JS: shift(oldest chunk)
        JS->>JS: move/reindex every surviving entry
    end
```

With 16,384 small live chunks, one append could shift roughly 16,384 array entries. Repeating that for another 16,384 chunks creates the performance cliff. The text work is bounded, but the repeated array bookkeeping is not.

### A tiny example

Pretend the cap is four one-character chunks:

```text
Full buffer:       [A][B][C][D]       saved text = ABCD
Append E:          [A][B][C][D][E]
Old eviction:         [B][C][D][E]    saved text = BCDE
                       ↑ every survivor moved left
```

The old result is correct, but producing it repeatedly is expensive.

## What changed

The new buffer keeps `firstChunkIndex`, a cursor pointing to the first live chunk.

```mermaid
flowchart LR
    A["Start<br/>[A][B][C][D]<br/>head = 0"]
    B["Append E, evict A<br/>[empty][B][C][D][E]<br/>head = 1"]
    C["Join result<br/>BCDE"]
    D["Later<br/>dead prefix + live suffix"]
    E["Occasional compaction<br/>[live suffix]<br/>head = 0"]
    A --> B --> C
    C -->|"more appends"| D
    D -->|"at least 64 dead slots<br/>and dead prefix is at least half"| E
```

For a fully consumed chunk, the new code:

1. replaces the old string reference with `''`;
2. advances the cursor by one;
3. leaves every live entry where it is.

Joining the array still produces the same text because empty strings contribute nothing. Once at least 64 leading slots are dead **and** the dead prefix is at least half the array, one `splice()` removes that prefix. That expensive operation happens only after enough cheap removals have accumulated to pay for it.

Partial overflow is unchanged. If only two characters must be removed from `ABCD`, both implementations store `CD` using the same `slice(2)` call.

Related precedent: [#13449](https://github.com/stablyai/orca/pull/13449) applies the same logical-head and amortized-compaction pattern to atomic relay frames. This PR keeps a domain-specific implementation because snapshot chunks also require partial head slicing and non-destructive joining.

## Why the output is unchanged

### One-append equivalence

The old and new implementations begin with the same logical text, character count, and `truncated` flag. Every possible append follows one of these cases:

| Case | Old implementation | New implementation | Observable result |
| --- | --- | --- | --- |
| No overflow | Push the chunk | Push the chunk | Identical |
| Entire oldest chunk overflows | Remove it with `shift()` | Replace it with `''` and advance the head | Identical joined text and count |
| Part of oldest chunk overflows | Slice the required prefix from array index 0 | Apply the same slice at the logical head | Identical joined text and count |
| Cleanup threshold reached | Nothing | Remove only already-empty leading slots | Identical joined text and count |

The same state goes in, and the same logical state comes out. Applying that argument to every append means the complete stream remains equivalent. `truncated` is still sticky after the first overflow.

### Concrete tail example

Using an eight-character cap:

| Operation | Logical text retained | Why |
| --- | --- | --- |
| append `ABCD` | `ABCD` | Under cap |
| append `EFGH` | `ABCDEFGH` | Exactly at cap |
| append `IJ` | `CDEFGHIJ` | Remove two characters from the oldest chunk |
| append `KLMN` | `GHIJKLMN` | Drop the rest of the oldest chunk, then slice the next one |

Both algorithms take exactly those actions. The new one simply avoids moving unrelated array entries.

### Differential test: old and new run side by side

The strongest regression test includes the exact pre-change `shift()` algorithm as a reference and feeds both versions the same deterministic stream.

```mermaid
flowchart LR
    A["80,000 mixed tokens<br/>plain text, ANSI, OSC, CR/LF,<br/>Unicode, controls, whitespace"]
    B["Seeded splitter<br/>chunks of 1–73 UTF-16 code units"]
    C["Exact old shift-based buffer"]
    D["New cursor-based buffer"]
    E{"Deep-equal snapshots?"}
    F["Compare every 2,048 chunks<br/>and at the end"]
    A --> B
    B --> C --> E
    B --> D --> E
    E --> F
```

This compares the full snapshot object—not merely a substring—including cleaned content, `truncated`, format, and the frozen capture time.

### Targeted boundaries

Focused tests separately lock down:

- FIFO order through repeated compactions;
- partial trimming after compaction;
- exact 262,144-unit retention and sticky truncation;
- ANSI/OSC escape sequences split across chunk boundaries;
- CR/LF normalization and terminal-control removal;
- the existing UTF-16 behavior when the cap bisects a surrogate pair;
- transcript text taking precedence over raw terminal redraw output;
- output persistence across later run-status updates.

## Scope and regression analysis

```mermaid
flowchart LR
    A["Terminal chunks"] --> B["CHANGED<br/>internal eviction bookkeeping"]
    B --> C["UNCHANGED<br/>join + sanitize"]
    C --> D["UNCHANGED<br/>assistant transcript precedence"]
    D --> E["UNCHANGED<br/>snapshot object shape"]
    E --> F["UNCHANGED<br/>IPC + persistence"]
    F --> G["UNCHANGED<br/>run history UI"]
```

| Risk area | Why this PR does not regress it | Evidence |
| --- | --- | --- |
| Saved text | Full removals become empty slots; partial removals use the identical slice; cleanup removes only empty slots | Exact old/new differential test plus boundary tests |
| Terminal formatting | Sanitization still runs once, after all raw chunks are joined | Split ANSI/OSC and control-character tests |
| Output cap | `totalChars` receives the same additions/subtractions and uses the same 262,144 limit | Cap, tail, partial-trim, randomized, and surrogate tests |
| Snapshot contract | `format`, `content`, `capturedAt`, and `truncated` creation is untouched | Deep equality against the old implementation |
| Dispatch lifecycle | A fresh buffer is still created per run; both fresh and reused-session callbacks append to it; completion/exit reads it | Dispatch lifecycle trace and focused dispatch tests |
| Persistence/UI | No type, normalizer, storage, or rendering file changes | Persistence tests and three-file diff boundary |
| Local/SSH/relay/folder workspaces | All use the same renderer string callback after host routing; this code has no path, shell, host, or platform branch | Call-path review; wire compatibility CI green |
| Windows/macOS/Linux | This is platform-independent JavaScript array/string bookkeeping | Typecheck, package CI, and absence of platform APIs |
| Concurrency | Buffer state remains closure-local to one dispatch and mutations remain synchronous | Ownership/call-path review |
| Memory growth | Live non-empty chunks are bounded by the character cap; consumed string references are cleared; dead logical slots are periodically removed | Invariants plus compaction stress test |

Headless dispatch is intentionally unchanged. Its caller reads one already-joined terminal tail and appends it once, so it does not encounter this repeated-small-chunk hot path.

## Performance proof

### Complexity

```mermaid
flowchart TD
    A["Buffer is full"]
    B["Old: each append shifts all live array entries"]
    C["Repeated appends: quadratic-style reindexing cost"]
    D["New: each discarded chunk is cleared and passed once"]
    E["Rare compaction only after enough prior discards"]
    F["Repeated appends: amortized linear work"]
    A --> B --> C
    A --> D --> E --> F
```

Snapshot creation still joins and sanitizes the bounded tail at completion; this PR specifically removes repeated front-of-array work during streaming appends.

### Measurements

The main benchmark used Node `v24.18.0` on macOS arm64. Each sample:

1. created a fresh buffer;
2. prefilled it with 16,384 × 16-character chunks (exactly at the cap) outside the timed region;
3. timed 16,384 more saturated appends;
4. alternated old/new order after five warmups for 101 paired samples.

| Metric | Exact base algorithm | Actual candidate module | Improvement |
| --- | ---: | ---: | ---: |
| Median | 28.774 ms | 0.248 ms | 116.2×; 99.14% lower |
| p95 | 57.229 ms | 0.545 ms | 104.9×; 99.05% lower |

An independent 31-sample rerun during final review reproduced the result: **24.894 ms → 0.239 ms median**, or **104.3× / 99.04% lower**.

These numbers describe the deliberately worst saturated, fragmented-output case. They are not a claim that the entire app becomes 100× faster. Short runs below the cap should behave as before; long noisy automations avoid the old cliff.

## Reliability readiness

- **Invariant / gate:** `terminal-performance.output-backpressure-budget` — each renderer-driven automation run retains the exact newest 262,144 UTF-16 code units while streaming append work and retained queue slots stay bounded.
- **Failure source:** repeated `Array.shift()` reindexed the entire fragmented tail after every saturated append, producing quadratic-style renderer work during long noisy automations.
- **Oracle:** exact old/new differential snapshots, named FIFO/compaction/partial-trim/ANSI/Unicode boundaries, dispatch and persistence tests, maximum-depth content verification, and paired before/after benchmarks.
- **Provider/platform coverage:** local, daemon, SSH, relay, folder-workspace, macOS, Linux, Windows, and WSL routing are unaffected after they deliver a string to the same renderer callback. No mobile-facing or mixed-version surface changes.
- **Performance budget:** no polling, timer, retry, provider call, IPC, subprocess, wake loop, or render subscription was added. A final current-main run measured 39.645 ms → 0.243 ms median for the saturated workload; maximum 262,144-live-slot compaction took 1.02 ms.
- **Diagnostics:** deterministic equality failures report the exact checkpoint; focused FIFO tests report the first mismatching retained tail. No new runtime failure state requires production logging.
- **Residual gap:** no live cross-platform/SSH automation was repeated for this representation-only change. The terminal/session delivery and ownership paths are unchanged; the pre-existing oversized sliced-string backing-store caveat remains documented below.

## Residual risk and non-goals

No test suite can promise that no regression is possible. The remaining risk here is small because the changed state is private, synchronous, bounded, and compared directly with the old implementation.

- A very large single source string that is partially sliced may keep its original backing storage alive, depending on the JavaScript engine. That behavior already existed in the old `slice()` path; this PR neither introduces nor enlarges it. Fixing it needs a separate owned-storage design.
- The occasional `splice()` is still linear for that one operation. The threshold makes the total streaming work amortized linear; it does not make every individual append constant-time.
- Headless capture is not optimized because it appends once and has no repeated-chunk cliff.

## Screenshots

No visual change. The same plain-text snapshot reaches the same existing UI.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` (local wrapper remained blocked by this checkout's unavailable patched `node-pty` source build; equivalent Vitest coverage and the complete CI matrices passed)
- [ ] `pnpm build` (full native release build not run locally; affected Electron targets and package CI passed)
- [x] Added or updated high-quality tests that would catch regressions

Completed validation:

- Final focused run after rebasing onto current `main`: **4 files / 485 tests passed**, covering the buffer, differential equivalence, dispatch lifecycle, and persistence.
- Complete renderer suite: **2,333 files / 21,601 tests passed**; one file and four tests skipped.
- GitHub test matrix: all **16 Node 24 shards** and all **16 Node 26 shards** passed.
- GitHub static analysis, root guard, typecheck, Git compatibility, shell contracts, cross-version wire compatibility, Linux package, and Windows package checks passed.
- Full Node, CLI, and web TypeScript checks passed; the final web typecheck was rerun successfully.
- Full lint previously passed; final changed-file native/type-aware code quality and React Doctor reported **0 findings across all 3 changed files**.
- Max-lines ratchet, reliability gates, formatting, and `git diff --check` passed.
- Electron main, preload, and renderer production builds passed with only existing Vite/CSS warnings.
- Independent performance reproduction: **104.3× median speedup** in the saturated small-chunk case.

## AI Review Report

Final review found no P0/P1/P2 issue. It traced:

- every old/new FIFO state transition;
- full and partial eviction;
- compaction thresholds and retained-slot bounds;
- repeated snapshots and sticky truncation;
- UTF-16 and terminal-control behavior;
- fresh and reused dispatch ownership;
- completion/exit cleanup;
- persistence consumers;
- local, SSH, relay, and folder-workspace routing;
- macOS, Linux, Windows, and WSL assumptions.

CodeRabbit also reported no actionable comments. The review conclusion is **correct with low regression risk**, not “safe because it is only a performance change.” The confidence comes from exact behavioral equivalence plus the narrow call-path boundary above.

## Security Audit

No authority boundary, validation path, command execution, shell input, file path, authentication, secret, network sink, IPC/RPC method, dependency, install hook, generated binary, or lockfile changes.

Terminal output remains bounded and passes through the same sanitization when a snapshot is created. Clearing fully evicted string references improves resource behavior under adversarially fragmented output. No malware, obfuscation, exfiltration path, unsafe evaluation, download-and-execute flow, or supply-chain change was found.

## Notes

- Three changed files: one implementation file and two focused test files.
- No user-facing text, visual, mobile, provider-specific, Git, or remote-wire surface changes.
- The cap still counts JavaScript UTF-16 code units, exactly as before.

@nwparker_

