### PR TITLE
[Perf-SS] Overlap Git status with conflict-marker reads

### DIFF
--- a/src/main/git/status-conflict-overlap.bench.test.ts
+++ b/src/main/git/status-conflict-overlap.bench.test.ts
@@ -1,0 +1,250 @@
+import { performance } from 'node:perf_hooks'
+import { join } from 'node:path'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type * as NodeFsPromises from 'node:fs/promises'
+import type * as GitRunner from './runner'
+import type { GitExec } from '../../relay/git-handler-ops'
+import type { RelayGitStreamExec } from '../../relay/git-stdout-stream'
+
+const { gitStreamStdoutMock, readFileMock } = vi.hoisted(() => ({
+  gitStreamStdoutMock: vi.fn(),
+  readFileMock: vi.fn()
+}))
+
+vi.mock('node:fs/promises', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeFsPromises>()
+  return { ...actual, readFile: readFileMock }
+})
+
+vi.mock('./runner', async (importOriginal) => {
+  const actual = await importOriginal<typeof GitRunner>()
+  return { ...actual, gitStreamStdout: gitStreamStdoutMock }
+})
+
+import { getStatus } from './status'
+import { getStatusOp } from '../../relay/git-handler-status-ops'
+
+const BENCH_DELAY_MS = 25
+const BENCH_SAMPLES = 31
+const BENCH_WARMUPS = 5
+const describeBench = process.env.ORCA_GIT_STATUS_OVERLAP_BENCH === '1' ? describe : describe.skip
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+type BenchmarkResult = {
+  path: string
+  medianMs: number
+  p95Ms: number
+  minMs: number
+  maxMs: number
+}
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+function wait(delayMs: number): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, delayMs))
+}
+
+function percentile(samples: number[], fraction: number): number {
+  const sorted = [...samples].sort((a, b) => a - b)
+  return sorted[Math.ceil(sorted.length * fraction) - 1]!
+}
+
+describe('git status conflict-read overlap', () => {
+  const relayGit: GitExec = async () => ({ stdout: '', stderr: '' })
+
+  beforeEach(() => {
+    readFileMock.mockReset()
+    gitStreamStdoutMock.mockReset()
+    readFileMock.mockResolvedValue('gitdir: /repo/.git/worktrees/feature\n')
+    gitStreamStdoutMock.mockResolvedValue({ stoppedEarly: false })
+  })
+
+  it('starts native status before conflict-marker I/O settles', async () => {
+    const markerRead = deferred<string>()
+    const statusStarted = deferred<void>()
+    readFileMock.mockReturnValue(markerRead.promise)
+    gitStreamStdoutMock.mockImplementation(async () => {
+      statusStarted.resolve()
+      return { stoppedEarly: false }
+    })
+
+    const resultPromise = getStatus('/repo')
+    await statusStarted.promise
+    expect(readFileMock).toHaveBeenCalledWith(join('/repo', '.git'), 'utf-8')
+
+    markerRead.resolve('gitdir: /repo/.git/worktrees/feature\n')
+    await expect(resultPromise).resolves.toMatchObject({
+      entries: [],
+      conflictOperation: 'unknown'
+    })
+  })
+
+  it('starts relay status before conflict-marker I/O settles', async () => {
+    const markerRead = deferred<string>()
+    const statusStarted = deferred<void>()
+    readFileMock.mockReturnValue(markerRead.promise)
+    const relayStreamGit: RelayGitStreamExec = async () => {
+      statusStarted.resolve()
+      return { stoppedEarly: false }
+    }
+
+    const resultPromise = getStatusOp(relayGit, relayStreamGit, { worktreePath: '/repo' })
+    await statusStarted.promise
+    expect(readFileMock).toHaveBeenCalledWith(join('/repo', '.git'), 'utf-8')
+
+    markerRead.resolve('gitdir: /repo/.git/worktrees/feature\n')
+    await expect(resultPromise).resolves.toMatchObject({
+      entries: [],
+      conflictOperation: 'unknown'
+    })
+  })
+
+  it('observes an early native status rejection while marker I/O remains pending', async () => {
+    const markerRead = deferred<string>()
+    readFileMock.mockReturnValue(markerRead.promise)
+    gitStreamStdoutMock.mockRejectedValue(new Error('status failed first'))
+    let settled = false
+
+    const resultPromise = getStatus('/repo').finally(() => {
+      settled = true
+    })
+    await Promise.resolve()
+    await Promise.resolve()
+    expect(settled).toBe(false)
+
+    markerRead.resolve('gitdir: /repo/.git/worktrees/feature\n')
+    await expect(resultPromise).resolves.toMatchObject({
+      entries: [],
+      conflictOperation: 'unknown'
+    })
+  })
+
+  it('keeps a synchronous native status failure fail-soft', async () => {
+    const statusError = new Error('status threw')
+    gitStreamStdoutMock.mockImplementation(() => {
+      throw statusError
+    })
+
+    await expect(getStatus('/repo')).resolves.toMatchObject({
+      entries: [],
+      conflictOperation: 'unknown'
+    })
+  })
+
+  it.each(['throw', 'reject'] as const)('keeps relay %s failures fail-soft', async (mode) => {
+    const statusError = new Error(`status ${mode}`)
+    const relayStreamGit = (() => {
+      if (mode === 'throw') {
+        throw statusError
+      }
+      return Promise.reject(statusError)
+    }) as RelayGitStreamExec
+
+    await expect(
+      getStatusOp(relayGit, relayStreamGit, { worktreePath: '/repo' })
+    ).resolves.toMatchObject({ entries: [], conflictOperation: 'unknown' })
+  })
+
+  it('rethrows the original relay status failure after cancellation', async () => {
+    const controller = new AbortController()
+    const statusError = new Error('cancelled status')
+    const relayStreamGit: RelayGitStreamExec = async () => {
+      controller.abort(statusError)
+      throw statusError
+    }
+
+    await expect(
+      getStatusOp(
+        relayGit,
+        relayStreamGit,
+        { worktreePath: '/repo' },
+        { signal: controller.signal }
+      )
+    ).rejects.toBe(statusError)
+  })
+
+  it('surfaces detector errors without waiting for a hung status read', async () => {
+    const statusStarted = deferred<void>()
+    const relayStreamGit: RelayGitStreamExec = () => {
+      statusStarted.resolve()
+      return new Promise(() => {})
+    }
+    const invalidPath = { toString: () => '/repo' }
+
+    const resultPromise = getStatusOp(relayGit, relayStreamGit, {
+      worktreePath: invalidPath
+    })
+    const rejection = expect(resultPromise).rejects.toThrow(TypeError)
+    await statusStarted.promise
+    await rejection
+  })
+
+  it('keeps detector errors ahead of concurrent status failures', async () => {
+    const statusError = new Error('status failed too')
+    const relayStreamGit = (() => {
+      throw statusError
+    }) as RelayGitStreamExec
+    const invalidPath = { toString: () => '/repo' }
+
+    const result = getStatusOp(relayGit, relayStreamGit, { worktreePath: invalidPath })
+    await expect(result).rejects.toBeInstanceOf(TypeError)
+  })
+})
+
+describeBench('git status conflict-read overlap benchmark', () => {
+  it('measures native and relay orchestration with matched independent latency', async () => {
+    readFileMock.mockImplementation(async () => {
+      await wait(BENCH_DELAY_MS)
+      return 'gitdir: /repo/.git/worktrees/feature\n'
+    })
+    gitStreamStdoutMock.mockImplementation(async () => {
+      await wait(BENCH_DELAY_MS)
+      return { stoppedEarly: false }
+    })
+    const relayGit: GitExec = async () => ({ stdout: '', stderr: '' })
+    const relayStreamGit: RelayGitStreamExec = async () => {
+      await wait(BENCH_DELAY_MS)
+      return { stoppedEarly: false }
+    }
+    const cases = [
+      { name: 'native', run: () => getStatus('/repo') },
+      {
+        name: 'relay',
+        run: () => getStatusOp(relayGit, relayStreamGit, { worktreePath: '/repo' })
+      }
+    ]
+
+    const results: BenchmarkResult[] = []
+    for (const benchmarkCase of cases) {
+      for (let index = 0; index < BENCH_WARMUPS; index += 1) {
+        await benchmarkCase.run()
+      }
+      const samples: number[] = []
+      for (let index = 0; index < BENCH_SAMPLES; index += 1) {
+        const startedAt = performance.now()
+        await benchmarkCase.run()
+        samples.push(performance.now() - startedAt)
+      }
+      results.push({
+        path: benchmarkCase.name,
+        medianMs: Number(percentile(samples, 0.5).toFixed(3)),
+        p95Ms: Number(percentile(samples, 0.95).toFixed(3)),
+        minMs: Number(Math.min(...samples).toFixed(3)),
+        maxMs: Number(Math.max(...samples).toFixed(3))
+      })
+    }
+
+    console.table(results)
+    expect(results).toHaveLength(2)
+  }, 10_000)
+})

--- a/src/main/git/status.ts
+++ b/src/main/git/status.ts
@@ -315,22 +315,32 @@ async function runGetStatus(
   // Why: stream + parse and stop at `limit` so a huge un-ignored folder can't buffer enough to crash the process.
   const parser = new StatusPorcelainParser()
   let didHitLimit = false
+  // Why: attach rejection ownership before awaiting marker I/O, so a fast Git failure cannot become unhandled.
+  const statusSettlementPromise = Promise.allSettled([
+    (async () => {
+      const result = await gitStreamStdout(statusArgs, {
+        cwd: worktreePath,
+        wslDistro: options.wslDistro,
+        preferWslDirectGit: true,
+        // Why: status polling is read-like; disable optional locks to avoid racing terminal Git on index.lock.
+        env: gitOptionalLocksDisabledEnv(),
+        signal: options.signal,
+        onStdout: (chunk) => parser.update(chunk, limit)
+      })
+      if (!result.stoppedEarly) {
+        parser.finish()
+      }
+      return result
+    })()
+  ])
   const conflictOperation = await conflictPromise
 
   try {
-    const { stoppedEarly } = await gitStreamStdout(statusArgs, {
-      cwd: worktreePath,
-      wslDistro: options.wslDistro,
-      preferWslDirectGit: true,
-      // Why: status polling is read-like; disable optional locks to avoid racing terminal Git on index.lock.
-      env: gitOptionalLocksDisabledEnv(),
-      signal: options.signal,
-      onStdout: (chunk) => parser.update(chunk, limit)
-    })
-    if (!stoppedEarly) {
-      parser.finish()
+    const [statusResult] = await statusSettlementPromise
+    if (statusResult.status === 'rejected') {
+      throw statusResult.reason
     }
-    didHitLimit = stoppedEarly
+    didHitLimit = statusResult.value.stoppedEarly
     statusSucceeded = true
   } catch (error) {
     // Why: an aborted scan must reject, not resolve as an empty result.

--- a/src/relay/git-handler-status-ops.ts
+++ b/src/relay/git-handler-status-ops.ts
@@ -91,7 +91,36 @@ export async function getStatusOp(
   )
   // Why: reject NaN/negative limits — NaN would silently disable capping, negatives would over-truncate.
   const limit = resolveGitStatusLimit(params.limit)
-  const conflictOperation = await detectConflictOperation(worktreePath)
+  const conflictPromise = detectConflictOperation(worktreePath)
+  // Why: core.quotePath=false keeps non-ASCII filenames as raw UTF-8 instead of octal escapes that render as gibberish.
+  const statusArgs = [
+    '-c',
+    'core.quotePath=false',
+    'status',
+    '--porcelain=v2',
+    '--branch',
+    '--untracked-files=all'
+  ]
+  if (includeIgnored) {
+    statusArgs.push('--ignored=matching')
+  }
+  // Why: attach rejection ownership before awaiting marker I/O, so a fast Git failure cannot become unhandled.
+  const statusSettlementPromise = Promise.allSettled([
+    (async () => {
+      const parser = new StatusPorcelainParser()
+      const result = await streamGit(statusArgs, worktreePath, {
+        // Why: status polling is read-like; avoid racing terminal Git on .git/worktrees/*/index.lock.
+        disableOptionalLocks: true,
+        signal: options.signal,
+        onStdout: (chunk) => parser.update(chunk, limit)
+      })
+      if (!result.stoppedEarly) {
+        parser.finish()
+      }
+      return { parser, stoppedEarly: result.stoppedEarly }
+    })()
+  ])
+  const conflictOperation = await conflictPromise
   const entries: Record<string, unknown>[] = []
   let head: string | undefined
   let branch: string | undefined
@@ -103,28 +132,11 @@ export async function getStatusOp(
   let branchLineTotal: GitBranchLineTotal | undefined
 
   try {
-    // Why: core.quotePath=false keeps non-ASCII filenames as raw UTF-8 instead of octal escapes that render as gibberish.
-    const statusArgs = [
-      '-c',
-      'core.quotePath=false',
-      'status',
-      '--porcelain=v2',
-      '--branch',
-      '--untracked-files=all'
-    ]
-    if (includeIgnored) {
-      statusArgs.push('--ignored=matching')
+    const [statusResult] = await statusSettlementPromise
+    if (statusResult.status === 'rejected') {
+      throw statusResult.reason
     }
-    const parser = new StatusPorcelainParser()
-    const { stoppedEarly } = await streamGit(statusArgs, worktreePath, {
-      // Why: status polling is read-like; avoid racing terminal Git on .git/worktrees/*/index.lock.
-      disableOptionalLocks: true,
-      signal: options.signal,
-      onStdout: (chunk) => parser.update(chunk, limit)
-    })
-    if (!stoppedEarly) {
-      parser.finish()
-    }
+    const { parser, stoppedEarly } = statusResult.value
     head = parser.branch.head
     branch = parser.branch.branch
     ignoredPaths = parser.ignoredPaths


### PR DESCRIPTION
## The one-sentence version

A Git status refresh does two unrelated chores. It used to do them one after the other; now it does both at once. **Roughly twice as fast.**

---

## The two chores

Every time Orca refreshes Git status for a workspace, it needs two facts:

1. **"Is a merge or rebase in progress?"** — answered by checking for marker files on disk (`MERGE_HEAD`, `REBASE_HEAD`, and friends).
2. **"Which files changed?"** — answered by running `git status` and streaming its output.

Neither one needs the other's answer. They were still run in sequence.

```mermaid
flowchart LR
    subgraph BEFORE["Before — sequential"]
        direction LR
        B1["Read marker files<br/>25 ms"] --> B2["THEN start git status<br/>25 ms"] --> B3["Done<br/>~52 ms"]
    end
```

```mermaid
flowchart LR
    subgraph AFTER["After — concurrent"]
        direction LR
        A0["Start both"] --> A1["Read marker files — 25 ms"]
        A0 --> A2["Run git status — 25 ms"]
        A1 --> A3["Done<br/>~26 ms"]
        A2 --> A3
    end
```

The critical path goes from `marker + status` to about `max(marker, status)`.

## Why this matters more than it sounds

On a fast local SSD, reading a marker file is nearly free and this saves little. The change targets the cases where it is **not** free:

- **SSH and relay hosts** — every filesystem probe is a network round trip.
- **Network mounts** (NFS, UNC paths) and **WSL mounts**, where a `stat` can take tens of milliseconds.

On those hosts the marker read was pure dead time sitting in front of Git.

## Measured

Node 24.18.0, using the real native and relay production modules, with controlled independent 25 ms marker-read and 25 ms status-stream latency, 5 warmups, 31 samples:

| Path | Before median | After median | Before p95 | After p95 | Median reduction |
| --- | ---: | ---: | ---: | ---: | ---: |
| Native | 51.984 ms | 26.329 ms | 52.405 ms | 26.697 ms | **49.3%** |
| Relay / SSH | 52.140 ms | 26.160 ms | 52.299 ms | 26.206 ms | **49.8%** |

Reproduce:

```bash
ORCA_GIT_STATUS_OVERLAP_BENCH=1 pnpm exec vitest run \
  --config config/vitest.config.ts \
  --disableConsoleIntercept \
  src/main/git/status-conflict-overlap.bench.test.ts
```

**Scope caveat:** the 25 ms latency is injected, not observed from a real slow mount. The shape of the win is what is being demonstrated; the magnitude on any given host depends on that host's marker-read latency. On a warm local FS the win is small.

---

## What reviewers should actually look at

The payload is unchanged: `entries`, `head`, `branch`, `upstreamStatus`, `ignoredPaths`, `didHitLimit`, `statusLength`, `branchLineTotal`, `conflictOperation` all keep their shape, argv, env, limits, and parser lifecycle. Abort-error identity (`createAbortError()`) and fail-soft catch semantics are preserved on both paths. Three things genuinely change.

### 1. Refreshes land sooner (intended)

Source Control and the sidebar dirty indicators update earlier on slow-FS hosts. This is the point of the PR, but it is a user-perceivable timing change and not a no-op.

### 2. The two facts are now sampled at the same moment, not in order

Before, the marker sample was always taken **strictly before** the `git status` index snapshot. Now they overlap, so the status snapshot can be up to one marker-read-latency **older** than the marker sample.

Both values are rendered together — `SourceControl.tsx` `shouldRenderCommitArea`, the resolved-conflicts panel gate, and the `WorktreeCard` badge. So if you start or abort a merge in a terminal at the exact instant a refresh runs, the pair shown for that one cycle can differ from what the old ordering would have shown.

Two consequences worth knowing:

- A transient non-`unknown` `conflictOperation` on a non-active worktree starts the 3-second `useStaleConflictOperationPolling` loop — an extra `git.conflictOperation` RPC per worktree until it clears.
- A transient skew the other way hides the commit area for one cycle.

**No new UI state is possible.** Both combinations were already reachable through the opposite race, and the code comment at `src/main/git/status.ts:1018` already acknowledges this `existsSync`/status race and its one-poll `unknown` fallback. What changed is *which* real-world timing triggers them.

### 3. Aborting mid-refresh now costs a spawned process

If a refresh is cancelled during the marker-read window (lease cancellation, worktree close, poll supersession), a real `git status` child process has already been spawned and must now be killed — including `taskkill` on Windows and `terminateRelaySubprocessTree` on relay hosts. Previously the pre-abort early return meant no process was ever created.

Same window, the rejected error object gains own-properties (`stderr`, `stdoutBytes` native; `stderr` relay) because it now travels the mid-flight abort path instead of the pre-abort one. `name` and `message` are identical (`AbortError` / "The operation was aborted."), so any consumer reading only those is unaffected.

Relatedly: because each spawn is no longer staggered behind its own marker read, more `git status` processes can be alive simultaneously across parallel worktree polls. On a host with many worktrees this raises peak concurrent subprocess and FD count.

### Residual risk (not a finding)

If `detectConflictOperation` rejects, the status stream is left running un-owned — `allSettled` prevents an unhandled rejection, but nothing cancels it. This needs a non-string `worktreePath`, and `resolveSubmoduleWorktreePath`/`path.join` throw at relay dispatch and `expandTilde` throws inside `streamRelayGitStdout` before any spawn, so it is judged unreachable in practice.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Benchmark test covering both native and relay paths

`git.exec` observability spans now start earlier and overlap the marker read; span duration and count are unchanged, so recorded telemetry values remain equivalent. Relay `statusArgs` construction moved out of the `try` block — verified nothing there can throw (`includeIgnored` is a boolean, `limit` is already validated), so there is no fail-soft-to-reject change.
