### PR TITLE
fix(github): skip Projects search index for unfiltered views

### DIFF
--- a/src/main/github/project-view.test.ts
+++ b/src/main/github/project-view.test.ts
@@ -26,8 +26,20 @@ import {
   isValidOwnerSlug,
   isValidRepoSlug,
   parseProjectPaste,
+  projectViewItemsUseSearchQuery,
   resolveProjectRef
 } from './project-view'
+
+describe('projectViewItemsUseSearchQuery', () => {
+  it('skips search for empty / whitespace-only filters so unfiltered boards avoid index lag', () => {
+    expect(projectViewItemsUseSearchQuery('')).toBe(false)
+    expect(projectViewItemsUseSearchQuery('   ')).toBe(false)
+  })
+
+  it('uses search when the view has a real filter string', () => {
+    expect(projectViewItemsUseSearchQuery('status:Todo')).toBe(true)
+  })
+})
 
 describe('classifyProjectError', () => {
   it('classifies HTTP 404 as not_found', () => {

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -829,6 +829,12 @@ function matchesSelector(
   return 'none'
 }
 
+// Why: empty filter must not use Projects `items(query:)` — GitHub's search
+// index can return totalCount 0 for minutes after bulk populate (#12648).
+export function projectViewItemsUseSearchQuery(query: string): boolean {
+  return query.trim().length > 0
+}
+
 // ─── Items fetch (paginated) ──────────────────────────────────────────
 
 type RawItemsPage = {
@@ -863,11 +869,21 @@ async function fetchItemsPageWithRaw(args: {
   const root = ownerQueryRoot(args.ownerType)
   const afterArg = args.after ? `, after: $after` : ''
   const afterVar = args.after ? `$after:String!, ` : ''
+  // Why: empty query still hits Projects search index and can return 0 during
+  // index lag on unfiltered views; omit query: for no filter (#12648).
+  const filterQuery = args.query.trim()
+  const useSearchQuery = projectViewItemsUseSearchQuery(filterQuery)
+  const queryVars = useSearchQuery
+    ? `${afterVar}$owner:String!, $num:Int!, $q:String!, $first:Int!`
+    : `${afterVar}$owner:String!, $num:Int!, $first:Int!`
+  const itemsArgs = useSearchQuery
+    ? `first:$first${afterArg}, query:$q, orderBy:{ field: POSITION, direction: ASC }`
+    : `first:$first${afterArg}, orderBy:{ field: POSITION, direction: ASC }`
   const query = `
-    query(${afterVar}$owner:String!, $num:Int!, $q:String!, $first:Int!) {
+    query(${queryVars}) {
       ${root}(login:$owner) {
         projectV2(number:$num) {
-          items(first:$first${afterArg}, query:$q, orderBy:{ field: POSITION, direction: ASC }) {
+          items(${itemsArgs}) {
             totalCount
             pageInfo { hasNextPage endCursor }
             nodes {
@@ -886,7 +902,9 @@ async function fetchItemsPageWithRaw(args: {
   const argsArr: string[] = ['api', 'graphql', '-f', `query=${query}`]
   argsArr.push('-f', `owner=${args.owner}`)
   argsArr.push('-F', `num=${args.projectNumber}`)
-  argsArr.push('-f', `q=${args.query}`)
+  if (useSearchQuery) {
+    argsArr.push('-f', `q=${filterQuery}`)
+  }
   argsArr.push('-F', `first=${args.first}`)
   if (args.after) {
     argsArr.push('-f', `after=${args.after}`)
@@ -1167,7 +1185,11 @@ async function fetchItemsCountOnly(args: {
   host?: string
 }): Promise<number | null> {
   const root = ownerQueryRoot(args.ownerType)
-  const query = `
+  const filterQuery = args.query.trim()
+  const useSearchQuery = projectViewItemsUseSearchQuery(filterQuery)
+  // Why: match item fetch — unfiltered count must not use the lagging search index (#12648).
+  const query = useSearchQuery
+    ? `
     query($owner:String!, $num:Int!, $q:String!) {
       ${root}(login:$owner) {
         projectV2(number:$num) {
@@ -1176,11 +1198,22 @@ async function fetchItemsCountOnly(args: {
       }
     }
   `
+    : `
+    query($owner:String!, $num:Int!) {
+      ${root}(login:$owner) {
+        projectV2(number:$num) {
+          items(first:1) { totalCount }
+        }
+      }
+    }
+  `
   const res = await runGraphql<
     Record<string, { projectV2?: { items?: { totalCount?: number } | null } | null } | null>
   >(
     query,
-    { owner: args.owner, num: args.projectNumber, q: args.query },
+    useSearchQuery
+      ? { owner: args.owner, num: args.projectNumber, q: filterQuery }
+      : { owner: args.owner, num: args.projectNumber },
     projectGhExecOptions(args.host)
   )
   if (!res.ok) {

--- a/src/main/github/project-view.ts
+++ b/src/main/github/project-view.ts
@@ -35,6 +35,7 @@ export {
   normalizeFieldValue
 } from './project-view/project-view-field-normalization'
 export { normalizeItem } from './project-view/project-view-item-normalization'
+export { projectViewItemsUseSearchQuery } from './project-view/project-view-items-search-query'
 export { getProjectViewTable } from './project-view/project-view-table'
 export { listAccessibleProjects } from './project-view/project-view-discovery'
 export { parseProjectPaste, resolveProjectRef } from './project-view/project-view-reference'

--- a/src/main/github/project-view/project-view-item-page.test.ts
+++ b/src/main/github/project-view/project-view-item-page.test.ts
@@ -1,0 +1,75 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { ghExecFileAsyncMock } = vi.hoisted(() => ({
+  ghExecFileAsyncMock: vi.fn()
+}))
+
+vi.mock('./internals', () => ({
+  acquire: vi.fn().mockResolvedValue(undefined),
+  release: vi.fn(),
+  extractExecError: vi.fn(),
+  ghExecFileAsync: ghExecFileAsyncMock,
+  noteRepositoryRateLimitSpend: vi.fn(),
+  projectGhExecOptions: () => ({}),
+  projectHostAuthenticationError: vi.fn().mockResolvedValue(null),
+  repositoryRateLimitGuard: vi.fn().mockReturnValue({ blocked: false })
+}))
+
+import { fetchItemsPageWithRaw } from './project-view-item-page'
+
+function itemsStdout(): string {
+  return JSON.stringify({
+    data: {
+      organization: {
+        projectV2: {
+          items: {
+            totalCount: 1,
+            pageInfo: { hasNextPage: false, endCursor: null },
+            nodes: []
+          }
+        }
+      }
+    }
+  })
+}
+
+describe('fetchItemsPageWithRaw search-index query', () => {
+  beforeEach(() => {
+    ghExecFileAsyncMock.mockReset().mockResolvedValue({ stdout: itemsStdout(), stderr: '' })
+  })
+
+  it('omits items(query:) for empty and whitespace filters', async () => {
+    for (const query of ['', '   ']) {
+      ghExecFileAsyncMock.mockClear()
+      await fetchItemsPageWithRaw({
+        owner: 'acme',
+        ownerType: 'organization',
+        projectNumber: 1,
+        query,
+        first: 100,
+        after: null,
+        includeParent: false
+      })
+      const args = ghExecFileAsyncMock.mock.calls[0]?.[0] as string[]
+      const graphql = args.find((part) => part.startsWith('query=')) ?? ''
+      expect(graphql).not.toContain('query:$q')
+      expect(args).not.toContainEqual(expect.stringMatching(/^q=/))
+    }
+  })
+
+  it('keeps items(query:) for a real view filter', async () => {
+    await fetchItemsPageWithRaw({
+      owner: 'acme',
+      ownerType: 'organization',
+      projectNumber: 1,
+      query: 'status:Todo',
+      first: 100,
+      after: null,
+      includeParent: false
+    })
+    const args = ghExecFileAsyncMock.mock.calls[0]?.[0] as string[]
+    const graphql = args.find((part) => part.startsWith('query=')) ?? ''
+    expect(graphql).toContain('query:$q')
+    expect(args).toContain('q=status:Todo')
+  })
+})

--- a/src/main/github/project-view/project-view-item-page.ts
+++ b/src/main/github/project-view/project-view-item-page.ts
@@ -17,6 +17,7 @@ import {
   type GhGraphqlErrorShape
 } from './project-error-classification'
 import { ownerQueryRoot } from './project-view-config'
+import { projectViewItemsUseSearchQuery } from './project-view-items-search-query'
 import type { RawItem } from './project-view-item-normalization'
 import {
   FIELD_CONFIG_FRAGMENT,
@@ -58,11 +59,21 @@ export async function fetchItemsPageWithRaw(args: {
   const root = ownerQueryRoot(args.ownerType)
   const afterArg = args.after ? `, after: $after` : ''
   const afterVar = args.after ? `$after:String!, ` : ''
+  // Why: empty query still hits Projects search index and can return 0 during
+  // index lag on unfiltered views; omit query: for no filter (#12648).
+  const filterQuery = args.query.trim()
+  const useSearchQuery = projectViewItemsUseSearchQuery(filterQuery)
+  const queryVars = useSearchQuery
+    ? `${afterVar}$owner:String!, $num:Int!, $q:String!, $first:Int!`
+    : `${afterVar}$owner:String!, $num:Int!, $first:Int!`
+  const itemsArgs = useSearchQuery
+    ? `first:$first${afterArg}, query:$q, orderBy:{ field: POSITION, direction: ASC }`
+    : `first:$first${afterArg}, orderBy:{ field: POSITION, direction: ASC }`
   const query = `
-    query(${afterVar}$owner:String!, $num:Int!, $q:String!, $first:Int!) {
+    query(${queryVars}) {
       ${root}(login:$owner) {
         projectV2(number:$num) {
-          items(first:$first${afterArg}, query:$q, orderBy:{ field: POSITION, direction: ASC }) {
+          items(${itemsArgs}) {
             totalCount
             pageInfo { hasNextPage endCursor }
             nodes {
@@ -81,7 +92,9 @@ export async function fetchItemsPageWithRaw(args: {
   const argsArr: string[] = ['api', 'graphql', '-f', `query=${query}`]
   argsArr.push('-f', `owner=${args.owner}`)
   argsArr.push('-F', `num=${args.projectNumber}`)
-  argsArr.push('-f', `q=${args.query}`)
+  if (useSearchQuery) {
+    argsArr.push('-f', `q=${filterQuery}`)
+  }
   argsArr.push('-F', `first=${args.first}`)
   if (args.after) {
     argsArr.push('-f', `after=${args.after}`)

--- a/src/main/github/project-view/project-view-items-search-query.ts
+++ b/src/main/github/project-view/project-view-items-search-query.ts
@@ -1,0 +1,5 @@
+// Why: empty filter must not use Projects `items(query:)` — GitHub's search
+// index can return totalCount 0 for minutes after bulk populate (#12648).
+export function projectViewItemsUseSearchQuery(query: string): boolean {
+  return query.trim().length > 0
+}

--- a/src/main/github/project-view/project-view-items.ts
+++ b/src/main/github/project-view/project-view-items.ts
@@ -12,6 +12,7 @@ import {
 } from './project-view-cache'
 import { ownerQueryRoot } from './project-view-config'
 import { fetchItemsPageWithRaw } from './project-view-item-page'
+import { projectViewItemsUseSearchQuery } from './project-view-items-search-query'
 import { normalizeItem, type RawItem } from './project-view-item-normalization'
 
 const ITEM_PAGE_SIZE = 100
@@ -209,7 +210,11 @@ export async function fetchItemsCountOnly(args: {
   host?: string
 }): Promise<number | null> {
   const root = ownerQueryRoot(args.ownerType)
-  const query = `
+  const filterQuery = args.query.trim()
+  const useSearchQuery = projectViewItemsUseSearchQuery(filterQuery)
+  // Why: match item fetch — unfiltered count must not use the lagging search index (#12648).
+  const query = useSearchQuery
+    ? `
     query($owner:String!, $num:Int!, $q:String!) {
       ${root}(login:$owner) {
         projectV2(number:$num) {
@@ -218,11 +223,22 @@ export async function fetchItemsCountOnly(args: {
       }
     }
   `
+    : `
+    query($owner:String!, $num:Int!) {
+      ${root}(login:$owner) {
+        projectV2(number:$num) {
+          items(first:1) { totalCount }
+        }
+      }
+    }
+  `
   const res = await runGraphql<
     Record<string, { projectV2?: { items?: { totalCount?: number } | null } | null } | null>
   >(
     query,
-    { owner: args.owner, num: args.projectNumber, q: args.query },
+    useSearchQuery
+      ? { owner: args.owner, num: args.projectNumber, q: filterQuery }
+      : { owner: args.owner, num: args.projectNumber },
     projectGhExecOptions(args.host)
   )
   if (!res.ok) {

--- a/src/shared/github/project-types.ts
+++ b/src/shared/github/project-types.ts
@@ -82,7 +82,7 @@ export type GitHubProjectView = {
   name: string
   layout: GitHubProjectViewLayout
   /** Normalized to '' when GitHub returns null. Empty/whitespace filters omit
-   *  `items(query:)` so unfiltered boards skip GitHub's search-index lag. */}
+   *  `items(query:)` so unfiltered boards skip GitHub's search-index lag. */
   filter: string
   fields: GitHubProjectField[]
   groupByFields: GitHubProjectField[]

--- a/src/shared/github/project-types.ts
+++ b/src/shared/github/project-types.ts
@@ -81,9 +81,8 @@ export type GitHubProjectView = {
   number: number
   name: string
   layout: GitHubProjectViewLayout
-  /** Normalized to '' when GitHub returns null. Why: passing null through as
-   *  `$q` in the items query would change the query shape between filtered
-   *  and unfiltered views; the empty string keeps the GraphQL shape stable. */
+  /** Normalized to '' when GitHub returns null. Empty/whitespace filters omit
+   *  `items(query:)` so unfiltered boards skip GitHub's search-index lag. */}
   filter: string
   fields: GitHubProjectField[]
   groupByFields: GitHubProjectField[]


### PR DESCRIPTION
## Summary

Unfiltered GitHub Project views can appear empty after bulk population because `items(query: "")` still uses the search index. Omit the search argument and its GraphQL variable for empty or whitespace-only filters, in both item-page and count-only requests. Filtered views continue using search.

Ported the fix to the current split Project-view modules. Pagination, field fragments, host authentication and rate-limit handling remain intact. Updated the old type comment that incorrectly recommended keeping an empty search query.

Fixes #12648

## Validation

- Rebased onto `bba68b1bddf1276c8bd27ad4ca41efcbd4260321`.
- 41 focused Project-view, query-generation and table tests passed.
- Changed-file lint/format, Node non-composite typecheck and diff checks passed.
- Cursor reviewed the final candidate; Codex independently checked the final diff, reran the focused suite and Node typecheck before publication.
- A live GitHub bulk-import reproduction, full suite/build and default composite typecheck were not run for this scoped query change. Default composite has the previously reproduced baseline TS2883 limitation.
