### PR TITLE
fix(wsl): reconcile hook relays on startup

### DIFF
--- a/config/scripts/wsl-hook-relay-reattach-benchmark.mjs
+++ b/config/scripts/wsl-hook-relay-reattach-benchmark.mjs
@@ -310,6 +310,9 @@ async function main() {
     const { ensureWslHookRelayForReattach } = await jiti.import(
       '../../src/main/agent-hooks/wsl-hook-relay-reattach.ts'
     )
+    const { reconcileWslHookRelaysOnStartup } = await jiti.import(
+      '../../src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.ts'
+    )
     const { codexHookService } = await jiti.import('../../src/main/codex/hook-service.ts')
     const { MANAGED_AGENT_HOOK_TARGETS } = await jiti.import(
       '../../src/shared/managed-agent-hook-targets.ts'
@@ -457,6 +460,38 @@ async function main() {
 
     delivered = 0
     manager = await createManager('after-restart-token')
+    const startupDistros = []
+    const startupStartedAt = performance.now()
+    await reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => [
+        {
+          id: survivingPty.id,
+          cwd: guestHome,
+          title: 'shell',
+          wslDistro: distro
+        }
+      ],
+      ensureForDistro: async (startupDistro) => {
+        startupDistros.push(startupDistro)
+        await manager.ensureForDistroReady(startupDistro)
+      }
+    })
+    const startupRelayReadyMs = performance.now() - startupStartedAt
+    if (startupDistros.length !== 1 || startupDistros[0] !== distro) {
+      throw new Error(
+        `Startup inventory did not reconcile '${distro}': [${startupDistros.join(', ')}]`
+      )
+    }
+    const refreshedEndpoint = await waitFor('startup relay endpoint rewrite', async () => {
+      const contents = await readGuestFile(distro, endpointPath)
+      const parsed = contents ? parseEndpoint(contents) : null
+      return parsed && parsed.token === 'after-restart-token' ? parsed : null
+    })
+
+    const immediateHook = await invokeHook(distro, scriptPath, endpointPath)
+    await waitFor('immediate startup hook delivery', async () => (delivered >= 1 ? true : null))
+
     // Reattach the surviving WSL PTY through main's real spawn path — no direct helper call.
     // Why delta: only the reattach phase should record ensureForDistro; length alone can false-
     // green if an earlier phase already refreshed (or if a future hooks-on change reintroduces it).
@@ -473,12 +508,8 @@ async function main() {
         `PTY reattach did not refresh the relay for '${distro}': before=${refreshesBeforeReattach} all=[${relayRefreshes.join(', ')}]`
       )
     }
-    const refreshedEndpoint = await waitFor('reattached relay endpoint rewrite', async () => {
-      const contents = await readGuestFile(distro, endpointPath)
-      const parsed = contents ? parseEndpoint(contents) : null
-      return parsed && parsed.token === 'after-restart-token' ? parsed : null
-    })
 
+    delivered = 0
     await invokeHook(distro, scriptPath, endpointPath)
     await waitFor('refreshed hook warmup delivery', async () => (delivered >= 1 ? true : null))
     delivered = 0
@@ -495,8 +526,11 @@ async function main() {
     const result = {
       distro,
       endpointPath,
-      endpointPortAfterReattach: refreshedEndpoint.port,
+      endpointPortAfterStartup: refreshedEndpoint.port,
       reattachedPtyId: reattachedPty.id,
+      startupDistros,
+      startupRelayReadyMs: Number(startupRelayReadyMs.toFixed(1)),
+      immediateHookMs: Number(immediateHook.elapsedMs.toFixed(1)),
       relayRefreshes,
       reattachRefreshes,
       stale,

--- a/config/scripts/wsl-hook-relay-reattach-benchmark.mjs
+++ b/config/scripts/wsl-hook-relay-reattach-benchmark.mjs
@@ -323,15 +323,15 @@ async function main() {
     // Why: if jiti ever returns a second manager module, our monkey-patch would miss the singleton
     // that ensureWslHookRelayForReattach (loaded via pty.ts) closes over — fail closed now.
     const singletonProbe = []
-    const previousEnsure = wslHookRelayManager.ensureForDistro.bind(wslHookRelayManager)
-    wslHookRelayManager.ensureForDistro = (probedDistro) => {
+    const previousEnsureReady = wslHookRelayManager.ensureForDistroReady.bind(wslHookRelayManager)
+    wslHookRelayManager.ensureForDistroReady = async (probedDistro) => {
       singletonProbe.push(probedDistro)
     }
-    ensureWslHookRelayForReattach(
+    await ensureWslHookRelayForReattach(
       { isReattach: true, wslDistro: '__bench-singleton-probe__' },
       null
     )
-    wslHookRelayManager.ensureForDistro = previousEnsure
+    wslHookRelayManager.ensureForDistroReady = previousEnsureReady
     if (singletonProbe.length !== 1 || singletonProbe[0] !== '__bench-singleton-probe__') {
       throw new Error(
         'jiti duplicated the WSL hook-relay manager graph; reattach patch would not observe pty.ts'
@@ -360,15 +360,15 @@ async function main() {
     // Why: pty.ts refreshes through the production singleton, so route that singleton at the
     // benchmark-scoped manager instead of calling the reattach helper from here — a removed or
     // mislocated integration call in pty.ts must fail this benchmark.
-    wslHookRelayManager.ensureForDistro = (refreshedDistro) => {
+    wslHookRelayManager.ensureForDistroReady = async (refreshedDistro) => {
       relayRefreshes.push(refreshedDistro)
-      manager?.ensureForDistro(refreshedDistro)
+      await manager?.ensureForDistroReady(refreshedDistro)
     }
 
     const { runtime, getController } = createRuntimeStub()
     // Why hooks off: fresh WSL spawn still runs buildPtyHostEnv, which calls ensureForDistro when
     // hooks are on. This bench isolates the reattach call site (ensureWslHookRelayForReattach);
-    // the manager's own hooks gate lives behind the ensureForDistro patch above, so it stays out
+    // the manager's own hooks gate lives behind the ensureForDistroReady patch above, so it stays out
     // of the measurement — `manager` below resolves its own (enabled) managed-hook settings.
     ptyIpc.registerPtyHandlers(
       createRendererWindowStub(),
@@ -474,7 +474,7 @@ async function main() {
       ],
       ensureForDistro: async (startupDistro) => {
         startupDistros.push(startupDistro)
-        await manager.ensureForDistroReady(startupDistro)
+        await manager.ensureRunningDistroForStartup(startupDistro)
       }
     })
     const startupRelayReadyMs = performance.now() - startupStartedAt

--- a/package.json
+++ b/package.json
@@ -109,6 +109,7 @@
     "bench:macos-computer-helper-owner-loss": "node config/scripts/macos-computer-helper-owner-loss-benchmark.mjs",
     "bench:startup": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/startup-time-bench.mjs",
     "bench:daemon-coldstart": "pnpm run ensure:electron-runtime && node tests/tools/benchmarks/daemon-coldstart-bench.mjs",
+    "bench:wsl-hook-relay-startup": "pnpm run build:relay && node config/scripts/wsl-hook-relay-reattach-benchmark.mjs",
     "bench:wsl-hook-relay-reattach": "pnpm run build:relay && node config/scripts/wsl-hook-relay-reattach-benchmark.mjs",
     "bench:wsl-git-shell": "node config/scripts/wsl-git-shell-benchmark.mjs",
     "bench:hang-watchdog-memory": "pnpm run ensure:electron-runtime && node config/scripts/hang-watchdog-memory-benchmark.mjs",

--- a/src/main/agent-hooks/wsl-hook-relay-default-distro.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-default-distro.ts
@@ -1,0 +1,13 @@
+export async function resolveWslHookRelayDefaultDistro(
+  cached: string | null,
+  listDistros: () => Promise<string[]>
+): Promise<string | null> {
+  if (cached) {
+    return cached
+  }
+  try {
+    return (await listDistros())[0] ?? null
+  } catch {
+    return null
+  }
+}

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -16,6 +16,7 @@ import {
   type WslRelayStartupFailure
 } from './wsl-hook-relay-sentinel'
 import { addOrcaWslInteropEnv } from '../pty/wsl-orca-env'
+import { wslHookRelayStateKey } from './wsl-hook-relay-state-key'
 import {
   WSL_HOOK_RELAY_BUNDLE_NAME,
   WSL_HOOK_RELAY_DIR,
@@ -140,14 +141,8 @@ export function spawnWslRelayProcess(
   })
 }
 
-/** True when the distro shows in `wsl --list --running`. Listing does NOT
- *  boot anything — unlike `wsl -d`, which starts a stopped distro. The
- *  restart timer must check this so relay recovery never resurrects a VM the
- *  user shut down with `wsl --shutdown`. Fails CLOSED (false) on probe
- *  errors: booting a VM the user shut down is worse than a skipped restart
- *  (the next WSL PTY spawn re-ensures), and a wsl.exe too wedged to list
- *  distros would not have launched the relay anyway. */
-export function isWslDistroRunning(distro: string): Promise<boolean> {
+/** One non-booting snapshot; null fails closed when WSL cannot report authority. */
+export function listRunningWslDistros(): Promise<string[] | null> {
   return new Promise((resolve) => {
     execFile(
       'wsl.exe',
@@ -157,18 +152,24 @@ export function isWslDistroRunning(distro: string): Promise<boolean> {
       { env: { ...process.env, WSL_UTF8: '1' }, timeout: 10_000, windowsHide: true },
       (err, stdout) => {
         if (err) {
-          resolve(false)
+          resolve(null)
           return
         }
-        const wanted = distro.trim().toLowerCase()
         const running = decodeWslText(String(stdout))
           .split(/\r?\n/)
-          .map((line) => line.trim().toLowerCase())
+          .map((line) => line.trim())
           .filter(Boolean)
-        resolve(running.includes(wanted))
+        resolve(running)
       }
     )
   })
+}
+
+/** Recovery must not resurrect a distro the user stopped with `wsl --shutdown`. */
+export async function isWslDistroRunning(distro: string): Promise<boolean> {
+  const running = await listRunningWslDistros()
+  const wanted = wslHookRelayStateKey(distro)
+  return running?.some((candidate) => wslHookRelayStateKey(candidate) === wanted) ?? false
 }
 
 export function runWslInstallProcess(

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -249,15 +249,26 @@ export async function launchWslRelayWithInstall(options: {
   onChild: (child: ChildProcessWithoutNullStreams) => void
   onNoNode: () => void
   onFailure: (message: string) => void
+  continueAfterFailure?: () => Promise<boolean>
+  onContinuationBlocked: () => void
   connect: (transport: MultiplexerTransport, child: ChildProcessWithoutNullStreams) => Promise<void>
 }): Promise<void> {
   const { distro, env, bundleJsPath, version, io } = options
   let installTried = false
   let transientRetries = 0
+  let continuationRequiresRunning = false
   for (;;) {
     if (options.isDisposed()) {
       return
     }
+    if (
+      continuationRequiresRunning &&
+      !(await canContinueRelayStartup(options.continueAfterFailure))
+    ) {
+      options.onContinuationBlocked()
+      return
+    }
+    continuationRequiresRunning = false
     const child = io.spawnRelay(distro, env, version)
     options.onChild(child)
     try {
@@ -284,13 +295,19 @@ export async function launchWslRelayWithInstall(options: {
       ) {
         transientRetries++
         await new Promise((resolve) => setTimeout(resolve, io.transientRetryDelayMs))
+        continuationRequiresRunning = true
         continue
       }
       if (!installTried) {
+        if (!(await canContinueRelayStartup(options.continueAfterFailure))) {
+          options.onContinuationBlocked()
+          return
+        }
         installTried = true
         const script = buildGuestInstallScript(io.readBundle(bundleJsPath), version)
         const result = await io.runInstall(distro, script, env)
         if (result.code === 0) {
+          continuationRequiresRunning = true
           continue
         }
         options.onFailure(
@@ -301,6 +318,19 @@ export async function launchWslRelayWithInstall(options: {
       options.onFailure(formatWslRelayFailure(failure))
       return
     }
+  }
+}
+
+async function canContinueRelayStartup(
+  continueAfterFailure: (() => Promise<boolean>) | undefined
+): Promise<boolean> {
+  if (!continueAfterFailure) {
+    return true
+  }
+  try {
+    return await continueAfterFailure()
+  } catch {
+    return false
   }
 }
 

--- a/src/main/agent-hooks/wsl-hook-relay-launch.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-launch.ts
@@ -234,12 +234,7 @@ export type WslRelayLaunchIo = {
   transientRetryDelayMs: number
 }
 
-/** Spawn → sentinel → connect, with the guest-install/retry policy: stale or
- *  missing installs get exactly one streamed reinstall, wsl.exe's transient
- *  "Catastrophic failure (E_UNEXPECTED)" gets a bounded retry, a distro
- *  without node >= 18 reports through `onNoNode`. Terminal failures report
- *  through `onFailure`; non-startup errors propagate to the caller. */
-export async function launchWslRelayWithInstall(options: {
+type WslRelayLaunchOptions = {
   distro: string
   env: NodeJS.ProcessEnv
   bundleJsPath: string
@@ -252,7 +247,14 @@ export async function launchWslRelayWithInstall(options: {
   continueAfterFailure?: () => Promise<boolean>
   onContinuationBlocked: () => void
   connect: (transport: MultiplexerTransport, child: ChildProcessWithoutNullStreams) => Promise<void>
-}): Promise<void> {
+}
+
+/** Spawn → sentinel → connect, with the guest-install/retry policy: stale or
+ *  missing installs get exactly one streamed reinstall, wsl.exe's transient
+ *  "Catastrophic failure (E_UNEXPECTED)" gets a bounded retry, a distro
+ *  without node >= 18 reports through `onNoNode`. Terminal failures report
+ *  through `onFailure`; non-startup errors propagate to the caller. */
+export async function launchWslRelayWithInstall(options: WslRelayLaunchOptions): Promise<void> {
   const { distro, env, bundleJsPath, version, io } = options
   let installTried = false
   let transientRetries = 0
@@ -261,11 +263,7 @@ export async function launchWslRelayWithInstall(options: {
     if (options.isDisposed()) {
       return
     }
-    if (
-      continuationRequiresRunning &&
-      !(await canContinueRelayStartup(options.continueAfterFailure))
-    ) {
-      options.onContinuationBlocked()
+    if (continuationRequiresRunning && !(await canContinueRelayStartup(options))) {
       return
     }
     continuationRequiresRunning = false
@@ -299,8 +297,7 @@ export async function launchWslRelayWithInstall(options: {
         continue
       }
       if (!installTried) {
-        if (!(await canContinueRelayStartup(options.continueAfterFailure))) {
-          options.onContinuationBlocked()
+        if (!(await canContinueRelayStartup(options))) {
           return
         }
         installTried = true
@@ -321,17 +318,18 @@ export async function launchWslRelayWithInstall(options: {
   }
 }
 
-async function canContinueRelayStartup(
-  continueAfterFailure: (() => Promise<boolean>) | undefined
-): Promise<boolean> {
-  if (!continueAfterFailure) {
-    return true
-  }
+async function canContinueRelayStartup(options: WslRelayLaunchOptions): Promise<boolean> {
+  let canContinue = true
   try {
-    return await continueAfterFailure()
+    canContinue = (await options.continueAfterFailure?.()) ?? true
   } catch {
-    return false
+    canContinue = false
   }
+  const disposed = options.isDisposed()
+  if (!disposed && !canContinue) {
+    options.onContinuationBlocked()
+  }
+  return !disposed && canContinue
 }
 
 export function formatWslRelayFailure(failure: WslRelayStartupFailure): string {

--- a/src/main/agent-hooks/wsl-hook-relay-lifecycle-state.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-lifecycle-state.ts
@@ -1,0 +1,21 @@
+import type { ChildProcessWithoutNullStreams } from 'node:child_process'
+
+import type { SshChannelMultiplexer } from '../ssh/ssh-channel-multiplexer'
+
+export type WslHookRelayLifecycleState = {
+  /** Original casing for wsl.exe argv and breadcrumbs; map keys are lowercased. */
+  distro: string
+  phase: 'starting' | 'running' | 'failed'
+  child?: ChildProcessWithoutNullStreams
+  mux?: SshChannelMultiplexer
+  guestHome?: string
+  guestEndpointFilePath?: string
+  opencodeOverlayDir?: string
+  failures: number
+  cooldownUntil: number
+  connectedAt?: number
+  restartTimer?: ReturnType<typeof setTimeout>
+  reinstallTimer?: ReturnType<typeof setTimeout>
+  lastInstallAt?: number
+  firstAttempt?: Promise<void>
+}

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -275,7 +275,7 @@ describe('WslHookRelayManager', () => {
     const { manager, deps } = createManager({ installHooks })
     let ready = false
 
-    const firstAttempt = manager.ensureForDistroReady('Ubuntu').then(() => {
+    const firstAttempt = manager.ensureRunningDistroForStartup('Ubuntu').then(() => {
       ready = true
     })
     await vi.waitFor(() => expect(deps.installHooks).toHaveBeenCalledTimes(1))
@@ -285,6 +285,90 @@ describe('WslHookRelayManager', () => {
     await firstAttempt
     expect(manager.getGuestEndpointFilePath('Ubuntu')).not.toBeNull()
     expect(ready).toBe(true)
+    expect(deps.isDistroRunning).not.toHaveBeenCalled()
+    manager.disposeAll()
+  })
+
+  it('awaits an equivalent first attempt already started by a PTY path', async () => {
+    let releaseInstall: (() => void) | undefined
+    const installHooks = vi.fn(
+      () => new Promise<never[]>((resolve) => (releaseInstall = () => resolve([])))
+    )
+    const { manager, deps } = createManager({ installHooks })
+
+    manager.ensureForDistro('Ubuntu')
+    await vi.waitFor(() => expect(deps.installHooks).toHaveBeenCalledTimes(1))
+    let ready = false
+    const startupAttempt = manager.ensureForDistroReady('ubuntu').then(() => {
+      ready = true
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(ready).toBe(false)
+
+    releaseInstall?.()
+    await startupAttempt
+    expect(ready).toBe(true)
+    expect(deps.spawnRelay).toHaveBeenCalledTimes(1)
+    manager.disposeAll()
+  })
+
+  it('does not respawn when a startup-owned distro stops during guest install', async () => {
+    const isDistroRunning = vi
+      .fn<() => Promise<boolean>>()
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    const waitForSentinel = vi
+      .fn()
+      .mockRejectedValueOnce(startupError(42))
+      .mockImplementationOnce(async () => guestTransport())
+    const { manager, deps } = createManager({ isDistroRunning, waitForSentinel })
+
+    await manager.ensureRunningDistroForStartup('Ubuntu')
+
+    expect(deps.spawnRelay).toHaveBeenCalledTimes(1)
+    expect(deps.runInstall).toHaveBeenCalledTimes(1)
+    expect(isDistroRunning).toHaveBeenCalledTimes(2)
+    expect(deps.warn).toHaveBeenCalledWith(expect.stringContaining('continuation skipped'))
+    manager.disposeAll()
+  })
+
+  it('does not retry a transient startup failure after the distro stops', async () => {
+    const isDistroRunning = vi.fn(async () => false)
+    const waitForSentinel = vi
+      .fn()
+      .mockRejectedValueOnce(startupError(1, 'Catastrophic failure (E_UNEXPECTED)'))
+      .mockImplementationOnce(async () => guestTransport())
+    const { manager, deps } = createManager({ isDistroRunning, waitForSentinel })
+
+    await manager.ensureRunningDistroForStartup('Ubuntu')
+
+    expect(deps.spawnRelay).toHaveBeenCalledTimes(1)
+    expect(deps.runInstall).not.toHaveBeenCalled()
+    expect(isDistroRunning).toHaveBeenCalledOnce()
+    manager.disposeAll()
+  })
+
+  it('lets a concurrent reattach retry after startup drops a stopped attempt', async () => {
+    let rejectStartup!: (error: Error) => void
+    const waitForSentinel = vi
+      .fn()
+      .mockImplementationOnce(
+        () => new Promise<MultiplexerTransport>((_resolve, reject) => (rejectStartup = reject))
+      )
+      .mockImplementationOnce(async () => guestTransport())
+    const { manager, deps } = createManager({
+      isDistroRunning: vi.fn(async () => false),
+      waitForSentinel
+    })
+
+    const startup = manager.ensureRunningDistroForStartup('Ubuntu')
+    await vi.waitFor(() => expect(deps.spawnRelay).toHaveBeenCalledTimes(1))
+    const reattach = manager.ensureForDistroReady('ubuntu')
+    rejectStartup(startupError(42))
+    await Promise.all([startup, reattach])
+
+    expect(deps.spawnRelay).toHaveBeenCalledTimes(2)
+    expect(deps.installHooks).toHaveBeenCalledTimes(1)
     manager.disposeAll()
   })
 

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -348,6 +348,31 @@ describe('WslHookRelayManager', () => {
     manager.disposeAll()
   })
 
+  it.each([
+    ['guest install', startupError(42)],
+    ['transient retry', startupError(1, 'Catastrophic failure (E_UNEXPECTED)')]
+  ])('does not continue %s after teardown during its liveness probe', async (_label, failure) => {
+    let resolveRunning!: (running: boolean) => void
+    const isDistroRunning = vi
+      .fn<() => Promise<boolean>>()
+      .mockImplementationOnce(() => new Promise<boolean>((resolve) => (resolveRunning = resolve)))
+      .mockResolvedValue(false)
+    const waitForSentinel = vi
+      .fn()
+      .mockRejectedValueOnce(failure)
+      .mockImplementationOnce(async () => guestTransport())
+    const { manager, deps } = createManager({ isDistroRunning, waitForSentinel })
+
+    const attempt = manager.ensureRunningDistroForStartup('Ubuntu')
+    await vi.waitFor(() => expect(isDistroRunning).toHaveBeenCalledOnce())
+    manager.disposeAll()
+    resolveRunning(true)
+    await attempt
+
+    expect(deps.spawnRelay).toHaveBeenCalledTimes(1)
+    expect(deps.runInstall).not.toHaveBeenCalled()
+  })
+
   it('lets a concurrent reattach retry after startup drops a stopped attempt', async () => {
     let rejectStartup!: (error: Error) => void
     const waitForSentinel = vi

--- a/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.test.ts
@@ -267,6 +267,27 @@ describe('WslHookRelayManager', () => {
     manager.disposeAll()
   })
 
+  it('exposes first-attempt readiness for startup ordering', async () => {
+    let releaseInstall: (() => void) | undefined
+    const installHooks = vi.fn(
+      () => new Promise<never[]>((resolve) => (releaseInstall = () => resolve([])))
+    )
+    const { manager, deps } = createManager({ installHooks })
+    let ready = false
+
+    const firstAttempt = manager.ensureForDistroReady('Ubuntu').then(() => {
+      ready = true
+    })
+    await vi.waitFor(() => expect(deps.installHooks).toHaveBeenCalledTimes(1))
+    expect(ready).toBe(false)
+
+    releaseInstall?.()
+    await firstAttempt
+    expect(manager.getGuestEndpointFilePath('Ubuntu')).not.toBeNull()
+    expect(ready).toBe(true)
+    manager.disposeAll()
+  })
+
   it('ships the OpenCode plugin to the guest and exposes the overlay dir', async () => {
     const { manager } = createManager({})
     manager.ensureForDistro('Ubuntu')

--- a/src/main/agent-hooks/wsl-hook-relay-manager.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.ts
@@ -22,6 +22,7 @@ import {
 import { wireWslRelayLink } from './wsl-hook-relay-link'
 import { WslRelayRecovery } from './wsl-hook-relay-recovery'
 import { wslHookRelayStateKey } from './wsl-hook-relay-state-key'
+import type { WslHookRelayLifecycleState } from './wsl-hook-relay-lifecycle-state'
 import { SshChannelMultiplexer, type MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
 import { AGENT_HOOK_REQUEST_REPLAY_METHOD } from '../../shared/agent-hook-relay'
 import {
@@ -30,27 +31,10 @@ import {
   wslHookRelayEndpointFilePath
 } from '../../shared/wsl-hook-relay-contract'
 
-type DistroState = {
-  /** Original casing for wsl.exe argv and breadcrumbs; map keys are lowercased. */
-  distro: string
-  phase: 'starting' | 'running' | 'failed'
-  child?: ChildProcessWithoutNullStreams
-  mux?: SshChannelMultiplexer
-  guestHome?: string
-  guestEndpointFilePath?: string
-  opencodeOverlayDir?: string
-  failures: number
-  cooldownUntil: number
-  connectedAt?: number
-  restartTimer?: ReturnType<typeof setTimeout>
-  reinstallTimer?: ReturnType<typeof setTimeout>
-  lastInstallAt?: number
-}
-
 export class WslHookRelayManager {
   private deps: WslHookRelayManagerDeps
   private recovery: WslRelayRecovery
-  private states = new Map<string, DistroState>()
+  private states = new Map<string, WslHookRelayLifecycleState>()
   /** Distros a hooks-off teardown stopped, so re-enabling can put them back. */
   private stoppedByHooksOff = new Set<string>()
   private defaultDistro: string | null = null
@@ -85,18 +69,30 @@ export class WslHookRelayManager {
     void this.ensureForDistroReady(distro)
   }
 
-  /** Awaitable first attempt for the startup gate; failures retain timer-driven recovery. */
+  /** Awaitable first attempt for startup and reattach ordering. */
   async ensureForDistroReady(distro: string | null): Promise<void> {
+    await this.ensureForDistroReadyWhile(distro)
+  }
+
+  /** Startup retries must not resurrect a distro that stopped after inventory. */
+  async ensureRunningDistroForStartup(distro: string): Promise<void> {
+    await this.ensureForDistroReadyWhile(distro, () => this.deps.isDistroRunning(distro))
+  }
+
+  private async ensureForDistroReadyWhile(
+    distro: string | null,
+    continueAfterFailure?: () => Promise<boolean>
+  ): Promise<void> {
     if (this.disposed || !isWslHookRelayAllowed(this.deps)) {
       return
     }
-    await this.ensureInternal(distro).catch((err) => {
+    await this.ensureInternal(distro, continueAfterFailure).catch((err) => {
       const detail = err instanceof Error ? err.message : String(err)
       this.deps.warn(`[agent-hooks] WSL hook relay ensure failed: ${detail}`)
     })
   }
 
-  private stateFor(distro: string | null): DistroState | undefined {
+  private stateFor(distro: string | null): WslHookRelayLifecycleState | undefined {
     // Empty key never matches a real (non-empty) distro state.
     return this.states.get(wslHookRelayStateKey(distro ?? this.defaultDistro ?? ''))
   }
@@ -146,7 +142,10 @@ export class WslHookRelayManager {
     }
   }
 
-  private async ensureInternal(requestedDistro: string | null): Promise<void> {
+  private async ensureInternal(
+    requestedDistro: string | null,
+    continueAfterFailure?: () => Promise<boolean>
+  ): Promise<void> {
     const distro = requestedDistro ?? (await this.resolveDefaultDistro())
     if (!distro || this.disposed) {
       return
@@ -157,6 +156,10 @@ export class WslHookRelayManager {
       if (existing.phase === 'running') {
         void maybeRerunWslRelayGuestInstall(this.deps, existing)
         return
+      }
+      if (existing.phase === 'starting') {
+        await existing.firstAttempt
+        return await this.ensureInternal(requestedDistro, continueAfterFailure)
       }
       if (existing.phase !== 'failed' || Date.now() < existing.cooldownUntil) {
         return
@@ -182,7 +185,7 @@ export class WslHookRelayManager {
     if (existing) {
       this.recovery.clearTimers(existing)
     }
-    const state: DistroState = {
+    const state: WslHookRelayLifecycleState = {
       distro,
       phase: 'starting',
       failures: existing?.failures ?? 0,
@@ -195,31 +198,44 @@ export class WslHookRelayManager {
 
     const env = buildWslRelaySpawnEnv(coords, bundle.version, instanceKey)
 
+    state.firstAttempt = launchWslRelayWithInstall({
+      distro: state.distro,
+      env,
+      bundleJsPath: bundle.jsPath,
+      version: bundle.version,
+      io: this.deps,
+      // Why the identity half: a hooks-off teardown drops this state and kills its child, but
+      // that kill reads as a startup failure and the retry loop would respawn an untracked relay.
+      isDisposed: () => this.disposed || this.states.get(key) !== state,
+      onChild: (child) => {
+        state.child = child
+      },
+      onNoNode: () =>
+        this.markFailed(
+          state,
+          `no node >= 18 found in distro '${state.distro}'; agent hooks stay degraded there`,
+          { cooldownBaseMs: NO_NODE_COOLDOWN_MS }
+        ),
+      onFailure: (message) =>
+        this.markFailed(state, message, {
+          cooldownBaseMs: FAILURE_COOLDOWN_BASE_MS
+        }),
+      continueAfterFailure,
+      onContinuationBlocked: () => {
+        state.phase = 'failed'
+        state.child = undefined
+        if (this.states.get(key) === state) {
+          this.states.delete(key)
+        }
+        this.deps.warn(
+          `[agent-hooks] WSL hook relay (${state.distro}): distro no longer confirmed running; startup continuation skipped`
+        )
+      },
+      connect: (transport, child) => this.connect(state, transport, child, instanceKey)
+    })
+
     try {
-      await launchWslRelayWithInstall({
-        distro: state.distro,
-        env,
-        bundleJsPath: bundle.jsPath,
-        version: bundle.version,
-        io: this.deps,
-        // Why the identity half: a hooks-off teardown drops this state and kills its child, but
-        // that kill reads as a startup failure and the retry loop would respawn an untracked relay.
-        isDisposed: () => this.disposed || this.states.get(key) !== state,
-        onChild: (child) => {
-          state.child = child
-        },
-        onNoNode: () =>
-          this.markFailed(
-            state,
-            `no node >= 18 found in distro '${state.distro}'; agent hooks stay degraded there`,
-            { cooldownBaseMs: NO_NODE_COOLDOWN_MS }
-          ),
-        onFailure: (message) =>
-          this.markFailed(state, message, {
-            cooldownBaseMs: FAILURE_COOLDOWN_BASE_MS
-          }),
-        connect: (transport, child) => this.connect(state, transport, child, instanceKey)
-      })
+      await state.firstAttempt
     } catch (err) {
       // Why: teardown may have already recorded this failure; don't double-
       // count. A request-level error can leave a live child — never leak it.
@@ -230,11 +246,13 @@ export class WslHookRelayManager {
           cooldownBaseMs: FAILURE_COOLDOWN_BASE_MS
         })
       }
+    } finally {
+      state.firstAttempt = undefined
     }
   }
 
   private async connect(
-    state: DistroState,
+    state: WslHookRelayLifecycleState,
     transport: MultiplexerTransport,
     child: ChildProcessWithoutNullStreams,
     instanceKey: string
@@ -306,7 +324,7 @@ export class WslHookRelayManager {
    *  one failed relaunch must not end self-recovery; the timer's
    *  distro-running probe keeps this from booting stopped distros. */
   private markFailed(
-    state: DistroState,
+    state: WslHookRelayLifecycleState,
     message: string,
     options: { cooldownBaseMs: number }
   ): void {

--- a/src/main/agent-hooks/wsl-hook-relay-manager.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.ts
@@ -82,10 +82,15 @@ export class WslHookRelayManager {
 
   /** Fire-and-forget from every WSL PTY spawn-env build; errors breadcrumb. */
   ensureForDistro(distro: string | null): void {
+    void this.ensureForDistroReady(distro)
+  }
+
+  /** Awaitable first attempt for the startup gate; failures retain timer-driven recovery. */
+  async ensureForDistroReady(distro: string | null): Promise<void> {
     if (this.disposed || !isWslHookRelayAllowed(this.deps)) {
       return
     }
-    void this.ensureInternal(distro).catch((err) => {
+    await this.ensureInternal(distro).catch((err) => {
       const detail = err instanceof Error ? err.message : String(err)
       this.deps.warn(`[agent-hooks] WSL hook relay ensure failed: ${detail}`)
     })

--- a/src/main/agent-hooks/wsl-hook-relay-manager.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.ts
@@ -23,6 +23,7 @@ import { wireWslRelayLink } from './wsl-hook-relay-link'
 import { WslRelayRecovery } from './wsl-hook-relay-recovery'
 import { wslHookRelayStateKey } from './wsl-hook-relay-state-key'
 import type { WslHookRelayLifecycleState } from './wsl-hook-relay-lifecycle-state'
+import { resolveWslHookRelayDefaultDistro } from './wsl-hook-relay-default-distro'
 import { SshChannelMultiplexer, type MultiplexerTransport } from '../ssh/ssh-channel-multiplexer'
 import { AGENT_HOOK_REQUEST_REPLAY_METHOD } from '../../shared/agent-hook-relay'
 import {
@@ -343,15 +344,9 @@ export class WslHookRelayManager {
   }
 
   private async resolveDefaultDistro(): Promise<string | null> {
-    if (this.defaultDistro) {
-      return this.defaultDistro
-    }
-    try {
-      const distros = await this.deps.listDistros()
-      this.defaultDistro = distros[0] ?? null
-    } catch {
-      this.defaultDistro = null
-    }
+    this.defaultDistro = await resolveWslHookRelayDefaultDistro(this.defaultDistro, () =>
+      this.deps.listDistros()
+    )
     return this.defaultDistro
   }
 }

--- a/src/main/agent-hooks/wsl-hook-relay-manager.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.ts
@@ -71,13 +71,13 @@ export class WslHookRelayManager {
   }
 
   /** Awaitable first attempt for startup and reattach ordering. */
-  async ensureForDistroReady(distro: string | null): Promise<void> {
-    await this.ensureForDistroReadyWhile(distro)
+  ensureForDistroReady(distro: string | null): Promise<void> {
+    return this.ensureForDistroReadyWhile(distro)
   }
 
   /** Startup retries must not resurrect a distro that stopped after inventory. */
-  async ensureRunningDistroForStartup(distro: string): Promise<void> {
-    await this.ensureForDistroReadyWhile(distro, () => this.deps.isDistroRunning(distro))
+  ensureRunningDistroForStartup(distro: string): Promise<void> {
+    return this.ensureForDistroReadyWhile(distro, () => this.deps.isDistroRunning(distro))
   }
 
   private async ensureForDistroReadyWhile(

--- a/src/main/agent-hooks/wsl-hook-relay-manager.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-manager.ts
@@ -70,17 +70,13 @@ export class WslHookRelayManager {
     void this.ensureForDistroReady(distro)
   }
 
-  /** Awaitable first attempt for startup and reattach ordering. */
-  ensureForDistroReady(distro: string | null): Promise<void> {
-    return this.ensureForDistroReadyWhile(distro)
-  }
-
   /** Startup retries must not resurrect a distro that stopped after inventory. */
   ensureRunningDistroForStartup(distro: string): Promise<void> {
-    return this.ensureForDistroReadyWhile(distro, () => this.deps.isDistroRunning(distro))
+    return this.ensureForDistroReady(distro, () => this.deps.isDistroRunning(distro))
   }
 
-  private async ensureForDistroReadyWhile(
+  /** Awaitable first attempt for startup and reattach ordering. */
+  async ensureForDistroReady(
     distro: string | null,
     continueAfterFailure?: () => Promise<boolean>
   ): Promise<void> {

--- a/src/main/agent-hooks/wsl-hook-relay-reattach.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-reattach.test.ts
@@ -1,12 +1,19 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { ensureWslHookRelayForReattach } from './wsl-hook-relay-reattach'
+import {
+  ensureWslHookRelayForReattach,
+  WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS
+} from './wsl-hook-relay-reattach'
 
 describe('ensureWslHookRelayForReattach', () => {
-  it('refreshes the surviving session distro after a local reattach', () => {
+  it('refreshes the surviving session distro after a local reattach', async () => {
     const ensure = vi.fn()
 
-    ensureWslHookRelayForReattach({ isReattach: true, wslDistro: 'Ubuntu-24.04' }, null, ensure)
+    await ensureWslHookRelayForReattach(
+      { isReattach: true, wslDistro: 'Ubuntu-24.04' },
+      null,
+      ensure
+    )
 
     expect(ensure).toHaveBeenCalledOnce()
     expect(ensure).toHaveBeenCalledWith('Ubuntu-24.04')
@@ -19,20 +26,76 @@ describe('ensureWslHookRelayForReattach', () => {
     ['blank distro', { isReattach: true, wslDistro: '  ' }, null],
     ['SSH reattach', { isReattach: true, wslDistro: 'Ubuntu' }, 'ssh-1'],
     ['relay reattach', { isReattach: true, wslDistro: 'Ubuntu' }, 'relay-1']
-  ])('does not refresh a %s', (_label, result, connectionId) => {
+  ])('does not refresh a %s', async (_label, result, connectionId) => {
     const ensure = vi.fn()
 
-    ensureWslHookRelayForReattach(result, connectionId, ensure)
+    await ensureWslHookRelayForReattach(result, connectionId, ensure)
 
     expect(ensure).not.toHaveBeenCalled()
   })
 
-  it('preserves exact distro ownership across multiple local reattachments', () => {
+  it('preserves exact distro ownership across multiple local reattachments', async () => {
     const ensure = vi.fn()
 
-    ensureWslHookRelayForReattach({ isReattach: true, wslDistro: 'Ubuntu' }, null, ensure)
-    ensureWslHookRelayForReattach({ isReattach: true, wslDistro: 'Debian' }, null, ensure)
+    await ensureWslHookRelayForReattach({ isReattach: true, wslDistro: 'Ubuntu' }, null, ensure)
+    await ensureWslHookRelayForReattach({ isReattach: true, wslDistro: 'Debian' }, null, ensure)
 
     expect(ensure.mock.calls).toEqual([['Ubuntu'], ['Debian']])
+  })
+
+  it('awaits relay readiness only for the reattached WSL session', async () => {
+    let release!: () => void
+    const ensure = vi.fn(() => new Promise<void>((resolve) => (release = resolve)))
+    let ready = false
+
+    const reattach = ensureWslHookRelayForReattach(
+      { isReattach: true, wslDistro: 'Ubuntu' },
+      null,
+      ensure
+    ).then(() => {
+      ready = true
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(ready).toBe(false)
+
+    release()
+    await reattach
+    expect(ready).toBe(true)
+  })
+
+  it('fails open a WSL reattach when optional relay readiness stalls', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      const reattach = ensureWslHookRelayForReattach(
+        { isReattach: true, wslDistro: 'Ubuntu' },
+        null,
+        () => new Promise<void>(() => {})
+      )
+      await vi.advanceTimersByTimeAsync(WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS)
+      await expect(reattach).resolves.toBeUndefined()
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('timed out'))
+      expect(vi.getTimerCount()).toBe(0)
+    } finally {
+      warn.mockRestore()
+      vi.useRealTimers()
+    }
+  })
+
+  it('fails open a WSL reattach when relay readiness rejects', async () => {
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    try {
+      await expect(
+        ensureWslHookRelayForReattach({ isReattach: true, wslDistro: 'Ubuntu' }, null, () =>
+          Promise.reject(new Error('relay failed'))
+        )
+      ).resolves.toBeUndefined()
+      expect(warn).toHaveBeenCalledWith(
+        expect.stringContaining('reattach failed'),
+        expect.any(Error)
+      )
+    } finally {
+      warn.mockRestore()
+    }
   })
 })

--- a/src/main/agent-hooks/wsl-hook-relay-reattach.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-reattach.test.ts
@@ -17,7 +17,8 @@ describe('ensureWslHookRelayForReattach', () => {
     ['native reattach', { isReattach: true, wslDistro: null }, null],
     ['legacy reattach without ownership context', { isReattach: true }, null],
     ['blank distro', { isReattach: true, wslDistro: '  ' }, null],
-    ['SSH reattach', { isReattach: true, wslDistro: 'Ubuntu' }, 'ssh-1']
+    ['SSH reattach', { isReattach: true, wslDistro: 'Ubuntu' }, 'ssh-1'],
+    ['relay reattach', { isReattach: true, wslDistro: 'Ubuntu' }, 'relay-1']
   ])('does not refresh a %s', (_label, result, connectionId) => {
     const ensure = vi.fn()
 

--- a/src/main/agent-hooks/wsl-hook-relay-reattach.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-reattach.ts
@@ -3,18 +3,37 @@ import { wslHookRelayManager } from './wsl-hook-relay-manager'
 
 type ReattachResult = Pick<PtySpawnResult, 'isReattach' | 'wslDistro'>
 
-export function ensureWslHookRelayForReattach(
+export const WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS = 60_000
+
+export async function ensureWslHookRelayForReattach(
   result: ReattachResult,
   connectionId?: string | null,
-  ensureForDistro: (distro: string) => void = (distro) =>
-    wslHookRelayManager.ensureForDistro(distro)
-): void {
+  ensureForDistro: (distro: string) => void | Promise<void> = (distro) =>
+    wslHookRelayManager.ensureForDistroReady(distro)
+): Promise<void> {
   // Why: the current renderer preference can differ from the surviving PTY's proven distro ownership.
   if (connectionId || result.isReattach !== true || typeof result.wslDistro !== 'string') {
     return
   }
   const distro = result.wslDistro.trim()
   if (distro) {
-    ensureForDistro(distro)
+    let timeout: ReturnType<typeof setTimeout> | undefined
+    try {
+      await Promise.race([
+        Promise.resolve().then(() => ensureForDistro(distro)),
+        new Promise<void>((resolve) => {
+          timeout = setTimeout(() => {
+            console.warn(`[agent-hooks] WSL hook relay reattach timed out for '${distro}'`)
+            resolve()
+          }, WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS)
+        })
+      ])
+    } catch (error) {
+      console.warn(`[agent-hooks] WSL hook relay reattach failed for '${distro}':`, error)
+    } finally {
+      if (timeout) {
+        clearTimeout(timeout)
+      }
+    }
   }
 }

--- a/src/main/agent-hooks/wsl-hook-relay-reattach.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-reattach.ts
@@ -3,7 +3,7 @@ import { wslHookRelayManager } from './wsl-hook-relay-manager'
 
 type ReattachResult = Pick<PtySpawnResult, 'isReattach' | 'wslDistro'>
 
-export const WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS = 60_000
+export const WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS = 2_000
 
 export async function ensureWslHookRelayForReattach(
   result: ReattachResult,

--- a/src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.test.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.test.ts
@@ -1,0 +1,127 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import { reconcileWslHookRelaysOnStartup } from './wsl-hook-relay-startup-reconciliation'
+
+function session(id: string, wslDistro?: string | null): PtyProcessInfo {
+  return {
+    id,
+    cwd: '',
+    title: 'shell',
+    ...(wslDistro !== undefined ? { wslDistro } : {})
+  }
+}
+
+describe('reconcileWslHookRelaysOnStartup', () => {
+  it('groups surviving panes by distro and awaits one relay per distro', async () => {
+    const events: string[] = []
+    const releases = new Map<string, () => void>()
+    const ensureForDistro = vi.fn(
+      (distro: string) =>
+        new Promise<void>((resolve) => {
+          events.push(`ensure:${distro}`)
+          releases.set(distro, resolve)
+        })
+    )
+    const listRunningDistros = vi.fn(async () => ['Ubuntu', 'Debian'])
+
+    const reconciliation = reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => [
+        session('pane-1', 'Ubuntu'),
+        session('pane-2', 'ubuntu'),
+        session('pane-3', 'Debian')
+      ],
+      listRunningDistros,
+      ensureForDistro
+    }).then(() => events.push('ready'))
+
+    await vi.waitFor(() => expect(events).toEqual(['ensure:Ubuntu', 'ensure:Debian']))
+    releases.get('Ubuntu')?.()
+    await Promise.resolve()
+    expect(events).not.toContain('ready')
+    releases.get('Debian')?.()
+    await reconciliation
+
+    expect(events).toEqual(['ensure:Ubuntu', 'ensure:Debian', 'ready'])
+    expect(listRunningDistros).toHaveBeenCalledOnce()
+  })
+
+  it('ignores native panes, blank values, and old daemons without WSL metadata', async () => {
+    const ensureForDistro = vi.fn(async () => {})
+
+    await reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => [
+        session('native', null),
+        session('old-daemon'),
+        session('blank', '  ')
+      ],
+      listRunningDistros: vi.fn(async () => ['Ubuntu']),
+      ensureForDistro
+    })
+
+    expect(ensureForDistro).not.toHaveBeenCalled()
+  })
+
+  it('does not infer desired distros from unavailable inventory', async () => {
+    const ensureForDistro = vi.fn(async () => {})
+
+    await reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => null,
+      listRunningDistros: vi.fn(async () => ['Ubuntu']),
+      ensureForDistro
+    })
+
+    expect(ensureForDistro).not.toHaveBeenCalled()
+  })
+
+  it('does not query local daemon inventory on native hosts', async () => {
+    const listLiveProcesses = vi.fn(async () => [session('remote', 'Ubuntu')])
+
+    await reconcileWslHookRelaysOnStartup({ platform: 'linux', listLiveProcesses })
+    await reconcileWslHookRelaysOnStartup({ platform: 'darwin', listLiveProcesses })
+
+    expect(listLiveProcesses).not.toHaveBeenCalled()
+  })
+
+  it('does not boot a distro that stopped after the live inventory was captured', async () => {
+    const ensureForDistro = vi.fn(async () => {})
+
+    await reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => [session('survivor', 'Ubuntu')],
+      listRunningDistros: async () => [],
+      ensureForDistro
+    })
+
+    expect(ensureForDistro).not.toHaveBeenCalled()
+  })
+
+  it('fails closed when the running-distro snapshot is unavailable', async () => {
+    const ensureForDistro = vi.fn(async () => {})
+
+    await reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => [session('survivor', 'Ubuntu')],
+      listRunningDistros: async () => null,
+      ensureForDistro
+    })
+
+    expect(ensureForDistro).not.toHaveBeenCalled()
+  })
+
+  it('uses live ownership for folder workspace sessions without parsing their ids', async () => {
+    const ensureForDistro = vi.fn(async () => {})
+
+    await reconcileWslHookRelaysOnStartup({
+      platform: 'win32',
+      listLiveProcesses: async () => [session('folder-workspace@@pane', 'Ubuntu-24.04')],
+      listRunningDistros: async () => ['Ubuntu-24.04'],
+      ensureForDistro
+    })
+
+    expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu-24.04')
+  })
+})

--- a/src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.ts
@@ -15,7 +15,7 @@ const defaultDeps: StartupReconciliationDeps = {
   platform: process.platform,
   listLiveProcesses: listLiveDaemonProcesses,
   listRunningDistros: listRunningWslDistros,
-  ensureForDistro: (distro) => wslHookRelayManager.ensureForDistroReady(distro)
+  ensureForDistro: (distro) => wslHookRelayManager.ensureRunningDistroForStartup(distro)
 }
 
 export async function reconcileWslHookRelaysOnStartup(

--- a/src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.ts
+++ b/src/main/agent-hooks/wsl-hook-relay-startup-reconciliation.ts
@@ -1,0 +1,56 @@
+import type { PtyProcessInfo } from '../providers/pty-process-info'
+import { listLiveDaemonProcesses } from '../daemon/daemon-init'
+import { wslHookRelayManager } from './wsl-hook-relay-manager'
+import { wslHookRelayStateKey } from './wsl-hook-relay-state-key'
+import { listRunningWslDistros } from './wsl-hook-relay-launch'
+
+type StartupReconciliationDeps = {
+  platform: NodeJS.Platform
+  listLiveProcesses: () => Promise<PtyProcessInfo[] | null>
+  listRunningDistros: () => Promise<string[] | null>
+  ensureForDistro: (distro: string) => Promise<void>
+}
+
+const defaultDeps: StartupReconciliationDeps = {
+  platform: process.platform,
+  listLiveProcesses: listLiveDaemonProcesses,
+  listRunningDistros: listRunningWslDistros,
+  ensureForDistro: (distro) => wslHookRelayManager.ensureForDistroReady(distro)
+}
+
+export async function reconcileWslHookRelaysOnStartup(
+  deps: Partial<StartupReconciliationDeps> = {}
+): Promise<void> {
+  const io = { ...defaultDeps, ...deps }
+  if (io.platform !== 'win32') {
+    return
+  }
+  const processes = await io.listLiveProcesses()
+  if (!processes) {
+    return
+  }
+  const distros = new Map<string, string>()
+  for (const process of processes) {
+    if (typeof process.wslDistro !== 'string') {
+      continue
+    }
+    const distro = process.wslDistro.trim()
+    const key = wslHookRelayStateKey(distro)
+    if (distro && !distros.has(key)) {
+      distros.set(key, distro)
+    }
+  }
+  if (distros.size === 0) {
+    return
+  }
+  const runningSnapshot = await io.listRunningDistros()
+  if (!runningSnapshot) {
+    return
+  }
+  const runningKeys = new Set(runningSnapshot.map(wslHookRelayStateKey))
+  await Promise.all(
+    [...distros].flatMap(([key, distro]) =>
+      runningKeys.has(key) ? [io.ensureForDistro(distro)] : []
+    )
+  )
+}

--- a/src/main/daemon/daemon-init.ts
+++ b/src/main/daemon/daemon-init.ts
@@ -59,6 +59,7 @@ import {
 } from '../claude-accounts/live-pty-gate'
 import { parseDaemonReadyIdentity, readDaemonProcessIncarnation } from './daemon-ready-identity'
 import type { DaemonEndpointIdentity } from './daemon-hello-protocol'
+import type { PtyProcessInfo } from '../providers/pty-process-info'
 
 // Why: daemon init runs concurrent with window load, so an in-process t timestamp (not harness stderr timing) measures cold-start.
 function logDaemonMilestone(event: string, details: Record<string, unknown> = {}): void {
@@ -1081,7 +1082,7 @@ export async function getCurrentDaemonMacTccAttributionHealth(): Promise<MacDaem
 }
 
 /** Returns null unless every daemon generation supplied an authoritative inventory. */
-export async function listLiveDaemonPtyIds(): Promise<string[] | null> {
+export async function listLiveDaemonProcesses(): Promise<PtyProcessInfo[] | null> {
   if (!adapter) {
     return null
   }
@@ -1096,8 +1097,13 @@ export async function listLiveDaemonPtyIds(): Promise<string[] | null> {
     return null
   }
   return inventories.flatMap((inventory) =>
-    inventory.status === 'fulfilled' ? inventory.value.map((process) => process.id) : []
+    inventory.status === 'fulfilled' ? inventory.value : []
   )
+}
+
+export async function listLiveDaemonPtyIds(): Promise<string[] | null> {
+  const processes = await listLiveDaemonProcesses()
+  return processes?.map((process) => process.id) ?? null
 }
 
 // Why: keep the module-level adapter and ipc/pty.ts's localProvider in sync so app-quit can't dispose a stale reference.

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -35,6 +35,7 @@ import {
   initDaemonPtyProvider,
   disconnectDaemon,
   getDaemonProvider,
+  listLiveDaemonProcesses,
   listLiveDaemonPtyIds,
   shutdownDaemon
 } from './daemon/daemon-init'
@@ -249,6 +250,7 @@ import { agentHookServer, type AgentHookProviderSessionIdentity } from './agent-
 import { createHookProviderSessionInvalidator } from './agent-hooks/hook-provider-session-invalidation'
 import { createHookStatusSessionTabsInvalidator } from './agent-hooks/hook-status-session-tabs-invalidation'
 import { wslHookRelayManager } from './agent-hooks/wsl-hook-relay-manager'
+import { reconcileWslHookRelaysOnStartup } from './agent-hooks/wsl-hook-relay-startup-reconciliation'
 import { maybeAutoRenameBranchOnFirstWork } from './agent-hooks/first-work-branch-rename'
 import { rememberBranchRenameFailureOutput } from './agent-hooks/branch-rename-failure-output'
 import { renameWorktreeFolderOnFirstWork } from './agent-hooks/first-work-folder-rename'
@@ -940,6 +942,14 @@ function startTerminalRuntimeStartupServices(): Promise<void> {
       })
       logStartupMilestone('startup-service-done', { service: 'agent-hook-server' })
     },
+    reconcileWslHookRelays: async () => {
+      if (!isAgentStatusHooksEnabled(store?.getSettings())) {
+        return
+      }
+      logStartupMilestone('startup-service-start', { service: 'wsl-hook-relay-reconciliation' })
+      await reconcileWslHookRelaysOnStartup({ listLiveProcesses: listLiveDaemonProcesses })
+      logStartupMilestone('startup-service-done', { service: 'wsl-hook-relay-reconciliation' })
+    },
     onDaemonError: (error) => {
       // Why: daemon failure silently falls back to non-persistent local PTYs; log + telemetry so a fleet-wide outage is observable (was invisible in v1.4.129-rc.1).
       const reason = error instanceof Error ? error.message : String(error)
@@ -951,6 +961,9 @@ function startTerminalRuntimeStartupServices(): Promise<void> {
     onAgentHookServerError: (error) => {
       // Why: hook callbacks are sidebar enrichment only; Orca must still boot if the loopback receiver fails.
       console.error('[agent-hooks] Failed to start local hook server:', error)
+    },
+    onWslHookRelayReconciliationError: (error) => {
+      console.warn('[agent-hooks] Failed to reconcile startup WSL hook relays:', error)
     }
   })
   firstWindowStartupServicesReady = startupServices.firstWindowReady

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -1174,6 +1174,84 @@ describe('registerPtyHandlers', () => {
     clearProviderPtyState(ptyId)
   })
 
+  it.each(['renderer', 'runtime'] as const)(
+    'rejects %s publication when a WSL PTY exits during relay readiness',
+    async (entry) => {
+      const ptyId = `pty-${entry}-relay-exit`
+      const incarnationId = `incarnation-${entry}-relay-exit`
+      const runtime = new OrcaRuntimeService()
+      const registerRuntimePty = vi.spyOn(runtime, 'registerPty')
+      let releaseRelay!: () => void
+      const ensureForDistro = vi
+        .spyOn(wslHookRelayManager, 'ensureForDistroReady')
+        .mockImplementation(() => new Promise<void>((resolve) => (releaseRelay = resolve)))
+      const provider = createAgentClaimProvider({
+        spawn: vi.fn(async () => {
+          runtime.onPtySpawned(ptyId, incarnationId)
+          return {
+            id: ptyId,
+            incarnationId,
+            isReattach: true,
+            wslDistro: 'Ubuntu-24.04'
+          }
+        }),
+        authoritativeOwnerListings: false
+      })
+      const store = { persistPtyBinding: vi.fn() }
+      setLocalPtyProvider(provider as never)
+      registerPtyHandlers(
+        mainWindow as never,
+        runtime,
+        undefined,
+        undefined,
+        undefined,
+        store as never
+      )
+      const spawnArgs = {
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp/worktree',
+        sessionId: ptyId,
+        worktreeId: 'repo::/tmp/worktree',
+        tabId: `tab-${entry}-relay-exit`,
+        leafId: '55555555-5555-4555-8555-555555555555'
+      }
+      const controller = (
+        runtime as unknown as {
+          ptyController: { spawn(args: Record<string, unknown>): Promise<unknown> }
+        }
+      ).ptyController
+
+      try {
+        const spawn =
+          entry === 'renderer'
+            ? (handlers.get('pty:spawn')!(null, spawnArgs) as Promise<unknown>)
+            : controller.spawn({
+                ...spawnArgs,
+                preAllocatedHandle: 'term-runtime-relay-exit',
+                persistHostSessionBinding: true
+              })
+        const rejectedSpawn = expect(spawn).rejects.toThrow('agent_session_exited_during_start')
+        await vi.waitFor(() => expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu-24.04'))
+        runtime.onPtyExit(ptyId, 0, incarnationId)
+        releaseRelay()
+        await rejectedSpawn
+
+        expect(store.persistPtyBinding).not.toHaveBeenCalled()
+        expect(registerRuntimePty).not.toHaveBeenCalled()
+        const internals = runtime as unknown as {
+          earlyExitedPtyIncarnations: Map<string, string | null>
+          pendingPtyRegistrationIncarnations: Map<string, string | null>
+        }
+        expect(internals.earlyExitedPtyIncarnations.size).toBe(0)
+        expect(internals.pendingPtyRegistrationIncarnations.size).toBe(0)
+      } finally {
+        ensureForDistro.mockRestore()
+        clearProviderPtyState(ptyId)
+      }
+    }
+  )
+
   it('adopts a live controller-owned local fallback when listings cannot serialize claims', async () => {
     const sessions: {
       id: string
@@ -9069,7 +9147,7 @@ describe('registerPtyHandlers', () => {
     'adopts a completed runtime-owned pane before replacement launch preflight ($label)',
     async ({ worktreeId, cwd }) => {
       type StableAdoption = {
-        result: { id: string; incarnationId?: string; isReattach?: boolean }
+        result: { id: string; incarnationId?: string; isReattach?: boolean; wslDistro?: string }
         owner: { handle?: string; tabId: string; leafId: string; ptyId: string }
         materialized?: true
       } | null
@@ -9091,6 +9169,9 @@ describe('registerPtyHandlers', () => {
       const tabId = 'tab-live-owner'
       const leafId = '66666666-6666-4666-8666-666666666666'
       const paneKey = makePaneKey(tabId, leafId)
+      const ensureForDistro = vi
+        .spyOn(wslHookRelayManager, 'ensureForDistroReady')
+        .mockResolvedValue(undefined)
       let ownerPublished = false
       let releaseAttach!: () => void
       let attachBarrier: Promise<void>
@@ -9110,6 +9191,7 @@ describe('registerPtyHandlers', () => {
               id: 'pty-live-owner',
               incarnationId: 'inc-live-owner',
               isReattach: true,
+              wslDistro: 'Ubuntu-24.04',
               snapshot: 'original-live-output',
               providerSequence: { value: 20, generation: 'continued' as const }
             }
@@ -9334,6 +9416,8 @@ describe('registerPtyHandlers', () => {
       expect(
         mainWindow.webContents.send.mock.calls.filter(([channel]) => channel === 'pty:spawned')
       ).toHaveLength(1)
+      expect(ensureForDistro).toHaveBeenCalledTimes(2)
+      ensureForDistro.mockRestore()
     }
   )
 
@@ -17482,9 +17566,10 @@ describe('registerPtyHandlers', () => {
   it('refreshes the WSL hook relay for the distro a reattached pane already owns', async () => {
     // Why here and not only in the helper's unit test: nothing else catches pty.ts dropping the
     // reattach call — the manager owns the hooks/platform gating this spy stands in for.
+    let releaseRelay!: () => void
     const ensureForDistro = vi
-      .spyOn(wslHookRelayManager, 'ensureForDistro')
-      .mockImplementation(() => {})
+      .spyOn(wslHookRelayManager, 'ensureForDistroReady')
+      .mockImplementation(() => new Promise<void>((resolve) => (releaseRelay = resolve)))
     setLocalPtyProvider({
       spawn: vi.fn(async () => ({ id: 'pty-wsl', isReattach: true, wslDistro: 'Ubuntu-24.04' })),
       write: vi.fn(),
@@ -17499,7 +17584,23 @@ describe('registerPtyHandlers', () => {
     registerPtyHandlers(mainWindow as never)
 
     try {
-      await handlers.get('pty:spawn')!(null, { cols: 80, rows: 24, sessionId: 'pty-wsl' })
+      let spawnReady = false
+      const spawn = (
+        handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          sessionId: 'pty-wsl'
+        }) as Promise<unknown>
+      ).then(() => {
+        spawnReady = true
+      })
+      await vi.waitFor(() => expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu-24.04'))
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(spawnReady).toBe(false)
+
+      releaseRelay()
+      await spawn
+      expect(spawnReady).toBe(true)
       expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu-24.04')
     } finally {
       ensureForDistro.mockRestore()

--- a/src/main/ipc/pty.test.ts
+++ b/src/main/ipc/pty.test.ts
@@ -266,6 +266,7 @@ import {
 import { resolveWindowsShellLaunchArgs } from '../providers/windows-shell-args'
 import { _resetWslCachesForTests, _setWslCachesForTests } from '../wsl'
 import { wslHookRelayManager } from '../agent-hooks/wsl-hook-relay-manager'
+import { WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS } from '../agent-hooks/wsl-hook-relay-reattach'
 import { acquireWatcherRemovalGate } from './watcher-removal-gate'
 import { __resetShellStartupEnvCache } from '../pty/shell-startup-env'
 import {
@@ -1251,6 +1252,64 @@ describe('registerPtyHandlers', () => {
       }
     }
   )
+
+  it('rejects a materialized WSL adoption that exits during relay readiness', async () => {
+    const ptyId = 'pty-materialized-relay-exit'
+    const incarnationId = 'incarnation-materialized-relay-exit'
+    const worktreeId = 'repo::/tmp/materialized-relay-exit'
+    const tabId = 'tab-materialized-relay-exit'
+    const leafId = '77777777-7777-4777-8777-777777777777'
+    const runtime = new OrcaRuntimeService()
+    let releaseRelay!: () => void
+    const ensureForDistro = vi
+      .spyOn(wslHookRelayManager, 'ensureForDistroReady')
+      .mockImplementation(() => new Promise<void>((resolve) => (releaseRelay = resolve)))
+    registerPtyHandlers(mainWindow as never, runtime)
+    const controller = (
+      runtime as unknown as {
+        ptyController: { spawn(args: Record<string, unknown>): Promise<unknown> }
+      }
+    ).ptyController
+
+    runtime.onPtySpawned(ptyId, incarnationId)
+    runtime.registerPty(ptyId, worktreeId, null, { tabId, leafId, incarnationId })
+
+    try {
+      const spawn = controller.spawn({
+        cols: 80,
+        rows: 24,
+        cwd: '/tmp/materialized-relay-exit',
+        worktreeId,
+        tabId,
+        leafId,
+        preAllocatedHandle: 'term-materialized-relay-exit',
+        adoptedStablePane: {
+          result: {
+            id: ptyId,
+            incarnationId,
+            isReattach: true,
+            wslDistro: 'Ubuntu-24.04'
+          },
+          owner: {
+            handle: 'term-materialized-relay-exit',
+            tabId,
+            leafId,
+            ptyId,
+            incarnationId
+          },
+          materialized: true
+        }
+      })
+      const rejectedSpawn = expect(spawn).rejects.toThrow('agent_session_exited_during_start')
+      await vi.waitFor(() => expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu-24.04'))
+      runtime.onPtyExit(ptyId, 0, incarnationId)
+      releaseRelay()
+      await rejectedSpawn
+    } finally {
+      ensureForDistro.mockRestore()
+      clearProviderPtyState(ptyId)
+    }
+  })
 
   it('adopts a live controller-owned local fallback when listings cannot serialize claims', async () => {
     const sessions: {
@@ -9169,9 +9228,16 @@ describe('registerPtyHandlers', () => {
       const tabId = 'tab-live-owner'
       const leafId = '66666666-6666-4666-8666-666666666666'
       const paneKey = makePaneKey(tabId, leafId)
+      let relayAttempt = 0
+      let releaseMaterializedRelay!: () => void
       const ensureForDistro = vi
         .spyOn(wslHookRelayManager, 'ensureForDistroReady')
-        .mockResolvedValue(undefined)
+        .mockImplementation(() => {
+          relayAttempt++
+          return relayAttempt === 3
+            ? new Promise<void>((resolve) => (releaseMaterializedRelay = resolve))
+            : Promise.resolve()
+        })
       let ownerPublished = false
       let releaseAttach!: () => void
       let attachBarrier: Promise<void>
@@ -9367,28 +9433,38 @@ describe('registerPtyHandlers', () => {
       const adoptedOwner = await pendingRuntimeAdoption
       expect(adoptedOwner).toMatchObject({ materialized: true })
 
-      const claimedResultPromise = spawnController.spawn({
-        cols: 120,
-        rows: 40,
-        cwd,
-        command: 'codex resume should-not-run',
-        launchAgent: 'codex',
-        worktreeId,
-        preAllocatedHandle: 'term-live-owner',
-        tabId,
-        leafId,
-        env: { ORCA_PANE_KEY: paneKey },
-        persistHostSessionBinding: true,
-        adoptedStablePane: adoptedOwner,
-        agentSessionEnsure: {
-          claim: {
-            ...recoveredAgentClaim,
-            identityDigest: 'ccccccccccccccccccccccccccccccccccccccccccc'
+      let materializedSpawnReady = false
+      const claimedResultPromise = spawnController
+        .spawn({
+          cols: 120,
+          rows: 40,
+          cwd,
+          command: 'codex resume should-not-run',
+          launchAgent: 'codex',
+          worktreeId,
+          preAllocatedHandle: 'term-live-owner',
+          tabId,
+          leafId,
+          env: { ORCA_PANE_KEY: paneKey },
+          persistHostSessionBinding: true,
+          adoptedStablePane: adoptedOwner,
+          agentSessionEnsure: {
+            claim: {
+              ...recoveredAgentClaim,
+              identityDigest: 'ccccccccccccccccccccccccccccccccccccccccccc'
+            },
+            surface: { worktreeId, tabId, leafId, terminalHandle: 'term-live-owner' }
           },
-          surface: { worktreeId, tabId, leafId, terminalHandle: 'term-live-owner' }
-        },
-        agentSessionCreateOperationId: 'create-op-must-not-run'
-      })
+          agentSessionCreateOperationId: 'create-op-must-not-run'
+        })
+        .then((result) => {
+          materializedSpawnReady = true
+          return result
+        })
+      await vi.waitFor(() => expect(ensureForDistro).toHaveBeenCalledTimes(3))
+      await new Promise((resolve) => setImmediate(resolve))
+      expect(materializedSpawnReady).toBe(false)
+      releaseMaterializedRelay()
       const [rendererFirstResult, claimedResult] = await Promise.all([
         rendererFirstMount,
         claimedResultPromise
@@ -9416,7 +9492,7 @@ describe('registerPtyHandlers', () => {
       expect(
         mainWindow.webContents.send.mock.calls.filter(([channel]) => channel === 'pty:spawned')
       ).toHaveLength(1)
-      expect(ensureForDistro).toHaveBeenCalledTimes(2)
+      expect(ensureForDistro).toHaveBeenCalledTimes(3)
       ensureForDistro.mockRestore()
     }
   )
@@ -17604,6 +17680,67 @@ describe('registerPtyHandlers', () => {
       expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu-24.04')
     } finally {
       ensureForDistro.mockRestore()
+    }
+  })
+
+  it('publishes a WSL reattach within the optional relay readiness budget', async () => {
+    vi.useFakeTimers()
+    const warn = vi.spyOn(console, 'warn').mockImplementation(() => {})
+    let releaseRelay!: () => void
+    let relayCompleted = false
+    const ensureForDistro = vi
+      .spyOn(wslHookRelayManager, 'ensureForDistroReady')
+      .mockImplementation(
+        () =>
+          new Promise<void>((resolve) => {
+            releaseRelay = () => {
+              relayCompleted = true
+              resolve()
+            }
+          })
+      )
+    setLocalPtyProvider({
+      spawn: vi.fn(async () => ({ id: 'pty-wsl-budget', isReattach: true, wslDistro: 'Ubuntu' })),
+      write: vi.fn(),
+      resize: vi.fn(),
+      kill: vi.fn(),
+      shutdown: vi.fn(),
+      onData: vi.fn(() => vi.fn()),
+      onExit: vi.fn(() => vi.fn()),
+      listProcesses: vi.fn(async () => []),
+      getForegroundProcess: vi.fn(async () => null)
+    } as never)
+    registerPtyHandlers(mainWindow as never)
+
+    try {
+      let spawnReady = false
+      const spawn = (
+        handlers.get('pty:spawn')!(null, {
+          cols: 80,
+          rows: 24,
+          sessionId: 'pty-wsl-budget'
+        }) as Promise<unknown>
+      ).then(() => {
+        spawnReady = true
+      })
+      await vi.advanceTimersByTimeAsync(0)
+      expect(ensureForDistro).toHaveBeenCalledWith('Ubuntu')
+      await vi.advanceTimersByTimeAsync(WSL_HOOK_RELAY_REATTACH_FAIL_OPEN_MS - 1)
+      expect(spawnReady).toBe(false)
+
+      await vi.advanceTimersByTimeAsync(1)
+      await spawn
+      expect(spawnReady).toBe(true)
+      expect(relayCompleted).toBe(false)
+
+      releaseRelay()
+      await Promise.resolve()
+      expect(relayCompleted).toBe(true)
+      expect(warn).toHaveBeenCalledWith(expect.stringContaining('timed out'))
+    } finally {
+      ensureForDistro.mockRestore()
+      warn.mockRestore()
+      vi.useRealTimers()
     }
   })
 

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4414,6 +4414,19 @@ export function registerPtyHandlers(
             leafId: preAdoptedStablePane.owner.leafId
           }
         }
+        if (!args.connectionId && result.wslDistro?.trim()) {
+          runtime?.beginPtyRegistration?.(result.id, result.incarnationId)
+          try {
+            await ensureWslHookRelayForReattach(
+              { isReattach: true, wslDistro: result.wslDistro },
+              args.connectionId
+            )
+            runtime?.assertPtyRegistrationAllowed?.(result.id, result.incarnationId)
+          } catch (error) {
+            runtime?.cancelPendingPtyRegistration?.(result.id, result.incarnationId)
+            throw error
+          }
+        }
         if (!args.connectionId) {
           options?.onCodexHomePtySpawned?.({
             id: result.id,

--- a/src/main/ipc/pty.ts
+++ b/src/main/ipc/pty.ts
@@ -4414,10 +4414,6 @@ export function registerPtyHandlers(
             leafId: preAdoptedStablePane.owner.leafId
           }
         }
-        ensureWslHookRelayForReattach(
-          { isReattach: true, wslDistro: preAdoptedStablePane.result.wslDistro },
-          args.connectionId
-        )
         if (!args.connectionId) {
           options?.onCodexHomePtySpawned?.({
             id: result.id,
@@ -4997,7 +4993,6 @@ export function registerPtyHandlers(
               sequenceBeforeProviderSpawn
             )
           }
-          ensureWslHookRelayForReattach(result, args.connectionId)
           runtime?.preparePtyExecutionContext?.(
             result.id,
             args.connectionId
@@ -5006,6 +5001,9 @@ export function registerPtyHandlers(
                 ? expectedWslDistro
                 : result.wslDistro
           )
+          await ensureWslHookRelayForReattach(result, args.connectionId)
+          // Why: the PTY can exit while WSL relay readiness is pending.
+          runtime?.assertPtyRegistrationAllowed?.(result.id, result.incarnationId)
         } catch (err) {
           if (
             (isNewDaemonSession || preparedProvisionalExecutionContext) &&
@@ -6430,7 +6428,6 @@ export function registerPtyHandlers(
               sequenceBeforeProviderSpawn
             )
           }
-          ensureWslHookRelayForReattach(result, args.connectionId)
           runtime?.preparePtyExecutionContext?.(
             result.id,
             args.connectionId
@@ -6439,6 +6436,9 @@ export function registerPtyHandlers(
                 ? expectedWslDistro
                 : result.wslDistro
           )
+          await ensureWslHookRelayForReattach(result, args.connectionId)
+          // Why: the PTY can exit while WSL relay readiness is pending.
+          runtime?.assertPtyRegistrationAllowed?.(result.id, result.incarnationId)
           spawnTiming.mark('provider_spawn')
         } catch (err) {
           if ((isMintedSessionId || preparedProvisionalExecutionContext) && effectiveSessionAppId) {

--- a/src/main/startup/first-window-startup-services.test.ts
+++ b/src/main/startup/first-window-startup-services.test.ts
@@ -47,7 +47,7 @@ describe('startFirstWindowStartupServices', () => {
     expect(completed).toBe(true)
   })
 
-  it('reconciles after both authorities and keeps local reattach gated until relays are ready', async () => {
+  it('starts reconciliation after both authorities without gating unrelated local PTYs', async () => {
     const events: string[] = []
     let resolveDaemon!: () => void
     let resolveHooks!: () => void
@@ -66,7 +66,10 @@ describe('startFirstWindowStartupServices', () => {
       reconcileWslHookRelays: () =>
         new Promise<void>((resolve) => {
           events.push('relay-reconciliation-started')
-          resolveRelays = resolve
+          resolveRelays = () => {
+            events.push('relay-reconciliation-ready')
+            resolve()
+          }
         }),
       onDaemonError: vi.fn(),
       onAgentHookServerError: vi.fn(),
@@ -80,16 +83,22 @@ describe('startFirstWindowStartupServices', () => {
 
     resolveDaemon()
     await vi.waitFor(() => expect(events).toContain('relay-reconciliation-started'))
+    let firstWindowReady = false
+    void started.firstWindowReady.then(() => {
+      firstWindowReady = true
+    })
+    await new Promise((resolve) => setImmediate(resolve))
+    expect(firstWindowReady).toBe(true)
     let localPtyReady = false
     void started.localPtyReady.then(() => {
       localPtyReady = true
     })
-    await Promise.resolve()
-    expect(localPtyReady).toBe(false)
-
-    resolveRelays()
     await started.localPtyReady
     expect(localPtyReady).toBe(true)
+    expect(events).not.toContain('relay-reconciliation-ready')
+
+    resolveRelays()
+    await vi.waitFor(() => expect(events).toContain('relay-reconciliation-ready'))
   })
 
   it('reports reconciliation failure and still opens the startup gate', async () => {
@@ -104,7 +113,9 @@ describe('startFirstWindowStartupServices', () => {
     })
 
     await expect(started.localPtyReady).resolves.toBeUndefined()
-    expect(onWslHookRelayReconciliationError).toHaveBeenCalledWith(expect.any(Error))
+    await vi.waitFor(() =>
+      expect(onWslHookRelayReconciliationError).toHaveBeenCalledWith(expect.any(Error))
+    )
   })
 
   it('opens the provider gate when daemon startup finishes without waiting for hooks', async () => {
@@ -233,16 +244,19 @@ describe('startFirstWindowStartupServices', () => {
     vi.useFakeTimers()
     const onDaemonError = vi.fn()
     const onAgentHookServerError = vi.fn()
+    const reconcileWslHookRelays = vi.fn(async () => {})
     let daemonSignal: AbortSignal | undefined
 
     try {
       const started = startFirstWindowStartupServices({
         startDaemonPtyProvider: (signal) => {
           daemonSignal = signal
-          return new Promise<void>(() => {})
+          return new Promise<void>((resolve) => {
+            signal.addEventListener('abort', () => resolve(), { once: true })
+          })
         },
         startAgentHookServer: () => Promise.resolve(),
-        reconcileWslHookRelays: vi.fn(async () => {}),
+        reconcileWslHookRelays,
         onDaemonError,
         onAgentHookServerError,
         onWslHookRelayReconciliationError: vi.fn()
@@ -257,6 +271,7 @@ describe('startFirstWindowStartupServices', () => {
       expect(onDaemonError).toHaveBeenCalledWith(expect.any(Error))
       expect(onAgentHookServerError).not.toHaveBeenCalled()
       expect(daemonSignal?.aborted).toBe(true)
+      expect(reconcileWslHookRelays).not.toHaveBeenCalled()
     } finally {
       vi.useRealTimers()
     }

--- a/src/main/startup/first-window-startup-services.test.ts
+++ b/src/main/startup/first-window-startup-services.test.ts
@@ -22,8 +22,10 @@ describe('startFirstWindowStartupServices', () => {
           events.push('hooks-started')
           resolveHooks = resolve
         }),
+      reconcileWslHookRelays: vi.fn(async () => {}),
       onDaemonError: vi.fn(),
-      onAgentHookServerError: vi.fn()
+      onAgentHookServerError: vi.fn(),
+      onWslHookRelayReconciliationError: vi.fn()
     })
 
     await Promise.resolve()
@@ -45,6 +47,66 @@ describe('startFirstWindowStartupServices', () => {
     expect(completed).toBe(true)
   })
 
+  it('reconciles after both authorities and keeps local reattach gated until relays are ready', async () => {
+    const events: string[] = []
+    let resolveDaemon!: () => void
+    let resolveHooks!: () => void
+    let resolveRelays!: () => void
+    const started = startFirstWindowStartupServices({
+      startDaemonPtyProvider: () =>
+        new Promise<void>((resolve) => {
+          events.push('daemon-started')
+          resolveDaemon = resolve
+        }),
+      startAgentHookServer: () =>
+        new Promise<void>((resolve) => {
+          events.push('hooks-started')
+          resolveHooks = resolve
+        }),
+      reconcileWslHookRelays: () =>
+        new Promise<void>((resolve) => {
+          events.push('relay-reconciliation-started')
+          resolveRelays = resolve
+        }),
+      onDaemonError: vi.fn(),
+      onAgentHookServerError: vi.fn(),
+      onWslHookRelayReconciliationError: vi.fn()
+    })
+    await Promise.resolve()
+
+    resolveHooks()
+    await Promise.resolve()
+    expect(events).toEqual(['daemon-started', 'hooks-started'])
+
+    resolveDaemon()
+    await vi.waitFor(() => expect(events).toContain('relay-reconciliation-started'))
+    let localPtyReady = false
+    void started.localPtyReady.then(() => {
+      localPtyReady = true
+    })
+    await Promise.resolve()
+    expect(localPtyReady).toBe(false)
+
+    resolveRelays()
+    await started.localPtyReady
+    expect(localPtyReady).toBe(true)
+  })
+
+  it('reports reconciliation failure and still opens the startup gate', async () => {
+    const onWslHookRelayReconciliationError = vi.fn()
+    const started = startFirstWindowStartupServices({
+      startDaemonPtyProvider: () => Promise.resolve(),
+      startAgentHookServer: () => Promise.resolve(),
+      reconcileWslHookRelays: () => Promise.reject(new Error('inventory unavailable')),
+      onDaemonError: vi.fn(),
+      onAgentHookServerError: vi.fn(),
+      onWslHookRelayReconciliationError
+    })
+
+    await expect(started.localPtyReady).resolves.toBeUndefined()
+    expect(onWslHookRelayReconciliationError).toHaveBeenCalledWith(expect.any(Error))
+  })
+
   it('opens the provider gate when daemon startup finishes without waiting for hooks', async () => {
     let resolveDaemon!: () => void
     let resolveHooks!: () => void
@@ -57,8 +119,10 @@ describe('startFirstWindowStartupServices', () => {
         new Promise<void>((resolve) => {
           resolveHooks = resolve
         }),
+      reconcileWslHookRelays: vi.fn(async () => {}),
       onDaemonError: vi.fn(),
-      onAgentHookServerError: vi.fn()
+      onAgentHookServerError: vi.fn(),
+      onWslHookRelayReconciliationError: vi.fn()
     })
     await Promise.resolve()
 
@@ -81,8 +145,10 @@ describe('startFirstWindowStartupServices', () => {
     const started = startFirstWindowStartupServices({
       startDaemonPtyProvider: () => Promise.reject(new Error('daemon failed')),
       startAgentHookServer: () => Promise.reject(new Error('hooks failed')),
+      reconcileWslHookRelays: vi.fn(async () => {}),
       onDaemonError,
-      onAgentHookServerError
+      onAgentHookServerError,
+      onWslHookRelayReconciliationError: vi.fn()
     })
 
     await expect(started.firstWindowReady).resolves.toBeUndefined()
@@ -104,8 +170,10 @@ describe('startFirstWindowStartupServices', () => {
       startAgentHookServer: () => {
         throw new Error('hooks sync failed')
       },
+      reconcileWslHookRelays: vi.fn(async () => {}),
       onDaemonError,
-      onAgentHookServerError
+      onAgentHookServerError,
+      onWslHookRelayReconciliationError: vi.fn()
     })
 
     await expect(started.firstWindowReady).resolves.toBeUndefined()
@@ -131,8 +199,10 @@ describe('startFirstWindowStartupServices', () => {
           })
         },
         startAgentHookServer: () => Promise.resolve(),
+        reconcileWslHookRelays: vi.fn(async () => {}),
         onDaemonError,
-        onAgentHookServerError: vi.fn()
+        onAgentHookServerError: vi.fn(),
+        onWslHookRelayReconciliationError: vi.fn()
       })
 
       let ptyGateOpened = false
@@ -172,8 +242,10 @@ describe('startFirstWindowStartupServices', () => {
           return new Promise<void>(() => {})
         },
         startAgentHookServer: () => Promise.resolve(),
+        reconcileWslHookRelays: vi.fn(async () => {}),
         onDaemonError,
-        onAgentHookServerError
+        onAgentHookServerError,
+        onWslHookRelayReconciliationError: vi.fn()
       })
 
       await Promise.resolve()

--- a/src/main/startup/first-window-startup-services.ts
+++ b/src/main/startup/first-window-startup-services.ts
@@ -79,13 +79,15 @@ export function startFirstWindowStartupServices({
   const daemon = startService('daemon PTY provider', startDaemonPtyProvider, onDaemonError)
   const hooks = startService('agent hook server', startAgentHookServer, onAgentHookServerError)
   let failOpened = false
-  const allServicesReady = Promise.all([daemon.ready, hooks.ready])
+  const startupAuthoritiesReady = Promise.all([daemon.ready, hooks.ready]).then(() => undefined)
+  const wslHookRelayReconciliation = startupAuthoritiesReady
     .then(() => (failOpened ? undefined : reconcileWslHookRelays()))
     .catch(onWslHookRelayReconciliationError)
     .then(() => undefined)
+  void wslHookRelayReconciliation
   let windowTimeout: ReturnType<typeof setTimeout> | null = null
   let failOpenTimeout: ReturnType<typeof setTimeout> | null = null
-  const servicesSettled = allServicesReady.finally(() => {
+  const startupAuthoritiesSettled = startupAuthoritiesReady.finally(() => {
     if (windowTimeout) {
       clearTimeout(windowTimeout)
     }
@@ -102,12 +104,12 @@ export function startFirstWindowStartupServices({
     }, LOCAL_PTY_STARTUP_FAIL_OPEN_TIMEOUT_MS)
   })
   const firstWindowReady = Promise.race([
-    servicesSettled,
+    startupAuthoritiesSettled,
     new Promise<void>((resolve) => {
       windowTimeout = setTimeout(resolve, FIRST_WINDOW_STARTUP_SERVICE_TIMEOUT_MS)
     })
   ])
-  const localPtyReady = Promise.race([servicesSettled, failOpenReady])
+  const localPtyReady = Promise.race([startupAuthoritiesSettled, failOpenReady])
   // Why: destructive routing only needs daemon authority. A stalled optional
   // hook server must not hold terminal close for the full fail-open window.
   const localPtyProviderReady = Promise.race([daemon.ready, failOpenReady])

--- a/src/main/startup/first-window-startup-services.ts
+++ b/src/main/startup/first-window-startup-services.ts
@@ -1,8 +1,10 @@
 type FirstWindowStartupServices = {
   startDaemonPtyProvider: (signal: AbortSignal) => Promise<void>
   startAgentHookServer: (signal: AbortSignal) => Promise<void>
+  reconcileWslHookRelays: () => Promise<void>
   onDaemonError: (error: unknown) => void
   onAgentHookServerError: (error: unknown) => void
+  onWslHookRelayReconciliationError: (error: unknown) => void
 }
 
 type StartupService = {
@@ -62,8 +64,10 @@ function startService(
 export function startFirstWindowStartupServices({
   startDaemonPtyProvider,
   startAgentHookServer,
+  reconcileWslHookRelays,
   onDaemonError,
-  onAgentHookServerError
+  onAgentHookServerError,
+  onWslHookRelayReconciliationError
 }: FirstWindowStartupServices): FirstWindowStartupServicesResult {
   // Why: daemon startup and hook-server binding are independent, but both gate
   // restored terminals; run them together so cold-start latency is max(), not sum().
@@ -74,7 +78,11 @@ export function startFirstWindowStartupServices({
   // strand any fallback PTYs that spawn after the gate opens.
   const daemon = startService('daemon PTY provider', startDaemonPtyProvider, onDaemonError)
   const hooks = startService('agent hook server', startAgentHookServer, onAgentHookServerError)
-  const allServicesReady = Promise.all([daemon.ready, hooks.ready]).then(() => undefined)
+  let failOpened = false
+  const allServicesReady = Promise.all([daemon.ready, hooks.ready])
+    .then(() => (failOpened ? undefined : reconcileWslHookRelays()))
+    .catch(onWslHookRelayReconciliationError)
+    .then(() => undefined)
   let windowTimeout: ReturnType<typeof setTimeout> | null = null
   let failOpenTimeout: ReturnType<typeof setTimeout> | null = null
   const servicesSettled = allServicesReady.finally(() => {
@@ -87,6 +95,7 @@ export function startFirstWindowStartupServices({
   })
   const failOpenReady = new Promise<void>((resolve) => {
     failOpenTimeout = setTimeout(() => {
+      failOpened = true
       daemon.reportTimeout()
       hooks.reportTimeout()
       resolve()


### PR DESCRIPTION
## Summary

- reconcile WSL hook relays from authoritative live-daemon inventory after daemon and hook authority are ready
- use one non-booting running-distro snapshot, dedupe by normalized distro, and guard exceptional install/retry continuations from reviving a distro that stopped
- keep first-window, native, SSH, and remote terminal startup independent of reconciliation; only an exact local WSL reattach awaits relay readiness
- fence relay waits with exact PTY incarnations so an exit during readiness cannot publish or persist a dead terminal

## Reliability contract

Invariant: daemon-surviving local WSL PTYs give their authoritative distro's current hook relay a bounded readiness opportunity before reattach returns, without withholding publication beyond two seconds, delaying native/SSH/relay PTYs, reviving stopped distros during failure continuation, or republishing a PTY that exited during readiness.

Oracle:

- authoritative all-generation daemon inventory
- one shared non-booting running-distro snapshot
- one relay attempt per normalized live distro
- exact local WSL reattach readiness, with a two-second diagnostic fail-open
- exact-incarnation admission rechecked after readiness and before durable publication

Diagnostics cover inventory/reconciliation failure, stopped-distro continuation, relay startup failure, and reattach timeout/failure. No RPC field, stream opcode, schema, dependency, or remote payload changed.

There is no new reliability-manifest entry; focused deterministic coverage is the explicit gate for this change.

## Provider matrix

- Local native: no reconciliation or reattach gate
- Local daemon WSL: deterministic ordering, dedupe, stopped-distro, failure, and exit-race coverage
- Older daemon: absent optional wslDistro metadata skips safely and retains degraded fallback behavior
- SSH / paired relay / mobile: excluded by connection ownership; wire behavior unchanged
- Folder workspace: covered without parsing workspace IDs as git worktrees
- macOS / Linux: platform guard skips startup inventory

## Performance budget

- first-window readiness waits only for daemon and hook authority, not WSL reconciliation
- successful startup performs one daemon inventory fanout, one wsl --list --running --quiet snapshot, and one relay per unique running distro
- successful relay startup adds no per-distro liveness subprocess
- extra liveness probes occur only before exceptional retry/install continuations
- native, SSH, and remote terminals allocate no relay-readiness timer
- local WSL reattach fail-opens after two seconds, clears its timer, and leaves relay recovery running

## Testing

- [x] pnpm typecheck
- [x] focused WSL relay/startup suite: 65 passed, 3 platform-skipped
- [x] focused PTY readiness/adoption suite: 7 passed
- [x] changed-file Oxlint and Oxfmt checks
- [x] pnpm check:reliability-gates
- [x] pnpm check:max-lines-ratchet
- [x] benchmark script syntax and git diff checks
- [x] real installed-WSL non-booting distro listing and exact/folded liveness lookup
- [ ] live wall-clock relay benchmark intentionally not collected during review

The full PTY file completed with 452 passed and 19 skipped. Its three failures reproduce independently on this Windows checkout and are unrelated existing expectations: one POSIX sequenced-command assertion and two slash-direction path assertions.

## Review

Three adversarial review rounds completed. The review found and fixed:

1. concurrent callers returning before the shared first relay attempt settled
2. WSL reconciliation delaying first-window visibility
3. one failed WSL relay globally gating native/local terminals
4. stopped distros being restarted by exceptional install/retry continuations
5. a PTY exiting during relay readiness and then being persisted or republished as alive
6. materialized stable-pane adoption skipping relay readiness
7. teardown during an awaited liveness probe resuming install or retry work
8. optional relay readiness withholding a healthy terminal for up to 60 seconds

The final independent round was clean across incarnation races, concurrency, stopped-distro behavior, timer cleanup, startup latency, and native/WSL/SSH/folder/mobile/mixed-version paths.

## Security

Distro names remain argv values passed to execFile/wsl.exe, never shell-interpolated input. The running snapshot is non-booting and fails closed. No token, credential, dependency, IPC method, or remote wire contract changed.