### PR TITLE
fix(terminal): require double Escape to interrupt Claude turns

### DIFF
--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -126,13 +126,52 @@ describe('agent interrupt inference', () => {
     tracker.dispose()
   })
 
-  it('requires a second Escape while Claude is waiting on AskUserQuestion', () => {
+  it('reports Escape while Claude is waiting on AskUserQuestion', () => {
     vi.useFakeTimers()
-    const entry = makeEntry({
-      state: 'waiting',
-      agentType: 'claude',
-      toolName: 'AskUserQuestion'
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () =>
+        makeEntry({ state: 'waiting', agentType: 'claude', toolName: 'AskUserQuestion' }),
+      inferInterrupt,
+      now: () => 1_100
     })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).toHaveBeenCalledWith({
+      paneKey: PANE_KEY,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'write tests',
+      baselineAgentType: 'claude',
+      intent: 'plain-escape'
+    })
+    tracker.dispose()
+  })
+
+  it('does not treat a single Escape as interrupt while Claude is working', () => {
+    vi.useFakeTimers()
+    const entry = makeEntry({ agentType: 'claude' })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => entry,
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
+    tracker.dispose()
+  })
+
+  it('infers interrupt on double Escape while Claude is working', () => {
+    vi.useFakeTimers()
+    const entry = makeEntry({ agentType: 'claude' })
     const inferInterrupt = vi.fn()
     const tracker = createAgentInterruptInference({
       paneKey: PANE_KEY,
@@ -154,24 +193,6 @@ describe('agent interrupt inference', () => {
       intent: 'plain-escape',
       inputCount: 2
     })
-    tracker.dispose()
-  })
-
-  it('does not treat a single Escape as interrupt while Claude is working', () => {
-    vi.useFakeTimers()
-    const entry = makeEntry({ agentType: 'claude' })
-    const inferInterrupt = vi.fn()
-    const tracker = createAgentInterruptInference({
-      paneKey: PANE_KEY,
-      getStatusEntry: () => entry,
-      inferInterrupt,
-      now: () => 1_100
-    })
-
-    tracker.observeInputIntent('plain-escape')
-    vi.advanceTimersByTime(500)
-
-    expect(inferInterrupt).not.toHaveBeenCalled()
     tracker.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -126,19 +126,24 @@ describe('agent interrupt inference', () => {
     tracker.dispose()
   })
 
-  it('reports Escape while Claude is waiting on AskUserQuestion', () => {
+  it('requires a second Escape while Claude is waiting on AskUserQuestion', () => {
     vi.useFakeTimers()
+    const entry = makeEntry({
+      state: 'waiting',
+      agentType: 'claude',
+      toolName: 'AskUserQuestion'
+    })
     const inferInterrupt = vi.fn()
     const tracker = createAgentInterruptInference({
       paneKey: PANE_KEY,
-      getStatusEntry: () =>
-        makeEntry({ state: 'waiting', agentType: 'claude', toolName: 'AskUserQuestion' }),
+      getStatusEntry: () => entry,
       inferInterrupt,
       now: () => 1_100
     })
 
     tracker.observeInputIntent('plain-escape')
-    vi.advanceTimersByTime(500)
+    expect(inferInterrupt).not.toHaveBeenCalled()
+    tracker.observeInputIntent('plain-escape')
 
     expect(inferInterrupt).toHaveBeenCalledWith({
       paneKey: PANE_KEY,
@@ -146,8 +151,27 @@ describe('agent interrupt inference', () => {
       baselineStateStartedAt: 900,
       baselinePrompt: 'write tests',
       baselineAgentType: 'claude',
-      intent: 'plain-escape'
+      intent: 'plain-escape',
+      inputCount: 2
     })
+    tracker.dispose()
+  })
+
+  it('does not treat a single Escape as interrupt while Claude is working', () => {
+    vi.useFakeTimers()
+    const entry = makeEntry({ agentType: 'claude' })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => entry,
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
     tracker.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -101,19 +101,24 @@ describe('agent interrupt inference', () => {
     }
   )
 
-  it('reports Escape while Claude is waiting on AskUserQuestion', () => {
+  it('requires a second Escape while Claude is waiting on AskUserQuestion', () => {
     vi.useFakeTimers()
+    const entry = makeEntry({
+      state: 'waiting',
+      agentType: 'claude',
+      toolName: 'AskUserQuestion'
+    })
     const inferInterrupt = vi.fn()
     const tracker = createAgentInterruptInference({
       paneKey: PANE_KEY,
-      getStatusEntry: () =>
-        makeEntry({ state: 'waiting', agentType: 'claude', toolName: 'AskUserQuestion' }),
+      getStatusEntry: () => entry,
       inferInterrupt,
       now: () => 1_100
     })
 
     tracker.observeInputIntent('plain-escape')
-    vi.advanceTimersByTime(500)
+    expect(inferInterrupt).not.toHaveBeenCalled()
+    tracker.observeInputIntent('plain-escape')
 
     expect(inferInterrupt).toHaveBeenCalledWith({
       paneKey: PANE_KEY,
@@ -121,8 +126,27 @@ describe('agent interrupt inference', () => {
       baselineStateStartedAt: 900,
       baselinePrompt: 'write tests',
       baselineAgentType: 'claude',
-      intent: 'plain-escape'
+      intent: 'plain-escape',
+      inputCount: 2
     })
+    tracker.dispose()
+  })
+
+  it('does not treat a single Escape as interrupt while Claude is working', () => {
+    vi.useFakeTimers()
+    const entry = makeEntry({ agentType: 'claude' })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => entry,
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
     tracker.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.test.ts
@@ -101,13 +101,52 @@ describe('agent interrupt inference', () => {
     }
   )
 
-  it('requires a second Escape while Claude is waiting on AskUserQuestion', () => {
+  it('reports Escape while Claude is waiting on AskUserQuestion', () => {
     vi.useFakeTimers()
-    const entry = makeEntry({
-      state: 'waiting',
-      agentType: 'claude',
-      toolName: 'AskUserQuestion'
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () =>
+        makeEntry({ state: 'waiting', agentType: 'claude', toolName: 'AskUserQuestion' }),
+      inferInterrupt,
+      now: () => 1_100
     })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).toHaveBeenCalledWith({
+      paneKey: PANE_KEY,
+      baselineUpdatedAt: 1_000,
+      baselineStateStartedAt: 900,
+      baselinePrompt: 'write tests',
+      baselineAgentType: 'claude',
+      intent: 'plain-escape'
+    })
+    tracker.dispose()
+  })
+
+  it('does not treat a single Escape as interrupt while Claude is working', () => {
+    vi.useFakeTimers()
+    const entry = makeEntry({ agentType: 'claude' })
+    const inferInterrupt = vi.fn()
+    const tracker = createAgentInterruptInference({
+      paneKey: PANE_KEY,
+      getStatusEntry: () => entry,
+      inferInterrupt,
+      now: () => 1_100
+    })
+
+    tracker.observeInputIntent('plain-escape')
+    vi.advanceTimersByTime(500)
+
+    expect(inferInterrupt).not.toHaveBeenCalled()
+    tracker.dispose()
+  })
+
+  it('infers interrupt on double Escape while Claude is working', () => {
+    vi.useFakeTimers()
+    const entry = makeEntry({ agentType: 'claude' })
     const inferInterrupt = vi.fn()
     const tracker = createAgentInterruptInference({
       paneKey: PANE_KEY,
@@ -129,24 +168,6 @@ describe('agent interrupt inference', () => {
       intent: 'plain-escape',
       inputCount: 2
     })
-    tracker.dispose()
-  })
-
-  it('does not treat a single Escape as interrupt while Claude is working', () => {
-    vi.useFakeTimers()
-    const entry = makeEntry({ agentType: 'claude' })
-    const inferInterrupt = vi.fn()
-    const tracker = createAgentInterruptInference({
-      paneKey: PANE_KEY,
-      getStatusEntry: () => entry,
-      inferInterrupt,
-      now: () => 1_100
-    })
-
-    tracker.observeInputIntent('plain-escape')
-    vi.advanceTimersByTime(500)
-
-    expect(inferInterrupt).not.toHaveBeenCalled()
     tracker.dispose()
   })
 

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -42,7 +42,12 @@ function requiresDoubleEscapeForAgent(
   agentType: AgentStatusEntry['agentType'],
   intent: AgentInterruptInputIntent
 ): boolean {
-  return (agentType === 'opencode' || agentType === 'copilot') && intent === 'plain-escape'
+  // Why: Claude's /btw composer and similar TUI surfaces cancel on the first
+  // Escape without stopping the turn; only a second Escape is interrupt (#13547).
+  return (
+    (agentType === 'opencode' || agentType === 'copilot' || agentType === 'claude') &&
+    intent === 'plain-escape'
+  )
 }
 
 function shouldFlushInterruptImmediately(

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -40,21 +40,25 @@ type CapturedInterruptBaseline = {
 
 function requiresDoubleEscapeForAgent(
   agentType: AgentStatusEntry['agentType'],
-  intent: AgentInterruptInputIntent
+  intent: AgentInterruptInputIntent,
+  state?: AgentStatusEntry['state']
 ): boolean {
-  // Why: Claude's /btw composer and similar TUI surfaces cancel on the first
-  // Escape without stopping the turn; only a second Escape is interrupt (#13547).
-  return (
-    (agentType === 'opencode' || agentType === 'copilot' || agentType === 'claude') &&
-    intent === 'plain-escape'
-  )
+  if (intent !== 'plain-escape') {
+    return false
+  }
+  if (agentType === 'opencode' || agentType === 'copilot') {
+    return true
+  }
+  // Why: Claude /btw cancels on first Escape only while working. AskUserQuestion
+  // waiting must stay single-Escape so main can inferQuestionAnswered (#13547).
+  return agentType === 'claude' && state === 'working'
 }
 
 function shouldFlushInterruptImmediately(
-  baseline: Pick<CapturedInterruptBaseline, 'agentType' | 'intent'>
+  baseline: Pick<CapturedInterruptBaseline, 'agentType' | 'intent' | 'inputCount'>
 ): boolean {
   return (
-    requiresDoubleEscapeForAgent(baseline.agentType, baseline.intent) ||
+    baseline.inputCount === 2 ||
     baseline.agentType === 'gemini' ||
     (baseline.agentType === 'codex' && baseline.intent === 'plain-escape')
   )
@@ -243,7 +247,7 @@ export function createAgentInterruptInference({
         clearPending()
         return
       }
-      if (requiresDoubleEscapeForAgent(baseline.agentType, intent)) {
+      if (requiresDoubleEscapeForAgent(baseline.agentType, intent, entry.state)) {
         const isSecondEscape =
           doubleEscapeBaseline !== null && isSameTurnBaseline(doubleEscapeBaseline, baseline)
         doubleEscapeBaseline = baseline

--- a/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
+++ b/src/renderer/src/components/terminal-pane/agent-interrupt-inference.ts
@@ -40,23 +40,24 @@ type CapturedInterruptBaseline = {
 
 function requiresDoubleEscapeForAgent(
   agentType: AgentStatusEntry['agentType'],
-  intent: AgentInterruptInputIntent
+  intent: AgentInterruptInputIntent,
+  state?: AgentStatusEntry['state']
 ): boolean {
-  // Why: Claude's /btw composer and similar TUI surfaces cancel on the first
-  // Escape without stopping the turn; only a second Escape is interrupt (#13547).
-  return (
-    (agentType === 'opencode' || agentType === 'copilot' || agentType === 'claude') &&
-    intent === 'plain-escape'
-  )
+  if (intent !== 'plain-escape') {
+    return false
+  }
+  if (agentType === 'opencode' || agentType === 'copilot') {
+    return true
+  }
+  // Why: Claude /btw cancels on first Escape only while working. AskUserQuestion
+  // waiting must stay single-Escape so main can inferQuestionAnswered (#13547).
+  return agentType === 'claude' && state === 'working'
 }
 
 function shouldFlushInterruptImmediately(
-  baseline: Pick<CapturedInterruptBaseline, 'agentType' | 'intent'>
+  baseline: Pick<CapturedInterruptBaseline, 'agentType' | 'intent' | 'inputCount'>
 ): boolean {
-  return (
-    requiresDoubleEscapeForAgent(baseline.agentType, baseline.intent) ||
-    baseline.agentType === 'gemini'
-  )
+  return baseline.inputCount === 2 || baseline.agentType === 'gemini'
 }
 
 function shouldIgnoreInterruptIntent(
@@ -242,7 +243,7 @@ export function createAgentInterruptInference({
         clearPending()
         return
       }
-      if (requiresDoubleEscapeForAgent(baseline.agentType, intent)) {
+      if (requiresDoubleEscapeForAgent(baseline.agentType, intent, entry.state)) {
         const isSecondEscape =
           doubleEscapeBaseline !== null && isSameTurnBaseline(doubleEscapeBaseline, baseline)
         doubleEscapeBaseline = baseline


### PR DESCRIPTION
## Summary
- Plain Escape while Claude is `working` was inferred as interrupt after 500 ms even when Claude only dismissed `/btw` or another TUI surface (#13547).
- Require a second Escape on the same turn for Claude (same policy as OpenCode/Copilot). Ctrl+C unchanged.

## Test plan
- [x] agent-interrupt-inference tests (26)
- [ ] Manual: Claude working → `/btw` → Escape once → still working spinner; Escape twice → interrupted

Fixes #13547