### PR TITLE
[perf-remote] perf(renderer): collapse remote lineage refresh fan-out

### DIFF
--- a/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
+++ b/src/renderer/src/components/settings/RuntimeEnvironmentsPane.tsx
@@ -62,6 +62,7 @@ import {
   RemoteServerUpdateStatus
 } from './RemoteServerUpdateStatus'
 import { RuntimeHostAccessForm, type RuntimeHostAccessFailure } from './RuntimeHostAccessForm'
+import { refreshRuntimeProjectCatalog } from '@/hooks/runtime-project-refresh-scheduler'
 
 const LOCAL_RUNTIME_VALUE = '__local__'
 const NO_RUNTIME_VALUE = '__none__'
@@ -674,8 +675,12 @@ export function RuntimeEnvironmentsPane({
       // Why: Connect is not the Active Server selector anymore, but connected
       // hosts should still contribute their projects/workspaces to the sidebar.
       const repos = await store.fetchRuntimeEnvironmentRepos(environment.id)
-      await Promise.all(repos.map((repo) => useAppStore.getState().fetchWorktrees(repo.id)))
-      await useAppStore.getState().fetchWorktreeLineage()
+      await refreshRuntimeProjectCatalog(
+        environment.id,
+        repos,
+        (repoId, options) => useAppStore.getState().fetchWorktrees(repoId, options),
+        (options) => useAppStore.getState().fetchWorktreeLineage(options)
+      )
       if (mountedRef.current) {
         toast.success(
           translate(

--- a/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.test.ts
@@ -20,7 +20,16 @@ describe('connectRuntimeHostForNavigation', () => {
 
     expect(fetchRepos).toHaveBeenCalledWith('windows-2')
     expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchWorktrees).toHaveBeenNthCalledWith(1, 'repo-a', {
+      executionHostId: 'runtime:windows-2',
+      deferRemoteLineageRefresh: true
+    })
+    expect(fetchWorktrees).toHaveBeenNthCalledWith(2, 'repo-b', {
+      executionHostId: 'runtime:windows-2',
+      deferRemoteLineageRefresh: true
+    })
     expect(fetchLineage).toHaveBeenCalledOnce()
+    expect(fetchLineage).toHaveBeenCalledWith({ executionHostId: 'runtime:windows-2' })
   })
 
   it('does not load a catalog when the server is unreachable', async () => {

--- a/src/renderer/src/components/status-bar/SshStatusSegment.tsx
+++ b/src/renderer/src/components/status-bar/SshStatusSegment.tsx
@@ -36,20 +36,25 @@ import {
   runtimeHostConnectionState,
   runtimeStatusForOverall
 } from '@/runtime/runtime-host-connection-state'
+import { refreshRuntimeProjectCatalog } from '@/hooks/runtime-project-refresh-scheduler'
 
 export async function connectRuntimeHostForNavigation(args: {
   environmentId: string
   refreshStatus: (environmentId: string, timeoutMs: number) => Promise<boolean>
   fetchRepos: (environmentId: string) => Promise<{ id: string }[]>
-  fetchWorktrees: (repoId: string) => Promise<unknown>
-  fetchLineage: () => Promise<unknown>
+  fetchWorktrees: Parameters<typeof refreshRuntimeProjectCatalog>[2]
+  fetchLineage: Parameters<typeof refreshRuntimeProjectCatalog>[3]
 }): Promise<boolean> {
   if (!(await args.refreshStatus(args.environmentId, 5_000))) {
     return false
   }
   const repos = await args.fetchRepos(args.environmentId)
-  await Promise.all(repos.map((repo) => args.fetchWorktrees(repo.id)))
-  await args.fetchLineage()
+  await refreshRuntimeProjectCatalog(
+    args.environmentId,
+    repos,
+    args.fetchWorktrees,
+    args.fetchLineage
+  )
   return true
 }
 

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.test.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import {
   createRuntimeProjectRefreshScheduler,
+  refreshRuntimeProjectCatalog,
   refreshRuntimeProjectWorktrees
 } from './runtime-project-refresh-scheduler'
 
@@ -16,11 +17,63 @@ describe('refreshRuntimeProjectWorktrees', () => {
 
     expect(fetchWorktrees).toHaveBeenCalledTimes(2)
     expect(fetchWorktrees).toHaveBeenNthCalledWith(1, 'same-repo', {
-      executionHostId: 'runtime:env-1'
+      executionHostId: 'runtime:env-1',
+      deferRemoteLineageRefresh: true
     })
     expect(fetchWorktrees).toHaveBeenNthCalledWith(2, 'same-repo', {
-      executionHostId: 'runtime:env-1'
+      executionHostId: 'runtime:env-1',
+      deferRemoteLineageRefresh: true
     })
+  })
+
+  it('refreshes host-wide lineage once after a large repo batch', async () => {
+    const fetchWorktrees = vi.fn().mockResolvedValue(true)
+    const fetchLineage = vi.fn().mockResolvedValue(undefined)
+    const repos = Array.from({ length: 40 }, (_, index) => ({ id: `repo-${index}` }))
+
+    await refreshRuntimeProjectCatalog('env-1', repos, fetchWorktrees, fetchLineage)
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(40)
+    for (const [repoId, options] of fetchWorktrees.mock.calls) {
+      expect(repoId).toMatch(/^repo-\d+$/)
+      expect(options).toEqual({
+        executionHostId: 'runtime:env-1',
+        deferRemoteLineageRefresh: true
+      })
+    }
+    expect(fetchLineage).toHaveBeenCalledOnce()
+    expect(fetchLineage).toHaveBeenCalledWith({ executionHostId: 'runtime:env-1' })
+  })
+
+  it('refreshes host-wide lineage when the host has no repos', async () => {
+    const fetchWorktrees = vi.fn()
+    const fetchLineage = vi.fn().mockResolvedValue(undefined)
+
+    await refreshRuntimeProjectCatalog('env-1', [], fetchWorktrees, fetchLineage)
+
+    expect(fetchWorktrees).not.toHaveBeenCalled()
+    expect(fetchLineage).toHaveBeenCalledOnce()
+    expect(fetchLineage).toHaveBeenCalledWith({ executionHostId: 'runtime:env-1' })
+  })
+
+  it('still refreshes host-wide lineage when a repo callback rejects', async () => {
+    const fetchWorktrees = vi.fn((repoId: string) =>
+      repoId === 'repo-b' ? Promise.reject(new Error('scan failed')) : Promise.resolve(true)
+    )
+    const fetchLineage = vi.fn().mockResolvedValue(undefined)
+
+    await expect(
+      refreshRuntimeProjectCatalog(
+        'env-1',
+        [{ id: 'repo-a' }, { id: 'repo-b' }],
+        fetchWorktrees,
+        fetchLineage
+      )
+    ).rejects.toThrow('Failed to refresh 1 runtime project worktree(s): repo-b')
+
+    expect(fetchWorktrees).toHaveBeenCalledTimes(2)
+    expect(fetchLineage).toHaveBeenCalledOnce()
+    expect(fetchLineage).toHaveBeenCalledWith({ executionHostId: 'runtime:env-1' })
   })
 })
 

--- a/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
+++ b/src/renderer/src/hooks/runtime-project-refresh-scheduler.ts
@@ -13,6 +13,15 @@ export type RuntimeProjectRefreshScheduler = {
   stop: () => void
 }
 
+type RuntimeProjectWorktreeRefreshOptions = {
+  executionHostId: ExecutionHostId
+  deferRemoteLineageRefresh: true
+}
+
+type RuntimeProjectLineageRefreshOptions = {
+  executionHostId: ExecutionHostId
+}
+
 type RefreshEntry = {
   inFlight: boolean
   lastStartedAt: number
@@ -29,7 +38,7 @@ export async function refreshRuntimeProjectWorktrees(
   repos: readonly { id: string }[],
   fetchWorktrees: (
     repoId: string,
-    options: { executionHostId: ExecutionHostId }
+    options: RuntimeProjectWorktreeRefreshOptions
   ) => Promise<unknown>,
   concurrency = DEFAULT_REFRESH_CONCURRENCY
 ): Promise<void> {
@@ -46,7 +55,7 @@ export async function refreshRuntimeProjectWorktrees(
         nextIndex += 1
         const repoId = repos[index].id
         try {
-          await fetchWorktrees(repoId, { executionHostId })
+          await fetchWorktrees(repoId, { executionHostId, deferRemoteLineageRefresh: true })
         } catch (error) {
           failures.push({ repoId, error })
         }
@@ -61,6 +70,22 @@ export async function refreshRuntimeProjectWorktrees(
         .join(', ')}`
     )
   }
+}
+
+export async function refreshRuntimeProjectCatalog(
+  environmentId: string,
+  repos: readonly { id: string }[],
+  fetchWorktrees: (
+    repoId: string,
+    options: RuntimeProjectWorktreeRefreshOptions
+  ) => Promise<unknown>,
+  fetchLineage: (options: RuntimeProjectLineageRefreshOptions) => Promise<unknown>
+): Promise<void> {
+  const executionHostId = toRuntimeExecutionHostId(environmentId)
+  // Why: one failed repo must not prevent the host-wide snapshot from refreshing.
+  await refreshRuntimeProjectWorktrees(environmentId, repos, fetchWorktrees).finally(() =>
+    fetchLineage({ executionHostId })
+  )
 }
 
 export function createRuntimeProjectRefreshScheduler(

--- a/src/renderer/src/hooks/useIpcEvents.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents.test.ts
@@ -4932,9 +4932,23 @@ describe('useIpcEvents CLI-created worktree activation', () => {
     await new Promise((resolve) => setTimeout(resolve, 0))
 
     expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', {
-      executionHostId: 'runtime:env-1'
+      executionHostId: 'runtime:env-1',
+      deferRemoteLineageRefresh: true
     })
     expect(fetchWorktreeLineage).toHaveBeenCalledWith({
+      executionHostId: 'runtime:env-1'
+    })
+
+    fetchWorktrees.mockClear()
+    fetchWorktreeLineage.mockClear()
+    runtimeOnResponse({
+      ok: true,
+      result: { type: 'activateWorktree', repoId: 'repo-1', worktreeId: 'wt-new' }
+    })
+    await new Promise((resolve) => setTimeout(resolve, 0))
+    await new Promise((resolve) => setTimeout(resolve, 0))
+
+    expect(fetchWorktrees).toHaveBeenCalledWith('repo-1', {
       executionHostId: 'runtime:env-1'
     })
   })

--- a/src/renderer/src/hooks/useIpcEvents.ts
+++ b/src/renderer/src/hooks/useIpcEvents.ts
@@ -104,7 +104,7 @@ import {
 } from '@/runtime/runtime-environment-ssh-state'
 import {
   createRuntimeProjectRefreshScheduler,
-  refreshRuntimeProjectWorktrees
+  refreshRuntimeProjectCatalog
 } from './runtime-project-refresh-scheduler'
 import { createRuntimeClientEventsSync } from './runtime-client-events-sync'
 import { detectLanguage } from '@/lib/language-detect'
@@ -798,7 +798,10 @@ export function useIpcEvents(): void {
         options?.forceLocalOwner
           ? { forceLocalOwner: true }
           : options?.executionHostId
-            ? { executionHostId: options.executionHostId }
+            ? {
+                executionHostId: options.executionHostId,
+                deferRemoteLineageRefresh: true
+              }
             : undefined
       )
       await useAppStore
@@ -869,7 +872,7 @@ export function useIpcEvents(): void {
         startup,
         defaultTabs
       }: Extract<RuntimeClientEvent, { type: 'activateWorktree' }>,
-      options: { allowRuntimeEnvironment: boolean }
+      options: { allowRuntimeEnvironment: boolean; executionHostId?: ExecutionHostId }
     ): Promise<void> => {
       if (!options.allowRuntimeEnvironment && isRuntimeEnvironmentActive()) {
         // Why: local CLI worktree events carry local ids; runtime activation comes via the remote stream, allowed separately.
@@ -877,7 +880,12 @@ export function useIpcEvents(): void {
       }
       const existedBeforeFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
       // Why: fetch first so activation can resolve the CLI-created worktree; it arrived from main, not yet in renderer state.
-      await useAppStore.getState().fetchWorktrees(repoId)
+      // Keep lineage enabled because a transport gap can drop the preceding worktreesChanged event.
+      await (options.executionHostId
+        ? useAppStore.getState().fetchWorktrees(repoId, {
+            executionHostId: options.executionHostId
+          })
+        : useAppStore.getState().fetchWorktrees(repoId))
       const existsAfterFetch = Boolean(useAppStore.getState().getKnownWorktreeById(worktreeId))
       // Why: use the canonical activation path so the CLI switch records a back/forward visit, or the nav buttons ignore it.
       activateAndRevealWorktree(worktreeId, {
@@ -905,12 +913,12 @@ export function useIpcEvents(): void {
         // Why: refresh the env's SSH bucket on (re)connect so a pre-drop snapshot can't keep a reconnect overlay stale.
         void hydrateRuntimeEnvironmentSshState(environmentId, { force: true }).catch(() => {})
         const repos = await useAppStore.getState().fetchRuntimeEnvironmentRepos(environmentId)
-        await refreshRuntimeProjectWorktrees(environmentId, repos, (repoId, options) =>
-          useAppStore.getState().fetchWorktrees(repoId, options)
+        await refreshRuntimeProjectCatalog(
+          environmentId,
+          repos,
+          (repoId, options) => useAppStore.getState().fetchWorktrees(repoId, options),
+          (options) => useAppStore.getState().fetchWorktreeLineage(options)
         )
-        await useAppStore.getState().fetchWorktreeLineage({
-          executionHostId: toRuntimeExecutionHostId(environmentId)
-        })
       },
       onError: (error) => {
         console.error('Failed to refresh runtime projects:', error)
@@ -973,7 +981,12 @@ export function useIpcEvents(): void {
         return
       }
       void ensureRuntimeEventRepoKnown(environmentId, event.repoId)
-        .then(() => activateNotifiedWorktree(event, { allowRuntimeEnvironment: true }))
+        .then(() =>
+          activateNotifiedWorktree(event, {
+            allowRuntimeEnvironment: true,
+            executionHostId: toRuntimeExecutionHostId(environmentId)
+          })
+        )
         .catch((error) => {
           console.error('Failed to activate runtime-created worktree:', error)
         })

--- a/src/renderer/src/store/slices/worktree-helpers.ts
+++ b/src/renderer/src/store/slices/worktree-helpers.ts
@@ -51,6 +51,8 @@ export type WorktreeFetchOptions = {
   requireAuthoritative?: boolean
   executionHostId?: ExecutionHostId
   forceLocalOwner?: boolean
+  /** Caller owns the host-wide lineage refresh after this scan. */
+  deferRemoteLineageRefresh?: boolean
 }
 
 export type DirectSshWorktreeFetchOptions = WorktreeFetchOptions & {

--- a/src/renderer/src/store/slices/worktrees.test.ts
+++ b/src/renderer/src/store/slices/worktrees.test.ts
@@ -3036,6 +3036,61 @@ describe('fetchWorktrees', () => {
     expect(store.getState().sortEpoch).toBe(8)
   })
 
+  it('defers remote lineage when a batch caller owns the host-wide refresh', async () => {
+    const store = createTestStore()
+    const worktree = makeWorktree({
+      id: 'repo1::/remote/wt1',
+      repoId: 'repo1',
+      path: '/remote/wt1',
+      branch: 'refs/heads/remote'
+    })
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-1' } as never })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: makeDetectedResult('repo1', [worktree]),
+      _meta: { runtimeId: 'runtime-remote' }
+    })
+
+    await store.getState().fetchWorktrees('repo1', { deferRemoteLineageRefresh: true })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(1)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith(
+      expect.objectContaining({ method: 'worktree.detectedList' })
+    )
+    expect(store.getState().worktreesByRepo.repo1).toEqual([worktree])
+  })
+
+  it('defers lineage for an explicitly targeted non-focused runtime', async () => {
+    const store = createTestStore()
+    const worktree = makeWorktree({
+      id: 'repo1::/remote/wt1',
+      repoId: 'repo1',
+      path: '/remote/wt1',
+      branch: 'refs/heads/remote'
+    })
+    store.setState({ settings: { activeRuntimeEnvironmentId: 'env-a' } as never })
+    runtimeEnvironmentCall.mockResolvedValue({
+      id: 'rpc-1',
+      ok: true,
+      result: makeDetectedResult('repo1', [worktree]),
+      _meta: { runtimeId: 'runtime-b' }
+    })
+
+    await store.getState().fetchWorktrees('repo1', {
+      executionHostId: 'runtime:env-b',
+      deferRemoteLineageRefresh: true
+    })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(1)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledWith({
+      selector: 'env-b',
+      method: 'worktree.detectedList',
+      params: { repo: 'repo1' },
+      timeoutMs: 15_000
+    })
+  })
+
   it('updates worktree records when only GitLab link metadata changes', async () => {
     const store = createTestStore()
     const initial = makeWorktree({

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -3527,8 +3527,8 @@ export const createWorktreeSlice: StateCreator<AppState, [], [], WorktreeSlice> 
           ? (staleDetectedWorktreeProviderResult(refresh) ?? false)
           : false
       }
-      // Direct SSH lineage requires its own qualified authority result.
-      if (!directSshAuthority) {
+      // Direct SSH needs a qualified result; deferred runtime callers refresh lineage after their scans.
+      if (!directSshAuthority && !options?.deferRemoteLineageRefresh) {
         await refreshRemoteWorktreeLineageBestEffort(settings, set)
       }
       return directCallerAuthority ? refresh.providerResult! : refresh.result.authoritative


### PR DESCRIPTION
## Summary\n\n- Collapse remote runtime project refreshes from one host-wide lineage RPC per repository plus a final RPC to exactly one final lineage RPC.\n- Apply the same batching to remote worktree-change events and manual host connects.\n- Pin remote-created workspace activation and manual connects to the event host so another active server cannot receive the refresh.\n- Bound manual connect repository scans with the existing five-worker limit.\n\n## ELI5\n\nA remote host has one family tree for all of its workspaces. We were asking for that same whole family tree after every repository scan, then asking once more at the end.\n\nNow we scan the repositories and ask for the family tree once. With 40 repositories, that changes 41 identical lineage requests into 1.\n\n## Screenshots\n\nNo visual change.\n\n## Testing\n\n- [ ] pnpm lint\n- [x] pnpm typecheck\n- [ ] pnpm test\n- [ ] pnpm build\n- [x] Added or updated high-quality tests that would catch regressions\n\nFocused validation:\n- 390 tests across runtime project scheduling, IPC events, worktree state, and manual runtime connect\n- pnpm run check:code-quality:changed\n- pnpm run check:max-lines-ratchet\n- git diff --check\n\nCoverage includes 40 repositories, zero repositories, a rejected repository callback, a non-focused target host, event-driven refresh, and manual host connect.\n\n## AI Review Report\n\nThree read-only hotspot investigations and two adversarial diff reviews checked RPC fan-out, multi-host routing, mixed client/server operation, transport gaps, direct SSH, folder workspaces, and async failure behavior.\n\nThe review caught an unsafe attempt to defer lineage during runtime activation even though a transport gap can drop the preceding worktreesChanged event. That deferral was removed, preserving activation as the fallback discovery path. It also requested explicit non-focused-host coverage and clearer rejection-only test semantics; both were added.\n\nCross-platform compatibility was explicitly checked for macOS, Linux, and Windows. This change touches no shortcuts, labels, paths, shell behavior, native modules, or platform-specific Electron behavior.\n\n## Security Audit\n\nNo new commands, path handling, auth, secrets, dependencies, or externally supplied input are introduced. The defer option is renderer-internal and is not sent over RPC, so the remote wire contract and mixed-version server compatibility are unchanged. Direct SSH keeps its qualified lineage path.\n\n## Notes\n\nActivated-workspace discovery intentionally retains its own lineage refresh because it can be the only surviving event after a transport gap. A safe follow-up is host-keyed in-flight lineage coalescing, rather than dropping that fallback.