### PR TITLE
fix(window): stop slow renderer recovery loops

### DIFF
--- a/src/main/crash-reporting/renderer-recovery-circuit-breaker.test.ts
+++ b/src/main/crash-reporting/renderer-recovery-circuit-breaker.test.ts
@@ -50,6 +50,21 @@ describe('RendererRecoveryCircuitBreaker', () => {
     expect(breaker.registerRecoveryAttempt(10_000_000).allowed).toBe(true)
   })
 
+  it('opens for the b32b2865 recovery cadence after a GPU child crash', () => {
+    const breaker = new RendererRecoveryCircuitBreaker({
+      windowMs: DEFAULT_RENDERER_RECOVERY_WINDOW_MS,
+      maxRecoveries: DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES
+    })
+
+    for (const at of [0, 7_000, 64_000]) {
+      expect(breaker.registerRecoveryAttempt(at).allowed).toBe(true)
+    }
+    expect(breaker.registerRecoveryAttempt(70_000)).toEqual({
+      allowed: false,
+      recentRecoveryCount: 3
+    })
+  })
+
   it('reset() clears history so the next recovery is allowed', () => {
     const breaker = new RendererRecoveryCircuitBreaker({ windowMs: 60_000, maxRecoveries: 1 })
     expect(breaker.registerRecoveryAttempt(0).allowed).toBe(true)
@@ -59,7 +74,7 @@ describe('RendererRecoveryCircuitBreaker', () => {
   })
 
   it('ships conservative defaults', () => {
-    expect(DEFAULT_RENDERER_RECOVERY_WINDOW_MS).toBe(60_000)
+    expect(DEFAULT_RENDERER_RECOVERY_WINDOW_MS).toBe(120_000)
     expect(DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES).toBe(3)
   })
 })

--- a/src/main/crash-reporting/renderer-recovery-circuit-breaker.ts
+++ b/src/main/crash-reporting/renderer-recovery-circuit-breaker.ts
@@ -9,9 +9,9 @@ export type RendererRecoveryCircuitBreakerOptions = {
 // AV interference) crashes on every load. Orca auto-reloads recoverable
 // renderer deaths, so without a breaker it reloads every ~0.25-1.3s forever,
 // burning CPU and spamming breadcrumbs (Windows clusters F0BDRAZN55L /
-// F0BDPCL93UM). 3 reloads in 60s is well above any single transient crash but
-// far below a runaway loop.
-export const DEFAULT_RENDERER_RECOVERY_WINDOW_MS = 60_000
+// F0BDPCL93UM). Keep the window above slow process-start failures so attempts
+// cannot age out while the same renderer fault is still recurring.
+export const DEFAULT_RENDERER_RECOVERY_WINDOW_MS = 120_000
 export const DEFAULT_RENDERER_RECOVERY_MAX_RECOVERIES = 3
 
 /**

--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -193,6 +193,7 @@ import {
   ensureAutoUpdaterConfigured
 } from './window/attach-main-window-services'
 import { createMainWindow, loadMainWindow } from './window/createMainWindow'
+import { RendererRecoveryPromptController } from './window/renderer-recovery-prompt-controller'
 import {
   getDashboardPopoutWindow,
   zoomDashboardPopoutIfFocused
@@ -1590,6 +1591,8 @@ function sendOpenCrashReport(targetWindow?: BrowserWindow | null): void {
   webContents?.send('ui:openCrashReport')
 }
 
+const rendererRecoveryPromptController = new RendererRecoveryPromptController()
+
 // Why: on renderer crash-loop the breaker stops auto-reloading and the window goes blank, so a main-process dialog is the only retry/quit surface.
 async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promise<void> {
   if (isQuitting) {
@@ -1605,16 +1608,26 @@ async function presentRendererRecoveryPrompt(recentRecoveryCount: number): Promi
     message: 'The app window crashed repeatedly and stopped reloading automatically.',
     detail: `Orca tried to recover ${recentRecoveryCount} times in a row without success. This is often a graphics-driver or installation problem. Reload to try again, or quit and relaunch Orca.`
   }
-  const { response } = window
-    ? await dialog.showMessageBox(window, options)
-    : await dialog.showMessageBox(options)
-  if (response === 0 && mainWindow && !mainWindow.isDestroyed()) {
-    recordDurableCrashBreadcrumb('renderer_recovery_manual_retry')
-    loadMainWindow(mainWindow)
-  } else if (response === 1) {
-    isQuitting = true
-    app.quit()
-  }
+  await rendererRecoveryPromptController.present({
+    showPrompt: () =>
+      window ? dialog.showMessageBox(window, options) : dialog.showMessageBox(options),
+    isQuitting: () => isQuitting,
+    reload: () => {
+      if (!mainWindow || mainWindow.isDestroyed()) {
+        return
+      }
+      markRecoveryReloadInFlight(mainWindow.webContents.id)
+      recordDurableCrashBreadcrumb('renderer_recovery_manual_retry')
+      loadMainWindow(mainWindow)
+    },
+    quit: () => {
+      isQuitting = true
+      app.quit()
+    },
+    onPromptError: (error) => {
+      console.warn('[renderer-recovery] failed to show recovery prompt; quitting:', error)
+    }
+  })
 }
 
 function getGpuFallbackEnvironment(): GpuFallbackEnvironment {

--- a/src/main/window/createMainWindow.test.ts
+++ b/src/main/window/createMainWindow.test.ts
@@ -3425,6 +3425,48 @@ describe('createMainWindow', () => {
     }
   })
 
+  it('opens the breaker for the b32b2865 renderer recovery timestamps', () => {
+    vi.useFakeTimers()
+
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+    const onRendererRecoveryExhausted = vi.fn()
+    const { browserWindowInstance, windowHandlers } = createRendererRecoveryWindowHarness()
+
+    try {
+      createMainWindow(null, { onRendererRecoveryExhausted })
+
+      const driveFailure = (
+        reason: Electron.RenderProcessGoneDetails['reason'],
+        exitCode: number
+      ) => {
+        windowHandlers['render-process-gone']?.(
+          {} as never,
+          { reason, exitCode } as Electron.RenderProcessGoneDetails
+        )
+        vi.advanceTimersByTime(250)
+      }
+
+      driveFailure('crashed', 1)
+      vi.advanceTimersByTime(6_750)
+      driveFailure('oom', -536_870_904)
+      vi.advanceTimersByTime(56_750)
+      driveFailure('oom', -536_870_904)
+      vi.advanceTimersByTime(5_750)
+      driveFailure('launch-failed', 18)
+
+      expect(browserWindowInstance.loadFile).toHaveBeenCalledTimes(4)
+      expect(onRendererRecoveryExhausted).toHaveBeenCalledOnce()
+      expect(onRendererRecoveryExhausted).toHaveBeenCalledWith(
+        expect.objectContaining({
+          details: expect.objectContaining({ reason: 'launch-failed', exitCode: 18 }),
+          recentRecoveryCount: 3
+        })
+      )
+    } finally {
+      consoleError.mockRestore()
+    }
+  })
+
   function createStartupRevealWindowFixture() {
     const windowHandlers: Record<string, (...args: any[]) => void> = {}
     const webContents = {

--- a/src/main/window/renderer-recovery-prompt-controller.test.ts
+++ b/src/main/window/renderer-recovery-prompt-controller.test.ts
@@ -1,0 +1,80 @@
+import { describe, expect, it, vi } from 'vitest'
+import { RendererRecoveryPromptController } from './renderer-recovery-prompt-controller'
+
+function createOptions(showPrompt: () => Promise<{ response: number }>) {
+  return {
+    showPrompt: vi.fn(showPrompt),
+    isQuitting: vi.fn(() => false),
+    reload: vi.fn(),
+    quit: vi.fn(),
+    onPromptError: vi.fn()
+  }
+}
+
+describe('RendererRecoveryPromptController', () => {
+  it('routes the dialog choices', async () => {
+    const controller = new RendererRecoveryPromptController()
+    const reload = createOptions(async () => ({ response: 0 }))
+    const quit = createOptions(async () => ({ response: 1 }))
+
+    await controller.present(reload)
+    await controller.present(quit)
+
+    expect(reload.reload).toHaveBeenCalledOnce()
+    expect(reload.quit).not.toHaveBeenCalled()
+    expect(quit.quit).toHaveBeenCalledOnce()
+    expect(quit.reload).not.toHaveBeenCalled()
+  })
+
+  it('allows only one concurrent prompt', async () => {
+    const controller = new RendererRecoveryPromptController()
+    let resolveFirst: ((value: { response: number }) => void) | undefined
+    const first = createOptions(
+      () =>
+        new Promise((resolve) => {
+          resolveFirst = resolve
+        })
+    )
+    const second = createOptions(async () => ({ response: 0 }))
+
+    const pending = controller.present(first)
+    await controller.present(second)
+
+    expect(second.showPrompt).not.toHaveBeenCalled()
+    resolveFirst?.({ response: 0 })
+    await pending
+  })
+
+  it('quits cleanly when the native prompt fails', async () => {
+    const controller = new RendererRecoveryPromptController()
+    const error = new Error('dialog failed')
+    const options = createOptions(async () => {
+      throw error
+    })
+
+    await controller.present(options)
+
+    expect(options.onPromptError).toHaveBeenCalledWith(error)
+    expect(options.quit).toHaveBeenCalledOnce()
+    expect(options.reload).not.toHaveBeenCalled()
+  })
+
+  it('does nothing when teardown starts while the prompt is open', async () => {
+    const controller = new RendererRecoveryPromptController()
+    let resolvePrompt: ((value: { response: number }) => void) | undefined
+    const options = createOptions(
+      () =>
+        new Promise((resolve) => {
+          resolvePrompt = resolve
+        })
+    )
+
+    const pending = controller.present(options)
+    options.isQuitting.mockReturnValue(true)
+    resolvePrompt?.({ response: 0 })
+    await pending
+
+    expect(options.reload).not.toHaveBeenCalled()
+    expect(options.quit).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/window/renderer-recovery-prompt-controller.ts
+++ b/src/main/window/renderer-recovery-prompt-controller.ts
@@ -1,0 +1,38 @@
+export type RendererRecoveryPromptControllerOptions = {
+  showPrompt: () => Promise<{ response: number }>
+  isQuitting: () => boolean
+  reload: () => void
+  quit: () => void
+  onPromptError: (error: unknown) => void
+}
+
+export class RendererRecoveryPromptController {
+  private showing = false
+
+  async present(options: RendererRecoveryPromptControllerOptions): Promise<void> {
+    if (this.showing) {
+      return
+    }
+    this.showing = true
+    let response: number
+    try {
+      response = (await options.showPrompt()).response
+    } catch (error) {
+      options.onPromptError(error)
+      if (!options.isQuitting()) {
+        options.quit()
+      }
+      return
+    } finally {
+      this.showing = false
+    }
+    if (options.isQuitting()) {
+      return
+    }
+    if (response === 0) {
+      options.reload()
+    } else if (response === 1) {
+      options.quit()
+    }
+  }
+}


### PR DESCRIPTION
## Diagnosis

Crash `b32b2865-4f75-4f1e-96e9-8f6afc51c03b` was a native Windows GPU/Chromium failure chain, not JavaScript heap exhaustion: renderer heap was 50/82 MiB against a 4,192 MiB limit, then the GPU child exited 34, WebGL was lost, renderers reported OOM `0xE0000008`, and the final renderer failed to launch with exit 18.

The native trigger is environmental (GPU/driver/Chromium), but Orca had a reproducible recovery-policy defect. Its 60-second rolling breaker admitted recovery attempts at +0s, +7s, +64s, and +70s because older attempts aged out while the same failure was still recurring. The fourth death therefore requested another reload instead of stopping the loop. This behavior is present on current `origin/main`; it was not already fixed or outdated.

## Fix

- Widen the renderer-recovery stability window from 60s to 120s while preserving the maximum of three automatic recoveries.
- Serialize the native recovery prompt so duplicate process-gone events cannot stack dialogs.
- Recheck teardown after the dialog resolves.
- Mark a user-requested recovery reload so the PTY orphan sweep preserves local terminals.
- Cleanly quit if Electron cannot show the only recovery surface, avoiding both a blank-window strand and an automatic relaunch loop.

## ELI5

Orca allowed three retries, but forgot the first retries too quickly. This crash failed slowly enough that Orca kept saying “this is only retry number two” forever. Orca now remembers retries for two minutes, stops after the third, and asks the user what to do.

## Reproduction evidence

Before the production edit:

```text
pnpm exec vitest run src/main/crash-reporting/renderer-recovery-circuit-breaker.test.ts --testNamePattern "b32b2865" --reporter=verbose
```

Failed as expected at +70s:

```text
Expected: { allowed: false, recentRecoveryCount: 3 }
Received: { allowed: true, recentRecoveryCount: 2 }
```

The integration regression also drives renderer recoveries at the report's +0/+7/+64/+70-second cadence and verifies the final `launch-failed` opens the breaker without a fifth document load. The GPU child event remains on its separate `child-process-gone` path and is not misclassified as a renderer death.

## Windows-native verification

All commands ran on Windows x64 in the issue worktree:

```text
pnpm exec vitest run src/main/crash-reporting/gpu-crash-fallback-decision.test.ts src/main/crash-reporting/renderer-recovery-circuit-breaker.test.ts src/main/crash-reporting/process-gone-classification.test.ts src/main/window/renderer-recovery-prompt-controller.test.ts src/main/window/createMainWindow.test.ts --reporter=dot
# 5 files passed, 131 tests passed

pnpm run typecheck:node
# passed

pnpm exec oxlint <changed TypeScript files>
# passed

pnpm exec oxlint --config config/oxlint-react-doctor.json <changed TypeScript files>
# passed

pnpm run build:electron-vite
# passed (only pre-existing bundler/CSS warnings)

git diff --check
# passed
```

## Compatibility and trade-offs

- A fourth renderer death within 120 seconds now prompts sooner than before; four renderer deaths in two minutes is already an unhealthy loop, while isolated failures still recover automatically.
- This does not force safe graphics mode after one GPU child crash. The existing threshold of three clustered GPU crashes remains intact to avoid false-positive driver fallback.
- No RPC, stream, persistence schema, Git, provider, SSH, folder-workspace, or remote-wire behavior changes.
- The recovery policy is platform-neutral; only the evidence/reproduction is Windows-specific.
- State stays bounded to three timestamps and one prompt-controller boolean; no polling or new timer is added.

## Review evidence

- Adversarial reviews: 3 fresh rounds. Round 1 found 5 issues, round 2 found 1 P2, round 3 was clean.
- Performance reviews: 3 rounds; final review clean. No benchmark was warranted for this constant-size, crash-only path.