### PR TITLE
[leas code] Share usage tracking pane shell

### DIFF
--- a/src/renderer/src/components/stats/ClaudeUsagePane.tsx
+++ b/src/renderer/src/components/stats/ClaudeUsagePane.tsx
@@ -5,29 +5,16 @@ import {
   DatabaseZap,
   FolderKanban,
   Gauge,
-  RefreshCw,
-  SlidersHorizontal,
   Sparkles,
   Waypoints
 } from 'lucide-react'
 import type { ClaudeUsageRange, ClaudeUsageScope } from '../../../../shared/claude-usage-types'
 import { useAppStore } from '../../store'
-import { Button } from '../ui/button'
-import { Switch } from '../ui/switch'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from '../ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { ClaudeUsageDetails } from './ClaudeUsageDetails'
 import { ClaudeUsageLoadingState } from './ClaudeUsageLoadingState'
 import { ShareUsageButton } from './ShareUsageButton'
 import { StatCard } from './StatCard'
+import { UsageFilterRadioGroup, UsageTrackingPaneShell } from './UsageTrackingPaneShell'
 import { formatCost, formatTokens, formatUpdatedAt } from './usage-formatters'
 import { translate } from '@/i18n/i18n'
 
@@ -86,34 +73,27 @@ export function ClaudeUsagePane(): React.JSX.Element {
     void setClaudeUsageEnabled(enabled)
   }
 
+  const title = translate(
+    'auto.components.stats.ClaudeUsagePane.6afacbee37',
+    'Claude Usage Tracking'
+  )
+  const enableLabel = translate(
+    'auto.components.stats.ClaudeUsagePane.424cd50412',
+    'Enable Claude usage analytics'
+  )
+
   if (!scanState?.enabled) {
     return (
-      <div className="rounded-lg border border-border/60 bg-card/40 p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-foreground">
-              {translate(
-                'auto.components.stats.ClaudeUsagePane.6afacbee37',
-                'Claude Usage Tracking'
-              )}
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              {translate(
-                'auto.components.stats.ClaudeUsagePane.0cb1a36d7d',
-                'Reads local Claude usage logs to show token, model, and session stats.'
-              )}
-            </p>
-          </div>
-          <Switch
-            checked={false}
-            aria-label={translate(
-              'auto.components.stats.ClaudeUsagePane.424cd50412',
-              'Enable Claude usage analytics'
-            )}
-            onCheckedChange={handleSetEnabled}
-          />
-        </div>
-      </div>
+      <UsageTrackingPaneShell
+        enabled={false}
+        title={title}
+        disabledDescription={translate(
+          'auto.components.stats.ClaudeUsagePane.0cb1a36d7d',
+          'Reads local Claude usage logs to show token, model, and session stats.'
+        )}
+        enableLabel={enableLabel}
+        onEnabledChange={handleSetEnabled}
+      />
     )
   }
 
@@ -124,204 +104,145 @@ export function ClaudeUsagePane(): React.JSX.Element {
   const hasAnyData = summary?.hasAnyClaudeData ?? scanState.hasAnyClaudeData
 
   return (
-    <div className="space-y-4 rounded-lg border border-border/60 bg-card/30 p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-semibold text-foreground">
-            {translate('auto.components.stats.ClaudeUsagePane.6afacbee37', 'Claude Usage Tracking')}
-          </h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {formatUpdatedAt(scanState.lastScanCompletedAt)}
-            {scanState.lastScanError
-              ? translate(
-                  'auto.components.stats.ClaudeUsagePane.2d41fd45c6',
-                  ' • Last scan error: {{value0}}',
-                  { value0: scanState.lastScanError }
-                )
-              : ''}
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 self-start">
-          {summary && daily.length > 0 && (
-            <ShareUsageButton provider="claude" summary={summary} daily={daily} range={range} />
-          )}
-          <DropdownMenu>
-            <TooltipProvider delayDuration={250}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label={translate(
-                        'auto.components.stats.ClaudeUsagePane.e9bf9fce0e',
-                        'Claude usage options'
-                      )}
-                    >
-                      <SlidersHorizontal className="size-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate('auto.components.stats.ClaudeUsagePane.dd29209b21', 'Filters')}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <DropdownMenuContent align="end" className="w-60">
-              <DropdownMenuLabel>
-                {translate('auto.components.stats.ClaudeUsagePane.f61cffb9c8', 'Scope')}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={scope}
-                onValueChange={(value) => void setClaudeUsageScope(value as ClaudeUsageScope)}
-              >
-                {SCOPE_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem key={option.value} value={option.value}>
-                    {option.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>
-                {translate('auto.components.stats.ClaudeUsagePane.505be9aac4', 'Range')}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={range}
-                onValueChange={(value) => void setClaudeUsageRange(value as ClaudeUsageRange)}
-              >
-                {RANGE_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem key={option} value={option}>
-                    {RANGE_LABELS[option]}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <TooltipProvider delayDuration={250}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => void refreshClaudeUsage()}
-                  disabled={scanState.isScanning}
-                  aria-label={translate(
-                    'auto.components.stats.ClaudeUsagePane.c5b9b344d0',
-                    'Refresh Claude usage'
-                  )}
-                >
-                  <RefreshCw className={`size-3.5 ${scanState.isScanning ? 'animate-spin' : ''}`} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {translate('auto.components.stats.ClaudeUsagePane.8d18bbb771', 'Refresh')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <Switch
-            checked
-            aria-label={translate(
-              'auto.components.stats.ClaudeUsagePane.424cd50412',
-              'Enable Claude usage analytics'
-            )}
-            onCheckedChange={handleSetEnabled}
-          />
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs text-muted-foreground">
-          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
-        </p>
-      </div>
-
-      {!hasAnyData ? (
-        <div className="rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-6 text-sm text-muted-foreground">
-          {translate(
-            'auto.components.stats.ClaudeUsagePane.7dde9331fd',
-            'No local Claude usage found yet for this scope.'
-          )}
-        </div>
-      ) : (
+    <UsageTrackingPaneShell
+      enabled
+      title={title}
+      status={
         <>
-          <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
-            <StatCard
-              label={translate('auto.components.stats.ClaudeUsagePane.ea71fae8fc', 'Input tokens')}
-              value={formatTokens(summary?.inputTokens ?? 0)}
-              icon={<Sparkles className="size-4" />}
-            />
-            <StatCard
-              label={translate('auto.components.stats.ClaudeUsagePane.2b8a2f14aa', 'Output tokens')}
-              value={formatTokens(summary?.outputTokens ?? 0)}
-              icon={<Activity className="size-4" />}
-            />
-            <StatCard
-              label={translate('auto.components.stats.ClaudeUsagePane.268cf0af51', 'Cache read')}
-              value={formatTokens(summary?.cacheReadTokens ?? 0)}
-              icon={<DatabaseZap className="size-4" />}
-            />
-            <StatCard
-              label={translate('auto.components.stats.ClaudeUsagePane.b786fb4a70', 'Cache write')}
-              value={formatTokens(summary?.cacheWriteTokens ?? 0)}
-              icon={<Waypoints className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.ClaudeUsagePane.1634c4f404',
-                'Cache reuse rate'
-              )}
-              value={
-                summary?.cacheReuseRate !== null && summary?.cacheReuseRate !== undefined
-                  ? `${Math.round(summary.cacheReuseRate * 100)}%`
-                  : 'n/a'
-              }
-              icon={<Gauge className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.ClaudeUsagePane.8cc23be4a3',
-                'Zero-cache-read turns'
-              )}
-              value={
-                summary && summary.turns > 0
-                  ? `${Math.round((summary.zeroCacheReadTurns / summary.turns) * 100)}%`
-                  : 'n/a'
-              }
-              icon={<DatabaseZap className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.ClaudeUsagePane.0f3e696ca9',
-                'Sessions / Turns'
-              )}
-              value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.turns ?? 0).toLocaleString()}`}
-              icon={<FolderKanban className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.ClaudeUsagePane.b26d4ddb58',
-                'Est. API-equivalent cost'
-              )}
-              value={formatCost(summary?.estimatedCostUsd ?? null)}
-              icon={<Coins className="size-4" />}
-            />
-          </div>
-          <p className="px-1 text-xs text-muted-foreground">
-            {translate(
-              'auto.components.stats.ClaudeUsagePane.51ae85fa00',
-              'Cache reuse rate is calculated as cache read tokens / (input tokens + cache read tokens).'
-            )}
-          </p>
-
-          <ClaudeUsageDetails
-            daily={daily}
-            modelBreakdown={modelBreakdown}
-            projectBreakdown={projectBreakdown}
-            recentSessions={recentSessions}
-            summary={summary}
-          />
+          {formatUpdatedAt(scanState.lastScanCompletedAt)}
+          {scanState.lastScanError
+            ? translate(
+                'auto.components.stats.ClaudeUsagePane.2d41fd45c6',
+                ' • Last scan error: {{value0}}',
+                { value0: scanState.lastScanError }
+              )
+            : ''}
         </>
+      }
+      isRefreshing={scanState.isScanning}
+      hasData={hasAnyData}
+      enableLabel={enableLabel}
+      optionsLabel={translate(
+        'auto.components.stats.ClaudeUsagePane.e9bf9fce0e',
+        'Claude usage options'
       )}
-    </div>
+      filtersLabel={translate('auto.components.stats.ClaudeUsagePane.dd29209b21', 'Filters')}
+      refreshAriaLabel={translate(
+        'auto.components.stats.ClaudeUsagePane.c5b9b344d0',
+        'Refresh Claude usage'
+      )}
+      refreshLabel={translate('auto.components.stats.ClaudeUsagePane.8d18bbb771', 'Refresh')}
+      filterSections={[
+        <UsageFilterRadioGroup
+          key="scope"
+          label={translate('auto.components.stats.ClaudeUsagePane.f61cffb9c8', 'Scope')}
+          value={scope}
+          options={SCOPE_OPTIONS}
+          onValueChange={(value) => void setClaudeUsageScope(value)}
+        />,
+        <UsageFilterRadioGroup
+          key="range"
+          label={translate('auto.components.stats.ClaudeUsagePane.505be9aac4', 'Range')}
+          value={range}
+          options={RANGE_OPTIONS.map((value) => ({ value, label: RANGE_LABELS[value] }))}
+          onValueChange={(value) => void setClaudeUsageRange(value)}
+        />
+      ]}
+      selectionSummary={
+        <>
+          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
+        </>
+      }
+      emptyMessage={translate(
+        'auto.components.stats.ClaudeUsagePane.7dde9331fd',
+        'No local Claude usage found yet for this scope.'
+      )}
+      onEnabledChange={handleSetEnabled}
+      onRefresh={() => void refreshClaudeUsage()}
+      headerAction={
+        summary && daily.length > 0 ? (
+          <ShareUsageButton provider="claude" summary={summary} daily={daily} range={range} />
+        ) : undefined
+      }
+    >
+      <>
+        <div className="grid gap-3 md:grid-cols-2 xl:grid-cols-4">
+          <StatCard
+            label={translate('auto.components.stats.ClaudeUsagePane.ea71fae8fc', 'Input tokens')}
+            value={formatTokens(summary?.inputTokens ?? 0)}
+            icon={<Sparkles className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.ClaudeUsagePane.2b8a2f14aa', 'Output tokens')}
+            value={formatTokens(summary?.outputTokens ?? 0)}
+            icon={<Activity className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.ClaudeUsagePane.268cf0af51', 'Cache read')}
+            value={formatTokens(summary?.cacheReadTokens ?? 0)}
+            icon={<DatabaseZap className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.ClaudeUsagePane.b786fb4a70', 'Cache write')}
+            value={formatTokens(summary?.cacheWriteTokens ?? 0)}
+            icon={<Waypoints className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.ClaudeUsagePane.1634c4f404',
+              'Cache reuse rate'
+            )}
+            value={
+              summary?.cacheReuseRate !== null && summary?.cacheReuseRate !== undefined
+                ? `${Math.round(summary.cacheReuseRate * 100)}%`
+                : 'n/a'
+            }
+            icon={<Gauge className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.ClaudeUsagePane.8cc23be4a3',
+              'Zero-cache-read turns'
+            )}
+            value={
+              summary && summary.turns > 0
+                ? `${Math.round((summary.zeroCacheReadTurns / summary.turns) * 100)}%`
+                : 'n/a'
+            }
+            icon={<DatabaseZap className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.ClaudeUsagePane.0f3e696ca9',
+              'Sessions / Turns'
+            )}
+            value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.turns ?? 0).toLocaleString()}`}
+            icon={<FolderKanban className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.ClaudeUsagePane.b26d4ddb58',
+              'Est. API-equivalent cost'
+            )}
+            value={formatCost(summary?.estimatedCostUsd ?? null)}
+            icon={<Coins className="size-4" />}
+          />
+        </div>
+        <p className="px-1 text-xs text-muted-foreground">
+          {translate(
+            'auto.components.stats.ClaudeUsagePane.51ae85fa00',
+            'Cache reuse rate is calculated as cache read tokens / (input tokens + cache read tokens).'
+          )}
+        </p>
+
+        <ClaudeUsageDetails
+          daily={daily}
+          modelBreakdown={modelBreakdown}
+          projectBreakdown={projectBreakdown}
+          recentSessions={recentSessions}
+          summary={summary}
+        />
+      </>
+    </UsageTrackingPaneShell>
   )
 }

--- a/src/renderer/src/components/stats/CodexUsagePane.tsx
+++ b/src/renderer/src/components/stats/CodexUsagePane.tsx
@@ -1,32 +1,12 @@
 import { useEffect } from 'react'
-import {
-  Activity,
-  Brain,
-  Coins,
-  DatabaseZap,
-  FolderKanban,
-  RefreshCw,
-  SlidersHorizontal,
-  Sparkles
-} from 'lucide-react'
+import { Activity, Brain, Coins, DatabaseZap, FolderKanban, Sparkles } from 'lucide-react'
 import type { CodexUsageRange, CodexUsageScope } from '../../../../shared/codex-usage-types'
 import { useAppStore } from '../../store'
-import { Button } from '../ui/button'
-import { Switch } from '../ui/switch'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from '../ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { ClaudeUsageLoadingState } from './ClaudeUsageLoadingState'
 import { CodexUsageDetails } from './CodexUsageDetails'
 import { ShareUsageButton } from './ShareUsageButton'
 import { StatCard } from './StatCard'
+import { UsageFilterRadioGroup, UsageTrackingPaneShell } from './UsageTrackingPaneShell'
 import { formatCost, formatTokens, formatUpdatedAt } from './usage-formatters'
 import { translate } from '@/i18n/i18n'
 
@@ -85,38 +65,31 @@ export function CodexUsagePane(): React.JSX.Element {
     void setCodexUsageEnabled(enabled)
   }
 
+  const title = translate('auto.components.stats.CodexUsagePane.408210470c', 'Codex Usage Tracking')
+  const enableLabel = translate(
+    'auto.components.stats.CodexUsagePane.f7c1affbd5',
+    'Enable Codex usage analytics'
+  )
+
   if (!scanState?.enabled) {
     return (
-      <div className="rounded-lg border border-border/60 bg-card/40 p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-foreground">
-              {translate('auto.components.stats.CodexUsagePane.408210470c', 'Codex Usage Tracking')}
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              {translate(
-                'auto.components.stats.CodexUsagePane.13badcd8f2',
-                'Reads local Codex usage logs to show token, model, and session stats.'
-              )}
-            </p>
-          </div>
-          <Switch
-            checked={false}
-            aria-label={translate(
-              'auto.components.stats.CodexUsagePane.f7c1affbd5',
-              'Enable Codex usage analytics'
-            )}
-            onCheckedChange={handleSetEnabled}
-          />
-        </div>
-      </div>
+      <UsageTrackingPaneShell
+        enabled={false}
+        title={title}
+        disabledDescription={translate(
+          'auto.components.stats.CodexUsagePane.13badcd8f2',
+          'Reads local Codex usage logs to show token, model, and session stats.'
+        )}
+        enableLabel={enableLabel}
+        onEnabledChange={handleSetEnabled}
+      />
     )
   }
 
   if (!summary && (scanState.isScanning || scanState.lastScanCompletedAt === null)) {
     return (
       <ClaudeUsageLoadingState
-        title={translate('auto.components.stats.CodexUsagePane.408210470c', 'Codex Usage Tracking')}
+        title={title}
         summaryCardCount={6}
         summaryGridClassName="md:grid-cols-3"
       />
@@ -126,183 +99,121 @@ export function CodexUsagePane(): React.JSX.Element {
   const hasAnyData = summary?.hasAnyCodexData ?? scanState.hasAnyCodexData
 
   return (
-    <div className="space-y-4 rounded-lg border border-border/60 bg-card/30 p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-semibold text-foreground">
-            {translate('auto.components.stats.CodexUsagePane.408210470c', 'Codex Usage Tracking')}
-          </h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {formatUpdatedAt(scanState.lastScanCompletedAt)}
-            {scanState.lastScanError
-              ? translate(
-                  'auto.components.stats.CodexUsagePane.8a6655f7a2',
-                  ' • Last scan error: {{value0}}',
-                  { value0: scanState.lastScanError }
-                )
-              : ''}
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 self-start">
-          {summary && daily.length > 0 && (
-            <ShareUsageButton provider="codex" summary={summary} daily={daily} range={range} />
-          )}
-          <DropdownMenu>
-            <TooltipProvider delayDuration={250}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label={translate(
-                        'auto.components.stats.CodexUsagePane.70b5b8581f',
-                        'Codex usage options'
-                      )}
-                    >
-                      <SlidersHorizontal className="size-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate('auto.components.stats.CodexUsagePane.1af1a39b2f', 'Filters')}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <DropdownMenuContent align="end" className="w-60">
-              <DropdownMenuLabel>
-                {translate('auto.components.stats.CodexUsagePane.6d68e8399a', 'Scope')}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={scope}
-                onValueChange={(value) => void setCodexUsageScope(value as CodexUsageScope)}
-              >
-                {SCOPE_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem key={option.value} value={option.value}>
-                    {option.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>
-                {translate('auto.components.stats.CodexUsagePane.89162e019b', 'Range')}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={range}
-                onValueChange={(value) => void setCodexUsageRange(value as CodexUsageRange)}
-              >
-                {RANGE_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem key={option} value={option}>
-                    {RANGE_LABELS[option]}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <TooltipProvider delayDuration={250}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => void refreshCodexUsage()}
-                  disabled={scanState.isScanning}
-                  aria-label={translate(
-                    'auto.components.stats.CodexUsagePane.ec4d270e2c',
-                    'Refresh Codex usage'
-                  )}
-                >
-                  <RefreshCw className={`size-3.5 ${scanState.isScanning ? 'animate-spin' : ''}`} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {translate('auto.components.stats.CodexUsagePane.3022cda443', 'Refresh')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <Switch
-            checked
-            aria-label={translate(
-              'auto.components.stats.CodexUsagePane.f7c1affbd5',
-              'Enable Codex usage analytics'
-            )}
-            onCheckedChange={handleSetEnabled}
-          />
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs text-muted-foreground">
-          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
-        </p>
-      </div>
-
-      {!hasAnyData ? (
-        <div className="rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-6 text-sm text-muted-foreground">
-          {translate(
-            'auto.components.stats.CodexUsagePane.4c865393b4',
-            'No local Codex usage found yet for this scope.'
-          )}
-        </div>
-      ) : (
+    <UsageTrackingPaneShell
+      enabled
+      title={title}
+      status={
         <>
-          <div className="grid gap-3 md:grid-cols-3">
-            <StatCard
-              label={translate('auto.components.stats.CodexUsagePane.e365eaa6fd', 'Input tokens')}
-              value={formatTokens(summary?.inputTokens ?? 0)}
-              icon={<Sparkles className="size-4" />}
-            />
-            <StatCard
-              label={translate('auto.components.stats.CodexUsagePane.5d8eba87bd', 'Output tokens')}
-              value={formatTokens(summary?.outputTokens ?? 0)}
-              icon={<Activity className="size-4" />}
-            />
-            <StatCard
-              label={translate('auto.components.stats.CodexUsagePane.a9ac0f423a', 'Cached input')}
-              value={formatTokens(summary?.cachedInputTokens ?? 0)}
-              icon={<DatabaseZap className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.CodexUsagePane.6e18146e9b',
-                'Reasoning output'
-              )}
-              value={formatTokens(summary?.reasoningOutputTokens ?? 0)}
-              icon={<Brain className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.CodexUsagePane.907b31865f',
-                'Sessions / Events'
-              )}
-              value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.events ?? 0).toLocaleString()}`}
-              icon={<FolderKanban className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.CodexUsagePane.1a18fbd56b',
-                'Est. API-equivalent cost'
-              )}
-              value={formatCost(summary?.estimatedCostUsd ?? null)}
-              icon={<Coins className="size-4" />}
-            />
-          </div>
-          <p className="px-1 text-xs text-muted-foreground">
-            {translate(
-              'auto.components.stats.CodexUsagePane.94ac1f1ee7',
-              'Reasoning tokens are shown for visibility, but cost is calculated from uncached input, cached input, and output only.'
-            )}
-          </p>
-
-          <CodexUsageDetails
-            daily={daily}
-            modelBreakdown={modelBreakdown}
-            projectBreakdown={projectBreakdown}
-            recentSessions={recentSessions}
-            summary={summary}
-          />
+          {formatUpdatedAt(scanState.lastScanCompletedAt)}
+          {scanState.lastScanError
+            ? translate(
+                'auto.components.stats.CodexUsagePane.8a6655f7a2',
+                ' • Last scan error: {{value0}}',
+                { value0: scanState.lastScanError }
+              )
+            : ''}
         </>
+      }
+      isRefreshing={scanState.isScanning}
+      hasData={hasAnyData}
+      enableLabel={enableLabel}
+      optionsLabel={translate(
+        'auto.components.stats.CodexUsagePane.70b5b8581f',
+        'Codex usage options'
       )}
-    </div>
+      filtersLabel={translate('auto.components.stats.CodexUsagePane.1af1a39b2f', 'Filters')}
+      refreshAriaLabel={translate(
+        'auto.components.stats.CodexUsagePane.ec4d270e2c',
+        'Refresh Codex usage'
+      )}
+      refreshLabel={translate('auto.components.stats.CodexUsagePane.3022cda443', 'Refresh')}
+      filterSections={[
+        <UsageFilterRadioGroup
+          key="scope"
+          label={translate('auto.components.stats.CodexUsagePane.6d68e8399a', 'Scope')}
+          value={scope}
+          options={SCOPE_OPTIONS}
+          onValueChange={(value) => void setCodexUsageScope(value)}
+        />,
+        <UsageFilterRadioGroup
+          key="range"
+          label={translate('auto.components.stats.CodexUsagePane.89162e019b', 'Range')}
+          value={range}
+          options={RANGE_OPTIONS.map((value) => ({ value, label: RANGE_LABELS[value] }))}
+          onValueChange={(value) => void setCodexUsageRange(value)}
+        />
+      ]}
+      selectionSummary={
+        <>
+          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
+        </>
+      }
+      emptyMessage={translate(
+        'auto.components.stats.CodexUsagePane.4c865393b4',
+        'No local Codex usage found yet for this scope.'
+      )}
+      onEnabledChange={handleSetEnabled}
+      onRefresh={() => void refreshCodexUsage()}
+      headerAction={
+        summary && daily.length > 0 ? (
+          <ShareUsageButton provider="codex" summary={summary} daily={daily} range={range} />
+        ) : undefined
+      }
+    >
+      <>
+        <div className="grid gap-3 md:grid-cols-3">
+          <StatCard
+            label={translate('auto.components.stats.CodexUsagePane.e365eaa6fd', 'Input tokens')}
+            value={formatTokens(summary?.inputTokens ?? 0)}
+            icon={<Sparkles className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.CodexUsagePane.5d8eba87bd', 'Output tokens')}
+            value={formatTokens(summary?.outputTokens ?? 0)}
+            icon={<Activity className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.CodexUsagePane.a9ac0f423a', 'Cached input')}
+            value={formatTokens(summary?.cachedInputTokens ?? 0)}
+            icon={<DatabaseZap className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.CodexUsagePane.6e18146e9b', 'Reasoning output')}
+            value={formatTokens(summary?.reasoningOutputTokens ?? 0)}
+            icon={<Brain className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.CodexUsagePane.907b31865f',
+              'Sessions / Events'
+            )}
+            value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.events ?? 0).toLocaleString()}`}
+            icon={<FolderKanban className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.CodexUsagePane.1a18fbd56b',
+              'Est. API-equivalent cost'
+            )}
+            value={formatCost(summary?.estimatedCostUsd ?? null)}
+            icon={<Coins className="size-4" />}
+          />
+        </div>
+        <p className="px-1 text-xs text-muted-foreground">
+          {translate(
+            'auto.components.stats.CodexUsagePane.94ac1f1ee7',
+            'Reasoning tokens are shown for visibility, but cost is calculated from uncached input, cached input, and output only.'
+          )}
+        </p>
+
+        <CodexUsageDetails
+          daily={daily}
+          modelBreakdown={modelBreakdown}
+          projectBreakdown={projectBreakdown}
+          recentSessions={recentSessions}
+          summary={summary}
+        />
+      </>
+    </UsageTrackingPaneShell>
   )
 }

--- a/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
+++ b/src/renderer/src/components/stats/OpenCodeUsagePane.tsx
@@ -1,34 +1,14 @@
 import { useEffect } from 'react'
-import {
-  Activity,
-  Brain,
-  Coins,
-  DatabaseZap,
-  FolderKanban,
-  RefreshCw,
-  SlidersHorizontal,
-  Sparkles
-} from 'lucide-react'
+import { Activity, Brain, Coins, DatabaseZap, FolderKanban, Sparkles } from 'lucide-react'
 import type {
   OpenCodeUsageRange,
   OpenCodeUsageScope
 } from '../../../../shared/opencode-usage-types'
 import { useAppStore } from '../../store'
-import { Button } from '../ui/button'
-import { Switch } from '../ui/switch'
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuLabel,
-  DropdownMenuRadioGroup,
-  DropdownMenuRadioItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger
-} from '../ui/dropdown-menu'
-import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
 import { ClaudeUsageLoadingState } from './ClaudeUsageLoadingState'
 import { OpenCodeUsageDetails } from './OpenCodeUsageDetails'
 import { StatCard } from './StatCard'
+import { UsageFilterRadioGroup, UsageTrackingPaneShell } from './UsageTrackingPaneShell'
 import { formatCost, formatTokens, formatUpdatedAt } from './usage-formatters'
 import { translate } from '@/i18n/i18n'
 
@@ -90,44 +70,34 @@ export function OpenCodeUsagePane(): React.JSX.Element {
     void setOpenCodeUsageEnabled(enabled)
   }
 
+  const title = translate(
+    'auto.components.stats.OpenCodeUsagePane.bea80ceae0',
+    'OpenCode Usage Tracking'
+  )
+  const enableLabel = translate(
+    'auto.components.stats.OpenCodeUsagePane.f04131b3be',
+    'Enable OpenCode usage analytics'
+  )
+
   if (!scanState?.enabled) {
     return (
-      <div className="rounded-lg border border-border/60 bg-card/40 p-4">
-        <div className="flex items-start justify-between gap-4">
-          <div className="space-y-2">
-            <h3 className="text-sm font-semibold text-foreground">
-              {translate(
-                'auto.components.stats.OpenCodeUsagePane.bea80ceae0',
-                'OpenCode Usage Tracking'
-              )}
-            </h3>
-            <p className="text-sm text-muted-foreground">
-              {translate(
-                'auto.components.stats.OpenCodeUsagePane.b8b3522436',
-                'Reads local OpenCode usage logs to show token, model, and session stats.'
-              )}
-            </p>
-          </div>
-          <Switch
-            checked={false}
-            aria-label={translate(
-              'auto.components.stats.OpenCodeUsagePane.f04131b3be',
-              'Enable OpenCode usage analytics'
-            )}
-            onCheckedChange={handleSetEnabled}
-          />
-        </div>
-      </div>
+      <UsageTrackingPaneShell
+        enabled={false}
+        title={title}
+        disabledDescription={translate(
+          'auto.components.stats.OpenCodeUsagePane.b8b3522436',
+          'Reads local OpenCode usage logs to show token, model, and session stats.'
+        )}
+        enableLabel={enableLabel}
+        onEnabledChange={handleSetEnabled}
+      />
     )
   }
 
   if (!summary && (scanState.isScanning || scanState.lastScanCompletedAt === null)) {
     return (
       <ClaudeUsageLoadingState
-        title={translate(
-          'auto.components.stats.OpenCodeUsagePane.bea80ceae0',
-          'OpenCode Usage Tracking'
-        )}
+        title={title}
         summaryCardCount={6}
         summaryGridClassName="md:grid-cols-3"
       />
@@ -137,192 +107,116 @@ export function OpenCodeUsagePane(): React.JSX.Element {
   const hasAnyData = summary?.hasAnyOpenCodeData ?? scanState.hasAnyOpenCodeData
 
   return (
-    <div className="space-y-4 rounded-lg border border-border/60 bg-card/30 p-4">
-      <div className="flex items-start justify-between gap-4">
-        <div className="min-w-0 flex-1">
-          <h3 className="text-sm font-semibold text-foreground">
-            {translate(
-              'auto.components.stats.OpenCodeUsagePane.bea80ceae0',
-              'OpenCode Usage Tracking'
-            )}
-          </h3>
-          <p className="mt-1 text-xs text-muted-foreground">
-            {formatUpdatedAt(scanState.lastScanCompletedAt)}
-            {scanState.lastScanError
-              ? translate(
-                  'auto.components.stats.OpenCodeUsagePane.6cc7782458',
-                  ' • Last scan error: {{value0}}',
-                  { value0: scanState.lastScanError }
-                )
-              : ''}
-          </p>
-        </div>
-        <div className="flex shrink-0 items-center gap-2 self-start">
-          <DropdownMenu>
-            <TooltipProvider delayDuration={250}>
-              <Tooltip>
-                <TooltipTrigger asChild>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon-xs"
-                      aria-label={translate(
-                        'auto.components.stats.OpenCodeUsagePane.230d6de108',
-                        'OpenCode usage options'
-                      )}
-                    >
-                      <SlidersHorizontal className="size-3.5" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                </TooltipTrigger>
-                <TooltipContent side="bottom" sideOffset={6}>
-                  {translate('auto.components.stats.OpenCodeUsagePane.01583b30aa', 'Filters')}
-                </TooltipContent>
-              </Tooltip>
-            </TooltipProvider>
-            <DropdownMenuContent align="end" className="w-60">
-              <DropdownMenuLabel>
-                {translate('auto.components.stats.OpenCodeUsagePane.40d283c837', 'Scope')}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={scope}
-                onValueChange={(value) => void setOpenCodeUsageScope(value as OpenCodeUsageScope)}
-              >
-                {SCOPE_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem key={option.value} value={option.value}>
-                    {option.label}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-              <DropdownMenuSeparator />
-              <DropdownMenuLabel>
-                {translate('auto.components.stats.OpenCodeUsagePane.b5ed5c9fd0', 'Range')}
-              </DropdownMenuLabel>
-              <DropdownMenuRadioGroup
-                value={range}
-                onValueChange={(value) => void setOpenCodeUsageRange(value as OpenCodeUsageRange)}
-              >
-                {RANGE_OPTIONS.map((option) => (
-                  <DropdownMenuRadioItem key={option} value={option}>
-                    {RANGE_LABELS[option]}
-                  </DropdownMenuRadioItem>
-                ))}
-              </DropdownMenuRadioGroup>
-            </DropdownMenuContent>
-          </DropdownMenu>
-          <TooltipProvider delayDuration={250}>
-            <Tooltip>
-              <TooltipTrigger asChild>
-                <Button
-                  variant="ghost"
-                  size="icon-xs"
-                  onClick={() => void refreshOpenCodeUsage()}
-                  disabled={scanState.isScanning}
-                  aria-label={translate(
-                    'auto.components.stats.OpenCodeUsagePane.bed558df0b',
-                    'Refresh OpenCode usage'
-                  )}
-                >
-                  <RefreshCw className={`size-3.5 ${scanState.isScanning ? 'animate-spin' : ''}`} />
-                </Button>
-              </TooltipTrigger>
-              <TooltipContent side="bottom" sideOffset={6}>
-                {translate('auto.components.stats.OpenCodeUsagePane.603cd138dc', 'Refresh')}
-              </TooltipContent>
-            </Tooltip>
-          </TooltipProvider>
-          <Switch
-            checked
-            aria-label={translate(
-              'auto.components.stats.OpenCodeUsagePane.f04131b3be',
-              'Enable OpenCode usage analytics'
-            )}
-            onCheckedChange={handleSetEnabled}
-          />
-        </div>
-      </div>
-
-      <div className="flex items-center justify-between gap-3">
-        <p className="text-xs text-muted-foreground">
-          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
-        </p>
-      </div>
-
-      {!hasAnyData ? (
-        <div className="rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-6 text-sm text-muted-foreground">
-          {translate(
-            'auto.components.stats.OpenCodeUsagePane.bb6363e08c',
-            'No local OpenCode usage found yet for this scope.'
-          )}
-        </div>
-      ) : (
+    <UsageTrackingPaneShell
+      enabled
+      title={title}
+      status={
         <>
-          <div className="grid gap-3 md:grid-cols-3">
-            <StatCard
-              label={translate(
-                'auto.components.stats.OpenCodeUsagePane.d637a892ed',
-                'Input tokens'
-              )}
-              value={formatTokens(summary?.inputTokens ?? 0)}
-              icon={<Sparkles className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.OpenCodeUsagePane.7aa4d8ce35',
-                'Output tokens'
-              )}
-              value={formatTokens(summary?.outputTokens ?? 0)}
-              icon={<Activity className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.OpenCodeUsagePane.603504ee3b',
-                'Cached input'
-              )}
-              value={formatTokens(summary?.cachedInputTokens ?? 0)}
-              icon={<DatabaseZap className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.OpenCodeUsagePane.5a65d68b77',
-                'Reasoning output'
-              )}
-              value={formatTokens(summary?.reasoningOutputTokens ?? 0)}
-              icon={<Brain className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.OpenCodeUsagePane.7e9433469a',
-                'Sessions / Events'
-              )}
-              value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.events ?? 0).toLocaleString()}`}
-              icon={<FolderKanban className="size-4" />}
-            />
-            <StatCard
-              label={translate(
-                'auto.components.stats.OpenCodeUsagePane.15c34d4b08',
-                'Recorded cost'
-              )}
-              value={formatCost(summary?.estimatedCostUsd ?? null)}
-              icon={<Coins className="size-4" />}
-            />
-          </div>
-          <p className="px-1 text-xs text-muted-foreground">
-            {translate(
-              'auto.components.stats.OpenCodeUsagePane.e5bb23d85e',
-              'Cost comes from the local OpenCode database when the assistant message recorded one.'
-            )}
-          </p>
-
-          <OpenCodeUsageDetails
-            daily={daily}
-            modelBreakdown={modelBreakdown}
-            projectBreakdown={projectBreakdown}
-            recentSessions={recentSessions}
-            summary={summary}
-          />
+          {formatUpdatedAt(scanState.lastScanCompletedAt)}
+          {scanState.lastScanError
+            ? translate(
+                'auto.components.stats.OpenCodeUsagePane.6cc7782458',
+                ' • Last scan error: {{value0}}',
+                { value0: scanState.lastScanError }
+              )
+            : ''}
         </>
+      }
+      isRefreshing={scanState.isScanning}
+      hasData={hasAnyData}
+      enableLabel={enableLabel}
+      optionsLabel={translate(
+        'auto.components.stats.OpenCodeUsagePane.230d6de108',
+        'OpenCode usage options'
       )}
-    </div>
+      filtersLabel={translate('auto.components.stats.OpenCodeUsagePane.01583b30aa', 'Filters')}
+      refreshAriaLabel={translate(
+        'auto.components.stats.OpenCodeUsagePane.bed558df0b',
+        'Refresh OpenCode usage'
+      )}
+      refreshLabel={translate('auto.components.stats.OpenCodeUsagePane.603cd138dc', 'Refresh')}
+      filterSections={[
+        <UsageFilterRadioGroup
+          key="scope"
+          label={translate('auto.components.stats.OpenCodeUsagePane.40d283c837', 'Scope')}
+          value={scope}
+          options={SCOPE_OPTIONS}
+          onValueChange={(value) => void setOpenCodeUsageScope(value)}
+        />,
+        <UsageFilterRadioGroup
+          key="range"
+          label={translate('auto.components.stats.OpenCodeUsagePane.b5ed5c9fd0', 'Range')}
+          value={range}
+          options={RANGE_OPTIONS.map((value) => ({ value, label: RANGE_LABELS[value] }))}
+          onValueChange={(value) => void setOpenCodeUsageRange(value)}
+        />
+      ]}
+      selectionSummary={
+        <>
+          {SCOPE_OPTIONS.find((option) => option.value === scope)?.label} • {RANGE_LABELS[range]}
+        </>
+      }
+      emptyMessage={translate(
+        'auto.components.stats.OpenCodeUsagePane.bb6363e08c',
+        'No local OpenCode usage found yet for this scope.'
+      )}
+      onEnabledChange={handleSetEnabled}
+      onRefresh={() => void refreshOpenCodeUsage()}
+    >
+      <>
+        <div className="grid gap-3 md:grid-cols-3">
+          <StatCard
+            label={translate('auto.components.stats.OpenCodeUsagePane.d637a892ed', 'Input tokens')}
+            value={formatTokens(summary?.inputTokens ?? 0)}
+            icon={<Sparkles className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.OpenCodeUsagePane.7aa4d8ce35', 'Output tokens')}
+            value={formatTokens(summary?.outputTokens ?? 0)}
+            icon={<Activity className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.OpenCodeUsagePane.603504ee3b', 'Cached input')}
+            value={formatTokens(summary?.cachedInputTokens ?? 0)}
+            icon={<DatabaseZap className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.OpenCodeUsagePane.5a65d68b77',
+              'Reasoning output'
+            )}
+            value={formatTokens(summary?.reasoningOutputTokens ?? 0)}
+            icon={<Brain className="size-4" />}
+          />
+          <StatCard
+            label={translate(
+              'auto.components.stats.OpenCodeUsagePane.7e9433469a',
+              'Sessions / Events'
+            )}
+            value={`${(summary?.sessions ?? 0).toLocaleString()} / ${(summary?.events ?? 0).toLocaleString()}`}
+            icon={<FolderKanban className="size-4" />}
+          />
+          <StatCard
+            label={translate('auto.components.stats.OpenCodeUsagePane.15c34d4b08', 'Recorded cost')}
+            value={formatCost(summary?.estimatedCostUsd ?? null)}
+            icon={<Coins className="size-4" />}
+          />
+        </div>
+        <p className="px-1 text-xs text-muted-foreground">
+          {translate(
+            'auto.components.stats.OpenCodeUsagePane.e5bb23d85e',
+            'Cost comes from the local OpenCode database when the assistant message recorded one.'
+          )}
+        </p>
+
+        <OpenCodeUsageDetails
+          daily={daily}
+          modelBreakdown={modelBreakdown}
+          projectBreakdown={projectBreakdown}
+          recentSessions={recentSessions}
+          summary={summary}
+        />
+      </>
+    </UsageTrackingPaneShell>
   )
 }

--- a/src/renderer/src/components/stats/UsageTrackingPaneShell.test.tsx
+++ b/src/renderer/src/components/stats/UsageTrackingPaneShell.test.tsx
@@ -1,0 +1,106 @@
+// @vitest-environment happy-dom
+
+import '@testing-library/jest-dom/vitest'
+
+import { cleanup, render, screen } from '@testing-library/react'
+import userEvent from '@testing-library/user-event'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { UsageFilterRadioGroup, UsageTrackingPaneShell } from './UsageTrackingPaneShell'
+
+afterEach(cleanup)
+
+function renderEnabled({
+  hasData = false,
+  isRefreshing = false
+}: { hasData?: boolean; isRefreshing?: boolean } = {}) {
+  const onEnabledChange = vi.fn()
+  const onRefresh = vi.fn()
+  const onScopeChange = vi.fn()
+
+  render(
+    <UsageTrackingPaneShell
+      enabled
+      title="Codex Usage Tracking"
+      status="Updated now"
+      isRefreshing={isRefreshing}
+      hasData={hasData}
+      enableLabel="Enable Codex usage analytics"
+      optionsLabel="Codex usage options"
+      filtersLabel="Filters"
+      refreshAriaLabel="Refresh Codex usage"
+      refreshLabel="Refresh"
+      filterSections={[
+        <UsageFilterRadioGroup
+          key="scope"
+          label="Scope"
+          value="orca"
+          options={[
+            { value: 'orca', label: 'Orca worktrees only' },
+            { value: 'all', label: 'All local usage' }
+          ]}
+          onValueChange={onScopeChange}
+        />,
+        <div key="range">Range filter</div>
+      ]}
+      selectionSummary="Orca worktrees only • Last 7 days"
+      emptyMessage="No local Codex usage found yet for this scope."
+      onEnabledChange={onEnabledChange}
+      onRefresh={onRefresh}
+      headerAction={<span>Share usage</span>}
+    >
+      <div>Ready content</div>
+    </UsageTrackingPaneShell>
+  )
+
+  return { onEnabledChange, onRefresh, onScopeChange }
+}
+
+describe('UsageTrackingPaneShell', () => {
+  it('renders the disabled state and enables tracking', async () => {
+    const onEnabledChange = vi.fn()
+    const user = userEvent.setup()
+    render(
+      <UsageTrackingPaneShell
+        enabled={false}
+        title="Codex Usage Tracking"
+        disabledDescription="Reads local Codex usage logs."
+        enableLabel="Enable Codex usage analytics"
+        onEnabledChange={onEnabledChange}
+      />
+    )
+
+    expect(screen.getByText('Reads local Codex usage logs.')).toBeInTheDocument()
+    await user.click(screen.getByRole('switch', { name: 'Enable Codex usage analytics' }))
+    expect(onEnabledChange).toHaveBeenCalledWith(true)
+  })
+
+  it('renders the empty state and wires header actions', async () => {
+    const user = userEvent.setup()
+    const { onEnabledChange, onRefresh, onScopeChange } = renderEnabled()
+
+    expect(screen.getByText('Updated now')).toBeInTheDocument()
+    expect(screen.getByText('Share usage')).toBeInTheDocument()
+    expect(screen.getByText('Orca worktrees only • Last 7 days')).toBeInTheDocument()
+    expect(screen.getByText('No local Codex usage found yet for this scope.')).toBeInTheDocument()
+    expect(screen.queryByText('Ready content')).not.toBeInTheDocument()
+
+    await user.click(screen.getByRole('button', { name: 'Codex usage options' }))
+    expect(screen.getByRole('separator')).toBeInTheDocument()
+    await user.click(screen.getByRole('menuitemradio', { name: 'All local usage' }))
+    await user.click(screen.getByRole('button', { name: 'Refresh Codex usage' }))
+    await user.click(screen.getByRole('switch', { name: 'Enable Codex usage analytics' }))
+    expect(onScopeChange).toHaveBeenCalledWith('all')
+    expect(onRefresh).toHaveBeenCalledOnce()
+    expect(onEnabledChange).toHaveBeenCalledWith(false)
+  })
+
+  it('renders ready content and disables refresh while scanning', () => {
+    renderEnabled({ hasData: true, isRefreshing: true })
+
+    expect(screen.getByText('Ready content')).toBeInTheDocument()
+    expect(
+      screen.queryByText('No local Codex usage found yet for this scope.')
+    ).not.toBeInTheDocument()
+    expect(screen.getByRole('button', { name: 'Refresh Codex usage' })).toBeDisabled()
+  })
+})

--- a/src/renderer/src/components/stats/UsageTrackingPaneShell.tsx
+++ b/src/renderer/src/components/stats/UsageTrackingPaneShell.tsx
@@ -1,0 +1,160 @@
+import { Fragment, type ReactElement, type ReactNode } from 'react'
+import { RefreshCw, SlidersHorizontal } from 'lucide-react'
+import { Button } from '../ui/button'
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuLabel,
+  DropdownMenuRadioGroup,
+  DropdownMenuRadioItem,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger
+} from '../ui/dropdown-menu'
+import { Switch } from '../ui/switch'
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip'
+
+type UsageFilterRadioGroupProps<Value extends string> = {
+  label: ReactNode
+  value: Value
+  options: readonly { value: Value; label: ReactNode }[]
+  onValueChange: (value: Value) => void | Promise<void>
+}
+
+export function UsageFilterRadioGroup<Value extends string>({
+  label,
+  value,
+  options,
+  onValueChange
+}: UsageFilterRadioGroupProps<Value>): React.JSX.Element {
+  return (
+    <>
+      <DropdownMenuLabel>{label}</DropdownMenuLabel>
+      <DropdownMenuRadioGroup
+        value={value}
+        onValueChange={(nextValue) => void onValueChange(nextValue as Value)}
+      >
+        {options.map((option) => (
+          <DropdownMenuRadioItem key={option.value} value={option.value}>
+            {option.label}
+          </DropdownMenuRadioItem>
+        ))}
+      </DropdownMenuRadioGroup>
+    </>
+  )
+}
+
+type UsageTrackingPaneShellProps = {
+  title: ReactNode
+  enableLabel: string
+  onEnabledChange: (enabled: boolean) => void
+} & (
+  | {
+      enabled: false
+      disabledDescription: ReactNode
+    }
+  | {
+      enabled: true
+      status: ReactNode
+      isRefreshing: boolean
+      hasData: boolean
+      optionsLabel: string
+      filtersLabel: ReactNode
+      refreshAriaLabel: string
+      refreshLabel: ReactNode
+      filterSections: readonly ReactElement[]
+      selectionSummary: ReactNode
+      emptyMessage: ReactNode
+      onRefresh: () => void | Promise<void>
+      headerAction?: ReactNode
+      children: ReactNode
+    }
+)
+
+export function UsageTrackingPaneShell(props: UsageTrackingPaneShellProps): React.JSX.Element {
+  if (!props.enabled) {
+    return (
+      <div className="rounded-lg border border-border/60 bg-card/40 p-4">
+        <div className="flex items-start justify-between gap-4">
+          <div className="space-y-2">
+            <h3 className="text-sm font-semibold text-foreground">{props.title}</h3>
+            <p className="text-sm text-muted-foreground">{props.disabledDescription}</p>
+          </div>
+          <Switch
+            checked={false}
+            aria-label={props.enableLabel}
+            onCheckedChange={props.onEnabledChange}
+          />
+        </div>
+      </div>
+    )
+  }
+
+  return (
+    <div className="space-y-4 rounded-lg border border-border/60 bg-card/30 p-4">
+      <div className="flex items-start justify-between gap-4">
+        <div className="min-w-0 flex-1">
+          <h3 className="text-sm font-semibold text-foreground">{props.title}</h3>
+          <p className="mt-1 text-xs text-muted-foreground">{props.status}</p>
+        </div>
+        <div className="flex shrink-0 items-center gap-2 self-start">
+          {props.headerAction}
+          <DropdownMenu>
+            <TooltipProvider delayDuration={250}>
+              <Tooltip>
+                <TooltipTrigger asChild>
+                  <DropdownMenuTrigger asChild>
+                    <Button variant="ghost" size="icon-xs" aria-label={props.optionsLabel}>
+                      <SlidersHorizontal className="size-3.5" />
+                    </Button>
+                  </DropdownMenuTrigger>
+                </TooltipTrigger>
+                <TooltipContent side="bottom" sideOffset={6}>
+                  {props.filtersLabel}
+                </TooltipContent>
+              </Tooltip>
+            </TooltipProvider>
+            <DropdownMenuContent align="end" className="w-60">
+              {props.filterSections.map((section, index) => (
+                <Fragment key={section.key}>
+                  {index > 0 && <DropdownMenuSeparator />}
+                  {section}
+                </Fragment>
+              ))}
+            </DropdownMenuContent>
+          </DropdownMenu>
+          <TooltipProvider delayDuration={250}>
+            <Tooltip>
+              <TooltipTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon-xs"
+                  onClick={() => void props.onRefresh()}
+                  disabled={props.isRefreshing}
+                  aria-label={props.refreshAriaLabel}
+                >
+                  <RefreshCw className={`size-3.5 ${props.isRefreshing ? 'animate-spin' : ''}`} />
+                </Button>
+              </TooltipTrigger>
+              <TooltipContent side="bottom" sideOffset={6}>
+                {props.refreshLabel}
+              </TooltipContent>
+            </Tooltip>
+          </TooltipProvider>
+          <Switch checked aria-label={props.enableLabel} onCheckedChange={props.onEnabledChange} />
+        </div>
+      </div>
+
+      <div className="flex items-center justify-between gap-3">
+        <p className="text-xs text-muted-foreground">{props.selectionSummary}</p>
+      </div>
+
+      {!props.hasData ? (
+        <div className="rounded-lg border border-dashed border-border/60 bg-card/30 px-4 py-6 text-sm text-muted-foreground">
+          {props.emptyMessage}
+        </div>
+      ) : (
+        props.children
+      )}
+    </div>
+  )
+}


### PR DESCRIPTION
## Summary

- share the disabled/enabled pane shell and filter radio rendering across Claude, Codex, and OpenCode usage panes
- preserve provider-owned loading, summary, data, translations, actions, and selection state
- remove 114 production lines and 8 net lines including regression coverage

## Screenshots

No visual change.

## Testing

- [ ] pnpm lint
- [ ] pnpm typecheck
- [ ] pnpm test
- [ ] pnpm build
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused verification:

- pnpm typecheck:web
- pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/stats (4 files, 12 tests)
- pnpm check:code-quality:changed
- pnpm lint:react-doctor:changed
- pnpm check:max-lines-ratchet
- pnpm verify:localization-catalog
- pnpm verify:localization-extraction
- pnpm exec oxfmt --check on all five changed files
- git diff --check

## AI Review Report

Reviewed behavior parity across disabled, loading, empty, ready, and refreshing states; header action order; tooltips; filters; share, refresh, and switch behavior; provider state ownership; TypeScript boundaries; and maintainability. The review found one low-severity gap: the shared filter interaction was not covered. Added a real menu interaction test that verifies separator rendering, radio selection, and callback dispatch. No findings remain.

Cross-platform review covered macOS, Linux, Windows, SSH, and folder workspaces. This renderer-only refactor changes no shortcuts, platform labels, paths, shell behavior, Electron behavior, Git commands, or remote-wire contracts.

## Security Audit

Pure renderer composition refactor. It adds no command execution, path handling, authentication, secrets, dependencies, persistence, IPC, or wire changes. Filter values still come from provider-owned option lists and flow to the existing store setters. No security follow-up is needed.

## Notes

Stacked on #13432.
