### PR TITLE
fix(search): bound git grep fallback records

### DIFF
--- a/src/main/ipc/filesystem-search-git.test.ts
+++ b/src/main/ipc/filesystem-search-git.test.ts
@@ -15,6 +15,7 @@ vi.mock('child_process', () => ({
 import { searchWithGitGrep } from './filesystem-search-git'
 import { EventEmitter } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
+import { PassThrough } from 'node:stream'
 import { GIT_GREP_MAX_RECORD_BYTES } from '../../shared/text-search'
 
 function createMockProcess(): ChildProcess {
@@ -215,12 +216,15 @@ describe('filesystem-search-git', () => {
         wslDistro: 'Ubuntu'
       })
       const stdout = proc.stdout as unknown as EventEmitter
-      const chunk = 'x'.repeat(1024 * 1024)
-      for (let bytes = 0; bytes <= GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
+      const chunk = Buffer.alloc(1024 * 1024, 0x78)
+      for (let bytes = 0; bytes < GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
         stdout.emit('data', chunk)
       }
 
+      expect(proc.kill).not.toHaveBeenCalled()
+      stdout.emit('data', Buffer.from('x'))
       expect(proc.kill).toHaveBeenCalledTimes(1)
+      expect(proc.stdout!.setEncoding).not.toHaveBeenCalled()
       await expect(promise).resolves.toMatchObject({ truncated: true })
       const [binary, wslArgs] = spawnMock.mock.calls[0]
       expect(binary).toBe('wsl.exe')
@@ -229,6 +233,24 @@ describe('filesystem-search-git', () => {
     } finally {
       Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
+  })
+
+  it('counts raw subprocess bytes before UTF-8 replacement decoding', async () => {
+    const proc = createMockProcess()
+    const stdout = new PassThrough()
+    ;(proc as unknown as Record<string, unknown>).stdout = stdout
+    spawnMock.mockReturnValue(proc)
+
+    const promise = searchWithGitGrep('/mock/root', { query: 'ok', rootPath: '/mock/root' }, 100)
+    stdout.write(Buffer.alloc(Math.floor(GIT_GREP_MAX_RECORD_BYTES / 3) + 1, 0xff))
+    stdout.write(Buffer.from('\nvalid.ts\x001\x00ok\n'))
+    proc.emit('close')
+
+    await expect(promise).resolves.toMatchObject({
+      files: [{ relativePath: 'valid.ts', matchCount: 1 }],
+      totalMatches: 1,
+      truncated: false
+    })
   })
 
   it('skips lines without null separator', async () => {

--- a/src/main/ipc/filesystem-search-git.test.ts
+++ b/src/main/ipc/filesystem-search-git.test.ts
@@ -204,25 +204,31 @@ describe('filesystem-search-git', () => {
   })
 
   it('bounds a WSL folder-workspace git grep record', async () => {
-    const proc = createMockProcess()
-    spawnMock.mockReturnValue(proc)
+    const originalPlatform = process.platform
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    try {
+      const proc = createMockProcess()
+      spawnMock.mockReturnValue(proc)
 
-    const rootPath = 'C:\\folder-workspace'
-    const promise = searchWithGitGrep(rootPath, { query: 'ok', rootPath }, 100, {
-      wslDistro: 'Ubuntu'
-    })
-    const stdout = proc.stdout as unknown as EventEmitter
-    const chunk = 'x'.repeat(1024 * 1024)
-    for (let bytes = 0; bytes <= GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
-      stdout.emit('data', chunk)
+      const rootPath = 'C:\\folder-workspace'
+      const promise = searchWithGitGrep(rootPath, { query: 'ok', rootPath }, 100, {
+        wslDistro: 'Ubuntu'
+      })
+      const stdout = proc.stdout as unknown as EventEmitter
+      const chunk = 'x'.repeat(1024 * 1024)
+      for (let bytes = 0; bytes <= GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
+        stdout.emit('data', chunk)
+      }
+
+      expect(proc.kill).toHaveBeenCalledTimes(1)
+      await expect(promise).resolves.toMatchObject({ truncated: true })
+      const [binary, wslArgs] = spawnMock.mock.calls[0]
+      expect(binary).toBe('wsl.exe')
+      expect(wslArgs.slice(0, 4)).toEqual(['-d', 'Ubuntu', '--', 'sh'])
+      expect(wslArgs.at(-1)).toContain('/mnt/c/folder-workspace')
+    } finally {
+      Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
     }
-
-    expect(proc.kill).toHaveBeenCalledTimes(1)
-    await expect(promise).resolves.toMatchObject({ truncated: true })
-    const [binary, wslArgs] = spawnMock.mock.calls[0]
-    expect(binary).toBe('wsl.exe')
-    expect(wslArgs.slice(0, 4)).toEqual(['-d', 'Ubuntu', '--', 'sh'])
-    expect(wslArgs.at(-1)).toContain('/mnt/c/folder-workspace')
   })
 
   it('skips lines without null separator', async () => {

--- a/src/main/ipc/filesystem-search-git.test.ts
+++ b/src/main/ipc/filesystem-search-git.test.ts
@@ -15,6 +15,7 @@ vi.mock('child_process', () => ({
 import { searchWithGitGrep } from './filesystem-search-git'
 import { EventEmitter } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
+import { GIT_GREP_MAX_RECORD_BYTES } from '../../shared/text-search'
 
 function createMockProcess(): ChildProcess {
   const p = new EventEmitter() as unknown as ChildProcess
@@ -200,6 +201,28 @@ describe('filesystem-search-git', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('bounds a WSL folder-workspace git grep record', async () => {
+    const proc = createMockProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const rootPath = 'C:\\folder-workspace'
+    const promise = searchWithGitGrep(rootPath, { query: 'ok', rootPath }, 100, {
+      wslDistro: 'Ubuntu'
+    })
+    const stdout = proc.stdout as unknown as EventEmitter
+    const chunk = 'x'.repeat(1024 * 1024)
+    for (let bytes = 0; bytes <= GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
+      stdout.emit('data', chunk)
+    }
+
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    await expect(promise).resolves.toMatchObject({ truncated: true })
+    const [binary, wslArgs] = spawnMock.mock.calls[0]
+    expect(binary).toBe('wsl.exe')
+    expect(wslArgs.slice(0, 4)).toEqual(['-d', 'Ubuntu', '--', 'sh'])
+    expect(wslArgs.at(-1)).toContain('/mnt/c/folder-workspace')
   })
 
   it('skips lines without null separator', async () => {

--- a/src/main/ipc/filesystem-search-git.ts
+++ b/src/main/ipc/filesystem-search-git.ts
@@ -4,9 +4,11 @@ import {
   buildSubmatchRegex,
   createAccumulator,
   finalize,
+  GIT_GREP_MAX_RECORD_BYTES,
   ingestGitGrepLine,
   SEARCH_TIMEOUT_MS
 } from '../../shared/text-search'
+import { SearchSubprocessLineAccumulator } from '../../shared/search-subprocess-lines'
 import { gitSpawn } from '../git/runner'
 
 /**
@@ -26,7 +28,7 @@ export function searchWithGitGrep(
     const gitArgs = buildGitGrepArgs(args.query, args)
     const matchRegex = buildSubmatchRegex(args.query, args)
     const acc = createAccumulator()
-    let stdoutBuffer = ''
+    const stdoutLines = new SearchSubprocessLineAccumulator(GIT_GREP_MAX_RECORD_BYTES)
     let done = false
 
     const child = gitSpawn(gitArgs, {
@@ -59,11 +61,10 @@ export function searchWithGitGrep(
     }
 
     function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
+      if (!stdoutLines.push(chunk, processLine)) {
+        acc.truncated = true
+        child.kill()
+        resolveOnce()
       }
     }
 
@@ -76,8 +77,9 @@ export function searchWithGitGrep(
     }
 
     function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
+      const trailingLine = stdoutLines.finish()
+      if (trailingLine !== null) {
+        processLine(trailingLine)
       }
       resolveOnce()
     }

--- a/src/main/ipc/filesystem-search-git.ts
+++ b/src/main/ipc/filesystem-search-git.ts
@@ -60,7 +60,7 @@ export function searchWithGitGrep(
       }
     }
 
-    function handleStdoutData(chunk: string): void {
+    function handleStdoutData(chunk: Buffer): void {
       if (!stdoutLines.push(chunk, processLine)) {
         acc.truncated = true
         child.kill()
@@ -84,7 +84,6 @@ export function searchWithGitGrep(
       resolveOnce()
     }
 
-    child.stdout!.setEncoding('utf-8')
     child.stdout!.on('data', handleStdoutData)
     child.stderr!.on('data', handleStderrData)
     child.once('error', handleError)

--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -311,7 +311,7 @@ export function searchWithGitGrep(
       }
     }
 
-    function handleStdoutData(chunk: string): void {
+    function handleStdoutData(chunk: Buffer): void {
       if (!stdoutLines.push(chunk, processLine)) {
         acc.truncated = true
         child.kill()
@@ -335,7 +335,6 @@ export function searchWithGitGrep(
       resolveOnce()
     }
 
-    child.stdout!.setEncoding('utf-8')
     child.stdout!.on('data', handleStdoutData)
     child.stderr!.on('data', handleStderrData)
     child.once('error', handleError)

--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -23,9 +23,11 @@ import {
   buildSubmatchRegex,
   createAccumulator,
   finalize,
+  GIT_GREP_MAX_RECORD_BYTES,
   ingestGitGrepLine,
   SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
+import { SearchSubprocessLineAccumulator } from '../shared/search-subprocess-lines'
 import { buildRelayGitEnv } from './relay-command-env'
 
 /**
@@ -277,7 +279,7 @@ export function searchWithGitGrep(
     const gitArgs = buildGitGrepArgs(query, opts)
     const matchRegex = buildSubmatchRegex(query, opts)
     const acc = createAccumulator()
-    let stdoutBuffer = ''
+    const stdoutLines = new SearchSubprocessLineAccumulator(GIT_GREP_MAX_RECORD_BYTES)
     let done = false
 
     const child = spawn('git', gitArgs, {
@@ -310,11 +312,10 @@ export function searchWithGitGrep(
     }
 
     function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
+      if (!stdoutLines.push(chunk, processLine)) {
+        acc.truncated = true
+        child.kill()
+        resolveOnce()
       }
     }
 
@@ -327,8 +328,9 @@ export function searchWithGitGrep(
     }
 
     function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
+      const trailingLine = stdoutLines.finish()
+      if (trailingLine !== null) {
+        processLine(trailingLine)
       }
       resolveOnce()
     }

--- a/src/relay/fs-handler-git-search.test.ts
+++ b/src/relay/fs-handler-git-search.test.ts
@@ -11,6 +11,7 @@ vi.mock('child_process', () => ({
 import { EventEmitter } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
 import { searchWithGitGrep } from './fs-handler-git-fallback'
+import { GIT_GREP_MAX_RECORD_BYTES } from '../shared/text-search'
 
 function createMockProcess(): ChildProcess {
   const p = new EventEmitter() as unknown as ChildProcess
@@ -55,5 +56,20 @@ describe('relay git grep fallback', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('bounds an SSH relay git grep record', async () => {
+    const proc = createMockProcess()
+    spawnMock.mockReturnValue(proc)
+
+    const promise = searchWithGitGrep('/remote/folder-workspace', 'ok', { maxResults: 100 })
+    const stdout = proc.stdout as unknown as EventEmitter
+    const chunk = 'x'.repeat(1024 * 1024)
+    for (let bytes = 0; bytes <= GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
+      stdout.emit('data', chunk)
+    }
+
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    await expect(promise).resolves.toMatchObject({ truncated: true })
   })
 })

--- a/src/relay/fs-handler-git-search.test.ts
+++ b/src/relay/fs-handler-git-search.test.ts
@@ -64,12 +64,15 @@ describe('relay git grep fallback', () => {
 
     const promise = searchWithGitGrep('/remote/folder-workspace', 'ok', { maxResults: 100 })
     const stdout = proc.stdout as unknown as EventEmitter
-    const chunk = 'x'.repeat(1024 * 1024)
-    for (let bytes = 0; bytes <= GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
+    const chunk = Buffer.alloc(1024 * 1024, 0x78)
+    for (let bytes = 0; bytes < GIT_GREP_MAX_RECORD_BYTES; bytes += chunk.length) {
       stdout.emit('data', chunk)
     }
 
+    expect(proc.kill).not.toHaveBeenCalled()
+    stdout.emit('data', Buffer.from('x'))
     expect(proc.kill).toHaveBeenCalledTimes(1)
+    expect(proc.stdout!.setEncoding).not.toHaveBeenCalled()
     await expect(promise).resolves.toMatchObject({ truncated: true })
   })
 })

--- a/src/shared/text-search.ts
+++ b/src/shared/text-search.ts
@@ -55,6 +55,8 @@ function joinSearchRoot(rootPath: string, relPath: string): string {
 export const MAX_MATCHES_PER_FILE = 100
 export const DEFAULT_SEARCH_MAX_RESULTS = 2000
 export const SEARCH_TIMEOUT_MS = 15_000
+// Why: mirror rg's 5 MiB file ceiling with room for path and record metadata.
+export const GIT_GREP_MAX_RECORD_BYTES = 8 * 1024 * 1024
 export const SEARCH_JSON_STRUCTURE_LIMITS = {
   structuralTokens: 32 * 1024,
   nestingDepth: 16


### PR DESCRIPTION
## Summary

Bounds newline-free `git grep` fallback records at 8 MiB on both local/WSL and SSH relay search paths. Oversized records now stop the child, detach listeners, and return the existing `truncated: true` result instead of retaining unbounded output.

A deterministic production-path unit reproduction failed before the fix after feeding 64 MiB + 1 byte without a newline (`kill` remained uncalled). The final regressions use the narrower production limit, aligned with the primary `rg` path's 5 MiB file ceiling plus record overhead.

The review-until-clean pass also caught decoded-string byte accounting: invalid UTF-8 can expand threefold into replacement characters and falsely truncate raw Git output below 8 MiB. Both production callers now pass raw subprocess buffers into the shared parser; a real `PassThrough` stream regression proves a raw record below the cap is accepted before a following valid result.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (focused direct oxlint passed; changed-file wrapper hits `spawnSync pnpm.cmd EINVAL` on Windows/Node 24)
- [ ] `pnpm typecheck` (`pnpm run typecheck:node` passed)
- [ ] `pnpm test` (focused 61-test run passed)
- [ ] `pnpm build`
- [x] Added high-quality regressions for raw-byte accounting, a WSL-routed folder workspace, and the SSH relay fallback

Additional checks:

- `pnpm exec vitest run --config config/vitest.config.ts src/shared/search-subprocess-lines.test.ts src/shared/text-search.test.ts src/main/ipc/filesystem-search-git.test.ts src/main/ipc/filesystem-search-rg-timeout.test.ts src/relay/fs-handler-git-search.test.ts src/relay/fs-handler-rg-availability.test.ts`
- focused `oxlint --deny-warnings`
- focused `oxfmt --check`
- `pnpm run check:max-lines-ratchet`
- `git diff --check`

## AI Review Report

Two adversarial review rounds covered the accumulator's reachable inputs, raw byte vs decoded character accounting, UTF-8 chunk boundaries, newline and exact-limit behavior, termination/error/close races, listener cleanup, memory amplification, false truncation, and parity between main and relay callers. The audit explicitly checked macOS, Linux, and Windows/WSL behavior: the limit is platform-neutral, existing WSL spawn routing is preserved, POSIX relay spawning is unchanged, and no UI, shortcut, path-label, or Electron renderer behavior changed.

Mixed versions remain compatible because there is no RPC, opcode, or payload-schema change; old and new clients already understand the existing `truncated` field.

## Security Audit

Scope was limited to benign memory bounds. The change adds no command construction, path authorization, authentication, credential, dependency, IPC, or secret-handling behavior. Existing search arguments and path routing are unchanged.

## Notes

The present-day audit ranked raw SSH directory browsing as a lower-priority remaining accumulator: it buffers the complete 15-second listing before parsing, but has a time ceiling and filesystem filename bounds. Terminal replay/recovery, WSL watcher parsing, Git runners, daemon history, and relay command capture already have explicit byte budgets.