### PR TITLE
feat(cli): support repo add --kind folder

### DIFF
--- a/src/cli/handlers/repo.ts
+++ b/src/cli/handlers/repo.ts
@@ -1,8 +1,25 @@
 import type { RuntimeRepoList, RuntimeRepoSearchRefs } from '../../shared/runtime-types'
+import type { RepoKind } from '../../shared/types'
 import type { CommandHandler } from '../dispatch'
 import { formatRepoList, formatRepoRefs, formatRepoShow, printResult } from '../format'
-import { getOptionalPositiveIntegerFlag, getRequiredStringFlag } from '../flags'
+import {
+  getOptionalPositiveIntegerFlag,
+  getOptionalStringFlag,
+  getRequiredStringFlag
+} from '../flags'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
+import { RuntimeClientError } from '../runtime-client'
+
+function getOptionalRepoKind(flags: Map<string, string | boolean>): RepoKind | undefined {
+  const kind = getOptionalStringFlag(flags, 'kind')
+  if (kind === undefined) {
+    return undefined
+  }
+  if (kind === 'git' || kind === 'folder') {
+    return kind
+  }
+  throw new RuntimeClientError('invalid_argument', '--kind must be git or folder')
+}
 
 export const REPO_HANDLERS: Record<string, CommandHandler> = {
   'repo list': async ({ client, json }) => {
@@ -11,8 +28,11 @@ export const REPO_HANDLERS: Record<string, CommandHandler> = {
   },
   'repo add': async ({ flags, client, cwd, json }) => {
     const repoPath = getRequiredStringFlag(flags, 'path')
+    const kind = getOptionalRepoKind(flags)
     const result = await client.call<{ repo: Record<string, unknown> }>('repo.add', {
-      path: resolveRepoPathArgument(repoPath, cwd, client.isRemote, 'Remote repo add')
+      path: resolveRepoPathArgument(repoPath, cwd, client.isRemote, 'Remote repo add'),
+      // Why: GUI already registers folder projects; CLI default remains git (#13358).
+      ...(kind ? { kind } : {})
     })
     printResult(result, json, formatRepoShow)
   },

--- a/src/cli/handlers/repo.ts
+++ b/src/cli/handlers/repo.ts
@@ -2,16 +2,12 @@ import type { RuntimeRepoList, RuntimeRepoSearchRefs } from '../../shared/runtim
 import type { RepoKind } from '../../shared/types'
 import type { CommandHandler } from '../dispatch'
 import { formatRepoList, formatRepoRefs, formatRepoShow, printResult } from '../format'
-import {
-  getOptionalPositiveIntegerFlag,
-  getOptionalStringFlag,
-  getRequiredStringFlag
-} from '../flags'
+import { getOptionalPositiveIntegerFlag, getRequiredStringFlag } from '../flags'
 import { resolveRepoPathArgument } from '../repo-path-arguments'
 import { RuntimeClientError } from '../runtime-client'
 
 function getOptionalRepoKind(flags: Map<string, string | boolean>): RepoKind | undefined {
-  const kind = getOptionalStringFlag(flags, 'kind')
+  const kind = flags.get('kind')
   if (kind === undefined) {
     return undefined
   }

--- a/src/cli/help.ts
+++ b/src/cli/help.ts
@@ -255,7 +255,7 @@ Common Commands:
   orca project setup-update --setup <setup-id> [--display-name <name>] [--path <path>] [--worktree-base-path <path>] [--git-username <name>] [--kind git|folder] [--state ready|not-set-up|setting-up|error|unsupported] [--method legacy-repo|imported-existing-folder|cloned|provisioned] [--json]
   orca project setup-delete --setup <setup-id> [--json]
   orca repo list [--json]
-  orca repo add --path <path> [--json]
+  orca repo add --path <path> [--kind git|folder] [--json]
   orca repo show --repo <selector> [--json]
   orca repo set-base-ref --repo <selector> --ref <ref> [--json]
   orca repo search-refs --repo <selector> --query <text> [--limit <n>] [--json]

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2620,6 +2620,47 @@ describe('orca cli worktree awareness', () => {
     })
   })
 
+  it('forwards repo.add --kind folder to the runtime', async () => {
+    queueFixtures(
+      callMock,
+      okFixture('req_repo_add_folder', {
+        repo: {
+          id: 'folder:notes',
+          path: path.resolve('/tmp/notes'),
+          displayName: 'notes',
+          kind: 'folder'
+        }
+      })
+    )
+    vi.spyOn(console, 'log').mockImplementation(() => {})
+
+    await main(['repo', 'add', '--path', '/tmp/notes', '--kind', 'folder', '--json'], '/tmp/repo')
+
+    expect(callMock).toHaveBeenCalledWith('repo.add', {
+      path: path.resolve('/tmp/notes'),
+      kind: 'folder'
+    })
+  })
+
+  it('rejects invalid repo.add --kind values', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['repo', 'add', '--path', '/tmp/notes', '--kind', 'zip', '--json'], '/tmp/repo')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument',
+        message: '--kind must be git or folder'
+      }
+    })
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('lists projects through the project-first runtime API', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/index.test.ts
+++ b/src/cli/index.test.ts
@@ -2661,6 +2661,25 @@ describe('orca cli worktree awareness', () => {
     process.exitCode = priorExitCode
   })
 
+  it('rejects a valueless repo.add --kind flag', async () => {
+    const logSpy = vi.spyOn(console, 'log').mockImplementation(() => {})
+    const priorExitCode = process.exitCode
+
+    await main(['repo', 'add', '--path', '/tmp/notes', '--kind', '--json'], '/tmp/repo')
+
+    expect(callMock).not.toHaveBeenCalled()
+    expect(JSON.parse(String(logSpy.mock.calls[0]?.[0]))).toMatchObject({
+      ok: false,
+      error: {
+        code: 'invalid_argument',
+        message: '--kind must be git or folder'
+      }
+    })
+    expect(process.exitCode).toBe(1)
+
+    process.exitCode = priorExitCode
+  })
+
   it('lists projects through the project-first runtime API', async () => {
     queueFixtures(
       callMock,

--- a/src/cli/specs/core.ts
+++ b/src/cli/specs/core.ts
@@ -39,8 +39,11 @@ export const CORE_COMMAND_SPECS: CommandSpec[] = [
   {
     path: ['repo', 'add'],
     summary: 'Add a project to Orca by filesystem path',
-    usage: 'orca repo add --path <path> [--json]',
-    allowedFlags: [...GLOBAL_FLAGS, 'path']
+    usage: 'orca repo add --path <path> [--kind git|folder] [--json]',
+    allowedFlags: [...GLOBAL_FLAGS, 'path', 'kind'],
+    notes: [
+      'Defaults to git (requires a valid git repository). Pass --kind folder to register a non-git folder the same way as Open as Folder in the app.'
+    ]
   },
   {
     path: ['repo', 'show'],


### PR DESCRIPTION
## Summary
- `orca repo add` was git-only even though `repo.add` RPC and the GUI already support folder projects.
- Accept `--kind git|folder` (default: omit/`git`), matching `project setup-*` and `repo create`.
- Invalid kinds fail with `invalid_argument` before contacting the runtime.

## Test plan
- [x] `vitest run src/cli/index.test.ts -t repo.add`
- [ ] Manual: `orca repo add --path ~/notes --kind folder --json` on a non-git folder

Fixes #13358