### PR TITLE
feat(native-chat): support OpenCode sessions on desktop Chat UI

### DIFF
--- a/src/main/native-chat/opencode-sqlite-live.test.ts
+++ b/src/main/native-chat/opencode-sqlite-live.test.ts
@@ -1,0 +1,383 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { DatabaseSync } from 'node:sqlite'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import {
+  createOpenCodeNativeChatState,
+  reconcileOpenCodeNativeChat,
+  subscribeOpenCodeNativeChatTranscript
+} from './opencode-sqlite-live'
+import { openCodeMessageSignature } from './opencode-sqlite-transcript'
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+
+let tempDirs: string[] = []
+
+afterEach(() => {
+  vi.useRealTimers()
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+function createTempDb(): { db: DatabaseSync; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-native-chat-live-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'opencode.db')
+  return { db: new DatabaseSync(path), path }
+}
+
+function applyOpenCodeSchema(db: DatabaseSync): void {
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `)
+}
+
+function insertSession(db: DatabaseSync, id: string): void {
+  db.prepare(
+    `INSERT INTO session (id, project_id, directory, title, time_created, time_updated)
+     VALUES (?, 'proj-1', '/work', 'S', 1777634000000, 1777634000000)`
+  ).run(id)
+}
+
+function upsertMessage(
+  db: DatabaseSync,
+  args: { id: string; sessionId: string; role: 'user' | 'assistant'; timeCreated: number }
+): void {
+  db.prepare(
+    `INSERT INTO message (id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO NOTHING`
+  ).run(
+    args.id,
+    args.sessionId,
+    args.timeCreated,
+    args.timeCreated,
+    JSON.stringify({ role: args.role })
+  )
+}
+
+function upsertPart(
+  db: DatabaseSync,
+  args: { id: string; messageId: string; sessionId: string; timeCreated: number; data: string }
+): void {
+  // Why: mirrors OpenCode mutating a part's data in place during streaming.
+  db.prepare(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)
+     ON CONFLICT(id) DO UPDATE SET data = excluded.data, time_updated = excluded.time_updated`
+  ).run(args.id, args.messageId, args.sessionId, args.timeCreated, Date.now(), args.data)
+}
+
+function textPart(text: string): string {
+  return JSON.stringify({ type: 'text', text })
+}
+
+describe('reconcileOpenCodeNativeChat', () => {
+  it('emits an initial tail snapshot then only delta appends', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_1')
+    upsertMessage(db, { id: 'm1', sessionId: 'ses_1', role: 'user', timeCreated: 1 })
+    upsertPart(db, {
+      id: 'p1',
+      messageId: 'm1',
+      sessionId: 'ses_1',
+      timeCreated: 1,
+      data: textPart('ask')
+    })
+    upsertMessage(db, { id: 'm2', sessionId: 'ses_1', role: 'assistant', timeCreated: 2 })
+    upsertPart(db, {
+      id: 'p2',
+      messageId: 'm2',
+      sessionId: 'ses_1',
+      timeCreated: 2,
+      data: textPart('going')
+    })
+    db.close()
+
+    const state = createOpenCodeNativeChatState()
+    const snapshots: NativeChatMessage[][] = []
+    const appends: NativeChatMessage[][] = []
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_1',
+      windowLimit: 40,
+      state,
+      onInitialSnapshot: (messages) => snapshots.push(messages),
+      onAppend: (messages) => appends.push(messages)
+    })
+    expect(snapshots).toEqual([
+      [expect.objectContaining({ id: 'm1' }), expect.objectContaining({ id: 'm2' })]
+    ])
+    expect(appends).toEqual([])
+
+    // No change → nothing re-emitted.
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_1',
+      windowLimit: 40,
+      state,
+      onInitialSnapshot: (messages) => snapshots.push(messages),
+      onAppend: (messages) => appends.push(messages)
+    })
+    expect(appends).toEqual([])
+  })
+
+  it('re-emits a mutated streaming part under the SAME stable id', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_1')
+    upsertMessage(db, { id: 'm1', sessionId: 'ses_1', role: 'user', timeCreated: 1 })
+    upsertPart(db, {
+      id: 'p1',
+      messageId: 'm1',
+      sessionId: 'ses_1',
+      timeCreated: 1,
+      data: textPart('ask')
+    })
+    upsertMessage(db, { id: 'm2', sessionId: 'ses_1', role: 'assistant', timeCreated: 2 })
+    upsertPart(db, {
+      id: 'p2',
+      messageId: 'm2',
+      sessionId: 'ses_1',
+      timeCreated: 2,
+      data: textPart('answ')
+    })
+    db.close()
+
+    const state = createOpenCodeNativeChatState()
+    const snapshots: NativeChatMessage[][] = []
+    const appends: NativeChatMessage[][] = []
+    const emit = {
+      onInitialSnapshot: (messages: NativeChatMessage[]) => snapshots.push(messages),
+      onAppend: (messages: NativeChatMessage[]) => appends.push(messages)
+    }
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_1',
+      windowLimit: 40,
+      state,
+      ...emit
+    })
+
+    // OpenCode rewrites the assistant text part in place (same part id).
+    const db2 = new DatabaseSync(path)
+    upsertPart(db2, {
+      id: 'p2',
+      messageId: 'm2',
+      sessionId: 'ses_1',
+      timeCreated: 2,
+      data: textPart('answering now')
+    })
+    db2.close()
+
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_1',
+      windowLimit: 40,
+      state,
+      ...emit
+    })
+    expect(appends).toHaveLength(1)
+    expect(appends[0]).toHaveLength(1)
+    expect(appends[0][0]).toMatchObject({ id: 'm2', role: 'assistant' })
+    expect(openCodeMessageSignature(appends[0][0])).not.toBe(
+      openCodeMessageSignature(snapshots[0][1])
+    )
+  })
+
+  it('appends only new messages as they arrive and never re-emits paged history', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_1')
+    upsertMessage(db, { id: 'm1', sessionId: 'ses_1', role: 'user', timeCreated: 1 })
+    upsertPart(db, {
+      id: 'p1',
+      messageId: 'm1',
+      sessionId: 'ses_1',
+      timeCreated: 1,
+      data: textPart('first')
+    })
+    db.close()
+
+    const state = createOpenCodeNativeChatState()
+    const snapshots: NativeChatMessage[][] = []
+    const appends: NativeChatMessage[][] = []
+    const emit = {
+      onInitialSnapshot: (messages: NativeChatMessage[]) => snapshots.push(messages),
+      onAppend: (messages: NativeChatMessage[]) => appends.push(messages)
+    }
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_1',
+      windowLimit: 2,
+      state,
+      ...emit
+    })
+
+    const db2 = new DatabaseSync(path)
+    upsertMessage(db2, { id: 'm2', sessionId: 'ses_1', role: 'assistant', timeCreated: 2 })
+    upsertPart(db2, {
+      id: 'p2',
+      messageId: 'm2',
+      sessionId: 'ses_1',
+      timeCreated: 2,
+      data: textPart('reply')
+    })
+    upsertMessage(db2, { id: 'm3', sessionId: 'ses_1', role: 'user', timeCreated: 3 })
+    upsertPart(db2, {
+      id: 'p3',
+      messageId: 'm3',
+      sessionId: 'ses_1',
+      timeCreated: 3,
+      data: textPart('second ask')
+    })
+    db2.close()
+
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_1',
+      windowLimit: 2,
+      state,
+      ...emit
+    })
+    // m1 ages out of the 2-wide window; only genuinely new messages append and
+    // the already-delivered m1 is never re-emitted (paged history is preserved).
+    expect(appends).toHaveLength(1)
+    expect(appends[0].map((m) => m.id)).toEqual(['m2', 'm3'])
+    expect(appends.flat().map((m) => m.id)).not.toContain('m1')
+  })
+
+  it('stays silent on a notFound read and still recovers once the session exists', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    db.close()
+
+    const state = createOpenCodeNativeChatState()
+    const snapshots: NativeChatMessage[][] = []
+    const errors: string[] = []
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_new',
+      windowLimit: 40,
+      state,
+      onInitialSnapshot: (messages, _hasMore, _beforeOffset, error) => {
+        if (error) {
+          errors.push(error)
+          return
+        }
+        snapshots.push(messages)
+      },
+      onAppend: () => {}
+    })
+    expect(errors).toEqual([])
+    expect(snapshots).toEqual([])
+
+    // The session appears.
+    const db2 = new DatabaseSync(path)
+    insertSession(db2, 'ses_new')
+    upsertMessage(db2, { id: 'm1', sessionId: 'ses_new', role: 'user', timeCreated: 1 })
+    upsertPart(db2, {
+      id: 'p1',
+      messageId: 'm1',
+      sessionId: 'ses_new',
+      timeCreated: 1,
+      data: textPart('hi')
+    })
+    db2.close()
+
+    await reconcileOpenCodeNativeChat({
+      dbPath: path,
+      sessionId: 'ses_new',
+      windowLimit: 40,
+      state,
+      onInitialSnapshot: (messages, _hasMore, _beforeOffset, error) => {
+        if (error) {
+          errors.push(error)
+          return
+        }
+        snapshots.push(messages)
+      },
+      onAppend: () => {}
+    })
+    expect(snapshots[0].map((m) => m.id)).toEqual(['m1'])
+  })
+
+  it('notifies once on a persistent schema error', async () => {
+    const { db, path } = createTempDb()
+    db.exec('CREATE TABLE session (id TEXT)')
+    db.close()
+
+    const state = createOpenCodeNativeChatState()
+    const errors: string[] = []
+    for (let i = 0; i < 3; i++) {
+      await reconcileOpenCodeNativeChat({
+        dbPath: path,
+        sessionId: 'ses_1',
+        windowLimit: 40,
+        state,
+        onInitialSnapshot: (_messages, _hasMore, _beforeOffset, error) => {
+          if (error) {
+            errors.push(error)
+          }
+        },
+        onAppend: () => {}
+      })
+    }
+    expect(errors).toEqual(['Transcript unavailable'])
+  })
+})
+
+describe('subscribeOpenCodeNativeChatTranscript', () => {
+  it('tears down the poll loop on unsubscribe without leaking watchers', async () => {
+    vi.useFakeTimers()
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_1')
+    db.close()
+
+    const onAppend = vi.fn()
+    const onInitialSnapshot = vi.fn()
+    const subscription = subscribeOpenCodeNativeChatTranscript({
+      dbPath: path,
+      sessionId: 'ses_1',
+      initialLimit: 40,
+      reconciliationIntervalMs: 10,
+      onAppend,
+      onInitialSnapshot
+    })
+    expect(subscription.watching).toBe(true)
+    await vi.advanceTimersByTimeAsync(50)
+    expect(onInitialSnapshot).toHaveBeenCalled()
+
+    onInitialSnapshot.mockClear()
+    subscription.unsubscribe()
+    await vi.advanceTimersByTimeAsync(200)
+    expect(onInitialSnapshot).not.toHaveBeenCalled()
+    expect(onAppend).not.toHaveBeenCalled()
+  })
+})

--- a/src/main/native-chat/opencode-sqlite-live.ts
+++ b/src/main/native-chat/opencode-sqlite-live.ts
@@ -1,0 +1,177 @@
+// OpenCode native-chat live reconciliation.
+//
+// Why: OpenCode keeps conversations in SQLite (~/.local/share/opencode/
+// opencode.db) whose `part` rows MUTATE in place while the assistant streams —
+// there is no append-only file to fs.watch. This polls the DB on a bounded
+// re-read, emits an initial tail snapshot, then emits only delta frames: brand
+// new messages append, mutated parts of an already-seen message re-emit under
+// the SAME stable message id so clients dedup by id (replacing in place) and
+// messages that age out of the window are simply no longer re-emitted (never a
+// removal frame, so paged history already delivered stays intact).
+
+import type { NativeChatMessage, NativeChatTurnLifecycle } from '../../shared/native-chat-types'
+import type { NativeChatTranscriptSubscription } from './transcript-watch-contract'
+import { createTranscriptWatchScheduler } from './transcript-watch-scheduler'
+import {
+  openCodeMessageSignature,
+  readOpenCodeNativeChatTranscriptTail
+} from './opencode-sqlite-transcript'
+
+export type OpenCodeNativeChatState = {
+  initialized: boolean
+  errorNotified: boolean
+  lastEmitted: Map<string, NativeChatMessage>
+}
+
+export function createOpenCodeNativeChatState(): OpenCodeNativeChatState {
+  return { initialized: false, errorNotified: false, lastEmitted: new Map() }
+}
+
+export type ReconcileOpenCodeArgs = {
+  dbPath: string
+  sessionId: string
+  /** Re-read window; appends/updates are detected inside this newest tail. */
+  windowLimit: number
+  state: OpenCodeNativeChatState
+  onInitialSnapshot: (
+    messages: NativeChatMessage[],
+    hasMore: boolean,
+    beforeOffset: number,
+    error?: string
+  ) => void
+  onAppend: (messages: NativeChatMessage[]) => void
+}
+
+/** One reconcile poll: read the tail window, then emit new + mutated messages.
+ *  Idempotent per content signature, so repeated polls with no change emit
+ *  nothing and a mutated part re-emits its stable message id exactly once. */
+export async function reconcileOpenCodeNativeChat(args: ReconcileOpenCodeArgs): Promise<void> {
+  const { dbPath, sessionId, windowLimit, state } = args
+  const result = await readOpenCodeNativeChatTranscriptTail({
+    dbPath,
+    sessionId,
+    limit: windowLimit
+  })
+
+  if ('error' in result) {
+    if (!result.notFound && !state.errorNotified) {
+      state.errorNotified = true
+      args.onInitialSnapshot([], false, 0, result.error)
+    }
+    return
+  }
+
+  if (!state.initialized) {
+    state.initialized = true
+    state.lastEmitted = new Map(result.messages.map((message) => [message.id, message]))
+    args.onInitialSnapshot(result.messages, result.hasMore, result.beforeOffset)
+    return
+  }
+
+  const updates: NativeChatMessage[] = []
+  for (const message of result.messages) {
+    const previous = state.lastEmitted.get(message.id)
+    if (
+      previous === undefined ||
+      openCodeMessageSignature(previous) !== openCodeMessageSignature(message)
+    ) {
+      updates.push(message)
+    }
+  }
+  if (updates.length > 0) {
+    args.onAppend(updates)
+  }
+  // Why: bound state to the newest window so a long-running session does not
+  // accumulate every emitted message in memory; messages that aged out are no
+  // longer re-emitted (the client keeps its paged copy).
+  state.lastEmitted = new Map(result.messages.map((message) => [message.id, message]))
+}
+
+// Why: 100 rounds up to a few medium assistant turns, includes every message
+// that could still be streaming (the newest) and bounds the poll cost to a few
+// hundred rows + their parts per tick at ~1 Hz.
+const OPENCODE_RECONCILE_WINDOW_MAX_CAP = 100
+const OPENCODE_RECONCILE_INTERVAL_MS = 1_000
+
+export function subscribeOpenCodeNativeChatTranscript(args: {
+  dbPath: string
+  sessionId: string
+  initialLimit?: number
+  onAppend: (messages: NativeChatMessage[], lifecycle?: NativeChatTurnLifecycle) => void
+  onInitialSnapshot?: (
+    messages: NativeChatMessage[],
+    hasMore: boolean,
+    beforeOffset: number,
+    error?: string,
+    lifecycle?: NativeChatTurnLifecycle
+  ) => void
+  /** Test-only override for the reconcile cadence. */
+  reconciliationIntervalMs?: number
+}): NativeChatTranscriptSubscription {
+  const limitedWindow = Math.max(
+    1,
+    Math.min(Math.floor(args.initialLimit ?? 40), OPENCODE_RECONCILE_WINDOW_MAX_CAP)
+  )
+  let closed = false
+  const state = createOpenCodeNativeChatState()
+
+  const emitInitial = args.onInitialSnapshot ?? (() => {})
+  const emitAppend = args.onAppend
+
+  async function poll(): Promise<void> {
+    if (closed) {
+      return
+    }
+    await reconcileOpenCodeNativeChat({
+      dbPath: args.dbPath,
+      sessionId: args.sessionId,
+      windowLimit: limitedWindow,
+      state,
+      onInitialSnapshot: (messages, hasMore, beforeOffset, error) =>
+        emitInitial(messages, hasMore, beforeOffset, error),
+      onAppend: (messages) => emitAppend(messages)
+    })
+  }
+
+  let reading = false
+  let pendingPoll = false
+
+  async function runPoll(): Promise<void> {
+    if (closed) {
+      return
+    }
+    if (reading) {
+      pendingPoll = true
+      return
+    }
+    reading = true
+    try {
+      do {
+        pendingPoll = false
+        await poll()
+      } while (pendingPoll && !closed)
+    } finally {
+      reading = false
+    }
+  }
+
+  const scheduler = createTranscriptWatchScheduler({
+    reconciliationIntervalMs: args.reconciliationIntervalMs ?? OPENCODE_RECONCILE_INTERVAL_MS,
+    drain: () => void runPoll(),
+    reconcile: runPoll
+  })
+
+  scheduler.startReconciliation()
+  scheduler.scheduleEventDrain()
+
+  return {
+    watching: true,
+    unsubscribe: () => {
+      if (closed) {
+        return
+      }
+      closed = true
+      scheduler.dispose()
+    }
+  }
+}

--- a/src/main/native-chat/opencode-sqlite-paging.ts
+++ b/src/main/native-chat/opencode-sqlite-paging.ts
@@ -1,0 +1,166 @@
+import type { NativeChatMessage } from '../../shared/native-chat-types'
+import type SyncDatabase from '../sqlite/sync-database'
+
+// SQLite's variable-bind limit is 999 by default; keep the parts IN-list well below it.
+const OPENCODE_PART_MESSAGE_BATCH = 400
+
+export type OpenCodeMessageRow = {
+  id: string
+  time_created: number
+  data: string | null
+}
+
+export type OpenCodePartRow = {
+  id: string
+  message_id: string
+  time_created: number
+  data: string | null
+}
+
+type OpenCodeMappedMessage = {
+  offset: number
+  message: NativeChatMessage
+}
+
+type OpenCodeMessageMapper = (
+  message: OpenCodeMessageRow,
+  parts: OpenCodePartRow[]
+) => NativeChatMessage | null
+
+function selectOpenCodeWindowMessages(
+  db: SyncDatabase,
+  sessionId: string,
+  limit: number,
+  offset: number
+): OpenCodeMessageRow[] {
+  return db
+    .prepare(
+      `SELECT m.id, m.time_created, m.data
+       FROM message m
+       WHERE m.session_id = ?
+       ORDER BY m.time_created ASC, m.id ASC
+       LIMIT ? OFFSET ?`
+    )
+    .all(sessionId, limit, offset) as OpenCodeMessageRow[]
+}
+
+function selectOpenCodePartsForMessages(
+  db: SyncDatabase,
+  messageIds: readonly string[]
+): OpenCodePartRow[] {
+  const rows: OpenCodePartRow[] = []
+  for (let start = 0; start < messageIds.length; start += OPENCODE_PART_MESSAGE_BATCH) {
+    const chunk = messageIds.slice(start, start + OPENCODE_PART_MESSAGE_BATCH)
+    const placeholders = chunk.map(() => '?').join(', ')
+    const batch = db
+      .prepare(
+        `SELECT id, message_id, time_created, data
+         FROM part
+         WHERE message_id IN (${placeholders})
+         ORDER BY message_id ASC, time_created ASC, id ASC`
+      )
+      .all(...chunk) as OpenCodePartRow[]
+    rows.push(...batch)
+  }
+  return rows
+}
+
+function mapOpenCodeWindowMessages(
+  db: SyncDatabase,
+  messageRows: readonly OpenCodeMessageRow[],
+  offset: number,
+  mapMessage: OpenCodeMessageMapper
+): OpenCodeMappedMessage[] {
+  const parts = selectOpenCodePartsForMessages(
+    db,
+    messageRows.map((row) => row.id)
+  )
+  const partsByMessage = new Map<string, OpenCodePartRow[]>()
+  for (const part of parts) {
+    const bucket = partsByMessage.get(part.message_id)
+    if (bucket) {
+      bucket.push(part)
+    } else {
+      partsByMessage.set(part.message_id, [part])
+    }
+  }
+
+  const mapped: OpenCodeMappedMessage[] = []
+  for (const [index, row] of messageRows.entries()) {
+    const message = mapMessage(row, partsByMessage.get(row.id) ?? [])
+    if (message) {
+      mapped.push({ offset: offset + index, message })
+    }
+  }
+  return mapped
+}
+
+function readMappedOpenCodeWindow(
+  db: SyncDatabase,
+  sessionId: string,
+  offset: number,
+  limit: number,
+  mapMessage: OpenCodeMessageMapper
+): OpenCodeMappedMessage[] {
+  return mapOpenCodeWindowMessages(
+    db,
+    selectOpenCodeWindowMessages(db, sessionId, limit, offset),
+    offset,
+    mapMessage
+  )
+}
+
+function hasMappedOpenCodeMessageBefore(
+  db: SyncDatabase,
+  sessionId: string,
+  beforeOffset: number,
+  scanLimit: number,
+  mapMessage: OpenCodeMessageMapper
+): boolean {
+  let cursor = beforeOffset
+  while (cursor > 0) {
+    const start = Math.max(0, cursor - scanLimit)
+    if (readMappedOpenCodeWindow(db, sessionId, start, cursor - start, mapMessage).length > 0) {
+      return true
+    }
+    cursor = start
+  }
+  return false
+}
+
+export function readMappedOpenCodeTail(args: {
+  db: SyncDatabase
+  sessionId: string
+  windowEnd: number
+  limit: number
+  mapMessage: OpenCodeMessageMapper
+}): { messages: NativeChatMessage[]; hasMore: boolean; beforeOffset: number } {
+  const { db, sessionId, windowEnd, limit, mapMessage } = args
+  const scanLimit = Math.max(limit, 40)
+  let cursor = windowEnd
+  let mapped: OpenCodeMappedMessage[] = []
+
+  // Page over raw rows in bounded chunks, but use mapped rows for the visible
+  // page so malformed/lifecycle rows cannot consume a history slot.
+  while (cursor > 0 && mapped.length < limit) {
+    const start = Math.max(0, cursor - scanLimit)
+    mapped = [
+      ...readMappedOpenCodeWindow(db, sessionId, start, cursor - start, mapMessage),
+      ...mapped
+    ]
+    cursor = start
+  }
+
+  const selected = mapped.slice(-limit)
+  const beforeOffset = selected[0]?.offset ?? 0
+  const hasScannedEarlierMessage = mapped.some(({ offset }) => offset < beforeOffset)
+  return {
+    messages: selected.map(({ message }) => message),
+    hasMore:
+      beforeOffset > 0 &&
+      (hasScannedEarlierMessage ||
+        (cursor > 0 &&
+          hasMappedOpenCodeMessageBefore(db, sessionId, beforeOffset, scanLimit, mapMessage))),
+    beforeOffset
+  }
+}

--- a/src/main/native-chat/opencode-sqlite-transcript.test.ts
+++ b/src/main/native-chat/opencode-sqlite-transcript.test.ts
@@ -1,0 +1,653 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it } from 'vitest'
+import SyncDatabase from '../sqlite/sync-database'
+import {
+  canReadOpenCodeChatSession,
+  mapOpenCodeNativeChatMessage,
+  openCodeMessageSignature,
+  readOpenCodeNativeChatTranscriptTail,
+  resolveOpenCodeNativeChatDbPath
+} from './opencode-sqlite-transcript'
+
+let tempDirs: string[] = []
+
+afterEach(() => {
+  for (const dir of tempDirs) {
+    rmSync(dir, { recursive: true, force: true })
+  }
+  tempDirs = []
+})
+
+function createTempDb(): { db: SyncDatabase; path: string } {
+  const dir = mkdtempSync(join(tmpdir(), 'orca-opencode-native-chat-'))
+  tempDirs.push(dir)
+  const path = join(dir, 'opencode.db')
+  return { db: new SyncDatabase(path), path }
+}
+
+function applyOpenCodeSchema(db: SyncDatabase): void {
+  db.exec(`
+    CREATE TABLE session (
+      id TEXT PRIMARY KEY,
+      project_id TEXT NOT NULL,
+      parent_id TEXT,
+      directory TEXT NOT NULL,
+      title TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      time_archived INTEGER
+    );
+    CREATE TABLE message (
+      id TEXT PRIMARY KEY,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+    CREATE TABLE part (
+      id TEXT PRIMARY KEY,
+      message_id TEXT NOT NULL,
+      session_id TEXT NOT NULL,
+      time_created INTEGER NOT NULL,
+      time_updated INTEGER NOT NULL,
+      data TEXT NOT NULL
+    );
+  `)
+}
+
+function insertSession(db: SyncDatabase, id: string, timeCreated = 1_777_634_000_000): void {
+  db.prepare(
+    `INSERT INTO session (id, project_id, parent_id, directory, title, time_created, time_updated)
+     VALUES (?, 'project-1', NULL, '/work', 'Session', ?, ?)`
+  ).run(id, timeCreated, timeCreated)
+}
+
+function insertMessage(
+  db: SyncDatabase,
+  args: { id: string; sessionId: string; role: 'user' | 'assistant'; timeCreated: number }
+): void {
+  db.prepare(
+    `INSERT INTO message (id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?)`
+  ).run(
+    args.id,
+    args.sessionId,
+    args.timeCreated,
+    args.timeCreated,
+    JSON.stringify({ role: args.role, time: { created: args.timeCreated } })
+  )
+}
+
+function insertPart(
+  db: SyncDatabase,
+  args: {
+    id: string
+    messageId: string
+    sessionId: string
+    timeCreated: number
+    data: string
+  }
+): void {
+  db.prepare(
+    `INSERT INTO part (id, message_id, session_id, time_created, time_updated, data)
+     VALUES (?, ?, ?, ?, ?, ?)`
+  ).run(args.id, args.messageId, args.sessionId, args.timeCreated, args.timeCreated, args.data)
+}
+
+const toolData = (status: 'pending' | 'completed' | 'error', tool = 'bash'): string =>
+  JSON.stringify({
+    type: 'tool',
+    tool,
+    callID: 'call_1',
+    state: {
+      status,
+      input: { command: 'ls' },
+      ...(status === 'completed' ? { output: 'a.txt\nb.ts' } : {}),
+      ...(status === 'error' ? { error: 'command failed' } : {})
+    }
+  })
+
+describe('resolveOpenCodeNativeChatDbPath', () => {
+  it('defaults to the OpenCode data directory canonical DB and honors an override', () => {
+    expect(resolveOpenCodeNativeChatDbPath().endsWith(join('opencode', 'opencode.db'))).toBe(true)
+    expect(resolveOpenCodeNativeChatDbPath('/tmp/db/db.sqlite')).toBe('/tmp/db/db.sqlite')
+  })
+})
+
+describe('mapOpenCodeNativeChatMessage', () => {
+  it('maps a user text prompt with a stable id and timestamp', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_1', time_created: 1_777_634_000_500, data: JSON.stringify({ role: 'user' }) },
+      [
+        {
+          id: 'part_1',
+          message_id: 'msg_1',
+          time_created: 1_777_634_000_500,
+          data: JSON.stringify({ type: 'text', text: 'Plan the work' })
+        }
+      ]
+    )
+    expect(message).toMatchObject({
+      id: 'msg_1',
+      role: 'user',
+      timestamp: 1_777_634_000_500,
+      source: 'transcript',
+      blocks: [{ type: 'text', text: 'Plan the work' }]
+    })
+  })
+
+  it('maps assistant text plus tool call and result blocks', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_2', time_created: 1_777_634_001_000, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_2',
+          message_id: 'msg_2',
+          time_created: 1_777_634_001_000,
+          data: JSON.stringify({ type: 'text', text: 'Running it now' })
+        },
+        {
+          id: 'part_3',
+          message_id: 'msg_2',
+          time_created: 1_777_634_001_100,
+          data: toolData('completed')
+        }
+      ]
+    )
+    expect(message?.role).toBe('assistant')
+    expect(message?.blocks).toEqual([
+      { type: 'text', text: 'Running it now' },
+      { type: 'tool-call', name: 'bash', input: { command: 'ls' } },
+      { type: 'tool-result', output: 'a.txt\nb.ts' }
+    ])
+  })
+
+  it('marks a failed tool with an error result', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_2', time_created: 1_777_634_001_000, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_3',
+          message_id: 'msg_2',
+          time_created: 1_777_634_001_100,
+          data: toolData('error')
+        }
+      ]
+    )
+    expect(message?.blocks).toEqual([
+      { type: 'tool-call', name: 'bash', input: { command: 'ls' } },
+      { type: 'tool-result', output: 'command failed', isError: true }
+    ])
+  })
+
+  it('shows a pending tool as a bare tool-call', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_2', time_created: 1_777_634_001_000, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_3',
+          message_id: 'msg_2',
+          time_created: 1_777_634_001_100,
+          data: toolData('pending')
+        }
+      ]
+    )
+    expect(message?.blocks).toEqual([{ type: 'tool-call', name: 'bash', input: { command: 'ls' } }])
+  })
+
+  it('maps reasoning-only messages to the reasoning role', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_3', time_created: 1_777_634_001_200, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_4',
+          message_id: 'msg_3',
+          time_created: 1_777_634_001_200,
+          data: JSON.stringify({ type: 'reasoning', text: 'think step by step' })
+        }
+      ]
+    )
+    expect(message).toMatchObject({ id: 'msg_3', role: 'reasoning' })
+    expect(message?.blocks).toEqual([{ type: 'text', text: 'think step by step' }])
+  })
+
+  it('surfaces patch activity as a patch tool-call', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_4', time_created: 1_777_634_001_300, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_5',
+          message_id: 'msg_4',
+          time_created: 1_777_634_001_300,
+          data: JSON.stringify({
+            type: 'patch',
+            hash: 'a1b2',
+            files: ['/work/src/a.ts', '/work/src/b.ts']
+          })
+        }
+      ]
+    )
+    expect(message?.blocks).toEqual([
+      {
+        type: 'tool-call',
+        name: 'patch',
+        input: { hash: 'a1b2', files: ['/work/src/a.ts', '/work/src/b.ts'] }
+      }
+    ])
+  })
+
+  it('ignores lifecycle noise parts (step-start, step-finish) when the message has real content', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      { id: 'msg_5', time_created: 1_777_634_001_400, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_6',
+          message_id: 'msg_5',
+          time_created: 1_777_634_001_400,
+          data: JSON.stringify({ type: 'step-start', snapshot: 'abc' })
+        },
+        {
+          id: 'part_7',
+          message_id: 'msg_5',
+          time_created: 1_777_634_001_400,
+          data: JSON.stringify({ type: 'text', text: 'final answer' })
+        }
+      ]
+    )
+    expect(message?.blocks).toEqual([{ type: 'text', text: 'final answer' }])
+  })
+
+  it('tolerates malformed message and part JSON without throwing', () => {
+    expect(
+      mapOpenCodeNativeChatMessage(
+        { id: 'msg_bad', time_created: 1_777_634_001_500, data: '{not json' },
+        []
+      )
+    ).toBeNull()
+    const valid = mapOpenCodeNativeChatMessage(
+      { id: 'msg_ok', time_created: 1_777_634_001_600, data: JSON.stringify({ role: 'user' }) },
+      [
+        {
+          id: 'part_bad',
+          message_id: 'msg_ok',
+          time_created: 1_777_634_001_600,
+          data: '{{{broken'
+        },
+        {
+          id: 'part_ok',
+          message_id: 'msg_ok',
+          time_created: 1_777_634_001_600,
+          data: JSON.stringify({ type: 'text', text: 'still works' })
+        }
+      ]
+    )
+    expect(valid?.blocks).toEqual([{ type: 'text', text: 'still works' }])
+  })
+
+  it('returns null for unknown roles and for no mapable content', () => {
+    expect(
+      mapOpenCodeNativeChatMessage(
+        {
+          id: 'msg_sys',
+          time_created: 1_777_634_001_000,
+          data: JSON.stringify({ role: 'system' })
+        },
+        []
+      )
+    ).toBeNull()
+    expect(
+      mapOpenCodeNativeChatMessage(
+        {
+          id: 'msg_empty',
+          time_created: 1_777_634_001_000,
+          data: JSON.stringify({ role: 'assistant' })
+        },
+        [
+          {
+            id: 'part_noise',
+            message_id: 'msg_empty',
+            time_created: 1_777_634_001_000,
+            data: JSON.stringify({ type: 'step-start', snapshot: 'x' })
+          }
+        ]
+      )
+    ).toBeNull()
+  })
+
+  it('caps oversized text and tool output rather than shipping them whole', () => {
+    const message = mapOpenCodeNativeChatMessage(
+      {
+        id: 'msg_big',
+        time_created: 1_777_634_001_000,
+        data: JSON.stringify({ role: 'assistant' })
+      },
+      [
+        {
+          id: 'part_big',
+          message_id: 'msg_big',
+          time_created: 1_777_634_001_000,
+          data: JSON.stringify({ type: 'text', text: 'x'.repeat(70_000) })
+        },
+        {
+          id: 'part_out',
+          message_id: 'msg_big',
+          time_created: 1_777_634_001_100,
+          data: JSON.stringify({
+            type: 'tool',
+            tool: 'read',
+            state: { status: 'completed', output: 'y'.repeat(200_000) }
+          })
+        }
+      ]
+    )
+    const textBlock = message?.blocks[0]
+    expect(textBlock?.type === 'text' ? textBlock.text.length : 0).toBeLessThan(70_000)
+    const resultBlock = message?.blocks[1]
+    expect(resultBlock?.type === 'tool-result' ? resultBlock.output.length : 0).toBeLessThan(
+      200_000
+    )
+  })
+
+  it('produces a content signature that tracks mutable parts', () => {
+    const base = mapOpenCodeNativeChatMessage(
+      { id: 'msg_s', time_created: 1_777_634_001_000, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_s',
+          message_id: 'msg_s',
+          time_created: 1_777_634_001_000,
+          data: JSON.stringify({ type: 'text', text: 'stream' })
+        }
+      ]
+    )!
+    const extended = mapOpenCodeNativeChatMessage(
+      { id: 'msg_s', time_created: 1_777_634_001_000, data: JSON.stringify({ role: 'assistant' }) },
+      [
+        {
+          id: 'part_s',
+          message_id: 'msg_s',
+          time_created: 1_777_634_001_000,
+          data: JSON.stringify({ type: 'text', text: 'streaming more' })
+        }
+      ]
+    )!
+    expect(openCodeMessageSignature(base)).not.toBe(openCodeMessageSignature(extended))
+  })
+})
+
+function buildOpenCodeFixture(): { db: SyncDatabase; path: string } {
+  const { db, path } = createTempDb()
+  applyOpenCodeSchema(db)
+  insertSession(db, 'ses_1')
+  insertMessage(db, {
+    id: 'msg_1',
+    sessionId: 'ses_1',
+    role: 'user',
+    timeCreated: 1_777_634_000_000
+  })
+  insertPart(db, {
+    id: 'part_1',
+    messageId: 'msg_1',
+    sessionId: 'ses_1',
+    timeCreated: 1_777_634_000_000,
+    data: JSON.stringify({ type: 'text', text: 'hello' })
+  })
+  insertMessage(db, {
+    id: 'msg_2',
+    sessionId: 'ses_1',
+    role: 'assistant',
+    timeCreated: 1_777_634_001_000
+  })
+  insertPart(db, {
+    id: 'part_2',
+    messageId: 'msg_2',
+    sessionId: 'ses_1',
+    timeCreated: 1_777_634_001_000,
+    data: JSON.stringify({ type: 'text', text: 'hi there' })
+  })
+  insertMessage(db, {
+    id: 'msg_3',
+    sessionId: 'ses_1',
+    role: 'user',
+    timeCreated: 1_777_634_002_000
+  })
+  insertPart(db, {
+    id: 'part_3',
+    messageId: 'msg_3',
+    sessionId: 'ses_1',
+    timeCreated: 1_777_634_002_000,
+    data: JSON.stringify({ type: 'text', text: 'second ask' })
+  })
+  insertMessage(db, {
+    id: 'msg_4',
+    sessionId: 'ses_1',
+    role: 'assistant',
+    timeCreated: 1_777_634_003_000
+  })
+  insertPart(db, {
+    id: 'part_4',
+    messageId: 'msg_4',
+    sessionId: 'ses_1',
+    timeCreated: 1_777_634_003_000,
+    data: JSON.stringify({ type: 'text', text: 'second answer' })
+  })
+  return { db, path }
+}
+
+describe('canReadOpenCodeChatSession', () => {
+  it('guards against missing schema tables', () => {
+    const { db, path } = createTempDb()
+    db.exec(
+      'CREATE TABLE session (id TEXT PRIMARY KEY, time_created INTEGER, time_updated INTEGER)'
+    )
+    expect(canReadOpenCodeChatSession(db)).toBe(false)
+    db.close()
+
+    const { db: completeDb } = createTempDb()
+    applyOpenCodeSchema(completeDb)
+    expect(canReadOpenCodeChatSession(completeDb)).toBe(true)
+    completeDb.close()
+    expect(path.endsWith('opencode.db')).toBe(true)
+  })
+})
+
+describe('readOpenCodeNativeChatTranscriptTail', () => {
+  it('reads the tail chronologically with stable ids and timestamps', async () => {
+    const { db, path } = buildOpenCodeFixture()
+    db.close()
+    const result = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_1',
+      limit: 40
+    })
+    expect('error' in result).toBe(false)
+    if ('error' in result) {
+      return
+    }
+    expect(result.messages.map((m) => m.id)).toEqual(['msg_1', 'msg_2', 'msg_3', 'msg_4'])
+    expect(result.messages.map((m) => m.timestamp)).toEqual([
+      1_777_634_000_000, 1_777_634_001_000, 1_777_634_002_000, 1_777_634_003_000
+    ])
+    expect(result.hasMore).toBe(false)
+    expect(result.beforeOffset).toBe(0)
+  })
+
+  it('pages older history with beforeOffset without overlap', async () => {
+    const { db, path } = buildOpenCodeFixture()
+    db.close()
+
+    const first = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_1',
+      limit: 2
+    })
+    if ('error' in first) {
+      throw new Error(first.error)
+    }
+    expect(first.messages.map((m) => m.id)).toEqual(['msg_3', 'msg_4'])
+    expect(first.hasMore).toBe(true)
+    expect(first.beforeOffset).toBe(2)
+
+    const older = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_1',
+      limit: 2,
+      beforeOffset: first.beforeOffset
+    })
+    if ('error' in older) {
+      throw new Error(older.error)
+    }
+    expect(older.messages.map((m) => m.id)).toEqual(['msg_1', 'msg_2'])
+    expect(older.hasMore).toBe(false)
+    expect(older.beforeOffset).toBe(0)
+  })
+
+  it('clamps pagination at the conversation start without repeating rows', async () => {
+    const { db, path } = buildOpenCodeFixture()
+    db.close()
+    const result = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_1',
+      limit: 10,
+      beforeOffset: 1
+    })
+    if ('error' in result) {
+      throw new Error(result.error)
+    }
+    // boundary index 1 → only msg_1 is older.
+    expect(result.messages.map((m) => m.id)).toEqual(['msg_1'])
+    expect(result.hasMore).toBe(false)
+    expect(result.beforeOffset).toBe(0)
+  })
+
+  it('returns an empty tail for a session with no mapable messages', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_empty')
+    db.close()
+    const result = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_empty',
+      limit: 40
+    })
+    expect(result).toEqual({ messages: [], hasMore: false, beforeOffset: 0 })
+  })
+
+  it('tolerates malformed rows in the middle of a session', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_mal')
+    insertMessage(db, { id: 'msg_good1', sessionId: 'ses_mal', role: 'user', timeCreated: 1 })
+    insertPart(db, {
+      id: 'p_good1',
+      messageId: 'msg_good1',
+      sessionId: 'ses_mal',
+      timeCreated: 1,
+      data: JSON.stringify({ type: 'text', text: 'one' })
+    })
+    db.prepare(
+      `INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('msg_bad', 'ses_mal', 2, 2, '{oops')`
+    ).run()
+    insertMessage(db, { id: 'msg_good2', sessionId: 'ses_mal', role: 'assistant', timeCreated: 3 })
+    insertPart(db, {
+      id: 'p_good2',
+      messageId: 'msg_good2',
+      sessionId: 'ses_mal',
+      timeCreated: 3,
+      data: '{broken too'
+    })
+    db.close()
+    const result = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_mal',
+      limit: 40
+    })
+    if ('error' in result) {
+      throw new Error(result.error)
+    }
+    expect(result.messages.map((m) => m.id)).toEqual(['msg_good1'])
+  })
+
+  it('pages across non-conversational rows without creating history gaps', async () => {
+    const { db, path } = createTempDb()
+    applyOpenCodeSchema(db)
+    insertSession(db, 'ses_mixed')
+    insertMessage(db, { id: 'msg_old', sessionId: 'ses_mixed', role: 'user', timeCreated: 1 })
+    insertPart(db, {
+      id: 'part_old',
+      messageId: 'msg_old',
+      sessionId: 'ses_mixed',
+      timeCreated: 1,
+      data: JSON.stringify({ type: 'text', text: 'old' })
+    })
+    db.prepare(
+      `INSERT INTO message (id, session_id, time_created, time_updated, data) VALUES ('msg_noise', 'ses_mixed', 2, 2, '{"role":"system"}')`
+    ).run()
+    insertMessage(db, { id: 'msg_new', sessionId: 'ses_mixed', role: 'assistant', timeCreated: 3 })
+    insertPart(db, {
+      id: 'part_new',
+      messageId: 'msg_new',
+      sessionId: 'ses_mixed',
+      timeCreated: 3,
+      data: JSON.stringify({ type: 'text', text: 'new' })
+    })
+    db.close()
+
+    const first = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_mixed',
+      limit: 1
+    })
+    if ('error' in first) {
+      throw new Error(first.error)
+    }
+    expect(first.messages.map((m) => m.id)).toEqual(['msg_new'])
+    expect(first.hasMore).toBe(true)
+    expect(first.beforeOffset).toBe(2)
+
+    const older = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_mixed',
+      limit: 1,
+      beforeOffset: first.beforeOffset
+    })
+    if ('error' in older) {
+      throw new Error(older.error)
+    }
+    expect(older.messages.map((m) => m.id)).toEqual(['msg_old'])
+    expect(older.hasMore).toBe(false)
+    expect(older.beforeOffset).toBe(0)
+  })
+
+  it('returns notFound for a missing session and a missing DB file', async () => {
+    const { db, path } = buildOpenCodeFixture()
+    db.close()
+    const missingSession = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_nope',
+      limit: 40
+    })
+    expect(missingSession).toMatchObject({ error: expect.any(String), notFound: true })
+
+    const missingDb = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: join(tmpdir(), 'does-not-exist-opencode.db'),
+      sessionId: 'ses_1',
+      limit: 40
+    })
+    expect(missingDb).toMatchObject({ error: expect.any(String), notFound: true })
+  })
+
+  it('returns Transcript unavailable when the schema is unreadable', async () => {
+    const { db, path } = createTempDb()
+    db.exec('CREATE TABLE session (id TEXT)')
+    db.close()
+    const result = await readOpenCodeNativeChatTranscriptTail({
+      dbPath: path,
+      sessionId: 'ses_1',
+      limit: 40
+    })
+    expect(result).toEqual({ error: 'Transcript unavailable' })
+  })
+})

--- a/src/main/native-chat/opencode-sqlite-transcript.ts
+++ b/src/main/native-chat/opencode-sqlite-transcript.ts
@@ -1,0 +1,273 @@
+// OpenCode 1.18.x native-chat transcript reader.
+//
+// Why: OpenCode migrated conversations from per-session JSON files to a single
+// SQLite DB at ~/.local/share/opencode/opencode.db (the same schema the AI Vault
+// scanner reads). Unlike the JSONL agents, there is no append-only file to tail:
+// the `part` rows mutate in place while the assistant streams, so a message's
+// blocks are rebuilt from its current parts on every read. This module maps
+// `message` + `part` rows to NativeChatMessages and pages the conversation by a
+// stable ordinal window (read query-only, schema-guarded, malformed-tolerant).
+
+import { existsSync } from 'node:fs'
+import { join } from 'node:path'
+import type {
+  NativeChatBlock,
+  NativeChatMessage,
+  NativeChatRole
+} from '../../shared/native-chat-types'
+import { resolveOpenCodeDataDirectory } from '../opencode/opencode-data-directory'
+import { columnExists, tableExists } from '../opencode-usage/schema-helpers'
+import SyncDatabase from '../sqlite/sync-database'
+import { asRecord, extractString, parseJsonObject } from '../ai-vault/session-scanner-values'
+import { toolResultOutput } from './transcript-record-blocks'
+import {
+  readMappedOpenCodeTail,
+  type OpenCodeMessageRow,
+  type OpenCodePartRow
+} from './opencode-sqlite-paging'
+
+// Why: a heavy OpenCode session holds ~10K parts with multi-hundred-KB tool
+// blobs (25-150 KB is common). Text/reasoning are the visible message body and
+// stream part-by-part, so a generous cap keeps a pathological single part from
+// freezing the message list; tool output is only previewed by the renderer.
+const OPENCODE_TEXT_CHAR_CAP = 64_000
+const OPENCODE_REASONING_CHAR_CAP = 32_000
+const OPENCODE_TOOL_OUTPUT_CHAR_CAP = 100_000
+
+export function resolveOpenCodeNativeChatDbPath(openCodeDbPath?: string): string {
+  return openCodeDbPath ?? join(resolveOpenCodeDataDirectory(), 'opencode.db')
+}
+
+function openReadonlyDatabase(dbPath: string): SyncDatabase {
+  const db = new SyncDatabase(dbPath, { readonly: true, fileMustExist: true })
+  db.pragma('query_only = ON')
+  return db
+}
+
+/** Schema guards mirroring session-scanner-opencode-sqlite.ts: require the
+ *  tables and columns the chat read actually touches, and bail out cleanly on
+ *  older generations rather than throwing. */
+export function canReadOpenCodeChatSession(db: SyncDatabase): boolean {
+  return (
+    tableExists(db, 'session') &&
+    tableExists(db, 'message') &&
+    tableExists(db, 'part') &&
+    columnExists(db, 'message', 'id') &&
+    columnExists(db, 'message', 'session_id') &&
+    columnExists(db, 'message', 'time_created') &&
+    columnExists(db, 'message', 'data') &&
+    columnExists(db, 'part', 'message_id') &&
+    columnExists(db, 'part', 'time_created') &&
+    columnExists(db, 'part', 'data')
+  )
+}
+
+function openCodeSessionRowExists(db: SyncDatabase, sessionId: string): boolean {
+  const row = db.prepare('SELECT 1 AS found FROM session WHERE id = ? LIMIT 1').get(sessionId) as
+    | { found?: number }
+    | undefined
+  return row?.found === 1
+}
+
+function countSessionMessages(db: SyncDatabase, sessionId: string): number {
+  const row = db
+    .prepare('SELECT COUNT(*) AS n FROM message m WHERE m.session_id = ?')
+    .get(sessionId) as { n?: number } | undefined
+  return typeof row?.n === 'number' ? row.n : 0
+}
+
+export function clipOpenCodeText(text: string, cap: number): string {
+  return text.length > cap ? `${text.slice(0, cap)}\n… (truncated)` : text
+}
+
+/** Build the tool-call + tool-result blocks for one OpenCode `tool` part. The
+ *  part mutates in place (pending → running → completed/error), so the message
+ *  id stays stable and the live reconcile re-emits the same message with the
+ *  finished blocks; the renderer's id-dedup replaces the old copy. */
+function openCodeToolBlocks(record: Record<string, unknown>): NativeChatBlock[] {
+  const state = asRecord(record.state)
+  const name = extractString(record.tool) ?? 'tool'
+  const input = state?.input
+  const status = extractString(state?.status)
+  const toolCall: NativeChatBlock = { type: 'tool-call', name, input }
+  if (status === 'completed') {
+    return [
+      toolCall,
+      {
+        type: 'tool-result',
+        output: clipOpenCodeText(toolResultOutput(state?.output), OPENCODE_TOOL_OUTPUT_CHAR_CAP)
+      }
+    ]
+  }
+  if (status === 'error') {
+    const errorText = extractString(state?.error) ?? toolResultOutput(state?.output)
+    return [
+      toolCall,
+      {
+        type: 'tool-result',
+        output: clipOpenCodeText(errorText, OPENCODE_TOOL_OUTPUT_CHAR_CAP),
+        isError: true
+      }
+    ]
+  }
+  // pending / running / unknown: the call is in flight, no result yet.
+  return [toolCall]
+}
+
+/** Map the current parts of one OpenCode message into NativeChat blocks.
+ *  Returns `{ blocks, reasoningText, reasonOnly }` so the caller can decide
+ *  whether to surface a reasoning-only message. */
+function openCodePartBlocks(partData: string | null): {
+  blocks: NativeChatBlock[]
+  reasoningText: string[]
+} {
+  const blocks: NativeChatBlock[] = []
+  const reasoningText: string[] = []
+  const record = parseJsonObject(partData ?? '')
+  if (!record) {
+    return { blocks, reasoningText }
+  }
+  const type = extractString(record.type)
+  if (type === 'text') {
+    const text = extractString(record.text)
+    if (text) {
+      blocks.push({ type: 'text', text: clipOpenCodeText(text, OPENCODE_TEXT_CHAR_CAP) })
+    }
+  } else if (type === 'reasoning') {
+    const text = extractString(record.text)
+    if (text) {
+      reasoningText.push(clipOpenCodeText(text, OPENCODE_REASONING_CHAR_CAP))
+    }
+  } else if (type === 'tool') {
+    blocks.push(...openCodeToolBlocks(record))
+  } else if (type === 'patch') {
+    // Why: a `patch` part records applied file edits; surface it as tool
+    // activity so the conversation shows what changed without shipping the diff.
+    const files = Array.isArray(record.files)
+      ? record.files.filter((f) => typeof f === 'string')
+      : []
+    blocks.push({ type: 'tool-call', name: 'patch', input: { hash: record.hash ?? null, files } })
+  }
+  // Everything else (step-start/step-finish, snapshot, compaction, agent, …)
+  // is lifecycle noise and intentionally dropped.
+  return { blocks, reasoningText }
+}
+
+/** Map one SQLite message row (with its parts) to a NativeChatMessage, or null
+ *  when the row is not a conversational turn (unknown role, no mapable parts,
+ *  malformed JSON — all tolerated, never thrown). */
+export function mapOpenCodeNativeChatMessage(
+  message: OpenCodeMessageRow,
+  parts: OpenCodePartRow[]
+): NativeChatMessage | null {
+  const dataRecord = parseJsonObject(message.data ?? '')
+  const role = extractString(dataRecord?.role)
+  if (role !== 'user' && role !== 'assistant') {
+    return null
+  }
+  const timestamp =
+    typeof message.time_created === 'number' &&
+    Number.isFinite(message.time_created) &&
+    message.time_created > 0
+      ? message.time_created
+      : null
+
+  const blocks: NativeChatBlock[] = []
+  const reasoningText: string[] = []
+  for (const part of parts) {
+    const mapped = openCodePartBlocks(part.data)
+    blocks.push(...mapped.blocks)
+    reasoningText.push(...mapped.reasoningText)
+  }
+
+  if (blocks.length === 0) {
+    if (reasoningText.length === 0) {
+      return null
+    }
+    // Why: a message holding only reasoning reads as a thinking bubble, matching
+    // the Codex decoder's reasoning-role handling.
+    return {
+      id: message.id,
+      role: 'reasoning',
+      blocks: [{ type: 'text', text: reasoningText.join('\n') }],
+      timestamp,
+      source: 'transcript'
+    }
+  }
+
+  const messageRole: NativeChatRole = role === 'assistant' ? 'assistant' : 'user'
+  return {
+    id: message.id,
+    role: messageRole,
+    blocks,
+    timestamp,
+    source: 'transcript'
+  }
+}
+
+/** Stable content signature for one message; the live reconcile compares it to
+ *  detect in-place part mutations (streaming text/tool state) under a stable id. */
+export function openCodeMessageSignature(message: NativeChatMessage): string {
+  return JSON.stringify([message.role, message.timestamp, message.blocks])
+}
+
+/** Resolve a session row's conversation window. `beforeOffset` is the ascending
+ *  ordinal of the OLDEST row in the previously returned page; the reader returns
+ *  the `limit` rows strictly before it. Undefined reads the newest tail. */
+export async function readOpenCodeNativeChatTranscriptTail(args: {
+  dbPath: string
+  sessionId: string
+  limit: number
+  beforeOffset?: number
+}): Promise<
+  | {
+      messages: NativeChatMessage[]
+      hasMore: boolean
+      beforeOffset: number
+    }
+  | { error: string; notFound?: true }
+> {
+  const { dbPath, sessionId } = args
+  const limit = Number.isInteger(args.limit) && args.limit > 0 ? args.limit : 40
+  let db: SyncDatabase | null = null
+  try {
+    // Why: SyncDatabase's fileMustExist guard throws a plain Error (no ENOENT
+    // code), so the miss must be detected before opening: a just-launched
+    // OpenCode session can legitimately not have a DB file yet, and that miss
+    // is retry-worthy like a JSONL first-flush.
+    if (!existsSync(dbPath)) {
+      return { error: `SQLite database does not exist: ${dbPath}`, notFound: true }
+    }
+    db = openReadonlyDatabase(dbPath)
+    if (!canReadOpenCodeChatSession(db)) {
+      return { error: 'Transcript unavailable' }
+    }
+    if (!openCodeSessionRowExists(db, sessionId)) {
+      // Why: a brand-new session can report its id before OpenCode flushes the
+      // first message; keep this retry-worthy like a JSONL first-flush miss.
+      return { error: 'Transcript unavailable', notFound: true }
+    }
+    const count = countSessionMessages(db, sessionId)
+    const windowEnd = Math.max(
+      0,
+      Math.min(args.beforeOffset === undefined ? count : args.beforeOffset, count)
+    )
+    if (windowEnd <= 0) {
+      return { messages: [], hasMore: false, beforeOffset: 0 }
+    }
+    return readMappedOpenCodeTail({
+      db,
+      sessionId,
+      windowEnd,
+      limit,
+      mapMessage: mapOpenCodeNativeChatMessage
+    })
+  } catch (error) {
+    const message = error instanceof Error ? error.message : String(error)
+    return (error as NodeJS.ErrnoException | null)?.code === 'ENOENT'
+      ? { error: message, notFound: true }
+      : { error: message }
+  } finally {
+    db?.close()
+  }
+}

--- a/src/main/native-chat/session-file-resolver.ts
+++ b/src/main/native-chat/session-file-resolver.ts
@@ -68,6 +68,9 @@ export type ResolveSessionFileOptions = {
    *  directly — recent Claude Code names the transcript with a UUID that differs
    *  from the hook session_id, so the id-based glob below would miss it. */
   transcriptPath?: string
+  /** Override the OpenCode SQLite DB path (default
+   *  `~/.local/share/opencode/opencode.db` — tests / isolated reads). */
+  openCodeDbPath?: string
 }
 
 /**

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -7,6 +7,10 @@ import type {
 import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
 import { resolveSessionFilePath, type ResolveSessionFileOptions } from './session-file-resolver'
 import {
+  readOpenCodeNativeChatTranscriptTail,
+  resolveOpenCodeNativeChatDbPath
+} from './opencode-sqlite-transcript'
+import {
   decodeClaudeTranscriptLine,
   decodeCodexTranscriptLine,
   decodeGrokTranscriptLine,
@@ -217,6 +221,17 @@ export async function readNativeChatTranscriptTail(
 > {
   const decode = nativeChatLineDecoderForAgent(args.agent)
   const decodeLifecycle = nativeChatTurnLifecycleDecoderForAgent(args.agent)
+  // Why: OpenCode stores conversations in SQLite (not JSONL) — route before
+  // the file-path resolver so missing .jsonl never becomes a false error.
+  if (resolveNativeChatTranscriptAgent(args.agent) === 'opencode') {
+    signal?.throwIfAborted()
+    return readOpenCodeNativeChatTranscriptTail({
+      dbPath: resolveOpenCodeNativeChatDbPath(args.openCodeDbPath),
+      sessionId: args.sessionId,
+      limit: args.limit,
+      beforeOffset: args.beforeOffset
+    })
+  }
   const filePath =
     args.filePath ?? (await resolveSessionFilePath(args.agent, args.sessionId, args, signal))
   signal?.throwIfAborted()

--- a/src/main/native-chat/transcript-watch.ts
+++ b/src/main/native-chat/transcript-watch.ts
@@ -1,9 +1,12 @@
 import { extname } from 'node:path'
 import type { NativeChatMessage } from '../../shared/native-chat-types'
+import { resolveNativeChatTranscriptAgent } from '../../shared/native-chat-agent-support'
 import {
   needsWslHostTranslation,
   toHostReadableTranscriptPath
 } from './host-readable-transcript-path'
+import { subscribeOpenCodeNativeChatTranscript } from './opencode-sqlite-live'
+import { resolveOpenCodeNativeChatDbPath } from './opencode-sqlite-transcript'
 import { resolveSessionFilePath } from './session-file-resolver'
 import { installTranscriptWatcher } from './transcript-watch-engine'
 import type {
@@ -195,6 +198,21 @@ export async function subscribeNativeChatTranscript(
   setupSignal?: AbortSignal
 ): Promise<NativeChatTranscriptSubscription> {
   setupSignal?.throwIfAborted()
+  // Why: OpenCode keeps conversations in SQLite, so live updates poll the DB
+  // instead of fs.watch on a JSONL path. Must run before the line-decoder gate.
+  if (resolveNativeChatTranscriptAgent(args.agent) === 'opencode') {
+    if (!args.sessionId.trim()) {
+      return { unsubscribe: () => {}, watching: false }
+    }
+    return subscribeOpenCodeNativeChatTranscript({
+      dbPath: resolveOpenCodeNativeChatDbPath(args.openCodeDbPath),
+      sessionId: args.sessionId,
+      initialLimit: args.initialLimit,
+      reconciliationIntervalMs: args.reconciliationIntervalMs,
+      onInitialSnapshot: args.onInitialSnapshot,
+      onAppend: args.onAppend
+    })
+  }
   const decode = nativeChatLineDecoderForAgent(args.agent)
   if (!decode) {
     // Nothing watchable — return a no-op teardown so callers can unconditionally

--- a/src/renderer/src/components/native-chat/native-chat-availability.test.ts
+++ b/src/renderer/src/components/native-chat/native-chat-availability.test.ts
@@ -105,6 +105,21 @@ describe('canToggleNativeChat', () => {
     expect(forConnection('runtime-ssh-env-1')).toBe(true)
   })
 
+  // Why: OpenCode keeps conversations in its local SQLite DB and reports no
+  // hook transcript path, so chat is only reachable on a readable disk.
+  it('rejects Model-A SSH opencode but accepts it local and runtime-owned', () => {
+    const forConnection = (connectionId: string | null): boolean =>
+      canToggleNativeChat({
+        experimentalNativeChatEnabled: true,
+        contentType: 'terminal',
+        launchAgent: 'opencode',
+        nativeChatTranscriptIsLocalReadable: isNativeChatTranscriptLocalReadable(connectionId)
+      })
+    expect(forConnection('ssh-target-1')).toBe(false)
+    expect(forConnection(null)).toBe(true)
+    expect(forConnection('runtime-ssh-env-1')).toBe(true)
+  })
+
   it('lets an existing Model-A SSH Grok chat toggle back to terminal', () => {
     expect(
       canToggleNativeChat({

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.test.ts
@@ -206,6 +206,34 @@ describe('useNativeChatLiveSession — transport routing', () => {
     expect(transport.subscribe).toHaveBeenCalledOnce()
   })
 
+  it('replaces a base message in place when a live append re-emits its id (OpenCode streaming)', async () => {
+    const transport = getMockTransport('env-1')
+    await render({ paneKey: PANE, agent: AGENT, sessionId: SESSION, runtimeEnvironmentId: 'env-1' })
+    await act(async () =>
+      transport.emit({
+        type: 'snapshot',
+        messages: [user('u-1', 'go'), assistant('a-1', 'partial stream')],
+        hasMore: false
+      })
+    )
+    expect(latest?.messages.find((m) => m.id === 'a-1')).toMatchObject({
+      role: 'assistant',
+      blocks: [{ type: 'text', text: 'partial stream' }]
+    })
+
+    // OpenCode mutates the same part in place, so the watcher re-emits message
+    // a-1 with the same id and finished text — the stale base copy must not
+    // shadow it (and no duplicate a-1 row may appear).
+    await act(async () =>
+      transport.emit({ type: 'appended', messages: [assistant('a-1', 'finished stream')] })
+    )
+
+    const a1 = latest?.messages.filter((m) => m.id === 'a-1')
+    expect(a1).toHaveLength(1)
+    expect(a1?.[0]).toMatchObject({ blocks: [{ type: 'text', text: 'finished stream' }] })
+    expect(latest?.messages.map((m) => m.id)).toEqual(['u-1', 'a-1'])
+  })
+
   it('discards a load-earlier resolve from the previous owner after a flip', async () => {
     // Fill the initial window so hasMore is true and load-earlier can fire.
     const many = Array.from({ length: NATIVE_CHAT_INITIAL_LIMIT }, (_unused, n) =>

--- a/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
+++ b/src/renderer/src/components/native-chat/use-native-chat-live-session.ts
@@ -310,8 +310,14 @@ export function useNativeChatLiveSession(
   // Computed outside the status memo so hookState churn (status-only) never re-runs the assembler.
   const baseMessages = read.phase === 'ready' ? read.messages : EMPTY_MESSAGES
   const assembledMessages = useMemo(() => {
+    // Why: OpenCode re-emits the same message id when a part mutates in place
+    // (streaming text / tool state). Drop base copies of those ids so the live
+    // append wins and the list never shows two rows for one turn.
+    const appendedIds = appended.length > 0 ? new Set(appended.map((m) => m.id)) : null
     const transcript =
-      appended.length > 0 ? [...baseMessages, ...appended] : (baseMessages as NativeChatMessage[])
+      appended.length > 0
+        ? [...baseMessages.filter((m) => !appendedIds?.has(m.id)), ...appended]
+        : (baseMessages as NativeChatMessage[])
     // Base-axis signature: any change forces a full assembler reset so a missed trigger can't leave the cache stale.
     const baseSig = `${agent}\u0000${sessionId ?? ''}`
     const baseChanged = baseSig !== baseSigRef.current || baseMessages !== baseMessagesRef.current

--- a/src/shared/native-chat-agent-profiles.test.ts
+++ b/src/shared/native-chat-agent-profiles.test.ts
@@ -22,6 +22,11 @@ describe('native chat agent picker profiles', () => {
       groupedSlash: true,
       skillSourceOwner: 'grok'
     })
+    expect(getNativeChatAgentProfile('opencode')).toMatchObject({
+      skillPrefix: '/',
+      groupedSlash: true,
+      skillSourceOwner: 'opencode'
+    })
   })
 
   it('does not grant custom or unverified agents a skill grammar', () => {

--- a/src/shared/native-chat-agent-profiles.ts
+++ b/src/shared/native-chat-agent-profiles.ts
@@ -28,6 +28,11 @@ const NATIVE_CHAT_AGENT_PROFILES: Partial<Record<AgentType, NativeChatAgentProfi
     skillPrefix: '/',
     groupedSlash: true,
     skillSourceOwner: 'grok'
+  },
+  opencode: {
+    skillPrefix: '/',
+    groupedSlash: true,
+    skillSourceOwner: 'opencode'
   }
 }
 

--- a/src/shared/native-chat-agent-support.test.ts
+++ b/src/shared/native-chat-agent-support.test.ts
@@ -12,10 +12,11 @@ describe('resolveNativeChatTranscriptAgent', () => {
     expect(resolveNativeChatTranscriptAgent('claude')).toBe('claude')
   })
 
-  it('passes codex, grok and omp through and rejects everything else', () => {
+  it('passes codex, grok, omp and opencode through and rejects everything else', () => {
     expect(resolveNativeChatTranscriptAgent('codex')).toBe('codex')
     expect(resolveNativeChatTranscriptAgent('grok')).toBe('grok')
     expect(resolveNativeChatTranscriptAgent('omp')).toBe('omp')
+    expect(resolveNativeChatTranscriptAgent('opencode')).toBe('opencode')
     expect(resolveNativeChatTranscriptAgent('cursor')).toBeNull()
     expect(resolveNativeChatTranscriptAgent(null)).toBeNull()
     expect(resolveNativeChatTranscriptAgent(undefined)).toBeNull()
@@ -27,6 +28,7 @@ describe('isNativeChatSupportedAgent', () => {
     expect(isNativeChatSupportedAgent('claude')).toBe(true)
     expect(isNativeChatSupportedAgent('openclaude')).toBe(true)
     expect(isNativeChatSupportedAgent('omp')).toBe(true)
+    expect(isNativeChatSupportedAgent('opencode')).toBe(true)
     expect(isNativeChatSupportedAgent('cursor')).toBe(false)
     expect(isNativeChatSupportedAgent(null)).toBe(false)
     expect(isNativeChatSupportedAgent(undefined)).toBe(false)
@@ -35,10 +37,12 @@ describe('isNativeChatSupportedAgent', () => {
 
 describe('nativeChatRequiresLocalTranscript', () => {
   it('covers the agents whose hook discloses no transcript path', () => {
-    // Claude/Codex report `transcript_path`; Grok and omp report only an id, so
-    // native chat has to find their file on a disk this process can read.
+    // Claude/Codex report `transcript_path`; Grok, omp, and OpenCode report only
+    // an id, so native chat has to find their session data on a disk this
+    // process can read (OpenCode conversations live in its local SQLite DB).
     expect(nativeChatRequiresLocalTranscript('grok')).toBe(true)
     expect(nativeChatRequiresLocalTranscript('omp')).toBe(true)
+    expect(nativeChatRequiresLocalTranscript('opencode')).toBe(true)
     expect(nativeChatRequiresLocalTranscript('claude')).toBe(false)
     expect(nativeChatRequiresLocalTranscript('openclaude')).toBe(false)
     expect(nativeChatRequiresLocalTranscript('codex')).toBe(false)

--- a/src/shared/native-chat-agent-support.ts
+++ b/src/shared/native-chat-agent-support.ts
@@ -1,4 +1,4 @@
-export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'omp'
+export type NativeChatTranscriptAgent = 'claude' | 'codex' | 'grok' | 'omp' | 'opencode'
 
 /** Agents whose transcripts the native chat view can parse and render. */
 export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
@@ -6,7 +6,8 @@ export const NATIVE_CHAT_SUPPORTED_AGENTS: ReadonlySet<string> = new Set([
   'openclaude',
   'codex',
   'grok',
-  'omp'
+  'omp',
+  'opencode'
 ])
 
 export function isNativeChatSupportedAgent(agent: string | null | undefined): boolean {
@@ -19,7 +20,13 @@ export function isNativeChatSupportedAgent(agent: string | null | undefined): bo
  *  so the chat view must stay closed instead of loading forever. */
 export function nativeChatRequiresLocalTranscript(agent: string | null | undefined): boolean {
   const transcriptAgent = resolveNativeChatTranscriptAgent(agent)
-  return transcriptAgent === 'grok' || transcriptAgent === 'omp'
+  return (
+    transcriptAgent === 'grok' ||
+    transcriptAgent === 'omp' ||
+    // Why: OpenCode reports only a session id; conversations live in its local
+    // SQLite DB (~/.local/share/opencode/opencode.db), so the reader needs that disk.
+    transcriptAgent === 'opencode'
+  )
 }
 
 /** True when the agent renders a digit-commit question selector that ignores
@@ -40,7 +47,7 @@ export function resolveNativeChatTranscriptAgent(
   if (agent === 'claude' || agent === 'openclaude') {
     return 'claude'
   }
-  if (agent === 'codex' || agent === 'grok' || agent === 'omp') {
+  if (agent === 'codex' || agent === 'grok' || agent === 'omp' || agent === 'opencode') {
     return agent
   }
   return null


### PR DESCRIPTION
## Summary
- Add OpenCode to desktop native-chat eligibility (`isNativeChatSupportedAgent` / local-transcript gate) so OpenCode sessions can open Chat UI when the SQLite DB is readable.
- Map OpenCode 1.17+ SQLite `message`/`part` rows (text, reasoning, tool, patch) into `NativeChatMessage`, with paged history and poll-based live reconcile for in-place streaming mutations (no JSONL file to watch).
- Replace base messages by id when live frames re-emit the same turn so streaming updates do not duplicate rows; leave Claude/Codex/Grok/omp JSONL paths and AbortSignal/WSL resolve behavior unchanged.
- Mobile #9308 intentionally out of scope (no mobile-specific UI work). Supersedes approach of #13287 on current main without regressing recent abort/WSL work.

## Validation
- Focused Vitest (config/vitest.config.ts): 82 passed
  - `opencode-sqlite-transcript` / `opencode-sqlite-live`
  - agent support + profiles + availability
  - live-session id replacement
- `pnpm run typecheck:node` and `pnpm run typecheck:web` clean
- oxlint on touched files: clean
- Manual reader check against a real OpenCode `opencode.db` (session/message/part schema): public `readNativeChatTranscriptTail({ agent: 'opencode', ... })` returned chronological turns
- UI screenshots: not captured — OpenCode CLI not installed on this host and no built Electron binary of this branch; full Chat toggle flow needs a running OpenCode session + experimental native chat enabled

## Notes for reviewers
- OpenCode reports session id only (no `transcriptPath`); chat requires a host-local `~/.local/share/opencode/opencode.db` (or Model-B runtime ownership), same local-disk pattern as Grok/omp.
- Send/interrupt reuse existing PTY chat input paths; no speculative OpenCode protocol changes.
- `openCodeDbPath` is a main-process test override only — not a new remote wire field.

Closes #9307