### PR TITLE
[Perf-SS] Stop abandoned native chat tail reads

### DIFF
--- a/src/main/native-chat/transcript-tail-reader-cancellation.test.ts
+++ b/src/main/native-chat/transcript-tail-reader-cancellation.test.ts
@@ -1,5 +1,5 @@
 import type * as NodeFsPromisesModule from 'node:fs/promises'
-import { describe, expect, it, vi } from 'vitest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
 
 const fsMocks = vi.hoisted(() => ({
   open: vi.fn(),
@@ -15,19 +15,33 @@ vi.mock('node:fs/promises', async (importOriginal) => ({
 import { readNativeChatTranscriptTail } from './transcript-tail-reader'
 
 describe('native chat transcript tail cancellation', () => {
-  it('rejects after pending tail I/O closes when the request is canceled', async () => {
-    let finishRead: (() => void) | undefined
+  beforeEach(() => {
+    fsMocks.open.mockReset()
+    fsMocks.stat.mockReset()
+  })
+
+  it('closes after a pending tail read without reading another chunk when canceled', async () => {
+    let finishTailRead: (() => void) | undefined
+    let readCount = 0
     const close = vi.fn(async () => {})
-    const read = vi.fn(
-      (buffer: Buffer) =>
-        new Promise<{ bytesRead: number; buffer: Buffer }>((resolve) => {
-          finishRead = () => {
-            buffer[0] = 0x0a
-            resolve({ bytesRead: 1, buffer })
-          }
-        })
-    )
-    fsMocks.stat.mockResolvedValue({ size: 1 })
+    const read = vi.fn((buffer: Buffer) => {
+      readCount++
+      if (readCount === 1) {
+        buffer[0] = 0x0a
+        return Promise.resolve({ bytesRead: 1, buffer })
+      }
+      if (readCount > 2) {
+        buffer.fill(0x0a)
+        return Promise.resolve({ bytesRead: buffer.length, buffer })
+      }
+      return new Promise<{ bytesRead: number; buffer: Buffer }>((resolve) => {
+        finishTailRead = () => {
+          buffer.fill(0x0a)
+          resolve({ bytesRead: buffer.length, buffer })
+        }
+      })
+    })
+    fsMocks.stat.mockResolvedValue({ size: 8 * 64 * 1024 + 1 })
     fsMocks.open.mockResolvedValue({ close, read })
     const controller = new AbortController()
     const canceled = new Error('request canceled')
@@ -41,12 +55,46 @@ describe('native chat transcript tail cancellation', () => {
       controller.signal
     )
     const rejection = expect(pending).rejects.toBe(canceled)
-    await vi.waitFor(() => expect(read).toHaveBeenCalledOnce())
+    await vi.waitFor(() => expect(read).toHaveBeenCalledTimes(2))
 
     controller.abort(canceled)
-    finishRead?.()
+    finishTailRead?.()
 
     await rejection
+    expect(read).toHaveBeenCalledTimes(2)
+    expect(close).toHaveBeenCalledOnce()
+  })
+
+  it('closes a handle opened after cancellation without starting a read', async () => {
+    let finishOpen: (() => void) | undefined
+    const close = vi.fn(async () => {})
+    const read = vi.fn()
+    fsMocks.stat.mockResolvedValue({ size: 1 })
+    fsMocks.open.mockImplementation(
+      () =>
+        new Promise((resolve) => {
+          finishOpen = () => resolve({ close, read })
+        })
+    )
+    const controller = new AbortController()
+    const canceled = new Error('request canceled while opening')
+    const pending = readNativeChatTranscriptTail(
+      {
+        agent: 'claude',
+        sessionId: 'session-id',
+        filePath: 'transcript.jsonl',
+        limit: 40
+      },
+      controller.signal
+    )
+    const rejection = expect(pending).rejects.toBe(canceled)
+    await vi.waitFor(() => expect(fsMocks.open).toHaveBeenCalledOnce())
+
+    controller.abort(canceled)
+    finishOpen?.()
+
+    await rejection
+    expect(read).not.toHaveBeenCalled()
     expect(close).toHaveBeenCalledOnce()
   })
 })

--- a/src/main/native-chat/transcript-tail-reader.ts
+++ b/src/main/native-chat/transcript-tail-reader.ts
@@ -46,7 +46,8 @@ export async function readNativeChatTranscriptTailFile(
   decode: NativeChatLineDecoder,
   includeTrailingLine = false,
   endOffset?: number,
-  decodeLifecycle?: NativeChatTurnLifecycleDecoder | null
+  decodeLifecycle?: NativeChatTurnLifecycleDecoder | null,
+  signal?: AbortSignal
 ): Promise<{
   messages: NativeChatMessage[]
   lifecycle?: NativeChatTurnLifecycle
@@ -56,7 +57,9 @@ export async function readNativeChatTranscriptTailFile(
   malformedRecordCount?: number
   oversizedRecordCount?: number
 }> {
+  signal?.throwIfAborted()
   const end = Math.min((await stat(filePath)).size, endOffset ?? Number.MAX_SAFE_INTEGER)
+  signal?.throwIfAborted()
   if (end === 0) {
     return { messages: [], consumedTo: 0, hasMore: false, beforeOffset: 0 }
   }
@@ -69,19 +72,25 @@ export async function readNativeChatTranscriptTailFile(
   let oversizedRecordCount = 0
   let ignoreNextMalformedRecord = false
   try {
-    const consumedTo = includeTrailingLine ? end : await findLastCompleteLineEnd(handle, end)
+    signal?.throwIfAborted()
+    const consumedTo = includeTrailingLine
+      ? end
+      : await findLastCompleteLineEnd(handle, end, signal)
     if (consumedTo === 0) {
       return { messages: [], consumedTo: 0, hasMore: false, beforeOffset: 0 }
     }
     const newestFirst: { message: NativeChatMessage; offset: number }[] = []
     const finalByte = Buffer.allocUnsafe(1)
     await handle.read(finalByte, 0, 1, consumedTo - 1)
+    signal?.throwIfAborted()
     ignoreNextMalformedRecord = finalByte[0] !== 0x0a
     let cursor = consumedTo - (finalByte[0] === 0x0a ? 1 : 0)
     while (cursor > 0 && newestFirst.length <= limit) {
+      signal?.throwIfAborted()
       const start = Math.max(0, cursor - TAIL_CHUNK_BYTES)
       const buffer = Buffer.allocUnsafe(cursor - start)
       const { bytesRead } = await handle.read(buffer, 0, buffer.length, start)
+      signal?.throwIfAborted()
       let segmentEnd = bytesRead
       for (let index = bytesRead - 1; index >= 0 && newestFirst.length <= limit; index--) {
         if (buffer[index] !== 0x0a) {
@@ -175,18 +184,23 @@ export async function readNativeChatTranscriptTailFile(
 
 async function findLastCompleteLineEnd(
   handle: Awaited<ReturnType<typeof open>>,
-  end: number
+  end: number,
+  signal?: AbortSignal
 ): Promise<number> {
+  signal?.throwIfAborted()
   const lastByte = Buffer.allocUnsafe(1)
   await handle.read(lastByte, 0, 1, end - 1)
+  signal?.throwIfAborted()
   if (lastByte[0] === 0x0a) {
     return end
   }
   let cursor = end
   while (cursor > 0) {
+    signal?.throwIfAborted()
     const start = Math.max(0, cursor - TAIL_CHUNK_BYTES)
     const buffer = Buffer.allocUnsafe(cursor - start)
     const { bytesRead } = await handle.read(buffer, 0, buffer.length, start)
+    signal?.throwIfAborted()
     const newline = buffer.subarray(0, bytesRead).lastIndexOf(0x0a)
     if (newline >= 0) {
       return start + newline + 1
@@ -235,7 +249,8 @@ export async function readNativeChatTranscriptTail(
       decode,
       true,
       args.beforeOffset,
-      decodeLifecycle
+      decodeLifecycle,
+      signal
     )
     signal?.throwIfAborted()
     return {


### PR DESCRIPTION
## Summary

- Stop an abandoned Native Chat RPC tail read at the next filesystem boundary instead of scanning the rest of a large transcript.
- Preserve the existing abort reason and close any file handle that finishes opening after cancellation.
- Leave uncanceled readers and no-signal watcher/worker paths unchanged.

### ELI5

Native Chat reads a transcript backward until it finds enough visible messages. If a web or mobile client disconnected during that read, Orca noticed only after the whole read finished. This passes the cancellation signal into the reader, so it finishes only the disk operation already in flight, closes the file, and stops before reading or decoding another chunk.

## Performance proof

Production reachability:

- Transcript files are documented in-tree as routinely tens of megabytes.
- A size-only local corpus sample contained 2,137 files: 9.25 MiB p95, 17.87 MiB p99, and 69.81 MiB maximum.
- The backward reader uses 64 KiB chunks and can scan to byte zero when recent JSONL records do not decode to visible chat messages.

Actual final module on Node 24, 11 alternating pairs, using a 64 MiB fixture with 1,024 valid non-message JSONL records and canceling after the first decoded record:

| Metric | Continued/base path | Cancellation-aware path | Improvement |
| --- | ---: | ---: | ---: |
| Median completion after cancel | 476.13 ms | 1.414 ms | 336.7×; 474.72 ms saved |
| `FileHandle.read` calls | 1,025 | 2 | 1,023 reads avoided |
| Record decodes | 1,024 | 1 | 1,023 decodes avoided |
| Additional bytes read | 63.94 MiB | 0 | 63.94 MiB avoided |

The deterministic regression test cancels while the first 64 KiB tail read is pending and proves that exactly two reads occur—the final-byte probe and that already-started chunk—with no third read.

## No-regression proof

- The existing RPC `AbortSignal` is the only new input; there is no RPC parameter, schema, stream opcode, IPC payload, persistence, or wire change.
- Checks sit before/after awaited `stat`/`open`/`read` boundaries. There is no per-record check or new work in the synchronous decode loop.
- An opened handle remains owned by the existing `finally`; a pending-open test proves cancel → open settles → zero reads → close once.
- Both tests require the exact caller-supplied abort reason, matching the pre-existing wrapper contract.
- Unaborted filesystem errors retain the existing `{ error, notFound? }` result behavior.
- Desktop IPC, live watchers, and orchestration-worker reads do not pass a signal and retain their previous path.
- The filesystem APIs and path routing are unchanged across macOS, Linux, Windows/WSL UNC, SSH-hosted runtimes, relay, and folder workspaces. Old and new mobile/web clients use the same wire contract.
- Three independent reviews found no remaining P0/P1/P2 across performance, cleanup/error precedence, concurrency/stale files, cross-platform/remote behavior, mobile/wire compatibility, security, and release readiness.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [ ] `pnpm test` — focused run passed 223 tests across 27 Native Chat/RPC/IPC files; standard PR CI runs the full Node 24/26 shards
- [ ] `pnpm build` — `pnpm run build:electron-vite` passed; standard PR CI runs macOS and Windows packaging
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed
- [x] Changed-code quality, type-aware quality, React Doctor, reliability, max-lines, localization, formatting, targeted oxlint, and `git diff --check`

## AI Review Report

Three read-only reviews traced WebSocket/RPC abort authority through the file reader, handle cleanup, exact error precedence, partial completion, concurrent calls, stale/truncated files, and no-signal consumers. They explicitly checked macOS, Linux, Windows/WSL, SSH/remote runtime, relay, folder workspaces, mobile/web version skew, and Electron build behavior.

One review found that the first draft test canceled during the one-byte probe instead of a 64 KiB tail read. The final test now holds the first tail chunk and proves no next chunk; a second test covers cancellation while `open()` is pending. A separate review caught and removed an unnecessary per-record abort check that would have added O(records) work without improving observable cancellation latency.

## Security Audit

No dependencies, commands, paths, auth, secrets, network sinks, parsers, or user-controlled payload contracts were added. The change only observes an existing host-owned `AbortSignal` and releases host-local filesystem work sooner. Path resolution and file authorization remain unchanged, and every opened handle still closes through `finally`.

## Notes

- Cancellation is cooperative: an already-started OS filesystem operation must settle before the signal can be observed. This is the existing Node filesystem limitation, not a new delay.
- X: @nwparker_
