### PR TITLE
fix(bench): report counterbalanced WSL Git medians

### DIFF
--- a/config/scripts/benchmark-sample-summary.mjs
+++ b/config/scripts/benchmark-sample-summary.mjs
@@ -1,0 +1,25 @@
+export const BENCHMARK_SAMPLE_AGGREGATION = Object.freeze({
+  version: 2,
+  median: 'average-middle',
+  p95: 'nearest-rank'
+})
+
+export function summarizeBenchmarkSamples(samples) {
+  if (samples.length === 0) {
+    throw new Error('Benchmark samples must not be empty')
+  }
+  const sorted = [...samples].sort((left, right) => left - right)
+  const middle = sorted.length / 2
+  const median = Number.isInteger(middle)
+    ? (sorted[middle - 1] + sorted[middle]) / 2
+    : sorted[Math.floor(middle)]
+  const p95 = sorted[Math.ceil(0.95 * sorted.length) - 1]
+
+  return {
+    samples: samples.length,
+    medianMs: Number(median.toFixed(1)),
+    p95Ms: Number(p95.toFixed(1)),
+    minMs: Number(sorted[0].toFixed(1)),
+    maxMs: Number(sorted.at(-1).toFixed(1))
+  }
+}

--- a/config/scripts/benchmark-sample-summary.mjs
+++ b/config/scripts/benchmark-sample-summary.mjs
@@ -1,7 +1,9 @@
 export const BENCHMARK_SAMPLE_AGGREGATION = Object.freeze({
   version: 2,
   median: 'average-middle',
-  p95: 'nearest-rank'
+  p95: 'nearest-rank',
+  p95Role: 'descriptive',
+  p95LinearDriftBoundLaunchSlots: 1
 })
 
 export function summarizeBenchmarkSamples(samples) {

--- a/config/scripts/benchmark-sample-summary.test.mjs
+++ b/config/scripts/benchmark-sample-summary.test.mjs
@@ -1,0 +1,23 @@
+import { describe, expect, it } from 'vitest'
+
+import { summarizeBenchmarkSamples } from './benchmark-sample-summary.mjs'
+
+describe('benchmark sample summary', () => {
+  it('averages the two middle samples for an even-sized median', () => {
+    expect(summarizeBenchmarkSamples([100, 1, 2, 99]).medianMs).toBe(50.5)
+  })
+
+  it('preserves nearest-rank p95 and range reporting', () => {
+    expect(summarizeBenchmarkSamples([1, 2, 3, 4, 5, 6])).toEqual({
+      samples: 6,
+      medianMs: 3.5,
+      p95Ms: 6,
+      minMs: 1,
+      maxMs: 6
+    })
+  })
+
+  it('rejects empty samples', () => {
+    expect(() => summarizeBenchmarkSamples([])).toThrow('must not be empty')
+  })
+})

--- a/config/scripts/benchmark-sample-summary.test.mjs
+++ b/config/scripts/benchmark-sample-summary.test.mjs
@@ -7,6 +7,10 @@ describe('benchmark sample summary', () => {
     expect(summarizeBenchmarkSamples([100, 1, 2, 99]).medianMs).toBe(50.5)
   })
 
+  it('selects the middle sample for an odd-sized median', () => {
+    expect(summarizeBenchmarkSamples([100, 1, 2, 99, 3]).medianMs).toBe(3)
+  })
+
   it('preserves nearest-rank p95 and range reporting', () => {
     expect(summarizeBenchmarkSamples([1, 2, 3, 4, 5, 6])).toEqual({
       samples: 6,

--- a/config/scripts/counterbalanced-benchmark-schedule.mjs
+++ b/config/scripts/counterbalanced-benchmark-schedule.mjs
@@ -1,0 +1,12 @@
+export function buildCounterbalancedSchedule(pairCount, firstArm, secondArm) {
+  if (!Number.isInteger(pairCount) || pairCount <= 0 || pairCount % 2 !== 0) {
+    throw new Error('Counterbalanced schedules require a positive even pair count')
+  }
+  if (!firstArm || !secondArm || firstArm === secondArm) {
+    throw new Error('Counterbalanced schedules require two distinct arms')
+  }
+
+  return Array.from({ length: pairCount }, (_, index) =>
+    index % 2 === 0 ? [firstArm, secondArm] : [secondArm, firstArm]
+  )
+}

--- a/config/scripts/counterbalanced-benchmark-schedule.test.mjs
+++ b/config/scripts/counterbalanced-benchmark-schedule.test.mjs
@@ -1,0 +1,55 @@
+import { describe, expect, it } from 'vitest'
+
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
+
+function mean(values) {
+  return values.reduce((sum, value) => sum + value, 0) / values.length
+}
+
+describe('counterbalanced benchmark schedule', () => {
+  it('builds complete ABBA blocks', () => {
+    expect(buildCounterbalancedSchedule(4, 'login', 'fast')).toEqual([
+      ['login', 'fast'],
+      ['fast', 'login'],
+      ['login', 'fast'],
+      ['fast', 'login']
+    ])
+  })
+
+  it('rejects counts that cannot balance launch positions', () => {
+    for (const pairCount of [0, 1, 3, 4.5]) {
+      expect(() => buildCounterbalancedSchedule(pairCount, 'login', 'fast')).toThrow(
+        'positive even pair count'
+      )
+    }
+  })
+
+  it('requires distinct arms', () => {
+    expect(() => buildCounterbalancedSchedule(2, 'login', 'login')).toThrow('two distinct arms')
+  })
+
+  it('gives each arm the same mean launch position', () => {
+    const launches = buildCounterbalancedSchedule(20, 'login', 'fast').flat()
+    const positions = { login: [], fast: [] }
+    launches.forEach((arm, index) => positions[arm].push(index))
+
+    expect(mean(positions.login)).toBe(mean(positions.fast))
+  })
+
+  it('cancels linear drift from paired arm deltas', () => {
+    const schedule = buildCounterbalancedSchedule(20, 'login', 'fast')
+    const trueDuration = { login: 100, fast: 80 }
+    const driftPerLaunch = 7
+    const pairDeltas = schedule.map((order, pairIndex) => {
+      const byArm = Object.fromEntries(
+        order.map((arm, orderIndex) => [
+          arm,
+          trueDuration[arm] + (pairIndex * 2 + orderIndex) * driftPerLaunch
+        ])
+      )
+      return byArm.fast - byArm.login
+    })
+
+    expect(mean(pairDeltas)).toBe(trueDuration.fast - trueDuration.login)
+  })
+})

--- a/config/scripts/counterbalanced-benchmark-schedule.test.mjs
+++ b/config/scripts/counterbalanced-benchmark-schedule.test.mjs
@@ -1,5 +1,9 @@
 import { describe, expect, it } from 'vitest'
 
+import {
+  BENCHMARK_SAMPLE_AGGREGATION,
+  summarizeBenchmarkSamples
+} from './benchmark-sample-summary.mjs'
 import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
 
 function mean(values) {
@@ -36,20 +40,27 @@ describe('counterbalanced benchmark schedule', () => {
     expect(mean(positions.login)).toBe(mean(positions.fast))
   })
 
-  it('cancels linear drift from paired arm deltas', () => {
+  it('cancels linear drift in the reported median difference', () => {
     const schedule = buildCounterbalancedSchedule(20, 'login', 'fast')
     const trueDuration = { login: 100, fast: 80 }
     const driftPerLaunch = 7
-    const pairDeltas = schedule.map((order, pairIndex) => {
-      const byArm = Object.fromEntries(
-        order.map((arm, orderIndex) => [
-          arm,
-          trueDuration[arm] + (pairIndex * 2 + orderIndex) * driftPerLaunch
-        ])
-      )
-      return byArm.fast - byArm.login
+    const samples = { login: [], fast: [] }
+    schedule.flat().forEach((arm, launchIndex) => {
+      samples[arm].push(trueDuration[arm] + launchIndex * driftPerLaunch)
     })
 
-    expect(mean(pairDeltas)).toBe(trueDuration.fast - trueDuration.login)
+    const login = summarizeBenchmarkSamples(samples.login)
+    const fast = summarizeBenchmarkSamples(samples.fast)
+    expect(fast.medianMs - login.medianMs).toBe(trueDuration.fast - trueDuration.login)
+
+    const lowerMedian = (values) => [...values].sort((left, right) => left - right)[9]
+    expect(lowerMedian(samples.fast) - lowerMedian(samples.login)).toBe(
+      trueDuration.fast - trueDuration.login - driftPerLaunch
+    )
+    expect(BENCHMARK_SAMPLE_AGGREGATION).toEqual({
+      version: 2,
+      median: 'average-middle',
+      p95: 'nearest-rank'
+    })
   })
 })

--- a/config/scripts/counterbalanced-benchmark-schedule.test.mjs
+++ b/config/scripts/counterbalanced-benchmark-schedule.test.mjs
@@ -10,6 +10,14 @@ function mean(values) {
   return values.reduce((sum, value) => sum + value, 0) / values.length
 }
 
+function linearDriftSamples(schedule, trueDuration, driftPerLaunch) {
+  const samples = { login: [], fast: [] }
+  schedule.flat().forEach((arm, launchIndex) => {
+    samples[arm].push(trueDuration[arm] + launchIndex * driftPerLaunch)
+  })
+  return samples
+}
+
 describe('counterbalanced benchmark schedule', () => {
   it('builds complete ABBA blocks', () => {
     expect(buildCounterbalancedSchedule(4, 'login', 'fast')).toEqual([
@@ -44,10 +52,7 @@ describe('counterbalanced benchmark schedule', () => {
     const schedule = buildCounterbalancedSchedule(20, 'login', 'fast')
     const trueDuration = { login: 100, fast: 80 }
     const driftPerLaunch = 7
-    const samples = { login: [], fast: [] }
-    schedule.flat().forEach((arm, launchIndex) => {
-      samples[arm].push(trueDuration[arm] + launchIndex * driftPerLaunch)
-    })
+    const samples = linearDriftSamples(schedule, trueDuration, driftPerLaunch)
 
     const login = summarizeBenchmarkSamples(samples.login)
     const fast = summarizeBenchmarkSamples(samples.fast)
@@ -57,10 +62,23 @@ describe('counterbalanced benchmark schedule', () => {
     expect(lowerMedian(samples.fast) - lowerMedian(samples.login)).toBe(
       trueDuration.fast - trueDuration.login - driftPerLaunch
     )
+  })
+
+  it('bounds the descriptive p95 bias to one linear-drift launch slot', () => {
+    const schedule = buildCounterbalancedSchedule(20, 'login', 'fast')
+    const trueDuration = { login: 100, fast: 80 }
+    const driftPerLaunch = 7
+    const samples = linearDriftSamples(schedule, trueDuration, driftPerLaunch)
+    const login = summarizeBenchmarkSamples(samples.login)
+    const fast = summarizeBenchmarkSamples(samples.fast)
+
+    expect(fast.p95Ms - login.p95Ms).toBe(trueDuration.fast - trueDuration.login + driftPerLaunch)
     expect(BENCHMARK_SAMPLE_AGGREGATION).toEqual({
       version: 2,
       median: 'average-middle',
-      p95: 'nearest-rank'
+      p95: 'nearest-rank',
+      p95Role: 'descriptive',
+      p95LinearDriftBoundLaunchSlots: 1
     })
   })
 })

--- a/config/scripts/wsl-git-shell-benchmark.mjs
+++ b/config/scripts/wsl-git-shell-benchmark.mjs
@@ -5,6 +5,10 @@ import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 
 import { createJiti } from 'jiti'
+import {
+  BENCHMARK_SAMPLE_AGGREGATION,
+  summarizeBenchmarkSamples
+} from './benchmark-sample-summary.mjs'
 import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
 
 const DEFAULT_SAMPLES = 20
@@ -113,21 +117,6 @@ async function resolveDistro(requested) {
   return distro
 }
 
-function percentile(samples, value) {
-  const sorted = [...samples].sort((left, right) => left - right)
-  return sorted[Math.ceil((value / 100) * sorted.length) - 1]
-}
-
-function summarize(samples) {
-  return {
-    samples: samples.length,
-    medianMs: Number(percentile(samples, 50).toFixed(1)),
-    p95Ms: Number(percentile(samples, 95).toFixed(1)),
-    minMs: Number(Math.min(...samples).toFixed(1)),
-    maxMs: Number(Math.max(...samples).toFixed(1))
-  }
-}
-
 function assertRepoPath(path, expectedPrefix) {
   if (!path.startsWith(expectedPrefix) || path.includes('\0') || path.includes('\n')) {
     throw new Error(`Unexpected benchmark repository path: ${path}`)
@@ -228,8 +217,8 @@ async function main() {
         )
       }
     }
-    const login = summarize(samples.login)
-    const fast = summarize(samples.fast)
+    const login = summarizeBenchmarkSamples(samples.login)
+    const fast = summarizeBenchmarkSamples(samples.fast)
     return {
       login,
       fast,
@@ -375,6 +364,7 @@ async function main() {
       .trim(),
     samples: options.samples,
     warmups: options.warmups,
+    sampleAggregation: BENCHMARK_SAMPLE_AGGREGATION,
     injectedLoginDelayMs: options.loginDelayMs,
     loginProbePreambleBytes: Buffer.byteLength(probeText.split('__ORCA_PATH__', 1)[0]),
     guestProcessShape: {

--- a/config/scripts/wsl-git-shell-benchmark.mjs
+++ b/config/scripts/wsl-git-shell-benchmark.mjs
@@ -5,6 +5,7 @@ import { performance } from 'node:perf_hooks'
 import process from 'node:process'
 
 import { createJiti } from 'jiti'
+import { buildCounterbalancedSchedule } from './counterbalanced-benchmark-schedule.mjs'
 
 const DEFAULT_SAMPLES = 20
 const DEFAULT_WARMUPS = 3
@@ -48,6 +49,9 @@ function parseArgs(argv) {
     if (!Number.isInteger(value) || value < minimum || value > 1_000) {
       throw new Error(`--${name} must be an integer between ${minimum} and 1000`)
     }
+  }
+  if (options.samples % 2 !== 0) {
+    throw new Error('--samples must be even so ABBA blocks are counterbalanced')
   }
   if (!options.nativeRepo || !options.mountedRepo) {
     throw new Error('--native-repo and --mounted-repo are required')
@@ -204,8 +208,8 @@ async function main() {
       await runArm('fast')
     }
     const samples = { login: [], fast: [] }
-    for (let index = 0; index < options.samples; index += 1) {
-      const order = index % 2 === 0 ? ['login', 'fast'] : ['fast', 'login']
+    const schedule = buildCounterbalancedSchedule(options.samples, 'login', 'fast')
+    for (const order of schedule) {
       const results = []
       for (const mode of order) {
         const result = await runArm(mode)


### PR DESCRIPTION
## Summary

- factor the WSL Git benchmark's ABBA order into a tested counterbalanced schedule
- reject odd `--samples` counts before starting WSL work
- report the conventional midpoint median for even sample sets while retaining nearest-rank p95 as a descriptive metric
- record the aggregation definition and p95 drift bound in result JSON

## Review correction

The first revision tested the mean of paired deltas, but the production benchmark reported separate nearest-rank p50 values. Coordinator review correctly found that with 20 ABBA pairs, the old lower p50 selected login launch position 19 and fast position 18, retaining one launch-slot of linear-drift bias.

The benchmark now uses the average of the two middle samples. For the same 20-pair schedule, the central launch positions are login 19/20 and fast 18/21; both average to 19.5. The regression test passes synthetic observations through the production summarizer, proves the reported median difference recovers the true arm difference exactly under linear drift, and pins the old lower-p50 bias at one drift step.

Nearest-rank p95 is not fully counterbalanced. With 20 pairs it selects login position 36 and fast position 37, so under linear drift its arm delta can retain one launch-slot of bias. The deterministic test pins that bound directly: a 7 ms-per-launch drift shifts the reported p95 delta by 7 ms. p95 is therefore descriptive only and must not be quoted as a drift-cancelled comparison.

## Compatibility

- `medianMs`, `medianSavedMs`, and `medianSpeedup` can differ from historical even-sized runs because the median definition is corrected from lower nearest-rank to the conventional midpoint median.
- p95 values retain their existing nearest-rank calculation, but are explicitly classified as descriptive with a one-launch-slot linear-drift bound.
- Results now include `sampleAggregation: { version: 2, median: "average-middle", p95: "nearest-rank", p95Role: "descriptive", p95LinearDriftBoundLaunchSlots: 1 }`. Captured output without this field used the old lower-p50 definition and should not be compared directly with version 2 medians.
- Min, max, launch order, Git commands, and byte-for-byte arm correctness checks are unchanged.
- No Git routing, RPC, SSH path, folder-workspace behavior, mixed-version contract, or Git 2.25 compatibility changes.

This remains measurement-only follow-up work for #9300 and the scheduling invariant explored in #11261.

## Testing

- `pnpm exec vitest run --config config/vitest.config.ts config/scripts/benchmark-sample-summary.test.mjs config/scripts/counterbalanced-benchmark-schedule.test.mjs` — 2 files, 10 tests passed
- formatter check on changed benchmark files
- oxlint on changed benchmark files with warnings denied
- max-lines ratchet
- syntax checks and `git diff --check`
- CLI correctness check: odd `--samples 5` exits before WSL work with the counterbalance error
- no wall-clock benchmark run; measurements require a quiet serialized host

## Screenshots

No visual change.

## AI Review Report

- Coordinator review found that the first synthetic test did not exercise the production median calculation. The aggregation and regression proof were corrected in `98b904e478`.
- CodeRabbit requested explicit odd-sized median coverage. Added in `1f6effa89a`; the test selects the single middle sample while the even-sized contract averages the two middle samples.
- Independent final review found that nearest-rank p95 retains one launch-slot of linear-drift bias. Added machine-readable descriptive/bound metadata and a production-path regression test in `eee1ebfee4`; the PR no longer implies p95 is fully counterbalanced.
- Review also checked the result compatibility boundary: corrected medians are tagged with aggregation version 2, and unversioned historical medians are not directly comparable.

## Security Audit

- Measurement tooling only; no shipped runtime path or privilege boundary changes.
- No new command construction, network request, credential handling, filesystem mutation, RPC field, or stream opcode.
- The result-schema change is additive metadata and does not expose paths or environment values beyond the benchmark's existing output.

## Notes

- No wall-clock benchmarks were run while sibling work was active.
- A real Windows/WSL timing run remains explicitly deferred to a quiet serialized host.
- Existing byte-for-byte stdout/stderr equality checks remain the correctness gate for both WSL-filesystem and DrvFS arms.
- Only average-middle median deltas receive the linear-drift cancellation claim; p95 remains descriptive and one-launch-slot bounded.
