### PR TITLE
[Perf-SS] Own oversized automation output snapshot tails

### DIFF
--- a/src/renderer/src/components/automations/automation-run-output-snapshot-equivalence.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot-equivalence.test.ts
@@ -103,4 +103,23 @@ describe('automation run output snapshot queue equivalence', () => {
 
     expect(candidate.snapshot()).toEqual(reference.snapshot())
   })
+
+  it('matches the shift reference across oversized and subsequent appends', () => {
+    const retained = `\ude00${'A'.repeat(MAX_OUTPUT_SNAPSHOT_CHARS - 2)}\ud83d`
+    const chunks = [
+      'older output',
+      `discarded\u001b[31m prefix${retained}`,
+      'TAIL',
+      `${'B'.repeat(MAX_OUTPUT_SNAPSHOT_CHARS)}extra`,
+      '\u001b[0mDone\r\n'
+    ]
+    const reference = createShiftReferenceBuffer()
+    const candidate = createAutomationRunOutputSnapshotBuffer()
+
+    for (const chunk of chunks) {
+      reference.append(chunk)
+      candidate.append(chunk)
+      expect(candidate.snapshot()).toEqual(reference.snapshot())
+    }
+  })
 })

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.test.ts
@@ -132,6 +132,22 @@ describe('automation run output snapshot buffer', () => {
     })
   })
 
+  it('owns the exact UTF-16 tail of one oversized chunk', () => {
+    const buffer = createAutomationRunOutputSnapshotBuffer()
+    const retained = `\ude00${'A'.repeat(256 * 1024 - 2)}\ud83d`
+
+    buffer.append('older output')
+    buffer.append(`discarded prefix${retained}`)
+
+    expect(buffer.snapshot()).toMatchObject({ content: retained, truncated: true })
+
+    buffer.append('TAIL')
+    expect(buffer.snapshot()).toMatchObject({
+      content: `${retained.slice(4)}TAIL`,
+      truncated: true
+    })
+  })
+
   it('creates a saved snapshot from agent transcript text', () => {
     expect(createAutomationRunOutputSnapshotFromText('\nFinal summary.\n')).toEqual({
       format: 'plain_text',

--- a/src/renderer/src/components/automations/automation-run-output-snapshot.ts
+++ b/src/renderer/src/components/automations/automation-run-output-snapshot.ts
@@ -3,6 +3,7 @@ import {
   stripAnsiEscapeSequences,
   TERMINAL_CONTROL_CHARACTER_PATTERN
 } from '../../../../shared/ansi-escape-sequences'
+import { copyUtf16SuffixToOwnedString } from '../../../../shared/owned-utf16-suffix'
 
 const MAX_OUTPUT_SNAPSHOT_CHARS = 256 * 1024
 const OUTPUT_SNAPSHOT_COMPACTION_HEAD_THRESHOLD = 64
@@ -68,7 +69,10 @@ export function createAutomationRunOutputSnapshotBuffer(): AutomationRunOutputSn
           truncated = true
           continue
         }
-        chunks[firstChunkIndex] = firstChunk.slice(overflowChars)
+        chunks[firstChunkIndex] =
+          firstChunk.length > MAX_OUTPUT_SNAPSHOT_CHARS
+            ? copyUtf16SuffixToOwnedString(firstChunk, firstChunk.length - overflowChars)
+            : firstChunk.slice(overflowChars)
         totalChars -= overflowChars
         truncated = true
         overflowChars = 0

--- a/src/shared/owned-utf16-suffix.ts
+++ b/src/shared/owned-utf16-suffix.ts
@@ -1,0 +1,20 @@
+const COPY_BLOCK_CODE_UNITS = 4 * 1024
+
+export function copyUtf16SuffixToOwnedString(value: string, suffixCodeUnits: number): string {
+  const suffixLength = Math.max(0, Math.min(value.length, suffixCodeUnits))
+  const start = value.length - suffixLength
+  const blocks: string[] = []
+  const codeUnits: number[] = []
+  codeUnits.length = Math.min(COPY_BLOCK_CODE_UNITS, suffixLength)
+
+  // Why: slice can retain an arbitrarily large V8 backing string.
+  for (let offset = start; offset < value.length; offset += COPY_BLOCK_CODE_UNITS) {
+    const blockLength = Math.min(COPY_BLOCK_CODE_UNITS, value.length - offset)
+    codeUnits.length = blockLength
+    for (let index = 0; index < blockLength; index += 1) {
+      codeUnits[index] = value.charCodeAt(offset + index)
+    }
+    blocks.push(String.fromCharCode(...codeUnits))
+  }
+  return blocks.join('')
+}


### PR DESCRIPTION
## Summary

### ELI5

JavaScript can keep an entire large string alive when code stores only a small `slice` of it. A new remote-runtime automation may receive one initial terminal snapshot approaching the 2 MiB transport cap, while Orca retains only its last 256 KiB. Previously that small logical tail could keep the full decoded snapshot backing allocation alive.

This change rebuilds only the rare oversized partial tail from its UTF-16 code units, so the retained 256 KiB owns its storage and the discarded prefix can be collected. Ordinary terminal chunks keep the PSS-013 fast path.

### Production reachability

- Background automation terminals start at 120×40.
- The remote host serializes the initial desktop terminal snapshot without a 256 KiB server trim.
- Snapshot frames are reassembled into one string up to the renderer transport limit of 2 MiB UTF-8.
- The automation watcher receives that initial string as one `append`.
- Orca's production xterm serializer at 120×40 produced a valid 964,878-code-unit / 1,924,878-byte snapshot with `A` plus 200 combining marks per cell. A smaller 55-mark shape already crossed the logical cap at 268,878 code units / 532,878 bytes.

No RPC, stream framing, persistence format, terminal cap, or UI behavior changes.

### Performance proof

Separate-process, actual-module, forced-GC measurement with the 1,924,878-byte production snapshot:

| Implementation | Retained heap |
| --- | ---: |
| Previous `slice` | +1,958,784 bytes |
| Owned UTF-16 tail | +554,520 bytes |
| Improvement | **-1,404,264 bytes / 71.7%** |

A separate 64 MiB backing-store probe retained about 64 MiB externally with `slice`; the owned copy retained approximately zero external backing plus the intended ~256 KiB string.

An independent Electron V8 15.0 audit used a 16 Mi-code-unit two-byte source:

- Previous slice: 33,554,784 retained heap bytes
- Owned copy: 533,080 retained heap bytes
- Copy cost for an 8 Mi-code-unit source, 120 samples: 0.402 ms median / 0.476 ms p95
- Immediate transient heap was bounded at 1,350,328 bytes and released after the copy.

The cost is determined by the retained 256 KiB tail, not the discarded source size. The copy runs only when one partially trimmed source chunk is itself larger than 256 KiB. Ordinary chunks do not enter it, and the ordinary append benchmark showed no measurable median regression.

### Proof of no regression

- The cap remains exactly 256 KiB of JavaScript UTF-16 code units.
- Copying uses `charCodeAt` / `fromCharCode`, preserving every code unit, including split and lone surrogates.
- Raw output is still capped before ANSI/control stripping.
- Sticky truncation, later appends, repeated oversized appends, transcript precedence, and snapshot persistence are unchanged.
- A differential oracle compares the candidate against the previous shift/slice algorithm across seeded chunk, control-sequence, surrogate, oversized, and subsequent-append boundaries.
- The helper copies in bounded 4,096-code-unit blocks; it has no timers, listeners, caches, subprocesses, paths, native dependencies, or platform branches.
- Renderer-only scope means local, SSH, relay, folder-workspace, mobile, and mixed-version wire contracts are unchanged.

## Screenshots

No visual change.

## Testing

- [ ] `pnpm lint` — the monolithic command was not rerun; targeted oxlint, changed-code quality, React Doctor, max-lines ratchet, reliability gates, formatting, and `git diff --check` passed
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused and adjacent suites were run instead:
  - 2 snapshot files / 14 tests
  - 27 automation-adjacent files / 172 tests
  - 3 remote snapshot/subscription files / 40 tests
  - 3 additional automation/settings/browser files / 7 tests
  - 6 lifecycle/service/persistence/buffer files / 502 tests
- [ ] `pnpm build` — Electron production build passed; the unrelated native release build was not rerun
- [x] Added high-quality exact-equivalence and boundary regression tests

## AI Review Report

Three independent final reviews found no P0/P1/P2 issues. They checked exact old-algorithm equivalence, source-backing ownership, retained/transient memory, CPU cost, UTF-16 and lone-surrogate behavior, ANSI/cap ordering, repeated/later appends, cleanup/resource bounds, and packaging of the new helper. The readiness review also checked macOS, Linux, and Windows behavior, SSH/relay/folder workspaces, mobile/backward compatibility, and remote wire compatibility. Its only pre-publication gate was including the new imported file; all four files are present in this commit.

Residual risk: source-backing ownership is verified with forced-GC process benchmarks rather than a timing-sensitive automated heap assertion.

## Security Audit

No new input authority, command execution, path handling, authentication, secrets, dependency, IPC, persistence, or network surface. The implementation copies already-received terminal string code units into bounded renderer memory. No follow-up is required.

## Notes

- Semantic performance scan item PSS-016.
- Headless automation reads stay below this threshold and were intentionally left unchanged.
- @nwparker_
