### PR TITLE
fix(sidebar): keep project name visible on pinned worktree rows

### DIFF
--- a/src/renderer/src/components/sidebar/WorktreeCard.pinned-repo-icon.test.tsx
+++ b/src/renderer/src/components/sidebar/WorktreeCard.pinned-repo-icon.test.tsx
@@ -126,6 +126,54 @@ describe('WorktreeCard pinned repo icon', () => {
 
       expect(markup).toContain('🦊')
       expect(markup).toContain('Project orca')
+      // Why: pinned rows leave the project header; show a readable project name, not only aria-label (#13353).
+      expect(markup).toContain('data-worktree-card-pinned-project-name')
+      expect(markup).toMatch(/data-worktree-card-pinned-project-name=""[^>]*>orca</)
+      expect(markup).toContain('Pinned tree')
+    },
+    WORKTREE_CARD_IMPORT_TIMEOUT_MS
+  )
+
+  it(
+    'does not duplicate the project name when the card title is already the project',
+    async () => {
+      const { default: WorktreeCard } = await import('./WorktreeCard')
+
+      const markup = renderToStaticMarkup(
+        <WorktreeCard
+          worktree={makeWorktree({ displayName: 'orca', branch: 'main' })}
+          repo={makeRepo()}
+          isActive={false}
+          inPinnedSection
+          hideRepoBadge
+        />
+      )
+
+      expect(markup).toContain('Project orca')
+      expect(markup).toContain('orca')
+      // Why: title already is the project; the disambiguation chip must stay off.
+      expect(markup).not.toContain('data-worktree-card-pinned-project-name')
+    },
+    WORKTREE_CARD_IMPORT_TIMEOUT_MS
+  )
+
+  it(
+    'falls back an empty display name to the branch on pinned rows',
+    async () => {
+      const { default: WorktreeCard } = await import('./WorktreeCard')
+
+      const markup = renderToStaticMarkup(
+        <WorktreeCard
+          worktree={makeWorktree({ displayName: '', branch: 'feature/fallback' })}
+          repo={makeRepo()}
+          isActive={false}
+          inPinnedSection
+          hideRepoBadge
+        />
+      )
+
+      expect(markup).toContain('data-worktree-card-pinned-project-name')
+      expect(markup).toContain('feature/fallback')
     },
     WORKTREE_CARD_IMPORT_TIMEOUT_MS
   )

--- a/src/renderer/src/components/sidebar/use-worktree-card-linked-details.ts
+++ b/src/renderer/src/components/sidebar/use-worktree-card-linked-details.ts
@@ -5,6 +5,7 @@ import { useAppStore } from '@/store'
 import type { IssueInfo, LinearIssue } from '../../../../shared/types'
 import { getWorktreeCardJiraIssueDisplay } from './worktree-card-jira-issue-display'
 import type { WorktreeCardIssueDisplay } from './WorktreeCardMeta'
+import { resolveWorktreeDisplayName } from '@/lib/worktree-default-display-name'
 import {
   coerceWorktreeCardVisibleTitle,
   getWorktreeCardTitleDisplay
@@ -115,7 +116,12 @@ export function useWorktreeCardLinkedDetails({
     reviewTitle: prDisplay?.title
   })
   const legacyCardTitleDisplay = coerceWorktreeCardVisibleTitle(worktree.displayName)
-  const visibleCardTitle = newCardStyle ? cardTitleDisplay : legacyCardTitleDisplay
+  // Why: cleared/nullish displayName arrives at runtime; never leave the closed card blank.
+  // Pinned rows also leave the project group header, so empty titles look like a missing name (#13353).
+  const preferredCardTitle = newCardStyle ? cardTitleDisplay : legacyCardTitleDisplay
+  const visibleCardTitle = preferredCardTitle.trim()
+    ? preferredCardTitle
+    : resolveWorktreeDisplayName(worktree)
   const isDeleting = deleteState?.isDeleting ?? false
   const isQueuedForDeletion = deleteState?.phase === 'queued'
   const deleteLabel = isQueuedForDeletion

--- a/src/renderer/src/components/sidebar/worktree-card-header.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-header.tsx
@@ -80,6 +80,8 @@ export function WorktreeCardHeader({
   } = card
   const {
     showPinnedRepoIcon,
+    showPinnedProjectName,
+    pinnedProjectName,
     showInlineRepoBadge,
     showHeaderActions,
     showTitleRowPrimary,
@@ -102,6 +104,15 @@ export function WorktreeCardHeader({
             />
           </RepoIdentityChip>
         )}
+        {showPinnedProjectName ? (
+          <span
+            data-worktree-card-pinned-project-name=""
+            className="max-w-[7rem] shrink-0 truncate text-[12px] font-medium leading-5 text-muted-foreground"
+            title={pinnedProjectName}
+          >
+            {pinnedProjectName}
+          </span>
+        ) : null}
 
         {repo?.connectionId && (
           <WorktreeCardSshHostControl

--- a/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
+++ b/src/renderer/src/components/sidebar/worktree-card-presentation.tsx
@@ -69,6 +69,13 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
 
   // Why: pinned trees mix repos, so the repo icon shows regardless of groupBy's hideRepoBadge.
   const showPinnedRepoIcon = inPinnedSection && !!repo
+  // Why: pinned section drops the project group header; show a visible project name when the
+  // card title is a worktree/branch label rather than the project itself (#13353).
+  const pinnedProjectName = repo?.displayName?.trim() ?? ''
+  const showPinnedProjectName =
+    showPinnedRepoIcon &&
+    pinnedProjectName.length > 0 &&
+    pinnedProjectName !== visibleCardTitle.trim()
   // Why: new card style retired the Compact/Detailed switch; repo identity uses the compact chip, not a lower pill.
   const showRepoIdentityInTitle = newCardStyle || compactCards
   const showInlineRepoBadge =
@@ -258,6 +265,8 @@ export function buildWorktreeCardPresentation(card: WorktreeCardController) {
 
   return {
     showPinnedRepoIcon,
+    showPinnedProjectName,
+    pinnedProjectName,
     showInlineRepoBadge,
     showRepoBadgeInMetaRow,
     showHostContextBadge,


### PR DESCRIPTION
## Summary
- Pinning moves a worktree into the Pinned section without the project group header, so project identity was only an icon + aria-label/tooltip.
- Show a visible project name chip when the card title is a worktree/branch label (not when the title is already the project name).
- Fall back blank card titles through `resolveWorktreeDisplayName` so cleared/nullish display names do not leave an empty row.

## Test plan
- [x] `pnpm exec vitest run --config config/vitest.config.ts src/renderer/src/components/sidebar/WorktreeCard.pinned-repo-icon.test.tsx`
- [ ] Manual: pin a feature worktree → project name + worktree title both readable; pin primary named after project → no duplicate chip

Fixes #13353