### PR TITLE
fix(windows): keep spaced batch launcher paths intact when spawning

### DIFF
--- a/src/cli/handlers/account.test.ts
+++ b/src/cli/handlers/account.test.ts
@@ -167,7 +167,7 @@ describe('account CLI handlers', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       getCmdExePath(),
-      ['/d', '/c', 'C:\\tools\\codex.cmd', 'login', '--device-auth'],
+      ['/d', '/c', '@', 'C:\\tools\\codex.cmd', 'login', '--device-auth'],
       expect.objectContaining({ stdio: ['inherit', 'inherit', 'inherit'] })
     )
   })
@@ -181,7 +181,7 @@ describe('account CLI handlers', () => {
 
     expect(spawnMock).toHaveBeenCalledWith(
       getCmdExePath(),
-      ['/d', '/c', shim, 'login', '--device-auth'],
+      ['/d', '/c', '@', shim, 'login', '--device-auth'],
       expect.anything()
     )
   })

--- a/src/cli/skills.test.ts
+++ b/src/cli/skills.test.ts
@@ -441,6 +441,7 @@ describe('orca skills CLI', () => {
       [
         '/d',
         '/c',
+        '@',
         'C:\\Program Files\\nodejs\\npx.cmd',
         '--yes',
         'skills',
@@ -709,7 +710,7 @@ describe('orca skills CLI', () => {
     await resultPromise
 
     expect(spawnMock.mock.calls[0]?.[0]).toBe('C:\\Windows\\System32\\cmd.exe')
-    expect(spawnMock.mock.calls[0]?.[1]?.slice(0, 3)).toEqual(['/d', '/c', npx])
+    expect(spawnMock.mock.calls[0]?.[1]?.slice(0, 4)).toEqual(['/d', '/c', '@', npx])
   })
 
   it('never puts the current directory on the child PATH when npx is unresolvable', async () => {

--- a/src/main/skills/skill-update-run.test.ts
+++ b/src/main/skills/skill-update-run.test.ts
@@ -311,7 +311,7 @@ describe('SkillUpdateRunner', () => {
       })
 
       expect(runner.start(['orca-cli']).started).toBe(true)
-      expect(spawnCalls[0]?.args.slice(0, 3)).toEqual(['/d', '/c', npx])
+      expect(spawnCalls[0]?.args.slice(0, 4)).toEqual(['/d', '/c', '@', npx])
     } finally {
       platform.mockRestore()
     }

--- a/src/main/text-generation/commit-message-text-generation.test.ts
+++ b/src/main/text-generation/commit-message-text-generation.test.ts
@@ -462,7 +462,7 @@ describe('discoverCommitMessageModelsLocal', () => {
     if (process.platform === 'win32') {
       expect(spawnMock).toHaveBeenCalledWith(
         expect.stringMatching(/cmd\.exe$/i),
-        ['/d', '/c', expect.stringMatching(/npx\.cmd$/i), 'cursor-agent', '--list-models'],
+        ['/d', '/c', '@', expect.stringMatching(/npx\.cmd$/i), 'cursor-agent', '--list-models'],
         expect.objectContaining({ windowsHide: true })
       )
     } else {
@@ -2028,7 +2028,7 @@ describe('generateCommitMessageFromContext', () => {
         })
         expect(spawnMock).toHaveBeenCalledWith(
           'C:\\Windows\\System32\\cmd.exe',
-          ['/d', '/c', 'C:/tools/agent.cmd'],
+          ['/d', '/c', '@', 'C:/tools/agent.cmd'],
           expect.objectContaining({
             cwd: 'C:\\repo',
             windowsHide: true

--- a/src/main/win32-utils.test.ts
+++ b/src/main/win32-utils.test.ts
@@ -1,4 +1,5 @@
-import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { spawnSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
 import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { describe, expect, it } from 'vitest'
@@ -11,6 +12,11 @@ import {
   resolveWindowsCommand,
   WINDOWS_BATCH_UNSAFE_CHARACTERS_LABEL
 } from './win32-utils'
+
+// Why: the exact pairing that breaks — a default VS Code install path needs
+// quoting, and so does the workspace path, which is what trips cmd.exe.
+const VS_CODE_SHIM = 'C:\\Users\\dev\\AppData\\Local\\Programs\\Microsoft VS Code\\bin\\code.cmd'
+const SPACED_WORKSPACE = 'C:\\Users\\dev\\Desktop Folder\\my project'
 
 function withPlatform<T>(platform: NodeJS.Platform, fn: () => T): T {
   const original = process.platform
@@ -69,9 +75,9 @@ describe('getSpawnArgsForWindows', () => {
           '--foo'
         ])
         expect(spawnCmd).toBe('C:\\Windows\\System32\\cmd.exe')
-        // Why: /d disables AutoRun; /c runs the batch command and exits.
-        // Separate argv entries avoid cmd.exe seeing Node-escaped quotes.
-        expect(spawnArgs).toEqual(['/d', '/c', 'C:\\tools\\codex.cmd', 'login', '--foo'])
+        // Why: /d disables AutoRun; /c runs the batch command and exits. `@`
+        // keeps the first character unquoted so cmd.exe never strips outer quotes.
+        expect(spawnArgs).toEqual(['/d', '/c', '@', 'C:\\tools\\codex.cmd', 'login', '--foo'])
       })
     } finally {
       if (originalComSpec === undefined) {
@@ -102,6 +108,7 @@ describe('getSpawnArgsForWindows', () => {
         getCmdExePath(),
         '/d',
         '/c',
+        '@',
         'C:\\Tools\\idea.cmd',
         'C:\\workspaces\\orca'
       ])
@@ -115,7 +122,7 @@ describe('getSpawnArgsForWindows', () => {
   it('keeps the waiting form for batch launches without detachedGui', () => {
     withPlatform('win32', () => {
       const { spawnArgs } = getSpawnArgsForWindows('C:\\Tools\\idea.cmd', ['C:\\workspaces\\orca'])
-      expect(spawnArgs).toEqual(['/d', '/c', 'C:\\Tools\\idea.cmd', 'C:\\workspaces\\orca'])
+      expect(spawnArgs).toEqual(['/d', '/c', '@', 'C:\\Tools\\idea.cmd', 'C:\\workspaces\\orca'])
     })
   })
 
@@ -143,6 +150,7 @@ describe('getSpawnArgsForWindows', () => {
       expect(spawnArgs).toEqual([
         '/d',
         '/c',
+        '@',
         'C:\\tools\\code.cmd',
         '--remote',
         'wsl+Ubuntu Preview',
@@ -150,6 +158,128 @@ describe('getSpawnArgsForWindows', () => {
       ])
     })
   })
+
+  it('keeps a space-bearing launcher path intact when an argument is also quoted', () => {
+    withPlatform('win32', () => {
+      const { spawnArgs } = getSpawnArgsForWindows(VS_CODE_SHIM, [SPACED_WORKSPACE])
+      expect(spawnArgs).toEqual(['/d', '/c', '@', VS_CODE_SHIM, SPACED_WORKSPACE])
+    })
+  })
+
+  it('keeps a space-bearing launcher path intact through the detached GUI form', () => {
+    withPlatform('win32', () => {
+      const { spawnArgs } = getSpawnArgsForWindows(VS_CODE_SHIM, [SPACED_WORKSPACE], {
+        detachedGui: true
+      })
+      // Why: `start` hands the inner cmd its own command line, so the inner
+      // `/c` needs the same bare leading token as the waiting form.
+      expect(spawnArgs).toEqual([
+        '/d',
+        '/c',
+        'start',
+        '',
+        '/B',
+        getCmdExePath(),
+        '/d',
+        '/c',
+        '@',
+        VS_CODE_SHIM,
+        SPACED_WORKSPACE
+      ])
+    })
+  })
+
+  // Why: argv-shape assertions cannot see the actual defect — cmd.exe re-parses
+  // the line libuv builds, so only a real spawn proves the launcher survives.
+  function withSpacedLauncher<T>(body: (launcher: string, tempDir: string) => T): T {
+    const tempDir = mkdtempSync(join(tmpdir(), 'orca-batch-spawn-'))
+    try {
+      const launcherDir = join(tempDir, 'Spaced Launcher Dir')
+      mkdirSync(launcherDir)
+      const launcher = join(launcherDir, 'edit.cmd')
+      writeFileSync(
+        launcher,
+        [
+          '@echo off',
+          'break>"%~dp0argv.txt"',
+          ':loop',
+          'if "%~1"=="" goto done',
+          // Why: the `arg=` prefix keeps a bare `/?` operand from being read as a
+          // help request by `echo` itself, which would log its usage text instead.
+          'echo arg=%~1>>"%~dp0argv.txt"',
+          'shift',
+          'goto loop',
+          ':done',
+          'exit /b 7',
+          ''
+        ].join('\r\n')
+      )
+      return body(launcher, tempDir)
+    } finally {
+      rmSync(tempDir, { recursive: true, force: true })
+    }
+  }
+
+  it.skipIf(process.platform !== 'win32')(
+    'round-trips arguments and the exit code through a real spaced-path .cmd',
+    () => {
+      withSpacedLauncher((launcher, tempDir) => {
+        const workspacePath = join(tempDir, 'my project')
+        mkdirSync(workspacePath)
+
+        const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(launcher, [workspacePath])
+        const result = spawnSync(spawnCmd, spawnArgs, { windowsHide: true })
+
+        expect(result.status).toBe(7)
+        expect(readFileSync(join(launcher, '..', 'argv.txt'), 'utf-8').trim()).toBe(
+          `arg=${workspacePath}`
+        )
+      })
+    }
+  )
+
+  // Why: `call` would satisfy the quoting fix too, but as an internal command it
+  // treats `/?` anywhere in the line as a request for its own help — silently
+  // swallowing the launch. `@` is not a command, so the operand reaches the shim.
+  it.skipIf(process.platform !== 'win32')(
+    'forwards a /? operand to the launcher instead of printing shell help',
+    () => {
+      withSpacedLauncher((launcher) => {
+        const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(launcher, ['/?'])
+        const result = spawnSync(spawnCmd, spawnArgs, { windowsHide: true })
+
+        expect(result.status).toBe(7)
+        expect(readFileSync(join(launcher, '..', 'argv.txt'), 'utf-8').trim()).toBe('arg=/?')
+      })
+    }
+  )
+
+  // Why: `call` reports the ERRORLEVEL live at end of script, so a shim ending on
+  // a statement after a benign failed probe would start reporting failure. The
+  // prefix must not change which exit code callers branching on status observe.
+  it.skipIf(process.platform !== 'win32')(
+    'leaves the exit code of a shim ending after a nonzero ERRORLEVEL unchanged',
+    () => {
+      const tempDir = mkdtempSync(join(tmpdir(), 'orca-batch-exit-'))
+      try {
+        const launcher = join(tempDir, 'probe.cmd')
+        // Why: `endlocal` after a failed probe is the shape real shims produce;
+        // the bare form reports the last statement's code, which is 0 here.
+        writeFileSync(
+          launcher,
+          ['@echo off', 'setlocal', 'cmd /c exit 9', 'endlocal', ''].join('\r\n')
+        )
+
+        const { spawnCmd, spawnArgs } = getSpawnArgsForWindows(launcher, [])
+        const wrapped = spawnSync(spawnCmd, spawnArgs, { windowsHide: true })
+        const direct = spawnSync(getCmdExePath(), ['/d', '/c', launcher], { windowsHide: true })
+
+        expect(wrapped.status).toBe(direct.status)
+      } finally {
+        rmSync(tempDir, { recursive: true, force: true })
+      }
+    }
+  )
 
   it('passes .exe through unchanged on win32', () => {
     withPlatform('win32', () => {
@@ -189,7 +319,7 @@ describe('getSpawnArgsForWindows', () => {
     withPlatform('win32', () => {
       expect(
         getSpawnArgsForWindows('C:\\tools\\agent.cmd', ['package,name;version']).spawnArgs
-      ).toEqual(['/d', '/c', 'C:\\tools\\agent.cmd', 'package,name;version'])
+      ).toEqual(['/d', '/c', '@', 'C:\\tools\\agent.cmd', 'package,name;version'])
     })
   })
 
@@ -200,10 +330,10 @@ describe('getSpawnArgsForWindows', () => {
       const npx = 'C:\\Program Files (x86)\\nodejs\\npx.cmd'
       expect(getSpawnArgsForWindows(npx, ['C:\\dev\\app (fork)'])).toEqual({
         spawnCmd: getCmdExePath(),
-        spawnArgs: ['/d', '/c', npx, 'C:\\dev\\app (fork)']
+        spawnArgs: ['/d', '/c', '@', npx, 'C:\\dev\\app (fork)']
       })
       expect(getSpawnArgsForWindows('C:\\tools\\agent.cmd', ['close)', '(open']).spawnArgs).toEqual(
-        ['/d', '/c', 'C:\\tools\\agent.cmd', 'close)', '(open']
+        ['/d', '/c', '@', 'C:\\tools\\agent.cmd', 'close)', '(open']
       )
     })
   })

--- a/src/shared/windows-batch-spawn.ts
+++ b/src/shared/windows-batch-spawn.ts
@@ -64,7 +64,14 @@ export function getSpawnArgsForWindows(
       }
     }
 
-    // Why: separate argv entries let Node quote spaces without breaking cmd.
+    // Why: `cmd /c` strips the line's outer quote pair unless exactly one token
+    // is quoted, severing a launcher whose own path needs quoting
+    // (`...\Microsoft VS Code\bin\code.cmd`). A leading `@` keeps the first
+    // character unquoted so the strip never fires. Not `call`: being an internal
+    // command it swallows a `/?` operand into its own help, and it reports the
+    // live ERRORLEVEL rather than the last statement's exit code.
+    const batchInvocation = ['@', command, ...args]
+
     if (options.detachedGui) {
       // Why: `start` launches a batch target through a nested `cmd /K`, which
       // stays resident after the script ends — `/B` only suppresses a *new*
@@ -80,10 +87,10 @@ export function getSpawnArgsForWindows(
       const cmdExePath = getCmdExePath()
       return {
         spawnCmd: cmdExePath,
-        spawnArgs: ['/d', '/c', 'start', '', '/B', cmdExePath, '/d', '/c', command, ...args]
+        spawnArgs: ['/d', '/c', 'start', '', '/B', cmdExePath, '/d', '/c', ...batchInvocation]
       }
     }
-    return { spawnCmd: getCmdExePath(), spawnArgs: ['/d', '/c', command, ...args] }
+    return { spawnCmd: getCmdExePath(), spawnArgs: ['/d', '/c', ...batchInvocation] }
   }
   return { spawnCmd: command, spawnArgs: args }
 }


### PR DESCRIPTION
## ELI5

To run a `.cmd` launcher, Orca hands a command line to `cmd.exe`, which re-reads it. `cmd.exe` has an old rule: unless a narrow set of conditions all hold, it throws away the first and last quote on the line.

Node quotes anything containing a space, so a launcher installed at `C:\…\Programs\Microsoft VS Code\bin\code.cmd` arrives quoted. As soon as a second thing on that line is quoted too — a workspace path with a space in it — the conditions stop holding, cmd strips the outer quotes, and the launcher gets cut off at its first space. cmd reports `'C:\…\Programs\Microsoft' is not recognized`.

Nobody sees that message. The launch is spawned with `stdio: 'ignore'`, and `cmd.exe` itself started fine, so Orca records success. **Open in → VS Code just does nothing** — no window, and not even the "Could not open workspace folder" toast that already exists for this. Both halves of the trigger are Windows defaults: VS Code's install path always has a space, and so does any workspace under `Desktop Folder` or a localized profile folder.

The fix puts a single `@` in front of the launcher so the line never *starts* with a quote, which is the condition that arms the stripping.

## Summary

- `src/shared/windows-batch-spawn.ts:73` — the batch invocation is now `['@', command, ...args]`. `@` is a cmd parser prefix, not a command, so it shifts the first character off the quote and changes nothing else.
- `src/shared/windows-batch-spawn.ts:90` — the `start /B` detached-GUI form had the identical defect one level down, since `start` hands the inner `cmd /c` its own command line beginning with the quoted launcher. Same prefix applied.
- Per `cmd /?` the preserving path needs *several* conditions together — among them exactly two quote characters, none of `&<>()@^|` between them, and the string between them naming an executable. That third clause means a launcher under `C:\Program Files (x86)\…` was broken even with no arguments, so this repairs more than the headline case.
- A launcher on a space-free path (`…\Programs\cursor\…\cursor.cmd`) is never quoted by Node, so its line never began with a quote and was never affected — which is why this reads as "VS Code specifically is dead".

Related: #5983 was the same user-visible symptom from a different cause (a configured command path misclassified as a compound shell command). Composes cleanly with the open #11384, which adds a PowerShell fallback inside the guard loop; this change is after it and the two do not touch the same lines.

## Why `@` and not `call`

`call` disarms the strip equally well and is the more obvious choice. It is also not behaviour-preserving, and both differences were measured against real `cmd.exe` rather than reasoned about:

- **It swallows a `/?` operand.** As an internal command, cmd's "`/?` in an internal command's arguments prints help" rule starts applying to the whole line. Against the real shim, `code.cmd /?` went from exit 0 with VS Code handling the flag, to exit 1 with `CALL`'s help text and no launch. Under `stdio: 'ignore'` that is a silent no-op — the exact failure mode this PR removes. Reachable wherever user CLI arguments are forwarded (`src/cli/handlers/skills.ts:126`, `src/cli/handlers/account.ts:96`).
- **It changes the reported exit code.** `cmd /c script.cmd` reports the last statement's code; `cmd /c call script.cmd` reports the live `ERRORLEVEL`. A shim ending on `endlocal` after a benign failed probe goes 0 → 9, which every caller branching on exit status would see.

`@` has neither property. Both differences are pinned by regression tests so the simplification is not made later by accident.

## Screenshots

No visual change. Measured against the real installed `code.cmd`, same argv shape the app builds:

```
BEFORE  cmd /d /c   <code.cmd> <spaced workspace>   exit 1, 'C:\…\Programs\Microsoft' is not recognized
AFTER   cmd /d /c @ <code.cmd> <spaced workspace>   exit 0, VS Code opens on the workspace
```

## Testing

- [x] `pnpm typecheck`
- [ ] `pnpm lint` — every individual gate passes; the chained command stops on the pre-existing stale generated skill manifests (`current-manifest.json`, `snapshot-registry.json`, `release-mapping.json`), which fail identically on a clean `main` and are untouched here
- [ ] `pnpm test` — `68 failed | 4474 passed | 33 skipped (4575)`; the failures need real native modules or spawned processes (SSH, PTY, daemon, relay, watchers) that this `--ignore-scripts` checkout cannot provide
- [ ] `pnpm build` — blocked by the same missing native rebuild; `build:electron-vite` runs clean separately
- [x] Added or updated high-quality tests that would catch regressions

`vitest run --config config/vitest.config.ts` over the five changed test files — 192 tests, 191 passing; the one failure (`writes the Claude list_models request to stdin`) also fails on the parent commit, because this machine has `claude.exe` on PATH and defeats a bare-name expectation.

Repo-wide, the exact failing set from the full run was executed twice under identical conditions — once with the change, once with only `windows-batch-spawn.ts` reverted — and the failing test names diffed: **0 fail only with the change**; 2 fail only on the reverted baseline, whose assertions encode the corrected argv.

**Verified failing on unfixed code.** Argv assertions were located by searching the `'/d', '/c'` shape rather than following imports — 15 files match, and the 5 asserting this helper's output were updated. Three of the five new tests are win32-gated real spawns, because argv shape structurally cannot catch this bug: cmd re-parses what libuv builds.

- reverting `windows-batch-spawn.ts` — `round-trips arguments and the exit code through a real spaced-path .cmd`: `AssertionError: expected 1 to be 7` (cmd's own "not recognized" exit, not the script's)
- substituting `call` for `@` — `forwards a /? operand to the launcher instead of printing shell help`: `AssertionError: expected 1 to be 7`
- substituting `call` for `@` — `leaves the exit code of a shim ending after a nonzero ERRORLEVEL unchanged`: `AssertionError: expected 9 to be +0`

## AI Review Report

Three independent passes: code/convention review, an adversarial pass attacking the fix against real `cmd.exe`, and a fact-check of this description.

The adversarial pass is what changed the patch: the first draft used `call`, and it found the two differences above. Review also deleted a test helper that could not fail (the token after each `/c` is a hardcoded literal, so it passed for every input) and replaced a `slice(-3)` assertion that would miss a regressed `start` prefix.

- **Cross-platform** — the change is inside `isWindowsBatchScript(command)`, already gated on `process.platform === 'win32'`; macOS and Linux return through the untouched pass-through. No Electron-specific differences are touched: this is a plain Node `child_process` argv helper in `src/shared/`.
- **SSH / remote / local** — the helper only runs for a local Windows batch launcher and carries no wire contract, so `remote-wire-compatibility.md` does not apply. Folder workspaces and worktrees are indistinguishable at this layer.
- **Callers** — 11 call sites across 10 modules, plus the injected `buildSpawnArgs` default in `skills/skill-update-run.ts:100`. All destructure `{ spawnCmd, spawnArgs }` and pass them straight to `spawn`; none indexes or persists them. `git/runner.ts` forwards them to telemetry, whose keys are unchanged because `classifySubprocessCommand` returns before scanning args when the command is `cmd`.
- **Performance** — one extra array element per batch spawn.

## Security Audit

The guard is untouched and still runs first, rejecting `& | < > ^ " % !`, `\r` and `\n` in the command and every argument. `@` is a parser prefix, so it adds no expansion or re-parse pass the bare form did not already have — verified with 20 payloads containing no guard-rejected character (fullwidth and homoglyph separators, C0/C1 controls, smart quotes, paren blocks, comma/semicolon/tab chains) run against plain and spaced launchers under both forms; none executed, all arrived as inert `%1`. Paths pass through unmodified as separate argv entries, with no new concatenation or shell rendering, and `getCmdExePath()` resolves `ComSpec` as before. No auth, secrets, IPC, permission or dependency changes.

## Notes

- Windows-only behaviour change.
- Out of scope, same symptom, separate path: `buildShellLaunchSpec` in `external-editor-launch.ts:177` builds `['/d','/s','/c', shellCommand]` and is spawned without `windowsVerbatimArguments`, so libuv escapes its embedded quotes to `\"` and a compound editor command plus a spaced path fails the same silent way. Fixing it changes what `resolveExternalEditorSpawn` returns, so it deserves its own PR — happy to follow up. (`relay/agent-exec-handler.ts` has the same shape; `claude-accounts/windows-command-invocation.ts` and `ssh/ssh-proxy-command.ts` pair `/s` with verbatim correctly.)
- Also noted, not fixed: `launchExternalEditor` treats a successful `spawn` of `cmd.exe` as a successful launch, which is why this surfaced as silence rather than the existing toast.
- Reproduced on Windows 11, VS Code 1.132.0 at the default per-user install path, workspace under a localized Desktop folder.
