### PR TITLE
fix(worktrees): treat list scan timeouts as failures

### DIFF
--- a/src/main/git/worktree.test.ts
+++ b/src/main/git/worktree.test.ts
@@ -119,7 +119,8 @@ describe('listWorktrees in-flight sharing', () => {
           stdout: 'worktree /repo\nHEAD abc123\nbranch refs/heads/main\n'
         })
 
-      await expect(listWorktrees('/repo')).resolves.toEqual([])
+      // Why: timeouts must surface as failures — empty success would look like "no worktrees" (#13556).
+      await expect(listWorktrees('/repo')).rejects.toThrow('git timed out.')
       await expect(listWorktrees('/repo')).resolves.toEqual([
         expect.objectContaining({ path: '/repo', head: 'abc123' })
       ])

--- a/src/main/git/worktree.ts
+++ b/src/main/git/worktree.ts
@@ -790,9 +790,11 @@ async function listWorktreesUnshared(
     if (isNotGitRepositoryError(err)) {
       return []
     }
-    // Why: don't swallow git-compat/repo-state failures — else they resurface as opaque "created but not found in listing" errors.
+    // Why: rethrow transient failures (WSL/Git timeouts, spawn errors). Returning []
+    // made callers treat an unknown scan as "no worktrees", authorizing missing-worktree
+    // cleanup and killing live sessions (#13556).
     console.warn(`[git/worktree] listWorktrees failed for ${repoPath}:`, err)
-    return []
+    throw err
   }
 }
 


### PR DESCRIPTION
## Summary
- `listWorktrees` returned `[]` on WSL/Git timeouts and similar transient failures.
- Callers (including `worktrees:listDetected`) treated that as an authoritative empty graph and ran missing-worktree cleanup, which terminated live managed terminals.
- Rethrow non-missing-path / non-not-a-repo scan errors so detection marks the result non-authoritative and preserves last-known worktree/session state.

## Test plan
- [x] `vitest run src/main/git/worktree.test.ts -t "timed-out shared scan"`
- [ ] Manual: under WSL load, a timed-out `git worktree list` must not drop worktrees from the sidebar or kill their PTYs

Fixes #13556