### PR TITLE
Minify production renderer bundles with symbolizable crash stacks

### DIFF
--- a/config/build-plugins/renderer-identity-source-map.ts
+++ b/config/build-plugins/renderer-identity-source-map.ts
@@ -1,0 +1,52 @@
+import { basename } from 'node:path'
+
+const BASE64_VLQ = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+
+function encodeVlq(value: number): string {
+  let encoded = ''
+  let remaining = value < 0 ? -value * 2 + 1 : value * 2
+  do {
+    let digit = remaining % 32
+    remaining = Math.floor(remaining / 32)
+    if (remaining > 0) {
+      digit += 32
+    }
+    encoded += BASE64_VLQ[digit]
+  } while (remaining > 0)
+  return encoded
+}
+
+function identityMappings(source: string): string {
+  let previousOriginalLine = 0
+  let previousOriginalColumn = 0
+  return source
+    .split('\n')
+    .map((line, lineIndex) => {
+      const lineLength = line.endsWith('\r') ? line.length - 1 : line.length
+      const firstSegment = [
+        encodeVlq(0),
+        encodeVlq(0),
+        encodeVlq(lineIndex - previousOriginalLine),
+        encodeVlq(-previousOriginalColumn)
+      ].join('')
+      previousOriginalLine = lineIndex
+      previousOriginalColumn = lineLength
+      return `${firstSegment}${',CAAC'.repeat(lineLength)}`
+    })
+    .join(';')
+}
+
+export function rendererIdentitySource(fileName: string): string {
+  return `source-map-identity/${basename(fileName)}`
+}
+
+export function createRendererIdentitySourceMap(fileName: string, source: string): string {
+  return JSON.stringify({
+    version: 3,
+    file: basename(fileName),
+    names: [],
+    sources: [rendererIdentitySource(fileName)],
+    sourcesContent: [source],
+    mappings: identityMappings(source)
+  })
+}

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -22,26 +22,13 @@ export const rendererProductionOutput = {
   minify: rendererProductionMinifyOptions
 } as const
 
-function removeSourcesContent(value: unknown): void {
-  if (Array.isArray(value)) {
-    value.forEach(removeSourcesContent)
-  } else if (value && typeof value === 'object') {
-    const record = value as Record<string, unknown>
-    delete record.sourcesContent
-    Object.values(record).forEach(removeSourcesContent)
-  }
-}
-
 function compactSourceMaps(directory: string): void {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const filePath = join(directory, entry.name)
     if (entry.isDirectory()) {
       compactSourceMaps(filePath)
     } else if (entry.name.endsWith('.js.map')) {
-      const sourceMap = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>
-      // Why: mappings plus the asset hash keep symbolization without 100 MB of source copies.
-      removeSourcesContent(sourceMap)
-      writeFileSync(`${filePath}.gz`, gzipSync(JSON.stringify(sourceMap), { level: 9 }))
+      writeFileSync(`${filePath}.gz`, gzipSync(readFileSync(filePath), { level: 9 }))
       unlinkSync(filePath)
     }
   }

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -17,6 +17,11 @@ export const rendererProductionMinifyOptions = {
   }
 } as const
 
+export const rendererProductionOutput = {
+  keepNames: true,
+  minify: rendererProductionMinifyOptions
+} as const
+
 function compactSourceMaps(directory: string): void {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const filePath = join(directory, entry.name)

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -1,8 +1,23 @@
 import { createHash } from 'node:crypto'
-import { readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
 import { isAbsolute, join, resolve } from 'node:path'
 import { gzipSync } from 'node:zlib'
-import type { BuildOptions, Plugin } from 'vite'
+import type { BuildOptions, Plugin, Rollup } from 'vite'
+
+export type RendererSourceMapMode =
+  | 'mapped'
+  | 'mappingless-json'
+  | 'source-less-asset'
+  | 'source-less-facade'
+  | 'source-less-generated'
+
+const sourceMapModePriority: Record<RendererSourceMapMode, number> = {
+  'source-less-asset': 0,
+  'source-less-facade': 1,
+  'source-less-generated': 2,
+  'mappingless-json': 3,
+  mapped: 4
+}
 
 export const rendererProductionBuild: Pick<BuildOptions, 'minify' | 'sourcemap'> = {
   minify: 'oxc',
@@ -23,6 +38,35 @@ export const rendererProductionOutput = {
   minify: rendererProductionMinifyOptions
 } as const
 
+function isJsonModule(moduleId: string): boolean {
+  return moduleId.split('?', 1)[0].endsWith('.json')
+}
+
+function classifySourceMap(output: Rollup.OutputAsset | Rollup.OutputChunk): RendererSourceMapMode {
+  if (output.type === 'asset') {
+    return 'source-less-asset'
+  }
+  const moduleIds = Object.keys(output.modules)
+  if (
+    output.code.length === 0 ||
+    moduleIds.length === 0 ||
+    Object.values(output.modules).every((module) => module.renderedLength === 0)
+  ) {
+    return 'source-less-facade'
+  }
+  if (moduleIds.every((moduleId) => moduleId.startsWith('\0') || moduleId === 'rolldown:runtime')) {
+    return 'source-less-generated'
+  }
+  if (
+    moduleIds.every(isJsonModule) &&
+    output.map?.mappings === '' &&
+    output.map.sources.length > 0
+  ) {
+    return 'mappingless-json'
+  }
+  return 'mapped'
+}
+
 export function createRendererSourceMapProvenancePlugin(): Plugin {
   return {
     name: 'orca-renderer-source-map-provenance',
@@ -34,7 +78,7 @@ export function createRendererSourceMapProvenancePlugin(): Plugin {
             ? [
                 {
                   file: output.fileName.replaceAll('\\', '/'),
-                  sourceMap: output.type === 'chunk' && Boolean(output.map)
+                  sourceMap: classifySourceMap(output)
                 }
               ]
             : []
@@ -68,13 +112,16 @@ function finalizeSourceMapProvenance(directory: string): void {
   const provenanceFiles = readdirSync(provenanceDirectory).filter((entry) =>
     entry.endsWith('.json')
   )
-  const sourceMapByFile = new Map<string, boolean>()
+  const sourceMapByFile = new Map<string, RendererSourceMapMode>()
   for (const provenanceFile of provenanceFiles) {
     const provenance = JSON.parse(
       readFileSync(join(provenanceDirectory, provenanceFile), 'utf8')
-    ) as { chunks: { file: string; sourceMap: boolean }[] }
+    ) as { chunks: { file: string; sourceMap: RendererSourceMapMode }[] }
     for (const chunk of provenance.chunks) {
-      sourceMapByFile.set(chunk.file, Boolean(sourceMapByFile.get(chunk.file)) || chunk.sourceMap)
+      const previous = sourceMapByFile.get(chunk.file)
+      if (!previous || sourceMapModePriority[chunk.sourceMap] > sourceMapModePriority[previous]) {
+        sourceMapByFile.set(chunk.file, chunk.sourceMap)
+      }
     }
   }
   const chunks = listOutputFiles(directory)
@@ -90,6 +137,12 @@ function finalizeSourceMapProvenance(directory: string): void {
   for (const provenanceFile of provenanceFiles) {
     unlinkSync(join(provenanceDirectory, provenanceFile))
   }
+  for (const chunk of chunks) {
+    const mapPath = join(directory, `${chunk.file}.map.gz`)
+    if (chunk.sourceMap.startsWith('source-less-') && existsSync(mapPath)) {
+      unlinkSync(mapPath)
+    }
+  }
   writeFileSync(
     join(provenanceDirectory, 'complete.json'),
     `${JSON.stringify({ version: 1, chunks })}\n`
@@ -103,15 +156,7 @@ function compactSourceMaps(directory: string): void {
       compactSourceMaps(filePath)
     } else if (entry.name.endsWith('.js.map')) {
       const source = readFileSync(filePath)
-      const sourceMap = JSON.parse(source.toString('utf8')) as {
-        mappings?: unknown
-        sources?: unknown[]
-      }
-      const compactedSource =
-        sourceMap.mappings === '' && sourceMap.sources?.length
-          ? Buffer.from(JSON.stringify({ ...sourceMap, mappings: 'AAAA' }))
-          : source
-      writeFileSync(`${filePath}.gz`, gzipSync(compactedSource, { level: 9 }))
+      writeFileSync(`${filePath}.gz`, gzipSync(source, { level: 9 }))
       unlinkSync(filePath)
     }
   }

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -22,6 +22,16 @@ export const rendererProductionOutput = {
   minify: rendererProductionMinifyOptions
 } as const
 
+function removeSourcesContent(value: unknown): void {
+  if (Array.isArray(value)) {
+    value.forEach(removeSourcesContent)
+  } else if (value && typeof value === 'object') {
+    const record = value as Record<string, unknown>
+    delete record.sourcesContent
+    Object.values(record).forEach(removeSourcesContent)
+  }
+}
+
 function compactSourceMaps(directory: string): void {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const filePath = join(directory, entry.name)
@@ -30,7 +40,7 @@ function compactSourceMaps(directory: string): void {
     } else if (entry.name.endsWith('.js.map')) {
       const sourceMap = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>
       // Why: mappings plus the asset hash keep symbolization without 100 MB of source copies.
-      delete sourceMap.sourcesContent
+      removeSourcesContent(sourceMap)
       writeFileSync(`${filePath}.gz`, gzipSync(JSON.stringify(sourceMap), { level: 9 }))
       unlinkSync(filePath)
     }

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -1,5 +1,6 @@
+import { createHash } from 'node:crypto'
 import { readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
-import { join } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import type { BuildOptions, Plugin } from 'vite'
 
@@ -22,13 +23,95 @@ export const rendererProductionOutput = {
   minify: rendererProductionMinifyOptions
 } as const
 
+export function createRendererSourceMapProvenancePlugin(): Plugin {
+  return {
+    name: 'orca-renderer-source-map-provenance',
+    apply: 'build',
+    generateBundle: function (_options, bundle) {
+      const chunks = Object.values(bundle)
+        .flatMap((output) =>
+          /\.m?js$/.test(output.fileName)
+            ? [
+                {
+                  file: output.fileName.replaceAll('\\', '/'),
+                  sourceMap: output.type === 'chunk' && Boolean(output.map)
+                }
+              ]
+            : []
+        )
+        .sort((left, right) => (left.file < right.file ? -1 : left.file > right.file ? 1 : 0))
+      if (chunks.length === 0) {
+        return
+      }
+      const source = `${JSON.stringify({ version: 1, chunks })}\n`
+      const digest = createHash('sha256').update(source).digest('hex').slice(0, 16)
+      this.emitFile({
+        type: 'asset',
+        fileName: `source-map-provenance/bundle-${digest}.json`,
+        source
+      })
+    }
+  }
+}
+
+function listOutputFiles(directory: string, prefix = ''): string[] {
+  return readdirSync(directory, { withFileTypes: true }).flatMap((entry) => {
+    const outputPath = prefix ? join(prefix, entry.name) : entry.name
+    return entry.isDirectory()
+      ? listOutputFiles(join(directory, entry.name), outputPath)
+      : [outputPath.replaceAll('\\', '/')]
+  })
+}
+
+function finalizeSourceMapProvenance(directory: string): void {
+  const provenanceDirectory = join(directory, 'source-map-provenance')
+  const provenanceFiles = readdirSync(provenanceDirectory).filter((entry) =>
+    entry.endsWith('.json')
+  )
+  const sourceMapByFile = new Map<string, boolean>()
+  for (const provenanceFile of provenanceFiles) {
+    const provenance = JSON.parse(
+      readFileSync(join(provenanceDirectory, provenanceFile), 'utf8')
+    ) as { chunks: { file: string; sourceMap: boolean }[] }
+    for (const chunk of provenance.chunks) {
+      sourceMapByFile.set(chunk.file, Boolean(sourceMapByFile.get(chunk.file)) || chunk.sourceMap)
+    }
+  }
+  const chunks = listOutputFiles(directory)
+    .filter((outputPath) => /\.m?js$/.test(outputPath))
+    .sort()
+    .map((file) => {
+      const sourceMap = sourceMapByFile.get(file)
+      if (sourceMap === undefined) {
+        throw new Error(`Missing bundler source-map provenance for ${file}`)
+      }
+      return { file, sourceMap }
+    })
+  for (const provenanceFile of provenanceFiles) {
+    unlinkSync(join(provenanceDirectory, provenanceFile))
+  }
+  writeFileSync(
+    join(provenanceDirectory, 'complete.json'),
+    `${JSON.stringify({ version: 1, chunks })}\n`
+  )
+}
+
 function compactSourceMaps(directory: string): void {
   for (const entry of readdirSync(directory, { withFileTypes: true })) {
     const filePath = join(directory, entry.name)
     if (entry.isDirectory()) {
       compactSourceMaps(filePath)
     } else if (entry.name.endsWith('.js.map')) {
-      writeFileSync(`${filePath}.gz`, gzipSync(readFileSync(filePath), { level: 9 }))
+      const source = readFileSync(filePath)
+      const sourceMap = JSON.parse(source.toString('utf8')) as {
+        mappings?: unknown
+        sources?: unknown[]
+      }
+      const compactedSource =
+        sourceMap.mappings === '' && sourceMap.sources?.length
+          ? Buffer.from(JSON.stringify({ ...sourceMap, mappings: 'AAAA' }))
+          : source
+      writeFileSync(`${filePath}.gz`, gzipSync(compactedSource, { level: 9 }))
       unlinkSync(filePath)
     }
   }
@@ -40,8 +123,13 @@ export function createRendererSourceMapCompactionPlugin(): Plugin {
     name: 'orca-renderer-source-map-compaction',
     apply: 'build',
     configResolved: (config) => {
-      outDir = config.build.outDir
+      outDir = isAbsolute(config.build.outDir)
+        ? config.build.outDir
+        : resolve(config.root, config.build.outDir)
     },
-    closeBundle: () => compactSourceMaps(outDir)
+    closeBundle: () => {
+      compactSourceMaps(outDir)
+      finalizeSourceMapProvenance(outDir)
+    }
   }
 }

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -1,0 +1,45 @@
+import { readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import { join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import type { BuildOptions, Plugin } from 'vite'
+
+export const rendererProductionBuild: Pick<BuildOptions, 'minify' | 'sourcemap'> = {
+  minify: 'oxc',
+  sourcemap: 'hidden'
+}
+
+export const rendererProductionMinifyOptions = {
+  compress: {
+    keepNames: { function: true, class: true }
+  },
+  mangle: {
+    keepNames: { function: true, class: true }
+  }
+} as const
+
+function compactSourceMaps(directory: string): void {
+  for (const entry of readdirSync(directory, { withFileTypes: true })) {
+    const filePath = join(directory, entry.name)
+    if (entry.isDirectory()) {
+      compactSourceMaps(filePath)
+    } else if (entry.name.endsWith('.js.map')) {
+      const sourceMap = JSON.parse(readFileSync(filePath, 'utf8')) as Record<string, unknown>
+      // Why: mappings plus the asset hash keep symbolization without 100 MB of source copies.
+      delete sourceMap.sourcesContent
+      writeFileSync(`${filePath}.gz`, gzipSync(JSON.stringify(sourceMap), { level: 9 }))
+      unlinkSync(filePath)
+    }
+  }
+}
+
+export function createRendererSourceMapCompactionPlugin(): Plugin {
+  let outDir = ''
+  return {
+    name: 'orca-renderer-source-map-compaction',
+    apply: 'build',
+    configResolved: (config) => {
+      outDir = config.build.outDir
+    },
+    closeBundle: () => compactSourceMaps(outDir)
+  }
+}

--- a/config/build-plugins/renderer-production-minification.ts
+++ b/config/build-plugins/renderer-production-minification.ts
@@ -1,22 +1,23 @@
 import { createHash } from 'node:crypto'
-import { existsSync, readFileSync, readdirSync, unlinkSync, writeFileSync } from 'node:fs'
+import {
+  existsSync,
+  readFileSync,
+  readdirSync,
+  realpathSync,
+  unlinkSync,
+  writeFileSync
+} from 'node:fs'
+import { createRequire } from 'node:module'
 import { isAbsolute, join, resolve } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import type { BuildOptions, Plugin, Rollup } from 'vite'
+import { createRendererIdentitySourceMap } from './renderer-identity-source-map'
 
-export type RendererSourceMapMode =
-  | 'mapped'
-  | 'mappingless-json'
-  | 'source-less-asset'
-  | 'source-less-facade'
-  | 'source-less-generated'
+export type RendererSourceMapMode = 'identity-generated' | 'mapped'
 
 const sourceMapModePriority: Record<RendererSourceMapMode, number> = {
-  'source-less-asset': 0,
-  'source-less-facade': 1,
-  'source-less-generated': 2,
-  'mappingless-json': 3,
-  mapped: 4
+  'identity-generated': 0,
+  mapped: 1
 }
 
 export const rendererProductionBuild: Pick<BuildOptions, 'minify' | 'sourcemap'> = {
@@ -33,6 +34,16 @@ export const rendererProductionMinifyOptions = {
   }
 } as const
 
+const nodeRequire = createRequire(import.meta.url)
+const { isJavaScriptOutputPath, isRawJavaScriptSourceMapPath } = nodeRequire(
+  '../scripts/renderer-javascript-output.cjs'
+) as {
+  isJavaScriptOutputPath: (fileName: string) => boolean
+  isRawJavaScriptSourceMapPath: (fileName: string) => boolean
+}
+const pdfWorkerPath = realpathSync(nodeRequire.resolve('pdfjs-dist/build/pdf.worker.min.mjs'))
+const pdfWorkerSource = readFileSync(pdfWorkerPath)
+
 export const rendererProductionOutput = {
   keepNames: true,
   minify: rendererProductionMinifyOptions
@@ -42,43 +53,80 @@ function isJsonModule(moduleId: string): boolean {
   return moduleId.split('?', 1)[0].endsWith('.json')
 }
 
-function classifySourceMap(output: Rollup.OutputAsset | Rollup.OutputChunk): RendererSourceMapMode {
+function isPdfWorkerAsset(output: Rollup.OutputAsset, root: string): boolean {
+  if (
+    output.names.length !== 1 ||
+    output.names[0] !== 'pdf.worker.min.mjs' ||
+    output.originalFileNames.length !== 1 ||
+    !output.fileName.endsWith('.mjs')
+  ) {
+    return false
+  }
+  const originalFileName = output.originalFileNames[0].replaceAll('\\', '/')
+  if (originalFileName.includes('\0') || isAbsolute(originalFileName)) {
+    return false
+  }
+  try {
+    const originalPath = realpathSync(resolve(root, ...originalFileName.split('/')))
+    const source =
+      typeof output.source === 'string' ? Buffer.from(output.source) : Buffer.from(output.source)
+    return originalPath === pdfWorkerPath && source.equals(pdfWorkerSource)
+  } catch {
+    return false
+  }
+}
+
+function hasUsableToolchainMap(output: Rollup.OutputChunk): boolean {
+  return Boolean(output.map?.mappings && output.map.sources.length > 0)
+}
+
+function classifySourceMap(
+  output: Rollup.OutputAsset | Rollup.OutputChunk,
+  root: string
+): RendererSourceMapMode {
   if (output.type === 'asset') {
-    return 'source-less-asset'
+    return isPdfWorkerAsset(output, root) ? 'identity-generated' : 'mapped'
   }
   const moduleIds = Object.keys(output.modules)
   if (
     output.code.length === 0 ||
-    moduleIds.length === 0 ||
-    Object.values(output.modules).every((module) => module.renderedLength === 0)
+    (output.facadeModuleId !== null &&
+      (moduleIds.length === 0 ||
+        Object.values(output.modules).every((module) => module.renderedLength === 0)))
   ) {
-    return 'source-less-facade'
+    return 'identity-generated'
   }
-  if (moduleIds.every((moduleId) => moduleId.startsWith('\0') || moduleId === 'rolldown:runtime')) {
-    return 'source-less-generated'
+  if (hasUsableToolchainMap(output)) {
+    return 'mapped'
   }
   if (
-    moduleIds.every(isJsonModule) &&
-    output.map?.mappings === '' &&
-    output.map.sources.length > 0
+    moduleIds.length > 0 &&
+    moduleIds.every((moduleId) => moduleId.startsWith('\0') || moduleId === 'rolldown:runtime')
   ) {
-    return 'mappingless-json'
+    return 'identity-generated'
+  }
+  if (moduleIds.length > 0 && moduleIds.every(isJsonModule)) {
+    return 'identity-generated'
   }
   return 'mapped'
 }
 
 export function createRendererSourceMapProvenancePlugin(): Plugin {
+  let root = ''
   return {
     name: 'orca-renderer-source-map-provenance',
     apply: 'build',
+    configResolved: (config) => {
+      root = config.root
+    },
     generateBundle: function (_options, bundle) {
       const chunks = Object.values(bundle)
         .flatMap((output) =>
-          /\.m?js$/.test(output.fileName)
+          isJavaScriptOutputPath(output.fileName)
             ? [
                 {
                   file: output.fileName.replaceAll('\\', '/'),
-                  sourceMap: classifySourceMap(output)
+                  sourceMap: classifySourceMap(output, root)
                 }
               ]
             : []
@@ -125,7 +173,7 @@ function finalizeSourceMapProvenance(directory: string): void {
     }
   }
   const chunks = listOutputFiles(directory)
-    .filter((outputPath) => /\.m?js$/.test(outputPath))
+    .filter(isJavaScriptOutputPath)
     .sort()
     .map((file) => {
       const sourceMap = sourceMapByFile.get(file)
@@ -134,14 +182,18 @@ function finalizeSourceMapProvenance(directory: string): void {
       }
       return { file, sourceMap }
     })
-  for (const provenanceFile of provenanceFiles) {
-    unlinkSync(join(provenanceDirectory, provenanceFile))
-  }
   for (const chunk of chunks) {
     const mapPath = join(directory, `${chunk.file}.map.gz`)
-    if (chunk.sourceMap.startsWith('source-less-') && existsSync(mapPath)) {
-      unlinkSync(mapPath)
+    if (chunk.sourceMap === 'identity-generated') {
+      const source = readFileSync(join(directory, chunk.file), 'utf8')
+      const identityMap = createRendererIdentitySourceMap(chunk.file, source)
+      writeFileSync(mapPath, gzipSync(identityMap, { level: 9 }))
+    } else if (!existsSync(mapPath)) {
+      throw new Error(`Missing compressed source map for ${chunk.file}`)
     }
+  }
+  for (const provenanceFile of provenanceFiles) {
+    unlinkSync(join(provenanceDirectory, provenanceFile))
   }
   writeFileSync(
     join(provenanceDirectory, 'complete.json'),
@@ -154,7 +206,7 @@ function compactSourceMaps(directory: string): void {
     const filePath = join(directory, entry.name)
     if (entry.isDirectory()) {
       compactSourceMaps(filePath)
-    } else if (entry.name.endsWith('.js.map')) {
+    } else if (isRawJavaScriptSourceMapPath(entry.name)) {
       const source = readFileSync(filePath)
       writeFileSync(`${filePath}.gz`, gzipSync(source, { level: 9 }))
       unlinkSync(filePath)

--- a/config/electron-builder.config.cjs
+++ b/config/electron-builder.config.cjs
@@ -15,6 +15,9 @@ const { verifyLinuxGlibcFloor } = require('./scripts/verify-linux-glibc-floor.cj
 const { writeMacBuildCompatibility } = require('./scripts/mac-build-compatibility.cjs')
 const { verifyPackagedPluginResources } = require('./scripts/verify-packaged-plugin-resources.cjs')
 const { verifySkillsCliRuntime } = require('./scripts/verify-skills-cli-runtime.cjs')
+const {
+  verifyPackagedRendererSourceMaps
+} = require('./scripts/verify-packaged-renderer-source-maps.cjs')
 
 // Why: dev-channel builds must carry the *release* identity — same bundle id,
 // Developer ID signature, and notarization ticket — or Squirrel.Mac refuses to
@@ -211,6 +214,9 @@ module.exports = {
         : join(context.appOutDir, 'resources')
     if (!existsSync(resourcesDir)) {
       throw new Error(`Missing packaged resources directory: ${resourcesDir}`)
+    }
+    if (existsSync(join(resourcesDir, 'app.asar'))) {
+      verifyPackagedRendererSourceMaps(resourcesDir, require('@electron/asar'))
     }
     if (context.electronPlatformName === 'darwin') {
       const architectureByEnum = { 1: 'x64', 3: 'arm64' }

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -212,6 +212,11 @@ describe('Electron Vite output contract', () => {
     expect(output.keepNames).toBe(true)
     expect(workerOutput.keepNames).toBe(true)
     expect(workerOutput.minify).toBe(output.minify)
+    expect(electronViteConfig.renderer?.worker?.plugins?.()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'orca-renderer-source-map-provenance' })
+      ])
+    )
     expect(output.minify).toMatchObject({
       compress: { keepNames: { function: true, class: true } },
       mangle: { keepNames: { function: true, class: true } }
@@ -224,6 +229,11 @@ describe('Electron Vite output contract', () => {
       throw new Error('Expected one direct web worker output')
     }
     expect(workerOutput.keepNames).toBe(true)
+    expect(webViteConfig.worker?.plugins?.()).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ name: 'orca-renderer-source-map-provenance' })
+      ])
+    )
     expect(workerOutput.minify).toMatchObject({
       compress: { keepNames: { function: true, class: true } },
       mangle: { keepNames: { function: true, class: true } }

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -204,6 +204,7 @@ describe('Electron Vite output contract', () => {
 
     expect(rendererBuild?.minify).toBe('oxc')
     expect(rendererBuild?.sourcemap).toBe('hidden')
+    expect(output.keepNames).toBe(true)
     expect(output.minify).toMatchObject({
       compress: { keepNames: { function: true, class: true } },
       mangle: { keepNames: { function: true, class: true } }

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -195,6 +195,21 @@ describe('Electron Vite output contract', () => {
     )
   })
 
+  it('minifies production renderers while retaining names and hidden source maps', () => {
+    const rendererBuild = electronViteConfig.renderer?.build
+    const output = rendererBuild?.rollupOptions?.output
+    if (!output || Array.isArray(output)) {
+      throw new Error('Expected one renderer output')
+    }
+
+    expect(rendererBuild?.minify).toBe('oxc')
+    expect(rendererBuild?.sourcemap).toBe('hidden')
+    expect(output.minify).toMatchObject({
+      compress: { keepNames: { function: true, class: true } },
+      mangle: { keepNames: { function: true, class: true } }
+    })
+  })
+
   it('rejects prototype properties as build targets', () => {
     expect(targetConfig).toContain('Object.prototype.hasOwnProperty.call(configByTarget, target)')
   })

--- a/config/scripts/electron-vite-output-contract.test.ts
+++ b/config/scripts/electron-vite-output-contract.test.ts
@@ -13,6 +13,7 @@ import {
 } from '../build-plugins/bootstrap-fatal-exit-banner'
 import { electronViteConfig } from '../../electron.vite.config'
 import { BOOTSTRAP_FATAL_EXIT_GUARD_KEY } from '../../src/main/startup/bootstrap-fatal-exit-guard'
+import webViteConfig from '../../vite.web.config'
 
 const targetConfig = readFileSync('config/electron-vite-target.config.ts', 'utf8')
 const devRunner = readFileSync('config/scripts/run-electron-vite-dev.mjs', 'utf8')
@@ -198,14 +199,32 @@ describe('Electron Vite output contract', () => {
   it('minifies production renderers while retaining names and hidden source maps', () => {
     const rendererBuild = electronViteConfig.renderer?.build
     const output = rendererBuild?.rollupOptions?.output
+    const workerOutput = electronViteConfig.renderer?.worker?.rollupOptions?.output
     if (!output || Array.isArray(output)) {
       throw new Error('Expected one renderer output')
+    }
+    if (!workerOutput || Array.isArray(workerOutput)) {
+      throw new Error('Expected one renderer worker output')
     }
 
     expect(rendererBuild?.minify).toBe('oxc')
     expect(rendererBuild?.sourcemap).toBe('hidden')
     expect(output.keepNames).toBe(true)
+    expect(workerOutput.keepNames).toBe(true)
+    expect(workerOutput.minify).toBe(output.minify)
     expect(output.minify).toMatchObject({
+      compress: { keepNames: { function: true, class: true } },
+      mangle: { keepNames: { function: true, class: true } }
+    })
+  })
+
+  it('retains names while bundling direct web workers', () => {
+    const workerOutput = webViteConfig.worker?.rollupOptions?.output
+    if (!workerOutput || Array.isArray(workerOutput)) {
+      throw new Error('Expected one direct web worker output')
+    }
+    expect(workerOutput.keepNames).toBe(true)
+    expect(workerOutput.minify).toMatchObject({
       compress: { keepNames: { function: true, class: true } },
       mangle: { keepNames: { function: true, class: true } }
     })

--- a/config/scripts/packaged-renderer-symbolication.test.ts
+++ b/config/scripts/packaged-renderer-symbolication.test.ts
@@ -1,0 +1,124 @@
+import { spawnSync } from 'node:child_process'
+import { cpSync, existsSync, mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { basename, dirname, join, resolve } from 'node:path'
+import { gunzipSync } from 'node:zlib'
+import { originalPositionFor, sourceContentFor, TraceMap } from '@jridgewell/trace-mapping'
+import { afterEach, describe, expect, it } from 'vitest'
+import { build } from 'vite'
+import {
+  createRendererSourceMapCompactionPlugin,
+  rendererProductionBuild,
+  rendererProductionOutput
+} from '../build-plugins/renderer-production-minification'
+import {
+  normalizeAsarEntry,
+  verifyPackagedRendererSourceMaps
+} from './verify-packaged-renderer-source-maps.cjs'
+
+const require = createRequire(import.meta.url)
+const asar = require('@electron/asar') as {
+  createPackage: (source: string, destination: string) => Promise<void>
+  extractFile: (archive: string, entry: string) => Buffer
+  listPackage: (archive: string) => string[]
+}
+const temporaryRoots: string[] = []
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('packaged renderer symbolication', () => {
+  it('resolves a minified exception and source line using only the ASAR map', async () => {
+    const fixtureParent = resolve('out', 'test-fixtures')
+    mkdirSync(fixtureParent, { recursive: true })
+    const root = mkdtempSync(join(fixtureParent, 'packaged-symbolication-'))
+    temporaryRoots.push(root)
+    const sourcePath = join(root, 'src', 'packaged-crash.ts')
+    mkdirSync(dirname(sourcePath), { recursive: true })
+    writeFileSync(
+      join(root, 'index.html'),
+      '<script type="module" src="/src/packaged-crash.ts"></script>'
+    )
+    writeFileSync(
+      sourcePath,
+      [
+        'const packagedDiagnosticValue = 42',
+        'function deliberatePackagedCrash(): never {',
+        '  const message = `packaged-symbolication:${packagedDiagnosticValue}`',
+        '  throw new TypeError(message)',
+        '}',
+        'deliberatePackagedCrash()'
+      ].join('\n')
+    )
+
+    const buildDir = join(root, 'build')
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [createRendererSourceMapCompactionPlugin()],
+      build: {
+        ...rendererProductionBuild,
+        outDir: buildDir,
+        emptyOutDir: true,
+        modulePreload: false,
+        rollupOptions: { output: rendererProductionOutput }
+      }
+    })
+
+    const stagingDir = join(root, 'staging')
+    cpSync(buildDir, join(stagingDir, 'out', 'renderer'), { recursive: true })
+    cpSync(buildDir, join(stagingDir, 'out', 'web'), { recursive: true })
+    const resourcesDir = join(root, 'resources')
+    mkdirSync(resourcesDir)
+    const archivePath = join(resourcesDir, 'app.asar')
+    await asar.createPackage(stagingDir, archivePath)
+    verifyPackagedRendererSourceMaps(resourcesDir, asar, {
+      renderer: buildDir,
+      web: join(stagingDir, 'out', 'web')
+    })
+
+    rmSync(sourcePath)
+    rmSync(buildDir, { recursive: true })
+    rmSync(stagingDir, { recursive: true })
+    expect(existsSync(sourcePath)).toBe(false)
+
+    const archiveEntries = asar.listPackage(archivePath)
+    const javascriptEntry = archiveEntries.find((entry) => {
+      const normalized = normalizeAsarEntry(entry)
+      return normalized.startsWith('out/renderer/assets/') && normalized.endsWith('.js')
+    })
+    expect(javascriptEntry).toBeDefined()
+    const normalizedJavaScriptEntry = normalizeAsarEntry(javascriptEntry!)
+    const mapEntry = archiveEntries.find(
+      (entry) => normalizeAsarEntry(entry) === `${normalizedJavaScriptEntry}.map.gz`
+    )
+    expect(mapEntry).toBeDefined()
+
+    const extractedJavaScriptPath = join(root, basename(normalizedJavaScriptEntry))
+    writeFileSync(
+      extractedJavaScriptPath,
+      asar.extractFile(archivePath, javascriptEntry!.replace(/^[\\/]+/, ''))
+    )
+    const execution = spawnSync(process.execPath, [extractedJavaScriptPath], { encoding: 'utf8' })
+    expect(execution.status).not.toBe(0)
+    expect(execution.stderr).toContain('TypeError: packaged-symbolication:42')
+    expect(execution.stderr).toContain('deliberatePackagedCrash')
+
+    const escapedFileName = basename(extractedJavaScriptPath).replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const frame = execution.stderr.match(new RegExp(`${escapedFileName}:(\\d+):(\\d+)`))
+    expect(frame).not.toBeNull()
+    const mapBytes = asar.extractFile(archivePath, mapEntry!.replace(/^[\\/]+/, ''))
+    const traceMap = new TraceMap(gunzipSync(mapBytes).toString('utf8'))
+    const original = originalPositionFor(traceMap, {
+      line: Number(frame![1]),
+      column: Number(frame![2]) - 1
+    })
+    expect(original.source).toMatch(/src\/packaged-crash\.ts$/)
+    expect(original.line).toBe(4)
+    expect(sourceContentFor(traceMap, original.source!)).toContain('throw new TypeError(message)')
+  })
+})

--- a/config/scripts/packaged-renderer-symbolication.test.ts
+++ b/config/scripts/packaged-renderer-symbolication.test.ts
@@ -8,6 +8,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { build } from 'vite'
 import {
   createRendererSourceMapCompactionPlugin,
+  createRendererSourceMapProvenancePlugin,
   rendererProductionBuild,
   rendererProductionOutput
 } from '../build-plugins/renderer-production-minification'
@@ -59,7 +60,10 @@ describe('packaged renderer symbolication', () => {
       root,
       configFile: false,
       logLevel: 'silent',
-      plugins: [createRendererSourceMapCompactionPlugin()],
+      plugins: [
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ],
       build: {
         ...rendererProductionBuild,
         outDir: buildDir,

--- a/config/scripts/project-renderer-web-client.mjs
+++ b/config/scripts/project-renderer-web-client.mjs
@@ -9,6 +9,9 @@ import {
   writeFileSync
 } from 'node:fs'
 import { dirname, join, posix, resolve, sep } from 'node:path'
+import javascriptOutput from './renderer-javascript-output.cjs'
+
+const { isJavaScriptOutputPath } = javascriptOutput
 
 const rendererOutput = resolve('out/renderer')
 const webOutput = resolve('out/web')
@@ -18,13 +21,7 @@ const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 const selectedFiles = new Set(['web-index.html'])
 const visitedEntries = new Set()
 const projectedProvenancePath = 'source-map-provenance/projected-web.json'
-const sourceMapModes = new Set([
-  'mapped',
-  'mappingless-json',
-  'source-less-asset',
-  'source-less-facade',
-  'source-less-generated'
-])
+const sourceMapModes = new Set(['identity-generated', 'mapped'])
 
 function assertEntryIsolation() {
   const entryKeys = new Set(
@@ -108,7 +105,7 @@ function includeReferencedOutputs() {
   while (foundReference) {
     foundReference = false
     for (const selectedFile of selectedFiles) {
-      if (!/\.(?:css|html|m?js|svg)$/.test(selectedFile)) {
+      if (!/\.(?:css|html|svg)$/.test(selectedFile) && !isJavaScriptOutputPath(selectedFile)) {
         continue
       }
       const contents = readFileSync(join(rendererOutput, selectedFile), 'utf8')
@@ -129,7 +126,7 @@ function includeReferencedOutputs() {
 function includeSelectedSourceMaps() {
   const outputs = new Set(listOutputFiles(rendererOutput))
   for (const selectedFile of selectedFiles) {
-    if (/\.m?js$/.test(selectedFile) && outputs.has(`${selectedFile}.map.gz`)) {
+    if (isJavaScriptOutputPath(selectedFile) && outputs.has(`${selectedFile}.map.gz`)) {
       selectedFiles.add(`${selectedFile}.map.gz`)
     }
   }
@@ -157,7 +154,7 @@ function createProjectedSourceMapProvenance() {
     }
   }
   const chunks = [...selectedFiles]
-    .filter((outputPath) => /\.m?js$/.test(outputPath))
+    .filter(isJavaScriptOutputPath)
     .sort()
     .map((file) => {
       const sourceMap = chunksByFile.get(file)

--- a/config/scripts/project-renderer-web-client.mjs
+++ b/config/scripts/project-renderer-web-client.mjs
@@ -18,6 +18,13 @@ const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 const selectedFiles = new Set(['web-index.html'])
 const visitedEntries = new Set()
 const projectedProvenancePath = 'source-map-provenance/projected-web.json'
+const sourceMapModes = new Set([
+  'mapped',
+  'mappingless-json',
+  'source-less-asset',
+  'source-less-facade',
+  'source-less-generated'
+])
 
 function assertEntryIsolation() {
   const entryKeys = new Set(
@@ -139,7 +146,7 @@ function createProjectedSourceMapProvenance() {
       throw new Error(`Invalid renderer source-map provenance: ${outputPath}`)
     }
     for (const chunk of provenance.chunks) {
-      if (typeof chunk?.file !== 'string' || typeof chunk.sourceMap !== 'boolean') {
+      if (typeof chunk?.file !== 'string' || !sourceMapModes.has(chunk.sourceMap)) {
         throw new Error(`Invalid renderer source-map provenance chunk: ${outputPath}`)
       }
       const previous = chunksByFile.get(chunk.file)

--- a/config/scripts/project-renderer-web-client.mjs
+++ b/config/scripts/project-renderer-web-client.mjs
@@ -1,15 +1,5 @@
-import {
-  cpSync,
-  mkdirSync,
-  readFileSync,
-  readdirSync,
-  renameSync,
-  rmSync,
-  statSync,
-  writeFileSync
-} from 'node:fs'
+import { cpSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs'
 import { dirname, join, posix, resolve, sep } from 'node:path'
-import { transform } from 'esbuild'
 
 const rendererOutput = resolve('out/renderer')
 const webOutput = resolve('out/web')
@@ -119,27 +109,19 @@ function includeReferencedOutputs() {
   }
 }
 
-async function minifyWebOutput() {
-  await Promise.all(
-    [...selectedFiles]
-      .filter((outputPath) => /\.(?:css|m?js)$/.test(outputPath))
-      .map(async (outputPath) => {
-        const targetPath = join(stagingOutput, outputPath)
-        const loader = outputPath.endsWith('.css') ? 'css' : 'js'
-        const result = await transform(readFileSync(targetPath, 'utf8'), {
-          legalComments: 'none',
-          loader,
-          minify: true,
-          target: 'es2020'
-        })
-        writeFileSync(targetPath, result.code)
-      })
-  )
+function includeSelectedSourceMaps() {
+  const outputs = new Set(listOutputFiles(rendererOutput))
+  for (const selectedFile of selectedFiles) {
+    if (/\.m?js$/.test(selectedFile) && outputs.has(`${selectedFile}.map.gz`)) {
+      selectedFiles.add(`${selectedFile}.map.gz`)
+    }
+  }
 }
 
 assertEntryIsolation()
 visitManifestEntry('web-index.html')
 includeReferencedOutputs()
+includeSelectedSourceMaps()
 
 rmSync(stagingOutput, { force: true, recursive: true })
 try {
@@ -148,8 +130,6 @@ try {
     mkdirSync(dirname(targetPath), { recursive: true })
     cpSync(join(rendererOutput, outputPath), targetPath)
   }
-  await minifyWebOutput()
-
   rmSync(webOutput, { force: true, recursive: true })
   renameSync(stagingOutput, webOutput)
 } finally {

--- a/config/scripts/project-renderer-web-client.mjs
+++ b/config/scripts/project-renderer-web-client.mjs
@@ -1,4 +1,13 @@
-import { cpSync, mkdirSync, readFileSync, readdirSync, renameSync, rmSync, statSync } from 'node:fs'
+import {
+  cpSync,
+  mkdirSync,
+  readFileSync,
+  readdirSync,
+  renameSync,
+  rmSync,
+  statSync,
+  writeFileSync
+} from 'node:fs'
 import { dirname, join, posix, resolve, sep } from 'node:path'
 
 const rendererOutput = resolve('out/renderer')
@@ -8,6 +17,7 @@ const manifestPath = join(rendererOutput, '.vite', 'manifest.json')
 const manifest = JSON.parse(readFileSync(manifestPath, 'utf8'))
 const selectedFiles = new Set(['web-index.html'])
 const visitedEntries = new Set()
+const projectedProvenancePath = 'source-map-provenance/projected-web.json'
 
 function assertEntryIsolation() {
   const entryKeys = new Set(
@@ -118,17 +128,57 @@ function includeSelectedSourceMaps() {
   }
 }
 
+function createProjectedSourceMapProvenance() {
+  const chunksByFile = new Map()
+  for (const outputPath of listOutputFiles(rendererOutput)) {
+    if (!outputPath.startsWith('source-map-provenance/') || !outputPath.endsWith('.json')) {
+      continue
+    }
+    const provenance = JSON.parse(readFileSync(join(rendererOutput, outputPath), 'utf8'))
+    if (provenance?.version !== 1 || !Array.isArray(provenance.chunks)) {
+      throw new Error(`Invalid renderer source-map provenance: ${outputPath}`)
+    }
+    for (const chunk of provenance.chunks) {
+      if (typeof chunk?.file !== 'string' || typeof chunk.sourceMap !== 'boolean') {
+        throw new Error(`Invalid renderer source-map provenance chunk: ${outputPath}`)
+      }
+      const previous = chunksByFile.get(chunk.file)
+      if (previous !== undefined && previous !== chunk.sourceMap) {
+        throw new Error(`Conflicting renderer source-map provenance for ${chunk.file}`)
+      }
+      chunksByFile.set(chunk.file, chunk.sourceMap)
+    }
+  }
+  const chunks = [...selectedFiles]
+    .filter((outputPath) => /\.m?js$/.test(outputPath))
+    .sort()
+    .map((file) => {
+      const sourceMap = chunksByFile.get(file)
+      if (sourceMap === undefined) {
+        throw new Error(`Renderer source-map provenance is missing ${file}`)
+      }
+      return { file, sourceMap }
+    })
+  return `${JSON.stringify({ version: 1, chunks })}\n`
+}
+
 assertEntryIsolation()
 visitManifestEntry('web-index.html')
 includeReferencedOutputs()
+const projectedProvenance = createProjectedSourceMapProvenance()
 includeSelectedSourceMaps()
+selectedFiles.add(projectedProvenancePath)
 
 rmSync(stagingOutput, { force: true, recursive: true })
 try {
   for (const outputPath of selectedFiles) {
     const targetPath = join(stagingOutput, outputPath)
     mkdirSync(dirname(targetPath), { recursive: true })
-    cpSync(join(rendererOutput, outputPath), targetPath)
+    if (outputPath === projectedProvenancePath) {
+      writeFileSync(targetPath, projectedProvenance)
+    } else {
+      cpSync(join(rendererOutput, outputPath), targetPath)
+    }
   }
   rmSync(webOutput, { force: true, recursive: true })
   renameSync(stagingOutput, webOutput)

--- a/config/scripts/project-renderer-web-client.test.mjs
+++ b/config/scripts/project-renderer-web-client.test.mjs
@@ -41,7 +41,7 @@ function createRendererFixture() {
   writeFixtureFile(
     root,
     'out/renderer/assets/web-entry.js',
-    'import "./web-shared.js"; new Worker(new URL("editor.worker-fixture.js", import.meta.url));'
+    'import "./web-shared.js"; new Worker(new URL("editor.worker-fixture.js", import.meta.url)); void "plugin.cjs";'
   )
   writeFixtureFile(root, 'out/renderer/assets/web-shared.js', 'export const value=1;\n')
   writeFixtureFile(root, 'out/renderer/assets/lazy.js', 'export const lazyValue = true;')
@@ -52,7 +52,14 @@ function createRendererFixture() {
     'out/renderer/assets/editor.worker-fixture.js',
     'self.onmessage = function (event) { self.postMessage(event.data) }'
   )
-  for (const fileName of ['web-entry.js', 'web-shared.js', 'lazy.js', 'editor.worker-fixture.js']) {
+  writeFixtureFile(root, 'out/renderer/assets/plugin.cjs', 'module.exports = true\n')
+  for (const fileName of [
+    'web-entry.js',
+    'web-shared.js',
+    'lazy.js',
+    'editor.worker-fixture.js',
+    'plugin.cjs'
+  ]) {
     writeFixtureFile(root, `out/renderer/assets/${fileName}.map.gz`, 'compressed-map-fixture')
   }
   writeFixtureFile(root, 'out/renderer/assets/desktop-entry.js', 'export const desktop = true;')
@@ -62,11 +69,14 @@ function createRendererFixture() {
     JSON.stringify({
       version: 1,
       chunks: [
-        ...['web-entry.js', 'web-shared.js', 'lazy.js', 'editor.worker-fixture.js'].map((file) => ({
-          file: `assets/${file}`,
-          sourceMap: 'mapped'
-        })),
-        { file: 'assets/desktop-entry.js', sourceMap: 'source-less-facade' }
+        ...[
+          'web-entry.js',
+          'web-shared.js',
+          'lazy.js',
+          'editor.worker-fixture.js',
+          'plugin.cjs'
+        ].map((file) => ({ file: `assets/${file}`, sourceMap: 'mapped' })),
+        { file: 'assets/desktop-entry.js', sourceMap: 'identity-generated' }
       ]
     })
   )
@@ -95,11 +105,12 @@ describe('renderer web client projection', () => {
     })
 
     expect(result.status, result.stderr).toBe(0)
-    expect(result.stdout).toContain('Projected web client: 12 files')
+    expect(result.stdout).toContain('Projected web client: 14 files')
     expect(existsSync(join(root, 'out/web/web-index.html'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/editor.worker-fixture.js'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/editor.worker-fixture.js.map.gz'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/logo.png'))).toBe(true)
+    expect(existsSync(join(root, 'out/web/assets/plugin.cjs.map.gz'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/desktop-entry.js'))).toBe(false)
     expect(existsSync(join(root, 'out/web/stale.js'))).toBe(false)
     expect(readFileSync(join(root, 'out/web/assets/web.css'), 'utf8')).toBe('.root{color:red}\n')
@@ -109,10 +120,10 @@ describe('renderer web client projection', () => {
     const provenance = JSON.parse(
       readFileSync(join(root, 'out/web/source-map-provenance/projected-web.json'), 'utf8')
     )
-    expect(provenance.chunks).toHaveLength(4)
+    expect(provenance.chunks).toHaveLength(5)
     expect(provenance.chunks).not.toContainEqual({
       file: 'assets/desktop-entry.js',
-      sourceMap: 'source-less-facade'
+      sourceMap: 'identity-generated'
     })
   })
 

--- a/config/scripts/project-renderer-web-client.test.mjs
+++ b/config/scripts/project-renderer-web-client.test.mjs
@@ -56,6 +56,20 @@ function createRendererFixture() {
     writeFixtureFile(root, `out/renderer/assets/${fileName}.map.gz`, 'compressed-map-fixture')
   }
   writeFixtureFile(root, 'out/renderer/assets/desktop-entry.js', 'export const desktop = true;')
+  writeFixtureFile(
+    root,
+    'out/renderer/source-map-provenance/bundle-fixture.json',
+    JSON.stringify({
+      version: 1,
+      chunks: [
+        ...['web-entry.js', 'web-shared.js', 'lazy.js', 'editor.worker-fixture.js'].map((file) => ({
+          file: `assets/${file}`,
+          sourceMap: true
+        })),
+        { file: 'assets/desktop-entry.js', sourceMap: false }
+      ]
+    })
+  )
   writeFixtureFile(root, 'out/web/stale.js', 'stale')
   return root
 }
@@ -81,7 +95,7 @@ describe('renderer web client projection', () => {
     })
 
     expect(result.status, result.stderr).toBe(0)
-    expect(result.stdout).toContain('Projected web client: 11 files')
+    expect(result.stdout).toContain('Projected web client: 12 files')
     expect(existsSync(join(root, 'out/web/web-index.html'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/editor.worker-fixture.js'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/editor.worker-fixture.js.map.gz'))).toBe(true)
@@ -92,6 +106,14 @@ describe('renderer web client projection', () => {
     expect(readFileSync(join(root, 'out/web/assets/web-shared.js'), 'utf8')).toBe(
       'export const value=1;\n'
     )
+    const provenance = JSON.parse(
+      readFileSync(join(root, 'out/web/source-map-provenance/projected-web.json'), 'utf8')
+    )
+    expect(provenance.chunks).toHaveLength(4)
+    expect(provenance.chunks).not.toContainEqual({
+      file: 'assets/desktop-entry.js',
+      sourceMap: false
+    })
   })
 
   it('fails when the renderer manifest omits the web entry', () => {

--- a/config/scripts/project-renderer-web-client.test.mjs
+++ b/config/scripts/project-renderer-web-client.test.mjs
@@ -64,9 +64,9 @@ function createRendererFixture() {
       chunks: [
         ...['web-entry.js', 'web-shared.js', 'lazy.js', 'editor.worker-fixture.js'].map((file) => ({
           file: `assets/${file}`,
-          sourceMap: true
+          sourceMap: 'mapped'
         })),
-        { file: 'assets/desktop-entry.js', sourceMap: false }
+        { file: 'assets/desktop-entry.js', sourceMap: 'source-less-facade' }
       ]
     })
   )
@@ -112,7 +112,7 @@ describe('renderer web client projection', () => {
     expect(provenance.chunks).toHaveLength(4)
     expect(provenance.chunks).not.toContainEqual({
       file: 'assets/desktop-entry.js',
-      sourceMap: false
+      sourceMap: 'source-less-facade'
     })
   })
 

--- a/config/scripts/project-renderer-web-client.test.mjs
+++ b/config/scripts/project-renderer-web-client.test.mjs
@@ -43,15 +43,18 @@ function createRendererFixture() {
     'out/renderer/assets/web-entry.js',
     'import "./web-shared.js"; new Worker(new URL("editor.worker-fixture.js", import.meta.url));'
   )
-  writeFixtureFile(root, 'out/renderer/assets/web-shared.js', 'export const value = 1;')
+  writeFixtureFile(root, 'out/renderer/assets/web-shared.js', 'export const value=1;\n')
   writeFixtureFile(root, 'out/renderer/assets/lazy.js', 'export const lazyValue = true;')
-  writeFixtureFile(root, 'out/renderer/assets/web.css', '.root { color: red; }')
+  writeFixtureFile(root, 'out/renderer/assets/web.css', '.root{color:red}\n')
   writeFixtureFile(root, 'out/renderer/assets/logo.png', 'fixture-logo')
   writeFixtureFile(
     root,
     'out/renderer/assets/editor.worker-fixture.js',
     'self.onmessage = function (event) { self.postMessage(event.data) }'
   )
+  for (const fileName of ['web-entry.js', 'web-shared.js', 'lazy.js', 'editor.worker-fixture.js']) {
+    writeFixtureFile(root, `out/renderer/assets/${fileName}.map.gz`, 'compressed-map-fixture')
+  }
   writeFixtureFile(root, 'out/renderer/assets/desktop-entry.js', 'export const desktop = true;')
   writeFixtureFile(root, 'out/web/stale.js', 'stale')
   return root
@@ -70,7 +73,7 @@ describe('renderer web client projection', () => {
     expect(builderConfig).toContain("'!out/renderer/.vite{,/**/*}'")
   })
 
-  it('copies and minifies only the web dependency closure', () => {
+  it('copies the already-minified web dependency closure without a second pass', () => {
     const root = createRendererFixture()
     const result = spawnSync(process.execPath, [scriptPath], {
       cwd: root,
@@ -78,13 +81,17 @@ describe('renderer web client projection', () => {
     })
 
     expect(result.status, result.stderr).toBe(0)
-    expect(result.stdout).toContain('Projected web client: 7 files')
+    expect(result.stdout).toContain('Projected web client: 11 files')
     expect(existsSync(join(root, 'out/web/web-index.html'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/editor.worker-fixture.js'))).toBe(true)
+    expect(existsSync(join(root, 'out/web/assets/editor.worker-fixture.js.map.gz'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/logo.png'))).toBe(true)
     expect(existsSync(join(root, 'out/web/assets/desktop-entry.js'))).toBe(false)
     expect(existsSync(join(root, 'out/web/stale.js'))).toBe(false)
     expect(readFileSync(join(root, 'out/web/assets/web.css'), 'utf8')).toBe('.root{color:red}\n')
+    expect(readFileSync(join(root, 'out/web/assets/web-shared.js'), 'utf8')).toBe(
+      'export const value=1;\n'
+    )
   })
 
   it('fails when the renderer manifest omits the web entry', () => {

--- a/config/scripts/renderer-identity-source-map-build.test.ts
+++ b/config/scripts/renderer-identity-source-map-build.test.ts
@@ -1,0 +1,133 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { gunzipSync } from 'node:zlib'
+import { afterEach, describe, expect, it } from 'vitest'
+import { build, type Plugin } from 'vite'
+import {
+  createRendererSourceMapCompactionPlugin,
+  createRendererSourceMapProvenancePlugin,
+  rendererProductionBuild,
+  rendererProductionOutput
+} from '../build-plugins/renderer-production-minification'
+import { verifyLocalRendererSourceMaps } from './renderer-source-map-contract.cjs'
+
+const temporaryRoots: string[] = []
+
+function createFixture(mainSource: string): string {
+  const parent = resolve('out', 'test-fixtures')
+  mkdirSync(parent, { recursive: true })
+  const root = mkdtempSync(join(parent, 'renderer-identity-map-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'package.json'), '{"type":"module"}\n')
+  writeFileSync(join(root, 'index.html'), '<script type="module" src="/src/main.ts"></script>')
+  writeFileSync(join(root, 'src', 'main.ts'), mainSource)
+  return root
+}
+
+function mutateChunk(moduleMatches: (moduleId: string) => boolean, appendedCode = ''): Plugin {
+  return {
+    name: 'mutate-identity-map-candidate',
+    generateBundle: (_options, bundle) => {
+      const chunk = Object.values(bundle).find(
+        (output) =>
+          output.type === 'chunk' &&
+          Object.keys(output.modules).length > 0 &&
+          Object.keys(output.modules).every(moduleMatches)
+      )
+      if (!chunk || chunk.type !== 'chunk') {
+        throw new Error('Identity-map mutation did not find its chunk')
+      }
+      chunk.code += appendedCode
+      chunk.map = null
+      delete bundle[`${chunk.fileName}.map`]
+    }
+  }
+}
+
+async function buildFixture(root: string, plugins: Plugin[]): Promise<string> {
+  await build({
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    plugins: [
+      ...plugins,
+      createRendererSourceMapProvenancePlugin(),
+      createRendererSourceMapCompactionPlugin()
+    ],
+    build: {
+      ...rendererProductionBuild,
+      outDir: 'out',
+      emptyOutDir: true,
+      modulePreload: false,
+      rollupOptions: { output: rendererProductionOutput }
+    }
+  })
+  const provenance = readdirSync(join(root, 'out', 'source-map-provenance')).flatMap(
+    (fileName) =>
+      JSON.parse(readFileSync(join(root, 'out', 'source-map-provenance', fileName), 'utf8')).chunks
+  ) as { file: string; sourceMap: string }[]
+  const identityChunk = provenance.find((chunk) => chunk.sourceMap === 'identity-generated')
+  expect(identityChunk).toBeDefined()
+  return identityChunk!.file
+}
+
+function expectExactIdentityMap(root: string, outputFile: string, marker: string): void {
+  const javascriptPath = join(root, 'out', outputFile)
+  const javascript = readFileSync(javascriptPath, 'utf8')
+  const sourceMap = JSON.parse(
+    gunzipSync(readFileSync(`${javascriptPath}.map.gz`)).toString('utf8')
+  ) as { sourcesContent: string[] }
+  expect(javascript).toContain(marker)
+  expect(sourceMap.sourcesContent).toEqual([javascript])
+  expect(() => verifyLocalRendererSourceMaps('renderer', join(root, 'out'))).not.toThrow()
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('renderer identity source maps', () => {
+  it('identity-maps a throwing virtual chunk after its toolchain map is removed', async () => {
+    const root = createFixture("void import('virtual:crash')\n")
+    const virtualModule: Plugin = {
+      name: 'throwing-virtual-module',
+      resolveId: (id) => (id === 'virtual:crash' ? '\0virtual:crash' : undefined),
+      load: (id) =>
+        id === '\0virtual:crash'
+          ? 'throw new Error("identity-virtual-crash")\nexport const reached = false\n'
+          : undefined
+    }
+    const outputFile = await buildFixture(root, [
+      virtualModule,
+      mutateChunk((moduleId) => moduleId.startsWith('\0') || moduleId === 'rolldown:runtime')
+    ])
+
+    expectExactIdentityMap(root, outputFile, 'identity-virtual-crash')
+    const execution = spawnSync(process.execPath, [join(root, 'out', outputFile)], {
+      encoding: 'utf8'
+    })
+    expect(execution.stderr).toContain('identity-virtual-crash')
+  })
+
+  it('identity-maps executable code appended to a generated JSON chunk', async () => {
+    const root = createFixture("void import('./data.json')\n")
+    writeFileSync(join(root, 'src', 'data.json'), '{"message":"identity"}\n')
+    const marker = 'identity-json-crash'
+    const outputFile = await buildFixture(root, [
+      mutateChunk(
+        (moduleId) => moduleId.split('?', 1)[0].endsWith('.json'),
+        `;throw new Error(${JSON.stringify(marker)});`
+      )
+    ])
+
+    expectExactIdentityMap(root, outputFile, marker)
+    const execution = spawnSync(process.execPath, [join(root, 'out', outputFile)], {
+      encoding: 'utf8'
+    })
+    expect(execution.stderr).toContain(marker)
+  })
+})

--- a/config/scripts/renderer-javascript-output.cjs
+++ b/config/scripts/renderer-javascript-output.cjs
@@ -1,0 +1,21 @@
+const JAVASCRIPT_OUTPUT_PATTERN = /\.(?:[cm]?js)$/
+const RAW_JAVASCRIPT_SOURCE_MAP_PATTERN = /\.(?:[cm]?js)\.map$/
+const COMPRESSED_JAVASCRIPT_SOURCE_MAP_PATTERN = /\.(?:[cm]?js)\.map\.gz$/
+
+function isJavaScriptOutputPath(fileName) {
+  return JAVASCRIPT_OUTPUT_PATTERN.test(fileName)
+}
+
+function isRawJavaScriptSourceMapPath(fileName) {
+  return RAW_JAVASCRIPT_SOURCE_MAP_PATTERN.test(fileName)
+}
+
+function isCompressedJavaScriptSourceMapPath(fileName) {
+  return COMPRESSED_JAVASCRIPT_SOURCE_MAP_PATTERN.test(fileName)
+}
+
+module.exports = {
+  isCompressedJavaScriptSourceMapPath,
+  isJavaScriptOutputPath,
+  isRawJavaScriptSourceMapPath
+}

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -8,7 +8,7 @@ import { build } from 'vite'
 import {
   createRendererSourceMapCompactionPlugin,
   rendererProductionBuild,
-  rendererProductionMinifyOptions
+  rendererProductionOutput
 } from '../build-plugins/renderer-production-minification'
 
 const temporaryRoots: string[] = []
@@ -27,15 +27,25 @@ function createFixture(): string {
   writeFileSync(
     join(root, 'src', 'probe.ts'),
     [
+      "import { Same as AlphaClass, same as alphaFunction } from './probe-alpha'",
+      "import { Same as BetaClass, same as betaFunction } from './probe-beta'",
       'const rendererMinificationDiagnosticPadding = "padding-padding-padding-padding"',
       'function deliberateRendererCrash(): never {',
       '  const descriptiveRendererState = rendererMinificationDiagnosticPadding.length',
-      '  throw new TypeError(`renderer-minification-probe:${descriptiveRendererState}`)',
+      '  const collisionNames = [alphaFunction.name, betaFunction.name, AlphaClass.name, BetaClass.name].join(",")',
+      '  throw new TypeError(`renderer-minification-probe:${descriptiveRendererState}:${collisionNames}`)',
       '}',
       'deliberateRendererCrash()'
     ].join('\n'),
     'utf8'
   )
+  for (const moduleName of ['probe-alpha', 'probe-beta']) {
+    writeFileSync(
+      join(root, 'src', `${moduleName}.ts`),
+      'export function same(): void {}\nexport class Same {}\n',
+      'utf8'
+    )
+  }
   return root
 }
 
@@ -59,7 +69,7 @@ describe('renderer production minification', () => {
         outDir,
         emptyOutDir: true,
         modulePreload: false,
-        rollupOptions: { output: { minify: rendererProductionMinifyOptions } }
+        rollupOptions: { output: rendererProductionOutput }
       }
     })
 
@@ -74,7 +84,9 @@ describe('renderer production minification', () => {
 
     const execution = spawnSync(process.execPath, [outputPath], { encoding: 'utf8' })
     expect(execution.status).not.toBe(0)
-    expect(execution.stderr).toContain('TypeError: renderer-minification-probe:31')
+    expect(execution.stderr).toContain(
+      'TypeError: renderer-minification-probe:31:same,same,Same,Same'
+    )
     expect(execution.stderr).toContain('deliberateRendererCrash')
 
     const escapedOutputFile = outputFile!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
@@ -89,6 +101,6 @@ describe('renderer production minification', () => {
       column: Number(frame![2]) - 1
     })
     expect(original.source).toMatch(/src\/probe\.ts$/)
-    expect(original.line).toBe(4)
+    expect(original.line).toBe(7)
   })
 })

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -1,8 +1,8 @@
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
-import { join, resolve } from 'node:path'
+import { isAbsolute, join, resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
-import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
+import { originalPositionFor, sourceContentFor, TraceMap } from '@jridgewell/trace-mapping'
 import { afterEach, describe, expect, it } from 'vitest'
 import { build } from 'vite'
 import {
@@ -129,7 +129,12 @@ describe('renderer production minification', () => {
     expect(frame).not.toBeNull()
     expect(() => readFileSync(`${outputPath}.map`)).toThrow()
     const mapContents = gunzipSync(readFileSync(`${outputPath}.map.gz`)).toString('utf8')
-    expect(JSON.parse(mapContents)).not.toHaveProperty('sourcesContent')
+    const sourceMap = JSON.parse(mapContents) as {
+      sources: string[]
+      sourcesContent: (string | null)[]
+    }
+    expect(sourceMap.sources.every((source) => !isAbsolute(source))).toBe(true)
+    expect(sourceMap.sourcesContent).toHaveLength(sourceMap.sources.length)
     const map = new TraceMap(mapContents)
     const original = originalPositionFor(map, {
       line: Number(frame![1]),
@@ -137,6 +142,9 @@ describe('renderer production minification', () => {
     })
     expect(original.source).toMatch(/src\/probe\.ts$/)
     expect(original.line).toBe(7)
+    expect(sourceContentFor(map, original.source!)).toContain(
+      'throw new TypeError(`renderer-minification-probe:'
+    )
   })
 
   it('keeps collided function and class names inside a real worker bundle', async () => {
@@ -177,5 +185,15 @@ describe('renderer production minification', () => {
     )
     expect(execution.status, execution.stderr).toBe(0)
     expect(execution.stdout).toContain('worker-collision:same,same,Same,Same')
+
+    const workerMap = JSON.parse(
+      gunzipSync(readFileSync(join(assetsDir, `${workerFile}.map.gz`))).toString('utf8')
+    ) as { sources: string[]; sourcesContent: (string | null)[] }
+    const workerSourceIndex = workerMap.sources.findIndex((source) =>
+      source.endsWith('src/worker-collision.ts')
+    )
+    expect(workerSourceIndex).toBeGreaterThanOrEqual(0)
+    expect(workerMap.sourcesContent).toHaveLength(workerMap.sources.length)
+    expect(workerMap.sourcesContent[workerSourceIndex]).toContain('worker-collision:')
   })
 })

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -1,0 +1,94 @@
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { join, resolve } from 'node:path'
+import { gunzipSync } from 'node:zlib'
+import { originalPositionFor, TraceMap } from '@jridgewell/trace-mapping'
+import { afterEach, describe, expect, it } from 'vitest'
+import { build } from 'vite'
+import {
+  createRendererSourceMapCompactionPlugin,
+  rendererProductionBuild,
+  rendererProductionMinifyOptions
+} from '../build-plugins/renderer-production-minification'
+
+const temporaryRoots: string[] = []
+
+function createFixture(): string {
+  const fixtureParent = resolve('out', 'test-fixtures')
+  mkdirSync(fixtureParent, { recursive: true })
+  const root = mkdtempSync(join(fixtureParent, 'renderer-minification-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(
+    join(root, 'index.html'),
+    '<script type="module" src="/src/probe.ts"></script>',
+    'utf8'
+  )
+  writeFileSync(
+    join(root, 'src', 'probe.ts'),
+    [
+      'const rendererMinificationDiagnosticPadding = "padding-padding-padding-padding"',
+      'function deliberateRendererCrash(): never {',
+      '  const descriptiveRendererState = rendererMinificationDiagnosticPadding.length',
+      '  throw new TypeError(`renderer-minification-probe:${descriptiveRendererState}`)',
+      '}',
+      'deliberateRendererCrash()'
+    ].join('\n'),
+    'utf8'
+  )
+  return root
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('renderer production minification', () => {
+  it('keeps crash names and emits an adjacent map that resolves the thrown frame', async () => {
+    const root = createFixture()
+    const outDir = 'out'
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [createRendererSourceMapCompactionPlugin()],
+      build: {
+        ...rendererProductionBuild,
+        outDir,
+        emptyOutDir: true,
+        modulePreload: false,
+        rollupOptions: { output: { minify: rendererProductionMinifyOptions } }
+      }
+    })
+
+    const assetsDir = join(root, outDir, 'assets')
+    const outputFile = readdirSync(assetsDir).find((fileName) => fileName.endsWith('.js'))
+    expect(outputFile).toBeDefined()
+    const outputPath = join(assetsDir, outputFile!)
+    const output = readFileSync(outputPath, 'utf8')
+    expect(output).not.toContain('rendererMinificationDiagnosticPadding')
+    expect(output).not.toContain('descriptiveRendererState')
+    expect(output).not.toContain('sourceMappingURL')
+
+    const execution = spawnSync(process.execPath, [outputPath], { encoding: 'utf8' })
+    expect(execution.status).not.toBe(0)
+    expect(execution.stderr).toContain('TypeError: renderer-minification-probe:31')
+    expect(execution.stderr).toContain('deliberateRendererCrash')
+
+    const escapedOutputFile = outputFile!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const frame = execution.stderr.match(new RegExp(`${escapedOutputFile}:(\\d+):(\\d+)`))
+    expect(frame).not.toBeNull()
+    expect(() => readFileSync(`${outputPath}.map`)).toThrow()
+    const mapContents = gunzipSync(readFileSync(`${outputPath}.map.gz`)).toString('utf8')
+    expect(JSON.parse(mapContents)).not.toHaveProperty('sourcesContent')
+    const map = new TraceMap(mapContents)
+    const original = originalPositionFor(map, {
+      line: Number(frame![1]),
+      column: Number(frame![2]) - 1
+    })
+    expect(original.source).toMatch(/src\/probe\.ts$/)
+    expect(original.line).toBe(4)
+  })
+})

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -4,13 +4,15 @@ import { isAbsolute, join, resolve } from 'node:path'
 import { gunzipSync } from 'node:zlib'
 import { originalPositionFor, sourceContentFor, TraceMap } from '@jridgewell/trace-mapping'
 import { afterEach, describe, expect, it } from 'vitest'
-import { build } from 'vite'
+import { build, type Plugin } from 'vite'
 import {
   createRendererSourceMapCompactionPlugin,
   createRendererSourceMapProvenancePlugin,
   rendererProductionBuild,
-  rendererProductionOutput
+  rendererProductionOutput,
+  type RendererSourceMapMode
 } from '../build-plugins/renderer-production-minification'
+import { verifyLocalRendererSourceMaps } from './renderer-source-map-contract.cjs'
 
 const temporaryRoots: string[] = []
 
@@ -101,13 +103,33 @@ function createGeneratedDataFixture(): string {
   return root
 }
 
-function readProvenanceChunks(outputDir: string): { file: string; sourceMap: boolean }[] {
+function readProvenanceChunks(
+  outputDir: string
+): { file: string; sourceMap: RendererSourceMapMode }[] {
   return readdirSync(join(outputDir, 'source-map-provenance')).flatMap((fileName) => {
     const provenance = JSON.parse(
       readFileSync(join(outputDir, 'source-map-provenance', fileName), 'utf8')
-    ) as { chunks: { file: string; sourceMap: boolean }[] }
+    ) as {
+      chunks: { file: string; sourceMap: RendererSourceMapMode }[]
+    }
     return provenance.chunks
   })
+}
+
+function stripOrdinaryChunkMap(): Plugin {
+  return {
+    name: 'strip-ordinary-chunk-map',
+    generateBundle: (_options, bundle) => {
+      for (const output of Object.values(bundle)) {
+        if (
+          output.type === 'chunk' &&
+          Object.keys(output.modules).some((id) => id.endsWith('probe.ts'))
+        ) {
+          output.map = null
+        }
+      }
+    }
+  }
 }
 
 afterEach(() => {
@@ -166,7 +188,7 @@ describe('renderer production minification', () => {
     expect(sourceMap.sourcesContent).toHaveLength(sourceMap.sources.length)
     expect(readProvenanceChunks(join(root, outDir))).toContainEqual({
       file: `assets/${outputFile}`,
-      sourceMap: true
+      sourceMap: 'mapped'
     })
     const map = new TraceMap(mapContents)
     const original = originalPositionFor(map, {
@@ -234,11 +256,11 @@ describe('renderer production minification', () => {
     expect(workerMap.sourcesContent[workerSourceIndex]).toContain('worker-collision:')
     expect(readProvenanceChunks(join(root, outDir))).toContainEqual({
       file: `assets/${workerFile}`,
-      sourceMap: true
+      sourceMap: 'mapped'
     })
   })
 
-  it('emits a usable mapping for a generated data chunk', async () => {
+  it('preserves an honest mappingless map for a generated JSON data chunk', async () => {
     const root = createGeneratedDataFixture()
     const outDir = 'out'
     await build({
@@ -272,6 +294,44 @@ describe('renderer production minification', () => {
     const sourceMap = JSON.parse(
       gunzipSync(readFileSync(join(assetsDir, mapFile!))).toString('utf8')
     ) as { mappings: string }
-    expect(sourceMap.mappings).toBe('AAAA')
+    expect(sourceMap.mappings).toBe('')
+    expect(readProvenanceChunks(join(root, outDir))).toContainEqual({
+      file: `assets/${mapFile!.slice(0, -'.map.gz'.length)}`,
+      sourceMap: 'mappingless-json'
+    })
+    expect(() => verifyLocalRendererSourceMaps('renderer', join(root, outDir))).not.toThrow()
+  })
+
+  it('requires a map when another plugin strips one from an ordinary chunk', async () => {
+    const root = createFixture()
+    const outDir = 'out'
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [
+        stripOrdinaryChunkMap(),
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ],
+      build: {
+        ...rendererProductionBuild,
+        outDir,
+        emptyOutDir: true,
+        modulePreload: false,
+        rollupOptions: { output: rendererProductionOutput }
+      }
+    })
+
+    expect(readProvenanceChunks(join(root, outDir))).toContainEqual(
+      expect.objectContaining({ sourceMap: 'mapped' })
+    )
+    const assetsDir = join(root, outDir, 'assets')
+    const mapFile = readdirSync(assetsDir).find((fileName) => fileName.endsWith('.js.map.gz'))
+    expect(mapFile).toBeDefined()
+    rmSync(join(assetsDir, mapFile!))
+    expect(() => verifyLocalRendererSourceMaps('renderer', join(root, outDir))).toThrow(
+      'source-map coverage differs from provenance (missing:'
+    )
   })
 })

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -7,6 +7,7 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { build } from 'vite'
 import {
   createRendererSourceMapCompactionPlugin,
+  createRendererSourceMapProvenancePlugin,
   rendererProductionBuild,
   rendererProductionOutput
 } from '../build-plugins/renderer-production-minification'
@@ -84,6 +85,31 @@ function createWorkerCollisionFixture(): string {
   return root
 }
 
+function createGeneratedDataFixture(): string {
+  const fixtureParent = resolve('out', 'test-fixtures')
+  mkdirSync(fixtureParent, { recursive: true })
+  const root = mkdtempSync(join(fixtureParent, 'renderer-generated-data-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(
+    join(root, 'index.html'),
+    '<script type="module" src="/src/main.ts"></script>',
+    'utf8'
+  )
+  writeFileSync(join(root, 'src', 'main.ts'), "void import('./strings.json')\n", 'utf8')
+  writeFileSync(join(root, 'src', 'strings.json'), '{"message":"diagnostic text"}\n', 'utf8')
+  return root
+}
+
+function readProvenanceChunks(outputDir: string): { file: string; sourceMap: boolean }[] {
+  return readdirSync(join(outputDir, 'source-map-provenance')).flatMap((fileName) => {
+    const provenance = JSON.parse(
+      readFileSync(join(outputDir, 'source-map-provenance', fileName), 'utf8')
+    ) as { chunks: { file: string; sourceMap: boolean }[] }
+    return provenance.chunks
+  })
+}
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -98,7 +124,10 @@ describe('renderer production minification', () => {
       root,
       configFile: false,
       logLevel: 'silent',
-      plugins: [createRendererSourceMapCompactionPlugin()],
+      plugins: [
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ],
       build: {
         ...rendererProductionBuild,
         outDir,
@@ -135,6 +164,10 @@ describe('renderer production minification', () => {
     }
     expect(sourceMap.sources.every((source) => !isAbsolute(source))).toBe(true)
     expect(sourceMap.sourcesContent).toHaveLength(sourceMap.sources.length)
+    expect(readProvenanceChunks(join(root, outDir))).toContainEqual({
+      file: `assets/${outputFile}`,
+      sourceMap: true
+    })
     const map = new TraceMap(mapContents)
     const original = originalPositionFor(map, {
       line: Number(frame![1]),
@@ -154,9 +187,13 @@ describe('renderer production minification', () => {
       root,
       configFile: false,
       logLevel: 'silent',
-      plugins: [createRendererSourceMapCompactionPlugin()],
+      plugins: [
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ],
       worker: {
         format: 'es',
+        plugins: () => [createRendererSourceMapProvenancePlugin()],
         rollupOptions: { output: rendererProductionOutput }
       },
       build: {
@@ -195,5 +232,46 @@ describe('renderer production minification', () => {
     expect(workerSourceIndex).toBeGreaterThanOrEqual(0)
     expect(workerMap.sourcesContent).toHaveLength(workerMap.sources.length)
     expect(workerMap.sourcesContent[workerSourceIndex]).toContain('worker-collision:')
+    expect(readProvenanceChunks(join(root, outDir))).toContainEqual({
+      file: `assets/${workerFile}`,
+      sourceMap: true
+    })
+  })
+
+  it('emits a usable mapping for a generated data chunk', async () => {
+    const root = createGeneratedDataFixture()
+    const outDir = 'out'
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ],
+      build: {
+        ...rendererProductionBuild,
+        outDir,
+        emptyOutDir: true,
+        modulePreload: false,
+        rollupOptions: { output: rendererProductionOutput }
+      }
+    })
+
+    const assetsDir = join(root, outDir, 'assets')
+    const mapFile = readdirSync(assetsDir).find((fileName) => {
+      if (!fileName.endsWith('.js.map.gz')) {
+        return false
+      }
+      const sourceMap = JSON.parse(
+        gunzipSync(readFileSync(join(assetsDir, fileName))).toString('utf8')
+      ) as { sources: string[] }
+      return sourceMap.sources.some((source) => source.endsWith('src/strings.json'))
+    })
+    expect(mapFile).toBeDefined()
+    const sourceMap = JSON.parse(
+      gunzipSync(readFileSync(join(assetsDir, mapFile!))).toString('utf8')
+    ) as { mappings: string }
+    expect(sourceMap.mappings).toBe('AAAA')
   })
 })

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -1,6 +1,7 @@
 import { spawnSync } from 'node:child_process'
 import { mkdirSync, mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
 import { isAbsolute, join, resolve } from 'node:path'
+import { pathToFileURL } from 'node:url'
 import { gunzipSync } from 'node:zlib'
 import { originalPositionFor, sourceContentFor, TraceMap } from '@jridgewell/trace-mapping'
 import { afterEach, describe, expect, it } from 'vitest'
@@ -103,6 +104,47 @@ function createGeneratedDataFixture(): string {
   return root
 }
 
+function createJavascriptAssetFixture(assetImport: string): string {
+  const fixtureParent = resolve('out', 'test-fixtures')
+  mkdirSync(fixtureParent, { recursive: true })
+  const root = mkdtempSync(join(fixtureParent, 'renderer-javascript-asset-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(
+    join(root, 'index.html'),
+    '<script type="module" src="/src/main.ts"></script>',
+    'utf8'
+  )
+  writeFileSync(
+    join(root, 'src', 'main.ts'),
+    `import assetUrl from ${JSON.stringify(assetImport)}\nvoid import(/* @vite-ignore */ assetUrl)\n`,
+    'utf8'
+  )
+  return root
+}
+
+function createFacadeFixture(): string {
+  const fixtureParent = resolve('out', 'test-fixtures')
+  mkdirSync(fixtureParent, { recursive: true })
+  const root = mkdtempSync(join(fixtureParent, 'renderer-facade-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(join(root, 'package.json'), '{"type":"module"}\n')
+  for (const entry of ['first', 'second']) {
+    writeFileSync(
+      join(root, 'src', `${entry}.ts`),
+      "export { facadeValue } from './facade-implementation'\n",
+      'utf8'
+    )
+  }
+  writeFileSync(
+    join(root, 'src', 'facade-implementation.ts'),
+    'export function facadeValue(): string { return "facade" }\n',
+    'utf8'
+  )
+  return root
+}
+
 function readProvenanceChunks(
   outputDir: string
 ): { file: string; sourceMap: RendererSourceMapMode }[] {
@@ -126,7 +168,52 @@ function stripOrdinaryChunkMap(): Plugin {
           Object.keys(output.modules).some((id) => id.endsWith('probe.ts'))
         ) {
           output.map = null
+          delete bundle[`${output.fileName}.map`]
         }
+      }
+    }
+  }
+}
+
+function appendExecutableFacadeCode(): Plugin {
+  return {
+    name: 'append-executable-facade-code',
+    generateBundle: (_options, bundle) => {
+      const facade = Object.values(bundle).find(
+        (output) =>
+          output.type === 'chunk' &&
+          output.code.length > 0 &&
+          Object.keys(output.modules).length > 0 &&
+          Object.values(output.modules).every((module) => module.renderedLength === 0)
+      )
+      if (!facade || facade.type !== 'chunk') {
+        return
+      }
+      facade.code +=
+        ';function injectedFirstPartyFacadeCrash(){throw new Error("injected-facade-crash")}injectedFirstPartyFacadeCrash();'
+      facade.map = null
+    }
+  }
+}
+
+function facadeBuild(root: string, plugins: Plugin[]): Parameters<typeof build>[0] {
+  return {
+    root,
+    configFile: false,
+    logLevel: 'silent',
+    plugins,
+    build: {
+      ...rendererProductionBuild,
+      outDir: 'out',
+      emptyOutDir: true,
+      modulePreload: false,
+      rollupOptions: {
+        preserveEntrySignatures: 'strict',
+        input: {
+          first: join(root, 'src', 'first.ts'),
+          second: join(root, 'src', 'second.ts')
+        },
+        output: rendererProductionOutput
       }
     }
   }
@@ -177,7 +264,7 @@ describe('renderer production minification', () => {
 
     const escapedOutputFile = outputFile!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
     const frame = execution.stderr.match(new RegExp(`${escapedOutputFile}:(\\d+):(\\d+)`))
-    expect(frame).not.toBeNull()
+    expect(frame, execution.stderr).not.toBeNull()
     expect(() => readFileSync(`${outputPath}.map`)).toThrow()
     const mapContents = gunzipSync(readFileSync(`${outputPath}.map.gz`)).toString('utf8')
     const sourceMap = JSON.parse(mapContents) as {
@@ -260,7 +347,7 @@ describe('renderer production minification', () => {
     })
   })
 
-  it('preserves an honest mappingless map for a generated JSON data chunk', async () => {
+  it('replaces a mappingless JSON map with an exact identity map', async () => {
     const root = createGeneratedDataFixture()
     const outDir = 'out'
     await build({
@@ -280,42 +367,94 @@ describe('renderer production minification', () => {
       }
     })
 
-    const assetsDir = join(root, outDir, 'assets')
-    const mapFile = readdirSync(assetsDir).find((fileName) => {
-      if (!fileName.endsWith('.js.map.gz')) {
-        return false
-      }
-      const sourceMap = JSON.parse(
-        gunzipSync(readFileSync(join(assetsDir, fileName))).toString('utf8')
-      ) as { sources: string[] }
-      return sourceMap.sources.some((source) => source.endsWith('src/strings.json'))
-    })
-    expect(mapFile).toBeDefined()
+    const identityChunk = readProvenanceChunks(join(root, outDir)).find(
+      (chunk) => chunk.sourceMap === 'identity-generated'
+    )
+    expect(identityChunk).toBeDefined()
+    const javascript = readFileSync(join(root, outDir, identityChunk!.file), 'utf8')
     const sourceMap = JSON.parse(
-      gunzipSync(readFileSync(join(assetsDir, mapFile!))).toString('utf8')
-    ) as { mappings: string }
-    expect(sourceMap.mappings).toBe('')
-    expect(readProvenanceChunks(join(root, outDir))).toContainEqual({
-      file: `assets/${mapFile!.slice(0, -'.map.gz'.length)}`,
-      sourceMap: 'mappingless-json'
-    })
+      gunzipSync(readFileSync(join(root, outDir, `${identityChunk!.file}.map.gz`))).toString('utf8')
+    ) as { mappings: string; sources: string[]; sourcesContent: string[] }
+    expect(sourceMap.mappings).not.toBe('')
+    expect(sourceMap.sources).toEqual([
+      `source-map-identity/${identityChunk!.file.split('/').at(-1)}`
+    ])
+    expect(sourceMap.sourcesContent).toEqual([javascript])
     expect(() => verifyLocalRendererSourceMaps('renderer', join(root, outDir))).not.toThrow()
   })
 
   it('requires a map when another plugin strips one from an ordinary chunk', async () => {
     const root = createFixture()
     const outDir = 'out'
+    await expect(
+      build({
+        root,
+        configFile: false,
+        logLevel: 'silent',
+        plugins: [
+          stripOrdinaryChunkMap(),
+          createRendererSourceMapProvenancePlugin(),
+          createRendererSourceMapCompactionPlugin()
+        ],
+        build: {
+          ...rendererProductionBuild,
+          outDir,
+          emptyOutDir: true,
+          modulePreload: false,
+          rollupOptions: { output: rendererProductionOutput }
+        }
+      })
+    ).rejects.toThrow(/Missing compressed source map for assets\/index-[^/]+\.js/)
+  })
+
+  it.each(['js', 'cjs'])(
+    'rejects a dynamically imported first-party .%s OutputAsset without a map',
+    async (extension) => {
+      const root = createJavascriptAssetFixture(`./lazy-first-party.${extension}?url`)
+      writeFileSync(
+        join(root, 'src', `lazy-first-party.${extension}`),
+        'export function firstPartyLazyModule() { return "first-party" }\n',
+        'utf8'
+      )
+
+      await expect(
+        build({
+          root,
+          configFile: false,
+          logLevel: 'silent',
+          plugins: [
+            createRendererSourceMapProvenancePlugin(),
+            createRendererSourceMapCompactionPlugin()
+          ],
+          build: {
+            ...rendererProductionBuild,
+            assetsInlineLimit: 0,
+            outDir: 'out',
+            emptyOutDir: true,
+            modulePreload: false,
+            rollupOptions: { output: rendererProductionOutput }
+          }
+        })
+      ).rejects.toThrow(
+        new RegExp(`Missing compressed source map for assets/lazy-first-party-[^/]+\\.${extension}`)
+      )
+    }
+  )
+
+  it('gives the metadata-verified prebuilt PDF worker an exact identity map', async () => {
+    const root = createJavascriptAssetFixture('pdfjs-dist/build/pdf.worker.min.mjs?url')
+    const outDir = 'out'
     await build({
       root,
       configFile: false,
       logLevel: 'silent',
       plugins: [
-        stripOrdinaryChunkMap(),
         createRendererSourceMapProvenancePlugin(),
         createRendererSourceMapCompactionPlugin()
       ],
       build: {
         ...rendererProductionBuild,
+        assetsInlineLimit: 0,
         outDir,
         emptyOutDir: true,
         modulePreload: false,
@@ -323,15 +462,77 @@ describe('renderer production minification', () => {
       }
     })
 
-    expect(readProvenanceChunks(join(root, outDir))).toContainEqual(
-      expect.objectContaining({ sourceMap: 'mapped' })
+    const pdfWorker = readProvenanceChunks(join(root, outDir)).find(
+      (chunk) => chunk.sourceMap === 'identity-generated' && chunk.file.endsWith('.mjs')
     )
-    const assetsDir = join(root, outDir, 'assets')
-    const mapFile = readdirSync(assetsDir).find((fileName) => fileName.endsWith('.js.map.gz'))
-    expect(mapFile).toBeDefined()
-    rmSync(join(assetsDir, mapFile!))
-    expect(() => verifyLocalRendererSourceMaps('renderer', join(root, outDir))).toThrow(
-      'source-map coverage differs from provenance (missing:'
+    expect(pdfWorker?.file).toMatch(/assets\/pdf\.worker\.min-[^/]+\.mjs$/)
+    const javascript = readFileSync(join(root, outDir, pdfWorker!.file), 'utf8')
+    const sourceMap = JSON.parse(
+      gunzipSync(readFileSync(join(root, outDir, `${pdfWorker!.file}.map.gz`))).toString('utf8')
+    ) as { sourcesContent: string[] }
+    expect(sourceMap.sourcesContent).toEqual([javascript])
+    expect(() => verifyLocalRendererSourceMaps('renderer', join(root, outDir))).not.toThrow()
+  })
+
+  it('gives a physical-module facade an exact identity map', async () => {
+    const root = createFacadeFixture()
+    await build(
+      facadeBuild(root, [
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ])
     )
+
+    const facade = readProvenanceChunks(join(root, 'out')).find(
+      (chunk) => chunk.sourceMap === 'identity-generated'
+    )
+    expect(facade).toBeDefined()
+    const facadeCode = readFileSync(join(root, 'out', facade!.file), 'utf8')
+    expect(facadeCode).toMatch(/^(?:import|export)/)
+    expect(() => verifyLocalRendererSourceMaps('renderer', join(root, 'out'))).not.toThrow()
+  })
+
+  it('identity-maps executable code appended to a physical-module facade', async () => {
+    const root = createFacadeFixture()
+    await build(
+      facadeBuild(root, [
+        appendExecutableFacadeCode(),
+        createRendererSourceMapProvenancePlugin(),
+        createRendererSourceMapCompactionPlugin()
+      ])
+    )
+
+    const assetsDir = join(root, 'out', 'assets')
+    const mutatedFacade = readdirSync(assetsDir).find((fileName) =>
+      readFileSync(join(assetsDir, fileName), 'utf8').includes('injected-facade-crash')
+    )
+    expect(mutatedFacade).toBeDefined()
+    const moduleUrl = pathToFileURL(join(assetsDir, mutatedFacade!)).href
+    const execution = spawnSync(
+      process.execPath,
+      ['--input-type=module', '--eval', `import(${JSON.stringify(moduleUrl)})`],
+      { encoding: 'utf8' }
+    )
+    expect(execution.status).not.toBe(0)
+    expect(execution.stderr).toContain('injected-facade-crash')
+    const escapedFileName = mutatedFacade!.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+    const frame = execution.stderr.match(new RegExp(`${escapedFileName}:(\\d+):(\\d+)`))
+    expect(frame, execution.stderr).not.toBeNull()
+    expect(() => verifyLocalRendererSourceMaps('renderer', join(root, 'out'))).not.toThrow()
+    const javascript = readFileSync(join(assetsDir, mutatedFacade!), 'utf8')
+    const mapContents = gunzipSync(
+      readFileSync(join(assetsDir, `${mutatedFacade}.map.gz`))
+    ).toString('utf8')
+    const sourceMap = JSON.parse(mapContents) as { sourcesContent: string[] }
+    const original = originalPositionFor(new TraceMap(mapContents), {
+      line: Number(frame![1]),
+      column: Number(frame![2]) - 1
+    })
+    expect(original).toMatchObject({
+      source: `source-map-identity/${mutatedFacade}`,
+      line: Number(frame![1]),
+      column: Number(frame![2]) - 1
+    })
+    expect(sourceMap.sourcesContent).toEqual([javascript])
   })
 })

--- a/config/scripts/renderer-production-minification.test.ts
+++ b/config/scripts/renderer-production-minification.test.ts
@@ -49,6 +49,41 @@ function createFixture(): string {
   return root
 }
 
+function createWorkerCollisionFixture(): string {
+  const fixtureParent = resolve('out', 'test-fixtures')
+  mkdirSync(fixtureParent, { recursive: true })
+  const root = mkdtempSync(join(fixtureParent, 'renderer-worker-minification-'))
+  temporaryRoots.push(root)
+  mkdirSync(join(root, 'src'))
+  writeFileSync(
+    join(root, 'index.html'),
+    '<script type="module" src="/src/main.ts"></script>',
+    'utf8'
+  )
+  writeFileSync(
+    join(root, 'src', 'main.ts'),
+    "new Worker(new URL('./worker-collision.ts', import.meta.url), { type: 'module' })\n",
+    'utf8'
+  )
+  writeFileSync(
+    join(root, 'src', 'worker-collision.ts'),
+    [
+      "import { Same as AlphaClass, same as alphaFunction } from './worker-alpha'",
+      "import { Same as BetaClass, same as betaFunction } from './worker-beta'",
+      'console.log(`worker-collision:${[alphaFunction.name, betaFunction.name, AlphaClass.name, BetaClass.name].join(",")}`)'
+    ].join('\n'),
+    'utf8'
+  )
+  for (const moduleName of ['worker-alpha', 'worker-beta']) {
+    writeFileSync(
+      join(root, 'src', `${moduleName}.ts`),
+      'export function same(): void {}\nexport class Same {}\n',
+      'utf8'
+    )
+  }
+  return root
+}
+
 afterEach(() => {
   for (const root of temporaryRoots.splice(0)) {
     rmSync(root, { recursive: true, force: true })
@@ -102,5 +137,45 @@ describe('renderer production minification', () => {
     })
     expect(original.source).toMatch(/src\/probe\.ts$/)
     expect(original.line).toBe(7)
+  })
+
+  it('keeps collided function and class names inside a real worker bundle', async () => {
+    const root = createWorkerCollisionFixture()
+    const outDir = 'out'
+    await build({
+      root,
+      configFile: false,
+      logLevel: 'silent',
+      plugins: [createRendererSourceMapCompactionPlugin()],
+      worker: {
+        format: 'es',
+        rollupOptions: { output: rendererProductionOutput }
+      },
+      build: {
+        ...rendererProductionBuild,
+        outDir,
+        emptyOutDir: true,
+        modulePreload: false,
+        rollupOptions: { output: rendererProductionOutput }
+      }
+    })
+
+    const assetsDir = join(root, outDir, 'assets')
+    const workerFile = readdirSync(assetsDir).find((fileName) => {
+      if (!fileName.endsWith('.js')) {
+        return false
+      }
+      return readFileSync(join(assetsDir, fileName), 'utf8').includes('worker-collision:')
+    })
+    expect(workerFile).toBeDefined()
+    const workerSource = readFileSync(join(assetsDir, workerFile!), 'utf8')
+    const workerUrl = `data:text/javascript;base64,${Buffer.from(workerSource).toString('base64')}`
+    const execution = spawnSync(
+      process.execPath,
+      ['--input-type=module', '--eval', `import(${JSON.stringify(workerUrl)})`],
+      { encoding: 'utf8' }
+    )
+    expect(execution.status, execution.stderr).toBe(0)
+    expect(execution.stdout).toContain('worker-collision:same,same,Same,Same')
   })
 })

--- a/config/scripts/renderer-source-map-contract.cjs
+++ b/config/scripts/renderer-source-map-contract.cjs
@@ -2,16 +2,15 @@ const { readFileSync, readdirSync } = require('node:fs')
 const { basename, join, relative, sep } = require('node:path')
 const { gunzipSync } = require('node:zlib')
 const { AnyMap, decodedMappings } = require('@jridgewell/trace-mapping')
+const {
+  isCompressedJavaScriptSourceMapPath,
+  isJavaScriptOutputPath,
+  isRawJavaScriptSourceMapPath
+} = require('./renderer-javascript-output.cjs')
 const { verifyBasicMappingsStrict } = require('./renderer-source-map-vlq.cjs')
 
 const PROVENANCE_PREFIX = 'source-map-provenance/'
-const SOURCE_MAP_MODES = new Set([
-  'mapped',
-  'mappingless-json',
-  'source-less-asset',
-  'source-less-facade',
-  'source-less-generated'
-])
+const SOURCE_MAP_MODES = new Set(['identity-generated', 'mapped'])
 const BASIC_MAP_FIELDS = [
   'mappings',
   'names',
@@ -84,7 +83,11 @@ function constructSourceMap(sourceMap, mapLabel) {
   }
 }
 
-function verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment) {
+function javascriptLines(source) {
+  return source.split('\n').map((line) => (line.endsWith('\r') ? line.slice(0, -1) : line))
+}
+
+function verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment, generatedLines) {
   let hasMappedSegment = false
   decoded.forEach((line, lineIndex) => {
     let previousColumn = -1
@@ -94,6 +97,14 @@ function verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment
       }
       if (!segment.every(Number.isInteger) || segment[0] < 0 || segment[0] < previousColumn) {
         throw new Error(`${mapLabel} has invalid generated column at ${lineIndex}:${segmentIndex}`)
+      }
+      if (
+        generatedLines &&
+        (lineIndex >= generatedLines.length || segment[0] > generatedLines[lineIndex].length)
+      ) {
+        throw new Error(
+          `${mapLabel} has out-of-range generated position at ${lineIndex}:${segmentIndex}`
+        )
       }
       previousColumn = segment[0]
       if (segment.length === 1) {
@@ -118,7 +129,46 @@ function verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment
   }
 }
 
-function verifyBasicMap(sourceMap, mapLabel, sourceMapMode) {
+function verifyIdentityMap(sourceMap, decoded, mapLabel, javascriptEntry, javascriptSource) {
+  const expectedSource = `source-map-identity/${basename(javascriptEntry)}`
+  if (
+    sourceMap.sources.length !== 1 ||
+    sourceMap.sources[0] !== expectedSource ||
+    sourceMap.names.length !== 0 ||
+    sourceMap.sourceRoot !== undefined ||
+    sourceMap.sourcesContent[0] !== javascriptSource
+  ) {
+    throw new Error(`${mapLabel} is not an exact self-contained identity map`)
+  }
+  const lines = javascriptLines(javascriptSource)
+  if (decoded.length !== lines.length) {
+    throw new Error(`${mapLabel} does not map every generated line exactly`)
+  }
+  decoded.forEach((line, lineIndex) => {
+    if (
+      line.length !== lines[lineIndex].length + 1 ||
+      line.some(
+        (segment, column) =>
+          segment.length !== 4 ||
+          segment[0] !== column ||
+          segment[1] !== 0 ||
+          segment[2] !== lineIndex ||
+          segment[3] !== column
+      )
+    ) {
+      throw new Error(`${mapLabel} does not preserve generated coordinates exactly`)
+    }
+  })
+}
+
+function verifyBasicMap(
+  sourceMap,
+  mapLabel,
+  sourceMapMode,
+  javascriptEntry,
+  javascriptSource,
+  requireMappedSegment
+) {
   if (typeof sourceMap.mappings !== 'string') {
     throw new Error(`${mapLabel} does not contain string mappings`)
   }
@@ -163,34 +213,27 @@ function verifyBasicMap(sourceMap, mapLabel, sourceMapMode) {
       }
     })
   }
-  if (sourceMapMode === 'mappingless-json') {
-    if (
-      sourceMap.mappings !== '' ||
-      sourceMap.sources.length === 0 ||
-      sourceMap.names.length !== 0 ||
-      !sourceMap.sources.every((source) => source.endsWith('.json'))
-    ) {
-      throw new Error(`${mapLabel} is not a JSON-only mappingless map`)
-    }
-    sourceMap.sourcesContent.forEach((content, index) => {
-      try {
-        JSON.parse(content)
-      } catch {
-        throw new Error(`${mapLabel} has non-JSON mappingless source ${sourceMap.sources[index]}`)
-      }
-    })
-  }
   const { traceMap, decoded } = constructSourceMap(sourceMap, mapLabel)
   verifyBasicMappingsStrict(sourceMap, decoded, mapLabel)
   verifyDecodedMappings(
     traceMap,
     decoded,
     mapLabel,
-    sourceMap.sources.length > 0 && sourceMapMode !== 'mappingless-json'
+    requireMappedSegment,
+    javascriptSource === undefined ? undefined : javascriptLines(javascriptSource)
   )
+  if (sourceMapMode === 'identity-generated') {
+    verifyIdentityMap(sourceMap, decoded, mapLabel, javascriptEntry, javascriptSource)
+  }
 }
 
-function verifyIndexedMap(sourceMap, mapLabel) {
+function verifyIndexedMap(
+  sourceMap,
+  mapLabel,
+  javascriptEntry,
+  javascriptSource,
+  requireMappedSegment
+) {
   const mixedField = BASIC_MAP_FIELDS.find((field) => Object.hasOwn(sourceMap, field))
   if (mixedField) {
     throw new Error(`${mapLabel} mixes indexed sections with basic field ${mixedField}`)
@@ -199,6 +242,8 @@ function verifyIndexedMap(sourceMap, mapLabel) {
     throw new Error(`${mapLabel} has non-array indexed-map sections`)
   }
   let previousOffset
+  const generatedLines =
+    javascriptSource === undefined ? undefined : javascriptLines(javascriptSource)
   sourceMap.sections.forEach((section, index) => {
     if (
       !isObject(section) ||
@@ -221,13 +266,30 @@ function verifyIndexedMap(sourceMap, mapLabel) {
       throw new Error(`${mapLabel} has unordered indexed-map offset at section ${index}`)
     }
     previousOffset = { line, column }
-    verifySourceMapObject(section.map, `${mapLabel} section ${index}`, 'mapped')
+    if (generatedLines && (line >= generatedLines.length || column > generatedLines[line].length)) {
+      throw new Error(`${mapLabel} has out-of-range indexed-map offset at section ${index}`)
+    }
+    verifySourceMapObject(
+      section.map,
+      `${mapLabel} section ${index}`,
+      'mapped',
+      javascriptEntry,
+      undefined,
+      false
+    )
   })
   const { traceMap, decoded } = constructSourceMap(sourceMap, mapLabel)
-  verifyDecodedMappings(traceMap, decoded, mapLabel, traceMap.sources.length > 0)
+  verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment, generatedLines)
 }
 
-function verifySourceMapObject(sourceMap, mapLabel, sourceMapMode = 'mapped') {
+function verifySourceMapObject(
+  sourceMap,
+  mapLabel,
+  sourceMapMode = 'mapped',
+  javascriptEntry = 'app.js',
+  javascriptSource,
+  requireMappedSegment = sourceMapMode === 'mapped'
+) {
   if (!isObject(sourceMap)) {
     throw new Error(`${mapLabel} is not a JSON object`)
   }
@@ -235,12 +297,19 @@ function verifySourceMapObject(sourceMap, mapLabel, sourceMapMode = 'mapped') {
     throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
   }
   if (Object.hasOwn(sourceMap, 'sections')) {
-    if (sourceMapMode === 'mappingless-json') {
-      throw new Error(`${mapLabel} uses indexed sections for a mappingless map`)
+    if (sourceMapMode === 'identity-generated') {
+      throw new Error(`${mapLabel} uses indexed sections for an identity map`)
     }
-    verifyIndexedMap(sourceMap, mapLabel)
+    verifyIndexedMap(sourceMap, mapLabel, javascriptEntry, javascriptSource, requireMappedSegment)
   } else {
-    verifyBasicMap(sourceMap, mapLabel, sourceMapMode)
+    verifyBasicMap(
+      sourceMap,
+      mapLabel,
+      sourceMapMode,
+      javascriptEntry,
+      javascriptSource,
+      requireMappedSegment
+    )
   }
 }
 
@@ -249,7 +318,8 @@ function verifySourceMapBytes(
   mapEntry,
   javascriptEntries,
   scope,
-  sourceMapMode = 'mapped'
+  sourceMapMode = 'mapped',
+  javascriptBytes
 ) {
   const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
   const mapLabel = `${scope} source map ${mapEntry}`
@@ -265,7 +335,13 @@ function verifySourceMapBytes(
       `${mapLabel} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
     )
   }
-  verifySourceMapObject(sourceMap, mapLabel, sourceMapMode)
+  verifySourceMapObject(
+    sourceMap,
+    mapLabel,
+    sourceMapMode,
+    javascriptEntry,
+    javascriptBytes.toString('utf8')
+  )
 }
 
 function readSourceMapProvenance(outputDir, files, label) {
@@ -288,7 +364,7 @@ function readSourceMapProvenance(outputDir, files, label) {
       if (
         !isObject(chunk) ||
         typeof chunk.file !== 'string' ||
-        !/\.m?js$/.test(chunk.file) ||
+        !isJavaScriptOutputPath(chunk.file) ||
         chunk.file.startsWith('/') ||
         chunk.file.includes('\\') ||
         chunk.file.split('/').includes('..') ||
@@ -318,7 +394,7 @@ function describeSetDifference(expected, actual) {
 }
 
 function verifyOutputCoverage(files, provenance, label) {
-  const javascript = new Set(files.filter((entry) => /\.m?js$/.test(entry)))
+  const javascript = new Set(files.filter(isJavaScriptOutputPath))
   const provenanceJavascript = new Set(provenance.chunks.keys())
   const javascriptDifference = describeSetDifference(provenanceJavascript, javascript)
   if (javascriptDifference) {
@@ -326,12 +402,8 @@ function verifyOutputCoverage(files, provenance, label) {
       `${label} JavaScript set differs from source-map provenance (${javascriptDifference})`
     )
   }
-  const expectedMaps = new Set(
-    [...provenance.chunks]
-      .filter(([, sourceMap]) => !sourceMap.startsWith('source-less-'))
-      .map(([entry]) => `${entry}.map.gz`)
-  )
-  const maps = new Set(files.filter((entry) => /\.m?js\.map\.gz$/.test(entry)))
+  const expectedMaps = new Set([...provenance.chunks.keys()].map((entry) => `${entry}.map.gz`))
+  const maps = new Set(files.filter(isCompressedJavaScriptSourceMapPath))
   const mapDifference = describeSetDifference(expectedMaps, maps)
   if (mapDifference) {
     throw new Error(`${label} source-map coverage differs from provenance (${mapDifference})`)
@@ -342,7 +414,7 @@ function verifyOutputCoverage(files, provenance, label) {
 function verifyLocalRendererSourceMaps(outputName, outputDir) {
   const label = `Local ${outputName}`
   const files = listOutputFiles(outputDir)
-  const rawMaps = files.filter((entry) => /\.m?js\.map$/.test(entry))
+  const rawMaps = files.filter(isRawJavaScriptSourceMapPath)
   if (rawMaps.length > 0) {
     throw new Error(`${label} output contains raw source maps: ${rawMaps.join(', ')}`)
   }
@@ -355,7 +427,8 @@ function verifyLocalRendererSourceMaps(outputName, outputDir) {
       mapEntry,
       coverage.javascript,
       label,
-      provenance.chunks.get(javascriptEntry)
+      provenance.chunks.get(javascriptEntry),
+      readFileSync(join(outputDir, ...javascriptEntry.split('/')))
     )
   }
   return { files, provenance, ...coverage }

--- a/config/scripts/renderer-source-map-contract.cjs
+++ b/config/scripts/renderer-source-map-contract.cjs
@@ -1,0 +1,323 @@
+const { readFileSync, readdirSync } = require('node:fs')
+const { basename, join, relative, sep } = require('node:path')
+const { gunzipSync } = require('node:zlib')
+const { AnyMap, decodedMappings } = require('@jridgewell/trace-mapping')
+
+const PROVENANCE_PREFIX = 'source-map-provenance/'
+const BASIC_MAP_FIELDS = [
+  'mappings',
+  'names',
+  'sources',
+  'sourcesContent',
+  'sourceRoot',
+  'ignoreList',
+  'x_google_ignoreList'
+]
+
+function isObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function listOutputFiles(outputDir) {
+  const files = []
+  function visit(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        visit(entryPath)
+      } else {
+        files.push(relative(outputDir, entryPath).split(sep).join('/'))
+      }
+    }
+  }
+  visit(outputDir)
+  return files.sort()
+}
+
+function parseJson(bytes, label) {
+  try {
+    return JSON.parse(bytes.toString('utf8'))
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'unknown JSON error'
+    throw new Error(`${label} is not valid JSON: ${detail}`)
+  }
+}
+
+function parseSourceMap(mapBytes, mapLabel) {
+  let json
+  try {
+    json = gunzipSync(mapBytes)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'unknown gzip error'
+    throw new Error(`${mapLabel} is not valid gzip: ${detail}`)
+  }
+  return parseJson(json, mapLabel)
+}
+
+function assertRelativeSource(source, mapLabel) {
+  if (source.startsWith('/') || /^[A-Za-z]:[\\/]/.test(source) || source.includes('\\')) {
+    throw new Error(`${mapLabel} contains non-relative source ${source}`)
+  }
+}
+
+function constructSourceMap(sourceMap, mapLabel) {
+  try {
+    const traceMap = new AnyMap(sourceMap)
+    return { traceMap, decoded: decodedMappings(traceMap) }
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'unknown source-map error'
+    throw new Error(`${mapLabel} cannot be constructed for symbolication: ${detail}`)
+  }
+}
+
+function verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment) {
+  let hasMappedSegment = false
+  decoded.forEach((line, lineIndex) => {
+    let previousColumn = -1
+    line.forEach((segment, segmentIndex) => {
+      if (!Array.isArray(segment) || ![1, 4, 5].includes(segment.length)) {
+        throw new Error(`${mapLabel} has invalid decoded segment ${lineIndex}:${segmentIndex}`)
+      }
+      if (!segment.every(Number.isInteger) || segment[0] < 0 || segment[0] < previousColumn) {
+        throw new Error(`${mapLabel} has invalid generated column at ${lineIndex}:${segmentIndex}`)
+      }
+      previousColumn = segment[0]
+      if (segment.length === 1) {
+        return
+      }
+      hasMappedSegment = true
+      if (
+        segment[1] < 0 ||
+        segment[1] >= traceMap.sources.length ||
+        segment[2] < 0 ||
+        segment[3] < 0
+      ) {
+        throw new Error(`${mapLabel} has invalid source position at ${lineIndex}:${segmentIndex}`)
+      }
+      if (segment.length === 5 && (segment[4] < 0 || segment[4] >= traceMap.names.length)) {
+        throw new Error(`${mapLabel} has invalid name index at ${lineIndex}:${segmentIndex}`)
+      }
+    })
+  })
+  if (requireMappedSegment && !hasMappedSegment) {
+    throw new Error(`${mapLabel} has no usable source mappings`)
+  }
+}
+
+function verifyBasicMap(sourceMap, mapLabel) {
+  if (typeof sourceMap.mappings !== 'string') {
+    throw new Error(`${mapLabel} does not contain string mappings`)
+  }
+  if (
+    !Array.isArray(sourceMap.sources) ||
+    !sourceMap.sources.every((source) => typeof source === 'string')
+  ) {
+    throw new Error(`${mapLabel} does not list string sources`)
+  }
+  if (
+    !Array.isArray(sourceMap.names) ||
+    !sourceMap.names.every((name) => typeof name === 'string')
+  ) {
+    throw new Error(`${mapLabel} does not list string names`)
+  }
+  sourceMap.sources.forEach((source) => assertRelativeSource(source, mapLabel))
+  if (sourceMap.sourceRoot !== undefined) {
+    if (typeof sourceMap.sourceRoot !== 'string') {
+      throw new Error(`${mapLabel} has non-string sourceRoot`)
+    }
+    assertRelativeSource(sourceMap.sourceRoot, mapLabel)
+  }
+  if (sourceMap.sources.length === 0) {
+    if (
+      sourceMap.sourcesContent !== undefined &&
+      (!Array.isArray(sourceMap.sourcesContent) || sourceMap.sourcesContent.length !== 0)
+    ) {
+      throw new Error(`${mapLabel} has sourcesContent without sources`)
+    }
+  } else {
+    if (!Array.isArray(sourceMap.sourcesContent)) {
+      throw new Error(`${mapLabel} does not embed sourcesContent`)
+    }
+    if (sourceMap.sourcesContent.length !== sourceMap.sources.length) {
+      throw new Error(
+        `${mapLabel} has ${sourceMap.sourcesContent.length} sourcesContent entries for ${sourceMap.sources.length} sources`
+      )
+    }
+    sourceMap.sources.forEach((source, index) => {
+      if (typeof sourceMap.sourcesContent[index] !== 'string') {
+        throw new Error(`${mapLabel} does not embed source text for ${source}`)
+      }
+    })
+  }
+  const { traceMap, decoded } = constructSourceMap(sourceMap, mapLabel)
+  verifyDecodedMappings(traceMap, decoded, mapLabel, sourceMap.sources.length > 0)
+}
+
+function verifyIndexedMap(sourceMap, mapLabel) {
+  const mixedField = BASIC_MAP_FIELDS.find((field) => Object.hasOwn(sourceMap, field))
+  if (mixedField) {
+    throw new Error(`${mapLabel} mixes indexed sections with basic field ${mixedField}`)
+  }
+  if (!Array.isArray(sourceMap.sections)) {
+    throw new Error(`${mapLabel} has non-array indexed-map sections`)
+  }
+  let previousOffset
+  sourceMap.sections.forEach((section, index) => {
+    if (
+      !isObject(section) ||
+      !isObject(section.offset) ||
+      !isObject(section.map) ||
+      Object.keys(section).some((key) => key !== 'offset' && key !== 'map') ||
+      Object.keys(section.offset).some((key) => key !== 'line' && key !== 'column')
+    ) {
+      throw new Error(`${mapLabel} has invalid indexed-map section ${index}`)
+    }
+    const { line, column } = section.offset
+    if (!Number.isInteger(line) || !Number.isInteger(column) || line < 0 || column < 0) {
+      throw new Error(`${mapLabel} has invalid indexed-map offset at section ${index}`)
+    }
+    if (
+      previousOffset &&
+      (line < previousOffset.line ||
+        (line === previousOffset.line && column <= previousOffset.column))
+    ) {
+      throw new Error(`${mapLabel} has unordered indexed-map offset at section ${index}`)
+    }
+    previousOffset = { line, column }
+    verifySourceMapObject(section.map, `${mapLabel} section ${index}`)
+  })
+  const { traceMap, decoded } = constructSourceMap(sourceMap, mapLabel)
+  verifyDecodedMappings(traceMap, decoded, mapLabel, traceMap.sources.length > 0)
+}
+
+function verifySourceMapObject(sourceMap, mapLabel) {
+  if (!isObject(sourceMap)) {
+    throw new Error(`${mapLabel} is not a JSON object`)
+  }
+  if (sourceMap.version !== 3) {
+    throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
+  }
+  if (Object.hasOwn(sourceMap, 'sections')) {
+    verifyIndexedMap(sourceMap, mapLabel)
+  } else {
+    verifyBasicMap(sourceMap, mapLabel)
+  }
+}
+
+function verifySourceMapBytes(mapBytes, mapEntry, javascriptEntries, scope) {
+  const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
+  const mapLabel = `${scope} source map ${mapEntry}`
+  if (!javascriptEntries.has(javascriptEntry)) {
+    throw new Error(`${mapLabel} has no adjacent JavaScript asset ${javascriptEntry}`)
+  }
+  const sourceMap = parseSourceMap(mapBytes, mapLabel)
+  if (!isObject(sourceMap)) {
+    throw new Error(`${mapLabel} is not a JSON object`)
+  }
+  if (sourceMap.file !== basename(javascriptEntry)) {
+    throw new Error(
+      `${mapLabel} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
+    )
+  }
+  verifySourceMapObject(sourceMap, mapLabel)
+}
+
+function readSourceMapProvenance(outputDir, files, label) {
+  const provenanceFiles = files.filter(
+    (entry) => entry.startsWith(PROVENANCE_PREFIX) && entry.endsWith('.json')
+  )
+  if (provenanceFiles.length === 0) {
+    throw new Error(`${label} output has no source-map provenance`)
+  }
+  const chunks = new Map()
+  for (const entry of provenanceFiles) {
+    const provenance = parseJson(
+      readFileSync(join(outputDir, ...entry.split('/'))),
+      `${label} ${entry}`
+    )
+    if (!isObject(provenance) || provenance.version !== 1 || !Array.isArray(provenance.chunks)) {
+      throw new Error(`${label} ${entry} has invalid source-map provenance shape`)
+    }
+    provenance.chunks.forEach((chunk, index) => {
+      if (
+        !isObject(chunk) ||
+        typeof chunk.file !== 'string' ||
+        !/\.m?js$/.test(chunk.file) ||
+        chunk.file.startsWith('/') ||
+        chunk.file.includes('\\') ||
+        chunk.file.split('/').includes('..') ||
+        typeof chunk.sourceMap !== 'boolean'
+      ) {
+        throw new Error(`${label} ${entry} has invalid source-map provenance chunk ${index}`)
+      }
+      const previous = chunks.get(chunk.file)
+      if (previous !== undefined && previous !== chunk.sourceMap) {
+        throw new Error(`${label} source-map provenance conflicts for ${chunk.file}`)
+      }
+      chunks.set(chunk.file, chunk.sourceMap)
+    })
+  }
+  return { chunks, provenanceFiles }
+}
+
+function describeSetDifference(expected, actual) {
+  const missing = [...expected].filter((entry) => !actual.has(entry)).sort()
+  const stale = [...actual].filter((entry) => !expected.has(entry)).sort()
+  return [
+    missing.length > 0 ? `missing: ${missing.join(', ')}` : '',
+    stale.length > 0 ? `stale: ${stale.join(', ')}` : ''
+  ]
+    .filter(Boolean)
+    .join('; ')
+}
+
+function verifyOutputCoverage(files, provenance, label) {
+  const javascript = new Set(files.filter((entry) => /\.m?js$/.test(entry)))
+  const provenanceJavascript = new Set(provenance.chunks.keys())
+  const javascriptDifference = describeSetDifference(provenanceJavascript, javascript)
+  if (javascriptDifference) {
+    throw new Error(
+      `${label} JavaScript set differs from source-map provenance (${javascriptDifference})`
+    )
+  }
+  const expectedMaps = new Set(
+    [...provenance.chunks].filter(([, sourceMap]) => sourceMap).map(([entry]) => `${entry}.map.gz`)
+  )
+  const maps = new Set(files.filter((entry) => /\.m?js\.map\.gz$/.test(entry)))
+  const mapDifference = describeSetDifference(expectedMaps, maps)
+  if (mapDifference) {
+    throw new Error(`${label} source-map coverage differs from provenance (${mapDifference})`)
+  }
+  return { javascript, maps: [...maps].sort() }
+}
+
+function verifyLocalRendererSourceMaps(outputName, outputDir) {
+  const label = `Local ${outputName}`
+  const files = listOutputFiles(outputDir)
+  const rawMaps = files.filter((entry) => /\.m?js\.map$/.test(entry))
+  if (rawMaps.length > 0) {
+    throw new Error(`${label} output contains raw source maps: ${rawMaps.join(', ')}`)
+  }
+  const provenance = readSourceMapProvenance(outputDir, files, label)
+  const coverage = verifyOutputCoverage(files, provenance, label)
+  for (const mapEntry of coverage.maps) {
+    verifySourceMapBytes(
+      readFileSync(join(outputDir, ...mapEntry.split('/'))),
+      mapEntry,
+      coverage.javascript,
+      label
+    )
+  }
+  return { files, provenance, ...coverage }
+}
+
+module.exports = {
+  PROVENANCE_PREFIX,
+  describeSetDifference,
+  listOutputFiles,
+  readSourceMapProvenance,
+  verifyLocalRendererSourceMaps,
+  verifyOutputCoverage,
+  verifySourceMapBytes,
+  verifySourceMapObject
+}

--- a/config/scripts/renderer-source-map-contract.cjs
+++ b/config/scripts/renderer-source-map-contract.cjs
@@ -2,8 +2,16 @@ const { readFileSync, readdirSync } = require('node:fs')
 const { basename, join, relative, sep } = require('node:path')
 const { gunzipSync } = require('node:zlib')
 const { AnyMap, decodedMappings } = require('@jridgewell/trace-mapping')
+const { verifyBasicMappingsStrict } = require('./renderer-source-map-vlq.cjs')
 
 const PROVENANCE_PREFIX = 'source-map-provenance/'
+const SOURCE_MAP_MODES = new Set([
+  'mapped',
+  'mappingless-json',
+  'source-less-asset',
+  'source-less-facade',
+  'source-less-generated'
+])
 const BASIC_MAP_FIELDS = [
   'mappings',
   'names',
@@ -55,7 +63,13 @@ function parseSourceMap(mapBytes, mapLabel) {
 }
 
 function assertRelativeSource(source, mapLabel) {
-  if (source.startsWith('/') || /^[A-Za-z]:[\\/]/.test(source) || source.includes('\\')) {
+  if (
+    source.startsWith('/') ||
+    /^[A-Za-z][A-Za-z0-9+.-]*:/.test(source) ||
+    source.includes('\\') ||
+    source.includes('\0') ||
+    /^<[^>]+>$/.test(source)
+  ) {
     throw new Error(`${mapLabel} contains non-relative source ${source}`)
   }
 }
@@ -104,7 +118,7 @@ function verifyDecodedMappings(traceMap, decoded, mapLabel, requireMappedSegment
   }
 }
 
-function verifyBasicMap(sourceMap, mapLabel) {
+function verifyBasicMap(sourceMap, mapLabel, sourceMapMode) {
   if (typeof sourceMap.mappings !== 'string') {
     throw new Error(`${mapLabel} does not contain string mappings`)
   }
@@ -149,8 +163,31 @@ function verifyBasicMap(sourceMap, mapLabel) {
       }
     })
   }
+  if (sourceMapMode === 'mappingless-json') {
+    if (
+      sourceMap.mappings !== '' ||
+      sourceMap.sources.length === 0 ||
+      sourceMap.names.length !== 0 ||
+      !sourceMap.sources.every((source) => source.endsWith('.json'))
+    ) {
+      throw new Error(`${mapLabel} is not a JSON-only mappingless map`)
+    }
+    sourceMap.sourcesContent.forEach((content, index) => {
+      try {
+        JSON.parse(content)
+      } catch {
+        throw new Error(`${mapLabel} has non-JSON mappingless source ${sourceMap.sources[index]}`)
+      }
+    })
+  }
   const { traceMap, decoded } = constructSourceMap(sourceMap, mapLabel)
-  verifyDecodedMappings(traceMap, decoded, mapLabel, sourceMap.sources.length > 0)
+  verifyBasicMappingsStrict(sourceMap, decoded, mapLabel)
+  verifyDecodedMappings(
+    traceMap,
+    decoded,
+    mapLabel,
+    sourceMap.sources.length > 0 && sourceMapMode !== 'mappingless-json'
+  )
 }
 
 function verifyIndexedMap(sourceMap, mapLabel) {
@@ -184,13 +221,13 @@ function verifyIndexedMap(sourceMap, mapLabel) {
       throw new Error(`${mapLabel} has unordered indexed-map offset at section ${index}`)
     }
     previousOffset = { line, column }
-    verifySourceMapObject(section.map, `${mapLabel} section ${index}`)
+    verifySourceMapObject(section.map, `${mapLabel} section ${index}`, 'mapped')
   })
   const { traceMap, decoded } = constructSourceMap(sourceMap, mapLabel)
   verifyDecodedMappings(traceMap, decoded, mapLabel, traceMap.sources.length > 0)
 }
 
-function verifySourceMapObject(sourceMap, mapLabel) {
+function verifySourceMapObject(sourceMap, mapLabel, sourceMapMode = 'mapped') {
   if (!isObject(sourceMap)) {
     throw new Error(`${mapLabel} is not a JSON object`)
   }
@@ -198,13 +235,22 @@ function verifySourceMapObject(sourceMap, mapLabel) {
     throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
   }
   if (Object.hasOwn(sourceMap, 'sections')) {
+    if (sourceMapMode === 'mappingless-json') {
+      throw new Error(`${mapLabel} uses indexed sections for a mappingless map`)
+    }
     verifyIndexedMap(sourceMap, mapLabel)
   } else {
-    verifyBasicMap(sourceMap, mapLabel)
+    verifyBasicMap(sourceMap, mapLabel, sourceMapMode)
   }
 }
 
-function verifySourceMapBytes(mapBytes, mapEntry, javascriptEntries, scope) {
+function verifySourceMapBytes(
+  mapBytes,
+  mapEntry,
+  javascriptEntries,
+  scope,
+  sourceMapMode = 'mapped'
+) {
   const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
   const mapLabel = `${scope} source map ${mapEntry}`
   if (!javascriptEntries.has(javascriptEntry)) {
@@ -219,7 +265,7 @@ function verifySourceMapBytes(mapBytes, mapEntry, javascriptEntries, scope) {
       `${mapLabel} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
     )
   }
-  verifySourceMapObject(sourceMap, mapLabel)
+  verifySourceMapObject(sourceMap, mapLabel, sourceMapMode)
 }
 
 function readSourceMapProvenance(outputDir, files, label) {
@@ -246,7 +292,7 @@ function readSourceMapProvenance(outputDir, files, label) {
         chunk.file.startsWith('/') ||
         chunk.file.includes('\\') ||
         chunk.file.split('/').includes('..') ||
-        typeof chunk.sourceMap !== 'boolean'
+        !SOURCE_MAP_MODES.has(chunk.sourceMap)
       ) {
         throw new Error(`${label} ${entry} has invalid source-map provenance chunk ${index}`)
       }
@@ -281,7 +327,9 @@ function verifyOutputCoverage(files, provenance, label) {
     )
   }
   const expectedMaps = new Set(
-    [...provenance.chunks].filter(([, sourceMap]) => sourceMap).map(([entry]) => `${entry}.map.gz`)
+    [...provenance.chunks]
+      .filter(([, sourceMap]) => !sourceMap.startsWith('source-less-'))
+      .map(([entry]) => `${entry}.map.gz`)
   )
   const maps = new Set(files.filter((entry) => /\.m?js\.map\.gz$/.test(entry)))
   const mapDifference = describeSetDifference(expectedMaps, maps)
@@ -301,11 +349,13 @@ function verifyLocalRendererSourceMaps(outputName, outputDir) {
   const provenance = readSourceMapProvenance(outputDir, files, label)
   const coverage = verifyOutputCoverage(files, provenance, label)
   for (const mapEntry of coverage.maps) {
+    const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
     verifySourceMapBytes(
       readFileSync(join(outputDir, ...mapEntry.split('/'))),
       mapEntry,
       coverage.javascript,
-      label
+      label,
+      provenance.chunks.get(javascriptEntry)
     )
   }
   return { files, provenance, ...coverage }

--- a/config/scripts/renderer-source-map-contract.test.mjs
+++ b/config/scripts/renderer-source-map-contract.test.mjs
@@ -34,7 +34,7 @@ function writeFixtureFile(root, relativePath, contents) {
   writeFileSync(filePath, contents)
 }
 
-function createFixture(sourceMap = basicMap()) {
+function createFixture(sourceMap = basicMap(), sourceMapMode = 'mapped') {
   const root = mkdtempSync(join(tmpdir(), 'orca-source-map-contract-'))
   temporaryRoots.push(root)
   writeFixtureFile(root, 'assets/app.js', 'throw new Error("contract")')
@@ -45,8 +45,8 @@ function createFixture(sourceMap = basicMap()) {
     `${JSON.stringify({
       version: 1,
       chunks: [
-        { file: 'assets/app.js', sourceMap: true },
-        { file: 'assets/source-less-facade.js', sourceMap: false }
+        { file: 'assets/app.js', sourceMap: sourceMapMode },
+        { file: 'assets/source-less-facade.js', sourceMap: 'source-less-facade' }
       ]
     })}\n`
   )
@@ -54,8 +54,8 @@ function createFixture(sourceMap = basicMap()) {
   return root
 }
 
-function verifyFixture(sourceMap) {
-  const root = createFixture(sourceMap)
+function verifyFixture(sourceMap, sourceMapMode = 'mapped') {
+  const root = createFixture(sourceMap, sourceMapMode)
   return () => verifyLocalRendererSourceMaps('renderer', root)
 }
 
@@ -76,6 +76,29 @@ describe('renderer source-map contract', () => {
     ).not.toThrow()
   })
 
+  it('keeps duplicate generated columns emitted by the toolchain valid', () => {
+    expect(verifyFixture(basicMap({ mappings: 'AAAA,AAAA' }))).not.toThrow()
+  })
+
+  it('accepts a provenance-backed mappingless JSON data map', () => {
+    expect(
+      verifyFixture(
+        basicMap({
+          sources: ['src/data.json'],
+          sourcesContent: ['{"message":"data"}'],
+          mappings: ''
+        }),
+        'mappingless-json'
+      )
+    ).not.toThrow()
+  })
+
+  it('does not let mappingless provenance bless ordinary executable source', () => {
+    expect(verifyFixture(basicMap({ mappings: '' }), 'mappingless-json')).toThrow(
+      'is not a JSON-only mappingless map'
+    )
+  })
+
   it('rejects a missing mappings field', () => {
     expect(verifyFixture(basicMap({ mappings: undefined }))).toThrow(
       'does not contain string mappings'
@@ -91,11 +114,33 @@ describe('renderer source-map contract', () => {
   })
 
   it('rejects mappings that decode to invalid source positions', () => {
-    expect(verifyFixture(basicMap({ mappings: '!bad' }))).toThrow('has invalid source position')
+    expect(verifyFixture(basicMap({ mappings: '!bad' }))).toThrow('has an invalid VLQ character')
   })
 
   it('rejects a negative decoded generated column', () => {
     expect(verifyFixture(basicMap({ mappings: 'DAAA' }))).toThrow('has invalid generated column')
+  })
+
+  it.each([
+    ['AA', 'two-field', 'has invalid decoded segment'],
+    ['AAA', 'three-field', 'has invalid decoded segment'],
+    ['AAAAAA', 'six-field', 'has invalid decoded segment'],
+    ['g', 'truncated', 'has a truncated VLQ value'],
+    ['ADAA', 'negative source index', 'has invalid source position'],
+    ['ACAA', 'out-of-range source index', 'has invalid source position'],
+    ['AADA', 'negative original line', 'has invalid source position'],
+    ['AACA', 'out-of-range original line', 'has out-of-range original position'],
+    ['AAAD', 'negative original column', 'has invalid source position'],
+    ['AAAAD', 'negative name index', 'has invalid name index'],
+    ['AAAAC', 'out-of-range name index', 'has invalid name index']
+  ])('rejects a %s VLQ segment (%s)', (mappings, _case, error) => {
+    expect(verifyFixture(basicMap({ mappings }))).toThrow(error)
+  })
+
+  it('rejects an original column beyond the embedded source line', () => {
+    expect(verifyFixture(basicMap({ sourcesContent: ['x'], mappings: 'AAAE' }))).toThrow(
+      'has out-of-range original position'
+    )
   })
 
   it('rejects an absolute sourceRoot', () => {
@@ -103,6 +148,31 @@ describe('renderer source-map contract', () => {
       'contains non-relative source /checkout'
     )
   })
+
+  it.each(['file:///checkout/app.ts', 'https://example.test/app.ts', 'custom+source:app.ts'])(
+    'rejects a URI source: %s',
+    (source) => {
+      expect(verifyFixture(basicMap({ sources: [source] }))).toThrow(
+        `contains non-relative source ${source}`
+      )
+    }
+  )
+
+  it.each(['file:///checkout', 'https://example.test/src', 'custom+root:src'])(
+    'rejects a URI sourceRoot: %s',
+    (sourceRoot) => {
+      expect(verifyFixture(basicMap({ sourceRoot }))).toThrow(
+        `contains non-relative source ${sourceRoot}`
+      )
+    }
+  )
+
+  it.each(['AAAA,', ',AAAA', 'AAAA,,AAAA'])(
+    'rejects an empty lexical VLQ segment: %s',
+    (mappings) => {
+      expect(verifyFixture(basicMap({ mappings }))).toThrow('has an empty VLQ segment')
+    }
+  )
 
   it('rejects a section without an offset', () => {
     expect(verifyFixture(indexedMap([{ map: sectionMap() }]))).toThrow(
@@ -161,11 +231,11 @@ describe('renderer source-map contract', () => {
     )
   })
 
-  it('rejects null source text even when the source name looks synthetic', () => {
+  it('rejects null source text for a relative source', () => {
     expect(
       verifyFixture(
-        basicMap({ sources: ['virtual:spoofed'], sourcesContent: [null], mappings: 'AAAA' })
+        basicMap({ sources: ['src/spoofed.ts'], sourcesContent: [null], mappings: 'AAAA' })
       )
-    ).toThrow('does not embed source text for virtual:spoofed')
+    ).toThrow('does not embed source text for src/spoofed.ts')
   })
 })

--- a/config/scripts/renderer-source-map-contract.test.mjs
+++ b/config/scripts/renderer-source-map-contract.test.mjs
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it } from 'vitest'
+import { createRendererIdentitySourceMap } from '../build-plugins/renderer-identity-source-map'
 import { verifyLocalRendererSourceMaps } from './renderer-source-map-contract.cjs'
 
 const temporaryRoots = []
@@ -34,28 +35,28 @@ function writeFixtureFile(root, relativePath, contents) {
   writeFileSync(filePath, contents)
 }
 
-function createFixture(sourceMap = basicMap(), sourceMapMode = 'mapped') {
+function createFixture(
+  sourceMap = basicMap(),
+  sourceMapMode = 'mapped',
+  javascript = 'throw new Error("contract")'
+) {
   const root = mkdtempSync(join(tmpdir(), 'orca-source-map-contract-'))
   temporaryRoots.push(root)
-  writeFixtureFile(root, 'assets/app.js', 'throw new Error("contract")')
-  writeFixtureFile(root, 'assets/source-less-facade.js', '')
+  writeFixtureFile(root, 'assets/app.js', javascript)
   writeFixtureFile(
     root,
     'source-map-provenance/bundle-fixture.json',
     `${JSON.stringify({
       version: 1,
-      chunks: [
-        { file: 'assets/app.js', sourceMap: sourceMapMode },
-        { file: 'assets/source-less-facade.js', sourceMap: 'source-less-facade' }
-      ]
+      chunks: [{ file: 'assets/app.js', sourceMap: sourceMapMode }]
     })}\n`
   )
   writeFixtureFile(root, 'assets/app.js.map.gz', gzipSync(JSON.stringify(sourceMap)))
   return root
 }
 
-function verifyFixture(sourceMap, sourceMapMode = 'mapped') {
-  const root = createFixture(sourceMap, sourceMapMode)
+function verifyFixture(sourceMap, sourceMapMode = 'mapped', javascript) {
+  const root = createFixture(sourceMap, sourceMapMode, javascript)
   return () => verifyLocalRendererSourceMaps('renderer', root)
 }
 
@@ -66,36 +67,32 @@ afterEach(() => {
 })
 
 describe('renderer source-map contract', () => {
-  it('constructs a basic map and permits a provenance-backed source-less facade', () => {
+  it('constructs a basic mapped map', () => {
     expect(verifyFixture(basicMap())).not.toThrow()
   })
 
-  it('keeps a zero-source basic map valid', () => {
+  it('rejects a zero-source basic map as mapped provenance', () => {
     expect(
       verifyFixture(basicMap({ sources: [], sourcesContent: undefined, mappings: '' }))
-    ).not.toThrow()
+    ).toThrow('has no usable source mappings')
   })
 
   it('keeps duplicate generated columns emitted by the toolchain valid', () => {
     expect(verifyFixture(basicMap({ mappings: 'AAAA,AAAA' }))).not.toThrow()
   })
 
-  it('accepts a provenance-backed mappingless JSON data map', () => {
-    expect(
-      verifyFixture(
-        basicMap({
-          sources: ['src/data.json'],
-          sourcesContent: ['{"message":"data"}'],
-          mappings: ''
-        }),
-        'mappingless-json'
-      )
-    ).not.toThrow()
+  it('accepts an exact self-contained identity map', () => {
+    const javascript = 'throw new Error("identity")\r\n'
+    const sourceMap = JSON.parse(createRendererIdentitySourceMap('assets/app.js', javascript))
+    expect(verifyFixture(sourceMap, 'identity-generated', javascript)).not.toThrow()
   })
 
-  it('does not let mappingless provenance bless ordinary executable source', () => {
-    expect(verifyFixture(basicMap({ mappings: '' }), 'mappingless-json')).toThrow(
-      'is not a JSON-only mappingless map'
+  it('rejects identity provenance backed by inexact source text or coordinates', () => {
+    const javascript = 'throw new Error("identity")'
+    const sourceMap = JSON.parse(createRendererIdentitySourceMap('assets/app.js', javascript))
+    sourceMap.sourcesContent[0] = `${javascript} changed`
+    expect(verifyFixture(sourceMap, 'identity-generated', javascript)).toThrow(
+      'is not an exact self-contained identity map'
     )
   })
 
@@ -141,6 +138,25 @@ describe('renderer source-map contract', () => {
     expect(verifyFixture(basicMap({ sourcesContent: ['x'], mappings: 'AAAE' }))).toThrow(
       'has out-of-range original position'
     )
+  })
+
+  it.each([
+    ['IAAA', 'column'],
+    [';;AAAA', 'line']
+  ])('rejects a generated position beyond the adjacent JavaScript %s', (mappings) => {
+    expect(verifyFixture(basicMap({ mappings }), 'mapped', 'abc')).toThrow(
+      'has out-of-range generated position'
+    )
+  })
+
+  it('accepts generated positions on UTF-16 CRLF boundaries', () => {
+    expect(
+      verifyFixture(
+        basicMap({ sourcesContent: ['abc\r\nx'], mappings: 'GAAA;CACC' }),
+        'mapped',
+        'abc\r\nx'
+      )
+    ).not.toThrow()
   })
 
   it('rejects an absolute sourceRoot', () => {
@@ -194,7 +210,7 @@ describe('renderer source-map contract', () => {
   it.each([
     [
       [
-        { offset: { line: 1, column: 0 }, map: sectionMap() },
+        { offset: { line: 0, column: 1 }, map: sectionMap() },
         { offset: { line: 0, column: 0 }, map: sectionMap() }
       ],
       'unordered'
@@ -229,6 +245,39 @@ describe('renderer source-map contract', () => {
     expect(verifyFixture(indexedMap([], { mappings: '' }))).toThrow(
       'mixes indexed sections with basic field mappings'
     )
+  })
+
+  it('rejects a zero-source indexed map as mapped provenance', () => {
+    expect(
+      verifyFixture(
+        indexedMap([
+          {
+            offset: { line: 0, column: 0 },
+            map: { version: 3, names: [], sources: [], mappings: 'A' }
+          }
+        ])
+      )
+    ).toThrow('has no usable source mappings')
+  })
+
+  it.each([
+    [{ line: 1, column: 0 }, sectionMap(), 'line'],
+    [{ line: 0, column: 4 }, sectionMap(), 'column'],
+    [{ line: 0, column: 3 }, { ...sectionMap(), mappings: 'CAAA' }, 'mapped column']
+  ])('rejects an indexed generated position beyond the adjacent JavaScript (%s)', (offset, map) => {
+    expect(verifyFixture(indexedMap([{ offset, map }]), 'mapped', 'abc')).toThrow(
+      /out-of-range (?:indexed-map offset|generated position)/
+    )
+  })
+
+  it('accepts an indexed section on the adjacent JavaScript boundary', () => {
+    expect(
+      verifyFixture(
+        indexedMap([{ offset: { line: 0, column: 3 }, map: sectionMap() }]),
+        'mapped',
+        'abc'
+      )
+    ).not.toThrow()
   })
 
   it('rejects null source text for a relative source', () => {

--- a/config/scripts/renderer-source-map-contract.test.mjs
+++ b/config/scripts/renderer-source-map-contract.test.mjs
@@ -1,0 +1,171 @@
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { afterEach, describe, expect, it } from 'vitest'
+import { verifyLocalRendererSourceMaps } from './renderer-source-map-contract.cjs'
+
+const temporaryRoots = []
+
+function basicMap(overrides = {}) {
+  return {
+    version: 3,
+    file: 'app.js',
+    names: [],
+    sources: ['src/app.ts'],
+    sourcesContent: ['throw new Error("contract")'],
+    mappings: 'AAAA',
+    ...overrides
+  }
+}
+
+function sectionMap() {
+  const { file: _file, ...sourceMap } = basicMap()
+  return sourceMap
+}
+
+function indexedMap(sections, overrides = {}) {
+  return { version: 3, file: 'app.js', sections, ...overrides }
+}
+
+function writeFixtureFile(root, relativePath, contents) {
+  const filePath = join(root, ...relativePath.split('/'))
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, contents)
+}
+
+function createFixture(sourceMap = basicMap()) {
+  const root = mkdtempSync(join(tmpdir(), 'orca-source-map-contract-'))
+  temporaryRoots.push(root)
+  writeFixtureFile(root, 'assets/app.js', 'throw new Error("contract")')
+  writeFixtureFile(root, 'assets/source-less-facade.js', '')
+  writeFixtureFile(
+    root,
+    'source-map-provenance/bundle-fixture.json',
+    `${JSON.stringify({
+      version: 1,
+      chunks: [
+        { file: 'assets/app.js', sourceMap: true },
+        { file: 'assets/source-less-facade.js', sourceMap: false }
+      ]
+    })}\n`
+  )
+  writeFixtureFile(root, 'assets/app.js.map.gz', gzipSync(JSON.stringify(sourceMap)))
+  return root
+}
+
+function verifyFixture(sourceMap) {
+  const root = createFixture(sourceMap)
+  return () => verifyLocalRendererSourceMaps('renderer', root)
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('renderer source-map contract', () => {
+  it('constructs a basic map and permits a provenance-backed source-less facade', () => {
+    expect(verifyFixture(basicMap())).not.toThrow()
+  })
+
+  it('keeps a zero-source basic map valid', () => {
+    expect(
+      verifyFixture(basicMap({ sources: [], sourcesContent: undefined, mappings: '' }))
+    ).not.toThrow()
+  })
+
+  it('rejects a missing mappings field', () => {
+    expect(verifyFixture(basicMap({ mappings: undefined }))).toThrow(
+      'does not contain string mappings'
+    )
+  })
+
+  it('rejects non-string mappings', () => {
+    expect(verifyFixture(basicMap({ mappings: 42 }))).toThrow('does not contain string mappings')
+  })
+
+  it('rejects a source-bearing map without a usable mapped segment', () => {
+    expect(verifyFixture(basicMap({ mappings: '' }))).toThrow('has no usable source mappings')
+  })
+
+  it('rejects mappings that decode to invalid source positions', () => {
+    expect(verifyFixture(basicMap({ mappings: '!bad' }))).toThrow('has invalid source position')
+  })
+
+  it('rejects a negative decoded generated column', () => {
+    expect(verifyFixture(basicMap({ mappings: 'DAAA' }))).toThrow('has invalid generated column')
+  })
+
+  it('rejects an absolute sourceRoot', () => {
+    expect(verifyFixture(basicMap({ sourceRoot: '/checkout' }))).toThrow(
+      'contains non-relative source /checkout'
+    )
+  })
+
+  it('rejects a section without an offset', () => {
+    expect(verifyFixture(indexedMap([{ map: sectionMap() }]))).toThrow(
+      'has invalid indexed-map section 0'
+    )
+  })
+
+  it.each([
+    [{ line: -1, column: 0 }, 'negative'],
+    [{ line: 0, column: -1 }, 'negative column'],
+    [{ line: 0.5, column: 0 }, 'fractional line'],
+    [{ line: 0, column: 0.5 }, 'fractional column']
+  ])('rejects a %s indexed-map offset (%s)', (offset) => {
+    expect(verifyFixture(indexedMap([{ offset, map: sectionMap() }]))).toThrow(
+      'has invalid indexed-map offset at section 0'
+    )
+  })
+
+  it.each([
+    [
+      [
+        { offset: { line: 1, column: 0 }, map: sectionMap() },
+        { offset: { line: 0, column: 0 }, map: sectionMap() }
+      ],
+      'unordered'
+    ],
+    [
+      [
+        { offset: { line: 0, column: 0 }, map: sectionMap() },
+        { offset: { line: 0, column: 0 }, map: sectionMap() }
+      ],
+      'duplicate'
+    ]
+  ])('rejects %s indexed-map sections (%s)', (sections) => {
+    expect(verifyFixture(indexedMap(sections))).toThrow(
+      'has unordered indexed-map offset at section 1'
+    )
+  })
+
+  it.each([
+    [{ offset: { line: 0, column: 0 } }, 'missing map'],
+    [{ offset: { line: 0, column: 0 }, map: null }, 'null map'],
+    [{ offset: { line: 0, column: 0, extra: 1 }, map: sectionMap() }, 'extra offset field'],
+    [{ offset: { line: 0, column: 0 }, map: sectionMap(), url: 'external.map' }, 'URL']
+  ])('rejects a malformed indexed-map section (%s: %s)', (section) => {
+    expect(verifyFixture(indexedMap([section]))).toThrow('has invalid indexed-map section 0')
+  })
+
+  it('rejects a non-array sections field', () => {
+    expect(verifyFixture(indexedMap(null))).toThrow('has non-array indexed-map sections')
+  })
+
+  it('rejects mixed indexed and basic map fields', () => {
+    expect(verifyFixture(indexedMap([], { mappings: '' }))).toThrow(
+      'mixes indexed sections with basic field mappings'
+    )
+  })
+
+  it('rejects null source text even when the source name looks synthetic', () => {
+    expect(
+      verifyFixture(
+        basicMap({ sources: ['virtual:spoofed'], sourcesContent: [null], mappings: 'AAAA' })
+      )
+    ).toThrow('does not embed source text for virtual:spoofed')
+  })
+})

--- a/config/scripts/renderer-source-map-vlq.cjs
+++ b/config/scripts/renderer-source-map-vlq.cjs
@@ -1,0 +1,133 @@
+const BASE64_VLQ = 'ABCDEFGHIJKLMNOPQRSTUVWXYZabcdefghijklmnopqrstuvwxyz0123456789+/'
+const BASE64_VLQ_VALUES = new Int8Array(128)
+BASE64_VLQ_VALUES.fill(-1)
+for (const [value, character] of [...BASE64_VLQ].entries()) {
+  BASE64_VLQ_VALUES[character.charCodeAt(0)] = value
+}
+
+function decodeVlqSegment(encoded, mapLabel, lineIndex, segmentIndex) {
+  if (encoded.length === 0) {
+    throw new Error(`${mapLabel} has an empty VLQ segment at ${lineIndex}:${segmentIndex}`)
+  }
+  const fields = []
+  let value = 0
+  let shift = 0
+  for (const character of encoded) {
+    const characterCode = character.charCodeAt(0)
+    const digit = characterCode < BASE64_VLQ_VALUES.length ? BASE64_VLQ_VALUES[characterCode] : -1
+    if (digit < 0) {
+      throw new Error(`${mapLabel} has an invalid VLQ character at ${lineIndex}:${segmentIndex}`)
+    }
+    value += (digit & 31) * 2 ** shift
+    if (!Number.isSafeInteger(value)) {
+      throw new Error(`${mapLabel} has an overflowing VLQ value at ${lineIndex}:${segmentIndex}`)
+    }
+    if (digit & 32) {
+      shift += 5
+      continue
+    }
+    const magnitude = Math.floor(value / 2)
+    fields.push(value & 1 ? -magnitude : magnitude)
+    value = 0
+    shift = 0
+  }
+  if (shift !== 0) {
+    throw new Error(`${mapLabel} has a truncated VLQ value at ${lineIndex}:${segmentIndex}`)
+  }
+  return fields
+}
+
+function assertOriginalPosition(
+  sourceMap,
+  sourceLines,
+  sourceIndex,
+  line,
+  column,
+  mapLabel,
+  location
+) {
+  if (sourceIndex < 0 || sourceIndex >= sourceMap.sources.length || line < 0 || column < 0) {
+    throw new Error(`${mapLabel} has invalid source position at ${location}`)
+  }
+  const lines = sourceLines?.[sourceIndex]
+  if (!lines) {
+    return
+  }
+  const sourceLine = lines[line]
+  if (sourceLine === undefined || column > sourceLine.length) {
+    throw new Error(`${mapLabel} has out-of-range original position at ${location}`)
+  }
+}
+
+function verifyBasicMappingsStrict(sourceMap, decoded, mapLabel) {
+  const sourceLines = sourceMap.sourcesContent?.map((content) =>
+    typeof content === 'string' ? content.split('\n').map((line) => line.replace(/\r$/, '')) : null
+  )
+  let sourceIndex = 0
+  let originalLine = 0
+  let originalColumn = 0
+  let nameIndex = 0
+  for (const [lineIndex, encodedLine] of sourceMap.mappings.split(';').entries()) {
+    const decodedLine = decoded[lineIndex]
+    if (!Array.isArray(decodedLine)) {
+      throw new Error(`${mapLabel} is normalized differently by the symbolication library`)
+    }
+    let generatedColumn = 0
+    let segmentCount = 0
+    if (encodedLine !== '') {
+      encodedLine.split(',').forEach((encodedSegment, segmentIndex) => {
+        segmentCount += 1
+        const fields = decodeVlqSegment(encodedSegment, mapLabel, lineIndex, segmentIndex)
+        if (![1, 4, 5].includes(fields.length)) {
+          throw new Error(`${mapLabel} has invalid decoded segment ${lineIndex}:${segmentIndex}`)
+        }
+        generatedColumn += fields[0]
+        if (!Number.isSafeInteger(generatedColumn) || generatedColumn < 0) {
+          throw new Error(
+            `${mapLabel} has invalid generated column at ${lineIndex}:${segmentIndex}`
+          )
+        }
+        const segment = [generatedColumn]
+        if (fields.length > 1) {
+          sourceIndex += fields[1]
+          originalLine += fields[2]
+          originalColumn += fields[3]
+          const location = `${lineIndex}:${segmentIndex}`
+          assertOriginalPosition(
+            sourceMap,
+            sourceLines,
+            sourceIndex,
+            originalLine,
+            originalColumn,
+            mapLabel,
+            location
+          )
+          segment.push(sourceIndex, originalLine, originalColumn)
+          if (fields.length === 5) {
+            nameIndex += fields[4]
+            if (nameIndex < 0 || nameIndex >= sourceMap.names.length) {
+              throw new Error(`${mapLabel} has invalid name index at ${location}`)
+            }
+            segment.push(nameIndex)
+          }
+        }
+        const librarySegment = decodedLine[segmentIndex]
+        if (
+          !Array.isArray(librarySegment) ||
+          librarySegment.length !== segment.length ||
+          librarySegment.some((value, index) => value !== segment[index])
+        ) {
+          throw new Error(`${mapLabel} is normalized differently by the symbolication library`)
+        }
+      })
+    }
+    if (decodedLine.length !== segmentCount) {
+      throw new Error(`${mapLabel} is normalized differently by the symbolication library`)
+    }
+  }
+  if (decoded.length !== sourceMap.mappings.split(';').length) {
+    throw new Error(`${mapLabel} is normalized differently by the symbolication library`)
+  }
+}
+
+module.exports = { verifyBasicMappingsStrict }

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -44,16 +44,58 @@ function parseSourceMap(mapBytes, mapLabel) {
   }
 }
 
-function containsSourcesContent(value) {
-  if (!value || typeof value !== 'object') {
-    return false
+function isSourceMapObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function isGeneratedSourceWithoutContent(source) {
+  return source.startsWith('\0') || source.startsWith('virtual:') || /^<[^>]+>$/.test(source)
+}
+
+function verifyEmbeddedSources(sourceMap, mapLabel) {
+  if (sourceMap.version !== 3) {
+    throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
   }
-  if (Array.isArray(value)) {
-    return value.some(containsSourcesContent)
+  if (sourceMap.sections !== undefined) {
+    if (!Array.isArray(sourceMap.sections)) {
+      throw new Error(`${mapLabel} has non-array indexed-map sections`)
+    }
+    sourceMap.sections.forEach((section, index) => {
+      if (!isSourceMapObject(section) || !isSourceMapObject(section.map)) {
+        throw new Error(`${mapLabel} has invalid indexed-map section ${index}`)
+      }
+      verifyEmbeddedSources(section.map, `${mapLabel} section ${index}`)
+    })
+    return
   }
-  return Object.entries(value).some(
-    ([key, nestedValue]) => key === 'sourcesContent' || containsSourcesContent(nestedValue)
-  )
+  if (
+    !Array.isArray(sourceMap.sources) ||
+    !sourceMap.sources.every((source) => typeof source === 'string')
+  ) {
+    throw new Error(`${mapLabel} does not list string sources`)
+  }
+  if (sourceMap.sources.length === 0 && sourceMap.sourcesContent === undefined) {
+    return
+  }
+  if (!Array.isArray(sourceMap.sourcesContent)) {
+    throw new Error(`${mapLabel} does not embed sourcesContent`)
+  }
+  if (sourceMap.sourcesContent.length !== sourceMap.sources.length) {
+    throw new Error(
+      `${mapLabel} has ${sourceMap.sourcesContent.length} sourcesContent entries for ${sourceMap.sources.length} sources`
+    )
+  }
+  sourceMap.sources.forEach((source, index) => {
+    const content = sourceMap.sourcesContent[index]
+    if (typeof content === 'string') {
+      return
+    }
+    // Rolldown can omit text only for a synthetic source with no source file.
+    if (content === null && isGeneratedSourceWithoutContent(source)) {
+      return
+    }
+    throw new Error(`${mapLabel} does not embed source text for ${source}`)
+  })
 }
 
 function verifySourceMap(mapBytes, mapEntry, javascriptEntries, scope) {
@@ -63,20 +105,15 @@ function verifySourceMap(mapBytes, mapEntry, javascriptEntries, scope) {
     throw new Error(`${mapLabel} has no adjacent JavaScript asset ${javascriptEntry}`)
   }
   const sourceMap = parseSourceMap(mapBytes, mapLabel)
-  if (!sourceMap || typeof sourceMap !== 'object' || Array.isArray(sourceMap)) {
+  if (!isSourceMapObject(sourceMap)) {
     throw new Error(`${mapLabel} is not a JSON object`)
-  }
-  if (sourceMap.version !== 3) {
-    throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
   }
   if (sourceMap.file !== basename(javascriptEntry)) {
     throw new Error(
       `${mapLabel} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
     )
   }
-  if (containsSourcesContent(sourceMap)) {
-    throw new Error(`${mapLabel} contains sourcesContent`)
-  }
+  verifyEmbeddedSources(sourceMap, mapLabel)
 }
 
 function verifyOutputSourceMaps({
@@ -169,8 +206,8 @@ function verifyPackagedRendererSourceMaps(
 }
 
 module.exports = {
-  containsSourcesContent,
   listOutputFiles,
   normalizeAsarEntry,
+  verifyEmbeddedSources,
   verifyPackagedRendererSourceMaps
 }

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -1,6 +1,12 @@
-const { readFileSync, readdirSync } = require('node:fs')
-const { basename, join, relative, resolve, sep } = require('node:path')
-const { gunzipSync } = require('node:zlib')
+const { readFileSync } = require('node:fs')
+const { join, resolve } = require('node:path')
+const {
+  PROVENANCE_PREFIX,
+  describeSetDifference,
+  verifyLocalRendererSourceMaps,
+  verifyOutputCoverage,
+  verifySourceMapBytes
+} = require('./renderer-source-map-contract.cjs')
 
 const OUTPUT_NAMES = ['renderer', 'web']
 
@@ -8,112 +14,15 @@ function normalizeAsarEntry(entry) {
   return entry.replace(/^[/\\]+/, '').replaceAll('\\', '/')
 }
 
-function listOutputFiles(outputDir) {
-  const files = []
-  function visit(directory) {
-    for (const entry of readdirSync(directory, { withFileTypes: true })) {
-      const entryPath = join(directory, entry.name)
-      if (entry.isDirectory()) {
-        visit(entryPath)
-      } else {
-        files.push(relative(outputDir, entryPath).split(sep).join('/'))
-      }
-    }
-  }
-  visit(outputDir)
-  return files.sort()
-}
-
 function extractArchiveFile(asar, asarPath, archiveEntry) {
-  return asar.extractFile(asarPath, archiveEntry.replace(/^[\\/]+/, ''))
+  return asar.extractFile(asarPath, archiveEntry.replace(/^[/\\]+/, ''))
 }
 
-function parseSourceMap(mapBytes, mapLabel) {
-  let json
-  try {
-    json = gunzipSync(mapBytes).toString('utf8')
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : 'unknown gzip error'
-    throw new Error(`${mapLabel} is not valid gzip: ${detail}`)
+function verifyPackagedSet(label, expectedEntries, actualEntries) {
+  const difference = describeSetDifference(new Set(expectedEntries), new Set(actualEntries))
+  if (difference) {
+    throw new Error(`${label} differs from local output (${difference})`)
   }
-  try {
-    return JSON.parse(json)
-  } catch (error) {
-    const detail = error instanceof Error ? error.message : 'unknown JSON error'
-    throw new Error(`${mapLabel} is not valid JSON: ${detail}`)
-  }
-}
-
-function isSourceMapObject(value) {
-  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
-}
-
-function isGeneratedSourceWithoutContent(source) {
-  return source.startsWith('\0') || source.startsWith('virtual:') || /^<[^>]+>$/.test(source)
-}
-
-function verifyEmbeddedSources(sourceMap, mapLabel) {
-  if (sourceMap.version !== 3) {
-    throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
-  }
-  if (sourceMap.sections !== undefined) {
-    if (!Array.isArray(sourceMap.sections)) {
-      throw new Error(`${mapLabel} has non-array indexed-map sections`)
-    }
-    sourceMap.sections.forEach((section, index) => {
-      if (!isSourceMapObject(section) || !isSourceMapObject(section.map)) {
-        throw new Error(`${mapLabel} has invalid indexed-map section ${index}`)
-      }
-      verifyEmbeddedSources(section.map, `${mapLabel} section ${index}`)
-    })
-    return
-  }
-  if (
-    !Array.isArray(sourceMap.sources) ||
-    !sourceMap.sources.every((source) => typeof source === 'string')
-  ) {
-    throw new Error(`${mapLabel} does not list string sources`)
-  }
-  if (sourceMap.sources.length === 0 && sourceMap.sourcesContent === undefined) {
-    return
-  }
-  if (!Array.isArray(sourceMap.sourcesContent)) {
-    throw new Error(`${mapLabel} does not embed sourcesContent`)
-  }
-  if (sourceMap.sourcesContent.length !== sourceMap.sources.length) {
-    throw new Error(
-      `${mapLabel} has ${sourceMap.sourcesContent.length} sourcesContent entries for ${sourceMap.sources.length} sources`
-    )
-  }
-  sourceMap.sources.forEach((source, index) => {
-    const content = sourceMap.sourcesContent[index]
-    if (typeof content === 'string') {
-      return
-    }
-    // Rolldown can omit text only for a synthetic source with no source file.
-    if (content === null && isGeneratedSourceWithoutContent(source)) {
-      return
-    }
-    throw new Error(`${mapLabel} does not embed source text for ${source}`)
-  })
-}
-
-function verifySourceMap(mapBytes, mapEntry, javascriptEntries, scope) {
-  const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
-  const mapLabel = `${scope} source map ${mapEntry}`
-  if (!javascriptEntries.has(javascriptEntry)) {
-    throw new Error(`${mapLabel} has no adjacent JavaScript asset ${javascriptEntry}`)
-  }
-  const sourceMap = parseSourceMap(mapBytes, mapLabel)
-  if (!isSourceMapObject(sourceMap)) {
-    throw new Error(`${mapLabel} is not a JSON object`)
-  }
-  if (sourceMap.file !== basename(javascriptEntry)) {
-    throw new Error(
-      `${mapLabel} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
-    )
-  }
-  verifyEmbeddedSources(sourceMap, mapLabel)
 }
 
 function verifyOutputSourceMaps({
@@ -124,47 +33,48 @@ function verifyOutputSourceMaps({
   archiveEntryByNormalizedPath
 }) {
   const archivePrefix = `out/${outputName}/`
-  const localFiles = listOutputFiles(outputDir)
-  const localRawMaps = localFiles.filter((entry) => entry.endsWith('.js.map'))
-  if (localRawMaps.length > 0) {
-    throw new Error(
-      `Local ${outputName} output contains raw source maps: ${localRawMaps.join(', ')}`
-    )
-  }
-
+  const local = verifyLocalRendererSourceMaps(outputName, outputDir)
   const archiveEntries = [...archiveEntryByNormalizedPath.keys()]
     .filter((entry) => entry.startsWith(archivePrefix))
     .map((entry) => entry.slice(archivePrefix.length))
     .sort()
-  const packagedRawMaps = archiveEntries.filter((entry) => entry.endsWith('.js.map'))
+  const packagedRawMaps = archiveEntries.filter((entry) => /\.m?js\.map$/.test(entry))
   if (packagedRawMaps.length > 0) {
     throw new Error(
       `Packaged ${outputName} output contains raw source maps: ${packagedRawMaps.join(', ')}`
     )
   }
 
-  const localMaps = localFiles.filter((entry) => entry.endsWith('.js.map.gz'))
-  if (localMaps.length === 0) {
-    throw new Error(`Local ${outputName} output has no compressed source maps: ${outputDir}`)
-  }
-  const packagedMaps = archiveEntries.filter((entry) => entry.endsWith('.js.map.gz'))
-  const packagedMapSet = new Set(packagedMaps)
-  const localMapSet = new Set(localMaps)
-  const missingMaps = localMaps.filter((entry) => !packagedMapSet.has(entry))
-  const staleMaps = packagedMaps.filter((entry) => !localMapSet.has(entry))
-  if (missingMaps.length > 0 || staleMaps.length > 0) {
-    const differences = [
-      missingMaps.length > 0 ? `missing: ${missingMaps.join(', ')}` : '',
-      staleMaps.length > 0 ? `stale: ${staleMaps.join(', ')}` : ''
-    ].filter(Boolean)
-    throw new Error(
-      `Packaged ${outputName} source-map set differs from local output (${differences.join('; ')})`
+  const packagedProvenanceFiles = archiveEntries.filter(
+    (entry) => entry.startsWith(PROVENANCE_PREFIX) && entry.endsWith('.json')
+  )
+  verifyPackagedSet(
+    `Packaged ${outputName} source-map provenance set`,
+    local.provenance.provenanceFiles,
+    packagedProvenanceFiles
+  )
+  for (const entry of local.provenance.provenanceFiles) {
+    const localBytes = readFileSync(join(outputDir, ...entry.split('/')))
+    const packagedBytes = extractArchiveFile(
+      asar,
+      asarPath,
+      archiveEntryByNormalizedPath.get(`${archivePrefix}${entry}`)
     )
+    if (!localBytes.equals(packagedBytes)) {
+      const firstDifference = localBytes.findIndex((byte, index) => byte !== packagedBytes[index])
+      throw new Error(
+        `Packaged ${outputName} source-map provenance ${entry} differs (${localBytes.length} local bytes, ${packagedBytes.length} packaged bytes, first difference ${firstDifference}: ${localBytes[firstDifference]}/${packagedBytes[firstDifference]})`
+      )
+    }
   }
 
-  const localJavaScript = new Set(localFiles.filter((entry) => entry.endsWith('.js')))
-  const packagedJavaScript = new Set(archiveEntries.filter((entry) => entry.endsWith('.js')))
-  for (const mapEntry of localMaps) {
+  const packagedCoverage = verifyOutputCoverage(
+    archiveEntries,
+    local.provenance,
+    `Packaged ${outputName}`
+  )
+  verifyPackagedSet(`Packaged ${outputName} source-map set`, local.maps, packagedCoverage.maps)
+  for (const mapEntry of local.maps) {
     const archiveMapEntry = `${archivePrefix}${mapEntry}`
     const localMapBytes = readFileSync(join(outputDir, ...mapEntry.split('/')))
     const packagedMapBytes = extractArchiveFile(
@@ -177,8 +87,12 @@ function verifyOutputSourceMaps({
         `Packaged ${outputName} source map ${mapEntry} differs from the local build output`
       )
     }
-    verifySourceMap(localMapBytes, mapEntry, localJavaScript, `Local ${outputName}`)
-    verifySourceMap(packagedMapBytes, mapEntry, packagedJavaScript, `Packaged ${outputName}`)
+    verifySourceMapBytes(
+      packagedMapBytes,
+      mapEntry,
+      packagedCoverage.javascript,
+      `Packaged ${outputName}`
+    )
   }
 }
 
@@ -206,8 +120,6 @@ function verifyPackagedRendererSourceMaps(
 }
 
 module.exports = {
-  listOutputFiles,
   normalizeAsarEntry,
-  verifyEmbeddedSources,
   verifyPackagedRendererSourceMaps
 }

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -4,8 +4,10 @@ function normalizeAsarEntry(entry) {
 
 function verifyPackagedRendererSourceMaps(resourcesDir, asar) {
   const asarPath = require('node:path').join(resourcesDir, 'app.asar')
-  const entries = new Set(asar.listPackage(asarPath).map(normalizeAsarEntry))
-  const rendererMaps = [...entries].filter((entry) =>
+  const archiveEntryByNormalizedPath = new Map(
+    asar.listPackage(asarPath).map((entry) => [normalizeAsarEntry(entry), entry])
+  )
+  const rendererMaps = [...archiveEntryByNormalizedPath.keys()].filter((entry) =>
     /^out\/renderer\/assets\/[^/]+\.js\.map\.gz$/.test(entry)
   )
   if (rendererMaps.length === 0) {
@@ -14,15 +16,20 @@ function verifyPackagedRendererSourceMaps(resourcesDir, asar) {
 
   const missingMaps = ['index.html', 'web-index.html', 'popout.html'].flatMap((htmlFile) => {
     const htmlEntry = `out/renderer/${htmlFile}`
-    if (!entries.has(htmlEntry)) {
+    const archiveHtmlEntry = archiveEntryByNormalizedPath.get(htmlEntry)
+    if (!archiveHtmlEntry) {
       return [`${htmlEntry} (entry HTML missing)`]
     }
-    const html = asar.extractFile(asarPath, htmlEntry).toString('utf8')
+    const html = asar
+      .extractFile(asarPath, archiveHtmlEntry.replace(/^[\\/]+/, ''))
+      .toString('utf8')
     const script = html.match(/<script[^>]+src="\.\/(assets\/[^"?]+\.js)"/i)?.[1]
     if (!script) {
       return [`${htmlEntry} (entry script missing)`]
     }
-    return entries.has(`out/renderer/${script}.map.gz`) ? [] : [`out/renderer/${script}`]
+    return archiveEntryByNormalizedPath.has(`out/renderer/${script}.map.gz`)
+      ? []
+      : [`out/renderer/${script}`]
   })
   if (missingMaps.length > 0) {
     throw new Error(`Packaged renderer entries are missing source maps: ${missingMaps.join(', ')}`)

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -1,39 +1,101 @@
+const { readdirSync } = require('node:fs')
+const { basename, join, relative, resolve, sep } = require('node:path')
+const { gunzipSync } = require('node:zlib')
+
+const RENDERER_ARCHIVE_PREFIX = 'out/renderer/'
+
 function normalizeAsarEntry(entry) {
   return entry.replace(/^[/\\]+/, '').replaceAll('\\', '/')
 }
 
-function verifyPackagedRendererSourceMaps(resourcesDir, asar) {
-  const asarPath = require('node:path').join(resourcesDir, 'app.asar')
-  const archiveEntryByNormalizedPath = new Map(
-    asar.listPackage(asarPath).map((entry) => [normalizeAsarEntry(entry), entry])
-  )
-  const rendererMaps = [...archiveEntryByNormalizedPath.keys()].filter((entry) =>
-    /^out\/renderer\/assets\/[^/]+\.js\.map\.gz$/.test(entry)
-  )
-  if (rendererMaps.length === 0) {
-    throw new Error('Packaged app has no renderer source maps')
+function listRendererSourceMaps(rendererOutputDir) {
+  const maps = []
+  function visit(directory) {
+    for (const entry of readdirSync(directory, { withFileTypes: true })) {
+      const entryPath = join(directory, entry.name)
+      if (entry.isDirectory()) {
+        visit(entryPath)
+      } else if (entry.name.endsWith('.js.map.gz')) {
+        maps.push(
+          `${RENDERER_ARCHIVE_PREFIX}${relative(rendererOutputDir, entryPath).split(sep).join('/')}`
+        )
+      }
+    }
   }
+  visit(rendererOutputDir)
+  return maps.sort()
+}
 
-  const missingMaps = ['index.html', 'web-index.html', 'popout.html'].flatMap((htmlFile) => {
-    const htmlEntry = `out/renderer/${htmlFile}`
-    const archiveHtmlEntry = archiveEntryByNormalizedPath.get(htmlEntry)
-    if (!archiveHtmlEntry) {
-      return [`${htmlEntry} (entry HTML missing)`]
-    }
-    const html = asar
-      .extractFile(asarPath, archiveHtmlEntry.replace(/^[\\/]+/, ''))
-      .toString('utf8')
-    const script = html.match(/<script[^>]+src="\.\/(assets\/[^"?]+\.js)"/i)?.[1]
-    if (!script) {
-      return [`${htmlEntry} (entry script missing)`]
-    }
-    return archiveEntryByNormalizedPath.has(`out/renderer/${script}.map.gz`)
-      ? []
-      : [`out/renderer/${script}`]
-  })
-  if (missingMaps.length > 0) {
-    throw new Error(`Packaged renderer entries are missing source maps: ${missingMaps.join(', ')}`)
+function extractArchiveFile(asar, asarPath, archiveEntry) {
+  return asar.extractFile(asarPath, archiveEntry.replace(/^[\\/]+/, ''))
+}
+
+function parsePackagedSourceMap(asar, asarPath, mapEntry, archiveEntry) {
+  try {
+    const contents = extractArchiveFile(asar, asarPath, archiveEntry)
+    return JSON.parse(gunzipSync(contents).toString('utf8'))
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'unknown parse error'
+    throw new Error(`Packaged renderer source map ${mapEntry} is not valid gzip JSON: ${detail}`)
   }
 }
 
-module.exports = { normalizeAsarEntry, verifyPackagedRendererSourceMaps }
+function verifyPackagedRendererSourceMaps(
+  resourcesDir,
+  asar,
+  rendererOutputDir = resolve('out', 'renderer')
+) {
+  const asarPath = join(resourcesDir, 'app.asar')
+  const archiveEntryByNormalizedPath = new Map(
+    asar.listPackage(asarPath).map((entry) => [normalizeAsarEntry(entry), entry])
+  )
+  const archiveEntries = [...archiveEntryByNormalizedPath.keys()]
+  const rawMaps = archiveEntries.filter((entry) => /^out\/renderer\/.*\.js\.map$/.test(entry))
+  if (rawMaps.length > 0) {
+    throw new Error(`Packaged renderer contains raw source maps: ${rawMaps.sort().join(', ')}`)
+  }
+
+  const expectedMaps = listRendererSourceMaps(rendererOutputDir)
+  if (expectedMaps.length === 0) {
+    throw new Error(`Renderer output has no compressed source maps: ${rendererOutputDir}`)
+  }
+  const missingMaps = expectedMaps.filter((entry) => !archiveEntryByNormalizedPath.has(entry))
+  if (missingMaps.length > 0) {
+    throw new Error(`Packaged renderer is missing source maps: ${missingMaps.join(', ')}`)
+  }
+
+  const packagedMaps = archiveEntries.filter((entry) =>
+    /^out\/renderer\/.*\.js\.map\.gz$/.test(entry)
+  )
+  for (const mapEntry of packagedMaps) {
+    const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
+    if (!archiveEntryByNormalizedPath.has(javascriptEntry)) {
+      throw new Error(
+        `Packaged renderer source map ${mapEntry} has no adjacent JavaScript asset ${javascriptEntry}`
+      )
+    }
+    const sourceMap = parsePackagedSourceMap(
+      asar,
+      asarPath,
+      mapEntry,
+      archiveEntryByNormalizedPath.get(mapEntry)
+    )
+    if (!sourceMap || typeof sourceMap !== 'object' || Array.isArray(sourceMap)) {
+      throw new Error(`Packaged renderer source map ${mapEntry} is not a JSON object`)
+    }
+    if (Object.prototype.hasOwnProperty.call(sourceMap, 'sourcesContent')) {
+      throw new Error(`Packaged renderer source map ${mapEntry} contains sourcesContent`)
+    }
+    if (sourceMap.file !== basename(javascriptEntry)) {
+      throw new Error(
+        `Packaged renderer source map ${mapEntry} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
+      )
+    }
+  }
+}
+
+module.exports = {
+  listRendererSourceMaps,
+  normalizeAsarEntry,
+  verifyPackagedRendererSourceMaps
+}

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -7,6 +7,7 @@ const {
   verifyOutputCoverage,
   verifySourceMapBytes
 } = require('./renderer-source-map-contract.cjs')
+const { isRawJavaScriptSourceMapPath } = require('./renderer-javascript-output.cjs')
 
 const OUTPUT_NAMES = ['renderer', 'web']
 
@@ -38,7 +39,7 @@ function verifyOutputSourceMaps({
     .filter((entry) => entry.startsWith(archivePrefix))
     .map((entry) => entry.slice(archivePrefix.length))
     .sort()
-  const packagedRawMaps = archiveEntries.filter((entry) => /\.m?js\.map$/.test(entry))
+  const packagedRawMaps = archiveEntries.filter(isRawJavaScriptSourceMapPath)
   if (packagedRawMaps.length > 0) {
     throw new Error(
       `Packaged ${outputName} output contains raw source maps: ${packagedRawMaps.join(', ')}`
@@ -106,7 +107,12 @@ function verifyOutputSourceMaps({
       mapEntry,
       packagedCoverage.javascript,
       `Packaged ${outputName}`,
-      local.provenance.chunks.get(javascriptEntry)
+      local.provenance.chunks.get(javascriptEntry),
+      extractArchiveFile(
+        asar,
+        asarPath,
+        archiveEntryByNormalizedPath.get(`${archivePrefix}${javascriptEntry}`)
+      )
     )
   }
 }

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -1,101 +1,176 @@
-const { readdirSync } = require('node:fs')
+const { readFileSync, readdirSync } = require('node:fs')
 const { basename, join, relative, resolve, sep } = require('node:path')
 const { gunzipSync } = require('node:zlib')
 
-const RENDERER_ARCHIVE_PREFIX = 'out/renderer/'
+const OUTPUT_NAMES = ['renderer', 'web']
 
 function normalizeAsarEntry(entry) {
   return entry.replace(/^[/\\]+/, '').replaceAll('\\', '/')
 }
 
-function listRendererSourceMaps(rendererOutputDir) {
-  const maps = []
+function listOutputFiles(outputDir) {
+  const files = []
   function visit(directory) {
     for (const entry of readdirSync(directory, { withFileTypes: true })) {
       const entryPath = join(directory, entry.name)
       if (entry.isDirectory()) {
         visit(entryPath)
-      } else if (entry.name.endsWith('.js.map.gz')) {
-        maps.push(
-          `${RENDERER_ARCHIVE_PREFIX}${relative(rendererOutputDir, entryPath).split(sep).join('/')}`
-        )
+      } else {
+        files.push(relative(outputDir, entryPath).split(sep).join('/'))
       }
     }
   }
-  visit(rendererOutputDir)
-  return maps.sort()
+  visit(outputDir)
+  return files.sort()
 }
 
 function extractArchiveFile(asar, asarPath, archiveEntry) {
   return asar.extractFile(asarPath, archiveEntry.replace(/^[\\/]+/, ''))
 }
 
-function parsePackagedSourceMap(asar, asarPath, mapEntry, archiveEntry) {
+function parseSourceMap(mapBytes, mapLabel) {
+  let json
   try {
-    const contents = extractArchiveFile(asar, asarPath, archiveEntry)
-    return JSON.parse(gunzipSync(contents).toString('utf8'))
+    json = gunzipSync(mapBytes).toString('utf8')
   } catch (error) {
-    const detail = error instanceof Error ? error.message : 'unknown parse error'
-    throw new Error(`Packaged renderer source map ${mapEntry} is not valid gzip JSON: ${detail}`)
+    const detail = error instanceof Error ? error.message : 'unknown gzip error'
+    throw new Error(`${mapLabel} is not valid gzip: ${detail}`)
+  }
+  try {
+    return JSON.parse(json)
+  } catch (error) {
+    const detail = error instanceof Error ? error.message : 'unknown JSON error'
+    throw new Error(`${mapLabel} is not valid JSON: ${detail}`)
+  }
+}
+
+function containsSourcesContent(value) {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  if (Array.isArray(value)) {
+    return value.some(containsSourcesContent)
+  }
+  return Object.entries(value).some(
+    ([key, nestedValue]) => key === 'sourcesContent' || containsSourcesContent(nestedValue)
+  )
+}
+
+function verifySourceMap(mapBytes, mapEntry, javascriptEntries, scope) {
+  const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
+  const mapLabel = `${scope} source map ${mapEntry}`
+  if (!javascriptEntries.has(javascriptEntry)) {
+    throw new Error(`${mapLabel} has no adjacent JavaScript asset ${javascriptEntry}`)
+  }
+  const sourceMap = parseSourceMap(mapBytes, mapLabel)
+  if (!sourceMap || typeof sourceMap !== 'object' || Array.isArray(sourceMap)) {
+    throw new Error(`${mapLabel} is not a JSON object`)
+  }
+  if (sourceMap.version !== 3) {
+    throw new Error(`${mapLabel} has source-map version ${String(sourceMap.version)} instead of 3`)
+  }
+  if (sourceMap.file !== basename(javascriptEntry)) {
+    throw new Error(
+      `${mapLabel} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
+    )
+  }
+  if (containsSourcesContent(sourceMap)) {
+    throw new Error(`${mapLabel} contains sourcesContent`)
+  }
+}
+
+function verifyOutputSourceMaps({
+  outputName,
+  outputDir,
+  asar,
+  asarPath,
+  archiveEntryByNormalizedPath
+}) {
+  const archivePrefix = `out/${outputName}/`
+  const localFiles = listOutputFiles(outputDir)
+  const localRawMaps = localFiles.filter((entry) => entry.endsWith('.js.map'))
+  if (localRawMaps.length > 0) {
+    throw new Error(
+      `Local ${outputName} output contains raw source maps: ${localRawMaps.join(', ')}`
+    )
+  }
+
+  const archiveEntries = [...archiveEntryByNormalizedPath.keys()]
+    .filter((entry) => entry.startsWith(archivePrefix))
+    .map((entry) => entry.slice(archivePrefix.length))
+    .sort()
+  const packagedRawMaps = archiveEntries.filter((entry) => entry.endsWith('.js.map'))
+  if (packagedRawMaps.length > 0) {
+    throw new Error(
+      `Packaged ${outputName} output contains raw source maps: ${packagedRawMaps.join(', ')}`
+    )
+  }
+
+  const localMaps = localFiles.filter((entry) => entry.endsWith('.js.map.gz'))
+  if (localMaps.length === 0) {
+    throw new Error(`Local ${outputName} output has no compressed source maps: ${outputDir}`)
+  }
+  const packagedMaps = archiveEntries.filter((entry) => entry.endsWith('.js.map.gz'))
+  const packagedMapSet = new Set(packagedMaps)
+  const localMapSet = new Set(localMaps)
+  const missingMaps = localMaps.filter((entry) => !packagedMapSet.has(entry))
+  const staleMaps = packagedMaps.filter((entry) => !localMapSet.has(entry))
+  if (missingMaps.length > 0 || staleMaps.length > 0) {
+    const differences = [
+      missingMaps.length > 0 ? `missing: ${missingMaps.join(', ')}` : '',
+      staleMaps.length > 0 ? `stale: ${staleMaps.join(', ')}` : ''
+    ].filter(Boolean)
+    throw new Error(
+      `Packaged ${outputName} source-map set differs from local output (${differences.join('; ')})`
+    )
+  }
+
+  const localJavaScript = new Set(localFiles.filter((entry) => entry.endsWith('.js')))
+  const packagedJavaScript = new Set(archiveEntries.filter((entry) => entry.endsWith('.js')))
+  for (const mapEntry of localMaps) {
+    const archiveMapEntry = `${archivePrefix}${mapEntry}`
+    const localMapBytes = readFileSync(join(outputDir, ...mapEntry.split('/')))
+    const packagedMapBytes = extractArchiveFile(
+      asar,
+      asarPath,
+      archiveEntryByNormalizedPath.get(archiveMapEntry)
+    )
+    if (!localMapBytes.equals(packagedMapBytes)) {
+      throw new Error(
+        `Packaged ${outputName} source map ${mapEntry} differs from the local build output`
+      )
+    }
+    verifySourceMap(localMapBytes, mapEntry, localJavaScript, `Local ${outputName}`)
+    verifySourceMap(packagedMapBytes, mapEntry, packagedJavaScript, `Packaged ${outputName}`)
   }
 }
 
 function verifyPackagedRendererSourceMaps(
   resourcesDir,
   asar,
-  rendererOutputDir = resolve('out', 'renderer')
+  outputDirectories = {
+    renderer: resolve('out', 'renderer'),
+    web: resolve('out', 'web')
+  }
 ) {
   const asarPath = join(resourcesDir, 'app.asar')
   const archiveEntryByNormalizedPath = new Map(
     asar.listPackage(asarPath).map((entry) => [normalizeAsarEntry(entry), entry])
   )
-  const archiveEntries = [...archiveEntryByNormalizedPath.keys()]
-  const rawMaps = archiveEntries.filter((entry) => /^out\/renderer\/.*\.js\.map$/.test(entry))
-  if (rawMaps.length > 0) {
-    throw new Error(`Packaged renderer contains raw source maps: ${rawMaps.sort().join(', ')}`)
-  }
-
-  const expectedMaps = listRendererSourceMaps(rendererOutputDir)
-  if (expectedMaps.length === 0) {
-    throw new Error(`Renderer output has no compressed source maps: ${rendererOutputDir}`)
-  }
-  const missingMaps = expectedMaps.filter((entry) => !archiveEntryByNormalizedPath.has(entry))
-  if (missingMaps.length > 0) {
-    throw new Error(`Packaged renderer is missing source maps: ${missingMaps.join(', ')}`)
-  }
-
-  const packagedMaps = archiveEntries.filter((entry) =>
-    /^out\/renderer\/.*\.js\.map\.gz$/.test(entry)
-  )
-  for (const mapEntry of packagedMaps) {
-    const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
-    if (!archiveEntryByNormalizedPath.has(javascriptEntry)) {
-      throw new Error(
-        `Packaged renderer source map ${mapEntry} has no adjacent JavaScript asset ${javascriptEntry}`
-      )
-    }
-    const sourceMap = parsePackagedSourceMap(
+  for (const outputName of OUTPUT_NAMES) {
+    verifyOutputSourceMaps({
+      outputName,
+      outputDir: outputDirectories[outputName],
       asar,
       asarPath,
-      mapEntry,
-      archiveEntryByNormalizedPath.get(mapEntry)
-    )
-    if (!sourceMap || typeof sourceMap !== 'object' || Array.isArray(sourceMap)) {
-      throw new Error(`Packaged renderer source map ${mapEntry} is not a JSON object`)
-    }
-    if (Object.prototype.hasOwnProperty.call(sourceMap, 'sourcesContent')) {
-      throw new Error(`Packaged renderer source map ${mapEntry} contains sourcesContent`)
-    }
-    if (sourceMap.file !== basename(javascriptEntry)) {
-      throw new Error(
-        `Packaged renderer source map ${mapEntry} identifies ${String(sourceMap.file)} instead of ${basename(javascriptEntry)}`
-      )
-    }
+      archiveEntryByNormalizedPath
+    })
   }
 }
 
 module.exports = {
-  listRendererSourceMaps,
+  containsSourcesContent,
+  listOutputFiles,
   normalizeAsarEntry,
   verifyPackagedRendererSourceMaps
 }

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -73,9 +73,23 @@ function verifyOutputSourceMaps({
     local.provenance,
     `Packaged ${outputName}`
   )
+  for (const javascriptEntry of local.provenance.chunks.keys()) {
+    const localBytes = readFileSync(join(outputDir, ...javascriptEntry.split('/')))
+    const packagedBytes = extractArchiveFile(
+      asar,
+      asarPath,
+      archiveEntryByNormalizedPath.get(`${archivePrefix}${javascriptEntry}`)
+    )
+    if (!localBytes.equals(packagedBytes)) {
+      throw new Error(
+        `Packaged ${outputName} JavaScript ${javascriptEntry} differs from the local build output`
+      )
+    }
+  }
   verifyPackagedSet(`Packaged ${outputName} source-map set`, local.maps, packagedCoverage.maps)
   for (const mapEntry of local.maps) {
     const archiveMapEntry = `${archivePrefix}${mapEntry}`
+    const javascriptEntry = mapEntry.slice(0, -'.map.gz'.length)
     const localMapBytes = readFileSync(join(outputDir, ...mapEntry.split('/')))
     const packagedMapBytes = extractArchiveFile(
       asar,
@@ -91,7 +105,8 @@ function verifyOutputSourceMaps({
       packagedMapBytes,
       mapEntry,
       packagedCoverage.javascript,
-      `Packaged ${outputName}`
+      `Packaged ${outputName}`,
+      local.provenance.chunks.get(javascriptEntry)
     )
   }
 }

--- a/config/scripts/verify-packaged-renderer-source-maps.cjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.cjs
@@ -1,0 +1,32 @@
+function normalizeAsarEntry(entry) {
+  return entry.replace(/^[/\\]+/, '').replaceAll('\\', '/')
+}
+
+function verifyPackagedRendererSourceMaps(resourcesDir, asar) {
+  const asarPath = require('node:path').join(resourcesDir, 'app.asar')
+  const entries = new Set(asar.listPackage(asarPath).map(normalizeAsarEntry))
+  const rendererMaps = [...entries].filter((entry) =>
+    /^out\/renderer\/assets\/[^/]+\.js\.map\.gz$/.test(entry)
+  )
+  if (rendererMaps.length === 0) {
+    throw new Error('Packaged app has no renderer source maps')
+  }
+
+  const missingMaps = ['index.html', 'web-index.html', 'popout.html'].flatMap((htmlFile) => {
+    const htmlEntry = `out/renderer/${htmlFile}`
+    if (!entries.has(htmlEntry)) {
+      return [`${htmlEntry} (entry HTML missing)`]
+    }
+    const html = asar.extractFile(asarPath, htmlEntry).toString('utf8')
+    const script = html.match(/<script[^>]+src="\.\/(assets\/[^"?]+\.js)"/i)?.[1]
+    if (!script) {
+      return [`${htmlEntry} (entry script missing)`]
+    }
+    return entries.has(`out/renderer/${script}.map.gz`) ? [] : [`out/renderer/${script}`]
+  })
+  if (missingMaps.length > 0) {
+    throw new Error(`Packaged renderer entries are missing source maps: ${missingMaps.join(', ')}`)
+  }
+}
+
+module.exports = { normalizeAsarEntry, verifyPackagedRendererSourceMaps }

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -13,12 +13,14 @@ const temporaryRoots = []
 const mappedAssets = ['index-entry.js', 'shared.js', 'dynamic.js']
 
 function sourceMap(file, overrides = {}) {
+  const sources = overrides.sources ?? [`src/${file}.ts`]
   return gzipSync(
     JSON.stringify({
       version: 3,
       file,
       names: [],
-      sources: [`src/${file}.ts`],
+      sources,
+      sourcesContent: sources.map((source) => `source text for ${source}`),
       mappings: '',
       ...overrides
     })
@@ -100,7 +102,7 @@ afterEach(() => {
 })
 
 describe('packaged renderer source maps', () => {
-  it('accepts exact Windows-style renderer and web maps plus source-less facades', () => {
+  it('accepts exact Windows-style maps with embedded sources plus source-less facades', () => {
     const { asar, outputDirectories } = createFixture()
 
     expect(() =>
@@ -228,18 +230,112 @@ describe('packaged renderer source maps', () => {
       )
     })
 
-    it('rejects recursively nested sourcesContent', () => {
+    it('rejects a map without embedded sourcesContent', () => {
       const { asar, outputDirectories } = createFixture((fixture) => {
         fixture.writeMapPair(
           outputName,
           'shared.js',
-          sourceMap('shared.js', { sections: [{ map: { sourcesContent: ['source'] } }] })
+          sourceMap('shared.js', { sourcesContent: undefined })
         )
       })
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
-        `Local ${outputName} source map assets/shared.js.map.gz contains sourcesContent`
+        `Local ${outputName} source map assets/shared.js.map.gz does not embed sourcesContent`
       )
     })
+
+    it('rejects sourcesContent that is not aligned with sources', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(
+          outputName,
+          'shared.js',
+          sourceMap('shared.js', { sourcesContent: [] })
+        )
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz has 0 sourcesContent entries for 1 sources`
+      )
+    })
+
+    it('rejects absent text for a source file', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(
+          outputName,
+          'shared.js',
+          sourceMap('shared.js', { sourcesContent: [null] })
+        )
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz does not embed source text for src/shared.js.ts`
+      )
+    })
+
+    it('recursively enforces embedded sources in indexed maps', () => {
+      const indexedMap = sourceMap('shared.js', {
+        sources: undefined,
+        sourcesContent: undefined,
+        mappings: undefined,
+        sections: [
+          {
+            offset: { line: 0, column: 0 },
+            map: {
+              version: 3,
+              names: [],
+              sources: ['src/section.ts'],
+              mappings: ''
+            }
+          }
+        ]
+      })
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(outputName, 'shared.js', indexedMap)
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz section 0 does not embed sourcesContent`
+      )
+    })
+  })
+
+  it('accepts aligned indexed maps, source-less maps, and generated null content', () => {
+    const { asar, outputDirectories } = createFixture((fixture) => {
+      fixture.writeMapPair(
+        'renderer',
+        'shared.js',
+        sourceMap('shared.js', {
+          sources: undefined,
+          sourcesContent: undefined,
+          mappings: undefined,
+          sections: [
+            {
+              offset: { line: 0, column: 0 },
+              map: {
+                version: 3,
+                names: [],
+                sources: ['src/section.ts'],
+                sourcesContent: ['const section = true'],
+                mappings: ''
+              }
+            }
+          ]
+        })
+      )
+      fixture.writeMapPair(
+        'renderer',
+        'dynamic.js',
+        sourceMap('dynamic.js', { sources: [], sourcesContent: undefined })
+      )
+      fixture.writeMapPair(
+        'web',
+        'dynamic.js',
+        sourceMap('dynamic.js', { sources: ['\0generated'], sourcesContent: [null] })
+      )
+    })
+
+    expect(() =>
+      verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)
+    ).not.toThrow()
   })
 })

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -3,6 +3,7 @@ import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { gzipSync } from 'node:zlib'
 import { afterEach, describe, expect, it } from 'vitest'
+import { createRendererIdentitySourceMap } from '../build-plugins/renderer-identity-source-map'
 import {
   normalizeAsarEntry,
   verifyPackagedRendererSourceMaps
@@ -10,7 +11,8 @@ import {
 
 const outputNames = ['renderer', 'web']
 const temporaryRoots = []
-const mappedAssets = ['index-entry.js', 'shared.js', 'dynamic.js']
+const mappedAssets = ['index-entry.js', 'shared.js', 'dynamic.js', 'plugin.cjs']
+const identityAsset = 'identity.js'
 
 function sourceMap(file, overrides = {}) {
   const sources = overrides.sources ?? [`src/${file}.ts`]
@@ -25,6 +27,16 @@ function sourceMap(file, overrides = {}) {
       ...overrides
     })
   )
+}
+
+function sectionSourceMap() {
+  return {
+    version: 3,
+    names: [],
+    sources: ['src/section.ts'],
+    sourcesContent: ['const section = true'],
+    mappings: 'AAAA'
+  }
 }
 
 function writeOutputFile(outputDir, relativePath, contents) {
@@ -42,7 +54,7 @@ function createFixture(mutate = () => {}) {
   const archiveFiles = new Map()
   for (const outputName of outputNames) {
     const outputDir = outputDirectories[outputName]
-    for (const asset of [...mappedAssets, 'source-less-facade.js']) {
+    for (const asset of [...mappedAssets, identityAsset]) {
       const contents = Buffer.from(`${outputName} fixture JavaScript`)
       writeOutputFile(outputDir, `assets/${asset}`, contents)
       archiveFiles.set(`out/${outputName}/assets/${asset}`, contents)
@@ -52,12 +64,18 @@ function createFixture(mutate = () => {}) {
       writeOutputFile(outputDir, `assets/${asset}.map.gz`, contents)
       archiveFiles.set(`out/${outputName}/assets/${asset}.map.gz`, contents)
     }
+    const identityJavascript = archiveFiles.get(`out/${outputName}/assets/${identityAsset}`)
+    const identityMap = gzipSync(
+      createRendererIdentitySourceMap(`assets/${identityAsset}`, identityJavascript.toString())
+    )
+    writeOutputFile(outputDir, `assets/${identityAsset}.map.gz`, identityMap)
+    archiveFiles.set(`out/${outputName}/assets/${identityAsset}.map.gz`, identityMap)
     const provenance = Buffer.from(
       `${JSON.stringify({
         version: 1,
         chunks: [
           ...mappedAssets.map((file) => ({ file: `assets/${file}`, sourceMap: 'mapped' })),
-          { file: 'assets/source-less-facade.js', sourceMap: 'source-less-facade' }
+          { file: `assets/${identityAsset}`, sourceMap: 'identity-generated' }
         ]
       })}\n`
     )
@@ -122,7 +140,7 @@ afterEach(() => {
 })
 
 describe('packaged renderer source maps', () => {
-  it('accepts exact Windows-style maps with embedded sources plus source-less facades', () => {
+  it('accepts exact Windows-style maps with embedded sources and identity maps', () => {
     const { asar, outputDirectories } = createFixture()
 
     expect(() =>
@@ -205,6 +223,16 @@ describe('packaged renderer source maps', () => {
       )
     })
 
+    it('rejects a packaged raw CommonJS map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writePackaged(outputName, 'assets/plugin.cjs.map', Buffer.from('{}'))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} output contains raw source maps: assets/plugin.cjs.map`
+      )
+    })
+
     it('rejects a packaged raw map', () => {
       const { asar, outputDirectories } = createFixture((fixture) => {
         fixture.writePackaged(outputName, 'assets/index-entry.js.map', Buffer.from('{}'))
@@ -242,6 +270,37 @@ describe('packaged renderer source maps', () => {
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
         `Local ${outputName} source map assets/shared.js.map.gz has source-map version 2 instead of 3`
+      )
+    })
+
+    it('rejects a basic map beyond the adjacent JavaScript column', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(
+          outputName,
+          'shared.js',
+          sourceMap('shared.js', { mappings: 'u+BAAA' })
+        )
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz has out-of-range generated position`
+      )
+    })
+
+    it('rejects an indexed map beyond the adjacent JavaScript line', () => {
+      const invalidMap = sourceMap('shared.js', {
+        names: undefined,
+        sources: undefined,
+        sourcesContent: undefined,
+        mappings: undefined,
+        sections: [{ offset: { line: 1, column: 0 }, map: sectionSourceMap() }]
+      })
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(outputName, 'shared.js', invalidMap)
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz has out-of-range indexed-map offset`
       )
     })
 
@@ -344,19 +403,18 @@ describe('packaged renderer source maps', () => {
       )
     })
 
-    it('does not let mappingless provenance bless ordinary executable source', () => {
+    it('does not let identity provenance bless an ordinary non-identity map', () => {
       const { asar, outputDirectories } = createFixture((fixture) => {
-        fixture.setSourceMapMode(outputName, 'dynamic.js', 'mappingless-json')
-        fixture.writeMapPair(outputName, 'dynamic.js', sourceMap('dynamic.js', { mappings: '' }))
+        fixture.setSourceMapMode(outputName, 'dynamic.js', 'identity-generated')
       })
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
-        `Local ${outputName} source map assets/dynamic.js.map.gz is not a JSON-only mappingless map`
+        `Local ${outputName} source map assets/dynamic.js.map.gz is not an exact self-contained identity map`
       )
     })
   })
 
-  it('accepts aligned indexed maps, source-less maps, and generated source text', () => {
+  it('accepts aligned indexed maps and exact generated identity source text', () => {
     const { asar, outputDirectories } = createFixture((fixture) => {
       fixture.writeMapPair(
         'renderer',
@@ -380,21 +438,6 @@ describe('packaged renderer source maps', () => {
           ]
         })
       )
-      fixture.writeMapPair(
-        'renderer',
-        'dynamic.js',
-        sourceMap('dynamic.js', { sources: [], sourcesContent: undefined, mappings: '' })
-      )
-      fixture.writeMapPair(
-        'web',
-        'dynamic.js',
-        sourceMap('dynamic.js', {
-          sources: ['src/generated-data.json'],
-          sourcesContent: ['{"generated":true}'],
-          mappings: ''
-        })
-      )
-      fixture.setSourceMapMode('web', 'dynamic.js', 'mappingless-json')
     })
 
     expect(() =>

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -1,54 +1,137 @@
-import { describe, expect, it } from 'vitest'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { dirname, join } from 'node:path'
+import { gzipSync } from 'node:zlib'
+import { afterEach, describe, expect, it } from 'vitest'
 import {
   normalizeAsarEntry,
   verifyPackagedRendererSourceMaps
 } from './verify-packaged-renderer-source-maps.cjs'
 
-describe('packaged renderer source maps', () => {
-  it('accepts Windows-style asar paths with maps adjacent to every renderer chunk', () => {
-    const html = (entry) => `<script type="module" src="./assets/${entry}.js"></script>`
-    const htmlByArchiveEntry = new Map([
-      ['out\\renderer\\index.html', html('index-abc')],
-      ['out\\renderer\\web-index.html', html('web-def')],
-      ['out\\renderer\\popout.html', html('popout-ghi')]
-    ])
-    const asar = {
-      listPackage: () => [
-        '\\out\\renderer\\index.html',
-        '\\out\\renderer\\web-index.html',
-        '\\out\\renderer\\popout.html',
-        '\\out\\renderer\\assets\\index-abc.js.map.gz',
-        '\\out\\renderer\\assets\\web-def.js.map.gz',
-        '\\out\\renderer\\assets\\popout-ghi.js.map.gz'
-      ],
-      extractFile: (_asarPath, entry) => {
-        const contents = htmlByArchiveEntry.get(entry)
-        if (!contents) {
-          throw new Error(`Unexpected archive entry: ${entry}`)
-        }
-        return Buffer.from(contents)
-      }
-    }
+const temporaryRoots = []
+const mappedAssets = ['index-entry.js', 'shared.js', 'dynamic.js']
 
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar)).not.toThrow()
+function sourceMap(file, sourcesContent) {
+  const map = { version: 3, file, names: [], sources: [`src/${file}.ts`], mappings: '' }
+  if (sourcesContent !== undefined) {
+    map.sourcesContent = sourcesContent
+  }
+  return gzipSync(JSON.stringify(map))
+}
+
+function createFixture(mutateArchive = () => {}) {
+  const rendererOutputDir = mkdtempSync(join(tmpdir(), 'orca-renderer-maps-'))
+  temporaryRoots.push(rendererOutputDir)
+  const archiveFiles = new Map()
+  for (const asset of [...mappedAssets, 'source-less-facade.js']) {
+    archiveFiles.set(`out/renderer/assets/${asset}`, Buffer.from('fixture JavaScript'))
+  }
+  for (const asset of mappedAssets) {
+    const mapEntry = `out/renderer/assets/${asset}.map.gz`
+    archiveFiles.set(mapEntry, sourceMap(asset))
+    const outputMapPath = join(rendererOutputDir, 'assets', `${asset}.map.gz`)
+    mkdirSync(dirname(outputMapPath), { recursive: true })
+    writeFileSync(outputMapPath, 'expected map marker')
+  }
+  mutateArchive(archiveFiles)
+
+  const windowsArchiveFiles = new Map(
+    [...archiveFiles].map(([entry, contents]) => [entry.replaceAll('/', '\\'), contents])
+  )
+  const asar = {
+    listPackage: () => [...windowsArchiveFiles.keys()].map((entry) => `\\${entry}`),
+    extractFile: (_asarPath, entry) => {
+      const contents = windowsArchiveFiles.get(entry)
+      if (!contents) {
+        throw new Error(`Unexpected archive entry: ${entry}`)
+      }
+      return contents
+    }
+  }
+  return { asar, rendererOutputDir }
+}
+
+afterEach(() => {
+  for (const root of temporaryRoots.splice(0)) {
+    rmSync(root, { recursive: true, force: true })
+  }
+})
+
+describe('packaged renderer source maps', () => {
+  it('accepts every map-bearing Windows output while allowing a source-less facade', () => {
+    const { asar, rendererOutputDir } = createFixture()
+
+    expect(() =>
+      verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)
+    ).not.toThrow()
     expect(normalizeAsarEntry('\\out\\renderer\\assets\\index.js')).toBe(
       'out/renderer/assets/index.js'
     )
   })
 
-  it('fails packaging when a renderer chunk has no matching map', () => {
-    const asar = {
-      listPackage: () => [
-        '/out/renderer/index.html',
-        '/out/renderer/web-index.html',
-        '/out/renderer/popout.html',
-        '/out/renderer/assets/index-abc.js.map.gz'
-      ],
-      extractFile: () => Buffer.from('<script type="module" src="./assets/missing.js"></script>')
-    }
+  it('rejects a missing shared or dynamic chunk map', () => {
+    const { asar, rendererOutputDir } = createFixture((files) => {
+      files.delete('out/renderer/assets/dynamic.js.map.gz')
+    })
 
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar)).toThrow(
-      'Packaged renderer entries are missing source maps: out/renderer/assets/missing.js'
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
+      'Packaged renderer is missing source maps: out/renderer/assets/dynamic.js.map.gz'
+    )
+  })
+
+  it.each([
+    ['non-gzip', Buffer.from('{"version":3}')],
+    ['non-JSON', gzipSync('not JSON')]
+  ])('rejects a %s map', (_case, corruptMap) => {
+    const { asar, rendererOutputDir } = createFixture((files) => {
+      files.set('out/renderer/assets/shared.js.map.gz', corruptMap)
+    })
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
+      /shared\.js\.map\.gz is not valid gzip JSON/
+    )
+  })
+
+  it('rejects raw source-map leakage', () => {
+    const { asar, rendererOutputDir } = createFixture((files) => {
+      files.set('out/renderer/assets/index-entry.js.map', Buffer.from('{}'))
+    })
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
+      'Packaged renderer contains raw source maps: out/renderer/assets/index-entry.js.map'
+    )
+  })
+
+  it('rejects embedded sourcesContent', () => {
+    const { asar, rendererOutputDir } = createFixture((files) => {
+      files.set(
+        'out/renderer/assets/index-entry.js.map.gz',
+        sourceMap('index-entry.js', ['source'])
+      )
+    })
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
+      'out/renderer/assets/index-entry.js.map.gz contains sourcesContent'
+    )
+  })
+
+  it('rejects a map without its adjacent JavaScript asset', () => {
+    const { asar, rendererOutputDir } = createFixture((files) => {
+      files.delete('out/renderer/assets/shared.js')
+    })
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
+      'out/renderer/assets/shared.js.map.gz has no adjacent JavaScript asset out/renderer/assets/shared.js'
+    )
+  })
+
+  it('rejects a map that identifies a different JavaScript asset', () => {
+    const { asar, rendererOutputDir } = createFixture((files) => {
+      files.set('out/renderer/assets/shared.js.map.gz', sourceMap('other.js'))
+    })
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
+      'out/renderer/assets/shared.js.map.gz identifies other.js instead of shared.js'
     )
   })
 })

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -1,0 +1,50 @@
+import { describe, expect, it } from 'vitest'
+import {
+  normalizeAsarEntry,
+  verifyPackagedRendererSourceMaps
+} from './verify-packaged-renderer-source-maps.cjs'
+
+describe('packaged renderer source maps', () => {
+  it('accepts Windows-style asar paths with maps adjacent to every renderer chunk', () => {
+    const html = (entry) => `<script type="module" src="./assets/${entry}.js"></script>`
+    const asar = {
+      listPackage: () => [
+        '\\out\\renderer\\index.html',
+        '\\out\\renderer\\web-index.html',
+        '\\out\\renderer\\popout.html',
+        '\\out\\renderer\\assets\\index-abc.js.map.gz',
+        '\\out\\renderer\\assets\\web-def.js.map.gz',
+        '\\out\\renderer\\assets\\popout-ghi.js.map.gz'
+      ],
+      extractFile: (_asarPath, entry) =>
+        Buffer.from(
+          entry.endsWith('web-index.html')
+            ? html('web-def')
+            : entry.endsWith('popout.html')
+              ? html('popout-ghi')
+              : html('index-abc')
+        )
+    }
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar)).not.toThrow()
+    expect(normalizeAsarEntry('\\out\\renderer\\assets\\index.js')).toBe(
+      'out/renderer/assets/index.js'
+    )
+  })
+
+  it('fails packaging when a renderer chunk has no matching map', () => {
+    const asar = {
+      listPackage: () => [
+        '/out/renderer/index.html',
+        '/out/renderer/web-index.html',
+        '/out/renderer/popout.html',
+        '/out/renderer/assets/index-abc.js.map.gz'
+      ],
+      extractFile: () => Buffer.from('<script type="module" src="./assets/missing.js"></script>')
+    }
+
+    expect(() => verifyPackagedRendererSourceMaps('resources', asar)).toThrow(
+      'Packaged renderer entries are missing source maps: out/renderer/assets/missing.js'
+    )
+  })
+})

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -21,7 +21,7 @@ function sourceMap(file, overrides = {}) {
       names: [],
       sources,
       sourcesContent: sources.map((source) => `source text for ${source}`),
-      mappings: '',
+      mappings: 'AAAA',
       ...overrides
     })
   )
@@ -52,6 +52,17 @@ function createFixture(mutate = () => {}) {
       writeOutputFile(outputDir, `assets/${asset}.map.gz`, contents)
       archiveFiles.set(`out/${outputName}/assets/${asset}.map.gz`, contents)
     }
+    const provenance = Buffer.from(
+      `${JSON.stringify({
+        version: 1,
+        chunks: [
+          ...mappedAssets.map((file) => ({ file: `assets/${file}`, sourceMap: true })),
+          { file: 'assets/source-less-facade.js', sourceMap: false }
+        ]
+      })}\n`
+    )
+    writeOutputFile(outputDir, 'source-map-provenance/bundle-fixture.json', provenance)
+    archiveFiles.set(`out/${outputName}/source-map-provenance/bundle-fixture.json`, provenance)
   }
 
   const fixture = {
@@ -135,7 +146,18 @@ describe('packaged renderer source maps', () => {
       })
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
-        `Packaged ${outputName} source-map set differs from local output (missing: assets/dynamic.js.map.gz)`
+        `Packaged ${outputName} source-map coverage differs from provenance (missing: assets/dynamic.js.map.gz)`
+      )
+    })
+
+    it('rejects an ordinary map removed from both local and packaged output', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.deleteLocal(outputName, 'assets/dynamic.js.map.gz')
+        fixture.deletePackaged(outputName, 'assets/dynamic.js.map.gz')
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source-map coverage differs from provenance (missing: assets/dynamic.js.map.gz)`
       )
     })
 
@@ -146,7 +168,7 @@ describe('packaged renderer source maps', () => {
       })
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
-        `Packaged ${outputName} source-map set differs from local output (stale: assets/stale.js.map.gz)`
+        `Packaged ${outputName} JavaScript set differs from source-map provenance (stale: assets/stale.js)`
       )
     })
 
@@ -216,7 +238,7 @@ describe('packaged renderer source maps', () => {
       })
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
-        `Local ${outputName} source map assets/shared.js.map.gz has no adjacent JavaScript asset assets/shared.js`
+        `Local ${outputName} JavaScript set differs from source-map provenance (missing: assets/shared.js)`
       )
     })
 
@@ -226,7 +248,7 @@ describe('packaged renderer source maps', () => {
       })
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
-        `Packaged ${outputName} source map assets/shared.js.map.gz has no adjacent JavaScript asset assets/shared.js`
+        `Packaged ${outputName} JavaScript set differs from source-map provenance (missing: assets/shared.js)`
       )
     })
 
@@ -274,6 +296,7 @@ describe('packaged renderer source maps', () => {
 
     it('recursively enforces embedded sources in indexed maps', () => {
       const indexedMap = sourceMap('shared.js', {
+        names: undefined,
         sources: undefined,
         sourcesContent: undefined,
         mappings: undefined,
@@ -284,7 +307,7 @@ describe('packaged renderer source maps', () => {
               version: 3,
               names: [],
               sources: ['src/section.ts'],
-              mappings: ''
+              mappings: 'AAAA'
             }
           }
         ]
@@ -299,12 +322,13 @@ describe('packaged renderer source maps', () => {
     })
   })
 
-  it('accepts aligned indexed maps, source-less maps, and generated null content', () => {
+  it('accepts aligned indexed maps, source-less maps, and generated source text', () => {
     const { asar, outputDirectories } = createFixture((fixture) => {
       fixture.writeMapPair(
         'renderer',
         'shared.js',
         sourceMap('shared.js', {
+          names: undefined,
           sources: undefined,
           sourcesContent: undefined,
           mappings: undefined,
@@ -316,7 +340,7 @@ describe('packaged renderer source maps', () => {
                 names: [],
                 sources: ['src/section.ts'],
                 sourcesContent: ['const section = true'],
-                mappings: ''
+                mappings: 'AAAA'
               }
             }
           ]
@@ -325,12 +349,15 @@ describe('packaged renderer source maps', () => {
       fixture.writeMapPair(
         'renderer',
         'dynamic.js',
-        sourceMap('dynamic.js', { sources: [], sourcesContent: undefined })
+        sourceMap('dynamic.js', { sources: [], sourcesContent: undefined, mappings: '' })
       )
       fixture.writeMapPair(
         'web',
         'dynamic.js',
-        sourceMap('dynamic.js', { sources: ['\0generated'], sourcesContent: [null] })
+        sourceMap('dynamic.js', {
+          sources: ['\0generated'],
+          sourcesContent: ['const generated = true']
+        })
       )
     })
 

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -7,6 +7,11 @@ import {
 describe('packaged renderer source maps', () => {
   it('accepts Windows-style asar paths with maps adjacent to every renderer chunk', () => {
     const html = (entry) => `<script type="module" src="./assets/${entry}.js"></script>`
+    const htmlByArchiveEntry = new Map([
+      ['out\\renderer\\index.html', html('index-abc')],
+      ['out\\renderer\\web-index.html', html('web-def')],
+      ['out\\renderer\\popout.html', html('popout-ghi')]
+    ])
     const asar = {
       listPackage: () => [
         '\\out\\renderer\\index.html',
@@ -16,14 +21,13 @@ describe('packaged renderer source maps', () => {
         '\\out\\renderer\\assets\\web-def.js.map.gz',
         '\\out\\renderer\\assets\\popout-ghi.js.map.gz'
       ],
-      extractFile: (_asarPath, entry) =>
-        Buffer.from(
-          entry.endsWith('web-index.html')
-            ? html('web-def')
-            : entry.endsWith('popout.html')
-              ? html('popout-ghi')
-              : html('index-abc')
-        )
+      extractFile: (_asarPath, entry) => {
+        const contents = htmlByArchiveEntry.get(entry)
+        if (!contents) {
+          throw new Error(`Unexpected archive entry: ${entry}`)
+        }
+        return Buffer.from(contents)
+      }
     }
 
     expect(() => verifyPackagedRendererSourceMaps('resources', asar)).not.toThrow()

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -56,8 +56,8 @@ function createFixture(mutate = () => {}) {
       `${JSON.stringify({
         version: 1,
         chunks: [
-          ...mappedAssets.map((file) => ({ file: `assets/${file}`, sourceMap: true })),
-          { file: 'assets/source-less-facade.js', sourceMap: false }
+          ...mappedAssets.map((file) => ({ file: `assets/${file}`, sourceMap: 'mapped' })),
+          { file: 'assets/source-less-facade.js', sourceMap: 'source-less-facade' }
         ]
       })}\n`
     )
@@ -86,6 +86,15 @@ function createFixture(mutate = () => {}) {
     writeMapPair(outputName, asset, contents) {
       writeOutputFile(outputDirectories[outputName], `assets/${asset}.map.gz`, contents)
       archiveFiles.set(`out/${outputName}/assets/${asset}.map.gz`, contents)
+    },
+    setSourceMapMode(outputName, asset, sourceMapMode) {
+      const relativePath = 'source-map-provenance/bundle-fixture.json'
+      const provenance = JSON.parse(this.readLocal(outputName, relativePath))
+      const chunk = provenance.chunks.find((entry) => entry.file === `assets/${asset}`)
+      chunk.sourceMap = sourceMapMode
+      const contents = Buffer.from(`${JSON.stringify(provenance)}\n`)
+      this.writeLocal(outputName, relativePath, contents)
+      this.writePackaged(outputName, relativePath, contents)
     }
   }
   mutate(fixture)
@@ -137,6 +146,20 @@ describe('packaged renderer source maps', () => {
 
       expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
         `Packaged ${outputName} source map assets/shared.js.map.gz differs`
+      )
+    })
+
+    it('rejects changed packaged JavaScript with unchanged map and provenance', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writePackaged(
+          outputName,
+          'assets/dynamic.js',
+          Buffer.from('changed packaged JavaScript')
+        )
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} JavaScript assets/dynamic.js differs from the local build output`
       )
     })
 
@@ -320,6 +343,17 @@ describe('packaged renderer source maps', () => {
         `Local ${outputName} source map assets/shared.js.map.gz section 0 does not embed sourcesContent`
       )
     })
+
+    it('does not let mappingless provenance bless ordinary executable source', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.setSourceMapMode(outputName, 'dynamic.js', 'mappingless-json')
+        fixture.writeMapPair(outputName, 'dynamic.js', sourceMap('dynamic.js', { mappings: '' }))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/dynamic.js.map.gz is not a JSON-only mappingless map`
+      )
+    })
   })
 
   it('accepts aligned indexed maps, source-less maps, and generated source text', () => {
@@ -355,10 +389,12 @@ describe('packaged renderer source maps', () => {
         'web',
         'dynamic.js',
         sourceMap('dynamic.js', {
-          sources: ['\0generated'],
-          sourcesContent: ['const generated = true']
+          sources: ['src/generated-data.json'],
+          sourcesContent: ['{"generated":true}'],
+          mappings: ''
         })
       )
+      fixture.setSourceMapMode('web', 'dynamic.js', 'mappingless-json')
     })
 
     expect(() =>

--- a/config/scripts/verify-packaged-renderer-source-maps.test.mjs
+++ b/config/scripts/verify-packaged-renderer-source-maps.test.mjs
@@ -1,4 +1,4 @@
-import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { dirname, join } from 'node:path'
 import { gzipSync } from 'node:zlib'
@@ -8,32 +8,74 @@ import {
   verifyPackagedRendererSourceMaps
 } from './verify-packaged-renderer-source-maps.cjs'
 
+const outputNames = ['renderer', 'web']
 const temporaryRoots = []
 const mappedAssets = ['index-entry.js', 'shared.js', 'dynamic.js']
 
-function sourceMap(file, sourcesContent) {
-  const map = { version: 3, file, names: [], sources: [`src/${file}.ts`], mappings: '' }
-  if (sourcesContent !== undefined) {
-    map.sourcesContent = sourcesContent
-  }
-  return gzipSync(JSON.stringify(map))
+function sourceMap(file, overrides = {}) {
+  return gzipSync(
+    JSON.stringify({
+      version: 3,
+      file,
+      names: [],
+      sources: [`src/${file}.ts`],
+      mappings: '',
+      ...overrides
+    })
+  )
 }
 
-function createFixture(mutateArchive = () => {}) {
-  const rendererOutputDir = mkdtempSync(join(tmpdir(), 'orca-renderer-maps-'))
-  temporaryRoots.push(rendererOutputDir)
+function writeOutputFile(outputDir, relativePath, contents) {
+  const filePath = join(outputDir, ...relativePath.split('/'))
+  mkdirSync(dirname(filePath), { recursive: true })
+  writeFileSync(filePath, contents)
+}
+
+function createFixture(mutate = () => {}) {
+  const root = mkdtempSync(join(tmpdir(), 'orca-renderer-maps-'))
+  temporaryRoots.push(root)
+  const outputDirectories = Object.fromEntries(
+    outputNames.map((outputName) => [outputName, join(root, outputName)])
+  )
   const archiveFiles = new Map()
-  for (const asset of [...mappedAssets, 'source-less-facade.js']) {
-    archiveFiles.set(`out/renderer/assets/${asset}`, Buffer.from('fixture JavaScript'))
+  for (const outputName of outputNames) {
+    const outputDir = outputDirectories[outputName]
+    for (const asset of [...mappedAssets, 'source-less-facade.js']) {
+      const contents = Buffer.from(`${outputName} fixture JavaScript`)
+      writeOutputFile(outputDir, `assets/${asset}`, contents)
+      archiveFiles.set(`out/${outputName}/assets/${asset}`, contents)
+    }
+    for (const asset of mappedAssets) {
+      const contents = sourceMap(asset)
+      writeOutputFile(outputDir, `assets/${asset}.map.gz`, contents)
+      archiveFiles.set(`out/${outputName}/assets/${asset}.map.gz`, contents)
+    }
   }
-  for (const asset of mappedAssets) {
-    const mapEntry = `out/renderer/assets/${asset}.map.gz`
-    archiveFiles.set(mapEntry, sourceMap(asset))
-    const outputMapPath = join(rendererOutputDir, 'assets', `${asset}.map.gz`)
-    mkdirSync(dirname(outputMapPath), { recursive: true })
-    writeFileSync(outputMapPath, 'expected map marker')
+
+  const fixture = {
+    archiveFiles,
+    outputDirectories,
+    deleteLocal(outputName, relativePath) {
+      rmSync(join(outputDirectories[outputName], ...relativePath.split('/')), { force: true })
+    },
+    deletePackaged(outputName, relativePath) {
+      archiveFiles.delete(`out/${outputName}/${relativePath}`)
+    },
+    readLocal(outputName, relativePath) {
+      return readFileSync(join(outputDirectories[outputName], ...relativePath.split('/')))
+    },
+    writeLocal(outputName, relativePath, contents) {
+      writeOutputFile(outputDirectories[outputName], relativePath, contents)
+    },
+    writePackaged(outputName, relativePath, contents) {
+      archiveFiles.set(`out/${outputName}/${relativePath}`, contents)
+    },
+    writeMapPair(outputName, asset, contents) {
+      writeOutputFile(outputDirectories[outputName], `assets/${asset}.map.gz`, contents)
+      archiveFiles.set(`out/${outputName}/assets/${asset}.map.gz`, contents)
+    }
   }
-  mutateArchive(archiveFiles)
+  mutate(fixture)
 
   const windowsArchiveFiles = new Map(
     [...archiveFiles].map(([entry, contents]) => [entry.replaceAll('/', '\\'), contents])
@@ -48,7 +90,7 @@ function createFixture(mutateArchive = () => {}) {
       return contents
     }
   }
-  return { asar, rendererOutputDir }
+  return { asar, outputDirectories }
 }
 
 afterEach(() => {
@@ -58,80 +100,146 @@ afterEach(() => {
 })
 
 describe('packaged renderer source maps', () => {
-  it('accepts every map-bearing Windows output while allowing a source-less facade', () => {
-    const { asar, rendererOutputDir } = createFixture()
+  it('accepts exact Windows-style renderer and web maps plus source-less facades', () => {
+    const { asar, outputDirectories } = createFixture()
 
     expect(() =>
-      verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)
+      verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)
     ).not.toThrow()
     expect(normalizeAsarEntry('\\out\\renderer\\assets\\index.js')).toBe(
       'out/renderer/assets/index.js'
     )
   })
 
-  it('rejects a missing shared or dynamic chunk map', () => {
-    const { asar, rendererOutputDir } = createFixture((files) => {
-      files.delete('out/renderer/assets/dynamic.js.map.gz')
-    })
+  describe.each(outputNames)('%s output', (outputName) => {
+    it('rejects a byte-mismatched packaged map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        const localMap = fixture.readLocal(outputName, 'assets/shared.js.map.gz')
+        fixture.writePackaged(
+          outputName,
+          'assets/shared.js.map.gz',
+          Buffer.concat([localMap, Buffer.from('mismatch')])
+        )
+      })
 
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
-      'Packaged renderer is missing source maps: out/renderer/assets/dynamic.js.map.gz'
-    )
-  })
-
-  it.each([
-    ['non-gzip', Buffer.from('{"version":3}')],
-    ['non-JSON', gzipSync('not JSON')]
-  ])('rejects a %s map', (_case, corruptMap) => {
-    const { asar, rendererOutputDir } = createFixture((files) => {
-      files.set('out/renderer/assets/shared.js.map.gz', corruptMap)
-    })
-
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
-      /shared\.js\.map\.gz is not valid gzip JSON/
-    )
-  })
-
-  it('rejects raw source-map leakage', () => {
-    const { asar, rendererOutputDir } = createFixture((files) => {
-      files.set('out/renderer/assets/index-entry.js.map', Buffer.from('{}'))
-    })
-
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
-      'Packaged renderer contains raw source maps: out/renderer/assets/index-entry.js.map'
-    )
-  })
-
-  it('rejects embedded sourcesContent', () => {
-    const { asar, rendererOutputDir } = createFixture((files) => {
-      files.set(
-        'out/renderer/assets/index-entry.js.map.gz',
-        sourceMap('index-entry.js', ['source'])
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} source map assets/shared.js.map.gz differs`
       )
     })
 
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
-      'out/renderer/assets/index-entry.js.map.gz contains sourcesContent'
-    )
-  })
+    it('rejects a missing packaged shared or dynamic map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.deletePackaged(outputName, 'assets/dynamic.js.map.gz')
+      })
 
-  it('rejects a map without its adjacent JavaScript asset', () => {
-    const { asar, rendererOutputDir } = createFixture((files) => {
-      files.delete('out/renderer/assets/shared.js')
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} source-map set differs from local output (missing: assets/dynamic.js.map.gz)`
+      )
     })
 
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
-      'out/renderer/assets/shared.js.map.gz has no adjacent JavaScript asset out/renderer/assets/shared.js'
-    )
-  })
+    it('rejects a stale packaged map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writePackaged(outputName, 'assets/stale.js', Buffer.from('stale JavaScript'))
+        fixture.writePackaged(outputName, 'assets/stale.js.map.gz', sourceMap('stale.js'))
+      })
 
-  it('rejects a map that identifies a different JavaScript asset', () => {
-    const { asar, rendererOutputDir } = createFixture((files) => {
-      files.set('out/renderer/assets/shared.js.map.gz', sourceMap('other.js'))
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} source-map set differs from local output (stale: assets/stale.js.map.gz)`
+      )
     })
 
-    expect(() => verifyPackagedRendererSourceMaps('resources', asar, rendererOutputDir)).toThrow(
-      'out/renderer/assets/shared.js.map.gz identifies other.js instead of shared.js'
-    )
+    it('rejects a local raw map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeLocal(outputName, 'assets/index-entry.js.map', Buffer.from('{}'))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} output contains raw source maps: assets/index-entry.js.map`
+      )
+    })
+
+    it('rejects a packaged raw map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writePackaged(outputName, 'assets/index-entry.js.map', Buffer.from('{}'))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} output contains raw source maps: assets/index-entry.js.map`
+      )
+    })
+
+    it('rejects a corrupt gzip map', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(outputName, 'shared.js', Buffer.from('not gzip'))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz is not valid gzip`
+      )
+    })
+
+    it('rejects a gzip map containing invalid JSON', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(outputName, 'shared.js', gzipSync('not JSON'))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz is not valid JSON`
+      )
+    })
+
+    it('rejects an invalid source-map version', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(outputName, 'shared.js', sourceMap('shared.js', { version: 2 }))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz has source-map version 2 instead of 3`
+      )
+    })
+
+    it('rejects a map identifying a different JavaScript asset', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(outputName, 'shared.js', sourceMap('other.js'))
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz identifies other.js instead of shared.js`
+      )
+    })
+
+    it('rejects a local map without adjacent JavaScript', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.deleteLocal(outputName, 'assets/shared.js')
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz has no adjacent JavaScript asset assets/shared.js`
+      )
+    })
+
+    it('rejects a packaged map without adjacent JavaScript', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.deletePackaged(outputName, 'assets/shared.js')
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Packaged ${outputName} source map assets/shared.js.map.gz has no adjacent JavaScript asset assets/shared.js`
+      )
+    })
+
+    it('rejects recursively nested sourcesContent', () => {
+      const { asar, outputDirectories } = createFixture((fixture) => {
+        fixture.writeMapPair(
+          outputName,
+          'shared.js',
+          sourceMap('shared.js', { sections: [{ map: { sourcesContent: ['source'] } }] })
+        )
+      })
+
+      expect(() => verifyPackagedRendererSourceMaps('resources', asar, outputDirectories)).toThrow(
+        `Local ${outputName} source map assets/shared.js.map.gz contains sourcesContent`
+      )
+    })
   })
 })

--- a/config/scripts/verify-web-build.mjs
+++ b/config/scripts/verify-web-build.mjs
@@ -1,5 +1,9 @@
 import { readFile } from 'node:fs/promises'
+import { createRequire } from 'node:module'
 import { resolve } from 'node:path'
+
+const require = createRequire(import.meta.url)
+const { verifyLocalRendererSourceMaps } = require('./renderer-source-map-contract.cjs')
 
 const indexPath = resolve('out/web/web-index.html')
 const html = await readFile(indexPath, 'utf8')
@@ -12,3 +16,5 @@ if (absoluteAssetReference) {
   )
   process.exit(1)
 }
+
+verifyLocalRendererSourceMaps('web', resolve('out/web'))

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -297,7 +297,8 @@ export const electronViteConfig: UserConfig = {
     },
     plugins: [react(), tailwindcss(), createRendererSourceMapCompactionPlugin()],
     worker: {
-      format: 'es'
+      format: 'es',
+      rollupOptions: { output: rendererProductionOutput }
     },
     build: {
       ...rendererProductionBuild,

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -5,6 +5,11 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import { createBootstrapFatalExitBanner } from './config/build-plugins/bootstrap-fatal-exit-banner'
 import { createPlainNodeEntryGuardPlugin } from './config/build-plugins/plain-node-entry-guard'
+import {
+  createRendererSourceMapCompactionPlugin,
+  rendererProductionBuild,
+  rendererProductionMinifyOptions
+} from './config/build-plugins/renderer-production-minification'
 import packageJson from './package.json' with { type: 'json' }
 
 const BUNDLED_MAIN_DEPENDENCIES = new Set([
@@ -290,11 +295,12 @@ export const electronViteConfig: UserConfig = {
         '@': resolve('src/renderer/src')
       }
     },
-    plugins: [react(), tailwindcss()],
+    plugins: [react(), tailwindcss(), createRendererSourceMapCompactionPlugin()],
     worker: {
       format: 'es'
     },
     build: {
+      ...rendererProductionBuild,
       manifest: true,
       modulePreload: { polyfill: true },
       target: 'es2020',
@@ -311,7 +317,8 @@ export const electronViteConfig: UserConfig = {
           index: resolve('src/renderer/index.html'),
           popout: resolve('src/renderer/popout.html'),
           web: resolve('src/renderer/web-index.html')
-        }
+        },
+        output: { minify: rendererProductionMinifyOptions }
       }
     }
   }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -8,7 +8,7 @@ import { createPlainNodeEntryGuardPlugin } from './config/build-plugins/plain-no
 import {
   createRendererSourceMapCompactionPlugin,
   rendererProductionBuild,
-  rendererProductionMinifyOptions
+  rendererProductionOutput
 } from './config/build-plugins/renderer-production-minification'
 import packageJson from './package.json' with { type: 'json' }
 
@@ -318,7 +318,7 @@ export const electronViteConfig: UserConfig = {
           popout: resolve('src/renderer/popout.html'),
           web: resolve('src/renderer/web-index.html')
         },
-        output: { minify: rendererProductionMinifyOptions }
+        output: rendererProductionOutput
       }
     }
   }

--- a/electron.vite.config.ts
+++ b/electron.vite.config.ts
@@ -7,6 +7,7 @@ import { createBootstrapFatalExitBanner } from './config/build-plugins/bootstrap
 import { createPlainNodeEntryGuardPlugin } from './config/build-plugins/plain-node-entry-guard'
 import {
   createRendererSourceMapCompactionPlugin,
+  createRendererSourceMapProvenancePlugin,
   rendererProductionBuild,
   rendererProductionOutput
 } from './config/build-plugins/renderer-production-minification'
@@ -295,9 +296,15 @@ export const electronViteConfig: UserConfig = {
         '@': resolve('src/renderer/src')
       }
     },
-    plugins: [react(), tailwindcss(), createRendererSourceMapCompactionPlugin()],
+    plugins: [
+      react(),
+      tailwindcss(),
+      createRendererSourceMapProvenancePlugin(),
+      createRendererSourceMapCompactionPlugin()
+    ],
     worker: {
       format: 'es',
+      plugins: () => [createRendererSourceMapProvenancePlugin()],
       rollupOptions: { output: rendererProductionOutput }
     },
     build: {

--- a/package.json
+++ b/package.json
@@ -154,6 +154,7 @@
     "@dnd-kit/sortable": "^10.0.0",
     "@electron-toolkit/tsconfig": "^2.0.0",
     "@electron/rebuild": "^4.2.0",
+    "@jridgewell/trace-mapping": "0.3.31",
     "@monaco-editor/react": "^4.7.0",
     "@playwright/test": "^1.59.1",
     "@sanity/diff-match-patch": "^3.2.0",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -110,6 +110,9 @@ importers:
       '@electron/rebuild':
         specifier: ^4.2.0
         version: 4.2.0
+      '@jridgewell/trace-mapping':
+        specifier: 0.3.31
+        version: 0.3.31
       '@monaco-editor/react':
         specifier: ^4.7.0
         version: 4.7.0(monaco-editor@0.55.1)(react-dom@19.2.7(react@19.2.7))(react@19.2.7)

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -10,6 +10,22 @@ import {
 } from './crash-reporting'
 
 describe('crash-reporting shared helpers', () => {
+  it('preserves renderer asset coordinates while redacting install paths', () => {
+    const stack = [
+      'TypeError: renderer failed',
+      '    at fail (file:///Applications/Orca.app/Contents/Resources/app.asar/out/renderer/assets/App-AbC_123.js:7:19)',
+      '    at https://orca.example/client/assets/web-Z9.mjs:11:3'
+    ].join('\n')
+
+    expect(sanitizeCrashReportString(stack, 4_000)).toBe(
+      [
+        'TypeError: renderer failed',
+        '    at fail (renderer-asset:App-AbC_123.js:7:19)',
+        '    at renderer-asset:web-Z9.mjs:11:3'
+      ].join('\n')
+    )
+  })
+
   it('redacts paths and common secret-shaped strings', () => {
     const text =
       'file /Users/alice/My Project/.env /tmp/build log C:\\Users\\bob\\My Project token=abc123 ghp_abcdefghijklmnopqrstuvwxyz'

--- a/src/shared/crash-reporting.test.ts
+++ b/src/shared/crash-reporting.test.ts
@@ -26,6 +26,30 @@ describe('crash-reporting shared helpers', () => {
     )
   })
 
+  it('drops renderer URL queries and fragments without broad script-prefix matches', () => {
+    const stack = [
+      'at query (https://orca.example/client/assets/App.js?workspace=private&bearer=secret:7:19)',
+      'at fragment (file:///Applications/Orca.app/out/renderer/assets/web.mjs#api_key=private:11:3)',
+      'at commonjs (https://orca.example/client/assets/worker.cjs?custom_secret=private:9:4)',
+      'at map (https://orca.example/client/assets/App.js.map?token=private:4:2)',
+      'at commonjs map (https://orca.example/client/assets/worker.cjs.map#workspace=private:8:2)',
+      'at json (https://orca.example/client/assets/App.json#workspace=private:5:1)'
+    ].join('\n')
+    const sanitized = sanitizeCrashReportString(stack, 4_000)
+
+    expect(sanitized).toContain('renderer-asset:App.js:7:19')
+    expect(sanitized).toContain('renderer-asset:web.mjs:11:3')
+    expect(sanitized).toContain('renderer-asset:worker.cjs:9:4')
+    expect(sanitized).not.toContain('workspace=private')
+    expect(sanitized).not.toContain('bearer=secret')
+    expect(sanitized).not.toContain('api_key=private')
+    expect(sanitized).not.toContain('custom_secret=private')
+    expect(sanitized).not.toContain('token=private')
+    expect(sanitized).not.toContain('renderer-asset:App.js.map')
+    expect(sanitized).not.toContain('renderer-asset:worker.cjs.map')
+    expect(sanitized).not.toContain('renderer-asset:App.js.json')
+  })
+
   it('redacts paths and common secret-shaped strings', () => {
     const text =
       'file /Users/alice/My Project/.env /tmp/build log C:\\Users\\bob\\My Project token=abc123 ghp_abcdefghijklmnopqrstuvwxyz'

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -145,7 +145,7 @@ const PATH_PATTERNS = [
 ]
 
 const RENDERER_ASSET_LOCATION_PATTERN =
-  /(?:file|https?):\/\/[^\s)]+?\/assets\/([A-Za-z0-9._-]+\.m?js)(?::(\d+):(\d+))?/gi
+  /(?:file|https?):\/\/[^\s)]+?\/assets\/([A-Za-z0-9._-]+\.(?:[cm]?js))(?=$|[?#:\s)])(?:[?#][^\s)]*?)?(?::(\d+):(\d+))?(?=$|[\s)])/gi
 
 function preserveRendererAssetLocations(value: string): string {
   return value.replace(

--- a/src/shared/crash-reporting.ts
+++ b/src/shared/crash-reporting.ts
@@ -143,6 +143,18 @@ const PATH_PATTERNS = [
   /[A-Za-z]:\\(?:(?!\s+(?:\/|[A-Za-z]:\\|\\\\|gh[pousr]_|sk-|(?:token|api[_-]?key|secret|password)=))[^"'`<>\n\r)])+/gi,
   /\\\\[^\\\s"'`<>\n\r)]+\\(?:(?!\s+(?:\/|[A-Za-z]:\\|\\\\|gh[pousr]_|sk-|(?:token|api[_-]?key|secret|password)=))[^"'`<>\n\r)])+/gi
 ]
+
+const RENDERER_ASSET_LOCATION_PATTERN =
+  /(?:file|https?):\/\/[^\s)]+?\/assets\/([A-Za-z0-9._-]+\.m?js)(?::(\d+):(\d+))?/gi
+
+function preserveRendererAssetLocations(value: string): string {
+  return value.replace(
+    RENDERER_ASSET_LOCATION_PATTERN,
+    (_location, fileName: string, line: string | undefined, column: string | undefined) =>
+      `renderer-asset:${fileName}${line && column ? `:${line}:${column}` : ''}`
+  )
+}
+
 export function isCrashReportReason(reason: string): boolean {
   return [
     'abnormal-exit',
@@ -167,7 +179,7 @@ export function sanitizeCrashReportString(
   value: string,
   maxLength = MAX_STRING_DETAIL_LENGTH
 ): string {
-  let sanitized = value
+  let sanitized = preserveRendererAssetLocations(value)
   for (const pattern of PATH_PATTERNS) {
     sanitized = sanitized.replace(pattern, '[redacted-path]')
   }

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -33,6 +33,7 @@ export default defineConfig({
     }
   },
   worker: {
-    format: 'es'
+    format: 'es',
+    rollupOptions: { output: rendererProductionOutput }
   }
 })

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -2,13 +2,18 @@ import { resolve } from 'node:path'
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
+import {
+  createRendererSourceMapCompactionPlugin,
+  rendererProductionBuild,
+  rendererProductionMinifyOptions
+} from './config/build-plugins/renderer-production-minification'
 
 export default defineConfig({
   root: resolve('src/renderer'),
   // Why: pairing URLs may live under a reverse-proxy path prefix like
   // /orca/web-index.html, so built assets must resolve relative to the page.
   base: './',
-  plugins: [react(), tailwindcss()],
+  plugins: [react(), tailwindcss(), createRendererSourceMapCompactionPlugin()],
   define: {
     ORCA_FEATURE_WALL_ENABLED: 'true'
   },
@@ -19,10 +24,12 @@ export default defineConfig({
     }
   },
   build: {
+    ...rendererProductionBuild,
     outDir: resolve('out/web'),
     emptyOutDir: true,
     rollupOptions: {
-      input: resolve('src/renderer/web-index.html')
+      input: resolve('src/renderer/web-index.html'),
+      output: { minify: rendererProductionMinifyOptions }
     }
   },
   worker: {

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -4,6 +4,7 @@ import react from '@vitejs/plugin-react'
 import tailwindcss from '@tailwindcss/vite'
 import {
   createRendererSourceMapCompactionPlugin,
+  createRendererSourceMapProvenancePlugin,
   rendererProductionBuild,
   rendererProductionOutput
 } from './config/build-plugins/renderer-production-minification'
@@ -13,7 +14,12 @@ export default defineConfig({
   // Why: pairing URLs may live under a reverse-proxy path prefix like
   // /orca/web-index.html, so built assets must resolve relative to the page.
   base: './',
-  plugins: [react(), tailwindcss(), createRendererSourceMapCompactionPlugin()],
+  plugins: [
+    react(),
+    tailwindcss(),
+    createRendererSourceMapProvenancePlugin(),
+    createRendererSourceMapCompactionPlugin()
+  ],
   define: {
     ORCA_FEATURE_WALL_ENABLED: 'true'
   },
@@ -34,6 +40,7 @@ export default defineConfig({
   },
   worker: {
     format: 'es',
+    plugins: () => [createRendererSourceMapProvenancePlugin()],
     rollupOptions: { output: rendererProductionOutput }
   }
 })

--- a/vite.web.config.ts
+++ b/vite.web.config.ts
@@ -5,7 +5,7 @@ import tailwindcss from '@tailwindcss/vite'
 import {
   createRendererSourceMapCompactionPlugin,
   rendererProductionBuild,
-  rendererProductionMinifyOptions
+  rendererProductionOutput
 } from './config/build-plugins/renderer-production-minification'
 
 export default defineConfig({
@@ -29,7 +29,7 @@ export default defineConfig({
     emptyOutDir: true,
     rollupOptions: {
       input: resolve('src/renderer/web-index.html'),
-      output: { minify: rendererProductionMinifyOptions }
+      output: rendererProductionOutput
     }
   },
   worker: {


### PR DESCRIPTION
## Decision summary

This PR is primarily a **bundle-size change with crash-debugging safeguards**. It is **not a demonstrated memory or startup-performance improvement**.

- **Proven:** a pinned local before/after build produced 31.1–33.2% less eager renderer JavaScript and 15.4–21.2% smaller total eager asset closures.
- **Memory and speed:** unknown. This PR has no renderer RSS, heap, startup-time, parse-time, CPU, or user-latency benchmark. Smaller source means fewer JavaScript bytes for V8 to read and parse and may help, but this PR does not prove that users consume less memory or experience a faster app.
- **Raw crash report:** not full TypeScript context. For a JavaScript exception it retains the error, readable function/class names, and the minified asset filename plus generated line/column. The backend does not currently symbolicate it.
- **After symbolication:** full original file, line, column, and embedded source are recoverable for normally toolchain-mapped code using the exact matching packaged `.js.map.gz`. Bundler-generated outputs with identity maps recover their generated JavaScript, not TypeScript that never had an upstream map.
- **Hard renderer-process termination:** Electron's `render-process-gone` event still has no JavaScript exception stack, so there is nothing to symbolicate unless an earlier error breadcrumb captured one.
- **Merge bar:** if acceptance requires a measured user-memory, startup, or latency win, this PR does not meet that bar yet. If acceptance is substantially smaller production JavaScript while retaining package-based crash recovery, it does.

## Why is this so much code?

The exact diff is 2,816 additions and 33 deletions:

| Category | Added lines | Share of additions |
| --- | ---: | ---: |
| Tests | 1,666 | 59.2% |
| Source-map/package verification infrastructure | 741 | 26.3% |
| Core build and crash-report wiring | 409 | 14.5% |

The actual OXC minification and function/class name-retention settings are roughly 20 lines. **85.5% of the additions are tests or verification, not the minifier feature path.**

A much smaller PR could enable minification and trust the bundler's maps. This PR instead makes the debugging contract fail closed across desktop, paired web, direct web, popouts, workers, web projection, and packaged ASAR output. It rejects missing, malformed, stale, incomplete, out-of-range, or byte-mismatched JavaScript/maps before release. That stronger guarantee—not minification itself—is why the PR is large.

## Benefits

- Reduces desktop eager JavaScript from 8,759,207 B to 5,888,426 B: **2,870,781 B smaller (32.8%)** in the pinned comparison.
- Reduces paired-web eager JavaScript from 3,998,157 B to 2,670,975 B: **1,327,182 B smaller (33.2%)**.
- Reduces popout eager JavaScript from 5,552,812 B to 3,827,103 B: **1,725,709 B smaller (31.1%)**.
- Reduces the corresponding total eager asset closures by **21.2%, 15.4%, and 16.9%**.
- Gives V8 less JavaScript source to read and parse. This is a plausible performance input, but no runtime outcome is claimed without a benchmark.
- Preserves readable function/class names and generated asset coordinates in JavaScript exception reports.
- Packages full embedded source text for normally mapped modules, allowing exact offline recovery without a source checkout.
- Makes builds and packaging fail when the minified JavaScript and its recovery data no longer match.
- Does not load or decompress the packaged maps during normal app use. Their contents do not become renderer-heap data merely because they are shipped.

## Cons / tradeoffs

- **No measured user memory, startup, runtime-speed, CPU, or latency improvement.**
- Full maps add 31,395,065 B (about **29.9 MiB**) to one pinned darwin-arm64 logical unpacked-package snapshot. This is not an installer or download-size measurement.
- Raw crash reports are still not automatically symbolicated. Investigation needs the report's generated asset coordinate and the exact matching package map.
- A raw minified frame is less directly readable than an unminified frame until it is symbolicated.
- Identity-mapped bundler/prebuilt outputs recover exact generated JavaScript only; they cannot invent original TypeScript coordinates.
- Hard renderer-process terminations still provide no JavaScript exception stack.
- The custom map/provenance verifier adds significant maintenance surface and build/package verification work. Two complete local ASAR verification runs took 7.54 s and 7.95 s on the measurement machine.
- Exact compressed-map sizes can vary between equivalent builds, so artifact byte counts are snapshots rather than stable invariants.

## Crash reports: exact behavior

### What arrives in the submitted report

For renderer JavaScript exceptions and React error-boundary failures, the plain-text report can include:

- error name, message, and stack
- retained function/class names
- a sanitized generated frame such as `renderer-asset:App-AbC_123.js:7:19`
- React component stack and active-UI context where available
- app version, platform, Electron/Chrome versions, and recent breadcrumbs

The sanitizer now preserves the hashed/minified asset filename and terminal `:line:column` while removing the surrounding URL path, query, and fragment. Previously path redaction could remove the asset location needed for later mapping.

The raw report **does not include the source map, original TypeScript location, or original source text**, and the feedback service does not automatically add them.

### What can be recovered later

Using the generated asset filename/line/column and the adjacent map from the exact matching packaged app version:

- normal toolchain maps recover the original relative source file, line, column, mapping names, and full embedded `sourcesContent`
- identity maps recover the exact adjacent generated JavaScript when no meaningful upstream source map exists
- no repository checkout is required

The package-only regression deletes the fixture's source, staging, and local build directories, runs the packaged minified JavaScript, extracts only the matching JavaScript and `.js.map.gz` from the ASAR, and recovers `src/packaged-crash.ts:4` plus `throw new TypeError(message)`.

**So the direct answer is: no full TypeScript context in the raw report; yes, full context after manual symbolication for normally mapped source.**

## Implementation summary

- Minifies desktop, paired-web, popout, direct-web, and Vite/Monaco worker production bundles with OXC.
- Keeps function and class names through both compression and mangling.
- Emits hidden source maps with relative source paths and embedded source text.
- Gzips maps beside the final `.js`, `.mjs`, and `.cjs` assets and removes raw map files.
- Projects the already-minified paired-web closure without a second transform that would invalidate coordinates.
- Records whether each output has a real toolchain map or an exact generated-code identity map.
- Verifies local and packaged JavaScript, maps, provenance, coordinate bounds, embedded sources, and byte parity.

<details>
<summary>Detailed artifact evidence and verification</summary>

### Map coverage

| Output | JavaScript outputs | Toolchain maps | Identity maps | Embedded sources |
| --- | ---: | ---: | ---: | ---: |
| Renderer, including workers | 788 | 743 | 45 | 6,877 |
| Packaged paired web | 785 | 740 | 45 | 6,867 |
| Direct web | 737 | 701 | 36 | 6,857 |

Every final JavaScript output must be represented by build provenance. Normal physical-module chunks cannot silently fall back to an identity map. Identity eligibility is limited to concrete generated/prebuilt cases such as empty/facade output, virtual/generated modules, JSON-only output, or the exact PDF worker asset.

The verifier constructs and decodes every map with `@jridgewell/trace-mapping` and independently validates its raw VLQ stream. It rejects malformed segment shapes, invalid cumulative coordinates, bad source/name indexes, out-of-range original or generated positions, invalid indexed-map section offsets, absolute/URI source paths, missing or misaligned `sourcesContent`, raw map leakage, corrupt gzip, and packaged/local byte mismatches.

### Pinned artifact measurements

The current treatment's compressed maps measured:

| Output | Maps | Compressed map bytes |
| --- | ---: | ---: |
| Renderer, including workers | 788 | 21,525,166 B |
| Packaged paired web | 785 | 21,508,647 B |
| Direct web | 737 | 21,445,111 B |

The local darwin-arm64 package snapshot changed as follows:

| Measure | Control | Current | Delta |
| --- | ---: | ---: | ---: |
| `app.asar` | 130,444,869 B | 161,839,885 B | +31,395,016 B |
| Logical unpacked package bytes | 534,048,520 B | 565,443,585 B | +31,395,065 B |

“Logical unpacked package bytes” sums regular-file sizes and symlink target lengths. It is not installed disk usage, installer size, or download-compressed size. Maps use hidden mode and have no runtime `sourceMappingURL`; runtime code does not read them.

### Verification completed

- 165/165 focused tests across nine files
- desktop and direct-web production builds
- real ASAR packaging plus repeated package verification
- package-only, no-checkout symbolication regression
- mapped and identity-map coverage for workers, projection, `.js`, `.mjs`, and `.cjs`
- malformed basic/indexed/VLQ map and coordinate-boundary mutations
- missing/stale JavaScript, map, provenance, and embedded-source mutations
- packaged/local JavaScript and compressed-map byte mismatch mutations
- Windows-style ASAR-entry regression
- typecheck, changed-code quality, lint, max-lines ratchet, formatting, and diff checks

The local artifact measurement is one unpacked darwin-arm64 package with notarization disabled. It does not by itself measure Windows release installers, installed size, published download size, startup, memory, parse/compile time, or user-perceived latency.

</details>
