### PR TITLE
[perf-remote] perf(renderer): gate remote session mirror scans

### DIFF
--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
@@ -1,0 +1,339 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { shallow } from 'zustand/shallow'
+import { getDefaultSettings } from '../../../shared/constants'
+import type { ProjectGroup, Repo } from '../../../shared/types'
+import type * as RuntimeSessionMirrorTargetsModule from '@/lib/runtime-session-mirror-targets'
+import { makeWorktree } from '@/store/slices/store-test-helpers'
+
+const { getMirrorTargets } = vi.hoisted(() => ({ getMirrorTargets: vi.fn() }))
+
+vi.mock('@/lib/runtime-session-mirror-targets', async (importOriginal) => {
+  const actual = await importOriginal<typeof RuntimeSessionMirrorTargetsModule>()
+  getMirrorTargets.mockImplementation(actual.getReachableRuntimeSessionMirrorTargets)
+  return { ...actual, getReachableRuntimeSessionMirrorTargets: getMirrorTargets }
+})
+
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import {
+  selectRuntimeSessionMirrorTargetInputs,
+  useRuntimeSessionMirrorEnvironmentKey
+} from './use-runtime-session-mirror-environment-key'
+import { useWebSessionTabsSync } from './web-session-tabs-sync'
+
+const initialState = useAppStore.getInitialState()
+
+function makeRepo(id: string, executionHostId: Repo['executionHostId']): Repo {
+  return {
+    id,
+    path: `/tmp/${id}`,
+    displayName: id,
+    badgeColor: '#000',
+    addedAt: 0,
+    connectionId: null,
+    executionHostId
+  }
+}
+
+function makeProjectGroup(executionHostId: ProjectGroup['executionHostId']): ProjectGroup {
+  return {
+    id: 'group-b',
+    name: 'Group B',
+    parentPath: null,
+    parentGroupId: null,
+    createdFrom: 'manual',
+    tabOrder: 0,
+    isCollapsed: false,
+    color: null,
+    createdAt: 1,
+    updatedAt: 1,
+    connectionId: null,
+    executionHostId
+  }
+}
+
+function seedMirrorState(): void {
+  useAppStore.setState(
+    {
+      ...initialState,
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        activeRuntimeEnvironmentId: 'env-a'
+      },
+      repos: [],
+      worktreesByRepo: {},
+      detectedWorktreesByRepo: {},
+      projectGroups: [],
+      restoredRuntimeHostIdByWorkspaceSessionKey: {},
+      runtimeEnvironments: [
+        { id: 'env-a', createdAt: 100, pairingRevision: 101 },
+        { id: 'env-b', createdAt: 200, pairingRevision: 201 }
+      ] as AppState['runtimeEnvironments'],
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          'env-a',
+          {
+            status: { runtimeId: 'runtime-a' },
+            connectionGeneration: 1
+          }
+        ],
+        [
+          'env-b',
+          {
+            status: { runtimeId: 'runtime-b' },
+            connectionGeneration: 2
+          }
+        ]
+      ]) as AppState['runtimeStatusByEnvironmentId']
+    },
+    true
+  )
+}
+
+describe('useRuntimeSessionMirrorEnvironmentKey', () => {
+  beforeEach(() => {
+    getMirrorTargets.mockClear()
+    seedMirrorState()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialState, true)
+  })
+
+  it('does not rescan remote ownership for unrelated store writes or parent renders', () => {
+    const repos = Array.from({ length: 100 }, (_, index) =>
+      makeRepo(`repo-${index}`, 'runtime:env-a')
+    )
+    const worktreesByRepo: AppState['worktreesByRepo'] = Object.fromEntries(
+      repos.map((repo) => [
+        repo.id,
+        [
+          makeWorktree({
+            id: `${repo.id}::worktree`,
+            repoId: repo.id,
+            hostId: 'runtime:env-a'
+          })
+        ]
+      ])
+    )
+    useAppStore.setState({ repos, worktreesByRepo })
+    const hook = renderHook(() => useRuntimeSessionMirrorEnvironmentKey())
+    const initialCallCount = getMirrorTargets.mock.calls.length
+
+    expect(hook.result.current).toBe('env-a\u0001runtime-a\u00011\u0001101')
+    expect(initialCallCount).toBe(1)
+
+    act(() => {
+      for (let index = 0; index < 100; index += 1) {
+        useAppStore.setState({ agentStatusEpoch: useAppStore.getState().agentStatusEpoch + 1 })
+      }
+      useAppStore.setState({
+        settings: {
+          ...useAppStore.getState().settings!,
+          terminalFontSize: useAppStore.getState().settings!.terminalFontSize + 1
+        }
+      })
+    })
+    hook.rerender()
+
+    expect(getMirrorTargets).toHaveBeenCalledTimes(initialCallCount)
+  })
+
+  it('keeps the production session sync off the hot store-write path', () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+    const initialCallCount = getMirrorTargets.mock.calls.length
+
+    expect(initialCallCount).toBe(1)
+    act(() => {
+      useAppStore.setState({ agentStatusEpoch: useAppStore.getState().agentStatusEpoch + 1 })
+      useAppStore.setState({ sortEpoch: useAppStore.getState().sortEpoch + 1 })
+    })
+    hook.rerender()
+
+    expect(getMirrorTargets).toHaveBeenCalledTimes(initialCallCount)
+  })
+
+  it.each([
+    {
+      source: 'active environment',
+      change: (state: AppState): Partial<AppState> => ({
+        settings: { ...state.settings!, activeRuntimeEnvironmentId: 'env-b' }
+      })
+    },
+    {
+      source: 'repository host',
+      change: (): Partial<AppState> => ({
+        repos: [makeRepo('repo-b', 'runtime:env-b')]
+      })
+    },
+    {
+      source: 'published worktree owner',
+      change: (): Partial<AppState> => ({
+        worktreesByRepo: {
+          'repo-b': [
+            makeWorktree({
+              id: 'repo-b::worktree',
+              repoId: 'repo-b',
+              hostId: 'ssh:private',
+              runtimeOwnerEnvironmentId: 'env-b'
+            })
+          ]
+        }
+      })
+    },
+    {
+      source: 'detected worktree owner',
+      change: (): Partial<AppState> => ({
+        detectedWorktreesByRepo: {
+          'repo-b': {
+            repoId: 'repo-b',
+            authoritative: true,
+            source: 'git',
+            worktrees: [
+              {
+                ...makeWorktree({
+                  id: 'repo-b::detected',
+                  repoId: 'repo-b',
+                  hostId: 'ssh:private',
+                  runtimeOwnerEnvironmentId: 'env-b'
+                }),
+                ownership: 'external',
+                selectedCheckout: false,
+                visible: true
+              }
+            ]
+          }
+        }
+      })
+    },
+    {
+      source: 'project group host',
+      change: (): Partial<AppState> => ({
+        projectGroups: [makeProjectGroup('runtime:env-b')]
+      })
+    },
+    {
+      source: 'restored session host',
+      change: (): Partial<AppState> => ({
+        restoredRuntimeHostIdByWorkspaceSessionKey: { 'folder:restored': 'runtime:env-b' }
+      })
+    }
+  ])('rebuilds when the $source selects an online runtime', ({ change }) => {
+    useAppStore.setState({
+      settings: {
+        ...useAppStore.getState().settings!,
+        activeRuntimeEnvironmentId: null
+      }
+    })
+    const hook = renderHook(() => useRuntimeSessionMirrorEnvironmentKey())
+
+    expect(hook.result.current).toBe('')
+    act(() => useAppStore.setState(change(useAppStore.getState())))
+
+    expect(hook.result.current).toBe('env-b\u0001runtime-b\u00012\u0001201')
+    expect(getMirrorTargets).toHaveBeenCalledTimes(2)
+  })
+
+  it('rebuilds the key when connection or pairing identity changes', () => {
+    const hook = renderHook(() => useRuntimeSessionMirrorEnvironmentKey())
+
+    act(() => {
+      useAppStore.setState({
+        runtimeStatusByEnvironmentId: new Map([
+          [
+            'env-a',
+            {
+              status: { runtimeId: 'runtime-a' },
+              connectionGeneration: 2
+            }
+          ]
+        ]) as AppState['runtimeStatusByEnvironmentId']
+      })
+    })
+    expect(hook.result.current).toBe('env-a\u0001runtime-a\u00012\u0001101')
+
+    act(() => {
+      useAppStore.setState({
+        runtimeEnvironments: [
+          { id: 'env-a', createdAt: 100, pairingRevision: 102 }
+        ] as AppState['runtimeEnvironments']
+      })
+    })
+    expect(hook.result.current).toBe('env-a\u0001runtime-a\u00012\u0001102')
+    expect(getMirrorTargets).toHaveBeenCalledTimes(3)
+  })
+
+  it('clears the key when status, environment, or the final owner disappears', () => {
+    const hook = renderHook(() => useRuntimeSessionMirrorEnvironmentKey())
+    const onlineStatus = useAppStore.getState().runtimeStatusByEnvironmentId.get('env-a')!
+    const environments = useAppStore.getState().runtimeEnvironments
+
+    act(() => {
+      useAppStore.setState({
+        runtimeStatusByEnvironmentId: new Map([['env-a', { ...onlineStatus, status: null }]])
+      })
+    })
+    expect(hook.result.current).toBe('')
+
+    act(() => {
+      useAppStore.setState({ runtimeStatusByEnvironmentId: new Map([['env-a', onlineStatus]]) })
+    })
+    expect(hook.result.current).toBe('env-a\u0001runtime-a\u00011\u0001101')
+
+    act(() => useAppStore.setState({ runtimeEnvironments: [] }))
+    expect(hook.result.current).toBe('')
+
+    act(() => useAppStore.setState({ runtimeEnvironments: environments }))
+    expect(hook.result.current).toBe('env-a\u0001runtime-a\u00011\u0001101')
+
+    act(() => {
+      useAppStore.setState({
+        settings: {
+          ...useAppStore.getState().settings!,
+          activeRuntimeEnvironmentId: null
+        }
+      })
+    })
+    expect(hook.result.current).toBe('')
+    expect(getMirrorTargets).toHaveBeenCalledTimes(6)
+  })
+
+  it('invalidates only for state read by the mirror target builder', () => {
+    const state = useAppStore.getState()
+    const selected = selectRuntimeSessionMirrorTargetInputs(state)
+    const unrelated = selectRuntimeSessionMirrorTargetInputs({
+      ...state,
+      agentStatusEpoch: state.agentStatusEpoch + 1,
+      settings: { ...state.settings!, terminalFontSize: state.settings!.terminalFontSize + 1 }
+    })
+
+    expect(shallow(selected, unrelated)).toBe(true)
+
+    const relevantChanges: Partial<AppState>[] = [
+      { settings: { ...state.settings!, activeRuntimeEnvironmentId: 'env-b' } },
+      { repos: [...state.repos] },
+      { worktreesByRepo: { ...state.worktreesByRepo } },
+      { detectedWorktreesByRepo: { ...state.detectedWorktreesByRepo } },
+      { projectGroups: [...state.projectGroups] },
+      {
+        restoredRuntimeHostIdByWorkspaceSessionKey: {
+          ...state.restoredRuntimeHostIdByWorkspaceSessionKey
+        }
+      },
+      { runtimeEnvironments: [...state.runtimeEnvironments] },
+      { runtimeStatusByEnvironmentId: new Map(state.runtimeStatusByEnvironmentId) }
+    ]
+    for (const change of relevantChanges) {
+      expect(
+        shallow(
+          selected,
+          selectRuntimeSessionMirrorTargetInputs({ ...state, ...change } as AppState)
+        )
+      ).toBe(false)
+    }
+  })
+})

--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.ts
@@ -1,0 +1,91 @@
+import { useMemo } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { getReachableRuntimeSessionMirrorTargets } from '@/lib/runtime-session-mirror-targets'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+
+export type RuntimeSessionMirrorTargetInputs = Pick<
+  AppState,
+  | 'repos'
+  | 'worktreesByRepo'
+  | 'detectedWorktreesByRepo'
+  | 'projectGroups'
+  | 'restoredRuntimeHostIdByWorkspaceSessionKey'
+  | 'runtimeEnvironments'
+  | 'runtimeStatusByEnvironmentId'
+> & {
+  activeRuntimeEnvironmentId: string | null
+}
+
+export function selectRuntimeSessionMirrorTargetInputs(
+  state: AppState
+): RuntimeSessionMirrorTargetInputs {
+  return {
+    activeRuntimeEnvironmentId: state.settings?.activeRuntimeEnvironmentId ?? null,
+    repos: state.repos,
+    worktreesByRepo: state.worktreesByRepo,
+    detectedWorktreesByRepo: state.detectedWorktreesByRepo,
+    projectGroups: state.projectGroups,
+    restoredRuntimeHostIdByWorkspaceSessionKey: state.restoredRuntimeHostIdByWorkspaceSessionKey,
+    runtimeEnvironments: state.runtimeEnvironments,
+    runtimeStatusByEnvironmentId: state.runtimeStatusByEnvironmentId
+  }
+}
+
+export function buildRuntimeSessionMirrorEnvironmentKey(
+  inputs: RuntimeSessionMirrorTargetInputs
+): string {
+  return getReachableRuntimeSessionMirrorTargets({
+    settings: { activeRuntimeEnvironmentId: inputs.activeRuntimeEnvironmentId },
+    repos: inputs.repos,
+    worktreesByRepo: inputs.worktreesByRepo,
+    detectedWorktreesByRepo: inputs.detectedWorktreesByRepo,
+    projectGroups: inputs.projectGroups,
+    restoredRuntimeHostIdByWorkspaceSessionKey: inputs.restoredRuntimeHostIdByWorkspaceSessionKey,
+    runtimeEnvironments: inputs.runtimeEnvironments,
+    runtimeStatusByEnvironmentId: inputs.runtimeStatusByEnvironmentId
+  })
+    .map(
+      ({ environmentId, runtimeId, connectionGeneration, pairingRevision }) =>
+        `${environmentId}\u0001${runtimeId}\u0001${connectionGeneration}\u0001${pairingRevision}`
+    )
+    .join('\u0000')
+}
+
+export function useRuntimeSessionMirrorEnvironmentKey(): string {
+  // Why: agent/tab writes are hot; scan host ownership only when one of its sources changes.
+  const inputs = useAppStore(useShallow(selectRuntimeSessionMirrorTargetInputs))
+  const {
+    activeRuntimeEnvironmentId,
+    repos,
+    worktreesByRepo,
+    detectedWorktreesByRepo,
+    projectGroups,
+    restoredRuntimeHostIdByWorkspaceSessionKey,
+    runtimeEnvironments,
+    runtimeStatusByEnvironmentId
+  } = inputs
+  return useMemo(
+    () =>
+      buildRuntimeSessionMirrorEnvironmentKey({
+        activeRuntimeEnvironmentId,
+        repos,
+        worktreesByRepo,
+        detectedWorktreesByRepo,
+        projectGroups,
+        restoredRuntimeHostIdByWorkspaceSessionKey,
+        runtimeEnvironments,
+        runtimeStatusByEnvironmentId
+      }),
+    [
+      activeRuntimeEnvironmentId,
+      repos,
+      worktreesByRepo,
+      detectedWorktreesByRepo,
+      projectGroups,
+      restoredRuntimeHostIdByWorkspaceSessionKey,
+      runtimeEnvironments,
+      runtimeStatusByEnvironmentId
+    ]
+  )
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -35,7 +35,6 @@ import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import { isClientAuthoritativeAgentStatusPane } from '@/components/terminal-pane/renderer-owned-agent-status-registry'
 import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
-import { getReachableRuntimeSessionMirrorTargets } from '@/lib/runtime-session-mirror-targets'
 import {
   createWebRuntimeSessionTerminal,
   HOST_TERMINAL_SURFACE_SEPARATOR,
@@ -84,6 +83,7 @@ import {
   resolveWebAgentSessionHandoff
 } from './web-agent-session-handoff'
 import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
+import { useRuntimeSessionMirrorEnvironmentKey } from './use-runtime-session-mirror-environment-key'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
 
@@ -2704,14 +2704,7 @@ export function applyWebSessionTabsStorePatch(
 
 export function useWebSessionTabsSync(): void {
   const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
-  const runtimeSessionMirrorEnvironmentKey = useAppStore((state) =>
-    getReachableRuntimeSessionMirrorTargets(state)
-      .map(
-        ({ environmentId, runtimeId, connectionGeneration, pairingRevision }) =>
-          `${environmentId}\u0001${runtimeId}\u0001${connectionGeneration}\u0001${pairingRevision}`
-      )
-      .join('\u0000')
-  )
+  const runtimeSessionMirrorEnvironmentKey = useRuntimeSessionMirrorEnvironmentKey()
   const activeWorktreeRuntimeEnvironmentId = useAppStore((state) =>
     getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
   )


### PR DESCRIPTION
## Summary

- Stop `useWebSessionTabsSync` from walking every remote workspace owner on unrelated Zustand publications.
- Shallow-select only the ownership and runtime-connectivity inputs, then memoize the reachable-host key until one of those inputs changes.
- Preserve reconnect, pairing-revision, SSH-owned worktree, folder-workspace, restored-session, and offline cleanup behavior.

### ELI5

Before this change, nearly every renderer state update asked, “Which remote Orca servers own any of my workspaces?” Answering meant walking all repos, managed worktrees, detected worktrees, project groups, and restored sessions—even when the update was only an agent status or tab change.

Busy remote hosts create lots of those unrelated updates, so the renderer repeatedly did the same walk. Removing remote hosts made the issue disappear because it removed most of that ownership graph.

Now Orca keeps the answer until ownership or connection state actually changes. Hot agent/tab updates pay only a small fixed shallow comparison.

### Synthetic benchmark

Per unrelated store publication (ownership scan microbenchmark, not end-to-end frame timing):

| Managed + detected worktrees | Previous scan | Gated check | Reduction |
| --- | ---: | ---: | ---: |
| 1,000 + 1,000 | 44.5 µs | 0.714 µs | ~62× |
| 5,000 + 5,000 | 99.8 µs | 0.701 µs | ~142× |
| 10,000 + 10,000 | 195.4 µs | 0.704 µs | ~277× |

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test`
- [ ] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

Focused validation:

- 91 tests across the mirror-key hook, production session-sync hook, mirror target builder, session reconciliation, and remote status/title-flap suites
- `pnpm run check:code-quality:changed` — zero findings
- `pnpm run check:max-lines-ratchet`
- `git diff --check origin/main...HEAD`

## AI Review Report

Three independent adversarial passes reviewed this change:

- A correctness reviewer traced every transitive read used to compute mirror targets and checked reconnect identity, stale closures, SSH owners, and folder workspaces. No code defect found.
- A mutation audit inspected production writers for all selected arrays, records, and maps. They publish replacement references, so shallow reference gating is safe.
- A test adversary flagged missing semantic owner-change and teardown coverage. In response, tests now exercise all six owner sources (active environment, repo, managed worktree, detected worktree, project group, restored session), offline/catalog/final-owner removal, a 100-repo + 100-worktree hot-write fixture, and the real production hook wiring.

Cross-platform review found no changed shortcut, label, path, shell, native-module, or Electron platform behavior. The renderer-only state selection behaves identically on macOS, Linux, and Windows. SSH and folder-workspace ownership paths are explicitly covered.

## Security Audit

No new input handling, command execution, filesystem path handling, auth, secrets, dependency, IPC, RPC, or remote-wire behavior. This only gates an existing renderer-side computation over existing in-memory state. No follow-up security work identified.

## Notes

- No visual, IPC, RPC, or remote wire-format change.
- Mixed client/server versions are unaffected.
- The performance gate relies on the store's existing immutable container updates; the production mutation audit verified those paths.


## Reliability contract

- **Invariant (`agent-session.remote-host-authority`):** Every reachable paired-runtime owner keeps the same session-tab mirror lifecycle. Ownership, online status, runtime identity, connection generation, or pairing revision changes restart the exact subscription; unrelated store publications do not rescan the ownership graph.
- **Failure source:** Busy paired hosts publish frequent agent/tab state, which previously repeated the full renderer ownership scan on every publication.
- **Oracle:** The 91-test focused suite proves all six owner sources, unrelated-write scan counts, reconnect/re-pair identity changes, final-owner/offline cleanup, production hook wiring, reconciliation, and remote status/title flaps. The matching reliability slices also pass 144 and 433 tests.
- **Gate:** `config/reliability-gates.jsonc` → `agent-session.remote-host-authority` (focused renderer/runtime commands).
- **Provider/platform coverage:** Paired-runtime, SSH-owned worktrees, folder workspaces, and restored sessions are covered deterministically. Local daemon, WSL, native PTY behavior, macOS/Linux/Windows paths, and mobile/relay wire contracts are unaffected because this is a renderer-only subscription gate with no path, shell, PTY, RPC, IPC, or payload change.
- **Performance budget:** The count oracle holds the ownership scan to one call across 100 hot writes and a parent render; the recorded 1k/5k/10k benchmark shows the shallow gate remains roughly constant. No polling, timers, listeners, provider calls, subprocesses, or retained collections were added.
- **Diagnostics:** Existing list/subscribe failure warnings and generation/revision fencing remain unchanged; deterministic tests expose scan counts and mirror identities.
- **Residual gaps:** No new headed network-fault journey was run. Existing live remote-runtime gaps remain inherited; this diff changes neither transport behavior nor recovery policy, and deterministic reconnect, teardown, SSH-owner, folder-workspace, and restored-session paths are covered.