### PR TITLE
[Perf-SS] Reuse pinned OIDs for SSH file diffs

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -3098,6 +3098,42 @@ describe('registerFilesystemHandlers', () => {
     )
   })
 
+  it('forwards the pinned head through SSH branch diff queries', async () => {
+    const result = {
+      kind: 'text',
+      originalContent: 'left',
+      modifiedContent: 'right',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    }
+    const getBranchDiff = vi.fn().mockResolvedValue([result])
+    getSshGitProviderMock.mockReturnValue({ getBranchDiff })
+
+    registerFilesystemHandlers(store as never)
+
+    await expect(
+      handlers.get('git:branchDiff')!(null, {
+        worktreePath: '/home/user/project',
+        compare: {
+          baseRef: 'origin/main',
+          baseOid: 'base-oid',
+          headOid: 'head-oid',
+          mergeBase: 'merge-base-oid'
+        },
+        filePath: 'src/file.ts',
+        oldPath: 'src/old-file.ts',
+        connectionId: 'conn-1'
+      })
+    ).resolves.toEqual(result)
+
+    expect(getBranchDiff).toHaveBeenCalledWith('/home/user/project', 'merge-base-oid', {
+      includePatch: true,
+      headOid: 'head-oid',
+      filePath: 'src/file.ts',
+      oldPath: 'src/old-file.ts'
+    })
+  })
+
   // Why: the original SSH Quick Open bug had two halves — relay-side policy
   // drift AND the main dispatcher silently dropping excludePaths before the
   // provider saw them. This test guards the second half: regardless of

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -2042,6 +2042,7 @@ export function registerFilesystemHandlers(
         }
         const results = await provider.getBranchDiff(args.worktreePath, args.compare.mergeBase, {
           includePatch: true,
+          headOid: args.compare.headOid,
           filePath: args.filePath,
           oldPath: args.oldPath
         })

--- a/src/main/providers/git-provider-contract.ts
+++ b/src/main/providers/git-provider-contract.ts
@@ -66,7 +66,7 @@ export type IGitProvider = {
   getBranchDiff(
     worktreePath: string,
     baseRef: string,
-    options?: { includePatch?: boolean; filePath?: string; oldPath?: string }
+    options?: { includePatch?: boolean; filePath?: string; oldPath?: string; headOid?: string }
   ): Promise<GitDiffResult[]>
   getCommitDiff(
     worktreePath: string,

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1081,6 +1081,79 @@ describe('SshGitProvider', () => {
     expect(result).toEqual(diffs)
   })
 
+  it('getBranchDiff forwards a pinned head OID without adding it when omitted', async () => {
+    const headOid = 'a'.repeat(40)
+    mux.request.mockResolvedValue([])
+
+    await provider.getBranchDiff('/home/user/repo', 'main', {
+      includePatch: true,
+      filePath: 'src/file.ts',
+      headOid
+    })
+    await provider.getBranchDiff('/home/user/repo', 'main', {
+      includePatch: true,
+      filePath: 'src/other-file.ts',
+      headOid: undefined
+    })
+
+    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.branchDiff', {
+      worktreePath: '/home/user/repo',
+      baseRef: 'main',
+      includePatch: true,
+      filePath: 'src/file.ts',
+      headOid,
+      __streamResponse: true
+    })
+    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.branchDiff', {
+      worktreePath: '/home/user/repo',
+      baseRef: 'main',
+      includePatch: true,
+      filePath: 'src/other-file.ts',
+      __streamResponse: true
+    })
+  })
+
+  it('coalesces matching branch diff heads while keeping distinct and absent heads separate', async () => {
+    const diffs = [{ kind: 'text', originalContent: 'old', modifiedContent: 'new' }]
+    const pendingDiff = deferredValue(diffs)
+    const firstHeadOid = 'a'.repeat(40)
+    const secondHeadOid = 'b'.repeat(40)
+    mux.request.mockReturnValue(pendingDiff.promise)
+
+    const reads = [
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts',
+        headOid: firstHeadOid
+      }),
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        filePath: 'src/file.ts',
+        headOid: firstHeadOid,
+        includePatch: true
+      }),
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts',
+        headOid: secondHeadOid
+      }),
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts'
+      }),
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts',
+        headOid: undefined
+      })
+    ]
+
+    await waitForRequestCount(mux.request, 3)
+    expect(mux.request).toHaveBeenCalledTimes(3)
+
+    pendingDiff.resolve()
+    await expect(Promise.all(reads)).resolves.toEqual(Array.from({ length: 5 }, () => diffs))
+  })
+
   it('coalesces concurrent identical diff RPCs while in flight', async () => {
     const diff = {
       kind: 'text',

--- a/src/main/providers/ssh-git-provider.test.ts
+++ b/src/main/providers/ssh-git-provider.test.ts
@@ -1113,6 +1113,52 @@ describe('SshGitProvider', () => {
     })
   })
 
+  // Why: an unpinned compare snapshot reaches getBranchDiff as null despite the type.
+  it('omits a null head OID and shares the absent-head dedupe key', async () => {
+    const diffs = [{ kind: 'text', originalContent: 'old', modifiedContent: 'new' }]
+    const pendingDiff = deferredValue(diffs)
+    const headOid = 'a'.repeat(40)
+    mux.request.mockReturnValue(pendingDiff.promise)
+
+    const reads = [
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts',
+        headOid: null as unknown as undefined
+      }),
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts'
+      }),
+      provider.getBranchDiff('/home/user/repo', 'main', {
+        includePatch: true,
+        filePath: 'src/file.ts',
+        headOid
+      })
+    ]
+
+    await waitForRequestCount(mux.request, 2)
+    expect(mux.request).toHaveBeenCalledTimes(2)
+    expect(mux.request).toHaveBeenNthCalledWith(1, 'git.branchDiff', {
+      worktreePath: '/home/user/repo',
+      baseRef: 'main',
+      includePatch: true,
+      filePath: 'src/file.ts',
+      __streamResponse: true
+    })
+    expect(mux.request).toHaveBeenNthCalledWith(2, 'git.branchDiff', {
+      worktreePath: '/home/user/repo',
+      baseRef: 'main',
+      includePatch: true,
+      filePath: 'src/file.ts',
+      headOid,
+      __streamResponse: true
+    })
+
+    pendingDiff.resolve()
+    await expect(Promise.all(reads)).resolves.toEqual(Array.from({ length: 3 }, () => diffs))
+  })
+
   it('coalesces matching branch diff heads while keeping distinct and absent heads separate', async () => {
     const diffs = [{ kind: 'text', originalContent: 'old', modifiedContent: 'new' }]
     const pendingDiff = deferredValue(diffs)

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -41,6 +41,7 @@ type NonInteractiveExecQueueEntry = {
 }
 
 const NON_INTERACTIVE_TRANSPORT_TIMEOUT_MARGIN_MS = 5_000
+const ABSENT_BRANCH_DIFF_HEAD_OID = { absent: true } as const
 
 function isJsonRpcMethodNotFoundError(error: unknown): boolean {
   if (!error || typeof error !== 'object') {
@@ -658,9 +659,10 @@ export class SshGitProvider implements IGitProvider {
   async getBranchDiff(
     worktreePath: string,
     baseRef: string,
-    options?: { includePatch?: boolean; filePath?: string; oldPath?: string }
+    options?: { includePatch?: boolean; filePath?: string; oldPath?: string; headOid?: string }
   ): Promise<GitDiffResult[]> {
     const keyOptions = options ?? {}
+    const { headOid, ...relayOptions } = keyOptions
     return this.gitDiffReadDedupe.run(
       stableInFlightKey([
         'branchDiff',
@@ -668,13 +670,15 @@ export class SshGitProvider implements IGitProvider {
         baseRef,
         keyOptions.includePatch ?? null,
         keyOptions.filePath ?? null,
-        keyOptions.oldPath ?? null
+        keyOptions.oldPath ?? null,
+        headOid === undefined ? ABSENT_BRANCH_DIFF_HEAD_OID : headOid
       ]),
       async () =>
         (await requestGitStreamable(this.mux, 'git.branchDiff', {
           worktreePath,
           baseRef,
-          ...options
+          ...relayOptions,
+          ...(headOid === undefined ? {} : { headOid })
         })) as GitDiffResult[]
     ) as Promise<GitDiffResult[]>
   }

--- a/src/main/providers/ssh-git-provider.ts
+++ b/src/main/providers/ssh-git-provider.ts
@@ -662,7 +662,11 @@ export class SshGitProvider implements IGitProvider {
     options?: { includePatch?: boolean; filePath?: string; oldPath?: string; headOid?: string }
   ): Promise<GitDiffResult[]> {
     const keyOptions = options ?? {}
-    const { headOid, ...relayOptions } = keyOptions
+    const { headOid: rawHeadOid, ...relayOptions } = keyOptions
+    // Why: compare snapshots type headOid as `string | null`, so collapse an
+    // unpinned null to absent instead of putting a field on the wire that a
+    // pinned-OID relay must reject.
+    const headOid = rawHeadOid == null ? undefined : rawHeadOid
     return this.gitDiffReadDedupe.run(
       stableInFlightKey([
         'branchDiff',

--- a/src/main/runtime/orca-runtime-git-branch-diff.test.ts
+++ b/src/main/runtime/orca-runtime-git-branch-diff.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { GlobalSettings } from '../../shared/types'
+import { RuntimeGitCommands, type ResolvedRuntimeGitWorktree } from './orca-runtime-git'
+
+const getSshGitProviderMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../providers/ssh-git-dispatch', () => ({
+  getSshGitProvider: getSshGitProviderMock
+}))
+
+function makeWorktree(path: string): ResolvedRuntimeGitWorktree {
+  const worktree = {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path,
+    linkedIssue: null,
+    git: {
+      path,
+      branch: 'main',
+      isBare: false,
+      isMainWorktree: false,
+      head: 'a'.repeat(40)
+    }
+  } satisfies Partial<ResolvedRuntimeGitWorktree>
+  return worktree as unknown as ResolvedRuntimeGitWorktree
+}
+
+describe('RuntimeGitCommands branch diff', () => {
+  beforeEach(() => {
+    getSshGitProviderMock.mockReset()
+  })
+
+  it('forwards the pinned head through normalized nested SSH paths', async () => {
+    const mergeBase = 'a'.repeat(40)
+    const headOid = 'b'.repeat(40)
+    const result = {
+      kind: 'text',
+      originalContent: 'left',
+      modifiedContent: 'right',
+      originalIsBinary: false,
+      modifiedIsBinary: false
+    }
+    const provider = { getBranchDiff: vi.fn().mockResolvedValue([result]) }
+    getSshGitProviderMock.mockReturnValue(provider)
+    const commands = new RuntimeGitCommands({
+      resolveRuntimeGitTarget: async () => ({
+        worktree: makeWorktree('/remote/repo'),
+        connectionId: 'conn-1'
+      }),
+      getRuntimeSettings: () => ({}) as GlobalSettings
+    })
+
+    await expect(
+      commands.getRuntimeGitBranchDiff(
+        'id:wt-1',
+        { mergeBase, headOid },
+        'src\\file.ts',
+        'src\\old-file.ts'
+      )
+    ).resolves.toEqual(result)
+
+    expect(provider.getBranchDiff).toHaveBeenCalledWith('/remote/repo', mergeBase, {
+      includePatch: true,
+      headOid,
+      filePath: 'src/file.ts',
+      oldPath: 'src/old-file.ts'
+    })
+  })
+})

--- a/src/main/runtime/orca-runtime-git.ts
+++ b/src/main/runtime/orca-runtime-git.ts
@@ -538,6 +538,7 @@ export class RuntimeGitCommands {
       }
       const results = await provider.getBranchDiff(target.worktree.path, compare.mergeBase, {
         includePatch: true,
+        headOid: compare.headOid,
         filePath: relativePath,
         oldPath: oldRelativePath
       })

--- a/src/relay/git-handler-branch-diff-equivalence.test.ts
+++ b/src/relay/git-handler-branch-diff-equivalence.test.ts
@@ -1,0 +1,207 @@
+import { execFileSync } from 'node:child_process'
+import { mkdirSync, mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it } from 'vitest'
+import { RelayContext } from './context'
+import { GitHandler } from './git-handler'
+import {
+  createMockDispatcher,
+  gitCommit,
+  gitInit,
+  type MockDispatcher,
+  type RelayDispatcher
+} from './git-handler-test-setup'
+
+// Why this file exists: the pinned route replaced the legacy route's own
+// `diff --name-status -M -C` rediscovery with values the caller already holds.
+// These tests drive the real product contract against real Git and assert the
+// two routes agree entry-for-entry, so "SSH still renders what it used to" is
+// evidence rather than an argument about call sites.
+
+type BranchCompareResult = {
+  summary: { mergeBase: string; headOid: string; status: string; changedFiles: number }
+  entries: { path: string; oldPath?: string; status: string }[]
+}
+
+type DiffEntry = Record<string, unknown>
+
+function git(repoPath: string, args: string[]): string {
+  return execFileSync('git', args, { cwd: repoPath, encoding: 'utf8' })
+}
+
+/**
+ * Builds one repo whose base..head range exercises every shape the review
+ * panel can hand to a single-file branch diff.
+ */
+function buildScenarioRepo(): { repoPath: string; baseOid: string } {
+  const repoPath = mkdtempSync(path.join(tmpdir(), 'relay-branch-diff-equivalence-'))
+  gitInit(repoPath)
+
+  const write = (relativePath: string, contents: string | Buffer): void => {
+    const target = path.join(repoPath, relativePath)
+    mkdirSync(path.dirname(target), { recursive: true })
+    writeFileSync(target, contents)
+  }
+
+  write('modified.txt', 'before\n')
+  write('deleted.txt', 'doomed\n')
+  write('renamed-from.txt', 'stable rename payload\n')
+  write('renamed-and-edited-from.txt', 'rename plus edit, line one\nline two\nline three\n')
+  write('copied-source.txt', 'copy me, line one\nline two\nline three\nline four\n')
+  write('nested/deep/inner.txt', 'nested before\n')
+  write('spaced name.txt', 'spaced before\n')
+  write('ünïcode-ページ.txt', 'unicode before\n')
+  write('binary-modified.bin', Buffer.from([0, 1, 2, 3, 0, 255]))
+  write('binary-deleted.bin', Buffer.from([9, 8, 7, 0]))
+  write('emptied.txt', 'about to be emptied\n')
+  write('crlf.txt', 'crlf before\r\nsecond line\r\n')
+  write('mode-changed.sh', '#!/bin/sh\necho hi\n')
+  gitCommit(repoPath, 'base')
+  const baseOid = git(repoPath, ['rev-parse', 'HEAD']).trim()
+
+  write('modified.txt', 'after\n')
+  rmSync(path.join(repoPath, 'deleted.txt'))
+  rmSync(path.join(repoPath, 'binary-deleted.bin'))
+  git(repoPath, ['mv', 'renamed-from.txt', 'renamed-to.txt'])
+  git(repoPath, ['mv', 'renamed-and-edited-from.txt', 'renamed-and-edited-to.txt'])
+  write('renamed-and-edited-to.txt', 'rename plus edit, line one\nline two CHANGED\nline three\n')
+  write('copied-target.txt', 'copy me, line one\nline two\nline three\nline four\n')
+  write('added.txt', 'brand new\n')
+  write('binary-added.bin', Buffer.from([4, 4, 0, 4]))
+  write('binary-modified.bin', Buffer.from([0, 1, 2, 3, 0, 254]))
+  write('nested/deep/inner.txt', 'nested after\n')
+  write('spaced name.txt', 'spaced after\n')
+  write('ünïcode-ページ.txt', 'unicode after\n')
+  write('emptied.txt', '')
+  write('crlf.txt', 'crlf after\r\nsecond line\r\n')
+  git(repoPath, ['update-index', '--chmod=+x', 'mode-changed.sh'])
+  gitCommit(repoPath, 'head')
+
+  return { repoPath, baseOid }
+}
+
+describe('pinned and legacy branch diff equivalence against real Git', () => {
+  let dispatcher: MockDispatcher
+  let handler: GitHandler
+  let repoPath = ''
+  let baseOid = ''
+
+  beforeEach(() => {
+    dispatcher = createMockDispatcher()
+    handler = new GitHandler(dispatcher as unknown as RelayDispatcher, new RelayContext())
+    const built = buildScenarioRepo()
+    repoPath = built.repoPath
+    baseOid = built.baseOid
+  })
+
+  afterEach(() => {
+    handler.dispose()
+    if (repoPath) {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+
+  async function branchCompare(): Promise<BranchCompareResult> {
+    return (await dispatcher.callRequest('git.branchCompare', {
+      worktreePath: repoPath,
+      baseRef: baseOid
+    })) as BranchCompareResult
+  }
+
+  async function branchDiff(params: Record<string, unknown>): Promise<DiffEntry[]> {
+    return (await dispatcher.callRequest('git.branchDiff', {
+      worktreePath: repoPath,
+      baseRef: baseOid,
+      includePatch: true,
+      ...params
+    })) as DiffEntry[]
+  }
+
+  it('produces identical results for every changed file the review panel can open', async () => {
+    const compare = await branchCompare()
+    expect(compare.summary.status).toBe('ready')
+    // Guard the guard: a truncated scenario set would make this test vacuously pass.
+    expect(compare.entries.length).toBeGreaterThanOrEqual(14)
+
+    const divergences: string[] = []
+    for (const entry of compare.entries) {
+      // Exactly what the renderer sends: paths from the compare entry list,
+      // OIDs from the compare summary that produced that same list.
+      const callerShape = { filePath: entry.path, oldPath: entry.oldPath }
+      const legacy = await branchDiff(callerShape)
+      const pinned = await branchDiff({
+        ...callerShape,
+        baseRef: compare.summary.mergeBase,
+        headOid: compare.summary.headOid
+      })
+
+      if (JSON.stringify(legacy) !== JSON.stringify(pinned)) {
+        divergences.push(
+          `${entry.status} ${entry.path}${entry.oldPath ? ` (from ${entry.oldPath})` : ''}\n` +
+            `  legacy: ${JSON.stringify(legacy)}\n  pinned: ${JSON.stringify(pinned)}`
+        )
+      }
+    }
+
+    expect(divergences.join('\n')).toBe('')
+  })
+
+  it('agrees on content for renames, additions, deletions and binaries specifically', async () => {
+    const compare = await branchCompare()
+    const byPath = new Map(compare.entries.map((entry) => [entry.path, entry]))
+
+    // Why assert content and not just equality: two identically-empty results
+    // would satisfy the equivalence test above while rendering nothing.
+    const rename = byPath.get('renamed-and-edited-to.txt')
+    expect(rename?.oldPath).toBe('renamed-and-edited-from.txt')
+    const [renamePinned] = await branchDiff({
+      baseRef: compare.summary.mergeBase,
+      headOid: compare.summary.headOid,
+      filePath: rename!.path,
+      oldPath: rename!.oldPath
+    })
+    expect(renamePinned).toMatchObject({
+      originalContent: 'rename plus edit, line one\nline two\nline three\n',
+      modifiedContent: 'rename plus edit, line one\nline two CHANGED\nline three\n'
+    })
+
+    const [addedPinned] = await branchDiff({
+      baseRef: compare.summary.mergeBase,
+      headOid: compare.summary.headOid,
+      filePath: 'added.txt'
+    })
+    expect(addedPinned).toMatchObject({ originalContent: '', modifiedContent: 'brand new\n' })
+
+    const [deletedPinned] = await branchDiff({
+      baseRef: compare.summary.mergeBase,
+      headOid: compare.summary.headOid,
+      filePath: 'deleted.txt'
+    })
+    expect(deletedPinned).toMatchObject({ originalContent: 'doomed\n', modifiedContent: '' })
+
+    const [binaryPinned] = await branchDiff({
+      baseRef: compare.summary.mergeBase,
+      headOid: compare.summary.headOid,
+      filePath: 'binary-modified.bin'
+    })
+    expect(binaryPinned).toMatchObject({ kind: 'binary' })
+  })
+
+  it('holds the pinned revision when HEAD moves mid-review, where legacy drifts', async () => {
+    const compare = await branchCompare()
+    writeFileSync(path.join(repoPath, 'modified.txt'), 'drifted after the snapshot\n')
+    gitCommit(repoPath, 'drift')
+
+    const pinned = await branchDiff({
+      baseRef: compare.summary.mergeBase,
+      headOid: compare.summary.headOid,
+      filePath: 'modified.txt'
+    })
+    const legacy = await branchDiff({ filePath: 'modified.txt' })
+
+    expect(pinned[0]).toMatchObject({ modifiedContent: 'after\n' })
+    // The divergence is the fix: legacy silently re-resolves live HEAD.
+    expect(legacy[0]).toMatchObject({ modifiedContent: 'drifted after the snapshot\n' })
+  })
+})

--- a/src/relay/git-handler-branch-diff-ops.ts
+++ b/src/relay/git-handler-branch-diff-ops.ts
@@ -9,13 +9,20 @@ function assertFullGitObjectId(value: unknown, label: string): asserts value is 
   }
 }
 
+export function isFullGitObjectId(value: unknown): value is string {
+  return typeof value === 'string' && FULL_GIT_OBJECT_ID_PATTERN.test(value)
+}
+
 export function parseOptionalBranchDiffHeadOid(
   params: Record<string, unknown>
 ): string | undefined {
-  if (!Object.hasOwn(params, 'headOid')) {
+  const { headOid } = params
+  // Why: GitBranchCompareSummary.headOid is `string | null`, so a mixed-version
+  // client can put an explicit null on the wire. Treat it as unpinned rather
+  // than rejecting a request the legacy path would have served.
+  if (headOid == null) {
     return undefined
   }
-  const { headOid } = params
   assertFullGitObjectId(headOid, 'headOid')
   return headOid
 }

--- a/src/relay/git-handler-branch-diff-ops.ts
+++ b/src/relay/git-handler-branch-diff-ops.ts
@@ -1,0 +1,50 @@
+import { buildDiffResult } from './git-diff-result'
+import { readBlobAtOid, type GitBufferExec } from './git-handler-ops'
+
+const FULL_GIT_OBJECT_ID_PATTERN = /^(?:[0-9a-fA-F]{40}|[0-9a-fA-F]{64})$/
+
+function assertFullGitObjectId(value: unknown, label: string): asserts value is string {
+  if (typeof value !== 'string' || !FULL_GIT_OBJECT_ID_PATTERN.test(value)) {
+    throw new Error(`${label} must be a full git object id`)
+  }
+}
+
+export function parseOptionalBranchDiffHeadOid(
+  params: Record<string, unknown>
+): string | undefined {
+  if (!Object.hasOwn(params, 'headOid')) {
+    return undefined
+  }
+  const { headOid } = params
+  assertFullGitObjectId(headOid, 'headOid')
+  return headOid
+}
+
+export async function branchDiffEntryAtPinnedOids(
+  gitBuffer: GitBufferExec,
+  worktreePath: string,
+  baseOid: string,
+  headOid: string,
+  filePath: string,
+  oldPath?: string
+) {
+  assertFullGitObjectId(baseOid, 'baseRef')
+  assertFullGitObjectId(headOid, 'headOid')
+  try {
+    const [left, right] = await Promise.all([
+      readBlobAtOid(gitBuffer, worktreePath, baseOid, oldPath ?? filePath),
+      readBlobAtOid(gitBuffer, worktreePath, headOid, filePath)
+    ])
+    return [buildDiffResult(left.content, right.content, left.isBinary, right.isBinary, filePath)]
+  } catch {
+    return [
+      {
+        kind: 'text' as const,
+        originalContent: '',
+        modifiedContent: '',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      }
+    ]
+  }
+}

--- a/src/relay/git-handler-branch-diff.test.ts
+++ b/src/relay/git-handler-branch-diff.test.ts
@@ -1,0 +1,305 @@
+import { execFileSync } from 'node:child_process'
+import { mkdtempSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import * as path from 'node:path'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { RelayContext } from './context'
+import {
+  branchDiffEntryAtPinnedOids,
+  parseOptionalBranchDiffHeadOid
+} from './git-handler-branch-diff-ops'
+import { GitHandler } from './git-handler'
+import { branchDiffEntries, type GitBufferExec, type GitExec } from './git-handler-ops'
+import {
+  createMockDispatcher,
+  gitCommit,
+  gitInit,
+  type MockDispatcher,
+  type RelayDispatcher
+} from './git-handler-test-setup'
+
+const BASE_OID = 'a'.repeat(40)
+const HEAD_OID = 'b'.repeat(40)
+const OTHER_HEAD_OID = 'c'.repeat(40)
+const FILE_PATH = 'src/file.ts'
+
+type GitBufferTarget = {
+  gitBuffer(args: string[], cwd: string): Promise<Buffer>
+}
+
+type GitTarget = {
+  git(args: string[], cwd: string): Promise<{ stdout: string; stderr: string }>
+}
+
+function deferredBuffer(): { promise: Promise<Buffer>; resolve: (content: string) => void } {
+  let resolve!: (value: Buffer) => void
+  const promise = new Promise<Buffer>((innerResolve) => {
+    resolve = innerResolve
+  })
+  return { promise, resolve: (content) => resolve(Buffer.from(content)) }
+}
+
+describe('pinned relay branch diff operation', () => {
+  it.each([
+    {
+      name: 'addition',
+      status: `A\t${FILE_PATH}\n`,
+      left: new Error('missing'),
+      right: Buffer.from('added\n')
+    },
+    {
+      name: 'deletion',
+      status: `D\t${FILE_PATH}\n`,
+      left: Buffer.from('deleted\n'),
+      right: new Error('missing')
+    },
+    {
+      name: 'binary content',
+      status: `M\t${FILE_PATH}\n`,
+      left: Buffer.from([0, 1]),
+      right: Buffer.from([0, 2])
+    },
+    {
+      name: 'blob read failure',
+      status: `M\t${FILE_PATH}\n`,
+      left: new Error('left failed'),
+      right: new Error('right failed')
+    }
+  ])('matches the legacy $name result', async ({ status, left, right }) => {
+    const createGitBuffer = (): GitBufferExec =>
+      vi.fn<GitBufferExec>(async (args) => {
+        const value = args[2].startsWith(`${BASE_OID}:`) ? left : right
+        if (value instanceof Error) {
+          throw value
+        }
+        return value
+      })
+    const git = vi.fn<GitExec>(async (args) => {
+      if (args[0] === 'rev-parse' && args.includes('HEAD')) {
+        return { stdout: `${HEAD_OID}\n`, stderr: '' }
+      }
+      if (args[0] === 'rev-parse' || args[0] === 'merge-base') {
+        return { stdout: `${BASE_OID}\n`, stderr: '' }
+      }
+      return { stdout: status, stderr: '' }
+    })
+
+    const pinned = await branchDiffEntryAtPinnedOids(
+      createGitBuffer(),
+      '/repo',
+      BASE_OID,
+      HEAD_OID,
+      FILE_PATH
+    )
+    const legacy = await branchDiffEntries(git, createGitBuffer(), '/repo', BASE_OID, {
+      includePatch: true,
+      filePath: FILE_PATH
+    })
+
+    expect(pinned).toEqual(legacy)
+  })
+
+  it('treats an omitted head OID differently from a supplied invalid value', () => {
+    expect(parseOptionalBranchDiffHeadOid({})).toBeUndefined()
+    expect(() => parseOptionalBranchDiffHeadOid({ headOid: null })).toThrow(
+      'headOid must be a full git object id'
+    )
+  })
+})
+
+describe('GitHandler pinned branch diff route', () => {
+  let dispatcher: MockDispatcher
+  let handler: GitHandler
+
+  beforeEach(() => {
+    dispatcher = createMockDispatcher()
+    handler = new GitHandler(dispatcher as unknown as RelayDispatcher, new RelayContext())
+  })
+
+  afterEach(() => {
+    handler.dispose()
+    vi.restoreAllMocks()
+  })
+
+  function request(overrides: Record<string, unknown> = {}): Promise<unknown> {
+    return dispatcher.callRequest('git.branchDiff', {
+      worktreePath: '/repo',
+      baseRef: BASE_OID,
+      headOid: HEAD_OID,
+      includePatch: true,
+      filePath: FILE_PATH,
+      ...overrides
+    })
+  }
+
+  it('starts exactly two pinned blob reads concurrently without metadata commands', async () => {
+    const left = deferredBuffer()
+    const right = deferredBuffer()
+    const gitBufferSpy = vi
+      .spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+      .mockImplementation((args) => {
+        if (args[2] === `${BASE_OID}:${FILE_PATH}`) {
+          return left.promise
+        }
+        if (args[2] === `${HEAD_OID}:${FILE_PATH}`) {
+          return right.promise
+        }
+        throw new Error(`unexpected blob spec: ${args[2]}`)
+      })
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitTarget, 'git')
+      .mockRejectedValue(new Error('metadata command should not run'))
+
+    const resultPromise = request()
+    await vi.waitFor(() => expect(gitBufferSpy).toHaveBeenCalledTimes(2))
+
+    expect(gitSpy).not.toHaveBeenCalled()
+    expect(gitBufferSpy.mock.calls.map(([args]) => args)).toEqual([
+      ['show', '--end-of-options', `${BASE_OID}:${FILE_PATH}`],
+      ['show', '--end-of-options', `${HEAD_OID}:${FILE_PATH}`]
+    ])
+
+    left.resolve('before\n')
+    right.resolve('after\n')
+    await expect(resultPromise).resolves.toEqual([
+      {
+        kind: 'text',
+        originalContent: 'before\n',
+        modifiedContent: 'after\n',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      }
+    ])
+  })
+
+  it('reads the old path only from the base OID', async () => {
+    const oldPath = 'src/old-file.ts'
+    const gitBufferSpy = vi
+      .spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+      .mockImplementation(async (args) => Buffer.from(args[2].startsWith(BASE_OID) ? 'old' : 'new'))
+
+    await request({ oldPath })
+
+    expect(gitBufferSpy.mock.calls.map(([args]) => args[2])).toEqual([
+      `${BASE_OID}:${oldPath}`,
+      `${HEAD_OID}:${FILE_PATH}`
+    ])
+  })
+
+  it('coalesces the same head OID while keeping different heads independent', async () => {
+    const pending = deferredBuffer()
+    const gitBufferSpy = vi
+      .spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+      .mockImplementation(() => pending.promise)
+
+    const requests = [request(), request(), request({ headOid: OTHER_HEAD_OID })]
+    await vi.waitFor(() => expect(gitBufferSpy).toHaveBeenCalledTimes(4))
+
+    const specs = gitBufferSpy.mock.calls.map(([args]) => args[2])
+    expect(specs.filter((spec) => spec === `${BASE_OID}:${FILE_PATH}`)).toHaveLength(2)
+    expect(specs.filter((spec) => spec === `${HEAD_OID}:${FILE_PATH}`)).toHaveLength(1)
+    expect(specs.filter((spec) => spec === `${OTHER_HEAD_OID}:${FILE_PATH}`)).toHaveLength(1)
+
+    pending.resolve('content\n')
+    await Promise.all(requests)
+  })
+
+  it('rejects every supplied malformed head OID before running Git', async () => {
+    const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+    const invalidHeadOids = [null, 7, {}, '', 'a'.repeat(39), 'g'.repeat(40)]
+
+    for (const headOid of invalidHeadOids) {
+      await expect(request({ headOid })).rejects.toThrow('headOid must be a full git object id')
+    }
+
+    expect(gitBufferSpy).not.toHaveBeenCalled()
+  })
+
+  it('accepts SHA-256 object IDs', async () => {
+    const baseOid = 'A'.repeat(64)
+    const headOid = 'b'.repeat(64)
+    const gitBufferSpy = vi
+      .spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+      .mockResolvedValue(Buffer.from('content\n'))
+
+    await request({ baseRef: baseOid, headOid })
+
+    expect(gitBufferSpy.mock.calls.map(([args]) => args[2])).toEqual([
+      `${baseOid}:${FILE_PATH}`,
+      `${headOid}:${FILE_PATH}`
+    ])
+  })
+
+  it('requires a full base OID only on the pinned route', async () => {
+    const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+
+    await expect(request({ baseRef: 'main' })).rejects.toThrow(
+      'baseRef must be a full git object id'
+    )
+    expect(gitBufferSpy).not.toHaveBeenCalled()
+  })
+
+  it('uses the legacy path when patch or file-path conditions are not met', async () => {
+    const gitSpy = vi
+      .spyOn(handler as unknown as GitTarget, 'git')
+      .mockImplementation(async (args) => {
+        if (args[0] === 'rev-parse' && args.includes('HEAD')) {
+          return { stdout: `${HEAD_OID}\n`, stderr: '' }
+        }
+        if (args[0] === 'rev-parse' || args[0] === 'merge-base') {
+          return { stdout: `${BASE_OID}\n`, stderr: '' }
+        }
+        return { stdout: '', stderr: '' }
+      })
+    const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+
+    await Promise.all([
+      request({ baseRef: 'main', includePatch: false }),
+      request({ baseRef: 'main', filePath: '' }),
+      request({ baseRef: 'main', filePath: { malformed: true } })
+    ])
+
+    expect(gitSpy).toHaveBeenCalledTimes(12)
+    expect(gitBufferSpy).not.toHaveBeenCalled()
+  })
+
+  it('keeps the requested head pinned after repository HEAD moves', async () => {
+    const repoPath = mkdtempSync(path.join(tmpdir(), 'relay-pinned-branch-diff-'))
+    try {
+      gitInit(repoPath)
+      writeFileSync(path.join(repoPath, 'file.txt'), 'base\n')
+      gitCommit(repoPath, 'base')
+      const baseOid = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: repoPath,
+        encoding: 'utf8'
+      }).trim()
+
+      writeFileSync(path.join(repoPath, 'file.txt'), 'pinned\n')
+      gitCommit(repoPath, 'pinned')
+      const pinnedHeadOid = execFileSync('git', ['rev-parse', 'HEAD'], {
+        cwd: repoPath,
+        encoding: 'utf8'
+      }).trim()
+
+      writeFileSync(path.join(repoPath, 'file.txt'), 'moved\n')
+      gitCommit(repoPath, 'moved')
+
+      const result = (await request({
+        worktreePath: repoPath,
+        baseRef: baseOid,
+        headOid: pinnedHeadOid,
+        filePath: 'file.txt'
+      })) as { originalContent: string; modifiedContent: string }[]
+
+      expect(result[0]).toMatchObject({
+        originalContent: 'base\n',
+        modifiedContent: 'pinned\n'
+      })
+      expect(
+        execFileSync('git', ['show', 'HEAD:file.txt'], { cwd: repoPath, encoding: 'utf8' })
+      ).toBe('moved\n')
+    } finally {
+      rmSync(repoPath, { recursive: true, force: true })
+    }
+  })
+})

--- a/src/relay/git-handler-branch-diff.test.ts
+++ b/src/relay/git-handler-branch-diff.test.ts
@@ -6,6 +6,7 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { RelayContext } from './context'
 import {
   branchDiffEntryAtPinnedOids,
+  isFullGitObjectId,
   parseOptionalBranchDiffHeadOid
 } from './git-handler-branch-diff-ops'
 import { GitHandler } from './git-handler'
@@ -21,6 +22,7 @@ import {
 const BASE_OID = 'a'.repeat(40)
 const HEAD_OID = 'b'.repeat(40)
 const OTHER_HEAD_OID = 'c'.repeat(40)
+const MERGE_BASE_OID = 'd'.repeat(40)
 const FILE_PATH = 'src/file.ts'
 
 type GitBufferTarget = {
@@ -99,11 +101,51 @@ describe('pinned relay branch diff operation', () => {
     expect(pinned).toEqual(legacy)
   })
 
-  it('treats an omitted head OID differently from a supplied invalid value', () => {
-    expect(parseOptionalBranchDiffHeadOid({})).toBeUndefined()
-    expect(() => parseOptionalBranchDiffHeadOid({ headOid: null })).toThrow(
-      'headOid must be a full git object id'
-    )
+  // Why: GitBranchCompareSummary.headOid is `string | null`, so an unpinned
+  // snapshot arrives as an explicit null and must stay servable.
+  it.each([
+    { name: 'absent', params: {} },
+    { name: 'null', params: { headOid: null } },
+    { name: 'undefined', params: { headOid: undefined } }
+  ])('treats a $name head OID as unpinned', ({ params }) => {
+    expect(parseOptionalBranchDiffHeadOid(params)).toBeUndefined()
+  })
+
+  it.each([
+    { name: 'SHA-1', headOid: HEAD_OID },
+    { name: 'SHA-256', headOid: 'b'.repeat(64) }
+  ])('returns a supplied $name head OID', ({ headOid }) => {
+    expect(parseOptionalBranchDiffHeadOid({ headOid })).toBe(headOid)
+  })
+
+  it.each([{ headOid: 'abc123' }, { headOid: '' }, { headOid: 'main' }, { headOid: 123 }])(
+    'rejects the supplied malformed head OID $headOid',
+    ({ headOid }) => {
+      expect(() => parseOptionalBranchDiffHeadOid({ headOid })).toThrow(
+        'headOid must be a full git object id'
+      )
+    }
+  )
+
+  it('recognizes only full object ids', () => {
+    expect(isFullGitObjectId(BASE_OID)).toBe(true)
+    expect(isFullGitObjectId('A'.repeat(64))).toBe(true)
+    for (const value of ['origin/main', 'abc123', '', 'g'.repeat(40), null, undefined, 123, {}]) {
+      expect(isFullGitObjectId(value)).toBe(false)
+    }
+  })
+
+  // Why: the route guards this today, but the export is reachable on its own —
+  // a symbolic ref here would resolve `git show origin/main:<path>` at live HEAD.
+  it('rejects a symbolic ref at the module boundary', async () => {
+    const gitBuffer = vi.fn<GitBufferExec>(async () => Buffer.from(''))
+    await expect(
+      branchDiffEntryAtPinnedOids(gitBuffer, '/repo', 'origin/main', HEAD_OID, FILE_PATH)
+    ).rejects.toThrow('baseRef must be a full git object id')
+    await expect(
+      branchDiffEntryAtPinnedOids(gitBuffer, '/repo', BASE_OID, 'HEAD', FILE_PATH)
+    ).rejects.toThrow('headOid must be a full git object id')
+    expect(gitBuffer).not.toHaveBeenCalled()
   })
 })
 
@@ -129,6 +171,21 @@ describe('GitHandler pinned branch diff route', () => {
       includePatch: true,
       filePath: FILE_PATH,
       ...overrides
+    })
+  }
+
+  function mockLegacyGit(nameStatus = '') {
+    return vi.spyOn(handler as unknown as GitTarget, 'git').mockImplementation(async (args) => {
+      if (args[0] === 'rev-parse' && args.includes('HEAD')) {
+        return { stdout: `${HEAD_OID}\n`, stderr: '' }
+      }
+      if (args[0] === 'rev-parse') {
+        return { stdout: `${BASE_OID}\n`, stderr: '' }
+      }
+      if (args[0] === 'merge-base') {
+        return { stdout: `${MERGE_BASE_OID}\n`, stderr: '' }
+      }
+      return { stdout: nameStatus, stderr: '' }
     })
   }
 
@@ -206,7 +263,7 @@ describe('GitHandler pinned branch diff route', () => {
 
   it('rejects every supplied malformed head OID before running Git', async () => {
     const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
-    const invalidHeadOids = [null, 7, {}, '', 'a'.repeat(39), 'g'.repeat(40)]
+    const invalidHeadOids = [7, {}, '', 'a'.repeat(39), 'g'.repeat(40)]
 
     for (const headOid of invalidHeadOids) {
       await expect(request({ headOid })).rejects.toThrow('headOid must be a full git object id')
@@ -230,27 +287,57 @@ describe('GitHandler pinned branch diff route', () => {
     ])
   })
 
-  it('requires a full base OID only on the pinned route', async () => {
+  // Why: a symbolic base ref used to select the pinned route and then throw.
+  it('selects the pinned route only when the base ref is a full object id', async () => {
+    const gitSpy = mockLegacyGit(`M\t${FILE_PATH}\n`)
+    const gitBufferSpy = vi
+      .spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
+      .mockResolvedValue(Buffer.from('content\n'))
+
+    await expect(request({ baseRef: 'origin/main' })).resolves.toHaveLength(1)
+
+    expect(gitSpy.mock.calls.map(([args]) => args.join(' '))).toEqual([
+      'rev-parse --verify HEAD',
+      'rev-parse --verify origin/main',
+      `merge-base ${BASE_OID} ${HEAD_OID}`,
+      `-c core.quotePath=false diff --name-status -M -C ${MERGE_BASE_OID} ${HEAD_OID}`
+    ])
+    expect(gitBufferSpy.mock.calls.map(([args]) => args[2])).toEqual([
+      `${MERGE_BASE_OID}:${FILE_PATH}`,
+      `${HEAD_OID}:${FILE_PATH}`
+    ])
+
+    gitSpy.mockClear()
+    gitBufferSpy.mockClear()
+    await request()
+
+    expect(gitSpy).not.toHaveBeenCalled()
+    expect(gitBufferSpy.mock.calls.map(([args]) => args[2])).toEqual([
+      `${BASE_OID}:${FILE_PATH}`,
+      `${HEAD_OID}:${FILE_PATH}`
+    ])
+  })
+
+  it('serves an explicitly null head OID through the legacy path', async () => {
+    const gitSpy = mockLegacyGit(`M\t${FILE_PATH}\n`)
     const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
 
-    await expect(request({ baseRef: 'main' })).rejects.toThrow(
-      'baseRef must be a full git object id'
-    )
+    await expect(request({ headOid: null, includePatch: false })).resolves.toEqual([
+      {
+        kind: 'text',
+        originalContent: '',
+        modifiedContent: '',
+        originalIsBinary: false,
+        modifiedIsBinary: false
+      }
+    ])
+
+    expect(gitSpy).toHaveBeenCalledTimes(4)
     expect(gitBufferSpy).not.toHaveBeenCalled()
   })
 
   it('uses the legacy path when patch or file-path conditions are not met', async () => {
-    const gitSpy = vi
-      .spyOn(handler as unknown as GitTarget, 'git')
-      .mockImplementation(async (args) => {
-        if (args[0] === 'rev-parse' && args.includes('HEAD')) {
-          return { stdout: `${HEAD_OID}\n`, stderr: '' }
-        }
-        if (args[0] === 'rev-parse' || args[0] === 'merge-base') {
-          return { stdout: `${BASE_OID}\n`, stderr: '' }
-        }
-        return { stdout: '', stderr: '' }
-      })
+    const gitSpy = mockLegacyGit()
     const gitBufferSpy = vi.spyOn(handler as unknown as GitBufferTarget, 'gitBuffer')
 
     await Promise.all([

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -20,6 +20,7 @@ import {
 } from './git-handler-ops'
 import {
   branchDiffEntryAtPinnedOids,
+  isFullGitObjectId,
   parseOptionalBranchDiffHeadOid
 } from './git-handler-branch-diff-ops'
 import {
@@ -1171,6 +1172,7 @@ export class GitHandler {
       () => {
         if (
           headOid &&
+          isFullGitObjectId(baseRef) &&
           options.includePatch === true &&
           typeof options.filePath === 'string' &&
           options.filePath.length > 0

--- a/src/relay/git-handler.ts
+++ b/src/relay/git-handler.ts
@@ -19,6 +19,10 @@ import {
   type GitExec
 } from './git-handler-ops'
 import {
+  branchDiffEntryAtPinnedOids,
+  parseOptionalBranchDiffHeadOid
+} from './git-handler-branch-diff-ops'
+import {
   buildSubmoduleInnerCommitRangeDiff,
   computeSubmodulePointerDiff,
   computeSubmoduleRangeEntries,
@@ -1148,6 +1152,7 @@ export class GitHandler {
     if (baseRef.startsWith('-')) {
       throw new Error('Base ref must not start with "-"')
     }
+    const headOid = parseOptionalBranchDiffHeadOid(params)
     const options = {
       includePatch: params.includePatch as boolean | undefined,
       filePath: params.filePath as string | undefined,
@@ -1158,18 +1163,35 @@ export class GitHandler {
         'branchDiff',
         worktreePath,
         baseRef,
+        headOid ?? null,
         options.includePatch ?? null,
         options.filePath ?? null,
         options.oldPath ?? null
       ]),
-      () =>
-        branchDiffEntries(
+      () => {
+        if (
+          headOid &&
+          options.includePatch === true &&
+          typeof options.filePath === 'string' &&
+          options.filePath.length > 0
+        ) {
+          return branchDiffEntryAtPinnedOids(
+            this.gitBuffer.bind(this),
+            worktreePath,
+            baseRef,
+            headOid,
+            options.filePath,
+            options.oldPath
+          )
+        }
+        return branchDiffEntries(
           this.git.bind(this),
           this.gitBuffer.bind(this),
           worktreePath,
           baseRef,
           options
         )
+      }
     )
     return this.maybeStreamResponse(result, params, context)
   }

--- a/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
+++ b/src/renderer/src/components/editor/useEditorPanelContentState.test.tsx
@@ -426,7 +426,7 @@ describe('useEditorPanelContentState', () => {
         connectionId: 'ssh-1'
       }),
       expect.objectContaining({
-        compare: expect.objectContaining({ mergeBase: 'merge-base' }),
+        compare: expect.objectContaining({ headOid: 'head', mergeBase: 'merge-base' }),
         filePath: 'api/src/file.ts'
       })
     )

--- a/src/shared/git-binary-compatibility.test.ts
+++ b/src/shared/git-binary-compatibility.test.ts
@@ -226,4 +226,25 @@ describeBinaryCompatibility('real Git binary compatibility', () => {
     expect(lines[0]).toBe('--end-of-options')
     expect(lines.find((line) => line !== '--end-of-options')).toMatch(/^refs\//)
   })
+
+  // Why pin this: `show --end-of-options <oid>:<path>` is the only Git command on the
+  // pinned SSH branch-diff path, and both blob sides depend on it resolving against the
+  // named commit rather than live HEAD, and on failing (not falling back) for a path
+  // absent at that commit — that failure is what renders additions and deletions.
+  it('reads a blob at a pinned object id', async () => {
+    await writeFile(join(repoPath, 'pinned.txt'), 'pinned\n')
+    await runGit(['add', 'pinned.txt'])
+    await runGit(['commit', '-qm', 'pinned'])
+    const pinnedOid = (await runGit(['rev-parse', 'HEAD'])).stdout.trim()
+
+    await writeFile(join(repoPath, 'pinned.txt'), 'moved on\n')
+    await runGit(['commit', '-qam', 'after pinned'])
+
+    await expect(
+      runGit(['show', '--end-of-options', `${pinnedOid}:pinned.txt`])
+    ).resolves.toMatchObject({ stdout: 'pinned\n' })
+    await expect(
+      runGit(['show', '--end-of-options', `${pinnedOid}:absent.txt`])
+    ).rejects.toBeDefined()
+  })
 })


### PR DESCRIPTION
## Summary

### ELI5

When Orca opens one changed file over SSH, the renderer already knows the exact merge-base commit and head commit for that review snapshot. The SSH path kept the merge base but discarded the head, so the relay rediscovered live `HEAD`, recomputed the merge base, scanned the full changed-file list, and only then read the same two blobs the native path reads directly.

This change forwards the already-pinned head as an optional field. A new relay operation validates both object IDs, then reads the requested file at those two commits concurrently. That removes four Git processes from every SSH single-file branch diff and also prevents a branch move during the request from changing which revision is displayed.

### Execution shape

| Route | Git processes | Ordering |
| --- | ---: | --- |
| Previous SSH relay | 6 | `rev-parse HEAD` → `rev-parse base` → `merge-base` → `diff --name-status` → two serial `show` reads |
| Pinned SSH relay | 2 | Two overlapping `show --end-of-options <oid>:<path>` reads |

The fast path is selected only when **all** of these hold: a pinned `headOid`, a **full 40/64-hex `baseRef`**, `includePatch === true`, and a nonempty string `filePath`. Anything else — including an absent or explicitly `null` `headOid`, or a symbolic base ref — falls through to the untouched legacy implementation rather than failing.

This mirrors the native path exactly: `loadBranchDiff` in `src/main/git/status.ts` already reads the two pinned blobs concurrently. The change makes SSH match native, it does not invent a new shape.

No response shape, stream frame, protocol version, persisted state, UI, or native/WSL/local Git path changes.

### Performance proof

Real Git, five warmups plus 31 alternating pairs:

| Implementation | Median | p95 |
| --- | ---: | ---: |
| Previous relay path | 131.34 ms | 166.37 ms |
| Pinned two-read path | 29.61 ms | 45.54 ms |
| Improvement | **4.44× / 101.72 ms saved** | **120.83 ms saved** |

A separate reproduction measured 119.99 → 23.53 ms median.

An independent audit then exercised the actual production modules with real Git on macOS arm64/Git 2.44, again with five warmups and 31 alternating pairs:

- Previous: 36.33 ms median / 43.66 ms p95
- Candidate: 6.74 ms median / 10.07 ms p95
- **5.39× faster; 29.59 ms median saved**
- Instrumentation proved legacy max concurrency 1, pinned max concurrency 2, both pinned process lifetimes overlapped, and no metadata Git command ran.

Absolute milliseconds depend on host, repository, and storage, and were **not** re-measured in the readiness review below. The deterministic, structurally-verified claim is relay-side Git work: six sequential processes become two concurrent reads; SSH/RPC overhead is unchanged. Instantaneous per-file Git concurrency does rise from 1 to 2 even though total spawns drop from 6 to 2.

### Deliberate behavior changes

Only **one** behavioral difference survives against real Git, and it is the fix itself:

- **A branch move mid-review no longer changes what you see.** Legacy silently re-resolved live `HEAD`; the pinned route returns the revision the caller asked for. Asserted directly in `git-handler-branch-diff-equivalence.test.ts`.

Two differences I previously listed turned out **not** to be reachable divergences, and the equivalence harness proves it:

- **Rename detection did not move.** `git.branchCompare` derives its entry list from `diff --name-status -M -C` at the *same two OIDs it reports in its summary*. So the `filePath`/`oldPath` the renderer forwards are literally the output of the same rename detection the legacy route re-ran internally. Exact renames (R100) and edited renames (R069) produce byte-identical results on both routes.
- **The changed-file membership filter is not observably lost.** The renderer's file list *is* that change set, so a request for a path outside it is not reachable through the review panel; and both consumers coalesce the two shapes to the same rendering anyway.

One residual difference remains, in a state that is **essentially unreachable without a manual aggressive `gc`**. If the pinned head OID has been *pruned*, its read fails and is swallowed to an empty string, so the file renders as a **full deletion** (all-red left pane, blank right pane) rather than falling back to a live-`HEAD` diff. The native path already does exactly this in the same state, so it is SSH matching native rather than SSH regressing.

Two independent gates must both fail before that is possible, verified against real Git 2.44:

| Scenario | Pinned OID still readable |
| --- | --- |
| `commit --amend`, no gc | yes |
| amend + `git gc` (defaults) | yes |
| amend + `git gc --auto` | yes |
| amend + `gc --prune=now` | yes — the reflog still pins it |
| amend + `reflog expire --expire=now --all` + `gc --prune=now` | **no** — the only way in |

Defaults that govern it: `gc.reflogExpireUnreachable` = 30 days, `gc.pruneExpire` = 2 weeks, `gc.cruftPacks` = true. Expiring the reflog alone with a default `pruneExpire` still leaves the object readable. Orca itself never runs `gc`, `prune`, `repack` or `reflog expire` anywhere in `src/main`, `src/relay` or `src/shared` — only `git worktree prune` and `fetch --prune`, neither of which touches the object database. Separately, any HEAD move re-pins the snapshot immediately (`SourceControl.tsx:4998-5016`) and a diff tab's identity bakes in `baseOid:headOid:mergeBase` (`editor.ts:5139-5147`), so only a tab left open across the rewrite can hold a stale pin, and diff tabs are not restored across restarts.

### Proof of no regression

The central evidence is a real-Git differential harness (`src/relay/git-handler-branch-diff-equivalence.test.ts`). It drives `git.branchCompare` and then `git.branchDiff` on **both** routes, through the real dispatcher, using exactly the parameters the renderer sends, over one repository covering **14 change entries**: additions, deletions, modifications, an exact rename (R100), an edited rename (R069), binary add/delete/modify, a unicode path, a path with spaces, a nested path, a CRLF file, and a file emptied to zero bytes. It asserts the two routes agree entry-for-entry and reports any divergence by name.

The harness is proven non-vacuous by mutation: dropping `oldPath` rename handling, pointing the right-hand read at live `HEAD`, and swapping the left/right blob order each make it fail and name the affected files. Source restored byte-identical after each.

Supporting evidence:

- Desktop SSH and nested-runtime SSH both forward the same `headOid` already paired with `mergeBase` in the renderer/runtime compare snapshot.
- `mergeBase` is only assigned after `headOid` is proven non-null in both summary producers, and every consumer gates on both fields, so no current caller can request a pinned diff without a head.
- The SSH provider and relay dedupe identities both include the head, so different revisions cannot share an in-flight result; identical revisions still coalesce. The dedupe map is bounded (128 entries, evicted on settle plus a 30s timeout).
- The new operation reuses the existing binary/overflow reader and diff-result builder.
- A live-repository test advances `HEAD` after capturing the requested commit and proves the response still comes from the pinned head.
- Full SHA-1 and SHA-256 command shapes are accepted. A **malformed** pinned field rejects rather than silently showing live-`HEAD` content; an **absent or null** one degrades to the legacy path.
- No new Git command or option was introduced. `git show --end-of-options` is already used by the existing relay reader and is supported at Orca's Git 2.25 baseline.
- Windows separators are normalized by the unchanged blob reader; nested runtime normalization and folder-workspace forwarding have focused coverage.
- No GitHub-specific behavior or naming was added.

### Mixed-version behavior

| Client/runtime | Relay | Behavior |
| --- | --- | --- |
| New | New | Valid pinned shape uses the two-read path |
| Old | New | Field is absent; untouched legacy path |
| New | Old | Unknown optional JSON field is ignored; previous legacy path |
| Old | Old | Unchanged |

An old relay therefore remains correct and compatible, but keeps the previous six-process/live-`HEAD` behavior until it is upgraded. Because the same UI silently means two different things depending on relay version, any *future* change that depends on the pin being honored would need capability negotiation; this one does not.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` (exit 0; nine existing unrelated exhaustive-deps warnings remain in `WorktreeJumpPalette.tsx`)
- [x] `pnpm typecheck` (exit 0, re-run after the hardening commit)
- [x] **macOS** — all seven affected suites (including the new equivalence harness): **349 passed, 1 skipped**. Broad sweep over `src/relay` + `src/main/git` + `src/main/providers`: **3629 passed**, 2 failures in `agent-exec-handler.test.ts` proven pre-existing (identical with this branch's changes stashed; env-var assertions sensitive to the local shell).
- [x] **Windows** — real Windows host, **Git 2.55.0.windows.3**, Node 24.18. The PR's targeted suites are green in two independent runs. This exercises `git show --end-of-options <oid>:<path>` and the backslash→forward-slash normalization in the blob reader against a real Windows Git.
- [x] **Windows regression control** — the same broad sweep was run on the PR branch and on the PR's exact fork point on `origin/main` (`a63df91790`, which differs from the branch by exactly the 11 PR files), back to back on the same host with JSON reporters. Both produce **13 failed files / 39 failed tests**, and the 39 fully-qualified failing test names **diff to empty — identical sets**. Zero files fail only on the PR branch. Those 39 are pre-existing Windows-environment artifacts in untouched files: `EPERM` symlink without Developer Mode, hardcoded `C:\` backslash literals, temp-dir `EBUSY`/`ENOENT`, and host `PATH`/env leakage.
- [x] **WSL** — Ubuntu-24.04 (WSL 2) on real Linux Node 24.18 (`process.platform = linux`): `git-handler-branch-diff`, `ssh-git-provider`, and `orca-runtime-git-branch-diff` all pass, **112 passed, 0 failed**. `src/main/ipc/filesystem.test.ts` could not be loaded there — it transitively imports `node-pty`, which ships no `linux-x64` prebuild, and the distro has no `make`/`g++` and no passwordless sudo to install one. Unverified under WSL, not failing.
- [x] **Git compat matrix** — `show --end-of-options <oid>:<path>` now has a pinned version boundary, asserting it resolves against the named commit rather than live `HEAD` and that an absent path fails (that failure is what renders additions and deletions).
- [x] **Real SSH socket, real relay bundles** — an `sshd` container (git 2.39.5 / node 22 / Linux arm64) with three separately built relay bundles at distinct paths and distinct md5s: this branch, `main` tip, and the PR's pre-merge-base. Driven over a real SSH exec channel using the repo's own wire codec (`src/main/ssh/relay-protocol.ts`) with the exact param shape `SshGitProvider.getBranchDiff` emits. A `git` PATH shim inside the container logged every argv.
  - **New relay:** the pinned path ran **exactly 2 processes** — `show --end-of-options <mergeBase>:<path>` and `show --end-of-options <headOid>:<path>` — with zero `rev-parse`/`merge-base`/`name-status`.
  - **Old relay (main tip and pre-merge-base):** a new-client request carrying `headOid` returned `error: null` and a **byte-identical diff** via the legacy 6-process path. The old relay simply never reads the field — the new optional param is wire-safe, proven against a real old binary rather than by policy.
  - **All four shapes** — with `headOid`, without it, explicit `headOid: null`, and a rename with `oldPath` — succeeded on both old relays and the new one, byte-identical throughout.
- [ ] `pnpm build` — all relay targets and the Electron production build passed; unrelated native release compilation was not rerun

## AI Review Report

A seven-dimension readiness review (41 agents: semantic equivalence, wire compat, crash/retry/growth, security, cross-platform, concurrency/dedupe, tests/perf) ran every candidate finding through three independent refutation lenses — correctness, reachability, and already-handled. **Eleven candidate findings, zero survived: no P0/P1/P2.**

Two residual sharp edges were judged worth removing outright rather than accepting, and are fixed in `321e932`:

1. `parseOptionalBranchDiffHeadOid` ran before the route decision, so an explicitly `null` `headOid` rejected the whole request even for the legacy shape. `GitBranchCompareSummary.headOid` is typed `string | null`, so a client built at `a7e662a` could put null on the wire. Null is now treated as unpinned, and `SshGitProvider` collapses it to absent so it never reaches the wire.
2. Route selection ignored `baseRef` shape and then hard-asserted it *outside* the try, so a symbolic base ref with a pinned head produced an RPC error where legacy resolved it. The route now requires a full-hex base and otherwise falls through to legacy.

Both were unreachable from current callers; the fixes convert "argued-unreachable" into "structurally impossible" and remove the only two new hard-error paths the PR introduced. A follow-up review of the hardening itself confirmed no new regression, verified the wire-compat matrix for the null case, and returned SHIP with no must-fix items.

Residuals, now narrowed: the old-relay wire-compatibility question has been **closed empirically** over a real SSH socket against real `main`-built and pre-merge-base relay bundles (see Testing). Windows, the Windows regression control, WSL, and the `--end-of-options` version boundary are likewise covered rather than deferred. What remains unexercised is only the *client* half of that hop — the SSH driver reuses the repo's real wire codec and param shape but is not `SshGitProvider`/`ssh-channel-multiplexer` itself, and the SFTP relay-deploy and renderer IPC hops were not run; none of those are touched by this PR. `src/main/ipc/filesystem.test.ts` is unverified under WSL for `node-pty` toolchain reasons unrelated to this change. The absolute millisecond figures above were not reproduced during review; the structurally verified claim is six sequential Git processes becoming two concurrent reads. The existing relay blob reader still lacks timeout/cancellation, but this change reduces total processes from six to two and does not broaden that pre-existing behavior. CI remains the final platform proof.

## Security Audit

The new fast path accepts only full 40/64-hex object IDs before command construction, executes Git with argv arrays, and reuses `--end-of-options`. There are no shell strings, dependencies, credentials, auth changes, new network sinks, path-authority changes, persistence changes, or executable artifacts.

The legacy `--name-status` filter previously acted as an implicit membership check, and the pinned route drops it. This was examined closely and is **not** a widening: `git.commitDiff` already ships the identical unfiltered `<oid>:<path>` read with *no* OID validation at all, so the pinned route is strictly narrower than an existing sibling RPC. Confinement rests on Git's `<rev>:<path>` semantics — `../`, absolute paths, and `.git/...` all fail, and the token always begins with validated hex so it cannot parse as a flag. Existing worktree/file-path authorization and response streaming remain unchanged.

## Notes

- Semantic performance scan item PSS-018.
- @nwparker_
