### PR TITLE
fix(orchestration): settle agent TUI before worker-start inject

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -90,8 +90,8 @@ import {
 import {
   AGENT_PROMPT_BRACKETED_PASTE_END,
   AGENT_PROMPT_SUBMIT,
-  AGENT_PROMPT_SUBMIT_DELAY_MS,
-  buildAgentPromptPasteBytes
+  buildAgentPromptPasteBytes,
+  getAgentPromptSubmitDelayMs
 } from '../../shared/agent-prompt-injection'
 import { gitExecFileAsync, gitSpawn, nonInteractiveGitEnv } from '../git/runner'
 import { runWithGitReadCacheInvalidation } from '../git/status'
@@ -17164,7 +17164,13 @@ export class OrcaRuntimeService {
       throw error
     }
 
-    await new Promise((resolve) => setTimeout(resolve, AGENT_PROMPT_SUBMIT_DELAY_MS))
+    // Why: long bracketed pastes need more render time before Enter; fixed 500ms left
+    // multi-KB worker-start preambles in the Claude composer unsubmitted (#13488).
+    const submitDelayMs = getAgentPromptSubmitDelayMs(
+      process.platform,
+      Buffer.byteLength(pastePayload, 'utf8')
+    )
+    await new Promise((resolve) => setTimeout(resolve, submitDelayMs))
     try {
       await options.beforeWrite?.(ptyId)
     } catch (error) {

--- a/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.test.ts
@@ -1,0 +1,79 @@
+import { describe, expect, it, vi } from 'vitest'
+import { waitForWorkerAgentTuiReady } from './orchestration-worker-agent-readiness'
+
+describe('waitForWorkerAgentTuiReady', () => {
+  it('returns the first wait when it is not satisfied', async () => {
+    const waitForTerminal = vi.fn().mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: false,
+      status: 'exited',
+      exitCode: 1
+    })
+
+    const result = await waitForWorkerAgentTuiReady({
+      runtime: { waitForTerminal },
+      terminalHandle: 'term_worker',
+      timeoutMs: 30_000,
+      externalTerminal: false
+    })
+
+    expect(result).toMatchObject({ satisfied: false, status: 'exited' })
+    expect(waitForTerminal).toHaveBeenCalledTimes(1)
+  })
+
+  it('skips settle re-wait for an external --terminal agent', async () => {
+    const waitForTerminal = vi.fn().mockResolvedValue({
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    })
+
+    await waitForWorkerAgentTuiReady({
+      runtime: { waitForTerminal },
+      terminalHandle: 'term_worker',
+      timeoutMs: 30_000,
+      externalTerminal: true
+    })
+
+    expect(waitForTerminal).toHaveBeenCalledTimes(1)
+  })
+
+  it('re-confirms tui-idle after settle for Orca-created agents', async () => {
+    const waitForTerminal = vi
+      .fn()
+      .mockResolvedValueOnce({
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running',
+        exitCode: null
+      })
+      .mockResolvedValueOnce({
+        handle: 'term_worker',
+        condition: 'tui-idle',
+        satisfied: true,
+        status: 'running',
+        exitCode: null
+      })
+
+    const result = await waitForWorkerAgentTuiReady({
+      runtime: { waitForTerminal },
+      terminalHandle: 'term_worker',
+      timeoutMs: 30_000,
+      externalTerminal: false
+    })
+
+    expect(result).toMatchObject({ satisfied: true })
+    expect(waitForTerminal).toHaveBeenCalledTimes(2)
+    expect(waitForTerminal.mock.calls[0]?.[1]).toMatchObject({
+      condition: 'tui-idle',
+      timeoutMs: 30_000
+    })
+    expect(waitForTerminal.mock.calls[1]?.[1]).toMatchObject({
+      condition: 'tui-idle'
+    })
+  })
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.test.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.test.ts
@@ -77,3 +77,31 @@ describe('waitForWorkerAgentTuiReady', () => {
     })
   })
 })
+
+it('throws when the readiness budget is already exhausted after the first idle', async () => {
+  const waitForTerminal = vi.fn().mockImplementation(async () => {
+    // Advance wall clock past the budget between first wait and remaining check.
+    vi.setSystemTime(Date.now() + 60_000)
+    return {
+      handle: 'term_worker',
+      condition: 'tui-idle',
+      satisfied: true,
+      status: 'running',
+      exitCode: null
+    }
+  })
+  vi.useFakeTimers()
+  vi.setSystemTime(0)
+
+  await expect(
+    waitForWorkerAgentTuiReady({
+      runtime: { waitForTerminal },
+      terminalHandle: 'term_worker',
+      timeoutMs: 1_000,
+      externalTerminal: false
+    })
+  ).rejects.toThrow('timeout')
+
+  expect(waitForTerminal).toHaveBeenCalledTimes(1)
+  vi.useRealTimers()
+})

--- a/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.ts
@@ -1,0 +1,41 @@
+import type { OrcaRuntimeService } from '../../orca-runtime'
+
+/** Pause after first tui-idle so MCP/skills boot can leave idle before inject (#13488). */
+export const WORKER_AGENT_TUI_IDLE_SETTLE_MS = process.env.VITEST ? 0 : 1_000
+
+type TerminalWait = Awaited<ReturnType<OrcaRuntimeService['waitForTerminal']>>
+
+/**
+ * Wait for agent TUI readiness before worker-start injects the task.
+ * Newly launched agents (not `--terminal`) settle after the first idle so a
+ * premature Claude/Codex idle blip during MCP load does not accept the paste
+ * before the composer will submit.
+ */
+export async function waitForWorkerAgentTuiReady(args: {
+  runtime: Pick<OrcaRuntimeService, 'waitForTerminal'>
+  terminalHandle: string
+  timeoutMs: number
+  /** True when the caller bound an already-running agent via `--terminal`. */
+  externalTerminal: boolean
+}): Promise<TerminalWait> {
+  const startedAt = Date.now()
+  const first = await args.runtime.waitForTerminal(args.terminalHandle, {
+    condition: 'tui-idle',
+    timeoutMs: args.timeoutMs
+  })
+  if (!first.satisfied || args.externalTerminal) {
+    return first
+  }
+
+  if (WORKER_AGENT_TUI_IDLE_SETTLE_MS > 0) {
+    await new Promise((resolve) => setTimeout(resolve, WORKER_AGENT_TUI_IDLE_SETTLE_MS))
+  }
+
+  // Why: re-confirm idle after settle so a boot-time idle blip that becomes
+  // "working" (MCP load) is waited out before paste+Enter (#13488).
+  const remainingMs = Math.max(1_000, args.timeoutMs - (Date.now() - startedAt))
+  return args.runtime.waitForTerminal(args.terminalHandle, {
+    condition: 'tui-idle',
+    timeoutMs: remainingMs
+  })
+}

--- a/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.ts
+++ b/src/main/runtime/rpc/methods/orchestration-worker-agent-readiness.ts
@@ -33,7 +33,11 @@ export async function waitForWorkerAgentTuiReady(args: {
 
   // Why: re-confirm idle after settle so a boot-time idle blip that becomes
   // "working" (MCP load) is waited out before paste+Enter (#13488).
-  const remainingMs = Math.max(1_000, args.timeoutMs - (Date.now() - startedAt))
+  const remainingMs = args.timeoutMs - (Date.now() - startedAt)
+  // Why: settle is part of the caller budget — do not floor a second wait past the deadline.
+  if (remainingMs <= 0) {
+    throw new Error('timeout')
+  }
   return args.runtime.waitForTerminal(args.terminalHandle, {
     condition: 'tui-idle',
     timeoutMs: remainingMs

--- a/src/main/runtime/rpc/methods/orchestration-workers.ts
+++ b/src/main/runtime/rpc/methods/orchestration-workers.ts
@@ -13,6 +13,7 @@ import {
   type WorkerEffect,
   type WorkerSetupReceipt
 } from './orchestration-worker-topology'
+import { waitForWorkerAgentTuiReady } from './orchestration-worker-agent-readiness'
 import {
   persistGatedSetupSpawnFailure,
   persistWorkerReadinessStage,
@@ -194,9 +195,13 @@ export const ORCHESTRATION_WORKER_START_METHODS: RpcMethod[] = [
         persistWorkerReadinessStage(setupStage)
 
         failedStage = 'agent_readiness'
-        const wait = await runtime.waitForTerminal(terminalHandle, {
-          condition: 'tui-idle',
-          timeoutMs: params.timeoutMs ?? 60_000
+        // Why: a single tui-idle can fire during Claude MCP boot while the composer
+        // will not submit; settle + re-wait for Orca-created agents (#13488).
+        const wait = await waitForWorkerAgentTuiReady({
+          runtime,
+          terminalHandle,
+          timeoutMs: params.timeoutMs ?? 60_000,
+          externalTerminal: Boolean(params.terminal)
         })
         persistWorkerSetupWaitOutcome({ ...setupStage, wait })
         if (!wait.satisfied) {

--- a/src/shared/agent-prompt-injection.test.ts
+++ b/src/shared/agent-prompt-injection.test.ts
@@ -30,6 +30,14 @@ describe('agent prompt injection bytes', () => {
     expect(getAgentPromptSubmitDelayMs('linux')).toBe(500)
   })
 
+  it('scales submit delay for long orchestration pastes', () => {
+    // 10_000 bytes / 20 = 500ms base floor on darwin; 20_000 → 1_000ms
+    expect(getAgentPromptSubmitDelayMs('darwin', 10_000)).toBe(500)
+    expect(getAgentPromptSubmitDelayMs('darwin', 20_000)).toBe(1_000)
+    expect(getAgentPromptSubmitDelayMs('win32', 20_000)).toBe(1_500)
+    expect(getAgentPromptSubmitDelayMs('darwin', 200_000)).toBe(5_000)
+  })
+
   it('sanitizes embedded escape bytes before framing', () => {
     const bytes = buildAgentPromptPasteBytes('before\x1b[201~after\x1b')
     expect(bytes).toBe(`${BEGIN}before<ESC>[201~after<ESC>${END}`)

--- a/src/shared/agent-prompt-injection.test.ts
+++ b/src/shared/agent-prompt-injection.test.ts
@@ -31,11 +31,12 @@ describe('agent prompt injection bytes', () => {
   })
 
   it('scales submit delay for long orchestration pastes', () => {
-    // 10_000 bytes / 20 = 500ms base floor on darwin; 20_000 → 1_000ms
-    expect(getAgentPromptSubmitDelayMs('darwin', 10_000)).toBe(500)
-    expect(getAgentPromptSubmitDelayMs('darwin', 20_000)).toBe(1_000)
-    expect(getAgentPromptSubmitDelayMs('win32', 20_000)).toBe(1_500)
+    // #13488 mid-size preambles (~8–10KB) must exceed the 500ms floor on darwin.
+    expect(getAgentPromptSubmitDelayMs('darwin', 8_000)).toBe(1_600)
+    expect(getAgentPromptSubmitDelayMs('darwin', 10_000)).toBe(2_000)
+    expect(getAgentPromptSubmitDelayMs('win32', 8_000)).toBe(1_600)
     expect(getAgentPromptSubmitDelayMs('darwin', 200_000)).toBe(5_000)
+    expect(getAgentPromptSubmitDelayMs('darwin', 100)).toBe(500)
   })
 
   it('sanitizes embedded escape bytes before framing', () => {

--- a/src/shared/agent-prompt-injection.ts
+++ b/src/shared/agent-prompt-injection.ts
@@ -7,8 +7,8 @@ export const AGENT_PROMPT_SUBMIT = '\r'
 const DEFAULT_AGENT_PROMPT_SUBMIT_DELAY_MS = 500
 const WINDOWS_AGENT_PROMPT_SUBMIT_DELAY_MS = 1_500
 const MAX_AGENT_PROMPT_SUBMIT_DELAY_MS = 5_000
-// Why: ~5ms per 100 bytes scales long orchestration preambles without punishing tiny prompts.
-const AGENT_PROMPT_SUBMIT_DELAY_BYTES_PER_MS = 20
+// Why: #13488 mid-size preambles were ~8–10KB; bytes/5 yields ~1.6–2s on darwin (vs bytes/20 still flooring at 500ms).
+const AGENT_PROMPT_SUBMIT_DELAY_BYTES_PER_MS = 5
 
 // Why: ConPTY (and long Claude pastes on macOS/Linux) need more time before Enter is accepted (#13488).
 export function getAgentPromptSubmitDelayMs(

--- a/src/shared/agent-prompt-injection.ts
+++ b/src/shared/agent-prompt-injection.ts
@@ -6,12 +6,22 @@ export const AGENT_PROMPT_SUBMIT = '\r'
 
 const DEFAULT_AGENT_PROMPT_SUBMIT_DELAY_MS = 500
 const WINDOWS_AGENT_PROMPT_SUBMIT_DELAY_MS = 1_500
+const MAX_AGENT_PROMPT_SUBMIT_DELAY_MS = 5_000
+// Why: ~5ms per 100 bytes scales long orchestration preambles without punishing tiny prompts.
+const AGENT_PROMPT_SUBMIT_DELAY_BYTES_PER_MS = 20
 
-// Why: ConPTY renders long bracketed pastes more slowly; an early Enter leaves the task in the agent input buffer.
-export function getAgentPromptSubmitDelayMs(platform: NodeJS.Platform): number {
-  return platform === 'win32'
-    ? WINDOWS_AGENT_PROMPT_SUBMIT_DELAY_MS
-    : DEFAULT_AGENT_PROMPT_SUBMIT_DELAY_MS
+// Why: ConPTY (and long Claude pastes on macOS/Linux) need more time before Enter is accepted (#13488).
+export function getAgentPromptSubmitDelayMs(
+  platform: NodeJS.Platform,
+  pasteByteLength = 0
+): number {
+  const base =
+    platform === 'win32'
+      ? WINDOWS_AGENT_PROMPT_SUBMIT_DELAY_MS
+      : DEFAULT_AGENT_PROMPT_SUBMIT_DELAY_MS
+  const sized =
+    pasteByteLength > 0 ? Math.ceil(pasteByteLength / AGENT_PROMPT_SUBMIT_DELAY_BYTES_PER_MS) : 0
+  return Math.min(MAX_AGENT_PROMPT_SUBMIT_DELAY_MS, Math.max(base, sized))
 }
 
 export const AGENT_PROMPT_SUBMIT_DELAY_MS = getAgentPromptSubmitDelayMs(process.platform)


### PR DESCRIPTION
## Summary
- `worker-start --worktree new-child --agent` waited for a single `tui-idle` then paste+Enter.
- Claude can report idle during MCP/skills boot while the composer still ignores submit, so the task sat unsubmitted while the receipt claimed `input_accepted`.
- For Orca-created agent terminals: settle after the first idle and re-wait for `tui-idle` before inject. External `--terminal` reuse is unchanged.
- Scale paste→Enter delay with payload size so multi-KB preambles get enough render time (especially non-Windows).

## Test plan
- [x] `vitest` agent-prompt-injection, worker-agent-readiness, workers-new-worktree
- [ ] Manual: `worker-start --worktree new-child --agent claude` with a setup hook + MCP-heavy agent; receipt `ready` should mean the turn actually started

Fixes #13488