### PR TITLE
perf(terminal): debounce find-as-you-type search

### DIFF
--- a/src/renderer/src/components/TerminalSearch.test.tsx
+++ b/src/renderer/src/components/TerminalSearch.test.tsx
@@ -3,7 +3,7 @@
 import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import type { SearchAddon } from '@xterm/addon-search'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
-import { matchSearchNavigate, type SearchState } from '@/components/terminal-pane/keyboard-handlers'
+import type { SearchState } from '@/components/terminal-pane/keyboard-handlers'
 import TerminalSearch from './TerminalSearch'
 
 vi.mock('@/i18n/i18n', () => ({
@@ -78,37 +78,51 @@ describe('TerminalSearch debounce', () => {
 
   it('updates shortcut search state on every input change before the debounce', () => {
     const addon = createSearchAddon()
-    const searchStateRef = {
+    const searchStateRef: React.RefObject<SearchState> = {
       current: { query: '', caseSensitive: false, regex: false }
     }
     const view = renderSearch(addon, searchStateRef)
     const input = view.getByPlaceholderText('Search...')
 
     fireEvent.change(input, { target: { value: 'n' } })
-    expect(searchStateRef.current).toEqual({ query: 'n', caseSensitive: false, regex: false })
+    expect(searchStateRef.current).toEqual(
+      expect.objectContaining({ query: 'n', caseSensitive: false, regex: false })
+    )
     fireEvent.change(input, { target: { value: 'needle' } })
-    expect(searchStateRef.current).toEqual({ query: 'needle', caseSensitive: false, regex: false })
+    expect(searchStateRef.current).toEqual(
+      expect.objectContaining({ query: 'needle', caseSensitive: false, regex: false })
+    )
+    expect(searchStateRef.current.flushPendingSearch).toEqual(expect.any(Function))
   })
 
   it.each([
-    ['macOS', true, { metaKey: true, ctrlKey: false }],
-    ['Linux/Windows', false, { metaKey: false, ctrlKey: true }]
-  ])('exposes the pending query to %s search navigation', (_platform, isMac, modifiers) => {
+    ['Previous match', 'previous'],
+    ['Next match', 'next']
+  ])('flushes before the %s button navigates', (buttonTitle, direction) => {
     const addon = createSearchAddon()
-    const searchStateRef = {
-      current: { query: '', caseSensitive: false, regex: false }
-    }
-    const view = renderSearch(addon, searchStateRef)
+    const view = renderSearch(addon)
+    clearAddonMocks(addon)
     fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    fireEvent.click(view.getByTitle(buttonTitle))
 
-    expect(
-      matchSearchNavigate(
-        { key: 'g', shiftKey: false, altKey: false, ...modifiers },
-        isMac,
-        true,
-        searchStateRef.current
-      )
-    ).toBe('next')
+    expect(addon.findNext).toHaveBeenNthCalledWith(
+      1,
+      'needle',
+      expect.objectContaining({ incremental: true })
+    )
+    const navigation = direction === 'next' ? addon.findNext : addon.findPrevious
+    expect(navigation).toHaveBeenCalledWith(
+      'needle',
+      expect.objectContaining({ incremental: false })
+    )
+    const navigationCallIndex = direction === 'next' ? 1 : 0
+    expect(vi.mocked(addon.findNext).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(navigation).mock.invocationCallOrder[navigationCallIndex]
+    )
+    const findNextCalls = vi.mocked(addon.findNext).mock.calls.length
+
+    advanceSearchDebounce()
+    expect(addon.findNext).toHaveBeenCalledTimes(findNextCalls)
   })
 
   it('flushes an armed search on Enter and does not rerun its timer', () => {

--- a/src/renderer/src/components/TerminalSearch.test.tsx
+++ b/src/renderer/src/components/TerminalSearch.test.tsx
@@ -1,15 +1,22 @@
 // @vitest-environment happy-dom
 
-import { cleanup, fireEvent, render, waitFor } from '@testing-library/react'
+import { act, cleanup, fireEvent, render } from '@testing-library/react'
 import type { SearchAddon } from '@xterm/addon-search'
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { matchSearchNavigate, type SearchState } from '@/components/terminal-pane/keyboard-handlers'
 import TerminalSearch from './TerminalSearch'
 
 vi.mock('@/i18n/i18n', () => ({
   translate: (_key: string, fallback: string) => fallback
 }))
 
-afterEach(cleanup)
+beforeEach(() => vi.useFakeTimers())
+
+afterEach(() => {
+  cleanup()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+})
 
 function createSearchAddon(): SearchAddon {
   return {
@@ -19,68 +26,235 @@ function createSearchAddon(): SearchAddon {
   } as unknown as SearchAddon
 }
 
-function renderSearch(searchAddon: SearchAddon): ReturnType<typeof render> {
+function clearAddonMocks(addon: SearchAddon): void {
+  vi.mocked(addon.findNext).mockClear()
+  vi.mocked(addon.findPrevious).mockClear()
+  vi.mocked(addon.clearDecorations).mockClear()
+}
+
+function advanceSearchDebounce(): void {
+  act(() => vi.advanceTimersByTime(75))
+}
+
+function renderSearch(
+  searchAddon: SearchAddon,
+  searchStateRef: React.RefObject<SearchState> = {
+    current: { query: '', caseSensitive: false, regex: false }
+  }
+): ReturnType<typeof render> {
   return render(
     <TerminalSearch
       isOpen
       onClose={vi.fn()}
       searchAddon={searchAddon}
-      searchStateRef={{ current: { query: '', caseSensitive: false, regex: false } }}
+      searchStateRef={searchStateRef}
     />
   )
 }
 
-describe('TerminalSearch cleanup', () => {
-  it('clears the current addon when the query is erased', async () => {
+describe('TerminalSearch debounce', () => {
+  it('runs one search with the latest query after a typing burst', () => {
     const addon = createSearchAddon()
     const view = renderSearch(addon)
+    const input = view.getByPlaceholderText('Search...')
+    clearAddonMocks(addon)
 
-    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
-    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
-    vi.mocked(addon.clearDecorations).mockClear()
-    vi.mocked(addon.findNext).mockClear()
+    fireEvent.change(input, { target: { value: 'n' } })
+    act(() => vi.advanceTimersByTime(30))
+    fireEvent.change(input, { target: { value: 'nee' } })
+    act(() => vi.advanceTimersByTime(30))
+    fireEvent.change(input, { target: { value: 'needle' } })
 
-    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: '' } })
+    act(() => vi.advanceTimersByTime(74))
+    expect(addon.findNext).not.toHaveBeenCalled()
 
-    await waitFor(() => expect(addon.clearDecorations).toHaveBeenCalledTimes(1))
-    expect(addon.findNext).toHaveBeenCalledWith('')
+    act(() => vi.advanceTimersByTime(1))
+    expect(addon.findNext).toHaveBeenCalledTimes(1)
+    expect(addon.findNext).toHaveBeenCalledWith(
+      'needle',
+      expect.objectContaining({ caseSensitive: false, regex: false, incremental: true })
+    )
   })
 
-  it('clears the previous addon when the search moves to another pane', async () => {
+  it('updates shortcut search state on every input change before the debounce', () => {
+    const addon = createSearchAddon()
+    const searchStateRef = {
+      current: { query: '', caseSensitive: false, regex: false }
+    }
+    const view = renderSearch(addon, searchStateRef)
+    const input = view.getByPlaceholderText('Search...')
+
+    fireEvent.change(input, { target: { value: 'n' } })
+    expect(searchStateRef.current).toEqual({ query: 'n', caseSensitive: false, regex: false })
+    fireEvent.change(input, { target: { value: 'needle' } })
+    expect(searchStateRef.current).toEqual({ query: 'needle', caseSensitive: false, regex: false })
+  })
+
+  it.each([
+    ['macOS', true, { metaKey: true, ctrlKey: false }],
+    ['Linux/Windows', false, { metaKey: false, ctrlKey: true }]
+  ])('exposes the pending query to %s search navigation', (_platform, isMac, modifiers) => {
+    const addon = createSearchAddon()
+    const searchStateRef = {
+      current: { query: '', caseSensitive: false, regex: false }
+    }
+    const view = renderSearch(addon, searchStateRef)
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+
+    expect(
+      matchSearchNavigate(
+        { key: 'g', shiftKey: false, altKey: false, ...modifiers },
+        isMac,
+        true,
+        searchStateRef.current
+      )
+    ).toBe('next')
+  })
+
+  it('flushes an armed search on Enter and does not rerun its timer', () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+    const input = view.getByPlaceholderText('Search...')
+    clearAddonMocks(addon)
+
+    fireEvent.change(input, { target: { value: 'needle' } })
+    fireEvent.keyDown(input, { key: 'Enter' })
+
+    expect(addon.findNext).toHaveBeenCalledTimes(2)
+    expect(addon.findNext).toHaveBeenNthCalledWith(
+      1,
+      'needle',
+      expect.objectContaining({ incremental: true })
+    )
+    expect(addon.findNext).toHaveBeenNthCalledWith(
+      2,
+      'needle',
+      expect.objectContaining({ incremental: false })
+    )
+
+    advanceSearchDebounce()
+    expect(addon.findNext).toHaveBeenCalledTimes(2)
+  })
+
+  it('flushes before Shift+Enter navigates to the previous match', () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+    const input = view.getByPlaceholderText('Search...')
+    clearAddonMocks(addon)
+
+    fireEvent.change(input, { target: { value: 'needle' } })
+    fireEvent.keyDown(input, { key: 'Enter', shiftKey: true })
+
+    expect(addon.findNext).toHaveBeenCalledTimes(1)
+    expect(addon.findNext).toHaveBeenCalledWith(
+      'needle',
+      expect.objectContaining({ incremental: true })
+    )
+    expect(addon.findPrevious).toHaveBeenCalledWith(
+      'needle',
+      expect.objectContaining({ incremental: false })
+    )
+  })
+
+  it('restarts an armed search with the latest option values', () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+    const input = view.getByPlaceholderText('Search...')
+    clearAddonMocks(addon)
+
+    fireEvent.change(input, { target: { value: 'needle' } })
+    fireEvent.click(view.getByTitle('Case sensitive'))
+    fireEvent.click(view.getByTitle('Regex'))
+    advanceSearchDebounce()
+
+    expect(addon.findNext).toHaveBeenCalledTimes(1)
+    expect(addon.findNext).toHaveBeenCalledWith(
+      'needle',
+      expect.objectContaining({ caseSensitive: true, regex: true, incremental: true })
+    )
+  })
+})
+
+describe('TerminalSearch cleanup', () => {
+  it('clears immediately when the query is erased and cancels its search', () => {
+    const addon = createSearchAddon()
+    const view = renderSearch(addon)
+    const input = view.getByPlaceholderText('Search...')
+    clearAddonMocks(addon)
+
+    fireEvent.change(input, { target: { value: 'needle' } })
+    fireEvent.change(input, { target: { value: '' } })
+
+    expect(addon.clearDecorations).toHaveBeenCalledTimes(1)
+    expect(addon.findNext).toHaveBeenCalledWith('')
+    advanceSearchDebounce()
+    expect(addon.findNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears immediately when the search closes', () => {
+    const addon = createSearchAddon()
+    const searchStateRef = {
+      current: { query: '', caseSensitive: false, regex: false }
+    }
+    const view = renderSearch(addon, searchStateRef)
+    fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
+    clearAddonMocks(addon)
+
+    view.rerender(
+      <TerminalSearch
+        isOpen={false}
+        onClose={vi.fn()}
+        searchAddon={addon}
+        searchStateRef={searchStateRef}
+      />
+    )
+
+    expect(addon.clearDecorations).toHaveBeenCalledTimes(1)
+    expect(addon.findNext).toHaveBeenCalledWith('')
+    advanceSearchDebounce()
+    expect(addon.findNext).toHaveBeenCalledTimes(1)
+  })
+
+  it('clears the previous addon and does not run its armed search after a pane swap', () => {
     const previousAddon = createSearchAddon()
     const nextAddon = createSearchAddon()
-    const view = renderSearch(previousAddon)
-
+    const searchStateRef = {
+      current: { query: '', caseSensitive: false, regex: false }
+    }
+    const view = renderSearch(previousAddon, searchStateRef)
     fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
-    await waitFor(() => expect(previousAddon.findNext).toHaveBeenCalled())
-    vi.mocked(previousAddon.clearDecorations).mockClear()
-    vi.mocked(previousAddon.findNext).mockClear()
+    clearAddonMocks(previousAddon)
 
     view.rerender(
       <TerminalSearch
         isOpen
         onClose={vi.fn()}
         searchAddon={nextAddon}
-        searchStateRef={{ current: { query: '', caseSensitive: false, regex: false } }}
+        searchStateRef={searchStateRef}
       />
     )
 
     expect(previousAddon.clearDecorations).toHaveBeenCalledTimes(1)
     expect(previousAddon.findNext).toHaveBeenCalledWith('')
+    advanceSearchDebounce()
+    expect(previousAddon.findNext).toHaveBeenCalledTimes(1)
+    expect(nextAddon.findNext).toHaveBeenCalledWith(
+      'needle',
+      expect.objectContaining({ incremental: true })
+    )
   })
 
-  it('clears the addon when the search portal unmounts', async () => {
+  it('clears the addon and cancels the armed search on unmount', () => {
     const addon = createSearchAddon()
     const view = renderSearch(addon)
-
     fireEvent.change(view.getByPlaceholderText('Search...'), { target: { value: 'needle' } })
-    await waitFor(() => expect(addon.findNext).toHaveBeenCalled())
-    vi.mocked(addon.clearDecorations).mockClear()
-    vi.mocked(addon.findNext).mockClear()
+    clearAddonMocks(addon)
 
     view.unmount()
 
     expect(addon.clearDecorations).toHaveBeenCalledTimes(1)
     expect(addon.findNext).toHaveBeenCalledWith('')
+    advanceSearchDebounce()
+    expect(addon.findNext).toHaveBeenCalledTimes(1)
   })
 })

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -1,4 +1,4 @@
-import { useEffect, useState, useCallback } from 'react'
+import { useEffect, useRef, useState, useCallback } from 'react'
 import { ChevronUp, ChevronDown, X, CaseSensitive, Regex } from 'lucide-react'
 import type { SearchAddon } from '@xterm/addon-search'
 import { Button } from '@/components/ui/button'
@@ -12,6 +12,14 @@ type TerminalSearchProps = {
   onClose: () => void
   searchAddon: SearchAddon | null
   searchStateRef: React.RefObject<SearchState>
+}
+
+const SEARCH_DEBOUNCE_MS = 75
+
+type PendingSearch = {
+  addon: SearchAddon
+  query: string
+  options: NonNullable<Parameters<SearchAddon['findNext']>[1]>
 }
 
 function clearTerminalSearch(searchAddon: SearchAddon | null): void {
@@ -32,6 +40,8 @@ export default function TerminalSearch({
   const [query, setQuery] = useState('')
   const [caseSensitive, setCaseSensitive] = useState(false)
   const [regex, setRegex] = useState(false)
+  const pendingSearchRef = useRef<PendingSearch | null>(null)
+  const searchTimerRef = useRef<number | null>(null)
   const requestQuery = getFindRequestQuery(query)
 
   // Why: the default xterm SearchAddon highlights blend into common
@@ -81,11 +91,32 @@ export default function TerminalSearch({
     input?.focus()
   }, [])
 
+  const cancelPendingSearch = useCallback((): void => {
+    if (searchTimerRef.current !== null) {
+      window.clearTimeout(searchTimerRef.current)
+      searchTimerRef.current = null
+    }
+    pendingSearchRef.current = null
+  }, [])
+
+  const flushPendingSearch = useCallback((): void => {
+    const pending = pendingSearchRef.current
+    cancelPendingSearch()
+    if (pending) {
+      safeFind(
+        (term, options) => pending.addon.findNext(term, options),
+        pending.query,
+        pending.options
+      )
+    }
+  }, [cancelPendingSearch])
+
   useEffect(
     () => () => {
+      cancelPendingSearch()
       clearTerminalSearch(searchAddon)
     },
-    [searchAddon]
+    [cancelPendingSearch, searchAddon]
   )
 
   useEffect(() => {
@@ -93,6 +124,7 @@ export default function TerminalSearch({
     // can read the current search state without lifting it to parent state.
     searchStateRef.current = { query: requestQuery ?? '', caseSensitive, regex }
 
+    cancelPendingSearch()
     if (!isOpen) {
       clearTerminalSearch(searchAddon)
       return
@@ -102,13 +134,32 @@ export default function TerminalSearch({
       return
     }
     if (searchAddon) {
-      safeFind(
-        (term, options) => searchAddon.findNext(term, options),
-        requestQuery,
-        searchOptions(true)
-      )
+      const pending = { addon: searchAddon, query: requestQuery, options: searchOptions(true) }
+      pendingSearchRef.current = pending
+      searchTimerRef.current = window.setTimeout(() => {
+        if (pendingSearchRef.current !== pending) {
+          return
+        }
+        pendingSearchRef.current = null
+        searchTimerRef.current = null
+        safeFind(
+          (term, options) => pending.addon.findNext(term, options),
+          pending.query,
+          pending.options
+        )
+      }, SEARCH_DEBOUNCE_MS)
     }
-  }, [requestQuery, searchAddon, isOpen, caseSensitive, regex, searchStateRef, searchOptions])
+    return cancelPendingSearch
+  }, [
+    requestQuery,
+    searchAddon,
+    isOpen,
+    caseSensitive,
+    regex,
+    searchStateRef,
+    searchOptions,
+    cancelPendingSearch
+  ])
 
   const handleKeyDown = useCallback(
     (e: React.KeyboardEvent) => {
@@ -117,12 +168,26 @@ export default function TerminalSearch({
       if (e.key === 'Escape') {
         onClose()
       } else if (e.key === 'Enter' && e.shiftKey) {
+        flushPendingSearch()
         findPrevious()
       } else if (e.key === 'Enter') {
+        flushPendingSearch()
         findNext()
       }
     },
-    [onClose, findNext, findPrevious]
+    [onClose, findNext, findPrevious, flushPendingSearch]
+  )
+
+  const handleQueryChange = useCallback(
+    (nextQuery: string): void => {
+      searchStateRef.current = {
+        query: getFindRequestQuery(nextQuery) ?? '',
+        caseSensitive,
+        regex
+      }
+      setQuery(nextQuery)
+    },
+    [caseSensitive, regex, searchStateRef]
   )
 
   if (!isOpen) {
@@ -140,7 +205,7 @@ export default function TerminalSearch({
         ref={handleInputRef}
         type="text"
         value={query}
-        onChange={(e) => setQuery(e.target.value)}
+        onChange={(e) => handleQueryChange(e.target.value)}
         placeholder={translate('auto.components.TerminalSearch.e07012f26e', 'Search...')}
         className="min-w-0 flex-1 border-none bg-transparent text-sm text-white outline-none placeholder:text-zinc-500"
       />

--- a/src/renderer/src/components/TerminalSearch.tsx
+++ b/src/renderer/src/components/TerminalSearch.tsx
@@ -111,6 +111,16 @@ export default function TerminalSearch({
     }
   }, [cancelPendingSearch])
 
+  const navigateNext = useCallback((): void => {
+    flushPendingSearch()
+    findNext()
+  }, [findNext, flushPendingSearch])
+
+  const navigatePrevious = useCallback((): void => {
+    flushPendingSearch()
+    findPrevious()
+  }, [findPrevious, flushPendingSearch])
+
   useEffect(
     () => () => {
       cancelPendingSearch()
@@ -122,7 +132,12 @@ export default function TerminalSearch({
   useEffect(() => {
     // Keep the ref in sync so the keyboard handler (Cmd+G / Cmd+Shift+G)
     // can read the current search state without lifting it to parent state.
-    searchStateRef.current = { query: requestQuery ?? '', caseSensitive, regex }
+    searchStateRef.current = {
+      query: requestQuery ?? '',
+      caseSensitive,
+      regex,
+      flushPendingSearch
+    }
 
     cancelPendingSearch()
     if (!isOpen) {
@@ -158,7 +173,8 @@ export default function TerminalSearch({
     regex,
     searchStateRef,
     searchOptions,
-    cancelPendingSearch
+    cancelPendingSearch,
+    flushPendingSearch
   ])
 
   const handleKeyDown = useCallback(
@@ -168,14 +184,12 @@ export default function TerminalSearch({
       if (e.key === 'Escape') {
         onClose()
       } else if (e.key === 'Enter' && e.shiftKey) {
-        flushPendingSearch()
-        findPrevious()
+        navigatePrevious()
       } else if (e.key === 'Enter') {
-        flushPendingSearch()
-        findNext()
+        navigateNext()
       }
     },
-    [onClose, findNext, findPrevious, flushPendingSearch]
+    [onClose, navigateNext, navigatePrevious]
   )
 
   const handleQueryChange = useCallback(
@@ -183,11 +197,12 @@ export default function TerminalSearch({
       searchStateRef.current = {
         query: getFindRequestQuery(nextQuery) ?? '',
         caseSensitive,
-        regex
+        regex,
+        flushPendingSearch
       }
       setQuery(nextQuery)
     },
-    [caseSensitive, regex, searchStateRef]
+    [caseSensitive, regex, searchStateRef, flushPendingSearch]
   )
 
   if (!isOpen) {
@@ -242,7 +257,7 @@ export default function TerminalSearch({
         type="button"
         variant="ghost"
         size="icon-xs"
-        onClick={findPrevious}
+        onClick={navigatePrevious}
         className="flex size-6 shrink-0 items-center justify-center rounded text-zinc-400 hover:text-zinc-200"
         title={translate('auto.components.TerminalSearch.0f3066256e', 'Previous match')}
       >
@@ -253,7 +268,7 @@ export default function TerminalSearch({
         type="button"
         variant="ghost"
         size="icon-xs"
-        onClick={findNext}
+        onClick={navigateNext}
         className="flex size-6 shrink-0 items-center justify-center rounded text-zinc-400 hover:text-zinc-200"
         title={translate('auto.components.TerminalSearch.7cb40c04eb', 'Next match')}
       >

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers-search-debounce.test.tsx
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers-search-debounce.test.tsx
@@ -1,0 +1,156 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, fireEvent, render, renderHook } from '@testing-library/react'
+import type { SearchAddon } from '@xterm/addon-search'
+import { afterEach, beforeEach, expect, it, vi } from 'vitest'
+import TerminalSearch from '@/components/TerminalSearch'
+import type { PaneManager } from '@/lib/pane-manager/pane-manager'
+import type { PtyTransport } from './pty-transport'
+import { type SearchState, useTerminalKeyboardShortcuts } from './keyboard-handlers'
+
+vi.mock('@/i18n/i18n', () => ({
+  translate: (_key: string, fallback: string) => fallback
+}))
+
+type KeyboardHandlersDeps = Parameters<typeof useTerminalKeyboardShortcuts>[0]
+
+function createSearchAddon(): SearchAddon {
+  return {
+    findNext: vi.fn(() => true),
+    findPrevious: vi.fn(() => true),
+    clearDecorations: vi.fn()
+  } as unknown as SearchAddon
+}
+
+function createHarness(userAgent: string): {
+  addon: SearchAddon
+  input: HTMLElement
+  paneFocus: ReturnType<typeof vi.fn>
+  shortcutTarget: HTMLTextAreaElement
+} {
+  vi.spyOn(window.navigator, 'userAgent', 'get').mockReturnValue(userAgent)
+  const addon = createSearchAddon()
+  const searchStateRef: React.RefObject<SearchState> = {
+    current: { query: '', caseSensitive: false, regex: false }
+  }
+  const view = render(
+    <TerminalSearch isOpen onClose={vi.fn()} searchAddon={addon} searchStateRef={searchStateRef} />
+  )
+
+  const scope = document.createElement('div')
+  const terminalElement = document.createElement('div')
+  const shortcutTarget = document.createElement('textarea')
+  terminalElement.append(shortcutTarget)
+  scope.append(terminalElement)
+  document.body.append(scope)
+
+  const paneFocus = vi.fn()
+  const pane = {
+    id: 1,
+    leafId: '00000000-0000-4000-8000-000000000001',
+    searchAddon: addon,
+    terminal: {
+      element: terminalElement,
+      focus: paneFocus,
+      getSelection: vi.fn(() => '')
+    }
+  }
+  const manager = {
+    getActivePane: () => pane,
+    getPanes: () => [pane]
+  } as unknown as PaneManager
+  const transport = {
+    getPtyId: () => 'pty-1',
+    sendInput: vi.fn(() => true)
+  } as unknown as PtyTransport
+  const deps: KeyboardHandlersDeps = {
+    tabId: 'tab-1',
+    worktreeId: 'worktree-1',
+    isActive: true,
+    keyboardScopeRef: { current: scope },
+    managerRef: { current: manager },
+    paneTransportsRef: { current: new Map([[pane.id, transport]]) },
+    panePtyBindingsRef: { current: new Map() },
+    paneCwdRef: { current: new Map() },
+    fallbackCwd: '',
+    expandedPaneIdRef: { current: null },
+    setExpandedPane: vi.fn(),
+    restoreExpandedLayout: vi.fn(),
+    refreshPaneSizes: vi.fn(),
+    persistLayoutSnapshot: vi.fn(),
+    toggleExpandPane: vi.fn(),
+    setSearchOpen: vi.fn(),
+    onSearchSelectedText: vi.fn(),
+    onRequestClosePane: vi.fn(),
+    onClearPaneScrollback: vi.fn(),
+    onSetTitle: vi.fn(),
+    onClearPaneTitle: vi.fn(),
+    searchOpenRef: { current: true },
+    searchStateRef,
+    macOptionAsAltRef: { current: 'false' }
+  }
+  renderHook(() => useTerminalKeyboardShortcuts(deps))
+  vi.mocked(addon.findNext).mockClear()
+  vi.mocked(addon.findPrevious).mockClear()
+  vi.mocked(addon.clearDecorations).mockClear()
+
+  return {
+    addon,
+    input: view.getByPlaceholderText('Search...'),
+    paneFocus,
+    shortcutTarget
+  }
+}
+
+beforeEach(() => vi.useFakeTimers())
+
+afterEach(() => {
+  cleanup()
+  document.body.replaceChildren()
+  vi.clearAllTimers()
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+})
+
+it.each([
+  ['Cmd+G', 'Mac', { metaKey: true }, 'next'],
+  ['Cmd+Shift+G', 'Mac', { metaKey: true, shiftKey: true }, 'previous'],
+  ['Ctrl+G', 'Linux', { ctrlKey: true }, 'next'],
+  ['Ctrl+Shift+G', 'Linux', { ctrlKey: true, shiftKey: true }, 'previous']
+])(
+  'flushes pending search before captured %s navigation',
+  (_name, platform, modifiers, direction) => {
+    const harness = createHarness(platform)
+    fireEvent.change(harness.input, { target: { value: 'needle' } })
+    const shortcut = new KeyboardEvent('keydown', {
+      bubbles: true,
+      cancelable: true,
+      key: 'g',
+      code: 'KeyG',
+      ...modifiers
+    })
+
+    harness.shortcutTarget.dispatchEvent(shortcut)
+
+    expect(shortcut.defaultPrevented).toBe(true)
+    expect(harness.addon.findNext).toHaveBeenNthCalledWith(
+      1,
+      'needle',
+      expect.objectContaining({ incremental: true })
+    )
+    const navigation = direction === 'next' ? harness.addon.findNext : harness.addon.findPrevious
+    const navigationCallIndex = direction === 'next' ? 1 : 0
+    expect(vi.mocked(navigation).mock.calls[navigationCallIndex]).toEqual([
+      'needle',
+      { caseSensitive: false, regex: false }
+    ])
+    expect(vi.mocked(harness.addon.findNext).mock.invocationCallOrder[0]).toBeLessThan(
+      vi.mocked(navigation).mock.invocationCallOrder[navigationCallIndex]
+    )
+    const findNextCalls = vi.mocked(harness.addon.findNext).mock.calls.length
+
+    act(() => vi.advanceTimersByTime(75))
+    expect(harness.addon.findNext).toHaveBeenCalledTimes(findNextCalls)
+    expect(harness.paneFocus).toHaveBeenCalledTimes(1)
+  }
+)

--- a/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
+++ b/src/renderer/src/components/terminal-pane/keyboard-handlers.ts
@@ -127,6 +127,7 @@ export type SearchState = {
   query: string
   caseSensitive: boolean
   regex: boolean
+  flushPendingSearch?: () => void
 }
 
 export type SearchNavigationDirection = 'next' | 'previous'
@@ -171,6 +172,8 @@ export function runTerminalSearchNavigation(
 ): boolean {
   const { query, caseSensitive, regex } = searchState
   const options = { caseSensitive, regex }
+
+  searchState.flushPendingSearch?.()
 
   // Why: Cmd/Ctrl+G hits the same xterm decoration path as the search panel,
   // so narrow-viewport highlight failures need the same containment.


### PR DESCRIPTION
## Summary

- trailing-debounce xterm find-as-you-type searches by 75 ms while updating shortcut-visible search state on each input change
- cancel pending work and clear search immediately on empty queries, close, pane/addon changes, and unmount
- consume a pending incremental search before Enter, button, or Cmd/Ctrl+G navigation, while preserving case, regex, decorations, and `safeFind` handling

## Performance exercise

A local happy-dom exercise used the real xterm `Terminal` and `SearchAddon` with 20,001 scrollback lines. Measurements varied across isolated runs (about 18–38 ms for one final search and 22–28 ms for a six-prefix incremental sequence), so this PR claims the deterministic reduction from one add-on call per typed burst rather than a user-perceived latency improvement.

## Validation

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/TerminalSearch.test.tsx src/renderer/src/components/terminal-pane/keyboard-handlers-search-debounce.test.tsx src/renderer/src/components/terminal-pane/keyboard-handlers.test.ts src/renderer/src/components/terminal-search-safe-find.test.ts src/renderer/src/components/terminal-search-decoration-leak.test.ts` (47 tests)
- `pnpm run typecheck`
- `pnpm run lint`