### PR TITLE
[Perf-SS] Keep shutdown rollback buffering linear under saturation

### DIFF
--- a/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.test.ts
@@ -3,12 +3,16 @@ import {
   bufferPtyShutdownData,
   bufferPtyShutdownReplayData,
   drainRolledBackPtyShutdownData,
+  isPtyDataHandlerShutdownPending,
   ptyDataHandlers,
+  ptyDataSidecars,
   ptyReplayHandlers,
   ptyShutdownLifecycleHandlers,
   ptyTeardownHandlers,
   unregisterPtyDataHandlers
 } from './pty-shutdown-data-suspension'
+import { bufferPreHandlerPtyData } from './pty-pre-handler-buffer'
+import { PtyShutdownOutputQueue } from './pty-shutdown-output-queue'
 
 it('does not remove handlers installed by a remount while sleep is pending', () => {
   const ptyId = 'pty-shutdown-remount'
@@ -33,16 +37,45 @@ it('does not remove handlers installed by a remount while sleep is pending', () 
 it('replays rollback output in its original replay and live arrival order', () => {
   const ptyId = 'pty-shutdown-output-order'
   const delivered: string[] = []
+  const meta = { seq: 9, rawLength: 3, transformed: true }
+  const sidecar = vi.fn((data: string) => delivered.push(`sidecar:${data}`))
   ptyDataHandlers.set(ptyId, (data) => delivered.push(`data:${data}`))
   ptyReplayHandlers.set(ptyId, (data) => delivered.push(`replay:${data}`))
+  ptyDataSidecars.set(ptyId, new Set([sidecar]))
 
   const [snapshot] = unregisterPtyDataHandlers([ptyId])
   bufferPtyShutdownReplayData(ptyId, 'old')
-  bufferPtyShutdownData(ptyId, 'new')
+  bufferPtyShutdownData(ptyId, 'new', meta)
   snapshot.rollback()
 
-  expect(delivered).toEqual(['replay:old', 'data:new'])
+  expect(delivered).toEqual(['replay:old', 'data:new', 'sidecar:new'])
+  expect(sidecar).toHaveBeenCalledOnce()
   ptyDataHandlers.delete(ptyId)
+  ptyDataSidecars.delete(ptyId)
+  ptyReplayHandlers.delete(ptyId)
+})
+
+it('drains pre-handler data before ordered shutdown output', () => {
+  const ptyId = 'pty-shutdown-pre-handler-order'
+  const delivered: string[] = []
+  const preHandlerMeta = { seq: 1, rawLength: 3 }
+  const shutdownMeta = { seq: 2, rawLength: 4, background: true }
+  const dataHandler = vi.fn((data: string) => delivered.push(`data:${data}`))
+  ptyDataHandlers.set(ptyId, dataHandler)
+  ptyReplayHandlers.set(ptyId, (data) => delivered.push(`replay:${data}`))
+  ptyDataSidecars.set(ptyId, new Set([(data) => delivered.push(`sidecar:${data}`)]))
+
+  const [snapshot] = unregisterPtyDataHandlers([ptyId])
+  bufferPreHandlerPtyData(ptyId, 'pre', preHandlerMeta)
+  bufferPtyShutdownReplayData(ptyId, 'old')
+  bufferPtyShutdownData(ptyId, 'live', shutdownMeta)
+  snapshot.rollback()
+
+  expect(delivered).toEqual(['data:pre', 'sidecar:pre', 'replay:old', 'data:live', 'sidecar:live'])
+  expect(dataHandler).toHaveBeenNthCalledWith(1, 'pre', preHandlerMeta)
+  expect(dataHandler).toHaveBeenNthCalledWith(2, 'live', shutdownMeta)
+  ptyDataHandlers.delete(ptyId)
+  ptyDataSidecars.delete(ptyId)
   ptyReplayHandlers.delete(ptyId)
 })
 
@@ -50,27 +83,65 @@ it('retains ordered rollback output across detach and another pending shutdown',
   const ptyId = 'pty-shutdown-detached-overlap'
   const originalData = vi.fn()
   const originalReplay = vi.fn()
+  const drain = vi.spyOn(PtyShutdownOutputQueue.prototype, 'drain')
+  const encode = vi.spyOn(TextEncoder.prototype, 'encode')
   ptyDataHandlers.set(ptyId, originalData)
   ptyReplayHandlers.set(ptyId, originalReplay)
 
   const [first] = unregisterPtyDataHandlers([ptyId])
   ptyDataHandlers.delete(ptyId)
   ptyReplayHandlers.delete(ptyId)
-  bufferPtyShutdownData(ptyId, 'live-first')
+  const meta = { seq: 3, rawLength: 10, transformed: true }
+  bufferPtyShutdownData(ptyId, 'live-first', meta)
   bufferPtyShutdownReplayData(ptyId, 'replay-second')
   first.rollback()
+  expect(drain).not.toHaveBeenCalled()
 
   const [second] = unregisterPtyDataHandlers([ptyId])
+  expect(encode).not.toHaveBeenCalled()
   const delivered: string[] = []
-  ptyDataHandlers.set(ptyId, (data) => delivered.push(`data:${data}`))
+  const replacementData = vi.fn((data: string) => delivered.push(`data:${data}`))
+  ptyDataHandlers.set(ptyId, replacementData)
   ptyReplayHandlers.set(ptyId, (data) => delivered.push(`replay:${data}`))
   drainRolledBackPtyShutdownData(ptyId)
   expect(delivered).toEqual([])
+  expect(drain).not.toHaveBeenCalled()
 
   second.rollback()
   expect(delivered).toEqual(['data:live-first', 'replay:replay-second'])
+  expect(replacementData).toHaveBeenCalledWith('live-first', meta)
+  expect(drain).toHaveBeenCalledOnce()
+  drain.mockRestore()
+  encode.mockRestore()
   ptyDataHandlers.delete(ptyId)
   ptyReplayHandlers.delete(ptyId)
   ptyTeardownHandlers.delete(ptyId)
   ptyShutdownLifecycleHandlers.delete(ptyId)
+})
+
+it('detaches the delivered batch from a reentrant shutdown queue', () => {
+  const ptyId = 'pty-shutdown-reentrant-delivery'
+  const delivered: string[] = []
+  let reentrantSnapshot: ReturnType<typeof unregisterPtyDataHandlers>[number] | undefined
+  ptyDataHandlers.set(ptyId, (data) => {
+    delivered.push(data)
+    if (data === 'old-first') {
+      reentrantSnapshot = unregisterPtyDataHandlers([ptyId])[0]
+      bufferPtyShutdownData(ptyId, 'new-pending')
+    }
+  })
+  ptyReplayHandlers.set(ptyId, vi.fn())
+
+  const [first] = unregisterPtyDataHandlers([ptyId])
+  bufferPtyShutdownData(ptyId, 'old-first')
+  bufferPtyShutdownData(ptyId, 'old-second')
+  first.rollback()
+
+  expect(delivered).toEqual(['old-first', 'old-second'])
+  expect(isPtyDataHandlerShutdownPending(ptyId)).toBe(true)
+  reentrantSnapshot?.rollback()
+  expect(delivered).toEqual(['old-first', 'old-second', 'new-pending'])
+  expect(isPtyDataHandlerShutdownPending(ptyId)).toBe(false)
+  ptyDataHandlers.delete(ptyId)
+  ptyReplayHandlers.delete(ptyId)
 })

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-data-suspension.ts
@@ -1,7 +1,6 @@
-import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
-import { clampUtf8Tail } from './pty-eager-buffer-clamp'
 import { clearPreHandlerPtyState, drainPreHandlerPtyData } from './pty-pre-handler-buffer'
 import type { PtyDataMeta } from './pty-dispatcher'
+import { PtyShutdownOutputQueue, type PtyShutdownOutputEvent } from './pty-shutdown-output-queue'
 
 export const ptyDataHandlers = new Map<string, (data: string, meta?: PtyDataMeta) => void>()
 export const ptyDataSidecars = new Map<string, Set<(data: string) => void>>()
@@ -25,8 +24,7 @@ export type PtyDataHandlerShutdownSnapshot = {
 type PendingPtyHandlerShutdown = {
   owners: number
   committed: boolean
-  bufferedBytes: number
-  events: PtyShutdownOutputEvent[]
+  outputQueue: PtyShutdownOutputQueue
   dataHandler?: (data: string, meta?: PtyDataMeta) => void
   replayHandler?: (data: string) => void
   teardownHandler?: () => void
@@ -34,13 +32,8 @@ type PendingPtyHandlerShutdown = {
 }
 
 const pendingPtyHandlerShutdowns = new Map<string, PendingPtyHandlerShutdown>()
-type PtyShutdownOutputEvent =
-  | { kind: 'data'; data: string; meta?: PtyDataMeta }
-  | { kind: 'replay'; data: string }
-
-const rolledBackShutdownEvents = new Map<string, PtyShutdownOutputEvent[]>()
+const rolledBackShutdownEvents = new Map<string, PtyShutdownOutputQueue>()
 const ROLLED_BACK_SHUTDOWN_REPLAY_MAX_PTYS = 64
-const shutdownBufferTextEncoder = new TextEncoder()
 
 /** Suspend delivery until every overlapping shutdown owner commits or rolls back. */
 export function unregisterPtyDataHandlers(ptyIds: string[]): PtyDataHandlerShutdownSnapshot[] {
@@ -50,16 +43,12 @@ export function unregisterPtyDataHandlers(ptyIds: string[]): PtyDataHandlerShutd
     if (pending) {
       pending.owners += 1
     } else {
-      const retainedEvents = rolledBackShutdownEvents.get(id) ?? []
+      const outputQueue = rolledBackShutdownEvents.get(id) ?? new PtyShutdownOutputQueue()
       rolledBackShutdownEvents.delete(id)
       pending = {
         owners: 1,
         committed: false,
-        bufferedBytes: retainedEvents.reduce(
-          (total, event) => total + shutdownBufferTextEncoder.encode(event.data).byteLength,
-          0
-        ),
-        events: retainedEvents,
+        outputQueue,
         dataHandler: ptyDataHandlers.get(id),
         replayHandler: ptyReplayHandlers.get(id),
         teardownHandler: ptyTeardownHandlers.get(id),
@@ -113,17 +102,7 @@ function bufferPtyShutdownOutput(ptyId: string, event: PtyShutdownOutputEvent): 
   if (!pending) {
     return false
   }
-  const clamped = clampUtf8Tail(event.data, TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT)
-  pending.events.push({ ...event, data: clamped.data })
-  pending.bufferedBytes += clamped.bytes
-  while (
-    pending.bufferedBytes > TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT &&
-    pending.events.length > 1
-  ) {
-    pending.bufferedBytes -= shutdownBufferTextEncoder.encode(
-      pending.events.shift()?.data ?? ''
-    ).byteLength
-  }
+  pending.outputQueue.enqueue(event)
   return true
 }
 
@@ -131,14 +110,14 @@ export function drainRolledBackPtyShutdownData(ptyId: string): void {
   if (pendingPtyHandlerShutdowns.has(ptyId)) {
     return
   }
-  const events = rolledBackShutdownEvents.get(ptyId)
+  const outputQueue = rolledBackShutdownEvents.get(ptyId)
   const dataHandler = ptyDataHandlers.get(ptyId)
   const replayHandler = ptyReplayHandlers.get(ptyId)
-  if (!events || !dataHandler || !replayHandler) {
+  if (!outputQueue || !dataHandler || !replayHandler) {
     return
   }
   rolledBackShutdownEvents.delete(ptyId)
-  deliverShutdownEvents(ptyId, events, dataHandler, replayHandler)
+  outputQueue.drain((event) => deliverShutdownEvent(ptyId, event, dataHandler, replayHandler))
 }
 
 function settlePtyDataHandlerShutdown(ptyId: string, committed: boolean): void {
@@ -154,6 +133,7 @@ function settlePtyDataHandlerShutdown(ptyId: string, committed: boolean): void {
   pendingPtyHandlerShutdowns.delete(ptyId)
   if (pending.committed) {
     rolledBackShutdownEvents.delete(ptyId)
+    pending.outputQueue.discard()
     pending.lifecycleHandler?.commit()
     deleteCapturedHandler(ptyDataHandlers, ptyId, pending.dataHandler)
     deleteCapturedHandler(ptyReplayHandlers, ptyId, pending.replayHandler)
@@ -173,10 +153,12 @@ function settlePtyDataHandlerShutdown(ptyId: string, committed: boolean): void {
   const dataHandler = ptyDataHandlers.get(ptyId)
   const replayHandler = ptyReplayHandlers.get(ptyId)
   if (dataHandler && replayHandler) {
-    deliverShutdownEvents(ptyId, pending.events, dataHandler, replayHandler)
-  } else if (pending.events.length > 0) {
+    pending.outputQueue.drain((event) =>
+      deliverShutdownEvent(ptyId, event, dataHandler, replayHandler)
+    )
+  } else if (pending.outputQueue.length > 0) {
     // Why: a hidden pane can detach during the RPC; retain rollback output until both ordered channels reattach.
-    rolledBackShutdownEvents.set(ptyId, pending.events)
+    rolledBackShutdownEvents.set(ptyId, pending.outputQueue)
     while (rolledBackShutdownEvents.size > ROLLED_BACK_SHUTDOWN_REPLAY_MAX_PTYS) {
       const oldestPtyId = rolledBackShutdownEvents.keys().next().value
       if (typeof oldestPtyId !== 'string') {
@@ -197,20 +179,18 @@ function deleteCapturedHandler<T>(
   }
 }
 
-function deliverShutdownEvents(
+function deliverShutdownEvent(
   ptyId: string,
-  events: readonly PtyShutdownOutputEvent[],
+  event: PtyShutdownOutputEvent,
   dataHandler: (data: string, meta?: PtyDataMeta) => void,
   replayHandler: (data: string) => void
 ): void {
-  for (const event of events) {
-    if (event.kind === 'replay') {
-      replayHandler(event.data)
-      continue
-    }
-    dataHandler(event.data, event.meta)
-    for (const sidecar of Array.from(ptyDataSidecars.get(ptyId) ?? [])) {
-      sidecar(event.data)
-    }
+  if (event.kind === 'replay') {
+    replayHandler(event.data)
+    return
+  }
+  dataHandler(event.data, event.meta)
+  for (const sidecar of Array.from(ptyDataSidecars.get(ptyId) ?? [])) {
+    sidecar(event.data)
   }
 }

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-output-queue.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-output-queue.test.ts
@@ -1,0 +1,290 @@
+import { describe, expect, it } from 'vitest'
+import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
+import { clampUtf8Tail } from './pty-eager-buffer-clamp'
+import { PtyShutdownOutputQueue, type PtyShutdownOutputEvent } from './pty-shutdown-output-queue'
+
+const BYTE_LIMIT = TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT
+const CHUNK_SIZE = 64
+
+class ReferenceShutdownOutputQueue {
+  private events: PtyShutdownOutputEvent[] = []
+  private retainedBytes = 0
+  private readonly encoder = new TextEncoder()
+
+  enqueue(event: PtyShutdownOutputEvent): void {
+    const clamped = clampUtf8Tail(event.data, BYTE_LIMIT)
+    this.events.push({ ...event, data: clamped.data })
+    this.retainedBytes += clamped.bytes
+    while (this.retainedBytes > BYTE_LIMIT && this.events.length > 1) {
+      this.retainedBytes -= this.encoder.encode(this.events.shift()?.data ?? '').byteLength
+    }
+  }
+
+  takeAll(): PtyShutdownOutputEvent[] {
+    const events = this.events
+    this.events = []
+    this.retainedBytes = 0
+    return events
+  }
+}
+
+function createSeededRandom(seed: number): () => number {
+  let state = seed >>> 0
+  return () => {
+    state ^= state << 13
+    state ^= state >>> 17
+    state ^= state << 5
+    return state >>> 0
+  }
+}
+
+function createDifferentialData(value: number): string {
+  const bucket = value % 100
+  if (bucket < 8) {
+    return ''
+  }
+  if (bucket < 48) {
+    return String.fromCharCode(65 + (value % 26)).repeat(value % 513)
+  }
+  if (bucket < 70) {
+    return '界'.repeat(value % 257)
+  }
+  if (bucket < 88) {
+    return '😀'.repeat(value % 129)
+  }
+  if (bucket < 96) {
+    return `\ud800${'x'.repeat(value % 511)}`
+  }
+  return String.fromCharCode(65 + (value % 26)).repeat(64 * 1024)
+}
+
+describe('PTY shutdown output queue', () => {
+  it('does not shift or re-encode retained events while saturated', () => {
+    const originalShift = Array.prototype.shift
+    const originalEncode = TextEncoder.prototype.encode
+    const queue = new PtyShutdownOutputQueue()
+
+    try {
+      Object.defineProperties(Array.prototype, {
+        shift: {
+          configurable: true,
+          writable: true,
+          value() {
+            throw new Error('Array.shift should not run on enqueue')
+          }
+        }
+      })
+      Object.defineProperties(TextEncoder.prototype, {
+        encode: {
+          configurable: true,
+          writable: true,
+          value() {
+            throw new Error('TextEncoder.encode should not run on enqueue')
+          }
+        }
+      })
+      for (let index = 0; index < 1_536; index += 1) {
+        queue.enqueue({ kind: 'data', data: 'x'.repeat(1_024), meta: { seq: index } })
+      }
+    } finally {
+      Object.defineProperties(Array.prototype, {
+        shift: { configurable: true, writable: true, value: originalShift }
+      })
+      Object.defineProperties(TextEncoder.prototype, {
+        encode: { configurable: true, writable: true, value: originalEncode }
+      })
+    }
+
+    expect(queue.takeAll()).toHaveLength(512)
+  })
+
+  it('keeps exact UTF-8 boundaries, Unicode tails, and metadata identity', () => {
+    const boundaryQueue = new PtyShutdownOutputQueue()
+    const emptyMeta = { rawLength: 9, transformed: true, droppedOutput: true }
+    boundaryQueue.enqueue({ kind: 'replay', data: 'a'.repeat(BYTE_LIMIT) })
+    boundaryQueue.enqueue({ kind: 'data', data: '', meta: emptyMeta })
+    expect(boundaryQueue.getStorageForTest()).toMatchObject({
+      retainedBytes: BYTE_LIMIT,
+      retainedEvents: 2
+    })
+    boundaryQueue.enqueue({ kind: 'replay', data: 'b' })
+
+    const boundary = boundaryQueue.takeAll()
+    expect(boundary).toEqual([
+      { kind: 'data', data: '', meta: emptyMeta },
+      { kind: 'replay', data: 'b' }
+    ])
+    expect(boundary[0]?.kind === 'data' ? boundary[0].meta : undefined).toBe(emptyMeta)
+
+    const unicodeQueue = new PtyShutdownOutputQueue()
+    const emojiTail = '😀'.repeat(BYTE_LIMIT / 4)
+    const unicodeMeta = { seq: 7, rawLength: emojiTail.length + 1, background: true }
+    unicodeQueue.enqueue({ kind: 'data', data: `P${emojiTail}`, meta: unicodeMeta })
+    const [unicode] = unicodeQueue.takeAll()
+    expect(unicode?.data).toBe(emojiTail)
+    expect(unicode?.kind === 'data' ? unicode.meta : undefined).toBe(unicodeMeta)
+
+    const loneSurrogateQueue = new PtyShutdownOutputQueue()
+    const loneSurrogateTail = `\ud800${'z'.repeat(BYTE_LIMIT - 3)}`
+    loneSurrogateQueue.enqueue({ kind: 'replay', data: `P${loneSurrogateTail}` })
+    expect(loneSurrogateQueue.takeAll()[0]?.data).toBe(loneSurrogateTail)
+  })
+
+  it('evicts whole oldest events without merging replay and live boundaries', () => {
+    const queue = new PtyShutdownOutputQueue()
+    const meta = { seq: 42, rawLength: BYTE_LIMIT - 3, transformed: true }
+    queue.enqueue({ kind: 'replay', data: 'old' })
+    queue.enqueue({ kind: 'data', data: 'x'.repeat(BYTE_LIMIT - 3), meta })
+    queue.enqueue({ kind: 'replay', data: 'new' })
+
+    const retained = queue.takeAll()
+    expect(retained).toEqual([
+      { kind: 'data', data: 'x'.repeat(BYTE_LIMIT - 3), meta },
+      { kind: 'replay', data: 'new' }
+    ])
+    expect(retained[0]?.kind === 'data' ? retained[0].meta : undefined).toBe(meta)
+  })
+
+  it('retains zero-byte event boundaries without imposing a count cap', () => {
+    const queue = new PtyShutdownOutputQueue()
+    for (let index = 0; index < 4_097; index += 1) {
+      queue.enqueue({ kind: 'data', data: '', meta: { seq: index, transformed: true } })
+    }
+
+    expect(queue.getStorageForTest()).toMatchObject({
+      retainedBytes: 0,
+      retainedEvents: 4_097
+    })
+    const retained = queue.takeAll()
+    expect(retained).toHaveLength(4_097)
+    expect(retained[0]).toEqual({ kind: 'data', data: '', meta: { seq: 0, transformed: true } })
+    expect(retained.at(-1)).toEqual({
+      kind: 'data',
+      data: '',
+      meta: { seq: 4_096, transformed: true }
+    })
+  })
+
+  it('repeatedly compacts cleared prefixes and resets transferred storage', () => {
+    const queue = new PtyShutdownOutputQueue()
+    const fullEvent = '界'.repeat(Math.floor(BYTE_LIMIT / 3))
+    for (let index = 0; index < 513; index += 1) {
+      queue.enqueue({ kind: 'replay', data: fullEvent })
+      const storage = queue.getStorageForTest()
+      expect(storage.retainedEvents).toBe(1)
+      expect(storage.retainedBytes).toBe(BYTE_LIMIT - 2)
+      expect(storage.backingLength).toBeLessThanOrEqual(CHUNK_SIZE)
+      expect(storage.byteBackingLength).toBeLessThanOrEqual(CHUNK_SIZE)
+    }
+
+    expect(queue.takeAll()).toEqual([{ kind: 'replay', data: fullEvent }])
+    expect(queue.getStorageForTest()).toEqual({
+      backingLength: 0,
+      byteBackingLength: 0,
+      chunkBackingLength: 0,
+      head: 0,
+      headChunk: 0,
+      retainedBytes: 0,
+      retainedEvents: 0
+    })
+
+    queue.enqueue({ kind: 'data', data: 'discarded' })
+    queue.discard()
+    expect(queue.takeAll()).toEqual([])
+  })
+
+  it('releases dead backing storage under release-scale one-byte churn', () => {
+    const queue = new PtyShutdownOutputQueue()
+    for (let index = 0; index < BYTE_LIMIT + CHUNK_SIZE * 3 + 17; index += 1) {
+      queue.enqueue({ kind: 'replay', data: 'x' })
+    }
+
+    const storage = queue.getStorageForTest()
+    expect(storage.retainedEvents).toBe(BYTE_LIMIT)
+    expect(storage.retainedBytes).toBe(BYTE_LIMIT)
+    expect(storage.backingLength - storage.retainedEvents).toBeLessThan(CHUNK_SIZE)
+    expect(storage.byteBackingLength).toBe(0)
+    expect(storage.head).toBeLessThan(CHUNK_SIZE)
+    expect(storage.headChunk).toBeLessThan(storage.chunkBackingLength)
+  })
+
+  it('repeatedly compacts the consumed chunk cursor', () => {
+    const queue = new PtyShutdownOutputQueue()
+    const data = 'x'.repeat(BYTE_LIMIT / CHUNK_SIZE)
+    for (let index = 0; index < CHUNK_SIZE; index += 1) {
+      queue.enqueue({ kind: 'replay', data })
+    }
+
+    for (let cycle = 0; cycle < 3; cycle += 1) {
+      for (let index = 0; index < CHUNK_SIZE * CHUNK_SIZE; index += 1) {
+        queue.enqueue({ kind: 'replay', data })
+      }
+      expect(queue.getStorageForTest()).toEqual({
+        backingLength: CHUNK_SIZE,
+        byteBackingLength: 0,
+        chunkBackingLength: 1,
+        head: 0,
+        headChunk: 0,
+        retainedBytes: BYTE_LIMIT,
+        retainedEvents: CHUNK_SIZE
+      })
+    }
+  })
+
+  it('recounts a returned Unicode event after mutation and re-enqueue', () => {
+    const queue = new PtyShutdownOutputQueue()
+    const reference = new ReferenceShutdownOutputQueue()
+    const unicode: PtyShutdownOutputEvent = { kind: 'replay', data: '界' }
+    queue.enqueue(unicode)
+    reference.enqueue(unicode)
+    const returned = queue.takeAll()[0]
+    const referenceReturned = reference.takeAll()[0]
+    if (!returned || !referenceReturned) {
+      throw new Error('Expected queued events')
+    }
+    returned.data = 'x'
+    referenceReturned.data = 'x'
+    queue.enqueue(returned)
+    reference.enqueue(referenceReturned)
+    const newest: PtyShutdownOutputEvent = { kind: 'data', data: 'y'.repeat(BYTE_LIMIT) }
+    queue.enqueue(newest)
+    reference.enqueue(newest)
+    expect(queue.getStorageForTest().retainedBytes).toBe(BYTE_LIMIT)
+    const overflow: PtyShutdownOutputEvent = { kind: 'replay', data: 'z' }
+    queue.enqueue(overflow)
+    reference.enqueue(overflow)
+
+    expect(queue.takeAll()).toEqual(reference.takeAll())
+  })
+
+  it('matches the previous algorithm across a seeded adversarial stream', () => {
+    const queue = new PtyShutdownOutputQueue()
+    const reference = new ReferenceShutdownOutputQueue()
+    const random = createSeededRandom(0x15c0ffee)
+
+    for (let index = 0; index < 5_000; index += 1) {
+      const value = random()
+      const data = createDifferentialData(value)
+      const event: PtyShutdownOutputEvent =
+        value % 3 === 0
+          ? { kind: 'replay', data }
+          : {
+              kind: 'data',
+              data,
+              meta: {
+                seq: index,
+                rawLength: data.length + (value % 5),
+                transformed: value % 2 === 0,
+                ...(value % 7 === 0 ? { background: true } : {}),
+                ...(value % 97 === 0 ? { droppedOutput: true } : {})
+              }
+            }
+      queue.enqueue(event)
+      reference.enqueue(event)
+
+      if ((index + 1) % 1_000 === 0) {
+        expect(queue.takeAll()).toEqual(reference.takeAll())
+      }
+    }
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-shutdown-output-queue.ts
+++ b/src/renderer/src/components/terminal-pane/pty-shutdown-output-queue.ts
@@ -1,0 +1,149 @@
+import { TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT } from '../../../../shared/terminal-scrollback-limits'
+import { clampUtf8Tail } from './pty-eager-buffer-clamp'
+import type { PtyDataMeta } from './pty-dispatcher'
+
+const EVENT_CHUNK_SIZE = 64
+const COMPACTION_MIN_HEAD_CHUNKS = 64
+
+export type PtyShutdownOutputEvent =
+  | { kind: 'data'; data: string; meta?: PtyDataMeta }
+  | { kind: 'replay'; data: string }
+
+type PtyShutdownOutputChunk = {
+  events: (PtyShutdownOutputEvent | undefined)[]
+  eventBytes?: Uint32Array
+}
+
+export type PtyShutdownOutputQueueStorage = {
+  backingLength: number
+  byteBackingLength: number
+  chunkBackingLength: number
+  head: number
+  headChunk: number
+  retainedBytes: number
+  retainedEvents: number
+}
+
+export class PtyShutdownOutputQueue {
+  private chunks: (PtyShutdownOutputChunk | undefined)[] = []
+  private headChunk = 0
+  private headOffset = 0
+  private retainedBytes = 0
+  private retainedEvents = 0
+
+  enqueue(event: PtyShutdownOutputEvent): void {
+    const clamped = clampUtf8Tail(event.data, TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT)
+    let tail = this.chunks.at(-1)
+    if (!tail || tail.events.length >= EVENT_CHUNK_SIZE) {
+      tail = { events: [] }
+      this.chunks.push(tail)
+    }
+    const tailOffset = tail.events.length
+    tail.events.push({ ...event, data: clamped.data })
+    if (clamped.bytes !== clamped.data.length) {
+      tail.eventBytes ??= new Uint32Array(EVENT_CHUNK_SIZE)
+      tail.eventBytes[tailOffset] = clamped.bytes
+    }
+    this.retainedBytes += clamped.bytes
+    this.retainedEvents += 1
+
+    while (this.length > 1 && this.retainedBytes > TERMINAL_SCROLLBACK_SESSION_BUFFER_BYTE_LIMIT) {
+      this.evictOldest()
+    }
+  }
+
+  takeAll(): PtyShutdownOutputEvent[] {
+    const events: PtyShutdownOutputEvent[] = []
+    this.drain((event) => events.push(event))
+    return events
+  }
+
+  drain(consumer: (event: PtyShutdownOutputEvent) => void): void {
+    const chunks = this.chunks
+    const headChunk = this.headChunk
+    const headOffset = this.headOffset
+    this.reset()
+    for (let chunkIndex = headChunk; chunkIndex < chunks.length; chunkIndex += 1) {
+      const chunk = chunks[chunkIndex]
+      if (!chunk) {
+        continue
+      }
+      const start = chunkIndex === headChunk ? headOffset : 0
+      for (let eventIndex = start; eventIndex < chunk.events.length; eventIndex += 1) {
+        const event = chunk.events[eventIndex]
+        if (event) {
+          consumer(event)
+        }
+      }
+    }
+  }
+
+  discard(): void {
+    this.reset()
+  }
+
+  get length(): number {
+    return this.retainedEvents
+  }
+
+  getStorageForTest(): PtyShutdownOutputQueueStorage {
+    let backingLength = 0
+    let byteBackingLength = 0
+    for (const chunk of this.chunks) {
+      if (chunk) {
+        backingLength += chunk.events.length
+        byteBackingLength += chunk.eventBytes?.length ?? 0
+      }
+    }
+    return {
+      backingLength,
+      byteBackingLength,
+      chunkBackingLength: this.chunks.length,
+      head: this.headOffset,
+      headChunk: this.headChunk,
+      retainedBytes: this.retainedBytes,
+      retainedEvents: this.length
+    }
+  }
+
+  private evictOldest(): void {
+    const chunk = this.chunks[this.headChunk]
+    if (!chunk) {
+      throw new Error('Missing PTY shutdown output queue chunk')
+    }
+    const event = chunk.events[this.headOffset]
+    if (!event) {
+      throw new Error('Missing PTY shutdown output queue event')
+    }
+    this.retainedBytes -= chunk.eventBytes?.[this.headOffset] || event.data.length
+    chunk.events[this.headOffset] = undefined
+    if (chunk.eventBytes) {
+      chunk.eventBytes[this.headOffset] = 0
+    }
+    this.headOffset += 1
+    this.retainedEvents -= 1
+    if (this.headOffset < chunk.events.length) {
+      return
+    }
+    this.chunks[this.headChunk] = undefined
+    this.headChunk += 1
+    this.headOffset = 0
+    this.compactChunks()
+  }
+
+  private compactChunks(): void {
+    if (this.headChunk < COMPACTION_MIN_HEAD_CHUNKS || this.headChunk * 2 < this.chunks.length) {
+      return
+    }
+    this.chunks = this.chunks.slice(this.headChunk)
+    this.headChunk = 0
+  }
+
+  private reset(): void {
+    this.chunks = []
+    this.headChunk = 0
+    this.headOffset = 0
+    this.retainedBytes = 0
+    this.retainedEvents = 0
+  }
+}


### PR DESCRIPTION
## Summary

- Keeps the 512 KiB terminal shutdown rollback queue amortized O(1) per saturated arrival instead of shifting the full retained array and UTF-8 re-encoding every evicted event.
- Preserves exact UTF-8 tail clamping, whole-oldest-event eviction, replay/live FIFO boundaries, metadata identity, overlapping shutdown ownership, detach/re-adoption, lifecycle ordering, and sidecar delivery.

### ELI5

When Orca tries to put a workspace to sleep, it briefly saves new terminal output in case the shutdown fails and the terminal needs to resume. Once that saved line was full, Orca moved every remaining item forward and recounted the oldest item's bytes for every new chunk. This change stores the line in small blocks with a movable front, so dropping the oldest item stays cheap without changing which output survives or how it is replayed.

### Performance proof

Node 24.18.0 on macOS arm64; 5 warmups and 31 samples per implementation. Each sample exercised the actual `pty-shutdown-data-suspension` module: register real data/replay handlers, suspend delivery, prefill 16,384 32-byte events to the exact 512 KiB cap, force GC outside the timed region, then time 16,384 additional saturated arrivals through `bufferPtyShutdownData`. Settlement and cleanup ran after timing. The baseline module was captured before implementation; its source was unchanged through final `origin/main`. The candidate is commit `852746f2425` after unrelated test workers exited.

| Implementation | Median | p95 | Min / max |
| --- | ---: | ---: | ---: |
| Previous production module | 234.090 ms | 272.183 ms | 215.199 / 298.734 ms |
| Current production module | 1.561 ms | 2.226 ms | 1.265 / 2.512 ms |
| Improvement | 150.0× / 99.33% lower | 122.3× / 99.18% lower | — |

The benchmark is reproducible with `node --expose-gc --import tsx`: perform the prefill through `unregisterPtyDataHandlers` + `bufferPtyShutdownData`, call `global.gc()`, time only the saturated arrival loop with `performance.now()`, then commit the snapshot outside timing. The differential oracle independently verifies the retained FIFO tail against the exact previous algorithm.

### No-regression proof

- A 5,000-event seeded differential test compares the queue with the exact previous algorithm across ASCII, CJK, emoji, lone surrogates, empty events, oversized tails, data/replay boundaries, and metadata.
- Structural coverage fails if saturated enqueue reintroduces `Array.shift` or historical `TextEncoder.encode` work.
- Exact byte-cap tests cover whole-event eviction, a full-cap event plus an empty metadata event, returned Unicode-event mutation/re-enqueue, and the next one-byte overflow.
- Release-scale one-byte churn proves cleared event storage stays within one 64-event chunk; Unicode churn and three repeated 64-chunk compactions prove byte/chunk backing storage is released and reused.
- Production delivery drains directly from chunks after detaching queue ownership, avoiding a flat retained-event copy while preserving reentrant shutdown boundaries, pre-handler-first ordering, primary-before-sidecar delivery, and `PtyDataMeta` identity.
- Focused integration covers shutdown exits, overlapping owners and sticky commit, detach/remount re-adoption, local/WSL/SSH transport, relay/remote-runtime delivery, and snapshot ownership.
- This changes renderer-local storage only: no RPC/IPC payload, stream opcode, persistence, mobile contract, provider routing, dependency, or filesystem behavior changed.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — the complete renderer suite and focused integration runs below passed directly; the repository-wide wrapper was not needed for this renderer-only diff.
- [ ] `pnpm build` — the Electron main/preload/renderer production build passed before and after final base sync; native packaging is left to CI.
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Passed:

- Full renderer: 2,333 files / 21,614 tests passed; one file and four tests skipped.
- Focused shutdown queue, suspension, pre-handler, exit, desktop transport, and remote-runtime transport: 6 files / 253 tests after final base sync.
- Full lint and Node/CLI/web typecheck; post-sync targeted regular/native/type-aware lint.
- Changed-code quality, React Doctor, max-lines ratchet, reliability gates, formatting, and diff checks.
- `pnpm run build:electron-vite` before and after syncing final `origin/main` at `d6362deb044`.

## AI Review Report

Three independent final reviews found no P0, P1, or P2 issues. They traced byte-for-byte queue equivalence, malformed-surrogate handling, FIFO and metadata identity, overlapping-owner commit/rollback, detach/re-adoption, remount identity guards, reentrant drains, lifecycle ordering, cleared storage, local/WSL/direct-SSH/relay/remote-runtime ownership, and folder workspaces.

Review caught two intermediate design risks before publication: an event-attached byte cache could become stale after a drained event was mutated and re-enqueued, and eager per-chunk byte arrays amplified the existing empty-event path. The final design keeps byte sidecars private to chunks and allocates them only for Unicode. Review also drove direct stale-accounting/overflow regressions and repeated production-threshold chunk-compaction coverage.

Cross-platform review found no macOS, Linux, Windows, or WSL-specific behavior: the change is platform-neutral TypeScript string/array bookkeeping and does not touch shortcuts, labels, paths, shells, Git, native modules, or Electron platform branches.

## Security Audit

No security findings. The diff adds no dependency, network sink, command execution, path handling, auth, secret, persistence, IPC schema, or wire payload. Existing arbitrary PTY text remains UTF-8 tail-clamped and bounded to 512 KiB; data is never evaluated. Evicted references are cleared, dead chunks are released, ASCII/empty streams allocate no byte sidecars, and production drains transfer ownership before external callbacks.

## Notes

- Local, WSL, SSH, relay, remote-runtime, and folder-workspace behavior share the unchanged ingress and lifecycle APIs.
- Empty/metadata-only events intentionally retain their observable boundaries and remain count-unbounded as before; semantic coalescing is tracked separately as PSS-017 rather than adding a regression-prone event cap here.
- Existing callback-exception, detached pre-handler, and suspended remote-snapshot edge semantics are unchanged and remain separate correctness follow-ups.
- X: @nwparker_
