### PR TITLE
Cache main-process compilation between launches

### DIFF
--- a/config/build-plugins/main-process-bootstrap.test.ts
+++ b/config/build-plugins/main-process-bootstrap.test.ts
@@ -1,0 +1,188 @@
+import { EventEmitter } from 'node:events'
+import { posix } from 'node:path'
+import { runInNewContext } from 'node:vm'
+import { describe, expect, it, vi } from 'vitest'
+import {
+  MAIN_PROCESS_BOOTSTRAP_FILE,
+  MAIN_PROCESS_COMPILE_CACHE_DIRECTORY,
+  createMainProcessBootstrap
+} from './main-process-bootstrap'
+import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap-fatal-exit-guard'
+
+function runBootstrap(options: {
+  compileCacheSupported?: boolean
+  enableCompileCache?: (directory: string) => unknown
+  flushCompileCache?: () => void
+  getUserDataPath?: () => string
+  isPackaged?: boolean
+  loadMain?: () => unknown
+  nodeCompileCache?: string
+  startupDiagnostics?: '1' | 'trace'
+}): { exports: unknown; timeline: string[] } {
+  const timeline: string[] = []
+  const processMock = new EventEmitter() as EventEmitter & {
+    argv: string[]
+    env: Record<string, string>
+    execPath: string
+    exit: (code: number) => void
+    exitCode?: number
+    pid: number
+    ppid: number
+  }
+  processMock.argv = []
+  processMock.env = {
+    ...(options.nodeCompileCache ? { NODE_COMPILE_CACHE: options.nodeCompileCache } : {}),
+    ...(options.startupDiagnostics ? { ORCA_STARTUP_DIAGNOSTICS: options.startupDiagnostics } : {})
+  }
+  processMock.execPath = '/electron'
+  processMock.exit = () => {}
+  processMock.pid = 42
+  processMock.ppid = 7
+  const moduleMock = { exports: undefined as unknown }
+  const compileCacheModule =
+    options.compileCacheSupported === false
+      ? {}
+      : {
+          enableCompileCache: (directory: string) => {
+            timeline.push(`enable:${directory}`)
+            return options.enableCompileCache?.(directory)
+          },
+          flushCompileCache: () => {
+            timeline.push('flush')
+            options.flushCompileCache?.()
+          }
+        }
+  const requireMock = (specifier: string): unknown => {
+    if (specifier === 'node:module') {
+      return compileCacheModule
+    }
+    if (specifier === 'node:path') {
+      return posix
+    }
+    if (specifier === 'node:fs') {
+      return {
+        writeSync: (_descriptor: number, message: string) => {
+          timeline.push(`diagnostic:${message.trim()}`)
+        }
+      }
+    }
+    if (specifier === 'electron') {
+      return {
+        app: {
+          getPath: options.getUserDataPath ?? (() => '/user-data'),
+          isPackaged: options.isPackaged ?? true
+        }
+      }
+    }
+    if (specifier === './index.js') {
+      timeline.push('main')
+      return options.loadMain?.() ?? { loaded: true }
+    }
+    throw new Error(`Unexpected require: ${specifier}`)
+  }
+
+  runInNewContext(createMainProcessBootstrap(), {
+    globalThis: {},
+    module: moduleMock,
+    process: processMock,
+    require: requireMock,
+    setImmediate: () => {},
+    setTimeout: (callback: () => void) => {
+      callback()
+      return { unref: () => {} }
+    }
+  })
+  return { exports: moduleMock.exports, timeline }
+}
+
+describe('main-process bootstrap', () => {
+  it('installs fatal and diagnostic guards before cache setup and the real bundle', () => {
+    const source = createMainProcessBootstrap()
+
+    expect(source.indexOf(BOOTSTRAP_FATAL_EXIT_GUARD_KEY)).toBeLessThan(
+      source.indexOf('ORCA_STARTUP_DIAGNOSTICS')
+    )
+    expect(source.indexOf('ORCA_STARTUP_DIAGNOSTICS')).toBeLessThan(
+      source.indexOf('enableCompileCache')
+    )
+    expect(source.indexOf('enableCompileCache')).toBeLessThan(source.indexOf('./index.js'))
+    expect(MAIN_PROCESS_BOOTSTRAP_FILE).toBe('bootstrap.cjs')
+  })
+
+  it('enables and flushes the compile cache around the real main bundle', () => {
+    const result = runBootstrap({})
+
+    expect(result.timeline).toEqual([
+      `enable:/user-data/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`,
+      'main',
+      'flush'
+    ])
+    expect(result.exports).toEqual({ loaded: true })
+  })
+
+  it('preserves startup diagnostics before cache setup', () => {
+    const result = runBootstrap({ startupDiagnostics: '1' })
+
+    expect(result.timeline[0]).toContain('diagnostic:[bootstrap] bundle-enter chunk="index.js"')
+    expect(result.timeline[1]).toBe(`enable:/user-data/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`)
+  })
+
+  it('respects Node compile-cache directory configuration', () => {
+    const result = runBootstrap({ nodeCompileCache: '/configured-cache' })
+
+    expect(result.timeline[0]).toBe('enable:/configured-cache')
+  })
+
+  it('keeps development caches out of the packaged profile', () => {
+    const result = runBootstrap({
+      getUserDataPath: (name?: string) =>
+        name === 'appData' ? '/app-data' : '/packaged-user-data',
+      isPackaged: false
+    })
+
+    expect(result.timeline[0]).toBe(
+      `enable:/app-data/orca-dev/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`
+    )
+  })
+
+  it('launches when the cache directory is read-only', () => {
+    const result = runBootstrap({
+      enableCompileCache: () => ({ status: 0, message: 'permission denied' })
+    })
+
+    expect(result.timeline).toContain('main')
+    expect(result.exports).toEqual({ loaded: true })
+  })
+
+  it('launches when cache-directory resolution is unavailable', () => {
+    const result = runBootstrap({
+      getUserDataPath: () => {
+        throw new Error('userData unavailable')
+      }
+    })
+
+    expect(result.timeline).toEqual(['main', 'flush'])
+    expect(result.exports).toEqual({ loaded: true })
+  })
+
+  it('launches when the compile-cache API is unavailable', () => {
+    const result = runBootstrap({ compileCacheSupported: false })
+
+    expect(result.timeline).toEqual(['main'])
+    expect(result.exports).toEqual({ loaded: true })
+  })
+
+  it('does not hide a real-main failure behind cache persistence', () => {
+    const flushCompileCache = vi.fn()
+
+    expect(() =>
+      runBootstrap({
+        flushCompileCache,
+        loadMain: () => {
+          throw new Error('main failed')
+        }
+      })
+    ).toThrow('main failed')
+    expect(flushCompileCache).not.toHaveBeenCalled()
+  })
+})

--- a/config/build-plugins/main-process-bootstrap.test.ts
+++ b/config/build-plugins/main-process-bootstrap.test.ts
@@ -1,7 +1,7 @@
 import { EventEmitter } from 'node:events'
 import { posix } from 'node:path'
 import { runInNewContext } from 'node:vm'
-import { describe, expect, it, vi } from 'vitest'
+import { describe, expect, it } from 'vitest'
 import {
   MAIN_PROCESS_BOOTSTRAP_FILE,
   MAIN_PROCESS_COMPILE_CACHE_DIRECTORY,
@@ -10,13 +10,14 @@ import {
 import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap-fatal-exit-guard'
 
 function runBootstrap(options: {
+  appImagePath?: string
   compileCacheSupported?: boolean
   enableCompileCache?: (directory: string) => unknown
-  flushCompileCache?: () => void
   getUserDataPath?: () => string
   isPackaged?: boolean
   loadMain?: () => unknown
   nodeCompileCache?: string
+  platform?: NodeJS.Platform
   startupDiagnostics?: '1' | 'trace'
 }): { exports: unknown; timeline: string[] } {
   const timeline: string[] = []
@@ -27,16 +28,19 @@ function runBootstrap(options: {
     exit: (code: number) => void
     exitCode?: number
     pid: number
+    platform: NodeJS.Platform
     ppid: number
   }
   processMock.argv = []
   processMock.env = {
     ...(options.nodeCompileCache ? { NODE_COMPILE_CACHE: options.nodeCompileCache } : {}),
+    ...(options.appImagePath ? { APPIMAGE: options.appImagePath } : {}),
     ...(options.startupDiagnostics ? { ORCA_STARTUP_DIAGNOSTICS: options.startupDiagnostics } : {})
   }
   processMock.execPath = '/electron'
   processMock.exit = () => {}
   processMock.pid = 42
+  processMock.platform = options.platform ?? 'darwin'
   processMock.ppid = 7
   const moduleMock = { exports: undefined as unknown }
   const compileCacheModule =
@@ -46,10 +50,6 @@ function runBootstrap(options: {
           enableCompileCache: (directory: string) => {
             timeline.push(`enable:${directory}`)
             return options.enableCompileCache?.(directory)
-          },
-          flushCompileCache: () => {
-            timeline.push('flush')
-            options.flushCompileCache?.()
           }
         }
   const requireMock = (specifier: string): unknown => {
@@ -86,11 +86,7 @@ function runBootstrap(options: {
     module: moduleMock,
     process: processMock,
     require: requireMock,
-    setImmediate: () => {},
-    setTimeout: (callback: () => void) => {
-      callback()
-      return { unref: () => {} }
-    }
+    setImmediate: () => {}
   })
   return { exports: moduleMock.exports, timeline }
 }
@@ -109,14 +105,33 @@ describe('main-process bootstrap', () => {
     expect(MAIN_PROCESS_BOOTSTRAP_FILE).toBe('bootstrap.cjs')
   })
 
-  it('enables and flushes the compile cache around the real main bundle', () => {
+  it('enables the compile cache before the real main bundle', () => {
     const result = runBootstrap({})
 
     expect(result.timeline).toEqual([
       `enable:/user-data/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`,
-      'main',
-      'flush'
+      'main'
     ])
+    expect(result.exports).toEqual({ loaded: true })
+  })
+
+  it.each<NodeJS.Platform>(['darwin', 'win32', 'linux'])(
+    'enables the cache on supported %s launches',
+    (platform) => {
+      const result = runBootstrap({ platform })
+
+      expect(result.timeline[0]).toBe(`enable:/user-data/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`)
+    }
+  )
+
+  it('skips the path-keyed cache for Linux AppImage launches', () => {
+    const result = runBootstrap({
+      appImagePath: '/tmp/.mount_Orca123/orca',
+      nodeCompileCache: '/user-data/v8-compile-cache',
+      platform: 'linux'
+    })
+
+    expect(result.timeline).toEqual(['main'])
     expect(result.exports).toEqual({ loaded: true })
   })
 
@@ -161,7 +176,7 @@ describe('main-process bootstrap', () => {
       }
     })
 
-    expect(result.timeline).toEqual(['main', 'flush'])
+    expect(result.timeline).toEqual(['main'])
     expect(result.exports).toEqual({ loaded: true })
   })
 
@@ -173,16 +188,19 @@ describe('main-process bootstrap', () => {
   })
 
   it('does not hide a real-main failure behind cache persistence', () => {
-    const flushCompileCache = vi.fn()
-
     expect(() =>
       runBootstrap({
-        flushCompileCache,
         loadMain: () => {
           throw new Error('main failed')
         }
       })
     ).toThrow('main failed')
-    expect(flushCompileCache).not.toHaveBeenCalled()
+  })
+
+  it('relies on Node exit persistence instead of a synchronous flush timer', () => {
+    const source = createMainProcessBootstrap()
+
+    expect(source).not.toContain('flushCompileCache')
+    expect(source).not.toContain('setTimeout')
   })
 })

--- a/config/build-plugins/main-process-bootstrap.test.ts
+++ b/config/build-plugins/main-process-bootstrap.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, it } from 'vitest'
 import {
   MAIN_PROCESS_BOOTSTRAP_FILE,
   MAIN_PROCESS_COMPILE_CACHE_DIRECTORY,
+  MAIN_PROCESS_DEVELOPMENT_CACHE_PARENT_DIRECTORY,
   createMainProcessBootstrap
 } from './main-process-bootstrap'
 import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap-fatal-exit-guard'
@@ -12,6 +13,7 @@ import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap
 function runBootstrap(options: {
   appImagePath?: string
   compileCacheSupported?: boolean
+  devUserDataPath?: string
   enableCompileCache?: (directory: string) => unknown
   getUserDataPath?: () => string
   isPackaged?: boolean
@@ -34,6 +36,7 @@ function runBootstrap(options: {
   processMock.argv = []
   processMock.env = {
     ...(options.nodeCompileCache ? { NODE_COMPILE_CACHE: options.nodeCompileCache } : {}),
+    ...(options.devUserDataPath ? { ORCA_DEV_USER_DATA_PATH: options.devUserDataPath } : {}),
     ...(options.appImagePath ? { APPIMAGE: options.appImagePath } : {}),
     ...(options.startupDiagnostics ? { ORCA_STARTUP_DIAGNOSTICS: options.startupDiagnostics } : {})
   }
@@ -82,6 +85,7 @@ function runBootstrap(options: {
   }
 
   runInNewContext(createMainProcessBootstrap(), {
+    __dirname: '/repo/out/main',
     globalThis: {},
     module: moduleMock,
     process: processMock,
@@ -148,15 +152,27 @@ describe('main-process bootstrap', () => {
     expect(result.timeline[0]).toBe('enable:/configured-cache')
   })
 
-  it('keeps development caches out of the packaged profile', () => {
+  it('uses a generated source-local cache for default development launches', () => {
     const result = runBootstrap({
-      getUserDataPath: (name?: string) =>
-        name === 'appData' ? '/app-data' : '/packaged-user-data',
+      getUserDataPath: () => {
+        throw new Error('development cache must not use shared app data')
+      },
       isPackaged: false
     })
 
     expect(result.timeline[0]).toBe(
-      `enable:/app-data/orca-dev/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`
+      `enable:/repo/out/${MAIN_PROCESS_DEVELOPMENT_CACHE_PARENT_DIRECTORY}/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`
+    )
+  })
+
+  it('keeps explicit development user-data overrides authoritative', () => {
+    const result = runBootstrap({
+      devUserDataPath: '/configured-dev-profile',
+      isPackaged: false
+    })
+
+    expect(result.timeline[0]).toBe(
+      `enable:/configured-dev-profile/${MAIN_PROCESS_COMPILE_CACHE_DIRECTORY}`
     )
   })
 

--- a/config/build-plugins/main-process-bootstrap.ts
+++ b/config/build-plugins/main-process-bootstrap.ts
@@ -1,0 +1,180 @@
+import type { Plugin } from 'vite'
+import { createBootstrapFatalExitBanner } from './bootstrap-fatal-exit-banner'
+
+export const MAIN_PROCESS_BOOTSTRAP_FILE = 'bootstrap.cjs'
+export const MAIN_PROCESS_BUNDLE_FILE = 'index.js'
+export const MAIN_PROCESS_COMPILE_CACHE_DIRECTORY = 'v8-compile-cache'
+
+export function createStartupDiagnosticsBanner(chunkName: string): string {
+  return `
+;(() => {
+  const env = typeof process !== 'undefined' ? process.env : undefined
+  const mode = env?.ORCA_STARTUP_DIAGNOSTICS
+  if (mode !== '1' && mode !== 'trace') {
+    return
+  }
+  const safeJson = (value) => {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return '"<unserializable>"'
+    }
+  }
+  let closeSync
+  let diagnosticFileDescriptor
+  let openSync
+  let writeSync
+  try {
+    const fs = require('node:fs')
+    closeSync = fs.closeSync
+    openSync = fs.openSync
+    writeSync = fs.writeSync
+  } catch {
+    closeSync = undefined
+    openSync = undefined
+    writeSync = undefined
+  }
+  const diagnosticFile = env?.ORCA_STARTUP_DIAGNOSTICS_FILE
+  if (typeof diagnosticFile === 'string' && diagnosticFile.length > 0 && typeof openSync === 'function') {
+    try {
+      diagnosticFileDescriptor = openSync(diagnosticFile, 'a', 0o600)
+    } catch {
+      diagnosticFileDescriptor = undefined
+    }
+  }
+  const writeLine = (message) => {
+    try {
+      const line = message.endsWith('\\n') ? message : message + '\\n'
+      if (typeof writeSync === 'function') {
+        writeSync(2, line)
+        if (typeof diagnosticFileDescriptor === 'number') {
+          writeSync(diagnosticFileDescriptor, line)
+        }
+      }
+    } catch {
+      // Diagnostics must never affect startup.
+    }
+  }
+  const chunkName = ${JSON.stringify(chunkName)}
+  writeLine('[bootstrap] bundle-enter chunk=' + safeJson(chunkName) + ' pid=' + process.pid + ' ppid=' + process.ppid + ' execPath=' + safeJson(process.execPath) + ' argv=' + safeJson(process.argv) + ' electronRunAsNode=' + safeJson(env?.ELECTRON_RUN_AS_NODE ?? null))
+  if (!globalThis.__ORCA_BOOTSTRAP_EXIT_LOG_INSTALLED__) {
+    globalThis.__ORCA_BOOTSTRAP_EXIT_LOG_INSTALLED__ = true
+    process.once('exit', (code) => {
+      writeLine('[bootstrap] process-exit code=' + code)
+      if (typeof closeSync === 'function' && typeof diagnosticFileDescriptor === 'number') {
+        try {
+          closeSync(diagnosticFileDescriptor)
+        } catch {
+          // Diagnostics must never affect shutdown.
+        }
+      }
+    })
+    process.on('uncaughtExceptionMonitor', (error, origin) => {
+      const message = error && typeof error === 'object' && 'stack' in error ? error.stack : error
+      writeLine('[bootstrap] uncaught-exception origin=' + safeJson(origin) + ' error=' + safeJson(String(message)))
+    })
+    process.on('unhandledRejection', (reason) => {
+      const message = reason && typeof reason === 'object' && 'stack' in reason ? reason.stack : reason
+      writeLine('[bootstrap] unhandled-rejection error=' + safeJson(String(message)))
+    })
+  }
+  if (mode === 'trace' && !globalThis.__ORCA_BOOTSTRAP_REQUIRE_TRACE_INSTALLED__) {
+    globalThis.__ORCA_BOOTSTRAP_REQUIRE_TRACE_INSTALLED__ = true
+    try {
+      const Module = require('node:module')
+      const originalLoad = Module._load
+      const parsedTraceLimit = Number(env?.ORCA_STARTUP_DIAGNOSTICS_TRACE_LIMIT ?? 20000)
+      const traceLimit = Number.isFinite(parsedTraceLimit) && parsedTraceLimit > 0 ? parsedTraceLimit : 20000
+      let traceLineCount = 0
+      let traceLimitReported = false
+      const writeTraceLine = (message) => {
+        if (traceLineCount >= traceLimit) {
+          if (!traceLimitReported) {
+            traceLimitReported = true
+            writeLine('[bootstrap] require-trace-limit-reached limit=' + safeJson(traceLimit))
+          }
+          return
+        }
+        traceLineCount += 1
+        writeLine(message)
+      }
+      Module._load = function (request, parent, isMain) {
+        const parentName = parent && parent.filename ? parent.filename : null
+        writeTraceLine('[bootstrap] require-start request=' + safeJson(request) + ' parent=' + safeJson(parentName) + ' isMain=' + safeJson(Boolean(isMain)))
+        try {
+          const result = Reflect.apply(originalLoad, this, arguments)
+          writeTraceLine('[bootstrap] require-ok request=' + safeJson(request))
+          return result
+        } catch (error) {
+          const message = error && typeof error === 'object' && 'stack' in error ? error.stack : error
+          writeTraceLine('[bootstrap] require-error request=' + safeJson(request) + ' error=' + safeJson(String(message)))
+          throw error
+        }
+      }
+    } catch (error) {
+      writeLine('[bootstrap] require-trace-install-error error=' + safeJson(String(error)))
+    }
+  }
+})();
+`
+}
+
+export function createMainProcessBootstrap(mainFileName = MAIN_PROCESS_BUNDLE_FILE): string {
+  return `${createBootstrapFatalExitBanner()}${createStartupDiagnosticsBanner(mainFileName)}
+let compileCacheModule
+try {
+  compileCacheModule = require('node:module')
+  if (typeof compileCacheModule.enableCompileCache === 'function') {
+    let cacheDirectory = process.env.NODE_COMPILE_CACHE
+    if (typeof cacheDirectory !== 'string' || cacheDirectory.length === 0) {
+      const electronApp = require('electron').app
+      const path = require('node:path')
+      let userDataDirectory = process.env.ORCA_E2E_USER_DATA_DIR
+      if (typeof userDataDirectory !== 'string' || userDataDirectory.length === 0) {
+        const devOverride = process.env.ORCA_DEV_USER_DATA_PATH
+        userDataDirectory = electronApp.isPackaged
+          ? electronApp.getPath('userData')
+          : typeof devOverride === 'string' && devOverride.length > 0
+            ? devOverride
+            : path.join(electronApp.getPath('appData'), 'orca-dev')
+      }
+      cacheDirectory = path.join(userDataDirectory, ${JSON.stringify(MAIN_PROCESS_COMPILE_CACHE_DIRECTORY)})
+    }
+    compileCacheModule.enableCompileCache(cacheDirectory)
+  }
+} catch {
+  // Why: compile caching is an optimization and must never prevent launch.
+}
+
+module.exports = require(${JSON.stringify(`./${mainFileName}`)})
+try {
+  const flushTimer = setTimeout(() => {
+    try {
+      compileCacheModule?.flushCompileCache?.()
+    } catch {
+      // Why: an unwritable cache must not affect a running main process.
+    }
+  }, 5000)
+  flushTimer.unref?.()
+} catch {
+  // Why: cache persistence must never replace the main bundle's outcome.
+}
+`
+}
+
+export function createMainProcessBootstrapPlugin(): Plugin {
+  return {
+    name: 'orca-main-process-bootstrap',
+    generateBundle(_options, bundle) {
+      const mainChunk = bundle[MAIN_PROCESS_BUNDLE_FILE]
+      if (!mainChunk || mainChunk.type !== 'chunk') {
+        this.error(`Missing main-process entry chunk: ${MAIN_PROCESS_BUNDLE_FILE}`)
+      }
+      this.emitFile({
+        type: 'asset',
+        fileName: MAIN_PROCESS_BOOTSTRAP_FILE,
+        source: createMainProcessBootstrap(mainChunk.fileName)
+      })
+    }
+  }
+}

--- a/config/build-plugins/main-process-bootstrap.ts
+++ b/config/build-plugins/main-process-bootstrap.ts
@@ -121,44 +121,35 @@ export function createStartupDiagnosticsBanner(chunkName: string): string {
 
 export function createMainProcessBootstrap(mainFileName = MAIN_PROCESS_BUNDLE_FILE): string {
   return `${createBootstrapFatalExitBanner()}${createStartupDiagnosticsBanner(mainFileName)}
-let compileCacheModule
 try {
-  compileCacheModule = require('node:module')
-  if (typeof compileCacheModule.enableCompileCache === 'function') {
-    let cacheDirectory = process.env.NODE_COMPILE_CACHE
-    if (typeof cacheDirectory !== 'string' || cacheDirectory.length === 0) {
-      const electronApp = require('electron').app
-      const path = require('node:path')
-      let userDataDirectory = process.env.ORCA_E2E_USER_DATA_DIR
-      if (typeof userDataDirectory !== 'string' || userDataDirectory.length === 0) {
-        const devOverride = process.env.ORCA_DEV_USER_DATA_PATH
-        userDataDirectory = electronApp.isPackaged
-          ? electronApp.getPath('userData')
-          : typeof devOverride === 'string' && devOverride.length > 0
-            ? devOverride
-            : path.join(electronApp.getPath('appData'), 'orca-dev')
+  // Why: macOS, Windows, and installed Linux have stable paths; AppImage FUSE paths change each run.
+  const isLinuxAppImage = process.platform === 'linux' && typeof process.env.APPIMAGE === 'string' && process.env.APPIMAGE.length > 0
+  if (!isLinuxAppImage) {
+    const compileCacheModule = require('node:module')
+    if (typeof compileCacheModule.enableCompileCache === 'function') {
+      let cacheDirectory = process.env.NODE_COMPILE_CACHE
+      if (typeof cacheDirectory !== 'string' || cacheDirectory.length === 0) {
+        const electronApp = require('electron').app
+        const path = require('node:path')
+        let userDataDirectory = process.env.ORCA_E2E_USER_DATA_DIR
+        if (typeof userDataDirectory !== 'string' || userDataDirectory.length === 0) {
+          const devOverride = process.env.ORCA_DEV_USER_DATA_PATH
+          userDataDirectory = electronApp.isPackaged
+            ? electronApp.getPath('userData')
+            : typeof devOverride === 'string' && devOverride.length > 0
+              ? devOverride
+              : path.join(electronApp.getPath('appData'), 'orca-dev')
+        }
+        cacheDirectory = path.join(userDataDirectory, ${JSON.stringify(MAIN_PROCESS_COMPILE_CACHE_DIRECTORY)})
       }
-      cacheDirectory = path.join(userDataDirectory, ${JSON.stringify(MAIN_PROCESS_COMPILE_CACHE_DIRECTORY)})
+      compileCacheModule.enableCompileCache(cacheDirectory)
     }
-    compileCacheModule.enableCompileCache(cacheDirectory)
   }
 } catch {
   // Why: compile caching is an optimization and must never prevent launch.
 }
 
 module.exports = require(${JSON.stringify(`./${mainFileName}`)})
-try {
-  const flushTimer = setTimeout(() => {
-    try {
-      compileCacheModule?.flushCompileCache?.()
-    } catch {
-      // Why: an unwritable cache must not affect a running main process.
-    }
-  }, 5000)
-  flushTimer.unref?.()
-} catch {
-  // Why: cache persistence must never replace the main bundle's outcome.
-}
 `
 }
 

--- a/config/build-plugins/main-process-bootstrap.ts
+++ b/config/build-plugins/main-process-bootstrap.ts
@@ -4,6 +4,7 @@ import { createBootstrapFatalExitBanner } from './bootstrap-fatal-exit-banner'
 export const MAIN_PROCESS_BOOTSTRAP_FILE = 'bootstrap.cjs'
 export const MAIN_PROCESS_BUNDLE_FILE = 'index.js'
 export const MAIN_PROCESS_COMPILE_CACHE_DIRECTORY = 'v8-compile-cache'
+export const MAIN_PROCESS_DEVELOPMENT_CACHE_PARENT_DIRECTORY = '.cache'
 
 export function createStartupDiagnosticsBanner(chunkName: string): string {
   return `
@@ -131,16 +132,17 @@ try {
       if (typeof cacheDirectory !== 'string' || cacheDirectory.length === 0) {
         const electronApp = require('electron').app
         const path = require('node:path')
-        let userDataDirectory = process.env.ORCA_E2E_USER_DATA_DIR
-        if (typeof userDataDirectory !== 'string' || userDataDirectory.length === 0) {
+        let cacheRoot = process.env.ORCA_E2E_USER_DATA_DIR
+        if (typeof cacheRoot !== 'string' || cacheRoot.length === 0) {
           const devOverride = process.env.ORCA_DEV_USER_DATA_PATH
-          userDataDirectory = electronApp.isPackaged
+          // Why: generated source-local storage disappears with its workspace instead of orphaning path-keyed entries in shared app data.
+          cacheRoot = electronApp.isPackaged
             ? electronApp.getPath('userData')
             : typeof devOverride === 'string' && devOverride.length > 0
               ? devOverride
-              : path.join(electronApp.getPath('appData'), 'orca-dev')
+              : path.join(__dirname, '..', ${JSON.stringify(MAIN_PROCESS_DEVELOPMENT_CACHE_PARENT_DIRECTORY)})
         }
-        cacheDirectory = path.join(userDataDirectory, ${JSON.stringify(MAIN_PROCESS_COMPILE_CACHE_DIRECTORY)})
+        cacheDirectory = path.join(cacheRoot, ${JSON.stringify(MAIN_PROCESS_COMPILE_CACHE_DIRECTORY)})
       }
       compileCacheModule.enableCompileCache(cacheDirectory)
     }

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -127,6 +127,8 @@ module.exports = {
     '!Casks{,/**/*}',
     '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md,ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md,ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md}',
     '!out/**/*.test.js',
+    // Why: source launches write a worktree-local cache that must never enter app.asar.
+    '!out/.cache{,/**/*}',
     // Why: Vite's manifest is only used to project the paired web client.
     '!out/renderer/.vite{,/**/*}',
     '!electron.vite.config.{js,ts,mjs,cjs}',

--- a/config/packaged-runtime-node-modules.cjs
+++ b/config/packaged-runtime-node-modules.cjs
@@ -218,7 +218,11 @@ function verifyPackagedMainRuntimeDeps(resourcesDir, asar = require('@electron/a
     return
   }
 
-  const mainFiles = ['out/main/index.js', 'out/main/agent-hooks/managed-agent-hook-controls.js']
+  const mainFiles = [
+    'out/main/bootstrap.cjs',
+    'out/main/index.js',
+    'out/main/agent-hooks/managed-agent-hook-controls.js'
+  ]
   const entries = asar.listPackage(asarPath)
   const missing = new Set()
 

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -44,6 +44,7 @@ describe('electron-builder config', () => {
         '!Casks{,/**/*}',
         '!{AGENTS.md,CLAUDE.md,DEVELOPING.md,bundle-size-progress.md,ORCHESTRATION_IMPLEMENTATION_CHECKLIST.md,ORCHESTRATION_STRUCTURED_OUTPUT_DESIGN.md}',
         '!out/**/*.test.js',
+        '!out/.cache{,/**/*}',
         '!resources/plugins/launch/**'
       ])
     )
@@ -70,6 +71,16 @@ describe('electron-builder config', () => {
     }
     // The negation stays anchored at the app root, so nested `examples` segments still ship.
     expect(packs('out/main/examples/index.js')).toBe(true)
+  })
+
+  it('keeps source-launch compile caches out of app.asar', () => {
+    const matcher = new FileMatcher('/app', '/dest', (value) => value, electronBuilderConfig.files)
+    matcher.prependPattern('**/*')
+    const isPacked = matcher.createFilter()
+    const packs = (repoPath) => isPacked(join('/app', repoPath), { isDirectory: () => false })
+
+    expect(packs('out/.cache/v8-compile-cache/v24/cache-entry')).toBe(false)
+    expect(packs('out/main/bootstrap.cjs')).toBe(true)
   })
 
   it('keeps runtime resources available through extraResources', () => {

--- a/config/scripts/electron-builder-config.test.mjs
+++ b/config/scripts/electron-builder-config.test.mjs
@@ -280,6 +280,7 @@ describe('electron-builder config', () => {
       await mkdir(join(resourcesDir, 'node_modules', 'zod'), { recursive: true })
 
       const sources = new Map([
+        ['out\\main\\bootstrap.cjs', 'module.exports = require("./index.js")'],
         ['out\\main\\index.js', 'const z = require("zod")'],
         ['out\\main\\agent-hooks\\managed-agent-hook-controls.js', 'const YAML = require("yaml")']
       ])
@@ -295,10 +296,30 @@ describe('electron-builder config', () => {
   })
 
   it('normalizes host-specific asar entry separators', () => {
+    expect(findAsarEntry(['\\out\\main\\bootstrap.cjs'], 'out/main/bootstrap.cjs')).toBe(
+      '\\out\\main\\bootstrap.cjs'
+    )
     expect(findAsarEntry(['\\out\\main\\index.js'], 'out/main/index.js')).toBe(
       '\\out\\main\\index.js'
     )
     expect(findAsarEntry(['/out/main/index.js'], 'out/main/index.js')).toBe('/out/main/index.js')
+  })
+
+  it('rejects a package that omits the main-process bootstrap', async () => {
+    const resourcesDir = await mkdtemp(join(tmpdir(), 'orca-bootstrap-package-'))
+    try {
+      await writeFile(join(resourcesDir, 'app.asar'), '', 'utf8')
+      const asar = {
+        listPackage: () => ['/out/main/index.js'],
+        extractFile: () => Buffer.from('', 'utf8')
+      }
+
+      expect(() => verifyPackagedMainRuntimeDeps(resourcesDir, asar)).toThrow(
+        'Packaged main file out/main/bootstrap.cjs was not found'
+      )
+    } finally {
+      await rm(resourcesDir, { recursive: true, force: true })
+    }
   })
 
   it('prunes non-target node-pty architecture outputs from packaged runtime resources', async () => {

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -16,6 +16,7 @@ import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap
 
 const targetConfig = readFileSync('config/electron-vite-target.config.ts', 'utf8')
 const devRunner = readFileSync('config/scripts/run-electron-vite-dev.mjs', 'utf8')
+const packageJson = JSON.parse(readFileSync('package.json', 'utf8')) as { main?: string }
 
 type BootstrapProcessMock = EventEmitter & {
   env: Record<string, string>
@@ -68,6 +69,16 @@ function failBootstrapWithBanner(options: {
 }
 
 describe('Electron Vite output contract', () => {
+  it('launches through the generated CommonJS bootstrap', () => {
+    expect(packageJson.main).toBe('./out/main/bootstrap.cjs')
+    expect(
+      electronViteConfig.main?.build?.rollupOptions?.plugins?.some(
+        (plugin) =>
+          plugin && typeof plugin === 'object' && plugin.name === 'orca-main-process-bootstrap'
+      )
+    ).toBe(true)
+  })
+
   it('keeps main-process and plain-Node entries at stable CommonJS paths', () => {
     const output = electronViteConfig.main?.build?.rollupOptions?.output
     if (!output || Array.isArray(output)) {

--- a/config/scripts/run-codex-real-account-validation.mjs
+++ b/config/scripts/run-codex-real-account-validation.mjs
@@ -333,14 +333,14 @@ export function resolveElectronViteBuildCommand(repoRoot) {
   if (!existsSync(electronViteEntry)) {
     throw new Error(
       `Cannot build the validation app: electron-vite entry not found at ${electronViteEntry}. ` +
-        'Install dependencies (pnpm install) or pass --skip-build with a prebuilt out/main/index.js.'
+        'Install dependencies (pnpm install) or pass --skip-build with a prebuilt out/main/bootstrap.cjs.'
     )
   }
   return { command: process.execPath, args: [electronViteEntry, 'build', '--mode', 'e2e'] }
 }
 
 function buildAppIfNeeded(repoRoot, skipBuild) {
-  const mainPath = path.join(repoRoot, 'out', 'main', 'index.js')
+  const mainPath = path.join(repoRoot, 'out', 'main', 'bootstrap.cjs')
   if (skipBuild) {
     if (!existsSync(mainPath)) {
       throw new Error(`--skip-build requested, but ${mainPath} does not exist`)

--- a/config/scripts/run-idle-cpu-benchmark.mjs
+++ b/config/scripts/run-idle-cpu-benchmark.mjs
@@ -91,7 +91,7 @@ function parseArgs(argv) {
 }
 function printUsage() {
   console.log(
-    `Usage: node config/scripts/run-idle-cpu-benchmark.mjs [options]\n\nOptions:\n  --warmup-ms <n>    Time to wait after app readiness before sampling (default ${DEFAULT_WARMUP_MS})\n  --sample-ms <n>    Sampling window duration (default ${DEFAULT_SAMPLE_MS})\n  --interval-ms <n>  Sampling cadence (default ${DEFAULT_INTERVAL_MS})\n  --worktrees <n>    Seed repo worktree count, including primary (default ${DEFAULT_WORKTREE_COUNT})\n  --headful          Show the Electron window while measuring\n  --skip-build       Reuse out/main/index.js instead of building first\n  --output <path>    Write JSON report to this path\n  --disable-renderer-animations  Inject measurement-only CSS that disables animations/transitions\n  --synthetic-visible-spinners <n>  Measurement-only: add visible working spinners\n  --synthetic-spinner-animation <smooth|steps>  Spinner animation style (default smooth)\n  --synthetic-spinner-steps <n>  Step count for --synthetic-spinner-animation steps (default 12)\n`
+    `Usage: node config/scripts/run-idle-cpu-benchmark.mjs [options]\n\nOptions:\n  --warmup-ms <n>    Time to wait after app readiness before sampling (default ${DEFAULT_WARMUP_MS})\n  --sample-ms <n>    Sampling window duration (default ${DEFAULT_SAMPLE_MS})\n  --interval-ms <n>  Sampling cadence (default ${DEFAULT_INTERVAL_MS})\n  --worktrees <n>    Seed repo worktree count, including primary (default ${DEFAULT_WORKTREE_COUNT})\n  --headful          Show the Electron window while measuring\n  --skip-build       Reuse out/main/bootstrap.cjs instead of building first\n  --output <path>    Write JSON report to this path\n  --disable-renderer-animations  Inject measurement-only CSS that disables animations/transitions\n  --synthetic-visible-spinners <n>  Measurement-only: add visible working spinners\n  --synthetic-spinner-animation <smooth|steps>  Spinner animation style (default smooth)\n  --synthetic-spinner-steps <n>  Step count for --synthetic-spinner-animation steps (default 12)\n`
   )
 }
 function run(command, args, options = {}) {
@@ -99,7 +99,7 @@ function run(command, args, options = {}) {
 }
 
 function buildAppIfNeeded(root, skipBuild) {
-  const mainPath = path.join(root, 'out', 'main', 'index.js')
+  const mainPath = path.join(root, 'out', 'main', 'bootstrap.cjs')
   if (skipBuild && existsSync(mainPath)) {
     return mainPath
   }

--- a/config/scripts/verify-linux-wayland-gpu-sandbox.mjs
+++ b/config/scripts/verify-linux-wayland-gpu-sandbox.mjs
@@ -20,7 +20,7 @@ import {
 } from './linux-wayland-validation-watchdog.mjs'
 
 const rootDir = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
-const outMain = path.join(rootDir, 'out', 'main', 'index.js')
+const outMain = path.join(rootDir, 'out', 'main', 'bootstrap.cjs')
 const timeoutMs = 45_000
 const rendererSetupTimeoutMs = 30_000
 const appCloseTimeoutMs = 5_000
@@ -80,7 +80,7 @@ function ensureElectronRuntime() {
 
 function buildAppIfNeeded() {
   if (process.env.SKIP_BUILD === '1' && existsSync(outMain)) {
-    console.log('[wayland-gpu] SKIP_BUILD=1 and out/main/index.js exists; skipping build.')
+    console.log('[wayland-gpu] SKIP_BUILD=1 and out/main/bootstrap.cjs exists; skipping build.')
     return
   }
   run('npx', ['electron-vite', 'build', '--mode', 'e2e'])

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -3,7 +3,7 @@ import { resolve } from 'node:path'
 import { defineConfig, type UserConfig } from 'electron-vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
-import { createBootstrapFatalExitBanner } from './config/build-plugins/bootstrap-fatal-exit-banner'
+import { createMainProcessBootstrapPlugin } from './config/build-plugins/main-process-bootstrap'
 import { createPlainNodeEntryGuardPlugin } from './config/build-plugins/plain-node-entry-guard'
 import packageJson from './package.json' with { type: 'json' }
 
@@ -57,139 +57,6 @@ const ORCA_DIAGNOSTICS_TOKEN_URL_LITERAL =
   typeof orcaDiagnosticsTokenUrl === 'string' && orcaDiagnosticsTokenUrl.length > 0
     ? JSON.stringify(orcaDiagnosticsTokenUrl)
     : 'null'
-
-function createStartupDiagnosticsBanner(chunkName: string): string {
-  return `
-;(() => {
-  const env = typeof process !== 'undefined' ? process.env : undefined
-  const mode = env?.ORCA_STARTUP_DIAGNOSTICS
-  if (mode !== '1' && mode !== 'trace') {
-    return
-  }
-  const safeJson = (value) => {
-    try {
-      return JSON.stringify(value)
-    } catch {
-      return '"<unserializable>"'
-    }
-  }
-  let closeSync
-  let diagnosticFileDescriptor
-  let openSync
-  let writeSync
-  try {
-    const fs = require('node:fs')
-    closeSync = fs.closeSync
-    openSync = fs.openSync
-    writeSync = fs.writeSync
-  } catch {
-    closeSync = undefined
-    openSync = undefined
-    writeSync = undefined
-  }
-  const diagnosticFile = env?.ORCA_STARTUP_DIAGNOSTICS_FILE
-  if (typeof diagnosticFile === 'string' && diagnosticFile.length > 0 && typeof openSync === 'function') {
-    try {
-      diagnosticFileDescriptor = openSync(diagnosticFile, 'a', 0o600)
-    } catch {
-      diagnosticFileDescriptor = undefined
-    }
-  }
-  const writeLine = (message) => {
-    try {
-      const line = message.endsWith('\\n') ? message : message + '\\n'
-      if (typeof writeSync === 'function') {
-        writeSync(2, line)
-        if (typeof diagnosticFileDescriptor === 'number') {
-          writeSync(diagnosticFileDescriptor, line)
-        }
-      }
-    } catch {
-      // Diagnostics must never affect startup.
-    }
-  }
-  const chunkName = ${JSON.stringify(chunkName)}
-  writeLine('[bootstrap] bundle-enter chunk=' + safeJson(chunkName) + ' pid=' + process.pid + ' ppid=' + process.ppid + ' execPath=' + safeJson(process.execPath) + ' argv=' + safeJson(process.argv) + ' electronRunAsNode=' + safeJson(env?.ELECTRON_RUN_AS_NODE ?? null))
-  if (!globalThis.__ORCA_BOOTSTRAP_EXIT_LOG_INSTALLED__) {
-    globalThis.__ORCA_BOOTSTRAP_EXIT_LOG_INSTALLED__ = true
-    process.once('exit', (code) => {
-      writeLine('[bootstrap] process-exit code=' + code)
-      if (typeof closeSync === 'function' && typeof diagnosticFileDescriptor === 'number') {
-        try {
-          closeSync(diagnosticFileDescriptor)
-        } catch {
-          // Diagnostics must never affect shutdown.
-        }
-      }
-    })
-    process.on('uncaughtExceptionMonitor', (error, origin) => {
-      const message = error && typeof error === 'object' && 'stack' in error ? error.stack : error
-      writeLine('[bootstrap] uncaught-exception origin=' + safeJson(origin) + ' error=' + safeJson(String(message)))
-    })
-    process.on('unhandledRejection', (reason) => {
-      const message = reason && typeof reason === 'object' && 'stack' in reason ? reason.stack : reason
-      writeLine('[bootstrap] unhandled-rejection error=' + safeJson(String(message)))
-    })
-  }
-  if (mode === 'trace' && !globalThis.__ORCA_BOOTSTRAP_REQUIRE_TRACE_INSTALLED__) {
-    globalThis.__ORCA_BOOTSTRAP_REQUIRE_TRACE_INSTALLED__ = true
-    try {
-      const Module = require('node:module')
-      const originalLoad = Module._load
-      const parsedTraceLimit = Number(env?.ORCA_STARTUP_DIAGNOSTICS_TRACE_LIMIT ?? 20000)
-      const traceLimit = Number.isFinite(parsedTraceLimit) && parsedTraceLimit > 0 ? parsedTraceLimit : 20000
-      let traceLineCount = 0
-      let traceLimitReported = false
-      const writeTraceLine = (message) => {
-        if (traceLineCount >= traceLimit) {
-          if (!traceLimitReported) {
-            traceLimitReported = true
-            writeLine('[bootstrap] require-trace-limit-reached limit=' + safeJson(traceLimit))
-          }
-          return
-        }
-        traceLineCount += 1
-        writeLine(message)
-      }
-      Module._load = function (request, parent, isMain) {
-        const parentName = parent && parent.filename ? parent.filename : null
-        writeTraceLine('[bootstrap] require-start request=' + safeJson(request) + ' parent=' + safeJson(parentName) + ' isMain=' + safeJson(Boolean(isMain)))
-        try {
-          const result = Reflect.apply(originalLoad, this, arguments)
-          writeTraceLine('[bootstrap] require-ok request=' + safeJson(request))
-          return result
-        } catch (error) {
-          const message = error && typeof error === 'object' && 'stack' in error ? error.stack : error
-          writeTraceLine('[bootstrap] require-error request=' + safeJson(request) + ' error=' + safeJson(String(message)))
-          throw error
-        }
-      }
-    } catch (error) {
-      writeLine('[bootstrap] require-trace-install-error error=' + safeJson(String(error)))
-    }
-  }
-})();
-`
-}
-
-function createMainBootstrapPlugin() {
-  return {
-    name: 'orca-main-bootstrap',
-    generateBundle(_options, bundle) {
-      const mainChunk = bundle['index.js']
-      if (!mainChunk || mainChunk.type !== 'chunk') {
-        return
-      }
-
-      // Why: source guards and diagnostics run after Rollup's generated require
-      // prelude, too late to handle a missing bootstrap dependency.
-      mainChunk.code =
-        createBootstrapFatalExitBanner() +
-        createStartupDiagnosticsBanner(mainChunk.fileName) +
-        mainChunk.code
-    }
-  }
-}
 
 export const electronViteConfig: UserConfig = {
   main: {
@@ -254,7 +121,7 @@ export const electronViteConfig: UserConfig = {
           entryFileNames: '[name].js',
           chunkFileNames: 'chunks/[name]-[hash].js'
         },
-        plugins: [createMainBootstrapPlugin(), createPlainNodeEntryGuardPlugin()]
+        plugins: [createMainProcessBootstrapPlugin(), createPlainNodeEntryGuardPlugin()]
       }
     },
     // Why: compile-time substitution for the telemetry gate. See the block

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "orca": "./out/cli/index.js",
     "orca-dev": "./config/scripts/orca-dev.mjs"
   },
-  "main": "./out/main/index.js",
+  "main": "./out/main/bootstrap.cjs",
   "scripts": {
     "format": "oxfmt --write .",
     "lint": "oxlint && pnpm run audit:code-quality:native && pnpm run audit:code-quality:type-aware && pnpm run check:reliability-gates && pnpm run check:max-lines-ratchet && pnpm run verify:bundled-skill-guides && pnpm run verify:skill-bundle-manifest && pnpm run verify:localization-catalog && pnpm run verify:localization-extraction && pnpm run verify:localization-coverage",

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -797,9 +797,12 @@ if (!hasSingleInstanceLock) {
 
 // Why: when another process holds the lock we've already exited; skip file-writing side effects so this transient process never touches userData.
 if (hasSingleInstanceLock) {
-  // Why: couple to dev-parent only for electron-vite desktop runs; `orca serve`'s parent (CLI shim/background shell) isn't the intended server lifetime.
+  // Why: benchmark IPC disconnect requests a real quit so Node persists caches through its normal exit path.
+  const shouldQuitOnParentDisconnect =
+    !isServeMode && (is.dev || process.env.ORCA_STARTUP_BENCHMARK === '1')
+  // Why: only electron-vite desktop runs should inherit the parent's PID and signal lifetime.
   const shouldCoupleToDevParent = is.dev && !isServeMode
-  installDevParentDisconnectQuit(shouldCoupleToDevParent)
+  installDevParentDisconnectQuit(shouldQuitOnParentDisconnect)
   installDevParentWatchdog(shouldCoupleToDevParent)
   installDevParentSignalQuit(shouldCoupleToDevParent)
   // Why: run after configureDevUserDataPath but before app.setName('Orca') (whenReady), which changes the resolved path on case-sensitive filesystems.

--- a/tests/e2e/global-setup.ts
+++ b/tests/e2e/global-setup.ts
@@ -1,7 +1,7 @@
 /**
  * Playwright globalSetup: builds the Electron app and creates a test git repo.
  *
- * Why: _electron.launch() needs the compiled output in out/main/index.js.
+ * Why: _electron.launch() needs the compiled output in out/main/bootstrap.cjs.
  * Running electron-vite build here ensures the tests are always against
  * the current source, without requiring the user to remember a manual step.
  *
@@ -25,13 +25,13 @@ const WEB_E2E_BUILD_TIMEOUT_MS = 300_000
 
 export default function globalSetup(): void {
   const root = process.cwd()
-  const outMain = path.join(root, 'out', 'main', 'index.js')
+  const outMain = path.join(root, 'out', 'main', 'bootstrap.cjs')
   const outCli = path.join(root, 'out', 'cli', 'index.js')
   const outWeb = path.join(root, 'out', 'web', 'web-index.html')
 
   // ── 1. Build the Electron app ──────────────────────────────────────
   if (process.env.SKIP_BUILD && existsSync(outMain)) {
-    console.error('[e2e] SKIP_BUILD set and out/main/index.js exists — skipping build')
+    console.error('[e2e] SKIP_BUILD set and out/main/bootstrap.cjs exists — skipping build')
   } else {
     // Why: --mode e2e is the build-time signal that exposes window.__store;
     // the explicit env var keeps older local overrides working too.

--- a/tests/e2e/headless-serve-desktop-activation.spec.ts
+++ b/tests/e2e/headless-serve-desktop-activation.spec.ts
@@ -125,7 +125,7 @@ test('promotes the headless owner without replacing its daemon terminal', async 
     return
   }
 
-  const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
+  const mainPath = path.join(process.cwd(), 'out', 'main', 'bootstrap.cjs')
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-serve-promotion-'))
   const homeIsolation = createHeadlessLaunchIsolation(userDataDir)
   const env = homeIsolation.env

--- a/tests/e2e/helpers/electron-launch-args.unit.test.ts
+++ b/tests/e2e/helpers/electron-launch-args.unit.test.ts
@@ -5,7 +5,7 @@ import { getOrcaElectronLaunchArgs } from './electron-launch-args'
 describe('getOrcaElectronLaunchArgs', () => {
   it('launches the package root that owns the compiled main entry', () => {
     const root = join('workspace', 'orca')
-    const mainPath = join(root, 'out', 'main', 'index.js')
+    const mainPath = join(root, 'out', 'main', 'bootstrap.cjs')
 
     expect(getOrcaElectronLaunchArgs(mainPath, true)).toEqual([root])
     expect(getOrcaElectronLaunchArgs(mainPath, false).at(-1)).toBe(root)

--- a/tests/e2e/helpers/headless-paired-runtime-host.ts
+++ b/tests/e2e/helpers/headless-paired-runtime-host.ts
@@ -203,7 +203,7 @@ export async function launchHeadlessPairedRuntimeHost(): Promise<HeadlessPairedR
       extraEnv: {},
       userDataDir
     })
-    const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
+    const mainPath = path.join(process.cwd(), 'out', 'main', 'bootstrap.cjs')
     app = await electron.launch({
       args: [
         ...getOrcaElectronLaunchArgs(mainPath, false),

--- a/tests/e2e/helpers/orca-app.ts
+++ b/tests/e2e/helpers/orca-app.ts
@@ -183,7 +183,7 @@ export const test = base.extend<OrcaTestFixtures, OrcaWorkerFixtures>({
     // Establish fixture ordering: registered path cleanup must run only after
     // this Electron fixture has released watchers, terminals, and daemons.
     void registerPostElectronShutdownCleanup
-    const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
+    const mainPath = path.join(process.cwd(), 'out', 'main', 'bootstrap.cjs')
     const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-userdata-'))
 
     if (dismissOnboarding) {

--- a/tests/e2e/helpers/orca-restart.ts
+++ b/tests/e2e/helpers/orca-restart.ts
@@ -135,7 +135,7 @@ export function createRestartSession(
   testInfo: TestInfo,
   extraEnv: Record<string, string> = {}
 ): RestartSession {
-  const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
+  const mainPath = path.join(process.cwd(), 'out', 'main', 'bootstrap.cjs')
   const userDataDir = mkdtempSync(path.join(os.tmpdir(), 'orca-e2e-restart-'))
   const headful = shouldLaunchHeadful(testInfo)
   const homeIsolation = createRestartLaunchIsolation(userDataDir, headful, extraEnv)

--- a/tests/e2e/helpers/paired-electron-client.ts
+++ b/tests/e2e/helpers/paired-electron-client.ts
@@ -157,7 +157,7 @@ export async function launchPairedElectronClient(
     extraEnv: {},
     userDataDir
   })
-  const mainPath = path.join(process.cwd(), 'out', 'main', 'index.js')
+  const mainPath = path.join(process.cwd(), 'out', 'main', 'bootstrap.cjs')
   const app = await electron.launch({
     args: getOrcaElectronLaunchArgs(mainPath, false),
     env: {

--- a/tests/tools/benchmarks/daemon-coldstart-bench.mjs
+++ b/tests/tools/benchmarks/daemon-coldstart-bench.mjs
@@ -24,7 +24,7 @@ import os from 'node:os'
 import { join, resolve } from 'node:path'
 
 const scriptDir = import.meta.dirname
-const repoRoot = resolve(scriptDir, '..', '..')
+const repoRoot = resolve(scriptDir, '..', '..', '..')
 
 const CURRENT_PROTOCOL_VERSION = 12
 const LEGACY_PROTOCOL_VERSIONS = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 11]
@@ -302,8 +302,8 @@ async function main() {
   const fixtureDir = resolve(join(os.tmpdir(), 'orca-daemon-bench', 'userdata'))
   ensureFixture(fixtureDir)
 
-  if (!args.exe && !existsSync(join(repoRoot, 'out', 'main', 'index.js'))) {
-    throw new Error('out/main/index.js missing — run `pnpm build:electron-vite` first')
+  if (!args.exe && !existsSync(join(repoRoot, 'out', 'main', 'bootstrap.cjs'))) {
+    throw new Error('out/main/bootstrap.cjs missing — run `pnpm build:electron-vite` first')
   }
 
   // A live unrelated process whose pid the stale pid files point at — the

--- a/tests/tools/benchmarks/startup-benchmark-electron-launch.mjs
+++ b/tests/tools/benchmarks/startup-benchmark-electron-launch.mjs
@@ -1,0 +1,117 @@
+import { spawn, spawnSync } from 'node:child_process'
+import { createRequire } from 'node:module'
+
+const require = createRequire(import.meta.url)
+const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000
+
+function killProcessTree(proc) {
+  if (proc.exitCode !== null || proc.signalCode !== null) {
+    return
+  }
+  if (process.platform === 'win32') {
+    spawnSync('taskkill', ['/PID', String(proc.pid), '/T', '/F'], { stdio: 'ignore' })
+  } else {
+    try {
+      proc.kill('SIGKILL')
+    } catch {
+      // already gone
+    }
+  }
+}
+
+function requestGracefulShutdown(proc) {
+  if (!proc.connected) {
+    return false
+  }
+  try {
+    // Why: Orca maps benchmark IPC disconnect to app.quit() on every platform.
+    proc.disconnect()
+    return true
+  } catch {
+    return false
+  }
+}
+
+export function runElectronStartupBenchmarkIteration(options) {
+  return new Promise((resolvePromise) => {
+    const command = options.exe ?? require('electron')
+    const commandArgs = options.exe ? [] : [options.appPath]
+    const events = []
+    const startedAt = process.hrtime.bigint()
+    const child = spawn(command, commandArgs, {
+      env: options.launchEnv,
+      stdio: ['ignore', 'ignore', 'pipe', 'ipc']
+    })
+    let exitCode = null
+    let exitSignal = null
+    let finishOutcome = null
+    let gracefulShutdownRequested = false
+    let lingerTimer = null
+    let settled = false
+    let shutdownTimer = null
+    let buffer = ''
+    const settle = (outcome) => {
+      if (settled) {
+        return
+      }
+      settled = true
+      clearTimeout(timer)
+      clearTimeout(lingerTimer)
+      clearTimeout(shutdownTimer)
+      resolvePromise({ outcome, events, exitCode, exitSignal, gracefulShutdownRequested })
+    }
+    const finish = (outcome) => {
+      if (finishOutcome !== null) {
+        return
+      }
+      finishOutcome = outcome
+      clearTimeout(timer)
+      if (outcome === 'early-exit' || outcome === 'spawn-error') {
+        settle(outcome)
+        return
+      }
+      lingerTimer = setTimeout(() => {
+        if (child.exitCode !== null || child.signalCode !== null) {
+          settle(outcome)
+          return
+        }
+        gracefulShutdownRequested = requestGracefulShutdown(child)
+        if (!gracefulShutdownRequested) {
+          killProcessTree(child)
+          settle('graceful-shutdown-unavailable')
+          return
+        }
+        shutdownTimer = setTimeout(() => {
+          killProcessTree(child)
+          settle('graceful-shutdown-timeout')
+        }, GRACEFUL_SHUTDOWN_TIMEOUT_MS)
+      }, options.lingerMs)
+    }
+    const timer = setTimeout(() => finish('timeout'), options.timeoutMs)
+    child.stderr.setEncoding('utf-8')
+    child.stderr.on('data', (chunk) => {
+      buffer += chunk
+      let newlineIndex = buffer.indexOf('\n')
+      while (newlineIndex !== -1) {
+        const line = buffer.slice(0, newlineIndex).trimEnd()
+        buffer = buffer.slice(newlineIndex + 1)
+        newlineIndex = buffer.indexOf('\n')
+        const parsed = options.parseStartupLine(line)
+        if (!parsed) {
+          continue
+        }
+        const harnessMs = Number(process.hrtime.bigint() - startedAt) / 1e6
+        events.push({ ...parsed, harnessMs: Math.round(harnessMs * 10) / 10 })
+        if (parsed.event === options.waitForEvent) {
+          finish('ok')
+        }
+      }
+    })
+    child.on('exit', (code, signal) => {
+      exitCode = code
+      exitSignal = signal
+      settle(finishOutcome ?? 'early-exit')
+    })
+    child.on('error', () => finish('spawn-error'))
+  })
+}

--- a/tests/tools/benchmarks/startup-benchmark-electron-launch.mjs
+++ b/tests/tools/benchmarks/startup-benchmark-electron-launch.mjs
@@ -1,5 +1,6 @@
 import { spawn, spawnSync } from 'node:child_process'
 import { createRequire } from 'node:module'
+import { normalizeStartupBenchmarkOutcome } from './startup-benchmark-sample.mjs'
 
 const require = createRequire(import.meta.url)
 const GRACEFUL_SHUTDOWN_TIMEOUT_MS = 30_000
@@ -58,7 +59,9 @@ export function runElectronStartupBenchmarkIteration(options) {
       clearTimeout(timer)
       clearTimeout(lingerTimer)
       clearTimeout(shutdownTimer)
-      resolvePromise({ outcome, events, exitCode, exitSignal, gracefulShutdownRequested })
+      const result = { outcome, events, exitCode, exitSignal, gracefulShutdownRequested }
+      result.outcome = normalizeStartupBenchmarkOutcome(result)
+      resolvePromise(result)
     }
     const finish = (outcome) => {
       if (finishOutcome !== null) {

--- a/tests/tools/benchmarks/startup-benchmark-sample.mjs
+++ b/tests/tools/benchmarks/startup-benchmark-sample.mjs
@@ -1,0 +1,30 @@
+export function normalizeStartupBenchmarkOutcome(sample) {
+  if (sample.outcome !== 'ok') {
+    return sample.outcome
+  }
+  if (!sample.gracefulShutdownRequested) {
+    return 'graceful-shutdown-not-requested'
+  }
+  if (sample.exitSignal !== null) {
+    return 'signal-exit'
+  }
+  if (sample.exitCode !== 0) {
+    return sample.exitCode === null ? 'missing-exit-code' : 'nonzero-exit'
+  }
+  return 'ok'
+}
+
+export function describeInvalidStartupBenchmarkSample(sample) {
+  const outcome = normalizeStartupBenchmarkOutcome(sample)
+  if (outcome === 'ok') {
+    return null
+  }
+  return `outcome=${outcome}, gracefulShutdownRequested=${String(sample.gracefulShutdownRequested)}, exitCode=${String(sample.exitCode)}, exitSignal=${String(sample.exitSignal)}`
+}
+
+export function assertValidStartupBenchmarkSample(sample) {
+  const diagnostic = describeInvalidStartupBenchmarkSample(sample)
+  if (diagnostic !== null) {
+    throw new Error(`Invalid startup benchmark sample: ${diagnostic}`)
+  }
+}

--- a/tests/tools/benchmarks/startup-benchmark-sample.test.mjs
+++ b/tests/tools/benchmarks/startup-benchmark-sample.test.mjs
@@ -1,0 +1,51 @@
+import { describe, expect, it } from 'vitest'
+import {
+  assertValidStartupBenchmarkSample,
+  normalizeStartupBenchmarkOutcome
+} from './startup-benchmark-sample.mjs'
+
+function sample(overrides = {}) {
+  return {
+    outcome: 'ok',
+    gracefulShutdownRequested: true,
+    exitCode: 0,
+    exitSignal: null,
+    ...overrides
+  }
+}
+
+describe('startup benchmark sample validity', () => {
+  it('accepts only graceful zero-code exits without a signal', () => {
+    const result = sample()
+
+    expect(normalizeStartupBenchmarkOutcome(result)).toBe('ok')
+    expect(() => assertValidStartupBenchmarkSample(result)).not.toThrow()
+  })
+
+  it('rejects a nonzero child exit with actionable metadata', () => {
+    const result = sample({ exitCode: 7 })
+
+    expect(normalizeStartupBenchmarkOutcome(result)).toBe('nonzero-exit')
+    expect(() => assertValidStartupBenchmarkSample(result)).toThrow(
+      'outcome=nonzero-exit, gracefulShutdownRequested=true, exitCode=7, exitSignal=null'
+    )
+  })
+
+  it('rejects a signaled child exit with actionable metadata', () => {
+    const result = sample({ exitCode: null, exitSignal: 'SIGTERM' })
+
+    expect(normalizeStartupBenchmarkOutcome(result)).toBe('signal-exit')
+    expect(() => assertValidStartupBenchmarkSample(result)).toThrow(
+      'outcome=signal-exit, gracefulShutdownRequested=true, exitCode=null, exitSignal=SIGTERM'
+    )
+  })
+
+  it('rejects a sample taken before graceful shutdown was requested', () => {
+    const result = sample({ gracefulShutdownRequested: false })
+
+    expect(normalizeStartupBenchmarkOutcome(result)).toBe('graceful-shutdown-not-requested')
+    expect(() => assertValidStartupBenchmarkSample(result)).toThrow(
+      'outcome=graceful-shutdown-not-requested, gracefulShutdownRequested=false, exitCode=0, exitSignal=null'
+    )
+  })
+})

--- a/tests/tools/benchmarks/startup-time-bench.mjs
+++ b/tests/tools/benchmarks/startup-time-bench.mjs
@@ -38,6 +38,7 @@ import {
 import os from 'node:os'
 import { delimiter, join, resolve } from 'node:path'
 import { runElectronStartupBenchmarkIteration } from './startup-benchmark-electron-launch.mjs'
+import { assertValidStartupBenchmarkSample } from './startup-benchmark-sample.mjs'
 
 const scriptDir = import.meta.dirname
 const repoRoot = resolve(scriptDir, '..', '..', '..')
@@ -551,6 +552,12 @@ async function main() {
       launchEnv,
       parseStartupLine
     })
+    try {
+      assertValidStartupBenchmarkSample(result)
+    } catch (error) {
+      console.log(result.outcome)
+      throw new Error(`Iteration ${i + 1} rejected: ${error.message}`, { cause: error })
+    }
     const phases = derivePhases(result.events)
     iterations.push({ ...result, phases })
     console.log(

--- a/tests/tools/benchmarks/startup-time-bench.mjs
+++ b/tests/tools/benchmarks/startup-time-bench.mjs
@@ -40,7 +40,7 @@ import os from 'node:os'
 import { delimiter, join, resolve } from 'node:path'
 
 const scriptDir = import.meta.dirname
-const repoRoot = resolve(scriptDir, '..', '..')
+const repoRoot = resolve(scriptDir, '..', '..', '..')
 const require = createRequire(import.meta.url)
 
 function parseArgs(argv) {
@@ -602,8 +602,8 @@ async function main() {
     ghShimDir
   })
 
-  if (!args.exe && !existsSync(join(repoRoot, 'out', 'main', 'index.js'))) {
-    throw new Error('out/main/index.js missing — run `pnpm build:electron-vite` first')
+  if (!args.exe && !existsSync(join(repoRoot, 'out', 'main', 'bootstrap.cjs'))) {
+    throw new Error('out/main/bootstrap.cjs missing — run `pnpm build:electron-vite` first')
   }
 
   const iterations = []

--- a/tests/tools/benchmarks/startup-time-bench.mjs
+++ b/tests/tools/benchmarks/startup-time-bench.mjs
@@ -26,7 +26,7 @@
  * Prereq (when not using --exe): `pnpm build:electron-vite` so out/ exists.
  * Results: tests/tools/benchmarks/results/startup-<label>-<timestamp>.json
  */
-import { spawn, spawnSync } from 'node:child_process'
+import { spawnSync } from 'node:child_process'
 import {
   existsSync,
   mkdirSync,
@@ -35,13 +35,12 @@ import {
   unlinkSync,
   writeFileSync
 } from 'node:fs'
-import { createRequire } from 'node:module'
 import os from 'node:os'
 import { delimiter, join, resolve } from 'node:path'
+import { runElectronStartupBenchmarkIteration } from './startup-benchmark-electron-launch.mjs'
 
 const scriptDir = import.meta.dirname
 const repoRoot = resolve(scriptDir, '..', '..', '..')
-const require = createRequire(import.meta.url)
 
 function parseArgs(argv) {
   const args = {
@@ -364,7 +363,8 @@ function buildLaunchEnvironment({ fixtureDir, githubRepos, ghShimDir }) {
     HOME: isolatedHome,
     USERPROFILE: isolatedHome,
     ORCA_E2E_HOME_DIR: isolatedHome,
-    ORCA_E2E_HEADLESS: '1'
+    ORCA_E2E_HEADLESS: '1',
+    ORCA_STARTUP_BENCHMARK: '1'
   }
   delete env.CODEX_HOME
   delete env.ORCA_CODEX_HOME
@@ -382,21 +382,6 @@ function buildLaunchEnvironment({ fixtureDir, githubRepos, ghShimDir }) {
     env.GIT_CONFIG_NOSYSTEM = '1'
   }
   return env
-}
-
-function killProcessTree(proc) {
-  if (proc.exitCode !== null || proc.signalCode !== null) {
-    return
-  }
-  if (process.platform === 'win32') {
-    spawnSync('taskkill', ['/PID', String(proc.pid), '/T', '/F'], { stdio: 'ignore' })
-  } else {
-    try {
-      proc.kill('SIGKILL')
-    } catch {
-      // already gone
-    }
-  }
 }
 
 function parseStartupLine(line) {
@@ -420,58 +405,6 @@ function parseStartupLine(line) {
     }
   }
   return { event: match[1], details }
-}
-
-function runIteration({ exe, timeoutMs, lingerMs, waitForEvent, launchEnv }) {
-  return new Promise((resolvePromise) => {
-    // Why: npm's `electron` package exposes the platform-specific executable;
-    // hardcoding electron.exe made this benchmark unusable on macOS/Linux.
-    const command = exe ?? require('electron')
-    const commandArgs = exe ? [] : [repoRoot]
-    const events = []
-    const startedAt = process.hrtime.bigint()
-    const child = spawn(command, commandArgs, {
-      env: launchEnv,
-      stdio: ['ignore', 'ignore', 'pipe']
-    })
-    let finished = false
-    let buffer = ''
-    const finish = (outcome) => {
-      if (finished) {
-        return
-      }
-      finished = true
-      clearTimeout(timer)
-      // Keep the app alive briefly so trailing diagnostic lines (and, with
-      // --linger-ms raised, background work like the async ACL grant) finish.
-      setTimeout(() => {
-        killProcessTree(child)
-        resolvePromise({ outcome, events })
-      }, lingerMs)
-    }
-    const timer = setTimeout(() => finish('timeout'), timeoutMs)
-    child.stderr.setEncoding('utf-8')
-    child.stderr.on('data', (chunk) => {
-      buffer += chunk
-      let newlineIndex = buffer.indexOf('\n')
-      while (newlineIndex !== -1) {
-        const line = buffer.slice(0, newlineIndex).trimEnd()
-        buffer = buffer.slice(newlineIndex + 1)
-        newlineIndex = buffer.indexOf('\n')
-        const parsed = parseStartupLine(line)
-        if (!parsed) {
-          continue
-        }
-        const harnessMs = Number(process.hrtime.bigint() - startedAt) / 1e6
-        events.push({ ...parsed, harnessMs: Math.round(harnessMs * 10) / 10 })
-        if (parsed.event === waitForEvent) {
-          finish('ok')
-        }
-      }
-    })
-    child.on('exit', () => finish('early-exit'))
-    child.on('error', () => finish('spawn-error'))
-  })
 }
 
 function eventTime(events, name, key) {
@@ -609,12 +542,14 @@ async function main() {
   const iterations = []
   for (let i = 0; i < args.iterations; i++) {
     process.stdout.write(`[bench] iteration ${i + 1}/${args.iterations}… `)
-    const result = await runIteration({
+    const result = await runElectronStartupBenchmarkIteration({
+      appPath: repoRoot,
       exe: args.exe,
       timeoutMs: args.timeoutMs,
       lingerMs: args.lingerMs,
       waitForEvent: args.waitForEvent,
-      launchEnv
+      launchEnv,
+      parseStartupLine
     })
     const phases = derivePhases(result.events)
     iterations.push({ ...result, phases })


### PR DESCRIPTION
## Summary

- generate a CommonJS main-process bootstrap that preserves the existing fatal-exit guard and startup diagnostics before loading any main-bundle dependency
- enable Node's supported module compile cache on macOS, Windows, and stable-path Linux launches, while deliberately skipping Linux AppImage launches because each FUSE mount changes the source paths used as cache keys
- keep packaged caches in the stable user-data profile, but place the default source-development cache under the ignored generated `out/.cache/` tree so cache entries leave with a folder or worktree; explicit `NODE_COMPILE_CACHE`, E2E roots, and development user-data overrides remain authoritative
- treat unavailable APIs, path failures, and read-only locations as non-fatal, and rely on Node's graceful-exit persistence instead of a synchronous runtime `flushCompileCache()` timer
- accept a startup benchmark sample only after graceful shutdown was requested and the child exited with code 0 and no signal; rejected samples carry the outcome and shutdown metadata and are never aggregated

## Validation

- `pnpm build:electron-vite`
- focused bootstrap/build/packaging/launch/config suite: 89 tests passed (the former 87-test set plus the new source-cache and packaging exclusions)
- benchmark validity plus shutdown/ordering suite: 21 tests passed, including nonzero exit, signal exit, and missing graceful-request cases
- `pnpm run typecheck:node`
- changed-code quality gate, focused `oxlint`, max-lines ratchet, formatting, and `git diff --check`
- generated-bootstrap missing-main smoke: startup diagnostics emitted, durable fatal log written, exit status 1
- generated bootstrap contains no `flushCompileCache` call or timer
- two cache-enabled and two cache-disabled review smoke launches were processed by the new validity gate; all four requested graceful shutdown and exited with code 0 and no signal, and they are not used as a performance comparison

## Platform and cache scope

The Orca bootstrap enables the cache for packaged macOS and Windows, Linux packages with stable install paths (such as deb/rpm), and development/E2E launches with stable source paths. It does not call `enableCompileCache()` when `process.platform === "linux"` and `APPIMAGE` is set, because the changing AppImage source mount makes Orca-created path-keyed entries miss and accumulate; an explicit user-supplied `NODE_COMPILE_CACHE` can independently enable Node's cache before app code runs, and Orca does not override that Node-level choice.

Packaged launches continue to use `<userData>/v8-compile-cache`. Default source launches use the source folder's ignored generated `out/.cache/v8-compile-cache`, without Git discovery or a worktree assumption, and electron-builder explicitly excludes that directory from `app.asar`.

## Representative measurements

macOS arm64, Electron 43.1.0 / Node 24.18.0, production source bundle, isolated empty synthetic profiles, six cache-enabled and six cache-disabled launches. Every sample listed below records `gracefulShutdownRequested: true`, `exitCode: 0`, and `exitSignal: null`; each iteration lingered 200 ms after the target milestone, then disconnected the benchmark IPC channel so Orca ran `app.quit()` and Node performed its normal exit persistence.

| measurement | cache enabled | cache disabled |
|---|---:|---:|
| first launch to `did-finish-load` (single sample) | 1178.2 ms | 1026.4 ms |
| repeat launch to `app-ready` (runs 2-6 median) | 417.9 ms | 461.0 ms |
| repeat launch to `did-finish-load` (runs 2-6 median) | 673.3 ms | 726.8 ms |
| repeat launch to workspace ready (runs 2-6 median) | 855.8 ms | 894.5 ms |

These are local source-build samples, not release gates or packaged-app results. The single cold samples show first-launch cache recording cost and should not be over-interpreted; `spawnToAppReady` is a source-compilation-oriented proxy that also includes Electron process startup and main top-level execution, so it is not a full Electron startup result.
