### PR TITLE
[Perf-SS] Skip unused accessibility summary walks

### DIFF
--- a/config/scripts/verify-computer-native.mjs
+++ b/config/scripts/verify-computer-native.mjs
@@ -28,6 +28,12 @@ const checks = [
     enabled: true
   },
   {
+    name: 'Linux snapshot renderer tests',
+    command: 'python3',
+    args: ['native/computer-use-linux/runtime_render_test.py'],
+    enabled: true
+  },
+  {
     name: 'native provider argument guardrails',
     run: verifyNativeArgumentGuardrails,
     enabled: true
@@ -67,6 +73,19 @@ const checks = [
   {
     name: 'Windows provider handshake',
     run: verifyWindowsProviderHandshake,
+    enabled: process.platform === 'win32'
+  },
+  {
+    name: 'Windows snapshot renderer tests',
+    command: 'powershell.exe',
+    args: [
+      '-NoLogo',
+      '-NoProfile',
+      '-ExecutionPolicy',
+      'Bypass',
+      '-File',
+      'native/computer-use-windows/runtime-render.test.ps1'
+    ],
     enabled: process.platform === 'win32'
   },
   {

--- a/native/computer-use-linux/runtime.py
+++ b/native/computer-use-linux/runtime.py
@@ -408,8 +408,11 @@ def render_accessibility_tree(root, window_rect, root_path, compact_browser_tabs
         item = record(node, len(records), path, window_rect)
         child_items = list(children(node))
         role_key = (item["controlType"] or "").lower()
-        summary_values = text_snippets(node, limit=8, max_depth=4)
-        generic_summary = " ".join(summary_values) if role_key in {"panel", "filler", "unknown", "section"} and not item["name"] and not item["value"] and len(summary_values) >= 2 and is_plain_text_subtree(node) else None
+        generic_summary = None
+        if role_key in {"panel", "filler", "unknown", "section"} and not item["name"] and not item["value"]:
+            summary_values = text_snippets(node, limit=8, max_depth=4)
+            if len(summary_values) >= 2 and is_plain_text_subtree(node):
+                generic_summary = " ".join(summary_values)
         if should_elide(item, len(child_items), generic_summary):
             for child_index, child in child_items:
                 walk(child, depth, path + [child_index])

--- a/native/computer-use-linux/runtime_render_test.py
+++ b/native/computer-use-linux/runtime_render_test.py
@@ -1,0 +1,198 @@
+import importlib.util
+import sys
+import types
+import unittest
+from pathlib import Path
+
+
+class FakeStateType:
+    PROTECTED = 1
+    SELECTED = 2
+
+
+class FakeText:
+    @staticmethod
+    def get_character_count(node):
+        return len(node.value)
+
+    @staticmethod
+    def get_text(node, start, end):
+        return node.value[start:end]
+
+
+def load_runtime():
+    gi = types.ModuleType("gi")
+    repository = types.ModuleType("gi.repository")
+    gi.require_version = lambda *_: None
+    repository.Atspi = types.SimpleNamespace(StateType=FakeStateType, Text=FakeText)
+    repository.Gdk = types.SimpleNamespace()
+    repository.GdkPixbuf = types.SimpleNamespace()
+    gi.repository = repository
+    sys.modules["gi"] = gi
+    sys.modules["gi.repository"] = repository
+
+    path = Path(__file__).with_name("runtime.py")
+    spec = importlib.util.spec_from_file_location("orca_linux_runtime_test", path)
+    module = importlib.util.module_from_spec(spec)
+    sys.modules[spec.name] = module
+    spec.loader.exec_module(module)
+    return module
+
+
+runtime = load_runtime()
+
+
+class FakeAccessible:
+    def __init__(self, role, name="", value="", children=(), counter=None):
+        self.role = role
+        self.name = name
+        self.value = value
+        self.children = list(children)
+        self.counter = counter or {"child_reads": 0}
+        for child in self.children:
+            child.use_counter(self.counter)
+
+    def use_counter(self, counter):
+        self.counter = counter
+        for child in self.children:
+            child.use_counter(counter)
+
+    def get_child_count(self):
+        self.counter["child_reads"] += 1
+        return len(self.children)
+
+    def get_child_at_index(self, index):
+        self.counter["child_reads"] += 1
+        return self.children[index]
+
+    def get_role_name(self):
+        return self.role
+
+    def get_name(self):
+        return self.name
+
+    def get_accessible_id(self):
+        return ""
+
+    def get_toolkit_name(self):
+        return "fake"
+
+    def get_component_iface(self):
+        return None
+
+    def get_state_set(self):
+        return None
+
+    def get_n_actions(self):
+        return 0
+
+    def is_text(self):
+        return bool(self.value)
+
+    def get_text_iface(self):
+        return self if self.value else None
+
+    def get_value_iface(self):
+        return None
+
+
+class FailingChildrenAccessible(FakeAccessible):
+    def get_child_count(self):
+        raise RuntimeError("defunct node")
+
+
+def render(root):
+    return runtime.render_accessibility_tree(root, None, [0])
+
+
+class RuntimeRenderTest(unittest.TestCase):
+    def test_named_non_generic_node_skips_unused_summary_walk(self):
+        root = FakeAccessible("button", "Save", children=[FakeAccessible("text", "unused")])
+
+        records, lines, truncation = render(root)
+
+        self.assertEqual([record["name"] for record in records], ["Save"])
+        self.assertEqual(lines, ["0 button Save"])
+        self.assertEqual(root.counter["child_reads"], 2)
+        self.assertFalse(truncation["truncated"])
+
+    def test_named_generic_node_skips_unused_summary_walk(self):
+        root = FakeAccessible("section", "Details", children=[FakeAccessible("text", "body")])
+
+        records, lines, _ = render(root)
+
+        self.assertEqual([record["name"] for record in records], ["Details", "body"])
+        self.assertEqual(lines, ["0 section Details", "\t1 text body"])
+        self.assertEqual(root.counter["child_reads"], 3)
+
+    def test_unnamed_generic_node_keeps_plain_text_summary(self):
+        root = FakeAccessible(
+            "section",
+            children=[FakeAccessible("text", "Alpha"), FakeAccessible("text", "Beta")],
+        )
+
+        records, lines, _ = render(root)
+
+        self.assertEqual(len(records), 1)
+        self.assertEqual(lines, ["0 section, Text: Alpha Beta"])
+        self.assertEqual(root.counter["child_reads"], 13)
+
+    def test_row_keeps_its_specific_summary_walk(self):
+        root = FakeAccessible(
+            "row",
+            "Invoice",
+            children=[FakeAccessible("text", "Alpha"), FakeAccessible("text", "Beta")],
+        )
+
+        records, lines, _ = render(root)
+
+        self.assertEqual([record["name"] for record in records], ["Invoice", "Alpha", "Beta"])
+        self.assertEqual(lines, ["0 row Invoice, Text: Alpha Beta", "\t1 text Alpha", "\t2 text Beta"])
+        self.assertEqual(root.counter["child_reads"], 10)
+
+    def test_empty_generic_wrapper_keeps_elision_path_and_depth(self):
+        root = FakeAccessible("section", children=[FakeAccessible("button", "Continue")])
+
+        records, lines, _ = render(root)
+
+        self.assertEqual([record["runtimeId"] for record in records], [[0, 0]])
+        self.assertEqual(lines, ["0 button Continue"])
+
+    def test_child_failure_keeps_fail_soft_row_output(self):
+        root = FailingChildrenAccessible("row", "Invoice")
+
+        records, lines, truncation = render(root)
+
+        self.assertEqual([record["name"] for record in records], ["Invoice"])
+        self.assertEqual(lines, ["0 row Invoice"])
+        self.assertFalse(truncation["truncated"])
+
+    def test_node_limit_keeps_exact_prefix_and_truncation(self):
+        root = FakeAccessible(
+            "document",
+            "Results",
+            children=[FakeAccessible("text", f"Item {index}") for index in range(runtime.MAX_NODES)],
+        )
+
+        records, _, truncation = render(root)
+
+        self.assertEqual(len(records), runtime.MAX_NODES)
+        self.assertEqual(records[-1]["name"], f"Item {runtime.MAX_NODES - 2}")
+        self.assertTrue(truncation["truncated"])
+        self.assertFalse(truncation["maxDepthReached"])
+
+    def test_depth_limit_keeps_exact_prefix_and_flag(self):
+        root = FakeAccessible("document", "Depth 65")
+        for depth in range(runtime.MAX_DEPTH, -1, -1):
+            root = FakeAccessible("document", f"Depth {depth}", children=[root])
+
+        records, _, truncation = render(root)
+
+        self.assertEqual(len(records), runtime.MAX_DEPTH + 1)
+        self.assertEqual(records[-1]["name"], f"Depth {runtime.MAX_DEPTH}")
+        self.assertTrue(truncation["truncated"])
+        self.assertTrue(truncation["maxDepthReached"])
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/native/computer-use-windows/runtime-render.test.ps1
+++ b/native/computer-use-windows/runtime-render.test.ps1
@@ -1,0 +1,224 @@
+$ErrorActionPreference = "Stop"
+
+function Assert-TestEqual($Actual, $Expected, [string]$Label) {
+    if ($Actual -ne $Expected) {
+        throw "$Label expected '$Expected', received '$Actual'"
+    }
+}
+
+Add-Type -TypeDefinition @"
+using System.Collections;
+using System.Collections.Generic;
+
+public sealed class OrcaRenderTestCounter {
+    public int FindAll;
+}
+
+public sealed class OrcaRenderTestBounds {
+    public bool IsEmpty = true;
+    public double X;
+    public double Y;
+    public double Width;
+    public double Height;
+}
+
+public sealed class OrcaRenderTestControlType {
+    public string ProgrammaticName = "";
+}
+
+public sealed class OrcaRenderTestCurrent {
+    public string AutomationId = "";
+    public OrcaRenderTestBounds BoundingRectangle = new OrcaRenderTestBounds();
+    public string ClassName = "fake";
+    public OrcaRenderTestControlType ControlType = new OrcaRenderTestControlType();
+    public bool IsPassword;
+    public string LocalizedControlType = "";
+    public string Name = "";
+    public long NativeWindowHandle;
+}
+
+public sealed class OrcaRenderTestPatternCurrent {
+    public bool IsSelected;
+    public string Value = "";
+}
+
+public sealed class OrcaRenderTestPattern {
+    public OrcaRenderTestPatternCurrent Current = new OrcaRenderTestPatternCurrent();
+}
+
+public sealed class OrcaRenderTestCollection : IEnumerable {
+    private readonly OrcaRenderTestElement[] values;
+
+    public OrcaRenderTestCollection(OrcaRenderTestElement[] values) {
+        this.values = values;
+    }
+
+    public int Count {
+        get { return values.Length; }
+    }
+
+    public OrcaRenderTestElement Item(int index) {
+        return values[index];
+    }
+
+    public IEnumerator GetEnumerator() {
+        return values.GetEnumerator();
+    }
+}
+
+public sealed class OrcaRenderTestElement {
+    public readonly List<OrcaRenderTestElement> Children =
+        new List<OrcaRenderTestElement>();
+    public OrcaRenderTestCounter Counter = new OrcaRenderTestCounter();
+    public readonly OrcaRenderTestCurrent Current = new OrcaRenderTestCurrent();
+    public bool FailFindAll;
+    public int RuntimeIdValue;
+    public string ValueText = "";
+
+    public OrcaRenderTestCollection FindAll(object scope, object condition) {
+        Counter.FindAll++;
+        if (FailFindAll) {
+            throw new System.InvalidOperationException("defunct node");
+        }
+        return new OrcaRenderTestCollection(Children.ToArray());
+    }
+
+    public OrcaRenderTestPattern GetCurrentPattern(object pattern) {
+        OrcaRenderTestPattern result = new OrcaRenderTestPattern();
+        result.Current.Value = ValueText;
+        return result;
+    }
+
+    public int[] GetRuntimeId() {
+        return new int[] { RuntimeIdValue };
+    }
+
+    public object[] GetSupportedPatterns() {
+        return new object[0];
+    }
+}
+"@
+
+function New-TestCounter {
+    New-Object -TypeName OrcaRenderTestCounter
+}
+
+function New-TestElement {
+    param(
+        [string]$Role,
+        [string]$Name = "",
+        [string]$Value = "",
+        [object[]]$Children = @(),
+        $Counter = $(New-TestCounter),
+        [switch]$FailFindAll,
+        [int]$RuntimeId = 1
+    )
+    $element = New-Object -TypeName OrcaRenderTestElement
+    $element.Counter = $Counter
+    $element.FailFindAll = [bool]$FailFindAll
+    $element.RuntimeIdValue = $RuntimeId
+    $element.ValueText = $Value
+    $element.Current.ControlType.ProgrammaticName = $Role
+    $element.Current.LocalizedControlType = $Role
+    $element.Current.Name = $Name
+    foreach ($child in @($Children)) {
+        [void]$element.Children.Add($child)
+    }
+    $element
+}
+
+$operationPath = Join-Path ([IO.Path]::GetTempPath()) ("orca-runtime-render-test-" + [guid]::NewGuid() + ".json")
+try {
+    Set-Content -LiteralPath $operationPath -Encoding UTF8 -Value '{"tool":"handshake"}'
+    $runtimeOutput = . (Join-Path $PSScriptRoot "runtime.ps1") -OperationPath $operationPath
+    $handshake = $runtimeOutput | ConvertFrom-Json
+    Assert-TestEqual $handshake.ok $true "runtime handshake"
+
+    $counter = New-TestCounter
+    $leaf = New-TestElement -Role "text" -Name "unused" -Counter $counter -RuntimeId 2
+    $root = New-TestElement -Role "button" -Name "Save" -Children @($leaf) -Counter $counter
+    $tree = Render-OrcaTree $root $null
+    Assert-TestEqual $tree.elements.Count 1 "named control record count"
+    Assert-TestEqual ([string]$tree.lines[0]) "0 button Save" "named control line"
+    Assert-TestEqual $counter.findAll 1 "named control child enumeration"
+
+    $counter = New-TestCounter
+    $leaf = New-TestElement -Role "text" -Name "body" -Counter $counter -RuntimeId 2
+    $root = New-TestElement -Role "group" -Name "Details" -Children @($leaf) -Counter $counter
+    $tree = Render-OrcaTree $root $null
+    Assert-TestEqual (($tree.elements | ForEach-Object { $_.name }) -join "|") "Details|body" "named generic records"
+    Assert-TestEqual (@($tree.lines) -join "|") "0 group Details|`t1 text body" "named generic lines"
+    Assert-TestEqual $counter.findAll 2 "named generic child enumeration"
+
+    $counter = New-TestCounter
+    $alpha = New-TestElement -Role "text" -Name "Alpha" -Counter $counter -RuntimeId 2
+    $beta = New-TestElement -Role "text" -Name "Beta" -Counter $counter -RuntimeId 3
+    $root = New-TestElement -Role "group" -Children @($alpha, $beta) -Counter $counter
+    $tree = Render-OrcaTree $root $null
+    Assert-TestEqual $tree.elements.Count 1 "anonymous generic record count"
+    Assert-TestEqual ([string]$tree.lines[0]) "0 group, Text: Alpha Beta" "anonymous generic summary"
+    Assert-TestEqual $counter.findAll 7 "anonymous generic child enumeration"
+
+    $counter = New-TestCounter
+    $alpha = New-TestElement -Role "text" -Name "Alpha" -Counter $counter -RuntimeId 2
+    $beta = New-TestElement -Role "text" -Name "Beta" -Counter $counter -RuntimeId 3
+    $root = New-TestElement -Role "row" -Name "Invoice" -Children @($alpha, $beta) -Counter $counter
+    $tree = Render-OrcaTree $root $null
+    Assert-TestEqual (($tree.elements | ForEach-Object { $_.name }) -join "|") "Invoice|Alpha|Beta" "row records"
+    Assert-TestEqual ([string]$tree.lines[0]) "0 row Invoice, Text: Alpha Beta" "row summary"
+    Assert-TestEqual $counter.findAll 6 "row child enumeration"
+
+    $counter = New-TestCounter
+    $button = New-TestElement -Role "button" -Name "Continue" -Counter $counter -RuntimeId 2
+    $root = New-TestElement -Role "group" -Children @($button) -Counter $counter
+    $tree = Render-OrcaTree $root $null
+    Assert-TestEqual $tree.elements.Count 1 "elided wrapper record count"
+    Assert-TestEqual ([string]$tree.lines[0]) "0 button Continue" "elided wrapper line"
+    Assert-TestEqual $counter.findAll 4 "elided wrapper child enumeration"
+
+    $counter = New-TestCounter
+    $root = New-TestElement -Role "row" -Name "Invoice" -Counter $counter -FailFindAll
+    $tree = Render-OrcaTree $root $null
+    Assert-TestEqual $tree.elements.Count 1 "failed child read record count"
+    Assert-TestEqual ([string]$tree.lines[0]) "0 row Invoice" "failed child read line"
+    Assert-TestEqual $counter.findAll 2 "failed child read retries"
+
+    $originalMaxNodes = $MaxNodes
+    try {
+        $MaxNodes = 3
+        $counter = New-TestCounter
+        $children = @()
+        for ($index = 0; $index -lt 3; $index++) {
+            $children += New-TestElement -Role "text" -Name "Item $index" -Counter $counter -RuntimeId ($index + 2)
+        }
+        $root = New-TestElement -Role "document" -Name "Results" -Children $children -Counter $counter
+        $tree = Render-OrcaTree $root $null
+        Assert-TestEqual $tree.elements.Count 3 "node limit record count"
+        Assert-TestEqual ([string]$tree.elements[-1].name) "Item 1" "node limit prefix"
+        Assert-TestEqual $tree.truncation.truncated $true "node limit truncation"
+        Assert-TestEqual $tree.truncation.maxDepthReached $false "node limit depth flag"
+    } finally {
+        $MaxNodes = $originalMaxNodes
+    }
+
+    $originalMaxDepth = $MaxDepth
+    try {
+        $MaxDepth = 2
+        $counter = New-TestCounter
+        $root = New-TestElement -Role "document" -Name "Depth 3" -Counter $counter -RuntimeId 4
+        for ($depth = 2; $depth -ge 0; $depth--) {
+            $root = New-TestElement -Role "document" -Name "Depth $depth" -Children @($root) -Counter $counter -RuntimeId ($depth + 1)
+        }
+        $tree = Render-OrcaTree $root $null
+        Assert-TestEqual $tree.elements.Count 3 "depth limit record count"
+        Assert-TestEqual ([string]$tree.elements[-1].name) "Depth 2" "depth limit prefix"
+        Assert-TestEqual $tree.truncation.truncated $true "depth limit truncation"
+        Assert-TestEqual $tree.truncation.maxDepthReached $true "depth limit flag"
+    } finally {
+        $MaxDepth = $originalMaxDepth
+    }
+
+    Write-Output "windows-snapshot-render-tests-ok"
+} finally {
+    Remove-Item -LiteralPath $operationPath -Force -ErrorAction SilentlyContinue
+}

--- a/native/computer-use-windows/runtime.ps1
+++ b/native/computer-use-windows/runtime.ps1
@@ -561,10 +561,12 @@ function Render-OrcaTree($RootElement, $WindowFrame, [bool]$CompactBrowserTabs =
         $title = if ([string]::IsNullOrWhiteSpace($record.name)) { $record.automationId } else { $record.name }
         $role = if ([string]::IsNullOrWhiteSpace($record.localizedControlType)) { $record.controlType } else { $record.localizedControlType }
         $roleKey = $role.ToLowerInvariant()
-        $snippets = @(Get-OrcaTextSnippets $Node 8 4)
         $genericSummary = $null
-        if (($roleKey -in @("pane", "group", "custom", "unknown")) -and [string]::IsNullOrWhiteSpace($title) -and [string]::IsNullOrWhiteSpace($record.value) -and $snippets.Count -ge 2 -and (Test-OrcaPlainTextSubtree $Node)) {
-            $genericSummary = ($snippets -join " ")
+        if (($roleKey -in @("pane", "group", "custom", "unknown")) -and [string]::IsNullOrWhiteSpace($title) -and [string]::IsNullOrWhiteSpace($record.value)) {
+            $snippets = @(Get-OrcaTextSnippets $Node 8 4)
+            if ($snippets.Count -ge 2 -and (Test-OrcaPlainTextSubtree $Node)) {
+                $genericSummary = ($snippets -join " ")
+            }
         }
         if (($roleKey -in @("pane", "group", "custom", "unknown")) -and [string]::IsNullOrWhiteSpace($title) -and [string]::IsNullOrWhiteSpace($record.value) -and $meaningfulActions.Count -eq 0 -and $null -eq $genericSummary -and $children.Count -le 1) {
             for ($i = 0; $i -lt $children.Count; $i++) {


### PR DESCRIPTION
## Summary

Linux and Windows accessibility snapshots used to perform a depth-four descendant text scan for every node, even though the result can only be published for an unnamed, value-empty generic container. This moves that scan behind the existing eligibility predicate while keeping the row/list-specific summary path unchanged.

ELI5: every item used to ask its descendants for a detailed summary, then most items threw the answer away. Now only the few container items that can show that summary ask for it.

The PR also adds direct Linux and Windows renderer harnesses to the native verification gate. They cover the optimized paths plus anonymous summaries, row summaries, wrapper elision, fail-soft child reads, and node/depth limits.

## Performance proof

A controlled harness loaded the exact parent and candidate `runtime.py` sources, rendered the same counter-backed accessibility trees, and canonicalized the outputs. Each timing used 5 warmups and 101 alternating parent/candidate pairs, with GC outside the timed region.

| Linux fixture | Parent calls | Candidate calls | Parent median | Candidate median | Parent p95 | Candidate p95 |
| --- | ---: | ---: | ---: | ---: | ---: | ---: |
| 1,195-node grid | 47,662 | 28,272 (-40.7%) | 16.885 ms | 10.562 ms (-37.4%) | 18.423 ms | 11.506 ms (-37.5%) |
| 1,093-node balanced rows | 61,509 | 34,087 (-44.6%) | 22.321 ms | 13.023 ms (-41.7%) | 32.796 ms | 18.243 ms (-44.4%) |
| 200-record summary-heavy cards | 11,658 | 11,556 (-0.9%) | 4.274 ms | 4.259 ms | 7.066 ms | 6.008 ms |

The grid's child-enumeration calls fell from 7,782 to 4,578 (-41.2%); balanced rows fell from 14,778 to 7,748 (-47.6%).

A source-faithful Windows model showed the same deleted work without making an unverified wall-time claim:

| Windows fixture | Parent `FindAll` | Candidate `FindAll` |
| --- | ---: | ---: |
| 1,196-node grid | 4,600 | 2,390 (-48.0%) |
| 1,300-child node-cap case | 4,899 | 2,399 (-51.0%) |
| 12-tab browser compaction | 53 | 14 (-73.6%) |
| depth-limit case | 650 | 325 (-50.0%) |

Caveat: the timing harness uses in-process fake accessibility objects, so these are controlled renderer costs, not live AT-SPI/UIA device timings. The deterministic reduction in accessibility getter/child calls is the primary proof; real providers make those calls cross process.

## No-regression proof

- Four Linux benchmark shapes and seven Windows-shaped fixtures retained byte-identical serialized records, lines, indices/runtime IDs, and truncation metadata.
- An independent differential review matched 2,000 randomized Linux trees in both browser-compaction modes.
- Anonymous generic containers still run the same depth-four summary in the same order.
- Rows, data items, and list items still run their existing depth-three summary.
- Elision, compact-control suppression, duplicate runtime IDs, browser-tab compaction, defunct-node fallbacks, node/depth limits, and secure-value handling were reviewed and exercised.
- There is no cache, retained accessibility object, new retry, persistent state, payload/schema/opcode, or dependency change.
- Mobile, SSH, relay, folder-workspace, Git-provider, and mixed-version wire surfaces are untouched.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — direct full Vitest passed 4,582 files / 49,200 tests. The local Node 24 `node-pty` mismatch failed two unrelated fd tests; one renderer test timed out under full-suite contention and passed focused; the cross-version checkout harness independently reproduces a missing staging-directory failure.
- [x] `pnpm build`
- [x] Added high-quality Linux and Windows renderer regression tests
- [x] `pnpm verify:computer-native` — 72 macOS tests, 8 Linux renderer tests, syntax/guardrails, and signed helper verification passed
- [x] 26 focused computer-use files / 219 tests
- [x] Changed-code quality, max-lines, reliability, formatting, and diff checks

## AI Review Report

Three independent final reviews found no P0/P1/P2 issues across Linux semantic equivalence, PowerShell 5.1/UIA behavior, failure/mutation handling, resource bounds, platform/SSH/folder behavior, remote-wire compatibility, packaging, and performance-claim accuracy.

Review caught an initial test-harness fidelity bug before commit: a PowerShell `PSCustomObject` collection would not enumerate like `AutomationElementCollection`. The harness was replaced with a CLR `IEnumerable`/Count/Item collection, expanded with failure and boundary cases, and re-reviewed clean.

The readiness audit also checked crash/retry/growth, data loss, mobile backward compatibility, macOS/Linux/Windows paths and shells, and Electron packaging. No release-blocking or acceptance-required finding remains.

## Security Audit

No production input handling, command execution, auth, secret, network, IPC, dependency, lockfile, or binary surface changes. The optimization removes read-only accessibility calls and introduces no persistent data. Test-only PowerShell compiles fixed local fake types; its GUID-scoped handshake file is created under the system temp directory and removed in `finally`. Native tests are not copied into the packaged runtime.

## Notes

- The new PowerShell renderer harness runs on the Windows CI verifier; this macOS host could statically validate it but could not execute Windows UI Automation locally.
- No mobile-facing surface touched.
- No visual change.
- X: @nwparker_
