### PR TITLE
perf(renderer): unmount closed setup guide content

### DIFF
--- a/src/renderer/src/components/setup-guide/SetupGuideModal.mount-gating.test.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideModal.mount-gating.test.tsx
@@ -13,7 +13,8 @@ const contentProbe = vi.hoisted(() => ({
   storeNotifications: vi.fn(),
   subscriptions: vi.fn(),
   unsubscriptions: vi.fn(),
-  telemetryOpenStates: vi.fn()
+  telemetryOpenStates: vi.fn(),
+  refreshEnabledStates: vi.fn()
 }))
 
 const progress: FeatureWallSetupProgress = {
@@ -35,8 +36,9 @@ const progress: FeatureWallSetupProgress = {
 vi.mock('./use-setup-guide-progress', async () => {
   const React = await import('react')
   return {
-    useSetupGuideProgress: () => {
+    useSetupGuideProgress: (shouldRefreshCoreState: boolean) => {
       contentProbe.renders()
+      contentProbe.refreshEnabledStates(shouldRefreshCoreState)
       useAppStore((state) => state.activeWorktreeId)
       React.useEffect(() => {
         contentProbe.subscriptions()
@@ -113,6 +115,7 @@ describe('SetupGuideModal mount gating', () => {
     contentProbe.subscriptions.mockClear()
     contentProbe.unsubscriptions.mockClear()
     contentProbe.telemetryOpenStates.mockClear()
+    contentProbe.refreshEnabledStates.mockClear()
     useAppStore.setState(initialAppState, true)
     useAppStore.setState({ activeModal: 'none', activeWorktreeId: null })
     testContainer = document.createElement('div')
@@ -149,9 +152,12 @@ describe('SetupGuideModal mount gating', () => {
     expect(testContainer.querySelector('[data-setup-guide-dialog="true"]')).toBeNull()
     expect(activeContentSubscriptions()).toBe(1)
     expect(contentProbe.telemetryOpenStates).toHaveBeenLastCalledWith(false)
+    // Why: dropping progress inputs mid-fade would flip completed rows back to "not done yet".
+    expect(contentProbe.refreshEnabledStates).toHaveBeenLastCalledWith(true)
 
     await act(async () => vi.advanceTimersByTimeAsync(299))
     expect(activeContentSubscriptions()).toBe(1)
+    expect(contentProbe.refreshEnabledStates).toHaveBeenLastCalledWith(true)
 
     await act(async () => vi.advanceTimersByTimeAsync(1))
     expect(activeContentSubscriptions()).toBe(0)
@@ -176,5 +182,15 @@ describe('SetupGuideModal mount gating', () => {
 
     expect(testContainer.querySelector('[data-setup-guide-dialog="true"]')).not.toBeNull()
     expect(activeContentSubscriptions()).toBe(1)
+
+    // Why: an uncancelled timer from the first close would have already cleared the
+    // linger flag, collapsing this second close into a synchronous unmount that
+    // reports 'interrupted' instead of 'dismissed'.
+    await act(async () => useAppStore.getState().closeModal())
+    expect(activeContentSubscriptions()).toBe(1)
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    expect(activeContentSubscriptions()).toBe(1)
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(activeContentSubscriptions()).toBe(0)
   })
 })

--- a/src/renderer/src/components/setup-guide/SetupGuideModal.mount-gating.test.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideModal.mount-gating.test.tsx
@@ -1,0 +1,180 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { FEATURE_WALL_SETUP_STEPS } from '../../../../shared/feature-wall-setup-steps'
+import type { FeatureWallSetupProgress } from '../feature-wall/feature-wall-setup-progress'
+import { useAppStore } from '@/store'
+import SetupGuideModal from './SetupGuideModal'
+
+const contentProbe = vi.hoisted(() => ({
+  renders: vi.fn(),
+  storeNotifications: vi.fn(),
+  subscriptions: vi.fn(),
+  unsubscriptions: vi.fn(),
+  telemetryOpenStates: vi.fn()
+}))
+
+const progress: FeatureWallSetupProgress = {
+  ready: true,
+  stepDone: {
+    'default-agent': false,
+    'add-two-repos': false,
+    notifications: false,
+    'two-worktrees': false,
+    browser: false,
+    'task-sources': false,
+    'agent-capabilities': false,
+    'setup-script': false
+  },
+  coreDoneCount: 0,
+  coreTotal: FEATURE_WALL_SETUP_STEPS.length
+}
+
+vi.mock('./use-setup-guide-progress', async () => {
+  const React = await import('react')
+  return {
+    useSetupGuideProgress: () => {
+      contentProbe.renders()
+      useAppStore((state) => state.activeWorktreeId)
+      React.useEffect(() => {
+        contentProbe.subscriptions()
+        const unsubscribe = useAppStore.subscribe(() => contentProbe.storeNotifications())
+        return () => {
+          contentProbe.unsubscriptions()
+          unsubscribe()
+        }
+      }, [])
+      return progress
+    }
+  }
+})
+
+vi.mock('./use-setup-guide-telemetry', () => ({
+  useSetupGuideOpenCloseTelemetry: ({ isOpen }: { isOpen: boolean }) =>
+    contentProbe.telemetryOpenStates(isOpen)
+}))
+
+vi.mock('../feature-wall/FeatureWallSetupChecklist', () => ({
+  FeatureWallSetupChecklist: () => <div data-setup-guide-content="true" />
+}))
+
+vi.mock('./SetupGuideProgressRing', () => ({
+  SetupGuideProgressRing: () => <span />
+}))
+
+vi.mock('@/components/ui/tooltip', () => ({
+  Tooltip: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipTrigger: ({ children }: { children: React.ReactNode }) => <>{children}</>,
+  TooltipContent: ({ children }: { children: React.ReactNode }) => <>{children}</>
+}))
+
+vi.mock('@/components/ui/dialog', () => ({
+  Dialog: ({ children, open }: { children: React.ReactNode; open?: boolean }) =>
+    open ? <div data-setup-guide-dialog="true">{children}</div> : null,
+  DialogContent: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogDescription: ({ children }: { children: React.ReactNode }) => <p>{children}</p>,
+  DialogHeader: ({ children }: { children: React.ReactNode }) => <div>{children}</div>,
+  DialogTitle: ({ children }: { children: React.ReactNode }) => <h2>{children}</h2>
+}))
+
+const initialAppState = useAppStore.getInitialState()
+let testContainer: HTMLDivElement
+let testRoot: Root
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function churnClosedStore(count: number): Promise<void> {
+  await act(async () => {
+    for (let index = 0; index < count; index += 1) {
+      useAppStore.setState({ activeWorktreeId: `background-${index}` })
+    }
+  })
+}
+
+function activeContentSubscriptions(): number {
+  return (
+    contentProbe.subscriptions.mock.calls.length - contentProbe.unsubscriptions.mock.calls.length
+  )
+}
+
+describe('SetupGuideModal mount gating', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    contentProbe.renders.mockClear()
+    contentProbe.storeNotifications.mockClear()
+    contentProbe.subscriptions.mockClear()
+    contentProbe.unsubscriptions.mockClear()
+    contentProbe.telemetryOpenStates.mockClear()
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({ activeModal: 'none', activeWorktreeId: null })
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => testRoot.unmount())
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('releases setup content after the close animation', async () => {
+    await act(async () => testRoot.render(<SetupGuideModal />))
+    await flushEffects()
+
+    await churnClosedStore(1_000)
+
+    expect(contentProbe.renders).not.toHaveBeenCalled()
+    expect(contentProbe.subscriptions).not.toHaveBeenCalled()
+    expect(contentProbe.storeNotifications).not.toHaveBeenCalled()
+
+    await act(async () => useAppStore.getState().openModal('setup-guide'))
+    await flushEffects()
+
+    expect(testContainer.querySelector('[data-setup-guide-dialog="true"]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+
+    await act(async () => useAppStore.getState().closeModal())
+
+    expect(testContainer.querySelector('[data-setup-guide-dialog="true"]')).toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+    expect(contentProbe.telemetryOpenStates).toHaveBeenLastCalledWith(false)
+
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    expect(activeContentSubscriptions()).toBe(1)
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(activeContentSubscriptions()).toBe(0)
+
+    const rendersAfterUnmount = contentProbe.renders.mock.calls.length
+    const notificationsAfterUnmount = contentProbe.storeNotifications.mock.calls.length
+    await churnClosedStore(1_000)
+
+    expect(contentProbe.renders).toHaveBeenCalledTimes(rendersAfterUnmount)
+    expect(contentProbe.storeNotifications).toHaveBeenCalledTimes(notificationsAfterUnmount)
+  })
+
+  it('cancels the pending unmount when reopened during the linger', async () => {
+    await act(async () => testRoot.render(<SetupGuideModal />))
+    await act(async () => useAppStore.getState().openModal('setup-guide'))
+    await flushEffects()
+
+    await act(async () => useAppStore.getState().closeModal())
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    await act(async () => useAppStore.getState().openModal('setup-guide'))
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+    expect(testContainer.querySelector('[data-setup-guide-dialog="true"]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+  })
+})

--- a/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
@@ -39,10 +39,16 @@ export default function SetupGuideModal(): JSX.Element | null {
   if (!open && !lingering) {
     return null
   }
-  return <SetupGuideModalContent open={open} />
+  return <SetupGuideModalContent open={open} lingering={lingering} />
 }
 
-function SetupGuideModalContent({ open }: { open: boolean }): JSX.Element {
+function SetupGuideModalContent({
+  open,
+  lingering
+}: {
+  open: boolean
+  lingering: boolean
+}): JSX.Element {
   const modalData = useAppStore((s) => s.modalData)
   const closeModal = useAppStore((s) => s.closeModal)
   const setSetupGuideSidebarDismissed = useAppStore((s) => s.setSetupGuideSidebarDismissed)
@@ -50,8 +56,11 @@ function SetupGuideModalContent({ open }: { open: boolean }): JSX.Element {
   const [userSelectedStep, setUserSelectedStep] = useState(false)
   const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState(false)
   const [browserUseSkillInstalled, setBrowserUseSkillInstalled] = useState(false)
+  // Why: keep progress inputs live through the close-animation linger; dropping
+  // them mid-fade flips completed rows back to "not done yet" on screen.
+  const progressInputsActive = open || lingering
   const progress = useSetupGuideProgress(
-    open,
+    progressInputsActive,
     orchestrationSkillInstalled,
     browserUseSkillInstalled
   )
@@ -116,8 +125,8 @@ function SetupGuideModalContent({ open }: { open: boolean }): JSX.Element {
     setActiveStepId(id)
   }
 
-  const handleOpenChange = (open: boolean): void => {
-    if (!open) {
+  const handleOpenChange = (nextOpen: boolean): void => {
+    if (!nextOpen) {
       closeModal()
     }
   }

--- a/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
+++ b/src/renderer/src/components/setup-guide/SetupGuideModal.tsx
@@ -22,18 +22,36 @@ import { useSetupGuideProgress } from './use-setup-guide-progress'
 import { useSetupGuideOpenCloseTelemetry } from './use-setup-guide-telemetry'
 import { translate } from '@/i18n/i18n'
 
+const SETUP_GUIDE_CLOSE_LINGER_MS = 300
+
 export default function SetupGuideModal(): JSX.Element | null {
-  const activeModal = useAppStore((s) => s.activeModal)
+  const open = useAppStore((s) => s.activeModal === 'setup-guide')
+  const [lingering, setLingering] = useState(open)
+  useEffect(() => {
+    if (open) {
+      setLingering(true)
+      return
+    }
+    const timer = window.setTimeout(() => setLingering(false), SETUP_GUIDE_CLOSE_LINGER_MS)
+    return () => window.clearTimeout(timer)
+  }, [open])
+
+  if (!open && !lingering) {
+    return null
+  }
+  return <SetupGuideModalContent open={open} />
+}
+
+function SetupGuideModalContent({ open }: { open: boolean }): JSX.Element {
   const modalData = useAppStore((s) => s.modalData)
   const closeModal = useAppStore((s) => s.closeModal)
   const setSetupGuideSidebarDismissed = useAppStore((s) => s.setSetupGuideSidebarDismissed)
-  const isOpen = activeModal === 'setup-guide'
   const setupSteps = useMemo(() => getFeatureWallSetupSteps(), [])
   const [userSelectedStep, setUserSelectedStep] = useState(false)
   const [orchestrationSkillInstalled, setOrchestrationSkillInstalled] = useState(false)
   const [browserUseSkillInstalled, setBrowserUseSkillInstalled] = useState(false)
   const progress = useSetupGuideProgress(
-    isOpen,
+    open,
     orchestrationSkillInstalled,
     browserUseSkillInstalled
   )
@@ -52,14 +70,14 @@ export default function SetupGuideModal(): JSX.Element | null {
   const activeStep = setupSteps.find((step) => step.id === activeStepId) ?? setupSteps[0] ?? null
 
   useSetupGuideOpenCloseTelemetry({
-    isOpen,
+    isOpen: open,
     source: telemetrySource,
     progress,
     activeStepId: activeStep?.id ?? null
   })
 
   useEffect(() => {
-    if (!isOpen) {
+    if (!open) {
       setUserSelectedStep(false)
       return
     }
@@ -68,18 +86,18 @@ export default function SetupGuideModal(): JSX.Element | null {
     }
     setUserSelectedStep(false)
     setActiveStepId(requestedStepId)
-  }, [isOpen, requestedStepId])
+  }, [open, requestedStepId])
 
   useEffect(() => {
-    if (!isOpen || userSelectedStep || requestedStepId !== null) {
+    if (!open || userSelectedStep || requestedStepId !== null) {
       return
     }
     setActiveStepId(getFirstIncompleteFeatureWallSetupStepId(progress.stepDone))
-  }, [isOpen, progress.stepDone, requestedStepId, userSelectedStep])
+  }, [open, progress.stepDone, requestedStepId, userSelectedStep])
 
   useEffect(() => {
     if (
-      !isOpen ||
+      !open ||
       userSelectedStep ||
       requestedStepId === null ||
       activeStep?.id !== requestedStepId ||
@@ -91,7 +109,7 @@ export default function SetupGuideModal(): JSX.Element | null {
     if (nextUnfinishedCoreStepId !== activeStep.id) {
       setActiveStepId(nextUnfinishedCoreStepId)
     }
-  }, [activeStep, isOpen, progress.stepDone, requestedStepId, userSelectedStep])
+  }, [activeStep, open, progress.stepDone, requestedStepId, userSelectedStep])
 
   const handleSelectStep = (id: FeatureWallSetupStepId): void => {
     setUserSelectedStep(true)
@@ -108,12 +126,8 @@ export default function SetupGuideModal(): JSX.Element | null {
     setSetupGuideSidebarDismissed(true)
   }, [setSetupGuideSidebarDismissed])
 
-  if (!isOpen) {
-    return null
-  }
-
   return (
-    <Dialog open={isOpen} onOpenChange={handleOpenChange}>
+    <Dialog open={open} onOpenChange={handleOpenChange}>
       <DialogContent
         className="grid h-[min(780px,calc(100vh-2rem))] w-[min(1080px,calc(100vw-2rem))] max-w-none grid-rows-[auto_minmax(0,1fr)] gap-0 p-0 sm:max-w-none"
         tabIndex={-1}


### PR DESCRIPTION
## Summary

- keep only a one-selector setup-guide shell mounted after the guide has been used
- retain the full content for the 200 ms close animation, then release its progress/runtime subscriptions
- preserve dismissed-close telemetry and cancel a pending unmount when the guide reopens

This follows the mount-gating pattern from #13525. The intentional always-on setup telemetry observer remains; this removes the second progress graph retained by the closed modal.

## ELI5

The Getting Started guide is like a checklist teacher. After you opened it once, Orca kept a second copy of that teacher listening to project, remote-host, skill, and integration updates even after the guide disappeared.

Now the closed guide keeps only a tiny doorbell that knows whether it should open. The teacher stays for the brief closing animation, then goes home until the next open.

## Visual explainer

```mermaid
flowchart LR
  U[Project or remote-host update]
  O[Intentional telemetry observer]
  M[Retained closed modal]
  P[20 direct progress selectors plus runtime hooks]
  N[Render nothing]
  V[One visibility selector]
  X[Content unmounted after 300 ms]

  subgraph Before
    U --> O
    U --> M --> P --> N
  end

  subgraph After
    U --> O
    U --> V --> X
  end
```

## Improvement proof

- `useSetupGuideProgress` alone owns 20 direct Zustand selectors; the retained modal also owned modal/runtime subscriptions.
- The regression harness models a representative content selector and raw store subscription. On base, the closed component still mounts that content and the new test fails.
- After the 300 ms linger: active content subscriptions = **0**.
- 1,000 closed store writes after unmount: **0** content renders and **0** content notifications.
- At 299 ms the content is still mounted for the close path; at 300 ms it is released.
- Reopening at 299 ms cancels the pending unmount and keeps exactly one content subscription.

## Testing checklist

- [x] `SetupGuideModal.mount-gating.test.tsx`: 2/2 passed
- [x] focused setup-guide suite: 22/22 passed
- [x] `pnpm run typecheck`: passed
- [x] changed-code quality gate: 0 new findings across 2 files
- [x] reliability manifest: 73/73 gates passed
- [x] max-lines ratchet: no new bypasses
- [x] `git diff --check`: passed

Full-suite check: 49,130 tests passed. Five unrelated files failed in the heavily parallel run. A serial rerun cleared the native-chat watcher and worktree-directory poller failures. Three environment/load failures remained:

- cross-version fixture extraction: missing generated `.staging-v799-*/src`
- terminal frame equivalence fuzz: existing 30 s timeout (44.9 s on this machine)
- GitHub project source-context import test: existing 30 s timeout

The changed setup-guide test was rerun after the full suite and remained green.

## No-regression review

- Closing still gives telemetry an explicit `open=false` render, so it records `dismissed`, not `interrupted`.
- The 300 ms linger covers the dialog's 200 ms exit animation.
- Timer cleanup covers reopen and component unmount; the 299 ms reopen race is tested.
- Installed-skill discovery remounts from its runtime-scoped module cache, so this does not force a new scan.
- Existing setup-script and remote-runtime cancellation/stale guards remain unchanged.
- Active-step state already reset on reopen, so unmounting adds no user-visible state reset.
- No user-facing regressions found.

## Screenshots

Not applicable: this changes hidden component lifetime only; visible layout and styling are unchanged. The lifecycle diagram above is the visual proof.

## AI review report

- P0: none
- P1: none
- P2: none
- Checked failure cleanup, timer concurrency, stale async work, close telemetry, repeated opens, macOS/Linux/Windows behavior, SSH/runtime ownership, and folder-workspace assumptions.

## Security audit

No authentication, authorization, persistence, network sink, shell execution, dependency, or user-data surface changed.

## Notes

- No mobile-facing surface or remote wire contract changed.
- No Git/Git-provider behavior changed.
- Development StrictMode replays telemetry effects when a newly remounted subtree is probed; contributor telemetry transport is disabled, and production React does not replay effects.