### PR TITLE
perf(search): cancel superseded content scans

### DIFF
--- a/src/main/ipc/filesystem-search-git.test.ts
+++ b/src/main/ipc/filesystem-search-git.test.ts
@@ -13,11 +13,12 @@ vi.mock('child_process', () => ({
 }))
 
 import { searchWithGitGrep } from './filesystem-search-git'
-import { EventEmitter } from 'node:events'
+import { EventEmitter, getEventListeners } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
 
 function createMockProcess(): ChildProcess {
   const p = new EventEmitter() as unknown as ChildProcess
+  ;(p as unknown as Record<string, unknown>).pid = 1234
   ;(p as unknown as Record<string, unknown>).stdout = new EventEmitter()
   ;(
     (p as unknown as Record<string, unknown>).stdout as EventEmitter & {
@@ -27,6 +28,14 @@ function createMockProcess(): ChildProcess {
   ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
   ;(p as unknown as Record<string, unknown>).kill = vi.fn()
   return p
+}
+
+function expectDetached(proc: ChildProcess, signal: AbortSignal): void {
+  expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+  expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+  expect(proc.listenerCount('error')).toBe(0)
+  expect(proc.listenerCount('close')).toBe(0)
+  expect(getEventListeners(signal, 'abort')).toHaveLength(0)
 }
 
 describe('filesystem-search-git', () => {
@@ -200,6 +209,44 @@ describe('filesystem-search-git', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not spawn git grep for a pre-aborted search', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    const promise = searchWithGitGrep(
+      '/mock/root',
+      { query: 'ok', rootPath: '/mock/root' },
+      100,
+      {},
+      controller.signal
+    )
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+  })
+
+  it('aborts an in-flight git grep and detaches every listener', async () => {
+    const proc = createMockProcess()
+    const controller = new AbortController()
+    spawnMock.mockReturnValue(proc)
+
+    const promise = searchWithGitGrep(
+      '/mock/root',
+      { query: 'ok', rootPath: '/mock/root' },
+      100,
+      {},
+      controller.signal
+    )
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(1)
+
+    controller.abort()
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    expectDetached(proc, controller.signal)
   })
 
   it('skips lines without null separator', async () => {

--- a/src/main/ipc/filesystem-search-rg-timeout.test.ts
+++ b/src/main/ipc/filesystem-search-rg-timeout.test.ts
@@ -76,6 +76,7 @@ import { registerFilesystemHandlers } from './filesystem'
 
 function createMockProcess(): ChildProcess {
   const p = new EventEmitter() as unknown as ChildProcess
+  ;(p as unknown as Record<string, unknown>).pid = 1234
   ;(p as unknown as Record<string, unknown>).stdout = new EventEmitter()
   ;(
     (p as unknown as Record<string, unknown>).stdout as EventEmitter & {
@@ -130,6 +131,69 @@ describe('filesystem rg search timeout', () => {
     }
   })
 
+  it('rejects an aborted rg search and detaches every listener', async () => {
+    const child = createMockProcess()
+    let searchSignal: AbortSignal | undefined
+    checkRgAvailableMock.mockImplementation(
+      async (_rootPath: string, _wslDistro: string | undefined, signal: AbortSignal) => {
+        searchSignal = signal
+        return true
+      }
+    )
+    wslAwareSpawnMock.mockReturnValue(child)
+    registerFilesystemHandlers({} as never)
+
+    const senderEvent = { sender: { id: 7 } }
+    const promise = handlers.get('fs:search')!(senderEvent, {
+      rootPath: '/repo',
+      query: 'ok',
+      requestToken: 'search-1'
+    }) as Promise<unknown>
+    await vi.waitFor(() => expect(wslAwareSpawnMock).toHaveBeenCalledTimes(1))
+    const removeAbortListener = vi.spyOn(searchSignal!, 'removeEventListener')
+
+    await handlers.get('fs:cancelSearch')!(senderEvent, { requestToken: 'search-1' })
+
+    expect(searchSignal?.aborted).toBe(true)
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect((child.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+    expect((child.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(removeAbortListener).toHaveBeenCalledWith('abort', expect.any(Function))
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('does not spawn rg when cancellation wins before availability resolves', async () => {
+    let searchSignal: AbortSignal | undefined
+    let resolveAvailability!: (available: boolean) => void
+    checkRgAvailableMock.mockImplementation(
+      (_rootPath: string, _wslDistro: string | undefined, signal: AbortSignal) => {
+        searchSignal = signal
+        return new Promise<boolean>((resolve) => {
+          resolveAvailability = resolve
+        })
+      }
+    )
+    registerFilesystemHandlers({} as never)
+
+    const senderEvent = { sender: { id: 7 } }
+    const promise = handlers.get('fs:search')!(senderEvent, {
+      rootPath: '/repo',
+      query: 'ok',
+      requestToken: 'search-before-spawn'
+    }) as Promise<unknown>
+    await vi.waitFor(() => expect(searchSignal).toBeDefined())
+
+    await handlers.get('fs:cancelSearch')!(senderEvent, {
+      requestToken: 'search-before-spawn'
+    })
+    resolveAvailability(true)
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(wslAwareSpawnMock).not.toHaveBeenCalled()
+  })
+
   it('routes rg through the registered WSL project runtime for Windows-path worktrees', async () => {
     const child = createMockProcess()
     wslAwareSpawnMock.mockReturnValue(child)
@@ -147,7 +211,7 @@ describe('filesystem rg search timeout', () => {
 
     await promise
 
-    expect(checkRgAvailableMock).toHaveBeenCalledWith('C:\\repo', 'Ubuntu')
+    expect(checkRgAvailableMock).toHaveBeenCalledWith('C:\\repo', 'Ubuntu', undefined)
     expect(wslAwareSpawnMock).toHaveBeenCalledWith(
       'rg',
       expect.any(Array),

--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -3098,6 +3098,113 @@ describe('registerFilesystemHandlers', () => {
     )
   })
 
+  it('fs:cancelSearch only aborts the issuing sender remote search', async () => {
+    const searches: {
+      signal: AbortSignal | undefined
+      resolve: (result: { files: []; totalMatches: number; truncated: boolean }) => void
+    }[] = []
+    const searchMock = vi.fn(
+      (
+        _options: unknown,
+        context: { signal?: AbortSignal }
+      ): Promise<{ files: []; totalMatches: number; truncated: boolean }> =>
+        new Promise((resolve) => searches.push({ signal: context.signal, resolve }))
+    )
+    getSshFilesystemProviderMock.mockReturnValue({ search: searchMock })
+    registerFilesystemHandlers(store as never)
+
+    const ownerEvent = { sender: { id: 7 } }
+    const otherEvent = { sender: { id: 8 } }
+    const pending = handlers.get('fs:search')!(ownerEvent, {
+      rootPath: '/home/user/repo',
+      query: 'needle',
+      connectionId: 'conn-1',
+      requestToken: 'search-1'
+    }) as Promise<unknown>
+    await vi.waitFor(() => expect(searches).toHaveLength(1))
+
+    await handlers.get('fs:cancelSearch')!(otherEvent, { requestToken: 'search-1' })
+    expect(searches[0]?.signal?.aborted).toBe(false)
+
+    await handlers.get('fs:cancelSearch')!(ownerEvent, { requestToken: 'search-1' })
+    expect(searches[0]?.signal?.aborted).toBe(true)
+    expect(searchMock).toHaveBeenCalledWith(
+      { rootPath: '/home/user/repo', query: 'needle' },
+      { signal: searches[0]?.signal }
+    )
+
+    searches[0]?.resolve({ files: [], totalMatches: 0, truncated: false })
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('fs:search token reuse aborts its predecessor without dropping the replacement', async () => {
+    const searches: {
+      signal: AbortSignal | undefined
+      resolve: (result: { files: []; totalMatches: number; truncated: boolean }) => void
+    }[] = []
+    const searchMock = vi.fn(
+      (
+        _options: unknown,
+        context: { signal?: AbortSignal }
+      ): Promise<{ files: []; totalMatches: number; truncated: boolean }> =>
+        new Promise((resolve) => searches.push({ signal: context.signal, resolve }))
+    )
+    getSshFilesystemProviderMock.mockReturnValue({ search: searchMock })
+    registerFilesystemHandlers(store as never)
+
+    const senderEvent = { sender: { id: 7 } }
+    const first = handlers.get('fs:search')!(senderEvent, {
+      rootPath: '/home/user/repo',
+      query: 'first',
+      connectionId: 'conn-1',
+      requestToken: 'reused'
+    }) as Promise<unknown>
+    const second = handlers.get('fs:search')!(senderEvent, {
+      rootPath: '/home/user/repo',
+      query: 'second',
+      connectionId: 'conn-1',
+      requestToken: 'reused'
+    }) as Promise<unknown>
+    await vi.waitFor(() => expect(searches).toHaveLength(2))
+
+    expect(searches[0]?.signal?.aborted).toBe(true)
+    expect(searches[1]?.signal?.aborted).toBe(false)
+
+    searches[0]?.resolve({ files: [], totalMatches: 0, truncated: false })
+    await expect(first).rejects.toMatchObject({ name: 'AbortError' })
+    await handlers.get('fs:cancelSearch')!(senderEvent, { requestToken: 'reused' })
+    expect(searches[1]?.signal?.aborted).toBe(true)
+
+    searches[1]?.resolve({ files: [], totalMatches: 0, truncated: false })
+    await expect(second).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('fs:cancelSearch ignores settled and unknown tokens', async () => {
+    let settledSignal: AbortSignal | undefined
+    const searchMock = vi.fn((_options: unknown, context: { signal?: AbortSignal }) => {
+      settledSignal = context.signal
+      return Promise.resolve({ files: [], totalMatches: 0, truncated: false })
+    })
+    getSshFilesystemProviderMock.mockReturnValue({ search: searchMock })
+    registerFilesystemHandlers(store as never)
+
+    const senderEvent = { sender: { id: 7 } }
+    await handlers.get('fs:search')!(senderEvent, {
+      rootPath: '/home/user/repo',
+      query: 'settled',
+      connectionId: 'conn-1',
+      requestToken: 'settled'
+    })
+
+    expect(() =>
+      handlers.get('fs:cancelSearch')!(senderEvent, { requestToken: 'settled' })
+    ).not.toThrow()
+    expect(() =>
+      handlers.get('fs:cancelSearch')!(senderEvent, { requestToken: 'unknown' })
+    ).not.toThrow()
+    expect(settledSignal?.aborted).toBe(false)
+  })
+
   // Why: the original SSH Quick Open bug had two halves — relay-side policy
   // drift AND the main dispatcher silently dropping excludePaths before the
   // provider saw them. This test guards the second half: regardless of

--- a/src/main/ipc/filesystem.ts
+++ b/src/main/ipc/filesystem.ts
@@ -41,6 +41,10 @@ import {
   SEARCH_TIMEOUT_MS
 } from '../../shared/text-search'
 import {
+  createTextSearchAbortError,
+  throwIfTextSearchAborted
+} from '../../shared/text-search-cancellation'
+import {
   getStatus,
   getSubmoduleStatus,
   abortMerge,
@@ -139,6 +143,7 @@ import { sanitizeLocalDownloadFilename } from '../local-download-filename'
 import { registerFilesystemDownloadFolderHandlers } from './filesystem-download-folder'
 import { getWorktreeSharedLinkPaths } from '../git/worktree-shared-directories'
 import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
+import { terminateSpawnedChild } from '../../shared/spawned-child-cancellation'
 import {
   applyGitStatusUpstreamRefWatchRequest,
   type GitStatusUpstreamRefWatchRequest
@@ -962,117 +967,179 @@ export function registerFilesystemHandlers(
   )
 
   // ─── Search ────────────────────────────────────────────
+  const textSearchCancellations = createSenderScopedRequestCancellations()
   ipcMain.handle(
     'fs:search',
-    async (event, args: SearchOptions & { connectionId?: string }): Promise<SearchResult> => {
-      if (args.connectionId) {
-        const provider = requireSshFilesystemProvider(args.connectionId)
-        return provider.search(args)
-      }
-      const rootPath = await resolveAuthorizedPath(args.rootPath, store)
-      const localGitOptions = getLocalGitOptionsForRegisteredWorktree(
-        store,
-        args.rootPath,
-        rootPath
-      )
-      const maxResults = Math.max(
-        1,
-        Math.min(args.maxResults ?? DEFAULT_SEARCH_MAX_RESULTS, DEFAULT_SEARCH_MAX_RESULTS)
-      )
-      const searchKey = `${event.sender.id}:${rootPath}`
+    async (
+      event,
+      args: SearchOptions & { connectionId?: string; requestToken?: string }
+    ): Promise<SearchResult> => {
+      const controller = textSearchCancellations.begin(event, args.requestToken)
+      const signal = controller?.signal
+      const { connectionId, requestToken: _requestToken, ...searchOptions } = args
+      try {
+        if (connectionId) {
+          const provider = requireSshFilesystemProvider(connectionId)
+          const result = await provider.search(searchOptions, { signal })
+          throwIfTextSearchAborted(signal)
+          return result
+        }
+        const rootPath = await resolveAuthorizedPath(searchOptions.rootPath, store)
+        const localGitOptions = getLocalGitOptionsForRegisteredWorktree(
+          store,
+          searchOptions.rootPath,
+          rootPath
+        )
+        const maxResults = Math.max(
+          1,
+          Math.min(
+            searchOptions.maxResults ?? DEFAULT_SEARCH_MAX_RESULTS,
+            DEFAULT_SEARCH_MAX_RESULTS
+          )
+        )
+        const searchKey = `${event.sender.id}:${rootPath}`
 
-      // Why: probe rg upfront; on some platforms spawn emits 'close' before 'error', resolving empty before the git-grep fallback runs.
-      const rgAvailable = await checkRgAvailable(rootPath, localGitOptions.wslDistro)
-      if (!rgAvailable) {
-        return searchWithGitGrep(rootPath, args, maxResults, localGitOptions)
-      }
-
-      return new Promise((resolvePromise) => {
-        const rgArgs = buildRgArgs(args.query, rootPath, args)
-
-        // Why: kill the prior rg so it stops parsing thousands of matches on the main thread (the large-repo freeze) after the UI moved on.
-        activeTextSearches.get(searchKey)?.kill()
-
-        const acc = createAccumulator()
-        let stdoutBuffer = ''
-        let resolved = false
-        let child: ChildProcess | null = null
-        let killTimeout: ReturnType<typeof setTimeout>
-
-        // Why: WSL-routed rg emits Linux paths; UNC repos carry the distro in the path, Windows-path repos in project runtime.
-        const wslDistroForOutput = parseWslPath(rootPath)?.distro ?? localGitOptions.wslDistro
-        const transformAbsPath = wslDistroForOutput
-          ? (p: string): string => (p.startsWith('/') ? toWindowsWslPath(p, wslDistroForOutput) : p)
-          : undefined
-
-        const resolveOnce = (): void => {
-          if (resolved) {
-            return
-          }
-          resolved = true
-          if (activeTextSearches.get(searchKey) === child) {
-            activeTextSearches.delete(searchKey)
-          }
-          clearTimeout(killTimeout)
-          // Why: child.kill() is advisory; detach our closures so repeated searches don't retain old scans if rg ignores it.
-          child?.stdout?.off('data', handleStdoutData)
-          child?.stderr?.off('data', handleStderrData)
-          child?.off('error', handleError)
-          child?.off('close', handleClose)
-          resolvePromise(finalize(acc))
+        // Why: probe rg upfront; on some platforms spawn emits 'close' before 'error', resolving empty before the git-grep fallback runs.
+        const rgAvailable = await checkRgAvailable(rootPath, localGitOptions.wslDistro, signal)
+        throwIfTextSearchAborted(signal)
+        if (!rgAvailable) {
+          return await searchWithGitGrep(
+            rootPath,
+            searchOptions,
+            maxResults,
+            localGitOptions,
+            signal
+          )
         }
 
-        const processLine = (line: string): void => {
-          const verdict = ingestRgJsonLine(line, rootPath, acc, maxResults, transformAbsPath)
-          if (verdict === 'stop') {
-            child?.kill()
-          }
-        }
+        return await new Promise<SearchResult>((resolvePromise, rejectPromise) => {
+          const rgArgs = buildRgArgs(searchOptions.query, rootPath, searchOptions)
 
-        const nextChild = wslAwareSpawn('rg', rgArgs, {
-          cwd: rootPath,
-          ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
-          stdio: ['ignore', 'pipe', 'pipe']
+          // Why: kill the prior rg so it stops parsing thousands of matches on the main thread (the large-repo freeze) after the UI moved on.
+          const previousChild = activeTextSearches.get(searchKey)
+          if (previousChild) {
+            terminateSpawnedChild(previousChild)
+          }
+
+          const acc = createAccumulator()
+          let stdoutBuffer = ''
+          let resolved = false
+          let child: ChildProcess | null = null
+          let killTimeout: ReturnType<typeof setTimeout> | null = null
+
+          // Why: WSL-routed rg emits Linux paths; UNC repos carry the distro in the path, Windows-path repos in project runtime.
+          const wslDistroForOutput = parseWslPath(rootPath)?.distro ?? localGitOptions.wslDistro
+          const transformAbsPath = wslDistroForOutput
+            ? (p: string): string =>
+                p.startsWith('/') ? toWindowsWslPath(p, wslDistroForOutput) : p
+            : undefined
+
+          const cleanup = (): void => {
+            if (killTimeout) {
+              clearTimeout(killTimeout)
+              killTimeout = null
+            }
+            child?.stdout?.off('data', handleStdoutData)
+            child?.stderr?.off('data', handleStderrData)
+            child?.off('error', handleError)
+            child?.off('close', handleClose)
+            signal?.removeEventListener('abort', handleAbort)
+          }
+
+          const finish = (): boolean => {
+            if (resolved) {
+              return false
+            }
+            resolved = true
+            if (activeTextSearches.get(searchKey) === child) {
+              activeTextSearches.delete(searchKey)
+            }
+            cleanup()
+            return true
+          }
+
+          const resolveOnce = (options: { kill?: boolean } = {}): void => {
+            if (!finish()) {
+              return
+            }
+            // Why: child.kill() is advisory; detach our closures so repeated searches don't retain old scans if rg ignores it.
+            if (options.kill && child) {
+              terminateSpawnedChild(child)
+            }
+            resolvePromise(finalize(acc))
+          }
+
+          const rejectAborted = (): void => {
+            if (!finish()) {
+              return
+            }
+            if (child) {
+              terminateSpawnedChild(child)
+            }
+            rejectPromise(createTextSearchAbortError())
+          }
+
+          const processLine = (line: string): void => {
+            const verdict = ingestRgJsonLine(line, rootPath, acc, maxResults, transformAbsPath)
+            if (verdict === 'stop' && child) {
+              terminateSpawnedChild(child)
+            }
+          }
+
+          const nextChild = wslAwareSpawn('rg', rgArgs, {
+            cwd: rootPath,
+            ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
+            stdio: ['ignore', 'pipe', 'pipe']
+          })
+          child = nextChild
+          activeTextSearches.set(searchKey, nextChild)
+
+          const handleStdoutData = (chunk: string): void => {
+            stdoutBuffer += chunk
+            const lines = stdoutBuffer.split('\n')
+            stdoutBuffer = lines.pop() ?? ''
+            for (const line of lines) {
+              processLine(line)
+            }
+          }
+          const handleStderrData = (): void => {
+            // Drain stderr so rg cannot block on a full pipe.
+          }
+          const handleError = (): void => resolveOnce()
+          const handleClose = (): void => {
+            if (stdoutBuffer) {
+              processLine(stdoutBuffer)
+            }
+            resolveOnce()
+          }
+          const handleAbort = (): void => {
+            rejectAborted()
+          }
+
+          nextChild.stdout!.setEncoding('utf-8')
+          nextChild.stdout!.on('data', handleStdoutData)
+          nextChild.stderr!.on('data', handleStderrData)
+          nextChild.once('error', handleError)
+          nextChild.once('close', handleClose)
+
+          // Why: timeout kills the child mid-scan; mark truncated so the UI shows incomplete results.
+          killTimeout = setTimeout(() => {
+            acc.truncated = true
+            resolveOnce({ kill: true })
+          }, SEARCH_TIMEOUT_MS)
+          signal?.addEventListener('abort', handleAbort, { once: true })
+          if (signal?.aborted) {
+            handleAbort()
+          }
         })
-        child = nextChild
-        activeTextSearches.set(searchKey, nextChild)
-
-        const handleStdoutData = (chunk: string): void => {
-          stdoutBuffer += chunk
-          const lines = stdoutBuffer.split('\n')
-          stdoutBuffer = lines.pop() ?? ''
-          for (const line of lines) {
-            processLine(line)
-          }
-        }
-        const handleStderrData = (): void => {
-          // Drain stderr so rg cannot block on a full pipe.
-        }
-        const handleError = (): void => {
-          resolveOnce()
-        }
-        const handleClose = (): void => {
-          if (stdoutBuffer) {
-            processLine(stdoutBuffer)
-          }
-          resolveOnce()
-        }
-
-        nextChild.stdout!.setEncoding('utf-8')
-        nextChild.stdout!.on('data', handleStdoutData)
-        nextChild.stderr!.on('data', handleStderrData)
-        nextChild.once('error', handleError)
-        nextChild.once('close', handleClose)
-
-        // Why: timeout kills the child mid-scan; mark truncated so the UI shows incomplete results.
-        killTimeout = setTimeout(() => {
-          acc.truncated = true
-          child?.kill()
-          resolveOnce()
-        }, SEARCH_TIMEOUT_MS)
-      })
+      } finally {
+        textSearchCancellations.finish(event, args.requestToken, controller)
+      }
     }
   )
+  ipcMain.handle('fs:cancelSearch', (event, args: { requestToken: string }): void => {
+    textSearchCancellations.cancel(event, args.requestToken)
+  })
 
   // ─── List all files (for quick-open) ─────────────────────
   // Why #7721: token-keyed so a workspace switch aborts the prior full-tree scan (SSH otherwise stacks scans past the 30s timeout).

--- a/src/main/ipc/rg-availability.test.ts
+++ b/src/main/ipc/rg-availability.test.ts
@@ -14,13 +14,24 @@ import { checkRgAvailable } from './rg-availability'
 
 function createMockProcess(): ChildProcess {
   const child = new EventEmitter() as unknown as ChildProcess
+  ;(child as unknown as { pid: number }).pid = 1234
   ;(child as unknown as { kill: () => boolean }).kill = vi.fn(() => true)
   return child
 }
 
 describe('checkRgAvailable', () => {
   beforeEach(() => {
-    vi.clearAllMocks()
+    wslAwareSpawnMock.mockReset()
+  })
+
+  it('does not spawn when already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(checkRgAvailable('/repo', undefined, controller.signal)).rejects.toMatchObject({
+      name: 'AbortError'
+    })
+    expect(wslAwareSpawnMock).not.toHaveBeenCalled()
   })
 
   it('returns true when rg exits successfully', async () => {
@@ -35,6 +46,38 @@ describe('checkRgAvailable', () => {
       cwd: '/repo',
       stdio: 'ignore'
     })
+  })
+
+  it('returns false when rg is unavailable', async () => {
+    const child = createMockProcess()
+    wslAwareSpawnMock.mockReturnValue(child)
+
+    const promise = checkRgAvailable('/repo')
+    child.emit('error', new Error('rg not found'))
+
+    await expect(promise).resolves.toBe(false)
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('aborts a pending probe without starting fallback', async () => {
+    const child = createMockProcess()
+    const controller = new AbortController()
+    const fallback = vi.fn()
+    wslAwareSpawnMock.mockReturnValue(child)
+
+    const search = async (): Promise<void> => {
+      if (!(await checkRgAvailable('/repo', undefined, controller.signal))) {
+        fallback()
+      }
+    }
+    const promise = search()
+    controller.abort()
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(fallback).not.toHaveBeenCalled()
   })
 
   it('settles and detaches when rg availability check ignores timeout kills', async () => {

--- a/src/main/ipc/rg-availability.ts
+++ b/src/main/ipc/rg-availability.ts
@@ -1,4 +1,5 @@
 import { wslAwareSpawn } from '../git/runner'
+import { terminateSpawnedChild } from '../../shared/spawned-child-cancellation'
 
 const RG_AVAILABILITY_TIMEOUT_MS = 5000
 
@@ -14,8 +15,15 @@ const RG_AVAILABILITY_TIMEOUT_MS = 5000
 // while a positive cache could mask an rg that was uninstalled or broken
 // mid-session.
 
-export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promise<boolean> {
-  return new Promise((resolve) => {
+export function checkRgAvailable(
+  searchPath?: string,
+  wslDistro?: string,
+  signal?: AbortSignal
+): Promise<boolean> {
+  if (signal?.aborted) {
+    return Promise.reject(createRgAvailabilityAbortError())
+  }
+  return new Promise((resolve, reject) => {
     let settled = false
     // Why: pass cwd plus project-runtime distro so WSL projects are checked
     // inside their distro even when the search root is a Windows path.
@@ -24,12 +32,16 @@ export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promi
       ...(wslDistro ? { wslDistro } : {}),
       stdio: 'ignore'
     })
-    let timeout: ReturnType<typeof setTimeout>
+    let timeout: ReturnType<typeof setTimeout> | null = null
 
     const cleanup = (): void => {
-      clearTimeout(timeout)
+      if (timeout) {
+        clearTimeout(timeout)
+        timeout = null
+      }
       child.off('error', onError)
       child.off('close', onClose)
+      signal?.removeEventListener('abort', onAbort)
     }
 
     const settle = (available: boolean, options?: { kill?: boolean }): void => {
@@ -39,13 +51,22 @@ export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promi
       settled = true
       cleanup()
       if (options?.kill) {
-        child.kill()
+        terminateSpawnedChild(child)
       }
       resolve(available)
     }
 
     const onError = (): void => settle(false)
     const onClose = (code: number | null): void => settle(code === 0)
+    const onAbort = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      terminateSpawnedChild(child)
+      reject(createRgAvailabilityAbortError())
+    }
 
     child.once('error', onError)
     child.once('close', onClose)
@@ -53,5 +74,15 @@ export function checkRgAvailable(searchPath?: string, wslDistro?: string): Promi
     if (typeof timeout.unref === 'function') {
       timeout.unref()
     }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+    }
   })
+}
+
+function createRgAvailabilityAbortError(): Error {
+  const error = new Error('rg availability check aborted')
+  error.name = 'AbortError'
+  return error
 }

--- a/src/main/ipc/runtime-environment-pending-subscription-handler.test.ts
+++ b/src/main/ipc/runtime-environment-pending-subscription-handler.test.ts
@@ -1,0 +1,266 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { handleMock, subscribeRuntimeEnvironmentMock } = vi.hoisted(() => ({
+  handleMock: vi.fn(),
+  subscribeRuntimeEnvironmentMock: vi.fn()
+}))
+
+vi.mock('electron', () => ({
+  app: { getPath: vi.fn(() => '/user-data') },
+  ipcMain: {
+    handle: handleMock,
+    on: vi.fn(),
+    removeHandler: vi.fn(),
+    removeAllListeners: vi.fn()
+  }
+}))
+
+vi.mock('../../shared/runtime-environment-store', () => ({
+  resolveEnvironment: vi.fn(() => ({
+    id: 'environment-a',
+    createdAt: 1,
+    pairingRevision: 1
+  }))
+}))
+
+vi.mock('./runtime-environment-connectivity-handlers', () => ({
+  isRuntimeEnvironmentManuallyDisconnected: vi.fn(() => false),
+  registerRuntimeEnvironmentConnectivityHandlers: vi.fn(),
+  registerRuntimeEnvironmentPassiveHandlers: vi.fn()
+}))
+
+vi.mock('./runtime-environment-recovery-handler', () => ({
+  registerRuntimeEnvironmentRecoveryHandler: vi.fn()
+}))
+
+vi.mock('./runtime-environment-request-connections', () => ({
+  closeRemoteRuntimeRequestConnection: vi.fn()
+}))
+
+vi.mock('./runtime-environment-transport-generation', () => ({
+  advanceRuntimeEnvironmentTransportGeneration: vi.fn(),
+  getRuntimeEnvironmentTransportGeneration: vi.fn(() => 0)
+}))
+
+vi.mock('./runtime-environment-transport-routing', () => ({
+  clearSharedControlSupport: vi.fn(),
+  resetSharedControlSupport: vi.fn(),
+  subscribeRuntimeEnvironment: subscribeRuntimeEnvironmentMock
+}))
+
+import { registerRuntimeEnvironmentHandlers } from './runtime-environments'
+
+function handler<TArgs, TResult>(
+  channel: string
+): (event: { sender: Record<string, unknown> }, args: TArgs) => TResult | Promise<TResult> {
+  const match = handleMock.mock.calls.find((call) => call[0] === channel)
+  if (!match) {
+    throw new Error(`Missing IPC handler: ${channel}`)
+  }
+  return match[1]
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  registerRuntimeEnvironmentHandlers({} as never)
+})
+
+describe('pending runtime environment subscription handler', () => {
+  it('aborts only when the owning sender unsubscribes', async () => {
+    let setupSignal: AbortSignal | undefined
+    subscribeRuntimeEnvironmentMock.mockImplementation(
+      (_userDataPath, _selector, _method, _params, _timeoutMs, _callbacks, signal: AbortSignal) => {
+        setupSignal = signal
+        return new Promise((_resolve, reject) => {
+          signal.addEventListener(
+            'abort',
+            () => {
+              const error = new Error('setup aborted')
+              error.name = 'AbortError'
+              reject(error)
+            },
+            { once: true }
+          )
+        })
+      }
+    )
+    const subscribe = handler<
+      { selector: string; method: string; subscriptionId: string },
+      { subscriptionId: string; requestId: string }
+    >('runtimeEnvironments:subscribe')
+    const pending = subscribe(
+      {
+        sender: {
+          id: 1,
+          isDestroyed: () => false,
+          send: vi.fn(),
+          once: vi.fn(),
+          removeListener: vi.fn()
+        }
+      },
+      {
+        selector: 'environment-a',
+        method: 'files.watch',
+        subscriptionId: 'pending-subscription'
+      }
+    )
+    const unsubscribe = handler<{ subscriptionId: string }, { unsubscribed: boolean }>(
+      'runtimeEnvironments:unsubscribe'
+    )
+
+    expect(setupSignal?.aborted).toBe(false)
+    expect(unsubscribe({ sender: { id: 2 } }, { subscriptionId: 'pending-subscription' })).toEqual({
+      unsubscribed: false
+    })
+    expect(setupSignal?.aborted).toBe(false)
+    expect(unsubscribe({ sender: { id: 1 } }, { subscriptionId: 'pending-subscription' })).toEqual({
+      unsubscribed: true
+    })
+    expect(setupSignal?.aborted).toBe(true)
+    await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('ignores a delayed close from an unsubscribed id after it is reused', async () => {
+    type SubscriptionEvent =
+      | { type: 'close' }
+      | {
+          type: 'response'
+          response: {
+            id: string
+            ok: true
+            result: unknown
+            _meta: { runtimeId: string }
+          }
+        }
+    const callbacks: { onEvent: (payload: SubscriptionEvent) => void; onClose: () => void }[] = []
+    const closeFirst = vi.fn()
+    const closeReplacement = vi.fn()
+    const handles = [
+      { requestId: 'first-request', close: closeFirst, sendBinary: vi.fn() },
+      { requestId: 'replacement-request', close: closeReplacement, sendBinary: vi.fn() }
+    ]
+    subscribeRuntimeEnvironmentMock.mockImplementation(
+      async (_userDataPath, _selector, _method, _params, _timeoutMs, subscriptionCallbacks) => {
+        callbacks.push(subscriptionCallbacks)
+        return handles.shift()
+      }
+    )
+    const subscribe = handler<
+      { selector: string; method: string; subscriptionId: string },
+      { subscriptionId: string; requestId: string }
+    >('runtimeEnvironments:subscribe')
+    const unsubscribe = handler<{ subscriptionId: string }, { unsubscribed: boolean }>(
+      'runtimeEnvironments:unsubscribe'
+    )
+    const send = vi.fn()
+    const sender = {
+      id: 1,
+      isDestroyed: () => false,
+      send,
+      once: vi.fn(),
+      removeListener: vi.fn()
+    }
+    const event = { sender }
+    const args = {
+      selector: 'environment-a',
+      method: 'files.watch',
+      subscriptionId: 'reused-subscription'
+    }
+
+    await subscribe(event, args)
+    expect(unsubscribe(event, { subscriptionId: args.subscriptionId })).toEqual({
+      unsubscribed: true
+    })
+    await subscribe(event, args)
+
+    callbacks[0]?.onEvent({
+      type: 'response',
+      response: {
+        id: 'stale-response',
+        ok: true,
+        result: {},
+        _meta: { runtimeId: 'old-runtime' }
+      }
+    })
+    callbacks[0]?.onEvent({ type: 'close' })
+    callbacks[0]?.onClose()
+
+    expect(send).not.toHaveBeenCalled()
+    expect(unsubscribe(event, { subscriptionId: args.subscriptionId })).toEqual({
+      unsubscribed: true
+    })
+    expect(closeFirst).toHaveBeenCalledOnce()
+    expect(closeReplacement).toHaveBeenCalledOnce()
+  })
+
+  it('keeps a reused id when the original pending sender is destroyed', async () => {
+    const closeFirst = vi.fn()
+    const closeReplacement = vi.fn()
+    let resolveFirst: (value: {
+      requestId: string
+      close: () => void
+      sendBinary: () => void
+    }) => void = () => {}
+    subscribeRuntimeEnvironmentMock
+      .mockImplementationOnce(
+        () =>
+          new Promise((resolve) => {
+            resolveFirst = resolve
+          })
+      )
+      .mockResolvedValueOnce({
+        requestId: 'replacement-request',
+        close: closeReplacement,
+        sendBinary: vi.fn()
+      })
+    const subscribe = handler<
+      { selector: string; method: string; subscriptionId: string },
+      { subscriptionId: string; requestId: string }
+    >('runtimeEnvironments:subscribe')
+    const unsubscribe = handler<{ subscriptionId: string }, { unsubscribed: boolean }>(
+      'runtimeEnvironments:unsubscribe'
+    )
+    let destroyFirst = (): void => {}
+    const firstEvent = {
+      sender: {
+        id: 1,
+        isDestroyed: () => false,
+        send: vi.fn(),
+        once: vi.fn((_event: string, listener: () => void) => {
+          destroyFirst = listener
+        }),
+        removeListener: vi.fn()
+      }
+    }
+    const replacementEvent = {
+      sender: {
+        id: 2,
+        isDestroyed: () => false,
+        send: vi.fn(),
+        once: vi.fn(),
+        removeListener: vi.fn()
+      }
+    }
+    const args = {
+      selector: 'environment-a',
+      method: 'files.watch',
+      subscriptionId: 'reused-pending-subscription'
+    }
+    const first = subscribe(firstEvent, args)
+    const firstRejection = expect(first).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(unsubscribe(firstEvent, { subscriptionId: args.subscriptionId })).toEqual({
+      unsubscribed: true
+    })
+    await subscribe(replacementEvent, args)
+    destroyFirst()
+
+    expect(unsubscribe(replacementEvent, { subscriptionId: args.subscriptionId })).toEqual({
+      unsubscribed: true
+    })
+    resolveFirst({ requestId: 'first-request', close: closeFirst, sendBinary: vi.fn() })
+    await firstRejection
+    expect(closeFirst).toHaveBeenCalledOnce()
+    expect(closeReplacement).toHaveBeenCalledOnce()
+  })
+})

--- a/src/main/ipc/runtime-environment-subscription-setup.test.ts
+++ b/src/main/ipc/runtime-environment-subscription-setup.test.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import {
+  beginRuntimeEnvironmentSubscriptionSetup,
+  cancelAllRuntimeEnvironmentSubscriptionSetups,
+  cancelRuntimeEnvironmentSubscriptionSetup,
+  cancelRuntimeEnvironmentSubscriptionSetupsForEnvironment,
+  finishRuntimeEnvironmentSubscriptionSetup,
+  hasRuntimeEnvironmentSubscriptionSetup
+} from './runtime-environment-subscription-setup'
+
+afterEach(() => {
+  cancelAllRuntimeEnvironmentSubscriptionSetups()
+})
+
+describe('pending runtime environment subscription setup', () => {
+  it('aborts a pending setup and releases its subscription id', () => {
+    const controller = beginRuntimeEnvironmentSubscriptionSetup({
+      subscriptionId: 'pending-subscription',
+      environmentId: 'environment-a',
+      ownerWebContentsId: 1
+    })
+
+    expect(cancelRuntimeEnvironmentSubscriptionSetup('pending-subscription', 1)).toBe(true)
+    expect(controller.signal.aborted).toBe(true)
+    expect(hasRuntimeEnvironmentSubscriptionSetup('pending-subscription')).toBe(false)
+  })
+
+  it('isolates cancellation by sender', () => {
+    const controller = beginRuntimeEnvironmentSubscriptionSetup({
+      subscriptionId: 'owned-subscription',
+      environmentId: 'environment-a',
+      ownerWebContentsId: 1
+    })
+
+    expect(cancelRuntimeEnvironmentSubscriptionSetup('owned-subscription', 2)).toBe(false)
+    expect(controller.signal.aborted).toBe(false)
+    expect(hasRuntimeEnvironmentSubscriptionSetup('owned-subscription')).toBe(true)
+  })
+
+  it('aborts only setups for the invalidated environment', () => {
+    const firstController = beginRuntimeEnvironmentSubscriptionSetup({
+      subscriptionId: 'first-subscription',
+      environmentId: 'environment-a',
+      ownerWebContentsId: 1
+    })
+    const secondController = beginRuntimeEnvironmentSubscriptionSetup({
+      subscriptionId: 'second-subscription',
+      environmentId: 'environment-b',
+      ownerWebContentsId: 1
+    })
+
+    cancelRuntimeEnvironmentSubscriptionSetupsForEnvironment('environment-a')
+
+    expect(firstController.signal.aborted).toBe(true)
+    expect(secondController.signal.aborted).toBe(false)
+    expect(hasRuntimeEnvironmentSubscriptionSetup('first-subscription')).toBe(false)
+    expect(hasRuntimeEnvironmentSubscriptionSetup('second-subscription')).toBe(true)
+  })
+
+  it('keeps a reused id when an earlier setup finishes late', () => {
+    const firstController = beginRuntimeEnvironmentSubscriptionSetup({
+      subscriptionId: 'reused-subscription',
+      environmentId: 'environment-a',
+      ownerWebContentsId: 1
+    })
+    cancelRuntimeEnvironmentSubscriptionSetup('reused-subscription', 1)
+    const replacementController = beginRuntimeEnvironmentSubscriptionSetup({
+      subscriptionId: 'reused-subscription',
+      environmentId: 'environment-a',
+      ownerWebContentsId: 1
+    })
+
+    finishRuntimeEnvironmentSubscriptionSetup('reused-subscription', firstController)
+
+    expect(replacementController.signal.aborted).toBe(false)
+    expect(hasRuntimeEnvironmentSubscriptionSetup('reused-subscription')).toBe(true)
+  })
+})

--- a/src/main/ipc/runtime-environment-subscription-setup.ts
+++ b/src/main/ipc/runtime-environment-subscription-setup.ts
@@ -1,0 +1,81 @@
+type PendingRuntimeEnvironmentSubscriptionSetup = {
+  environmentId: string
+  ownerWebContentsId: number
+  controller: AbortController
+}
+
+const pendingSetups = new Map<string, PendingRuntimeEnvironmentSubscriptionSetup>()
+
+export function createRuntimeSubscriptionSetupAbortError(): Error {
+  const error = new Error('Runtime environment subscription setup aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+export function hasRuntimeEnvironmentSubscriptionSetup(subscriptionId: string): boolean {
+  return pendingSetups.has(subscriptionId)
+}
+
+export function isRuntimeEnvironmentSubscriptionSetupCurrent(
+  subscriptionId: string,
+  controller: AbortController
+): boolean {
+  return pendingSetups.get(subscriptionId)?.controller === controller
+}
+
+export function beginRuntimeEnvironmentSubscriptionSetup(args: {
+  subscriptionId: string
+  environmentId: string
+  ownerWebContentsId: number
+}): AbortController {
+  if (pendingSetups.has(args.subscriptionId)) {
+    throw new Error('Runtime environment subscription id already exists')
+  }
+  const controller = new AbortController()
+  pendingSetups.set(args.subscriptionId, {
+    environmentId: args.environmentId,
+    ownerWebContentsId: args.ownerWebContentsId,
+    controller
+  })
+  return controller
+}
+
+export function finishRuntimeEnvironmentSubscriptionSetup(
+  subscriptionId: string,
+  controller: AbortController
+): void {
+  if (pendingSetups.get(subscriptionId)?.controller === controller) {
+    pendingSetups.delete(subscriptionId)
+  }
+}
+
+export function cancelRuntimeEnvironmentSubscriptionSetup(
+  subscriptionId: string,
+  ownerWebContentsId: number
+): boolean {
+  const pending = pendingSetups.get(subscriptionId)
+  if (!pending || pending.ownerWebContentsId !== ownerWebContentsId) {
+    return false
+  }
+  pendingSetups.delete(subscriptionId)
+  pending.controller.abort()
+  return true
+}
+
+export function cancelRuntimeEnvironmentSubscriptionSetupsForEnvironment(
+  environmentId: string
+): void {
+  for (const [subscriptionId, pending] of pendingSetups) {
+    if (pending.environmentId === environmentId) {
+      pendingSetups.delete(subscriptionId)
+      pending.controller.abort()
+    }
+  }
+}
+
+export function cancelAllRuntimeEnvironmentSubscriptionSetups(): void {
+  for (const pending of pendingSetups.values()) {
+    pending.controller.abort()
+  }
+  pendingSetups.clear()
+}

--- a/src/main/ipc/runtime-environment-transport-routing-abort.test.ts
+++ b/src/main/ipc/runtime-environment-transport-routing-abort.test.ts
@@ -1,0 +1,171 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const {
+  resolveEnvironmentMock,
+  subscribeRemoteRuntimeRequestMock,
+  subscribeRemoteRuntimeSharedControlRequestMock,
+  supportsSharedControlMock
+} = vi.hoisted(() => ({
+  resolveEnvironmentMock: vi.fn(),
+  subscribeRemoteRuntimeRequestMock: vi.fn(),
+  subscribeRemoteRuntimeSharedControlRequestMock: vi.fn(),
+  supportsSharedControlMock: vi.fn()
+}))
+
+vi.mock('../../shared/runtime-environment-store', () => ({
+  markEnvironmentUsed: vi.fn(),
+  resolveEnvironment: resolveEnvironmentMock
+}))
+
+vi.mock('../../shared/remote-runtime-client', () => ({
+  sendRemoteRuntimeRequest: vi.fn(),
+  subscribeRemoteRuntimeRequest: subscribeRemoteRuntimeRequestMock
+}))
+
+vi.mock('./runtime-environment-request-connections', () => ({
+  getRemoteRuntimeSharedControlDiagnostics: vi.fn(() => null),
+  reconnectRemoteRuntimeSharedControlConnection: vi.fn(),
+  sendRemoteRuntimeConnectionRequest: vi.fn(),
+  sendRemoteRuntimeSharedControlRequest: vi.fn(),
+  subscribeRemoteRuntimeSharedControlRequest: subscribeRemoteRuntimeSharedControlRequestMock
+}))
+
+vi.mock('./runtime-environment-shared-control-support', () => ({
+  clearSharedControlSupport: vi.fn(),
+  resetSharedControlSupport: vi.fn(),
+  supportsSharedControl: supportsSharedControlMock
+}))
+
+import { subscribeRuntimeEnvironment } from './runtime-environment-transport-routing'
+
+const callbacks = {
+  onEvent: vi.fn(),
+  onClose: vi.fn()
+}
+
+beforeEach(() => {
+  vi.clearAllMocks()
+  resolveEnvironmentMock.mockReturnValue({
+    id: 'environment-a',
+    name: 'desk',
+    createdAt: 1,
+    updatedAt: 1,
+    lastUsedAt: null,
+    runtimeId: null,
+    preferredEndpointId: 'endpoint-a',
+    endpoints: [
+      {
+        id: 'endpoint-a',
+        kind: 'websocket',
+        label: 'primary',
+        endpoint: 'ws://127.0.0.1:6768',
+        deviceToken: 'device-token',
+        publicKeyB64: 'public-key'
+      }
+    ]
+  })
+})
+
+describe('runtime environment subscription cancellation', () => {
+  it('rejects pre-aborted setup without probing or opening a subscription', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      subscribeRuntimeEnvironment(
+        '/user-data',
+        'environment-a',
+        'files.watch',
+        {},
+        1000,
+        callbacks,
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(supportsSharedControlMock).not.toHaveBeenCalled()
+    expect(subscribeRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+    expect(subscribeRemoteRuntimeSharedControlRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('stops after a pending shared-control probe is aborted', async () => {
+    const controller = new AbortController()
+    let resolveSupport: (supported: boolean) => void = () => {}
+    supportsSharedControlMock.mockImplementation(
+      () =>
+        new Promise<boolean>((resolve) => {
+          resolveSupport = resolve
+        })
+    )
+    const setup = subscribeRuntimeEnvironment(
+      '/user-data',
+      'environment-a',
+      'files.watch',
+      {},
+      1000,
+      callbacks,
+      controller.signal
+    )
+
+    await vi.waitFor(() => expect(supportsSharedControlMock).toHaveBeenCalled())
+    controller.abort()
+    resolveSupport(true)
+
+    await expect(setup).rejects.toMatchObject({ name: 'AbortError' })
+    expect(subscribeRemoteRuntimeRequestMock).not.toHaveBeenCalled()
+    expect(subscribeRemoteRuntimeSharedControlRequestMock).not.toHaveBeenCalled()
+  })
+
+  it('closes shared-control setup that resolves after cancellation', async () => {
+    const controller = new AbortController()
+    const close = vi.fn()
+    supportsSharedControlMock.mockResolvedValue(true)
+    subscribeRemoteRuntimeSharedControlRequestMock.mockImplementation(async () => {
+      controller.abort()
+      return { requestId: 'shared-request', close, sendBinary: vi.fn() }
+    })
+
+    await expect(
+      subscribeRuntimeEnvironment(
+        '/user-data',
+        'environment-a',
+        'files.watch',
+        {},
+        1000,
+        callbacks,
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+
+  it('passes cancellation to a dedicated socket and closes a late result', async () => {
+    const controller = new AbortController()
+    const close = vi.fn()
+    subscribeRemoteRuntimeRequestMock.mockImplementation(async () => {
+      controller.abort()
+      return { requestId: 'dedicated-request', close, sendBinary: vi.fn() }
+    })
+
+    await expect(
+      subscribeRuntimeEnvironment(
+        '/user-data',
+        'environment-a',
+        'terminal.multiplex',
+        {},
+        1000,
+        callbacks,
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+    expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
+      expect.any(Object),
+      'terminal.multiplex',
+      {},
+      1000,
+      expect.any(Object),
+      undefined,
+      controller.signal
+    )
+    expect(close).toHaveBeenCalledTimes(1)
+  })
+})

--- a/src/main/ipc/runtime-environment-transport-routing.ts
+++ b/src/main/ipc/runtime-environment-transport-routing.ts
@@ -171,7 +171,8 @@ export async function subscribeRuntimeEnvironment(
         | { type: 'close' }
     ) => void
     onClose: () => void
-  }
+  },
+  signal?: AbortSignal
 ): Promise<RemoteRuntimeSubscription> {
   const environment = resolveEnvironment(userDataPath, selector)
   const pairing = getPreferredPairingOffer(environment)
@@ -207,33 +208,59 @@ export async function subscribeRuntimeEnvironment(
   // Why: an initial-connect failure rejects (mid-stream drops go through
   // onError above), so the hint is applied to the thrown error here too.
   try {
+    signal?.throwIfAborted()
     if (
       shouldUseSharedControlSubscription(method) &&
       !shouldKeepDedicatedSubscriptionSocket(method) &&
       (await supportsSharedControl(userDataPath, environment, pairing, effectiveTimeoutMs))
     ) {
-      return await subscribeRemoteRuntimeSharedControlRequest(
-        environment.id,
+      signal?.throwIfAborted()
+      return retainActiveRuntimeSubscription(
+        await subscribeRemoteRuntimeSharedControlRequest(
+          environment.id,
+          pairing,
+          method,
+          params,
+          effectiveTimeoutMs,
+          callbacksWithMarkUsed
+        ),
+        signal
+      )
+    }
+    signal?.throwIfAborted()
+    return retainActiveRuntimeSubscription(
+      await subscribeRemoteRuntimeRequest(
         pairing,
         method,
         params,
         effectiveTimeoutMs,
-        callbacksWithMarkUsed
-      )
-    }
-    return await subscribeRemoteRuntimeRequest(
-      pairing,
-      method,
-      params,
-      effectiveTimeoutMs,
-      callbacksWithMarkUsed
+        callbacksWithMarkUsed,
+        undefined,
+        signal
+      ),
+      signal
     )
   } catch (error) {
-    if (error instanceof Error) {
+    if (error instanceof Error && error.name !== 'AbortError') {
       error.message = withRemoteRuntimeTailscaleHint(error.message, pairing.endpoint)
     }
     throw error
   }
+}
+
+function retainActiveRuntimeSubscription(
+  subscription: RemoteRuntimeSubscription,
+  signal?: AbortSignal
+): RemoteRuntimeSubscription {
+  if (signal?.aborted) {
+    try {
+      subscription.close()
+    } catch {
+      // Best-effort cleanup must not mask cancellation.
+    }
+    signal.throwIfAborted()
+  }
+  return subscription
 }
 
 function markEnvironmentUsedFromResponse(

--- a/src/main/ipc/runtime-environments.test.ts
+++ b/src/main/ipc/runtime-environments.test.ts
@@ -1127,14 +1127,18 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'browser.screencast',
       { pageId: 'page-1' },
       15_000,
-      expect.any(Object)
+      expect.any(Object),
+      undefined,
+      expect.any(AbortSignal)
     )
     expect(subscribeRemoteRuntimeRequestMock).toHaveBeenCalledWith(
       expect.any(Object),
       'terminal.multiplex',
       { client: { id: 'client-1' } },
       15_000,
-      expect.any(Object)
+      expect.any(Object),
+      undefined,
+      expect.any(AbortSignal)
     )
     expect(subscribeRemoteRuntimeSharedControlRequestMock).not.toHaveBeenCalled()
   })
@@ -1315,7 +1319,9 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'session.tabs.subscribeAll',
       undefined,
       15_000,
-      expect.any(Object)
+      expect.any(Object),
+      undefined,
+      expect.any(AbortSignal)
     )
     expect(subscribeRemoteRuntimeSharedControlRequestMock).not.toHaveBeenCalled()
   })
@@ -1659,7 +1665,9 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       'terminal.subscribe',
       { terminal: 't1' },
       25,
-      expect.any(Object)
+      expect.any(Object),
+      undefined,
+      expect.any(AbortSignal)
     )
     expect(sent).toEqual([
       expect.objectContaining({ subscriptionId: result.subscriptionId, type: 'response' }),
@@ -2242,10 +2250,7 @@ describe('registerRuntimeEnvironmentHandlers', () => {
     ;(destroyedHandler as () => void)()
     resolveSubscribe({ requestId: 'stream-late', close, sendBinary: vi.fn() })
 
-    await expect(resultPromise).resolves.toEqual({
-      subscriptionId: 'late-sub',
-      requestId: 'stream-late'
-    })
+    await expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' })
     expect(close).toHaveBeenCalledTimes(1)
     expect(destroyedListenerRemoved).toHaveBeenCalledWith('destroyed', expect.any(Function))
 
@@ -2335,9 +2340,7 @@ describe('registerRuntimeEnvironmentHandlers', () => {
       expect(senderSend).not.toHaveBeenCalled()
       resolveSubscribe({ requestId: 'retired-stream', close, sendBinary })
 
-      await expect(resultPromise).rejects.toThrow(
-        'Runtime environment pairing changed; refresh and try again'
-      )
+      await expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' })
       expect(close).toHaveBeenCalledTimes(1)
 
       const binaryListener = onMock.mock.calls.find(

--- a/src/main/ipc/runtime-environments.ts
+++ b/src/main/ipc/runtime-environments.ts
@@ -20,6 +20,16 @@ import {
   subscribeRuntimeEnvironment
 } from './runtime-environment-transport-routing'
 import { RUNTIME_ENVIRONMENT_HANDLER_CHANNELS } from './runtime-environment-handler-channels'
+import {
+  beginRuntimeEnvironmentSubscriptionSetup,
+  cancelAllRuntimeEnvironmentSubscriptionSetups,
+  cancelRuntimeEnvironmentSubscriptionSetup,
+  cancelRuntimeEnvironmentSubscriptionSetupsForEnvironment,
+  createRuntimeSubscriptionSetupAbortError,
+  finishRuntimeEnvironmentSubscriptionSetup,
+  hasRuntimeEnvironmentSubscriptionSetup,
+  isRuntimeEnvironmentSubscriptionSetupCurrent
+} from './runtime-environment-subscription-setup'
 
 type RetainedRemoteRuntimeSubscription = RemoteRuntimeSubscription & {
   environmentId: string
@@ -31,17 +41,13 @@ const remoteRuntimeSubscriptions = new Map<string, RetainedRemoteRuntimeSubscrip
 const getUserDataPath = (): string => app.getPath('userData')
 
 function closeSubscriptionsForEnvironment(environmentId: string): void {
-  // Why: removed runtimes must not retain terminal/browser WebSockets until renderer teardown.
+  cancelRuntimeEnvironmentSubscriptionSetupsForEnvironment(environmentId)
   for (const [subscriptionId, subscription] of remoteRuntimeSubscriptions) {
     if (subscription.environmentId !== environmentId) {
       continue
     }
     remoteRuntimeSubscriptions.delete(subscriptionId)
-    // Why: one failing teardown must not abandon this environment's other
-    // sockets -- that strands exactly the dead handles this sweep exists to
-    // retire. Guard the two steps independently so neither can skip the other,
-    // and so the isolation stays structural rather than resting on a claim that
-    // nothing inside notifyClosed will ever throw.
+    // Why: one failing teardown must not strand this environment's other sockets.
     try {
       subscription.close()
     } catch (error) {
@@ -64,9 +70,9 @@ export function invalidateRuntimeEnvironmentTransport(environmentId: string): vo
 }
 
 export function registerRuntimeEnvironmentHandlers(store: Store): void {
-  // Why: keep direct re-registration safe even though register-core-handlers
-  // normally guards this path; otherwise the binary send listener can stack.
+  // Why: direct re-registration must not stack the binary send listener.
   resetSharedControlSupport()
+  cancelAllRuntimeEnvironmentSubscriptionSetups()
   for (const channel of RUNTIME_ENVIRONMENT_HANDLER_CHANNELS) {
     ipcMain.removeHandler(channel)
   }
@@ -96,7 +102,10 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
         typeof args.subscriptionId === 'string' && args.subscriptionId.length > 0
           ? args.subscriptionId
           : randomUUID()
-      if (remoteRuntimeSubscriptions.has(subscriptionId)) {
+      if (
+        remoteRuntimeSubscriptions.has(subscriptionId) ||
+        hasRuntimeEnvironmentSubscriptionSetup(subscriptionId)
+      ) {
         throw new Error('Runtime environment subscription id already exists')
       }
       const environment = resolveEnvironment(getUserDataPath(), args.selector)
@@ -115,9 +124,19 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
         getRuntimeEnvironmentTransportGeneration(environment.id) === transportGeneration
       const sender = event.sender
       const ownerWebContentsId = sender.id
+      const setupController = beginRuntimeEnvironmentSubscriptionSetup({
+        subscriptionId,
+        environmentId: environment.id,
+        ownerWebContentsId
+      })
       let senderDestroyed = sender.isDestroyed()
       let subscription: RemoteRuntimeSubscription | null = null
+      let retainedSubscription: RetainedRemoteRuntimeSubscription | null = null
+      let subscriptionClosed = false
       let destroyedListenerAttached = false
+      const ownsSubscriptionId = (): boolean =>
+        isRuntimeEnvironmentSubscriptionSetupCurrent(subscriptionId, setupController) ||
+        remoteRuntimeSubscriptions.get(subscriptionId) === retainedSubscription
       const removeDestroyedListener = (): void => {
         if (!destroyedListenerAttached) {
           return
@@ -127,18 +146,17 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
       }
       const closeSubscription = (): void => {
         senderDestroyed = true
+        cancelRuntimeEnvironmentSubscriptionSetup(subscriptionId, ownerWebContentsId)
         const retained = remoteRuntimeSubscriptions.get(subscriptionId) ?? null
-        remoteRuntimeSubscriptions.delete(subscriptionId)
-        if (retained) {
+        if (retained && retained === retainedSubscription) {
+          remoteRuntimeSubscriptions.delete(subscriptionId)
           retained.close()
           return
         }
         removeDestroyedListener()
         subscription?.close()
       }
-      // Why: the renderer treats close as terminal and drops its handle, so send it once.
-      // Latch before sending so a re-entrant call cannot duplicate it, and never
-      // throw: a dying renderer must not abort its siblings' retirement.
+      // Why: a re-entrant or dying renderer must not duplicate or interrupt close notices.
       let closeNotified = false
       const notifyClosed = (): void => {
         if (closeNotified || sender.isDestroyed()) {
@@ -162,13 +180,14 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
           args.timeoutMs,
           {
             onEvent: (payload) => {
+              if (!ownsSubscriptionId() || sender.isDestroyed()) {
+                return
+              }
               if (payload.type === 'close') {
-                // Why: retirement advances the generation before closing, so gating
-                // close on it stranded the renderer with a dead subscription.
                 notifyClosed()
                 return
               }
-              if (transportIsCurrent() && !sender.isDestroyed()) {
+              if (transportIsCurrent()) {
                 sender.send('runtimeEnvironments:subscriptionEvent', {
                   subscriptionId,
                   ...payload
@@ -176,15 +195,28 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
               }
             },
             onClose: () => {
-              const retained = remoteRuntimeSubscriptions.get(subscriptionId) ?? null
-              retained?.removeDestroyedListener()
-              remoteRuntimeSubscriptions.delete(subscriptionId)
+              subscriptionClosed = true
+              removeDestroyedListener()
+              if (remoteRuntimeSubscriptions.get(subscriptionId) === retainedSubscription) {
+                remoteRuntimeSubscriptions.delete(subscriptionId)
+              }
             }
-          }
+          },
+          setupController.signal
         )
       } catch (error) {
         removeDestroyedListener()
         throw error
+      } finally {
+        finishRuntimeEnvironmentSubscriptionSetup(subscriptionId, setupController)
+      }
+      if (setupController.signal.aborted) {
+        removeDestroyedListener()
+        subscription.close()
+        throw createRuntimeSubscriptionSetupAbortError()
+      }
+      if (subscriptionClosed) {
+        throw new Error('Runtime environment subscription closed during setup')
       }
       let pairingIsCurrent = false
       try {
@@ -204,7 +236,7 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
         subscription.close()
         return { subscriptionId, requestId: subscription.requestId }
       }
-      remoteRuntimeSubscriptions.set(subscriptionId, {
+      retainedSubscription = {
         requestId: subscription.requestId,
         environmentId: environment.id,
         ownerWebContentsId,
@@ -215,13 +247,17 @@ export function registerRuntimeEnvironmentHandlers(store: Store): void {
           removeDestroyedListener()
           subscription?.close()
         }
-      })
+      }
+      remoteRuntimeSubscriptions.set(subscriptionId, retainedSubscription)
       return { subscriptionId, requestId: subscription.requestId }
     }
   )
   ipcMain.handle(
     'runtimeEnvironments:unsubscribe',
     (event, args: { subscriptionId: string }): { unsubscribed: boolean } => {
+      if (cancelRuntimeEnvironmentSubscriptionSetup(args.subscriptionId, event.sender.id)) {
+        return { unsubscribed: true }
+      }
       const subscription = remoteRuntimeSubscriptions.get(args.subscriptionId)
       if (!subscription || subscription.ownerWebContentsId !== event.sender.id) {
         return { unsubscribed: false }

--- a/src/main/providers/filesystem-provider-contract.ts
+++ b/src/main/providers/filesystem-provider-contract.ts
@@ -47,7 +47,7 @@ export type IFilesystemProvider = {
   renameNoClobber(oldPath: string, newPath: string): Promise<void>
   copy(source: string, destination: string): Promise<void>
   realpath(filePath: string): Promise<string>
-  search(opts: SearchOptions): Promise<SearchResult>
+  search(opts: SearchOptions, options?: { signal?: AbortSignal }): Promise<SearchResult>
   listFiles(
     rootPath: string,
     options?: { excludePaths?: string[]; signal?: AbortSignal; maxResults?: number }

--- a/src/main/providers/ssh-filesystem-provider.test.ts
+++ b/src/main/providers/ssh-filesystem-provider.test.ts
@@ -6,19 +6,9 @@ import { PassThrough } from 'node:stream'
 import { SshFilesystemProvider } from './ssh-filesystem-provider'
 import { JsonRpcErrorCode } from '../ssh/relay-protocol'
 
-type MockMultiplexer = {
-  request: ReturnType<typeof vi.fn>
-  notify: ReturnType<typeof vi.fn>
-  onNotification: ReturnType<typeof vi.fn>
-  onNotificationByMethod: ReturnType<typeof vi.fn>
-  onDispose: ReturnType<typeof vi.fn>
-  dispose: ReturnType<typeof vi.fn>
-  isDisposed: ReturnType<typeof vi.fn>
-  _methodHandlers: Map<string, Set<(params: Record<string, unknown>) => void>>
-  _emitMethod: (method: string, params: Record<string, unknown>) => void
-}
+type MockMultiplexer = ReturnType<typeof createMockMux>
 
-function createMockMux(): MockMultiplexer {
+function createMockMux() {
   const methodHandlers = new Map<string, Set<(params: Record<string, unknown>) => void>>()
   return {
     request: vi.fn().mockResolvedValue(undefined),
@@ -472,18 +462,22 @@ describe('SshFilesystemProvider', () => {
     expect(result).toBe('/home/user/real/path')
   })
 
-  it('search sends fs.search request with all options', async () => {
+  it('search keeps cancellation out of params and preserves the legacy call shape', async () => {
     const searchResult = { files: [], totalMatches: 0, truncated: false }
+    const controller = new AbortController()
+    const opts = { query: 'TODO', rootPath: '/home/user/project', caseSensitive: true }
     mux.request.mockResolvedValue(searchResult)
 
-    const opts = {
-      query: 'TODO',
-      rootPath: '/home/user/project',
-      caseSensitive: true
-    }
-    const result = await provider.search(opts)
-    expect(mux.request).toHaveBeenCalledWith('fs.search', opts)
-    expect(result).toEqual(searchResult)
+    await expect(provider.search(opts)).resolves.toEqual(searchResult)
+    await expect(provider.search(opts, { signal: controller.signal })).resolves.toEqual(
+      searchResult
+    )
+
+    expect(mux.request.mock.calls).toEqual([
+      ['fs.search', opts],
+      ['fs.search', opts, { signal: controller.signal }]
+    ])
+    expect(mux.request.mock.calls[1]?.[1]).not.toHaveProperty('signal')
   })
 
   it('listFiles sends fs.listFiles request', async () => {

--- a/src/main/providers/ssh-filesystem-provider.ts
+++ b/src/main/providers/ssh-filesystem-provider.ts
@@ -296,8 +296,11 @@ export class SshFilesystemProvider implements IFilesystemProvider {
     return (await this.mux.request('fs.realpath', { filePath })) as string
   }
 
-  async search(opts: SearchOptions): Promise<SearchResult> {
-    return (await this.mux.request('fs.search', opts)) as SearchResult
+  async search(opts: SearchOptions, options?: { signal?: AbortSignal }): Promise<SearchResult> {
+    if (!options?.signal) {
+      return (await this.mux.request('fs.search', opts)) as SearchResult
+    }
+    return (await this.mux.request('fs.search', opts, { signal: options.signal })) as SearchResult
   }
 
   async listFiles(

--- a/src/main/runtime/orca-runtime-files.test.ts
+++ b/src/main/runtime/orca-runtime-files.test.ts
@@ -107,6 +107,7 @@ import {
 import { SEARCH_TIMEOUT_MS } from '../../shared/text-search'
 
 type MockRuntimeSearchChild = EventEmitter & {
+  pid: number
   stdout: EventEmitter & { setEncoding: ReturnType<typeof vi.fn> }
   stderr: EventEmitter
   kill: ReturnType<typeof vi.fn>
@@ -195,6 +196,7 @@ function createRuntimeFileCommands(options?: {
 
 function createRuntimeSearchChild(): MockRuntimeSearchChild {
   const child = new EventEmitter() as MockRuntimeSearchChild
+  child.pid = 1234
   child.stdout = new EventEmitter() as MockRuntimeSearchChild['stdout']
   child.stdout.setEncoding = vi.fn()
   child.stderr = new EventEmitter()
@@ -756,6 +758,72 @@ describe('RuntimeFileCommands', () => {
     expect(child.listenerCount('close')).toBe(0)
   })
 
+  it('forwards runtime text-search cancellation to nested SSH', async () => {
+    const controller = new AbortController()
+    let resolveSearch!: (result: {
+      files: never[]
+      totalMatches: number
+      truncated: boolean
+    }) => void
+    const search = vi.fn(
+      () =>
+        new Promise((resolve) => {
+          resolveSearch = resolve
+        })
+    )
+    vi.mocked(getSshFilesystemProvider).mockReturnValue({ search } as never)
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/remote/repo' },
+      connectionId: 'ssh-1'
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+
+    const result = commands.searchRuntimeFiles(
+      'id:wt-1',
+      { query: 'needle', maxResults: 10 },
+      controller.signal
+    )
+    await vi.waitFor(() => expect(search).toHaveBeenCalledOnce())
+    controller.abort()
+    resolveSearch({ files: [], totalMatches: 0, truncated: false })
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(search).toHaveBeenCalledWith(
+      { query: 'needle', maxResults: 10, rootPath: '/remote/repo' },
+      { signal: controller.signal }
+    )
+  })
+
+  it('kills and detaches an aborted runtime rg search', async () => {
+    const controller = new AbortController()
+    const resolveRuntimeFileTarget = vi.fn(async () => ({
+      worktree: { id: 'wt-1', repoId: 'repo-1', path: '/repo' },
+      connectionId: null
+    }))
+    const { commands } = createRuntimeFileCommands({ resolveRuntimeFileTarget })
+    const child = createRuntimeSearchChild()
+    resolveAuthorizedPathMock.mockResolvedValue('/repo')
+    checkRgAvailableMock.mockResolvedValue(true)
+    wslAwareSpawnMock.mockReturnValue(child)
+
+    const resultPromise = commands.searchRuntimeFiles(
+      'id:wt-1',
+      { query: 'needle', maxResults: 10 },
+      controller.signal
+    )
+    await vi.waitFor(() => expect(wslAwareSpawnMock).toHaveBeenCalledOnce())
+    controller.abort()
+
+    await expect(resultPromise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(child.kill).toHaveBeenCalledOnce()
+    expect(child.stdout.listenerCount('data')).toBe(0)
+    expect(child.stderr.listenerCount('data')).toBe(0)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(checkRgAvailableMock).toHaveBeenCalledWith('/repo', undefined, controller.signal)
+  })
+
   it('routes runtime rg searches through the registered WSL project runtime', async () => {
     const resolveRuntimeFileTarget = vi.fn(async () => ({
       worktree: {
@@ -787,7 +855,7 @@ describe('RuntimeFileCommands', () => {
       'C:\\repo',
       'C:\\repo'
     )
-    expect(checkRgAvailableMock).toHaveBeenCalledWith('C:\\repo', 'Ubuntu')
+    expect(checkRgAvailableMock).toHaveBeenCalledWith('C:\\repo', 'Ubuntu', undefined)
     expect(wslAwareSpawnMock).toHaveBeenCalledWith(
       'rg',
       expect.any(Array),

--- a/src/main/runtime/orca-runtime-files.ts
+++ b/src/main/runtime/orca-runtime-files.ts
@@ -70,6 +70,10 @@ import {
   ingestRgJsonLine,
   SEARCH_TIMEOUT_MS
 } from '../../shared/text-search'
+import {
+  createTextSearchAbortError,
+  throwIfTextSearchAborted
+} from '../../shared/text-search-cancellation'
 import type { Store } from '../persistence'
 import {
   getSshFilesystemProvider,
@@ -90,6 +94,7 @@ import { beginWatcherInstall } from '../ipc/watcher-removal-gate'
 import { assertSshMutationExpectation } from '../ssh/ssh-connection-generation'
 import { toSshExecutionHostId, type ExecutionHostId } from '../../shared/execution-host'
 import { renameLocalPathSerializedByDestination } from '../destination-serialized-local-rename'
+import { terminateSpawnedChild } from '../../shared/spawned-child-cancellation'
 
 const MOBILE_FILE_LIST_LIMIT = 5000
 const MOBILE_FILE_PATH_SEARCH_CACHE_LIMIT = 20_000
@@ -1840,9 +1845,12 @@ export class RuntimeFileCommands {
 
   async searchRuntimeFiles(
     worktreeSelector: string,
-    options: Omit<SearchOptions, 'rootPath'>
+    options: Omit<SearchOptions, 'rootPath'>,
+    signal?: AbortSignal
   ): Promise<SearchResult> {
+    throwIfTextSearchAborted(signal)
     const target = await this.host.resolveRuntimeFileTarget(worktreeSelector)
+    throwIfTextSearchAborted(signal)
     const provider = target.connectionId ? getSshFilesystemProvider(target.connectionId) : null
     const rootPath = target.worktree.path
     const searchOptions = { ...options, rootPath }
@@ -1850,9 +1858,11 @@ export class RuntimeFileCommands {
       if (!provider) {
         throw new Error(SSH_FILESYSTEM_PROVIDER_UNAVAILABLE_MESSAGE)
       }
-      return provider.search(searchOptions)
+      const result = await provider.search(searchOptions, { signal })
+      throwIfTextSearchAborted(signal)
+      return result
     }
-    return this.searchLocalRuntimeFiles(rootPath, searchOptions)
+    return this.searchLocalRuntimeFiles(rootPath, searchOptions, signal)
   }
 
   async listRuntimeFiles(
@@ -1907,10 +1917,13 @@ export class RuntimeFileCommands {
 
   private async searchLocalRuntimeFiles(
     rootPath: string,
-    options: SearchOptions
+    options: SearchOptions,
+    signal?: AbortSignal
   ): Promise<SearchResult> {
+    throwIfTextSearchAborted(signal)
     const store = this.host.requireStore()
     const authorizedRootPath = await resolveAuthorizedPath(rootPath, store)
+    throwIfTextSearchAborted(signal)
     const localGitOptions = getLocalGitOptionsForRegisteredWorktree(
       store,
       rootPath,
@@ -1920,15 +1933,23 @@ export class RuntimeFileCommands {
       1,
       Math.min(options.maxResults ?? DEFAULT_SEARCH_MAX_RESULTS, DEFAULT_SEARCH_MAX_RESULTS)
     )
-    const rgAvailable = await checkRgAvailable(authorizedRootPath, localGitOptions.wslDistro)
+    const rgAvailable = await checkRgAvailable(
+      authorizedRootPath,
+      localGitOptions.wslDistro,
+      signal
+    )
+    throwIfTextSearchAborted(signal)
     if (!rgAvailable) {
-      return searchWithGitGrep(authorizedRootPath, options, maxResults, localGitOptions)
+      return searchWithGitGrep(authorizedRootPath, options, maxResults, localGitOptions, signal)
     }
 
-    return new Promise((resolvePromise) => {
+    return new Promise((resolvePromise, rejectPromise) => {
       const searchKey = `${this.host.getRuntimeId()}:${authorizedRootPath}`
       const rgArgs = buildRgArgs(options.query, authorizedRootPath, options)
-      this.activeRuntimeTextSearches.get(searchKey)?.kill()
+      const previousChild = this.activeRuntimeTextSearches.get(searchKey)
+      if (previousChild) {
+        terminateSpawnedChild(previousChild)
+      }
 
       const acc = createAccumulator()
       let stdoutBuffer = ''
@@ -1938,18 +1959,6 @@ export class RuntimeFileCommands {
       const transformAbsPath = wslInfo
         ? (p: string): string => toWindowsWslPath(p, wslInfo.distro)
         : undefined
-
-      const resolveOnce = (): void => {
-        if (resolved) {
-          return
-        }
-        resolved = true
-        if (this.activeRuntimeTextSearches.get(searchKey) === child) {
-          this.activeRuntimeTextSearches.delete(searchKey)
-        }
-        cleanupListeners()
-        resolvePromise(finalize(acc))
-      }
 
       let killTimeout: ReturnType<typeof setTimeout> | null = null
       const cleanupListeners = (): void => {
@@ -1961,6 +1970,39 @@ export class RuntimeFileCommands {
         child?.stderr?.off('data', onStderrData)
         child?.off('error', onError)
         child?.off('close', onClose)
+        signal?.removeEventListener('abort', onAbort)
+      }
+
+      const finish = (): boolean => {
+        if (resolved) {
+          return false
+        }
+        resolved = true
+        if (this.activeRuntimeTextSearches.get(searchKey) === child) {
+          this.activeRuntimeTextSearches.delete(searchKey)
+        }
+        cleanupListeners()
+        return true
+      }
+
+      const resolveOnce = (options: { kill?: boolean } = {}): void => {
+        if (!finish()) {
+          return
+        }
+        if (options.kill && child) {
+          terminateSpawnedChild(child)
+        }
+        resolvePromise(finalize(acc))
+      }
+
+      const rejectAborted = (): void => {
+        if (!finish()) {
+          return
+        }
+        if (child) {
+          terminateSpawnedChild(child)
+        }
+        rejectPromise(createTextSearchAbortError())
       }
 
       const processLine = (line: string): void => {
@@ -1971,8 +2013,8 @@ export class RuntimeFileCommands {
           maxResults,
           transformAbsPath
         )
-        if (verdict === 'stop') {
-          child?.kill()
+        if (verdict === 'stop' && child) {
+          terminateSpawnedChild(child)
         }
       }
 
@@ -2003,6 +2045,9 @@ export class RuntimeFileCommands {
         }
         resolveOnce()
       }
+      const onAbort = (): void => {
+        rejectAborted()
+      }
 
       nextChild.stdout!.on('data', onStdoutData)
       nextChild.stderr!.on('data', onStderrData)
@@ -2011,9 +2056,12 @@ export class RuntimeFileCommands {
 
       killTimeout = setTimeout(() => {
         acc.truncated = true
-        child?.kill()
-        resolveOnce()
+        resolveOnce({ kill: true })
       }, SEARCH_TIMEOUT_MS)
+      signal?.addEventListener('abort', onAbort, { once: true })
+      if (signal?.aborted) {
+        onAbort()
+      }
     })
   }
 

--- a/src/main/runtime/rpc/methods/files.test.ts
+++ b/src/main/runtime/rpc/methods/files.test.ts
@@ -781,6 +781,7 @@ describe('file RPC methods', () => {
   })
 
   it('searches files for a selected worktree', async () => {
+    const controller = new AbortController()
     const runtime = {
       getRuntimeId: () => 'test-runtime',
       searchRuntimeFiles: vi.fn().mockResolvedValue({
@@ -797,18 +798,23 @@ describe('file RPC methods', () => {
         query: 'needle',
         caseSensitive: true,
         maxResults: 50
-      })
+      }),
+      { signal: controller.signal }
     )
 
-    expect(runtime.searchRuntimeFiles).toHaveBeenCalledWith('id:wt-1', {
-      query: 'needle',
-      caseSensitive: true,
-      wholeWord: undefined,
-      useRegex: undefined,
-      includePattern: undefined,
-      excludePattern: undefined,
-      maxResults: 50
-    })
+    expect(runtime.searchRuntimeFiles).toHaveBeenCalledWith(
+      'id:wt-1',
+      {
+        query: 'needle',
+        caseSensitive: true,
+        wholeWord: undefined,
+        useRegex: undefined,
+        includePattern: undefined,
+        excludePattern: undefined,
+        maxResults: 50
+      },
+      controller.signal
+    )
     expect(response).toMatchObject({ ok: true, result: { files: [], totalMatches: 0 } })
   })
 

--- a/src/main/runtime/rpc/methods/files.ts
+++ b/src/main/runtime/rpc/methods/files.ts
@@ -433,16 +433,20 @@ export const FILE_METHODS: RpcAnyMethod[] = [
   defineMethod({
     name: 'files.search',
     params: FileSearch,
-    handler: async (params, { runtime }) =>
-      runtime.searchRuntimeFiles(params.worktree, {
-        query: params.query,
-        caseSensitive: params.caseSensitive,
-        wholeWord: params.wholeWord,
-        useRegex: params.useRegex,
-        includePattern: params.includePattern,
-        excludePattern: params.excludePattern,
-        maxResults: params.maxResults
-      })
+    handler: async (params, { runtime, signal }) =>
+      runtime.searchRuntimeFiles(
+        params.worktree,
+        {
+          query: params.query,
+          caseSensitive: params.caseSensitive,
+          wholeWord: params.wholeWord,
+          useRegex: params.useRegex,
+          includePattern: params.includePattern,
+          excludePattern: params.excludePattern,
+          maxResults: params.maxResults
+        },
+        signal
+      )
   }),
   defineMethod({
     name: 'files.listAll',

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -3473,6 +3473,7 @@ export type PreloadApi = {
         params?: unknown
         timeoutMs?: number
         expectedEnvironmentPairingRevision?: number
+        subscriptionId?: string
       },
       callbacks: {
         onResponse: (response: RuntimeRpcResponse<unknown>) => void
@@ -3481,6 +3482,7 @@ export type PreloadApi = {
         onClose?: () => void
       }
     ) => Promise<RuntimeEnvironmentSubscriptionHandle>
+    cancelSubscription?: (args: { subscriptionId: string }) => Promise<{ unsubscribed: boolean }>
   }
   rateLimits: {
     get: () => Promise<RateLimitState>

--- a/src/preload/api-types.ts
+++ b/src/preload/api-types.ts
@@ -2877,7 +2877,10 @@ export type PreloadApi = {
       requestToken?: string
     }) => Promise<string[]>
     cancelListFiles: (args: { requestToken: string }) => Promise<void>
-    search: (args: SearchOptions & { connectionId?: string }) => Promise<SearchResult>
+    search: (
+      args: SearchOptions & { connectionId?: string; requestToken?: string }
+    ) => Promise<SearchResult>
+    cancelSearch: (args: { requestToken: string }) => Promise<void>
     importExternalPaths: (
       args: {
         sourcePaths: string[]

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4457,6 +4457,7 @@ const api = {
         params?: unknown
         timeoutMs?: number
         expectedEnvironmentPairingRevision?: number
+        subscriptionId?: string
       },
       callbacks: {
         onResponse: (response: RuntimeRpcResponse<unknown>) => void
@@ -4465,7 +4466,9 @@ const api = {
         onClose?: () => void
       }
     ): Promise<RuntimeEnvironmentSubscriptionHandle> =>
-      subscribeRuntimeEnvironmentFromPreload(ipcRenderer, args, callbacks)
+      subscribeRuntimeEnvironmentFromPreload(ipcRenderer, args, callbacks),
+    cancelSubscription: (args: { subscriptionId: string }): Promise<{ unsubscribed: boolean }> =>
+      ipcRenderer.invoke('runtimeEnvironments:unsubscribe', args)
   },
 
   rateLimits: {

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -3208,7 +3208,10 @@ const api = {
       excludePattern?: string
       maxResults?: number
       connectionId?: string
+      requestToken?: string
     }): Promise<SearchResult> => ipcRenderer.invoke('fs:search', args),
+    cancelSearch: (args: { requestToken: string }): Promise<void> =>
+      ipcRenderer.invoke('fs:cancelSearch', args),
     importExternalPaths: (
       args: {
         sourcePaths: string[]

--- a/src/preload/runtime-environment-subscriptions.test.ts
+++ b/src/preload/runtime-environment-subscriptions.test.ts
@@ -55,6 +55,38 @@ function dispatch(ipc: ReturnType<typeof createIpc>, event: SubscriptionEvent): 
 }
 
 describe('subscribeRuntimeEnvironmentFromPreload', () => {
+  it('forwards a caller-provided subscription id without generating another', async () => {
+    const ipc = createIpc()
+    const createSubscriptionId = vi.fn(() => 'generated-sub')
+    ipc.invoke.mockImplementation((channel: string, args: unknown) =>
+      channel === 'runtimeEnvironments:subscribe'
+        ? Promise.resolve({
+            subscriptionId: (args as { subscriptionId: string }).subscriptionId,
+            requestId: 'rpc-provided'
+          })
+        : Promise.resolve({})
+    )
+
+    const handle = await subscribeRuntimeEnvironmentFromPreload(
+      ipc,
+      {
+        selector: 'desk',
+        method: 'files.search',
+        subscriptionId: 'provided-sub'
+      },
+      { onResponse: vi.fn() },
+      createSubscriptionId
+    )
+
+    expect(createSubscriptionId).not.toHaveBeenCalled()
+    expect(ipc.invoke).toHaveBeenCalledWith('runtimeEnvironments:subscribe', {
+      selector: 'desk',
+      method: 'files.search',
+      subscriptionId: 'provided-sub'
+    })
+    handle.unsubscribe()
+  })
+
   it('registers the subscription event listener before invoking main', async () => {
     const subscription = deferred<{ subscriptionId: string; requestId: string }>()
     const ipc = createIpc()

--- a/src/preload/runtime-environment-subscriptions.ts
+++ b/src/preload/runtime-environment-subscriptions.ts
@@ -5,6 +5,7 @@ type RuntimeEnvironmentSubscribeArgs = {
   method: string
   params?: unknown
   timeoutMs?: number
+  subscriptionId?: string
 }
 
 type RuntimeEnvironmentSubscriptionCallbacks = {
@@ -128,7 +129,7 @@ export async function subscribeRuntimeEnvironmentFromPreload(
   callbacks: RuntimeEnvironmentSubscriptionCallbacks,
   createSubscriptionId = createRuntimeEnvironmentSubscriptionId
 ): Promise<RuntimeEnvironmentSubscriptionHandle> {
-  const subscriptionId = createSubscriptionId()
+  const subscriptionId = args.subscriptionId?.trim() || createSubscriptionId()
   // Why: streaming RPCs can emit their first frame before ipcMain.handle()
   // resolves, so the dispatcher must be routing this id before invoking.
   const dispatcher = getOrCreateDispatcher(ipc)

--- a/src/relay/fs-handler-git-fallback.ts
+++ b/src/relay/fs-handler-git-fallback.ts
@@ -1,14 +1,12 @@
 /**
- * Git-based fallbacks for file listing and text search.
+ * Git-based fallback for file listing.
  *
  * Why: the relay depends on ripgrep (rg) for fs.listFiles and fs.search, but
- * rg is not installed on many remote machines. These functions use git ls-files
- * and git grep as universal fallbacks — git is always available since this is
- * a git-focused app.
+ * rg is not installed on many remote machines. This uses git ls-files as a
+ * universal fallback — git is always available since this is a git-focused app.
  */
 import { spawn } from 'node:child_process'
 import { fileListingCancellationError } from '../shared/file-listing-cancellation'
-import type { SearchOptions, SearchResult } from './fs-handler-utils'
 import {
   buildGitLsFilesArgsForQuickOpen,
   shouldExcludeQuickOpenRelPath,
@@ -18,14 +16,6 @@ import {
   expandQuickOpenGitFileListing,
   parseQuickOpenGitLsFilesEntry
 } from '../shared/quick-open-readdir-walk'
-import {
-  buildGitGrepArgs,
-  buildSubmatchRegex,
-  createAccumulator,
-  finalize,
-  ingestGitGrepLine,
-  SEARCH_TIMEOUT_MS
-} from '../shared/text-search'
 import { buildRelayGitEnv } from './relay-command-env'
 
 /**
@@ -263,86 +253,4 @@ export function listFilesWithGit(
     .finally(() => {
       signal?.removeEventListener('abort', onAbort)
     })
-}
-
-/**
- * Text search using `git grep`. Fallback when rg is not installed.
- */
-export function searchWithGitGrep(
-  rootPath: string,
-  query: string,
-  opts: SearchOptions
-): Promise<SearchResult> {
-  return new Promise((resolve) => {
-    const gitArgs = buildGitGrepArgs(query, opts)
-    const matchRegex = buildSubmatchRegex(query, opts)
-    const acc = createAccumulator()
-    let stdoutBuffer = ''
-    let done = false
-
-    const child = spawn('git', gitArgs, {
-      cwd: rootPath,
-      env: buildRelayGitEnv(),
-      stdio: ['ignore', 'pipe', 'pipe']
-    })
-    let killTimeout: ReturnType<typeof setTimeout>
-
-    function resolveOnce(): void {
-      if (done) {
-        return
-      }
-      done = true
-      clearTimeout(killTimeout)
-      // Why: child.kill() is advisory. If git ignores it, detach our
-      // closures so repeated relay searches do not retain old scans.
-      child.stdout!.off('data', handleStdoutData)
-      child.stderr!.off('data', handleStderrData)
-      child.off('error', handleError)
-      child.off('close', handleClose)
-      resolve(finalize(acc))
-    }
-
-    function processLine(line: string): void {
-      const verdict = ingestGitGrepLine(line, rootPath, matchRegex, acc, opts.maxResults)
-      if (verdict === 'stop') {
-        child.kill()
-      }
-    }
-
-    function handleStdoutData(chunk: string): void {
-      stdoutBuffer += chunk
-      const lines = stdoutBuffer.split('\n')
-      stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
-      }
-    }
-
-    function handleStderrData(): void {
-      /* drain */
-    }
-
-    function handleError(): void {
-      resolveOnce()
-    }
-
-    function handleClose(): void {
-      if (stdoutBuffer) {
-        processLine(stdoutBuffer)
-      }
-      resolveOnce()
-    }
-
-    child.stdout!.setEncoding('utf-8')
-    child.stdout!.on('data', handleStdoutData)
-    child.stderr!.on('data', handleStderrData)
-    child.once('error', handleError)
-    child.once('close', handleClose)
-
-    killTimeout = setTimeout(() => {
-      acc.truncated = true
-      child.kill()
-      resolveOnce()
-    }, SEARCH_TIMEOUT_MS)
-  })
 }

--- a/src/relay/fs-handler-git-search.test.ts
+++ b/src/relay/fs-handler-git-search.test.ts
@@ -8,12 +8,13 @@ vi.mock('child_process', () => ({
   spawn: spawnMock
 }))
 
-import { EventEmitter } from 'node:events'
+import { EventEmitter, getEventListeners } from 'node:events'
 import type { ChildProcess } from 'node:child_process'
-import { searchWithGitGrep } from './fs-handler-git-fallback'
+import { searchWithGitGrep } from './fs-handler-git-search'
 
 function createMockProcess(): ChildProcess {
   const p = new EventEmitter() as unknown as ChildProcess
+  ;(p as unknown as Record<string, unknown>).pid = 1234
   ;(p as unknown as Record<string, unknown>).stdout = new EventEmitter()
   ;(
     (p as unknown as Record<string, unknown>).stdout as EventEmitter & {
@@ -23,6 +24,14 @@ function createMockProcess(): ChildProcess {
   ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
   ;(p as unknown as Record<string, unknown>).kill = vi.fn()
   return p
+}
+
+function expectDetached(proc: ChildProcess, signal: AbortSignal): void {
+  expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+  expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+  expect(proc.listenerCount('error')).toBe(0)
+  expect(proc.listenerCount('close')).toBe(0)
+  expect(getEventListeners(signal, 'abort')).toHaveLength(0)
 }
 
 describe('relay git grep fallback', () => {
@@ -55,5 +64,31 @@ describe('relay git grep fallback', () => {
     } finally {
       vi.useRealTimers()
     }
+  })
+
+  it('does not spawn git grep for a pre-aborted search', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    const promise = searchWithGitGrep('/remote/root', 'ok', { maxResults: 100 }, controller.signal)
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+  })
+
+  it('aborts an in-flight git grep and detaches every listener', async () => {
+    const proc = createMockProcess()
+    const controller = new AbortController()
+    spawnMock.mockReturnValue(proc)
+
+    const promise = searchWithGitGrep('/remote/root', 'ok', { maxResults: 100 }, controller.signal)
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(1)
+
+    controller.abort()
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    expectDetached(proc, controller.signal)
   })
 })

--- a/src/relay/fs-handler-git-search.ts
+++ b/src/relay/fs-handler-git-search.ts
@@ -1,4 +1,4 @@
-import type { SearchOptions, SearchResult } from '../../shared/types'
+import { spawn } from 'node:child_process'
 import {
   buildGitGrepArgs,
   buildSubmatchRegex,
@@ -6,26 +6,19 @@ import {
   finalize,
   ingestGitGrepLine,
   SEARCH_TIMEOUT_MS
-} from '../../shared/text-search'
+} from '../shared/text-search'
 import {
   createTextSearchAbortError,
   throwIfTextSearchAborted
-} from '../../shared/text-search-cancellation'
-import { gitSpawn } from '../git/runner'
-import { terminateSpawnedChild } from '../../shared/spawned-child-cancellation'
+} from '../shared/text-search-cancellation'
+import type { SearchOptions, SearchResult } from './fs-handler-utils'
+import { buildRelayGitEnv } from './relay-command-env'
+import { terminateSpawnedChild } from '../shared/spawned-child-cancellation'
 
-/**
- * Fallback text search using git grep. Used when rg is not available.
- *
- * Why: On Linux, rg may not be installed or may not be in PATH when the app
- * is launched from a desktop entry (which inherits a minimal system PATH).
- * git grep is always available since this is a git-focused app.
- */
 export function searchWithGitGrep(
   rootPath: string,
-  args: SearchOptions,
-  maxResults: number,
-  localGitOptions: { wslDistro?: string } = {},
+  query: string,
+  opts: SearchOptions,
   signal?: AbortSignal
 ): Promise<SearchResult> {
   try {
@@ -34,15 +27,15 @@ export function searchWithGitGrep(
     return Promise.reject(error)
   }
   return new Promise((resolve, reject) => {
-    const gitArgs = buildGitGrepArgs(args.query, args)
-    const matchRegex = buildSubmatchRegex(args.query, args)
+    const gitArgs = buildGitGrepArgs(query, opts)
+    const matchRegex = buildSubmatchRegex(query, opts)
     const acc = createAccumulator()
     let stdoutBuffer = ''
     let done = false
 
-    const child = gitSpawn(gitArgs, {
+    const child = spawn('git', gitArgs, {
       cwd: rootPath,
-      ...(localGitOptions.wslDistro ? { wslDistro: localGitOptions.wslDistro } : {}),
+      env: buildRelayGitEnv(),
       stdio: ['ignore', 'pipe', 'pipe']
     })
     let killTimeout: ReturnType<typeof setTimeout> | null = null
@@ -65,8 +58,7 @@ export function searchWithGitGrep(
       }
       done = true
       cleanup()
-      // Why: child.kill() is advisory. If git ignores it, detach our
-      // closures so repeated fallback searches do not retain old scans.
+      // Why: kill is advisory over SSH; detach listeners before it can emit close synchronously.
       if (options.kill) {
         terminateSpawnedChild(child)
       }
@@ -84,7 +76,7 @@ export function searchWithGitGrep(
     }
 
     function processLine(line: string): void {
-      const verdict = ingestGitGrepLine(line, rootPath, matchRegex, acc, maxResults)
+      const verdict = ingestGitGrepLine(line, rootPath, matchRegex, acc, opts.maxResults)
       if (verdict === 'stop') {
         terminateSpawnedChild(child)
       }
@@ -94,8 +86,8 @@ export function searchWithGitGrep(
       stdoutBuffer += chunk
       const lines = stdoutBuffer.split('\n')
       stdoutBuffer = lines.pop() ?? ''
-      for (const l of lines) {
-        processLine(l)
+      for (const line of lines) {
+        processLine(line)
       }
     }
 

--- a/src/relay/fs-handler-list-files-ignored.test.ts
+++ b/src/relay/fs-handler-list-files-ignored.test.ts
@@ -33,6 +33,7 @@ function createMockProcess(): ChildProcess {
     }
   ).setEncoding = vi.fn()
   ;(p as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(p as unknown as Record<string, unknown>).pid = 1234
   ;(p as unknown as Record<string, unknown>).kill = vi.fn()
   ;(p as unknown as Record<string, unknown>).exitCode = null
   ;(p as unknown as Record<string, unknown>).signalCode = null

--- a/src/relay/fs-handler-rg-availability.test.ts
+++ b/src/relay/fs-handler-rg-availability.test.ts
@@ -1,5 +1,5 @@
 import { EventEmitter } from 'node:events'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const { execFileMock, spawnMock } = vi.hoisted(() => ({
   execFileMock: vi.fn(),
@@ -14,10 +14,26 @@ vi.mock('child_process', () => ({
 import { checkRgAvailable } from './fs-handler-utils'
 
 class FakeChildProcess extends EventEmitter {
+  pid = 1234
   kill = vi.fn()
 }
 
 describe('relay rg availability', () => {
+  beforeEach(() => {
+    execFileMock.mockReset()
+    spawnMock.mockReset()
+  })
+
+  it('does not spawn when already aborted', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(checkRgAvailable(controller.signal)).rejects.toMatchObject({
+      name: 'AbortError'
+    })
+    expect(execFileMock).not.toHaveBeenCalled()
+  })
+
   it('removes listeners after a successful probe', async () => {
     const child = new FakeChildProcess()
     execFileMock.mockReturnValueOnce(child)
@@ -28,6 +44,38 @@ describe('relay rg availability', () => {
     await expect(result).resolves.toBe(true)
     expect(child.listenerCount('error')).toBe(0)
     expect(child.listenerCount('close')).toBe(0)
+  })
+
+  it('returns false when rg is unavailable', async () => {
+    const child = new FakeChildProcess()
+    execFileMock.mockReturnValueOnce(child)
+
+    const result = checkRgAvailable()
+    child.emit('error', new Error('rg not found'))
+
+    await expect(result).resolves.toBe(false)
+    expect(child.kill).not.toHaveBeenCalled()
+  })
+
+  it('aborts a pending probe without starting fallback', async () => {
+    const child = new FakeChildProcess()
+    const controller = new AbortController()
+    const fallback = vi.fn()
+    execFileMock.mockReturnValueOnce(child)
+
+    const search = async (): Promise<void> => {
+      if (!(await checkRgAvailable(controller.signal))) {
+        fallback()
+      }
+    }
+    const result = search()
+    controller.abort()
+
+    await expect(result).rejects.toMatchObject({ name: 'AbortError' })
+    expect(child.kill).toHaveBeenCalledTimes(1)
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+    expect(fallback).not.toHaveBeenCalled()
   })
 
   it('settles and detaches when a wedged probe ignores timeout kill', async () => {

--- a/src/relay/fs-handler-rg-search.test.ts
+++ b/src/relay/fs-handler-rg-search.test.ts
@@ -1,0 +1,102 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({
+  spawnMock: vi.fn()
+}))
+
+vi.mock('node:child_process', () => ({
+  execFile: vi.fn(),
+  spawn: spawnMock
+}))
+
+import type { ChildProcess } from 'node:child_process'
+import { EventEmitter, getEventListeners } from 'node:events'
+import { searchWithRg } from './fs-handler-utils'
+
+function createMockProcess(): ChildProcess {
+  const proc = new EventEmitter() as unknown as ChildProcess
+  ;(proc as unknown as Record<string, unknown>).pid = 1234
+  ;(proc as unknown as Record<string, unknown>).stdout = new EventEmitter()
+  ;(
+    (proc as unknown as Record<string, unknown>).stdout as EventEmitter & {
+      setEncoding: () => void
+    }
+  ).setEncoding = vi.fn()
+  ;(proc as unknown as Record<string, unknown>).stderr = new EventEmitter()
+  ;(proc as unknown as Record<string, unknown>).kill = vi.fn()
+  return proc
+}
+
+function expectDetached(proc: ChildProcess, signal: AbortSignal): void {
+  expect((proc.stdout as unknown as EventEmitter).listenerCount('data')).toBe(0)
+  expect((proc.stderr as unknown as EventEmitter).listenerCount('data')).toBe(0)
+  expect(proc.listenerCount('error')).toBe(0)
+  expect(proc.listenerCount('close')).toBe(0)
+  expect(getEventListeners(signal, 'abort')).toHaveLength(0)
+}
+
+function rgMatchLine(): string {
+  return JSON.stringify({
+    type: 'match',
+    data: {
+      path: { text: '/remote/root/src/index.ts' },
+      line_number: 4,
+      lines: { text: 'const ok = true\n' },
+      submatches: [{ start: 6, end: 8 }]
+    }
+  })
+}
+
+describe('relay rg search cancellation', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('does not spawn rg for a pre-aborted search', async () => {
+    const proc = createMockProcess()
+    const controller = new AbortController()
+    spawnMock.mockReturnValue(proc)
+    controller.abort()
+
+    const promise = searchWithRg('/remote/root', 'ok', { maxResults: 100 }, controller.signal)
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(0)
+  })
+
+  it('aborts an in-flight rg search and detaches every listener', async () => {
+    const proc = createMockProcess()
+    const controller = new AbortController()
+    spawnMock.mockReturnValue(proc)
+
+    const promise = searchWithRg('/remote/root', 'ok', { maxResults: 100 }, controller.signal)
+    expect(getEventListeners(controller.signal, 'abort')).toHaveLength(1)
+
+    controller.abort()
+
+    await expect(promise).rejects.toMatchObject({ name: 'AbortError' })
+    expect(proc.kill).toHaveBeenCalledTimes(1)
+    expectDetached(proc, controller.signal)
+  })
+
+  it('returns partial truncated results when rg ignores the timeout kill', async () => {
+    vi.useFakeTimers()
+    try {
+      const proc = createMockProcess()
+      const controller = new AbortController()
+      spawnMock.mockReturnValue(proc)
+
+      const promise = searchWithRg('/remote/root', 'ok', { maxResults: 100 }, controller.signal)
+      ;(proc.stdout as unknown as EventEmitter).emit('data', `${rgMatchLine()}\n`)
+
+      await vi.runOnlyPendingTimersAsync()
+
+      await expect(promise).resolves.toMatchObject({ totalMatches: 1, truncated: true })
+      expect(proc.kill).toHaveBeenCalledTimes(1)
+      expectDetached(proc, controller.signal)
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/relay/fs-handler-utils.ts
+++ b/src/relay/fs-handler-utils.ts
@@ -14,8 +14,13 @@ import {
   ingestRgJsonLine,
   SEARCH_TIMEOUT_MS as SHARED_SEARCH_TIMEOUT_MS
 } from '../shared/text-search'
+import {
+  createTextSearchAbortError,
+  throwIfTextSearchAborted
+} from '../shared/text-search-cancellation'
 import { IMAGE_FILE_MIME_TYPES } from '../shared/image-file-extensions'
 import type { SearchResult as SharedSearchResult } from '../shared/types'
+import { terminateSpawnedChild } from '../shared/spawned-child-cancellation'
 
 // ─── Constants ───────────────────────────────────────────────────────
 
@@ -87,9 +92,15 @@ export type SearchResult = SharedSearchResult
 export function searchWithRg(
   rootPath: string,
   query: string,
-  opts: SearchOptions
+  opts: SearchOptions,
+  signal?: AbortSignal
 ): Promise<SearchResult> {
-  return new Promise((resolve) => {
+  try {
+    throwIfTextSearchAborted(signal)
+  } catch (error) {
+    return Promise.reject(error)
+  }
+  return new Promise((resolve, reject) => {
     const rgArgs = buildRgArgs(query, rootPath, opts)
     const acc = createAccumulator()
     let buffer = ''
@@ -110,27 +121,48 @@ export function searchWithRg(
       return
     }
 
-    let killTimeout: ReturnType<typeof setTimeout>
+    let killTimeout: ReturnType<typeof setTimeout> | null = null
 
-    function resolveOnce(): void {
-      if (resolved) {
-        return
+    function cleanup(): void {
+      if (killTimeout) {
+        clearTimeout(killTimeout)
+        killTimeout = null
       }
-      resolved = true
-      clearTimeout(killTimeout)
-      // Why: child.kill() is advisory over SSH; detach listeners if the
-      // process ignores timeout kill so old searches cannot retain closures.
       child.stdout!.off('data', handleStdoutData)
       child.stderr!.off('data', handleStderrData)
       child.off('error', handleError)
       child.off('close', handleClose)
+      signal?.removeEventListener('abort', handleAbort)
+    }
+
+    function resolveOnce(options: { kill?: boolean } = {}): void {
+      if (resolved) {
+        return
+      }
+      resolved = true
+      cleanup()
+      // Why: child.kill() is advisory over SSH; detach listeners if the
+      // process ignores timeout kill so old searches cannot retain closures.
+      if (options.kill) {
+        terminateSpawnedChild(child)
+      }
       resolve(finalize(acc))
+    }
+
+    function rejectAborted(): void {
+      if (resolved) {
+        return
+      }
+      resolved = true
+      cleanup()
+      terminateSpawnedChild(child)
+      reject(createTextSearchAbortError())
     }
 
     function processLine(line: string): void {
       const verdict = ingestRgJsonLine(line, rootPath, acc, opts.maxResults)
       if (verdict === 'stop') {
-        child.kill()
+        terminateSpawnedChild(child)
       }
     }
 
@@ -158,6 +190,10 @@ export function searchWithRg(
       resolveOnce()
     }
 
+    function handleAbort(): void {
+      rejectAborted()
+    }
+
     child.stdout!.setEncoding('utf-8')
     child.stdout!.on('data', handleStdoutData)
     child.stderr!.on('data', handleStderrData)
@@ -166,9 +202,12 @@ export function searchWithRg(
 
     killTimeout = setTimeout(() => {
       acc.truncated = true
-      child.kill()
-      resolveOnce()
+      resolveOnce({ kill: true })
     }, SEARCH_TIMEOUT_MS)
+    signal?.addEventListener('abort', handleAbort, { once: true })
+    if (signal?.aborted) {
+      handleAbort()
+    }
   })
 }
 
@@ -182,8 +221,11 @@ export function searchWithRg(
 // to paper over, so re-checking per call is both simpler and safer.
 const RG_AVAILABILITY_TIMEOUT_MS = 5000
 
-export function checkRgAvailable(): Promise<boolean> {
-  return new Promise((resolve) => {
+export function checkRgAvailable(signal?: AbortSignal): Promise<boolean> {
+  if (signal?.aborted) {
+    return Promise.reject(createRgAvailabilityAbortError())
+  }
+  return new Promise((resolve, reject) => {
     let settled = false
     const child = execFile('rg', ['--version'])
     let timeout: ReturnType<typeof setTimeout> | null = null
@@ -194,6 +236,7 @@ export function checkRgAvailable(): Promise<boolean> {
       }
       child.off('error', onError)
       child.off('close', onClose)
+      signal?.removeEventListener('abort', onAbort)
     }
     const settle = (available: boolean, options?: { kill?: boolean }): void => {
       if (settled) {
@@ -202,12 +245,21 @@ export function checkRgAvailable(): Promise<boolean> {
       settled = true
       cleanup()
       if (options?.kill) {
-        child.kill()
+        terminateSpawnedChild(child)
       }
       resolve(available)
     }
     const onError = (): void => settle(false)
     const onClose = (code: number | null): void => settle(code === 0)
+    const onAbort = (): void => {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanup()
+      terminateSpawnedChild(child)
+      reject(createRgAvailabilityAbortError())
+    }
 
     child.once('error', onError)
     child.once('close', onClose)
@@ -215,7 +267,17 @@ export function checkRgAvailable(): Promise<boolean> {
     if (typeof timeout.unref === 'function') {
       timeout.unref()
     }
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+    }
   })
+}
+
+function createRgAvailabilityAbortError(): Error {
+  const error = new Error('rg availability check aborted')
+  error.name = 'AbortError'
+  return error
 }
 
 // Moved to fs-handler-list-files.ts to keep this file under 300 lines (oxlint)

--- a/src/relay/fs-handler.ts
+++ b/src/relay/fs-handler.ts
@@ -16,7 +16,8 @@ import {
   listFilesWithRg,
   checkRgAvailable
 } from './fs-handler-utils'
-import { listFilesWithGit, searchWithGitGrep } from './fs-handler-git-fallback'
+import { listFilesWithGit } from './fs-handler-git-fallback'
+import { searchWithGitGrep } from './fs-handler-git-search'
 import { listFilesWithReaddir } from './fs-handler-readdir-fallback'
 import { ListFilesScanCoordinator } from './fs-list-files-scan-coordinator'
 import {
@@ -119,7 +120,7 @@ export class FsHandler {
     this.dispatcher.onRequest('fs.renameNoClobber', (p) => this.renameNoClobber(p))
     this.dispatcher.onRequest('fs.copy', (p) => this.copy(p))
     this.dispatcher.onRequest('fs.realpath', (p) => this.realpath(p))
-    this.dispatcher.onRequest('fs.search', (p) => this.search(p))
+    this.dispatcher.onRequest('fs.search', (p, c) => this.search(p, c))
     this.dispatcher.onRequest('fs.listFiles', (p, c) => this.listFiles(p, c))
     this.dispatcher.onRequest('fs.workspaceSpaceScan', (p, c) => this.workspaceSpaceScan(p, c))
     this.dispatcher.onRequest('fs.watch', (p, context) =>
@@ -315,7 +316,7 @@ export class FsHandler {
     return await realpath(filePath)
   }
 
-  private async search(params: Record<string, unknown>) {
+  private async search(params: Record<string, unknown>, context?: RequestContext) {
     const query = params.query as string
     const rootPath = expandTilde(params.rootPath as string)
     const caseSensitive = params.caseSensitive as boolean | undefined
@@ -328,26 +329,37 @@ export class FsHandler {
       DEFAULT_MAX_RESULTS
     )
 
-    const rgAvailable = await checkRgAvailable()
+    const rgAvailable = await checkRgAvailable(context?.signal)
+    context?.signal?.throwIfAborted()
     if (!rgAvailable) {
-      return searchWithGitGrep(rootPath, query, {
+      return searchWithGitGrep(
+        rootPath,
+        query,
+        {
+          caseSensitive,
+          wholeWord,
+          useRegex,
+          includePattern,
+          excludePattern,
+          maxResults
+        },
+        context?.signal
+      )
+    }
+
+    return searchWithRg(
+      rootPath,
+      query,
+      {
         caseSensitive,
         wholeWord,
         useRegex,
         includePattern,
         excludePattern,
         maxResults
-      })
-    }
-
-    return searchWithRg(rootPath, query, {
-      caseSensitive,
-      wholeWord,
-      useRegex,
-      includePattern,
-      excludePattern,
-      maxResults
-    })
+      },
+      context?.signal
+    )
   }
 
   private listFiles(params: Record<string, unknown>, context?: RequestContext): Promise<string[]> {

--- a/src/relay/fs-search-cancel.integration.test.ts
+++ b/src/relay/fs-search-cancel.integration.test.ts
@@ -1,0 +1,166 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { fakeSearchWithRg } = vi.hoisted(() => {
+  type SearchResult = {
+    files: unknown[]
+    totalMatches: number
+    truncated: boolean
+  }
+  type SearchRecord = {
+    signal: AbortSignal | undefined
+    resolve: (result: SearchResult) => void
+  }
+  const searches: SearchRecord[] = []
+  const fakeSearchWithRg = Object.assign(
+    vi.fn(
+      (
+        _rootPath: string,
+        _query: string,
+        _options: Record<string, unknown>,
+        signal?: AbortSignal
+      ) =>
+        new Promise<SearchResult>((resolve, reject) => {
+          searches.push({ signal, resolve })
+          signal?.addEventListener(
+            'abort',
+            () =>
+              reject(
+                signal.reason instanceof Error ? signal.reason : new Error('Search cancelled')
+              ),
+            { once: true }
+          )
+        })
+    ),
+    { searches }
+  )
+  return { fakeSearchWithRg }
+})
+
+vi.mock('./fs-handler-utils', async (importOriginal) => {
+  const original = (await importOriginal()) as Record<string, unknown>
+  return {
+    ...original,
+    checkRgAvailable: () => Promise.resolve(true),
+    searchWithRg: fakeSearchWithRg
+  }
+})
+
+import {
+  SshChannelMultiplexer,
+  type MultiplexerTransport
+} from '../main/ssh/ssh-channel-multiplexer'
+import {
+  FrameDecoder,
+  MessageType,
+  parseJsonRpcMessage,
+  type JsonRpcMessage
+} from '../main/ssh/relay-protocol'
+import { RelayContext } from './context'
+import { RelayDispatcher } from './dispatcher'
+import { FsHandler } from './fs-handler'
+
+const SEARCH_PARAMS = {
+  query: 'needle',
+  rootPath: '/workspace',
+  caseSensitive: false,
+  wholeWord: false,
+  useRegex: false,
+  maxResults: 100
+}
+
+const SEARCH_RESULT = {
+  files: [],
+  totalMatches: 0,
+  truncated: false
+}
+
+async function flushPipe(): Promise<void> {
+  for (let index = 0; index < 10; index += 1) {
+    await new Promise((resolve) => setImmediate(resolve))
+  }
+}
+
+describe('Integration: cancellable fs.search', () => {
+  let mux: SshChannelMultiplexer
+  let dispatcher: RelayDispatcher
+  let fsHandler: FsHandler
+  let clientMessages: JsonRpcMessage[]
+
+  beforeEach(() => {
+    fakeSearchWithRg.mockClear()
+    fakeSearchWithRg.searches.length = 0
+    clientMessages = []
+
+    let relayFeed: (data: Buffer) => void
+    const clientDataCallbacks: ((data: Buffer) => void)[] = []
+    const clientFrameDecoder = new FrameDecoder((frame) => {
+      if (frame.type === MessageType.Regular) {
+        clientMessages.push(parseJsonRpcMessage(frame.payload))
+      }
+    })
+    const clientTransport: MultiplexerTransport = {
+      write: (data) => {
+        clientFrameDecoder.feed(data)
+        setImmediate(() => relayFeed(data))
+      },
+      onData: (callback) => clientDataCallbacks.push(callback),
+      onClose: () => {}
+    }
+    dispatcher = new RelayDispatcher((data) => {
+      setImmediate(() => {
+        for (const callback of clientDataCallbacks) {
+          callback(data)
+        }
+      })
+    })
+    relayFeed = (data) => dispatcher.feed(data)
+    fsHandler = new FsHandler(dispatcher, new RelayContext())
+    mux = new SshChannelMultiplexer(clientTransport)
+  })
+
+  afterEach(() => {
+    mux.dispose()
+    dispatcher.dispose()
+    fsHandler.dispose()
+  })
+
+  it('propagates client cancellation to the relay search signal', async () => {
+    const controller = new AbortController()
+    const searchPromise = mux.request('fs.search', SEARCH_PARAMS, { signal: controller.signal })
+    await flushPipe()
+
+    expect(fakeSearchWithRg.searches).toHaveLength(1)
+    expect(fakeSearchWithRg.searches[0].signal?.aborted).toBe(false)
+
+    controller.abort()
+    await expect(searchPromise).rejects.toThrow('was cancelled')
+    await flushPipe()
+
+    const searchRequest = clientMessages.find(
+      (message) => 'method' in message && message.method === 'fs.search'
+    ) as { id: number } | undefined
+    expect(searchRequest?.id).toEqual(expect.any(Number))
+    expect(clientMessages).toContainEqual({
+      jsonrpc: '2.0',
+      method: 'rpc.cancel',
+      params: { id: searchRequest?.id }
+    })
+    expect(fakeSearchWithRg.searches[0].signal?.aborted).toBe(true)
+  })
+
+  it('returns a completed search result without cancellation', async () => {
+    const searchPromise = mux.request('fs.search', SEARCH_PARAMS)
+    await flushPipe()
+
+    expect(fakeSearchWithRg).toHaveBeenCalledWith(
+      '/workspace',
+      'needle',
+      expect.objectContaining({ maxResults: 100 }),
+      expect.any(AbortSignal)
+    )
+    fakeSearchWithRg.searches[0].resolve(SEARCH_RESULT)
+
+    await expect(searchPromise).resolves.toEqual(SEARCH_RESULT)
+    expect(fakeSearchWithRg.searches[0].signal?.aborted).toBe(false)
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.test.tsx
@@ -1,0 +1,301 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook } from '@testing-library/react'
+import type { ChangeEvent } from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { SearchResult } from '../../../../shared/types'
+import { useFileSearchPanel } from './useFileSearchPanel'
+
+type FileSearchState = {
+  query: string
+  caseSensitive: boolean
+  wholeWord: boolean
+  useRegex: boolean
+  includePattern: string
+  excludePattern: string
+  results: SearchResult | null
+  resultOwner: unknown
+  loading: boolean
+  collapsedFiles: Set<string>
+  seedRequestId?: number
+}
+
+type MockStoreState = {
+  activeWorktreeId: string | null
+  fileSearchStateByWorktree: Record<string, FileSearchState>
+  openFile: () => void
+  setPendingEditorReveal: () => void
+  updateFileSearchState: (worktreeId: string, updates: Partial<FileSearchState>) => void
+  consumeFileSearchSeedRequest: (worktreeId: string, requestId: number) => void
+  toggleFileSearchCollapsedFile: () => void
+  clearFileSearch: (worktreeId: string) => void
+}
+
+const WORKTREE_ID = 'repo-a::/repo'
+const SECOND_WORKTREE_ID = 'repo-b::/other'
+const RESULTS_A: SearchResult = { files: [], totalMatches: 1, truncated: false }
+const RESULTS_B: SearchResult = { files: [], totalMatches: 2, truncated: false }
+
+const mocks = vi.hoisted(() => ({
+  activeWorktree: null as { id: string; path: string } | null,
+  getConnectionId: vi.fn(),
+  getRuntimeSettings: vi.fn(),
+  searchRuntimeFiles: vi.fn(),
+  state: null as unknown as MockStoreState
+}))
+
+vi.mock('@/lib/connection-context', () => ({
+  getConnectionId: mocks.getConnectionId
+}))
+
+vi.mock('@/runtime/runtime-file-client', () => ({
+  searchRuntimeFiles: mocks.searchRuntimeFiles
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: Object.assign(
+    (selector: (state: MockStoreState) => unknown) => selector(mocks.state),
+    { getState: () => mocks.state }
+  )
+}))
+
+vi.mock('@/store/selectors', () => ({
+  useActiveWorktree: () => mocks.activeWorktree
+}))
+
+vi.mock('./file-explorer-runtime-owner', () => ({
+  getRightSidebarWorktreeRuntimeSettings: mocks.getRuntimeSettings
+}))
+
+function makeFileSearchState(query = 'alpha'): FileSearchState {
+  return {
+    query,
+    caseSensitive: false,
+    wholeWord: false,
+    useRegex: false,
+    includePattern: '',
+    excludePattern: '',
+    results: RESULTS_A,
+    resultOwner: null,
+    loading: false,
+    collapsedFiles: new Set()
+  }
+}
+
+function resetStore(): void {
+  mocks.state = {
+    activeWorktreeId: WORKTREE_ID,
+    fileSearchStateByWorktree: { [WORKTREE_ID]: makeFileSearchState() },
+    openFile: vi.fn(),
+    setPendingEditorReveal: vi.fn(),
+    updateFileSearchState: vi.fn((worktreeId, updates) => {
+      Object.assign(mocks.state.fileSearchStateByWorktree[worktreeId], updates)
+    }),
+    consumeFileSearchSeedRequest: vi.fn((worktreeId) => {
+      delete mocks.state.fileSearchStateByWorktree[worktreeId]?.seedRequestId
+    }),
+    toggleFileSearchCollapsedFile: vi.fn(),
+    clearFileSearch: vi.fn((worktreeId) => {
+      mocks.state.fileSearchStateByWorktree[worktreeId] = makeFileSearchState('')
+    })
+  }
+}
+
+function queryChange(value: string): ChangeEvent<HTMLInputElement> {
+  return { target: { value } } as ChangeEvent<HTMLInputElement>
+}
+
+function mockPendingSearches(): AbortSignal[] {
+  const signals: AbortSignal[] = []
+  mocks.searchRuntimeFiles.mockImplementation(
+    (_context: unknown, _options: unknown, signal?: AbortSignal): Promise<SearchResult> => {
+      if (!signal) {
+        return Promise.reject(new Error('Expected an abort signal'))
+      }
+      signals.push(signal)
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            const error = new Error('Search aborted')
+            error.name = 'AbortError'
+            reject(error)
+          },
+          { once: true }
+        )
+      })
+    }
+  )
+  return signals
+}
+
+type PanelProps = { explorerView: 'files' | 'search' }
+
+function renderPanel() {
+  const initialProps: PanelProps = { explorerView: 'search' }
+  return renderHook(({ explorerView }: PanelProps) => useFileSearchPanel(explorerView), {
+    initialProps
+  })
+}
+
+describe('useFileSearchPanel interrupted searches', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    vi.clearAllMocks()
+    resetStore()
+    mocks.activeWorktree = { id: WORKTREE_ID, path: '/repo' }
+    mocks.getConnectionId.mockReturnValue(null)
+    mocks.getRuntimeSettings.mockReturnValue({ activeRuntimeEnvironmentId: null })
+    mocks.searchRuntimeFiles.mockResolvedValue(RESULTS_B)
+  })
+
+  afterEach(() => {
+    cleanup()
+    vi.clearAllTimers()
+    vi.useRealTimers()
+  })
+
+  it('restarts the current query after canceling its debounce on Files view', async () => {
+    const hook = renderPanel()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    hook.rerender({ explorerView: 'files' })
+    expect(mocks.state.fileSearchStateByWorktree[WORKTREE_ID].results).toBeNull()
+    hook.rerender({ explorerView: 'search' })
+
+    await act(async () => vi.advanceTimersByTimeAsync(299))
+    expect(mocks.searchRuntimeFiles).not.toHaveBeenCalled()
+
+    await act(async () => vi.advanceTimersByTimeAsync(1))
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledTimes(1)
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
+      expect.any(Object),
+      expect.objectContaining({ query: 'beta' }),
+      expect.any(AbortSignal)
+    )
+  })
+
+  it('aborts an in-flight query and keeps its replacement live on re-entry', async () => {
+    const hook = renderPanel()
+    const signals = mockPendingSearches()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.aborted).toBe(false)
+
+    hook.rerender({ explorerView: 'files' })
+    await act(() => Promise.resolve())
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+
+    expect(signals).toHaveLength(2)
+    expect(signals[0]?.aborted).toBe(true)
+    expect(signals[1]?.aborted).toBe(false)
+  })
+
+  it('discards prior-query results when unmount interrupts a search', async () => {
+    const hook = renderPanel()
+    const signals = mockPendingSearches()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+    expect(mocks.state.fileSearchStateByWorktree[WORKTREE_ID].results).toBe(RESULTS_A)
+
+    await act(async () => {
+      hook.unmount()
+      await Promise.resolve()
+    })
+
+    expect(signals[0]?.aborted).toBe(true)
+    expect(mocks.state.fileSearchStateByWorktree[WORKTREE_ID]).toMatchObject({
+      query: 'beta',
+      results: null,
+      resultOwner: null,
+      loading: false
+    })
+    const reopened = renderPanel()
+    expect(reopened.result.current.resultsProps.results).toBeNull()
+  })
+
+  it('discards prior-query results across a worktree round-trip', async () => {
+    const hook = renderPanel()
+    const signals = mockPendingSearches()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+
+    mocks.state.fileSearchStateByWorktree[SECOND_WORKTREE_ID] = makeFileSearchState('other')
+    mocks.state.activeWorktreeId = SECOND_WORKTREE_ID
+    mocks.activeWorktree = { id: SECOND_WORKTREE_ID, path: '/other' }
+    hook.rerender({ explorerView: 'search' })
+    mocks.state.activeWorktreeId = WORKTREE_ID
+    mocks.activeWorktree = { id: WORKTREE_ID, path: '/repo' }
+    hook.rerender({ explorerView: 'search' })
+
+    expect(signals[0]?.aborted).toBe(true)
+    expect(mocks.state.fileSearchStateByWorktree[WORKTREE_ID].results).toBeNull()
+    expect(hook.result.current.resultsProps.results).toBeNull()
+  })
+
+  it('reuses completed results without starting another search', async () => {
+    const hook = renderPanel()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+    hook.rerender({ explorerView: 'search' })
+
+    expect(hook.result.current.resultsProps.results).toBe(RESULTS_B)
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledTimes(1)
+
+    hook.rerender({ explorerView: 'files' })
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+
+    expect(hook.result.current.resultsProps.results).toBe(RESULTS_B)
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledTimes(1)
+  })
+
+  it('drops resume ownership when the hidden query changes', async () => {
+    const hook = renderPanel()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    hook.rerender({ explorerView: 'files' })
+
+    mocks.state.fileSearchStateByWorktree[WORKTREE_ID].query = 'gamma'
+    hook.rerender({ explorerView: 'files' })
+    mocks.state.fileSearchStateByWorktree[WORKTREE_ID].query = 'beta'
+    hook.rerender({ explorerView: 'files' })
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+
+    expect(mocks.searchRuntimeFiles).not.toHaveBeenCalled()
+  })
+
+  it('drops resume ownership when the hidden worktree changes', async () => {
+    const hook = renderPanel()
+
+    act(() => hook.result.current.queryRowProps.onQueryChange(queryChange('beta')))
+    hook.rerender({ explorerView: 'search' })
+    hook.rerender({ explorerView: 'files' })
+
+    mocks.state.fileSearchStateByWorktree[SECOND_WORKTREE_ID] = makeFileSearchState('beta')
+    mocks.state.activeWorktreeId = SECOND_WORKTREE_ID
+    mocks.activeWorktree = { id: SECOND_WORKTREE_ID, path: '/other' }
+    hook.rerender({ explorerView: 'files' })
+    mocks.state.activeWorktreeId = WORKTREE_ID
+    mocks.activeWorktree = { id: WORKTREE_ID, path: '/repo' }
+    hook.rerender({ explorerView: 'files' })
+    hook.rerender({ explorerView: 'search' })
+    await act(async () => vi.advanceTimersByTimeAsync(300))
+
+    expect(mocks.searchRuntimeFiles).not.toHaveBeenCalled()
+  })
+})

--- a/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchPanel.ts
@@ -62,6 +62,7 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
   const seededInputSelectionRafRef = useRef<number | null>(null)
   const includeInputRef = useRef<HTMLInputElement>(null)
   const excludeInputRef = useRef<HTMLInputElement>(null)
+  const resumableSearchRef = useRef<{ worktreeId: string; query: string } | null>(null)
 
   const updateActiveSearchState = useCallback(
     (updates: Partial<NonNullable<typeof searchState>>) => {
@@ -174,11 +175,40 @@ export function useFileSearchPanel(explorerView: 'files' | 'search'): FileSearch
 
   const previousExplorerViewRef = useRef(explorerView)
   useEffect(() => {
-    if (previousExplorerViewRef.current !== 'search' && explorerView === 'search') {
+    const previousExplorerView = previousExplorerViewRef.current
+    const resumableSearch = resumableSearchRef.current
+    if (previousExplorerView === 'search' && explorerView !== 'search') {
+      resumableSearchRef.current =
+        cancelPendingSearch({ discardResults: true }) && activeWorktreeId
+          ? { worktreeId: activeWorktreeId, query: fileSearchQuery }
+          : null
+    } else if (previousExplorerView !== 'search' && explorerView === 'search') {
       focusQueryInput()
+      resumableSearchRef.current = null
+      if (
+        resumableSearch?.worktreeId === activeWorktreeId &&
+        resumableSearch.query === fileSearchQuery &&
+        fileSearchSeedRequestId === undefined
+      ) {
+        executeSearch(fileSearchQuery)
+      }
+    } else if (
+      explorerView !== 'search' &&
+      resumableSearch &&
+      (resumableSearch.worktreeId !== activeWorktreeId || resumableSearch.query !== fileSearchQuery)
+    ) {
+      resumableSearchRef.current = null
     }
     previousExplorerViewRef.current = explorerView
-  }, [explorerView, focusQueryInput])
+  }, [
+    activeWorktreeId,
+    cancelPendingSearch,
+    executeSearch,
+    explorerView,
+    fileSearchQuery,
+    fileSearchSeedRequestId,
+    focusQueryInput
+  ])
 
   const handleClearSearch = useCallback(() => {
     cancelPendingSearch()

--- a/src/renderer/src/components/right-sidebar/useFileSearchRunner.test.tsx
+++ b/src/renderer/src/components/right-sidebar/useFileSearchRunner.test.tsx
@@ -29,27 +29,70 @@ const RESULTS: SearchResult = {
   truncated: false
 }
 
+type SearchRunnerProps = {
+  activeWorktreeId: string
+  worktreePath: string
+}
+
 function renderSearchRunner(state: Record<string, unknown>, worktreeId: string) {
   const updates: Record<string, unknown>[] = []
+  const updateActiveSearchState = (update: Record<string, unknown>): void => {
+    updates.push(update)
+  }
   mocks.getState.mockImplementation(() => state)
   mocks.searchRuntimeFiles.mockResolvedValue(RESULTS)
 
-  const hook = renderHook(() =>
-    useFileSearchRunner({
-      activeWorktreeId: worktreeId,
-      worktreePath: '/repo',
-      updateActiveSearchState: (update) => updates.push(update)
-    })
+  const hook = renderHook(
+    ({ activeWorktreeId, worktreePath }: SearchRunnerProps) =>
+      useFileSearchRunner({
+        activeWorktreeId,
+        worktreePath,
+        updateActiveSearchState
+      }),
+    { initialProps: { activeWorktreeId: worktreeId, worktreePath: '/repo' } }
   )
 
   return { hook, updates }
 }
 
-async function finishSearch(executeSearch: (query: string) => void): Promise<void> {
+async function startSearch(executeSearch: (query: string) => void, query = 'owner'): Promise<void> {
   await act(async () => {
-    executeSearch('owner')
+    executeSearch(query)
     await vi.advanceTimersByTimeAsync(300)
   })
+}
+
+function mockPendingSearches(): AbortSignal[] {
+  const signals: AbortSignal[] = []
+  mocks.searchRuntimeFiles.mockImplementation(
+    (_context: unknown, _options: unknown, signal?: AbortSignal): Promise<SearchResult> => {
+      if (!signal) {
+        return Promise.reject(new Error('Expected an abort signal'))
+      }
+      signals.push(signal)
+      return new Promise((_resolve, reject) => {
+        signal.addEventListener(
+          'abort',
+          () => {
+            const error = new Error('Search aborted')
+            error.name = 'AbortError'
+            reject(error)
+          },
+          { once: true }
+        )
+      })
+    }
+  )
+  return signals
+}
+
+function makeSearchState(...worktreeIds: string[]): Record<string, unknown> {
+  return {
+    settings: { activeRuntimeEnvironmentId: null },
+    repos: [],
+    worktreesByRepo: {},
+    fileSearchStateByWorktree: Object.fromEntries(worktreeIds.map((id) => [id, {}]))
+  }
 }
 
 describe('useFileSearchRunner result ownership', () => {
@@ -60,6 +103,7 @@ describe('useFileSearchRunner result ownership', () => {
 
   afterEach(() => {
     vi.useRealTimers()
+    vi.restoreAllMocks()
     vi.clearAllMocks()
   })
 
@@ -75,14 +119,15 @@ describe('useFileSearchRunner result ownership', () => {
     }
     const { hook, updates } = renderSearchRunner(state, worktreeId)
 
-    await finishSearch(hook.result.current.executeSearch)
+    await startSearch(hook.result.current.executeSearch)
 
     expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
       expect.objectContaining({
         settings: { activeRuntimeEnvironmentId: 'search-runtime-a' },
         worktreeId
       }),
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(AbortSignal)
     )
     expect(updates).toContainEqual({
       results: RESULTS,
@@ -105,11 +150,12 @@ describe('useFileSearchRunner result ownership', () => {
     }
     const { hook, updates } = renderSearchRunner(state, worktreeId)
 
-    await finishSearch(hook.result.current.executeSearch)
+    await startSearch(hook.result.current.executeSearch)
 
     expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
       expect.objectContaining({ settings: { activeRuntimeEnvironmentId: null }, worktreeId }),
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(AbortSignal)
     )
     expect(updates).toContainEqual({
       results: RESULTS,
@@ -130,7 +176,7 @@ describe('useFileSearchRunner result ownership', () => {
     mocks.getConnectionId.mockReturnValue('ssh-target')
     const { hook, updates } = renderSearchRunner(state, worktreeId)
 
-    await finishSearch(hook.result.current.executeSearch)
+    await startSearch(hook.result.current.executeSearch)
 
     expect(mocks.searchRuntimeFiles).toHaveBeenCalledWith(
       expect.objectContaining({
@@ -138,7 +184,8 @@ describe('useFileSearchRunner result ownership', () => {
         worktreeId,
         connectionId: 'ssh-target'
       }),
-      expect.any(Object)
+      expect.any(Object),
+      expect.any(AbortSignal)
     )
     expect(updates).toContainEqual({
       results: RESULTS,
@@ -156,11 +203,136 @@ describe('useFileSearchRunner result ownership', () => {
     }
     const { hook, updates } = renderSearchRunner(state, worktreeId)
 
-    await finishSearch(hook.result.current.executeSearch)
+    await startSearch(hook.result.current.executeSearch)
 
     expect(updates).toContainEqual({
       results: RESULTS,
       resultOwner: { worktreeId, runtimeEnvironmentId: null }
     })
+  })
+})
+
+describe('useFileSearchRunner cancellation', () => {
+  beforeEach(() => {
+    vi.useFakeTimers()
+    mocks.getConnectionId.mockReturnValue(null)
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+    vi.restoreAllMocks()
+    vi.clearAllMocks()
+  })
+
+  it('keeps only the newest of 100 started searches live', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const { hook } = renderSearchRunner(makeSearchState(worktreeId), worktreeId)
+    const signals = mockPendingSearches()
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    for (let index = 0; index < 100; index += 1) {
+      await startSearch(hook.result.current.executeSearch, `owner-${index}`)
+    }
+
+    expect(mocks.searchRuntimeFiles).toHaveBeenCalledTimes(100)
+    expect(signals.filter((signal) => signal.aborted)).toHaveLength(99)
+    expect(signals.at(-1)?.aborted).toBe(false)
+    expect(consoleError).not.toHaveBeenCalled()
+  })
+
+  it('aborts the active search when Clear cancels pending work', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const { hook, updates } = renderSearchRunner(makeSearchState(worktreeId), worktreeId)
+    const signals = mockPendingSearches()
+
+    await startSearch(hook.result.current.executeSearch)
+    let didCancel = false
+    act(() => {
+      didCancel = hook.result.current.cancelPendingSearch()
+    })
+
+    expect(didCancel).toBe(true)
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.aborted).toBe(true)
+    expect(updates.at(-1)).toEqual({ loading: false })
+  })
+
+  it('reports canceled debounce work only once', () => {
+    const worktreeId = 'repo-a::/repo'
+    const { hook } = renderSearchRunner(makeSearchState(worktreeId), worktreeId)
+
+    act(() => hook.result.current.executeSearch('pending'))
+    let firstCancellation = false
+    let secondCancellation = true
+    act(() => {
+      firstCancellation = hook.result.current.cancelPendingSearch()
+      secondCancellation = hook.result.current.cancelPendingSearch()
+    })
+
+    expect(firstCancellation).toBe(true)
+    expect(secondCancellation).toBe(false)
+    expect(mocks.searchRuntimeFiles).not.toHaveBeenCalled()
+  })
+
+  it('reports no pending work after a search completes', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const { hook } = renderSearchRunner(makeSearchState(worktreeId), worktreeId)
+
+    await startSearch(hook.result.current.executeSearch)
+    let didCancel = true
+    act(() => {
+      didCancel = hook.result.current.cancelPendingSearch()
+    })
+
+    expect(didCancel).toBe(false)
+  })
+
+  it('aborts the active search on unmount', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const { hook } = renderSearchRunner(makeSearchState(worktreeId), worktreeId)
+    const signals = mockPendingSearches()
+
+    await startSearch(hook.result.current.executeSearch)
+    await act(async () => {
+      hook.unmount()
+      await Promise.resolve()
+    })
+
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.aborted).toBe(true)
+  })
+
+  it('aborts the active search when the worktree changes', async () => {
+    const firstWorktreeId = 'repo-a::/repo-a'
+    const secondWorktreeId = 'repo-b::/repo-b'
+    const { hook } = renderSearchRunner(
+      makeSearchState(firstWorktreeId, secondWorktreeId),
+      firstWorktreeId
+    )
+    const signals = mockPendingSearches()
+
+    await startSearch(hook.result.current.executeSearch)
+    await act(async () => {
+      hook.rerender({ activeWorktreeId: secondWorktreeId, worktreePath: '/repo-b' })
+      await Promise.resolve()
+    })
+
+    expect(signals).toHaveLength(1)
+    expect(signals[0]?.aborted).toBe(true)
+  })
+
+  it('treats AbortError as silent cancellation', async () => {
+    const worktreeId = 'repo-a::/repo'
+    const { hook, updates } = renderSearchRunner(makeSearchState(worktreeId), worktreeId)
+    const error = new Error('Search aborted')
+    error.name = 'AbortError'
+    mocks.searchRuntimeFiles.mockRejectedValue(error)
+    const consoleError = vi.spyOn(console, 'error').mockImplementation(() => {})
+
+    await startSearch(hook.result.current.executeSearch)
+
+    expect(consoleError).not.toHaveBeenCalled()
+    expect(updates.filter((update) => 'results' in update)).toEqual([])
+    expect(updates.at(-1)).toEqual({ loading: false })
   })
 })

--- a/src/renderer/src/components/right-sidebar/useFileSearchRunner.ts
+++ b/src/renderer/src/components/right-sidebar/useFileSearchRunner.ts
@@ -28,27 +28,44 @@ type UseFileSearchRunnerArgs = {
   updateActiveSearchState: UpdateSearchState
 }
 
+type CancelPendingSearchOptions = {
+  discardResults?: boolean
+}
+
 export function useFileSearchRunner({
   activeWorktreeId,
   worktreePath,
   updateActiveSearchState
 }: UseFileSearchRunnerArgs): {
   executeSearch: (query: string) => void
-  cancelPendingSearch: () => void
+  cancelPendingSearch: (options?: CancelPendingSearchOptions) => boolean
 } {
   const searchTimerRef = useRef<ReturnType<typeof setTimeout> | null>(null)
+  const activeSearchControllerRef = useRef<AbortController | null>(null)
   // Why: runtime searches can finish out of order; ids keep stale results
   // from overwriting the newest query state.
   const latestSearchIdRef = useRef(0)
 
-  const cancelPendingSearch = useCallback(() => {
-    latestSearchIdRef.current += 1
-    if (searchTimerRef.current) {
-      clearTimeout(searchTimerRef.current)
-      searchTimerRef.current = null
-    }
-    updateActiveSearchState({ loading: false })
-  }, [updateActiveSearchState])
+  const cancelPendingSearch = useCallback(
+    (options: CancelPendingSearchOptions = {}) => {
+      const hadPendingSearch =
+        searchTimerRef.current !== null || activeSearchControllerRef.current !== null
+      latestSearchIdRef.current += 1
+      if (searchTimerRef.current) {
+        clearTimeout(searchTimerRef.current)
+        searchTimerRef.current = null
+      }
+      activeSearchControllerRef.current?.abort()
+      activeSearchControllerRef.current = null
+      updateActiveSearchState(
+        options.discardResults && hadPendingSearch
+          ? { results: null, resultOwner: null, loading: false }
+          : { loading: false }
+      )
+      return hadPendingSearch
+    },
+    [updateActiveSearchState]
+  )
 
   const executeSearch = useCallback(
     (query: string) => {
@@ -59,6 +76,8 @@ export function useFileSearchRunner({
         clearTimeout(searchTimerRef.current)
         searchTimerRef.current = null
       }
+      activeSearchControllerRef.current?.abort()
+      activeSearchControllerRef.current = null
 
       if (!worktreePath || !activeWorktreeId) {
         updateActiveSearchState({ results: null, resultOwner: null, loading: false })
@@ -90,6 +109,8 @@ export function useFileSearchRunner({
       updateActiveSearchState({ loading: true })
       searchTimerRef.current = setTimeout(async () => {
         searchTimerRef.current = null
+        const controller = new AbortController()
+        activeSearchControllerRef.current = controller
         // Why: results can outlive the selected worktree; clicks must reuse the route that produced them.
         const runtimeSettings = getRightSidebarWorktreeRuntimeSettings(activeWorktreeId)
         const resultOwner = createFileSearchResultOwner(activeWorktreeId, runtimeSettings)
@@ -129,12 +150,16 @@ export function useFileSearchRunner({
               includePattern: activeSearchState?.includePattern || undefined,
               excludePattern: activeSearchState?.excludePattern || undefined,
               maxResults: SEARCH_MAX_RESULTS
-            }
+            },
+            controller.signal
           )
           if (latestSearchIdRef.current === searchId) {
             updateActiveSearchState({ results, resultOwner })
           }
         } catch (err) {
+          if (controller.signal.aborted || (err instanceof Error && err.name === 'AbortError')) {
+            return
+          }
           console.error('Search failed:', err)
           if (latestSearchIdRef.current === searchId) {
             updateActiveSearchState({
@@ -143,6 +168,9 @@ export function useFileSearchRunner({
             })
           }
         } finally {
+          if (activeSearchControllerRef.current === controller) {
+            activeSearchControllerRef.current = null
+          }
           if (latestSearchIdRef.current === searchId) {
             updateActiveSearchState({ loading: false })
           }
@@ -152,7 +180,12 @@ export function useFileSearchRunner({
     [activeWorktreeId, updateActiveSearchState, worktreePath]
   )
 
-  useEffect(() => cancelPendingSearch, [cancelPendingSearch])
+  useEffect(
+    () => () => {
+      cancelPendingSearch({ discardResults: true })
+    },
+    [activeWorktreeId, cancelPendingSearch, worktreePath]
+  )
 
   return { executeSearch, cancelPendingSearch }
 }

--- a/src/renderer/src/runtime/abortable-runtime-environment-call.test.ts
+++ b/src/renderer/src/runtime/abortable-runtime-environment-call.test.ts
@@ -1,0 +1,53 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { callAbortableRuntimeEnvironment } from './abortable-runtime-environment-call'
+
+function deferred<T>(): {
+  promise: Promise<T>
+  resolve: (value: T) => void
+} {
+  let resolve!: (value: T) => void
+  const promise = new Promise<T>((promiseResolve) => {
+    resolve = promiseResolve
+  })
+  return { promise, resolve }
+}
+
+describe('callAbortableRuntimeEnvironment', () => {
+  afterEach(() => {
+    vi.unstubAllGlobals()
+  })
+
+  it('cancels pending setup by id and unsubscribes a late handle', async () => {
+    const subscription = deferred<{ unsubscribe: () => void; sendBinary: () => void }>()
+    const unsubscribe = vi.fn()
+    const subscribe = vi.fn(
+      (_args: { subscriptionId?: string }, _callbacks: unknown) => subscription.promise
+    )
+    const cancelSubscription = vi.fn().mockResolvedValue({ unsubscribed: true })
+    vi.stubGlobal('window', {
+      api: { runtimeEnvironments: { subscribe, cancelSubscription } }
+    })
+    const controller = new AbortController()
+    const call = callAbortableRuntimeEnvironment(
+      'environment-1',
+      'files.search',
+      { query: 'needle' },
+      15_000,
+      controller.signal
+    )
+    const rejection = expect(call).rejects.toMatchObject({ name: 'AbortError' })
+    const subscriptionId = subscribe.mock.calls[0]?.[0].subscriptionId
+    if (!subscriptionId) {
+      throw new Error('Expected renderer-selected subscription id')
+    }
+
+    controller.abort()
+
+    await rejection
+    expect(cancelSubscription).toHaveBeenCalledWith({ subscriptionId })
+    expect(unsubscribe).not.toHaveBeenCalled()
+
+    subscription.resolve({ unsubscribe, sendBinary: vi.fn() })
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce())
+  })
+})

--- a/src/renderer/src/runtime/abortable-runtime-environment-call.ts
+++ b/src/renderer/src/runtime/abortable-runtime-environment-call.ts
@@ -1,4 +1,5 @@
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { createBrowserUuid } from '../lib/browser-uuid'
 
 export function createRuntimeRpcAbortError(): Error {
   const error = new Error('Runtime request aborted')
@@ -17,6 +18,7 @@ export async function callAbortableRuntimeEnvironment(
   if (signal.aborted) {
     throw createRuntimeRpcAbortError()
   }
+  const subscriptionId = createBrowserUuid()
   // Why: the one-shot runtime call bridge cannot cancel host work; the
   // subscription bridge closes its request context when we unsubscribe.
   return new Promise((resolve, reject) => {
@@ -40,14 +42,27 @@ export async function callAbortableRuntimeEnvironment(
         clearTimeout(deadline)
       }
       signal.removeEventListener('abort', onAbort)
-      handle?.unsubscribe()
+      if (handle) {
+        handle.unsubscribe()
+      } else {
+        // Why: setup can still be opening a dedicated remote socket, before a
+        // handle exists; cancel by id so superseded calls do not fan out sockets.
+        void window.api.runtimeEnvironments.cancelSubscription?.({ subscriptionId }).catch(() => {})
+      }
       complete()
     }
     const onAbort = (): void => finish(() => reject(createRuntimeRpcAbortError()))
     signal.addEventListener('abort', onAbort, { once: true })
     void window.api.runtimeEnvironments
       .subscribe(
-        { selector: environmentId, method, params, timeoutMs, expectedEnvironmentPairingRevision },
+        {
+          selector: environmentId,
+          method,
+          params,
+          timeoutMs,
+          expectedEnvironmentPairingRevision,
+          subscriptionId
+        },
         {
           onResponse: (response) => finish(() => resolve(response)),
           onError: (error) => finish(() => reject(new Error(error.message))),

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -2136,7 +2136,8 @@ describe('runtime file client', () => {
         method: 'files.search',
         params: { worktree: 'id:wt-1', query: 'needle', maxResults: 50 },
         timeoutMs: 15_000,
-        expectedEnvironmentPairingRevision: undefined
+        expectedEnvironmentPairingRevision: undefined,
+        subscriptionId: expect.any(String)
       },
       expect.any(Object)
     )

--- a/src/renderer/src/runtime/runtime-file-client.test.ts
+++ b/src/renderer/src/runtime/runtime-file-client.test.ts
@@ -46,6 +46,7 @@ const fsDeletePath = vi.fn()
 const fsStat = vi.fn()
 const fsPathExists = vi.fn()
 const fsSearch = vi.fn()
+const fsCancelSearch = vi.fn()
 const fsListFiles = vi.fn()
 const fsCancelListFiles = vi.fn()
 const fsDownloadFile = vi.fn()
@@ -76,6 +77,8 @@ beforeEach(() => {
   fsStat.mockReset()
   fsPathExists.mockReset()
   fsSearch.mockReset()
+  fsCancelSearch.mockReset()
+  fsCancelSearch.mockResolvedValue(undefined)
   fsListFiles.mockReset()
   fsCancelListFiles.mockReset()
   fsCancelListFiles.mockResolvedValue(undefined)
@@ -120,6 +123,7 @@ beforeEach(() => {
         stat: fsStat,
         pathExists: fsPathExists,
         search: fsSearch,
+        cancelSearch: fsCancelSearch,
         listFiles: fsListFiles,
         cancelListFiles: fsCancelListFiles,
         downloadFile: fsDownloadFile,
@@ -2023,6 +2027,120 @@ describe('runtime file client', () => {
       params: { worktree: 'id:wt-1', query: 'needle', caseSensitive: true, maxResults: 50 },
       timeoutMs: 15_000
     })
+  })
+
+  it('pairs local text-search cancellation with its request token', async () => {
+    const controller = new AbortController()
+    let resolveSearch!: (result: {
+      files: never[]
+      totalMatches: number
+      truncated: boolean
+    }) => void
+    fsSearch.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          resolveSearch = resolve
+        })
+    )
+
+    const request = searchRuntimeFiles(
+      {
+        settings: { activeRuntimeEnvironmentId: null },
+        worktreeId: 'wt-1',
+        worktreePath: '/repo',
+        connectionId: 'ssh-1'
+      },
+      { query: 'needle', rootPath: '/repo', maxResults: 50 },
+      controller.signal
+    )
+    await vi.waitFor(() => expect(fsSearch).toHaveBeenCalledOnce())
+    const searchArgs = fsSearch.mock.calls[0]?.[0] as { requestToken?: string }
+
+    controller.abort()
+    resolveSearch({ files: [], totalMatches: 0, truncated: false })
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+    expect(fsSearch).toHaveBeenCalledWith({
+      query: 'needle',
+      rootPath: '/repo',
+      maxResults: 50,
+      connectionId: 'ssh-1',
+      requestToken: expect.any(String)
+    })
+    expect(fsCancelSearch).toHaveBeenCalledWith({ requestToken: searchArgs.requestToken })
+  })
+
+  it('starts no local text search for a pre-aborted signal', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      searchRuntimeFiles(
+        {
+          settings: { activeRuntimeEnvironmentId: null },
+          worktreeId: 'wt-1',
+          worktreePath: '/repo'
+        },
+        { query: 'needle', rootPath: '/repo', maxResults: 50 },
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(fsSearch).not.toHaveBeenCalled()
+    expect(fsCancelSearch).not.toHaveBeenCalled()
+  })
+
+  it('starts no paired-runtime work for a pre-aborted text search', async () => {
+    const controller = new AbortController()
+    controller.abort()
+
+    await expect(
+      searchRuntimeFiles(
+        {
+          settings: { activeRuntimeEnvironmentId: 'env-1' },
+          worktreeId: 'wt-1',
+          worktreePath: '/remote/repo'
+        },
+        { query: 'needle', rootPath: '/remote/repo', maxResults: 50 },
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+
+    expect(runtimeEnvironmentTransportCall).not.toHaveBeenCalled()
+    expect(runtimeEnvironmentSubscribe).not.toHaveBeenCalled()
+  })
+
+  it('uses an abortable subscription for paired-runtime text search', async () => {
+    const controller = new AbortController()
+    const unsubscribe = vi.fn()
+    runtimeEnvironmentSubscribe.mockResolvedValue({ unsubscribe, sendBinary: vi.fn() })
+
+    const request = searchRuntimeFiles(
+      {
+        settings: { activeRuntimeEnvironmentId: 'env-1' },
+        worktreeId: 'wt-1',
+        worktreePath: '/remote/repo'
+      },
+      { query: 'needle', rootPath: '/remote/repo', maxResults: 50 },
+      controller.signal
+    )
+    await vi.waitFor(() => expect(runtimeEnvironmentSubscribe).toHaveBeenCalledOnce())
+
+    controller.abort()
+
+    await expect(request).rejects.toMatchObject({ name: 'AbortError' })
+    await vi.waitFor(() => expect(unsubscribe).toHaveBeenCalledOnce())
+    expect(runtimeEnvironmentSubscribe).toHaveBeenCalledWith(
+      {
+        selector: 'env-1',
+        method: 'files.search',
+        params: { worktree: 'id:wt-1', query: 'needle', maxResults: 50 },
+        timeoutMs: 15_000,
+        expectedEnvironmentPairingRevision: undefined
+      },
+      expect.any(Object)
+    )
+    expect(fsSearch).not.toHaveBeenCalled()
   })
 
   it('rejects oversized text search input before local IPC or runtime RPC', async () => {

--- a/src/renderer/src/runtime/runtime-file-client.ts
+++ b/src/renderer/src/runtime/runtime-file-client.ts
@@ -37,6 +37,7 @@ import {
   captureRuntimeEnvironmentRequestRevision,
   getRuntimeEnvironmentRevision
 } from './runtime-environment-revision'
+import { createBrowserUuid } from '@/lib/browser-uuid'
 
 export type RuntimeReadableFileContent = {
   content: string
@@ -929,25 +930,58 @@ async function ensureRuntimeDirectory(
 
 export async function searchRuntimeFiles(
   context: RuntimeFileOperationArgs,
-  options: SearchOptions
+  options: SearchOptions,
+  signal?: AbortSignal
 ): Promise<SearchResult> {
   if (getRuntimeFileSearchRejectedField(options)) {
     return createEmptyRuntimeFileSearchResult()
   }
+  if (signal?.aborted) {
+    throw createRuntimeFileSearchAbortError()
+  }
   const target = getActiveRuntimeTarget(context.settings)
   if (target.kind !== 'environment' || !context.worktreeId) {
-    return window.api.fs.search({
-      ...options,
-      connectionId: context.connectionId
-    })
+    return searchLocalRuntimeFiles({ ...options, connectionId: context.connectionId }, signal)
   }
   const { rootPath: _rootPath, ...runtimeOptions } = options
   return callRuntimeRpc<SearchResult>(
     target,
     'files.search',
     { worktree: toRuntimeWorktreeSelector(context.worktreeId), ...runtimeOptions },
-    { timeoutMs: 15_000 }
+    { timeoutMs: 15_000, signal }
   )
+}
+
+function createRuntimeFileSearchAbortError(): Error {
+  const error = new Error('Runtime file search aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+async function searchLocalRuntimeFiles(
+  args: SearchOptions & { connectionId?: string },
+  signal?: AbortSignal
+): Promise<SearchResult> {
+  if (!signal) {
+    return window.api.fs.search(args)
+  }
+  if (signal.aborted) {
+    throw createRuntimeFileSearchAbortError()
+  }
+  const requestToken = createBrowserUuid()
+  const cancel = (): void => {
+    void window.api.fs.cancelSearch({ requestToken }).catch(() => {})
+  }
+  signal.addEventListener('abort', cancel, { once: true })
+  try {
+    const result = await window.api.fs.search({ ...args, requestToken })
+    if (signal.aborted) {
+      throw createRuntimeFileSearchAbortError()
+    }
+    return result
+  } finally {
+    signal.removeEventListener('abort', cancel)
+  }
 }
 
 export async function listRuntimeFiles(

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -468,6 +468,73 @@ describe('web runtime environment identity', () => {
     })
   })
 
+  it('keeps a reused subscription id owned by its newest pending setup', async () => {
+    const signals: AbortSignal[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        subscribe(
+          _method: string,
+          _params: unknown,
+          _callbacks: unknown,
+          options?: { signal?: AbortSignal }
+        ): Promise<never> {
+          const signal = options?.signal
+          if (!signal) {
+            throw new Error('Expected pending subscription setup signal')
+          }
+          signals.push(signal)
+          return new Promise((_resolve, reject) => {
+            signal.addEventListener(
+              'abort',
+              () => {
+                const error = new Error('aborted')
+                error.name = 'AbortError'
+                reject(error)
+              },
+              { once: true }
+            )
+          })
+        }
+
+        close(): void {}
+      }
+    }))
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage, 'web-server-a')
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    const args = {
+      selector: 'web-server-a',
+      method: 'files.search',
+      subscriptionId: 'reused-sub'
+    }
+
+    const first = globals.window.api.runtimeEnvironments.subscribe(args, {
+      onResponse: vi.fn()
+    })
+    const firstRejection = expect(first).rejects.toMatchObject({ name: 'AbortError' })
+    const second = globals.window.api.runtimeEnvironments.subscribe(args, {
+      onResponse: vi.fn()
+    })
+    const secondRejection = expect(second).rejects.toMatchObject({ name: 'AbortError' })
+
+    await firstRejection
+    expect(signals).toHaveLength(2)
+    expect(signals[0]?.aborted).toBe(true)
+    expect(signals[1]?.aborted).toBe(false)
+    await expect(
+      globals.window.api.runtimeEnvironments.cancelSubscription?.({
+        subscriptionId: 'reused-sub'
+      })
+    ).resolves.toEqual({ unsubscribed: true })
+    await secondRejection
+    await expect(
+      globals.window.api.runtimeEnvironments.cancelSubscription?.({
+        subscriptionId: 'reused-sub'
+      })
+    ).resolves.toEqual({ unsubscribed: false })
+  })
+
   it.each(['active runtime', 'selected environment'] as const)(
     'returns a disconnect envelope when a queued %s call disconnects',
     async (route) => {

--- a/src/renderer/src/web/web-preload-api.test.ts
+++ b/src/renderer/src/web/web-preload-api.test.ts
@@ -3421,6 +3421,29 @@ describe('web SSH preload API', () => {
 })
 
 describe('web file preload API', () => {
+  const webFileWorktree = {
+    id: 'wt-1',
+    repoId: 'repo-1',
+    path: '/workspace/repo',
+    head: 'abc123',
+    branch: 'refs/heads/main',
+    isBare: false,
+    isMainWorktree: true,
+    displayName: 'repo',
+    comment: '',
+    linkedIssue: null,
+    linkedPR: null,
+    linkedLinearIssue: null,
+    linkedGitLabMR: null,
+    linkedGitLabIssue: null,
+    isArchived: false,
+    isUnread: false,
+    isPinned: false,
+    sortOrder: 0,
+    lastActivityAt: 0,
+    workspaceStatus: 'todo'
+  }
+
   beforeEach(() => {
     vi.resetModules()
   })
@@ -3455,28 +3478,6 @@ describe('web file preload API', () => {
 
   it('returns false for runtime missing-path errors from fs.pathExists', async () => {
     const runtimeCalls: { method: string; params: unknown }[] = []
-    const worktree = {
-      id: 'wt-1',
-      repoId: 'repo-1',
-      path: '/workspace/repo',
-      head: 'abc123',
-      branch: 'refs/heads/main',
-      isBare: false,
-      isMainWorktree: true,
-      displayName: 'repo',
-      comment: '',
-      linkedIssue: null,
-      linkedPR: null,
-      linkedLinearIssue: null,
-      linkedGitLabMR: null,
-      linkedGitLabIssue: null,
-      isArchived: false,
-      isUnread: false,
-      isPinned: false,
-      sortOrder: 0,
-      lastActivityAt: 0,
-      workspaceStatus: 'todo'
-    }
     vi.doMock('./web-runtime-client', () => ({
       WebRuntimeClient: class {
         call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
@@ -3493,7 +3494,11 @@ describe('web file preload API', () => {
             return Promise.resolve({
               id: `call-${runtimeCalls.length}`,
               ok: true,
-              result: { repoId: 'repo-1', authoritative: true, worktrees: [worktree] },
+              result: {
+                repoId: 'repo-1',
+                authoritative: true,
+                worktrees: [webFileWorktree]
+              },
               _meta: { runtimeId: 'runtime-1' }
             })
           }
@@ -3522,6 +3527,218 @@ describe('web file preload API', () => {
       { method: 'worktree.detectedList', params: { repo: 'repo-1' } },
       { method: 'files.stat', params: { worktree: 'id:wt-1', relativePath: 'untitled.md' } }
     ])
+  })
+
+  it('keeps untokenized search unary and cancels only the matching tokenized subscription', async () => {
+    const runtimeCalls: { method: string; params: unknown }[] = []
+    const subscriptions: {
+      method: string
+      params: unknown
+      onResponse: (response: RuntimeRpcResponse<unknown>) => void
+      unsubscribe: ReturnType<typeof vi.fn>
+    }[] = []
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string, params?: unknown): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeCalls.push({ method, params })
+          const result =
+            method === 'repo.list'
+              ? { repos: [{ id: 'repo-1' }] }
+              : method === 'worktree.detectedList'
+                ? { repoId: 'repo-1', authoritative: true, worktrees: [webFileWorktree] }
+                : { files: [], totalMatches: 0, truncated: false }
+          return Promise.resolve({
+            id: `call-${runtimeCalls.length}`,
+            ok: true,
+            result,
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        subscribe(
+          method: string,
+          params: unknown,
+          callbacks: { onResponse: (response: RuntimeRpcResponse<unknown>) => void }
+        ): Promise<{ unsubscribe: () => void }> {
+          const subscription = {
+            method,
+            params,
+            onResponse: callbacks.onResponse,
+            unsubscribe: vi.fn()
+          }
+          subscriptions.push(subscription)
+          return Promise.resolve({ unsubscribe: subscription.unsubscribe })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    const searchArgs = { rootPath: '/workspace/repo', query: 'needle' }
+
+    await expect(globals.window.api.fs.search(searchArgs)).resolves.toEqual({
+      files: [],
+      totalMatches: 0,
+      truncated: false
+    })
+    expect(subscriptions).toHaveLength(0)
+
+    const firstSearch = globals.window.api.fs.search({ ...searchArgs, requestToken: 'search-1' })
+    const firstRejection = expect(firstSearch).rejects.toMatchObject({ name: 'AbortError' })
+    const secondSearch = globals.window.api.fs.search({ ...searchArgs, requestToken: 'search-2' })
+    const secondSearchSettled = trackPromiseSettled(secondSearch)
+    await vi.waitFor(() => expect(subscriptions).toHaveLength(2))
+    await Promise.resolve()
+
+    await globals.window.api.fs.cancelSearch({ requestToken: 'search-1' })
+    await firstRejection
+    expect(subscriptions[0].unsubscribe).toHaveBeenCalledOnce()
+    expect(subscriptions[1].unsubscribe).not.toHaveBeenCalled()
+    expect(secondSearchSettled()).toBe(false)
+
+    subscriptions[1].onResponse({
+      id: 'search-2',
+      ok: true,
+      result: { files: [], totalMatches: 0, truncated: false },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+    await expect(secondSearch).resolves.toEqual({ files: [], totalMatches: 0, truncated: false })
+    expect(subscriptions[1].unsubscribe).toHaveBeenCalledOnce()
+    await globals.window.api.fs.cancelSearch({ requestToken: 'search-2' })
+    expect(subscriptions[1].unsubscribe).toHaveBeenCalledOnce()
+
+    expect(runtimeCalls.filter((call) => call.method === 'files.search')).toHaveLength(1)
+    expect(subscriptions.map(({ method }) => method)).toEqual(['files.search', 'files.search'])
+  })
+
+  it('cancels a token while its runtime file path is still resolving', async () => {
+    const runtimeMethods: string[] = []
+    const subscribe = vi.fn()
+    let resolveWorktrees!: (response: RuntimeRpcResponse<unknown>) => void
+    const pendingWorktrees = new Promise<RuntimeRpcResponse<unknown>>((resolve) => {
+      resolveWorktrees = resolve
+    })
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          runtimeMethods.push(method)
+          if (method === 'repo.list') {
+            return Promise.resolve({
+              id: 'repos',
+              ok: true,
+              result: { repos: [{ id: 'repo-1' }] },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          if (method === 'worktree.detectedList') {
+            return pendingWorktrees
+          }
+          return Promise.resolve({
+            id: method,
+            ok: true,
+            result: { files: [], totalMatches: 0, truncated: false },
+            _meta: { runtimeId: 'runtime-1' }
+          })
+        }
+
+        subscribe = subscribe
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+
+    const search = globals.window.api.fs.search({
+      rootPath: '/workspace/repo',
+      query: 'needle',
+      requestToken: 'search-during-resolution'
+    })
+    const rejection = expect(search).rejects.toMatchObject({ name: 'AbortError' })
+    await vi.waitFor(() => expect(runtimeMethods).toContain('worktree.detectedList'))
+    await globals.window.api.fs.cancelSearch({ requestToken: 'search-during-resolution' })
+    resolveWorktrees({
+      id: 'worktrees',
+      ok: true,
+      result: { repoId: 'repo-1', authoritative: true, worktrees: [webFileWorktree] },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+
+    await rejection
+    expect(subscribe).not.toHaveBeenCalled()
+    expect(runtimeMethods).not.toContain('files.search')
+  })
+
+  it('keeps a reused token owned by its successor after aborting the predecessor', async () => {
+    const subscriptions: {
+      params: unknown
+      unsubscribe: ReturnType<typeof vi.fn>
+    }[] = []
+    let resolveWorktrees!: (response: RuntimeRpcResponse<unknown>) => void
+    const pendingWorktrees = new Promise<RuntimeRpcResponse<unknown>>((resolve) => {
+      resolveWorktrees = resolve
+    })
+    vi.doMock('./web-runtime-client', () => ({
+      WebRuntimeClient: class {
+        call(method: string): Promise<RuntimeRpcResponse<unknown>> {
+          if (method === 'repo.list') {
+            return Promise.resolve({
+              id: 'repos',
+              ok: true,
+              result: { repos: [{ id: 'repo-1' }] },
+              _meta: { runtimeId: 'runtime-1' }
+            })
+          }
+          return pendingWorktrees
+        }
+
+        subscribe(_method: string, params: unknown): Promise<{ unsubscribe: () => void }> {
+          const subscription = { params, unsubscribe: vi.fn() }
+          subscriptions.push(subscription)
+          return Promise.resolve({ unsubscribe: subscription.unsubscribe })
+        }
+
+        close(): void {}
+      }
+    }))
+
+    const globals = installBrowserGlobals('Linux')
+    writeStoredRuntimeEnvironment(globals.storage)
+    const { installWebPreloadApi } = await import('./web-preload-api')
+    installWebPreloadApi()
+    const requestToken = 'reused-search-token'
+    const firstSearch = globals.window.api.fs.search({
+      rootPath: '/workspace/repo',
+      query: 'first',
+      requestToken
+    })
+    const firstRejection = expect(firstSearch).rejects.toMatchObject({ name: 'AbortError' })
+    await Promise.resolve()
+    const secondSearch = globals.window.api.fs.search({
+      rootPath: '/workspace/repo',
+      query: 'second',
+      requestToken
+    })
+    const secondRejection = expect(secondSearch).rejects.toMatchObject({ name: 'AbortError' })
+    resolveWorktrees({
+      id: 'worktrees',
+      ok: true,
+      result: { repoId: 'repo-1', authoritative: true, worktrees: [webFileWorktree] },
+      _meta: { runtimeId: 'runtime-1' }
+    })
+
+    await firstRejection
+    await vi.waitFor(() => expect(subscriptions).toHaveLength(1))
+    expect(subscriptions[0].params).toMatchObject({ query: 'second' })
+    await globals.window.api.fs.cancelSearch({ requestToken })
+    await secondRejection
+    expect(subscriptions[0].unsubscribe).toHaveBeenCalledOnce()
   })
 })
 

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -182,6 +182,7 @@ let activeEnvironment: StoredWebRuntimeEnvironment | null = readStoredWebRuntime
 let activeClient: WebRuntimeClient | null = null
 let activeClientEnvironmentId: string | null = null
 const manuallyDisconnectedEnvironmentIds = new Set<string>()
+const webRuntimeSubscriptionSetupControllers = new Map<string, AbortController>()
 let cachedWorktrees: { loadedAt: number; worktrees: Worktree[] } | null = null
 let cachedDetectedWorktrees: { loadedAt: number; worktrees: Worktree[] } | null = null
 const runtimeCallQueuePool = new RuntimeRpcCallQueuePool()
@@ -1543,15 +1544,40 @@ function createRuntimeEnvironmentsApi(): NonNullable<Partial<PreloadApi>['runtim
       callEnvironmentEnvelope<RuntimeStatus>(selector, 'status.get', undefined, timeoutMs),
     call: ({ selector, method, params, timeoutMs }) =>
       callEnvironmentEnvelope(selector, method, params, timeoutMs),
-    subscribe: async ({ selector, method, params, timeoutMs }, callbacks) => {
+    subscribe: async ({ selector, method, params, timeoutMs, subscriptionId }, callbacks) => {
       const environment = resolveEnvironment(selector)
       const client = getClientForEnvironment(environment)
-      const subscription = await client.subscribe(method, params, callbacks, { timeoutMs })
-      if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
-        subscription.unsubscribe()
-        throw new Error('runtime_manually_disconnected')
+      const controller = subscriptionId ? new AbortController() : null
+      if (subscriptionId && controller) {
+        webRuntimeSubscriptionSetupControllers.get(subscriptionId)?.abort()
+        webRuntimeSubscriptionSetupControllers.set(subscriptionId, controller)
       }
-      return subscription
+      try {
+        const subscription = await client.subscribe(method, params, callbacks, {
+          timeoutMs,
+          signal: controller?.signal
+        })
+        if (manuallyDisconnectedEnvironmentIds.has(environment.id)) {
+          subscription.unsubscribe()
+          throw new Error('runtime_manually_disconnected')
+        }
+        return subscription
+      } finally {
+        if (
+          subscriptionId &&
+          webRuntimeSubscriptionSetupControllers.get(subscriptionId) === controller
+        ) {
+          webRuntimeSubscriptionSetupControllers.delete(subscriptionId)
+        }
+      }
+    },
+    cancelSubscription: async ({ subscriptionId }) => {
+      const controller = webRuntimeSubscriptionSetupControllers.get(subscriptionId)
+      if (webRuntimeSubscriptionSetupControllers.get(subscriptionId) === controller) {
+        webRuntimeSubscriptionSetupControllers.delete(subscriptionId)
+      }
+      controller?.abort()
+      return { unsubscribed: controller !== undefined }
     }
   }
 }
@@ -3671,6 +3697,10 @@ function getClientForEnvironment(environment: StoredWebRuntimeEnvironment): WebR
 }
 
 function closeActiveRuntimeClients(): void {
+  for (const controller of webRuntimeSubscriptionSetupControllers.values()) {
+    controller.abort()
+  }
+  webRuntimeSubscriptionSetupControllers.clear()
   activeClient?.close()
   activeClient = null
   activeClientEnvironmentId = null

--- a/src/renderer/src/web/web-preload-api.ts
+++ b/src/renderer/src/web/web-preload-api.ts
@@ -1893,6 +1893,36 @@ function createWorktreesApi(): NonNullable<Partial<PreloadApi>['worktrees']> {
   }
 }
 
+const webFileSearchAbortControllers = new Map<string, AbortController>()
+
+function startWebFileSearch(requestToken: string): AbortController {
+  const previous = webFileSearchAbortControllers.get(requestToken)
+  const controller = new AbortController()
+  // Why: publish the successor first so predecessor cleanup cannot delete it.
+  webFileSearchAbortControllers.set(requestToken, controller)
+  previous?.abort()
+  return controller
+}
+
+async function callAbortableRuntimeFileSearch(
+  params: unknown,
+  signal: AbortSignal
+): Promise<SearchResult> {
+  const environment = requireActiveEnvironment()
+  const response = await callAbortableRuntimeEnvironment(
+    environment.id,
+    'files.search',
+    params,
+    15_000,
+    signal
+  )
+  updateEnvironmentFromResponse(environment, response)
+  if (!response.ok) {
+    throw new Error(response.error.message)
+  }
+  return response.result as SearchResult
+}
+
 function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
   return {
     readDir: async ({ dirPath }) => {
@@ -1985,17 +2015,37 @@ function createFileApi(): NonNullable<Partial<PreloadApi>['fs']> {
       // Why: paired-web lists files over runtime RPC with its own timeout; there's no host-side scan to abort here.
     },
     search: async (args) => {
-      const file = await resolveRuntimeFilePath(args.rootPath)
-      return callRuntimeResult<SearchResult>('files.search', {
-        worktree: toRuntimeWorktreeSelector(file.worktree.id),
-        query: args.query,
-        caseSensitive: args.caseSensitive,
-        wholeWord: args.wholeWord,
-        useRegex: args.useRegex,
-        includePattern: args.includePattern,
-        excludePattern: args.excludePattern,
-        maxResults: args.maxResults
-      })
+      const requestToken = args.requestToken
+      const controller = requestToken ? startWebFileSearch(requestToken) : null
+      try {
+        const file = await resolveRuntimeFilePath(args.rootPath)
+        const params = {
+          worktree: toRuntimeWorktreeSelector(file.worktree.id),
+          query: args.query,
+          caseSensitive: args.caseSensitive,
+          wholeWord: args.wholeWord,
+          useRegex: args.useRegex,
+          includePattern: args.includePattern,
+          excludePattern: args.excludePattern,
+          maxResults: args.maxResults
+        }
+        if (!controller) {
+          return callRuntimeResult<SearchResult>('files.search', params)
+        }
+        const result = await callAbortableRuntimeFileSearch(params, controller.signal)
+        return result
+      } finally {
+        if (requestToken && webFileSearchAbortControllers.get(requestToken) === controller) {
+          webFileSearchAbortControllers.delete(requestToken)
+        }
+      }
+    },
+    cancelSearch: async ({ requestToken }) => {
+      const controller = webFileSearchAbortControllers.get(requestToken)
+      if (webFileSearchAbortControllers.get(requestToken) === controller) {
+        webFileSearchAbortControllers.delete(requestToken)
+      }
+      controller?.abort()
     },
     importExternalPaths: async () => ({ results: [] }),
     stageExternalPathsForRuntimeUpload: async () => ({ sources: [] }),

--- a/src/renderer/src/web/web-runtime-client.test.ts
+++ b/src/renderer/src/web/web-runtime-client.test.ts
@@ -131,6 +131,61 @@ describe('WebRuntimeClient', () => {
     expect(child.close).toHaveBeenCalledWith({ notifySubscriptions: false })
   })
 
+  it('starts no child subscription socket for a pre-aborted signal', async () => {
+    const client = new WebRuntimeClient({
+      v: 2,
+      endpoint: 'ws://127.0.0.1:6768',
+      deviceToken: 'token',
+      publicKeyB64: Buffer.alloc(32).toString('base64')
+    })
+    const controller = new AbortController()
+    controller.abort()
+
+    try {
+      await expect(
+        client.subscribe('files.search', {}, { onResponse: vi.fn() }, { signal: controller.signal })
+      ).rejects.toMatchObject({ name: 'AbortError' })
+      expect(fakeSockets).toHaveLength(1)
+    } finally {
+      client.close()
+    }
+  })
+
+  it('closes and releases a connecting child subscription when aborted', async () => {
+    const client = new WebRuntimeClient({
+      v: 2,
+      endpoint: 'ws://127.0.0.1:6768',
+      deviceToken: 'token',
+      publicKeyB64: Buffer.alloc(32).toString('base64')
+    })
+    const controller = new AbortController()
+    const internals = client as unknown as { childClients: Set<WebRuntimeClient> }
+    let pending: Promise<unknown> | null = null
+
+    try {
+      pending = client
+        .subscribe(
+          'files.search',
+          { query: 'needle' },
+          { onResponse: vi.fn() },
+          { signal: controller.signal }
+        )
+        .catch((error: unknown) => error)
+      const childSocket = fakeSockets[1]!
+      expect(fakeSockets).toHaveLength(2)
+      expect(internals.childClients.size).toBe(1)
+
+      controller.abort()
+
+      expect(childSocket.close).toHaveBeenCalledOnce()
+      expect(internals.childClients.size).toBe(0)
+      await expect(pending).resolves.toMatchObject({ name: 'AbortError' })
+    } finally {
+      client.close()
+      await pending
+    }
+  })
+
   it('does not report locally closed subscriptions as remote closes', () => {
     const client = new WebRuntimeClient({
       v: 2,

--- a/src/renderer/src/web/web-runtime-client.ts
+++ b/src/renderer/src/web/web-runtime-client.ts
@@ -59,6 +59,7 @@ export type WebRuntimeSubscriptionHandle = {
 
 export type SubscribeOptions = {
   timeoutMs?: number
+  signal?: AbortSignal
   // Why: token-keyed server cleanup needs an explicit unsubscribe to be reaped on view-toggle, not just socket close.
   buildUnsubscribe?: (params: unknown) => { method: string; params: unknown } | null
 }
@@ -72,6 +73,12 @@ const SHARED_CONNECTION_SUBSCRIPTION_METHODS = new Set(['files.watch'])
 const HEARTBEAT_INTERVAL_MS = 10_000
 const HEARTBEAT_IDLE_MS = 25_000
 const HEARTBEAT_PROBE_GRACE_MS = 20_000
+
+function createWebRuntimeSubscriptionAbortError(): Error {
+  const error = new Error('Remote runtime subscription aborted.')
+  error.name = 'AbortError'
+  return error
+}
 
 export class WebRuntimeClient {
   private ws: WebSocket | null = null
@@ -133,12 +140,17 @@ export class WebRuntimeClient {
       // Why: sharing the main socket for file watches avoids exhausting the server's WebSocket connection cap.
       return this.subscribeSharedFileWatch(params, callbacks, options)
     }
+    if (options?.signal?.aborted) {
+      throw createWebRuntimeSubscriptionAbortError()
+    }
     const client = new WebRuntimeClient(this.pairing)
     this.childClients.add(client)
     const closeChild = (notifySubscriptions = false): void => {
       this.childClients.delete(client)
       client.close({ notifySubscriptions })
     }
+    const onAbort = (): void => closeChild()
+    options?.signal?.addEventListener('abort', onAbort, { once: true })
     try {
       const wrappedCallbacks: SubscriptionCallbacks = {
         ...callbacks,
@@ -167,7 +179,12 @@ export class WebRuntimeClient {
       }
     } catch (error) {
       closeChild()
+      if (options?.signal?.aborted) {
+        throw createWebRuntimeSubscriptionAbortError()
+      }
       throw error
+    } finally {
+      options?.signal?.removeEventListener('abort', onAbort)
     }
   }
 

--- a/src/shared/remote-runtime-client.test.ts
+++ b/src/shared/remote-runtime-client.test.ts
@@ -35,6 +35,63 @@ afterEach(async () => {
 })
 
 describe('subscribeRemoteRuntimeRequest', () => {
+  it('rejects a pre-aborted subscription before reading pairing data', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const pairing = new Proxy({} as PairingOffer, {
+      get: () => {
+        throw new Error('Pairing data was read')
+      }
+    })
+
+    await expect(
+      subscribeRemoteRuntimeRequest(
+        pairing,
+        'terminal.subscribe',
+        {},
+        1000,
+        { onResponse: vi.fn(), onError: vi.fn() },
+        undefined,
+        controller.signal
+      )
+    ).rejects.toMatchObject({ name: 'AbortError' })
+  })
+
+  it('closes a connecting socket and removes its listener when setup is aborted', async () => {
+    const server = await createSubscriptionServer()
+    const controller = new AbortController()
+    const closeStates: number[] = []
+    const originalClose = WebSocketClient.prototype.close
+    const closeSpy = vi.spyOn(WebSocketClient.prototype, 'close').mockImplementation(function (
+      this: WebSocketClient,
+      ...args: Parameters<WebSocketClient['close']>
+    ) {
+      closeStates.push(this.readyState)
+      return originalClose.apply(this, args)
+    })
+    const removeListenerSpy = vi.spyOn(controller.signal, 'removeEventListener')
+    try {
+      const pending = subscribeRemoteRuntimeRequest(
+        server.pairing,
+        'terminal.subscribe',
+        {},
+        1000,
+        { onResponse: vi.fn(), onError: vi.fn() },
+        undefined,
+        controller.signal
+      )
+
+      controller.abort()
+
+      await expect(pending).rejects.toMatchObject({ name: 'AbortError' })
+      expect(closeStates).toEqual([WebSocketClient.CONNECTING])
+      expect(removeListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function))
+    } finally {
+      closeSpy.mockRestore()
+      removeListenerSpy.mockRestore()
+    }
+  })
+
   it('includes WebSocket close details when subscription admission is rejected', async () => {
     const server = await createClosingServer(1013, 'Maximum connections reached')
 
@@ -52,6 +109,8 @@ describe('subscribeRemoteRuntimeRequest', () => {
     const server = await createSubscriptionServer()
     const onResponse = vi.fn()
     const onError = vi.fn()
+    const controller = new AbortController()
+    const removeListenerSpy = vi.spyOn(controller.signal, 'removeEventListener')
 
     const subscription = await subscribeRemoteRuntimeRequest(
       server.pairing,
@@ -61,9 +120,12 @@ describe('subscribeRemoteRuntimeRequest', () => {
       {
         onResponse,
         onError
-      }
+      },
+      undefined,
+      controller.signal
     )
 
+    expect(removeListenerSpy).toHaveBeenCalledWith('abort', expect.any(Function))
     await vi.waitFor(() =>
       expect(onResponse).toHaveBeenCalledWith(
         expect.objectContaining({ ok: true, result: { type: 'subscribed' } })
@@ -82,6 +144,7 @@ describe('subscribeRemoteRuntimeRequest', () => {
     await expect(server.nextBinary).resolves.toEqual(bytes)
     expect(onError).not.toHaveBeenCalled()
     subscription.close()
+    removeListenerSpy.mockRestore()
   })
 
   it('detaches subscription socket listeners after close', async () => {

--- a/src/shared/remote-runtime-client.ts
+++ b/src/shared/remote-runtime-client.ts
@@ -56,6 +56,12 @@ type HandshakeState = 'awaiting_ready' | 'awaiting_authenticated' | 'ready'
 
 function ignoreSettledRemoteRuntimeSocketError(): void {}
 
+function createRemoteRuntimeSubscriptionAbortError(): Error {
+  const error = new Error('Remote runtime subscription aborted.')
+  error.name = 'AbortError'
+  return error
+}
+
 function formatRemoteRuntimeCloseMessage(code: number, reason: Buffer): string {
   const suffixParts: string[] = []
   if (code !== 1005 && code !== 1006) {
@@ -501,8 +507,12 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
   params: unknown,
   timeoutMs: number,
   callbacks: RemoteRuntimeSubscriptionCallbacks<TResult>,
-  livenessOptions?: RemoteRuntimeSocketLivenessOptions
+  livenessOptions?: RemoteRuntimeSocketLivenessOptions,
+  signal?: AbortSignal
 ): Promise<RemoteRuntimeSubscription> {
+  if (signal?.aborted) {
+    throw createRemoteRuntimeSubscriptionAbortError()
+  }
   const requestId = randomUUID()
   const serializedRequest = serializeRemoteRuntimeRpcRequest({
     requestId,
@@ -569,6 +579,11 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
       )
     }, timeoutMs)
 
+    const cleanupPendingSetup = (): void => {
+      clearTimeout(timeout)
+      signal?.removeEventListener('abort', onAbort)
+    }
+
     const close = (): void => {
       try {
         ws?.close()
@@ -621,14 +636,14 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
         return
       }
       settled = true
-      clearTimeout(timeout)
+      cleanupPendingSetup()
       resolve({ requestId, close, sendBinary })
     }
 
     const fail = (error: RemoteRuntimeClientError): void => {
       if (!settled) {
         settled = true
-        clearTimeout(timeout)
+        cleanupPendingSetup()
         closeSocketAfterCleanup()
         reject(error)
         return
@@ -639,6 +654,22 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
       // and lets the IPC subscription registry drop its retained callbacks.
       closeSocketAfterCleanup()
       callbacks.onClose?.()
+    }
+
+    function onAbort(): void {
+      if (settled) {
+        return
+      }
+      settled = true
+      cleanupPendingSetup()
+      closeSocketAfterCleanup()
+      reject(createRemoteRuntimeSubscriptionAbortError())
+    }
+
+    signal?.addEventListener('abort', onAbort, { once: true })
+    if (signal?.aborted) {
+      onAbort()
+      return
     }
 
     try {
@@ -668,7 +699,7 @@ export async function subscribeRemoteRuntimeRequest<TResult>(
     }
 
     function onClose(code: number, reason: Buffer): void {
-      clearTimeout(timeout)
+      cleanupPendingSetup()
       cleanupSocketListeners()
       if (!settled) {
         settled = true

--- a/src/shared/spawned-child-cancellation-wsl.test.ts
+++ b/src/shared/spawned-child-cancellation-wsl.test.ts
@@ -1,0 +1,101 @@
+import type * as ChildProcessModule from 'node:child_process'
+import { EventEmitter } from 'node:events'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const { spawnMock } = vi.hoisted(() => ({ spawnMock: vi.fn() }))
+
+vi.mock('node:child_process', async (importOriginal) => {
+  const actual = await importOriginal<typeof ChildProcessModule>()
+  return { ...actual, spawn: spawnMock }
+})
+
+import { terminateSpawnedChild, WSL_TREE_KILL_TIMEOUT_MS } from './spawned-child-cancellation'
+
+const originalPlatform = process.platform
+
+function mockChild(pid: number | undefined, spawnfile: string): ChildProcessModule.ChildProcess {
+  const child = new EventEmitter() as ChildProcessModule.ChildProcess
+  Object.assign(child, { pid, spawnfile, kill: vi.fn(), unref: vi.fn() })
+  return child
+}
+
+afterEach(() => {
+  Object.defineProperty(process, 'platform', { configurable: true, value: originalPlatform })
+  vi.useRealTimers()
+  spawnMock.mockReset()
+})
+
+describe('terminateSpawnedChild WSL cleanup', () => {
+  it('deduplicates Windows tree termination for a WSL wrapper', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const child = mockChild(1234, 'C:\\Windows\\System32\\WSL.EXE')
+    const killer = mockChild(5678, 'taskkill')
+    spawnMock.mockReturnValue(killer)
+
+    terminateSpawnedChild(child)
+    terminateSpawnedChild(child)
+
+    expect(spawnMock).toHaveBeenCalledOnce()
+    expect(spawnMock).toHaveBeenCalledWith('taskkill', ['/pid', '1234', '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+    expect(child.kill).not.toHaveBeenCalled()
+    killer.emit('close', 0)
+  })
+
+  it.each(['error', 'nonzero-close'] as const)(
+    'falls back to direct termination after taskkill %s',
+    (failure) => {
+      Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+      const child = mockChild(1234, 'wsl.exe')
+      const killer = mockChild(5678, 'taskkill')
+      spawnMock.mockReturnValue(killer)
+
+      terminateSpawnedChild(child)
+      if (failure === 'error') {
+        killer.emit('error', new Error('taskkill unavailable'))
+      } else {
+        killer.emit('close', 1)
+      }
+
+      expect(child.kill).toHaveBeenCalledOnce()
+    }
+  )
+
+  it('falls back safely when Windows tree termination times out', async () => {
+    vi.useFakeTimers()
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const child = mockChild(1234, 'wsl.exe')
+    const killer = mockChild(5678, 'taskkill')
+    spawnMock.mockReturnValue(killer)
+
+    terminateSpawnedChild(child)
+    await vi.advanceTimersByTimeAsync(WSL_TREE_KILL_TIMEOUT_MS)
+
+    expect(killer.kill).toHaveBeenCalledOnce()
+    expect(child.kill).toHaveBeenCalledOnce()
+  })
+
+  it('terminates a native Windows child directly', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const child = mockChild(1234, 'C:\\tools\\rg.exe')
+
+    terminateSpawnedChild(child)
+
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(child.kill).toHaveBeenCalledOnce()
+  })
+
+  it('never tree-kills a WSL wrapper before spawn assigns a pid', () => {
+    Object.defineProperty(process, 'platform', { configurable: true, value: 'win32' })
+    const child = mockChild(undefined, 'wsl.exe')
+
+    terminateSpawnedChild(child)
+
+    expect(spawnMock).not.toHaveBeenCalled()
+    expect(child.kill).not.toHaveBeenCalled()
+    child.emit('error', new Error('spawn wsl.exe ENOENT'))
+    expect(child.listenerCount('error')).toBe(0)
+  })
+})

--- a/src/shared/spawned-child-cancellation.test.ts
+++ b/src/shared/spawned-child-cancellation.test.ts
@@ -1,0 +1,19 @@
+import { spawn } from 'node:child_process'
+import { describe, expect, it } from 'vitest'
+import { terminateSpawnedChild } from './spawned-child-cancellation'
+
+describe('terminateSpawnedChild', () => {
+  it('survives cancellation before an absent command reports its spawn error', async () => {
+    const child = spawn(`orca-absent-command-${process.pid}-${Date.now()}`)
+    const closed = new Promise<void>((resolve) => {
+      child.once('close', () => resolve())
+    })
+
+    expect(child.pid).toBeUndefined()
+    terminateSpawnedChild(child)
+
+    await closed
+    expect(child.listenerCount('error')).toBe(0)
+    expect(child.listenerCount('close')).toBe(0)
+  })
+})

--- a/src/shared/spawned-child-cancellation.ts
+++ b/src/shared/spawned-child-cancellation.ts
@@ -1,0 +1,102 @@
+import { spawn, type ChildProcess } from 'node:child_process'
+import { win32 as win32Path } from 'node:path'
+
+const childrenWithTerminationSink = new WeakSet<ChildProcess>()
+const childrenWithWslTreeTermination = new WeakSet<ChildProcess>()
+export const WSL_TREE_KILL_TIMEOUT_MS = 2_000
+
+function retainTerminationErrorSink(child: ChildProcess): void {
+  if (childrenWithTerminationSink.has(child)) {
+    return
+  }
+  childrenWithTerminationSink.add(child)
+
+  const release = (): void => {
+    childrenWithTerminationSink.delete(child)
+    child.off('error', onError)
+    child.off('close', release)
+  }
+  const onError = (): void => release()
+
+  child.once('error', onError)
+  child.once('close', release)
+}
+
+export function terminateSpawnedChild(child: ChildProcess): void {
+  if (!Number.isSafeInteger(child.pid) || (child.pid ?? 0) <= 0) {
+    // Why: a failed spawn reports ENOENT after cancellation cleanup; retain one
+    // sink for it, and never let kill(undefined) signal this process.
+    retainTerminationErrorSink(child)
+    return
+  }
+
+  if (
+    process.platform === 'win32' &&
+    typeof child.spawnfile === 'string' &&
+    win32Path.basename(child.spawnfile).toLowerCase() === 'wsl.exe'
+  ) {
+    terminateWslProcessTree(child)
+    return
+  }
+  terminateDirectChild(child)
+}
+
+function terminateDirectChild(child: ChildProcess): void {
+  if (!Number.isSafeInteger(child.pid) || (child.pid ?? 0) <= 0) {
+    retainTerminationErrorSink(child)
+    return
+  }
+  try {
+    child.kill()
+  } catch {
+    // Cancellation is best-effort; the child may have exited between checks.
+  }
+}
+
+function terminateWslProcessTree(child: ChildProcess): void {
+  if (childrenWithWslTreeTermination.has(child)) {
+    return
+  }
+  childrenWithWslTreeTermination.add(child)
+
+  let killer: ChildProcess
+  try {
+    // Why: killing wsl.exe alone can orphan its Linux command; /T terminates the wrapper tree.
+    killer = spawn('taskkill', ['/pid', String(child.pid), '/T', '/F'], {
+      stdio: 'ignore',
+      windowsHide: true
+    })
+  } catch {
+    terminateDirectChild(child)
+    return
+  }
+
+  let settled = false
+  let timeout: ReturnType<typeof setTimeout> | null = null
+  const finish = (fallbackToDirectKill: boolean): void => {
+    if (settled) {
+      return
+    }
+    settled = true
+    if (timeout) {
+      clearTimeout(timeout)
+      timeout = null
+    }
+    killer.off('error', onError)
+    killer.off('close', onClose)
+    if (fallbackToDirectKill) {
+      terminateDirectChild(child)
+    }
+  }
+  const onError = (): void => finish(true)
+  const onClose = (code: number | null): void => finish(code !== 0)
+
+  killer.once('error', onError)
+  killer.once('close', onClose)
+  timeout = setTimeout(() => {
+    terminateDirectChild(killer)
+    finish(true)
+  }, WSL_TREE_KILL_TIMEOUT_MS)
+  timeout.unref?.()
+  killer.unref?.()
+}

--- a/src/shared/text-search-cancellation.ts
+++ b/src/shared/text-search-cancellation.ts
@@ -1,0 +1,11 @@
+export function createTextSearchAbortError(): Error {
+  const error = new Error('Text search aborted')
+  error.name = 'AbortError'
+  return error
+}
+
+export function throwIfTextSearchAborted(signal?: AbortSignal): void {
+  if (signal?.aborted) {
+    throw createTextSearchAbortError()
+  }
+}


### PR DESCRIPTION
## Summary

### Description

Cancel content searches as soon as they are superseded, cleared, hidden, moved to another worktree, or unmounted.

Cancellation now propagates through native IPC, paired runtime subscriptions, direct and nested SSH, runtime hosts, relay `rpc.cancel`, `rg` availability probes, `rg`, and `git grep`. Intentional cancellation rejects with `AbortError`; the normal 15-second timeout still returns partial results marked `truncated`.

Search → Files → Search resumes only the exact interrupted worktree/query. Completed results remain reusable, while interrupted transitions discard stale prior-query rows.

The final slow-connect review also closed the setup gap before a subscription handle exists. The renderer now selects the subscription ID up front, native main and paired web can cancel that pending ID, and dedicated native/browser WebSockets close while still connecting. Sender, environment, and subscription-instance fencing prevents a canceled or reused ID from affecting its replacement.

### Relationship to #13525

#13525 unmounts the heavy Cmd+J palette content after its 300 ms close animation, eliminating hidden subscriptions and render work once the animation ends. This PR is the complementary execution cleanup: it cancels scans already started while the palette is open or lingering, plus scans superseded by query, worktree, view, clear, and unmount transitions. #13525 stops future hidden UI work; this PR stops obsolete work already running below the UI.

### ELI5

Previously, changing a search could leave old searches running after the UI stopped caring about them—like asking 100 librarians different questions and letting all 100 keep searching. Now each new question dismisses the previous librarian, leaving only the newest search running, and leaving Search dismisses the last one too.

The slow-connect fix also hangs up an obsolete phone call while it is still dialing. It no longer waits for the call to connect before it can cancel it.

### Cancellation flow

```mermaid
flowchart TD
  A["New query, Clear, Files view, worktree change, or unmount"] --> B["Renderer AbortController"]
  B --> C{"Execution route"}

  C -->|"Native local or direct SSH"| D["Sender-scoped IPC request token"]
  D --> E["Main-process AbortSignal"]

  C -->|"Runtime environment or paired web"| F["Renderer-selected subscription ID"]
  F --> G["Sender/environment-scoped pending setup"]
  G --> H["Abort connecting child WebSocket"]
  H --> I["Runtime-host AbortSignal or socket-close cleanup"]

  E --> J{"Execution host"}
  I --> J

  J -->|"Local"| K["rg probe, rg, or git grep"]
  J -->|"SSH, including nested SSH"| L["Existing rpc.cancel"]
  L --> M["Relay request AbortSignal"]
  M --> K

  K --> N["Terminate child or WSL process tree"]
  N --> O["Reject AbortError and ignore stale results"]
```

### Deterministic cancellation and resource proof

#### Logical `100 → 1 → 0`

This measures deliberately unresolved logical search signals, not operating-system PID counts.

| Phase | Deterministic fake-timer assertion | Live searches |
| --- | --- | ---: |
| Start 100 fully debounced searches | 100 signals created; the first 99 are aborted and the newest is not | 1 |
| Clear, unmount, or change worktree | The sole remaining signal is aborted | 0 |

The downstream integration and process tests connect those renderer signals to `rpc.cancel`, relay signals, and `rg`/`git grep` termination.

#### Slow-connect socket bound

Before the follow-up, cancellation could unsubscribe only after async setup returned a handle. With a 15-second setup deadline and 300 ms search debounce, a slow endpoint could therefore retain roughly `15,000 / 300 = 50` connecting subscription sockets before timeout cleanup, against the host's 128-connection cap.

The deterministic regressions now prove:

| Setup phase | Expected behavior |
| --- | --- |
| Signal already aborted | No native or paired-web child subscription socket is created |
| Native socket still `CONNECTING` | Abort listener/timer/socket listeners are removed, the socket closes, and setup rejects `AbortError` |
| Paired-web child still connecting | The child closes and is removed from client ownership |
| Main setup pending | Only the owning sender can cancel it; sender destruction, environment invalidation, and handler re-registration abort it |
| Handle resolves after cancellation | The late handle is closed/unsubscribed before setup can be retained |
| Explicit ID is reused | Stale response, close, and destroyed-sender callbacks cannot reach or delete the replacement |

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint` — passed at exact pushed tip; only the pre-existing `WorktreeJumpPalette` exhaustive-deps warnings
- [x] `pnpm typecheck` — passed at exact pushed tip
- [x] `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.178 pnpm test` — 4,604 files passed, 15 skipped; 49,325 tests passed, 97 skipped
- [x] `pnpm build` — passed at exact pushed tip, including Linux/macOS/Windows relay targets, WSL relay, web, CLI, Electron, and native builds
- [x] Added or updated deterministic tests that catch renderer, preload, main ownership, paired-web, native WebSocket, remote process, relay, SSH, WSL, timeout, and stale-state regressions

Additional verification:

- Focused matrix across all 26 changed test files: 651 passed, 1 skipped.
- Deterministic renderer cancellation proof: 11/11 passed.
- Reliability gate manifest: all 73 gates passed; max-lines ratchet passed with no new bypass.
- Oxfmt check, default/native/type-aware lint, changed-code quality, and React Doctor pre-commit checks passed.
- `git diff --check origin/main...HEAD`: passed.
- Exact pushed commit: `25fc819c437`.
- Exact-tip CI: 43 passed, 1 intentionally skipped.

## AI Review Report

Independent renderer, backend, resource, WSL/process, cross-platform, mixed-version, and final adversarial reviews checked cancellation races, stale state, process cleanup, IPC authority, remote propagation, socket/listener/timer ownership, identifier reuse, SSH/folder workspaces, Git compatibility, and macOS/Linux/Windows behavior.

They found and verified these fixes:

| Finding | Fix |
| --- | --- |
| Interrupted Search → Files, unmount/remount, and A → B → A worktree transitions could expose stale prior-query rows | Interrupted searches now discard result ownership; resume is limited to the exact interrupted worktree/query, while completed results remain reusable |
| Cancellation during a failed spawn could reach `kill(undefined)` | Shared child termination now validates a positive PID and retains an error sink without issuing a kill for failed spawns |
| Killing only `wsl.exe` could orphan its inner Linux `rg` or `git grep` process | WSL cancellation now uses deduplicated, bounded `taskkill /T /F`, with a two-second timeout and safe direct-kill fallback |
| Tokenized paired-web searches could lose their existing response deadline | Abortable paired-runtime searches retain the 15-second deadline |
| A superseded search could not cancel while a dedicated runtime socket was still connecting | Renderer-selected IDs cancel pending native/paired-web setup; pre-abort creates no child socket and mid-connect abort closes it immediately |
| A delayed callback from an explicitly reused subscription ID could delete or notify its replacement | Per-instance ownership gates fence stale payload, close, and destroyed-sender callbacks; close-during-setup cannot retain a dead handle |

The final re-review reports no remaining P0, P1, or P2 findings.

## Reliability contract

- Every new allocation has bounded cleanup: pending registries/controllers, abort listeners, setup timers, socket listeners, child clients, late handles, and sender listeners are released on pre-abort, mid-connect abort, setup failure, success, close, environment invalidation, sender destruction, and handler re-registration as applicable.
- Dedicated subscription setup is canceled immediately at the socket boundary. Shared-control capability/setup work is coalesced; cancellation is checked before and after its async boundaries and any late logical handle is closed.
- Cancellation authority is scoped to the issuing `webContents`; environment cleanup is scoped to the matching environment; late instance callbacks must still own the ID before they can publish or delete state.
- Existing response timeouts remain in force, so a connected-but-unresponsive runtime cannot stall a one-shot search indefinitely.

## Security Audit

- Cancellation tokens and pending subscription IDs are scoped to the issuing `webContents`; another sender cannot cancel the request.
- Reused identifiers are instance-fenced, so stale callbacks cannot act on a replacement owned by the same or another sender.
- Request tokens and `AbortSignal` objects are stripped before SSH or runtime RPC parameters are constructed.
- Existing filesystem path authorization remains unchanged.
- Existing argv-array process spawning remains unchanged; Windows tree termination uses a fixed executable, fixed flags, and a validated numeric PID.
- No dependency, secret, shell-construction, authentication, or authorization changes.
- Settled and unknown tokens are harmless, and reused search tokens abort only their predecessor.

## Compatibility and residual risk

- **macOS/Linux:** native children use direct termination with listener and timeout cleanup.
- **Windows:** native children retain direct termination; WSL wrapper trees use bounded `taskkill /T /F`.
- **WSL/SSH:** cancellation reaches WSL descendants and uses existing `rpc.cancel` for direct and nested SSH searches.
- **Folder workspaces:** search stays path-based and retains the existing authorization flow; no git-worktree-only assumption was added.
- **Git 2.25:** no Git subcommand or option changed; the existing `git grep` fallback remains baseline-compatible.
- **Provider neutrality:** no GitHub-specific behavior or review-provider assumption was introduced.
- **Mobile/backward compatibility:** no mobile-facing state, route, handshake, framing, or RPC schema changed.
- **Remote wire compatibility:** no RPC field, stream opcode, protocol version, or capability contract changed. The explicit subscription ID and cancellation hook are additive local preload/IPC behavior; remote WebSocket payloads are unchanged. Older peers continue working and may finish obsolete work through their existing timeout when they do not participate in cancellation.
- Remote cancellation is covered deterministically in memory and with a real local native WebSocket server, not a live SSH or paired-host journey. Paired-browser connecting-socket teardown uses a fake WebSocket.
- WSL process-tree termination is mocked; no physical Windows/WSL run was available. If `taskkill` is blocked or times out, direct wrapper termination may still orphan the inner Linux command.
- Shared-control setup observes cancellation at async boundaries rather than interrupting its coalesced capability probe internally; it does not create a child socket per search.
- The `100 → 1 → 0` proof counts logical searches/signals, not OS PIDs, CPU, RSS, or a production-host connection metric.
