### PR TITLE
fix(native-chat): release the occurrence a cancelled send would have taken

### DIFF
--- a/src/renderer/src/components/native-chat/NativeChatView.tsx
+++ b/src/renderer/src/components/native-chat/NativeChatView.tsx
@@ -20,20 +20,12 @@ import {
 } from './native-chat-working-suppression'
 import {
   applyCommandMarkerBoundaries,
-  appendPendingSendCache,
   commandMarkersAsMessages,
-  appendCommandMarkerCache,
   launchPromptAsMessage,
   pendingSendsAsMessages,
-  nextNativeChatPendingSendId,
-  prunePendingSends,
-  readCommandMarkerCache,
-  readPendingSendCache,
-  shouldPruneLaunchPrompt,
-  writePendingSendCache,
-  type NativeChatCommandMarker,
-  type NativeChatPendingSend
+  shouldPruneLaunchPrompt
 } from './native-chat-pending'
+import { useNativeChatPendingEchoes } from './use-native-chat-pending-echoes'
 import {
   deriveNativeChatStreamingText,
   nativeChatStreamingMessage
@@ -191,81 +183,26 @@ function NativeChatResolvedView({
     }
   })
 
-  // Optimistic "queued" sends (mobile parity): a composer send is echoed
-  // immediately and pruned once its real user turn lands in the transcript, so
-  // the message never vanishes between send and transcript catch-up.
-  const commandMarkerScope = useMemo(
-    () => ({ paneKey, agent, sessionId }),
-    [paneKey, agent, sessionId]
-  )
-  const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
-  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
-    readPendingSendCache(pendingScope)
-  )
-  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
-  // system line instead of a user bubble. Capped + cached per conversation.
-  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
-    readCommandMarkerCache(commandMarkerScope)
-  )
-  // Reset the optimistic queue only when the pane/agent changes. A fresh launch
-  // often learns its provider session id after the first send; clearing pending
-  // on that transition briefly flashes the empty state before the transcript
-  // user turn lands.
-  useEffect(() => {
-    setPending(readPendingSendCache(pendingScope))
-    setWorkingInterrupted(false)
-  }, [pendingScope])
-  // Command markers are session-scoped because slash commands like /clear are
-  // local feedback for a specific transcript boundary.
-  useEffect(() => {
-    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
-    setWorkingInterrupted(false)
-  }, [commandMarkerScope])
-  // Prune echoes whose real user turn is now in the transcript.
-  useEffect(() => {
-    setPending((prev) =>
-      writePendingSendCache(pendingScope, prunePendingSends(prev, session.messages))
-    )
-  }, [session.messages, pendingScope])
+  const {
+    pending,
+    commandMarkers,
+    recordSend: onOptimisticSend,
+    cancelSend: onOptimisticSendCanceled,
+    recordSlashCommand: onSlashCommand,
+    clearPending
+  } = useNativeChatPendingEchoes({
+    paneKey,
+    agent,
+    sessionId,
+    messages: session.messages,
+    setWorkingInterrupted
+  })
   useEffect(() => {
     if (!paneLaunchPrompt || !shouldPruneLaunchPrompt(paneLaunchPrompt, session.messages)) {
       return
     }
     clearNativeChatLaunchPrompt(terminalTabId)
   }, [clearNativeChatLaunchPrompt, paneLaunchPrompt, session.messages, terminalTabId])
-  const onOptimisticSend = useCallback(
-    (text: string, imagePaths?: string[]) => {
-      setWorkingInterrupted(false)
-      const sentAt = Date.now()
-      const boundary = session.messages.at(-1)
-      const entry: NativeChatPendingSend = {
-        id: nextNativeChatPendingSendId(sentAt),
-        text,
-        sentAt,
-        afterMessageId: boundary?.id ?? null,
-        afterMessageTimestamp: boundary?.timestamp ?? null,
-        ...(imagePaths ? { imagePaths } : {})
-      }
-      setPending(appendPendingSendCache(pendingScope, entry))
-      return entry.id
-    },
-    [pendingScope, session.messages]
-  )
-  const onOptimisticSendCanceled = useCallback(
-    (pendingId: string) => {
-      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered.
-      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
-      setPending(writePendingSendCache(pendingScope, next))
-    },
-    [pendingScope]
-  )
-  const onSlashCommand = useCallback(
-    (command: string) => {
-      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
-    },
-    [commandMarkerScope]
-  )
 
   const launchPromptMessage = useMemo(
     () => launchPromptAsMessage(paneLaunchPrompt, session.messages),
@@ -359,9 +296,9 @@ function NativeChatResolvedView({
     // Why: Stop after a submitted turn drops the delayed-write handle once it
     // settles, so cancelPendingSends no longer sees the optimistic id. Clear
     // the echo cache here so a cancelled prompt cannot stick as a ghost bubble.
-    setPending(writePendingSendCache(pendingScope, []))
+    clearPending()
     interactiveSend.cancel()
-  }, [interactiveSend, pendingScope])
+  }, [clearPending, interactiveSend])
   const nativeChatFileLinkClick = useNativeChatFileLinkClick(fileLinkContext)
 
   // Chat-only font zoom via Cmd/Ctrl +/-/0, gated to the live conversation so

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -174,9 +174,26 @@ describe('retainPendingSendsForConversation', () => {
       sessionId: 's1',
       markers: [clearMarker(150)]
     })
+    // 'beta' had no sibling dropped, so it keeps its untouched slot — undefined
+    // resolves to occurrence 1 through `nativeChatPendingOccurrence`.
     expect(next.map((entry) => [entry.id, entry.matchingOccurrence])).toEqual([
-      ['p2', 1],
+      ['p2', undefined],
       ['p3', 1]
     ])
+  })
+
+  it('leaves an unrelated key alone when a different key is dropped', () => {
+    // 'ping' holds occurrence 2 because its predecessor was pruned by a real
+    // landed turn, which is still in the transcript. Dropping an unrelated echo
+    // frees no 'ping' slot, so renumbering it down would retire it early.
+    const pending = [
+      pendingOf('p1', { sentAt: 50, sessionId: 's0', text: 'stale prompt' }),
+      pendingOf('p2', { sentAt: 300, sessionId: null, text: 'ping', matchingOccurrence: 2 })
+    ]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: 's1',
+      markers: noMarkers
+    })
+    expect(next.map((entry) => [entry.id, entry.matchingOccurrence])).toEqual([['p2', 2]])
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -146,6 +146,24 @@ describe('retainPendingSendsForConversation', () => {
     expect(pendingSendsAsMessages(next, replaced)).toEqual([])
   })
 
+  it('does not renumber when the only change is adopting the first session id', () => {
+    // A capped-out predecessor's send still landed, so its turn still consumes an
+    // occurrence. Adoption drops nothing, so renumbering would strand the survivor
+    // on an already-consumed turn.
+    const pending = [
+      pendingOf('p1', { sentAt: 100, text: 'ping', matchingOccurrence: 2 }),
+      pendingOf('p2', { sentAt: 200, text: 'ping', matchingOccurrence: 3 })
+    ]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: 's1',
+      markers: noMarkers
+    })
+    expect(next.map((entry) => [entry.sessionId, entry.matchingOccurrence])).toEqual([
+      ['s1', 2],
+      ['s1', 3]
+    ])
+  })
+
   it('keeps distinct texts independent when renumbering', () => {
     const pending = [
       pendingOf('p1', { sentAt: 100, sessionId: 's1', text: 'alpha' }),

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -1,0 +1,107 @@
+import { describe, expect, it } from 'vitest'
+import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
+import { pendingSendsAsMessages } from './native-chat-pending'
+import type { NativeChatCommandMarker, NativeChatPendingSend } from './native-chat-pending'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+
+function pendingOf(
+  id: string,
+  overrides: Partial<NativeChatPendingSend> = {}
+): NativeChatPendingSend {
+  return { id, text: `text-${id}`, sentAt: 100, ...overrides }
+}
+
+function clearMarker(sentAt: number): NativeChatCommandMarker {
+  return { id: `marker-${sentAt}`, command: '/clear', sentAt }
+}
+
+const noMarkers: readonly NativeChatCommandMarker[] = []
+
+describe('retainPendingSendsForConversation', () => {
+  it('returns the same reference when nothing changes', () => {
+    const pending = [pendingOf('p1', { sessionId: 's1' })]
+    expect(
+      retainPendingSendsForConversation(pending, { sessionId: 's1', markers: noMarkers })
+    ).toBe(pending)
+  })
+
+  it('drops an echo issued into a replaced provider session', () => {
+    const pending = [pendingOf('p1', { sessionId: 's1' }), pendingOf('p2', { sessionId: 's2' })]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: 's2',
+      markers: noMarkers
+    })
+    expect(next.map((entry) => entry.id)).toEqual(['p2'])
+  })
+
+  it('adopts the first session id for echoes sent before it was known', () => {
+    const pending = [pendingOf('p1'), pendingOf('p2', { sessionId: null })]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: 's1',
+      markers: noMarkers
+    })
+    expect(next.map((entry) => entry.sessionId)).toEqual(['s1', 's1'])
+  })
+
+  it('keeps echoes while the provider session is momentarily unknown', () => {
+    const pending = [pendingOf('p1', { sessionId: 's1' })]
+    expect(
+      retainPendingSendsForConversation(pending, { sessionId: null, markers: noMarkers })
+    ).toBe(pending)
+  })
+
+  it('drops echoes queued before the latest /clear', () => {
+    const pending = [
+      pendingOf('p1', { sentAt: 100, sessionId: 's1' }),
+      pendingOf('p2', { sentAt: 300, sessionId: 's1' })
+    ]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: 's1',
+      markers: [clearMarker(200)]
+    })
+    expect(next.map((entry) => entry.id)).toEqual(['p2'])
+  })
+
+  it('ignores non-clear command markers', () => {
+    const pending = [pendingOf('p1', { sentAt: 100, sessionId: 's1' })]
+    const markers = [{ id: 'm1', command: '/model opus', sentAt: 200 }]
+    expect(retainPendingSendsForConversation(pending, { sessionId: 's1', markers })).toBe(pending)
+  })
+
+  it('drops pre-clear echoes even while the session id is unknown', () => {
+    const pending = [pendingOf('p1', { sentAt: 100 })]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: null,
+      markers: [clearMarker(200)]
+    })
+    expect(next).toEqual([])
+  })
+
+  it('stops a replaced conversation from rendering the old prompt as the newest bubble', () => {
+    const pending = [pendingOf('p1', { text: 'summarize the diff', sessionId: 's1' })]
+    const replacedTranscript: NativeChatMessage[] = [
+      {
+        id: 'm1',
+        role: 'user',
+        blocks: [{ type: 'text', text: 'hi' }],
+        timestamp: 500,
+        source: 'transcript'
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        blocks: [{ type: 'text', text: 'hello' }],
+        timestamp: 600,
+        source: 'transcript'
+      }
+    ]
+    // The old echo can never match the new session's transcript, so without the
+    // conversation filter it renders after every real turn, forever.
+    expect(pendingSendsAsMessages(pending, replacedTranscript)).toHaveLength(1)
+    const retained = retainPendingSendsForConversation(pending, {
+      sessionId: 's2',
+      markers: noMarkers
+    })
+    expect(pendingSendsAsMessages(retained, replacedTranscript)).toEqual([])
+  })
+})

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
-import { pendingSendsAsMessages } from './native-chat-pending'
+import { pendingSendsAsMessages, prunePendingSends } from './native-chat-pending'
 import type { NativeChatCommandMarker, NativeChatPendingSend } from './native-chat-pending'
 import type { NativeChatMessage } from '../../../../shared/native-chat-types'
 
@@ -103,5 +103,62 @@ describe('retainPendingSendsForConversation', () => {
       markers: noMarkers
     })
     expect(pendingSendsAsMessages(retained, replacedTranscript)).toEqual([])
+  })
+
+  it('renumbers survivors so a dropped echo does not strand the one after it', () => {
+    // `assignNativeChatPendingOccurrence` numbers a repeat send past its
+    // predecessors, which is right when a real turn consumed the earlier one. A
+    // conversation swap consumes nothing, so the survivor has to count from 1 or
+    // it waits forever for a second identical turn that will never arrive.
+    const pending = [
+      pendingOf('p1', { sentAt: 100, sessionId: 's1', text: 'continue' }),
+      pendingOf('p2', {
+        sentAt: 200,
+        sessionId: 's1',
+        text: 'continue',
+        matchingOccurrence: 2
+      })
+    ]
+    const markers = [clearMarker(150)]
+    const next = retainPendingSendsForConversation(pending, { sessionId: 's1', markers })
+    expect(next.map((entry) => entry.id)).toEqual(['p2'])
+    expect(next[0]?.matchingOccurrence).toBe(1)
+
+    // The replacement conversation answers "continue" exactly once, which is all
+    // the survivor is owed.
+    const replaced: NativeChatMessage[] = [
+      {
+        id: 'm1',
+        role: 'user',
+        blocks: [{ type: 'text', text: 'continue' }],
+        timestamp: 500,
+        source: 'transcript'
+      },
+      {
+        id: 'm2',
+        role: 'assistant',
+        blocks: [{ type: 'text', text: 'ok' }],
+        timestamp: 600,
+        source: 'transcript'
+      }
+    ]
+    expect(prunePendingSends(next, replaced)).toEqual([])
+    expect(pendingSendsAsMessages(next, replaced)).toEqual([])
+  })
+
+  it('keeps distinct texts independent when renumbering', () => {
+    const pending = [
+      pendingOf('p1', { sentAt: 100, sessionId: 's1', text: 'alpha' }),
+      pendingOf('p2', { sentAt: 200, sessionId: 's1', text: 'beta' }),
+      pendingOf('p3', { sentAt: 300, sessionId: 's1', text: 'alpha', matchingOccurrence: 2 })
+    ]
+    const next = retainPendingSendsForConversation(pending, {
+      sessionId: 's1',
+      markers: [clearMarker(150)]
+    })
+    expect(next.map((entry) => [entry.id, entry.matchingOccurrence])).toEqual([
+      ['p2', 1],
+      ['p3', 1]
+    ])
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -3,7 +3,7 @@ import {
   type NativeChatCommandMarker,
   type NativeChatPendingSend
 } from './native-chat-pending'
-import { renumberNativeChatPendingOccurrences } from './native-chat-pending-occurrence'
+import { nativeChatPendingMatchKey } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingConversation = {
   /** Provider session currently resolved for the pane; null while unknown. */
@@ -26,35 +26,37 @@ export function retainPendingSendsForConversation(
 ): NativeChatPendingSend[] {
   const clearedAt = latestClearSentAt(conversation.markers)
   const { sessionId } = conversation
-  let dropped = false
-  let adopted = false
+  // Why: a dropped echo's turn will never arrive, so each later sibling sharing
+  // its match key must give up exactly the slots those drops freed — counted per
+  // key, so an unrelated drop cannot erase elevation a landed turn already earned.
+  const droppedByKey = new Map<string, number>()
+  let changed = false
   const next: NativeChatPendingSend[] = []
   for (const entry of pending) {
-    if (clearedAt !== null && entry.sentAt <= clearedAt) {
-      dropped = true
+    const replacedSession =
+      sessionId !== null && entry.sessionId != null && entry.sessionId !== sessionId
+    if ((clearedAt !== null && entry.sentAt <= clearedAt) || replacedSession) {
+      const key = nativeChatPendingMatchKey(entry)
+      droppedByKey.set(key, (droppedByKey.get(key) ?? 0) + 1)
+      changed = true
       continue
     }
     // Why: a reconnect can briefly drop provider-session metadata, and the
-    // session gate already holds the last identity — don't drop echoes on it.
-    if (sessionId === null || entry.sessionId === sessionId) {
-      next.push(entry)
-      continue
+    // session gate already holds the last identity — don't drop echoes on it. A
+    // fresh launch learns its id only after the first send, so the first id
+    // observed claims those echoes instead of dropping them.
+    let kept = entry
+    if (sessionId !== null && entry.sessionId == null) {
+      kept = { ...entry, sessionId }
+      changed = true
     }
-    if (entry.sessionId == null) {
-      // Why: a fresh launch learns its session id only after the first send, so
-      // the first id observed claims those echoes instead of dropping them.
-      next.push({ ...entry, sessionId })
-      adopted = true
-      continue
+    const shift = droppedByKey.get(nativeChatPendingMatchKey(kept)) ?? 0
+    const occurrence = kept.matchingOccurrence
+    if (shift > 0 && occurrence !== undefined) {
+      kept = { ...kept, matchingOccurrence: Math.max(1, occurrence - shift) }
+      changed = true
     }
-    dropped = true
+    next.push(kept)
   }
-  // Why: a dropped echo's turn will never arrive, so leaving a survivor numbered
-  // past it would keep demanding a transcript occurrence that cannot exist.
-  // Adoption alone drops nothing, and renumbering it would erase the elevation a
-  // capped-out predecessor still owns (its send landed; its turn is still coming).
-  if (dropped) {
-    return renumberNativeChatPendingOccurrences(next)
-  }
-  return adopted ? next : pending
+  return changed ? next : pending
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -26,11 +26,12 @@ export function retainPendingSendsForConversation(
 ): NativeChatPendingSend[] {
   const clearedAt = latestClearSentAt(conversation.markers)
   const { sessionId } = conversation
-  let changed = false
+  let dropped = false
+  let adopted = false
   const next: NativeChatPendingSend[] = []
   for (const entry of pending) {
     if (clearedAt !== null && entry.sentAt <= clearedAt) {
-      changed = true
+      dropped = true
       continue
     }
     // Why: a reconnect can briefly drop provider-session metadata, and the
@@ -43,12 +44,17 @@ export function retainPendingSendsForConversation(
       // Why: a fresh launch learns its session id only after the first send, so
       // the first id observed claims those echoes instead of dropping them.
       next.push({ ...entry, sessionId })
-      changed = true
+      adopted = true
       continue
     }
-    changed = true
+    dropped = true
   }
   // Why: a dropped echo's turn will never arrive, so leaving a survivor numbered
   // past it would keep demanding a transcript occurrence that cannot exist.
-  return changed ? renumberNativeChatPendingOccurrences(next) : pending
+  // Adoption alone drops nothing, and renumbering it would erase the elevation a
+  // capped-out predecessor still owns (its send landed; its turn is still coming).
+  if (dropped) {
+    return renumberNativeChatPendingOccurrences(next)
+  }
+  return adopted ? next : pending
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -3,7 +3,7 @@ import {
   type NativeChatCommandMarker,
   type NativeChatPendingSend
 } from './native-chat-pending'
-import { nativeChatPendingMatchKey } from './native-chat-pending-occurrence'
+import { dropNativeChatPendingOccurrences } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingConversation = {
   /** Provider session currently resolved for the pane; null while unknown. */
@@ -26,37 +26,17 @@ export function retainPendingSendsForConversation(
 ): NativeChatPendingSend[] {
   const clearedAt = latestClearSentAt(conversation.markers)
   const { sessionId } = conversation
-  // Why: a dropped echo's turn will never arrive, so each later sibling sharing
-  // its match key must give up exactly the slots those drops freed — counted per
-  // key, so an unrelated drop cannot erase elevation a landed turn already earned.
-  const droppedByKey = new Map<string, number>()
-  let changed = false
-  const next: NativeChatPendingSend[] = []
-  for (const entry of pending) {
-    const replacedSession =
-      sessionId !== null && entry.sessionId != null && entry.sessionId !== sessionId
-    if ((clearedAt !== null && entry.sentAt <= clearedAt) || replacedSession) {
-      const key = nativeChatPendingMatchKey(entry)
-      droppedByKey.set(key, (droppedByKey.get(key) ?? 0) + 1)
-      changed = true
-      continue
-    }
-    // Why: a reconnect can briefly drop provider-session metadata, and the
-    // session gate already holds the last identity — don't drop echoes on it. A
-    // fresh launch learns its id only after the first send, so the first id
-    // observed claims those echoes instead of dropping them.
-    let kept = entry
-    if (sessionId !== null && entry.sessionId == null) {
-      kept = { ...entry, sessionId }
-      changed = true
-    }
-    const shift = droppedByKey.get(nativeChatPendingMatchKey(kept)) ?? 0
-    const occurrence = kept.matchingOccurrence
-    if (shift > 0 && occurrence !== undefined) {
-      kept = { ...kept, matchingOccurrence: Math.max(1, occurrence - shift) }
-      changed = true
-    }
-    next.push(kept)
+  const retained = dropNativeChatPendingOccurrences(
+    pending,
+    (entry) =>
+      (clearedAt !== null && entry.sentAt <= clearedAt) ||
+      (sessionId !== null && entry.sessionId != null && entry.sessionId !== sessionId)
+  )
+  // Why: a reconnect can briefly drop provider-session metadata, and the session
+  // gate already holds the last identity — don't drop echoes on it. A fresh launch
+  // learns its id only after the first send, so the first id observed claims them.
+  if (sessionId === null || !retained.some((entry) => entry.sessionId == null)) {
+    return retained
   }
-  return changed ? next : pending
+  return retained.map((entry) => (entry.sessionId == null ? { ...entry, sessionId } : entry))
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -3,6 +3,7 @@ import {
   type NativeChatCommandMarker,
   type NativeChatPendingSend
 } from './native-chat-pending'
+import { renumberNativeChatPendingOccurrences } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingConversation = {
   /** Provider session currently resolved for the pane; null while unknown. */
@@ -47,5 +48,7 @@ export function retainPendingSendsForConversation(
     }
     changed = true
   }
-  return changed ? next : pending
+  // Why: a dropped echo's turn will never arrive, so leaving a survivor numbered
+  // past it would keep demanding a transcript occurrence that cannot exist.
+  return changed ? renumberNativeChatPendingOccurrences(next) : pending
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-conversation.ts
@@ -1,0 +1,51 @@
+import {
+  latestClearSentAt,
+  type NativeChatCommandMarker,
+  type NativeChatPendingSend
+} from './native-chat-pending'
+
+export type NativeChatPendingConversation = {
+  /** Provider session currently resolved for the pane; null while unknown. */
+  sessionId: string | null
+  /** Slash commands recorded for that session (`/clear` resets the transcript). */
+  markers: readonly NativeChatCommandMarker[]
+}
+
+/**
+ * Keep only the echoes that belong to the pane's current conversation.
+ *
+ * Echoes are cached per pane+agent and clear only by matching a transcript turn,
+ * so one left behind when the conversation is replaced (`/clear`, agent restart,
+ * resuming another session) can never match and stays pinned at the list tail —
+ * an old prompt rendered as the newest message for the rest of the session.
+ */
+export function retainPendingSendsForConversation(
+  pending: NativeChatPendingSend[],
+  conversation: NativeChatPendingConversation
+): NativeChatPendingSend[] {
+  const clearedAt = latestClearSentAt(conversation.markers)
+  const { sessionId } = conversation
+  let changed = false
+  const next: NativeChatPendingSend[] = []
+  for (const entry of pending) {
+    if (clearedAt !== null && entry.sentAt <= clearedAt) {
+      changed = true
+      continue
+    }
+    // Why: a reconnect can briefly drop provider-session metadata, and the
+    // session gate already holds the last identity — don't drop echoes on it.
+    if (sessionId === null || entry.sessionId === sessionId) {
+      next.push(entry)
+      continue
+    }
+    if (entry.sessionId == null) {
+      // Why: a fresh launch learns its session id only after the first send, so
+      // the first id observed claims those echoes instead of dropping them.
+      next.push({ ...entry, sessionId })
+      changed = true
+      continue
+    }
+    changed = true
+  }
+  return changed ? next : pending
+}

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.test.ts
@@ -7,6 +7,10 @@ import {
   prunePendingSends,
   type NativeChatPendingSendScope
 } from './native-chat-pending'
+import {
+  dropNativeChatPendingOccurrences,
+  type NativeChatPendingOccurrence
+} from './native-chat-pending-occurrence'
 
 const scope: NativeChatPendingSendScope = { paneKey: 'tab:leaf', agent: 'codex' }
 
@@ -62,5 +66,62 @@ describe('pending send occurrence reconciliation', () => {
     ]
     expect(pendingSendsAsMessages(afterFirstPrune, secondCompletedTurn)).toEqual([])
     expect(prunePendingSends(afterFirstPrune, secondCompletedTurn)).toEqual([])
+  })
+})
+
+describe('dropNativeChatPendingOccurrences', () => {
+  type Entry = NativeChatPendingOccurrence & { id: string }
+
+  function entry(id: string, text: string, matchingOccurrence?: number): Entry {
+    return { id, text, sentAt: 100, afterMessageId: null, matchingOccurrence }
+  }
+
+  it('returns the same reference when nothing is dropped', () => {
+    const pending = [entry('p1', 'ping'), entry('p2', 'ping', 2)]
+    expect(dropNativeChatPendingOccurrences(pending, () => false)).toBe(pending)
+  })
+
+  it('pulls a later same-key sibling down by one slot per drop', () => {
+    const pending = [entry('p1', 'ping'), entry('p2', 'ping', 2), entry('p3', 'ping', 3)]
+    const next = dropNativeChatPendingOccurrences(pending, (candidate) => candidate.id === 'p1')
+    expect(next.map((candidate) => [candidate.id, candidate.matchingOccurrence])).toEqual([
+      ['p2', 1],
+      ['p3', 2]
+    ])
+  })
+
+  it('counts drops per key, so two same-key drops release two slots', () => {
+    const pending = [entry('p1', 'ping'), entry('p2', 'ping', 2), entry('p3', 'ping', 3)]
+    const next = dropNativeChatPendingOccurrences(pending, (candidate) => candidate.id !== 'p3')
+    expect(next.map((candidate) => [candidate.id, candidate.matchingOccurrence])).toEqual([
+      ['p3', 1]
+    ])
+  })
+
+  it('leaves another key alone, so an unrelated drop cannot retire it early', () => {
+    // 'ping' holds slot 2 because a real landed turn consumed slot 1; dropping
+    // 'other' frees no 'ping' slot.
+    const pending = [entry('p1', 'other'), entry('p2', 'ping', 2)]
+    const next = dropNativeChatPendingOccurrences(pending, (candidate) => candidate.id === 'p1')
+    expect(next.map((candidate) => [candidate.id, candidate.matchingOccurrence])).toEqual([
+      ['p2', 2]
+    ])
+  })
+
+  it('leaves a sibling that precedes the drop untouched', () => {
+    const pending = [entry('p1', 'ping', 2), entry('p2', 'ping', 3)]
+    const next = dropNativeChatPendingOccurrences(pending, (candidate) => candidate.id === 'p2')
+    expect(next.map((candidate) => [candidate.id, candidate.matchingOccurrence])).toEqual([
+      ['p1', 2]
+    ])
+  })
+
+  it('never invents an occurrence or falls below the first slot', () => {
+    const pending = [entry('p1', 'ping'), entry('p2', 'ping'), entry('p3', 'ping', 1)]
+    const next = dropNativeChatPendingOccurrences(pending, (candidate) => candidate.id === 'p1')
+    expect(next.map((candidate) => [candidate.id, candidate.matchingOccurrence])).toEqual([
+      ['p2', undefined],
+      ['p3', 1]
+    ])
   })
 })

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -227,33 +227,33 @@ export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOcc
 }
 
 /**
- * Remove `removedIndex` and pull its later same-key siblings down one occurrence.
- * Only the removed send consumes no transcript turn, so renumbering from 1 would
- * also erase the elevation a pruned or capped-out predecessor still owns.
+ * Drop the selected entries and pull each survivor down by the same-key slots
+ * those drops vacated. A dropped send consumes no transcript turn, but a pruned
+ * or capped-out predecessor still owns the slot it earned — so renumbering from
+ * 1, or across keys, would retire a survivor against an already-consumed turn.
+ * Returns `pending` untouched when nothing was dropped.
  */
-export function withoutNativeChatPendingOccurrence<T extends NativeChatPendingOccurrence>(
-  pending: readonly T[],
-  removedIndex: number
+export function dropNativeChatPendingOccurrences<T extends NativeChatPendingOccurrence>(
+  pending: T[],
+  shouldDrop: (entry: T) => boolean
 ): T[] {
-  const removed = pending[removedIndex]
-  if (!removed) {
-    return [...pending]
-  }
-  const key = nativeChatPendingMatchKey(removed)
+  const vacatedByKey = new Map<string, number>()
   const next: T[] = []
-  for (const [index, entry] of pending.entries()) {
-    if (index === removedIndex) {
+  for (const entry of pending) {
+    const key = nativeChatPendingMatchKey(entry)
+    if (shouldDrop(entry)) {
+      vacatedByKey.set(key, (vacatedByKey.get(key) ?? 0) + 1)
       continue
     }
+    const vacated = vacatedByKey.get(key) ?? 0
     const occurrence = entry.matchingOccurrence
-    const shifts =
-      index > removedIndex &&
-      occurrence !== undefined &&
-      occurrence > 1 &&
-      nativeChatPendingMatchKey(entry) === key
-    next.push(shifts ? { ...entry, matchingOccurrence: occurrence - 1 } : entry)
+    next.push(
+      vacated > 0 && occurrence !== undefined
+        ? { ...entry, matchingOccurrence: Math.max(1, occurrence - vacated) }
+        : entry
+    )
   }
-  return next
+  return vacatedByKey.size === 0 ? pending : next
 }
 
 export function nativeChatPendingMatchingAfter(pending: NativeChatPendingOccurrence): number {

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -227,24 +227,6 @@ export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOcc
 }
 
 /**
- * Renumber occurrences so each match key counts from 1 again — for a replaced
- * conversation, where no dropped echo's turn will ever arrive to consume a slot.
- */
-export function renumberNativeChatPendingOccurrences<T extends NativeChatPendingOccurrence>(
-  pending: readonly T[]
-): T[] {
-  const counted = new Map<string, number>()
-  return pending.map((entry) => {
-    const key = nativeChatPendingMatchKey(entry)
-    const occurrence = (counted.get(key) ?? 0) + 1
-    counted.set(key, occurrence)
-    return entry.matchingOccurrence === occurrence
-      ? entry
-      : { ...entry, matchingOccurrence: occurrence }
-  })
-}
-
-/**
  * Remove `removedIndex` and pull its later same-key siblings down one occurrence.
  * Only the removed send consumes no transcript turn, so renumbering from 1 would
  * also erase the elevation a pruned or capped-out predecessor still owns.

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -226,6 +226,29 @@ export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOcc
   }
 }
 
+/**
+ * Renumber occurrences so each match key counts from 1 again.
+ *
+ * `assignNativeChatPendingOccurrence` numbers a repeat send past its predecessors
+ * on purpose: pruning an earlier echo means a real turn consumed that occurrence,
+ * so the later send must not reuse it. Dropping an echo because its *conversation*
+ * was replaced is the opposite — no turn will ever arrive for it — and a survivor
+ * left demanding occurrence 2 can then never retire.
+ */
+export function renumberNativeChatPendingOccurrences<T extends NativeChatPendingOccurrence>(
+  pending: readonly T[]
+): T[] {
+  const counted = new Map<string, number>()
+  return pending.map((entry) => {
+    const key = nativeChatPendingMatchKey(entry)
+    const occurrence = (counted.get(key) ?? 0) + 1
+    counted.set(key, occurrence)
+    return entry.matchingOccurrence === occurrence
+      ? entry
+      : { ...entry, matchingOccurrence: occurrence }
+  })
+}
+
 export function nativeChatPendingMatchingAfter(pending: NativeChatPendingOccurrence): number {
   return pending.matchingAfterTimestamp ?? pending.afterMessageTimestamp ?? pending.sentAt
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -249,6 +249,41 @@ export function renumberNativeChatPendingOccurrences<T extends NativeChatPending
   })
 }
 
+/**
+ * Remove `removedIndex` and pull its later same-key siblings down one occurrence.
+ *
+ * For a cancelled send the transcript is unchanged, so — unlike a conversation
+ * swap — absolute renumbering would be wrong: it also erases the elevation a
+ * pruned or capped-out predecessor legitimately left behind (`PENDING_SEND_LIMIT`
+ * drops the oldest echo while its send still lands, so its turn still arrives and
+ * still consumes an occurrence). Only the cancelled send consumes nothing, so
+ * only the entries queued after it move, and only by one.
+ */
+export function withoutNativeChatPendingOccurrence<T extends NativeChatPendingOccurrence>(
+  pending: readonly T[],
+  removedIndex: number
+): T[] {
+  const removed = pending[removedIndex]
+  if (!removed) {
+    return [...pending]
+  }
+  const key = nativeChatPendingMatchKey(removed)
+  const next: T[] = []
+  for (const [index, entry] of pending.entries()) {
+    if (index === removedIndex) {
+      continue
+    }
+    const occurrence = entry.matchingOccurrence
+    const shifts =
+      index > removedIndex &&
+      occurrence !== undefined &&
+      occurrence > 1 &&
+      nativeChatPendingMatchKey(entry) === key
+    next.push(shifts ? { ...entry, matchingOccurrence: occurrence - 1 } : entry)
+  }
+  return next
+}
+
 export function nativeChatPendingMatchingAfter(pending: NativeChatPendingOccurrence): number {
   return pending.matchingAfterTimestamp ?? pending.afterMessageTimestamp ?? pending.sentAt
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending-occurrence.ts
@@ -227,13 +227,8 @@ export function assignNativeChatPendingOccurrence<T extends NativeChatPendingOcc
 }
 
 /**
- * Renumber occurrences so each match key counts from 1 again.
- *
- * `assignNativeChatPendingOccurrence` numbers a repeat send past its predecessors
- * on purpose: pruning an earlier echo means a real turn consumed that occurrence,
- * so the later send must not reuse it. Dropping an echo because its *conversation*
- * was replaced is the opposite — no turn will ever arrive for it — and a survivor
- * left demanding occurrence 2 can then never retire.
+ * Renumber occurrences so each match key counts from 1 again — for a replaced
+ * conversation, where no dropped echo's turn will ever arrive to consume a slot.
  */
 export function renumberNativeChatPendingOccurrences<T extends NativeChatPendingOccurrence>(
   pending: readonly T[]
@@ -251,13 +246,8 @@ export function renumberNativeChatPendingOccurrences<T extends NativeChatPending
 
 /**
  * Remove `removedIndex` and pull its later same-key siblings down one occurrence.
- *
- * For a cancelled send the transcript is unchanged, so — unlike a conversation
- * swap — absolute renumbering would be wrong: it also erases the elevation a
- * pruned or capped-out predecessor legitimately left behind (`PENDING_SEND_LIMIT`
- * drops the oldest echo while its send still lands, so its turn still arrives and
- * still consumes an occurrence). Only the cancelled send consumes nothing, so
- * only the entries queued after it move, and only by one.
+ * Only the removed send consumes no transcript turn, so renumbering from 1 would
+ * also erase the elevation a pruned or capped-out predecessor still owns.
  */
 export function withoutNativeChatPendingOccurrence<T extends NativeChatPendingOccurrence>(
   pending: readonly T[],

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -34,6 +34,9 @@ export type NativeChatPendingSend = {
   afterMessageId?: string | null
   /** Timestamp of that boundary in the transcript host's clock domain. */
   afterMessageTimestamp?: number | null
+  /** Provider session this send was issued into, once known. An echo from a
+   * replaced conversation can never match the new transcript. */
+  sessionId?: string | null
   /** 1-based occurrence among identical sends sharing the same boundary. */
   matchingOccurrence?: number
   /** Shared time boundary when that message boundary is unavailable. */
@@ -337,7 +340,7 @@ function isClearCommand(command: string): boolean {
   return command.trim().toLowerCase().split(/\s+/)[0] === '/clear'
 }
 
-function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
+export function latestClearSentAt(markers: readonly NativeChatCommandMarker[]): number | null {
   let latest: number | null = null
   for (const marker of markers) {
     if (isClearCommand(marker.command) && (latest === null || marker.sentAt > latest)) {

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -102,22 +102,6 @@ describe('useNativeChatPendingEchoes', () => {
     expect(result.current.pending.map((entry) => entry.text)).toEqual(['leaf two prompt'])
   })
 
-  it('releases the occurrence a cancelled send would have taken', () => {
-    const { result } = renderEchoes('session-1')
-    let firstId = ''
-    act(() => {
-      firstId = result.current.recordSend('ping')
-    })
-    act(() => {
-      result.current.recordSend('ping')
-    })
-    expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([undefined, 2])
-    act(() => {
-      result.current.cancelSend(firstId)
-    })
-    expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([1])
-  })
-
   it('keeps the occurrence a capped-out echo owns when the session id first resolves', () => {
     // Sends before the launch reports its session id adopt that id — but adoption
     // drops nothing, so it must not renumber a trimmed echo's slot away.
@@ -133,26 +117,6 @@ describe('useNativeChatPendingEchoes', () => {
     expect(result.current.pending.map((entry) => entry.sessionId)).toEqual(
       Array.from({ length: 8 }, () => 'session-1')
     )
-    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
-  })
-
-  it('keeps the occurrence a capped-out echo still owns when a later send is cancelled', () => {
-    // The echo trimmed at PENDING_SEND_LIMIT still landed, so its turn still
-    // consumes an occurrence that a later cancellation must not renumber away.
-    const { result } = renderEchoes('session-1')
-    for (let index = 0; index < 9; index += 1) {
-      act(() => {
-        result.current.recordSend('ping')
-      })
-    }
-    expect(result.current.pending).toHaveLength(8)
-    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
-    const survivorId = result.current.pending[1]?.id ?? ''
-    act(() => {
-      result.current.cancelSend(result.current.pending[0]?.id ?? '')
-    })
-    expect(result.current.pending[0]?.id).toBe(survivorId)
-    // Was 3 (behind the trimmed and the cancelled echo); only one slot released.
     expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -102,6 +102,22 @@ describe('useNativeChatPendingEchoes', () => {
     expect(result.current.pending.map((entry) => entry.text)).toEqual(['leaf two prompt'])
   })
 
+  it('releases the occurrence a cancelled send would have taken', () => {
+    const { result } = renderEchoes('session-1')
+    let firstId = ''
+    act(() => {
+      firstId = result.current.recordSend('ping')
+    })
+    act(() => {
+      result.current.recordSend('ping')
+    })
+    expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([undefined, 2])
+    act(() => {
+      result.current.cancelSend(firstId)
+    })
+    expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([1])
+  })
+
   it('keeps the occurrence a capped-out echo owns when the session id first resolves', () => {
     // Sends before the launch reports its session id adopt that id — but adoption
     // drops nothing, so it must not renumber a trimmed echo's slot away.
@@ -117,6 +133,26 @@ describe('useNativeChatPendingEchoes', () => {
     expect(result.current.pending.map((entry) => entry.sessionId)).toEqual(
       Array.from({ length: 8 }, () => 'session-1')
     )
+    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
+  })
+
+  it('keeps the occurrence a capped-out echo still owns when a later send is cancelled', () => {
+    // The echo trimmed at PENDING_SEND_LIMIT still landed, so its turn still
+    // consumes an occurrence that a later cancellation must not renumber away.
+    const { result } = renderEchoes('session-1')
+    for (let index = 0; index < 9; index += 1) {
+      act(() => {
+        result.current.recordSend('ping')
+      })
+    }
+    expect(result.current.pending).toHaveLength(8)
+    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
+    const survivorId = result.current.pending[1]?.id ?? ''
+    act(() => {
+      result.current.cancelSend(result.current.pending[0]?.id ?? '')
+    })
+    expect(result.current.pending[0]?.id).toBe(survivorId)
+    // Was 3 (behind the trimmed and the cancelled echo); only one slot released.
     expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -18,6 +18,9 @@ type EchoProps = {
 }
 
 function renderEchoProps(initialProps: EchoProps) {
+  // A fresh mock per render would model a caller React does not have: the only
+  // one passes a `useState` setter, whose identity React guarantees is stable.
+  const setWorkingInterrupted = vi.fn()
   return renderHook(
     (props: EchoProps) =>
       useNativeChatPendingEchoes({
@@ -25,7 +28,7 @@ function renderEchoProps(initialProps: EchoProps) {
         agent: 'claude',
         sessionId: props.sessionId,
         messages: props.messages,
-        setWorkingInterrupted: vi.fn()
+        setWorkingInterrupted
       }),
     { initialProps }
   )

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -115,6 +115,24 @@ describe('useNativeChatPendingEchoes', () => {
     expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([1])
   })
 
+  it('keeps the occurrence a capped-out echo owns when the session id first resolves', () => {
+    // Sends before the launch reports its session id adopt that id — but adoption
+    // drops nothing, so it must not renumber a trimmed echo's slot away.
+    const { result, rerender } = renderEchoProps({ sessionId: null, messages: NO_MESSAGES })
+    for (let index = 0; index < 9; index += 1) {
+      act(() => {
+        result.current.recordSend('ping')
+      })
+    }
+    expect(result.current.pending).toHaveLength(8)
+    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
+    rerender({ sessionId: 'session-1', messages: NO_MESSAGES })
+    expect(result.current.pending.map((entry) => entry.sessionId)).toEqual(
+      Array.from({ length: 8 }, () => 'session-1')
+    )
+    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
+  })
+
   it('keeps the occurrence a capped-out echo still owns when a later send is cancelled', () => {
     // The echo trimmed at PENDING_SEND_LIMIT still landed, so its turn still
     // consumes an occurrence that a later cancellation must not renumber away.

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -81,9 +81,8 @@ describe('useNativeChatPendingEchoes', () => {
   })
 
   it('does not judge a pane with the previous pane markers when the chat view moves', () => {
-    // The chat surface is one portal per tab, so moving it to another leaf changes
-    // paneKey in place: both scopes change in the same commit while the marker
-    // state still describes the leaf we came from.
+    // One portal per tab, so a leaf move changes paneKey in place — both scopes
+    // change while the marker state still describes the leaf we came from.
     const { result, rerender } = renderEchoProps({
       sessionId: 'session-2',
       messages: NO_MESSAGES,
@@ -117,14 +116,12 @@ describe('useNativeChatPendingEchoes', () => {
   })
 
   it('keeps the occurrence a capped-out echo still owns when a later send is cancelled', () => {
-    // The oldest echo is trimmed at PENDING_SEND_LIMIT while its send still
-    // lands, so its transcript turn still arrives and still consumes an
-    // occurrence. Cancelling a later send must not renumber that away.
+    // The echo trimmed at PENDING_SEND_LIMIT still landed, so its turn still
+    // consumes an occurrence that a later cancellation must not renumber away.
     const { result } = renderEchoes('session-1')
-    const ids: string[] = []
     for (let index = 0; index < 9; index += 1) {
       act(() => {
-        ids.push(result.current.recordSend('ping'))
+        result.current.recordSend('ping')
       })
     }
     expect(result.current.pending).toHaveLength(8)
@@ -134,8 +131,7 @@ describe('useNativeChatPendingEchoes', () => {
       result.current.cancelSend(result.current.pending[0]?.id ?? '')
     })
     expect(result.current.pending[0]?.id).toBe(survivorId)
-    // Was occurrence 3 behind the trimmed echo and the cancelled one; only the
-    // cancelled one released its slot.
+    // Was 3 (behind the trimmed and the cancelled echo); only one slot released.
     expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -11,18 +11,28 @@ import { useNativeChatPendingEchoes } from './use-native-chat-pending-echoes'
 
 const NO_MESSAGES: NativeChatMessage[] = []
 
-function renderEchoes(sessionId: string | null, messages: NativeChatMessage[] = NO_MESSAGES) {
+type EchoProps = {
+  sessionId: string | null
+  messages: NativeChatMessage[]
+  paneKey?: string
+}
+
+function renderEchoProps(initialProps: EchoProps) {
   return renderHook(
-    (props: { sessionId: string | null; messages: NativeChatMessage[] }) =>
+    (props: EchoProps) =>
       useNativeChatPendingEchoes({
-        paneKey: 'tab-1:leaf-1',
+        paneKey: props.paneKey ?? 'tab-1:leaf-1',
         agent: 'claude',
         sessionId: props.sessionId,
         messages: props.messages,
         setWorkingInterrupted: vi.fn()
       }),
-    { initialProps: { sessionId, messages } }
+    { initialProps }
   )
+}
+
+function renderEchoes(sessionId: string | null, messages: NativeChatMessage[] = NO_MESSAGES) {
+  return renderEchoProps({ sessionId, messages })
 }
 
 describe('useNativeChatPendingEchoes', () => {
@@ -68,5 +78,64 @@ describe('useNativeChatPendingEchoes', () => {
       result.current.recordSlashCommand('/clear')
     })
     expect(result.current.pending).toEqual([])
+  })
+
+  it('does not judge a pane with the previous pane markers when the chat view moves', () => {
+    // The chat surface is one portal per tab, so moving it to another leaf changes
+    // paneKey in place: both scopes change in the same commit while the marker
+    // state still describes the leaf we came from.
+    const { result, rerender } = renderEchoProps({
+      sessionId: 'session-2',
+      messages: NO_MESSAGES,
+      paneKey: 'tab-1:leaf-2'
+    })
+    act(() => {
+      result.current.recordSend('leaf two prompt')
+    })
+    rerender({ sessionId: 'session-1', messages: NO_MESSAGES, paneKey: 'tab-1:leaf-1' })
+    act(() => {
+      result.current.recordSlashCommand('/clear')
+    })
+    rerender({ sessionId: 'session-2', messages: NO_MESSAGES, paneKey: 'tab-1:leaf-2' })
+    expect(result.current.pending.map((entry) => entry.text)).toEqual(['leaf two prompt'])
+  })
+
+  it('releases the occurrence a cancelled send would have taken', () => {
+    const { result } = renderEchoes('session-1')
+    let firstId = ''
+    act(() => {
+      firstId = result.current.recordSend('ping')
+    })
+    act(() => {
+      result.current.recordSend('ping')
+    })
+    expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([undefined, 2])
+    act(() => {
+      result.current.cancelSend(firstId)
+    })
+    expect(result.current.pending.map((entry) => entry.matchingOccurrence)).toEqual([1])
+  })
+
+  it('keeps the occurrence a capped-out echo still owns when a later send is cancelled', () => {
+    // The oldest echo is trimmed at PENDING_SEND_LIMIT while its send still
+    // lands, so its transcript turn still arrives and still consumes an
+    // occurrence. Cancelling a later send must not renumber that away.
+    const { result } = renderEchoes('session-1')
+    const ids: string[] = []
+    for (let index = 0; index < 9; index += 1) {
+      act(() => {
+        ids.push(result.current.recordSend('ping'))
+      })
+    }
+    expect(result.current.pending).toHaveLength(8)
+    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
+    const survivorId = result.current.pending[1]?.id ?? ''
+    act(() => {
+      result.current.cancelSend(result.current.pending[0]?.id ?? '')
+    })
+    expect(result.current.pending[0]?.id).toBe(survivorId)
+    // Was occurrence 3 behind the trimmed echo and the cancelled one; only the
+    // cancelled one released its slot.
+    expect(result.current.pending[0]?.matchingOccurrence).toBe(2)
   })
 })

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.test.tsx
@@ -1,0 +1,72 @@
+// @vitest-environment happy-dom
+
+import { act, renderHook } from '@testing-library/react'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import {
+  clearCommandMarkerCacheForTests,
+  clearPendingSendCacheForTests
+} from './native-chat-pending'
+import { useNativeChatPendingEchoes } from './use-native-chat-pending-echoes'
+
+const NO_MESSAGES: NativeChatMessage[] = []
+
+function renderEchoes(sessionId: string | null, messages: NativeChatMessage[] = NO_MESSAGES) {
+  return renderHook(
+    (props: { sessionId: string | null; messages: NativeChatMessage[] }) =>
+      useNativeChatPendingEchoes({
+        paneKey: 'tab-1:leaf-1',
+        agent: 'claude',
+        sessionId: props.sessionId,
+        messages: props.messages,
+        setWorkingInterrupted: vi.fn()
+      }),
+    { initialProps: { sessionId, messages } }
+  )
+}
+
+describe('useNativeChatPendingEchoes', () => {
+  afterEach(() => {
+    clearPendingSendCacheForTests()
+    clearCommandMarkerCacheForTests()
+  })
+
+  it('keeps an echo while the conversation is unchanged', () => {
+    const { result } = renderEchoes('session-1')
+    act(() => {
+      result.current.recordSend('summarize the diff')
+    })
+    expect(result.current.pending.map((entry) => entry.text)).toEqual(['summarize the diff'])
+  })
+
+  it('drops an echo once the pane swaps to another provider session', () => {
+    const { result, rerender } = renderEchoes('session-1')
+    act(() => {
+      result.current.recordSend('summarize the diff')
+    })
+    rerender({ sessionId: 'session-2', messages: NO_MESSAGES })
+    expect(result.current.pending).toEqual([])
+  })
+
+  it('keeps an echo sent before the session id resolved, then binds it', () => {
+    const { result, rerender } = renderEchoes(null)
+    act(() => {
+      result.current.recordSend('first prompt')
+    })
+    rerender({ sessionId: 'session-1', messages: NO_MESSAGES })
+    expect(result.current.pending.map((entry) => entry.sessionId)).toEqual(['session-1'])
+    rerender({ sessionId: 'session-2', messages: NO_MESSAGES })
+    expect(result.current.pending).toEqual([])
+  })
+
+  it('drops an echo queued before /clear reset the transcript', () => {
+    const { result } = renderEchoes('session-1')
+    act(() => {
+      result.current.recordSend('summarize the diff')
+    })
+    act(() => {
+      result.current.recordSlashCommand('/clear')
+    })
+    expect(result.current.pending).toEqual([])
+  })
+})

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -20,6 +20,7 @@ import {
   type NativeChatPendingSend
 } from './native-chat-pending'
 import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
+import { dropNativeChatPendingOccurrences } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingEchoes = {
   pending: NativeChatPendingSend[]
@@ -119,8 +120,12 @@ export function useNativeChatPendingEchoes(args: {
   const cancelSend = useCallback(
     (pendingId: string) => {
       // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered.
-      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
+      // must not come back from the pane cache as a prompt that was delivered,
+      // and a later repeat must stop waiting on the slot it would have taken.
+      const next = dropNativeChatPendingOccurrences(
+        readPendingSendCache(pendingScope),
+        (entry) => entry.id === pendingId
+      )
       setPending(writePendingSendCache(pendingScope, next))
     },
     [pendingScope]

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -20,7 +20,6 @@ import {
   type NativeChatPendingSend
 } from './native-chat-pending'
 import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
-import { dropNativeChatPendingOccurrences } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingEchoes = {
   pending: NativeChatPendingSend[]
@@ -120,12 +119,8 @@ export function useNativeChatPendingEchoes(args: {
   const cancelSend = useCallback(
     (pendingId: string) => {
       // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered,
-      // and a later repeat must stop waiting on the slot it would have taken.
-      const next = dropNativeChatPendingOccurrences(
-        readPendingSendCache(pendingScope),
-        (entry) => entry.id === pendingId
-      )
+      // must not come back from the pane cache as a prompt that was delivered.
+      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
       setPending(writePendingSendCache(pendingScope, next))
     },
     [pendingScope]

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -1,8 +1,8 @@
 import {
   useCallback,
   useEffect,
+  useEffectEvent,
   useMemo,
-  useRef,
   useState,
   type Dispatch,
   type SetStateAction
@@ -17,11 +17,10 @@ import {
   readPendingSendCache,
   writePendingSendCache,
   type NativeChatCommandMarker,
-  type NativeChatCommandMarkerScope,
   type NativeChatPendingSend
 } from './native-chat-pending'
 import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
-import { withoutNativeChatPendingOccurrence } from './native-chat-pending-occurrence'
+import { dropNativeChatPendingOccurrences } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingEchoes = {
   pending: NativeChatPendingSend[]
@@ -51,15 +50,11 @@ export function useNativeChatPendingEchoes(args: {
   setWorkingInterrupted: Dispatch<SetStateAction<boolean>>
 }): NativeChatPendingEchoes {
   const { paneKey, agent, sessionId, messages, setWorkingInterrupted } = args
-  // Why: the effects below re-read pane caches, so an unstable setter in their
-  // deps would loop. Keep the suppression reset behind a stable callback.
-  const setWorkingInterruptedRef = useRef(setWorkingInterrupted)
-  useEffect(() => {
-    setWorkingInterruptedRef.current = setWorkingInterrupted
-  }, [setWorkingInterrupted])
-  const clearWorkingSuppression = useCallback(() => {
-    setWorkingInterruptedRef.current(false)
-  }, [])
+  // Why: the scope effects below re-read pane caches, so an unstable setter in
+  // their deps would loop. Event handlers call the setter directly.
+  const clearWorkingSuppression = useEffectEvent(() => {
+    setWorkingInterrupted(false)
+  })
   const commandMarkerScope = useMemo(
     () => ({ paneKey, agent, sessionId }),
     [paneKey, agent, sessionId]
@@ -70,12 +65,9 @@ export function useNativeChatPendingEchoes(args: {
   )
   // Slash commands aren't chat turns, so they get a small local "Ran /clear"
   // system line instead of a user bubble. Capped + cached per conversation.
-  // The scope travels along so the retain effect can reject a stale value.
-  const [markerState, setMarkerState] = useState<{
-    scope: NativeChatCommandMarkerScope
-    markers: NativeChatCommandMarker[]
-  }>(() => ({ scope: commandMarkerScope, markers: readCommandMarkerCache(commandMarkerScope) }))
-  const commandMarkers = markerState.markers
+  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
+    readCommandMarkerCache(commandMarkerScope)
+  )
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
   // often learns its provider session id after the first send; clearing pending
   // on that transition briefly flashes the empty state before the transcript
@@ -83,39 +75,32 @@ export function useNativeChatPendingEchoes(args: {
   useEffect(() => {
     setPending(readPendingSendCache(pendingScope))
     clearWorkingSuppression()
-  }, [clearWorkingSuppression, pendingScope])
+  }, [pendingScope])
   // Command markers are session-scoped because slash commands like /clear are
   // local feedback for a specific transcript boundary.
   useEffect(() => {
-    setMarkerState({
-      scope: commandMarkerScope,
-      markers: readCommandMarkerCache(commandMarkerScope)
-    })
+    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
     clearWorkingSuppression()
-  }, [clearWorkingSuppression, commandMarkerScope])
+  }, [commandMarkerScope])
   // Prune echoes whose real user turn is now in the transcript.
   useEffect(() => {
     setPending((prev) => writePendingSendCache(pendingScope, prunePendingSends(prev, messages)))
   }, [messages, pendingScope])
   // Drop echoes the pane's current conversation can never match, so a replaced
-  // conversation cannot strand an old prompt as its newest bubble.
+  // conversation cannot strand an old prompt as its newest bubble. `commandMarkers`
+  // is the trigger only: a chat-view move changes both scopes in one commit, so the
+  // markers are re-read by scope rather than taken from state that still describes
+  // the leaf we came from — judging by that writes a permanent drop.
   useEffect(() => {
-    // Why: a chat-view move changes both scopes in one commit, and judging the
-    // new pane's echoes by the old pane's `/clear` writes a permanent drop.
-    if (markerState.scope !== commandMarkerScope) {
-      return
-    }
+    const markers = readCommandMarkerCache(commandMarkerScope)
     setPending((prev) => {
-      const next = retainPendingSendsForConversation(prev, {
-        sessionId,
-        markers: markerState.markers
-      })
+      const next = retainPendingSendsForConversation(prev, { sessionId, markers })
       return next === prev ? prev : writePendingSendCache(pendingScope, next)
     })
-  }, [commandMarkerScope, markerState, pendingScope, sessionId])
+  }, [commandMarkers, commandMarkerScope, pendingScope, sessionId])
   const recordSend = useCallback(
     (text: string, imagePaths?: string[]) => {
-      clearWorkingSuppression()
+      setWorkingInterrupted(false)
       const sentAt = Date.now()
       const boundary = messages.at(-1)
       const entry: NativeChatPendingSend = {
@@ -130,27 +115,24 @@ export function useNativeChatPendingEchoes(args: {
       setPending(appendPendingSendCache(pendingScope, entry))
       return entry.id
     },
-    [clearWorkingSuppression, messages, pendingScope, sessionId]
+    [messages, pendingScope, sessionId, setWorkingInterrupted]
   )
   const cancelSend = useCallback(
     (pendingId: string) => {
       // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
       // must not come back from the pane cache as a prompt that was delivered,
       // and a later repeat must stop waiting on the slot it would have taken.
-      const cached = readPendingSendCache(pendingScope)
-      const removedIndex = cached.findIndex((entry) => entry.id === pendingId)
-      const next =
-        removedIndex < 0 ? cached : withoutNativeChatPendingOccurrence(cached, removedIndex)
+      const next = dropNativeChatPendingOccurrences(
+        readPendingSendCache(pendingScope),
+        (entry) => entry.id === pendingId
+      )
       setPending(writePendingSendCache(pendingScope, next))
     },
     [pendingScope]
   )
   const recordSlashCommand = useCallback(
     (command: string) => {
-      setMarkerState({
-        scope: commandMarkerScope,
-        markers: appendCommandMarkerCache(commandMarkerScope, command)
-      })
+      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
     },
     [commandMarkerScope]
   )

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -70,8 +70,7 @@ export function useNativeChatPendingEchoes(args: {
   )
   // Slash commands aren't chat turns, so they get a small local "Ran /clear"
   // system line instead of a user bubble. Capped + cached per conversation.
-  // The scope travels with the markers: the retain effect below must be able to
-  // tell that a value still describes the conversation it was read for.
+  // The scope travels along so the retain effect can reject a stale value.
   const [markerState, setMarkerState] = useState<{
     scope: NativeChatCommandMarkerScope
     markers: NativeChatCommandMarker[]
@@ -101,11 +100,8 @@ export function useNativeChatPendingEchoes(args: {
   // Drop echoes the pane's current conversation can never match, so a replaced
   // conversation cannot strand an old prompt as its newest bubble.
   useEffect(() => {
-    // Why: moving the chat view to another leaf changes both scopes in one
-    // commit, so this would otherwise run against the new pane's echoes while
-    // still holding the previous pane's `/clear` — and the drop it writes to the
-    // pane cache is permanent. Wait for the markers that describe this
-    // conversation; the effect above delivers them in that same commit.
+    // Why: a chat-view move changes both scopes in one commit, and judging the
+    // new pane's echoes by the old pane's `/clear` writes a permanent drop.
     if (markerState.scope !== commandMarkerScope) {
       return
     }
@@ -139,10 +135,8 @@ export function useNativeChatPendingEchoes(args: {
   const cancelSend = useCallback(
     (pendingId: string) => {
       // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
-      // must not come back from the pane cache as a prompt that was delivered.
-      // A cancelled send also consumes no transcript occurrence, so a repeat of
-      // the same text queued after it must stop waiting on the slot this echo
-      // would have taken.
+      // must not come back from the pane cache as a prompt that was delivered,
+      // and a later repeat must stop waiting on the slot it would have taken.
       const cached = readPendingSendCache(pendingScope)
       const removedIndex = cached.findIndex((entry) => entry.id === pendingId)
       const next =

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -17,9 +17,11 @@ import {
   readPendingSendCache,
   writePendingSendCache,
   type NativeChatCommandMarker,
+  type NativeChatCommandMarkerScope,
   type NativeChatPendingSend
 } from './native-chat-pending'
 import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
+import { withoutNativeChatPendingOccurrence } from './native-chat-pending-occurrence'
 
 export type NativeChatPendingEchoes = {
   pending: NativeChatPendingSend[]
@@ -65,9 +67,13 @@ export function useNativeChatPendingEchoes(args: {
   )
   // Slash commands aren't chat turns, so they get a small local "Ran /clear"
   // system line instead of a user bubble. Capped + cached per conversation.
-  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
-    readCommandMarkerCache(commandMarkerScope)
-  )
+  // The scope travels with the markers: the retain effect below must be able to
+  // tell that a value still describes the conversation it was read for.
+  const [markerState, setMarkerState] = useState<{
+    scope: NativeChatCommandMarkerScope
+    markers: NativeChatCommandMarker[]
+  }>(() => ({ scope: commandMarkerScope, markers: readCommandMarkerCache(commandMarkerScope) }))
+  const commandMarkers = markerState.markers
   // Reset the optimistic queue only when the pane/agent changes. A fresh launch
   // often learns its provider session id after the first send; clearing pending
   // on that transition briefly flashes the empty state before the transcript
@@ -79,7 +85,10 @@ export function useNativeChatPendingEchoes(args: {
   // Command markers are session-scoped because slash commands like /clear are
   // local feedback for a specific transcript boundary.
   useEffect(() => {
-    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
+    setMarkerState({
+      scope: commandMarkerScope,
+      markers: readCommandMarkerCache(commandMarkerScope)
+    })
     clearWorkingSuppression()
   }, [clearWorkingSuppression, commandMarkerScope])
   // Prune echoes whose real user turn is now in the transcript.
@@ -89,11 +98,22 @@ export function useNativeChatPendingEchoes(args: {
   // Drop echoes the pane's current conversation can never match, so a replaced
   // conversation cannot strand an old prompt as its newest bubble.
   useEffect(() => {
+    // Why: moving the chat view to another leaf changes both scopes in one
+    // commit, so this would otherwise run against the new pane's echoes while
+    // still holding the previous pane's `/clear` — and the drop it writes to the
+    // pane cache is permanent. Wait for the markers that describe this
+    // conversation; the effect above delivers them in that same commit.
+    if (markerState.scope !== commandMarkerScope) {
+      return
+    }
     setPending((prev) => {
-      const next = retainPendingSendsForConversation(prev, { sessionId, markers: commandMarkers })
+      const next = retainPendingSendsForConversation(prev, {
+        sessionId,
+        markers: markerState.markers
+      })
       return next === prev ? prev : writePendingSendCache(pendingScope, next)
     })
-  }, [commandMarkers, pendingScope, sessionId])
+  }, [commandMarkerScope, markerState, pendingScope, sessionId])
   const recordSend = useCallback(
     (text: string, imagePaths?: string[]) => {
       clearWorkingSuppression()
@@ -117,14 +137,23 @@ export function useNativeChatPendingEchoes(args: {
     (pendingId: string) => {
       // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
       // must not come back from the pane cache as a prompt that was delivered.
-      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
+      // A cancelled send also consumes no transcript occurrence, so a repeat of
+      // the same text queued after it must stop waiting on the slot this echo
+      // would have taken.
+      const cached = readPendingSendCache(pendingScope)
+      const removedIndex = cached.findIndex((entry) => entry.id === pendingId)
+      const next =
+        removedIndex < 0 ? cached : withoutNativeChatPendingOccurrence(cached, removedIndex)
       setPending(writePendingSendCache(pendingScope, next))
     },
     [pendingScope]
   )
   const recordSlashCommand = useCallback(
     (command: string) => {
-      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
+      setMarkerState({
+        scope: commandMarkerScope,
+        markers: appendCommandMarkerCache(commandMarkerScope, command)
+      })
     },
     [commandMarkerScope]
   )

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -28,8 +28,11 @@ export type NativeChatPendingEchoes = {
   commandMarkers: NativeChatCommandMarker[]
   /** Echo a composer send and return its optimistic id. */
   recordSend: (text: string, imagePaths?: string[]) => string
+  /** Retire the echo for a send whose delayed Enter was cancelled. */
   cancelSend: (pendingId: string) => void
+  /** Record a slash command as a local system line for this conversation. */
   recordSlashCommand: (command: string) => void
+  /** Drop every echo in the pane, e.g. when Stop interrupts the agent. */
   clearPending: () => void
 }
 

--- a/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-pending-echoes.ts
@@ -1,0 +1,135 @@
+import {
+  useCallback,
+  useEffect,
+  useMemo,
+  useRef,
+  useState,
+  type Dispatch,
+  type SetStateAction
+} from 'react'
+import type { NativeChatMessage, NativeChatSession } from '../../../../shared/native-chat-types'
+import {
+  appendCommandMarkerCache,
+  appendPendingSendCache,
+  nextNativeChatPendingSendId,
+  prunePendingSends,
+  readCommandMarkerCache,
+  readPendingSendCache,
+  writePendingSendCache,
+  type NativeChatCommandMarker,
+  type NativeChatPendingSend
+} from './native-chat-pending'
+import { retainPendingSendsForConversation } from './native-chat-pending-conversation'
+
+export type NativeChatPendingEchoes = {
+  pending: NativeChatPendingSend[]
+  commandMarkers: NativeChatCommandMarker[]
+  /** Echo a composer send and return its optimistic id. */
+  recordSend: (text: string, imagePaths?: string[]) => string
+  cancelSend: (pendingId: string) => void
+  recordSlashCommand: (command: string) => void
+  clearPending: () => void
+}
+
+/**
+ * Owns the pane's locally-minted chat entries — optimistic "queued" sends
+ * (mobile parity) and slash-command markers — plus the rules that retire them.
+ * A send is echoed immediately and pruned once its real user turn lands in the
+ * transcript, so the message never vanishes between send and transcript
+ * catch-up.
+ */
+export function useNativeChatPendingEchoes(args: {
+  paneKey: string
+  agent: NativeChatSession['agent']
+  sessionId: string | null
+  messages: NativeChatMessage[]
+  setWorkingInterrupted: Dispatch<SetStateAction<boolean>>
+}): NativeChatPendingEchoes {
+  const { paneKey, agent, sessionId, messages, setWorkingInterrupted } = args
+  // Why: the effects below re-read pane caches, so an unstable setter in their
+  // deps would loop. Keep the suppression reset behind a stable callback.
+  const setWorkingInterruptedRef = useRef(setWorkingInterrupted)
+  useEffect(() => {
+    setWorkingInterruptedRef.current = setWorkingInterrupted
+  }, [setWorkingInterrupted])
+  const clearWorkingSuppression = useCallback(() => {
+    setWorkingInterruptedRef.current(false)
+  }, [])
+  const commandMarkerScope = useMemo(
+    () => ({ paneKey, agent, sessionId }),
+    [paneKey, agent, sessionId]
+  )
+  const pendingScope = useMemo(() => ({ paneKey, agent }), [paneKey, agent])
+  const [pending, setPending] = useState<NativeChatPendingSend[]>(() =>
+    readPendingSendCache(pendingScope)
+  )
+  // Slash commands aren't chat turns, so they get a small local "Ran /clear"
+  // system line instead of a user bubble. Capped + cached per conversation.
+  const [commandMarkers, setCommandMarkers] = useState<NativeChatCommandMarker[]>(() =>
+    readCommandMarkerCache(commandMarkerScope)
+  )
+  // Reset the optimistic queue only when the pane/agent changes. A fresh launch
+  // often learns its provider session id after the first send; clearing pending
+  // on that transition briefly flashes the empty state before the transcript
+  // user turn lands.
+  useEffect(() => {
+    setPending(readPendingSendCache(pendingScope))
+    clearWorkingSuppression()
+  }, [clearWorkingSuppression, pendingScope])
+  // Command markers are session-scoped because slash commands like /clear are
+  // local feedback for a specific transcript boundary.
+  useEffect(() => {
+    setCommandMarkers(readCommandMarkerCache(commandMarkerScope))
+    clearWorkingSuppression()
+  }, [clearWorkingSuppression, commandMarkerScope])
+  // Prune echoes whose real user turn is now in the transcript.
+  useEffect(() => {
+    setPending((prev) => writePendingSendCache(pendingScope, prunePendingSends(prev, messages)))
+  }, [messages, pendingScope])
+  // Drop echoes the pane's current conversation can never match, so a replaced
+  // conversation cannot strand an old prompt as its newest bubble.
+  useEffect(() => {
+    setPending((prev) => {
+      const next = retainPendingSendsForConversation(prev, { sessionId, markers: commandMarkers })
+      return next === prev ? prev : writePendingSendCache(pendingScope, next)
+    })
+  }, [commandMarkers, pendingScope, sessionId])
+  const recordSend = useCallback(
+    (text: string, imagePaths?: string[]) => {
+      clearWorkingSuppression()
+      const sentAt = Date.now()
+      const boundary = messages.at(-1)
+      const entry: NativeChatPendingSend = {
+        id: nextNativeChatPendingSendId(sentAt),
+        text,
+        sentAt,
+        afterMessageId: boundary?.id ?? null,
+        afterMessageTimestamp: boundary?.timestamp ?? null,
+        sessionId,
+        ...(imagePaths ? { imagePaths } : {})
+      }
+      setPending(appendPendingSendCache(pendingScope, entry))
+      return entry.id
+    },
+    [clearWorkingSuppression, messages, pendingScope, sessionId]
+  )
+  const cancelSend = useCallback(
+    (pendingId: string) => {
+      // Why: detach/interrupt cancels the delayed Enter, so its optimistic echo
+      // must not come back from the pane cache as a prompt that was delivered.
+      const next = readPendingSendCache(pendingScope).filter((entry) => entry.id !== pendingId)
+      setPending(writePendingSendCache(pendingScope, next))
+    },
+    [pendingScope]
+  )
+  const recordSlashCommand = useCallback(
+    (command: string) => {
+      setCommandMarkers(appendCommandMarkerCache(commandMarkerScope, command))
+    },
+    [commandMarkerScope]
+  )
+  const clearPending = useCallback(() => {
+    setPending(writePendingSendCache(pendingScope, []))
+  }, [pendingScope])
+  return { pending, commandMarkers, recordSend, cancelSend, recordSlashCommand, clearPending }
+}


### PR DESCRIPTION
> **Stacked on #11509 — review the last commit only** (`fix(native-chat): release the occurrence a cancelled send would have taken`).
>
> The fix lives in `use-native-chat-pending-echoes.ts`, a file #11509 creates, so this branch is built on top of it. I only have read access to this repo, so I cannot push the parent branch here and target it as a base — GitHub therefore diffs this against `main` and shows #11509's commits alongside mine. This repo squash-merges, so they will **not** fall out of the diff on their own — once #11509 lands I will rebase this branch onto the new `main`, which leaves exactly the one commit. Ping me and it is done the same day; I will also do it unprompted as soon as I see #11509 merge. Split out at @brennanb2025's request on that PR, since the strand below is reachable on `main` today with no dependency on the stale-echo work there.

## Summary

Repeat sends of identical text carry an explicit `matchingOccurrence`, so a later echo cannot retire against a transcript turn an earlier one already consumed. Cancelling the delayed Enter (detach, interrupt) removes an echo **without any transcript turn consuming its slot** — the survivor is left numbered past a sibling that no longer exists, waits for a second identical user turn that can never arrive, and its "queued" bubble is stranded at the list tail for the rest of the pane's life.

Send `ping`, send `ping` again, cancel the first: the survivor holds `matchingOccurrence: 2` and the transcript only ever produces one `ping`.

### Change

`cancelSend` releases the slot through `dropNativeChatPendingOccurrences`, which shifts only the later **same-key** siblings down by exactly one.

Deliberately *not* a renumber from 1, which Greptile suggested on #11509 and which I measured to be wrong on this path. `PENDING_SEND_LIMIT = 8` trims the *oldest* echo while its send still landed, so its transcript turn still arrives and still consumes an occurrence — a survivor can legitimately hold slot 3+ with no pruning involved. Renumbering from 1 erases that trimmed echo's real slot and retires the survivor against an already-consumed turn (`expected 1 to be 2`). A conversation swap replaces the transcript, so renumbering from 1 is right *there*; a cancellation replaces nothing, so only the one slot it vacated is released.

## Screenshots

`No visual change` in the fixed state — this removes a bubble that should never have stayed on screen. Both behaviours are pinned by tests that fail on revert.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [ ] `pnpm build` — not run; renderer-only change with no main/preload, packaging, or native surface touched. Say the word if you want it anyway.
- [x] Added or updated high-quality tests that would catch regressions

`pnpm lint` (including `check:max-lines-ratchet`, no new bypasses) and all three `pnpm typecheck` projects exit 0. `native-chat` is green at 93 files / 839 tests. Full suite: 3759 files passed, 8 failed, 9 skipped (39757 tests passed, 43 failed, 71 skipped) — **0 new failures**:

- 7 files fail on `TypeError: window.localStorage.<removeItem|clear|getItem> is not a function`, the happy-dom stub under local Node 25 against the repo's Node 24 requirement.
- `src/relay/agent-exec-handler.test.ts` (2 tests) fails identically on `origin/main`; I checked it out and reran to confirm.

Nothing in `native-chat` fails, and the same run on the parent branch differs only by the two tests this PR adds.

**Differential evidence** — I reverted the source hunk alone, kept both tests, and ran them:

```
× releases the occurrence a cancelled send would have taken
  AssertionError: expected [ 2 ] to deeply equal [ 1 ]
× keeps the occurrence a capped-out echo still owns when a later send is cancelled
  AssertionError: expected 3 to be 2
Tests  2 failed | 6 passed (8)
```

| Test | What it pins |
| --- | --- |
| `releases the occurrence a cancelled send would have taken` | the strand itself — survivor drops to slot 1 and retires normally |
| `keeps the occurrence a capped-out echo still owns when a later send is cancelled` | the over-correction — a trimmed echo's slot survives, so exactly one slot is released, not all of them |

`dropNativeChatPendingOccurrences` already carries six direct tests from #11509 (per-key counting, unrelated keys untouched, never inventing an occurrence, never below slot 1, same-reference when nothing dropped); this change adds the second caller they were written for.

## AI Review Report

Reviewed as part of #11509 and carried over intact — the code and both tests are byte-identical to what was reviewed there, only the PR boundary changed.

- **Pure logic:** the asymmetry between "conversation replaced" (renumber from 1) and "send cancelled" (shift by one) is the whole point of the change and is the part most worth disagreeing with; the capped-out-echo test is what makes it falsifiable rather than an argument.
- **React effects:** `cancelSend` is a `useCallback` over `pendingScope` that reads the pane cache, transforms, and writes back — no new effect, no new dependency, no new render path.
- **Cross-platform:** explicitly checked. Renderer-only pure TypeScript — array filtering and integer arithmetic over at most 8 entries. No paths, no shell, no shortcuts or key handling, no user-visible strings or labels (no localisation surface), no `process.platform` branch, and no Electron main/preload/IPC surface. Nothing here can behave differently on macOS, Linux, or Windows.
- **Bot review on #11509** raised this gap (P2) and proposed the dense renumber; the measurement above is why the fix takes a different shape than suggested.

## Security Audit

No new attack surface.

- **Input handling:** none added. The predicate compares an internally-minted pending id (`nextNativeChatPendingSendId`) for equality; no external input is parsed, evaluated, or rendered.
- **Command execution / path handling:** none. No PTY write, no filesystem path.
- **Auth / secrets:** none touched.
- **IPC:** unchanged — no new channel, handler, or payload shape.
- **Dependencies:** none added.
- **Memory/DoS:** operates on the existing pane cache, bounded at `PENDING_SEND_LIMIT = 8`; the pass is O(n) over at most 8 entries and allocates no new retained state.
- **Follow-up:** none required.

## Notes

- **Merge order:** needs #11509 first, and the rebase onto the squashed `main` is a manual step I own — do not merge this before #11509 or the parent's changes land twice.
- The known limits documented on #11509 (never-resolved session id, clock-domain mix in #11519, the unrecoverable send in #11511) are unchanged by this PR — it narrows one strand cause, not the matcher itself.

