### PR TITLE
fix(cli): classify a permission-denied runtime connect instead of reporting "starting"

### DIFF
--- a/src/cli/runtime/permission-denied-classification.test.ts
+++ b/src/cli/runtime/permission-denied-classification.test.ts
@@ -5,18 +5,13 @@ import { tmpdir } from 'node:os'
 import { join } from 'node:path'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { getRuntimeMetadataPath, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
-// vi.mock below is hoisted above these imports, so both modules load against the
-// faked connection factory.
+// vi.mock is hoisted above these imports, so both load against the faked factory.
 import { getCliStatus } from './status'
 import { sendRequest } from './transport'
 
-// Why: a real permission-denied connect is not reproducible across platforms —
-// a root CI user bypasses Unix mode bits and Windows guards named pipes by ACL.
-// Faking the connect keeps the classification itself under test everywhere.
-//
-// Scope: this exercises how Node's errno is classified, not the OS enforcement
-// that produces it. It does not prove anything about a real named-pipe DACL or
-// Unix socket mode bits.
+// Why: a real permission-denied connect is not portable (root bypasses mode bits;
+// Windows guards pipes by ACL), so the connect is faked. Scope: this covers errno
+// classification, not the OS enforcement behind it — no real DACL is exercised.
 const { nextConnection } = vi.hoisted(() => ({
   nextConnection: { create: null as null | (() => EventEmitter) }
 }))
@@ -131,9 +126,8 @@ describe('CLI status permission-denied classification', () => {
   })
 
   it('treats an EPERM liveness probe as alive, not as a dead pid', async () => {
-    // The macOS half of this defect: in a sandbox `process.kill(pid, 0)` throws
-    // EPERM for a healthy runtime owned by another user. Reading that as "dead"
-    // reported stale_bootstrap for a process that was running the whole time.
+    // In a sandbox `process.kill(pid, 0)` throws EPERM for a healthy runtime owned
+    // by another user; reading that as dead reported stale_bootstrap.
     const userDataPath = writeGuardedMetadata(4242)
     stubLivenessProbe('EPERM')
     failConnectWith('EACCES')
@@ -146,9 +140,8 @@ describe('CLI status permission-denied classification', () => {
   })
 
   it('keeps stale_bootstrap when the pid is provably gone', async () => {
-    // ESRCH means the pid is absent. A guarded endpoint behind a dead pid is a
-    // leftover, so the pre-existing stale_bootstrap answer keeps precedence
-    // over the new permission_denied branch.
+    // ESRCH means absent. A denied endpoint behind a dead pid is a leftover, so
+    // stale_bootstrap keeps precedence over the permission_denied branch.
     const userDataPath = writeGuardedMetadata(4242)
     stubLivenessProbe('ESRCH')
     failConnectWith('EACCES')

--- a/src/cli/runtime/permission-denied-classification.test.ts
+++ b/src/cli/runtime/permission-denied-classification.test.ts
@@ -146,7 +146,7 @@ describe('CLI status permission-denied classification', () => {
   })
 
   it('keeps stale_bootstrap when the pid is provably gone', async () => {
-    // Only ESRCH proves death. A guarded endpoint behind a dead pid is a
+    // ESRCH means the pid is absent. A guarded endpoint behind a dead pid is a
     // leftover, so the pre-existing stale_bootstrap answer keeps precedence
     // over the new permission_denied branch.
     const userDataPath = writeGuardedMetadata(4242)

--- a/src/cli/runtime/permission-denied-classification.test.ts
+++ b/src/cli/runtime/permission-denied-classification.test.ts
@@ -1,0 +1,115 @@
+import { EventEmitter } from 'node:events'
+import type * as NodeNet from 'node:net'
+import { mkdtempSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { getRuntimeMetadataPath, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
+// vi.mock below is hoisted above these imports, so both modules load against the
+// faked connection factory.
+import { getCliStatus } from './status'
+import { sendRequest } from './transport'
+
+// Why: a real permission-denied connect is not reproducible across platforms —
+// a root CI user bypasses Unix mode bits and Windows guards named pipes by ACL.
+// Faking the connect keeps the classification itself under test everywhere,
+// including Windows, where the named-pipe path is exactly where this bug bites.
+const { nextConnection } = vi.hoisted(() => ({
+  nextConnection: { create: null as null | (() => EventEmitter) }
+}))
+
+vi.mock('node:net', async (importOriginal) => {
+  const actual = await importOriginal<typeof NodeNet>()
+  return {
+    ...actual,
+    createConnection: (...args: unknown[]) => {
+      const create = nextConnection.create
+      if (!create) {
+        return (actual.createConnection as (...a: unknown[]) => unknown)(...args)
+      }
+      return create()
+    }
+  }
+})
+
+afterEach(() => {
+  nextConnection.create = null
+})
+
+// Emits 'error' then 'close', matching Node's real ordering — the close handler
+// must not overwrite the classified error that the error handler already settled.
+function failConnectWith(code: string): void {
+  nextConnection.create = () => {
+    const socket = new EventEmitter() as EventEmitter & Record<string, unknown>
+    socket.setEncoding = () => socket
+    socket.write = () => true
+    socket.end = () => socket
+    socket.destroy = () => socket
+    setImmediate(() => {
+      socket.emit('error', Object.assign(new Error(`connect ${code}`), { code }))
+      socket.emit('close')
+    })
+    return socket
+  }
+}
+
+const metadata: RuntimeMetadata = {
+  runtimeId: 'runtime-1',
+  pid: process.pid,
+  transports: [{ kind: 'unix', endpoint: '/tmp/orca-guarded.sock' }],
+  authToken: 'token',
+  startedAt: 1
+}
+
+describe('runtime transport permission-denied classification', () => {
+  it.each(['EACCES', 'EPERM'])('reports %s as permission denied, not unavailable', async (code) => {
+    failConnectWith(code)
+
+    // The old handler took no error parameter at all, so every failure collapsed
+    // into 'runtime_unavailable' and the causing syscall code was unrecoverable.
+    await expect(sendRequest(metadata, 'status.get', undefined, 1000)).rejects.toMatchObject({
+      code: 'runtime_permission_denied',
+      message: expect.stringContaining(code)
+    })
+  })
+
+  it('still reports a refused connect as unavailable', async () => {
+    failConnectWith('ECONNREFUSED')
+
+    await expect(sendRequest(metadata, 'status.get', undefined, 1000)).rejects.toMatchObject({
+      code: 'runtime_unavailable'
+    })
+  })
+})
+
+describe('CLI status permission-denied classification', () => {
+  it('does not report a guarded endpoint as starting while the pid is alive', async () => {
+    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-permission-'))
+    writeFileSync(
+      getRuntimeMetadataPath(userDataPath),
+      JSON.stringify({
+        runtimeId: 'runtime-1',
+        // Why: this process is provably alive, which is the exact condition that
+        // drove the old code down the 'starting' branch.
+        pid: process.pid,
+        transports: [{ kind: 'unix', endpoint: join(userDataPath, 'runtime.sock') }],
+        authToken: 'token',
+        startedAt: Date.now()
+      })
+    )
+    failConnectWith('EACCES')
+
+    const status = await getCliStatus(userDataPath)
+
+    expect(status.result.runtime.state).not.toBe('starting')
+    expect(status.result.graph.state).not.toBe('starting')
+    expect(status.result.runtime).toMatchObject({
+      state: 'permission_denied',
+      reachable: false,
+      runtimeId: null
+    })
+    // A live pid disproves 'not_running'; we were refused, not told it stopped.
+    expect(status.result.graph.state).toBe('unavailable')
+    expect(status.result.app.running).toBe(true)
+  })
+})

--- a/src/cli/runtime/permission-denied-classification.test.ts
+++ b/src/cli/runtime/permission-denied-classification.test.ts
@@ -12,8 +12,11 @@ import { sendRequest } from './transport'
 
 // Why: a real permission-denied connect is not reproducible across platforms —
 // a root CI user bypasses Unix mode bits and Windows guards named pipes by ACL.
-// Faking the connect keeps the classification itself under test everywhere,
-// including Windows, where the named-pipe path is exactly where this bug bites.
+// Faking the connect keeps the classification itself under test everywhere.
+//
+// Scope: this exercises how Node's errno is classified, not the OS enforcement
+// that produces it. It does not prove anything about a real named-pipe DACL or
+// Unix socket mode bits.
 const { nextConnection } = vi.hoisted(() => ({
   nextConnection: { create: null as null | (() => EventEmitter) }
 }))
@@ -34,7 +37,31 @@ vi.mock('node:net', async (importOriginal) => {
 
 afterEach(() => {
   nextConnection.create = null
+  vi.restoreAllMocks()
 })
+
+// The liveness probe is `process.kill(pid, 0)`. Stubbing it is the only portable
+// way to reach the errno branches: a real cross-user pid is not available in CI.
+function stubLivenessProbe(code: 'EPERM' | 'ESRCH'): void {
+  vi.spyOn(process, 'kill').mockImplementation(() => {
+    throw Object.assign(new Error(`kill ${code}`), { code })
+  })
+}
+
+function writeGuardedMetadata(pid: number): string {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-permission-'))
+  writeFileSync(
+    getRuntimeMetadataPath(userDataPath),
+    JSON.stringify({
+      runtimeId: 'runtime-1',
+      pid,
+      transports: [{ kind: 'unix', endpoint: join(userDataPath, 'runtime.sock') }],
+      authToken: 'token',
+      startedAt: Date.now()
+    })
+  )
+  return userDataPath
+}
 
 // Emits 'error' then 'close', matching Node's real ordering — the close handler
 // must not overwrite the classified error that the error handler already settled.
@@ -84,19 +111,9 @@ describe('runtime transport permission-denied classification', () => {
 
 describe('CLI status permission-denied classification', () => {
   it('does not report a guarded endpoint as starting while the pid is alive', async () => {
-    const userDataPath = mkdtempSync(join(tmpdir(), 'orca-runtime-permission-'))
-    writeFileSync(
-      getRuntimeMetadataPath(userDataPath),
-      JSON.stringify({
-        runtimeId: 'runtime-1',
-        // Why: this process is provably alive, which is the exact condition that
-        // drove the old code down the 'starting' branch.
-        pid: process.pid,
-        transports: [{ kind: 'unix', endpoint: join(userDataPath, 'runtime.sock') }],
-        authToken: 'token',
-        startedAt: Date.now()
-      })
-    )
+    // This process is provably alive, which is the exact condition that drove
+    // the old code down the 'starting' branch.
+    const userDataPath = writeGuardedMetadata(process.pid)
     failConnectWith('EACCES')
 
     const status = await getCliStatus(userDataPath)
@@ -111,5 +128,36 @@ describe('CLI status permission-denied classification', () => {
     // A live pid disproves 'not_running'; we were refused, not told it stopped.
     expect(status.result.graph.state).toBe('unavailable')
     expect(status.result.app.running).toBe(true)
+  })
+
+  it('treats an EPERM liveness probe as alive, not as a dead pid', async () => {
+    // The macOS half of this defect: in a sandbox `process.kill(pid, 0)` throws
+    // EPERM for a healthy runtime owned by another user. Reading that as "dead"
+    // reported stale_bootstrap for a process that was running the whole time.
+    const userDataPath = writeGuardedMetadata(4242)
+    stubLivenessProbe('EPERM')
+    failConnectWith('EACCES')
+
+    const status = await getCliStatus(userDataPath)
+
+    expect(status.result.runtime.state).toBe('permission_denied')
+    expect(status.result.runtime.state).not.toBe('stale_bootstrap')
+    expect(status.result.app).toMatchObject({ running: true, pid: 4242 })
+  })
+
+  it('keeps stale_bootstrap when the pid is provably gone', async () => {
+    // Only ESRCH proves death. A guarded endpoint behind a dead pid is a
+    // leftover, so the pre-existing stale_bootstrap answer keeps precedence
+    // over the new permission_denied branch.
+    const userDataPath = writeGuardedMetadata(4242)
+    stubLivenessProbe('ESRCH')
+    failConnectWith('EACCES')
+
+    const status = await getCliStatus(userDataPath)
+
+    expect(status.result.runtime.state).toBe('stale_bootstrap')
+    expect(status.result.runtime.state).not.toBe('permission_denied')
+    expect(status.result.app).toMatchObject({ running: false, pid: null })
+    expect(status.result.graph.state).toBe('not_running')
   })
 })

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -62,13 +62,9 @@ export async function getCliStatus(
     })
   } catch (error) {
     const running = isProcessRunning(metadata.pid)
-    // Why: a guarded endpoint and a mid-startup runtime both fail to answer, but
-    // only one of them ever resolves. Reporting 'starting' here left the CLI
-    // advertising progress that could not arrive.
-    //
-    // Gated on liveness: a permission-denied connect against a pid that is
-    // provably gone is a leftover endpoint, so the stale_bootstrap answer below
-    // stays correct and keeps precedence.
+    // Why: waiting never clears a permission problem, so this must not report
+    // 'starting'. Gated on liveness — a dead pid means a leftover endpoint, which
+    // the stale_bootstrap fallback below already describes correctly.
     if (running && isRuntimePermissionDeniedError(error)) {
       return buildCliStatusResponse({
         app: {
@@ -136,10 +132,8 @@ function isProcessRunning(pid: number | null | undefined): boolean {
     process.kill(pid, 0)
     return true
   } catch (error) {
-    // Why: EPERM means the process is present but owned by another user — the
-    // sandbox case — so reporting it dead is wrong. ESRCH means absent. Any other
-    // errno is unexpected on a signal-0 probe and is treated conservatively as
-    // absent, matching the behaviour before this branch existed.
+    // Why: EPERM means the process exists but is inaccessible, not dead. Any
+    // other errno, ESRCH included, is treated as absent.
     return (error as NodeJS.ErrnoException).code === 'EPERM'
   }
 }

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -65,11 +65,15 @@ export async function getCliStatus(
     // Why: a guarded endpoint and a mid-startup runtime both fail to answer, but
     // only one of them ever resolves. Reporting 'starting' here left the CLI
     // advertising progress that could not arrive.
-    if (isRuntimePermissionDeniedError(error)) {
+    //
+    // Gated on liveness: a permission-denied connect against a pid that is
+    // provably gone is a leftover endpoint, so the stale_bootstrap answer below
+    // stays correct and keeps precedence.
+    if (running && isRuntimePermissionDeniedError(error)) {
       return buildCliStatusResponse({
         app: {
-          running,
-          pid: running ? metadata.pid : null
+          running: true,
+          pid: metadata.pid
         },
         runtime: {
           state: 'permission_denied',
@@ -131,7 +135,10 @@ function isProcessRunning(pid: number | null | undefined): boolean {
   try {
     process.kill(pid, 0)
     return true
-  } catch {
-    return false
+  } catch (error) {
+    // Why: only ESRCH proves the process is gone. EPERM means it exists but is
+    // owned by another user — the sandbox case — and collapsing "can't tell"
+    // into "dead" is what reported a healthy runtime as stale_bootstrap.
+    return (error as NodeJS.ErrnoException).code === 'EPERM'
   }
 }

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -136,9 +136,10 @@ function isProcessRunning(pid: number | null | undefined): boolean {
     process.kill(pid, 0)
     return true
   } catch (error) {
-    // Why: only ESRCH proves the process is gone. EPERM means it exists but is
-    // owned by another user — the sandbox case — and collapsing "can't tell"
-    // into "dead" is what reported a healthy runtime as stale_bootstrap.
+    // Why: EPERM means the process is present but owned by another user — the
+    // sandbox case — so reporting it dead is wrong. ESRCH means absent. Any other
+    // errno is unexpected on a signal-0 probe and is treated conservatively as
+    // absent, matching the behaviour before this branch existed.
     return (error as NodeJS.ErrnoException).code === 'EPERM'
   }
 }

--- a/src/cli/runtime/status.ts
+++ b/src/cli/runtime/status.ts
@@ -2,7 +2,11 @@ import type { CliStatusResult, RuntimeStatus } from '../../shared/runtime-types'
 import { findTransport } from '../../shared/runtime-bootstrap'
 import { tryReadMetadata } from './metadata'
 import { sendRequest } from './transport'
-import { RuntimeRpcFailureError, type RuntimeRpcSuccess } from './types'
+import {
+  isRuntimePermissionDeniedError,
+  RuntimeRpcFailureError,
+  type RuntimeRpcSuccess
+} from './types'
 
 export async function getCliStatus(
   userDataPath: string
@@ -56,8 +60,29 @@ export async function getCliStatus(
         state: graphState
       }
     })
-  } catch {
+  } catch (error) {
     const running = isProcessRunning(metadata.pid)
+    // Why: a guarded endpoint and a mid-startup runtime both fail to answer, but
+    // only one of them ever resolves. Reporting 'starting' here left the CLI
+    // advertising progress that could not arrive.
+    if (isRuntimePermissionDeniedError(error)) {
+      return buildCliStatusResponse({
+        app: {
+          running,
+          pid: running ? metadata.pid : null
+        },
+        runtime: {
+          state: 'permission_denied',
+          reachable: false,
+          runtimeId: null
+        },
+        graph: {
+          // Why: 'not_running' would claim the graph stopped, which a live pid
+          // contradicts. We were refused, so it is unreachable, not absent.
+          state: 'unavailable'
+        }
+      })
+    }
     return buildCliStatusResponse({
       app: {
         running,

--- a/src/cli/runtime/transport.ts
+++ b/src/cli/runtime/transport.ts
@@ -3,7 +3,12 @@ import { randomUUID } from 'node:crypto'
 import { findTransport, type RuntimeMetadata } from '../../shared/runtime-bootstrap'
 import type { RuntimeOrchestrationEnvelope } from '../../shared/runtime-rpc-envelope'
 import { isKeepaliveFrame, RuntimeRpcEnvelopeSchema } from './envelope-schema'
-import { RuntimeClientError, type RuntimeRpcResponse } from './types'
+import {
+  isPermissionDeniedSyscallCode,
+  RUNTIME_PERMISSION_DENIED_CODE,
+  RuntimeClientError,
+  type RuntimeRpcResponse
+} from './types'
 import { MAX_TIMER_DELAY_MS, isSafeTimerDelayMs } from '../../shared/timer-delay'
 
 export async function sendRequest<TResult>(
@@ -66,13 +71,20 @@ export async function sendRequest<TResult>(
     }
 
     socket.setEncoding('utf8')
-    socket.once('error', () => {
+    socket.once('error', (err: NodeJS.ErrnoException) => {
+      // Why: 'error' always precedes 'close', so classifying here wins over the
+      // generic close handler below (finish() guards the double-settle).
       finish({
         ok: false,
-        error: new RuntimeClientError(
-          'runtime_unavailable',
-          'Could not connect to the running Orca app. Restart Orca and try again.'
-        )
+        error: isPermissionDeniedSyscallCode(err.code)
+          ? new RuntimeClientError(
+              RUNTIME_PERMISSION_DENIED_CODE,
+              `Permission denied (${err.code}) connecting to the Orca runtime at ${transport.endpoint}. Check the ownership and permissions of that endpoint.`
+            )
+          : new RuntimeClientError(
+              'runtime_unavailable',
+              'Could not connect to the running Orca app. Restart Orca and try again.'
+            )
       })
     })
     // Why: a clean peer close (FIN, no 'error') before a terminal frame never

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -7,15 +7,15 @@ export type {
   RuntimeRpcSuccess
 } from '../../shared/runtime-rpc-envelope'
 
-// Why: the OS rejected the connect on permissions, so the endpoint exists and is
-// guarded rather than absent. Collapsing it into 'runtime_unavailable' tells the
-// user to restart Orca, which recreates the endpoint with the same permissions.
+// Why: the OS denied access to the transport path. Collapsing that into
+// 'runtime_unavailable' tells the user to restart Orca, which recreates the
+// endpoint with the same permissions and cannot clear an ownership or ACL problem.
 export const RUNTIME_PERMISSION_DENIED_CODE = 'runtime_permission_denied'
 
 const PERMISSION_DENIED_SYSCALL_CODES: ReadonlySet<string> = new Set(['EACCES', 'EPERM'])
 
-// Covers both Unix domain sockets and Windows named pipes, which surface a
-// guarded endpoint as EACCES/EPERM on connect.
+// Covers both Unix domain sockets and Windows named pipes, which surface a denied
+// transport path as EACCES/EPERM on connect.
 export function isPermissionDeniedSyscallCode(code: string | undefined): boolean {
   return code !== undefined && PERMISSION_DENIED_SYSCALL_CODES.has(code)
 }

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -7,6 +7,19 @@ export type {
   RuntimeRpcSuccess
 } from '../../shared/runtime-rpc-envelope'
 
+// Why: a connect refused on permissions proves the endpoint exists and is guarded.
+// Collapsing it into 'runtime_unavailable' tells the user to restart Orca, which
+// never clears an ownership or ACL problem.
+export const RUNTIME_PERMISSION_DENIED_CODE = 'runtime_permission_denied'
+
+const PERMISSION_DENIED_SYSCALL_CODES: ReadonlySet<string> = new Set(['EACCES', 'EPERM'])
+
+// Covers both Unix domain sockets and Windows named pipes, which surface a
+// guarded endpoint as EACCES/EPERM on connect.
+export function isPermissionDeniedSyscallCode(code: string | undefined): boolean {
+  return code !== undefined && PERMISSION_DENIED_SYSCALL_CODES.has(code)
+}
+
 export class RuntimeClientError extends Error {
   readonly code: string
   // Why: optional structured recovery payload (e.g. did-you-mean suggestions,
@@ -18,6 +31,10 @@ export class RuntimeClientError extends Error {
     this.code = code
     this.data = redactOrchestrationCompatibilitySecrets(data)
   }
+}
+
+export function isRuntimePermissionDeniedError(error: unknown): boolean {
+  return error instanceof RuntimeClientError && error.code === RUNTIME_PERMISSION_DENIED_CODE
 }
 
 export class RuntimeRpcFailureError extends RuntimeClientError {

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -7,9 +7,8 @@ export type {
   RuntimeRpcSuccess
 } from '../../shared/runtime-rpc-envelope'
 
-// Why: the OS denied access to the transport path. Collapsing that into
-// 'runtime_unavailable' tells the user to restart Orca, which recreates the
-// endpoint with the same permissions and cannot clear an ownership or ACL problem.
+// Why: the OS denied access to the transport path. 'runtime_unavailable' would
+// tell the user to restart Orca, which recreates it with the same permissions.
 export const RUNTIME_PERMISSION_DENIED_CODE = 'runtime_permission_denied'
 
 const PERMISSION_DENIED_SYSCALL_CODES: ReadonlySet<string> = new Set(['EACCES', 'EPERM'])

--- a/src/cli/runtime/types.ts
+++ b/src/cli/runtime/types.ts
@@ -7,9 +7,9 @@ export type {
   RuntimeRpcSuccess
 } from '../../shared/runtime-rpc-envelope'
 
-// Why: a connect refused on permissions proves the endpoint exists and is guarded.
-// Collapsing it into 'runtime_unavailable' tells the user to restart Orca, which
-// never clears an ownership or ACL problem.
+// Why: the OS rejected the connect on permissions, so the endpoint exists and is
+// guarded rather than absent. Collapsing it into 'runtime_unavailable' tells the
+// user to restart Orca, which recreates the endpoint with the same permissions.
 export const RUNTIME_PERMISSION_DENIED_CODE = 'runtime_permission_denied'
 
 const PERMISSION_DENIED_SYSCALL_CODES: ReadonlySet<string> = new Set(['EACCES', 'EPERM'])

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -102,6 +102,9 @@ export type CliRuntimeState =
   | 'ready'
   | 'graph_not_ready'
   | 'stale_bootstrap'
+  // Why: the endpoint answered but refused us. Distinct from 'starting' because
+  // no amount of waiting clears an ownership or ACL problem.
+  | 'permission_denied'
 
 export type CliStatusResult = {
   app: {

--- a/src/shared/runtime-types.ts
+++ b/src/shared/runtime-types.ts
@@ -102,8 +102,8 @@ export type CliRuntimeState =
   | 'ready'
   | 'graph_not_ready'
   | 'stale_bootstrap'
-  // Why: the endpoint answered but refused us. Distinct from 'starting' because
-  // no amount of waiting clears an ownership or ACL problem.
+  // Why: the OS refused the connection before the runtime ever saw it. Distinct
+  // from 'starting' because no waiting clears an ownership or ACL problem.
   | 'permission_denied'
 
 export type CliStatusResult = {


### PR DESCRIPTION
Addresses **Defect 2 only** of #13539 (`Defect 2 — permission-denied connect is mapped to
permanent "starting"`). Deliberately **not** `Closes #13539`: Defect 1, the named-pipe
DACL that excludes the Codex sandbox principal, is untouched and needs a native
`CreateNamedPipeW` security descriptor. That issue notes Defect 2 "could land
independently of Defect 1", which is what this PR does.

It also improves the liveness classification relevant to #12528 (the macOS counterpart) via
the liveness-probe change below. Stated deliberately narrowly: that issue shows the pid
probe is permission-limited under sandbox, but I have not reproduced on macOS whether the
socket `connect()` there also returns `EACCES`/`EPERM`, so I am not claiming this resolves
that issue's classification outright.

**This does not restore connectivity.** Inside the Codex sandbox, `orca` commands that need
the runtime — `orchestration send --type worker_done` among them — still cannot connect.
What changes is how the failure is described, and that differs by command:

- `orca status` returns `runtime.state: permission_denied` where it previously returned
  `starting`, so a caller polling it is no longer told to keep waiting for a state that
  will never arrive.
- Every other runtime command throws `runtime_permission_denied` with the endpoint named,
  where it previously threw `runtime_unavailable` and its "restart Orca" advice. These
  commands never reported `starting` themselves — they failed with misleading guidance.

## Summary

`orca status` reported `runtimeState: starting` whenever it could not reach the local
runtime socket and the recorded pid was still visible. A permission problem on the endpoint
— wrong owner, restrictive mode bits, or a named-pipe ACL — lands in exactly that state, so
the CLI advertised progress that could never arrive. `starting` is indistinguishable from a
runtime that is genuinely still booting, so the correct client behaviour (keep waiting) is
precisely the behaviour that hangs forever.

Three changes:

1. **The errno is preserved.** `EACCES`/`EPERM` on connect now surfaces as a distinct
   `permission_denied` runtime state with a message naming the endpoint, instead of being
   collapsed into `runtime_unavailable` — whose advice, "restart Orca", recreates the
   endpoint with the same permissions.
2. **The liveness probe stops guessing.** `process.kill(pid, 0)` throwing `EPERM` means the
   process is present but owned by another user; `ESRCH` means absent. Any other errno is
   still treated conservatively as absent. This is the probe behaviour #12528 describes on
   macOS, where a present-but-inaccessible process was read as gone.
3. **Precedence is explicit.** `permission_denied` requires a live pid. A permission-denied
   connect behind a provably dead pid is a leftover, so the pre-existing `stale_bootstrap`
   answer keeps precedence.

## Screenshots

`No visual change` — CLI output only.

## Testing

- [x] `pnpm typecheck`
- [x] `pnpm lint` — exits 0. One caveat worth reporting: on Windows the chain first fails at
      `verify:skill-bundle-manifest`, claiming
      `resources/skills/{current-manifest,snapshot-registry,release-mapping}.json` are
      stale. This is **not** caused by this PR — it reproduces on a pristine checkout of
      current `main` with zero changes. Root cause is line endings: `.gitattributes` pins
      `eol=lf` for byte-compared paths such as `/resources/plugins/**`, but not for
      `resources/skills/*.json`, so with `core.autocrlf=true` they are checked out CRLF
      while the generator writes LF and the comparison fails. Converting those three files
      to LF makes the gate pass and the **whole chain exit 0**, which is the result recorded
      here. The artifacts are deliberately not regenerated in this PR. A one-line
      `.gitattributes` entry would fix it for Windows contributors; happy to send that
      separately if useful.
- [ ] `pnpm test` — **not a clean signal locally.** The full run completes in ~20 min on the
      rebased branch: 48,438 passed, 229 failed across 79 files, 643 skipped. **Zero of the
      failures are under `src/cli`**, where every behavioural change in this PR lives. They
      are overwhelmingly `EPERM: operation not permitted, symlink` (Windows requires
      Developer Mode to create symlinks) and `spawn /bin/sh ENOENT`, clustered in
      `src/main/{ipc,git,ssh,ai-vault}`, `src/relay`, and `config/scripts`. These are
      environmental rather than related to this change, but CI remains the
      supported-environment signal, so I cannot tick this box from here. Targeted evidence
      instead: `src/cli` — 732 passed, 28 skipped.
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions

### Tests

New `src/cli/runtime/permission-denied-classification.test.ts`, six cases. Each was verified
to fail against the unfixed code by reverting the relevant hunk:

| Test | Without the fix |
| --- | --- |
| `EACCES` → `runtime_permission_denied` | fails: `runtime_unavailable` |
| `EPERM` → `runtime_permission_denied` | fails: `runtime_unavailable` |
| status does not report `starting` on a live pid | fails: `starting` |
| `EPERM` liveness probe treated as alive | fails: `stale_bootstrap` |
| `ESRCH` liveness probe keeps `stale_bootstrap` | fails: `permission_denied` |
| `ECONNREFUSED` → still `runtime_unavailable` | passes both ways (guards over-classification) |

The connect is faked rather than genuinely permission-denied, because that is not
reproducible across platforms — a root CI user bypasses Unix mode bits and Windows guards
named pipes by ACL. **Scope caveat:** this exercises how Node's errno is classified, not the
OS enforcement that produces it. It does not prove anything about a real named-pipe DACL,
and it is not a test for Defect 1. The fake emits `error` then `close` in Node's real order,
pinning the double-settle guard so the close handler cannot overwrite the classified error.

## AI Review Report

Reviewed with Claude. Risks checked, and what came of each:

- **Cross-platform (macOS, Linux, Windows)**: `EACCES`/`EPERM` are the codes both Unix
  domain sockets and Windows named pipes raise for a permission-denied transport path;
  libuv's Windows error mapping produces both. No path strings are constructed — the
  endpoint is echoed from existing metadata — so no separator assumptions. No shortcuts,
  labels, shell
  invocation, or Electron-specific surface is touched. The new tests run on all three
  platforms, unlike the existing socket suites in this directory, which are `skipIf(win32)`.
- **Flagged and fixed during review**: (a) the liveness probe collapsed `EPERM` into "dead",
  so on macOS the new branch would have reported `permission_denied` alongside
  `app.running: false` and `pid: null` — incoherent, and the probe behaviour #12528
  describes; (b) the permission branch originally ran before the pid-dependent
  fallback, silently overriding
  `stale_bootstrap` for a dead pid; (c) several comments claimed more than the code or the
  syscalls support — that the endpoint "answered" (the OS refuses before the runtime sees
  the connection), that `EACCES` proves the endpoint exists (it can equally mean denied
  path traversal), and that "only ESRCH proves death" (the implementation treats every
  non-`EPERM` errno as absent). All are corrected, and (a) and (b) now have dedicated
  regression tests.
- **SSH / remote / local**: scoped to the local `unix`/`named-pipe` transport. The remote
  pairing branch in `client.ts` returns before this code, and the remote path
  (`websocket-transport.ts`, `remote-runtime-client-error-classification.ts`) is untouched —
  its agreement corpus still passes. The new code is deliberately **not** added to
  `RECOVERABLE_CODES`: retrying never clears a permission problem.
- **Agents / integrations / git providers**: no agent-, integration-, or provider-specific
  behavior involved.
- **Performance**: one `Set` lookup on an already-failing connect. Nothing in a hot path.
- **UI**: not applicable, no renderer change. `CliRuntimeState` has no exhaustive switch or
  i18n mapping — its two consumers (`cli/format.ts`, `ssh-remote-cli-format.ts`) interpolate
  the raw string — so the localization gates are unaffected.
- **Wire compatibility**: none. `CliStatusResult` is built client-side from the `status.get`
  result; the classification derives from a *local* socket error and never crosses the wire,
  so no host/client capability negotiation is involved.

## Security Audit

- **Authorization unchanged.** This PR widens no permission and grants no access. It only
  changes how an already-failing connect is described. A caller denied by the OS is still
  denied; `metadata.authToken` remains the RPC authority and is untouched.
- **Information disclosure**: the error message includes the runtime endpoint path, which is
  already present in `orca-runtime.json` readable by the same principal, and is shown to the
  local user who just tried to open it. No token, credential, payload, or RPC data is added
  to the message. The existing `redactOrchestrationCompatibilitySecrets` path for structured
  error data is unchanged.
- **Input handling**: the only new input is `err.code`, compared against a fixed two-element
  allowlist. No parsing, no interpolation into a shell or path.
- **Command execution / IPC**: no command execution added. `process.kill(pid, 0)` is a
  signal-0 liveness probe that was already there; the change only reads the errno it throws
  rather than discarding it. No new IPC surface.
- **Dependencies**: none added.
- **Follow-up**: none outstanding for this change. Defect 1 remains open and is where the
  actual security-relevant decision lives — any DACL work there should grant only duplex
  client rights, and specifically not `WRITE_DAC`, `WRITE_OWNER`, or
  `FILE_CREATE_PIPE_INSTANCE`, per the analysis in #13539.

## Notes

- **Platform-specific**: the reported symptom is Windows-only (the sandbox user can see the
  pid, so it yields `starting`), but the fix is platform-independent. #12528 describes the
  macOS side, where an `EPERM` liveness probe yields `stale_bootstrap`; change 2 above makes
  that probe accurate, but I have not reproduced that issue on this branch and am not
  claiming it resolves it.
- **Behavior change beyond the bug**: treating an `EPERM` liveness probe as alive also
  affects the pre-existing non-permission fallback — a runtime owned by another user that is
  unreachable for some other reason now reports `starting` rather than `stale_bootstrap`.
  That is the more accurate answer, but it is a visible change outside the permission path
  and worth a maintainer's eye.
- **Follow-up not included**: `RuntimeClient.openOrca()` polls `getCliStatus()` for up to
  15s and then reports `runtime_open_timeout`. A `permission_denied` endpoint could now bail
  out of that loop early with a useful message. Left out to keep this PR to a single topic;
  behavior there is unchanged by this patch.
- **Unrelated finding**: `resources/skills/*.json` are byte-compared by
  `verify:skill-bundle-manifest` but have no `eol=lf` rule in `.gitattributes`, so
  `pnpm lint` fails for any Windows contributor with `core.autocrlf=true`. Not touched here.
- Rebased onto `main` (`a63df9179`) before submitting.

X: [@Flamingpuffins](https://x.com/Flamingpuffins)
