### PR TITLE
fix(git): support Windows-linked worktrees in WSL projects

### DIFF
--- a/src/main/git/git-capability-state.test.ts
+++ b/src/main/git/git-capability-state.test.ts
@@ -1,13 +1,19 @@
-import { beforeEach, describe, expect, it } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   clearGitCapabilityStateForTests,
   getLocalGitCapabilityCache,
-  getSshGitCapabilityCache
+  getSshGitCapabilityCache,
+  withLocalGitCapabilityCacheForExecution
 } from './git-capability-state'
+import {
+  resetWslLinkedWorktreeGitRoutingForTests,
+  seedWslLinkedWorktreeGitRoutingForTests
+} from './wsl-linked-worktree-git-routing'
 
 describe('Git capability execution-host state', () => {
   beforeEach(() => {
     clearGitCapabilityStateForTests()
+    resetWslLinkedWorktreeGitRoutingForTests()
   })
 
   it('shares native state while isolating each WSL distro', () => {
@@ -33,5 +39,35 @@ describe('Git capability execution-host state', () => {
     expect(getSshGitCapabilityCache(provider)).not.toBe(
       getSshGitCapabilityCache(replacementProvider)
     )
+  })
+
+  it('uses native capability state for a prepared host-routed WSL worktree', async () => {
+    const platform = vi.spyOn(process, 'platform', 'get').mockReturnValue('win32')
+    try {
+      seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked`)
+
+      await expect(
+        withLocalGitCapabilityCacheForExecution(
+          { cwd: String.raw`C:\repo\linked`, wslDistro: 'Ubuntu' },
+          async (capabilities) => capabilities
+        )
+      ).resolves.toBe(getLocalGitCapabilityCache())
+      expect(getLocalGitCapabilityCache()).not.toBe(
+        getLocalGitCapabilityCache({ wslDistro: 'Ubuntu' })
+      )
+    } finally {
+      platform.mockRestore()
+    }
+  })
+
+  it('starts non-candidate capability work without an added async turn', async () => {
+    let started = false
+    const result = withLocalGitCapabilityCacheForExecution({ cwd: '/repo' }, async () => {
+      started = true
+      return 'done'
+    })
+
+    expect(started).toBe(true)
+    await expect(result).resolves.toBe('done')
   })
 })

--- a/src/main/git/git-capability-state.ts
+++ b/src/main/git/git-capability-state.ts
@@ -1,9 +1,14 @@
 import { GitCapabilityCache } from '../../shared/git-capability-cache'
 import { parseWslUncPath } from '../../shared/wsl-paths'
+import {
+  isWslLinkedWorktreeGitRoutingCandidate,
+  prepareWslLinkedWorktreeGitRouting
+} from './wsl-linked-worktree-git-routing'
 
 type LocalGitCapabilityTarget = {
   cwd?: string
   wslDistro?: string
+  signal?: AbortSignal
 }
 
 const localCapabilitiesByExecutionHost = new Map<string, GitCapabilityCache>()
@@ -27,6 +32,28 @@ export function getLocalGitCapabilityCache(
     localCapabilitiesByExecutionHost.set(executionHost, cache)
   }
   return cache
+}
+
+export function withLocalGitCapabilityCacheForExecution<T>(
+  target: LocalGitCapabilityTarget,
+  run: (capabilities: GitCapabilityCache) => Promise<T>
+): Promise<T> {
+  if (!target.cwd || !isWslLinkedWorktreeGitRoutingCandidate(target.cwd, target.wslDistro)) {
+    try {
+      return run(getLocalGitCapabilityCache(target))
+    } catch (error) {
+      return Promise.reject(error)
+    }
+  }
+  return prepareWslLinkedWorktreeGitRouting(target.cwd, target.wslDistro, {
+    signal: target.signal
+  }).then((usesHostGit) =>
+    run(
+      getLocalGitCapabilityCache(
+        usesHostGit ? { cwd: target.cwd } : { cwd: target.cwd, wslDistro: target.wslDistro }
+      )
+    )
+  )
 }
 
 export function getSshGitCapabilityCache(provider: object): GitCapabilityCache {

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -17,12 +17,18 @@ vi.mock('../observability/instrumentation', () => ({
 }))
 vi.mock('../diagnostics/main-thread-churn-probe', () => ({ recordSubprocessSpawn: vi.fn() }))
 
-import { gitExecFileAsync, gitStreamStdout } from './runner'
+import { gitExecFileAsync, gitSpawn, gitStreamStdout } from './runner'
 import {
   getWslGitReadEnvironment,
   resetWslGitReadEnvironmentForTests,
   seedWslGitReadEnvironmentForTests
 } from './wsl-git-read-environment'
+import {
+  prepareWslLinkedWorktreeGitRouting,
+  resetWslLinkedWorktreeGitRoutingForTests,
+  WSL_LINKED_WORKTREE_ROUTE_TTL_MS,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-routing'
 
 const DISTRO = 'Ubuntu'
 const LOGIN_ENVIRONMENT = {
@@ -71,10 +77,12 @@ describe('WSL direct Git reads', () => {
     execFileSyncMock.mockReset()
     spawnMock.mockReset()
     resetWslGitReadEnvironmentForTests()
+    resetWslLinkedWorktreeGitRoutingForTests()
   })
 
   afterEach(() => {
     resetWslGitReadEnvironmentForTests()
+    resetWslLinkedWorktreeGitRoutingForTests()
   })
 
   it('coalesces the login-shell environment probe per distro', async () => {
@@ -493,6 +501,90 @@ describe('WSL direct Git reads', () => {
       })
 
       expect(execFileMock.mock.calls[0]?.[0]).toBe('git')
+    })
+  })
+
+  it('keeps gitSpawn cache-only while async linked-worktree discovery is pending', async () => {
+    await withPlatform('win32', async () => {
+      let releaseStat: (() => void) | undefined
+      const delayedStat = new Promise<void>((resolve) => {
+        releaseStat = resolve
+      })
+      const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+        stat: vi.fn(async () => {
+          await delayedStat
+          return { isDirectory: () => false, isFile: () => true }
+        }),
+        readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+      }
+      const pending = prepareWslLinkedWorktreeGitRouting(
+        String.raw`C:\repo`,
+        DISTRO,
+        'win32',
+        fileSystem
+      )
+      spawnMock.mockReturnValue(createMockChild())
+
+      gitSpawn(['ls-files'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: DISTRO,
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+
+      expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+      expect(spawnMock.mock.calls[0]?.[0]).toBe('wsl.exe')
+      releaseStat?.()
+      await expect(pending).resolves.toBe(true)
+
+      gitSpawn(['ls-files'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: DISTRO,
+        stdio: ['ignore', 'pipe', 'pipe']
+      })
+      expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+      expect(spawnMock.mock.calls[1]?.[0]).toBe('git')
+    })
+  })
+
+  it('keeps gitSpawn cache-only when a linked-worktree route expires', async () => {
+    await withPlatform('win32', async () => {
+      let currentTime = 1_000
+      const nowSpy = vi.spyOn(Date, 'now').mockImplementation(() => currentTime)
+      try {
+        const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+          stat: vi.fn(async () => ({ isDirectory: () => false, isFile: () => true })),
+          readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+        }
+        await prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, 'win32', fileSystem)
+        spawnMock.mockReturnValue(createMockChild())
+
+        gitSpawn(['ls-files'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: DISTRO,
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+        currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS
+        gitSpawn(['ls-files'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: DISTRO,
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+
+        expect(spawnMock.mock.calls[0]?.[0]).toBe('git')
+        expect(spawnMock.mock.calls[1]?.[0]).toBe('wsl.exe')
+        expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+
+        await prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, 'win32', fileSystem)
+        gitSpawn(['ls-files'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: DISTRO,
+          stdio: ['ignore', 'pipe', 'pipe']
+        })
+        expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+        expect(spawnMock.mock.calls[2]?.[0]).toBe('git')
+      } finally {
+        nowSpy.mockRestore()
+      }
     })
   })
 })

--- a/src/main/git/runner-wsl-direct-read.test.ts
+++ b/src/main/git/runner-wsl-direct-read.test.ts
@@ -517,12 +517,10 @@ describe('WSL direct Git reads', () => {
         }),
         readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
       }
-      const pending = prepareWslLinkedWorktreeGitRouting(
-        String.raw`C:\repo`,
-        DISTRO,
-        'win32',
+      const pending = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, {
+        platform: 'win32',
         fileSystem
-      )
+      })
       spawnMock.mockReturnValue(createMockChild())
 
       gitSpawn(['ls-files'], {
@@ -546,6 +544,39 @@ describe('WSL direct Git reads', () => {
     })
   })
 
+  it('aborts an async Git call while linked-worktree discovery remains pending', async () => {
+    await withPlatform('win32', async () => {
+      let releaseStat: (() => void) | undefined
+      const delayedStat = new Promise<void>((resolve) => {
+        releaseStat = resolve
+      })
+      const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+        stat: vi.fn(async () => {
+          await delayedStat
+          return { isDirectory: () => false, isFile: () => true }
+        }),
+        readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+      }
+      const discovery = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, {
+        platform: 'win32',
+        fileSystem
+      })
+      const controller = new AbortController()
+
+      const command = gitExecFileAsync(['status', '--short'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: DISTRO,
+        signal: controller.signal
+      })
+      controller.abort()
+
+      await expect(command).rejects.toMatchObject({ name: 'AbortError' })
+      expect(execFileMock).not.toHaveBeenCalled()
+      releaseStat?.()
+      await expect(discovery).resolves.toBe(true)
+    })
+  })
+
   it('keeps gitSpawn cache-only when a linked-worktree route expires', async () => {
     await withPlatform('win32', async () => {
       let currentTime = 1_000
@@ -555,7 +586,10 @@ describe('WSL direct Git reads', () => {
           stat: vi.fn(async () => ({ isDirectory: () => false, isFile: () => true })),
           readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
         }
-        await prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, 'win32', fileSystem)
+        await prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, {
+          platform: 'win32',
+          fileSystem
+        })
         spawnMock.mockReturnValue(createMockChild())
 
         gitSpawn(['ls-files'], {
@@ -574,7 +608,10 @@ describe('WSL direct Git reads', () => {
         expect(spawnMock.mock.calls[1]?.[0]).toBe('wsl.exe')
         expect(fileSystem.stat).toHaveBeenCalledTimes(1)
 
-        await prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, 'win32', fileSystem)
+        await prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, DISTRO, {
+          platform: 'win32',
+          fileSystem
+        })
         gitSpawn(['ls-files'], {
           cwd: String.raw`C:\repo`,
           wslDistro: DISTRO,

--- a/src/main/git/runner-wsl-linked-gitdir-timeout.test.ts
+++ b/src/main/git/runner-wsl-linked-gitdir-timeout.test.ts
@@ -1,0 +1,98 @@
+import { EventEmitter } from 'node:events'
+import type * as FsPromises from 'node:fs/promises'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { execFileMock, statMock, readFileMock } = vi.hoisted(() => ({
+  execFileMock: vi.fn(),
+  statMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: execFileMock,
+  execFileSync: vi.fn(),
+  spawn: vi.fn()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => ({
+  ...(await importOriginal<typeof FsPromises>()),
+  stat: statMock,
+  readFile: readFileMock
+}))
+
+import { gitExecFileAsync } from './runner'
+import {
+  resetWslLinkedWorktreeGitRoutingForTests,
+  WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS
+} from './wsl-linked-worktree-git-routing'
+
+function createMockChild(): EventEmitter & { pid: number; kill: ReturnType<typeof vi.fn> } {
+  const child = new EventEmitter() as EventEmitter & {
+    pid: number
+    kill: ReturnType<typeof vi.fn>
+  }
+  child.pid = 1234
+  child.kill = vi.fn()
+  return child
+}
+
+async function withWindowsPlatform(run: () => Promise<void>): Promise<void> {
+  const original = process.platform
+  Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+  try {
+    await run()
+  } finally {
+    Object.defineProperty(process, 'platform', { configurable: true, value: original })
+  }
+}
+
+afterEach(() => {
+  vi.useRealTimers()
+  vi.restoreAllMocks()
+  resetWslLinkedWorktreeGitRoutingForTests()
+})
+
+describe('WSL linked-worktree routing probe timeout', () => {
+  it('retries discovery on the next production Git call', async () => {
+    vi.useFakeTimers()
+    await withWindowsPlatform(async () => {
+      statMock
+        .mockImplementationOnce(() => new Promise(() => {}))
+        .mockResolvedValue({ isDirectory: () => false, isFile: () => true })
+      readFileMock.mockResolvedValue('gitdir: C:/main/.git/worktrees/linked\n')
+      execFileMock.mockImplementation((command, _args, _options, callback) => {
+        const child = createMockChild()
+        queueMicrotask(() => {
+          if (command === 'wsl.exe') {
+            callback?.(
+              Object.assign(new Error('not a git repository'), { code: 128 }),
+              '',
+              'fatal: not a git repository'
+            )
+          } else {
+            callback?.(null, 'host git recovered\n', '')
+          }
+        })
+        return child
+      })
+
+      const first = gitExecFileAsync(['status', '--short'], {
+        cwd: String.raw`C:\repo`,
+        wslDistro: 'Ubuntu'
+      })
+      const firstFailure = expect(first).rejects.toThrow('not a git repository')
+      await vi.advanceTimersByTimeAsync(WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+      await firstFailure
+
+      await expect(
+        gitExecFileAsync(['status', '--short'], {
+          cwd: String.raw`C:\repo`,
+          wslDistro: 'Ubuntu'
+        })
+      ).resolves.toEqual({ stdout: 'host git recovered\n', stderr: '' })
+
+      expect(statMock).toHaveBeenCalledTimes(2)
+      expect(execFileMock.mock.calls.map(([command]) => command)).toEqual(['wsl.exe', 'git'])
+    })
+  })
+})

--- a/src/main/git/runner-wsl-linked-gitdir-windows.test.ts
+++ b/src/main/git/runner-wsl-linked-gitdir-windows.test.ts
@@ -11,6 +11,7 @@ import {
   toLinuxPath,
   toWindowsWslPath
 } from './runner'
+import { listWorktrees } from './worktree'
 import { resetWslLinkedWorktreeGitRoutingForTests } from './wsl-linked-worktree-git-routing'
 
 const distro = process.env.ORCA_TEST_WSL_DISTRO?.trim()
@@ -123,6 +124,17 @@ describe.runIf(process.platform === 'win32' && Boolean(distro))(
       })
       expect(linkedExecPath.stdout).toMatch(/^[A-Za-z]:\//)
       expect(mainExecPath.stdout).toMatch(/(?:^|\n)\/[^\n]+\n$/)
+      await expect(listWorktrees(linkedPath, { wslDistro: distro! })).resolves.toEqual(
+        expect.arrayContaining([
+          expect.objectContaining({ path: expect.stringMatching(/[\\/]linked$/) })
+        ])
+      )
+
+      const nestedPath = join(linkedPath, 'nested')
+      wslExec(['git', 'init', toLinuxPath(nestedPath)])
+      await expect(
+        gitExecFileAsync(['--exec-path'], { cwd: nestedPath, wslDistro: distro! })
+      ).resolves.toMatchObject({ stdout: expect.stringMatching(/(?:^|\n)\/[^\n]+\n$/) })
     })
 
     it('keeps WSL-native repositories on WSL Git', async () => {

--- a/src/main/git/runner-wsl-linked-gitdir-windows.test.ts
+++ b/src/main/git/runner-wsl-linked-gitdir-windows.test.ts
@@ -1,0 +1,149 @@
+import { execFileSync } from 'node:child_process'
+import { mkdir, mkdtemp, readFile, rm, writeFile } from 'node:fs/promises'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import { listFilesWithGit } from '../ipc/filesystem-list-files-git-fallback'
+import { searchWithGitGrep } from '../ipc/filesystem-search-git'
+import {
+  gitExecFileAsync,
+  gitExecFileAsyncBuffer,
+  gitStreamStdout,
+  toLinuxPath,
+  toWindowsWslPath
+} from './runner'
+import { resetWslLinkedWorktreeGitRoutingForTests } from './wsl-linked-worktree-git-routing'
+
+const distro = process.env.ORCA_TEST_WSL_DISTRO?.trim()
+const fixtureRoots: string[] = []
+const wslFixtureRoots: string[] = []
+
+function hostGit(args: string[], cwd: string): string {
+  return execFileSync('git', args, { cwd, encoding: 'utf8' })
+}
+
+function wslExec(args: string[]): string {
+  return execFileSync('wsl.exe', ['-d', distro!, '--exec', ...args], { encoding: 'utf8' })
+}
+
+afterEach(async () => {
+  await Promise.all(
+    fixtureRoots.splice(0).map((path) => rm(path, { recursive: true, force: true }))
+  )
+  for (const path of wslFixtureRoots.splice(0)) {
+    if (!/^\/tmp\/orca-wsl-native-[A-Za-z0-9]+$/.test(path)) {
+      throw new Error(`Refusing to remove unexpected WSL fixture path: ${path}`)
+    }
+    wslExec(['rm', '-rf', '--', path])
+  }
+})
+
+describe.runIf(process.platform === 'win32' && Boolean(distro))(
+  'Windows-authored linked worktree in WSL',
+  () => {
+    it('handles the worktree through the production Git runner', async () => {
+      const fixtureRoot = await mkdtemp(join(process.cwd(), '.wsl-linked-gitdir-'))
+      fixtureRoots.push(fixtureRoot)
+      const mainPath = join(fixtureRoot, 'main')
+      const linkedPath = join(fixtureRoot, 'linked')
+
+      hostGit(['init', mainPath], fixtureRoot)
+      hostGit(['config', 'user.name', 'Orca Test'], mainPath)
+      hostGit(['config', 'user.email', 'test@invalid'], mainPath)
+      await writeFile(join(mainPath, 'tracked.txt'), 'tracked\n')
+      hostGit(['add', 'tracked.txt'], mainPath)
+      hostGit(['commit', '-m', 'fixture'], mainPath)
+      hostGit(['worktree', 'add', '-b', 'linked', linkedPath], mainPath)
+      await writeFile(join(linkedPath, 'untracked.txt'), 'untracked\n')
+
+      const gitFile = await readFile(join(linkedPath, '.git'), 'utf8')
+      expect(gitFile).toMatch(/^gitdir: [A-Za-z]:\//)
+      expect(() =>
+        execFileSync(
+          'wsl.exe',
+          ['-d', distro!, '--exec', 'git', '-C', toLinuxPath(linkedPath), 'status', '--short'],
+          { encoding: 'utf8', stdio: ['ignore', 'pipe', 'pipe'] }
+        )
+      ).toThrow(/not a git repository/i)
+
+      await expect(listFilesWithGit(linkedPath, [], { wslDistro: distro! })).resolves.toEqual(
+        expect.arrayContaining(['tracked.txt', 'untracked.txt'])
+      )
+      resetWslLinkedWorktreeGitRoutingForTests()
+      await expect(
+        searchWithGitGrep(linkedPath, { query: 'tracked', rootPath: linkedPath }, 10, {
+          wslDistro: distro!
+        })
+      ).resolves.toMatchObject({ totalMatches: 2 })
+
+      let streamedStatus = ''
+      await expect(
+        gitStreamStdout(['status', '--short'], {
+          cwd: linkedPath,
+          wslDistro: distro!,
+          onStdout: (chunk) => {
+            streamedStatus += chunk
+          }
+        })
+      ).resolves.toEqual({ stoppedEarly: false })
+      expect(streamedStatus).toBe('?? untracked.txt\n')
+
+      await gitExecFileAsync(['add', '--', 'untracked.txt'], {
+        cwd: linkedPath,
+        wslDistro: distro!
+      })
+      await expect(
+        gitExecFileAsync(['status', '--short'], { cwd: linkedPath, wslDistro: distro! })
+      ).resolves.toMatchObject({ stdout: 'A  untracked.txt\n' })
+      await expect(
+        gitExecFileAsync(['status', '--short'], { cwd: linkedPath })
+      ).resolves.toMatchObject({ stdout: 'A  untracked.txt\n' })
+      await expect(
+        gitExecFileAsyncBuffer(['show', ':untracked.txt'], {
+          cwd: linkedPath,
+          wslDistro: distro!
+        })
+      ).resolves.toMatchObject({ stdout: Buffer.from('untracked\n') })
+
+      const folderPath = join(linkedPath, 'packages', 'app')
+      await mkdir(folderPath, { recursive: true })
+      await expect(
+        gitExecFileAsync(['rev-parse', '--show-toplevel'], {
+          cwd: folderPath,
+          wslDistro: distro!
+        })
+      ).resolves.toMatchObject({ stdout: `${linkedPath.replace(/\\/g, '/')}\n` })
+
+      const linkedExecPath = await gitExecFileAsync(['--exec-path'], {
+        cwd: linkedPath,
+        wslDistro: distro!
+      })
+      const mainExecPath = await gitExecFileAsync(['--exec-path'], {
+        cwd: mainPath,
+        wslDistro: distro!
+      })
+      expect(linkedExecPath.stdout).toMatch(/^[A-Za-z]:\//)
+      expect(mainExecPath.stdout).toMatch(/(?:^|\n)\/[^\n]+\n$/)
+    })
+
+    it('keeps WSL-native repositories on WSL Git', async () => {
+      const linuxRoot = wslExec(['mktemp', '-d', '/tmp/orca-wsl-native-XXXXXX']).trim()
+      wslFixtureRoots.push(linuxRoot)
+      const windowsRoot = toWindowsWslPath(linuxRoot, distro!)
+
+      wslExec(['git', 'init', linuxRoot])
+      wslExec(['git', '-C', linuxRoot, 'config', 'user.name', 'Orca Test'])
+      wslExec(['git', '-C', linuxRoot, 'config', 'user.email', 'test@invalid'])
+      await writeFile(join(windowsRoot, 'tracked.txt'), 'tracked\n')
+      wslExec(['git', '-C', linuxRoot, 'add', 'tracked.txt'])
+      wslExec(['git', '-C', linuxRoot, 'commit', '-m', 'fixture'])
+      await writeFile(join(windowsRoot, 'untracked.txt'), 'untracked\n')
+
+      await expect(
+        gitExecFileAsync(['status', '--short'], { cwd: windowsRoot, wslDistro: distro! })
+      ).resolves.toMatchObject({ stdout: expect.stringMatching(/(?:^|\n)\?\? untracked\.txt\n$/) })
+      await expect(
+        gitExecFileAsync(['--exec-path'], { cwd: windowsRoot, wslDistro: distro! })
+      ).resolves.toMatchObject({ stdout: expect.stringMatching(/(?:^|\n)\/[^\n]+\n$/) })
+    })
+  }
+)

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -48,6 +48,11 @@ import {
   peekWslGitReadEnvironment,
   type WslGitReadEnvironment
 } from './wsl-git-read-environment'
+import {
+  isWslLinkedWorktreeGitRoutingCandidate,
+  prepareWslLinkedWorktreeGitRouting,
+  usesHostGitForWslLinkedWorktree
+} from './wsl-linked-worktree-git-routing'
 // Re-exported for existing importers; lightweight consumers should import from './exec-error' to avoid this heavy module.
 import { extractExecError, parseRetryAfterMs } from './exec-error'
 export { extractExecError, parseRetryAfterMs }
@@ -335,6 +340,10 @@ function resolveGitCommand(
   options: GitExecOptions,
   forceLoginShell = false
 ): ResolvedCommand {
+  if (usesHostGitForWslLinkedWorktree(options.cwd, options.wslDistro)) {
+    // Why: WSL Git resolves a Windows-authored linked-worktree pointer relative to cwd.
+    return { binary: 'git', args, cwd: options.cwd, wsl: null, wslMode: null }
+  }
   if (!forceLoginShell && shouldAttemptWslDirectGit(options)) {
     const distro = wslDistroForCommand(options.cwd, options.wslDistro)
     const environment = distro ? peekWslGitReadEnvironment(distro) : undefined
@@ -908,13 +917,7 @@ async function buildNetworkSshPolicyEnv(options: GitExecOptions): Promise<{
     return { env: promptEnv, mode: 'explicit-env' }
   }
 
-  const resolved = resolveCommand(
-    'git',
-    ['config', '--get', 'core.sshCommand'],
-    options.cwd,
-    options.wslDistro,
-    { useWslLoginShell: Boolean(options.wslDistro) }
-  )
+  const resolved = resolveGitCommand(['config', '--get', 'core.sshCommand'], options, true)
   let configuredCommand = ''
   try {
     const { stdout } = await execFileCapture(resolved.binary, resolved.args, {
@@ -964,6 +967,9 @@ export async function gitExecFileAsync(
   return withGitSpan(
     { args, ...(options.cwd !== undefined ? { cwd: options.cwd } : {}) },
     async () => {
+      if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
+        await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
+      }
       const resolved = resolveGitCommand(args, options)
       const policy = options.useConfiguredSshCommandForNetwork
         ? await buildNetworkSshPolicyEnv(options)
@@ -1055,9 +1061,10 @@ export async function gitExecFileAsyncBuffer(
   args: string[],
   options: { cwd: string; maxBuffer?: number; wslDistro?: string }
 ): Promise<{ stdout: Buffer }> {
-  const resolved = resolveCommand('git', args, options.cwd, options.wslDistro, {
-    useWslLoginShell: Boolean(options.wslDistro)
-  })
+  if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
+    await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
+  }
+  const resolved = resolveGitCommand(args, options, true)
   const { stdout } = (await execFileCapture(resolved.binary, resolved.args, {
     cwd: resolved.cwd,
     encoding: 'buffer',
@@ -1098,6 +1105,9 @@ export async function gitStreamStdout(
 ): Promise<GitStreamResult> {
   const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
   return withGitSpan({ args, cwd: options.cwd }, async () => {
+    if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
+      await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
+    }
     const gitOptions: GitExecOptions = {
       cwd: options.cwd,
       ...(options.env ? { env: options.env } : {}),
@@ -1294,8 +1304,10 @@ export function gitSpawn(
   options: SpawnOptions & { cwd: string; wslDistro?: string }
 ): ChildProcess {
   const { wslDistro, ...spawnOptions } = options
-  const resolved = resolveCommand('git', args, options.cwd, wslDistro, {
-    useWslLoginShell: Boolean(wslDistro)
+  const resolved = resolveGitCommand(args, {
+    cwd: options.cwd,
+    ...(wslDistro ? { wslDistro } : {}),
+    ...(spawnOptions.env ? { env: spawnOptions.env } : {})
   })
   const spawnStartedAt = performance.now()
   const child = spawn(resolved.binary, resolved.args, {

--- a/src/main/git/runner.ts
+++ b/src/main/git/runner.ts
@@ -968,7 +968,9 @@ export async function gitExecFileAsync(
     { args, ...(options.cwd !== undefined ? { cwd: options.cwd } : {}) },
     async () => {
       if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
-        await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
+        await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro, {
+          signal: options.signal
+        })
       }
       const resolved = resolveGitCommand(args, options)
       const policy = options.useConfiguredSshCommandForNetwork
@@ -1106,7 +1108,9 @@ export async function gitStreamStdout(
   const maxBuffer = options.maxBuffer ?? DEFAULT_GIT_MAX_BUFFER
   return withGitSpan({ args, cwd: options.cwd }, async () => {
     if (isWslLinkedWorktreeGitRoutingCandidate(options.cwd, options.wslDistro)) {
-      await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro)
+      await prepareWslLinkedWorktreeGitRouting(options.cwd, options.wslDistro, {
+        signal: options.signal
+      })
     }
     const gitOptions: GitExecOptions = {
       cwd: options.cwd,

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -30,7 +30,7 @@ import {
   isUnsupportedRevParsePathFormatError,
   isUnsupportedWorktreeListZError
 } from '../../shared/git-worktree-command-capabilities'
-import { getLocalGitCapabilityCache } from './git-capability-state'
+import { withLocalGitCapabilityCacheForExecution } from './git-capability-state'
 import { gitExecFileAsync, translateWslOutputPaths } from './runner'
 import { resolveGitDir, runWithGitReadCacheInvalidation } from './status'
 import { hasWorktreeBaseCommitRef } from './worktree-base-ref-probe'
@@ -410,32 +410,32 @@ async function readRepoLocation(
   resolveBasePath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<RepoLocation | undefined> {
-  const capabilities = getLocalGitCapabilityCache({
-    cwd: repoPath,
-    wslDistro: options.wslDistro
-  })
   try {
-    return await capabilities.runWithFallback(
-      'rev-parse-path-format',
-      async () => {
-        const { stdout } = await gitExecFileAsync(
-          ['rev-parse', '--path-format=absolute', '--show-toplevel', '--git-common-dir'],
-          gitExecOptions(repoPath, options)
+    return await withLocalGitCapabilityCacheForExecution(
+      { cwd: repoPath, wslDistro: options.wslDistro, signal: options.signal },
+      (capabilities) =>
+        capabilities.runWithFallback(
+          'rev-parse-path-format',
+          async () => {
+            const { stdout } = await gitExecFileAsync(
+              ['rev-parse', '--path-format=absolute', '--show-toplevel', '--git-common-dir'],
+              gitExecOptions(repoPath, options)
+            )
+            if (hasUnsupportedRevParsePathFormatEcho(stdout)) {
+              // Why: some old Git echoes the unknown option and exits zero; remember that compat signal even though parsing recovers.
+              capabilities.rememberUnsupported('rev-parse-path-format')
+            }
+            return parseRepoLocation(resolveBasePath, stdout)
+          },
+          async () => {
+            const { stdout } = await gitExecFileAsync(
+              ['rev-parse', '--show-toplevel', '--git-common-dir'],
+              gitExecOptions(repoPath, options)
+            )
+            return parseRepoLocation(resolveBasePath, stdout)
+          },
+          isUnsupportedRevParsePathFormatError
         )
-        if (hasUnsupportedRevParsePathFormatEcho(stdout)) {
-          // Why: some old Git echoes the unknown option and exits zero; remember that compat signal even though parsing recovers.
-          capabilities.rememberUnsupported('rev-parse-path-format')
-        }
-        return parseRepoLocation(resolveBasePath, stdout)
-      },
-      async () => {
-        const { stdout } = await gitExecFileAsync(
-          ['rev-parse', '--show-toplevel', '--git-common-dir'],
-          gitExecOptions(repoPath, options)
-        )
-        return parseRepoLocation(resolveBasePath, stdout)
-      },
-      isUnsupportedRevParsePathFormatError
     )
   } catch {
     return undefined
@@ -578,41 +578,44 @@ async function readWorktreeList(
   repoPath: string,
   options: GitWorktreeExecOptions = {}
 ): Promise<GitWorktreeInfo[]> {
-  const capabilities = getLocalGitCapabilityCache({
-    cwd: repoPath,
-    wslDistro: options.wslDistro
-  })
   const execOptions = {
     cwd: repoPath,
     ...options,
     timeout: options.timeout ?? WORKTREE_LIST_TIMEOUT_MS
   }
-  return capabilities.runWithFallback(
-    'worktree-list-z',
-    async () => {
-      const { stdout } = await gitExecFileAsync(
-        ['worktree', 'list', '--porcelain', '-z'],
-        execOptions
+  return withLocalGitCapabilityCacheForExecution(
+    { cwd: repoPath, wslDistro: options.wslDistro, signal: options.signal },
+    (capabilities) =>
+      capabilities.runWithFallback(
+        'worktree-list-z',
+        async () => {
+          const { stdout } = await gitExecFileAsync(
+            ['worktree', 'list', '--porcelain', '-z'],
+            execOptions
+          )
+          return normalizeMainWorktreePath(
+            repoPath,
+            parseWorktreeList(stdout, { nulDelimited: true }),
+            options
+          )
+        },
+        async () => {
+          // Why: `-z` preserves worktree paths with newlines but Git <2.36 rejects it; fall back to the line parser.
+          const { stdout } = await gitExecFileAsync(
+            ['worktree', 'list', '--porcelain'],
+            execOptions
+          )
+          const normalized = await normalizeMainWorktreePath(
+            repoPath,
+            parseWorktreeList(stdout),
+            options
+          )
+          // Why: Git <2.31 emits no `prunable`, so probe each linked path for existence instead of trusting
+          // stale registrations; a harmless backstop on 2.31–2.35 where parseWorktreeList already set it (#8389).
+          return annotatePrunableByExistence(normalized, repoPath, options)
+        },
+        isUnsupportedWorktreeListZError
       )
-      return normalizeMainWorktreePath(
-        repoPath,
-        parseWorktreeList(stdout, { nulDelimited: true }),
-        options
-      )
-    },
-    async () => {
-      // Why: `-z` preserves worktree paths with newlines but Git <2.36 rejects it; fall back to the line parser.
-      const { stdout } = await gitExecFileAsync(['worktree', 'list', '--porcelain'], execOptions)
-      const normalized = await normalizeMainWorktreePath(
-        repoPath,
-        parseWorktreeList(stdout),
-        options
-      )
-      // Why: Git <2.31 emits no `prunable`, so probe each linked path for existence instead of trusting
-      // stale registrations; a harmless backstop on 2.31–2.35 where parseWorktreeList already set it (#8389).
-      return annotatePrunableByExistence(normalized, repoPath, options)
-    },
-    isUnsupportedWorktreeListZError
   )
 }
 
@@ -1355,14 +1358,12 @@ async function deleteAlreadyMergedBranchAfterSafeDeleteFailure(
     })
   const targetRefs = await getBranchCleanupTargetRefs(runGit, branchName)
   // Why: squash merges rewrite commit IDs, so `branch -d` rejects already-merged branches; delete only when Git proves no unmerged tree changes.
-  if (
-    !(await branchHasNoUnmergedChangesWithLazyTargetRefresh(
-      runGit,
-      branchName,
-      targetRefs,
-      getLocalGitCapabilityCache({ cwd: repoPath, wslDistro: options.wslDistro })
-    ))
-  ) {
+  const hasNoUnmergedChanges = await withLocalGitCapabilityCacheForExecution(
+    { cwd: repoPath, wslDistro: options.wslDistro, signal: options.signal },
+    (capabilities) =>
+      branchHasNoUnmergedChangesWithLazyTargetRefresh(runGit, branchName, targetRefs, capabilities)
+  )
+  if (!hasNoUnmergedChanges) {
     return false
   }
   await forceDeleteLocalBranch(repoPath, branchName, branchHead, (args, cwd) =>

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -6,7 +6,10 @@ import {
   seedWslLinkedWorktreeGitRoutingForTests,
   usesHostGitForWslLinkedWorktree,
   WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD,
+  WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_PER_CWD,
+  WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_TOTAL,
   WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS,
+  WSL_LINKED_WORKTREE_ROUTE_RETRY_BASE_MS,
   WSL_LINKED_WORKTREE_ROUTE_TTL_MS,
   type WslLinkedWorktreeRoutingFileSystem
 } from './wsl-linked-worktree-git-routing'
@@ -120,12 +123,13 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     expect(fileSystem.readFile).not.toHaveBeenCalled()
   })
 
-  it('fails closed when a marker cannot be read', async () => {
+  it('fails closed without caching a marker read error', async () => {
     const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
       stat: vi.fn(async () => fileMarker),
-      readFile: vi.fn(async () => {
-        throw Object.assign(new Error('access denied'), { code: 'EACCES' })
-      })
+      readFile: vi
+        .fn<WslLinkedWorktreeRoutingFileSystem['readFile']>()
+        .mockRejectedValueOnce(Object.assign(new Error('access denied'), { code: 'EACCES' }))
+        .mockResolvedValueOnce('gitdir: C:/main/.git/worktrees/linked\n')
     }
 
     await expect(
@@ -134,6 +138,42 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
         fileSystem
       })
     ).resolves.toBe(false)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(2)
+  })
+
+  it('backs off repeated marker stat errors after one immediate retry', async () => {
+    let currentTime = 1_000
+    const now = (): number => currentTime
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => {
+        throw Object.assign(new Error('device unavailable'), { code: 'EIO' })
+      }),
+      readFile: vi.fn(async () => '')
+    }
+    const prepare = (): Promise<boolean> =>
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
+
+    await expect(prepare()).resolves.toBe(false)
+    await expect(prepare()).resolves.toBe(false)
+    await expect(prepare()).resolves.toBe(false)
+    currentTime += WSL_LINKED_WORKTREE_ROUTE_RETRY_BASE_MS - 1
+    await expect(prepare()).resolves.toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+
+    currentTime += 1
+    await expect(prepare()).resolves.toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(3)
   })
 
   it('does not inherit a linked-parent route across a nested repository boundary', async () => {
@@ -380,11 +420,56 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     expect(fileSystem.stat).toHaveBeenCalledTimes(1)
   })
 
-  it('fails closed and clears coalescing after a stalled discovery deadline', async () => {
+  it('ignores an old probe that settles after reset and a new same-path probe starts', async () => {
+    let releaseOld: ((marker: typeof fileMarker) => void) | undefined
+    const oldMarker = new Promise<typeof fileMarker>((resolve) => {
+      releaseOld = resolve
+    })
+    const oldFileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(() => oldMarker),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    const oldRoute = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
+      fileSystem: oldFileSystem
+    })
+
+    resetWslLinkedWorktreeGitRoutingForTests()
+    let releaseCurrent: ((marker: typeof directoryMarker) => void) | undefined
+    const currentMarker = new Promise<typeof directoryMarker>((resolve) => {
+      releaseCurrent = resolve
+    })
+    const currentFileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(() => currentMarker),
+      readFile: vi.fn(async () => '')
+    }
+    const currentRoute = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
+      fileSystem: currentFileSystem
+    })
+
+    releaseOld?.(fileMarker)
+    await expect(oldRoute).resolves.toBe(false)
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo`, 'Ubuntu', 'win32')).toBe(false)
+    const currentJoiner = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
+      fileSystem: currentFileSystem
+    })
+    expect(currentFileSystem.stat).toHaveBeenCalledTimes(1)
+
+    releaseCurrent?.(directoryMarker)
+    await expect(Promise.all([currentRoute, currentJoiner])).resolves.toEqual([false, false])
+    expect(currentFileSystem.stat).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed and retries after a stalled discovery deadline', async () => {
     vi.useFakeTimers()
     try {
       const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
-        stat: vi.fn(() => new Promise<typeof fileMarker>(() => {})),
+        stat: vi
+          .fn<WslLinkedWorktreeRoutingFileSystem['stat']>()
+          .mockImplementationOnce(() => new Promise<typeof fileMarker>(() => {}))
+          .mockResolvedValueOnce(fileMarker),
         readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
       }
 
@@ -405,8 +490,67 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
           platform: 'win32',
           fileSystem
         })
+      ).resolves.toBe(true)
+      expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+      expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps outstanding probes for one working directory after repeated deadlines', async () => {
+    vi.useFakeTimers()
+    try {
+      const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+        stat: vi.fn(() => new Promise<typeof fileMarker>(() => {})),
+        readFile: vi.fn(async () => '')
+      }
+      const prepare = (): Promise<boolean> =>
+        prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+          platform: 'win32',
+          fileSystem
+        })
+
+      for (let index = 0; index < WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_PER_CWD; index += 1) {
+        const route = prepare()
+        await vi.advanceTimersByTimeAsync(WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+        await expect(route).resolves.toBe(false)
+      }
+      await vi.advanceTimersByTimeAsync(WSL_LINKED_WORKTREE_ROUTE_RETRY_BASE_MS)
+      await expect(prepare()).resolves.toBe(false)
+      expect(fileSystem.stat).toHaveBeenCalledTimes(WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_PER_CWD)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('caps outstanding probes across working directories', async () => {
+    vi.useFakeTimers()
+    try {
+      const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+        stat: vi.fn(() => new Promise<typeof fileMarker>(() => {})),
+        readFile: vi.fn(async () => '')
+      }
+      const pending = Array.from(
+        { length: WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_TOTAL },
+        (_, index) =>
+          prepareWslLinkedWorktreeGitRouting(`C:\\repo-${index}`, 'Ubuntu', {
+            platform: 'win32',
+            fileSystem
+          })
+      )
+
+      await expect(
+        prepareWslLinkedWorktreeGitRouting(String.raw`C:\blocked`, 'Ubuntu', {
+          platform: 'win32',
+          fileSystem
+        })
       ).resolves.toBe(false)
-      expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+      expect(fileSystem.stat).toHaveBeenCalledTimes(WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_TOTAL)
+      await vi.advanceTimersByTimeAsync(WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+      await expect(Promise.all(pending)).resolves.toEqual(
+        Array.from({ length: WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_TOTAL }, () => false)
+      )
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -420,7 +420,10 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
       releaseStat = resolve
     })
     const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
-      stat: vi.fn().mockResolvedValueOnce(directoryMarker).mockReturnValueOnce(delayedStat),
+      stat: vi
+        .fn<WslLinkedWorktreeRoutingFileSystem['stat']>()
+        .mockResolvedValueOnce(directoryMarker)
+        .mockReturnValueOnce(delayedStat),
       readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
     }
 

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -1,0 +1,295 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  parseWindowsLinkedGitdir,
+  prepareWslLinkedWorktreeGitRouting,
+  resetWslLinkedWorktreeGitRoutingForTests,
+  seedWslLinkedWorktreeGitRoutingForTests,
+  usesHostGitForWslLinkedWorktree,
+  WSL_LINKED_WORKTREE_ROUTE_TTL_MS,
+  type WslLinkedWorktreeRoutingFileSystem
+} from './wsl-linked-worktree-git-routing'
+
+afterEach(() => resetWslLinkedWorktreeGitRoutingForTests())
+
+const fileMarker = { isDirectory: () => false, isFile: () => true }
+const directoryMarker = { isDirectory: () => true, isFile: () => false }
+
+function missingMarker(): NodeJS.ErrnoException {
+  return Object.assign(new Error('missing'), { code: 'ENOENT' })
+}
+
+describe('parseWindowsLinkedGitdir', () => {
+  it.each([
+    ['gitdir: C:/repo/.git/worktrees/linked\n', 'C:/repo/.git/worktrees/linked'],
+    [String.raw`gitdir: D:\repo\.git\worktrees\linked`, String.raw`D:\repo\.git\worktrees\linked`]
+  ])('accepts a Windows drive-qualified gitdir', (content, expected) => {
+    expect(parseWindowsLinkedGitdir(content)).toBe(expected)
+  })
+
+  it.each([
+    'gitdir: ../main/.git/worktrees/linked',
+    'gitdir: /home/dev/repo/.git/worktrees/linked',
+    'gitdir: C:repo/.git/worktrees/linked',
+    'not a gitdir'
+  ])('rejects the non-Windows-linked marker %s', (content) => {
+    expect(parseWindowsLinkedGitdir(content)).toBeNull()
+  })
+})
+
+describe('usesHostGitForWslLinkedWorktree', () => {
+  it('scopes a cached route to the linked root and its folder workspaces', () => {
+    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked`)
+
+    expect(
+      usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked\packages\app`, 'Ubuntu', 'win32')
+    ).toBe(true)
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo\main`, 'Ubuntu', 'win32')).toBe(false)
+  })
+
+  it('treats a child named ..data as inside the linked root', () => {
+    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked`)
+
+    expect(
+      usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked\..data`, 'Ubuntu', 'win32')
+    ).toBe(true)
+    expect(
+      usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked-sibling`, 'Ubuntu', 'win32')
+    ).toBe(false)
+  })
+
+  it('does not affect native Windows, WSL-native, or non-Windows execution', () => {
+    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked`)
+
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked`, undefined, 'win32')).toBe(
+      false
+    )
+    expect(
+      usesHostGitForWslLinkedWorktree(
+        '\\\\wsl.localhost\\Ubuntu\\home\\dev\\repo',
+        'Ubuntu',
+        'win32'
+      )
+    ).toBe(false)
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked`, 'Ubuntu', 'linux')).toBe(
+      false
+    )
+  })
+})
+
+describe('prepareWslLinkedWorktreeGitRouting', () => {
+  it('discovers a parent marker asynchronously and caches its folder tree', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async (path) => {
+        if (path === String.raw`c:\repo\.git`) {
+          return fileMarker
+        }
+        throw missingMarker()
+      }),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(
+        String.raw`C:\repo\packages\app`,
+        'Ubuntu',
+        'win32',
+        fileSystem
+      )
+    ).resolves.toBe(true)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(
+        String.raw`C:\repo\packages\other`,
+        'Ubuntu',
+        'win32',
+        fileSystem
+      )
+    ).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(3)
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('caches an ordinary repository marker without reading it', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => directoryMarker),
+      readFile: vi.fn(async () => '')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem)
+    ).resolves.toBe(false)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem)
+    ).resolves.toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+    expect(fileSystem.readFile).not.toHaveBeenCalled()
+  })
+
+  it('revalidates a linked route that becomes an ordinary repository', async () => {
+    let linked = true
+    let currentTime = 1_000
+    const now = (): number => currentTime
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => (linked ? fileMarker : directoryMarker)),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(true)
+    linked = false
+    currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS - 1
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+
+    currentTime += 1
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(false)
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo`, 'Ubuntu', 'win32', now)).toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('revalidates an ordinary repository that becomes a linked worktree', async () => {
+    let linked = false
+    let currentTime = 1_000
+    const now = (): number => currentTime
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => (linked ? fileMarker : directoryMarker)),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(false)
+    linked = true
+    currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS - 1
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+
+    currentTime += 1
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(true)
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo`, 'Ubuntu', 'win32', now)).toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets a revalidated linked parent supersede an unexpired child miss', async () => {
+    let linked = false
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async (path) => {
+        if (path === String.raw`c:\repo\.git`) {
+          return linked ? fileMarker : directoryMarker
+        }
+        throw missingMarker()
+      }),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(
+        String.raw`C:\repo\packages\app`,
+        'Ubuntu',
+        'win32',
+        fileSystem
+      )
+    ).resolves.toBe(false)
+    linked = true
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(
+        String.raw`C:\repo\packages\other`,
+        'Ubuntu',
+        'win32',
+        fileSystem
+      )
+    ).resolves.toBe(true)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(
+        String.raw`C:\repo\packages\app`,
+        'Ubuntu',
+        'win32',
+        fileSystem
+      )
+    ).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(6)
+  })
+
+  it('coalesces delayed discovery without blocking an event-loop turn', async () => {
+    let releaseStat: ((marker: typeof fileMarker) => void) | undefined
+    const delayedStat = new Promise<typeof fileMarker>((resolve) => {
+      releaseStat = resolve
+    })
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(() => delayedStat),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    let settled = false
+
+    const first = prepareWslLinkedWorktreeGitRouting(
+      String.raw`C:\repo`,
+      'Ubuntu',
+      'win32',
+      fileSystem
+    ).finally(() => {
+      settled = true
+    })
+    const second = prepareWslLinkedWorktreeGitRouting(
+      String.raw`C:\repo`,
+      'Ubuntu',
+      'win32',
+      fileSystem
+    )
+    await new Promise<void>((resolve) => setImmediate(resolve))
+
+    expect(settled).toBe(false)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+    releaseStat?.(fileMarker)
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('coalesces concurrent revalidation after a cached route expires', async () => {
+    let currentTime = 1_000
+    const now = (): number => currentTime
+    let releaseStat: ((marker: typeof fileMarker) => void) | undefined
+    const delayedStat = new Promise<typeof fileMarker>((resolve) => {
+      releaseStat = resolve
+    })
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn().mockResolvedValueOnce(directoryMarker).mockReturnValueOnce(delayedStat),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+    ).resolves.toBe(false)
+    currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS
+
+    const first = prepareWslLinkedWorktreeGitRouting(
+      String.raw`C:\repo`,
+      'Ubuntu',
+      'win32',
+      fileSystem,
+      now
+    )
+    const second = prepareWslLinkedWorktreeGitRouting(
+      String.raw`C:\repo`,
+      'Ubuntu',
+      'win32',
+      fileSystem,
+      now
+    )
+
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+    releaseStat?.(fileMarker)
+    await expect(Promise.all([first, second])).resolves.toEqual([true, true])
+    expect(fileSystem.stat).toHaveBeenCalledTimes(2)
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/git/wsl-linked-worktree-git-routing.test.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.test.ts
@@ -5,6 +5,8 @@ import {
   resetWslLinkedWorktreeGitRoutingForTests,
   seedWslLinkedWorktreeGitRoutingForTests,
   usesHostGitForWslLinkedWorktree,
+  WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD,
+  WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS,
   WSL_LINKED_WORKTREE_ROUTE_TTL_MS,
   type WslLinkedWorktreeRoutingFileSystem
 } from './wsl-linked-worktree-git-routing'
@@ -37,24 +39,16 @@ describe('parseWindowsLinkedGitdir', () => {
 })
 
 describe('usesHostGitForWslLinkedWorktree', () => {
-  it('scopes a cached route to the linked root and its folder workspaces', () => {
-    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked`)
+  it('scopes a cached route to the exact primed folder workspace', () => {
+    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked\packages\app`)
 
     expect(
       usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked\packages\app`, 'Ubuntu', 'win32')
     ).toBe(true)
+    expect(usesHostGitForWslLinkedWorktree('C:/repo/linked/packages/app/', 'Ubuntu', 'win32')).toBe(
+      true
+    )
     expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo\main`, 'Ubuntu', 'win32')).toBe(false)
-  })
-
-  it('treats a child named ..data as inside the linked root', () => {
-    seedWslLinkedWorktreeGitRoutingForTests(String.raw`C:\repo\linked`)
-
-    expect(
-      usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked\..data`, 'Ubuntu', 'win32')
-    ).toBe(true)
-    expect(
-      usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked-sibling`, 'Ubuntu', 'win32')
-    ).toBe(false)
   })
 
   it('does not affect native Windows, WSL-native, or non-Windows execution', () => {
@@ -77,10 +71,10 @@ describe('usesHostGitForWslLinkedWorktree', () => {
 })
 
 describe('prepareWslLinkedWorktreeGitRouting', () => {
-  it('discovers a parent marker asynchronously and caches its folder tree', async () => {
+  it('discovers parent markers independently for sibling folder workspaces', async () => {
     const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
       stat: vi.fn(async (path) => {
-        if (path === String.raw`c:\repo\.git`) {
+        if (path === String.raw`C:\repo\.git`) {
           return fileMarker
         }
         throw missingMarker()
@@ -89,23 +83,19 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
 
     await expect(
-      prepareWslLinkedWorktreeGitRouting(
-        String.raw`C:\repo\packages\app`,
-        'Ubuntu',
-        'win32',
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\packages\app`, 'Ubuntu', {
+        platform: 'win32',
         fileSystem
-      )
+      })
     ).resolves.toBe(true)
     await expect(
-      prepareWslLinkedWorktreeGitRouting(
-        String.raw`C:\repo\packages\other`,
-        'Ubuntu',
-        'win32',
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\packages\other`, 'Ubuntu', {
+        platform: 'win32',
         fileSystem
-      )
+      })
     ).resolves.toBe(true)
-    expect(fileSystem.stat).toHaveBeenCalledTimes(3)
-    expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(6)
+    expect(fileSystem.readFile).toHaveBeenCalledTimes(2)
   })
 
   it('caches an ordinary repository marker without reading it', async () => {
@@ -115,13 +105,82 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
 
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
     ).resolves.toBe(false)
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
     ).resolves.toBe(false)
     expect(fileSystem.stat).toHaveBeenCalledTimes(1)
     expect(fileSystem.readFile).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when a marker cannot be read', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => fileMarker),
+      readFile: vi.fn(async () => {
+        throw Object.assign(new Error('access denied'), { code: 'EACCES' })
+      })
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(false)
+  })
+
+  it('does not inherit a linked-parent route across a nested repository boundary', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async (path) =>
+        path === String.raw`C:\repo\linked\nested\.git` ? directoryMarker : fileMarker
+      ),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\linked`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(true)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\linked\nested`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(false)
+    expect(
+      usesHostGitForWslLinkedWorktree(String.raw`C:\repo\linked\nested`, 'Ubuntu', 'win32')
+    ).toBe(false)
+  })
+
+  it('does not conflate case-distinct directories on case-sensitive Windows storage', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async (path) =>
+        path === String.raw`C:\Repo\.git` ? fileMarker : directoryMarker
+      ),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\Repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(true)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(false)
   })
 
   it('revalidates a linked route that becomes an ordinary repository', async () => {
@@ -134,18 +193,30 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
 
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(true)
     linked = false
     currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS - 1
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(true)
     expect(fileSystem.stat).toHaveBeenCalledTimes(1)
 
     currentTime += 1
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(false)
     expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo`, 'Ubuntu', 'win32', now)).toBe(false)
     expect(fileSystem.stat).toHaveBeenCalledTimes(2)
@@ -162,29 +233,41 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
 
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(false)
     linked = true
     currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS - 1
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(false)
     expect(fileSystem.stat).toHaveBeenCalledTimes(1)
 
     currentTime += 1
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(true)
     expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo`, 'Ubuntu', 'win32', now)).toBe(true)
     expect(fileSystem.stat).toHaveBeenCalledTimes(2)
     expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
   })
 
-  it('lets a revalidated linked parent supersede an unexpired child miss', async () => {
+  it('does not let a sibling route supersede an unexpired nested-repository miss', async () => {
     let linked = false
     const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
       stat: vi.fn(async (path) => {
-        if (path === String.raw`c:\repo\.git`) {
+        if (path === String.raw`C:\repo\.git`) {
           return linked ? fileMarker : directoryMarker
         }
         throw missingMarker()
@@ -193,31 +276,48 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
 
     await expect(
-      prepareWslLinkedWorktreeGitRouting(
-        String.raw`C:\repo\packages\app`,
-        'Ubuntu',
-        'win32',
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\packages\app`, 'Ubuntu', {
+        platform: 'win32',
         fileSystem
-      )
+      })
     ).resolves.toBe(false)
     linked = true
     await expect(
-      prepareWslLinkedWorktreeGitRouting(
-        String.raw`C:\repo\packages\other`,
-        'Ubuntu',
-        'win32',
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\packages\other`, 'Ubuntu', {
+        platform: 'win32',
         fileSystem
-      )
+      })
     ).resolves.toBe(true)
     await expect(
-      prepareWslLinkedWorktreeGitRouting(
-        String.raw`C:\repo\packages\app`,
-        'Ubuntu',
-        'win32',
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo\packages\app`, 'Ubuntu', {
+        platform: 'win32',
         fileSystem
-      )
-    ).resolves.toBe(true)
+      })
+    ).resolves.toBe(false)
     expect(fileSystem.stat).toHaveBeenCalledTimes(6)
+  })
+
+  it('does not evict fresh routes while pruning under working-directory churn', async () => {
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(async () => fileMarker),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+
+    for (let index = 0; index <= WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD; index += 1) {
+      await prepareWslLinkedWorktreeGitRouting(`C:\\repo-${index}`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    }
+
+    expect(usesHostGitForWslLinkedWorktree(String.raw`C:\repo-0`, 'Ubuntu', 'win32')).toBe(true)
+    expect(
+      usesHostGitForWslLinkedWorktree(
+        `C:\\repo-${WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD}`,
+        'Ubuntu',
+        'win32'
+      )
+    ).toBe(true)
   })
 
   it('coalesces delayed discovery without blocking an event-loop turn', async () => {
@@ -231,20 +331,16 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
     let settled = false
 
-    const first = prepareWslLinkedWorktreeGitRouting(
-      String.raw`C:\repo`,
-      'Ubuntu',
-      'win32',
+    const first = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
       fileSystem
-    ).finally(() => {
+    }).finally(() => {
       settled = true
     })
-    const second = prepareWslLinkedWorktreeGitRouting(
-      String.raw`C:\repo`,
-      'Ubuntu',
-      'win32',
+    const second = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
       fileSystem
-    )
+    })
     await new Promise<void>((resolve) => setImmediate(resolve))
 
     expect(settled).toBe(false)
@@ -252,6 +348,68 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     releaseStat?.(fileMarker)
     await expect(Promise.all([first, second])).resolves.toEqual([true, true])
     expect(fileSystem.readFile).toHaveBeenCalledTimes(1)
+  })
+
+  it('cancels a waiter without canceling or duplicating shared discovery', async () => {
+    let releaseStat: ((marker: typeof fileMarker) => void) | undefined
+    const delayedStat = new Promise<typeof fileMarker>((resolve) => {
+      releaseStat = resolve
+    })
+    const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+      stat: vi.fn(() => delayedStat),
+      readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+    }
+    const controller = new AbortController()
+
+    const cancelled = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
+      fileSystem,
+      signal: controller.signal
+    })
+    controller.abort()
+
+    await expect(cancelled).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+    releaseStat?.(fileMarker)
+    await expect(
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+    ).resolves.toBe(true)
+    expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+  })
+
+  it('fails closed and clears coalescing after a stalled discovery deadline', async () => {
+    vi.useFakeTimers()
+    try {
+      const fileSystem: WslLinkedWorktreeRoutingFileSystem = {
+        stat: vi.fn(() => new Promise<typeof fileMarker>(() => {})),
+        readFile: vi.fn(async () => 'gitdir: C:/main/.git/worktrees/linked\n')
+      }
+
+      const first = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+      const second = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem
+      })
+      await vi.advanceTimersByTimeAsync(WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+
+      await expect(Promise.all([first, second])).resolves.toEqual([false, false])
+      expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+      await expect(
+        prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+          platform: 'win32',
+          fileSystem
+        })
+      ).resolves.toBe(false)
+      expect(fileSystem.stat).toHaveBeenCalledTimes(1)
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('coalesces concurrent revalidation after a cached route expires', async () => {
@@ -267,24 +425,24 @@ describe('prepareWslLinkedWorktreeGitRouting', () => {
     }
 
     await expect(
-      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', 'win32', fileSystem, now)
+      prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+        platform: 'win32',
+        fileSystem,
+        now
+      })
     ).resolves.toBe(false)
     currentTime += WSL_LINKED_WORKTREE_ROUTE_TTL_MS
 
-    const first = prepareWslLinkedWorktreeGitRouting(
-      String.raw`C:\repo`,
-      'Ubuntu',
-      'win32',
+    const first = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
       fileSystem,
       now
-    )
-    const second = prepareWslLinkedWorktreeGitRouting(
-      String.raw`C:\repo`,
-      'Ubuntu',
-      'win32',
+    })
+    const second = prepareWslLinkedWorktreeGitRouting(String.raw`C:\repo`, 'Ubuntu', {
+      platform: 'win32',
       fileSystem,
       now
-    )
+    })
 
     expect(fileSystem.stat).toHaveBeenCalledTimes(2)
     releaseStat?.(fileMarker)

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -3,14 +3,23 @@ import { win32 } from 'node:path'
 import type { Stats } from 'node:fs'
 
 type CachedRoute = { usesHostGit: boolean; expiresAt: number }
+type TransientRouteFailure = { count: number; retryAfter: number }
 
 // Bounds stale routing after delete/recreate while amortizing async parent walks on slow storage.
 export const WSL_LINKED_WORKTREE_ROUTE_TTL_MS = 30_000
 export const WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD = 512
 export const WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS = 5_000
+export const WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_PER_CWD = 2
+export const WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_TOTAL = 32
+export const WSL_LINKED_WORKTREE_ROUTE_RETRY_BASE_MS = 1_000
+const WSL_LINKED_WORKTREE_ROUTE_RETRY_MAX_MS = 30_000
 
 const routeByCwd = new Map<string, CachedRoute>()
 const pendingRoutes = new Map<string, Promise<boolean>>()
+const transientFailuresByCwd = new Map<string, TransientRouteFailure>()
+const activeProbeCountByCwd = new Map<string, number>()
+let activeProbeCount = 0
+let routeProbeGeneration = 0
 let nextRoutePruneAt = 0
 
 export function isWslLinkedWorktreeGitRoutingCandidate(
@@ -79,7 +88,7 @@ async function shouldUseHostGit(
     } catch (error) {
       const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
       if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-        return false
+        throw error
       }
     }
     if (candidate === driveRoot) {
@@ -108,6 +117,55 @@ function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean 
 
 function routingAbortError(): Error {
   return Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })
+}
+
+function rememberTransientFailure(cwd: string, now: number): void {
+  const count = (transientFailuresByCwd.get(cwd)?.count ?? 0) + 1
+  const retryDelay =
+    count === 1
+      ? 0
+      : Math.min(
+          WSL_LINKED_WORKTREE_ROUTE_RETRY_BASE_MS * 2 ** Math.min(count - 2, 10),
+          WSL_LINKED_WORKTREE_ROUTE_RETRY_MAX_MS
+        )
+  if (
+    !transientFailuresByCwd.has(cwd) &&
+    transientFailuresByCwd.size >= WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD
+  ) {
+    const oldest = transientFailuresByCwd.keys().next().value
+    if (oldest !== undefined) {
+      transientFailuresByCwd.delete(oldest)
+    }
+  }
+  transientFailuresByCwd.delete(cwd)
+  transientFailuresByCwd.set(cwd, { count, retryAfter: now + retryDelay })
+}
+
+function canStartRouteProbe(cwd: string, now: number): boolean {
+  const failure = transientFailuresByCwd.get(cwd)
+  return Boolean(
+    (!failure || failure.retryAfter <= now) &&
+    (activeProbeCountByCwd.get(cwd) ?? 0) < WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_PER_CWD &&
+    activeProbeCount < WSL_LINKED_WORKTREE_ROUTE_MAX_PROBES_TOTAL
+  )
+}
+
+function trackRouteProbe(cwd: string): () => void {
+  const generation = routeProbeGeneration
+  activeProbeCount += 1
+  activeProbeCountByCwd.set(cwd, (activeProbeCountByCwd.get(cwd) ?? 0) + 1)
+  return () => {
+    if (generation !== routeProbeGeneration) {
+      return
+    }
+    activeProbeCount -= 1
+    const remaining = (activeProbeCountByCwd.get(cwd) ?? 1) - 1
+    if (remaining === 0) {
+      activeProbeCountByCwd.delete(cwd)
+    } else {
+      activeProbeCountByCwd.set(cwd, remaining)
+    }
+  }
 }
 
 function waitForRouteUnlessAborted(
@@ -145,20 +203,38 @@ function discoverRoute(
   now: () => number
 ): Promise<boolean> {
   return new Promise((resolve) => {
+    const generation = routeProbeGeneration
     let settled = false
-    const finish = (usesHostGit: boolean): void => {
+    const finish = (usesHostGit: boolean, cacheable: boolean): void => {
       if (settled) {
         return
       }
       settled = true
       clearTimeout(timer)
-      resolve(rememberRoute(cwd, usesHostGit, now()))
+      if (generation !== routeProbeGeneration) {
+        resolve(false)
+        return
+      }
+      if (cacheable) {
+        transientFailuresByCwd.delete(cwd)
+        resolve(rememberRoute(cwd, usesHostGit, now()))
+      } else {
+        rememberTransientFailure(cwd, now())
+        resolve(usesHostGit)
+      }
     }
-    const timer = setTimeout(() => finish(false), WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+    const timer = setTimeout(() => finish(false, false), WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
     timer.unref()
+    const releaseProbe = trackRouteProbe(cwd)
     void shouldUseHostGit(cwd, fileSystem).then(
-      (usesHostGit) => finish(usesHostGit),
-      () => finish(false)
+      (usesHostGit) => {
+        releaseProbe()
+        finish(usesHostGit, true)
+      },
+      () => {
+        releaseProbe()
+        finish(false, false)
+      }
     )
   })
 }
@@ -186,9 +262,15 @@ export async function prepareWslLinkedWorktreeGitRouting(
   if (pending) {
     return waitForRouteUnlessAborted(pending, options.signal)
   }
-  const route = discoverRoute(normalizedCwd, fileSystem, now).finally(() =>
-    pendingRoutes.delete(normalizedCwd)
-  )
+  if (!canStartRouteProbe(normalizedCwd, now())) {
+    return false
+  }
+  const discovery = discoverRoute(normalizedCwd, fileSystem, now)
+  const route = discovery.finally(() => {
+    if (pendingRoutes.get(normalizedCwd) === route) {
+      pendingRoutes.delete(normalizedCwd)
+    }
+  })
   pendingRoutes.set(normalizedCwd, route)
   return waitForRouteUnlessAborted(route, options.signal)
 }
@@ -208,6 +290,10 @@ export function usesHostGitForWslLinkedWorktree(
 export function resetWslLinkedWorktreeGitRoutingForTests(): void {
   routeByCwd.clear()
   pendingRoutes.clear()
+  transientFailuresByCwd.clear()
+  activeProbeCountByCwd.clear()
+  activeProbeCount = 0
+  routeProbeGeneration += 1
   nextRoutePruneAt = 0
 }
 

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -2,14 +2,16 @@ import { readFile, stat } from 'node:fs/promises'
 import { win32 } from 'node:path'
 import type { Stats } from 'node:fs'
 
-type CachedRoute = { root: string | null; expiresAt: number }
+type CachedRoute = { usesHostGit: boolean; expiresAt: number }
 
 // Bounds stale routing after delete/recreate while amortizing async parent walks on slow storage.
 export const WSL_LINKED_WORKTREE_ROUTE_TTL_MS = 30_000
+export const WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD = 512
+export const WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS = 5_000
 
 const routeByCwd = new Map<string, CachedRoute>()
 const pendingRoutes = new Map<string, Promise<boolean>>()
-const hostGitRoots = new Map<string, number>()
+let nextRoutePruneAt = 0
 
 export function isWslLinkedWorktreeGitRoutingCandidate(
   cwd: string,
@@ -20,38 +22,19 @@ export function isWslLinkedWorktreeGitRoutingCandidate(
 }
 
 function normalize(path: string): string {
-  return win32.resolve(path).toLowerCase()
-}
-
-function containsPath(root: string, cwd: string): boolean {
-  const relative = win32.relative(root, cwd)
-  return (
-    relative === '' ||
-    (relative !== '..' && !relative.startsWith(`..${win32.sep}`) && !win32.isAbsolute(relative))
-  )
+  return win32.resolve(path)
 }
 
 function cachedRoute(cwd: string, now: number): boolean | undefined {
   const exact = routeByCwd.get(cwd)
-  let hasFreshExactMiss = false
-  if (exact) {
-    if (exact.expiresAt > now && exact.root !== null) {
-      return true
-    }
-    if (exact.expiresAt <= now) {
-      routeByCwd.delete(cwd)
-    } else {
-      hasFreshExactMiss = true
-    }
+  if (!exact) {
+    return undefined
   }
-  for (const [root, expiresAt] of hostGitRoots) {
-    if (expiresAt <= now) {
-      hostGitRoots.delete(root)
-    } else if (containsPath(root, cwd)) {
-      return true
-    }
+  if (exact.expiresAt <= now) {
+    routeByCwd.delete(cwd)
+    return undefined
   }
-  return hasFreshExactMiss ? false : undefined
+  return exact.usesHostGit
 }
 
 export function parseWindowsLinkedGitdir(content: string): string | null {
@@ -64,15 +47,22 @@ export type WslLinkedWorktreeRoutingFileSystem = {
   readFile(path: string): Promise<string>
 }
 
+export type WslLinkedWorktreeRoutingOptions = {
+  platform?: NodeJS.Platform
+  fileSystem?: WslLinkedWorktreeRoutingFileSystem
+  now?: () => number
+  signal?: AbortSignal
+}
+
 const defaultFileSystem: WslLinkedWorktreeRoutingFileSystem = {
   stat,
   readFile: (path) => readFile(path, 'utf8')
 }
 
-async function findLinkedWorktreeRoot(
+async function shouldUseHostGit(
   cwd: string,
   fileSystem: WslLinkedWorktreeRoutingFileSystem
-): Promise<string | null> {
+): Promise<boolean> {
   let candidate = cwd
   const driveRoot = win32.parse(candidate).root
   while (true) {
@@ -80,44 +70,112 @@ async function findLinkedWorktreeRoot(
     try {
       const marker = await fileSystem.stat(markerPath)
       if (marker.isDirectory()) {
-        return null
+        return false
       }
       if (marker.isFile()) {
-        return parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) ? candidate : null
+        return parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) !== null
       }
-      return null
+      return false
     } catch (error) {
       const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
       if (code !== 'ENOENT' && code !== 'ENOTDIR') {
-        return null
+        return false
       }
     }
     if (candidate === driveRoot) {
-      return null
+      return false
     }
     candidate = win32.dirname(candidate)
   }
 }
 
-function rememberRoute(cwd: string, root: string | null, now: number): boolean {
-  const normalizedRoot = root ? normalize(root) : null
+function rememberRoute(cwd: string, usesHostGit: boolean, now: number): boolean {
   const expiresAt = now + WSL_LINKED_WORKTREE_ROUTE_TTL_MS
-  routeByCwd.set(cwd, { root: normalizedRoot, expiresAt })
-  if (normalizedRoot) {
-    hostGitRoots.set(normalizedRoot, expiresAt)
+  if (
+    routeByCwd.size >= WSL_LINKED_WORKTREE_ROUTE_CACHE_PRUNE_THRESHOLD &&
+    now >= nextRoutePruneAt
+  ) {
+    for (const [cachedCwd, route] of routeByCwd) {
+      if (route.expiresAt <= now) {
+        routeByCwd.delete(cachedCwd)
+      }
+    }
+    nextRoutePruneAt = now + WSL_LINKED_WORKTREE_ROUTE_TTL_MS
   }
-  return normalizedRoot !== null
+  routeByCwd.set(cwd, { usesHostGit, expiresAt })
+  return usesHostGit
+}
+
+function routingAbortError(): Error {
+  return Object.assign(new Error('The operation was aborted.'), { name: 'AbortError' })
+}
+
+function waitForRouteUnlessAborted(
+  route: Promise<boolean>,
+  signal?: AbortSignal
+): Promise<boolean> {
+  if (!signal) {
+    return route
+  }
+  if (signal.aborted) {
+    return Promise.reject(routingAbortError())
+  }
+  return new Promise((resolve, reject) => {
+    const onAbort = (): void => {
+      signal.removeEventListener('abort', onAbort)
+      reject(routingAbortError())
+    }
+    signal.addEventListener('abort', onAbort, { once: true })
+    route.then(
+      (result) => {
+        signal.removeEventListener('abort', onAbort)
+        resolve(result)
+      },
+      (error) => {
+        signal.removeEventListener('abort', onAbort)
+        reject(error)
+      }
+    )
+  })
+}
+
+function discoverRoute(
+  cwd: string,
+  fileSystem: WslLinkedWorktreeRoutingFileSystem,
+  now: () => number
+): Promise<boolean> {
+  return new Promise((resolve) => {
+    let settled = false
+    const finish = (usesHostGit: boolean): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      resolve(rememberRoute(cwd, usesHostGit, now()))
+    }
+    const timer = setTimeout(() => finish(false), WSL_LINKED_WORKTREE_ROUTE_PROBE_TIMEOUT_MS)
+    timer.unref()
+    void shouldUseHostGit(cwd, fileSystem).then(
+      (usesHostGit) => finish(usesHostGit),
+      () => finish(false)
+    )
+  })
 }
 
 export async function prepareWslLinkedWorktreeGitRouting(
   cwd: string,
   wslDistro: string | undefined,
-  platform: NodeJS.Platform = process.platform,
-  fileSystem: WslLinkedWorktreeRoutingFileSystem = defaultFileSystem,
-  now: () => number = Date.now
+  options: WslLinkedWorktreeRoutingOptions = {}
 ): Promise<boolean> {
+  const platform = options.platform ?? process.platform
+  const fileSystem = options.fileSystem ?? defaultFileSystem
+  const now = options.now ?? Date.now
   if (!isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform)) {
     return false
+  }
+  if (options.signal?.aborted) {
+    throw routingAbortError()
   }
   const normalizedCwd = normalize(cwd)
   const cached = cachedRoute(normalizedCwd, now())
@@ -126,13 +184,13 @@ export async function prepareWslLinkedWorktreeGitRouting(
   }
   const pending = pendingRoutes.get(normalizedCwd)
   if (pending) {
-    return pending
+    return waitForRouteUnlessAborted(pending, options.signal)
   }
-  const route = findLinkedWorktreeRoot(normalizedCwd, fileSystem)
-    .then((root) => rememberRoute(normalizedCwd, root, now()))
-    .finally(() => pendingRoutes.delete(normalizedCwd))
+  const route = discoverRoute(normalizedCwd, fileSystem, now).finally(() =>
+    pendingRoutes.delete(normalizedCwd)
+  )
   pendingRoutes.set(normalizedCwd, route)
-  return route
+  return waitForRouteUnlessAborted(route, options.signal)
 }
 
 export function usesHostGitForWslLinkedWorktree(
@@ -150,14 +208,13 @@ export function usesHostGitForWslLinkedWorktree(
 export function resetWslLinkedWorktreeGitRoutingForTests(): void {
   routeByCwd.clear()
   pendingRoutes.clear()
-  hostGitRoots.clear()
+  nextRoutePruneAt = 0
 }
 
 export function seedWslLinkedWorktreeGitRoutingForTests(root: string): void {
   const normalizedRoot = normalize(root)
   routeByCwd.set(normalizedRoot, {
-    root: normalizedRoot,
+    usesHostGit: true,
     expiresAt: Number.POSITIVE_INFINITY
   })
-  hostGitRoots.set(normalizedRoot, Number.POSITIVE_INFINITY)
 }

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -1,0 +1,163 @@
+import { readFile, stat } from 'node:fs/promises'
+import { win32 } from 'node:path'
+import type { Stats } from 'node:fs'
+
+type CachedRoute = { root: string | null; expiresAt: number }
+
+// Bounds stale routing after delete/recreate while amortizing async parent walks on slow storage.
+export const WSL_LINKED_WORKTREE_ROUTE_TTL_MS = 30_000
+
+const routeByCwd = new Map<string, CachedRoute>()
+const pendingRoutes = new Map<string, Promise<boolean>>()
+const hostGitRoots = new Map<string, number>()
+
+export function isWslLinkedWorktreeGitRoutingCandidate(
+  cwd: string,
+  wslDistro: string | undefined,
+  platform: NodeJS.Platform = process.platform
+): boolean {
+  return platform === 'win32' && Boolean(wslDistro) && /^[A-Za-z]:[/\\]/.test(cwd)
+}
+
+function normalize(path: string): string {
+  return win32.resolve(path).toLowerCase()
+}
+
+function containsPath(root: string, cwd: string): boolean {
+  const relative = win32.relative(root, cwd)
+  return (
+    relative === '' ||
+    (relative !== '..' && !relative.startsWith(`..${win32.sep}`) && !win32.isAbsolute(relative))
+  )
+}
+
+function cachedRoute(cwd: string, now: number): boolean | undefined {
+  const exact = routeByCwd.get(cwd)
+  let hasFreshExactMiss = false
+  if (exact) {
+    if (exact.expiresAt > now && exact.root !== null) {
+      return true
+    }
+    if (exact.expiresAt <= now) {
+      routeByCwd.delete(cwd)
+    } else {
+      hasFreshExactMiss = true
+    }
+  }
+  for (const [root, expiresAt] of hostGitRoots) {
+    if (expiresAt <= now) {
+      hostGitRoots.delete(root)
+    } else if (containsPath(root, cwd)) {
+      return true
+    }
+  }
+  return hasFreshExactMiss ? false : undefined
+}
+
+export function parseWindowsLinkedGitdir(content: string): string | null {
+  const firstLine = content.split(/\r?\n/, 1)[0] ?? ''
+  return firstLine.match(/^gitdir:\s*([A-Za-z]:[/\\].*?)\s*$/i)?.[1] ?? null
+}
+
+export type WslLinkedWorktreeRoutingFileSystem = {
+  stat(path: string): Promise<Pick<Stats, 'isDirectory' | 'isFile'>>
+  readFile(path: string): Promise<string>
+}
+
+const defaultFileSystem: WslLinkedWorktreeRoutingFileSystem = {
+  stat,
+  readFile: (path) => readFile(path, 'utf8')
+}
+
+async function findLinkedWorktreeRoot(
+  cwd: string,
+  fileSystem: WslLinkedWorktreeRoutingFileSystem
+): Promise<string | null> {
+  let candidate = cwd
+  const driveRoot = win32.parse(candidate).root
+  while (true) {
+    const markerPath = win32.join(candidate, '.git')
+    try {
+      const marker = await fileSystem.stat(markerPath)
+      if (marker.isDirectory()) {
+        return null
+      }
+      if (marker.isFile()) {
+        return parseWindowsLinkedGitdir(await fileSystem.readFile(markerPath)) ? candidate : null
+      }
+      return null
+    } catch (error) {
+      const code = error && typeof error === 'object' ? (error as NodeJS.ErrnoException).code : null
+      if (code !== 'ENOENT' && code !== 'ENOTDIR') {
+        return null
+      }
+    }
+    if (candidate === driveRoot) {
+      return null
+    }
+    candidate = win32.dirname(candidate)
+  }
+}
+
+function rememberRoute(cwd: string, root: string | null, now: number): boolean {
+  const normalizedRoot = root ? normalize(root) : null
+  const expiresAt = now + WSL_LINKED_WORKTREE_ROUTE_TTL_MS
+  routeByCwd.set(cwd, { root: normalizedRoot, expiresAt })
+  if (normalizedRoot) {
+    hostGitRoots.set(normalizedRoot, expiresAt)
+  }
+  return normalizedRoot !== null
+}
+
+export async function prepareWslLinkedWorktreeGitRouting(
+  cwd: string,
+  wslDistro: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+  fileSystem: WslLinkedWorktreeRoutingFileSystem = defaultFileSystem,
+  now: () => number = Date.now
+): Promise<boolean> {
+  if (!isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform)) {
+    return false
+  }
+  const normalizedCwd = normalize(cwd)
+  const cached = cachedRoute(normalizedCwd, now())
+  if (cached !== undefined) {
+    return cached
+  }
+  const pending = pendingRoutes.get(normalizedCwd)
+  if (pending) {
+    return pending
+  }
+  const route = findLinkedWorktreeRoot(normalizedCwd, fileSystem)
+    .then((root) => rememberRoute(normalizedCwd, root, now()))
+    .finally(() => pendingRoutes.delete(normalizedCwd))
+  pendingRoutes.set(normalizedCwd, route)
+  return route
+}
+
+export function usesHostGitForWslLinkedWorktree(
+  cwd: string,
+  wslDistro: string | undefined,
+  platform: NodeJS.Platform = process.platform,
+  now: () => number = Date.now
+): boolean {
+  return (
+    isWslLinkedWorktreeGitRoutingCandidate(cwd, wslDistro, platform) &&
+    cachedRoute(normalize(cwd), now()) === true
+  )
+}
+
+export function resetWslLinkedWorktreeGitRoutingForTests(): void {
+  routeByCwd.clear()
+  pendingRoutes.clear()
+  hostGitRoots.clear()
+}
+
+export function seedWslLinkedWorktreeGitRoutingForTests(root: string): void {
+  const normalizedRoot = normalize(root)
+  routeByCwd.set(normalizedRoot, {
+    root: normalizedRoot,
+    expiresAt: Number.POSITIVE_INFINITY
+  })
+  hostGitRoots.set(normalizedRoot, Number.POSITIVE_INFINITY)
+}

--- a/src/main/git/wsl-linked-worktree-git-routing.ts
+++ b/src/main/git/wsl-linked-worktree-git-routing.ts
@@ -1,4 +1,4 @@
-import { readFile, stat } from 'node:fs/promises'
+import * as fsPromises from 'node:fs/promises'
 import { win32 } from 'node:path'
 import type { Stats } from 'node:fs'
 
@@ -55,8 +55,8 @@ export type WslLinkedWorktreeRoutingOptions = {
 }
 
 const defaultFileSystem: WslLinkedWorktreeRoutingFileSystem = {
-  stat,
-  readFile: (path) => readFile(path, 'utf8')
+  stat: (path) => fsPromises.stat(path),
+  readFile: (path) => fsPromises.readFile(path, 'utf8')
 }
 
 async function shouldUseHostGit(

--- a/src/main/github/conflict-summary.ts
+++ b/src/main/github/conflict-summary.ts
@@ -6,7 +6,7 @@ import {
 import { gitExecFileAsync } from '../git/runner'
 import {
   clearGitCapabilityStateForTests,
-  getLocalGitCapabilityCache
+  withLocalGitCapabilityCacheForExecution
 } from '../git/git-capability-state'
 import {
   __resetPRConflictSummaryDerivationCachesForTests,
@@ -219,10 +219,6 @@ async function loadConflictingFiles(
   baseOid: string,
   localGitOptions: LocalGitExecOptions
 ): Promise<string[]> {
-  const capabilities = getLocalGitCapabilityCache({
-    cwd: repoPath,
-    wslDistro: localGitOptions.wslDistro
-  })
   const modernArgs = [
     'merge-tree',
     '--write-tree',
@@ -244,40 +240,44 @@ async function loadConflictingFiles(
     baseOid
   ]
 
-  return capabilities.runWithFallback(
-    'merge-tree-write-tree',
-    () =>
+  return withLocalGitCapabilityCacheForExecution(
+    { cwd: repoPath, wslDistro: localGitOptions.wslDistro },
+    (capabilities) =>
       capabilities.runWithFallback(
-        'merge-tree-merge-base',
+        'merge-tree-write-tree',
+        () =>
+          capabilities.runWithFallback(
+            'merge-tree-merge-base',
+            async () => {
+              try {
+                const result = await gitExecFileAsync(modernArgs, {
+                  cwd: repoPath,
+                  ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
+                })
+                return parseMergeTreeNameOnlyOutput(result.stdout)
+              } catch (error) {
+                if (isUnsupportedMergeTreeWriteTreeError(error)) {
+                  throw error
+                }
+                // Why: `git merge-tree --write-tree` exits 1 for conflicts but still
+                // writes the useful file list; only option rejection reaches fallback.
+                const stdoutFromError = getGitErrorOutput(error, 'stdout')
+                if (stdoutFromError) {
+                  return parseMergeTreeNameOnlyOutput(stdoutFromError)
+                }
+                throw error
+              }
+            },
+            () => loadConflictingFilesWithLegacyMergeTree(repoPath, legacyArgs, localGitOptions),
+            isUnsupportedMergeTreeMergeBaseError
+          ),
         async () => {
-          try {
-            const result = await gitExecFileAsync(modernArgs, {
-              cwd: repoPath,
-              ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {})
-            })
-            return parseMergeTreeNameOnlyOutput(result.stdout)
-          } catch (error) {
-            if (isUnsupportedMergeTreeWriteTreeError(error)) {
-              throw error
-            }
-            // Why: `git merge-tree --write-tree` exits 1 for conflicts but still
-            // writes the useful file list; only option rejection reaches fallback.
-            const stdoutFromError = getGitErrorOutput(error, 'stdout')
-            if (stdoutFromError) {
-              return parseMergeTreeNameOnlyOutput(stdoutFromError)
-            }
-            throw error
-          }
+          // Why: Git before 2.38 cannot derive a reliable real-merge conflict list;
+          // fail closed without respawning the same rejected command every refresh.
+          throw new Error('Git merge-tree --write-tree is unavailable on this execution host.')
         },
-        () => loadConflictingFilesWithLegacyMergeTree(repoPath, legacyArgs, localGitOptions),
-        isUnsupportedMergeTreeMergeBaseError
-      ),
-    async () => {
-      // Why: Git before 2.38 cannot derive a reliable real-merge conflict list;
-      // fail closed without respawning the same rejected command every refresh.
-      throw new Error('Git merge-tree --write-tree is unavailable on this execution host.')
-    },
-    isUnsupportedMergeTreeWriteTreeError
+        isUnsupportedMergeTreeWriteTreeError
+      )
   )
 }
 

--- a/src/main/ipc/filesystem-list-files-git-fallback.ts
+++ b/src/main/ipc/filesystem-list-files-git-fallback.ts
@@ -33,7 +33,14 @@ async function isInsideGitWorkTree(
     throw fileListingCancellationError(signal)
   }
   if (isWslLinkedWorktreeGitRoutingCandidate(rootPath, localGitOptions.wslDistro)) {
-    await prepareWslLinkedWorktreeGitRouting(rootPath, localGitOptions.wslDistro)
+    try {
+      await prepareWslLinkedWorktreeGitRouting(rootPath, localGitOptions.wslDistro, { signal })
+    } catch (error) {
+      if (signal?.aborted) {
+        throw fileListingCancellationError(signal)
+      }
+      throw error
+    }
   }
   if (signal?.aborted) {
     throw fileListingCancellationError(signal)

--- a/src/main/ipc/filesystem-list-files-git-fallback.ts
+++ b/src/main/ipc/filesystem-list-files-git-fallback.ts
@@ -1,6 +1,10 @@
 import type { ChildProcess } from 'node:child_process'
 import { gitSpawn } from '../git/runner'
 import {
+  isWslLinkedWorktreeGitRoutingCandidate,
+  prepareWslLinkedWorktreeGitRouting
+} from '../git/wsl-linked-worktree-git-routing'
+import {
   buildGitLsFilesArgsForQuickOpen,
   shouldExcludeQuickOpenRelPath,
   shouldIncludeQuickOpenPath
@@ -25,6 +29,12 @@ async function isInsideGitWorkTree(
   localGitOptions: { wslDistro?: string },
   signal?: AbortSignal
 ): Promise<boolean> {
+  if (signal?.aborted) {
+    throw fileListingCancellationError(signal)
+  }
+  if (isWslLinkedWorktreeGitRoutingCandidate(rootPath, localGitOptions.wslDistro)) {
+    await prepareWslLinkedWorktreeGitRouting(rootPath, localGitOptions.wslDistro)
+  }
   if (signal?.aborted) {
     throw fileListingCancellationError(signal)
   }

--- a/src/main/ipc/filesystem-search-git.ts
+++ b/src/main/ipc/filesystem-search-git.ts
@@ -8,6 +8,10 @@ import {
   SEARCH_TIMEOUT_MS
 } from '../../shared/text-search'
 import { gitSpawn } from '../git/runner'
+import {
+  isWslLinkedWorktreeGitRoutingCandidate,
+  prepareWslLinkedWorktreeGitRouting
+} from '../git/wsl-linked-worktree-git-routing'
 
 /**
  * Fallback text search using git grep. Used when rg is not available.
@@ -16,12 +20,15 @@ import { gitSpawn } from '../git/runner'
  * is launched from a desktop entry (which inherits a minimal system PATH).
  * git grep is always available since this is a git-focused app.
  */
-export function searchWithGitGrep(
+export async function searchWithGitGrep(
   rootPath: string,
   args: SearchOptions,
   maxResults: number,
   localGitOptions: { wslDistro?: string } = {}
 ): Promise<SearchResult> {
+  if (isWslLinkedWorktreeGitRoutingCandidate(rootPath, localGitOptions.wslDistro)) {
+    await prepareWslLinkedWorktreeGitRouting(rootPath, localGitOptions.wslDistro)
+  }
   return new Promise((resolve) => {
     const gitArgs = buildGitGrepArgs(args.query, args)
     const matchRegex = buildSubmatchRegex(args.query, args)


### PR DESCRIPTION
## Summary

Fix Orca Git operations for a Windows-authored linked worktree when its project runtime is WSL.

### Reproduction

1. Create a repository and linked worktree with Windows Git.
2. Confirm the linked worktree `.git` file contains `gitdir: C:/.../.git/worktrees/...`.
3. Run Git from WSL against the mounted linked path. WSL Git exits 128 after resolving the Windows pointer as `<linked-worktree>/C:/...`.
4. Before this change, Orca's production Git runner fails in the same way.

The real Windows/WSL integration test builds this fixture from scratch, proves the raw WSL failure, and proves the production runner succeeds after routing that linked worktree through Windows Git.

### Design

Classify only a local Windows drive path with an explicit WSL runtime whose nearest `.git` marker is a file containing an absolute Windows-drive `gitdir`. Cache the result for that exact working directory and run Orca Git operations there with Windows Git. Folder workspaces perform their own asynchronous parent walk, so a nested repository boundary is inspected independently instead of inheriting a parent's route. Ordinary DrvFS and WSL-native repositories remain on WSL Git.

Discovery uses only asynchronous filesystem calls. Async exec, buffer, stream, file-list, and text-search paths prepare routing before resolving or spawning Git. `gitSpawn` performs no filesystem discovery and consumes only a fresh, already-prepared exact-cwd answer.

Positive and negative answers expire after 30 seconds. Discovery has a five-second fail-closed deadline, concurrent callers share one probe, and cancellation stops an individual waiter without canceling or duplicating shared discovery. Expired entries are pruned once the cache reaches 512 entries, with scans throttled to once per TTL window. Path keys preserve case for case-sensitive Windows/DrvFS directories.

Git capability state follows the Git binary that actually executes: Windows-routed linked worktrees use local/native capability state, while ordinary WSL repositories retain distro-scoped state.

Translating only the front pointer was rejected because linked-worktree administration also stores a Windows back-pointer. WSL Git could otherwise treat a live registration as prunable.

### Correctness matrix

| Execution case | Result |
| --- | --- |
| Native Windows repository or linked worktree | Windows Git, unchanged |
| Ordinary drive-mounted repository with WSL runtime | WSL Git, unchanged and exercised through the production runner |
| Windows-authored linked worktree with WSL runtime | Windows Git for each independently classified cwd |
| Folder workspace beneath the linked worktree | Walks parents asynchronously and selects Windows Git when its nearest repository boundary is the linked worktree |
| Nested ordinary or WSL-native repository beneath that linked worktree | Its own `.git` boundary wins; it remains on WSL Git |
| Repository shape changes at the same cwd | Revalidated asynchronously within the 30-second freshness window |
| WSL-native repository | WSL Git, unchanged and exercised through the production runner |
| SSH, relay, or runtime-owned repository | Unchanged; classification requires local Windows, an explicit WSL distro, and a drive path |
| Mixed client/host versions | No wire or published-content change |
| Git 2.25 baseline | No new command, option, or output dependency |

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — code-quality, type-aware, reliability, max-lines, and bundled-guide gates pass; the command then stops at pre-existing stale bundled-skill manifest artifacts untouched by this PR
- [x] `pnpm typecheck`
- [ ] `pnpm test` — full suite delegated to PR CI
- [ ] `pnpm build` — delegated to PR CI
- [x] Latest-head affected matrix: 13 files, 191 tests passed, including the real Windows/WSL integration
- [x] Additional capability/worktree matrix: 5 files, 89 tests passed
- [x] Deterministic cache coverage includes exact-cwd behavior, nested repository boundaries, both repository-shape transitions, exact expiry, timeout and retry, cancellation, concurrent-call coalescing, case-sensitive keys, bounded pruning, delayed async I/O, and cache-only spawn behavior
- [x] Real Windows/WSL fixture covers the raw exit-128 reproduction, cold-cache file listing and text search, streamed status, staging, buffered reads, folder-workspace discovery, nested repositories, native Windows, ordinary mounted WSL, WSL-native routing, and real worktree listing
- [x] Focused formatting and lint checks, reliability gates, max-lines ratchet, Git compatibility contract, and `git diff --check`

No wall-clock benchmark is claimed. The relevant hot-path properties are deterministic: non-candidate/native work remains synchronous; concurrent discovery performs one filesystem walk; `gitSpawn` performs zero filesystem calls; cache expiry and pruning are controlled with fake time.

## AI Review Report

Four adversarial rounds covered correctness, elegance, performance, Git crash behavior, and Windows/Linux compatibility. Findings fixed before the latest head:

- Nested repositories no longer inherit the host-Git route of an outer linked worktree.
- Abort signals reach routing preparation without canceling shared discovery for other callers.
- A stuck filesystem probe times out after five seconds and can be retried.
- Case-distinct directories no longer share a cache entry.
- Expired cache entries are pruned after the cache reaches 512 entries without evicting fresh routes.
- Capability probes are scoped to the host whose Git binary actually executes.
- The default filesystem adapter is lazy so non-WSL modules with partial filesystem mocks do not fail during import.

The final review round found no additional proven issue.

## Security Audit

- `.git` content is parsed only as a routing classification; it is never executed or interpolated into a shell command.
- The accepted pointer shape requires an absolute Windows drive path. Relative, POSIX, drive-relative, malformed, and non-file markers do not select host Git.
- No new command syntax, subprocess arguments, IPC fields, RPC fields, credentials, secrets, dependencies, or network requests were added.
- Concurrent discovery and revalidation are coalesced by exact normalized working directory, and failure degrades to existing WSL routing.
- Filesystem discovery is asynchronous; `gitSpawn` remains free of blocking filesystem traversal.

## Notes

- Orca Git operations for this exact Windows-authored linked worktree use Windows Git configuration, hooks, credentials, and version even when the project runtime is WSL. This is intentional because both linked-worktree metadata pointers are Windows-qualified.
- A timed-out linked-repository probe is negatively cached for up to 30 seconds. During that window Git may fail through the existing WSL route; the next revalidation can recover. This bounds a hung probe while keeping the hot path asynchronous.
- Correctness-sensitive operations may await one asynchronous parent walk per active working directory every 30 seconds. On very slow storage this can delay that Git operation, but cannot synchronously block the main loop.
- Windows UNC and extended-length pointer forms are outside this PR; only drive-qualified pointers such as `C:/...` are routed.
- One unrelated Windows-local test file passes its assertions but can fail temp-directory cleanup with `EBUSY`; CI runs that suite on Linux, and the changed WSL branch is bypassed when no distro is configured.
- Latest pushed head: `a53e10cbae`.



