### PR TITLE
[Perf-SS] Keep reattach live queues linear during replay

### DIFF
--- a/src/renderer/src/components/terminal-pane/deferred-reattach-live-data-queue.test.ts
+++ b/src/renderer/src/components/terminal-pane/deferred-reattach-live-data-queue.test.ts
@@ -1,0 +1,336 @@
+import { describe, expect, it, vi } from 'vitest'
+import {
+  DeferredReattachLiveDataQueue,
+  MAX_DEFERRED_REATTACH_LIVE_CHARS,
+  MAX_DEFERRED_REATTACH_LIVE_CHUNKS,
+  type DeferredReattachLiveDataChunk
+} from './deferred-reattach-live-data-queue'
+
+function createChunk(
+  data: string,
+  streamGeneration = 1,
+  options: Omit<DeferredReattachLiveDataChunk, 'data' | 'streamGeneration'> = {
+    ptyId: 'pty-1'
+  }
+): DeferredReattachLiveDataChunk {
+  return { data, streamGeneration, ...options }
+}
+
+function releaseTransferred(chunks: DeferredReattachLiveDataChunk[]): void {
+  for (const chunk of chunks) {
+    chunk.ackCredit?.()
+  }
+}
+
+class ReferenceDeferredQueue {
+  private chunks: DeferredReattachLiveDataChunk[] = []
+  private retainedChars = 0
+
+  enqueue(chunk: DeferredReattachLiveDataChunk): void {
+    this.chunks = this.chunks.filter((queued) => {
+      const keep = queued.streamGeneration === chunk.streamGeneration
+      if (!keep) {
+        queued.ackCredit?.()
+      }
+      return keep
+    })
+    this.retainedChars = this.chunks.reduce((total, queued) => total + queued.data.length, 0)
+    const oversized = chunk.data.length > MAX_DEFERRED_REATTACH_LIVE_CHARS
+    this.chunks.push({
+      ...chunk,
+      data: oversized ? chunk.data.slice(-MAX_DEFERRED_REATTACH_LIVE_CHARS) : chunk.data
+    })
+    this.retainedChars += this.chunks.at(-1)?.data.length ?? 0
+
+    let dropped = oversized
+    while (
+      this.chunks.length > 1 &&
+      (this.chunks.length > MAX_DEFERRED_REATTACH_LIVE_CHUNKS ||
+        this.retainedChars > MAX_DEFERRED_REATTACH_LIVE_CHARS)
+    ) {
+      const removed = this.chunks.shift()
+      this.retainedChars -= removed?.data.length ?? 0
+      removed?.ackCredit?.()
+      dropped = true
+    }
+    if (dropped && this.chunks[0]) {
+      this.chunks[0].meta = { ...this.chunks[0].meta, droppedOutput: true }
+    }
+  }
+
+  takeAll(): DeferredReattachLiveDataChunk[] {
+    const chunks = this.chunks
+    this.chunks = []
+    this.retainedChars = 0
+    return chunks
+  }
+
+  discard(): void {
+    for (const chunk of this.takeAll()) {
+      chunk.ackCredit?.()
+    }
+  }
+}
+
+function normalizedChunks(chunks: DeferredReattachLiveDataChunk[]): unknown[] {
+  return chunks.map(({ ackCredit: _ackCredit, ...chunk }) => chunk)
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return state >>> 0
+  }
+}
+
+describe('deferred reattach live data queue', () => {
+  it('does not rescan or shift the live queue while saturated', () => {
+    const originalFilter = Array.prototype.filter
+    const originalReduce = Array.prototype.reduce
+    const originalShift = Array.prototype.shift
+    const queue = new DeferredReattachLiveDataQueue()
+
+    try {
+      for (const method of ['filter', 'reduce', 'shift'] as const) {
+        Object.defineProperty(Array.prototype, method, {
+          configurable: true,
+          writable: true,
+          value() {
+            throw new Error(`Array.${method} should not run on enqueue`)
+          }
+        })
+      }
+      for (let index = 0; index < MAX_DEFERRED_REATTACH_LIVE_CHUNKS * 2; index += 1) {
+        queue.enqueue(createChunk('x'.repeat(512)))
+      }
+    } finally {
+      Object.defineProperties(Array.prototype, {
+        filter: { configurable: true, writable: true, value: originalFilter },
+        reduce: { configurable: true, writable: true, value: originalReduce },
+        shift: { configurable: true, writable: true, value: originalShift }
+      })
+    }
+
+    expect(queue.takeAll()).toHaveLength(MAX_DEFERRED_REATTACH_LIVE_CHUNKS)
+  })
+
+  it('evicts whole chunks only after the count and character boundaries are exceeded', () => {
+    const countQueue = new DeferredReattachLiveDataQueue()
+    const countAcks = Array.from({ length: MAX_DEFERRED_REATTACH_LIVE_CHUNKS + 1 }, () => vi.fn())
+    for (let index = 0; index < MAX_DEFERRED_REATTACH_LIVE_CHUNKS; index += 1) {
+      countQueue.enqueue(
+        createChunk('', 1, { ptyId: 'pty-1', meta: { seq: index }, ackCredit: countAcks[index] })
+      )
+    }
+
+    expect(countQueue.getStorageForTest().retainedChunks).toBe(MAX_DEFERRED_REATTACH_LIVE_CHUNKS)
+    expect(countAcks.every((ack) => ack.mock.calls.length === 0)).toBe(true)
+    countQueue.enqueue(
+      createChunk('', 1, {
+        ptyId: 'pty-1',
+        meta: { seq: MAX_DEFERRED_REATTACH_LIVE_CHUNKS },
+        ackCredit: countAcks.at(-1)
+      })
+    )
+
+    const counted = countQueue.takeAll()
+    expect(countAcks[0]).toHaveBeenCalledOnce()
+    expect(counted).toHaveLength(MAX_DEFERRED_REATTACH_LIVE_CHUNKS)
+    expect(counted[0]?.meta).toEqual({ seq: 1, droppedOutput: true })
+    expect(counted.at(-1)?.meta?.seq).toBe(MAX_DEFERRED_REATTACH_LIVE_CHUNKS)
+    releaseTransferred(counted)
+    expect(countAcks.every((ack) => ack.mock.calls.length === 1)).toBe(true)
+
+    const charQueue = new DeferredReattachLiveDataQueue()
+    const fullAck = vi.fn()
+    const tailAck = vi.fn()
+    charQueue.enqueue(
+      createChunk('a'.repeat(MAX_DEFERRED_REATTACH_LIVE_CHARS), 1, {
+        ptyId: 'pty-1',
+        ackCredit: fullAck
+      })
+    )
+    expect(charQueue.getStorageForTest().retainedChars).toBe(MAX_DEFERRED_REATTACH_LIVE_CHARS)
+    charQueue.enqueue(createChunk('tail', 1, { ptyId: 'pty-1', ackCredit: tailAck }))
+
+    const characterBounded = charQueue.takeAll()
+    expect(fullAck).toHaveBeenCalledOnce()
+    expect(characterBounded.map((chunk) => chunk.data)).toEqual(['tail'])
+    expect(characterBounded[0]?.meta).toEqual({ droppedOutput: true })
+    expect(tailAck).not.toHaveBeenCalled()
+    releaseTransferred(characterBounded)
+    expect(tailAck).toHaveBeenCalledOnce()
+  })
+
+  it('keeps the exact oversized tail and preserves metadata under the gap marker', () => {
+    const queue = new DeferredReattachLiveDataQueue()
+    const ackCredit = vi.fn()
+    const meta = { seq: 9, rawLength: MAX_DEFERRED_REATTACH_LIVE_CHARS + 1, background: true }
+    queue.enqueue(
+      createChunk(`P${'T'.repeat(MAX_DEFERRED_REATTACH_LIVE_CHARS)}`, 3, {
+        ptyId: 'pty-3',
+        meta,
+        ackCredit
+      })
+    )
+
+    const retained = queue.takeAll()
+    expect(retained).toHaveLength(1)
+    expect(retained[0]?.data).toBe('T'.repeat(MAX_DEFERRED_REATTACH_LIVE_CHARS))
+    expect(retained[0]?.meta).toEqual({ ...meta, droppedOutput: true })
+    expect(meta).not.toHaveProperty('droppedOutput')
+    expect(ackCredit).not.toHaveBeenCalled()
+    releaseTransferred(retained)
+    expect(ackCredit).toHaveBeenCalledOnce()
+  })
+
+  it('releases a replaced generation exactly once without carrying its gap marker forward', () => {
+    const queue = new DeferredReattachLiveDataQueue()
+    const firstAck = vi.fn()
+    const secondAck = vi.fn()
+    const thirdAck = vi.fn()
+    const replacementAck = vi.fn()
+    queue.enqueue(createChunk('a'.repeat(300 * 1024), 4, { ptyId: 'old', ackCredit: firstAck }))
+    queue.enqueue(createChunk('b'.repeat(300 * 1024), 4, { ptyId: 'old', ackCredit: secondAck }))
+    queue.enqueue(createChunk('c', 4, { ptyId: 'old', ackCredit: thirdAck }))
+
+    expect(firstAck).toHaveBeenCalledOnce()
+    queue.enqueue(
+      createChunk('replacement', 5, {
+        ptyId: 'new',
+        meta: { seq: 5, transformed: true },
+        ackCredit: replacementAck
+      })
+    )
+
+    const replacement = queue.takeAll()
+    expect(firstAck).toHaveBeenCalledOnce()
+    expect(secondAck).toHaveBeenCalledOnce()
+    expect(thirdAck).toHaveBeenCalledTimes(1)
+    expect(replacement).toHaveLength(1)
+    expect(replacement[0]?.data).toBe('replacement')
+    expect(replacement[0]?.meta).toEqual({ seq: 5, transformed: true })
+    expect(replacementAck).not.toHaveBeenCalled()
+    releaseTransferred(replacement)
+    expect(replacementAck).toHaveBeenCalledOnce()
+  })
+
+  it('compacts a cleared prefix repeatedly while settling every credit once', () => {
+    const queue = new DeferredReattachLiveDataQueue()
+    const acks = Array.from({ length: 513 }, () => vi.fn())
+    const fullChunk = 'x'.repeat(MAX_DEFERRED_REATTACH_LIVE_CHARS)
+    for (let index = 0; index < acks.length; index += 1) {
+      queue.enqueue(
+        createChunk(fullChunk, 1, {
+          ptyId: 'pty-1',
+          ackCredit: acks[index]
+        })
+      )
+      const storage = queue.getStorageForTest()
+      expect(storage.retainedChunks).toBe(1)
+      expect(storage.retainedChars).toBe(MAX_DEFERRED_REATTACH_LIVE_CHARS)
+      expect(storage.backingLength).toBeLessThanOrEqual(64)
+    }
+
+    const retained = queue.takeAll()
+    expect(retained).toHaveLength(1)
+    releaseTransferred(retained)
+    expect(acks.every((ack) => ack.mock.calls.length === 1)).toBe(true)
+    expect(queue.getStorageForTest()).toEqual({
+      backingLength: 0,
+      head: 0,
+      retainedChars: 0,
+      retainedChunks: 0
+    })
+  })
+
+  it('transfers credits from takeAll but settles retained credits on discard', () => {
+    const queue = new DeferredReattachLiveDataQueue()
+    const transferredAcks = [vi.fn(), vi.fn()]
+    queue.enqueue(createChunk('first', 1, { ptyId: 'pty-1', ackCredit: transferredAcks[0] }))
+    queue.enqueue(createChunk('second', 1, { ptyId: 'pty-1', ackCredit: transferredAcks[1] }))
+
+    const transferred = queue.takeAll()
+    expect(transferred.map((chunk) => chunk.data)).toEqual(['first', 'second'])
+    expect(transferredAcks.every((ack) => ack.mock.calls.length === 0)).toBe(true)
+
+    const discardedAcks = [vi.fn(), vi.fn()]
+    queue.enqueue(createChunk('third', 2, { ptyId: 'pty-2', ackCredit: discardedAcks[0] }))
+    queue.enqueue(createChunk('fourth', 2, { ptyId: 'pty-2', ackCredit: discardedAcks[1] }))
+    queue.discard()
+    queue.discard()
+    expect(discardedAcks.every((ack) => ack.mock.calls.length === 1)).toBe(true)
+    expect(transferredAcks.every((ack) => ack.mock.calls.length === 0)).toBe(true)
+    releaseTransferred(transferred)
+    expect(transferredAcks.every((ack) => ack.mock.calls.length === 1)).toBe(true)
+  })
+
+  it('matches the previous algorithm across a seeded adversarial stream', () => {
+    const queue = new DeferredReattachLiveDataQueue()
+    const reference = new ReferenceDeferredQueue()
+    const random = createSeededRandom(0x5eedc0de)
+    const queueAcks = new Map<number, number>()
+    const referenceAcks = new Map<number, number>()
+    let generation = 1
+
+    const recordAck =
+      (acks: Map<number, number>, index: number): (() => void) =>
+      () => {
+        acks.set(index, (acks.get(index) ?? 0) + 1)
+      }
+    for (let index = 0; index < 5_000; index += 1) {
+      const value = random()
+      if (index > 0 && value % 997 === 0) {
+        generation += 1
+      }
+      const bucket = value % 100
+      const length =
+        index < 1_500
+          ? value % 3
+          : bucket < 70
+            ? value % 1_025
+            : bucket < 90
+              ? 4 * 1024
+              : bucket < 97
+                ? 64 * 1024
+                : bucket < 99
+                  ? 300 * 1024
+                  : MAX_DEFERRED_REATTACH_LIVE_CHARS + 1
+      const data = String.fromCharCode(65 + (index % 26)).repeat(length)
+      const base = {
+        data,
+        ptyId: `pty-${generation % 3}`,
+        streamGeneration: generation,
+        meta: {
+          seq: index,
+          rawLength: length,
+          ...(value % 7 === 0 ? { background: true } : {})
+        }
+      }
+      queue.enqueue({ ...base, ackCredit: recordAck(queueAcks, index) })
+      reference.enqueue({ ...base, ackCredit: recordAck(referenceAcks, index) })
+
+      if ((index + 1) % 1_000 !== 0) {
+        continue
+      }
+      if ((index + 1) % 2_000 === 0) {
+        queue.discard()
+        reference.discard()
+      } else {
+        const actual = queue.takeAll()
+        const expected = reference.takeAll()
+        expect(normalizedChunks(actual)).toEqual(normalizedChunks(expected))
+        releaseTransferred(actual)
+        releaseTransferred(expected)
+      }
+      expect(queueAcks).toEqual(referenceAcks)
+    }
+
+    expect(queueAcks).toEqual(referenceAcks)
+    expect([...queueAcks.values()].every((count) => count === 1)).toBe(true)
+    expect(queueAcks.size).toBe(5_000)
+  })
+})

--- a/src/renderer/src/components/terminal-pane/deferred-reattach-live-data-queue.ts
+++ b/src/renderer/src/components/terminal-pane/deferred-reattach-live-data-queue.ts
@@ -1,0 +1,111 @@
+import type { PtyDataMeta } from './pty-dispatcher'
+
+export const MAX_DEFERRED_REATTACH_LIVE_CHARS = 512 * 1024
+export const MAX_DEFERRED_REATTACH_LIVE_CHUNKS = 1_024
+
+const COMPACTION_MIN_HEAD = 64
+
+export type DeferredReattachLiveDataChunk = {
+  data: string
+  ptyId: string | null
+  streamGeneration: number
+  meta?: PtyDataMeta
+  ackCredit?: () => void
+}
+
+export type DeferredReattachLiveDataQueueStorage = {
+  backingLength: number
+  head: number
+  retainedChars: number
+  retainedChunks: number
+}
+
+export class DeferredReattachLiveDataQueue {
+  private chunks: (DeferredReattachLiveDataChunk | undefined)[] = []
+  private head = 0
+  private retainedChars = 0
+  private streamGeneration: number | null = null
+
+  enqueue(chunk: DeferredReattachLiveDataChunk): void {
+    if (this.streamGeneration !== null && this.streamGeneration !== chunk.streamGeneration) {
+      this.discard()
+    }
+    this.streamGeneration = chunk.streamGeneration
+
+    const oversized = chunk.data.length > MAX_DEFERRED_REATTACH_LIVE_CHARS
+    const queuedChunk = {
+      ...chunk,
+      data: oversized ? chunk.data.slice(-MAX_DEFERRED_REATTACH_LIVE_CHARS) : chunk.data
+    }
+    this.chunks.push(queuedChunk)
+    this.retainedChars += queuedChunk.data.length
+
+    let dropped = oversized
+    while (
+      this.retainedChunkCount > 1 &&
+      (this.retainedChunkCount > MAX_DEFERRED_REATTACH_LIVE_CHUNKS ||
+        this.retainedChars > MAX_DEFERRED_REATTACH_LIVE_CHARS)
+    ) {
+      const removed = this.chunks[this.head]
+      this.chunks[this.head] = undefined
+      this.head += 1
+      if (removed) {
+        this.retainedChars -= removed.data.length
+        removed.ackCredit?.()
+      }
+      dropped = true
+    }
+
+    const oldest = this.chunks[this.head]
+    if (dropped && oldest) {
+      oldest.meta = { ...oldest.meta, droppedOutput: true }
+    }
+    this.compact()
+  }
+
+  takeAll(): DeferredReattachLiveDataChunk[] {
+    const retained: DeferredReattachLiveDataChunk[] = []
+    for (let index = this.head; index < this.chunks.length; index += 1) {
+      const chunk = this.chunks[index]
+      if (chunk) {
+        retained.push(chunk)
+      }
+    }
+    this.reset()
+    return retained
+  }
+
+  discard(): void {
+    for (const chunk of this.takeAll()) {
+      chunk.ackCredit?.()
+    }
+  }
+
+  getStorageForTest(): DeferredReattachLiveDataQueueStorage {
+    return {
+      backingLength: this.chunks.length,
+      head: this.head,
+      retainedChars: this.retainedChars,
+      retainedChunks: this.retainedChunkCount
+    }
+  }
+
+  private get retainedChunkCount(): number {
+    return this.chunks.length - this.head
+  }
+
+  private compact(): void {
+    if (this.head < COMPACTION_MIN_HEAD || this.head * 2 < this.chunks.length) {
+      return
+    }
+    this.chunks = this.chunks.slice(this.head)
+    this.head = 0
+  }
+
+  private reset(): void {
+    this.chunks = []
+    this.head = 0
+    this.retainedChars = 0
+    this.streamGeneration = null
+  }
+}

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -236,6 +236,10 @@ import { createCommandCodeOutputStatusDetector } from '../../../../shared/comman
 import { createCodexBackfillErrorDetector } from './codex-backfill-error-detector'
 import type { PtyDataMeta } from './pty-dispatcher'
 import { getEagerPtyBufferHandle } from './pty-dispatcher'
+import {
+  DeferredReattachLiveDataQueue,
+  MAX_DEFERRED_REATTACH_LIVE_CHARS
+} from './deferred-reattach-live-data-queue'
 import { createTerminalGitHubPRLinkDetector } from '../../../../shared/terminal-github-pr-link-detector'
 import { scheduleTerminalWebglAtlasRecovery } from './terminal-webgl-atlas-recovery'
 import {
@@ -3745,21 +3749,10 @@ export function connectPanePty(
   const hadExistingPaneTransportAtConnect = deps.paneTransportsRef.current.size > 0
   let lastTerminalInputAt = Number.NEGATIVE_INFINITY
   let hasReceivedPtyOutput = false
-  let deferredReattachLiveData:
-    | {
-        data: string
-        ptyId: string | null
-        streamGeneration: number
-        meta?: PtyDataMeta
-        ackCredit?: () => void
-      }[]
-    | null = null
-  let deferredReattachLiveDataChars = 0
+  let deferredReattachLiveData: DeferredReattachLiveDataQueue | null = null
   let reattachLiveDataDeferralDepth = 0
   let deferredReattachLiveDataOwners = new Map<number, { failed: boolean }>()
   let transportStreamGeneration = 0
-  const MAX_DEFERRED_REATTACH_LIVE_CHARS = 512 * 1024
-  const MAX_DEFERRED_REATTACH_LIVE_CHUNKS = 1_024
   const markTerminalInputSent = (): void => {
     lastTerminalInputAt = performance.now()
     // Why: input must probe a wedged xterm even when the PTY produces no renderer output.
@@ -7758,47 +7751,14 @@ export function connectPanePty(
         return
       }
       if (deferredReattachLiveData !== null) {
-        // Why: a replacement stream must not inherit bytes or a gap marker from the replay owner it superseded.
-        deferredReattachLiveData = deferredReattachLiveData.filter((chunk) => {
-          const keep = chunk.streamGeneration === streamGeneration
-          if (!keep) {
-            chunk.ackCredit?.()
-          }
-          return keep
-        })
-        deferredReattachLiveDataChars = deferredReattachLiveData.reduce(
-          (total, chunk) => total + chunk.data.length,
-          0
-        )
-        const oversized = data.length > MAX_DEFERRED_REATTACH_LIVE_CHARS
-        const deferredData = oversized ? data.slice(-MAX_DEFERRED_REATTACH_LIVE_CHARS) : data
         const ackCredit = takeCurrentTerminalDeliveryCredit()
-        deferredReattachLiveData.push({
-          data: deferredData,
+        deferredReattachLiveData.enqueue({
+          data,
           ptyId: transport.getPtyId(),
           streamGeneration,
           ...(meta ? { meta } : {}),
           ...(ackCredit ? { ackCredit } : {})
         })
-        deferredReattachLiveDataChars += deferredData.length
-        // Why: one huge IPC frame would bypass the queue's memory bound; mark a stream gap so snapshot recovery replaces it, not a partial ANSI frame.
-        let dropped = oversized
-        while (
-          deferredReattachLiveData.length > 1 &&
-          (deferredReattachLiveData.length > MAX_DEFERRED_REATTACH_LIVE_CHUNKS ||
-            deferredReattachLiveDataChars > MAX_DEFERRED_REATTACH_LIVE_CHARS)
-        ) {
-          const removed = deferredReattachLiveData.shift()
-          deferredReattachLiveDataChars -= removed?.data.length ?? 0
-          removed?.ackCredit?.()
-          dropped = true
-        }
-        if (dropped && deferredReattachLiveData[0]) {
-          deferredReattachLiveData[0].meta = {
-            ...deferredReattachLiveData[0].meta,
-            droppedOutput: true
-          }
-        }
         return
       }
       if (data.length > 0) {
@@ -7964,8 +7924,7 @@ export function connectPanePty(
     const beginReattachLiveDataDeferral = (ownerGeneration = transportStreamGeneration): void => {
       reattachLiveDataDeferralDepth += 1
       if (reattachLiveDataDeferralDepth === 1) {
-        deferredReattachLiveData = []
-        deferredReattachLiveDataChars = 0
+        deferredReattachLiveData = new DeferredReattachLiveDataQueue()
         deferredReattachLiveDataOwners = new Map()
       }
       if (!deferredReattachLiveDataOwners.has(ownerGeneration)) {
@@ -7998,19 +7957,17 @@ export function connectPanePty(
       if (reattachLiveDataDeferralDepth > 0) {
         return
       }
-      const chunks = deferredReattachLiveData
+      const queue = deferredReattachLiveData
       deferredReattachLiveData = null
-      deferredReattachLiveDataChars = 0
       const currentPtyId = transport.getPtyId()
       const currentGeneration = transportStreamGeneration
       const currentOwner = deferredReattachLiveDataOwners.get(currentGeneration)
       deferredReattachLiveDataOwners = new Map()
-      if (disposed || !chunks) {
-        for (const chunk of chunks ?? []) {
-          chunk.ackCredit?.()
-        }
+      if (disposed || !queue) {
+        queue?.discard()
         return
       }
+      const chunks = queue.takeAll()
       // Why: paint the authoritative replay first, then admit deferred live chunks so the replay clear can't erase newer output.
       let deliveredDeferredChunks = 0
       for (const chunk of chunks) {
@@ -9402,11 +9359,9 @@ export function connectPanePty(
       }
       directSshPaneRetrySettlementTimers.clear()
       // Why: a stalled xterm replay may never reach its finally; release live-frame credit when this renderer no longer owns the stream.
-      for (const chunk of deferredReattachLiveData ?? []) {
-        chunk.ackCredit?.()
-      }
+      const queue = deferredReattachLiveData
       deferredReattachLiveData = null
-      deferredReattachLiveDataChars = 0
+      queue?.discard()
       reattachLiveDataDeferralDepth = 0
       deferredReattachLiveDataOwners = new Map()
       cancelPendingSafeFitContinuations(pane)

--- a/tests/e2e/ssh-docker-relay-perf.spec.ts
+++ b/tests/e2e/ssh-docker-relay-perf.spec.ts
@@ -50,6 +50,11 @@ function shellQuote(value: string): string {
   return `'${value.replaceAll("'", "'\\''")}'`
 }
 
+function encodedRemoteNodeCommand(script: string): string {
+  const encoded = Buffer.from(script, 'utf8').toString('base64')
+  return `node -e ${shellQuote(`eval(Buffer.from('${encoded}', 'base64').toString('utf8'))`)}`
+}
+
 function remoteTypingLoadScript(runId: string): string {
   return [
     "process.stdin.setEncoding('utf8')",
@@ -368,7 +373,9 @@ test.describe('Docker SSH relay perf', () => {
       await waitForActiveTerminalManager(orcaPage, 60_000)
       const beforePtyId = await waitForActivePanePtyId(orcaPage, 60_000)
       const beforeMarker = `SSH_RECONNECT_BEFORE_${Date.now()}`
-      await execInTerminal(orcaPage, beforePtyId, `printf ${shellQuote(beforeMarker)}`)
+      const beforeCommand = encodedRemoteNodeCommand(`process.stdout.write('${beforeMarker}\\n')`)
+      expect(beforeCommand).not.toContain(beforeMarker)
+      await execInTerminal(orcaPage, beforePtyId, beforeCommand)
       await waitForTerminalOutput(orcaPage, beforeMarker, 20_000, 60_000)
       const recoveryStartedMarker = `SSH_RECONNECT_RECOVERY_STARTED_${Date.now()}`
       const recoveryMarker = `SSH_RECONNECT_RECOVERY_${Date.now()}`
@@ -382,7 +389,10 @@ test.describe('Docker SSH relay perf', () => {
         `if (frame === 256) { clearInterval(timer); process.stdout.write('${recoveryMarker}\\n') }`,
         '}, 10)'
       ].join(';')
-      await execInTerminal(orcaPage, beforePtyId, `node -e ${shellQuote(recoveryScript)}`)
+      const recoveryCommand = encodedRemoteNodeCommand(recoveryScript)
+      expect(recoveryCommand).not.toContain(recoveryStartedMarker)
+      expect(recoveryCommand).not.toContain(recoveryMarker)
+      await execInTerminal(orcaPage, beforePtyId, recoveryCommand)
       await waitForTerminalOutput(orcaPage, recoveryStartedMarker, 30_000, 80_000)
 
       await reconnectDockerSshRelayTarget(orcaPage, remote.targetId)
@@ -392,11 +402,16 @@ test.describe('Docker SSH relay perf', () => {
       await waitForTerminalOutput(orcaPage, recoveryMarker, 30_000, 80_000)
       const afterMarker = `SSH_RECONNECT_AFTER_${Date.now()}`
       const remoteProofPath = `/tmp/${afterMarker}`
-      await execInTerminal(
-        orcaPage,
-        afterPtyId,
-        `printf ${shellQuote(afterMarker)} | tee ${shellQuote(remoteProofPath)}`
+      const afterCommand = encodedRemoteNodeCommand(
+        [
+          "const fs = require('node:fs')",
+          `const marker = '${afterMarker}'`,
+          `fs.writeFileSync('${remoteProofPath}', marker)`,
+          "process.stdout.write(marker + '\\n')"
+        ].join(';')
       )
+      expect(afterCommand).not.toContain(afterMarker)
+      await execInTerminal(orcaPage, afterPtyId, afterCommand)
       await waitForTerminalOutput(orcaPage, afterMarker, 20_000, 60_000)
       expect(execDockerSshRelayTargetCommand(target, `cat ${shellQuote(remoteProofPath)}`)).toBe(
         afterMarker


### PR DESCRIPTION
## Summary

- Keeps live PTY output queued during terminal reattach replay amortized O(1) per arrival instead of rescanning the complete retained queue.
- Preserves replay-before-live ordering, the 512 KiB / 1,024-chunk caps, whole-chunk eviction, generation and PTY fencing, gap metadata, and deferred ACK ownership.
- Strengthens the Docker SSH reconnect test so terminal command echo cannot masquerade as remote process output.

### ELI5

While Orca repaints an old terminal snapshot, newer terminal output waits in a short line. Orca used to recount and recopy that whole line every time another piece arrived. This change keeps a running count and a movable front pointer, so adding one piece stays cheap even when the line is full.

### Safety assessment

**Verdict: this is a high-consequence code path, but the change itself now has low observed semantic-regression risk. With the latest CI run green, I would merge it.** A defect here could reorder or drop terminal output after reconnect, retain output from a replaced PTY, or strand delivery credit and stall a stream. The implementation is much narrower than those consequences suggest: it extracts the existing queue policy into one class and replaces repeated `filter` / `reduce` / `shift` work with a retained-character counter and head index. Replay, delivery, recovery, and provider policies are unchanged.

| Failure mode | Preserved invariant | Evidence |
| --- | --- | --- |
| Replay erases newer output | Authoritative replay finishes before queued live chunks drain; retained chunks remain FIFO | Corrected real Docker SSH reconnect test passed 6/6; focused parser-order coverage passed |
| Old PTY or stream leaks into a replacement | A generation change discards the previous queue; drain still fences every chunk by current generation and PTY id | Seeded differential test and stale-callback/replacement integration coverage |
| Output is silently lost at a cap | Eviction remains whole-chunk, and the oldest survivor receives `droppedOutput` so snapshot recovery replaces the gap | Exact boundary, oversized-frame, metadata, and snapshot-recovery tests |
| Delivery credit leaks or is acknowledged twice | Eviction/discard settles credit; `takeAll()` transfers it to parse delivery without settling it | ACK assertions across 5,000 events plus integration coverage for parse and disposal |
| The optimization becomes a new memory leak | Retained payload stays capped at 512 KiB / 1,024 chunks; evicted slots are cleared and the backing array compacts | Repeated-compaction test checks bounded backing storage and exactly-once cleanup |

The blast radius is narrow:

- The queue exists only while reattach/replay deferral is active; ordinary live terminal output bypasses it.
- State is renderer-local, per connection, and ephemeral. There is no migration, persistence, RPC/IPC schema, stream opcode, or mixed-version behavior change.
- Local, direct SSH, relay, and remote-runtime PTYs share the unchanged delivery callback around this queue.
- Folder workspaces and git worktrees use the same unchanged terminal path; no repository assumption was added.
- The fallback on any detected gap is still the existing authoritative snapshot-recovery path.
- Rollback is a single production-commit revert with no data, protocol, or wire cleanup.

#### Release gate: real SSH reconnect under output

The Docker SSH E2E is now a meaningful user-level oracle:

1. Start a real Linux Docker OpenSSH target and a live remote PTY.
2. Run an encoded readiness command whose plaintext marker is absent from the terminal input; seeing it proves the remote shell executed the command.
3. Start a remote process that emits 256 × 4 KiB frames (about 1 MiB) over 2.56 seconds.
4. After the remote-only start marker, explicitly disconnect and reconnect while output continues.
5. Require the remote-only final recovery marker after reattach.
6. Send a second encoded command through the reattached terminal, write its proof file inside the container, require its remote output, and verify the file independently with Docker exec.

The original test embedded its markers verbatim in the commands, so terminal echo could satisfy several waits before the remote process ran. The earlier isolated failure therefore did not prove a queue or SSH regression; its `Connecting…` screenshot was also captured after the test's `finally` cleanup stopped the Docker target. Commit `9a38f98e828` removes that ambiguity by encoding every asserted marker-bearing command and asserting the plaintext marker is absent from the input.

Results with the corrected oracle:

- 1/1 pass after a fresh Electron, CLI, and relay build.
- 5/5 consecutive isolated passes with the same fresh build (`--repeat-each=5`).
- 6/6 total, with no retries.

Expected regression signals are now unambiguous: a missing remote start/final marker, a terminal that cannot execute the post-reconnect command, or a proof file absent from the container. The latest CI run is green. Reverting the production commit restores the previous queue implementation without compatibility fallout.

### Performance proof

Node 24.18.0 on macOS arm64; 5 warmups and 31 alternating paired samples. Each run prefilled the real 1,024-chunk / 512 KiB cap with 512-character chunks, then timed 16,384 saturated arrivals. The baseline is the exact prior `filter` + `reduce` + `shift` algorithm; the candidate is the actual `DeferredReattachLiveDataQueue` module. Setup, drain, and result validation were outside the timed region.

| Implementation | Median | p95 |
| --- | ---: | ---: |
| Previous algorithm | 82.337 ms | 85.061 ms |
| Actual queue module | 0.562 ms | 0.695 ms |
| Improvement | 146.5× / 99.32% lower | 122.5× / 99.18% lower |

Every sample retained the same FIFO sequence and oldest-survivor gap marker and released exactly 16,384 eviction credits.

### No-regression proof

- A 5,000-event seeded differential test compares the new queue with the exact previous algorithm across count and character caps, oversized UTF-16 tails, generation replacement, metadata, transfer/discard, and ACK counts.
- A structural regression test fails if enqueue reintroduces `Array.filter`, `Array.reduce`, or `Array.shift`.
- Queue tests pass 7/7; focused replay/live PTY integration tests pass 7/7.
- Full `pty-connection` and renderer coverage passed on the latest commit, including replay-before-live delivery, stale replacement callbacks, nested deferral ownership, oversized recovery, disposal, SSH retry lease replacement, and post-parse viewport intent.
- The corrected real Docker SSH reconnect-under-output E2E passes 6/6 without retries.
- Local/main-process and remote-runtime credits are still held until parse delivery, and eviction, stale generation, failed replay, and disposal each release retained credit exactly once.
- This changes renderer-local queue storage only: no RPC/IPC payload, stream opcode, persistence, mobile contract, provider routing, filesystem behavior, or Git command changed.

### Coverage and residual gaps

- The real reconnect gate ran from macOS arm64 against a Linux x64 Docker SSH host and the actual relay bundle.
- The production code is platform-neutral TypeScript array/string bookkeeping. Linux and Windows packaging and the full Node 24/26 matrix passed on the latest test-only commit.
- The Docker SSH E2E intentionally skips Windows because its fixture uses POSIX SSH tooling. There is no equivalent Windows-host real SSH reconnect run in this PR.
- No mobile-facing or remote-wire surface changed, so mixed client/host versions do not receive new fields, opcodes, or publication semantics.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the local wrapper stopped before Vitest because the patched `node-pty` source build is unavailable in this workspace; direct Vitest runs below passed.
- [ ] `pnpm build` — the targeted Electron main/preload/renderer production build and fresh E2E build passed; full native packaging passed in CI.
- [x] Added or updated high-quality tests that would catch regressions

Passed:

- Full renderer on the production commit: 2,333 files / 21,604 tests; one file and four tests skipped.
- Focused queue, PTY connection, dispatcher credit, and remote-runtime ownership: 10 files / 622 tests.
- Latest local rerun: queue 7/7; focused replay/live PTY integration 7/7; corrected Docker SSH reconnect E2E 6/6.
- Full lint, Node/CLI/web typecheck, changed-code quality, max-lines ratchet, reliability gates, formatting, and diff checks.
- Fresh Electron E2E build plus CLI and all relay targets.
- Latest GitHub checks: 45 passed, none failed or pending; two unrelated E2E lanes skipped by their selectors. This includes changed-E2E validation, the full Node 24/26 matrix, and Linux and Windows packaging.

## AI Review Report

Three independent reviews found no P0, P1, or P2 issues. They traced queue equivalence, metadata identity, generation and PTY fencing, nested-owner failure, recursive drain, exactly-once credit transfer and cleanup, bounded storage, and viewport enforcement. The review also checked local, direct SSH, relay, remote-runtime, folder-workspace, and stale/disposal paths.

Cross-platform review found no macOS, Linux, Windows, or WSL-specific production behavior: the production change is platform-neutral TypeScript array/string bookkeeping and does not touch shortcuts, labels, paths, shells, native modules, or Electron platform branches.

## Security Audit

No production security findings. The production diff adds no dependency, network sink, command execution, path handling, auth, secret, persistence, IPC schema, or wire payload. Existing arbitrary PTY text remains bounded and is never evaluated; consumed entries clear their data, metadata, and credit closures before compaction. The E2E-only follow-up executes generated scripts solely inside its disposable Docker SSH fixture and contains no user-controlled input.

## Notes

- Local, SSH, relay, remote-runtime, and folder-workspace behavior share the unchanged connection callback and delivery paths.
- No mobile-facing, visual, provider-specific, persistence, Git-provider, Git-binary, or remote-wire surface changed.
- The pre-existing possibility that a JavaScript tail `slice()` can retain an oversized source string's backing storage is unchanged and belongs in a separate owned-storage follow-up.
- X: @nwparker_

