### PR TITLE
fix(sidebar): pin hostId when removing multi-host projects

### DIFF
--- a/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
@@ -10,6 +10,7 @@ import {
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/store'
 import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import { normalizeExecutionHostId } from '../../../../shared/execution-host'
 import { translate } from '@/i18n/i18n'
 
 // Why: interpolated into the sentence so locales control where the name sits;
@@ -25,7 +26,9 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   const isOpen = activeModal === 'confirm-remove-folder'
   const repoId = typeof modalData.repoId === 'string' ? modalData.repoId : ''
   const displayName = typeof modalData.displayName === 'string' ? modalData.displayName : ''
-  const hostId = typeof modalData.hostId === 'string' ? modalData.hostId : undefined
+  const hostId = normalizeExecutionHostId(
+    typeof modalData.hostId === 'string' ? modalData.hostId : null
+  )
 
   // Why: for an SSH project the files live on the remote host's disk, not the
   // user's — "still on your disk" would be misleading. Name the host (using the
@@ -62,10 +65,11 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   const [descriptionBeforeName, descriptionAfterName] = description.split(NAME_TOKEN)
 
   const handleConfirm = useCallback(() => {
-    if (repoId) {
+    // Why: refuse bare remove when host is unknown — multi-host twins must not guess (#13071).
+    if (repoId && hostId) {
       void removeProject(repoId, {
         errorFeedback: 'toast',
-        ...(hostId ? { hostId: hostId as never } : {})
+        hostId
       })
     }
     closeModal()

--- a/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
+++ b/src/renderer/src/components/sidebar/RemoveFolderDialog.tsx
@@ -9,6 +9,7 @@ import {
 } from '@/components/ui/dialog'
 import { Button } from '@/components/ui/button'
 import { useAppStore } from '@/store'
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
 import { translate } from '@/i18n/i18n'
 
 // Why: interpolated into the sentence so locales control where the name sits;
@@ -24,13 +25,16 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
   const isOpen = activeModal === 'confirm-remove-folder'
   const repoId = typeof modalData.repoId === 'string' ? modalData.repoId : ''
   const displayName = typeof modalData.displayName === 'string' ? modalData.displayName : ''
+  const hostId = typeof modalData.hostId === 'string' ? modalData.hostId : undefined
 
   // Why: for an SSH project the files live on the remote host's disk, not the
   // user's — "still on your disk" would be misleading. Name the host (using the
   // removed-target label when it's a ghost) so the user knows where it remains
   // and that re-adding that host recovers it.
   const sshHostLabel = useAppStore((s) => {
-    const connectionId = s.repos.find((r) => r.id === repoId)?.connectionId?.trim()
+    // Why: prefer host-scoped lookup so a twin id on another host does not label this dialog (#13071).
+    const repo = findRepoForHost(s.repos, repoId, hostId ? { hostId } : {})
+    const connectionId = repo?.connectionId?.trim()
     if (!connectionId) {
       return null
     }
@@ -59,10 +63,13 @@ const RemoveFolderDialog = React.memo(function RemoveFolderDialog() {
 
   const handleConfirm = useCallback(() => {
     if (repoId) {
-      void removeProject(repoId, { errorFeedback: 'toast' })
+      void removeProject(repoId, {
+        errorFeedback: 'toast',
+        ...(hostId ? { hostId: hostId as never } : {})
+      })
     }
     closeModal()
-  }, [closeModal, removeProject, repoId])
+  }, [closeModal, hostId, removeProject, repoId])
 
   const handleOpenChange = useCallback(
     (open: boolean) => {

--- a/src/renderer/src/components/sidebar/WorktreeList.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeList.tsx
@@ -6189,7 +6189,9 @@ const WorktreeList = React.memo(function WorktreeList({
     (repo: Repo) => {
       openModal('confirm-remove-folder', {
         repoId: repo.id,
-        displayName: repo.displayName
+        displayName: repo.displayName,
+        // Why: same repo id can exist on two hosts; bare id would remove the wrong row (#13071).
+        hostId: getRepoExecutionHostId(repo)
       })
     },
     [openModal]

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.test.ts
@@ -493,7 +493,8 @@ describe('delete worktree flow', () => {
     expect(mocks.state.removeWorktree).not.toHaveBeenCalled()
     expect(mocks.state.openModal).toHaveBeenCalledWith('confirm-remove-folder', {
       repoId: 'repo-1',
-      displayName: 'orca'
+      displayName: 'orca',
+      hostId: 'local'
     })
   })
 

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -1,11 +1,11 @@
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getWorktreeMapFromState } from '@/store/selectors'
-import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
   showNoDeletableWorkspacesToast,
   showWorkspaceListChangedToast
 } from './stale-workspace-list-toast'
 import { resolveRepoForWorktreeTarget } from './worktree-delete-repo-resolve'
+import { openMainWorktreeProjectRemove } from './worktree-delete-main-project-remove'
 import { getWorkspaceDeleteLineage } from './workspace-delete-lineage'
 import { resolveSshWorkspaceForget } from './ssh-workspace-forget-resolution'
 import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
@@ -45,15 +45,7 @@ export function runWorktreeDelete(worktreeId: string, options: WorktreeDeleteOpt
     return
   }
   if (target.isMainWorktree) {
-    const repo = resolveRepoForWorktreeTarget(state.repos, target)
-    const hostId = target.hostId ?? (repo ? getRepoExecutionHostId(repo) : undefined)
-    // Why: git refuses to delete the primary checkout; users can still remove the owning project from Orca (disk contents kept).
-    state.openModal('confirm-remove-folder', {
-      repoId: target.repoId,
-      displayName: repo?.displayName ?? target.displayName,
-      // Why: pin host so confirm-remove cannot fall through to a twin on another host (#13071).
-      ...(hostId ? { hostId } : {})
-    })
+    openMainWorktreeProjectRemove(target)
     return
   }
   state.clearWorktreeDeleteState(worktreeId)

--- a/src/renderer/src/components/sidebar/delete-worktree-flow.ts
+++ b/src/renderer/src/components/sidebar/delete-worktree-flow.ts
@@ -1,10 +1,11 @@
 import { useAppStore } from '@/store'
 import { getAllWorktreesFromState, getWorktreeMapFromState } from '@/store/selectors'
-import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
 import {
   showNoDeletableWorkspacesToast,
   showWorkspaceListChangedToast
 } from './stale-workspace-list-toast'
+import { resolveRepoForWorktreeTarget } from './worktree-delete-repo-resolve'
 import { getWorkspaceDeleteLineage } from './workspace-delete-lineage'
 import { resolveSshWorkspaceForget } from './ssh-workspace-forget-resolution'
 import { isPairedWebClientWindow } from '@/lib/desktop-window-chrome'
@@ -44,11 +45,14 @@ export function runWorktreeDelete(worktreeId: string, options: WorktreeDeleteOpt
     return
   }
   if (target.isMainWorktree) {
-    const repo = state.repos.find((entry) => entry.id === target.repoId)
+    const repo = resolveRepoForWorktreeTarget(state.repos, target)
+    const hostId = target.hostId ?? (repo ? getRepoExecutionHostId(repo) : undefined)
     // Why: git refuses to delete the primary checkout; users can still remove the owning project from Orca (disk contents kept).
     state.openModal('confirm-remove-folder', {
       repoId: target.repoId,
-      displayName: repo?.displayName ?? target.displayName
+      displayName: repo?.displayName ?? target.displayName,
+      // Why: pin host so confirm-remove cannot fall through to a twin on another host (#13071).
+      ...(hostId ? { hostId } : {})
     })
     return
   }
@@ -56,12 +60,7 @@ export function runWorktreeDelete(worktreeId: string, options: WorktreeDeleteOpt
 
   // Why: a disconnected SSH host has no provider, so worktrees:remove throws; route to reconnect-and-delete or local-only forget.
   // Skip on paired web/mobile clients: SSH state is desktop-only, so empty sshTargetLabels misclassifies SSH repos as ghosts; their worktree.rm RPC still handles the delete.
-  const matchingRepos = state.repos.filter((entry) => entry.id === target.repoId)
-  const repo = target.hostId
-    ? findRepoForHost(matchingRepos, target.repoId, { hostId: target.hostId })
-    : matchingRepos.length === 1
-      ? matchingRepos[0]
-      : null
+  const repo = resolveRepoForWorktreeTarget(state.repos, target)
   const sshResolution = isPairedWebClientWindow()
     ? { kind: 'not-ssh' as const }
     : resolveSshWorkspaceForget({

--- a/src/renderer/src/components/sidebar/worktree-delete-main-project-remove.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-main-project-remove.ts
@@ -1,0 +1,31 @@
+import { toast } from 'sonner'
+import { useAppStore } from '@/store'
+import { getRepoExecutionHostId } from '../../../../shared/execution-host'
+import type { Worktree } from '../../../../shared/types'
+import { translate } from '@/i18n/i18n'
+import { resolveRepoForWorktreeTarget } from './worktree-delete-repo-resolve'
+
+/** Open confirm-remove for a primary worktree, or refuse when the host is ambiguous. */
+export function openMainWorktreeProjectRemove(
+  target: Pick<Worktree, 'repoId' | 'hostId' | 'displayName'>
+): void {
+  const state = useAppStore.getState()
+  const repo = resolveRepoForWorktreeTarget(state.repos, target)
+  const hostId = target.hostId ?? (repo ? getRepoExecutionHostId(repo) : undefined)
+  // Why: without a host pin, confirm can remove a twin on the focused host (#13071/#13536).
+  if (!hostId) {
+    toast.error(
+      translate(
+        'auto.components.sidebar.delete.worktree.flow.ambiguousProjectHost',
+        'Could not determine which host owns this project. Select it from the sidebar and try again.'
+      )
+    )
+    return
+  }
+  // Why: git refuses to delete the primary checkout; users can still remove the project from Orca.
+  state.openModal('confirm-remove-folder', {
+    repoId: target.repoId,
+    displayName: repo?.displayName ?? target.displayName,
+    hostId
+  })
+}

--- a/src/renderer/src/components/sidebar/worktree-delete-repo-resolve.ts
+++ b/src/renderer/src/components/sidebar/worktree-delete-repo-resolve.ts
@@ -1,0 +1,13 @@
+import { findRepoForHost } from '@/store/slices/repo-host-identity'
+import type { Repo, Worktree } from '../../../../shared/types'
+
+export function resolveRepoForWorktreeTarget(
+  repos: readonly Repo[],
+  target: Pick<Worktree, 'repoId' | 'hostId'>
+): Repo | null {
+  const matching = repos.filter((entry) => entry.id === target.repoId)
+  if (target.hostId) {
+    return findRepoForHost(matching, target.repoId, { hostId: target.hostId })
+  }
+  return matching.length === 1 ? matching[0] : null
+}

--- a/src/renderer/src/store/slices/repos-cross-host-project-collisions.test.ts
+++ b/src/renderer/src/store/slices/repos-cross-host-project-collisions.test.ts
@@ -185,7 +185,8 @@ describe('deleting one host copy of a same-named project', () => {
   it('removes only remote A when the same name exists on remote B', async () => {
     const store = seed([remoteATwin, remoteBTwin], 'env-b')
 
-    await store.getState().removeProject('env-a-uuid')
+    // Why: bare id while focused on B would historically unique-match A and risk the wrong host (#13071).
+    await store.getState().removeProject('env-a-uuid', { hostId: 'runtime:env-a' })
 
     expect(repoRmCalls()).toEqual([
       expect.objectContaining({
@@ -194,6 +195,15 @@ describe('deleting one host copy of a same-named project', () => {
       })
     ])
     expect(remainingRepoIds(store)).toEqual(['env-b-uuid'])
+  })
+
+  it('refuses unique-id fallback when hostId is omitted and focus is on another host', async () => {
+    const store = seed([remoteATwin, remoteBTwin], 'env-b')
+
+    await store.getState().removeProject('env-a-uuid')
+
+    expect(repoRmCalls()).toEqual([])
+    expect(remainingRepoIds(store)).toEqual(['env-a-uuid', 'env-b-uuid'])
   })
 
   it('keeps remote B when remote A reports the project already gone', async () => {

--- a/src/renderer/src/store/slices/repos-cross-host-project-collisions.test.ts
+++ b/src/renderer/src/store/slices/repos-cross-host-project-collisions.test.ts
@@ -197,13 +197,45 @@ describe('deleting one host copy of a same-named project', () => {
     expect(remainingRepoIds(store)).toEqual(['env-b-uuid'])
   })
 
-  it('refuses unique-id fallback when hostId is omitted and focus is on another host', async () => {
+  it('allows unique-id bare remove even when focus is on another host', async () => {
+    // Why: env-a-uuid is unique across hosts; focus on B must not block a unambiguous remove.
+    // Same-id multi-host still requires hostId (covered above).
     const store = seed([remoteATwin, remoteBTwin], 'env-b')
 
     await store.getState().removeProject('env-a-uuid')
 
-    expect(repoRmCalls()).toEqual([])
-    expect(remainingRepoIds(store)).toEqual(['env-a-uuid', 'env-b-uuid'])
+    expect(repoRmCalls()).toEqual([
+      expect.objectContaining({
+        selector: 'env-a',
+        params: { repo: 'env-a-uuid' }
+      })
+    ])
+    expect(remainingRepoIds(store)).toEqual(['env-b-uuid'])
+  })
+
+  it('picks the focused host when the same id exists on multiple hosts without hostId', async () => {
+    // Why: bare multi-host id must not guess a non-focused twin; focused unique match is allowed.
+    const store = seed(
+      [
+        remoteATwin,
+        {
+          ...remoteBTwin,
+          id: 'env-a-uuid'
+        }
+      ],
+      'env-b'
+    )
+
+    await store.getState().removeProject('env-a-uuid')
+
+    expect(repoRmCalls()).toEqual([
+      expect.objectContaining({
+        selector: 'env-b',
+        params: { repo: 'env-a-uuid' }
+      })
+    ])
+    // Only the non-focused env-a twin remains.
+    expect(store.getState().repos.map((entry) => entry.executionHostId)).toEqual(['runtime:env-a'])
   })
 
   it('keeps remote B when remote A reports the project already gone', async () => {

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -79,7 +79,6 @@ import { notifyInstalledAgentSkillsChanged } from '@/hooks/installed-agent-skill
 import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
-  getSettingsFocusedExecutionHostId,
   isRuntimeOwnedSshTargetId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
@@ -2887,10 +2886,11 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
     const removedProjectIds: string[] = []
     const failedProjectRemovals: ProjectRemovalFailure[] = []
     for (const projectId of targets.projectIds) {
-      const existedBeforeRemoval = get().repos.some((repo) => repo.id === projectId)
+      const hostCopies = get().repos.filter((repo) => repo.id === projectId)
       try {
-        if (existedBeforeRemoval) {
-          await get().removeProject(projectId)
+        for (const repo of hostCopies) {
+          // Why: group delete must clear every host twin, not only the focused one (#13536).
+          await get().removeProject(projectId, { hostId: getRepoExecutionHostId(repo) })
         }
       } catch (err) {
         console.error('Failed to remove contained project:', err)
@@ -3380,21 +3380,12 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   removeProject: async (projectId, options) => {
     try {
-      // Why: removals must not use unique-id-any-host fallback — a vanished twin leaves
-      // one survivor that would be destroyed if the user meant the other host (#13071).
-      const ownerRepo = options?.hostId
-        ? findRepoForHost(get().repos, projectId, { hostId: options.hostId })
-        : (() => {
-            const matching = get().repos.filter((repo) => repo.id === projectId)
-            if (matching.length === 0) {
-              return null
-            }
-            const focusedHostId = getSettingsFocusedExecutionHostId(get().settings)
-            const focusedMatches = matching.filter(
-              (repo) => getRepoExecutionHostId(repo) === focusedHostId
-            )
-            return focusedMatches.length === 1 ? focusedMatches[0] : null
-          })()
+      // Why: hostId pins multi-host twins (#13071). Bare id still allows a unique
+      // any-host match (SSH under local focus); only ambiguous ids require hostId.
+      const ownerRepo = findRepoForHost(get().repos, projectId, {
+        hostId: options?.hostId,
+        settings: get().settings
+      })
       if (!ownerRepo) {
         return
       }

--- a/src/renderer/src/store/slices/repos.ts
+++ b/src/renderer/src/store/slices/repos.ts
@@ -79,6 +79,7 @@ import { notifyInstalledAgentSkillsChanged } from '@/hooks/installed-agent-skill
 import { translate } from '@/i18n/i18n'
 import {
   getRepoExecutionHostId,
+  getSettingsFocusedExecutionHostId,
   isRuntimeOwnedSshTargetId,
   LOCAL_EXECUTION_HOST_ID,
   parseExecutionHostId,
@@ -3379,11 +3380,21 @@ export const createRepoSlice: StateCreator<AppState, [], [], RepoSlice> = (set, 
 
   removeProject: async (projectId, options) => {
     try {
-      // Why: pass an explicit hostId so a duplicate id across hosts resolves to the intended row, not the focused-host fallback.
-      const ownerRepo = findRepoForHost(get().repos, projectId, {
-        settings: get().settings,
-        hostId: options?.hostId
-      })
+      // Why: removals must not use unique-id-any-host fallback — a vanished twin leaves
+      // one survivor that would be destroyed if the user meant the other host (#13071).
+      const ownerRepo = options?.hostId
+        ? findRepoForHost(get().repos, projectId, { hostId: options.hostId })
+        : (() => {
+            const matching = get().repos.filter((repo) => repo.id === projectId)
+            if (matching.length === 0) {
+              return null
+            }
+            const focusedHostId = getSettingsFocusedExecutionHostId(get().settings)
+            const focusedMatches = matching.filter(
+              (repo) => getRepoExecutionHostId(repo) === focusedHostId
+            )
+            return focusedMatches.length === 1 ? focusedMatches[0] : null
+          })()
       if (!ownerRepo) {
         return
       }

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1728,12 +1728,18 @@ async function purgeOrphanedRuntimeSshProjects(
   const orphanedSetupIds = get()
     .projectHostSetups.filter((setup) => destroyedHostIds.has(setup.hostId))
     .map((setup) => setup.id)
-  const purgedRepoIds = new Set<string>()
+  // Why: same repo id can exist on multiple hosts; only suppress the host+id we already purged (#13536).
+  const purgedRepoKeys = new Set<string>()
+  const repoHostKey = (repo: {
+    id: string
+    connectionId?: string | null
+    executionHostId?: string
+  }) => `${getRepoExecutionHostId(repo)}\0${repo.id}`
   for (const setupId of orphanedSetupIds) {
     try {
       const result = await get().deleteProjectHostSetup({ setupId })
       if (result?.repo) {
-        purgedRepoIds.add(result.repo.id)
+        purgedRepoKeys.add(repoHostKey(result.repo))
       }
     } catch (error) {
       console.error('Failed to purge orphaned per-workspace-env project:', error)
@@ -1741,7 +1747,8 @@ async function purgeOrphanedRuntimeSshProjects(
   }
   // A repo whose only host was the destroyed runtime can outlive its setup (pruned first by a projection refresh); remove it directly so no dead project lingers.
   const orphanedRepos = get().repos.filter(
-    (repo) => destroyedTargetIds.has(repo.connectionId ?? '') && !purgedRepoIds.has(repo.id)
+    (repo) =>
+      destroyedTargetIds.has(repo.connectionId ?? '') && !purgedRepoKeys.has(repoHostKey(repo))
   )
   for (const repo of orphanedRepos) {
     try {

--- a/src/renderer/src/store/slices/worktrees.ts
+++ b/src/renderer/src/store/slices/worktrees.ts
@@ -1740,14 +1740,13 @@ async function purgeOrphanedRuntimeSshProjects(
     }
   }
   // A repo whose only host was the destroyed runtime can outlive its setup (pruned first by a projection refresh); remove it directly so no dead project lingers.
-  const orphanedRepoIds = get()
-    .repos.filter(
-      (repo) => destroyedTargetIds.has(repo.connectionId ?? '') && !purgedRepoIds.has(repo.id)
-    )
-    .map((repo) => repo.id)
-  for (const repoId of orphanedRepoIds) {
+  const orphanedRepos = get().repos.filter(
+    (repo) => destroyedTargetIds.has(repo.connectionId ?? '') && !purgedRepoIds.has(repo.id)
+  )
+  for (const repo of orphanedRepos) {
     try {
-      await get().removeProject(repoId)
+      // Why: pin host so a same-id twin on another host is not the bare-id pick (#13536).
+      await get().removeProject(repo.id, { hostId: getRepoExecutionHostId(repo) })
     } catch (error) {
       console.error('Failed to purge orphaned per-workspace-env repo:', error)
     }


### PR DESCRIPTION
## Summary
- Removing a project from the sidebar only passed `repoId`, so when the same id existed on two hosts (or a twin vanished from the catalog) `findRepoForHost` could pick the wrong row.
- Thread `hostId` through `confirm-remove-folder` (WorktreeList + main-worktree delete path), resolve dialog labels/repos by host, and make `removeProject` refuse unique-id-any-host fallback when `hostId` is omitted (focused-host match only).

## Test plan
- [x] delete-worktree-flow + repos-cross-host-project-collisions + repos-host-identity-routing (36 passed)
- [ ] Manual: two hosts share a project id; remove one from sidebar; other host row remains

Fixes #13071