### PR TITLE
[Perf-LH] Skip impossible advertised URL scans in PTY output

### DIFF
--- a/config/scripts/advertised-url-watcher-benchmark.mjs
+++ b/config/scripts/advertised-url-watcher-benchmark.mjs
@@ -1,0 +1,255 @@
+#!/usr/bin/env node
+// Measures the no-URL PTY path that every terminal chunk enters.
+import { spawnSync } from 'node:child_process'
+import { existsSync, readFileSync } from 'node:fs'
+import nodeModule from 'node:module'
+import { performance } from 'node:perf_hooks'
+import { fileURLToPath } from 'node:url'
+
+if (!process.execArgv.includes('--experimental-transform-types')) {
+  const result = spawnSync(
+    process.execPath,
+    ['--experimental-transform-types', '--no-warnings', import.meta.filename],
+    { stdio: 'inherit' }
+  )
+  process.exit(result.status ?? 1)
+}
+
+nodeModule.registerHooks({
+  resolve(specifier, context, nextResolve) {
+    if (specifier.startsWith('.') && !/\.[cm]?[jt]s$/.test(specifier) && context.parentURL) {
+      const candidate = new URL(`${specifier}.ts`, context.parentURL)
+      if (existsSync(fileURLToPath(candidate))) {
+        return { url: candidate.href, shortCircuit: true }
+      }
+    }
+    return nextResolve(specifier, context)
+  }
+})
+
+const source = readFileSync(
+  new URL('../../src/main/ports/advertised-url-watcher.ts', import.meta.url),
+  'utf8'
+)
+for (const marker of [
+  "return mayContainHttpUrl(finalized) ? stripTerminalControls(finalized) : ''",
+  'if (chunk.length >= PER_PTY_BUFFER_LIMIT)',
+  'this.raw.length + chunk.length > PER_PTY_BUFFER_LIMIT'
+]) {
+  if (!source.includes(marker)) {
+    throw new Error(`advertised-url-watcher.ts no longer contains \`${marker}\``)
+  }
+}
+
+const { AdvertisedUrlWatcher, extractUrlCandidates, stripTerminalControls } = await import(
+  new URL('../../src/main/ports/advertised-url-watcher.ts', import.meta.url).href
+)
+
+const BUFFER_LIMIT = 4096
+const ITERATIONS = Number(process.env.ORCA_ADVERTISED_URL_BENCH_ITERATIONS ?? '10000')
+const ROUNDS = Number(process.env.ORCA_ADVERTISED_URL_BENCH_ROUNDS ?? '12')
+const WARMUP = Number(process.env.ORCA_ADVERTISED_URL_BENCH_WARMUP ?? '1000')
+
+for (const [name, value] of [
+  ['ORCA_ADVERTISED_URL_BENCH_ITERATIONS', ITERATIONS],
+  ['ORCA_ADVERTISED_URL_BENCH_ROUNDS', ROUNDS],
+  ['ORCA_ADVERTISED_URL_BENCH_WARMUP', WARMUP]
+]) {
+  if (!Number.isSafeInteger(value) || value <= 0) {
+    throw new Error(`${name} must be a positive integer, received ${value}`)
+  }
+}
+if (ROUNDS % 2 !== 0) {
+  throw new Error('ORCA_ADVERTISED_URL_BENCH_ROUNDS must be even')
+}
+
+class BeforePtyBuffer {
+  raw = ''
+
+  ingest(chunk) {
+    const chunkHasLineBreak = chunk.includes('\n') || chunk.includes('\r')
+    this.raw += chunk
+    if (this.raw.length > BUFFER_LIMIT) {
+      this.raw = this.raw.slice(-BUFFER_LIMIT)
+    }
+    if (!chunkHasLineBreak) {
+      return ''
+    }
+    const lastNewline = lastLineBreak(this.raw)
+    if (lastNewline === -1) {
+      return ''
+    }
+    const finalized = this.raw.slice(0, lastNewline + 1)
+    this.raw = this.raw.slice(lastNewline + 1)
+    return stripTerminalControls(finalized)
+  }
+}
+
+class BeforeWatcher {
+  buffers = new Map()
+  ptyToWorktree = new Map()
+
+  bindPty(ptyId, worktreeId) {
+    this.ptyToWorktree.set(ptyId, worktreeId)
+  }
+
+  ingest(ptyId, chunk) {
+    if (!this.ptyToWorktree.has(ptyId)) {
+      return 0
+    }
+    let buffer = this.buffers.get(ptyId)
+    if (!buffer) {
+      buffer = new BeforePtyBuffer()
+      this.buffers.set(ptyId, buffer)
+    }
+    const finalized = buffer.ingest(chunk)
+    return finalized ? extractUrlCandidates(finalized).length : 0
+  }
+}
+
+function lastLineBreak(text) {
+  for (let index = text.length - 1; index >= 0; index -= 1) {
+    const code = text.charCodeAt(index)
+    if (code === 0x0a || code === 0x0d) {
+      return index
+    }
+  }
+  return -1
+}
+
+function repeatToLine(text, length, sample) {
+  const unit = `${text}${sample}\n`
+  return `${unit.repeat(Math.ceil(length / unit.length)).slice(0, length - 1)}\n`
+}
+
+function repeatWithoutLineBreak(text, length, sample) {
+  const unit = `${text}${sample}`
+  return unit.repeat(Math.ceil(length / unit.length)).slice(0, length)
+}
+
+const fixtures = [
+  {
+    label: 'plain 32B line',
+    chunks: Array.from({ length: 32 }, (_, index) => `compiled module ${index} in 183ms\n`)
+  },
+  {
+    label: 'ANSI 32B line',
+    chunks: Array.from({ length: 32 }, (_, index) => `\x1b[2K\x1b[1GThinking ${index}...\r\n`)
+  },
+  {
+    label: 'guard fallthrough line',
+    chunks: Array.from(
+      { length: 32 },
+      (_, index) => `path/to/http_server: compiled module ${index}\n`
+    )
+  },
+  {
+    label: 'plain 4KiB line',
+    chunks: Array.from({ length: 32 }, (_, index) =>
+      repeatToLine('INFO build completed module=renderer duration=12ms ', BUFFER_LIMIT, index)
+    )
+  },
+  {
+    label: 'ANSI 4KiB line',
+    chunks: Array.from({ length: 32 }, (_, index) =>
+      repeatToLine(
+        '\x1b[2K\x1b[1Gthinking about compiler output and writing patches ',
+        BUFFER_LIMIT,
+        index
+      )
+    )
+  },
+  {
+    label: 'guard fallthrough 4KiB',
+    chunks: Array.from({ length: 32 }, (_, index) =>
+      repeatToLine(
+        'path/to/http_server: compiled without an advertised endpoint ',
+        BUFFER_LIMIT,
+        index
+      )
+    )
+  },
+  {
+    label: '64KiB partial chunk',
+    chunks: Array.from({ length: 32 }, (_, index) =>
+      repeatWithoutLineBreak('compiler output without a line break ', 64 * 1024, index)
+    )
+  },
+  {
+    label: '256KiB partial chunk',
+    chunks: Array.from({ length: 32 }, (_, index) =>
+      repeatWithoutLineBreak('compiler output without a line break ', 256 * 1024, index)
+    )
+  }
+]
+
+let checksum = 0
+
+function runBefore(chunks, iterations) {
+  const watcher = new BeforeWatcher()
+  watcher.bindPty('pty', 'repo::/bench')
+  let found = 0
+  for (let index = 0; index < iterations; index += 1) {
+    found += watcher.ingest('pty', chunks[index % chunks.length])
+  }
+  checksum = Math.imul(checksum ^ found ^ watcher.buffers.get('pty').raw.length, 16777619) >>> 0
+}
+
+function runAfter(chunks, iterations) {
+  const watcher = new AdvertisedUrlWatcher()
+  watcher.bindPty('pty', 'repo::/bench')
+  for (let index = 0; index < iterations; index += 1) {
+    watcher.ingest('pty', chunks[index % chunks.length], index)
+  }
+  const buffer = watcher.buffers.get('pty')
+  checksum = Math.imul(checksum ^ (buffer?.raw.length ?? 0), 16777619) >>> 0
+}
+
+function median(values) {
+  const sorted = [...values].sort((left, right) => left - right)
+  const middle = Math.floor(sorted.length / 2)
+  return sorted.length % 2 === 0 ? (sorted[middle - 1] + sorted[middle]) / 2 : sorted[middle]
+}
+
+function measure(fixture) {
+  runBefore(fixture.chunks, WARMUP)
+  runAfter(fixture.chunks, WARMUP)
+  const before = []
+  const after = []
+  for (let round = 0; round < ROUNDS; round += 1) {
+    const measureBefore = () => {
+      const startedAt = performance.now()
+      runBefore(fixture.chunks, ITERATIONS)
+      before.push(((performance.now() - startedAt) * 1000) / ITERATIONS)
+    }
+    const measureAfter = () => {
+      const startedAt = performance.now()
+      runAfter(fixture.chunks, ITERATIONS)
+      after.push(((performance.now() - startedAt) * 1000) / ITERATIONS)
+    }
+    if (round % 2 === 0) {
+      measureBefore()
+      measureAfter()
+    } else {
+      measureAfter()
+      measureBefore()
+    }
+  }
+  return { before: median(before), after: median(after) }
+}
+
+console.log('Advertised URL watcher no-match cost in microseconds/chunk. Lower is better.')
+console.log(`iterations=${ITERATIONS}, rounds=${ROUNDS}, warmup=${WARMUP}`)
+console.log('fixture                     before      after    speedup')
+for (const fixture of fixtures) {
+  const result = measure(fixture)
+  console.log(
+    `${fixture.label.padEnd(26)} ${result.before.toFixed(3).padStart(8)} ${result.after
+      .toFixed(3)
+      .padStart(10)} ${(result.before / result.after).toFixed(2).padStart(9)}x`
+  )
+}
+console.log(`checksum=${checksum}`)
+console.log(
+  'Limitations: synthetic in-process scan; explicit timestamps omit the production clock read and surrounding PTY dispatch.'
+)

--- a/src/main/ports/advertised-url-watcher.test.ts
+++ b/src/main/ports/advertised-url-watcher.test.ts
@@ -147,6 +147,13 @@ describe('AdvertisedUrlWatcher.ingest', () => {
     expect(watcher.lookup(WORKTREE, 3001)?.origin).toBe('https://local.getmontecarlo.com:3001')
   })
 
+  it('preserves a split URL inside the bounded suffix', () => {
+    const watcher = bindFresh()
+    watcher.ingest(PTY, `${'x'.repeat(4080)} https://local.`)
+    watcher.ingest(PTY, 'example.com:3003/\n')
+    expect(watcher.lookup(WORKTREE, 3003)?.origin).toBe('https://local.example.com:3003')
+  })
+
   it('does not scan buffered PTY text until a line break arrives', () => {
     const watcher = bindFresh()
     const charCodeAtSpy = vi.spyOn(String.prototype, 'charCodeAt')
@@ -166,6 +173,35 @@ describe('AdvertisedUrlWatcher.ingest', () => {
     expect(watcher.lookup(WORKTREE, 3001)).toBeUndefined()
     watcher.ingest(PTY, '[0m\n')
     expect(watcher.lookup(WORKTREE, 3001)?.origin).toBe('https://example.com:3001')
+  })
+
+  it('keeps URLs whose scheme is split by terminal controls', () => {
+    const watcher = bindFresh()
+    watcher.ingest(PTY, 'H\x1b[32mtT\x1b[0mP://example.com:3001/\n')
+    expect(watcher.lookup(WORKTREE, 3001)?.origin).toBe('http://example.com:3001')
+  })
+
+  it('rejects finalized lines missing any character required by an HTTP URL', () => {
+    const watcher = bindFresh()
+    for (const line of [
+      'ttp://example.com:3001/\n',
+      'hhp://example.com:3001/\n',
+      'htt://example.com:3001/\n',
+      'http//example.com/3001\n',
+      'http:example.com:3001\n'
+    ]) {
+      watcher.ingest(PTY, line)
+    }
+    expect(watcher.lookup(WORKTREE, 3001)).toBeUndefined()
+  })
+
+  it('retains exactly the latest bounded tail across oversized chunks', () => {
+    const watcher = bindFresh()
+    watcher.ingest(PTY, `https://stale.example.com:3001/${'x'.repeat(4096)}`)
+    watcher.ingest(PTY, ' https://fresh.example.com:3002/\n')
+
+    expect(watcher.lookup(WORKTREE, 3001)).toBeUndefined()
+    expect(watcher.lookup(WORKTREE, 3002)?.host).toBe('fresh.example.com')
   })
 
   it('sanitizes to origin (drops path, query, fragment, userinfo)', () => {

--- a/src/main/ports/advertised-url-watcher.ts
+++ b/src/main/ports/advertised-url-watcher.ts
@@ -66,9 +66,13 @@ class PtyBuffer {
   /** Append a chunk; return cleaned text up to the last newline. The tail stays buffered so a URL or ANSI sequence split across chunks survives. */
   ingest(chunk: string): string {
     const chunkHasLineBreak = chunk.includes('\n') || chunk.includes('\r')
-    this.raw += chunk
-    if (this.raw.length > PER_PTY_BUFFER_LIMIT) {
-      this.raw = this.raw.slice(-PER_PTY_BUFFER_LIMIT)
+    // Keep the suffix directly so oversized chunks never materialize a throwaway full concatenation.
+    if (chunk.length >= PER_PTY_BUFFER_LIMIT) {
+      this.raw = chunk.slice(-PER_PTY_BUFFER_LIMIT)
+    } else if (this.raw.length + chunk.length > PER_PTY_BUFFER_LIMIT) {
+      this.raw = `${this.raw.slice(-(PER_PTY_BUFFER_LIMIT - chunk.length))}${chunk}`
+    } else {
+      this.raw += chunk
     }
     if (!chunkHasLineBreak) {
       return ''
@@ -79,8 +83,19 @@ class PtyBuffer {
     }
     const finalized = this.raw.slice(0, lastNewline + 1)
     this.raw = this.raw.slice(lastNewline + 1)
-    return stripTerminalControls(finalized)
+    return mayContainHttpUrl(finalized) ? stripTerminalControls(finalized) : ''
   }
+}
+
+function mayContainHttpUrl(text: string): boolean {
+  // Control stripping cannot create any character required by an HTTP scheme.
+  return (
+    (text.includes('h') || text.includes('H')) &&
+    (text.includes('t') || text.includes('T')) &&
+    (text.includes('p') || text.includes('P')) &&
+    text.includes(':') &&
+    text.includes('/')
+  )
 }
 
 function lastLineBreak(text: string): number {


### PR DESCRIPTION
## ELI5: skip a search when the thing cannot be there

Orca watches terminal output for addresses such as `http://localhost:3000`. Finding one lets Orca show the right address in the Ports panel.

Imagine checking every receipt for the words “http://”. Previously, Orca scrubbed every completed line seven times and then searched it—even when the line was missing a character that every HTTP address must have.

Now Orca first asks a very cheap question: **does this line contain an `h`, `t`, `p`, `:`, and `/`?** Uppercase counts too.

- If even one is missing, neither `http://` nor `https://` can be present, so there is nothing to find and Orca stops.
- If all five are present, Orca runs the same cleanup and the same real URL matcher as before.

This first check is deliberately broad. It does **not** decide whether text is a valid URL; it only rejects lines where an HTTP URL is impossible.

```mermaid
flowchart TD
  A[Completed terminal line] --> B{"Contains h, t, p, :, and /?"}
  B -- No --> C[Skip the scan: an HTTP URL is impossible]
  B -- Yes --> D[Run the same terminal cleanup as before]
  D --> E[Run the same URL matcher as before]
```

There is also a second shortcut for very large unfinished chunks. Orca only remembers the final 4 KiB for the next chunk. Previously it joined the old tail to the entire new chunk, allocated that large combined string, and then threw away everything except the last 4 KiB. If the new chunk is already larger than 4 KiB, the old tail cannot affect the answer, so Orca now takes the new chunk’s last 4 KiB directly.

```text
Before: old tail + huge chunk -> allocate all of it -> discard most of it -> keep 4 KiB
After:             huge chunk -> take its final 4 KiB directly
```

**Why this is safe:** the cleanup step can delete characters, turn carriage returns into line feeds, or insert `[`. It cannot create a missing `h`, `t`, `p`, `:`, or `/`. A real HTTP URL therefore always reaches the unchanged matcher. The 4 KiB shortcut keeps exactly the same suffix as `(old tail + new chunk).slice(-4096)`.

**What the benchmark means:** impossible no-match fixtures were roughly **7×–67× faster** in this small scanner benchmark, and oversized partial chunks were **1.72×–4.80× faster**. A short line containing all five character types but no URL is the deliberately bad case: it pays for both checks and was about **0.035 µs slower**. This benchmark measures only the in-process URL-watcher work, not total terminal or UI latency.

## Summary

Every PTY output chunk enters the advertised-URL watcher so Orca can notice messages such as `http://localhost:3000` and show the right address in the Ports panel.

Before this change, each completed line paid for the full terminal-control cleanup pipeline: seven regular-expression replacements, followed by URL matching. Most build output cannot possibly contain an HTTP URL, so that work was usually guaranteed to find nothing.

This PR makes two behavior-preserving fast paths:

1. Before terminal-control cleanup, reject text that is missing any character required by an HTTP scheme: `h`, `t`, `p`, `:`, or `/` (with ASCII case handling).
2. When one incoming chunk is larger than the 4 KiB per-PTY buffer, retain its final 4 KiB directly instead of first concatenating a larger temporary string and then slicing it.

Why the URL guard is safe: the existing cleanup function only deletes characters, converts carriage returns to line feeds, or inserts `[` as a cursor-movement guard. It cannot manufacture a missing `h`, `t`, `p`, `:`, or `/`. Therefore, any cleaned `http://` or `https://` candidate must already have passed this broad prefilter.

The buffer rewrite is exactly equivalent to keeping `(oldBuffer + chunk).slice(-4096)`; it just avoids materializing the discarded prefix.

No URL matching, cache, port, SSH, or UI behavior changes.

## Benchmark

Reproduce with:

```bash
node config/scripts/advertised-url-watcher-benchmark.mjs
```

Environment: Node 24.18.0, Darwin 25.3.0. The harness runs 1,000 warmups and 12 alternating-order rounds of 10,000 operations, then reports the median microseconds per chunk. Lower is better.

| No-match fixture | Before | After | Result |
|---|---:|---:|---:|
| Plain 32 B line | 0.261 µs | 0.030 µs | 8.78× faster |
| ANSI 32 B line | 0.346 µs | 0.049 µs | 7.01× faster |
| Short guard fallthrough | 0.271 µs | 0.306 µs | 0.035 µs slower |
| Plain 4 KiB line | 7.058 µs | 0.201 µs | 35.07× faster |
| ANSI 4 KiB line | 8.943 µs | 0.134 µs | 66.67× faster |
| 4 KiB guard fallthrough | 7.105 µs | 7.181 µs | effectively neutral |
| 64 KiB partial chunk | 3.835 µs | 2.226 µs | 1.72× faster |
| 256 KiB partial chunk | 41.898 µs | 8.735 µs | 4.80× faster |

“Guard fallthrough” deliberately contains all five required character classes but no URL, so it measures the worst ordinary case: the new checks run and then the old cleanup still runs. The short fixture adds about 35 nanoseconds; the 4 KiB fixture is within roughly 1%. Real URL lines also take the unchanged full scan after this small guard.

This is a synthetic, in-process no-match benchmark. It excludes surrounding PTY dispatch and end-to-end UI latency. It passes explicit timestamps, omitting the production clock read; because impossible lines now return before that clock read, the measured savings are conservative.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint was not rerun
- [ ] `pnpm typecheck` — full multi-project typecheck was not rerun
- [ ] `pnpm test` — full repository suite was not rerun
- [ ] `pnpm build` — no packaging or bundle surface changed
- [x] Added high-quality regression tests

Passed:

- 5 focused watcher/ports test files, 105 tests
- `pnpm run typecheck:node`
- Basic and type-aware oxlint on the changed span
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- Oxfmt check
- `git diff --check`
- 135,306 deterministic randomized equivalence cases across buffer boundaries, split chunks, mixed case, ANSI, OSC, and control characters

## AI Review Report

An independent read-only review found no correctness, security, maintainability, SSH, folder-workspace, or cross-platform issue.

The review proved the suffix rewrite algebraically at the less-than, equal-to, and greater-than 4 KiB boundaries, then confirmed it with 135,306 randomized differential cases. It separately traced every transformation in `stripTerminalControls` to prove the prefilter cannot reject text that cleanup could turn into an HTTP URL.

Cross-platform review covered macOS, Linux, and Windows. This diff adds no paths, shell execution, shortcuts, labels, native modules, or Electron-specific behavior. Local, daemon, SSH, WSL, and folder workspaces all feed the same bounded string algorithm.

Readiness invariant: `advertised-url-watcher.buffer-equivalence` — retained suffixes and extracted URL sets must remain identical for every input stream. The deterministic tests and randomized differential oracle cover it. No matching reliability-manifest gate exists; the accepted residual gap is that no live Electron/PTy-throughput run was attached.

## Security Audit

No new dependency, network destination, command execution, path access, auth behavior, secret handling, persistence, IPC, or wire field is introduced.

URL parsing and origin sanitization are unchanged. The guard only avoids work when a URL is mathematically impossible, and the existing 4 KiB input cap remains unchanged.

## Notes

- No mobile-facing surface is touched.
- No remote wire content or opcode changes.
- The benchmark reports the small fallthrough cost as well as the wins.
- `PERF-28.local.md` is not included.
