### PR TITLE
[perf-remote] perf(renderer): avoid duplicate remote session inventory

### DIFF
--- a/src/main/runtime/orca-runtime.ts
+++ b/src/main/runtime/orca-runtime.ts
@@ -5678,6 +5678,25 @@ export class OrcaRuntimeService {
   async listAllMobileSessionTabs(
     clientNavigationId?: string
   ): Promise<RuntimeMobileSessionTabsResult[]> {
+    await this.refreshAllMobileSessionTabs()
+    return this.captureAllMobileSessionTabs(clientNavigationId)
+  }
+
+  async subscribeAllMobileSessionTabs(
+    listener: (snapshot: RuntimeMobileSessionTabsResult) => void,
+    clientNavigationId?: string
+  ): Promise<{ snapshots: RuntimeMobileSessionTabsResult[]; unsubscribe: () => void }> {
+    await this.refreshAllMobileSessionTabs()
+    const unsubscribe = this.onMobileSessionTabsChanged(listener, clientNavigationId)
+    try {
+      return { snapshots: this.captureAllMobileSessionTabs(clientNavigationId), unsubscribe }
+    } catch (error) {
+      unsubscribe()
+      throw error
+    }
+  }
+
+  private async refreshAllMobileSessionTabs(): Promise<void> {
     for (const worktreeId of this.getKnownWorkspaceSessionWorktreeIds()) {
       this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession(worktreeId, {
         allowAttachedWindow: true,
@@ -5686,6 +5705,11 @@ export class OrcaRuntimeService {
     }
     this.hydrateHeadlessMobileSessionTabsFromWorkspaceSession()
     await this.refreshMobileSessionPtyRecords()
+  }
+
+  private captureAllMobileSessionTabs(
+    clientNavigationId?: string
+  ): RuntimeMobileSessionTabsResult[] {
     return [...this.mobileSessionTabsByWorktree.values()].map((snapshot) =>
       this.clientSessionTabSelections.project(
         this.toMobileSessionTabsResult(snapshot),

--- a/src/main/runtime/rpc/methods/session-tabs-subscribe-all.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-subscribe-all.test.ts
@@ -1,0 +1,211 @@
+import { describe, expect, it, vi } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import { OrcaRuntimeService } from '../../orca-runtime'
+import type { RpcRequest } from '../core'
+import { RpcDispatcher } from '../dispatcher'
+import { SESSION_TAB_METHODS } from './session-tabs'
+
+function deferred<T>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function snapshot(
+  worktree: string,
+  snapshotVersion: number,
+  publicationEpoch = 'epoch-1'
+): RuntimeMobileSessionTabsResult {
+  return {
+    worktree,
+    publicationEpoch,
+    snapshotVersion,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+}
+
+describe('session.tabs.subscribeAll startup', () => {
+  it('coalesces post-capture changes until the initial inventory is emitted', async () => {
+    const unsubscribe = vi.fn()
+    const subscription = deferred<{
+      snapshots: RuntimeMobileSessionTabsResult[]
+      unsubscribe: () => void
+    }>()
+    let listener: ((next: RuntimeMobileSessionTabsResult) => void) | undefined
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      subscribeAllMobileSessionTabs: vi.fn(
+        (next: (snapshot: RuntimeMobileSessionTabsResult) => void) => {
+          listener = next
+          return subscription.promise
+        }
+      ),
+      registerSubscriptionCleanup: vi.fn(),
+      cleanupSubscription: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+    const messages: string[] = []
+    const request: RpcRequest = {
+      id: 'subscribe-all-1',
+      authToken: 'token',
+      method: 'session.tabs.subscribeAll'
+    }
+
+    const pending = dispatcher.dispatchStreaming(request, (message) => messages.push(message), {
+      connectionId: 'connection-1'
+    })
+
+    await vi.waitFor(() => expect(listener).toBeDefined())
+    listener?.(snapshot('worktree-1', 1, 'epoch-2'))
+    listener?.(snapshot('worktree-1', 2, 'epoch-2'))
+    listener?.(snapshot('worktree-2', 2))
+    subscription.resolve({
+      snapshots: [snapshot('worktree-1', 5), snapshot('worktree-2', 1)],
+      unsubscribe
+    })
+    await pending
+
+    expect(messages.map((message) => JSON.parse(message).result)).toEqual([
+      {
+        type: 'snapshots',
+        snapshots: [snapshot('worktree-1', 5), snapshot('worktree-2', 1)]
+      },
+      { type: 'updated', ...snapshot('worktree-1', 2, 'epoch-2') },
+      { type: 'updated', ...snapshot('worktree-2', 2) }
+    ])
+  })
+
+  it('unsubscribes an atomic listener that resolves after cleanup', async () => {
+    const subscription = deferred<{
+      snapshots: RuntimeMobileSessionTabsResult[]
+      unsubscribe: () => void
+    }>()
+    const unsubscribe = vi.fn()
+    let cleanup: (() => void) | undefined
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      subscribeAllMobileSessionTabs: vi.fn(() => subscription.promise),
+      registerSubscriptionCleanup: vi.fn((_id: string, next: () => void) => {
+        cleanup = next
+      }),
+      cleanupSubscription: vi.fn()
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+    const emit = vi.fn()
+    const pending = dispatcher.dispatchStreaming(
+      {
+        id: 'subscribe-all-close',
+        authToken: 'token',
+        method: 'session.tabs.subscribeAll'
+      },
+      emit,
+      { connectionId: 'connection-1' }
+    )
+
+    await vi.waitFor(() => expect(cleanup).toBeDefined())
+    cleanup?.()
+    subscription.resolve({ snapshots: [snapshot('worktree-1', 1)], unsubscribe })
+    await pending
+
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(emit).not.toHaveBeenCalled()
+  })
+
+  it('cleans up the listener when initial projection fails', async () => {
+    const unsubscribe = vi.fn()
+    let cleanup: (() => void) | undefined
+    const brokenSnapshot = {
+      ...snapshot('worktree-1', 1),
+      get tabs(): RuntimeMobileSessionTabsResult['tabs'] {
+        throw new Error('projection failed')
+      }
+    }
+    const runtime = {
+      getRuntimeId: () => 'test-runtime',
+      subscribeAllMobileSessionTabs: vi.fn(async () => ({
+        snapshots: [brokenSnapshot],
+        unsubscribe
+      })),
+      registerSubscriptionCleanup: vi.fn((_id: string, next: () => void) => {
+        cleanup = next
+      }),
+      cleanupSubscription: vi.fn(() => cleanup?.())
+    } as unknown as OrcaRuntimeService
+    const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })
+    const messages: string[] = []
+
+    await dispatcher.dispatchStreaming(
+      {
+        id: 'subscribe-all-projection-error',
+        authToken: 'token',
+        method: 'session.tabs.subscribeAll'
+      },
+      (message) => messages.push(message),
+      { connectionId: 'connection-1', clientKind: 'runtime', clientCapabilities: [] }
+    )
+
+    expect(runtime.cleanupSubscription).toHaveBeenCalledWith(
+      'session.tabs:connection-1:*:subscribe-all-projection-error'
+    )
+    expect(unsubscribe).toHaveBeenCalledOnce()
+    expect(messages.map((message) => JSON.parse(message).ok)).toEqual([false])
+  })
+})
+
+describe('atomic all-session inventory boundary', () => {
+  type InventoryBoundary = {
+    refreshAllMobileSessionTabs: () => Promise<void>
+    captureAllMobileSessionTabs: (clientNavigationId?: string) => RuntimeMobileSessionTabsResult[]
+  }
+
+  it('installs the listener after refresh and before capture', async () => {
+    const runtime = new OrcaRuntimeService()
+    const boundary = runtime as unknown as InventoryBoundary
+    const refreshed = deferred<void>()
+    const order: string[] = []
+    const unsubscribe = vi.fn()
+    const listener = vi.fn()
+    boundary.refreshAllMobileSessionTabs = vi.fn(async () => {
+      order.push('refresh:start')
+      await refreshed.promise
+      order.push('refresh:end')
+    })
+    const listen = vi
+      .spyOn(runtime, 'onMobileSessionTabsChanged')
+      .mockImplementation((_listener, clientNavigationId) => {
+        order.push(`listen:${clientNavigationId}`)
+        return unsubscribe
+      })
+    boundary.captureAllMobileSessionTabs = vi.fn((clientNavigationId) => {
+      order.push(`capture:${clientNavigationId}`)
+      return []
+    })
+
+    const pending = runtime.subscribeAllMobileSessionTabs(listener, 'client-1')
+    expect(order).toEqual(['refresh:start'])
+    refreshed.resolve()
+
+    await expect(pending).resolves.toEqual({ snapshots: [], unsubscribe })
+    expect(order).toEqual(['refresh:start', 'refresh:end', 'listen:client-1', 'capture:client-1'])
+    expect(listen).toHaveBeenCalledWith(listener, 'client-1')
+  })
+
+  it('removes the listener when synchronous capture fails', async () => {
+    const runtime = new OrcaRuntimeService()
+    const boundary = runtime as unknown as InventoryBoundary
+    const unsubscribe = vi.fn()
+    boundary.refreshAllMobileSessionTabs = vi.fn(async () => {})
+    vi.spyOn(runtime, 'onMobileSessionTabsChanged').mockReturnValue(unsubscribe)
+    boundary.captureAllMobileSessionTabs = vi.fn(() => {
+      throw new Error('capture failed')
+    })
+
+    await expect(runtime.subscribeAllMobileSessionTabs(vi.fn())).rejects.toThrow('capture failed')
+    expect(unsubscribe).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/runtime/rpc/methods/session-tabs-subscribe-all.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-subscribe-all.ts
@@ -1,0 +1,82 @@
+import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
+import { defineStreamingMethod } from '../core'
+import { projectSessionTabAgentStatus } from './session-tab-agent-status-projection'
+
+export const SESSION_TABS_SUBSCRIBE_ALL_METHOD = defineStreamingMethod({
+  name: 'session.tabs.subscribeAll',
+  params: null,
+  handler: async (
+    _params,
+    { runtime, connectionId, requestId, pairedDeviceId, clientKind, clientCapabilities },
+    emit
+  ) => {
+    let unsubscribe = (): void => {}
+    let closed = false
+    // Why: initial inventory errors should return one RPC error, not a leaked cleanup that later emits end.
+    let initialized = false
+    const bufferedByWorktree = new Map<string, RuntimeMobileSessionTabsResult>()
+    const cleanupPrefix = `session.tabs:${connectionId ?? 'local'}:*`
+    const subscriptionId = requestId ? `${cleanupPrefix}:${requestId}` : cleanupPrefix
+    // Why: one socket can carry sibling subscribers; the RPC id keeps their cleanup independent.
+    runtime.registerSubscriptionCleanup(
+      subscriptionId,
+      () => {
+        closed = true
+        unsubscribe()
+        if (initialized) {
+          emit({ type: 'end' })
+        }
+      },
+      connectionId
+    )
+
+    if (closed) {
+      return
+    }
+    const subscription = await runtime
+      .subscribeAllMobileSessionTabs((snapshot) => {
+        if (!initialized) {
+          bufferedByWorktree.set(snapshot.worktree, snapshot)
+          return
+        }
+        emit({
+          type: 'updated',
+          ...projectSessionTabAgentStatus(snapshot, clientKind, clientCapabilities)
+        })
+      }, pairedDeviceId)
+      .catch((error) => {
+        runtime.cleanupSubscription(subscriptionId)
+        throw error
+      })
+    unsubscribe = subscription.unsubscribe
+    try {
+      if (closed) {
+        unsubscribe()
+        return
+      }
+      emit({
+        type: 'snapshots',
+        snapshots: subscription.snapshots.map((snapshot) =>
+          projectSessionTabAgentStatus(snapshot, clientKind, clientCapabilities)
+        )
+      })
+      initialized = true
+      if (closed) {
+        return
+      }
+      for (const buffered of bufferedByWorktree.values()) {
+        emit({
+          type: 'updated',
+          ...projectSessionTabAgentStatus(buffered, clientKind, clientCapabilities)
+        })
+        if (closed) {
+          return
+        }
+      }
+      bufferedByWorktree.clear()
+    } catch (error) {
+      runtime.cleanupSubscription(subscriptionId)
+      throw error
+    }
+  }
+})

--- a/src/main/runtime/rpc/methods/session-tabs.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.test.ts
@@ -626,29 +626,31 @@ describe('session tab RPC methods', () => {
     const listeners: ((snapshot: unknown) => void)[] = []
     const runtime = {
       getRuntimeId: () => 'test-runtime',
-      listAllMobileSessionTabs: vi.fn(() => [
-        {
-          worktree: 'wt-1',
-          publicationEpoch: 'epoch-1',
-          snapshotVersion: 1,
-          activeGroupId: null,
-          activeTabId: null,
-          activeTabType: null,
-          tabs: []
-        },
-        {
-          worktree: 'wt-2',
-          publicationEpoch: 'epoch-2',
-          snapshotVersion: 1,
-          activeGroupId: null,
-          activeTabId: null,
-          activeTabType: null,
-          tabs: []
-        }
-      ]),
-      onMobileSessionTabsChanged: vi.fn((listener: (snapshot: unknown) => void) => {
+      subscribeAllMobileSessionTabs: vi.fn(async (listener: (snapshot: unknown) => void) => {
         listeners.push(listener)
-        return unsubscribe
+        return {
+          snapshots: [
+            {
+              worktree: 'wt-1',
+              publicationEpoch: 'epoch-1',
+              snapshotVersion: 1,
+              activeGroupId: null,
+              activeTabId: null,
+              activeTabType: null,
+              tabs: []
+            },
+            {
+              worktree: 'wt-2',
+              publicationEpoch: 'epoch-2',
+              snapshotVersion: 1,
+              activeGroupId: null,
+              activeTabId: null,
+              activeTabType: null,
+              tabs: []
+            }
+          ],
+          unsubscribe
+        }
       }),
       registerSubscriptionCleanup: vi.fn()
     } as unknown as OrcaRuntimeService
@@ -675,7 +677,7 @@ describe('session tab RPC methods', () => {
       expect.any(Function),
       'conn-1'
     )
-    expect(runtime.onMobileSessionTabsChanged).toHaveBeenCalledTimes(1)
+    expect(runtime.subscribeAllMobileSessionTabs).toHaveBeenCalledTimes(1)
     expect(messages.map((message) => JSON.parse(message).result)).toEqual([
       {
         type: 'snapshots',
@@ -691,8 +693,7 @@ describe('session tab RPC methods', () => {
   it('keeps duplicate all-session-tab subscribers independent on one connection', async () => {
     const runtime = {
       getRuntimeId: () => 'test-runtime',
-      listAllMobileSessionTabs: vi.fn(() => []),
-      onMobileSessionTabsChanged: vi.fn(() => vi.fn()),
+      subscribeAllMobileSessionTabs: vi.fn(async () => ({ snapshots: [], unsubscribe: vi.fn() })),
       registerSubscriptionCleanup: vi.fn()
     } as unknown as OrcaRuntimeService
     const dispatcher = new RpcDispatcher({ runtime, methods: SESSION_TAB_METHODS })

--- a/src/main/runtime/rpc/methods/session-tabs.ts
+++ b/src/main/runtime/rpc/methods/session-tabs.ts
@@ -13,6 +13,7 @@ import {
 } from './session-tabs-schemas'
 import { SESSION_TAB_CLOSE_METHODS } from './session-tab-close-methods'
 import { projectSessionTabAgentStatus } from './session-tab-agent-status-projection'
+import { SESSION_TABS_SUBSCRIBE_ALL_METHOD } from './session-tabs-subscribe-all'
 
 export const SESSION_TAB_METHODS: RpcAnyMethod[] = [
   defineMethod({
@@ -207,66 +208,7 @@ export const SESSION_TAB_METHODS: RpcAnyMethod[] = [
       return { unsubscribed: true }
     }
   }),
-  defineStreamingMethod({
-    name: 'session.tabs.subscribeAll',
-    params: null,
-    handler: async (
-      _params,
-      { runtime, connectionId, requestId, pairedDeviceId, clientKind, clientCapabilities },
-      emit
-    ) => {
-      let unsubscribe = (): void => {}
-      let closed = false
-      // Why: initial listAll errors should return one RPC error, not a leaked
-      // subscription cleanup that later emits a stray end frame.
-      let initialized = false
-      const cleanupPrefix = `session.tabs:${connectionId ?? 'local'}:*`
-      const subscriptionId = requestId ? `${cleanupPrefix}:${requestId}` : cleanupPrefix
-      // Why: shared-control can carry multiple all-tab subscribers on one
-      // socket; include the RPC id so closing one does not evict siblings.
-      runtime.registerSubscriptionCleanup(
-        subscriptionId,
-        () => {
-          closed = true
-          unsubscribe()
-          if (initialized) {
-            emit({ type: 'end' })
-          }
-        },
-        connectionId
-      )
-
-      if (closed) {
-        return
-      }
-      const snapshots = await Promise.resolve(
-        runtime.listAllMobileSessionTabs(pairedDeviceId)
-      ).catch((error) => {
-        runtime.cleanupSubscription(subscriptionId)
-        throw error
-      })
-      if (closed) {
-        return
-      }
-      emit({
-        type: 'snapshots',
-        snapshots: snapshots.map((snapshot) =>
-          projectSessionTabAgentStatus(snapshot, clientKind, clientCapabilities)
-        )
-      })
-      initialized = true
-
-      if (closed) {
-        return
-      }
-      unsubscribe = runtime.onMobileSessionTabsChanged((snapshot) => {
-        emit({
-          type: 'updated',
-          ...projectSessionTabAgentStatus(snapshot, clientKind, clientCapabilities)
-        })
-      }, pairedDeviceId)
-    }
-  }),
+  SESSION_TABS_SUBSCRIBE_ALL_METHOD,
   defineMethod({
     name: 'session.tabs.unsubscribeAll',
     params: z

--- a/src/renderer/src/runtime/web-session-tabs-sync-subscription.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-subscription.test.tsx
@@ -1,0 +1,273 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import type { RuntimeStatus } from '../../../shared/runtime-types'
+import type { Repo } from '../../../shared/types'
+import { useAppStore } from '../store'
+import { makeWorktree } from '../store/slices/store-test-helpers'
+import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
+import {
+  resetWebSessionTabsSnapshotFreshnessForTests,
+  useWebSessionTabsSync
+} from './web-session-tabs-sync'
+
+const ENVIRONMENT_ID = 'remote-env'
+const RUNTIME_ID = 'remote-runtime'
+const REPO_ID = 'remote-repo'
+const WORKTREE_ID = `${REPO_ID}::/remote/worktree`
+const PAIRING_REVISION = 17
+const initialState = useAppStore.getInitialState()
+type RuntimeSubscribeCallbacks = Parameters<typeof window.api.runtimeEnvironments.subscribe>[1]
+
+function environment(): PublicKnownRuntimeEnvironment {
+  return {
+    id: ENVIRONMENT_ID,
+    name: 'Remote host',
+    createdAt: 1,
+    updatedAt: 1,
+    pairingRevision: PAIRING_REVISION,
+    lastUsedAt: null,
+    runtimeId: RUNTIME_ID,
+    endpoints: [
+      {
+        id: 'remote-endpoint',
+        kind: 'websocket',
+        label: 'WebSocket',
+        endpoint: 'ws://remote.invalid'
+      }
+    ],
+    preferredEndpointId: 'remote-endpoint'
+  }
+}
+
+function runtimeStatus(): RuntimeStatus {
+  return {
+    runtimeId: RUNTIME_ID,
+    rendererGraphEpoch: 1,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0
+  }
+}
+
+function repo(): Repo {
+  return {
+    id: REPO_ID,
+    path: '/remote/repo',
+    displayName: 'Remote repo',
+    badgeColor: '#000',
+    addedAt: 1,
+    connectionId: null,
+    executionHostId: `runtime:${ENVIRONMENT_ID}`
+  }
+}
+
+function worktree() {
+  return makeWorktree({
+    id: WORKTREE_ID,
+    repoId: REPO_ID,
+    path: '/remote/worktree',
+    hostId: `runtime:${ENVIRONMENT_ID}`,
+    runtimeOwnerEnvironmentId: ENVIRONMENT_ID
+  })
+}
+
+function seedRemoteWorkspace(): void {
+  const remoteEnvironment = environment()
+  replaceRuntimeEnvironmentRevisions([remoteEnvironment])
+  useAppStore.setState(
+    {
+      ...initialState,
+      settings: {
+        ...getDefaultSettings('/tmp'),
+        activeRuntimeEnvironmentId: ENVIRONMENT_ID
+      },
+      repos: [repo()],
+      worktreesByRepo: { [REPO_ID]: [worktree()] },
+      activeRepoId: REPO_ID,
+      activeWorktreeId: WORKTREE_ID,
+      activeWorkspaceExecutionHostId: `runtime:${ENVIRONMENT_ID}`,
+      runtimeEnvironments: [remoteEnvironment],
+      runtimeStatusByEnvironmentId: new Map([
+        [
+          ENVIRONMENT_ID,
+          {
+            status: runtimeStatus(),
+            checkedAt: 1,
+            connectionGeneration: 3
+          }
+        ]
+      ]),
+      workspaceSessionReady: true
+    },
+    true
+  )
+}
+
+function response(result: unknown): RuntimeRpcResponse<unknown> {
+  return { id: 'subscribe-all', ok: true, result, _meta: { runtimeId: RUNTIME_ID } }
+}
+
+describe('useWebSessionTabsSync subscription topology', () => {
+  const globalUnsubscribe = vi.fn()
+  const activeUnsubscribe = vi.fn()
+  const runtimeCall = vi.fn()
+  const runtimeSubscribe = vi.fn()
+  let globalCallbacks: RuntimeSubscribeCallbacks | undefined
+
+  beforeEach(() => {
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    globalUnsubscribe.mockReset()
+    activeUnsubscribe.mockReset()
+    runtimeCall.mockReset()
+    runtimeSubscribe.mockReset()
+    globalCallbacks = undefined
+    runtimeCall.mockResolvedValue({
+      id: 'list-all',
+      ok: true,
+      result: { snapshots: [] },
+      _meta: { runtimeId: RUNTIME_ID }
+    })
+    runtimeSubscribe.mockImplementation(
+      async (args: { method: string }, callbacks: RuntimeSubscribeCallbacks) => {
+        if (args.method === 'session.tabs.subscribeAll') {
+          globalCallbacks = callbacks
+        }
+        return {
+          unsubscribe:
+            args.method === 'session.tabs.subscribeAll' ? globalUnsubscribe : activeUnsubscribe,
+          sendBinary: vi.fn()
+        }
+      }
+    )
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        runtimeEnvironments: {
+          call: runtimeCall,
+          subscribe: runtimeSubscribe
+        }
+      }
+    })
+    seedRemoteWorkspace()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialState, true)
+    replaceRuntimeEnvironmentRevisions([])
+    resetWebSessionTabsSnapshotFreshnessForTests()
+  })
+
+  it('hydrates through subscribeAll without an eager listAll request', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+
+    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    expect(runtimeSubscribe.mock.calls.map(([args]) => args)).toEqual(
+      expect.arrayContaining([
+        {
+          selector: ENVIRONMENT_ID,
+          method: 'session.tabs.subscribeAll',
+          params: {},
+          timeoutMs: 15_000,
+          expectedEnvironmentPairingRevision: PAIRING_REVISION
+        },
+        {
+          selector: ENVIRONMENT_ID,
+          method: 'session.tabs.subscribe',
+          params: { worktree: `id:${WORKTREE_ID}` },
+          timeoutMs: 15_000,
+          expectedEnvironmentPairingRevision: PAIRING_REVISION
+        }
+      ])
+    )
+    expect(runtimeCall).not.toHaveBeenCalled()
+
+    hook.unmount()
+    expect(globalUnsubscribe).toHaveBeenCalledTimes(1)
+    expect(activeUnsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('falls back to one listAll request when subscribeAll cannot start', async () => {
+    let rejectGlobalSubscription: (error: Error) => void = () => {}
+    const globalSubscription = new Promise<never>((_resolve, reject) => {
+      rejectGlobalSubscription = reject
+    })
+    runtimeSubscribe.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'session.tabs.subscribeAll') {
+        return globalSubscription
+      }
+      return { unsubscribe: activeUnsubscribe, sendBinary: vi.fn() }
+    })
+
+    const hook = renderHook(() => useWebSessionTabsSync())
+
+    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    expect(runtimeCall).not.toHaveBeenCalled()
+    rejectGlobalSubscription(new Error('shared-control unavailable'))
+    await waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
+    expect(runtimeCall).toHaveBeenCalledWith({
+      selector: ENVIRONMENT_ID,
+      method: 'session.tabs.listAll',
+      params: {},
+      timeoutMs: 15_000,
+      expectedEnvironmentPairingRevision: PAIRING_REVISION
+    })
+
+    hook.unmount()
+    expect(globalUnsubscribe).not.toHaveBeenCalled()
+    expect(activeUnsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('once-gates fallback across invalid and failed pre-initial stream events', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    expect(() => globalCallbacks?.onResponse(response(null))).not.toThrow()
+    globalCallbacks?.onResponse({
+      id: 'subscribe-all',
+      ok: false,
+      error: { code: 'method_not_found', message: 'missing' }
+    })
+    globalCallbacks?.onError?.({ code: 'transport_closed', message: 'closed' })
+    globalCallbacks?.onClose?.()
+
+    await waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
+    hook.unmount()
+  })
+
+  it('does not fall back after a valid initial snapshot batch', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    globalCallbacks?.onError?.({ code: 'transport_closed', message: 'closed' })
+    globalCallbacks?.onClose?.()
+
+    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    expect(runtimeCall).not.toHaveBeenCalled()
+    hook.unmount()
+  })
+
+  it('falls back when a started stream never sends its initial batch', async () => {
+    vi.useFakeTimers()
+    try {
+      const hook = renderHook(() => useWebSessionTabsSync())
+      await act(async () => {})
+
+      expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+      expect(runtimeCall).not.toHaveBeenCalled()
+      await act(async () => vi.advanceTimersByTimeAsync(15_000))
+      expect(runtimeCall).toHaveBeenCalledTimes(1)
+
+      hook.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -86,6 +86,7 @@ import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
 import { useRuntimeSessionMirrorEnvironmentKey } from './use-runtime-session-mirror-environment-key'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
+const WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS = 15_000
 
 type SessionTabsStreamEvent =
   | (RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' })
@@ -93,6 +94,11 @@ type SessionTabsStreamEvent =
   | { type: 'end' }
 
 type SessionTabsListAllResult = {
+  snapshots: RuntimeMobileSessionTabsResult[]
+}
+
+type SessionTabsSnapshotsEvent = {
+  type: 'snapshots'
   snapshots: RuntimeMobileSessionTabsResult[]
 }
 
@@ -165,11 +171,44 @@ export type WebSessionTabsSyncState = Pick<
 > &
   Partial<Pick<AppState, 'automaticAgentResumeClaimsByTabId' | 'pendingStartupByTabId'>>
 
+function isRuntimeSessionTabsSnapshot(value: unknown): value is RuntimeMobileSessionTabsResult {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const candidate = value as Partial<RuntimeMobileSessionTabsResult>
+  return (
+    typeof candidate.worktree === 'string' &&
+    typeof candidate.publicationEpoch === 'string' &&
+    typeof candidate.snapshotVersion === 'number' &&
+    Array.isArray(candidate.tabs)
+  )
+}
+
 function isSessionTabsListAllResult(value: unknown): value is SessionTabsListAllResult {
   return (
     Boolean(value) &&
     typeof value === 'object' &&
-    Array.isArray((value as { snapshots?: unknown }).snapshots)
+    Array.isArray((value as { snapshots?: unknown }).snapshots) &&
+    (value as SessionTabsListAllResult).snapshots.every(isRuntimeSessionTabsSnapshot)
+  )
+}
+
+function isSessionTabsSnapshotsEvent(value: unknown): value is SessionTabsSnapshotsEvent {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'snapshots' &&
+    isSessionTabsListAllResult(value)
+  )
+}
+
+function isSessionTabsSnapshotEvent(
+  value: unknown
+): value is RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' } {
+  return (
+    isRuntimeSessionTabsSnapshot(value) &&
+    ((value as { type?: unknown }).type === 'snapshot' ||
+      (value as { type?: unknown }).type === 'updated')
   )
 }
 
@@ -2702,6 +2741,38 @@ export function applyWebSessionTabsStorePatch(
   }
 }
 
+function startAllWebSessionTabsSubscription(
+  args: Parameters<typeof window.api.runtimeEnvironments.subscribe>[0],
+  callbacks: Parameters<typeof window.api.runtimeEnvironments.subscribe>[1],
+  onStartError: (error: unknown) => void
+): () => void {
+  let disposed = false
+  let unsubscribe: (() => void) | null = null
+  void window.api.runtimeEnvironments
+    .subscribe(args, callbacks)
+    .then((handle) => {
+      if (disposed) {
+        handle.unsubscribe()
+        return
+      }
+      unsubscribe = handle.unsubscribe
+    })
+    .catch((error) => {
+      if (!disposed) {
+        onStartError(error)
+      }
+    })
+  return () => {
+    disposed = true
+    unsubscribe?.()
+  }
+}
+
+function startWebSessionTabsInitialFallbackTimer(onTimeout: () => void): () => void {
+  const timer = setTimeout(onTimeout, WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS)
+  return () => clearTimeout(timer)
+}
+
 export function useWebSessionTabsSync(): void {
   const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
   const runtimeSessionMirrorEnvironmentKey = useRuntimeSessionMirrorEnvironmentKey()
@@ -2751,7 +2822,6 @@ export function useWebSessionTabsSync(): void {
 
     let disposed = false
     const unsubscribes: (() => void)[] = []
-    // Why: the stream's initial snapshot can land after first render, so a one-shot fetch makes initial parity deterministic.
     for (const { environmentId, expectedEnvironmentPairingRevision } of environments) {
       if (
         !shouldSyncAllRuntimeSessionTabs({
@@ -2761,73 +2831,105 @@ export function useWebSessionTabsSync(): void {
       ) {
         continue
       }
-      void window.api.runtimeEnvironments
-        .call({
-          selector: environmentId,
-          method: 'session.tabs.listAll',
-          params: {},
-          timeoutMs: 15_000,
-          expectedEnvironmentPairingRevision
-        })
-        .then(async (response: RuntimeRpcResponse<unknown>) => {
-          if (
-            disposed ||
-            getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
-          ) {
-            return
+      let receivedInitialSnapshots = false
+      let requestedInitialFallback = false
+      let stopInitialFallbackTimer = (): void => {}
+      const pairingIsCurrent = (): boolean =>
+        getRuntimeEnvironmentRevision(environmentId) === expectedEnvironmentPairingRevision
+      const recoverAndApplySnapshots = async (
+        snapshots: RuntimeMobileSessionTabsResult[],
+        replayed: boolean
+      ): Promise<void> => {
+        const recovered = await Promise.all(
+          snapshots.map((snapshot) =>
+            recoverWebSessionTerminalOrphansBeforeApply(
+              useAppStore.getState(),
+              snapshot,
+              environmentId
+            )
+          )
+        )
+        if (disposed || !pairingIsCurrent()) {
+          return
+        }
+        const applicable = recovered.filter(
+          (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
+        )
+        if (replayed) {
+          for (const snapshot of applicable) {
+            acceptReplayedWebSessionTabsSnapshot(environmentId, snapshot.worktree)
           }
-          if (response.ok === false) {
-            console.warn('[web-session-tabs-sync] initial listAll failed:', response.error.message)
-            return
-          }
-          const result = response.result
-          if (!isSessionTabsListAllResult(result)) {
-            console.warn('[web-session-tabs-sync] initial listAll returned an invalid payload')
-            return
-          }
-          const recovered = await Promise.all(
-            result.snapshots.map((snapshot) =>
-              recoverWebSessionTerminalOrphansBeforeApply(
-                useAppStore.getState(),
-                snapshot,
-                environmentId
+        }
+        applyWebSessionTabsStorePatch((state) =>
+          applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
+        )
+      }
+      const requestInitialSnapshotFallback = (): void => {
+        if (
+          disposed ||
+          !pairingIsCurrent() ||
+          receivedInitialSnapshots ||
+          requestedInitialFallback
+        ) {
+          return
+        }
+        requestedInitialFallback = true
+        stopInitialFallbackTimer()
+        void window.api.runtimeEnvironments
+          .call({
+            selector: environmentId,
+            method: 'session.tabs.listAll',
+            params: {},
+            timeoutMs: WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS,
+            expectedEnvironmentPairingRevision
+          })
+          .then((response: RuntimeRpcResponse<unknown>) => {
+            if (disposed || !pairingIsCurrent()) {
+              return
+            }
+            if (response.ok === false) {
+              console.warn(
+                '[web-session-tabs-sync] fallback listAll failed:',
+                response.error.message
               )
-            )
-          )
-          if (disposed) {
-            return
-          }
-          const applicable = recovered.filter(
-            (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
-          )
-          applyWebSessionTabsStorePatch((state) =>
-            applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
-          )
-        })
-        .catch((error) => {
-          if (!disposed) {
-            console.warn(
-              '[web-session-tabs-sync] failed to load initial session tabs:',
-              error instanceof Error ? error.message : String(error)
-            )
-          }
-        })
+              return
+            }
+            if (!isSessionTabsListAllResult(response.result)) {
+              console.warn('[web-session-tabs-sync] fallback listAll returned an invalid payload')
+              return
+            }
+            void recoverAndApplySnapshots(response.result.snapshots, false).catch((error) => {
+              if (!disposed) {
+                console.warn('[web-session-tabs-sync] fallback snapshot recovery failed:', error)
+              }
+            })
+          })
+          .catch((error) => {
+            if (!disposed && pairingIsCurrent()) {
+              console.warn(
+                '[web-session-tabs-sync] failed to load fallback session tabs:',
+                error instanceof Error ? error.message : String(error)
+              )
+            }
+          })
+      }
+      stopInitialFallbackTimer = startWebSessionTabsInitialFallbackTimer(
+        requestInitialSnapshotFallback
+      )
+      unsubscribes.push(stopInitialFallbackTimer)
 
-      void window.api.runtimeEnvironments
-        .subscribe(
+      unsubscribes.push(
+        startAllWebSessionTabsSubscription(
           {
             selector: environmentId,
             method: 'session.tabs.subscribeAll',
             params: {},
-            timeoutMs: 15_000,
+            timeoutMs: WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS,
             expectedEnvironmentPairingRevision
           },
           {
             onResponse: (response: RuntimeRpcResponse<unknown>) => {
-              if (
-                disposed ||
-                getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
-              ) {
+              if (disposed || !pairingIsCurrent()) {
                 return
               }
               if (response.ok === false) {
@@ -2835,44 +2937,27 @@ export function useWebSessionTabsSync(): void {
                   '[web-session-tabs-sync] global subscription failed:',
                   response.error.message
                 )
+                requestInitialSnapshotFallback()
                 return
               }
-              const event = response.result as SessionTabsStreamEvent
+              const event = response.result
               const replayed = isRuntimeSubscriptionReplayResponse(response)
-              if (event.type === 'snapshots') {
-                void Promise.all(
-                  event.snapshots.map((snapshot) =>
-                    recoverWebSessionTerminalOrphansBeforeApply(
-                      useAppStore.getState(),
-                      snapshot,
-                      environmentId
-                    )
-                  )
-                )
-                  .then((recovered) => {
-                    if (!disposed) {
-                      const applicable = recovered.filter(
-                        (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
-                      )
-                      if (replayed) {
-                        for (const snapshot of applicable) {
-                          acceptReplayedWebSessionTabsSnapshot(environmentId, snapshot.worktree)
-                        }
-                      }
-                      applyWebSessionTabsStorePatch((state) =>
-                        applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
-                      )
-                    }
-                  })
-                  .catch((error) => {
-                    if (!disposed) {
-                      console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
-                    }
-                  })
+              if (isSessionTabsSnapshotsEvent(event)) {
+                receivedInitialSnapshots = true
+                stopInitialFallbackTimer()
+                void recoverAndApplySnapshots(event.snapshots, replayed).catch((error) => {
+                  if (!disposed) {
+                    console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
+                  }
+                })
                 return
               }
-              if (event.type !== 'snapshot' && event.type !== 'updated') {
+              if (!isSessionTabsSnapshotEvent(event)) {
+                requestInitialSnapshotFallback()
                 return
+              }
+              if (!receivedInitialSnapshots) {
+                requestInitialSnapshotFallback()
               }
               void recoverWebSessionTerminalOrphansBeforeApply(
                 useAppStore.getState(),
@@ -2896,25 +2981,27 @@ export function useWebSessionTabsSync(): void {
                 })
             },
             onError: (error) => {
+              if (disposed || !pairingIsCurrent()) {
+                return
+              }
               console.warn('[web-session-tabs-sync] global subscription error:', error.message)
+              requestInitialSnapshotFallback()
+            },
+            onClose: () => {
+              requestInitialSnapshotFallback()
+            }
+          },
+          (error) => {
+            if (!disposed) {
+              console.warn(
+                '[web-session-tabs-sync] failed to subscribe globally:',
+                error instanceof Error ? error.message : String(error)
+              )
+              requestInitialSnapshotFallback()
             }
           }
         )
-        .then((handle) => {
-          if (disposed) {
-            handle.unsubscribe()
-            return
-          }
-          unsubscribes.push(handle.unsubscribe)
-        })
-        .catch((error) => {
-          if (!disposed) {
-            console.warn(
-              '[web-session-tabs-sync] failed to subscribe globally:',
-              error instanceof Error ? error.message : String(error)
-            )
-          }
-        })
+      )
     }
 
     return () => {


### PR DESCRIPTION
## Summary

- Makes the remote `session.tabs.subscribeAll` bootstrap atomic: refresh inventory, install the listener, then capture the initial batch.
- Uses that mandatory stream batch for normal renderer hydration instead of also fetching the same all-worktree inventory eagerly.
- Keeps `session.tabs.listAll` as a once-gated fallback when the stream fails, returns malformed data, closes, or sends no initial batch within 15 seconds.
- Retains the scoped active-worktree subscription for terminal bootstrap/wake behavior and protocol-v2 host compatibility.

### ELI5

Before, Orca asked every remote host to pack and send the same big box of workspace tabs twice at startup. The renderer then unpacked both boxes even though one was a duplicate. Now the live subscription brings the first box and keeps delivering changes; Orca asks for a separate box only if that subscription fails to arrive.

### Performance evidence

For one reachable host with 40 mirrored worktrees and one active worktree:

| Normal startup work | Before | After |
| --- | ---: | ---: |
| Full-host inventories | 2 | 1 |
| Remote tab RPCs | 3 | 2 |
| Host snapshot projections | 81 | 41 |
| Renderer orphan-recovery scans | 81 | 41 |

The deterministic projection/recovery count changes from `2W + A` to `W + A`: 81 to 41 in this example, a 49.4% reduction. This also removes one full `listAll` response plus its one-shot WebSocket/E2EE request per host. Failure paths still use the fallback, and steady-state active-update traffic is intentionally unchanged in this stage.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` (full repository lint not run; changed-code quality gate passed)
- [x] `pnpm typecheck`
- [ ] `pnpm test` (full repository suite not run; 170 focused tests passed)
- [ ] `pnpm build`
- [x] Added high-quality regression tests for request topology, fallback timing/deduplication, malformed/error/close signals, atomic ordering, cross-epoch buffering, late cleanup, and projection failures

Post-rebase commands:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/runtime/rpc/methods/session-tabs-subscribe-all.test.ts src/main/runtime/rpc/methods/session-tabs.test.ts src/renderer/src/runtime/web-session-tabs-sync-subscription.test.tsx src/renderer/src/runtime/web-session-tabs-sync.test.ts src/main/runtime/rpc/methods/session-tab-agent-status-projection.test.ts src/main/runtime/rpc/runtime-close-attribution-topology.test.ts src/main/runtime/rpc/runtime-close-attribution.test.ts src/main/ipc/runtime-environments.test.ts` — 170 passed
- `pnpm run typecheck`
- `pnpm run check:code-quality:changed` — native, type-aware, and React Doctor checks passed
- `pnpm run check:max-lines-ratchet`
- `git diff origin/main...HEAD --check`

## AI Review Report

Adversarial review used independent compatibility/performance, lifecycle/concurrency, test-coverage, and final repository-review passes.

The review flagged and this PR addressed:

- A mutation could land between the old initial inventory and listener installation. The runtime now uses an atomic refresh → listen → capture boundary and buffers only post-capture updates until the initial frame is emitted.
- Removing the scoped stream would break protocol-v2 hosts and active-worktree terminal bootstrap/wake behavior. This PR deliberately retains it.
- Initial projection/emission failure after acquiring the listener could leak work. Every initialization failure now routes through subscription cleanup, with a reproducing test.
- Shared control can start before its first response exists. A cleaned-up 15-second timer preserves deterministic fallback without restoring normal-path fan-out.
- Async subscription handles can resolve after unmount. The extracted starter closes late handles and passes React Doctor.

The final pass found no remaining blocking issues after checking replay freshness, publication-epoch ordering, pairing revision changes, malformed responses, fallback races, cleanup during partial initialization, SSH and folder workspaces, and mixed client/host versions.

Cross-platform audit: this changes RPC/session synchronization only. It introduces no shortcuts, labels, paths, shell behavior, native modules, or Electron platform branches; behavior is neutral across macOS, Linux, and Windows.

## Security Audit

- No command execution, filesystem paths, credentials, secrets, dependencies, or provider-specific behavior changed.
- Existing authenticated runtime RPC transport and pairing-revision fences remain in force.
- Incoming initial payloads are shape-checked before they suppress fallback.
- Listener ownership and cleanup were reviewed across failure, reconnect, unmount, and partial-initialization paths.
- No new persistence or IPC channel was added.

## Notes

- No wire schema, opcode, capability, or protocol-version change.
- `listAll` and `subscribeAll` shipped together in protocol v3; protocol-v2 hosts continue using the retained scoped subscription.
- The remaining duplicate active-worktree steady-state stream is intentionally left for a separately gated follow-up.


---

## Triage review (2026-08-15)

**Status:** CONFLICTING against `main`. Needs a rebase before it can be reviewed or merged. Held pending owner decision.

| | |
|---|---|
| **Perf impact if merged** | The largest measured win of the remaining PRs, and it lands on the startup path where users feel it. Projection/recovery work drops from `2W + A` to `W + A` — 81 to 41 in the worked example, a 49.4% reduction — plus one fewer full `listAll` response and its one-shot WebSocket/E2EE request per host. |
| **User-facing trade-off** | Adds a new RPC surface, `session.tabs.subscribeAll`. The body states `listAll` and `subscribeAll` shipped together in protocol v3 and that protocol-v2 hosts keep the retained scoped subscription, and the renderer does carry a `listAll` fallback behind a 15s timer. Not yet independently confirmed is whether that fallback fires on an explicit method-not-found (`-32601`) or only on timeout — on an old host the difference is a fast degrade versus a 15-second stall at startup. |
| **Resolvable?** | Yes on both counts. The conflict is mechanical: it is confined to `web-session-tabs-sync.ts`, which #8098 also changed. The wire question needs one test against a protocol-v2 host. |

### Why this one is worth the rebase

The headline +809/-189 across 7 files overstates it. Only 299 lines are real source; 63% of the diff is tests, and 484 of the added lines are three new test files. This is the only remaining large PR in the batch with a measured startup-path win.

### Required before merge

1. Rebase onto current `main` and re-resolve `web-session-tabs-sync.ts` against #8098.
2. Confirm the `listAll` fallback triggers on `-32601` from a protocol-v2 host, not only on the 15s timer.
