### PR TITLE
fix(orchestration): scope idle mail nag to the bound Run

### DIFF
--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -34342,6 +34342,42 @@ describe('OrcaRuntimeService', () => {
     db.close()
   })
 
+  it('does not nag when the bound Run has no undelivered terminal mail', async () => {
+    // Why: #13563 primary symptom — only foreign-Run handle mail must not write a pointer.
+    const runtime = new OrcaRuntimeService(store)
+    const db = new InMemoryOrchestrationMessages()
+    const write = vi.fn().mockReturnValue(true)
+    setInMemoryOrchestrationMessages(runtime, db)
+    runtime.setPtyController({
+      write,
+      kill: vi.fn(),
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    db.setRun({
+      id: 'run_bound',
+      coordinator_handle: terminal.handle,
+      coordinator_pane_key: 'tab-1:pane:1'
+    })
+    runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+    db.insertMessage({
+      from: 'sender',
+      to: terminal.handle,
+      subject: 'other run only',
+      runId: 'run_other'
+    })
+
+    runtime.deliverPendingMessagesForHandle(terminal.handle)
+
+    expect(write).not.toHaveBeenCalledWith(
+      'pty-1',
+      expect.stringContaining('orchestration message')
+    )
+    db.close()
+  })
+
   it('resolves message waiters when notifyMessageArrived is called', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -1062,11 +1062,12 @@ class InMemoryOrchestrationMessages {
     priority?: MessagePriority
     threadId?: string
     payload?: string
+    runId?: string
   }): MessageRow {
     this.sequence += 1
     const row: MessageRow = {
       id: `msg_${this.sequence}`,
-      run_id: 'run_test',
+      run_id: msg.runId ?? 'run_test',
       from_handle: msg.from,
       to_handle: msg.to,
       subject: msg.subject,
@@ -34292,6 +34293,51 @@ describe('OrcaRuntimeService', () => {
     expect(write).toHaveBeenCalledWith(
       'pty-1',
       expect.stringContaining('You have 1 orchestration message')
+    )
+    db.close()
+  })
+
+  it('scopes the idle mail pointer count to the pane bound Run only', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const db = new InMemoryOrchestrationMessages()
+    const write = vi.fn().mockReturnValue(true)
+    setInMemoryOrchestrationMessages(runtime, db)
+    runtime.setPtyController({
+      write,
+      kill: vi.fn(),
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    db.setRun({
+      id: 'run_bound',
+      coordinator_handle: terminal.handle,
+      coordinator_pane_key: 'tab-1:pane:1'
+    })
+    runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+    db.insertMessage({
+      from: 'sender',
+      to: terminal.handle,
+      subject: 'other run',
+      runId: 'run_other'
+    })
+    db.insertMessage({
+      from: 'sender',
+      to: terminal.handle,
+      subject: 'bound run',
+      runId: 'run_bound'
+    })
+
+    runtime.deliverPendingMessagesForHandle(terminal.handle)
+
+    expect(write).toHaveBeenCalledWith(
+      'pty-1',
+      expect.stringContaining('You have 1 orchestration message')
+    )
+    expect(write).not.toHaveBeenCalledWith(
+      'pty-1',
+      expect.stringContaining('You have 2 orchestration messages')
     )
     db.close()
   })

--- a/src/main/runtime/orca-runtime.test.ts
+++ b/src/main/runtime/orca-runtime.test.ts
@@ -34378,6 +34378,36 @@ describe('OrcaRuntimeService', () => {
     db.close()
   })
 
+  it('ignores Run-tagged terminal mail when the pane has no bound Run', async () => {
+    const runtime = new OrcaRuntimeService(store)
+    const db = new InMemoryOrchestrationMessages()
+    const write = vi.fn().mockReturnValue(true)
+    setInMemoryOrchestrationMessages(runtime, db)
+    runtime.setPtyController({
+      write,
+      kill: vi.fn(),
+      getForegroundProcess: async () => null
+    })
+    syncSinglePty(runtime)
+
+    const [terminal] = (await runtime.listTerminals()).terminals
+    runtime.onPtyData('pty-1', '\x1b]0;Codex done\x07', 101)
+    db.insertMessage({
+      from: 'sender',
+      to: terminal.handle,
+      subject: 'foreign run',
+      runId: 'run_other'
+    })
+
+    runtime.deliverPendingMessagesForHandle(terminal.handle)
+
+    expect(write).not.toHaveBeenCalledWith(
+      'pty-1',
+      expect.stringContaining('orchestration message')
+    )
+    db.close()
+  })
+
   it('resolves message waiters when notifyMessageArrived is called', async () => {
     const runtime = new OrcaRuntimeService(store)
 

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -31955,13 +31955,28 @@ export class OrcaRuntimeService {
     // still-blocked case; reservedTypes carries the notify-time snapshot for a
     // waiter resolved later in the same drain, which is already gone from the map.
     const waiters = this.messageWaitersByHandle.get(mailboxHandle)
+    // Why: a pane with a bound Run must only nag for that Run's mail. Counting every
+    // undelivered row for the terminal handle included other coordinators' Runs (#13563).
+    const boundRun = this._orchestrationDb.getCurrentRunForPane?.(`${leaf.tabId}:${leaf.leafId}`)
     const unread = this._orchestrationDb
       .getUndeliveredUnreadMessages(mailboxHandle)
-      .filter(
-        (message) =>
-          !options.reservedTypes?.has(message.type) &&
-          !messageTypeHasLiveWaiter(waiters, message.type)
-      )
+      .filter((message) => {
+        if (options.reservedTypes?.has(message.type)) {
+          return false
+        }
+        if (messageTypeHasLiveWaiter(waiters, message.type)) {
+          return false
+        }
+        if (
+          boundRun &&
+          !mailboxHandle.startsWith('run:') &&
+          message.run_id &&
+          message.run_id !== boundRun.id
+        ) {
+          return false
+        }
+        return true
+      })
     if (unread.length === 0) {
       return
     }

--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -31968,10 +31968,9 @@ export class OrcaRuntimeService {
           return false
         }
         if (
-          boundRun &&
           !mailboxHandle.startsWith('run:') &&
           message.run_id &&
-          message.run_id !== boundRun.id
+          message.run_id !== boundRun?.id
         ) {
           return false
         }


### PR DESCRIPTION
## Summary
- Idle push-on-idle mail pointers counted all undelivered messages for a terminal handle, so a pane bound to one Run could show a large N while `check --peek` for that Run was 0 (#13563).
- When the leaf has a current bound Run, only count terminal-handle rows with that `run_id` (Run mailboxes were already scoped via `run:<id>`).

## Test plan
- [x] `scopes the idle mail pointer count to the pane bound Run only`
- [ ] Manual multi-Run: bound Run peek=0 → no inflated nag for other Runs' terminal-addressed mail

Fixes #13563