### PR TITLE
perf(pty): load local node-pty on demand

### DIFF
--- a/src/main/providers/local-pty-provider.test.ts
+++ b/src/main/providers/local-pty-provider.test.ts
@@ -112,8 +112,23 @@ import {
   LOCAL_PTY_PHYSICAL_EXIT_TIMEOUT_MS,
   LocalPtyProvider
 } from './local-pty-provider'
+import type { NodePtyModule } from './node-pty-loader'
 import { isRootLikePath } from './pty-path-safety'
 import { POWERLEVEL10K_WIZARD_DISABLE_ENV } from '../pty/powerlevel10k-wizard-env'
+
+function createHeldNodePtyLoad() {
+  let finish!: (module: NodePtyModule) => void
+  const load = vi.fn(
+    () =>
+      new Promise<NodePtyModule>((resolve) => {
+        finish = resolve
+      })
+  )
+  return {
+    load,
+    finish: () => finish({ spawn: spawnMock } as unknown as NodePtyModule)
+  }
+}
 
 describe('LocalPtyProvider', () => {
   let provider: LocalPtyProvider
@@ -398,6 +413,66 @@ describe('LocalPtyProvider', () => {
         provider.spawn({ cols: 80, rows: 24, sessionId: 'pending-local-session' })
       ).resolves.toMatchObject({ id: 'pending-local-session' })
       expect(spawnMock).toHaveBeenCalledOnce()
+    })
+
+    it('does not spawn when shutdown wins during the native module load', async () => {
+      const heldLoad = createHeldNodePtyLoad()
+      provider = new LocalPtyProvider({ loadNodePty: heldLoad.load })
+      spawnMock.mockClear()
+
+      const spawn = provider.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'native-load-shutdown'
+      })
+      const canceledSpawn = expect(spawn).rejects.toThrow(
+        'PTY spawn canceled: native-load-shutdown'
+      )
+      await vi.waitFor(() => expect(heldLoad.load).toHaveBeenCalledOnce())
+
+      await provider.shutdown('native-load-shutdown', { immediate: true })
+      heldLoad.finish()
+
+      await canceledSpawn
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('does not spawn into a stale renderer generation after the native module load', async () => {
+      const heldLoad = createHeldNodePtyLoad()
+      provider = new LocalPtyProvider({ loadNodePty: heldLoad.load })
+      spawnMock.mockClear()
+
+      const spawn = provider.spawn({ cols: 80, rows: 24, sessionId: 'stale-load' })
+      const canceledSpawn = expect(spawn).rejects.toThrow('PTY spawn canceled: stale-load')
+      await vi.waitFor(() => expect(heldLoad.load).toHaveBeenCalledOnce())
+
+      provider.advanceGeneration()
+      heldLoad.finish()
+
+      await canceledSpawn
+      expect(spawnMock).not.toHaveBeenCalled()
+    })
+
+    it('revalidates client cancellation after the native module load', async () => {
+      const heldLoad = createHeldNodePtyLoad()
+      const abortController = new AbortController()
+      provider = new LocalPtyProvider({ loadNodePty: heldLoad.load })
+      spawnMock.mockClear()
+
+      const spawn = provider.spawn({
+        cols: 80,
+        rows: 24,
+        sessionId: 'aborted-load',
+        signal: abortController.signal
+      })
+      const canceledSpawn = expect(spawn).rejects.toThrow('client_disconnected')
+      await vi.waitFor(() => expect(heldLoad.load).toHaveBeenCalledOnce())
+
+      abortController.abort()
+      heldLoad.finish()
+
+      await canceledSpawn
+      expect(spawnMock).not.toHaveBeenCalled()
     })
 
     it('coalesces a concurrent same-session-id spawn before launching a redundant shell (F3)', async () => {

--- a/src/main/providers/local-pty-provider.ts
+++ b/src/main/providers/local-pty-provider.ts
@@ -10,7 +10,7 @@ import {
 import { buildWindowsPowerShellSpawnAttempts } from './windows-shell-fallback-chain'
 import { resolveProcessCwd } from './process-cwd'
 import { existsSync } from 'node:fs'
-import * as pty from 'node-pty'
+import type * as pty from 'node-pty'
 import { getDefaultWslDistro, parseWslPath, isWslAvailableAsync } from '../wsl'
 import { splitWorktreeIdForFilesystem } from '../../shared/worktree-id'
 import {
@@ -78,6 +78,7 @@ import {
   expandWindowsEnvironmentVariables,
   expandWindowsPathEnvironmentVariables
 } from '../../shared/windows-environment-expansion'
+import { loadNodePty, type NodePtyModule } from './node-pty-loader'
 
 const PANE_IDENTITY_ENV_KEYS = [
   'ORCA_PANE_KEY',
@@ -341,8 +342,13 @@ function allocatePtyId(sessionId: string | undefined): string {
   return id
 }
 
-async function prepareLocalPtySpawn(id: string): Promise<void> {
+async function prepareLocalPtySpawn(
+  id: string,
+  signal: AbortSignal | undefined,
+  load: () => Promise<NodePtyModule>
+): Promise<{ nodePty: NodePtyModule; generation: number }> {
   const pendingSpawn: PendingLocalPtySpawn = { canceled: false }
+  const generation = loadGeneration
   const pending = pendingLocalPtySpawns.get(id) ?? new Set()
   pending.add(pendingSpawn)
   pendingLocalPtySpawns.set(id, pending)
@@ -352,6 +358,17 @@ async function prepareLocalPtySpawn(id: string): Promise<void> {
     if (pendingSpawn.canceled) {
       throw new Error(`PTY spawn canceled: ${id}`)
     }
+    if (signal?.aborted) {
+      throw new Error('client_disconnected')
+    }
+    const nodePty = await load()
+    if (pendingSpawn.canceled || generation !== loadGeneration) {
+      throw new Error(`PTY spawn canceled: ${id}`)
+    }
+    if (signal?.aborted) {
+      throw new Error('client_disconnected')
+    }
+    return { nodePty, generation }
   } finally {
     pending.delete(pendingSpawn)
     if (pending.size === 0) {
@@ -489,6 +506,8 @@ function requestPtyTermination(id: string, proc: pty.IPty): void {
 }
 
 export type LocalPtyProviderOptions = {
+  /** Test seam for holding the native load across lifecycle races. */
+  loadNodePty?: () => Promise<NodePtyModule>
   /** Why: `ctx.command` (pi/omp/claude) must drive overlay source-dir selection — a disk-presence fallback shadows the other agent's extensions. */
   buildSpawnEnv?: (
     id: string,
@@ -838,10 +857,11 @@ export class LocalPtyProvider implements IPtyProvider {
       logHistoryInjection(worktreeId, historyResult)
     }
 
-    await prepareLocalPtySpawn(id)
-    if (args.signal?.aborted) {
-      throw new Error('client_disconnected')
-    }
+    const prepared = await prepareLocalPtySpawn(
+      id,
+      args.signal,
+      this.opts.loadNodePty ?? loadNodePty
+    )
     // Why: another same-id request can win while this one awaits preflight; attach before launching a redundant shell.
     const concurrentWinner = reattachId ? reattachLocalPty(id, args.cols, args.rows) : null
     if (concurrentWinner) {
@@ -855,7 +875,7 @@ export class LocalPtyProvider implements IPtyProvider {
       cwd: effectiveCwd,
       env: finalEnv,
       termName: finalEnv.TERM,
-      ptySpawn: pty.spawn,
+      ptySpawn: prepared.nodePty.spawn,
       getShellReadyConfig: getFallbackShellReadyConfig,
       // Why: on zsh→bash fallback HISTFILE still points to zsh_history; update before spawn so the child inherits it (design doc §8).
       onBeforeFallbackSpawn: historyResult?.histFile
@@ -906,7 +926,7 @@ export class LocalPtyProvider implements IPtyProvider {
       id,
       getAgentForegroundContextPaths({ cwd: args.cwd, worktreeId: args.worktreeId })
     )
-    ptyLoadGeneration.set(id, loadGeneration)
+    ptyLoadGeneration.set(id, prepared.generation)
     ptyIncarnations.set(id, incarnationId)
     this.opts.onSpawned?.(id, incarnationId)
 

--- a/src/main/providers/node-pty-loader.test.ts
+++ b/src/main/providers/node-pty-loader.test.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { NodePtyModule } from './node-pty-loader'
+import { createNodePtyLoader } from './node-pty-loader'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((res) => {
+    resolve = res
+  })
+  return { promise, resolve }
+}
+
+describe('createNodePtyLoader', () => {
+  it('single-flights concurrent loads and caches success', async () => {
+    const pending = deferred<NodePtyModule>()
+    const module = { spawn: vi.fn() } as unknown as NodePtyModule
+    const importer = vi.fn(() => pending.promise)
+    const load = createNodePtyLoader(importer)
+
+    const first = load()
+    const second = load()
+    expect(importer).toHaveBeenCalledOnce()
+
+    pending.resolve(module)
+    await expect(Promise.all([first, second])).resolves.toEqual([module, module])
+    await expect(load()).resolves.toBe(module)
+    expect(importer).toHaveBeenCalledOnce()
+  })
+
+  it('preserves an actionable failure until process restart', async () => {
+    const nativeFailure = new Error('dlopen: incompatible architecture')
+    const importer = vi.fn(() => Promise.reject(nativeFailure))
+    const load = createNodePtyLoader(importer)
+
+    const firstFailure = (await load().catch((error: unknown) => error)) as Error
+    const secondFailure = (await load().catch((error: unknown) => error)) as Error
+
+    expect(firstFailure).toBe(secondFailure)
+    expect(firstFailure).toMatchObject({ cause: nativeFailure })
+    expect(firstFailure.message).toContain('dlopen: incompatible architecture')
+    expect(firstFailure.message).toContain('Restart Orca')
+    expect(importer).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/providers/node-pty-loader.ts
+++ b/src/main/providers/node-pty-loader.ts
@@ -1,0 +1,43 @@
+import type * as NodePty from 'node-pty'
+
+export type NodePtyModule = typeof NodePty
+export type NodePtyImporter = () => Promise<NodePtyModule>
+
+function nodePtyLoadError(cause: unknown): Error {
+  const detail = cause instanceof Error ? cause.message : String(cause)
+  return new Error(
+    `Local terminals could not load node-pty (${detail}). Restart Orca after repairing or reinstalling its native dependencies.`,
+    { cause }
+  )
+}
+
+/** A failed native load is terminal for this process; restart is the only retry boundary. */
+export function createNodePtyLoader(importer: NodePtyImporter): () => Promise<NodePtyModule> {
+  let loaded: NodePtyModule | undefined
+  let inFlight: Promise<NodePtyModule> | undefined
+  let failure: Error | undefined
+
+  return (): Promise<NodePtyModule> => {
+    if (loaded) {
+      return Promise.resolve(loaded)
+    }
+    if (failure) {
+      return Promise.reject(failure)
+    }
+    if (!inFlight) {
+      inFlight = importer().then(
+        (module) => {
+          loaded = module
+          return module
+        },
+        (cause: unknown) => {
+          failure = nodePtyLoadError(cause)
+          throw failure
+        }
+      )
+    }
+    return inFlight
+  }
+}
+
+export const loadNodePty = createNodePtyLoader(() => import('node-pty'))


### PR DESCRIPTION
## Summary

Moves the main-process local fallback's `node-pty` import to the first fresh local PTY spawn. The daemon keeps its eager import and packaged native layout, while a broken POSIX native binding no longer prevents the Electron main process from starting far enough to report the daemon/local-terminal failure.

The loader single-flights concurrent requests, caches successful loads, and preserves one actionable failure for the remainder of the process; restarting Orca is the explicit retry boundary. Local spawn revalidates shutdown cancellation, client cancellation, and renderer generation after the load await before committing a PTY.

**Performance conclusion:** this is a narrow startup optimization, but the measurements do not establish a user-visible startup win. It removes one native-module load from the Electron main process on the normal daemon-backed path, with a median isolated cost of about 3.5 ms on this host. The daemon still loads the same binding in its own process, and a 48-launch app-level A/B was too noisy to resolve an improvement. Fault containment remains the stronger justification.

## Evidence

### What moves off the startup path

- At exact base `d9e84d88ef04341d3f91db9bec16b277e3cfce4b`, built `out/main/index.js` has a top-level `require("node-pty")`.
- At head `9650fc91fd63c3cabe8e126bdbfcb833a3fe4d43`, the top-level require is absent and the main-process fallback contains `import("node-pty")` at first fresh local spawn.
- `out/main/daemon-entry.js` remains eager in both builds. Normal terminal persistence therefore keeps the existing daemon behavior; this PR avoids a duplicate main-process load rather than eliminating `node-pty` from overall startup.
- SSH providers and folder-workspace routing are unchanged. The deferred load belongs only to the in-process local fallback used when the daemon is unavailable.

### Isolated native-load cost

Fresh Electron 43.1.0-as-Node processes on Apple Silicon macOS 26.3.1:

| Probe | Samples | Median | p10–p90 | Observed range |
| --- | ---: | ---: | ---: | ---: |
| Startup-equivalent `require("node-pty")` | 40 | 3.471 ms | 3.294–7.777 ms | 3.115–336.601 ms |
| First-use `import("node-pty")` | 40 | 5.116 ms | 4.640–8.689 ms | 4.620–9.925 ms |

These are loader microbenchmarks, not application-startup timings. Filesystem and native-loader cache state dominate the tail: the large `require` outlier is evidence that the load can occasionally be cold, not a claim that this PR saves 337 ms in typical launches. The import series ran after the require series, so the difference between their medians should not be interpreted as dynamic-import overhead.

### Full startup A/B

Both exact revisions were built with `pnpm build:electron-vite`; only the complete `out/main` artifact was swapped between batches. The existing startup harness launched the unpackaged production build against the same empty synthetic profile and measured process spawn to renderer `did-finish-load`. Each cell is the median of eight launches (48 launches total):

| Pair / launch order | Base | PR | PR − base |
| --- | ---: | ---: | ---: |
| 1, base → PR | 871 ms | 746 ms | −125 ms |
| 2, base → PR | 790 ms | 810 ms | +20 ms |
| 3, PR → base | 766 ms | 821 ms | +55 ms |

Negative favors the PR. The direction reverses across batches, and the 20–125 ms batch movement is much larger than the isolated 3–5 ms typical load cost. This does not prove the optimization has zero effect; it means any end-to-end improvement is below the noise floor of this benchmark on this host, so the PR should not claim a visible startup reduction.

### Tradeoff

- Normal daemon-backed startup avoids the main process's one native load.
- The uncommon first fresh local-fallback spawn pays the dynamic import once (5.116 ms median in the isolated probe); later spawns use the cached module.
- Concurrent first spawns share one import.
- If the binding is broken, the failure moves from main-process module evaluation to an actionable terminal-spawn error, leaving the rest of the app available.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (not run in full; changed-file oxlint and code-quality gates passed)
- [ ] `pnpm typecheck` (not run in full; `pnpm typecheck:node` passed)
- [ ] `pnpm test` (not run in full; 184 focused tests passed)
- [ ] `pnpm build` (not run in full; `pnpm build:electron-vite` passed on both exact A/B revisions)
- [x] Added concurrency, successful caching, process-lifetime failure, shutdown cancellation, client cancellation, and renderer-generation tests
- [x] `pnpm check:code-quality:changed`
- [x] `pnpm check:max-lines-ratchet`
- [x] GitHub PR checks: static analysis, typecheck, Node 24/26 test shards, macOS packaging, and Windows packaging

Focused tests:

- `src/main/providers/node-pty-loader.test.ts`
- `src/main/providers/local-pty-provider.test.ts`
- `src/main/providers/local-pty-utils-windows-fallback.test.ts`
- `src/main/daemon/daemon-init.test.ts`

## AI Review Report

Reviewed the loader and the local PTY lifecycle around stable-session reattach, concurrent same-ID spawns, shutdown/reload races, daemon fallback routing, and first-spawn failure propagation. The review specifically checked macOS/Linux POSIX binding fault containment, Windows ConPTY and PowerShell fallback behavior, WSL launch selection, SSH provider separation, folder workspaces, packaged external-module resolution, and Electron dynamic-import output; no platform-specific behavior was changed beyond deferring the local fallback import.

## Security Audit

No new external input, command construction, IPC surface, path handling, auth, secrets, or dependency was introduced. Native loader failures retain the original error as `cause` while exposing repair/restart guidance, and lifecycle cancellation is revalidated before any native process is spawned.

## Notes

The daemon still eagerly loads `node-pty` because it owns normal terminal persistence and Windows ConPTY warmup. The main-process loader intentionally does not retry after failure because native binding/import failures are process-stable; restart after repair is the bounded retry mechanism.
