### PR TITLE
[Perf-LH] Skip redundant native chat session rebuilds

### DIFF
--- a/config/scripts/native-chat-live-session-benchmark.ts
+++ b/config/scripts/native-chat-live-session-benchmark.ts
@@ -1,0 +1,335 @@
+/**
+ * Synthetic benchmark for native chat's post-incremental renderer hot paths.
+ * Run: pnpm exec tsx config/scripts/native-chat-live-session-benchmark.ts
+ *
+ * This excludes transcript parsing, IPC/remote latency, React, and DOM work. The
+ * 2 KB/message fixtures intentionally stress fallback-key normalization and are
+ * not estimates of average production message size or end-to-end frame latency.
+ */
+
+import { deepStrictEqual, strictEqual } from 'node:assert'
+import { performance } from 'node:perf_hooks'
+import type { NativeChatMessage, NativeChatSession } from '../../src/shared/native-chat-types'
+import { getVerifiedNativeChatCommands } from '../../src/shared/native-chat-agent-profiles'
+import { surfaceSkillInvocationUserTurns } from '../../src/shared/native-chat-command-envelope'
+import { prepareNativeChatLiveMessages } from '../../src/renderer/src/components/native-chat/native-chat-live-message-preparation'
+import { mergeNativeChatLiveSession } from '../../src/renderer/src/components/native-chat/native-chat-live-status'
+import {
+  matchingNativeChatUserTexts,
+  selectPendingIndicesRepresentedByUserTexts
+} from '../../src/renderer/src/components/native-chat/native-chat-pending-occurrence'
+import { pendingSendsAsMessages } from '../../src/renderer/src/components/native-chat/native-chat-pending'
+import { assembleNativeChatSession } from '../../src/renderer/src/components/native-chat/native-chat-session-assembler'
+
+type Operation = (index: number) => number
+type ExpectedChecksum = (iterations: number) => number
+type Calibration = { iterations: number; elapsedMs: number; capped: boolean }
+
+const TARGET_SAMPLE_MS = 50
+const MAX_ITERATIONS = 16_777_216
+const ROUNDS = 10
+let checksum = 0
+let expectedChecksum = 0
+let validatedCases = 0
+let cappedCalibrations = 0
+let sessionSink: NativeChatSession | null = null
+let messageArraySink: NativeChatMessage[] | null = null
+let contentSink = ''
+let pendingMatchSink: Set<number> | null = null
+const benchmarkStartedAt = performance.now()
+
+function proseFixture(count: number, bytes: number, withTurnId: boolean): NativeChatMessage[] {
+  const payload = 'Ab Cd  '.repeat(Math.ceil(bytes / 7)).slice(0, bytes)
+  return Array.from({ length: count }, (_, index) => ({
+    id: `message-${index}`,
+    role: index % 2 === 0 ? ('user' as const) : ('assistant' as const),
+    blocks: [{ type: 'text' as const, text: `${payload}-${index}` }],
+    timestamp: index,
+    source: 'transcript' as const,
+    ...(withTurnId ? { turnId: `turn-${index}` } : {})
+  }))
+}
+
+function toolFixture(count: number): NativeChatMessage[] {
+  return Array.from({ length: count }, (_, index) => ({
+    id: `tool-${index}`,
+    role: index % 2 === 0 ? ('assistant' as const) : ('tool' as const),
+    blocks:
+      index % 2 === 0
+        ? [
+            {
+              type: 'tool-call' as const,
+              name: 'read',
+              input: { path: `${index}.txt`, context: 'x'.repeat(512) }
+            }
+          ]
+        : [{ type: 'tool-result' as const, output: `result-${index}-${'x'.repeat(512)}` }],
+    timestamp: index,
+    source: 'transcript' as const
+  }))
+}
+
+function legacySession(messages: NativeChatMessage[]): NativeChatSession {
+  return assembleNativeChatSession({
+    sources: { transcript: messages },
+    sessionId: 'benchmark',
+    agent: 'claude'
+  })
+}
+
+function legacyMessageUpdateSession(messages: NativeChatMessage[]): NativeChatSession {
+  const commandNames = new Set(
+    getVerifiedNativeChatCommands('claude').map((command) => command.name)
+  )
+  return legacySession(surfaceSkillInvocationUserTurns(messages, commandNames))
+}
+
+function directMessageUpdateSession(messages: NativeChatMessage[]): NativeChatSession {
+  return mergeNativeChatLiveSession({
+    messages: prepareNativeChatLiveMessages(messages, 'claude'),
+    sessionId: 'benchmark',
+    agent: 'claude',
+    hookState: null
+  })
+}
+
+function oldEmptyPending(messages: NativeChatMessage[]): NativeChatMessage[] {
+  pendingMatchSink = selectPendingIndicesRepresentedByUserTexts(
+    [],
+    matchingNativeChatUserTexts(messages)
+  )
+  return []
+}
+
+function blockContent(message: NativeChatMessage): string {
+  const block = message.blocks[0]
+  if (!block) {
+    return ''
+  }
+  if (block.type === 'text') {
+    return block.text
+  }
+  if (block.type === 'tool-call') {
+    return block.name
+  }
+  if (block.type === 'tool-result') {
+    return block.output
+  }
+  return block.path ?? block.url ?? block.alt ?? ''
+}
+
+function messageWeight(message: NativeChatMessage, content: string): number {
+  const idTail = message.id.length > 0 ? message.id.charCodeAt(message.id.length - 1) : 0
+  const contentTail = content.length > 0 ? content.charCodeAt(content.length - 1) : 0
+  return message.id.length + idTail + message.role.charCodeAt(0) + content.length + contentTail
+}
+
+function consumeSession(session: NativeChatSession, index: number): number {
+  sessionSink = session
+  messageArraySink = session.messages
+  const message = session.messages[index % session.messages.length]
+  if (!message) {
+    contentSink = ''
+    return session.status.charCodeAt(0)
+  }
+  contentSink = blockContent(message)
+  return session.status.charCodeAt(0) + messageWeight(message, contentSink)
+}
+
+function consumePendingOutput(messages: NativeChatMessage[], index: number): number {
+  messageArraySink = messages
+  return (index % 7) + 1
+}
+
+function cyclicChecksum(values: readonly number[], iterations: number): number {
+  if (values.length === 0) {
+    return 0
+  }
+  const cycle = values.reduce((sum, value) => sum + value, 0)
+  const fullCycles = Math.floor(iterations / values.length)
+  let total = cycle * fullCycles
+  for (let index = 0; index < iterations % values.length; index += 1) {
+    total += values[index]!
+  }
+  return total
+}
+
+function sessionExpectedChecksum(session: NativeChatSession): ExpectedChecksum {
+  const statusWeight = session.status.charCodeAt(0)
+  const weights = session.messages.map((message) => {
+    const content = blockContent(message)
+    return messageWeight(message, content)
+  })
+  return (iterations) => statusWeight * iterations + cyclicChecksum(weights, iterations)
+}
+
+function pendingExpectedChecksum(iterations: number): number {
+  return cyclicChecksum([1, 2, 3, 4, 5, 6, 7], iterations)
+}
+
+function runSample(operation: Operation, expected: ExpectedChecksum, iterations: number): number {
+  let sampleChecksum = 0
+  const startedAt = performance.now()
+  for (let index = 0; index < iterations; index += 1) {
+    sampleChecksum += operation(index)
+  }
+  const elapsedMs = performance.now() - startedAt
+  checksum += sampleChecksum
+  expectedChecksum += expected(iterations)
+  return elapsedMs
+}
+
+function median(samples: number[]): number {
+  return [...samples].sort((left, right) => left - right)[Math.floor(samples.length / 2)]!
+}
+
+function calibrate(operation: Operation, expected: ExpectedChecksum): Calibration {
+  let iterations = 1
+  let reachedTarget = false
+  while (true) {
+    const elapsedMs = runSample(operation, expected, iterations)
+    if (elapsedMs >= TARGET_SAMPLE_MS) {
+      if (reachedTarget) {
+        return { iterations, elapsedMs, capped: false }
+      }
+      reachedTarget = true
+      continue
+    }
+    if (iterations >= MAX_ITERATIONS) {
+      return { iterations, elapsedMs, capped: true }
+    }
+    reachedTarget = false
+    iterations = Math.min(iterations * 2, MAX_ITERATIONS)
+  }
+}
+
+function benchmark(
+  name: string,
+  baseline: Operation,
+  optimized: Operation,
+  expected: ExpectedChecksum
+): void {
+  const baselineValue = baseline(0)
+  const optimizedValue = optimized(0)
+  strictEqual(optimizedValue, baselineValue, `${name}: timed arms returned different checksums`)
+  validatedCases += 1
+  const baselineCalibration = calibrate(baseline, expected)
+  const optimizedCalibration = calibrate(optimized, expected)
+  cappedCalibrations += Number(baselineCalibration.capped) + Number(optimizedCalibration.capped)
+  const baselineSamples: number[] = []
+  const optimizedSamples: number[] = []
+  for (let round = 0; round < ROUNDS; round += 1) {
+    if (round % 2 === 0) {
+      baselineSamples.push(
+        runSample(baseline, expected, baselineCalibration.iterations) /
+          baselineCalibration.iterations
+      )
+      optimizedSamples.push(
+        runSample(optimized, expected, optimizedCalibration.iterations) /
+          optimizedCalibration.iterations
+      )
+    } else {
+      optimizedSamples.push(
+        runSample(optimized, expected, optimizedCalibration.iterations) /
+          optimizedCalibration.iterations
+      )
+      baselineSamples.push(
+        runSample(baseline, expected, baselineCalibration.iterations) /
+          baselineCalibration.iterations
+      )
+    }
+  }
+  const baselineMs = median(baselineSamples)
+  const optimizedMs = median(optimizedSamples)
+  const speedup = baselineMs / Math.max(optimizedMs, Number.EPSILON)
+  console.log(
+    `${name}\t${baselineCalibration.iterations}\t${optimizedCalibration.iterations}\t${baselineCalibration.elapsedMs.toFixed(1)}\t${optimizedCalibration.elapsedMs.toFixed(1)}\t${baselineMs.toFixed(6)}\t${optimizedMs.toFixed(6)}\t${speedup.toFixed(1)}x`
+  )
+}
+
+function benchmarkSessionArms(
+  name: string,
+  baselineSession: () => NativeChatSession,
+  optimizedSession: () => NativeChatSession
+): void {
+  const expectedSession = baselineSession()
+  deepStrictEqual(optimizedSession(), expectedSession, `${name}: session mismatch`)
+  const expected = sessionExpectedChecksum(expectedSession)
+  benchmark(
+    name,
+    (index) => consumeSession(baselineSession(), index),
+    (index) => consumeSession(optimizedSession(), index),
+    expected
+  )
+}
+
+function benchmarkMessageUpdate(name: string, messages: NativeChatMessage[]): void {
+  benchmarkSessionArms(
+    name,
+    () => legacyMessageUpdateSession(messages),
+    () => directMessageUpdateSession(messages)
+  )
+}
+
+const prose300 = proseFixture(300, 2_048, false)
+const fixtures = [
+  ['300 x 2KB prose, no turnId', prose300],
+  ['300 x 2KB prose, with turnId', proseFixture(300, 2_048, true)],
+  ['300 tool-heavy, no turnId', toolFixture(300)],
+  ['100 x 2KB prose, no turnId', proseFixture(100, 2_048, false)],
+  ['500 x 2KB prose, no turnId', proseFixture(500, 2_048, false)]
+] as const
+
+console.log(
+  `Node ${process.version}; ${ROUNDS} alternating interleaved median rounds; ${TARGET_SAMPLE_MS} ms calibration target; ${MAX_ITERATIONS} iteration cap`
+)
+console.log(
+  'case\tbaseline iters\toptimized iters\tbaseline cal ms\toptimized cal ms\tbaseline ms/op\toptimized ms/op\tspeedup'
+)
+
+for (const [name, messages] of fixtures) {
+  benchmarkMessageUpdate(name, messages)
+}
+
+benchmarkSessionArms(
+  '300 x 2KB status-only frame',
+  () => legacySession(prose300),
+  () =>
+    mergeNativeChatLiveSession({
+      messages: prose300,
+      sessionId: 'benchmark',
+      agent: 'claude',
+      hookState: null
+    })
+)
+
+deepStrictEqual(pendingSendsAsMessages([], prose300), oldEmptyPending(prose300))
+benchmark(
+  '300 x 2KB empty pending',
+  (index) => consumePendingOutput(oldEmptyPending(prose300), index),
+  (index) => consumePendingOutput(pendingSendsAsMessages([], prose300), index),
+  pendingExpectedChecksum
+)
+
+const combinedSessionExpected = sessionExpectedChecksum(legacyMessageUpdateSession(prose300))
+benchmark(
+  '300 x 2KB combined',
+  (index) =>
+    consumeSession(legacyMessageUpdateSession(prose300), index) +
+    consumePendingOutput(oldEmptyPending(prose300), index),
+  (index) =>
+    consumeSession(directMessageUpdateSession(prose300), index) +
+    consumePendingOutput(pendingSendsAsMessages([], prose300), index),
+  (iterations) => combinedSessionExpected(iterations) + pendingExpectedChecksum(iterations)
+)
+
+strictEqual(checksum, expectedChecksum, 'benchmark checksum accounting drifted')
+strictEqual(sessionSink?.sessionId, 'benchmark', 'session outputs did not escape')
+strictEqual(Array.isArray(messageArraySink), true, 'message arrays did not escape')
+strictEqual(contentSink.length > 0, true, 'message content did not escape')
+strictEqual(pendingMatchSink instanceof Set, true, 'pending baseline scan did not escape')
+console.log(
+  `validated=${validatedCases} cases, checksum=${checksum}, capped calibrations=${cappedCalibrations}, runtime=${(
+    performance.now() - benchmarkStartedAt
+  ).toFixed(0)} ms`
+)

--- a/src/renderer/src/components/native-chat/native-chat-live-message-preparation.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-message-preparation.ts
@@ -1,0 +1,28 @@
+import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
+import { surfaceSkillInvocationUserTurns } from '../../../../shared/native-chat-command-envelope'
+import { normalizeImageTranscriptMessages } from '../../../../shared/native-chat-image-transcript-markers'
+import type { AgentType, NativeChatMessage } from '../../../../shared/native-chat-types'
+import { assembleNativeChatSession } from './native-chat-session-assembler'
+
+export function prepareNativeChatLiveMessages(
+  messages: NativeChatMessage[],
+  agent: AgentType
+): NativeChatMessage[] {
+  const commandNames = new Set(getVerifiedNativeChatCommands(agent).map((command) => command.name))
+  const surfaced = surfaceSkillInvocationUserTurns(messages, commandNames)
+  const normalized = normalizeImageTranscriptMessages(surfaced)
+  if (!hasMixedSources(normalized)) {
+    return normalized
+  }
+  // A second pass preserves legacy cross-source winners after sorting or presentation transforms.
+  return assembleNativeChatSession({
+    sources: { transcript: surfaced },
+    sessionId: null,
+    agent
+  }).messages
+}
+
+function hasMixedSources(messages: readonly NativeChatMessage[]): boolean {
+  const source = messages[0]?.source
+  return messages.some((message) => message.source !== source)
+}

--- a/src/renderer/src/components/native-chat/native-chat-live-status.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-status.test.ts
@@ -24,7 +24,7 @@ function user(id: string, text: string): NativeChatMessage {
 describe('mergeNativeChatLiveSession', () => {
   it("surfaces live 'working' before the assistant turn lands in the transcript", () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'do a thing')] },
+      messages: [user('u-1', 'do a thing')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working'
@@ -35,7 +35,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it("keeps 'working' authoritative when a prior assistant message is present", () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'do a thing'), assistant('a-1', 'done')] },
+      messages: [user('u-1', 'do a thing'), assistant('a-1', 'done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working'
@@ -45,7 +45,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('does not treat assistant prose as turn completion while lifecycle is mid-generation', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'go'), assistant('a-1', 'done')] },
+      messages: [user('u-1', 'go'), assistant('a-1', 'done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -57,7 +57,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('recovers via assistant prose when capable host has no in-progress lifecycle', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'go'), assistant('a-1', 'done')] },
+      messages: [user('u-1', 'go'), assistant('a-1', 'done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -68,7 +68,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('settles a dropped working hook from an explicit completion marker', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'go'), assistant('a-1', 'done')] },
+      messages: [user('u-1', 'go'), assistant('a-1', 'done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -80,7 +80,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('settles a dropped working hook from an explicit interruption marker', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'go')] },
+      messages: [user('u-1', 'go')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -92,7 +92,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('does not apply an older completion marker to a newer working turn', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'prior')] },
+      messages: [assistant('a-1', 'prior')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -104,7 +104,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('does not apply an older interruption marker to a newer working turn', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'prior')] },
+      messages: [assistant('a-1', 'prior')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -116,7 +116,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('settles an unorderable (null-timestamp) completion marker for live work', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'prior')] },
+      messages: [assistant('a-1', 'prior')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -129,7 +129,7 @@ describe('mergeNativeChatLiveSession', () => {
   it('settles a completion slightly before hook receipt within clock-skew slack', () => {
     const hookStartedAt = 1_700_000_000_000
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'done')] },
+      messages: [assistant('a-1', 'done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -145,7 +145,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('preserves the assistant fallback when the serving host lacks explicit boundaries', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'done')] },
+      messages: [assistant('a-1', 'done')],
       sessionId: 'sess',
       agent: 'grok',
       hookState: 'working',
@@ -156,7 +156,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('keeps working while the hook reports a live background child', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'lead done')] },
+      messages: [assistant('a-1', 'lead done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -169,7 +169,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('settles on an interruption even while the hook reports a live background child', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [assistant('a-1', 'lead done')] },
+      messages: [assistant('a-1', 'lead done')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',
@@ -182,7 +182,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('leaves completed states (done/waiting/blocked) on the derived status', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'hi')] },
+      messages: [user('u-1', 'hi')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'done'
@@ -193,7 +193,7 @@ describe('mergeNativeChatLiveSession', () => {
   it('surfaces live work while the transcript loads and honors errors outright', () => {
     expect(
       mergeNativeChatLiveSession({
-        sources: { transcript: [] },
+        messages: [],
         sessionId: null,
         agent: 'claude',
         hookState: 'working',
@@ -206,7 +206,7 @@ describe('mergeNativeChatLiveSession', () => {
     // selectNativeChatViewState's job; the status must stay 'working'.
     expect(
       mergeNativeChatLiveSession({
-        sources: { transcript: [] },
+        messages: [],
         sessionId: 'sess',
         agent: 'claude',
         hookState: 'working',
@@ -218,7 +218,7 @@ describe('mergeNativeChatLiveSession', () => {
     // slash-command marker) the pane is a live conversation, not a spinner.
     expect(
       mergeNativeChatLiveSession({
-        sources: { transcript: [user('u-1', 'run it')] },
+        messages: [user('u-1', 'run it')],
         sessionId: 'sess',
         agent: 'claude',
         hookState: 'working',
@@ -227,7 +227,7 @@ describe('mergeNativeChatLiveSession', () => {
     ).toBe('working')
 
     const errored = mergeNativeChatLiveSession({
-      sources: { transcript: [] },
+      messages: [],
       sessionId: 'sess',
       agent: 'claude',
       hookState: null,
@@ -239,7 +239,7 @@ describe('mergeNativeChatLiveSession', () => {
 
   it('assembles an empty transcript with no live work as empty', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [] },
+      messages: [],
       sessionId: 'sess',
       agent: 'claude',
       hookState: null
@@ -252,7 +252,7 @@ describe('mergeNativeChatLiveSession', () => {
   // typing indicator while the agent was working.
   it('keeps the Stop affordance for a working known session mid-flush', () => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: [user('u-1', 'run it')] },
+      messages: [user('u-1', 'run it')],
       sessionId: 'sess',
       agent: 'claude',
       hookState: 'working',

--- a/src/renderer/src/components/native-chat/native-chat-live-status.ts
+++ b/src/renderer/src/components/native-chat/native-chat-live-status.ts
@@ -4,16 +4,17 @@
 // reconciled once that boundary lands) is unit-testable without IPC.
 
 import type { AgentStatusState } from '../../../../shared/agent-status-types'
-import { assembleNativeChatSession, type NativeChatSources } from './native-chat-session-assembler'
 import type {
   AgentType,
+  NativeChatMessage,
   NativeChatSession,
   NativeChatSessionStatus,
   NativeChatTurnLifecycle
 } from '../../../../shared/native-chat-types'
 
 export type NativeChatLiveMergeInput = {
-  sources: NativeChatSources
+  /** Already deduped, ordered, and transcript-normalized by the live assembler. */
+  messages: NativeChatMessage[]
   sessionId: string | null
   agent: AgentType
   /** Live hook state for the pane, or null when no hook entry exists. */
@@ -22,6 +23,8 @@ export type NativeChatLiveMergeInput = {
   stateStartedAt?: number | null
   /** Latest provider-authored turn boundary recovered from the transcript. */
   transcriptLifecycle?: NativeChatTurnLifecycle
+  /** Transcript tail before presentation normalization or canonical re-dedup. */
+  statusTailMessage?: NativeChatMessage
   /** Claude can finish its lead turn while background children remain active. */
   hookHasWorkingSubagents?: boolean
   /** True before the initial snapshot resolves; forces 'loading'. */
@@ -44,23 +47,24 @@ export type NativeChatLiveMergeInput = {
  */
 export function mergeNativeChatLiveSession(input: NativeChatLiveMergeInput): NativeChatSession {
   const {
-    sources,
+    messages,
     sessionId,
     agent,
     hookState,
     stateStartedAt,
     transcriptLifecycle,
+    statusTailMessage,
     hookHasWorkingSubagents,
     loading,
     error
   } = input
   if (error) {
-    return assembleNativeChatSession({ sources, sessionId, agent, status: 'error', error })
+    return { messages, status: 'error', sessionId, agent, error }
   }
 
   const status = liveStatusOverride(
     hookState,
-    sources,
+    statusTailMessage ?? messages.at(-1),
     stateStartedAt,
     transcriptLifecycle,
     hookHasWorkingSubagents ?? false
@@ -70,14 +74,14 @@ export function mergeNativeChatLiveSession(input: NativeChatLiveMergeInput): Nat
   // idle pane while the agent works. A known session with nothing to show yet is
   // held on the loading surface by selectNativeChatViewState instead.
   if (loading && status !== 'working') {
-    return assembleNativeChatSession({ sources, sessionId, agent, status: 'loading' })
+    return { messages, status: 'loading', sessionId, agent }
   }
-  return assembleNativeChatSession({
-    sources,
+  return {
+    messages,
+    status: status ?? (messages.length === 0 ? 'empty' : 'ready'),
     sessionId,
-    agent,
-    ...(status ? { status } : {})
-  })
+    agent
+  }
 }
 
 /** Slack for comparing transcript timestamps to hook receipt times across hosts. */
@@ -85,7 +89,7 @@ export const LIFECYCLE_CLOCK_SKEW_SLACK_MS = 2_000
 
 function liveStatusOverride(
   hookState: AgentStatusState | null,
-  sources: NativeChatSources,
+  statusTailMessage: NativeChatMessage | undefined,
   stateStartedAt: number | null | undefined,
   transcriptLifecycle: NativeChatTurnLifecycle | undefined,
   hookHasWorkingSubagents: boolean
@@ -117,7 +121,7 @@ function liveStatusOverride(
   // do not settle early on capable providers.
   if (
     transcriptLifecycle?.state !== 'working' &&
-    trailingAssistantPostDates(sources, stateStartedAt)
+    trailingAssistantPostDates(statusTailMessage, stateStartedAt)
   ) {
     return undefined
   }
@@ -150,12 +154,15 @@ function lifecycleTerminatesCurrentTurn(
 }
 
 function trailingAssistantPostDates(
-  sources: NativeChatSources,
+  message: NativeChatMessage | undefined,
   stateStartedAt: number | null | undefined
 ): boolean {
   if (stateStartedAt == null) {
     return false
   }
-  const last = (sources.transcript ?? []).at(-1)
-  return last?.role === 'assistant' && last.timestamp != null && last.timestamp >= stateStartedAt
+  return (
+    message?.role === 'assistant' &&
+    message.timestamp != null &&
+    message.timestamp >= stateStartedAt
+  )
 }

--- a/src/renderer/src/components/native-chat/native-chat-pending.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.test.ts
@@ -173,6 +173,17 @@ describe('prunePendingSends', () => {
 })
 
 describe('pendingSendsAsMessages', () => {
+  it('returns the empty input without reading existing history', () => {
+    const pending: NativeChatPendingSend[] = []
+    const unreadableHistory = new Proxy([] as NativeChatMessage[], {
+      get: () => {
+        throw new Error('existing history was read')
+      }
+    })
+
+    expect(pendingSendsAsMessages(pending, unreadableHistory)).toEqual([])
+  })
+
   it('maps pending sends to prefixed scrape-source user messages sorted by sentAt', () => {
     const messages = pendingSendsAsMessages([{ id: 'p1', text: 'queued text', sentAt: 42 }])
     expect(messages).toEqual([

--- a/src/renderer/src/components/native-chat/native-chat-pending.ts
+++ b/src/renderer/src/components/native-chat/native-chat-pending.ts
@@ -179,6 +179,9 @@ export function pendingSendsAsMessages(
   pending: NativeChatPendingSend[],
   existingMessages: NativeChatMessage[] = []
 ): NativeChatMessage[] {
+  if (pending.length === 0) {
+    return []
+  }
   const consumed = new Map<string, number>()
   const exactVisible = pending.map((entry) => {
     const contentKey = nativeChatPendingContentKey(entry)

--- a/src/renderer/src/components/native-chat/native-chat-preassembled-session-parity.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-preassembled-session-parity.test.ts
@@ -1,0 +1,380 @@
+import { describe, expect, it } from 'vitest'
+import type { NativeChatMessage } from '../../../../shared/native-chat-types'
+import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
+import { surfaceSkillInvocationUserTurns } from '../../../../shared/native-chat-command-envelope'
+import {
+  createIncrementalAssembler,
+  reset as resetAssembler
+} from './native-chat-incremental-assembler'
+import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
+import { mergeNativeChatLiveSession } from './native-chat-live-status'
+import { assembleNativeChatSession } from './native-chat-session-assembler'
+
+const CLAUDE_COMMANDS = new Set(
+  getVerifiedNativeChatCommands('claude').map((command) => command.name)
+)
+
+function message(id: string, overrides: Partial<NativeChatMessage> = {}): NativeChatMessage {
+  return {
+    id,
+    role: 'assistant',
+    blocks: [{ type: 'text', text: id }],
+    timestamp: 0,
+    source: 'transcript',
+    ...overrides
+  }
+}
+
+function expectLegacyMessageParity(transcript: NativeChatMessage[]): NativeChatMessage[] {
+  const assembled = resetAssembler(createIncrementalAssembler(), transcript)
+  const surfaced = surfaceSkillInvocationUserTurns(assembled, CLAUDE_COMMANDS)
+  const direct = prepareNativeChatLiveMessages(assembled, 'claude')
+  const legacy = assembleNativeChatSession({
+    sources: { transcript: surfaced },
+    sessionId: 'session-1',
+    agent: 'claude'
+  }).messages
+  expect(direct).toEqual(legacy)
+  return direct
+}
+
+describe('preassembled native-chat live sessions', () => {
+  it('keeps the direct array for an ordinary single-source history', () => {
+    const messages = [message('user', { role: 'user', blocks: [{ type: 'text', text: 'hello' }] })]
+
+    expect(prepareNativeChatLiveMessages(messages, 'claude')).toBe(messages)
+  })
+
+  it('re-dedupes image-marker transforms that collide across sources', () => {
+    const transcript: NativeChatMessage[] = [
+      message('scrape-image', {
+        role: 'user',
+        blocks: [
+          { type: 'image-ref', path: '/tmp/a.png' },
+          { type: 'text', text: 'describe this' }
+        ],
+        timestamp: 1,
+        source: 'scrape'
+      }),
+      message('image-source', {
+        role: 'user',
+        blocks: [{ type: 'text', text: '[Image: source: /tmp/a.png]' }],
+        timestamp: 2
+      }),
+      message('image-prompt', {
+        role: 'user',
+        blocks: [{ type: 'text', text: '[Image #1] describe this' }],
+        timestamp: 3
+      })
+    ]
+
+    const out = expectLegacyMessageParity(transcript)
+
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ id: 'image-prompt', source: 'transcript' })
+  })
+
+  it('re-dedupes surfaced skill envelopes that collide across sources', () => {
+    const skill = (id: string, plugin: string, source: 'transcript' | 'scrape') =>
+      message(id, {
+        role: 'user',
+        blocks: [
+          {
+            type: 'text',
+            text: `<command-name>/${plugin}:review</command-name>\n<command-args>focus</command-args>`
+          }
+        ],
+        timestamp: source === 'scrape' ? 1 : 2,
+        source
+      })
+    const transcript = [
+      skill('scrape-skill', 'plugin-a', 'scrape'),
+      skill('skill', 'plugin-b', 'transcript')
+    ]
+
+    const out = expectLegacyMessageParity(transcript)
+
+    expect(out).toHaveLength(1)
+    expect(out[0]).toMatchObject({ id: 'skill', source: 'transcript' })
+    expect(out[0]?.blocks).toEqual([{ type: 'text', text: '/review focus' }])
+  })
+
+  it('re-dedupes unchanged mixed-source histories after the first pass reorders them', () => {
+    const transcript = [
+      message('scrape-1', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'same prompt' }],
+        timestamp: 3,
+        source: 'scrape'
+      }),
+      message('scrape-2', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'same prompt' }],
+        timestamp: 2,
+        source: 'scrape'
+      }),
+      message('transcript', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'same prompt' }],
+        timestamp: 1
+      })
+    ]
+
+    const out = expectLegacyMessageParity(transcript)
+
+    expect(out.map((entry) => entry.id)).toEqual(['transcript'])
+  })
+
+  it('keeps status inference on the pre-dedup transcript tail', () => {
+    const transcript = [
+      message('scrape-1', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'same prompt' }],
+        timestamp: 4,
+        source: 'scrape'
+      }),
+      message('scrape-2', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'same prompt' }],
+        timestamp: 3,
+        source: 'scrape'
+      }),
+      message('transcript', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'same prompt' }],
+        timestamp: 1
+      }),
+      message('answer', { blocks: [{ type: 'text', text: 'done' }], timestamp: 2 })
+    ]
+    const assembled = resetAssembler(createIncrementalAssembler(), transcript)
+    const prepared = prepareNativeChatLiveMessages(assembled, 'claude')
+
+    const session = mergeNativeChatLiveSession({
+      messages: prepared,
+      sessionId: 'session-1',
+      agent: 'claude',
+      hookState: 'working',
+      stateStartedAt: 2,
+      statusTailMessage: assembled.at(-1)
+    })
+
+    expect(prepared.map((entry) => entry.id)).toEqual(['transcript', 'answer'])
+    expect(session.status).toBe('working')
+  })
+
+  it('matches the legacy rebuild for images, tools, missing turn ids, and skills', () => {
+    const transcript: NativeChatMessage[] = [
+      message('scrape-duplicate', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'repeat this' }],
+        timestamp: null,
+        source: 'scrape'
+      }),
+      message('same-prompt-2', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'repeat this' }],
+        timestamp: 51
+      }),
+      message('tool-result-null', {
+        role: 'tool',
+        blocks: [{ type: 'tool-result', output: 'read complete' }],
+        timestamp: null
+      }),
+      message('image-source-a', {
+        role: 'user',
+        blocks: [{ type: 'text', text: '[Image: source: /tmp/a.png]' }],
+        timestamp: 20
+      }),
+      message('image-source-b', {
+        role: 'user',
+        blocks: [{ type: 'text', text: '[Image: source: /tmp/b.png]' }],
+        timestamp: 21
+      }),
+      message('image-prompt', {
+        role: 'user',
+        blocks: [{ type: 'text', text: '[Image #1] [Image #2] compare these' }],
+        timestamp: 22
+      }),
+      message('standalone-image', {
+        role: 'user',
+        blocks: [{ type: 'text', text: '[Image: source: /tmp/standalone.png]' }],
+        timestamp: 23
+      }),
+      message('tool-call', {
+        blocks: [{ type: 'tool-call', name: 'read', input: { path: 'AGENTS.md' } }],
+        timestamp: 30
+      }),
+      message('skill-envelope', {
+        role: 'user',
+        blocks: [
+          {
+            type: 'text',
+            text: '<command-name>/plugin:review</command-name>\n<command-args>focus</command-args>'
+          }
+        ],
+        timestamp: 40
+      }),
+      message('same-prompt-1', {
+        role: 'user',
+        blocks: [{ type: 'text', text: 'repeat this' }],
+        timestamp: 50
+      })
+    ]
+
+    const out = expectLegacyMessageParity(transcript)
+
+    expect(out.map((entry) => entry.id)).toEqual([
+      'tool-result-null',
+      'image-prompt',
+      'standalone-image',
+      'tool-call',
+      'skill-envelope',
+      'same-prompt-1',
+      'same-prompt-2'
+    ])
+    expect(out.find((entry) => entry.id === 'image-prompt')?.blocks).toEqual([
+      { type: 'image-ref', path: '/tmp/a.png' },
+      { type: 'image-ref', path: '/tmp/b.png' },
+      { type: 'text', text: 'compare these' }
+    ])
+    expect(out.find((entry) => entry.id === 'standalone-image')?.blocks).toEqual([
+      { type: 'image-ref', path: '/tmp/standalone.png' }
+    ])
+    expect(out.find((entry) => entry.id === 'skill-envelope')?.blocks).toEqual([
+      { type: 'text', text: '/review focus' }
+    ])
+  })
+
+  it('preserves the preassembled array through every status-precedence path', () => {
+    const messages = [message('answer', { timestamp: 10 })]
+    const base = { messages, sessionId: 'session-1', agent: 'claude' as const }
+    const sessions = [
+      mergeNativeChatLiveSession({
+        ...base,
+        hookState: 'working',
+        loading: true,
+        transcriptLifecycle: { state: 'working', turnId: 'turn-1', timestamp: 9 }
+      }),
+      mergeNativeChatLiveSession({
+        ...base,
+        hookState: 'working',
+        stateStartedAt: 9,
+        transcriptLifecycle: { state: 'completed', turnId: 'turn-1', timestamp: 10 },
+        hookHasWorkingSubagents: true
+      }),
+      mergeNativeChatLiveSession({
+        ...base,
+        hookState: 'working',
+        stateStartedAt: 9,
+        transcriptLifecycle: { state: 'interrupted', turnId: 'turn-1', timestamp: 10 },
+        hookHasWorkingSubagents: true
+      }),
+      mergeNativeChatLiveSession({ ...base, hookState: null, loading: true }),
+      mergeNativeChatLiveSession({
+        ...base,
+        hookState: 'working',
+        loading: true,
+        error: 'unreadable'
+      })
+    ]
+
+    expect(sessions.map((session) => session.status)).toEqual([
+      'working',
+      'working',
+      'ready',
+      'loading',
+      'error'
+    ])
+    for (const session of sessions) {
+      expect(session.messages).toBe(messages)
+    }
+    expect(sessions.at(-1)?.error).toBe('unreadable')
+  })
+
+  it('matches the legacy rebuild across deterministic randomized transcripts', () => {
+    for (let seed = 1; seed <= 512; seed += 1) {
+      expectLegacyMessageParity(randomTranscript(seed))
+    }
+  })
+})
+
+function randomTranscript(seed: number): NativeChatMessage[] {
+  const random = mulberry32(seed)
+  const count = 1 + Math.floor(random() * 48)
+  const messages: NativeChatMessage[] = []
+  for (let index = 0; index < count; index += 1) {
+    const priorIndex = index > 0 ? Math.floor(random() * index) : index
+    const idIndex = index > 0 && random() < 0.12 ? priorIndex : index
+    const timestamp = random() < 0.18 ? null : Math.floor(random() * 24)
+    const kind = Math.floor(random() * 7)
+    const entry = randomMessage(seed, index, idIndex, timestamp, kind)
+    if (random() < 0.2) {
+      entry.turnId = `turn-${seed}-${index}`
+    }
+    messages.push(entry)
+  }
+  return messages
+}
+
+function randomMessage(
+  seed: number,
+  index: number,
+  idIndex: number,
+  timestamp: number | null,
+  kind: number
+): NativeChatMessage {
+  const id = `message-${seed}-${idIndex}`
+  const source = (seed + index) % 4 === 0 ? ('scrape' as const) : ('transcript' as const)
+  const base = { id, timestamp, source }
+  switch (kind) {
+    case 0:
+      return { ...base, role: 'user', blocks: [{ type: 'text', text: ` prompt  ${index % 5} ` }] }
+    case 1:
+      return { ...base, role: 'assistant', blocks: [{ type: 'text', text: `answer ${index}` }] }
+    case 2:
+      return {
+        ...base,
+        role: 'assistant',
+        blocks: [{ type: 'tool-call', name: 'read', input: { path: `${index}.txt` } }]
+      }
+    case 3:
+      return {
+        ...base,
+        role: 'tool',
+        blocks: [{ type: 'tool-result', output: `result ${index}`, isError: index % 5 === 0 }]
+      }
+    case 4:
+      return {
+        ...base,
+        role: 'user',
+        blocks: [{ type: 'text', text: `[Image: source: /tmp/${seed}-${index}.png]` }]
+      }
+    case 5:
+      return {
+        ...base,
+        role: 'user',
+        blocks: [{ type: 'text', text: `[Image #1] [Image #2] inspect ${index}` }]
+      }
+    default:
+      return {
+        ...base,
+        role: 'user',
+        blocks: [
+          {
+            type: 'text',
+            text: `<command-name>/plugin:skill-${index % 3}</command-name>\n<command-args>arg ${index}</command-args>`
+          }
+        ]
+      }
+  }
+}
+
+function mulberry32(seed: number): () => number {
+  let state = seed
+  return () => {
+    state = (state + 0x6d2b79f5) | 0
+    let value = Math.imul(state ^ (state >>> 15), 1 | state)
+    value = (value + Math.imul(value ^ (value >>> 7), 61 | value)) ^ value
+    return ((value ^ (value >>> 14)) >>> 0) / 4_294_967_296
+  }
+}

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -16,8 +16,7 @@ import {
   reset as resetAssembler
 } from './native-chat-incremental-assembler'
 import { mergeNativeChatLiveSession } from './native-chat-live-status'
-import { getVerifiedNativeChatCommands } from '../../../../shared/native-chat-agent-profiles'
-import { surfaceSkillInvocationUserTurns } from '../../../../shared/native-chat-command-envelope'
+import { prepareNativeChatLiveMessages } from './native-chat-live-message-preparation'
 import {
   hasMoreNativeChatHistory,
   NATIVE_CHAT_INITIAL_LIMIT,
@@ -338,24 +337,21 @@ export function useNativeChatLiveSession(
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [baseMessages, appended, sessionId, agent])
 
-  // Why: skill invocations are user turns but Claude records them as noise-filtered command envelopes, so surface them as the literal token here.
-  const surfacedMessages = useMemo(
-    () =>
-      surfaceSkillInvocationUserTurns(
-        assembledMessages,
-        new Set(getVerifiedNativeChatCommands(agent).map((command) => command.name))
-      ),
+  // Keep presentation transforms off the status-only render axis.
+  const normalizedMessages = useMemo(
+    () => prepareNativeChatLiveMessages(assembledMessages, agent),
     [assembledMessages, agent]
   )
 
   return useMemo<NativeChatLiveSession>(() => {
     const session = mergeNativeChatLiveSession({
-      sources: { transcript: surfacedMessages },
+      messages: normalizedMessages,
       sessionId,
       agent,
       hookState,
       stateStartedAt: hookStateStartedAt,
       transcriptLifecycle,
+      statusTailMessage: assembledMessages.at(-1),
       hookHasWorkingSubagents,
       // Why: show live watcher-append content over a spinner/stale error (#8401), so overrides apply only when nothing is appended.
       loading: read.phase === 'loading' && appended.length === 0,
@@ -363,7 +359,8 @@ export function useNativeChatLiveSession(
     })
     return { ...session, hasMore, loadingEarlier, loadEarlier, readPhase: read.phase }
   }, [
-    surfacedMessages,
+    normalizedMessages,
+    assembledMessages,
     read,
     sessionId,
     agent,

--- a/src/shared/native-chat-image-transcript-markers.test.ts
+++ b/src/shared/native-chat-image-transcript-markers.test.ts
@@ -82,8 +82,31 @@ describe('normalizeImageTranscriptMessages', () => {
   })
 
   it('leaves ordinary user text untouched', () => {
-    const out = normalizeImageTranscriptMessages([userText('a', 'how about this')])
-    expect(out[0]!.blocks).toEqual([{ type: 'text', text: 'how about this' }])
+    const message = userText('a', 'how about this')
+    const messages = [message]
+    const out = normalizeImageTranscriptMessages(messages)
+    expect(out).toBe(messages)
+    expect(out[0]).toBe(message)
+    expect(out[0]!.blocks).toBe(message.blocks)
+  })
+
+  it('removes a whitespace-only first text block', () => {
+    const out = normalizeImageTranscriptMessages([userText('a', '   ')])
+
+    expect(out[0]?.blocks).toEqual([])
+  })
+
+  it('preserves unaffected rows when another row needs normalization', () => {
+    const before = userText('before', 'keep this row')
+    const marker = userText('marker', '[Image: source: /tmp/image.png]')
+    const after = userText('after', 'keep this row too')
+    const messages = [before, marker, after]
+
+    const out = normalizeImageTranscriptMessages(messages)
+
+    expect(out).not.toBe(messages)
+    expect(out[0]).toBe(before)
+    expect(out[2]).toBe(after)
   })
 
   it('leaves assistant messages untouched', () => {

--- a/src/shared/native-chat-image-transcript-markers.ts
+++ b/src/shared/native-chat-image-transcript-markers.ts
@@ -20,19 +20,23 @@ export function stripImagePromptMarker(text: string): string {
 function stripImagePromptMarkersFromFirstText(
   blocks: readonly NativeChatBlock[]
 ): NativeChatBlock[] {
-  let stripped = false
-  const next: NativeChatBlock[] = []
-  for (const block of blocks) {
-    if (!stripped && isTextBlock(block)) {
-      stripped = true
-      const text = stripImagePromptMarker(block.text)
-      if (text.trim().length > 0) {
-        next.push({ ...block, text })
-      }
-      continue
-    }
-    next.push(block)
+  const textIndex = blocks.findIndex(isTextBlock)
+  if (textIndex < 0) {
+    return blocks as NativeChatBlock[]
   }
+  const block = blocks[textIndex]
+  if (!block || !isTextBlock(block)) {
+    return blocks as NativeChatBlock[]
+  }
+  const text = stripImagePromptMarker(block.text)
+  if (text.trim().length === 0) {
+    return blocks.filter((_, index) => index !== textIndex)
+  }
+  if (text === block.text) {
+    return blocks as NativeChatBlock[]
+  }
+  const next = [...blocks]
+  next[textIndex] = { ...block, text }
   return next
 }
 
@@ -46,15 +50,16 @@ function imagePromptMarkerStartsMessage(message: NativeChatMessage): boolean {
 export function normalizeImageTranscriptMessages(
   messages: readonly NativeChatMessage[]
 ): NativeChatMessage[] {
-  const normalized: NativeChatMessage[] = []
+  let normalized: NativeChatMessage[] | null = null
   for (let index = 0; index < messages.length; index += 1) {
     const message = messages[index]!
     if (message.role !== 'user') {
-      normalized.push(message)
+      normalized?.push(message)
       continue
     }
     const imagePath = imageSourcePathFromText(soleText(message) ?? '')
     if (imagePath) {
+      normalized ??= messages.slice(0, index)
       const imagePaths = [imagePath]
       let nextIndex = index + 1
       while (nextIndex < messages.length) {
@@ -88,10 +93,13 @@ export function normalizeImageTranscriptMessages(
       })
       continue
     }
-    normalized.push({
-      ...message,
-      blocks: stripImagePromptMarkersFromFirstText(message.blocks)
-    })
+    const blocks = stripImagePromptMarkersFromFirstText(message.blocks)
+    if (blocks === message.blocks) {
+      normalized?.push(message)
+    } else {
+      normalized ??= messages.slice(0, index)
+      normalized.push({ ...message, blocks })
+    }
   }
-  return normalized
+  return normalized ?? (messages as NativeChatMessage[])
 }


### PR DESCRIPTION
## ELI5: stop re-sorting an already sorted bookshelf

Think of a conversation as a bookshelf. As new messages arrive, Orca already puts them in order and removes duplicates. But when only the small **working/ready** status sign changed, Orca took every book off the shelf, rebuilt its labels, sorted the whole shelf again, and then changed the sign.

That repeated work gets expensive in a long conversation. Messages without an explicit `turnId` are the worst case because Orca must lowercase and normalize their full text to build a fallback identity.

Now the shelf stays assembled:

- Message content is prepared only when the messages change.
- A status-only update reuses that prepared list and replaces only the lightweight session/status wrapper.
- If the pending-send tray is empty, Orca returns immediately instead of searching the full conversation for pending messages that cannot exist.

```mermaid
flowchart LR
  subgraph Before
    B1[Messages already ordered and de-duplicated] --> B2[Rebuild keys, maps, and sort everything again]
    B2 --> B3[Attach live status]
    B4[Pending queue is empty] --> B5[Scan the full transcript anyway]
  end
  subgraph After
    A1[Messages already ordered and de-duplicated] --> A2[Prepare display data once when messages change]
    A2 --> A3[Attach live status directly]
    A4[Pending queue is empty] --> A5[Return immediately]
  end
```

**The safety escape hatch:** any history containing messages from more than one source deliberately uses the old canonical assembler. This preserves legacy winners and status inference after sorting or presentation transforms. Ordinary single-source histories keep the shortcut.

**What does not change:** chat text, message order, duplicate handling, status precedence, images, skill display, and wire data are intended to remain identical. This changes how much repeated JavaScript work Orca performs, not what the user sees.

**What the benchmark means:** in the deliberately large 300-message stress fixture, the combined stage fell from about **5.358 ms to 0.0342 ms (99.36% less)**. A status-only update and an empty pending queue each removed more than **99.99%** of the measured work. These are pure-JavaScript measurements of this one stage—not end-to-end UI timings—and smaller real conversations save less absolute time.

## Summary

The live native-chat hook already maintains an ordered, de-duplicated message array incrementally as transcript frames arrive. However, it then passed that finished array through the full session assembler again whenever live status changed.

For a long conversation, that redundant second pass rebuilt maps, regenerated fallback turn keys, normalized text, and sorted the same messages again. Messages without explicit `turnId` values are the expensive case because fallback identity lowercases and normalizes their full text.

Separately, the optimistic-send overlay scanned the whole visible transcript even when the pending-send queue was empty.

This PR removes both kinds of guaranteed work:

1. Skill-envelope surfacing and image-marker normalization are prepared in a message-axis memo, outside status-only rerenders.
2. The status merge constructs the final session directly over those already assembled messages.
3. Image normalization is copy-on-write: histories with no image markers keep the original array, message, and block identities.
4. `pendingSendsAsMessages` returns immediately when there are no pending sends.

The normal flow is now:

```text
transcript updates
    -> incremental ordering/de-duplication
    -> memoized presentation preparation
    -> direct status/session wrapper

status-only updates
    -> direct status/session wrapper
```

### Rare mixed-source compatibility path

Independent review found that a type-valid mixed-source history can need another canonical pass after either sorting or presentation transforms. That second pass can also change the visible tail, while legacy status inference deliberately used the pre-pass tail.

The fast path therefore remains direct only when the result has one source. Every mixed-source history takes the canonical assembler and carries the pre-pass tail into status inference. Explicit unchanged, image, skill, and status-tail collision tests prove legacy parity.

No chat text, ordering, status precedence, image behavior, skill display, wire data, or UI changes are intended.

## Benchmark

Reproduce with:

```bash
pnpm exec tsx config/scripts/native-chat-live-session-benchmark.ts
```

Environment: Node 24.18.0. The harness calibrates each arm independently by doubling iterations until **two consecutive samples take at least 50 ms**, with a finite 16,777,216-iteration cap. It then runs 10 alternating-order rounds and reports the median milliseconds per operation.

It forces sessions, arrays, selected message content, and pending-match sets into module-scope sinks; consumes varying message content; checks deep output parity; and verifies an exact deterministic checksum. The final rebased run had zero capped calibrations and completed in 16.1 seconds.

| Synthetic fixture | Before | After | Reduction |
|---|---:|---:|---:|
| 300 × 2 KiB prose, no `turnId` | 4.173747 ms | 0.038305 ms | 99.08% |
| 300 × 2 KiB prose, with `turnId` | 0.070706 ms | 0.035060 ms | 50.41% |
| 300 tool-heavy messages | 0.335253 ms | 0.001727 ms | 99.48% |
| 100 × 2 KiB prose, no `turnId` | 1.343327 ms | 0.010889 ms | 99.19% |
| 500 × 2 KiB prose, no `turnId` | 6.836141 ms | 0.059069 ms | 99.14% |
| Status-only frame over 300 messages | 4.115732 ms | 0.000022 ms | >99.99% |
| Empty pending queue over 300 messages | 1.629243 ms | 0.000008 ms | >99.99% |
| Combined 300-message path | 5.358211 ms | 0.034231 ms | 99.36% |

The message-update arms measure the actual old and new preparation pipelines, including command lookup and skill-envelope surfacing. Status-only and empty-pending cases isolate their respective hot axes.

These are stress-fixture pure-function measurements, not end-to-end UI latency. They exclude transcript parsing, IPC/remote transport, React reconciliation, DOM rendering, and paint. The 2 KiB-per-message fixture is deliberately large and is not an estimate of average production message size. Smaller real conversations save less absolute time.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — full repository lint was not rerun
- [ ] `pnpm typecheck` — full multi-project typecheck was not rerun
- [ ] `pnpm test` — full repository suite was not rerun
- [ ] `pnpm build` — no packaging surface changed
- [x] Added high-quality regression tests

Passed:

- Alias-aware native-chat renderer/shared suite: 85 files, 865 tests
- Focused parity/status/pending/image suite: 4 files, 80 tests
- 20,000 randomized mixed-source legacy content/status parity cases
- 50,000 randomized shared image-normalizer parity/immutability cases
- Explicit unchanged, image, skill, and status-tail mixed-source collisions
- Status precedence and array/message/block identity assertions
- `pnpm run typecheck:web` and `pnpm run typecheck:node`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- Oxfmt and `git diff --check`
- Calibrated self-validating benchmark: 8 cases, zero capped calibrations
- 64 MB V8 heap run plus repeated 300 × 32 KiB mixed-source preparation with no retained-heap growth

Mobile Vitest could not boot in this worktree because its Expo dependency tree is absent (`expo/tsconfig.base.json` is unavailable). Static consumer tracing plus 50,000 shared parity/immutability cases cover the changed mobile-consumed function.

## AI Review Report

Three independent adversarial reviews found and reproduced three parity gaps: an unchanged mixed-source history could retain a lower-priority duplicate, canonical re-dedup could change legacy status-tail inference, and copy-on-write image normalization retained whitespace-only text that legacy removed. All three are fixed with focused regressions and randomized old/new differentials.

Benchmark review also found that the harness bypassed the real optimized preparation path. It now measures the actual old/new pipelines, calibrates both arms to two consecutive ≥50 ms samples, caps iterations, makes outputs escape, consumes varying content, and verifies exact checksums. Final independent reviews reported no remaining P0, P1, or P2 findings.

Cross-platform review covered macOS, Linux, Windows, SSH/remote, WSL, folder workspaces, and mixed-version runtime input. This change adds no paths, shell execution, shortcuts, labels, native modules, or Electron platform branches.

Reliability record:

- **Invariant:** `native-chat.live-session-content-status-parity` — message content/order/de-duplication and status precedence must remain legacy-equivalent, including transformed mixed-source input.
- **Failure source:** a redundant full assembly and an empty-queue history scan on live renderer updates.
- **Oracle:** 20,000 mixed-source content/status differentials, 50,000 shared-normalizer parity cases, explicit collision/status tests, identity tests, and 865 broad native-chat tests.
- **Gate:** no reliability-manifest gate currently targets live native-chat content assembly; this PR records that as an accepted gap and uses deterministic lower-layer oracles.
- **Provider/platform coverage:** local and remote transcript messages use the same preparation logic; type-valid old/mixed-source remote data takes the compatibility fallback. OS-specific behavior is unaffected.
- **Performance budget:** no polling, listener, timer, subprocess, cache, or unbounded retained state is added.
- **Residual gap:** no React Profiler, painted-frame, live SSH, or mobile package run is attached; the benchmark is intentionally below those layers.

## Security Audit

No new dependency, command execution, path access, auth behavior, secret handling, persistence, IPC/RPC method, or wire field is introduced.

Existing transcript content remains the only input. The change does not loosen parsing or validation. The mixed-source fallback deliberately preserves the prior canonical precedence instead of trusting transformed remote rows blindly.

## Notes

- Shared image-normalization output is unchanged; only allocation/identity behavior changes when no normalization is needed.
- Mobile consumes that shared function, but no mobile RPC, route, persisted field, or rendering contract changes.
- No Style Guide surface is touched because there is no layout, color, typography, spacing, component, or UX change.
- `PERF-28.local.md` is not included.
