### PR TITLE
fix(agent-dashboard): highlight agents awaiting input

### DIFF
--- a/src/renderer/src/components/dashboard-popout/AgentMap.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMap.test.tsx
@@ -192,9 +192,15 @@ describe('AgentMap', () => {
       name: /Open Finished worktree worktree details/
     })
 
-    expect(workingNode.querySelector('[data-agent-map-agent-working-glow]')).toBeInTheDocument()
-    expect(waitingNode.querySelector('[data-agent-map-agent-working-glow]')).not.toBeInTheDocument()
-    expect(doneNode.querySelector('[data-agent-map-agent-working-glow]')).not.toBeInTheDocument()
+    expect(workingNode.querySelector('[data-agent-map-agent-status-glow]')).toHaveAttribute(
+      'data-agent-active-status',
+      'working'
+    )
+    expect(waitingNode.querySelector('[data-agent-map-agent-status-glow]')).toHaveAttribute(
+      'data-agent-active-status',
+      'waiting'
+    )
+    expect(doneNode.querySelector('[data-agent-map-agent-status-glow]')).not.toBeInTheDocument()
     expect(workingRing).toHaveClass('is-waiting')
     expect(workingRing).not.toHaveClass('is-working')
     expect(doneRing).not.toHaveClass('is-working')
@@ -221,7 +227,7 @@ describe('AgentMap', () => {
     })
     const { container } = renderMap(cards, { selectedPaneKey: 'pane-0' })
 
-    expect(container.querySelectorAll('[data-agent-map-agent-working-glow]')).toHaveLength(60)
+    expect(container.querySelectorAll('[data-agent-map-agent-status-glow]')).toHaveLength(60)
     expect(container.querySelectorAll('[data-agent-map-worktree-status-glow]')).toHaveLength(1)
     expect(container.querySelectorAll('filter')).toHaveLength(0)
   })

--- a/src/renderer/src/components/dashboard-popout/AgentMap.test.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMap.test.tsx
@@ -164,6 +164,23 @@ describe('AgentMap', () => {
     expect(doneNode).toHaveAccessibleName(/unread/)
   })
 
+  it.each([
+    { bucket: 'working', dotState: 'working', unseen: false, glows: true },
+    { bucket: 'attention', dotState: 'waiting', unseen: false, glows: true },
+    { bucket: 'attention', dotState: 'blocked', unseen: false, glows: true },
+    { bucket: 'done', dotState: 'done', unseen: true, glows: false },
+    { bucket: 'idle', dotState: 'idle', unseen: false, glows: false }
+  ] as const)('applies the expected halo for $dotState agents', (state) => {
+    const { container } = renderMap([card(state)])
+    const glow = container.querySelector('[data-agent-map-agent-status-glow]')
+
+    if (state.glows) {
+      expect(glow).toHaveAttribute('data-agent-active-status', state.dotState)
+      return
+    }
+    expect(glow).not.toBeInTheDocument()
+  })
+
   it('lets attention override working on the worktree glow', () => {
     const done = card({
       paneKey: 'done',

--- a/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
+++ b/src/renderer/src/components/dashboard-popout/AgentMapWorktreeRingNode.tsx
@@ -303,6 +303,10 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
             </g>
             {worktree.agents.map((agent) => {
               const iconSize = Math.max(12, Math.min(22, agent.radius * 1.05))
+              const hasStatusGlow =
+                agent.status === 'working' ||
+                agent.status === 'waiting' ||
+                agent.status === 'blocked'
               return (
                 <g
                   key={agent.card.paneKey}
@@ -327,10 +331,11 @@ export const AgentMapWorktreeRingNode = memo(function AgentMapWorktreeRingNode({
                   }}
                   onKeyDown={(event) => onAgentKeyDown(event, agent)}
                 >
-                  {agent.status === 'working' ? (
+                  {hasStatusGlow ? (
                     <circle
-                      className="agent-map-agent-working-glow"
-                      data-agent-map-agent-working-glow=""
+                      className={`agent-map-agent-status-glow fleet-status-${agent.status}`}
+                      data-agent-map-agent-status-glow=""
+                      data-agent-active-status={agent.status}
                       r={agent.radius + 1}
                       aria-hidden="true"
                     />

--- a/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
@@ -20,12 +20,20 @@ describe('Agent Map glow performance boundary', () => {
 
   it('keeps glow styling free of animated and filtered paint work', () => {
     const css = source('agent-map.css')
-    const glowRules = css.match(/\.agent-map-(?:worktree-status|agent-status)-glow\s*\{[^}]+\}/gs)
+    const baseGlowRules = css.match(
+      /\.agent-map-(?:worktree-status|agent-status)-glow\s*\{[^}]+\}/gs
+    )
+    const glowRules = css.match(
+      /\.agent-map-(?:worktree-status|agent-status)-glow[^{}]*\{[^}]+\}/gs
+    )
 
-    expect(glowRules).toHaveLength(2)
-    for (const rule of glowRules ?? []) {
+    expect(baseGlowRules).toHaveLength(2)
+    for (const rule of baseGlowRules ?? []) {
       expect(rule).toContain('pointer-events: none')
       expect(rule).toContain('vector-effect: non-scaling-stroke')
+    }
+    expect(glowRules).toHaveLength(8)
+    for (const rule of glowRules ?? []) {
       expect(rule).not.toMatch(/filter:|animation:|transition:/)
     }
   })

--- a/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
+++ b/src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts
@@ -14,13 +14,13 @@ describe('Agent Map glow performance boundary', () => {
     const component = source('AgentMapWorktreeRingNode.tsx')
 
     expect(component.match(/data-agent-map-worktree-status-glow/g)).toHaveLength(1)
-    expect(component.match(/data-agent-map-agent-working-glow/g)).toHaveLength(1)
+    expect(component.match(/data-agent-map-agent-status-glow/g)).toHaveLength(1)
     expect(component).not.toMatch(/<filter|filter=/)
   })
 
   it('keeps glow styling free of animated and filtered paint work', () => {
     const css = source('agent-map.css')
-    const glowRules = css.match(/\.agent-map-(?:worktree-status|agent-working)-glow\s*\{[^}]+\}/gs)
+    const glowRules = css.match(/\.agent-map-(?:worktree-status|agent-status)-glow\s*\{[^}]+\}/gs)
 
     expect(glowRules).toHaveLength(2)
     for (const rule of glowRules ?? []) {

--- a/src/renderer/src/components/dashboard-popout/agent-map.css
+++ b/src/renderer/src/components/dashboard-popout/agent-map.css
@@ -218,12 +218,23 @@
   vector-effect: non-scaling-stroke;
 }
 
-.agent-map-agent-working-glow {
+.agent-map-agent-status-glow {
   fill: none;
   pointer-events: none;
-  stroke: color-mix(in srgb, var(--color-yellow-500) 32%, transparent);
   stroke-width: 7;
   vector-effect: non-scaling-stroke;
+}
+
+.agent-map-agent-status-glow.fleet-status-working {
+  stroke: color-mix(in srgb, var(--color-yellow-500) 32%, transparent);
+}
+
+.agent-map-agent-status-glow.fleet-status-waiting {
+  stroke: color-mix(in srgb, var(--color-amber-500) 42%, transparent);
+}
+
+.agent-map-agent-status-glow.fleet-status-blocked {
+  stroke: color-mix(in srgb, var(--color-red-500) 38%, transparent);
 }
 
 .agent-map-agent-icon {


### PR DESCRIPTION
## Summary

- add an amber halo to Agent Map nodes waiting for user input
- add a red halo to blocked nodes while preserving the existing yellow working halo
- keep done and idle nodes quiet and retain the filter-free SVG paint boundary

## Screenshots

![Waiting agent with amber halo](https://github.com/user-attachments/assets/98dbf1f9-e9e7-4976-93b6-39ab7c16bd50)

## Testing

- [ ] `pnpm lint`
- [ ] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation completed:

- `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/dashboard-popout/AgentMap.test.tsx src/renderer/src/components/dashboard-popout/agent-map-glow.performance.test.ts`
- `pnpm run typecheck:web`
- targeted `oxlint` and `oxfmt --check`
- `git diff --check`
- Electron QA with an isolated profile and a live waiting-question fixture

## AI Review Report

Reviewed the node-state mapping, worktree attention precedence, DOM bounds, accessibility labeling, and SVG paint cost. The review identified that only working nodes received a node-level halo; the implementation now generalizes that halo to all live attention states with state-specific existing palette tokens. Tests confirm waiting nodes glow, completed nodes do not, and the large-map halo count remains bounded without filters or animation.

Cross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This is token-based SVG/CSS presentation only and does not touch shortcuts, labels, paths, shells, native APIs, or platform-specific Electron behavior.

## Security Audit

Presentational-only renderer change. It adds no input handling, command execution, path handling, auth, secrets, dependencies, IPC, or external data flow. Existing status values remain the only class inputs, constrained by the dashboard status union. No security follow-up is needed.

## Notes

The halo uses the existing amber, red, and yellow state palette and stays free of animation and SVG filters.