### PR TITLE
feat: Improved markdown rendering in editor and preview

### DIFF
--- a/src/renderer/src/assets/main.css
+++ b/src/renderer/src/assets/main.css
@@ -223,6 +223,12 @@
   --annotation-highlight: #f59e0b;
   --markdown-search-match: #facc15;
   --markdown-search-match-active: #fb923c;
+  /* GitHub-style alert accents (> [!NOTE] etc.), matching github.com's palette. */
+  --markdown-alert-note: #0969da;
+  --markdown-alert-tip: #1a7f37;
+  --markdown-alert-important: #8250df;
+  --markdown-alert-warning: #9a6700;
+  --markdown-alert-caution: #cf222e;
   /* Why: tab-group splits use a dedicated divider — `--border` is too faint on
      card/editor surfaces when panes are side-by-side or stacked. Default must
      meet >=3:1 against `--card`, not only the hover/drag strong state. */
@@ -330,6 +336,11 @@
   --annotation-highlight: #fbbf24;
   --markdown-search-match: #facc15;
   --markdown-search-match-active: #fb923c;
+  --markdown-alert-note: #4493f8;
+  --markdown-alert-tip: #3fb950;
+  --markdown-alert-important: #ab7df8;
+  --markdown-alert-warning: #d29922;
+  --markdown-alert-caution: #f85149;
   /* Brighter than terminal defaults so the always-visible line clears 3:1 on `--card`. */
   --tab-group-split-divider: #71717a;
   --tab-group-split-divider-strong: #a1a1aa;

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -328,6 +328,16 @@
 .markdown-annotation-block,
 .markdown-annotation-list-block {
   position: relative;
+}
+
+/* Why: reserve the right-hand notes column only when a block actually carries a
+   note or is being composed on. Otherwise every block stays full width, so prose
+   (and full-width blocks like math) don't sit in a permanently narrowed column
+   beside an empty gutter. */
+.markdown-annotation-block.has-review-notes,
+.markdown-annotation-block.is-active,
+.markdown-annotation-list-block.has-review-notes,
+.markdown-annotation-list-block.is-active {
   display: grid;
   grid-template-columns: minmax(0, 1fr) minmax(220px, min(28cqw, 300px));
   column-gap: 32px;
@@ -362,6 +372,19 @@
   grid-row: 1;
   min-width: 0;
   margin-top: 0;
+}
+
+/* Why: when the gutter is collapsed (no note, not composing), the block is
+   display:block and this controls div would flow BELOW the content, dragging
+   the add-note "+" down with it. Pin it to the block's top-left so the "+"
+   stays beside the block in the left margin instead of underneath it. */
+.markdown-annotation-block:not(.has-review-notes):not(.is-active) > .markdown-annotation-controls,
+.markdown-annotation-list-block:not(.has-review-notes):not(.is-active)
+  > .markdown-annotation-controls {
+  position: absolute;
+  top: 0;
+  left: 0;
+  height: 0;
 }
 
 .markdown-annotation-add {
@@ -453,13 +476,28 @@
 }
 
 @container (max-width: 760px) {
+  /* Match the class-qualified grid rules (.has-review-notes/.is-active) so
+     annotated and composing blocks still stack instead of forcing a cramped
+     two-column grid on a narrow pane. */
   .markdown-annotation-block,
-  .markdown-annotation-list-block {
+  .markdown-annotation-block.has-review-notes,
+  .markdown-annotation-block.is-active,
+  .markdown-annotation-list-block,
+  .markdown-annotation-list-block.has-review-notes,
+  .markdown-annotation-list-block.is-active {
     display: block;
   }
 
   .markdown-annotation-controls {
     margin-top: 6px;
+  }
+
+  /* Undo the collapsed-gutter absolute pin so the stacked "+" flows normally. */
+  .markdown-annotation-block:not(.has-review-notes):not(.is-active) > .markdown-annotation-controls,
+  .markdown-annotation-list-block:not(.has-review-notes):not(.is-active)
+    > .markdown-annotation-controls {
+    position: static;
+    height: auto;
   }
 
   .markdown-annotation-add {
@@ -492,6 +530,15 @@
   font-size: 1.85em;
   font-weight: 700;
   letter-spacing: -0.02em;
+}
+
+/* Underline h1/h2 to break sections up, matching GitHub's rendered markdown. */
+.markdown-body h1,
+.markdown-body h2,
+.markdown-body details.orca-details[data-orca-toggle='heading-1'] > summary,
+.markdown-body details.orca-details[data-orca-toggle='heading-2'] > summary {
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
 }
 
 .markdown-body h2 {
@@ -656,48 +703,83 @@
   padding: 0;
   background: none;
   border: none;
-  font-size: inherit;
+  /* Match inline code (0.88em) and the rich editor's code blocks; `inherit`
+     left block code at full body size, larger than everything around it. */
+  font-size: 0.88em;
   border-radius: 0;
 }
 
-/* Code copy button — appears on hover over code blocks in preview mode */
+/* Why: the inline-code background is theme-scoped (.markdown-light/dark), which
+   outweighs the plain `.markdown-body pre code` reset above and repaints the
+   inline grey box behind block code — as per-line bands, since <code> is
+   inline. Match that specificity so block code stays background-free. */
+.markdown-light .markdown-body pre code,
+.markdown-dark .markdown-body pre code {
+  background: none;
+}
+
+/* Code block header — language label + copy button in a bar across the top,
+   matching the VS Code / Obsidian / ChatGPT convention. The wrapper owns the
+   frame so the header and body read as one unit. */
 .code-block-wrapper {
   position: relative;
+  margin: 1em 0;
+  border-radius: 8px;
+  overflow: hidden;
 }
-.code-block-copy-btn {
-  position: absolute;
-  top: 8px;
-  right: 8px;
-  opacity: 0;
-  transition: opacity 0.15s ease;
-  background: none;
-  border: 1px solid transparent;
-  border-radius: 4px;
-  padding: 4px;
-  cursor: pointer;
-  color: var(--muted-foreground);
+
+.markdown-body .code-block-wrapper {
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+}
+
+/* Body: the wrapper now carries the margin/border/radius. */
+.markdown-body .code-block-wrapper pre {
+  margin: 0;
+  border: none;
+  border-radius: 0;
+}
+
+.code-block-header {
   display: flex;
   align-items: center;
-  justify-content: center;
+  justify-content: space-between;
+  gap: 8px;
+  padding: 5px 8px 5px 14px;
+  border-bottom: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  background: color-mix(in srgb, var(--foreground) 3%, transparent);
+  font-family: var(--font-sans, system-ui, sans-serif);
 }
-.code-block-wrapper:hover .code-block-copy-btn {
-  opacity: 1;
+
+.code-block-language {
+  color: var(--muted-foreground);
+  font-size: 12px;
+  font-weight: 500;
+  line-height: 1;
+  user-select: none;
+}
+
+.code-block-copy-btn {
+  display: inline-flex;
+  align-items: center;
+  gap: 4px;
+  border: none;
+  border-radius: 5px;
+  padding: 3px 7px;
+  background: transparent;
+  color: var(--muted-foreground);
+  cursor: pointer;
+  line-height: 1;
+  transition:
+    background-color 0.12s ease,
+    color 0.12s ease;
 }
 .code-block-copy-btn:hover {
   background: var(--accent);
   color: var(--foreground);
 }
-/* Always show on touch devices that lack hover */
-@media (hover: none) {
-  .code-block-copy-btn {
-    opacity: 1;
-  }
-}
 
 .code-block-copy-label {
-  font-size: 11px;
-  margin-left: 3px;
-  font-family: var(--font-sans, sans-serif);
+  font-size: 12px;
 }
 
 /* Mermaid diagram container */
@@ -820,6 +902,78 @@
 .markdown-light .markdown-body blockquote {
   background: rgba(0, 0, 0, 0.02);
   color: rgba(0, 0, 0, 0.6);
+}
+
+/* Block math (KaTeX display): give it the same left-aligned, tinted, bordered
+   box as the rich editor instead of KaTeX's bare centered default. */
+.markdown-body .katex-display {
+  margin: 1em 0;
+  padding: 0.75em 1em;
+  overflow-x: auto;
+  overflow-y: hidden;
+  border: 1px solid color-mix(in srgb, var(--border) 72%, transparent);
+  border-radius: 4px;
+  background: color-mix(in srgb, var(--muted) 42%, transparent);
+  text-align: left;
+}
+
+/* ── GitHub-style alerts (> [!NOTE] etc.) ─────────────── */
+.markdown-body .markdown-alert {
+  --markdown-alert-accent: var(--border);
+  border-left-color: var(--markdown-alert-accent);
+}
+
+/* Alert body uses normal text; only the title carries the accent hue. */
+.markdown-light .markdown-body .markdown-alert,
+.markdown-dark .markdown-body .markdown-alert {
+  color: var(--foreground);
+}
+
+.markdown-body .markdown-alert-title {
+  display: flex;
+  align-items: center;
+  gap: 0.4em;
+  margin: 0 0 0.4em;
+  font-weight: 600;
+  line-height: 1.2;
+  color: var(--markdown-alert-accent);
+}
+
+.markdown-body .markdown-alert-title .markdown-alert-icon {
+  width: 1em;
+  height: 1em;
+  flex-shrink: 0;
+}
+
+.markdown-light .markdown-body .markdown-alert-note {
+  --markdown-alert-accent: #0969da;
+}
+.markdown-dark .markdown-body .markdown-alert-note {
+  --markdown-alert-accent: #4493f8;
+}
+.markdown-light .markdown-body .markdown-alert-tip {
+  --markdown-alert-accent: #1a7f37;
+}
+.markdown-dark .markdown-body .markdown-alert-tip {
+  --markdown-alert-accent: #3fb950;
+}
+.markdown-light .markdown-body .markdown-alert-important {
+  --markdown-alert-accent: #8250df;
+}
+.markdown-dark .markdown-body .markdown-alert-important {
+  --markdown-alert-accent: #ab7df8;
+}
+.markdown-light .markdown-body .markdown-alert-warning {
+  --markdown-alert-accent: #9a6700;
+}
+.markdown-dark .markdown-body .markdown-alert-warning {
+  --markdown-alert-accent: #d29922;
+}
+.markdown-light .markdown-body .markdown-alert-caution {
+  --markdown-alert-accent: #cf222e;
+}
+.markdown-dark .markdown-body .markdown-alert-caution {
+  --markdown-alert-accent: #f85149;
 }
 
 .markdown-body table {

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -375,16 +375,26 @@
 }
 
 /* Why: when the gutter is collapsed (no note, not composing), the block is
-   display:block and this controls div would flow BELOW the content, dragging
-   the add-note "+" down with it. Pin it to the block's top-left so the "+"
-   stays beside the block in the left margin instead of underneath it. */
+   display:block and this controls div would otherwise flow BELOW the content,
+   dragging the add-note "+" with it. Keep controls out of flow (static, so the
+   absolute "+" anchors to the position:relative block) and place the "+" in the
+   RIGHT margin — aligned with where the notes gutter opens once a block has a
+   note. */
 .markdown-annotation-block:not(.has-review-notes):not(.is-active) > .markdown-annotation-controls,
 .markdown-annotation-list-block:not(.has-review-notes):not(.is-active)
   > .markdown-annotation-controls {
-  position: absolute;
-  top: 0;
-  left: 0;
-  height: 0;
+  position: static;
+}
+
+.markdown-annotation-block:not(.has-review-notes):not(.is-active)
+  > .markdown-annotation-controls
+  > .markdown-annotation-add,
+.markdown-annotation-list-block:not(.has-review-notes):not(.is-active)
+  > .markdown-annotation-controls
+  > .markdown-annotation-add {
+  top: 2px;
+  left: auto;
+  right: -26px;
 }
 
 .markdown-annotation-add {
@@ -490,14 +500,6 @@
 
   .markdown-annotation-controls {
     margin-top: 6px;
-  }
-
-  /* Undo the collapsed-gutter absolute pin so the stacked "+" flows normally. */
-  .markdown-annotation-block:not(.has-review-notes):not(.is-active) > .markdown-annotation-controls,
-  .markdown-annotation-list-block:not(.has-review-notes):not(.is-active)
-    > .markdown-annotation-controls {
-    position: static;
-    height: auto;
   }
 
   .markdown-annotation-add {

--- a/src/renderer/src/assets/markdown-preview.css
+++ b/src/renderer/src/assets/markdown-preview.css
@@ -760,30 +760,6 @@
   user-select: none;
 }
 
-.code-block-copy-btn {
-  display: inline-flex;
-  align-items: center;
-  gap: 4px;
-  border: none;
-  border-radius: 5px;
-  padding: 3px 7px;
-  background: transparent;
-  color: var(--muted-foreground);
-  cursor: pointer;
-  line-height: 1;
-  transition:
-    background-color 0.12s ease,
-    color 0.12s ease;
-}
-.code-block-copy-btn:hover {
-  background: var(--accent);
-  color: var(--foreground);
-}
-
-.code-block-copy-label {
-  font-size: 12px;
-}
-
 /* Mermaid diagram container */
 .mermaid-block svg {
   max-width: 100%;
@@ -922,6 +898,7 @@
 /* ── GitHub-style alerts (> [!NOTE] etc.) ─────────────── */
 .markdown-body .markdown-alert {
   --markdown-alert-accent: var(--border);
+
   border-left-color: var(--markdown-alert-accent);
 }
 
@@ -947,35 +924,20 @@
   flex-shrink: 0;
 }
 
-.markdown-light .markdown-body .markdown-alert-note {
-  --markdown-alert-accent: #0969da;
+.markdown-body .markdown-alert-note {
+  --markdown-alert-accent: var(--markdown-alert-note);
 }
-.markdown-dark .markdown-body .markdown-alert-note {
-  --markdown-alert-accent: #4493f8;
+.markdown-body .markdown-alert-tip {
+  --markdown-alert-accent: var(--markdown-alert-tip);
 }
-.markdown-light .markdown-body .markdown-alert-tip {
-  --markdown-alert-accent: #1a7f37;
+.markdown-body .markdown-alert-important {
+  --markdown-alert-accent: var(--markdown-alert-important);
 }
-.markdown-dark .markdown-body .markdown-alert-tip {
-  --markdown-alert-accent: #3fb950;
+.markdown-body .markdown-alert-warning {
+  --markdown-alert-accent: var(--markdown-alert-warning);
 }
-.markdown-light .markdown-body .markdown-alert-important {
-  --markdown-alert-accent: #8250df;
-}
-.markdown-dark .markdown-body .markdown-alert-important {
-  --markdown-alert-accent: #ab7df8;
-}
-.markdown-light .markdown-body .markdown-alert-warning {
-  --markdown-alert-accent: #9a6700;
-}
-.markdown-dark .markdown-body .markdown-alert-warning {
-  --markdown-alert-accent: #d29922;
-}
-.markdown-light .markdown-body .markdown-alert-caution {
-  --markdown-alert-accent: #cf222e;
-}
-.markdown-dark .markdown-body .markdown-alert-caution {
-  --markdown-alert-accent: #f85149;
+.markdown-body .markdown-alert-caution {
+  --markdown-alert-accent: var(--markdown-alert-caution);
 }
 
 .markdown-body table {

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -542,6 +542,13 @@
   letter-spacing: -0.02em;
 }
 
+/* Underline h1/h2 to break sections up, matching GitHub's rendered markdown. */
+.rich-markdown-editor h1,
+.rich-markdown-editor h2 {
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
+}
+
 .rich-markdown-editor h2 {
   font-size: 1.4em;
 }
@@ -758,6 +765,15 @@
   font-weight: 700;
   letter-spacing: 0;
   line-height: 1.3;
+}
+
+/* Match the plain h1/h2 section underline on collapsible heading toggles. */
+.rich-markdown-editor details.orca-details[data-orca-toggle='heading-1'] > summary,
+.rich-markdown-editor .orca-details[data-type='details'][data-orca-toggle='heading-1'] summary,
+.rich-markdown-editor details.orca-details[data-orca-toggle='heading-2'] > summary,
+.rich-markdown-editor .orca-details[data-type='details'][data-orca-toggle='heading-2'] summary {
+  padding-bottom: 0.3em;
+  border-bottom: 1px solid var(--border);
 }
 
 .rich-markdown-editor .orca-details[data-type='details'][data-orca-toggle='heading-1'] > button {

--- a/src/renderer/src/assets/rich-markdown-editor.css
+++ b/src/renderer/src/assets/rich-markdown-editor.css
@@ -1000,6 +1000,12 @@
   display: flex;
   align-items: center;
   justify-content: center;
+  gap: 4px;
+  line-height: 1;
+}
+
+.rich-markdown-code-block-wrapper .code-block-copy-label {
+  font-size: 12px;
 }
 .rich-markdown-code-block-wrapper:hover .code-block-copy-btn {
   opacity: 1;

--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -4,10 +4,13 @@ import { translate } from '@/i18n/i18n'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
   children?: React.ReactNode
+  /** Fenced-code language shown as a label; omitted for plain fences. */
+  language?: string | null
 }
 
 export default function CodeBlockCopyButton({
   children,
+  language,
   ...props
 }: CodeBlockCopyButtonProps): React.JSX.Element {
   const [copied, setCopied] = useState(false)
@@ -67,26 +70,36 @@ export default function CodeBlockCopyButton({
 
   return (
     <div className="code-block-wrapper">
+      {/* Plain fences (no language) skip the header — they read fine as a bare
+          framed block, and the header only earns its space when it labels a language. */}
+      {language ? (
+        <div className="code-block-header">
+          <span className="code-block-language">{language}</span>
+          <button
+            ref={setCopyButtonRef}
+            type="button"
+            className="code-block-copy-btn"
+            onClick={handleCopy}
+            aria-label={translate(
+              'auto.components.editor.CodeBlockCopyButton.1f9f4def45',
+              'Copy code'
+            )}
+            title={translate('auto.components.editor.CodeBlockCopyButton.1f9f4def45', 'Copy code')}
+          >
+            {copied ? (
+              <>
+                <Check size={13} />
+                <span className="code-block-copy-label">
+                  {translate('auto.components.editor.CodeBlockCopyButton.28921f5bf9', 'Copied')}
+                </span>
+              </>
+            ) : (
+              <Copy size={13} />
+            )}
+          </button>
+        </div>
+      ) : null}
       <pre {...props}>{children}</pre>
-      <button
-        ref={setCopyButtonRef}
-        type="button"
-        className="code-block-copy-btn"
-        onClick={handleCopy}
-        aria-label={translate('auto.components.editor.CodeBlockCopyButton.1f9f4def45', 'Copy code')}
-        title={translate('auto.components.editor.CodeBlockCopyButton.1f9f4def45', 'Copy code')}
-      >
-        {copied ? (
-          <>
-            <Check size={14} />
-            <span className="code-block-copy-label">
-              {translate('auto.components.editor.CodeBlockCopyButton.28921f5bf9', 'Copied')}
-            </span>
-          </>
-        ) : (
-          <Copy size={14} />
-        )}
-      </button>
     </div>
   )
 }

--- a/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
+++ b/src/renderer/src/components/editor/CodeBlockCopyButton.tsx
@@ -1,5 +1,6 @@
 import React, { useCallback, useRef, useState } from 'react'
 import { Copy, Check } from 'lucide-react'
+import { Button } from '@/components/ui/button'
 import { translate } from '@/i18n/i18n'
 
 type CodeBlockCopyButtonProps = React.HTMLAttributes<HTMLPreElement> & {
@@ -75,10 +76,14 @@ export default function CodeBlockCopyButton({
       {language ? (
         <div className="code-block-header">
           <span className="code-block-language">{language}</span>
-          <button
+          {/* code-block-copy-btn is a functional marker: export scrubbing
+              removes the button from PDF/HTML output by that selector. */}
+          <Button
             ref={setCopyButtonRef}
             type="button"
-            className="code-block-copy-btn"
+            variant="ghost"
+            size="xs"
+            className="code-block-copy-btn text-muted-foreground"
             onClick={handleCopy}
             aria-label={translate(
               'auto.components.editor.CodeBlockCopyButton.1f9f4def45',
@@ -88,15 +93,13 @@ export default function CodeBlockCopyButton({
           >
             {copied ? (
               <>
-                <Check size={13} />
-                <span className="code-block-copy-label">
-                  {translate('auto.components.editor.CodeBlockCopyButton.28921f5bf9', 'Copied')}
-                </span>
+                <Check />
+                {translate('auto.components.editor.CodeBlockCopyButton.28921f5bf9', 'Copied')}
               </>
             ) : (
-              <Copy size={13} />
+              <Copy />
             )}
-          </button>
+          </Button>
         </div>
       ) : null}
       <pre {...props}>{children}</pre>

--- a/src/renderer/src/components/editor/EditorContent.tsx
+++ b/src/renderer/src/components/editor/EditorContent.tsx
@@ -19,6 +19,7 @@ import { getMarkdownRenderMode } from './markdown-render-mode'
 import { getMarkdownRichModeUnsupportedMessage } from './markdown-rich-mode'
 import { exceedsMarkdownRichModeSizeLimit } from './markdown-rich-size-limit'
 import { extractFrontMatter, prependFrontMatter } from './markdown-frontmatter'
+import { MarkdownFrontMatterView } from './MarkdownFrontMatterView'
 import { RichMarkdownErrorBoundary } from './RichMarkdownErrorBoundary'
 import { useMarkdownDocuments } from './useMarkdownDocuments'
 import {
@@ -972,12 +973,6 @@ export function EditorContent({
 
 // Why: no collapsible state — layout shifts would interfere with ProseMirror's scroll management.
 function FrontMatterBanner({ raw }: { raw: string }): React.JSX.Element {
-  // Strip the opening/closing delimiters to show only the YAML/TOML content.
-  const inner = raw
-    .replace(/^(?:---|\+\+\+)\r?\n/, '')
-    .replace(/\r?\n(?:---|\+\+\+)\r?\n?$/, '')
-    .trim()
-
   return (
     <div className="border-b border-border/60 bg-muted/40 px-3 py-2">
       <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
@@ -986,9 +981,7 @@ function FrontMatterBanner({ raw }: { raw: string }): React.JSX.Element {
           {translate('auto.components.editor.EditorContent.56dba34e1a', '(edit in source mode)')}
         </span>
       </div>
-      <pre className="max-h-32 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor">
-        {inner}
-      </pre>
+      <MarkdownFrontMatterView raw={raw} />
     </div>
   )
 }

--- a/src/renderer/src/components/editor/MarkdownFrontMatterView.tsx
+++ b/src/renderer/src/components/editor/MarkdownFrontMatterView.tsx
@@ -1,0 +1,57 @@
+import type React from 'react'
+import {
+  parseFrontMatterFields,
+  stripFrontMatterDelimiters,
+  type FrontMatterField
+} from './markdown-frontmatter-fields'
+
+// Renders a raw front-matter block as a key/value table, falling back to the
+// raw text for TOML or any non-map YAML. Shared by the rich editor banner and
+// the markdown preview so both surfaces stay in sync.
+export function MarkdownFrontMatterView({
+  raw,
+  maxHeightClass = 'max-h-32'
+}: {
+  raw: string
+  maxHeightClass?: string
+}): React.JSX.Element {
+  const fields = parseFrontMatterFields(raw)
+
+  if (!fields) {
+    return (
+      <pre
+        className={`${maxHeightClass} overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor`}
+      >
+        {stripFrontMatterDelimiters(raw)}
+      </pre>
+    )
+  }
+
+  return <FrontMatterTable fields={fields} maxHeightClass={maxHeightClass} />
+}
+
+function FrontMatterTable({
+  fields,
+  maxHeightClass
+}: {
+  fields: FrontMatterField[]
+  maxHeightClass: string
+}): React.JSX.Element {
+  return (
+    <div className={`${maxHeightClass} overflow-auto scrollbar-editor`}>
+      <table className="w-full border-collapse text-xs">
+        <tbody>
+          {fields.map((field) => (
+            <tr key={field.key} className="border-b border-border/40 last:border-b-0">
+              {/* w-[1%] + nowrap shrinks the key column to its content so the value column takes the rest. */}
+              <td className="w-[1%] py-1 pr-3 align-top font-medium text-muted-foreground whitespace-nowrap">
+                {field.key}
+              </td>
+              <td className="py-1 align-top break-words text-foreground/80">{field.value}</td>
+            </tr>
+          ))}
+        </tbody>
+      </table>
+    </div>
+  )
+}

--- a/src/renderer/src/components/editor/MarkdownGithubAlert.tsx
+++ b/src/renderer/src/components/editor/MarkdownGithubAlert.tsx
@@ -1,5 +1,6 @@
 import type React from 'react'
 import { Info, Lightbulb, MessageSquareWarning, OctagonAlert, TriangleAlert } from 'lucide-react'
+import { translate } from '@/i18n/i18n'
 import { GITHUB_ALERT_TYPES, type GithubAlertType } from './markdown-github-alerts'
 
 const ALERT_ICONS: Record<GithubAlertType, React.ComponentType<{ className?: string }>> = {
@@ -10,12 +11,19 @@ const ALERT_ICONS: Record<GithubAlertType, React.ComponentType<{ className?: str
   caution: OctagonAlert
 }
 
-export const GITHUB_ALERT_TITLES: Record<GithubAlertType, string> = {
-  note: 'Note',
-  tip: 'Tip',
-  important: 'Important',
-  warning: 'Warning',
-  caution: 'Caution'
+export function getGithubAlertTitle(type: GithubAlertType): string {
+  switch (type) {
+    case 'note':
+      return translate('auto.components.editor.MarkdownGithubAlert.8b6fda49fa', 'Note')
+    case 'tip':
+      return translate('auto.components.editor.MarkdownGithubAlert.b28ab35be4', 'Tip')
+    case 'important':
+      return translate('auto.components.editor.MarkdownGithubAlert.eb04b1d571', 'Important')
+    case 'warning':
+      return translate('auto.components.editor.MarkdownGithubAlert.013315d1fa', 'Warning')
+    case 'caution':
+      return translate('auto.components.editor.MarkdownGithubAlert.91dd428e07', 'Caution')
+  }
 }
 
 // Reads the alert type off the blockquote className the remark plugin attached.

--- a/src/renderer/src/components/editor/MarkdownGithubAlert.tsx
+++ b/src/renderer/src/components/editor/MarkdownGithubAlert.tsx
@@ -1,0 +1,32 @@
+import type React from 'react'
+import { Info, Lightbulb, MessageSquareWarning, OctagonAlert, TriangleAlert } from 'lucide-react'
+import { GITHUB_ALERT_TYPES, type GithubAlertType } from './markdown-github-alerts'
+
+const ALERT_ICONS: Record<GithubAlertType, React.ComponentType<{ className?: string }>> = {
+  note: Info,
+  tip: Lightbulb,
+  important: MessageSquareWarning,
+  warning: TriangleAlert,
+  caution: OctagonAlert
+}
+
+export const GITHUB_ALERT_TITLES: Record<GithubAlertType, string> = {
+  note: 'Note',
+  tip: 'Tip',
+  important: 'Important',
+  warning: 'Warning',
+  caution: 'Caution'
+}
+
+// Reads the alert type off the blockquote className the remark plugin attached.
+export function getGithubAlertType(className: unknown): GithubAlertType | null {
+  if (typeof className !== 'string') {
+    return null
+  }
+  return GITHUB_ALERT_TYPES.find((type) => className.includes(`markdown-alert-${type}`)) ?? null
+}
+
+export function GithubAlertIcon({ type }: { type: GithubAlertType }): React.JSX.Element {
+  const Icon = ALERT_ICONS[type]
+  return <Icon className="markdown-alert-icon" />
+}

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -24,7 +24,7 @@ import { extractFrontMatter } from './markdown-frontmatter'
 import { MarkdownFrontMatterView } from './MarkdownFrontMatterView'
 import { remarkGithubAlerts } from './markdown-github-alerts'
 import { rehypeWrapMathBlocks } from './rehype-wrap-math-blocks'
-import { getGithubAlertType, GITHUB_ALERT_TITLES, GithubAlertIcon } from './MarkdownGithubAlert'
+import { getGithubAlertType, getGithubAlertTitle, GithubAlertIcon } from './MarkdownGithubAlert'
 import {
   Check,
   ChevronDown,
@@ -305,7 +305,10 @@ function extractCodeBlockLanguage(children: React.ReactNode): string | null {
       continue
     }
     const className = (child.props as { className?: unknown }).className
-    const match = typeof className === 'string' ? className.match(/language-([\w-]+)/) : null
+    // Why: bounded charset (not \S+) — sanitize passes any `language-*` class, and
+    // the label renders raw; `#+.` keep c#/f#/c++/vb.net intact.
+    const match =
+      typeof className === 'string' ? className.match(/(?:^|\s)language-([\w#+.-]{1,32})/) : null
     if (match) {
       return match[1]
     }
@@ -1753,7 +1756,7 @@ export default function MarkdownPreview({
             {alertType ? (
               <p className="markdown-alert-title">
                 <GithubAlertIcon type={alertType} />
-                {GITHUB_ALERT_TITLES[alertType]}
+                {getGithubAlertTitle(alertType)}
               </p>
             ) : null}
             {children}

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -21,6 +21,10 @@ import rehypeRaw from 'rehype-raw'
 import rehypeSanitize, { defaultSchema } from 'rehype-sanitize'
 import rehypeSlug from 'rehype-slug'
 import { extractFrontMatter } from './markdown-frontmatter'
+import { MarkdownFrontMatterView } from './MarkdownFrontMatterView'
+import { remarkGithubAlerts } from './markdown-github-alerts'
+import { rehypeWrapMathBlocks } from './rehype-wrap-math-blocks'
+import { getGithubAlertType, GITHUB_ALERT_TITLES, GithubAlertIcon } from './MarkdownGithubAlert'
 import {
   Check,
   ChevronDown,
@@ -291,6 +295,24 @@ function hasMarkdownPreviewNestedBlock(node: MarkdownPreviewPositionNode | undef
   return Boolean(node?.children?.some((child) => child.tagName && blockTags.has(child.tagName)))
 }
 
+// Reads the fenced-code language off the code child's `language-*` class.
+// Returns null for plain fences (no language) so no label is shown. Reads the
+// className prop rather than matching on element type: react-markdown wraps the
+// child in the custom `code` component, so its type isn't the string 'code'.
+function extractCodeBlockLanguage(children: React.ReactNode): string | null {
+  for (const child of React.Children.toArray(children)) {
+    if (!React.isValidElement(child)) {
+      continue
+    }
+    const className = (child.props as { className?: unknown }).className
+    const match = typeof className === 'string' ? className.match(/language-([\w-]+)/) : null
+    if (match) {
+      return match[1]
+    }
+  }
+  return null
+}
+
 const markdownPreviewSanitizeSchema = {
   ...defaultSchema,
   tagNames: [...(defaultSchema.tagNames ?? []), 'details', 'summary', 'kbd', 'sub', 'sup', 'ins'],
@@ -304,6 +326,10 @@ const markdownPreviewSanitizeSchema = {
     ...defaultSchema.attributes,
     '*': [...(defaultSchema.attributes?.['*'] ?? []), 'id'],
     a: [...(defaultSchema.attributes?.a ?? []), 'href', 'title'],
+    blockquote: [
+      ...(defaultSchema.attributes?.blockquote ?? []),
+      ['className', 'markdown-alert', /^markdown-alert-\w+$/]
+    ],
     code: [
       ...(defaultSchema.attributes?.code ?? []),
       ['className', /^language-[\w-]+$/, 'math-inline', 'math-display']
@@ -337,6 +363,8 @@ const markdownPreviewSanitizeSchema = {
 type MarkdownPluginList = NonNullable<ReactMarkdownOptions['remarkPlugins']>
 const MARKDOWN_REMARK_PLUGINS: MarkdownPluginList = [
   remarkGfm,
+  // Why: must run before remark-breaks so the `[!TYPE]` marker and body share one text node.
+  remarkGithubAlerts,
   remarkBreaks,
   remarkFrontmatter,
   remarkMath,
@@ -348,6 +376,9 @@ const MARKDOWN_REHYPE_PLUGINS: MarkdownPluginList = [
   [rehypeSanitize, markdownPreviewSanitizeSchema],
   rehypeSlug,
   rehypeHighlight,
+  // Why: must run before rehype-katex, which otherwise replaces block math with a
+  // position-less span the annotation layer can't anchor a note to.
+  rehypeWrapMathBlocks,
   rehypeKatex
 ]
 
@@ -661,15 +692,6 @@ export default function MarkdownPreview({
     () => createMarkdownDocumentIndex(markdownDocuments),
     [markdownDocuments]
   )
-  const frontMatterInner = useMemo(() => {
-    if (!frontMatter) {
-      return ''
-    }
-    return frontMatter.raw
-      .replace(/^(?:---|\+\+\+)\r?\n/, '')
-      .replace(/\r?\n(?:---|\+\+\+)\r?\n?$/, '')
-      .trim()
-  }, [frontMatter])
   // Why: front matter is visible by default; the store map only carries per-file hide overrides.
   const toggleableSourceFileId: string | null = sourceFileId ?? null
   const frontmatterVisible = toggleableSourceFileId
@@ -1321,9 +1343,14 @@ export default function MarkdownPreview({
         return rendered
       }
       const hasReviewNotes = getMarkdownCommentsForRange(range).length > 0
+      const isActive = activeAnnotationBlockKey === blockKey
       return (
         <div
-          className={`markdown-annotation-block ${hasReviewNotes ? 'has-review-notes' : ''}`.trim()}
+          className={`markdown-annotation-block ${hasReviewNotes ? 'has-review-notes' : ''} ${
+            isActive ? 'is-active' : ''
+          }`
+            .replace(/\s+/g, ' ')
+            .trim()}
           data-source-line={range.startLine}
           data-source-end-line={range.endLine}
           data-annotation-block-key={blockKey}
@@ -1334,7 +1361,12 @@ export default function MarkdownPreview({
         </div>
       )
     },
-    [getMarkdownCommentsForRange, handleAnnotatedMarkdownBlockClick, renderAnnotationControls]
+    [
+      activeAnnotationBlockKey,
+      getMarkdownCommentsForRange,
+      handleAnnotatedMarkdownBlockClick,
+      renderAnnotationControls
+    ]
   )
 
   const components: Components = useMemo(() => {
@@ -1693,17 +1725,43 @@ export default function MarkdownPreview({
         return wrapAnnotatedBlock(
           'pre',
           node as MarkdownPreviewPositionNode,
-          <CodeBlockCopyButton {...props}>{children}</CodeBlockCopyButton>
+          <CodeBlockCopyButton language={extractCodeBlockLanguage(children)} {...props}>
+            {children}
+          </CodeBlockCopyButton>
         )
       },
       p: ({ node, children, ...props }) =>
         wrapAnnotatedBlock('p', node as MarkdownPreviewPositionNode, <p {...props}>{children}</p>),
-      blockquote: ({ node, children, ...props }) =>
-        wrapAnnotatedBlock(
+      // Why: block math is wrapped in <div class="math-block"> by rehypeWrapMathBlocks
+      // so it can be annotated like other blocks; route just that div through the
+      // annotation wrapper. Every other div passes through untouched.
+      div: ({ node, className, children, ...props }) => {
+        const rendered = (
+          <div className={className} {...props}>
+            {children}
+          </div>
+        )
+        if (!/\bmath-block\b/.test(className ?? '')) {
+          return rendered
+        }
+        return wrapAnnotatedBlock('div', node as MarkdownPreviewPositionNode, rendered)
+      },
+      blockquote: ({ node, children, className, ...props }) => {
+        const alertType = getGithubAlertType(className)
+        return wrapAnnotatedBlock(
           'blockquote',
           node as MarkdownPreviewPositionNode,
-          <blockquote {...props}>{children}</blockquote>
-        ),
+          <blockquote className={className} {...props}>
+            {alertType ? (
+              <p className="markdown-alert-title">
+                <GithubAlertIcon type={alertType} />
+                {GITHUB_ALERT_TITLES[alertType]}
+              </p>
+            ) : null}
+            {children}
+          </blockquote>
+        )
+      },
       table: ({ node, children, ...props }) =>
         wrapAnnotatedBlock(
           'table',
@@ -1730,7 +1788,9 @@ export default function MarkdownPreview({
             <div
               className={`markdown-annotation-list-block ${
                 hasReviewNotes ? 'has-review-notes' : ''
-              }`.trim()}
+              } ${activeAnnotationBlockKey === blockKey ? 'is-active' : ''}`
+                .replace(/\s+/g, ' ')
+                .trim()}
               data-source-line={range.startLine}
               data-source-end-line={range.endLine}
               // Why: only advertise the block to the add-review-note shortcut when the composer can render (mirrors wrapAnnotatedBlock).
@@ -1993,9 +2053,7 @@ export default function MarkdownPreview({
               <div className="mb-1 text-[10px] font-medium uppercase tracking-wider text-muted-foreground">
                 {translate('auto.components.editor.MarkdownPreview.2b2b31382c', 'Front Matter')}
               </div>
-              <pre className="max-h-48 overflow-auto whitespace-pre-wrap text-xs text-muted-foreground font-mono scrollbar-editor">
-                {frontMatterInner}
-              </pre>
+              <MarkdownFrontMatterView raw={frontMatter.raw} maxHeightClass="max-h-48" />
             </div>
           ) : null}
           <MarkdownBody content={renderedContent} components={components} />

--- a/src/renderer/src/components/editor/MarkdownPreview.tsx
+++ b/src/renderer/src/components/editor/MarkdownPreview.tsx
@@ -1748,9 +1748,7 @@ export default function MarkdownPreview({
       },
       blockquote: ({ node, children, className, ...props }) => {
         const alertType = getGithubAlertType(className)
-        return wrapAnnotatedBlock(
-          'blockquote',
-          node as MarkdownPreviewPositionNode,
+        const rendered = (
           <blockquote className={className} {...props}>
             {alertType ? (
               <p className="markdown-alert-title">
@@ -1761,6 +1759,14 @@ export default function MarkdownPreview({
             {children}
           </blockquote>
         )
+        // Why: a blockquote (incl. alerts) always wraps block children that are
+        // themselves annotatable; annotating the blockquote too would show a second
+        // "+" and render a comment twice (both ranges match the note). Defer to the
+        // inner blocks, mirroring the list-item renderer.
+        if (hasMarkdownPreviewNestedBlock(node as MarkdownPreviewPositionNode)) {
+          return rendered
+        }
+        return wrapAnnotatedBlock('blockquote', node as MarkdownPreviewPositionNode, rendered)
       },
       table: ({ node, children, ...props }) =>
         wrapAnnotatedBlock(

--- a/src/renderer/src/components/editor/markdown-frontmatter-fields.test.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter-fields.test.ts
@@ -1,0 +1,54 @@
+import { describe, expect, it } from 'vitest'
+import { parseFrontMatterFields } from './markdown-frontmatter-fields'
+
+describe('parseFrontMatterFields', () => {
+  it('parses scalar YAML fields into key/value rows', () => {
+    const raw = '---\ntitle: Hello\ndraft: true\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([
+      { key: 'title', value: 'Hello' },
+      { key: 'draft', value: 'true' }
+    ])
+  })
+
+  it('comma-joins array values', () => {
+    const raw = '---\ntags: [a, b, c]\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([{ key: 'tags', value: 'a, b, c' }])
+  })
+
+  it('renders nested maps as readable key: value pairs', () => {
+    const raw = '---\nauthor:\n  name: Ada\n  id: 7\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([{ key: 'author', value: 'name: Ada, id: 7' }])
+  })
+
+  it('renders nested maps under a top-level key inline', () => {
+    const raw = '---\nmetadata:\n  type: demo\n  version: 2\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([
+      { key: 'metadata', value: 'type: demo, version: 2' }
+    ])
+  })
+
+  it('renders YAML timestamp values as their string form', () => {
+    const raw = '---\ndate: 2021-06-15\nstamp: 2021-06-15T10:30:00Z\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([
+      { key: 'date', value: '2021-06-15' },
+      { key: 'stamp', value: '2021-06-15T10:30:00Z' }
+    ])
+  })
+
+  it('returns null for TOML front matter', () => {
+    expect(parseFrontMatterFields('+++\ntitle = "Hi"\n+++\n')).toBeNull()
+  })
+
+  it('returns null for a bare scalar or list', () => {
+    expect(parseFrontMatterFields('---\njust a string\n---\n')).toBeNull()
+    expect(parseFrontMatterFields('---\n- a\n- b\n---\n')).toBeNull()
+  })
+
+  it('returns null for an empty map', () => {
+    expect(parseFrontMatterFields('---\n---\n')).toBeNull()
+  })
+
+  it('returns null on invalid YAML', () => {
+    expect(parseFrontMatterFields('---\nkey: : :\n  bad\n---\n')).toBeNull()
+  })
+})

--- a/src/renderer/src/components/editor/markdown-frontmatter-fields.test.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter-fields.test.ts
@@ -35,6 +35,21 @@ describe('parseFrontMatterFields', () => {
     ])
   })
 
+  it('marks circular YAML alias structures instead of overflowing', () => {
+    const raw = '---\nnode: &node { title: Hello, self: *node }\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([
+      { key: 'node', value: 'title: Hello, self: [circular]' }
+    ])
+  })
+
+  it('formats repeated (non-circular) aliases normally', () => {
+    const raw = '---\nbase: &base { a: 1 }\npair:\n  left: *base\n  right: *base\n---\n'
+    expect(parseFrontMatterFields(raw)).toEqual([
+      { key: 'base', value: 'a: 1' },
+      { key: 'pair', value: 'left: a: 1, right: a: 1' }
+    ])
+  })
+
   it('returns null for TOML front matter', () => {
     expect(parseFrontMatterFields('+++\ntitle = "Hi"\n+++\n')).toBeNull()
   })

--- a/src/renderer/src/components/editor/markdown-frontmatter-fields.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter-fields.ts
@@ -50,24 +50,34 @@ export function stripFrontMatterDelimiters(raw: string): string {
     .trim()
 }
 
-function formatValue(value: unknown): string {
+function formatValue(value: unknown, ancestors = new WeakSet<object>()): string {
   if (value == null) {
     return ''
-  }
-  if (Array.isArray(value)) {
-    return value.map(formatValue).join(', ')
   }
   if (value instanceof Date) {
     return value.toISOString()
   }
-  if (typeof value === 'object') {
+  if (typeof value !== 'object') {
+    return String(value)
+  }
+  // YAML aliases can build self-referencing structures; mark the cycle instead
+  // of recursing forever.
+  if (ancestors.has(value)) {
+    return '[circular]'
+  }
+  ancestors.add(value)
+  try {
+    if (Array.isArray(value)) {
+      return value.map((item) => formatValue(item, ancestors)).join(', ')
+    }
     const entries = Object.entries(value as Record<string, unknown>)
     // Why: fall back to String() for objects with no enumerable entries (e.g. an
     // exotic tagged value) so they don't silently render as an empty cell.
     if (entries.length === 0) {
       return String(value)
     }
-    return entries.map(([key, nested]) => `${key}: ${formatValue(nested)}`).join(', ')
+    return entries.map(([key, nested]) => `${key}: ${formatValue(nested, ancestors)}`).join(', ')
+  } finally {
+    ancestors.delete(value)
   }
-  return String(value)
 }

--- a/src/renderer/src/components/editor/markdown-frontmatter-fields.ts
+++ b/src/renderer/src/components/editor/markdown-frontmatter-fields.ts
@@ -1,0 +1,73 @@
+import { parse } from 'yaml'
+
+export type FrontMatterField = {
+  key: string
+  /** Display string; arrays are comma-joined, nested maps flattened to `key: value` pairs. */
+  value: string
+}
+
+/**
+ * Parses a raw front-matter block into key/value rows for tabular display.
+ * Returns null when the block isn't a structured YAML map — TOML (`+++`), a
+ * bare scalar/list, an empty map, or a parse error — so callers can fall back
+ * to rendering the raw text.
+ */
+export function parseFrontMatterFields(raw: string): FrontMatterField[] | null {
+  // The yaml parser doesn't handle TOML front matter.
+  if (raw.trimStart().startsWith('+++')) {
+    return null
+  }
+
+  const inner = raw
+    .replace(/^(?:---|\+\+\+)\r?\n/, '')
+    .replace(/\r?\n(?:---|\+\+\+)\r?\n?$/, '')
+    .trim()
+
+  let data: unknown
+  try {
+    data = parse(inner)
+  } catch {
+    return null
+  }
+
+  if (!data || typeof data !== 'object' || Array.isArray(data)) {
+    return null
+  }
+
+  const entries = Object.entries(data as Record<string, unknown>)
+  if (entries.length === 0) {
+    return null
+  }
+
+  return entries.map(([key, value]) => ({ key, value: formatValue(value) }))
+}
+
+// Strip the opening/closing delimiters to expose only the raw YAML/TOML content.
+export function stripFrontMatterDelimiters(raw: string): string {
+  return raw
+    .replace(/^(?:---|\+\+\+)\r?\n/, '')
+    .replace(/\r?\n(?:---|\+\+\+)\r?\n?$/, '')
+    .trim()
+}
+
+function formatValue(value: unknown): string {
+  if (value == null) {
+    return ''
+  }
+  if (Array.isArray(value)) {
+    return value.map(formatValue).join(', ')
+  }
+  if (value instanceof Date) {
+    return value.toISOString()
+  }
+  if (typeof value === 'object') {
+    const entries = Object.entries(value as Record<string, unknown>)
+    // Why: fall back to String() for objects with no enumerable entries (e.g. an
+    // exotic tagged value) so they don't silently render as an empty cell.
+    if (entries.length === 0) {
+      return String(value)
+    }
+    return entries.map(([key, nested]) => `${key}: ${formatValue(nested)}`).join(', ')
+  }
+  return String(value)
+}

--- a/src/renderer/src/components/editor/markdown-github-alerts.test.ts
+++ b/src/renderer/src/components/editor/markdown-github-alerts.test.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { remarkGithubAlerts } from './markdown-github-alerts'
+
+type Node = {
+  type: string
+  value?: string
+  children?: Node[]
+  data?: { hProperties?: Record<string, unknown> }
+}
+
+function blockquote(...lines: string[]): Node {
+  // One paragraph whose text is the joined lines (soft breaks = one text node),
+  // mirroring the mdast shape before remark-breaks runs.
+  return {
+    type: 'blockquote',
+    children: [{ type: 'paragraph', children: [{ type: 'text', value: lines.join('\n') }] }]
+  }
+}
+
+function run(node: Node): Node {
+  remarkGithubAlerts()({ type: 'root', children: [node] })
+  return node
+}
+
+function className(node: Node): unknown {
+  return node.data?.hProperties?.className
+}
+
+describe('remarkGithubAlerts', () => {
+  it('tags a valid alert and strips the marker', () => {
+    const node = run(blockquote('[!NOTE]', 'Body text.'))
+    expect(className(node)).toEqual(['markdown-alert', 'markdown-alert-note'])
+    const text = node.children![0].children![0]
+    expect(text.value).toBe('Body text.')
+  })
+
+  it('matches every supported type case-insensitively', () => {
+    for (const [marker, cls] of [
+      ['[!TIP]', 'markdown-alert-tip'],
+      ['[!important]', 'markdown-alert-important'],
+      ['[!Warning]', 'markdown-alert-warning'],
+      ['[!CAUTION]', 'markdown-alert-caution']
+    ] as const) {
+      const node = run(blockquote(marker, 'x'))
+      expect(className(node)).toEqual(['markdown-alert', cls])
+    }
+  })
+
+  it('ignores an unknown alert type', () => {
+    const node = run(blockquote('[!DANGER]', 'Body.'))
+    expect(className(node)).toBeUndefined()
+  })
+
+  it('ignores a marker with inline content on the same line', () => {
+    const node = run(blockquote('[!TIP] inline text is not an alert'))
+    expect(className(node)).toBeUndefined()
+  })
+
+  it('drops the empty paragraph when the marker is alone', () => {
+    const node = run(blockquote('[!NOTE]'))
+    expect(className(node)).toEqual(['markdown-alert', 'markdown-alert-note'])
+    expect(node.children).toHaveLength(0)
+  })
+})

--- a/src/renderer/src/components/editor/markdown-github-alerts.ts
+++ b/src/renderer/src/components/editor/markdown-github-alerts.ts
@@ -1,0 +1,75 @@
+export const GITHUB_ALERT_TYPES = ['note', 'tip', 'important', 'warning', 'caution'] as const
+
+export type GithubAlertType = (typeof GITHUB_ALERT_TYPES)[number]
+
+// GitHub only treats a blockquote as an alert when the first line is exactly
+// `[!TYPE]` — a marker followed by inline text on the same line stays a plain
+// blockquote, and an unknown type is ignored.
+const ALERT_MARKER = /^\[!(note|tip|important|warning|caution)\](?=\r?\n|$)/i
+
+type AlertNode = {
+  type: string
+  value?: string
+  children?: AlertNode[]
+  data?: {
+    hName?: string
+    hProperties?: Record<string, unknown>
+  }
+}
+
+/**
+ * Remark plugin that tags GitHub-style alert blockquotes (`> [!NOTE]`) so the
+ * renderer can style them. Strips the marker line and attaches a
+ * `data-alert-type` attribute plus alert classes to the blockquote. Must run
+ * before remark-breaks so the marker and body share one text node.
+ */
+export function remarkGithubAlerts() {
+  return (tree: AlertNode): void => {
+    visitBlockquotes(tree, (blockquote) => {
+      const type = tagBlockquoteAlert(blockquote)
+      if (!type) {
+        return
+      }
+      const data = blockquote.data ?? (blockquote.data = {})
+      data.hProperties = {
+        ...data.hProperties,
+        className: ['markdown-alert', `markdown-alert-${type}`]
+      }
+    })
+  }
+}
+
+function tagBlockquoteAlert(blockquote: AlertNode): GithubAlertType | null {
+  const firstParagraph = blockquote.children?.[0]
+  if (!firstParagraph || firstParagraph.type !== 'paragraph' || !firstParagraph.children) {
+    return null
+  }
+  const firstChild = firstParagraph.children[0]
+  if (!firstChild || firstChild.type !== 'text' || typeof firstChild.value !== 'string') {
+    return null
+  }
+  const match = firstChild.value.match(ALERT_MARKER)
+  if (!match) {
+    return null
+  }
+
+  // Drop the marker and the newline that follows it.
+  firstChild.value = firstChild.value.slice(match[0].length).replace(/^\r?\n/, '')
+  if (firstChild.value === '') {
+    firstParagraph.children.shift()
+  }
+  if (firstParagraph.children.length === 0) {
+    blockquote.children!.shift()
+  }
+
+  return match[1].toLowerCase() as GithubAlertType
+}
+
+function visitBlockquotes(node: AlertNode, visit: (node: AlertNode) => void): void {
+  if (node.type === 'blockquote') {
+    visit(node)
+  }
+  for (const child of node.children ?? []) {
+    visitBlockquotes(child, visit)
+  }
+}

--- a/src/renderer/src/components/editor/rehype-wrap-math-blocks.test.ts
+++ b/src/renderer/src/components/editor/rehype-wrap-math-blocks.test.ts
@@ -1,0 +1,74 @@
+import { describe, expect, it } from 'vitest'
+import { rehypeWrapMathBlocks } from './rehype-wrap-math-blocks'
+
+type El = {
+  type: string
+  tagName?: string
+  properties?: { className?: string[] }
+  position?: unknown
+  children?: El[]
+}
+
+function pre(codeClass: string[], position?: unknown): El {
+  return {
+    type: 'element',
+    tagName: 'pre',
+    position,
+    children: [
+      { type: 'element', tagName: 'code', properties: { className: codeClass }, children: [] }
+    ]
+  }
+}
+
+function root(...children: El[]): El {
+  return { type: 'root', children }
+}
+
+function run(tree: El): El {
+  rehypeWrapMathBlocks()(tree)
+  return tree
+}
+
+describe('rehypeWrapMathBlocks', () => {
+  it('wraps a language-math pre in a positioned math-block div', () => {
+    const position = { start: { line: 3 }, end: { line: 5 } }
+    const tree = run(root(pre(['hljs', 'language-math'], position)))
+    const div = tree.children![0]
+    expect(div.tagName).toBe('div')
+    expect(div.properties?.className).toEqual(['math-block'])
+    // Position must survive so the annotation layer can anchor a note.
+    expect(div.position).toBe(position)
+    expect(div.children![0].tagName).toBe('pre')
+  })
+
+  it('also wraps a math-display pre', () => {
+    const tree = run(root(pre(['language-math', 'math-display'])))
+    expect(tree.children![0].properties?.className).toEqual(['math-block'])
+  })
+
+  it('leaves non-math code fences untouched', () => {
+    const tree = run(root(pre(['hljs', 'language-js'])))
+    expect(tree.children![0].tagName).toBe('pre')
+  })
+
+  it('wraps math nested inside a blockquote', () => {
+    const blockquote: El = {
+      type: 'element',
+      tagName: 'blockquote',
+      children: [pre(['language-math'])]
+    }
+    run(root(blockquote))
+    expect(blockquote.children![0].tagName).toBe('div')
+    expect(blockquote.children![0].properties?.className).toEqual(['math-block'])
+  })
+
+  it('does not double-wrap on a repeated pass', () => {
+    const tree = run(root(pre(['language-math'])))
+    const wrapper = tree.children![0]
+    run(tree)
+    expect(tree.children).toHaveLength(1)
+    expect(tree.children![0]).toBe(wrapper)
+    // The inner pre was not wrapped a second time.
+    expect(wrapper.children![0].tagName).toBe('pre')
+  })
+})

--- a/src/renderer/src/components/editor/rehype-wrap-math-blocks.test.ts
+++ b/src/renderer/src/components/editor/rehype-wrap-math-blocks.test.ts
@@ -42,7 +42,7 @@ describe('rehypeWrapMathBlocks', () => {
   })
 
   it('also wraps a math-display pre', () => {
-    const tree = run(root(pre(['language-math', 'math-display'])))
+    const tree = run(root(pre(['math-display'])))
     expect(tree.children![0].properties?.className).toEqual(['math-block'])
   })
 

--- a/src/renderer/src/components/editor/rehype-wrap-math-blocks.ts
+++ b/src/renderer/src/components/editor/rehype-wrap-math-blocks.ts
@@ -1,0 +1,64 @@
+type HastNode = {
+  type: string
+  tagName?: string
+  properties?: { className?: unknown }
+  position?: unknown
+  children?: HastNode[]
+}
+
+/**
+ * Rehype plugin that wraps block math in a positioned `<div class="math-block">`.
+ *
+ * remark-math emits block math as `<pre><code class="math-display">`, and
+ * rehype-katex then replaces the whole `<pre>` with a bare
+ * `<span class="katex-display">` that carries no source position — so the
+ * preview can't anchor a review note to it. Wrapping the `<pre>` first (this
+ * plugin must run BEFORE rehype-katex) preserves the line range on the surviving
+ * wrapper div, letting block math get the same annotation "+" as other blocks.
+ */
+export function rehypeWrapMathBlocks() {
+  return (tree: HastNode): void => wrapMathBlocks(tree)
+}
+
+function wrapMathBlocks(node: HastNode): void {
+  const children = node.children
+  if (!children) {
+    return
+  }
+  for (let index = 0; index < children.length; index += 1) {
+    const child = children[index]
+    if (child.tagName === 'pre' && containsMathCode(child)) {
+      children[index] = {
+        type: 'element',
+        tagName: 'div',
+        properties: { className: ['math-block'] },
+        position: child.position,
+        children: [child]
+      }
+      continue
+    }
+    // Don't descend into an existing wrapper, so a second pass can't double-wrap.
+    if (child.tagName === 'div' && hasClass(child, 'math-block')) {
+      continue
+    }
+    wrapMathBlocks(child)
+  }
+}
+
+// Match on `language-math` as well as `math-display`. This plugin runs after
+// rehype-sanitize, and `language-math` survives it reliably, whereas the
+// `math-display` allowance depends on sanitize-schema merge quirks — matching
+// either keeps detection robust regardless.
+function containsMathCode(pre: HastNode): boolean {
+  return (pre.children ?? []).some(
+    (child) =>
+      child.tagName === 'code' &&
+      (hasClass(child, 'math-display') || hasClass(child, 'language-math'))
+  )
+}
+
+function hasClass(node: HastNode, className: string): boolean {
+  const value = node.properties?.className
+  const list = Array.isArray(value) ? value : typeof value === 'string' ? value.split(/\s+/) : []
+  return list.includes(className)
+}

--- a/src/renderer/src/i18n/locales/en.json
+++ b/src/renderer/src/i18n/locales/en.json
@@ -13486,6 +13486,13 @@
           "59b6cd874b": "code",
           "ba149053d5": "markdown"
         },
+        "MarkdownGithubAlert": {
+          "8b6fda49fa": "Note",
+          "b28ab35be4": "Tip",
+          "eb04b1d571": "Important",
+          "013315d1fa": "Warning",
+          "91dd428e07": "Caution"
+        },
         "MarkdownPreview": {
           "e4683f70c4": "Cancel",
           "d737791433": "Add note for the AI",


### PR DESCRIPTION
## Summary

Improves the markdown **editor** and **preview** formatting, more in line with other standards like GitHub, and closes several consistency gaps between them. Renderer-only, **no new dependencies**, no wire/RPC/stream changes.

- **Front matter → table.** YAML front matter renders as a read-only key/value table (shared by the rich-editor banner and the preview) instead of a raw monospace block. Scalars become rows, arrays are comma-joined, nested maps flatten to `key: value`; falls back to raw text for TOML or non-map YAML.
- **h1/h2 section underlines** in both editor and preview, matching GitHub.
- **GitHub alert blockquotes** in the preview — `> [!NOTE] / TIP / IMPORTANT / WARNING / CAUTION` render with an icon + colored title (light/dark), following GitHub's rules (marker alone on the first line; unknown types and inline markers stay plain blockquotes).
- **Code blocks** get a header bar with a **language label + copy button** (plain, language-less fences stay bare). Fixes a specificity bug where the inline-code background bled into block code as per-line grey bands, and makes block-code font-size match inline/editor.
- **Block math** gets a bordered, left-aligned box (previously KaTeX's bare centered default) and is now **annotatable** like other blocks.
- **Review-notes gutter** collapses to full width when a block has no note and isn't being composed on (it previously reserved ~28% permanently, making prose look narrow next to full-width elements). The add-note "+" sits beside the block instead of below it.

## Screenshots
Rich Editor:
|Before|After|
|---|---|
|<img width="1279" height="749" alt="image" src="https://github.com/user-attachments/assets/a6602e57-6f7c-405e-9bb8-aa5eb3715614" />|<img width="1278" height="772" alt="image" src="https://github.com/user-attachments/assets/b9551296-e297-43cb-a35e-fea800bf92da" />|
|<img width="1281" height="750" alt="image" src="https://github.com/user-attachments/assets/91bddfbf-7967-4127-b4da-f86372563992" />|<img width="1278" height="766" alt="image" src="https://github.com/user-attachments/assets/8b08531d-d0c4-427c-8b29-32ef9fb043f9" />|

Markdown preview:
|Before|After|
|---|---|
|<img width="1278" height="1165" alt="image" src="https://github.com/user-attachments/assets/58206723-3e3e-41e5-9576-e436460955f0" />|<img width="1278" height="1041" alt="image" src="https://github.com/user-attachments/assets/728625a4-4ebe-45a7-a871-927f8a228161" />|
|<img width="1281" height="948" alt="image" src="https://github.com/user-attachments/assets/8abf460f-8d6a-4d36-9c27-8ff272eb02b2" />|<img width="1278" height="794" alt="image" src="https://github.com/user-attachments/assets/9a7d464b-9ea1-4903-8a6d-62418c1633fc" />|
|<img width="1281" height="551" alt="image" src="https://github.com/user-attachments/assets/1d3a592e-3c69-4433-8c3e-cbff2d32e708" />|<img width="1278" height="544" alt="image" src="https://github.com/user-attachments/assets/068d4837-4453-45c5-a473-0a38a4d6d99c" />|
|<img width="1278" height="171" alt="image" src="https://github.com/user-attachments/assets/7caaf5fb-007a-4b27-98df-7949d857aa31" />|<img width="1278" height="168" alt="image" src="https://github.com/user-attachments/assets/91b7d3ac-4a61-4e7e-9fd1-fcde0cd065cd" />|


## Testing

- [x] `pnpm lint` — all code-quality checks pass (oxlint, audits, reliability gates, max-lines ratchet). The only failure is `verify:skill-bundle-manifest`, which is **pre-existing and unrelated**: the stale generated files under `resources/skills/` are byte-identical to `main` and untouched by this branch.
- [x] `pnpm typecheck` — passes (node + cli + web).
- [x] `pnpm test` — this branch's tests all pass with **zero regressions**. The local Windows run reports 176 pre-existing failures (SSH, macOS/KDE/GNOME clipboard, host-boundary, text-generation, etc.); a representative sample was verified to fail identically on `main`, and none are in the changed area. These are platform/env tests expected to pass in Linux CI.
- [x] `pnpm build` — passes (`build:desktop && build:native`, exit 0).
- [x] Added high-quality tests: `markdown-frontmatter-fields.test.ts` (scalar/array/nested-map/timestamp formatting + TOML/bare-scalar/empty-map/invalid-YAML fallbacks), `markdown-github-alerts.test.ts` (valid/case-insensitive/unknown/inline/empty-paragraph markers), `rehype-wrap-math-blocks.test.ts` (wrap/skip-non-math/nesting/position-preservation/no-double-wrap). Existing annotation/preview tests still pass.

## AI Review Report

Reviewed against `.github/CONTRIBUTING.md` across two independent AI review passes; findings were fixed or consciously declined. **No FAIL.**

Main risks checked and outcomes:
- **Cross-platform (macOS / Linux / Windows):** Explicitly confirmed. This is renderer-only CSS/React — the diff adds **no keyboard shortcuts, no shortcut labels, no file paths, no shell/`cmd` behavior, and no Electron main-process or platform-specific code**. Front-matter parsing handles CRLF (`\r?\n`). Nothing platform-divergent is touched.
- **Responsive/layout:** A review pass caught that the gutter-collapse change raised a selector's specificity so the `@container (max-width: 760px)` stacking rule stopped winning on narrow/split panes — **fixed** by matching the container query to the class-qualified selectors and resetting the collapsed controls.
- **Correctness of new logic:** The math-wrap rehype plugin wraps only math `<pre>` blocks, preserves source position through KaTeX, skips non-math fences, and won't double-wrap (unit-tested). The gutter-collapse states (has-note / composing / neither) were checked against note display and composing.
- **Performance:** No new hot-path cost — the `div` renderer is a cheap class check, the math-wrap plugin is one O(nodes) pass per memoized parse, and the annotation-state dependency added to the components memo was already an indirect dependency (no new re-parse).
- **UI/STYLEGUIDE:** New borders converted to `var(--border)`/`color-mix` tokens after review; alert accent hues are intentionally hardcoded hex mirroring GitHub's palette, consistent with the file's existing link/hljs color precedent.
- **SSH/remote/local & provider/agent neutrality:** No execution, credentials, network, or wire changes; alert syntax is a client-side content format independent of any git provider.

## Security Audit

Basic security review by the AI agent. **No new attack surface.**

- **Input handling:** All rendered markdown still passes through `rehype-sanitize`. The one schema change is a **tight value-whitelist** allowing `class="markdown-alert"` / `markdown-alert-*` on blockquotes (className is not a script vector; only those exact values survive). Alert title text is static React, never entering the sanitized HTML tree.
- **Path handling:** None — no filesystem paths introduced or handled.
- **Command execution / IPC:** None added.
- **Auth / secrets:** None touched.
- **Dependencies:** **No new dependencies** (`package.json` / `pnpm-lock.yaml` unchanged); reuses existing `yaml`, `lucide-react`, and the remark/rehype stack.
- **One nuance reviewed:** `rehype-wrap-math-blocks` creates a `<div class="math-block">` *after* `rehype-sanitize` runs. This is safe — it wraps an already-sanitized `<pre>` with a constant, hardcoded class and adds no user-controlled attributes or content.
- **Follow-up:** None required.

## Notes

- **Platform-specific behavior:** none — renderer-only, no platform branches.
- Plain (language-less) code fences intentionally have no header bar or copy button (kept simple; text remains selectable/copyable normally).
- Alert titles ("Note"/"Tip"/…) are hardcoded English, matching GitHub which doesn't localize them; could be routed through i18n later if desired.
- Commits are split into four logical changes (front-matter + underlines / alerts / math annotatability / preview integration).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
