### PR TITLE
perf(renderer): unmount closed workspace cleanup content

### DIFF
--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.mount-gating.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.mount-gating.test.tsx
@@ -1,0 +1,332 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { useAppStore } from '@/store'
+import type { AppState } from '@/store/types'
+import { readStoreListenerCount } from '@/store/store-listener-census'
+import type {
+  WorkspaceCleanupCandidate,
+  WorkspaceCleanupScanResult
+} from '../../../../shared/workspace-cleanup'
+import type * as WorkspaceCleanupPresentation from './workspace-cleanup-presentation'
+import WorkspaceCleanupDialog from './WorkspaceCleanupDialog'
+import { NOW, makeCandidate, makeState } from './workspace-cleanup-presentation-fixtures'
+
+const contentProbe = vi.hoisted(() => ({
+  mounts: vi.fn(),
+  projections: vi.fn(),
+  renders: vi.fn(),
+  storeNotifications: vi.fn(),
+  unmounts: vi.fn()
+}))
+
+const toastProbe = vi.hoisted(() => ({
+  error: vi.fn(),
+  info: vi.fn(),
+  message: vi.fn(),
+  success: vi.fn(),
+  warning: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: toastProbe }))
+
+vi.mock('./workspace-cleanup-presentation', async (importOriginal) => {
+  const actual = await importOriginal<typeof WorkspaceCleanupPresentation>()
+  return {
+    ...actual,
+    filterWorkspaceCleanupCandidates: (
+      ...args: Parameters<typeof actual.filterWorkspaceCleanupCandidates>
+    ) => {
+      contentProbe.projections()
+      return actual.filterWorkspaceCleanupCandidates(...args)
+    },
+    getWorkspaceCleanupReviewInfo: (
+      ...args: Parameters<typeof actual.getWorkspaceCleanupReviewInfo>
+    ) => {
+      contentProbe.projections()
+      return actual.getWorkspaceCleanupReviewInfo(...args)
+    },
+    sortWorkspaceCleanupCandidates: (
+      ...args: Parameters<typeof actual.sortWorkspaceCleanupCandidates>
+    ) => {
+      contentProbe.projections()
+      return actual.sortWorkspaceCleanupCandidates(...args)
+    }
+  }
+})
+
+vi.mock('@/components/ui/dialog', async () => {
+  const React = await import('react')
+  const Passthrough = ({ children }: { children: React.ReactNode }) => <>{children}</>
+  const DialogContent = () => {
+    contentProbe.renders()
+    React.useEffect(() => {
+      contentProbe.mounts()
+      const unsubscribe = useAppStore.subscribe(() => contentProbe.storeNotifications())
+      return () => {
+        contentProbe.unmounts()
+        unsubscribe()
+      }
+    }, [])
+    // Why: render while closed so the marker measures Orca's content gate, not Radix's portal gate.
+    return <div data-workspace-cleanup-heavy-content="true" />
+  }
+  return {
+    Dialog: Passthrough,
+    DialogContent,
+    DialogDescription: Passthrough,
+    DialogFooter: Passthrough,
+    DialogHeader: Passthrough,
+    DialogTitle: Passthrough
+  }
+})
+
+type Deferred<T> = {
+  promise: Promise<T>
+  resolve: (value: T) => void
+}
+
+const initialAppState = useAppStore.getInitialState()
+const fixtureState = makeState()
+const initialCandidate = makeCandidate()
+const initialScan = makeScan(1, initialCandidate)
+let testContainer: HTMLDivElement
+let testRoot: Root
+
+function deferred<T>(): Deferred<T> {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((resolvePromise) => {
+    resolve = resolvePromise
+  })
+  return { promise, resolve }
+}
+
+function makeScan(index: number, candidate: WorkspaceCleanupCandidate): WorkspaceCleanupScanResult {
+  return {
+    scannedAt: NOW + index,
+    candidates: [candidate],
+    errors: []
+  }
+}
+
+function makeChurnCandidate(index: number): WorkspaceCleanupCandidate {
+  return makeCandidate({
+    worktreeId: `repo-1::/repo/background-${index}`,
+    displayName: `background-${index}`,
+    path: `/repo/background-${index}`,
+    fingerprint: `background-${index}`
+  })
+}
+
+function activeContentSubscriptions(): number {
+  return contentProbe.mounts.mock.calls.length - contentProbe.unmounts.mock.calls.length
+}
+
+function requireStoreListenerCount(): number {
+  const count = readStoreListenerCount()
+  expect(count).not.toBeNull()
+  return count ?? 0
+}
+
+async function flushEffects(): Promise<void> {
+  await act(async () => {
+    await Promise.resolve()
+    await Promise.resolve()
+  })
+}
+
+async function renderDialog(): Promise<void> {
+  await act(async () => testRoot.render(<WorkspaceCleanupDialog />))
+  await flushEffects()
+}
+
+async function openDialog(): Promise<void> {
+  await act(async () => useAppStore.getState().openModal('workspace-cleanup'))
+  await flushEffects()
+}
+
+async function closeDialog(): Promise<void> {
+  await act(async () => useAppStore.getState().closeModal())
+  await flushEffects()
+}
+
+async function publishScanProgress(index: number): Promise<void> {
+  const scan = makeScan(index, makeChurnCandidate(index))
+  await act(async () => {
+    useAppStore.setState({
+      workspaceCleanupScan: scan,
+      workspaceCleanupProgress: {
+        ...scan,
+        scanId: `scan-${index}`,
+        scannedWorktreeCount: 1,
+        totalWorktreeCount: 1
+      }
+    })
+  })
+}
+
+async function publishReviewChurn(index: number): Promise<void> {
+  await act(async () => {
+    useAppStore.setState({
+      hostedReviewCache: {
+        [`background-${index}`]: { data: null, fetchedAt: NOW + index }
+      }
+    })
+  })
+}
+
+async function publishDeleteChurn(index: number): Promise<void> {
+  const candidate = makeChurnCandidate(index)
+  await act(async () => {
+    useAppStore.setState({
+      deleteStateByWorktreeId: {
+        [candidate.worktreeId]: {
+          isDeleting: true,
+          phase: 'queued',
+          error: null,
+          canForceDelete: false,
+          forceDeleteReason: null
+        }
+      }
+    })
+  })
+}
+
+function seedStore(
+  scanWorkspaceCleanup: AppState['scanWorkspaceCleanup'] = vi.fn(async () => initialScan)
+): void {
+  useAppStore.setState(initialAppState, true)
+  useAppStore.setState({
+    activeModal: 'none',
+    repos: fixtureState.repos,
+    worktreesByRepo: fixtureState.worktreesByRepo,
+    hostedReviewCache: {},
+    deleteStateByWorktreeId: {},
+    workspaceCleanupScan: initialScan,
+    workspaceCleanupProgress: null,
+    workspaceCleanupLoading: false,
+    workspaceCleanupError: null,
+    scanWorkspaceCleanup
+  })
+}
+
+describe('WorkspaceCleanupDialog mount gating', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.useFakeTimers({ toFake: ['setTimeout', 'clearTimeout'] })
+    Object.values(contentProbe).forEach((probe) => probe.mockClear())
+    Object.values(toastProbe).forEach((probe) => probe.mockClear())
+    seedStore()
+    testContainer = document.createElement('div')
+    document.body.appendChild(testContainer)
+    testRoot = createRoot(testContainer)
+  })
+
+  afterEach(async () => {
+    await act(async () => testRoot.unmount())
+    document.body.replaceChildren()
+    useAppStore.setState(initialAppState, true)
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('keeps heavy content through 299 ms, then drops its projections and subscriptions', async () => {
+    const listenerBaseline = requireStoreListenerCount()
+    await renderDialog()
+    const shellListenerCount = requireStoreListenerCount()
+
+    expect(shellListenerCount).toBe(listenerBaseline + 1)
+    expect(testContainer.querySelector('[data-workspace-cleanup-heavy-content]')).toBeNull()
+    expect(activeContentSubscriptions()).toBe(0)
+
+    await openDialog()
+    const openListenerCount = requireStoreListenerCount()
+
+    expect(testContainer.querySelector('[data-workspace-cleanup-heavy-content]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+    expect(openListenerCount).toBeGreaterThan(shellListenerCount)
+
+    await closeDialog()
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+
+    expect(testContainer.querySelector('[data-workspace-cleanup-heavy-content]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+
+    const lingeringProjectionCount = contentProbe.projections.mock.calls.length
+    const lingeringNotificationCount = contentProbe.storeNotifications.mock.calls.length
+    await publishScanProgress(2)
+    await publishReviewChurn(2)
+    await publishDeleteChurn(2)
+
+    expect(contentProbe.projections.mock.calls.length).toBeGreaterThan(lingeringProjectionCount)
+    expect(contentProbe.storeNotifications.mock.calls.length).toBeGreaterThan(
+      lingeringNotificationCount
+    )
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+
+    expect(testContainer.querySelector('[data-workspace-cleanup-heavy-content]')).toBeNull()
+    expect(activeContentSubscriptions()).toBe(0)
+    expect(requireStoreListenerCount()).toBe(shellListenerCount)
+
+    const hiddenProjectionCount = contentProbe.projections.mock.calls.length
+    const hiddenRenderCount = contentProbe.renders.mock.calls.length
+    const hiddenNotificationCount = contentProbe.storeNotifications.mock.calls.length
+    for (let index = 3; index < 103; index += 1) {
+      await publishScanProgress(index)
+      await publishReviewChurn(index)
+      await publishDeleteChurn(index)
+    }
+
+    expect(contentProbe.projections).toHaveBeenCalledTimes(hiddenProjectionCount)
+    expect(contentProbe.renders).toHaveBeenCalledTimes(hiddenRenderCount)
+    expect(contentProbe.storeNotifications).toHaveBeenCalledTimes(hiddenNotificationCount)
+  })
+
+  it('cancels the pending content unmount when reopened during the linger', async () => {
+    await renderDialog()
+    await openDialog()
+    await closeDialog()
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    await openDialog()
+    await act(async () => vi.advanceTimersByTimeAsync(1_000))
+
+    expect(testContainer.querySelector('[data-workspace-cleanup-heavy-content]')).not.toBeNull()
+    expect(activeContentSubscriptions()).toBe(1)
+
+    const projectionCount = contentProbe.projections.mock.calls.length
+    await publishScanProgress(4)
+    expect(contentProbe.projections.mock.calls.length).toBeGreaterThan(projectionCount)
+  })
+
+  it('toasts when an open-time scan settles after the closed content unmounts', async () => {
+    const pendingScan = deferred<WorkspaceCleanupScanResult>()
+    const scanWorkspaceCleanup = vi.fn(() => pendingScan.promise)
+    seedStore(scanWorkspaceCleanup)
+    await renderDialog()
+    await openDialog()
+
+    expect(scanWorkspaceCleanup).toHaveBeenCalledTimes(1)
+
+    await closeDialog()
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+    expect(testContainer.querySelector('[data-workspace-cleanup-heavy-content]')).toBeNull()
+
+    const completedScan = makeScan(5, makeChurnCandidate(5))
+    await act(async () => {
+      pendingScan.resolve(completedScan)
+      await pendingScan.promise
+      await Promise.resolve()
+    })
+    await flushEffects()
+
+    expect(toastProbe.success).toHaveBeenCalledWith(
+      'Inactive workspace scan ready',
+      expect.objectContaining({
+        action: expect.objectContaining({ label: 'Review' })
+      })
+    )
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
+++ b/src/renderer/src/components/workspace-cleanup/WorkspaceCleanupDialog.tsx
@@ -1,7 +1,7 @@
 /* eslint-disable max-lines -- Why: the cleanup dialog keeps scan status,
    filters, row actions, localized review copy, and force-aware confirmation
    in one modal flow. */
-import React, { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import React, { useCallback, useEffect, useMemo, useState } from 'react'
 import {
   AlertTriangle,
   Info,
@@ -12,7 +12,6 @@ import {
   Trash2,
   X
 } from 'lucide-react'
-import { toast } from 'sonner'
 import { useShallow } from 'zustand/react/shallow'
 import {
   Dialog,
@@ -41,7 +40,6 @@ import { Progress } from '@/components/ui/progress'
 import RepoMultiCombobox from '@/components/ui/repo-multi-combobox'
 import { ScrollArea } from '@/components/ui/scroll-area'
 import { Tooltip, TooltipContent, TooltipTrigger } from '@/components/ui/tooltip'
-import { useMountedRef } from '@/hooks/useMountedRef'
 import { useAppStore } from '@/store'
 import { cn } from '@/lib/utils'
 import { activateAndRevealWorktree } from '@/lib/worktree-activation'
@@ -65,10 +63,7 @@ import {
   type WorkspaceCleanupSortKey,
   type WorkspaceCleanupTimeFilter
 } from './workspace-cleanup-presentation'
-import {
-  startWorkspaceCleanupBackgroundRemoval,
-  type WorkspaceCleanupRemovalProgress
-} from './workspace-cleanup-background-removal'
+import type { WorkspaceCleanupRemovalProgress } from './workspace-cleanup-background-removal'
 import { countEstimatedInactiveWorkspaces } from './inactive-workspace-estimate'
 import { CandidateRow, type WorkspaceCleanupDeletionPhase } from './workspace-cleanup-candidate-row'
 import { WorkspaceCleanupCandidateList } from './workspace-cleanup-candidate-list'
@@ -85,16 +80,14 @@ import {
   type WorkspaceCleanupView,
   type WorkspaceCleanupViewCounts
 } from './workspace-cleanup-view-selection'
-import { filterWorkspaceCleanupRemovalCandidates } from './workspace-cleanup-removal-candidates'
+import {
+  DEFAULT_WORKSPACE_CLEANUP_FILTERS,
+  useWorkspaceCleanupDialogSession,
+  type WorkspaceCleanupDialogSession
+} from './workspace-cleanup-dialog-session'
 import { translate } from '@/i18n/i18n'
 
-const DEFAULT_FILTERS: WorkspaceCleanupFilters = {
-  query: '',
-  time: 'all',
-  review: 'all',
-  git: 'all',
-  context: 'all'
-}
+const WORKSPACE_CLEANUP_CLOSE_LINGER_MS = 300
 
 const EMPTY_REVIEW_INFO: WorkspaceCleanupReviewInfo = {
   hasReview: false,
@@ -176,13 +169,67 @@ function formatScanErrorReason(message: string | undefined): string {
   return message.replace(/\.$/, '')
 }
 
-export default function WorkspaceCleanupDialog(): React.JSX.Element {
-  const activeModal = useAppStore((s) => s.activeModal)
-  const openModal = useAppStore((s) => s.openModal)
-  const closeModal = useAppStore((s) => s.closeModal)
+export default function WorkspaceCleanupDialog(): React.JSX.Element | null {
+  // Why: scans and removals outlive the modal; only the subscribed projection tree may unmount.
+  const session = useWorkspaceCleanupDialogSession()
+  const [lingering, setLingering] = useState(session.open)
+  useEffect(() => {
+    if (session.open) {
+      setLingering(true)
+      return
+    }
+    const timer = window.setTimeout(() => setLingering(false), WORKSPACE_CLEANUP_CLOSE_LINGER_MS)
+    return () => window.clearTimeout(timer)
+  }, [session.open])
+
+  if (!session.open && !lingering) {
+    return null
+  }
+  return <WorkspaceCleanupDialogContent session={session} />
+}
+
+function WorkspaceCleanupDialogContent({
+  session
+}: {
+  session: WorkspaceCleanupDialogSession
+}): React.JSX.Element {
+  const {
+    open,
+    loading,
+    selectedIds,
+    setSelectedIds,
+    expandedRowIds,
+    setExpandedRowIds,
+    activeView,
+    setActiveView,
+    confirming,
+    confirmCandidates,
+    removalProgress,
+    removalInFlight,
+    rowFailures,
+    repoSelection,
+    setRepoSelection,
+    filters,
+    setFilters,
+    sortKey,
+    setSortKey,
+    sortDirection,
+    setSortDirection,
+    selectedDefaultsScanAtRef,
+    removalInFlightRef,
+    close: closeModal,
+    markCandidateViewed,
+    restoreDismissals: resetDismissals,
+    startScan: startWorkspaceCleanupScan,
+    ignoreCandidate,
+    applyScanDefaults,
+    openConfirmRemove,
+    cancelConfirmRemove,
+    backToWorkspaceCleanupList,
+    confirmRemove
+  } = session
   const scan = useAppStore((s) => s.workspaceCleanupScan)
   const scanProgress = useAppStore((s) => s.workspaceCleanupProgress)
-  const loading = useAppStore((s) => s.workspaceCleanupLoading)
   const error = useAppStore((s) => s.workspaceCleanupError)
   const repos = useAppStore((s) => s.repos)
   const reviewStateInputs = useAppStore(
@@ -193,13 +240,6 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       settings: s.settings
     }))
   )
-  const scanWorkspaceCleanup = useAppStore((s) => s.scanWorkspaceCleanup)
-  const markCandidateViewed = useAppStore((s) => s.markWorkspaceCleanupCandidateViewed)
-  const dismissCandidates = useAppStore((s) => s.dismissWorkspaceCleanupCandidates)
-  const resetDismissals = useAppStore((s) => s.resetWorkspaceCleanupDismissals)
-  const removeCandidates = useAppStore((s) => s.removeWorkspaceCleanupCandidates)
-  const markWorktreesQueuedForDeletion = useAppStore((s) => s.markWorktreesQueuedForDeletion)
-  const clearWorktreeDeleteState = useAppStore((s) => s.clearWorktreeDeleteState)
   const deletionPhaseByWorktreeId = useAppStore(
     useShallow((s) => {
       const phases: Record<string, WorkspaceCleanupDeletionPhase> = {}
@@ -216,127 +256,16 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     [deletionPhaseByWorktreeId]
   )
 
-  const open = activeModal === 'workspace-cleanup'
-  const openRef = useRef(open)
-  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
-  const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
   const [rowsScrollElement, setRowsScrollElement] = useState<HTMLDivElement | null>(null)
-  const [activeView, setActiveView] = useState<WorkspaceCleanupView>('ready')
-  const [confirming, setConfirming] = useState(false)
-  const [confirmCandidates, setConfirmCandidates] = useState<WorkspaceCleanupCandidate[]>([])
-  const [removalProgress, setRemovalProgress] = useState<WorkspaceCleanupRemovalProgress | null>(
-    null
-  )
-  // Why: `removalProgress` only arrives once the batch reports, so rendering
-  // needs its own in-flight flag; removalInFlightRef stays the synchronous guard.
-  const [removalInFlight, setRemovalInFlight] = useState(false)
-  const [rowFailures, setRowFailures] = useState<Record<string, string>>({})
-  const [repoSelection, setRepoSelection] = useState<ReadonlySet<string>>(() => new Set())
-  const [filters, setFilters] = useState<WorkspaceCleanupFilters>(DEFAULT_FILTERS)
-  const [sortKey, setSortKey] = useState<WorkspaceCleanupSortKey>('activity')
-  const [sortDirection, setSortDirection] = useState<WorkspaceCleanupSortDirection>('asc')
-  const selectedDefaultsScanAtRef = useRef<number | null>(null)
-  const autoScanAttemptedForOpenRef = useRef(false)
-  const latestReadyToastScanAtRef = useRef<number | null>(null)
-  const wasOpenRef = useRef(false)
-  const removalInFlightRef = useRef(false)
-  // Why: the dialog stays mounted across cleanup runs, so late settlements from
-  // an earlier batch must not mutate a newer batch's row/selection state.
-  const removalBatchIdRef = useRef(0)
-  const mountedRef = useMountedRef()
   const eligibleRepos = useMemo(() => repos.filter((repo) => isGitRepoKind(repo)), [repos])
   const eligibleRepoIds = useMemo(() => eligibleRepos.map((repo) => repo.id), [eligibleRepos])
-
-  useEffect(() => {
-    openRef.current = open
-  }, [open])
-
-  const startWorkspaceCleanupScan = useCallback(
-    (options: { notifyWhenReady?: boolean } = {}) => {
-      setRowFailures({})
-      void scanWorkspaceCleanup()
-        .then((result) => {
-          if (!mountedRef.current || !options.notifyWhenReady || openRef.current) {
-            return
-          }
-          if (latestReadyToastScanAtRef.current === result.scannedAt) {
-            return
-          }
-          latestReadyToastScanAtRef.current = result.scannedAt
-          const suggestedCount = result.candidates.filter(
-            (candidate) => candidate.selectedByDefault
-          ).length
-          toast.success(
-            translate(
-              'auto.components.workspace.cleanup.WorkspaceCleanupDialog.0e2d235c63',
-              'Inactive workspace scan ready'
-            ),
-            {
-              description: formatWorkspaceCleanupReadyToastDescription(
-                result.candidates.length,
-                suggestedCount
-              ),
-              action: {
-                label: translate(
-                  'auto.components.workspace.cleanup.WorkspaceCleanupDialog.4a35c08764',
-                  'Review'
-                ),
-                onClick: () => openModal('workspace-cleanup')
-              }
-            }
-          )
-        })
-        .catch((err: unknown) => {
-          if (mountedRef.current) {
-            toast.error(
-              translate(
-                'auto.components.workspace.cleanup.WorkspaceCleanupDialog.662b8ec3f8',
-                'Workspace cleanup scan failed'
-              ),
-              {
-                description: err instanceof Error ? err.message : String(err)
-              }
-            )
-          }
-        })
-    },
-    [mountedRef, openModal, scanWorkspaceCleanup]
-  )
-
-  useEffect(() => {
-    if (!open) {
-      wasOpenRef.current = false
-      autoScanAttemptedForOpenRef.current = false
-      return
-    }
-    if (!wasOpenRef.current) {
-      wasOpenRef.current = true
-      autoScanAttemptedForOpenRef.current = false
-      if (!removalInFlightRef.current) {
-        setActiveView('ready')
-        setConfirming(false)
-        setRowFailures({})
-        setFilters(DEFAULT_FILTERS)
-        setSortKey('activity')
-        setSortDirection('asc')
-        setSelectedIds(new Set())
-      }
-    }
-    // Why: reopening mid-batch keeps the deletion progress view; a broad scan
-    // started here would be discarded by the removal's scan invalidation, so
-    // skip it while a removal batch is running (matches the reset guard above).
-    if (!loading && !autoScanAttemptedForOpenRef.current && !removalInFlightRef.current) {
-      autoScanAttemptedForOpenRef.current = true
-      startWorkspaceCleanupScan({ notifyWhenReady: true })
-    }
-  }, [loading, open, startWorkspaceCleanupScan])
 
   useEffect(() => {
     if (!open) {
       return
     }
     setRepoSelection(new Set(eligibleRepoIds))
-  }, [eligibleRepoIds, open])
+  }, [eligibleRepoIds, open, setRepoSelection])
 
   const candidates = useMemo(() => scan?.candidates ?? [], [scan?.candidates])
   const reviewInfoByWorktreeId = useMemo(() => {
@@ -400,13 +329,8 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       return
     }
     selectedDefaultsScanAtRef.current = scan.scannedAt
-    if (removalInFlightRef.current) {
-      return
-    }
-    setSelectedIds(getDefaultSelectedWorkspaceCleanupIds(scan.candidates, deletingWorktreeIds))
-    setConfirming(false)
-    setRowFailures({})
-  }, [deletingWorktreeIds, loading, scan])
+    applyScanDefaults(scan.candidates, deletingWorktreeIds)
+  }, [applyScanDefaults, deletingWorktreeIds, loading, scan, selectedDefaultsScanAtRef])
 
   const visibleCandidates = useMemo(() => {
     const rows = filteredCandidates.filter((candidate) => !candidate.blockers.includes('dismissed'))
@@ -501,7 +425,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       )
       return next.size === current.size ? current : next
     })
-  }, [activeRowIds, confirming, deletingWorktreeIds, open])
+  }, [activeRowIds, confirming, deletingWorktreeIds, open, setSelectedIds])
 
   const handleOpenChange = useCallback(
     (nextOpen: boolean) => {
@@ -516,54 +440,19 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     startWorkspaceCleanupScan({ notifyWhenReady: true })
   }, [startWorkspaceCleanupScan])
 
-  const ignoreCandidate = useCallback(
-    (candidate: WorkspaceCleanupCandidate) => {
-      void dismissCandidates([candidate])
-        .then(() => {
-          if (mountedRef.current) {
-            setSelectedIds((current) => {
-              const next = new Set(current)
-              next.delete(candidate.worktreeId)
-              return next
-            })
-          }
-        })
-        .catch((err: unknown) => {
-          if (mountedRef.current) {
-            toast.error(
-              translate(
-                'auto.components.workspace.cleanup.WorkspaceCleanupDialog.7f451a3e2c',
-                'Could not ignore cleanup suggestion'
-              ),
-              {
-                description: err instanceof Error ? err.message : String(err)
-              }
-            )
-          }
-        })
+  const toggleExpandedRow = useCallback(
+    (worktreeId: string) => {
+      setExpandedRowIds((current) => toggleSetMember(current, worktreeId))
     },
-    [dismissCandidates, mountedRef]
+    [setExpandedRowIds]
   )
 
-  const toggleExpandedRow = useCallback((worktreeId: string) => {
-    setExpandedRowIds((current) => toggleSetMember(current, worktreeId))
-  }, [])
-
-  const toggleSelectedRow = useCallback((worktreeId: string) => {
-    setSelectedIds((current) => toggleSetMember(current, worktreeId))
-  }, [])
-
-  const openConfirmRemove = useCallback((candidates: readonly WorkspaceCleanupCandidate[]) => {
-    const nextCandidates = filterWorkspaceCleanupRemovalCandidates(
-      candidates,
-      useAppStore.getState().deleteStateByWorktreeId
-    )
-    if (nextCandidates.length === 0) {
-      return
-    }
-    setConfirmCandidates(nextCandidates)
-    setConfirming(true)
-  }, [])
+  const toggleSelectedRow = useCallback(
+    (worktreeId: string) => {
+      setSelectedIds((current) => toggleSetMember(current, worktreeId))
+    },
+    [setSelectedIds]
+  )
 
   // Why: stable per-row handlers so React.memo keeps unchanged CandidateRow
   // instances from re-rendering on scan stream-in and selection changes.
@@ -575,7 +464,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
       setSelectedIds(new Set([candidate.worktreeId]))
       openConfirmRemove([candidate])
     },
-    [loading, openConfirmRemove]
+    [loading, openConfirmRemove, removalInFlightRef, setSelectedIds]
   )
 
   const handleViewCandidate = useCallback(
@@ -586,143 +475,6 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
     },
     [closeModal, markCandidateViewed]
   )
-
-  const cancelConfirmRemove = useCallback(() => {
-    if (removalProgress) {
-      closeModal()
-      return
-    }
-    setConfirming(false)
-    setConfirmCandidates([])
-  }, [closeModal, removalProgress])
-
-  // Why: the header X reads as "leave this screen", not "abandon the dialog". The batch
-  // keeps running in the background either way, and the list shows each row's progress.
-  // Diverges from cancelConfirmRemove, which closes the dialog mid-batch: here
-  // removalProgress stays set until the batch settles, so re-entry is still blocked.
-  const backToWorkspaceCleanupList = useCallback(() => {
-    setConfirming(false)
-    setConfirmCandidates([])
-  }, [])
-
-  const clearQueuedDeleteState = useCallback(
-    (worktreeId: string) => {
-      const deleteState = useAppStore.getState().deleteStateByWorktreeId[worktreeId]
-      // Why: candidates that fail before removal starts would otherwise stay
-      // marked "Queued for deletion" in the sidebar; rows already in the
-      // 'deleting' phase or failed with an error keep their own state.
-      if (deleteState?.isDeleting && deleteState.error === null && deleteState.phase === 'queued') {
-        clearWorktreeDeleteState(worktreeId)
-      }
-    },
-    [clearWorktreeDeleteState]
-  )
-
-  const deselectRemovedIds = useCallback((removedIds: readonly string[]) => {
-    if (removedIds.length === 0) {
-      return
-    }
-    setSelectedIds((current) => {
-      const next = new Set(current)
-      for (const id of removedIds) {
-        next.delete(id)
-      }
-      return next
-    })
-  }, [])
-
-  const confirmRemove = useCallback(() => {
-    if (confirmCandidates.length === 0 || removalInFlightRef.current) {
-      return
-    }
-    const removableCandidates = filterWorkspaceCleanupRemovalCandidates(
-      confirmCandidates,
-      useAppStore.getState().deleteStateByWorktreeId
-    )
-    if (removableCandidates.length === 0) {
-      setConfirming(false)
-      setConfirmCandidates([])
-      return
-    }
-    removalInFlightRef.current = true
-    setRemovalInFlight(true)
-    removalBatchIdRef.current += 1
-    const removalBatchId = removalBatchIdRef.current
-    // Why: a hung late settlement retains these callbacks for the renderer's
-    // lifetime; capture only ids so it cannot pin the candidate objects.
-    const removableWorktreeIds = removableCandidates.map((candidate) => candidate.worktreeId)
-    setRowFailures({})
-    markWorktreesQueuedForDeletion(removableWorktreeIds)
-    startWorkspaceCleanupBackgroundRemoval({
-      candidates: removableCandidates,
-      removeCandidates,
-      onProgress: (progress) => {
-        if (mountedRef.current) {
-          setRemovalProgress(progress)
-        }
-      },
-      onRowFailed: (failure) => {
-        clearQueuedDeleteState(failure.worktreeId)
-      },
-      onResult: (result) => {
-        const nextFailures: Record<string, string> = {}
-        for (const failure of result.failures) {
-          nextFailures[failure.worktreeId] = failure.message
-          clearQueuedDeleteState(failure.worktreeId)
-        }
-        if (mountedRef.current) {
-          setRowFailures(nextFailures)
-          deselectRemovedIds(result.removedIds)
-          setRemovalProgress(null)
-          setRemovalInFlight(false)
-          setConfirming(false)
-          setConfirmCandidates([])
-        }
-        removalInFlightRef.current = false
-      },
-      onLateResult: (result) => {
-        for (const failure of result.failures) {
-          // Why: a late failure can come from a hung preflight whose row never
-          // reached 'deleting'; clear its queued overlay like every other path.
-          clearQueuedDeleteState(failure.worktreeId)
-        }
-        if (!mountedRef.current || removalBatchIdRef.current !== removalBatchId) {
-          return
-        }
-        setRowFailures((current) => {
-          const next = { ...current }
-          for (const id of result.removedIds) {
-            delete next[id]
-          }
-          for (const failure of result.failures) {
-            next[failure.worktreeId] = failure.message
-          }
-          return next
-        })
-        deselectRemovedIds(result.removedIds)
-      },
-      onError: () => {
-        for (const worktreeId of removableWorktreeIds) {
-          clearWorktreeDeleteState(worktreeId)
-        }
-        if (mountedRef.current) {
-          setRemovalProgress(null)
-          setRemovalInFlight(false)
-          setConfirming(false)
-          setConfirmCandidates([])
-        }
-        removalInFlightRef.current = false
-      }
-    })
-  }, [
-    clearQueuedDeleteState,
-    clearWorktreeDeleteState,
-    confirmCandidates,
-    deselectRemovedIds,
-    markWorktreesQueuedForDeletion,
-    mountedRef,
-    removeCandidates
-  ])
 
   const selectedCount = selectedCandidates.length
 
@@ -961,7 +713,7 @@ export default function WorkspaceCleanupDialog(): React.JSX.Element {
                           'auto.components.workspace.cleanup.WorkspaceCleanupDialog.e94b1f8bb4',
                           'Clear filters'
                         )}
-                        onAction={() => setFilters(DEFAULT_FILTERS)}
+                        onAction={() => setFilters(DEFAULT_WORKSPACE_CLEANUP_FILTERS)}
                       />
                     ) : null}
                     {!loading &&
@@ -1549,31 +1301,6 @@ function hasActiveWorkspaceCleanupPanelControls(
     sortKey !== 'activity' ||
     sortDirection !== 'asc'
   )
-}
-
-function getDefaultSelectedWorkspaceCleanupIds(
-  candidates: readonly WorkspaceCleanupCandidate[],
-  deletingWorktreeIds: ReadonlySet<string> = new Set()
-): Set<string> {
-  return new Set(
-    candidates
-      .filter(
-        (candidate) => candidate.selectedByDefault && !deletingWorktreeIds.has(candidate.worktreeId)
-      )
-      .map((candidate) => candidate.worktreeId)
-  )
-}
-
-function formatWorkspaceCleanupReadyToastDescription(
-  inactiveCount: number,
-  suggestedCount: number
-): string {
-  if (inactiveCount === 0) {
-    return 'No inactive workspaces found.'
-  }
-  const inactiveNoun = inactiveCount === 1 ? 'workspace' : 'workspaces'
-  const suggestedNoun = suggestedCount === 1 ? 'suggestion' : 'suggestions'
-  return `${inactiveCount} inactive ${inactiveNoun} found, with ${suggestedCount} cleanup ${suggestedNoun}.`
 }
 
 function formatWorkspaceCleanupRemovalProgress(progress: WorkspaceCleanupRemovalProgress): string {

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-dialog-session.test.tsx
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-dialog-session.test.tsx
@@ -1,0 +1,175 @@
+// @vitest-environment happy-dom
+
+import { act } from 'react'
+import { createRoot, type Root } from 'react-dom/client'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { WorkspaceCleanupScanResult } from '../../../../shared/workspace-cleanup'
+import { useAppStore } from '@/store'
+import type { WorkspaceCleanupRemoveResult } from '@/store/slices/workspace-cleanup'
+import {
+  useWorkspaceCleanupDialogSession,
+  type WorkspaceCleanupDialogSession
+} from './workspace-cleanup-dialog-session'
+import { makeCandidate } from './workspace-cleanup-presentation-fixtures'
+
+const toastMocks = vi.hoisted(() => ({
+  error: vi.fn(),
+  info: vi.fn(),
+  success: vi.fn()
+}))
+
+vi.mock('sonner', () => ({ toast: toastMocks }))
+
+const initialAppState = useAppStore.getInitialState()
+let container: HTMLDivElement
+let root: Root
+let currentSession: WorkspaceCleanupDialogSession | null
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve }
+}
+
+function Probe(): null {
+  currentSession = useWorkspaceCleanupDialogSession()
+  return null
+}
+
+function session(): WorkspaceCleanupDialogSession {
+  if (!currentSession) {
+    throw new Error('Workspace cleanup session probe is not mounted')
+  }
+  return currentSession
+}
+
+async function renderProbe(): Promise<void> {
+  await act(async () => root.render(<Probe />))
+}
+
+describe('useWorkspaceCleanupDialogSession', () => {
+  beforeEach(() => {
+    globalThis.IS_REACT_ACT_ENVIRONMENT = true
+    vi.clearAllMocks()
+    useAppStore.setState(initialAppState, true)
+    useAppStore.setState({
+      activeModal: 'workspace-cleanup',
+      workspaceCleanupLoading: false,
+      deleteStateByWorktreeId: {}
+    })
+    currentSession = null
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    root = createRoot(container)
+  })
+
+  afterEach(async () => {
+    await act(async () => root.unmount())
+    container.remove()
+    currentSession = null
+    useAppStore.setState(initialAppState, true)
+  })
+
+  it('offers to reopen when a scan finishes after the dialog closes', async () => {
+    const candidate = makeCandidate()
+    const scan = deferred<WorkspaceCleanupScanResult>()
+    const scanWorkspaceCleanup = vi.fn(() => scan.promise)
+    useAppStore.setState({ scanWorkspaceCleanup })
+
+    await renderProbe()
+    expect(scanWorkspaceCleanup).toHaveBeenCalledOnce()
+
+    await act(async () => useAppStore.getState().closeModal())
+    expect(session().open).toBe(false)
+
+    await act(async () => {
+      scan.resolve({ scannedAt: 42, candidates: [candidate], errors: [] })
+      await scan.promise
+    })
+
+    expect(toastMocks.success).toHaveBeenCalledWith(
+      'Inactive workspace scan ready',
+      expect.objectContaining({
+        description: '1 inactive workspace found, with 1 cleanup suggestion.',
+        action: expect.objectContaining({ label: 'Review' })
+      })
+    )
+    const options = toastMocks.success.mock.lastCall?.[1] as {
+      action?: { onClick: () => void }
+    }
+
+    await act(async () => options.action?.onClick())
+
+    expect(useAppStore.getState().activeModal).toBe('workspace-cleanup')
+    expect(session().open).toBe(true)
+  })
+
+  it('keeps a deferred removal alive and visible across close and reopen', async () => {
+    const candidate = makeCandidate()
+    const removal = deferred<WorkspaceCleanupRemoveResult>()
+    const removeWorkspaceCleanupCandidates = vi.fn(() => removal.promise)
+    const scanWorkspaceCleanup = vi.fn().mockResolvedValue({
+      scannedAt: 41,
+      candidates: [candidate],
+      errors: []
+    } satisfies WorkspaceCleanupScanResult)
+    useAppStore.setState({ removeWorkspaceCleanupCandidates, scanWorkspaceCleanup })
+    await renderProbe()
+
+    await act(async () => session().openConfirmRemove([candidate]))
+    await act(async () => session().confirmRemove())
+
+    expect(removeWorkspaceCleanupCandidates).toHaveBeenCalledWith([candidate.worktreeId], {
+      approvedCandidates: [candidate]
+    })
+    expect(session()).toMatchObject({
+      open: true,
+      confirming: true,
+      removalInFlight: true,
+      removalProgress: {
+        totalCount: 1,
+        processedCount: 0,
+        removedCount: 0,
+        failedCount: 0
+      }
+    })
+
+    await act(async () => session().close())
+
+    expect(session()).toMatchObject({
+      open: false,
+      confirming: true,
+      removalInFlight: true
+    })
+    expect(session().removalProgress?.processedCount).toBe(0)
+
+    await act(async () => useAppStore.getState().openModal('workspace-cleanup'))
+
+    expect(session()).toMatchObject({
+      open: true,
+      confirming: true,
+      removalInFlight: true
+    })
+    expect(session().removalProgress?.processedCount).toBe(0)
+    expect(scanWorkspaceCleanup).toHaveBeenCalledOnce()
+
+    await act(async () => {
+      removal.resolve({ removedIds: [candidate.worktreeId], failures: [] })
+      await removal.promise
+      await Promise.resolve()
+    })
+
+    expect(session()).toMatchObject({
+      open: true,
+      confirming: false,
+      confirmCandidates: [],
+      removalInFlight: false,
+      removalProgress: null
+    })
+  })
+})

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-dialog-session.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-dialog-session.ts
@@ -1,0 +1,205 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction
+} from 'react'
+import { toast } from 'sonner'
+import { useShallow } from 'zustand/react/shallow'
+import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
+import { useMountedRef } from '@/hooks/useMountedRef'
+import { translate } from '@/i18n/i18n'
+import { useAppStore } from '@/store'
+import {
+  useWorkspaceCleanupRemovalSession,
+  type WorkspaceCleanupRemovalSession
+} from './workspace-cleanup-removal-session'
+import { useWorkspaceCleanupScanSession } from './workspace-cleanup-scan-session'
+import type {
+  WorkspaceCleanupFilters,
+  WorkspaceCleanupSortDirection,
+  WorkspaceCleanupSortKey
+} from './workspace-cleanup-presentation'
+import type { WorkspaceCleanupView } from './workspace-cleanup-view-selection'
+
+export const DEFAULT_WORKSPACE_CLEANUP_FILTERS: WorkspaceCleanupFilters = {
+  query: '',
+  time: 'all',
+  review: 'all',
+  git: 'all',
+  context: 'all'
+}
+
+type WorkspaceCleanupStateSetter<T> = Dispatch<SetStateAction<T>>
+type PublicRemovalSession = Omit<
+  WorkspaceCleanupRemovalSession,
+  'clearRowFailures' | 'resetForOpen'
+>
+
+export type WorkspaceCleanupDialogSession = PublicRemovalSession & {
+  open: boolean
+  loading: boolean
+  selectedIds: Set<string>
+  setSelectedIds: WorkspaceCleanupStateSetter<Set<string>>
+  expandedRowIds: Set<string>
+  setExpandedRowIds: WorkspaceCleanupStateSetter<Set<string>>
+  activeView: WorkspaceCleanupView
+  setActiveView: WorkspaceCleanupStateSetter<WorkspaceCleanupView>
+  repoSelection: ReadonlySet<string>
+  setRepoSelection: WorkspaceCleanupStateSetter<ReadonlySet<string>>
+  filters: WorkspaceCleanupFilters
+  setFilters: WorkspaceCleanupStateSetter<WorkspaceCleanupFilters>
+  sortKey: WorkspaceCleanupSortKey
+  setSortKey: WorkspaceCleanupStateSetter<WorkspaceCleanupSortKey>
+  sortDirection: WorkspaceCleanupSortDirection
+  setSortDirection: WorkspaceCleanupStateSetter<WorkspaceCleanupSortDirection>
+  selectedDefaultsScanAtRef: RefObject<number | null>
+  close: () => void
+  markCandidateViewed: (candidate: WorkspaceCleanupCandidate) => void
+  restoreDismissals: () => void
+  startScan: (options?: { notifyWhenReady?: boolean }) => void
+  ignoreCandidate: (candidate: WorkspaceCleanupCandidate) => void
+}
+
+export function useWorkspaceCleanupDialogSession(): WorkspaceCleanupDialogSession {
+  const {
+    open,
+    loading,
+    openModal,
+    closeModal,
+    scanWorkspaceCleanup,
+    markCandidateViewed,
+    dismissCandidates,
+    resetDismissals,
+    removeCandidates,
+    markWorktreesQueuedForDeletion,
+    clearWorktreeDeleteState
+  } = useAppStore(
+    useShallow((state) => ({
+      open: state.activeModal === 'workspace-cleanup',
+      loading: state.workspaceCleanupLoading,
+      openModal: state.openModal,
+      closeModal: state.closeModal,
+      scanWorkspaceCleanup: state.scanWorkspaceCleanup,
+      markCandidateViewed: state.markWorkspaceCleanupCandidateViewed,
+      dismissCandidates: state.dismissWorkspaceCleanupCandidates,
+      resetDismissals: state.resetWorkspaceCleanupDismissals,
+      removeCandidates: state.removeWorkspaceCleanupCandidates,
+      markWorktreesQueuedForDeletion: state.markWorktreesQueuedForDeletion,
+      clearWorktreeDeleteState: state.clearWorktreeDeleteState
+    }))
+  )
+  const [selectedIds, setSelectedIds] = useState<Set<string>>(() => new Set())
+  const [expandedRowIds, setExpandedRowIds] = useState<Set<string>>(() => new Set())
+  const [activeView, setActiveView] = useState<WorkspaceCleanupView>('ready')
+  const [repoSelection, setRepoSelection] = useState<ReadonlySet<string>>(() => new Set())
+  const [filters, setFilters] = useState<WorkspaceCleanupFilters>(DEFAULT_WORKSPACE_CLEANUP_FILTERS)
+  const [sortKey, setSortKey] = useState<WorkspaceCleanupSortKey>('activity')
+  const [sortDirection, setSortDirection] = useState<WorkspaceCleanupSortDirection>('asc')
+  const selectedDefaultsScanAtRef = useRef<number | null>(null)
+  const autoScanAttemptedForOpenRef = useRef(false)
+  const wasOpenRef = useRef(false)
+  const mountedRef = useMountedRef()
+  const removal = useWorkspaceCleanupRemovalSession({
+    mountedRef,
+    setSelectedIds,
+    closeModal,
+    removeCandidates,
+    markWorktreesQueuedForDeletion,
+    clearWorktreeDeleteState
+  })
+  const { clearRowFailures, resetForOpen, ...publicRemoval } = removal
+  const startScan = useWorkspaceCleanupScanSession({
+    open,
+    mountedRef,
+    openModal,
+    scanWorkspaceCleanup,
+    clearRowFailures
+  })
+
+  useEffect(() => {
+    if (!open) {
+      wasOpenRef.current = false
+      autoScanAttemptedForOpenRef.current = false
+      return
+    }
+    if (!wasOpenRef.current) {
+      wasOpenRef.current = true
+      autoScanAttemptedForOpenRef.current = false
+      if (!removal.removalInFlightRef.current) {
+        setActiveView('ready')
+        setFilters(DEFAULT_WORKSPACE_CLEANUP_FILTERS)
+        setSortKey('activity')
+        setSortDirection('asc')
+        resetForOpen()
+      }
+    }
+    // Why: reopening mid-batch must preserve progress and avoid a scan the removal would invalidate.
+    if (!loading && !autoScanAttemptedForOpenRef.current && !removal.removalInFlightRef.current) {
+      autoScanAttemptedForOpenRef.current = true
+      startScan({ notifyWhenReady: true })
+    }
+  }, [loading, open, removal.removalInFlightRef, resetForOpen, startScan])
+
+  const ignoreCandidate = useCallback(
+    (candidate: WorkspaceCleanupCandidate) => {
+      void dismissCandidates([candidate])
+        .then(() => {
+          if (!mountedRef.current) {
+            return
+          }
+          setSelectedIds((current) => {
+            const next = new Set(current)
+            next.delete(candidate.worktreeId)
+            return next
+          })
+        })
+        .catch((error: unknown) => {
+          if (!mountedRef.current) {
+            return
+          }
+          toast.error(
+            translate(
+              'auto.components.workspace.cleanup.WorkspaceCleanupDialog.7f451a3e2c',
+              'Could not ignore cleanup suggestion'
+            ),
+            { description: error instanceof Error ? error.message : String(error) }
+          )
+        })
+    },
+    [dismissCandidates, mountedRef]
+  )
+
+  const restoreDismissals = useCallback(() => {
+    void resetDismissals()
+  }, [resetDismissals])
+
+  return {
+    open,
+    loading,
+    selectedIds,
+    setSelectedIds,
+    expandedRowIds,
+    setExpandedRowIds,
+    activeView,
+    setActiveView,
+    repoSelection,
+    setRepoSelection,
+    filters,
+    setFilters,
+    sortKey,
+    setSortKey,
+    sortDirection,
+    setSortDirection,
+    selectedDefaultsScanAtRef,
+    close: closeModal,
+    markCandidateViewed,
+    restoreDismissals,
+    startScan,
+    ignoreCandidate,
+    ...publicRemoval
+  }
+}

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-session.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-session.ts
@@ -1,0 +1,261 @@
+import {
+  useCallback,
+  useRef,
+  useState,
+  type Dispatch,
+  type RefObject,
+  type SetStateAction
+} from 'react'
+import type { WorkspaceCleanupCandidate } from '../../../../shared/workspace-cleanup'
+import type { AppState } from '@/store/types'
+import { useAppStore } from '@/store'
+import {
+  startWorkspaceCleanupBackgroundRemoval,
+  type WorkspaceCleanupRemovalProgress
+} from './workspace-cleanup-background-removal'
+import { filterWorkspaceCleanupRemovalCandidates } from './workspace-cleanup-removal-candidates'
+
+type WorkspaceCleanupSelectedIdsSetter = Dispatch<SetStateAction<Set<string>>>
+
+export type WorkspaceCleanupRemovalSession = {
+  confirming: boolean
+  confirmCandidates: WorkspaceCleanupCandidate[]
+  removalProgress: WorkspaceCleanupRemovalProgress | null
+  removalInFlight: boolean
+  rowFailures: Record<string, string>
+  removalInFlightRef: RefObject<boolean>
+  clearRowFailures: () => void
+  resetForOpen: () => void
+  applyScanDefaults: (
+    candidates: readonly WorkspaceCleanupCandidate[],
+    deletingWorktreeIds: ReadonlySet<string>
+  ) => void
+  openConfirmRemove: (candidates: readonly WorkspaceCleanupCandidate[]) => void
+  cancelConfirmRemove: () => void
+  backToWorkspaceCleanupList: () => void
+  confirmRemove: () => void
+}
+
+export function useWorkspaceCleanupRemovalSession({
+  mountedRef,
+  setSelectedIds,
+  closeModal,
+  removeCandidates,
+  markWorktreesQueuedForDeletion,
+  clearWorktreeDeleteState
+}: {
+  mountedRef: RefObject<boolean>
+  setSelectedIds: WorkspaceCleanupSelectedIdsSetter
+  closeModal: AppState['closeModal']
+  removeCandidates: AppState['removeWorkspaceCleanupCandidates']
+  markWorktreesQueuedForDeletion: AppState['markWorktreesQueuedForDeletion']
+  clearWorktreeDeleteState: AppState['clearWorktreeDeleteState']
+}): WorkspaceCleanupRemovalSession {
+  const [confirming, setConfirming] = useState(false)
+  const [confirmCandidates, setConfirmCandidates] = useState<WorkspaceCleanupCandidate[]>([])
+  const [removalProgress, setRemovalProgress] = useState<WorkspaceCleanupRemovalProgress | null>(
+    null
+  )
+  // Why: progress arrives after the click; the ref synchronously rejects a second batch.
+  const [removalInFlight, setRemovalInFlight] = useState(false)
+  const [rowFailures, setRowFailures] = useState<Record<string, string>>({})
+  const removalInFlightRef = useRef(false)
+  // Why: an older batch's late settlement must not mutate a newer batch's UI.
+  const removalBatchIdRef = useRef(0)
+
+  const clearRowFailures = useCallback(() => setRowFailures({}), [])
+
+  const resetForOpen = useCallback(() => {
+    setConfirming(false)
+    setRowFailures({})
+    setSelectedIds(new Set())
+  }, [setSelectedIds])
+
+  const applyScanDefaults = useCallback(
+    (
+      candidates: readonly WorkspaceCleanupCandidate[],
+      deletingWorktreeIds: ReadonlySet<string>
+    ) => {
+      if (removalInFlightRef.current) {
+        return
+      }
+      setSelectedIds(getDefaultSelectedWorkspaceCleanupIds(candidates, deletingWorktreeIds))
+      setConfirming(false)
+      setRowFailures({})
+    },
+    [setSelectedIds]
+  )
+
+  const openConfirmRemove = useCallback((candidates: readonly WorkspaceCleanupCandidate[]) => {
+    const nextCandidates = filterWorkspaceCleanupRemovalCandidates(
+      candidates,
+      useAppStore.getState().deleteStateByWorktreeId
+    )
+    if (nextCandidates.length === 0) {
+      return
+    }
+    setConfirmCandidates(nextCandidates)
+    setConfirming(true)
+  }, [])
+
+  const cancelConfirmRemove = useCallback(() => {
+    if (removalProgress) {
+      closeModal()
+      return
+    }
+    setConfirming(false)
+    setConfirmCandidates([])
+  }, [closeModal, removalProgress])
+
+  // Why: Back exposes per-row progress without cancelling the batch; Close dismisses the modal.
+  const backToWorkspaceCleanupList = useCallback(() => {
+    setConfirming(false)
+    setConfirmCandidates([])
+  }, [])
+
+  const clearQueuedDeleteState = useCallback(
+    (worktreeId: string) => {
+      const deleteState = useAppStore.getState().deleteStateByWorktreeId[worktreeId]
+      // Why: rows that fail before removal starts must not stay queued in the sidebar.
+      if (deleteState?.isDeleting && deleteState.error === null && deleteState.phase === 'queued') {
+        clearWorktreeDeleteState(worktreeId)
+      }
+    },
+    [clearWorktreeDeleteState]
+  )
+
+  const deselectRemovedIds = useCallback(
+    (removedIds: readonly string[]) => {
+      if (removedIds.length === 0) {
+        return
+      }
+      setSelectedIds((current) => {
+        const next = new Set(current)
+        for (const id of removedIds) {
+          next.delete(id)
+        }
+        return next
+      })
+    },
+    [setSelectedIds]
+  )
+
+  const confirmRemove = useCallback(() => {
+    if (confirmCandidates.length === 0 || removalInFlightRef.current) {
+      return
+    }
+    const removableCandidates = filterWorkspaceCleanupRemovalCandidates(
+      confirmCandidates,
+      useAppStore.getState().deleteStateByWorktreeId
+    )
+    if (removableCandidates.length === 0) {
+      setConfirming(false)
+      setConfirmCandidates([])
+      return
+    }
+    removalInFlightRef.current = true
+    setRemovalInFlight(true)
+    removalBatchIdRef.current += 1
+    const removalBatchId = removalBatchIdRef.current
+    // Why: hung late settlements retain callbacks, so capture ids instead of candidate objects.
+    const removableWorktreeIds = removableCandidates.map((candidate) => candidate.worktreeId)
+    setRowFailures({})
+    markWorktreesQueuedForDeletion(removableWorktreeIds)
+    startWorkspaceCleanupBackgroundRemoval({
+      candidates: removableCandidates,
+      removeCandidates,
+      onProgress: (progress) => {
+        if (mountedRef.current) {
+          setRemovalProgress(progress)
+        }
+      },
+      onRowFailed: (failure) => {
+        clearQueuedDeleteState(failure.worktreeId)
+      },
+      onResult: (result) => {
+        const nextFailures: Record<string, string> = {}
+        for (const failure of result.failures) {
+          nextFailures[failure.worktreeId] = failure.message
+          clearQueuedDeleteState(failure.worktreeId)
+        }
+        if (mountedRef.current) {
+          setRowFailures(nextFailures)
+          deselectRemovedIds(result.removedIds)
+          setRemovalProgress(null)
+          setRemovalInFlight(false)
+          setConfirming(false)
+          setConfirmCandidates([])
+        }
+        removalInFlightRef.current = false
+      },
+      onLateResult: (result) => {
+        for (const failure of result.failures) {
+          // Why: a late preflight failure can leave a row that never started stuck as queued.
+          clearQueuedDeleteState(failure.worktreeId)
+        }
+        if (!mountedRef.current || removalBatchIdRef.current !== removalBatchId) {
+          return
+        }
+        setRowFailures((current) => {
+          const next = { ...current }
+          for (const id of result.removedIds) {
+            delete next[id]
+          }
+          for (const failure of result.failures) {
+            next[failure.worktreeId] = failure.message
+          }
+          return next
+        })
+        deselectRemovedIds(result.removedIds)
+      },
+      onError: () => {
+        for (const worktreeId of removableWorktreeIds) {
+          clearQueuedDeleteState(worktreeId)
+        }
+        if (mountedRef.current) {
+          setRemovalProgress(null)
+          setRemovalInFlight(false)
+          setConfirming(false)
+          setConfirmCandidates([])
+        }
+        removalInFlightRef.current = false
+      }
+    })
+  }, [
+    clearQueuedDeleteState,
+    confirmCandidates,
+    deselectRemovedIds,
+    markWorktreesQueuedForDeletion,
+    mountedRef,
+    removeCandidates
+  ])
+
+  return {
+    confirming,
+    confirmCandidates,
+    removalProgress,
+    removalInFlight,
+    rowFailures,
+    removalInFlightRef,
+    clearRowFailures,
+    resetForOpen,
+    applyScanDefaults,
+    openConfirmRemove,
+    cancelConfirmRemove,
+    backToWorkspaceCleanupList,
+    confirmRemove
+  }
+}
+
+function getDefaultSelectedWorkspaceCleanupIds(
+  candidates: readonly WorkspaceCleanupCandidate[],
+  deletingWorktreeIds: ReadonlySet<string>
+): Set<string> {
+  return new Set(
+    candidates
+      .filter(
+        (candidate) => candidate.selectedByDefault && !deletingWorktreeIds.has(candidate.worktreeId)
+      )
+      .map((candidate) => candidate.worktreeId)
+  )
+}

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-session.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-removal-session.ts
@@ -209,8 +209,11 @@ export function useWorkspaceCleanupRemovalSession({
         deselectRemovedIds(result.removedIds)
       },
       onError: () => {
+        // Why: the batch driver is gone, so nothing will settle these rows later; clear
+        // unconditionally (not just queued ones) or a hung 'deleting' row stays stuck in
+        // the sidebar and filterWorkspaceCleanupRemovalCandidates blocks every retry.
         for (const worktreeId of removableWorktreeIds) {
-          clearQueuedDeleteState(worktreeId)
+          clearWorktreeDeleteState(worktreeId)
         }
         if (mountedRef.current) {
           setRemovalProgress(null)
@@ -223,6 +226,7 @@ export function useWorkspaceCleanupRemovalSession({
     })
   }, [
     clearQueuedDeleteState,
+    clearWorktreeDeleteState,
     confirmCandidates,
     deselectRemovedIds,
     markWorktreesQueuedForDeletion,

--- a/src/renderer/src/components/workspace-cleanup/workspace-cleanup-scan-session.ts
+++ b/src/renderer/src/components/workspace-cleanup/workspace-cleanup-scan-session.ts
@@ -1,0 +1,88 @@
+import { useCallback, useEffect, useRef, type RefObject } from 'react'
+import { toast } from 'sonner'
+import type { AppState } from '@/store/types'
+import { translate } from '@/i18n/i18n'
+
+export function useWorkspaceCleanupScanSession({
+  open,
+  mountedRef,
+  openModal,
+  scanWorkspaceCleanup,
+  clearRowFailures
+}: {
+  open: boolean
+  mountedRef: RefObject<boolean>
+  openModal: AppState['openModal']
+  scanWorkspaceCleanup: AppState['scanWorkspaceCleanup']
+  clearRowFailures: () => void
+}): (options?: { notifyWhenReady?: boolean }) => void {
+  const openRef = useRef(open)
+  const latestReadyToastScanAtRef = useRef<number | null>(null)
+
+  useEffect(() => {
+    openRef.current = open
+  }, [open])
+
+  return useCallback(
+    (options: { notifyWhenReady?: boolean } = {}) => {
+      clearRowFailures()
+      void scanWorkspaceCleanup()
+        .then((result) => {
+          if (!mountedRef.current || !options.notifyWhenReady || openRef.current) {
+            return
+          }
+          if (latestReadyToastScanAtRef.current === result.scannedAt) {
+            return
+          }
+          latestReadyToastScanAtRef.current = result.scannedAt
+          const suggestedCount = result.candidates.filter(
+            (candidate) => candidate.selectedByDefault
+          ).length
+          toast.success(
+            translate(
+              'auto.components.workspace.cleanup.WorkspaceCleanupDialog.0e2d235c63',
+              'Inactive workspace scan ready'
+            ),
+            {
+              description: formatWorkspaceCleanupReadyToastDescription(
+                result.candidates.length,
+                suggestedCount
+              ),
+              action: {
+                label: translate(
+                  'auto.components.workspace.cleanup.WorkspaceCleanupDialog.4a35c08764',
+                  'Review'
+                ),
+                onClick: () => openModal('workspace-cleanup')
+              }
+            }
+          )
+        })
+        .catch((error: unknown) => {
+          if (!mountedRef.current) {
+            return
+          }
+          toast.error(
+            translate(
+              'auto.components.workspace.cleanup.WorkspaceCleanupDialog.662b8ec3f8',
+              'Workspace cleanup scan failed'
+            ),
+            { description: error instanceof Error ? error.message : String(error) }
+          )
+        })
+    },
+    [clearRowFailures, mountedRef, openModal, scanWorkspaceCleanup]
+  )
+}
+
+function formatWorkspaceCleanupReadyToastDescription(
+  inactiveCount: number,
+  suggestedCount: number
+): string {
+  if (inactiveCount === 0) {
+    return 'No inactive workspaces found.'
+  }
+  const inactiveNoun = inactiveCount === 1 ? 'workspace' : 'workspaces'
+  const suggestedNoun = suggestedCount === 1 ? 'suggestion' : 'suggestions'
+  return `${inactiveCount} inactive ${inactiveNoun} found, with ${suggestedCount} cleanup ${suggestedNoun}.`
+}


### PR DESCRIPTION
## ELI5

After the Workspace Cleanup dialog was opened once, closing it hid the pixels but left the whole spreadsheet recalculating behind the curtain. Remote scans stream cumulative candidate lists, so the hidden dialog kept rebuilding review metadata, filtering rows, and running three sorts as those lists grew.

This keeps a tiny session shell alive for the work that really must continue in the background, while unmounting the expensive subscribed content 300 ms after close.

```mermaid
flowchart LR
  Open[Open: session + content] -->|close| Linger[Closed: content lingers 300 ms]
  Linger -->|reopen before timeout| Open
  Linger -->|timeout| Shell[Closed: session shell only]
  Shell -->|scan or removal callbacks| Shell
  Shell -->|reopen| Open
```

The session shell owns scan completion toasts, deletion progress, confirm-time candidate snapshots, queued-delete cleanup, late-settlement fencing, and the small UI state needed on reopen. The gated content owns the broad store subscriptions and all candidate review/filter/sort projections.

## Quantitative proof

| Closed after first use | Before | After |
| --- | ---: | ---: |
| Retained `useAppStore` subscriptions | 17 | 1 |
| Delete-state projection on arbitrary store writes | scans all `D` delete entries | none |
| Candidate work after the 300 ms boundary | review projection + filters + 3 sorts | zero |

The deterministic regression fixture closes the dialog, crosses the exact 300 ms boundary, then publishes 300 representative store writes: 100 streamed scans, 100 review-cache updates, and 100 delete-state updates. It observes **0 additional content renders, 0 projections, and only the one session-shell listener above baseline**.

It also proves:

- content remains mounted through 299 ms so the close animation cannot flash empty;
- reopening at 299 ms cancels the pending unmount;
- a deferred scan still emits its ready toast while content is gone, and Review reopens the dialog;
- a deferred deletion keeps its 0/1 progress while closed, restores it on reopen, skips a duplicate scan, and settles normally.

For a streamed scan reaching `N` candidates, the old retained parent could repeat cumulative review/filter/index work across frames and three `O(k log k)` sorts per nonempty frame. Unmounting the parent removes that hidden cumulative work entirely.

## Compatibility

- Renderer lifecycle refactor only; no RPC, stream opcode, payload, persistence, or remote-wire change.
- Direct SSH, local, git-worktree, and folder-workspace behavior is unchanged.
- Scans and removals remain store-owned and continue while the visual content is unmounted.
- No platform-specific path, shortcut, or Git behavior changed.
- No visual or styling changes; the existing 300 ms close-animation safety window is preserved.

## Regression results

- Workspace Cleanup focused suite: **78/78 passed**.
- New lifecycle tests: **5/5 passed**.
- Full typecheck: passed.
- Full lint, native/type-aware audits, reliability gates, max-lines ratchet, skill manifest, and localization gates: passed.
- Full Vitest run: **49,211 passed, 103 skipped**. Two unrelated failures remained:
  - the existing cross-version v799 staging checkout `ENOENT`;
  - the terminal hover-link timing fixture measured 109.06 ms against its 100 ms suite-load threshold, then passed immediately in isolation (**1/1**).

This is the Workspace Cleanup counterpart to #13525.