### PR TITLE
Fix paginated Codex metadata and native-chat RPC image bounds

### DIFF
--- a/src/main/ai-vault/session-scanner-codex-message-records.ts
+++ b/src/main/ai-vault/session-scanner-codex-message-records.ts
@@ -1,0 +1,70 @@
+import { normalizePromptField } from '../../shared/agent-status-field-normalization'
+import { addPreviewContent } from './session-scanner-accumulator'
+import type { SessionAccumulator } from './session-scanner-types'
+import { asRecord, extractContentText, extractPreviewContentText } from './session-scanner-values'
+
+export function consumeCodexResponseMessage(
+  accumulator: SessionAccumulator,
+  payload: Record<string, unknown>,
+  timestamp: unknown
+): boolean {
+  accumulator.messageCount++
+  const role =
+    payload.role === 'assistant' ? 'assistant' : payload.role === 'user' ? 'user' : 'unknown'
+  const setTitle = role === 'user' && !accumulator.title
+  if (setTitle) {
+    accumulator.title = extractContentText(payload.content)
+  }
+  addPreviewContent(accumulator, role, payload.content, timestamp)
+  return setTitle && Boolean(accumulator.title)
+}
+
+export function consumeCodexCompletedMessage(
+  accumulator: SessionAccumulator,
+  payload: Record<string, unknown>,
+  timestamp: unknown
+): boolean {
+  const item = asRecord(payload.item)
+  if (!item) {
+    return false
+  }
+  const isUser = item.type === 'UserMessage' || item.type === 'user_message'
+  const isAssistant = item.type === 'AgentMessage' || item.type === 'agent_message'
+  if (!isUser && !isAssistant) {
+    return false
+  }
+  accumulator.messageCount++
+  const setTitle = isUser && !accumulator.title
+  if (isUser) {
+    const prompt = normalizePromptField(extractPreviewContentText(item.content))
+    if (prompt) {
+      accumulator.lastUserPrompt = prompt
+    }
+    if (setTitle) {
+      accumulator.title = extractContentText(item.content)
+    }
+  }
+  addPreviewContent(accumulator, isUser ? 'user' : 'assistant', item.content, timestamp)
+  return setTitle && Boolean(accumulator.title)
+}
+
+export function consumeCodexLegacyEventMessage(
+  accumulator: SessionAccumulator,
+  payload: Record<string, unknown>,
+  timestamp: unknown
+): boolean {
+  const isUser = payload.type === 'user_message'
+  accumulator.messageCount++
+  const setTitle = isUser && !accumulator.title
+  if (isUser) {
+    const prompt = normalizePromptField(payload.message)
+    if (prompt) {
+      accumulator.lastUserPrompt = prompt
+    }
+    if (setTitle) {
+      accumulator.title = extractContentText(payload.message)
+    }
+  }
+  addPreviewContent(accumulator, isUser ? 'user' : 'assistant', payload.message, timestamp)
+  return setTitle && Boolean(accumulator.title)
+}

--- a/src/main/ai-vault/session-scanner-codex-parser.test.ts
+++ b/src/main/ai-vault/session-scanner-codex-parser.test.ts
@@ -16,6 +16,76 @@ function jsonLines(records: unknown[]): string {
 }
 
 describe('parseCodexSessionFile', () => {
+  it('uses completed user items for paginated session metadata', async () => {
+    const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-paginated-'))
+    tempRoots.push(root)
+    const sessionPath = join(root, 'sessions', '2026', '08', '10', 'rollout-paginated.jsonl')
+    await mkdir(dirname(sessionPath), { recursive: true })
+
+    await writeFile(
+      sessionPath,
+      jsonLines([
+        {
+          timestamp: '2026-08-10T10:00:00.000Z',
+          type: 'session_meta',
+          payload: { id: 'paginated-session', history_mode: 'paginated', cwd: '/repo/app' }
+        },
+        {
+          timestamp: '2026-08-10T10:00:01.000Z',
+          type: 'response_item',
+          payload: {
+            type: 'message',
+            role: 'user',
+            content: [{ type: 'input_text', text: 'model-only prompt copy' }]
+          }
+        },
+        {
+          timestamp: '2026-08-10T10:00:02.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'item_completed',
+            item: {
+              type: 'UserMessage',
+              content: [{ type: 'text', text: 'Visible paginated prompt' }]
+            }
+          }
+        },
+        {
+          timestamp: '2026-08-10T10:00:03.000Z',
+          type: 'event_msg',
+          payload: {
+            type: 'item_completed',
+            item: {
+              type: 'AgentMessage',
+              content: [{ type: 'Text', text: 'Visible paginated response' }]
+            }
+          }
+        }
+      ])
+    )
+
+    const sessionStat = await stat(sessionPath)
+    const session = await parseCodexSessionFile(
+      {
+        path: sessionPath,
+        mtimeMs: sessionStat.mtimeMs,
+        modifiedAt: sessionStat.mtime.toISOString()
+      },
+      'darwin',
+      root
+    )
+
+    expect(session).toMatchObject({
+      title: 'Visible paginated prompt',
+      lastUserPrompt: 'Visible paginated prompt',
+      messageCount: 2,
+      previewMessages: [
+        { role: 'user', text: 'Visible paginated prompt' },
+        { role: 'assistant', text: 'Visible paginated response' }
+      ]
+    })
+  })
+
   it('uses user-message events instead of later injected user-role records', async () => {
     const root = await mkdtemp(join(tmpdir(), 'orca-ai-vault-codex-last-prompt-'))
     tempRoots.push(root)

--- a/src/main/ai-vault/session-scanner-codex-parser.ts
+++ b/src/main/ai-vault/session-scanner-codex-parser.ts
@@ -3,15 +3,18 @@ import { createInterface } from 'node:readline'
 import type { AiVaultSession } from '../../shared/ai-vault-types'
 import { readCodexSessionIndexTitle } from './session-scanner-codex-title-index'
 import type { ExecutionHostId } from '../../shared/execution-host'
-import { normalizePromptField } from '../../shared/agent-status-field-normalization'
 import {
-  addPreviewContent,
   cloneSessionAccumulator,
   createAccumulator,
   finalizeSession,
   sessionIdFromFileName,
   updateTimeline
 } from './session-scanner-accumulator'
+import {
+  consumeCodexCompletedMessage,
+  consumeCodexLegacyEventMessage,
+  consumeCodexResponseMessage
+} from './session-scanner-codex-message-records'
 import type {
   CodexUsageSnapshot,
   FileWithMtime,
@@ -22,7 +25,6 @@ import type {
 import {
   addCodexUsage,
   asRecord,
-  extractContentText,
   extractGitBranch,
   extractModel,
   extractString,
@@ -80,6 +82,7 @@ type CodexSessionParseState = {
   previousTotals: CodexUsageSnapshot | null
   rejectedWorkerSession: boolean
   sawSessionMeta: boolean
+  historyMode: string | null
   // Which source set the current title; an index-file title outranks the raw
   // first user prompt, so finalize must know whether 'meta' already won.
   titleSource: 'meta' | 'user' | null
@@ -95,6 +98,7 @@ function createCodexParseState(file: FileWithMtime): CodexSessionParseState {
     previousTotals: null,
     rejectedWorkerSession: false,
     sawSessionMeta: false,
+    historyMode: null,
     titleSource: null
   }
 }
@@ -128,6 +132,7 @@ function consumeCodexRecordLine(state: CodexSessionParseState, line: string): vo
       return
     }
     state.sawSessionMeta = true
+    state.historyMode = extractString(payload.history_mode)
     const sessionId = extractString(payload.id)
     if (sessionId) {
       accumulator.sessionId = sessionId
@@ -162,17 +167,12 @@ function consumeCodexRecordLine(state: CodexSessionParseState, line: string): vo
   }
 
   if (record.type === 'response_item' && payload.type === 'message') {
-    accumulator.messageCount++
-    if (payload.role === 'user' && !accumulator.title) {
-      accumulator.title = extractContentText(payload.content)
-      state.titleSource = accumulator.title ? 'user' : state.titleSource
+    if (state.historyMode === 'paginated') {
+      return
     }
-    addPreviewContent(
-      accumulator,
-      payload.role === 'assistant' ? 'assistant' : payload.role === 'user' ? 'user' : 'unknown',
-      payload.content,
-      record.timestamp
-    )
+    if (consumeCodexResponseMessage(accumulator, payload, record.timestamp)) {
+      state.titleSource = 'user'
+    }
     return
   }
 
@@ -180,23 +180,17 @@ function consumeCodexRecordLine(state: CodexSessionParseState, line: string): vo
     return
   }
 
-  if (payload.type === 'user_message') {
-    accumulator.messageCount++
-    const prompt = normalizePromptField(payload.message)
-    if (prompt) {
-      accumulator.lastUserPrompt = prompt
+  if (state.historyMode === 'paginated' && payload.type === 'item_completed') {
+    if (consumeCodexCompletedMessage(accumulator, payload, record.timestamp)) {
+      state.titleSource = 'user'
     }
-    if (!accumulator.title) {
-      accumulator.title = extractContentText(payload.message)
-      state.titleSource = accumulator.title ? 'user' : state.titleSource
-    }
-    addPreviewContent(accumulator, 'user', payload.message, record.timestamp)
     return
   }
 
-  if (payload.type === 'agent_message') {
-    accumulator.messageCount++
-    addPreviewContent(accumulator, 'assistant', payload.message, record.timestamp)
+  if (payload.type === 'user_message' || payload.type === 'agent_message') {
+    if (consumeCodexLegacyEventMessage(accumulator, payload, record.timestamp)) {
+      state.titleSource = 'user'
+    }
     return
   }
 

--- a/src/main/runtime/rpc/methods/native-chat-rpc-image-block.ts
+++ b/src/main/runtime/rpc/methods/native-chat-rpc-image-block.ts
@@ -1,0 +1,31 @@
+import type { NativeChatImageRefBlock } from '../../../../shared/native-chat-types'
+
+// Image refs are labels over RPC; inline bytes stay local and metadata cannot consume the frame.
+const NATIVE_CHAT_RPC_IMAGE_METADATA_CAP = 512
+
+export function sanitizeNativeChatRpcImageBlock(
+  block: NativeChatImageRefBlock
+): NativeChatImageRefBlock {
+  const path = boundedImageMetadata(block.path)
+  const boundedUrl = boundedImageMetadata(block.url)
+  const url = boundedUrl && !isInlineDataUrl(boundedUrl) ? boundedUrl : undefined
+  const alt = boundedImageMetadata(block.alt)
+  return {
+    type: 'image-ref',
+    ...(path ? { path } : {}),
+    ...(url ? { url } : {}),
+    ...(alt ? { alt } : {})
+  }
+}
+
+function boundedImageMetadata(value: string | undefined): string | undefined {
+  return value && value.length <= NATIVE_CHAT_RPC_IMAGE_METADATA_CAP ? value : undefined
+}
+
+function isInlineDataUrl(value: string): boolean {
+  let schemeStart = 0
+  while (schemeStart < value.length && value.charCodeAt(schemeStart) <= 0x20) {
+    schemeStart += 1
+  }
+  return /^data:/i.test(value.slice(schemeStart))
+}

--- a/src/main/runtime/rpc/methods/native-chat.test.ts
+++ b/src/main/runtime/rpc/methods/native-chat.test.ts
@@ -203,6 +203,43 @@ describe('nativeChat.readSession clientKind truncation gating', () => {
     expect(block.text).toBe(`${text.slice(0, 64_000)}\n… (truncated)`)
   })
 
+  it.each(['mobile', 'runtime', undefined] as const)(
+    'omits inline image bodies and oversized metadata for %s clients',
+    async (clientKind) => {
+      cachedResult.value = {
+        messages: [
+          {
+            ...makeMessage('ignored'),
+            blocks: [
+              {
+                type: 'image-ref',
+                url: `data:image/png;base64,${'a'.repeat(10_000)}`,
+                alt: 'Inline image'
+              },
+              { type: 'image-ref', url: ' \tdata:image/png;base64,abc' },
+              { type: 'image-ref', url: 'https://example.com/reference.png' },
+              { type: 'image-ref', path: '/'.repeat(600) }
+            ]
+          }
+        ]
+      }
+
+      const result = await readSessionHandler()(
+        { agent: 'codex', sessionId: 's' },
+        ctxWith(clientKind)
+      )
+      const messages = (result as { messages: NativeChatMessage[] }).messages
+
+      expect(messages[0].blocks).toEqual([
+        { type: 'image-ref', alt: 'Inline image' },
+        { type: 'image-ref' },
+        { type: 'image-ref', url: 'https://example.com/reference.png' },
+        { type: 'image-ref' }
+      ])
+      expect(JSON.stringify(messages).length).toBeLessThan(1_000)
+    }
+  )
+
   it('bounds raw tool-call inputs before sending them to mobile', async () => {
     cachedResult.value = {
       messages: [

--- a/src/main/runtime/rpc/methods/native-chat.ts
+++ b/src/main/runtime/rpc/methods/native-chat.ts
@@ -11,6 +11,7 @@ import {
   type SubscribeNativeChatTranscriptArgs
 } from '../../../native-chat/transcript-watch'
 import { defineMethod, defineStreamingMethod, type RpcAnyMethod, type RpcContext } from '../core'
+import { sanitizeNativeChatRpcImageBlock } from './native-chat-rpc-image-block'
 
 // Why: native chat renders an agent's own transcript (Claude/Codex JSONL). The
 // desktop reaches the readers via Electron IPC; mobile/web clients reach the
@@ -81,7 +82,16 @@ function clip(text: string, cap: number): string {
   return text.length > cap ? text.slice(0, cap) + TRUNCATION_MARKER : text
 }
 
-function clipBlock(block: NativeChatBlock): NativeChatBlock {
+function sanitizeBlock(
+  block: NativeChatBlock,
+  clientKind: RpcContext['clientKind']
+): NativeChatBlock {
+  if (block.type === 'image-ref') {
+    return sanitizeNativeChatRpcImageBlock(block)
+  }
+  if (clientKind !== 'mobile') {
+    return block
+  }
   if (block.type === 'text') {
     return block.text.length > MOBILE_TEXT_BLOCK_CHAR_CAP
       ? { ...block, text: clip(block.text, MOBILE_TEXT_BLOCK_CHAR_CAP) }
@@ -152,15 +162,18 @@ function sanitizeToolInput(
   return result
 }
 
-function sanitizeMessage(message: NativeChatMessage): NativeChatMessage {
-  return { ...message, blocks: message.blocks.map(clipBlock) }
+function sanitizeMessage(
+  message: NativeChatMessage,
+  clientKind: RpcContext['clientKind']
+): NativeChatMessage {
+  return { ...message, blocks: message.blocks.map((block) => sanitizeBlock(block, clientKind)) }
 }
 
 function sanitizeAppendForClient(
   messages: readonly NativeChatMessage[],
   clientKind: RpcContext['clientKind']
 ): NativeChatMessage[] {
-  return clientKind === 'mobile' ? messages.map(sanitizeMessage) : messages.slice()
+  return messages.map((message) => sanitizeMessage(message, clientKind))
 }
 
 /** Window a transcript to its most recent `limit` messages so a long session
@@ -175,17 +188,16 @@ function windowTranscript(
   return messages.length > window ? messages.slice(-window) : messages.slice()
 }
 
-/** Apply the windowed slice plus, for `mobile` clients only, oversized-block
- *  char truncation. Web/desktop (`runtime`, or undefined for in-process callers)
- *  are full-class surfaces and pass block bodies through untruncated — matching
- *  the desktop IPC path, which never clips. */
+/** Apply the windowed slice and keep inline image bytes off every RPC transport.
+ *  Mobile clients additionally receive bounded text and tool bodies; runtime
+ *  clients keep those bodies intact. */
 function windowForClient(
   messages: readonly NativeChatMessage[],
   clientKind: RpcContext['clientKind'],
   limit = MOBILE_NATIVE_CHAT_DEFAULT_WINDOW
 ): NativeChatMessage[] {
   const windowed = windowTranscript(messages, limit)
-  return clientKind === 'mobile' ? windowed.map(sanitizeMessage) : windowed
+  return windowed.map((message) => sanitizeMessage(message, clientKind))
 }
 
 export const NATIVE_CHAT_METHODS: readonly RpcAnyMethod[] = [


### PR DESCRIPTION
## Why this follow-up is needed

#13393 restored native-chat history across the three Codex transcript formats, but the readiness review found two related consumers outside that decoder:

1. **Paginated session metadata was still derived from the wrong records.** Codex paginated logs contain canonical completed items plus `response_item` message copies used for model context. The AI Vault session scanner is separate from the native-chat transcript reader and still consumed those copies. That could double-count messages and use model-only prompt text for the tab title, preview, or last-user-prompt metadata.
2. **Restored inline images could exceed RPC transport limits.** Transcript image blocks can contain full `data:` URLs. The local Electron IPC path can render those bytes directly, but native-chat RPC also publishes the same blocks to mobile, web/runtime, SSH, and relay clients. One inline image could therefore turn a small history response into a multi-megabyte RPC frame.

This PR closes those gaps so #13393 can be cherry-picked without leaving incorrect metadata or an unbounded remote payload path.

## What changed

- record the Codex `history_mode` while scanning session metadata
- for paginated sessions, derive titles, previews, message counts, and the last user prompt only from canonical `item_completed` records
- ignore paginated `response_item` message copies while preserving unwrapped-response and wrapped-event legacy formats
- sanitize image references at the native-chat RPC boundary for every RPC client kind
- omit inline `data:` bodies, including URL-parser whitespace/control-prefixed forms
- cap image path, URL, and alt metadata at 512 characters while preserving ordinary external references

## User impact

- paginated Codex sessions show the real user prompt in tab titles and previews
- session message counts no longer include duplicate model-context copies
- mobile, web/runtime, SSH, and relay history reads stay within bounded RPC payloads
- external image references continue to work; omitted inline references remain valid fieldless image placeholders

## Compatibility

This is an additive hardening follow-up with no persisted-schema, route, RPC field, stream opcode, dependency, or protocol-version change. Existing image-ref fields are optional, and older clients already tolerate a fieldless image placeholder. Legacy Codex transcript modes retain their prior behavior.

## Cherry-pick order

This PR is one commit intended to follow merged PR #13393:

```bash
git cherry-pick 1d3decdbc47c395c645e8b80f9e5436d55a2ebc9
git cherry-pick 47128dfa168fd9db7186568fe5bef2bfa091477f
```

If #13393 is already present, only cherry-pick `47128dfa168fd9db7186568fe5bef2bfa091477f`.

## Validation

- affected desktop suites: 583 passed
- mobile native-chat consumer suites: 33 passed
- final image-sanitizer regression suite: 26 passed
- root and mobile typechecks passed
- full lint, reliability gates, formatting, max-lines ratchet, and `git diff --check` passed
- PR CI: 43 checks passed, including Node 24/26 shards, cross-version wire compatibility, macOS packaging, Windows packaging, static analysis, and final verify
- CodeRabbit verified the whitespace-prefixed `data:` regression and resolved the review thread

## Readiness review

- no new network destination, dependency, binary, install hook, shell execution, or secret handling
- no platform-specific path or shell behavior
- no local-only assumption; sanitization occurs at the shared RPC publishing boundary
- metadata parsing remains linear, and image metadata inspection is bounded before scheme detection
- no visual layout or styling change