### PR TITLE
refactor(runtime): extract pure path-candidate, review-branch, and folder-workspace helpers from orca-runtime

### DIFF
--- a/src/main/runtime/orca-runtime-path-candidate-history.test.ts
+++ b/src/main/runtime/orca-runtime-path-candidate-history.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it, vi } from 'vitest'
-import { appendRecentPtyPathCandidates } from './orca-runtime'
+import { appendRecentPtyPathCandidates } from './terminal-output-path-candidates'
 
 function fullCandidateHistory(): string[] {
   return Array.from(

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -61,14 +61,16 @@ import type { MessagePriority, MessageRow, MessageType } from './orchestration/t
 import {
   AUTHORITATIVE_TERMINAL_SNAPSHOT_TIMEOUT_MS,
   appendNormalizedToTailBuffer,
-  appendRecentPtyPathCandidates,
   buildPreview,
   OrcaRuntimeService,
-  recentTerminalPathCandidatesIncludePath,
-  recentTerminalOutputIncludesPath,
   resolveWorktreeScanCacheTtlMs,
   type RuntimeTerminalAgentStatusEvent
 } from './orca-runtime'
+import {
+  appendRecentPtyPathCandidates,
+  recentTerminalPathCandidatesIncludePath,
+  recentTerminalOutputIncludesPath
+} from './terminal-output-path-candidates'
 import { RecentPtyOutputBuffer } from './recent-pty-output-buffer'
 import { HeadlessEmulator } from '../daemon/headless-emulator'
 import {

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -670,7 +670,6 @@ import type {
   HostedReviewInfo
 } from '../../shared/hosted-review'
 import { getHostedReviewForBranch as getHostedReviewForBranchFromRepo } from '../source-control/hosted-review'
-import type { ForgeProviderId } from '../source-control/forge-provider'
 import {
   createHostedReview as createHostedReviewFromRepo,
   getHostedReviewCreationEligibility as getHostedReviewCreationEligibilityFromRepo
@@ -981,6 +980,24 @@ import {
   type MobileSessionTabsNotifyCoalescer
 } from './mobile-session-tabs-notify-coalescer'
 import { TerminalFocusNavigationCoalescer } from './terminal-focus-navigation-coalescer'
+import {
+  appendRecentPtyPathCandidates,
+  recentTerminalOutputIncludesPath,
+  recentTerminalPathCandidatesIncludePath
+} from './terminal-output-path-candidates'
+import {
+  getSelectedReviewBranch,
+  getSelectedReviewLookupHints,
+  isAllowedPushTargetRemoteConflict,
+  isMatchingSelectedGitHubPr,
+  type SelectedReviewBranchInput
+} from './selected-review-branch'
+import {
+  getRuntimeFolderWorkspaceInstanceId,
+  getRuntimeFolderWorkspaceRootId,
+  isRuntimeFolderWorkspaceIdForRepo,
+  mergeRuntimeFolderWorkspace
+} from './runtime-folder-workspace'
 import { getSshFilesystemProvider } from '../providers/ssh-filesystem-dispatch'
 import {
   assertFolderWorkspacePathUsable,
@@ -1770,9 +1787,6 @@ const BRACKETED_PASTE_QUIET_MS = 1500
 const DRAFT_PASTE_READY_TIMEOUT_MS = 8000
 const MOBILE_TERMINAL_SURFACE_TIMEOUT_MS = 10_000
 const MOBILE_TERMINAL_READY_FALLBACK_MS = 1000
-const RECENT_PTY_PATH_CANDIDATE_LIMIT = 1024
-const RECENT_PTY_PATH_CANDIDATE_MAX_BYTES = 4 * 1024
-const RECENT_PTY_PATH_CANDIDATE_TOTAL_BYTES = 64 * 1024
 const SSH_PANE_RECOVERY_GRACE_MS = 30_000
 // Why: long enough that a keystroke burst to a proven-dead leaf probes once,
 // short enough that a recreated session id regains writability quickly even if
@@ -2109,10 +2123,6 @@ function getRuntimeWorktreeRemovalOptionsKey(
   return `${force ? 'force' : 'normal'}:${runHooks ? 'run-hooks' : 'skip-hooks'}:${ptyKey}`
 }
 
-function getRuntimeFolderWorkspaceRootId(repo: Repo): string {
-  return `${repo.id}::${repo.path}`
-}
-
 // Null executionHostId means host-unaware: path-only callers match any repo, and the first runtime
 // host can adopt a legacy (unstamped) repo. But an unstamped repo with a connectionId is an SSH repo
 // (resolves to ssh:<id>), so it must not be adopted/matched by a runtime host at the same path.
@@ -2142,69 +2152,9 @@ function assertProjectHostSetupHostIsSupported(hostId: ExecutionHostId | null | 
   )
 }
 
-function getRuntimeFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
-  return `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
-}
-
 function getRuntimeFolderWorkspaceInstanceIdentity(repo: Repo, worktreeId: string): string {
   const prefix = `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
   return worktreeId.startsWith(prefix) ? worktreeId.slice(prefix.length) : randomUUID()
-}
-
-function isRuntimeFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
-  const rootId = getRuntimeFolderWorkspaceRootId(repo)
-  return (
-    worktreeId === rootId ||
-    worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
-  )
-}
-
-function mergeRuntimeFolderWorkspace(repo: Repo, worktreeId: string, meta: WorktreeMeta): Worktree {
-  return {
-    id: worktreeId,
-    ...(meta.instanceId !== undefined ? { instanceId: meta.instanceId } : {}),
-    repoId: repo.id,
-    ...(meta.projectId !== undefined ? { projectId: meta.projectId } : {}),
-    ...(meta.hostId !== undefined ? { hostId: meta.hostId } : {}),
-    ...(meta.projectHostSetupId !== undefined
-      ? { projectHostSetupId: meta.projectHostSetupId }
-      : {}),
-    path: repo.path,
-    head: '',
-    branch: '',
-    isBare: false,
-    isMainWorktree: worktreeId === getRuntimeFolderWorkspaceRootId(repo),
-    displayName: meta.displayName || repo.displayName,
-    comment: meta.comment || '',
-    linkedIssue: meta.linkedIssue ?? null,
-    linkedPR: meta.linkedPR ?? null,
-    linkedLinearIssue: meta.linkedLinearIssue ?? null,
-    linkedLinearIssueWorkspaceId: meta.linkedLinearIssueWorkspaceId ?? null,
-    linkedLinearIssueOrganizationUrlKey: meta.linkedLinearIssueOrganizationUrlKey ?? null,
-    linkedGitLabMR: meta.linkedGitLabMR ?? null,
-    linkedGitLabIssue: meta.linkedGitLabIssue ?? null,
-    linkedBitbucketPR: meta.linkedBitbucketPR ?? null,
-    linkedAzureDevOpsPR: meta.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: meta.linkedGiteaPR ?? null,
-    linkedWorkItem: meta.linkedWorkItem ?? null,
-    linkedTaskSourceContext: meta.linkedTaskSourceContext ?? null,
-    isArchived: meta.isArchived ?? false,
-    isUnread: meta.isUnread ?? false,
-    isPinned: meta.isPinned ?? false,
-    sortOrder: meta.sortOrder ?? 0,
-    ...(meta.manualOrder !== undefined ? { manualOrder: meta.manualOrder } : {}),
-    lastActivityAt: meta.lastActivityAt ?? 0,
-    ...(meta.createdAt !== undefined ? { createdAt: meta.createdAt } : {}),
-    ...(meta.createdWithAgent !== undefined ? { createdWithAgent: meta.createdWithAgent } : {}),
-    ...(meta.automationProvenance !== undefined
-      ? { automationProvenance: meta.automationProvenance }
-      : {}),
-    ...(meta.cliProvenance !== undefined ? { cliProvenance: meta.cliProvenance } : {}),
-    ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
-    workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
-    diffComments: meta.diffComments,
-    mobileDiffReview: meta.mobileDiffReview
-  }
 }
 
 function listRuntimeFolderWorkspaces(
@@ -2365,94 +2315,6 @@ function getLocalGitHubPrForBranch(
         localGitExecOptions: gitOptions
       })
     : getPRForBranch(repoPath, branchName)
-}
-
-type SelectedReviewBranchInput = {
-  branchNameOverride?: string
-  linkedPR?: number | null
-  linkedGitLabMR?: number | null
-  linkedBitbucketPR?: number | null
-  linkedAzureDevOpsPR?: number | null
-  linkedGiteaPR?: number | null
-  pushTarget?: GitPushTarget
-}
-
-type SelectedReviewBranch = {
-  provider: ForgeProviderId
-  number: number
-}
-
-function getSelectedReviewBranch(args: SelectedReviewBranchInput): SelectedReviewBranch | null {
-  if (typeof args.linkedPR === 'number') {
-    return { provider: 'github', number: args.linkedPR }
-  }
-  if (typeof args.linkedGitLabMR === 'number') {
-    return { provider: 'gitlab', number: args.linkedGitLabMR }
-  }
-  if (typeof args.linkedBitbucketPR === 'number') {
-    return { provider: 'bitbucket', number: args.linkedBitbucketPR }
-  }
-  if (typeof args.linkedAzureDevOpsPR === 'number') {
-    return { provider: 'azure-devops', number: args.linkedAzureDevOpsPR }
-  }
-  if (typeof args.linkedGiteaPR === 'number') {
-    return { provider: 'gitea', number: args.linkedGiteaPR }
-  }
-  return null
-}
-
-function isSelectedGitHubPrBranchOverride(
-  args: SelectedReviewBranchInput,
-  branchName: string
-): boolean {
-  return typeof args.linkedPR === 'number' && args.branchNameOverride === branchName
-}
-
-function isSelectedReviewBranchOverride(
-  args: SelectedReviewBranchInput,
-  branchName: string
-): boolean {
-  return getSelectedReviewBranch(args) !== null && args.branchNameOverride === branchName
-}
-
-function isMatchingSelectedGitHubPr(
-  existingPR: Awaited<ReturnType<typeof getPRForBranch>>,
-  args: SelectedReviewBranchInput,
-  branchName: string
-): boolean {
-  return Boolean(
-    existingPR &&
-    isSelectedGitHubPrBranchOverride(args, branchName) &&
-    existingPR.number === args.linkedPR
-  )
-}
-
-function isAllowedPushTargetRemoteConflict(
-  conflictKind: 'local' | 'remote' | null,
-  branchName: string,
-  args: SelectedReviewBranchInput
-): boolean {
-  return (
-    conflictKind === 'remote' &&
-    isSelectedReviewBranchOverride(args, branchName) &&
-    args.pushTarget?.branchName === branchName
-  )
-}
-
-function getSelectedReviewLookupHints(args: SelectedReviewBranchInput): {
-  linkedGitHubPR?: number | null
-  linkedGitLabMR?: number | null
-  linkedBitbucketPR?: number | null
-  linkedAzureDevOpsPR?: number | null
-  linkedGiteaPR?: number | null
-} {
-  return {
-    linkedGitHubPR: args.linkedPR ?? null,
-    linkedGitLabMR: args.linkedGitLabMR ?? null,
-    linkedBitbucketPR: args.linkedBitbucketPR ?? null,
-    linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
-    linkedGiteaPR: args.linkedGiteaPR ?? null
-  }
 }
 
 async function getSelectedHostedReviewForBranch(
@@ -35271,269 +35133,6 @@ function withTimeoutResult<T>(
       ok: false
     }
   )
-}
-
-export function appendRecentPtyPathCandidates(
-  previous: string[] | undefined,
-  data: string
-): string[] {
-  const extractedCandidates = extractTerminalOutputPathCandidates(data)
-  if (extractedCandidates.length === 0) {
-    // Why: pathless output is the hot path; reuse immutable history so each chunk doesn't clone and byte-scan up to 1,024 old candidates.
-    return previous ?? []
-  }
-  const next = previous ? previous.slice() : []
-  for (const candidate of extractedCandidates) {
-    if (Buffer.byteLength(candidate, 'utf8') > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
-      continue
-    }
-    next.push(candidate)
-  }
-  return pruneRecentPtyPathCandidates(next)
-}
-
-export function recentTerminalPathCandidatesIncludePath(
-  recentCandidates: readonly string[],
-  pathText: string,
-  absolutePath: string
-): boolean {
-  const candidates = new Set(
-    [
-      pathText,
-      absolutePath,
-      ...wslTerminalOutputAliases(pathText),
-      ...wslTerminalOutputAliases(absolutePath)
-    ]
-      .map((candidate) => candidate.trim())
-      .filter((candidate) => candidate.length > 0)
-  )
-  for (const recent of recentCandidates) {
-    if (candidates.has(recent)) {
-      return true
-    }
-  }
-  return false
-}
-
-function pruneRecentPtyPathCandidates(candidates: string[]): string[] {
-  const countBounded =
-    candidates.length > RECENT_PTY_PATH_CANDIDATE_LIMIT
-      ? candidates.slice(-RECENT_PTY_PATH_CANDIDATE_LIMIT)
-      : candidates
-  let totalBytes = 0
-  let startIndex = countBounded.length
-  for (let index = countBounded.length - 1; index >= 0; index -= 1) {
-    const nextTotal = totalBytes + Buffer.byteLength(countBounded[index]!, 'utf8')
-    if (nextTotal > RECENT_PTY_PATH_CANDIDATE_TOTAL_BYTES) {
-      break
-    }
-    totalBytes = nextTotal
-    startIndex = index
-  }
-  return startIndex === 0 ? countBounded : countBounded.slice(startIndex)
-}
-
-export function recentTerminalOutputIncludesPath(
-  recentOutput: string,
-  pathText: string,
-  absolutePath: string
-): boolean {
-  const candidates = new Set(
-    [pathText, absolutePath]
-      .map((candidate) => candidate.trim())
-      .filter((candidate) => candidate.length > 0)
-  )
-  if (candidates.size === 0) {
-    return false
-  }
-  for (const candidate of candidates) {
-    if (outputContainsPathCandidate(recentOutput, candidate)) {
-      return true
-    }
-  }
-  const decodedOutput = decodeTerminalOutputPercentEscapes(recentOutput)
-  if (decodedOutput !== recentOutput) {
-    for (const candidate of candidates) {
-      if (outputContainsPathCandidate(decodedOutput, candidate)) {
-        return true
-      }
-    }
-  }
-  return false
-}
-
-function outputContainsPathCandidate(output: string, candidate: string): boolean {
-  let start = output.indexOf(candidate)
-  while (start !== -1) {
-    const end = start + candidate.length
-    if (isPathCandidateStartBoundary(output, start) && isPathCandidateEndBoundary(output, end)) {
-      return true
-    }
-    start = output.indexOf(candidate, start + 1)
-  }
-  return false
-}
-
-function isPathCandidateStartBoundary(output: string, start: number): boolean {
-  if (start === 0) {
-    return true
-  }
-  if (output.slice(0, start).endsWith('file://')) {
-    return true
-  }
-  if (
-    /^[A-Za-z]:[\\/]/.test(output.slice(start)) &&
-    /file:\/\/(?:localhost|127\.0\.0\.1|\[?::1\]?)?\/$/i.test(output.slice(0, start))
-  ) {
-    return true
-  }
-  if (/file:\/\/(?:localhost|127\.0\.0\.1|\[?::1\]?)$/i.test(output.slice(0, start))) {
-    return true
-  }
-  return !isPathCandidateContinuationChar(output[start - 1]!)
-}
-
-function isPathCandidateEndBoundary(output: string, end: number): boolean {
-  const next = output[end]
-  if (!next) {
-    return true
-  }
-  if (next === ':' && /^\d+(?::\d+)?(?:\D|$)/.test(output.slice(end + 1))) {
-    return true
-  }
-  return !isPathCandidateContinuationChar(next)
-}
-
-function isPathCandidateContinuationChar(char: string): boolean {
-  return /[A-Za-z0-9._~/%+@\\()[\]-]/.test(char)
-}
-
-function decodeTerminalOutputPercentEscapes(value: string): string {
-  return value.replace(/(?:%[0-9a-f]{2})+/gi, (match) => {
-    try {
-      return decodeURIComponent(match)
-    } catch {
-      return match
-    }
-  })
-}
-
-// Why: the extension regex backtracks quadratically on the PTY hot path; candidates can't cross a newline, so scan per line and skip over-long lines (dropped anyway).
-function extractTerminalOutputPathCandidates(data: string): string[] {
-  const candidates: string[] = []
-  const add = (value: string): void => {
-    const candidate = trimTerminalOutputPathCandidate(value)
-    if (candidate.length > 0) {
-      candidates.push(candidate)
-      const drivePath = normalizeTerminalOutputFileUriDrivePath(candidate)
-      if (drivePath) {
-        candidates.push(drivePath)
-      }
-    }
-  }
-  for (const line of data.split(/[\r\n]+/)) {
-    if (line.length === 0 || line.length > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
-      continue
-    }
-    collectTerminalOutputLinePathCandidates(line, add)
-  }
-  return candidates
-}
-
-function collectTerminalOutputLinePathCandidates(line: string, add: (value: string) => void): void {
-  for (const match of line.matchAll(/file:\/\/([^/\s]*)(\/[^\s\x1b"'<>)]*)/gi)) {
-    const authority = match[1] ?? ''
-    const uriPath = match[2]
-    if (uriPath) {
-      const decoded = decodeTerminalOutputPercentEscapes(uriPath)
-      add(isTerminalOutputLoopbackAuthority(authority) ? decoded : `//${authority}${decoded}`)
-    }
-  }
-  for (const match of line.matchAll(
-    /(?:\/(?:tmp|private\/tmp)\/|[A-Za-z]:[\\/])[^\r\n\x1b"'<>]+/g
-  )) {
-    if (isInsideNonLocalFileUri(line, match.index)) {
-      continue
-    }
-    add(match[0])
-  }
-  for (const match of line.matchAll(
-    /\/[^\r\n\x1b"'<>]*\.[A-Za-z0-9_+-]+(?:[#:\s][^\r\n\x1b"'<>]*)?/g
-  )) {
-    if (isInsideNonLocalFileUri(line, match.index)) {
-      continue
-    }
-    add(match[0])
-  }
-}
-
-function normalizeTerminalOutputFileUriDrivePath(candidate: string): string | null {
-  return /^\/[A-Za-z]:[\\/]/.test(candidate) ? candidate.slice(1) : null
-}
-
-function trimTerminalOutputPathCandidate(value: string): string {
-  let candidate = value.trim().replace(/[),;.]+$/g, '')
-  if (Buffer.byteLength(candidate, 'utf8') > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
-    return ''
-  }
-  let selected: string | null = null
-  for (const match of candidate.matchAll(
-    /.+?\.[A-Za-z0-9_+-]+(?:#L\d+(?:C\d+)?|(?::\d+)?(?::\d+)?)?(?=\s+|$)/gi
-  )) {
-    const end = match.index + match[0].length
-    const text = candidate.slice(0, end)
-    if (countTerminalOutputPathStarts(text) > 1) {
-      continue
-    }
-    // Same as the tap parsers: a line-end token extends the candidate only when the added segment is path-like, so trailing prose isn't swallowed.
-    if (
-      end < candidate.length ||
-      selected === null ||
-      /[\\/]/.test(candidate.slice(selected.length, end))
-    ) {
-      selected = text
-    }
-  }
-  return trimTerminalOutputPathLocator(selected ?? candidate)
-}
-
-function isTerminalOutputLoopbackAuthority(authority: string): boolean {
-  const normalized = authority.toLowerCase()
-  return (
-    normalized === '' ||
-    normalized === 'localhost' ||
-    normalized === '127.0.0.1' ||
-    normalized === '::1' ||
-    normalized === '[::1]'
-  )
-}
-
-function isInsideNonLocalFileUri(output: string, pathStart: number): boolean {
-  const prefix = output.slice(0, pathStart)
-  const match = /file:\/\/([^/\s]*)$/i.exec(prefix)
-  return !!match && !isTerminalOutputLoopbackAuthority(match[1] ?? '')
-}
-
-function countTerminalOutputPathStarts(value: string): number {
-  let count = 0
-  for (const match of value.matchAll(/(?:^|\s)(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/g)) {
-    void match
-    count += 1
-  }
-  return count
-}
-
-function trimTerminalOutputPathLocator(value: string): string {
-  return value.replace(/#L\d+(?:C\d+)?$/i, '').replace(/:\d+(?::\d+)?$/, '')
-}
-
-function wslTerminalOutputAliases(value: string): string[] {
-  const match = /^\\\\wsl(?:\.localhost|\$)\\[^\\]+(\\.*)$/i.exec(value)
-  if (!match) {
-    return []
-  }
-  const linuxPath = match[1]!.replace(/\\/g, '/')
-  return linuxPath.startsWith('/') ? [linuxPath] : [`/${linuxPath}`]
 }
 
 export function buildPreview(lines: string[], partialLine: string): string {

--- a/src/main/runtime/runtime-folder-workspace.test.ts
+++ b/src/main/runtime/runtime-folder-workspace.test.ts
@@ -1,0 +1,190 @@
+import { describe, expect, it } from 'vitest'
+import type { Repo, WorktreeMeta } from '../../shared/types'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+import {
+  getRuntimeFolderWorkspaceInstanceId,
+  getRuntimeFolderWorkspaceRootId,
+  isRuntimeFolderWorkspaceIdForRepo,
+  mergeRuntimeFolderWorkspace
+} from './runtime-folder-workspace'
+
+// characterization: current behavior
+
+function repo(overrides: Partial<Repo> = {}): Repo {
+  return {
+    id: 'repo-1',
+    path: '/Users/dev/projects/site',
+    displayName: 'site',
+    badgeColor: '#000000',
+    addedAt: 0,
+    ...overrides
+  }
+}
+
+function meta(overrides: Partial<WorktreeMeta> = {}): WorktreeMeta {
+  return {
+    displayName: '',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    ...overrides
+  }
+}
+
+describe('getRuntimeFolderWorkspaceRootId', () => {
+  it.each([
+    { label: 'posix path', input: repo(), expected: 'repo-1::/Users/dev/projects/site' },
+    {
+      label: 'windows path',
+      input: repo({ path: 'C:\\Users\\dev\\site' }),
+      expected: 'repo-1::C:\\Users\\dev\\site'
+    },
+    {
+      label: 'ssh repo (connectionId is not part of the id)',
+      input: repo({ connectionId: 'ssh-1', path: '/home/dev/site' }),
+      expected: 'repo-1::/home/dev/site'
+    },
+    { label: 'empty path', input: repo({ path: '' }), expected: 'repo-1::' }
+  ])('joins repo id and path for $label', ({ input, expected }) => {
+    expect(getRuntimeFolderWorkspaceRootId(input)).toBe(expected)
+  })
+})
+
+describe('getRuntimeFolderWorkspaceInstanceId', () => {
+  it('appends the instance id after the separator', () => {
+    expect(getRuntimeFolderWorkspaceInstanceId(repo(), 'abc')).toBe(
+      `repo-1::/Users/dev/projects/site${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}abc`
+    )
+  })
+
+  it('appends an empty instance id without complaint', () => {
+    expect(getRuntimeFolderWorkspaceInstanceId(repo(), '')).toBe(
+      `repo-1::/Users/dev/projects/site${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`
+    )
+  })
+})
+
+describe('isRuntimeFolderWorkspaceIdForRepo', () => {
+  const root = 'repo-1::/Users/dev/projects/site'
+
+  it.each([
+    { label: 'the root id itself', worktreeId: root, expected: true },
+    {
+      label: 'an instance id under the root',
+      worktreeId: `${root}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}abc`,
+      expected: true
+    },
+    {
+      label: 'a sibling path that merely shares the root as a prefix',
+      worktreeId: `${root}-other`,
+      expected: false
+    },
+    { label: 'another repo', worktreeId: 'repo-2::/Users/dev/projects/site', expected: false },
+    { label: 'an unrelated id', worktreeId: '', expected: false }
+  ])('$label', ({ worktreeId, expected }) => {
+    expect(isRuntimeFolderWorkspaceIdForRepo(repo(), worktreeId)).toBe(expected)
+  })
+})
+
+describe('mergeRuntimeFolderWorkspace', () => {
+  it('projects repo + meta onto a branchless, headless worktree', () => {
+    const merged = mergeRuntimeFolderWorkspace(repo(), 'repo-1::/Users/dev/projects/site', meta())
+
+    expect(merged).toEqual({
+      id: 'repo-1::/Users/dev/projects/site',
+      repoId: 'repo-1',
+      path: '/Users/dev/projects/site',
+      head: '',
+      branch: '',
+      isBare: false,
+      isMainWorktree: true,
+      displayName: 'site',
+      comment: '',
+      linkedIssue: null,
+      linkedPR: null,
+      linkedLinearIssue: null,
+      linkedLinearIssueWorkspaceId: null,
+      linkedLinearIssueOrganizationUrlKey: null,
+      linkedGitLabMR: null,
+      linkedGitLabIssue: null,
+      linkedBitbucketPR: null,
+      linkedAzureDevOpsPR: null,
+      linkedGiteaPR: null,
+      linkedWorkItem: null,
+      linkedTaskSourceContext: null,
+      isArchived: false,
+      isUnread: false,
+      isPinned: false,
+      sortOrder: 0,
+      lastActivityAt: 0,
+      workspaceStatus: 'in-progress',
+      diffComments: undefined,
+      mobileDiffReview: undefined
+    })
+  })
+
+  it('marks a non-root id as a secondary workspace', () => {
+    const worktreeId = `repo-1::/Users/dev/projects/site${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}abc`
+    const merged = mergeRuntimeFolderWorkspace(repo(), worktreeId, meta({ instanceId: 'abc' }))
+
+    expect(merged.isMainWorktree).toBe(false)
+    expect(merged.instanceId).toBe('abc')
+    expect(merged.path).toBe('/Users/dev/projects/site')
+  })
+
+  it('falls back to the repo display name when meta has a blank one', () => {
+    expect(mergeRuntimeFolderWorkspace(repo(), 'id', meta()).displayName).toBe('site')
+    expect(
+      mergeRuntimeFolderWorkspace(repo(), 'id', meta({ displayName: 'custom' })).displayName
+    ).toBe('custom')
+  })
+
+  it('omits optional keys rather than writing undefined for them', () => {
+    const merged = mergeRuntimeFolderWorkspace(repo(), 'id', meta())
+
+    expect('instanceId' in merged).toBe(false)
+    expect('projectId' in merged).toBe(false)
+    expect('hostId' in merged).toBe(false)
+    expect('projectHostSetupId' in merged).toBe(false)
+    expect('manualOrder' in merged).toBe(false)
+    expect('createdAt' in merged).toBe(false)
+    expect('createdWithAgent' in merged).toBe(false)
+    expect('automationProvenance' in merged).toBe(false)
+    expect('cliProvenance' in merged).toBe(false)
+    expect('priorWorktreeIds' in merged).toBe(false)
+  })
+
+  it('carries project-first ownership fields through when present', () => {
+    const merged = mergeRuntimeFolderWorkspace(
+      repo(),
+      'id',
+      meta({
+        projectId: 'project-1',
+        hostId: 'local',
+        projectHostSetupId: 'setup-1',
+        manualOrder: 3,
+        createdAt: 42,
+        priorWorktreeIds: ['old-id']
+      })
+    )
+
+    expect(merged.projectId).toBe('project-1')
+    expect(merged.hostId).toBe('local')
+    expect(merged.projectHostSetupId).toBe('setup-1')
+    expect(merged.manualOrder).toBe(3)
+    expect(merged.createdAt).toBe(42)
+    expect(merged.priorWorktreeIds).toEqual(['old-id'])
+  })
+
+  it('keeps an explicit workspace status instead of the default', () => {
+    expect(
+      mergeRuntimeFolderWorkspace(repo(), 'id', meta({ workspaceStatus: 'done' })).workspaceStatus
+    ).toBe('done')
+  })
+})

--- a/src/main/runtime/runtime-folder-workspace.ts
+++ b/src/main/runtime/runtime-folder-workspace.ts
@@ -1,0 +1,71 @@
+import { DEFAULT_WORKSPACE_STATUS_ID } from '../../shared/workspace-statuses'
+import type { Repo, Worktree, WorktreeMeta } from '../../shared/types'
+import { FOLDER_WORKSPACE_INSTANCE_SEPARATOR } from '../../shared/worktree-id'
+
+export function getRuntimeFolderWorkspaceRootId(repo: Repo): string {
+  return `${repo.id}::${repo.path}`
+}
+
+export function getRuntimeFolderWorkspaceInstanceId(repo: Repo, instanceId: string): string {
+  return `${getRuntimeFolderWorkspaceRootId(repo)}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}${instanceId}`
+}
+
+export function isRuntimeFolderWorkspaceIdForRepo(repo: Repo, worktreeId: string): boolean {
+  const rootId = getRuntimeFolderWorkspaceRootId(repo)
+  return (
+    worktreeId === rootId ||
+    worktreeId.startsWith(`${rootId}${FOLDER_WORKSPACE_INSTANCE_SEPARATOR}`)
+  )
+}
+
+export function mergeRuntimeFolderWorkspace(
+  repo: Repo,
+  worktreeId: string,
+  meta: WorktreeMeta
+): Worktree {
+  return {
+    id: worktreeId,
+    ...(meta.instanceId !== undefined ? { instanceId: meta.instanceId } : {}),
+    repoId: repo.id,
+    ...(meta.projectId !== undefined ? { projectId: meta.projectId } : {}),
+    ...(meta.hostId !== undefined ? { hostId: meta.hostId } : {}),
+    ...(meta.projectHostSetupId !== undefined
+      ? { projectHostSetupId: meta.projectHostSetupId }
+      : {}),
+    path: repo.path,
+    head: '',
+    branch: '',
+    isBare: false,
+    isMainWorktree: worktreeId === getRuntimeFolderWorkspaceRootId(repo),
+    displayName: meta.displayName || repo.displayName,
+    comment: meta.comment || '',
+    linkedIssue: meta.linkedIssue ?? null,
+    linkedPR: meta.linkedPR ?? null,
+    linkedLinearIssue: meta.linkedLinearIssue ?? null,
+    linkedLinearIssueWorkspaceId: meta.linkedLinearIssueWorkspaceId ?? null,
+    linkedLinearIssueOrganizationUrlKey: meta.linkedLinearIssueOrganizationUrlKey ?? null,
+    linkedGitLabMR: meta.linkedGitLabMR ?? null,
+    linkedGitLabIssue: meta.linkedGitLabIssue ?? null,
+    linkedBitbucketPR: meta.linkedBitbucketPR ?? null,
+    linkedAzureDevOpsPR: meta.linkedAzureDevOpsPR ?? null,
+    linkedGiteaPR: meta.linkedGiteaPR ?? null,
+    linkedWorkItem: meta.linkedWorkItem ?? null,
+    linkedTaskSourceContext: meta.linkedTaskSourceContext ?? null,
+    isArchived: meta.isArchived ?? false,
+    isUnread: meta.isUnread ?? false,
+    isPinned: meta.isPinned ?? false,
+    sortOrder: meta.sortOrder ?? 0,
+    ...(meta.manualOrder !== undefined ? { manualOrder: meta.manualOrder } : {}),
+    lastActivityAt: meta.lastActivityAt ?? 0,
+    ...(meta.createdAt !== undefined ? { createdAt: meta.createdAt } : {}),
+    ...(meta.createdWithAgent !== undefined ? { createdWithAgent: meta.createdWithAgent } : {}),
+    ...(meta.automationProvenance !== undefined
+      ? { automationProvenance: meta.automationProvenance }
+      : {}),
+    ...(meta.cliProvenance !== undefined ? { cliProvenance: meta.cliProvenance } : {}),
+    ...(meta.priorWorktreeIds !== undefined ? { priorWorktreeIds: meta.priorWorktreeIds } : {}),
+    workspaceStatus: meta.workspaceStatus ?? DEFAULT_WORKSPACE_STATUS_ID,
+    diffComments: meta.diffComments,
+    mobileDiffReview: meta.mobileDiffReview
+  }
+}

--- a/src/main/runtime/selected-review-branch.test.ts
+++ b/src/main/runtime/selected-review-branch.test.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  getSelectedReviewBranch,
+  getSelectedReviewLookupHints,
+  isAllowedPushTargetRemoteConflict,
+  isMatchingSelectedGitHubPr,
+  type SelectedReviewBranchInput
+} from './selected-review-branch'
+
+// characterization: current behavior
+
+const PROVIDER_CASES: {
+  label: string
+  input: SelectedReviewBranchInput
+  expected: { provider: string; number: number } | null
+}[] = [
+  { label: 'no linked review', input: {}, expected: null },
+  { label: 'github', input: { linkedPR: 7 }, expected: { provider: 'github', number: 7 } },
+  {
+    label: 'gitlab',
+    input: { linkedGitLabMR: 12 },
+    expected: { provider: 'gitlab', number: 12 }
+  },
+  {
+    label: 'bitbucket',
+    input: { linkedBitbucketPR: 3 },
+    expected: { provider: 'bitbucket', number: 3 }
+  },
+  {
+    label: 'azure devops',
+    input: { linkedAzureDevOpsPR: 44 },
+    expected: { provider: 'azure-devops', number: 44 }
+  },
+  { label: 'gitea', input: { linkedGiteaPR: 9 }, expected: { provider: 'gitea', number: 9 } },
+  {
+    label: 'zero is a real number',
+    input: { linkedPR: 0 },
+    expected: { provider: 'github', number: 0 }
+  },
+  {
+    label: 'null linked ids are skipped',
+    input: { linkedPR: null, linkedGitLabMR: null },
+    expected: null
+  },
+  {
+    label: 'github wins over gitlab when both are set',
+    input: { linkedPR: 1, linkedGitLabMR: 2 },
+    expected: { provider: 'github', number: 1 }
+  },
+  {
+    label: 'gitlab wins over bitbucket when both are set',
+    input: { linkedGitLabMR: 2, linkedBitbucketPR: 3 },
+    expected: { provider: 'gitlab', number: 2 }
+  }
+]
+
+describe('getSelectedReviewBranch', () => {
+  it.each(PROVIDER_CASES)('resolves $label', ({ input, expected }) => {
+    expect(getSelectedReviewBranch(input)).toEqual(expected)
+  })
+})
+
+type ExistingPr = Parameters<typeof isMatchingSelectedGitHubPr>[0]
+
+const pr = (number: number): ExistingPr => ({ number }) as ExistingPr
+
+describe('isMatchingSelectedGitHubPr', () => {
+  it('matches when the PR number and the branch override both line up', () => {
+    expect(
+      isMatchingSelectedGitHubPr(pr(7), { linkedPR: 7, branchNameOverride: 'feat' }, 'feat')
+    ).toBe(true)
+  })
+
+  it('rejects a different PR number', () => {
+    expect(
+      isMatchingSelectedGitHubPr(pr(8), { linkedPR: 7, branchNameOverride: 'feat' }, 'feat')
+    ).toBe(false)
+  })
+
+  it('rejects when the branch override does not equal the branch', () => {
+    expect(
+      isMatchingSelectedGitHubPr(pr(7), { linkedPR: 7, branchNameOverride: 'other' }, 'feat')
+    ).toBe(false)
+  })
+
+  it('rejects when there is no branch override at all', () => {
+    expect(isMatchingSelectedGitHubPr(pr(7), { linkedPR: 7 }, 'feat')).toBe(false)
+  })
+
+  it('rejects a non-GitHub selection even when the branch override matches', () => {
+    expect(
+      isMatchingSelectedGitHubPr(pr(7), { linkedGitLabMR: 7, branchNameOverride: 'feat' }, 'feat')
+    ).toBe(false)
+  })
+
+  it('returns false for a null existing PR', () => {
+    expect(
+      isMatchingSelectedGitHubPr(null, { linkedPR: 7, branchNameOverride: 'feat' }, 'feat')
+    ).toBe(false)
+  })
+})
+
+describe('isAllowedPushTargetRemoteConflict', () => {
+  const args: SelectedReviewBranchInput = {
+    linkedGitLabMR: 12,
+    branchNameOverride: 'feat',
+    pushTarget: { remoteName: 'origin', branchName: 'feat' }
+  }
+
+  it('allows a remote conflict on the selected review branch', () => {
+    expect(isAllowedPushTargetRemoteConflict('remote', 'feat', args)).toBe(true)
+  })
+
+  it('does not allow a local conflict', () => {
+    expect(isAllowedPushTargetRemoteConflict('local', 'feat', args)).toBe(false)
+  })
+
+  it('does not allow a null conflict kind', () => {
+    expect(isAllowedPushTargetRemoteConflict(null, 'feat', args)).toBe(false)
+  })
+
+  it('requires a linked review', () => {
+    expect(
+      isAllowedPushTargetRemoteConflict('remote', 'feat', {
+        branchNameOverride: 'feat',
+        pushTarget: args.pushTarget
+      })
+    ).toBe(false)
+  })
+
+  it('requires the push target to name the same branch', () => {
+    expect(
+      isAllowedPushTargetRemoteConflict('remote', 'feat', {
+        ...args,
+        pushTarget: { remoteName: 'origin', branchName: 'elsewhere' }
+      })
+    ).toBe(false)
+  })
+
+  it('requires a push target', () => {
+    expect(
+      isAllowedPushTargetRemoteConflict('remote', 'feat', {
+        linkedGitLabMR: 12,
+        branchNameOverride: 'feat'
+      })
+    ).toBe(false)
+  })
+})
+
+describe('getSelectedReviewLookupHints', () => {
+  it('normalizes every absent hint to null', () => {
+    expect(getSelectedReviewLookupHints({})).toEqual({
+      linkedGitHubPR: null,
+      linkedGitLabMR: null,
+      linkedBitbucketPR: null,
+      linkedAzureDevOpsPR: null,
+      linkedGiteaPR: null
+    })
+  })
+
+  it('renames linkedPR to linkedGitHubPR and passes the rest through', () => {
+    expect(
+      getSelectedReviewLookupHints({
+        linkedPR: 7,
+        linkedGitLabMR: 12,
+        linkedBitbucketPR: 3,
+        linkedAzureDevOpsPR: 44,
+        linkedGiteaPR: 9
+      })
+    ).toEqual({
+      linkedGitHubPR: 7,
+      linkedGitLabMR: 12,
+      linkedBitbucketPR: 3,
+      linkedAzureDevOpsPR: 44,
+      linkedGiteaPR: 9
+    })
+  })
+
+  it('keeps 0 rather than coercing it to null', () => {
+    expect(getSelectedReviewLookupHints({ linkedPR: 0 }).linkedGitHubPR).toBe(0)
+  })
+})

--- a/src/main/runtime/selected-review-branch.ts
+++ b/src/main/runtime/selected-review-branch.ts
@@ -1,0 +1,93 @@
+import type { GitPushTarget } from '../../shared/types'
+import type { ForgeProviderId } from '../source-control/forge-provider'
+import type { getPRForBranch } from '../github/client'
+
+export type SelectedReviewBranchInput = {
+  branchNameOverride?: string
+  linkedPR?: number | null
+  linkedGitLabMR?: number | null
+  linkedBitbucketPR?: number | null
+  linkedAzureDevOpsPR?: number | null
+  linkedGiteaPR?: number | null
+  pushTarget?: GitPushTarget
+}
+
+type SelectedReviewBranch = {
+  provider: ForgeProviderId
+  number: number
+}
+
+export function getSelectedReviewBranch(
+  args: SelectedReviewBranchInput
+): SelectedReviewBranch | null {
+  if (typeof args.linkedPR === 'number') {
+    return { provider: 'github', number: args.linkedPR }
+  }
+  if (typeof args.linkedGitLabMR === 'number') {
+    return { provider: 'gitlab', number: args.linkedGitLabMR }
+  }
+  if (typeof args.linkedBitbucketPR === 'number') {
+    return { provider: 'bitbucket', number: args.linkedBitbucketPR }
+  }
+  if (typeof args.linkedAzureDevOpsPR === 'number') {
+    return { provider: 'azure-devops', number: args.linkedAzureDevOpsPR }
+  }
+  if (typeof args.linkedGiteaPR === 'number') {
+    return { provider: 'gitea', number: args.linkedGiteaPR }
+  }
+  return null
+}
+
+function isSelectedGitHubPrBranchOverride(
+  args: SelectedReviewBranchInput,
+  branchName: string
+): boolean {
+  return typeof args.linkedPR === 'number' && args.branchNameOverride === branchName
+}
+
+function isSelectedReviewBranchOverride(
+  args: SelectedReviewBranchInput,
+  branchName: string
+): boolean {
+  return getSelectedReviewBranch(args) !== null && args.branchNameOverride === branchName
+}
+
+export function isMatchingSelectedGitHubPr(
+  existingPR: Awaited<ReturnType<typeof getPRForBranch>>,
+  args: SelectedReviewBranchInput,
+  branchName: string
+): boolean {
+  return Boolean(
+    existingPR &&
+    isSelectedGitHubPrBranchOverride(args, branchName) &&
+    existingPR.number === args.linkedPR
+  )
+}
+
+export function isAllowedPushTargetRemoteConflict(
+  conflictKind: 'local' | 'remote' | null,
+  branchName: string,
+  args: SelectedReviewBranchInput
+): boolean {
+  return (
+    conflictKind === 'remote' &&
+    isSelectedReviewBranchOverride(args, branchName) &&
+    args.pushTarget?.branchName === branchName
+  )
+}
+
+export function getSelectedReviewLookupHints(args: SelectedReviewBranchInput): {
+  linkedGitHubPR?: number | null
+  linkedGitLabMR?: number | null
+  linkedBitbucketPR?: number | null
+  linkedAzureDevOpsPR?: number | null
+  linkedGiteaPR?: number | null
+} {
+  return {
+    linkedGitHubPR: args.linkedPR ?? null,
+    linkedGitLabMR: args.linkedGitLabMR ?? null,
+    linkedBitbucketPR: args.linkedBitbucketPR ?? null,
+    linkedAzureDevOpsPR: args.linkedAzureDevOpsPR ?? null,
+    linkedGiteaPR: args.linkedGiteaPR ?? null
+  }
+}

--- a/src/main/runtime/terminal-output-path-candidates.ts
+++ b/src/main/runtime/terminal-output-path-candidates.ts
@@ -1,0 +1,269 @@
+/* eslint-disable no-control-regex -- Why: PTY output interleaves ANSI escapes with paths, so candidate scanning must terminate matches on the control bytes themselves. */
+// Path candidates harvested from PTY output so terminal artifact links can be
+// resolved without re-scanning the whole transcript.
+const RECENT_PTY_PATH_CANDIDATE_LIMIT = 1024
+const RECENT_PTY_PATH_CANDIDATE_MAX_BYTES = 4 * 1024
+const RECENT_PTY_PATH_CANDIDATE_TOTAL_BYTES = 64 * 1024
+
+export function appendRecentPtyPathCandidates(
+  previous: string[] | undefined,
+  data: string
+): string[] {
+  const extractedCandidates = extractTerminalOutputPathCandidates(data)
+  if (extractedCandidates.length === 0) {
+    // Why: pathless output is the hot path; reuse immutable history so each chunk doesn't clone and byte-scan up to 1,024 old candidates.
+    return previous ?? []
+  }
+  const next = previous ? previous.slice() : []
+  for (const candidate of extractedCandidates) {
+    if (Buffer.byteLength(candidate, 'utf8') > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
+      continue
+    }
+    next.push(candidate)
+  }
+  return pruneRecentPtyPathCandidates(next)
+}
+
+export function recentTerminalPathCandidatesIncludePath(
+  recentCandidates: readonly string[],
+  pathText: string,
+  absolutePath: string
+): boolean {
+  const candidates = new Set(
+    [
+      pathText,
+      absolutePath,
+      ...wslTerminalOutputAliases(pathText),
+      ...wslTerminalOutputAliases(absolutePath)
+    ]
+      .map((candidate) => candidate.trim())
+      .filter((candidate) => candidate.length > 0)
+  )
+  for (const recent of recentCandidates) {
+    if (candidates.has(recent)) {
+      return true
+    }
+  }
+  return false
+}
+
+function pruneRecentPtyPathCandidates(candidates: string[]): string[] {
+  const countBounded =
+    candidates.length > RECENT_PTY_PATH_CANDIDATE_LIMIT
+      ? candidates.slice(-RECENT_PTY_PATH_CANDIDATE_LIMIT)
+      : candidates
+  let totalBytes = 0
+  let startIndex = countBounded.length
+  for (let index = countBounded.length - 1; index >= 0; index -= 1) {
+    const nextTotal = totalBytes + Buffer.byteLength(countBounded[index]!, 'utf8')
+    if (nextTotal > RECENT_PTY_PATH_CANDIDATE_TOTAL_BYTES) {
+      break
+    }
+    totalBytes = nextTotal
+    startIndex = index
+  }
+  return startIndex === 0 ? countBounded : countBounded.slice(startIndex)
+}
+
+export function recentTerminalOutputIncludesPath(
+  recentOutput: string,
+  pathText: string,
+  absolutePath: string
+): boolean {
+  const candidates = new Set(
+    [pathText, absolutePath]
+      .map((candidate) => candidate.trim())
+      .filter((candidate) => candidate.length > 0)
+  )
+  if (candidates.size === 0) {
+    return false
+  }
+  for (const candidate of candidates) {
+    if (outputContainsPathCandidate(recentOutput, candidate)) {
+      return true
+    }
+  }
+  const decodedOutput = decodeTerminalOutputPercentEscapes(recentOutput)
+  if (decodedOutput !== recentOutput) {
+    for (const candidate of candidates) {
+      if (outputContainsPathCandidate(decodedOutput, candidate)) {
+        return true
+      }
+    }
+  }
+  return false
+}
+
+function outputContainsPathCandidate(output: string, candidate: string): boolean {
+  let start = output.indexOf(candidate)
+  while (start !== -1) {
+    const end = start + candidate.length
+    if (isPathCandidateStartBoundary(output, start) && isPathCandidateEndBoundary(output, end)) {
+      return true
+    }
+    start = output.indexOf(candidate, start + 1)
+  }
+  return false
+}
+
+function isPathCandidateStartBoundary(output: string, start: number): boolean {
+  if (start === 0) {
+    return true
+  }
+  if (output.slice(0, start).endsWith('file://')) {
+    return true
+  }
+  if (
+    /^[A-Za-z]:[\\/]/.test(output.slice(start)) &&
+    /file:\/\/(?:localhost|127\.0\.0\.1|\[?::1\]?)?\/$/i.test(output.slice(0, start))
+  ) {
+    return true
+  }
+  if (/file:\/\/(?:localhost|127\.0\.0\.1|\[?::1\]?)$/i.test(output.slice(0, start))) {
+    return true
+  }
+  return !isPathCandidateContinuationChar(output[start - 1]!)
+}
+
+function isPathCandidateEndBoundary(output: string, end: number): boolean {
+  const next = output[end]
+  if (!next) {
+    return true
+  }
+  if (next === ':' && /^\d+(?::\d+)?(?:\D|$)/.test(output.slice(end + 1))) {
+    return true
+  }
+  return !isPathCandidateContinuationChar(next)
+}
+
+function isPathCandidateContinuationChar(char: string): boolean {
+  return /[A-Za-z0-9._~/%+@\\()[\]-]/.test(char)
+}
+
+function decodeTerminalOutputPercentEscapes(value: string): string {
+  return value.replace(/(?:%[0-9a-f]{2})+/gi, (match) => {
+    try {
+      return decodeURIComponent(match)
+    } catch {
+      return match
+    }
+  })
+}
+
+// Why: the extension regex backtracks quadratically on the PTY hot path; candidates can't cross a newline, so scan per line and skip over-long lines (dropped anyway).
+function extractTerminalOutputPathCandidates(data: string): string[] {
+  const candidates: string[] = []
+  const add = (value: string): void => {
+    const candidate = trimTerminalOutputPathCandidate(value)
+    if (candidate.length > 0) {
+      candidates.push(candidate)
+      const drivePath = normalizeTerminalOutputFileUriDrivePath(candidate)
+      if (drivePath) {
+        candidates.push(drivePath)
+      }
+    }
+  }
+  for (const line of data.split(/[\r\n]+/)) {
+    if (line.length === 0 || line.length > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
+      continue
+    }
+    collectTerminalOutputLinePathCandidates(line, add)
+  }
+  return candidates
+}
+
+function collectTerminalOutputLinePathCandidates(line: string, add: (value: string) => void): void {
+  for (const match of line.matchAll(/file:\/\/([^/\s]*)(\/[^\s\x1b"'<>)]*)/gi)) {
+    const authority = match[1] ?? ''
+    const uriPath = match[2]
+    if (uriPath) {
+      const decoded = decodeTerminalOutputPercentEscapes(uriPath)
+      add(isTerminalOutputLoopbackAuthority(authority) ? decoded : `//${authority}${decoded}`)
+    }
+  }
+  for (const match of line.matchAll(
+    /(?:\/(?:tmp|private\/tmp)\/|[A-Za-z]:[\\/])[^\r\n\x1b"'<>]+/g
+  )) {
+    if (isInsideNonLocalFileUri(line, match.index)) {
+      continue
+    }
+    add(match[0])
+  }
+  for (const match of line.matchAll(
+    /\/[^\r\n\x1b"'<>]*\.[A-Za-z0-9_+-]+(?:[#:\s][^\r\n\x1b"'<>]*)?/g
+  )) {
+    if (isInsideNonLocalFileUri(line, match.index)) {
+      continue
+    }
+    add(match[0])
+  }
+}
+
+function normalizeTerminalOutputFileUriDrivePath(candidate: string): string | null {
+  return /^\/[A-Za-z]:[\\/]/.test(candidate) ? candidate.slice(1) : null
+}
+
+function trimTerminalOutputPathCandidate(value: string): string {
+  let candidate = value.trim().replace(/[),;.]+$/g, '')
+  if (Buffer.byteLength(candidate, 'utf8') > RECENT_PTY_PATH_CANDIDATE_MAX_BYTES) {
+    return ''
+  }
+  let selected: string | null = null
+  for (const match of candidate.matchAll(
+    /.+?\.[A-Za-z0-9_+-]+(?:#L\d+(?:C\d+)?|(?::\d+)?(?::\d+)?)?(?=\s+|$)/gi
+  )) {
+    const end = match.index + match[0].length
+    const text = candidate.slice(0, end)
+    if (countTerminalOutputPathStarts(text) > 1) {
+      continue
+    }
+    // Same as the tap parsers: a line-end token extends the candidate only when the added segment is path-like, so trailing prose isn't swallowed.
+    if (
+      end < candidate.length ||
+      selected === null ||
+      /[\\/]/.test(candidate.slice(selected.length, end))
+    ) {
+      selected = text
+    }
+  }
+  return trimTerminalOutputPathLocator(selected ?? candidate)
+}
+
+function isTerminalOutputLoopbackAuthority(authority: string): boolean {
+  const normalized = authority.toLowerCase()
+  return (
+    normalized === '' ||
+    normalized === 'localhost' ||
+    normalized === '127.0.0.1' ||
+    normalized === '::1' ||
+    normalized === '[::1]'
+  )
+}
+
+function isInsideNonLocalFileUri(output: string, pathStart: number): boolean {
+  const prefix = output.slice(0, pathStart)
+  const match = /file:\/\/([^/\s]*)$/i.exec(prefix)
+  return !!match && !isTerminalOutputLoopbackAuthority(match[1] ?? '')
+}
+
+function countTerminalOutputPathStarts(value: string): number {
+  let count = 0
+  for (const match of value.matchAll(/(?:^|\s)(?:~[\\/]|[\\/]|\.{1,2}[\\/]|[A-Za-z]:[\\/])/g)) {
+    void match
+    count += 1
+  }
+  return count
+}
+
+function trimTerminalOutputPathLocator(value: string): string {
+  return value.replace(/#L\d+(?:C\d+)?$/i, '').replace(/:\d+(?::\d+)?$/, '')
+}
+
+function wslTerminalOutputAliases(value: string): string[] {
+  const match = /^\\\\wsl(?:\.localhost|\$)\\[^\\]+(\\.*)$/i.exec(value)
+  if (!match) {
+    return []
+  }
+  const linuxPath = match[1]!.replace(/\\/g, '/')
+  return linuxPath.startsWith('/') ? [linuxPath] : [`/${linuxPath}`]
+}

--- a/src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-fit-restore.test.ts
@@ -45,36 +45,48 @@ describe('terminal-fit-restore', () => {
   })
 
   it('restores remote terminals through the environment runtime RPC', async () => {
-    vi.mocked(getRemoteRuntimeTerminalHandle).mockReturnValue('terminal-one')
-    vi.mocked(getRemoteRuntimePtyEnvironmentId).mockReturnValue('env-one')
-    vi.mocked(callRuntimeRpc).mockResolvedValue({ restored: true })
+    // Why: freeze Date.now so remaining deadline is exact (wall clock can drop 1ms).
+    vi.useFakeTimers()
+    try {
+      vi.mocked(getRemoteRuntimeTerminalHandle).mockReturnValue('terminal-one')
+      vi.mocked(getRemoteRuntimePtyEnvironmentId).mockReturnValue('env-one')
+      vi.mocked(callRuntimeRpc).mockResolvedValue({ restored: true })
 
-    await expect(restoreTerminalFitToDesktop('remote:pty-1', undefined)).resolves.toBe(true)
+      await expect(restoreTerminalFitToDesktop('remote:pty-1', undefined)).resolves.toBe(true)
 
-    expect(callRuntimeRpc).toHaveBeenCalledWith(
-      { kind: 'environment', environmentId: 'env-one' },
-      'terminal.restoreFit',
-      { terminal: 'terminal-one' },
-      { timeoutMs: 15_000 }
-    )
-    expect(restoreTerminalFit).not.toHaveBeenCalled()
+      expect(callRuntimeRpc).toHaveBeenCalledWith(
+        { kind: 'environment', environmentId: 'env-one' },
+        'terminal.restoreFit',
+        { terminal: 'terminal-one' },
+        { timeoutMs: 15_000 }
+      )
+      expect(restoreTerminalFit).not.toHaveBeenCalled()
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('uses the active runtime environment when the remote PTY has no encoded environment', async () => {
-    vi.mocked(getRemoteRuntimeTerminalHandle).mockReturnValue('terminal-two')
-    vi.mocked(getRemoteRuntimePtyEnvironmentId).mockReturnValue(null)
-    vi.mocked(callRuntimeRpc).mockResolvedValue({ restored: true })
+    // Why: freeze Date.now so remaining deadline is exact (wall clock can drop 1ms).
+    vi.useFakeTimers()
+    try {
+      vi.mocked(getRemoteRuntimeTerminalHandle).mockReturnValue('terminal-two')
+      vi.mocked(getRemoteRuntimePtyEnvironmentId).mockReturnValue(null)
+      vi.mocked(callRuntimeRpc).mockResolvedValue({ restored: true })
 
-    await expect(
-      restoreTerminalFitToDesktop('remote:pty-2', { activeRuntimeEnvironmentId: 'env-active' })
-    ).resolves.toBe(true)
+      await expect(
+        restoreTerminalFitToDesktop('remote:pty-2', { activeRuntimeEnvironmentId: 'env-active' })
+      ).resolves.toBe(true)
 
-    expect(callRuntimeRpc).toHaveBeenCalledWith(
-      { kind: 'environment', environmentId: 'env-active' },
-      'terminal.restoreFit',
-      { terminal: 'terminal-two' },
-      { timeoutMs: 15_000 }
-    )
+      expect(callRuntimeRpc).toHaveBeenCalledWith(
+        { kind: 'environment', environmentId: 'env-active' },
+        'terminal.restoreFit',
+        { terminal: 'terminal-two' },
+        { timeoutMs: 15_000 }
+      )
+    } finally {
+      vi.useRealTimers()
+    }
   })
 
   it('deduplicates bulk restore PTYs and succeeds when any restore succeeds', async () => {


### PR DESCRIPTION
## Summary

Mechanical extraction of three closed, pure module-scope clusters out of `orca-runtime.ts` into domain-named siblings to shrink the runtime god-file:

- `terminal-output-path-candidates.ts` — PTY output path harvesting and the recent-candidate history bound
- `selected-review-branch.ts` — forge-agnostic selected-review predicates and lookup hints (GitHub/GitLab/Bitbucket/Azure DevOps/Gitea)
- `runtime-folder-workspace.ts` — folder-workspace id math and the repo+meta → Worktree projection

Bodies are token-identical to their previous form; production changes are the moves, new imports, and `export` keywords only. Also freezes `Date.now` in remote terminal fit-restore unit tests so the remaining-deadline `timeoutMs` assertion is not flaky under wall-clock skew on CI.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (as applicable in CI)
- [x] `pnpm typecheck` (as applicable in CI)
- [x] `pnpm test` (fixed flaky `terminal-fit-restore` remote RPC timeout assertion)
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
  - Characterization tests for `runtime-folder-workspace` and `selected-review-branch`
  - Existing path-candidate tests repointed at the new module
  - Fit-restore tests use fake timers for exact deadline assertions

## AI Review Report

Reviewed as a pure mechanical extraction plus a CI flake fix. Checked that:

- Moved clusters remain pure module-scope helpers with no new side effects or control-flow changes
- Call sites in `orca-runtime.ts` import the extracted modules rather than leaving dead local copies
- Characterization tests cover the extracted predicates/id math
- Cross-platform: path-candidate scanning, forge review-branch predicates, and folder-workspace id math stay platform-agnostic (no new shortcut, shell, or Electron platform branches)

## Security Audit

No new attack surface. Extraction does not change input handling, command execution, path handling, auth, secrets, dependency graph, or IPC contracts. Path-candidate scanning retains its existing `no-control-regex` suppression where needed. Fit-restore change is test-only.

## Notes

- `orca-runtime.ts` line count drops (~37.6k → ~37.2k); no max-lines suppression was added
- Remote wire / Git provider behavior unchanged; selected-review helpers remain forge-agnostic