### PR TITLE
[perf-remote] perf(renderer): consolidate remote session tab streams

### DIFF
--- a/src/main/runtime/rpc/methods/session-tabs-subscribe-all.test.ts
+++ b/src/main/runtime/rpc/methods/session-tabs-subscribe-all.test.ts
@@ -1,4 +1,8 @@
 import { describe, expect, it, vi } from 'vitest'
+import {
+  RUNTIME_CAPABILITIES,
+  SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY
+} from '../../../../shared/protocol-version'
 import type { RuntimeMobileSessionTabsResult } from '../../../../shared/runtime-types'
 import { OrcaRuntimeService } from '../../orca-runtime'
 import type { RpcRequest } from '../core'
@@ -162,6 +166,10 @@ describe('atomic all-session inventory boundary', () => {
     refreshAllMobileSessionTabs: () => Promise<void>
     captureAllMobileSessionTabs: (clientNavigationId?: string) => RuntimeMobileSessionTabsResult[]
   }
+
+  it('advertises the atomic subscription boundary to paired clients', () => {
+    expect(RUNTIME_CAPABILITIES).toContain(SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY)
+  })
 
   it('installs the listener after refresh and before capture', async () => {
     const runtime = new OrcaRuntimeService()

--- a/src/renderer/src/App.tsx
+++ b/src/renderer/src/App.tsx
@@ -112,7 +112,7 @@ import {
   setRuntimeGraphStoreStateGetter,
   setRuntimeGraphSyncEnabled
 } from './runtime/sync-runtime-graph'
-import { useWebSessionTabsSync } from './runtime/web-session-tabs-sync'
+import { useWebSessionTabsSync } from './runtime/use-web-session-tabs-sync'
 import { useGlobalFileDrop } from './hooks/useGlobalFileDrop'
 import { MacosTccPromptNoticeHost } from './hooks/MacosTccPromptNoticeHost'
 import { useRadixBodyPointerEventsRecovery } from './hooks/useRadixBodyPointerEventsRecovery'

--- a/src/renderer/src/lib/runtime-session-mirror-targets.ts
+++ b/src/renderer/src/lib/runtime-session-mirror-targets.ts
@@ -19,6 +19,10 @@ export type RuntimeSessionMirrorTarget = {
   pairingRevision: number
 }
 
+export function toRuntimeSessionMirrorTargetKey(target: RuntimeSessionMirrorTarget): string {
+  return `${target.environmentId}\u0001${target.runtimeId}\u0001${target.connectionGeneration}\u0001${target.pairingRevision}`
+}
+
 export type RuntimeSessionMirrorTargetState = Omit<
   WorktreeRuntimeOwnerState,
   'runtimeEnvironments'

--- a/src/renderer/src/runtime/use-active-web-session-tabs-transport.ts
+++ b/src/renderer/src/runtime/use-active-web-session-tabs-transport.ts
@@ -1,0 +1,174 @@
+import { useEffect } from 'react'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { isRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
+import {
+  type ActiveSessionTabsContext,
+  type ActiveSessionTabsContextRef,
+  recoverAndApplyWebSessionTabsSnapshots
+} from './web-session-tabs-active-snapshot'
+import { isRuntimeSessionTabsSnapshot, isSessionTabsSnapshotEvent } from './web-session-tabs-events'
+import type { GlobalSessionTabsCoverage } from './web-session-tabs-global-subscription'
+import {
+  acceptReplayedWebSessionTabsSnapshot,
+  shouldSyncRuntimeSessionTabs
+} from './web-session-tabs-sync'
+import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
+import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
+
+const ACTIVE_SNAPSHOT_TIMEOUT_MS = 15_000
+
+type ActiveTransportArgs = {
+  context: ActiveSessionTabsContext | null
+  activeContextRef: ActiveSessionTabsContextRef
+  coverage: GlobalSessionTabsCoverage | undefined
+  workspaceSessionReady: boolean
+}
+
+function startActiveWebSessionTabsTransport(args: ActiveTransportArgs): () => void {
+  const { context, activeContextRef, coverage, workspaceSessionReady } = args
+  if (
+    !context ||
+    !shouldSyncRuntimeSessionTabs({
+      activeWorktreeId: context.worktreeId,
+      activeWorktreeRuntimeEnvironmentId: context.environmentId,
+      workspaceSessionReady
+    })
+  ) {
+    return () => {}
+  }
+  acceptReplayedWebSessionTabsSnapshot(context.environmentId, context.worktreeId)
+  if (coverage?.status === 'ready' && coverage.servicedActiveContext === context) {
+    return () => {}
+  }
+
+  let disposed = false
+  let startedScopedFallback = false
+  let unsubscribe: (() => void) | null = null
+  const isCurrent = (): boolean =>
+    !disposed &&
+    activeContextRef.current === context &&
+    getRuntimeEnvironmentRevision(context.environmentId) === context.pairingRevision
+  const applySnapshot = (
+    snapshot: Parameters<typeof recoverAndApplyWebSessionTabsSnapshots>[0]['snapshots'][number],
+    options: { replayed: boolean; acceptCurrent?: boolean }
+  ): Promise<ActiveSessionTabsContext | null> =>
+    recoverAndApplyWebSessionTabsSnapshots({
+      environmentId: context.environmentId,
+      targetKey: context.targetKey,
+      snapshots: [snapshot],
+      replayed: options.replayed,
+      acceptCurrent: options.acceptCurrent ?? false,
+      activeContextRef,
+      isCurrent
+    })
+  const startScopedFallback = (): void => {
+    if (!isCurrent() || startedScopedFallback) {
+      return
+    }
+    startedScopedFallback = true
+    void window.api.runtimeEnvironments
+      .subscribe(
+        {
+          selector: context.environmentId,
+          method: 'session.tabs.subscribe',
+          params: { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
+          timeoutMs: ACTIVE_SNAPSHOT_TIMEOUT_MS,
+          expectedEnvironmentPairingRevision: context.pairingRevision
+        },
+        {
+          onResponse: (response: RuntimeRpcResponse<unknown>) => {
+            if (!isCurrent()) {
+              return
+            }
+            if (response.ok === false) {
+              console.warn('[web-session-tabs-sync] subscription failed:', response.error.message)
+              return
+            }
+            if (
+              !isSessionTabsSnapshotEvent(response.result) ||
+              response.result.worktree !== context.worktreeId
+            ) {
+              return
+            }
+            void applySnapshot(
+              { snapshot: response.result, type: response.result.type },
+              { replayed: isRuntimeSubscriptionReplayResponse(response) }
+            ).catch((error) => {
+              if (isCurrent()) {
+                console.warn('[web-session-tabs-sync] active snapshot recovery failed:', error)
+              }
+            })
+          },
+          onError: (error) =>
+            console.warn('[web-session-tabs-sync] subscription error:', error.message)
+        }
+      )
+      .then((handle) => {
+        if (disposed) {
+          handle.unsubscribe()
+        } else {
+          unsubscribe = handle.unsubscribe
+        }
+      })
+      .catch((error) => {
+        if (!disposed) {
+          console.warn(
+            '[web-session-tabs-sync] failed to subscribe:',
+            error instanceof Error ? error.message : String(error)
+          )
+        }
+      })
+  }
+
+  if (coverage?.status !== 'ready') {
+    startScopedFallback()
+  } else {
+    void window.api.runtimeEnvironments
+      .call({
+        selector: context.environmentId,
+        method: 'session.tabs.list',
+        params: { worktree: toRuntimeWorktreeSelector(context.worktreeId) },
+        timeoutMs: ACTIVE_SNAPSHOT_TIMEOUT_MS,
+        expectedEnvironmentPairingRevision: context.pairingRevision
+      })
+      .then((response: RuntimeRpcResponse<unknown>) => {
+        if (
+          !isCurrent() ||
+          response.ok === false ||
+          !isRuntimeSessionTabsSnapshot(response.result) ||
+          response.result.worktree !== context.worktreeId
+        ) {
+          startScopedFallback()
+          return
+        }
+        return applySnapshot(
+          { snapshot: response.result, type: 'snapshot' },
+          { replayed: false, acceptCurrent: true }
+        ).then((serviced) => {
+          if (serviced !== context) {
+            startScopedFallback()
+          }
+        })
+      })
+      .catch(startScopedFallback)
+  }
+
+  return () => {
+    disposed = true
+    unsubscribe?.()
+  }
+}
+
+export function useActiveWebSessionTabsTransport(args: ActiveTransportArgs): void {
+  const { activeContextRef, context, coverage, workspaceSessionReady } = args
+  useEffect(
+    () =>
+      startActiveWebSessionTabsTransport({
+        activeContextRef,
+        context,
+        coverage,
+        workspaceSessionReady
+      }),
+    [activeContextRef, context, coverage, workspaceSessionReady]
+  )
+}

--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.test.ts
@@ -22,7 +22,7 @@ import {
   selectRuntimeSessionMirrorTargetInputs,
   useRuntimeSessionMirrorEnvironmentKey
 } from './use-runtime-session-mirror-environment-key'
-import { useWebSessionTabsSync } from './web-session-tabs-sync'
+import { useWebSessionTabsSync } from './use-web-session-tabs-sync'
 
 const initialState = useAppStore.getInitialState()
 

--- a/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.ts
+++ b/src/renderer/src/runtime/use-runtime-session-mirror-environment-key.ts
@@ -1,6 +1,9 @@
 import { useMemo } from 'react'
 import { useShallow } from 'zustand/react/shallow'
-import { getReachableRuntimeSessionMirrorTargets } from '@/lib/runtime-session-mirror-targets'
+import {
+  getReachableRuntimeSessionMirrorTargets,
+  toRuntimeSessionMirrorTargetKey
+} from '@/lib/runtime-session-mirror-targets'
 import { useAppStore } from '@/store'
 import type { AppState } from '@/store/types'
 
@@ -45,10 +48,7 @@ export function buildRuntimeSessionMirrorEnvironmentKey(
     runtimeEnvironments: inputs.runtimeEnvironments,
     runtimeStatusByEnvironmentId: inputs.runtimeStatusByEnvironmentId
   })
-    .map(
-      ({ environmentId, runtimeId, connectionGeneration, pairingRevision }) =>
-        `${environmentId}\u0001${runtimeId}\u0001${connectionGeneration}\u0001${pairingRevision}`
-    )
+    .map(toRuntimeSessionMirrorTargetKey)
     .join('\u0000')
 }
 

--- a/src/renderer/src/runtime/use-web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/use-web-session-tabs-sync.ts
@@ -1,0 +1,188 @@
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react'
+import { useShallow } from 'zustand/react/shallow'
+import { SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import type { RuntimeSessionMirrorTarget } from '@/lib/runtime-session-mirror-targets'
+import { toRuntimeSessionMirrorTargetKey } from '@/lib/runtime-session-mirror-targets'
+import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
+import { useAppStore } from '@/store'
+import { clearWebSessionCloseIntentsForOwner } from './web-session-close-intent'
+import { clearWebSessionFocusIntentsForOwner } from './web-session-focus-intent'
+import { clearWebSessionReorderIntentsForOwner } from './web-session-reorder-intent'
+import type { ActiveSessionTabsContext } from './web-session-tabs-active-snapshot'
+import {
+  type GlobalSessionTabsCoverage,
+  type GlobalSessionTabsCoverageSignal,
+  startGlobalWebSessionTabsSubscription
+} from './web-session-tabs-global-subscription'
+import {
+  clearWebSessionTabsTrackingForEnvironment,
+  shouldSyncAllRuntimeSessionTabs
+} from './web-session-tabs-sync'
+import { useActiveWebSessionTabsTransport } from './use-active-web-session-tabs-transport'
+import { useRuntimeSessionMirrorEnvironmentKey } from './use-runtime-session-mirror-environment-key'
+
+type CoverageState = {
+  mirrorKey: string
+  byTarget: ReadonlyMap<string, GlobalSessionTabsCoverage>
+}
+
+type ActiveRuntimeSessionMirrorTarget = RuntimeSessionMirrorTarget & {
+  supportsAtomicGlobalSubscription: boolean
+}
+
+function parseMirrorTargets(key: string): (RuntimeSessionMirrorTarget & { targetKey: string })[] {
+  if (!key) {
+    return []
+  }
+  return key.split('\u0000').flatMap((targetKey) => {
+    const [environmentId, runtimeId, rawGeneration, rawRevision] = targetKey.split('\u0001')
+    const connectionGeneration = Number(rawGeneration)
+    const pairingRevision = Number(rawRevision)
+    return environmentId &&
+      runtimeId &&
+      Number.isFinite(connectionGeneration) &&
+      Number.isFinite(pairingRevision)
+      ? [{ environmentId, runtimeId, connectionGeneration, pairingRevision, targetKey }]
+      : []
+  })
+}
+
+function makeActiveContext(
+  target: ActiveRuntimeSessionMirrorTarget | null,
+  worktreeId: string | null
+): ActiveSessionTabsContext | null {
+  if (!target || !worktreeId) {
+    return null
+  }
+  const targetKey = toRuntimeSessionMirrorTargetKey(target)
+  return {
+    targetKey,
+    environmentId: target.environmentId,
+    pairingRevision: target.pairingRevision,
+    supportsAtomicGlobalSubscription: target.supportsAtomicGlobalSubscription,
+    worktreeId,
+    requestedInitialTerminal: false,
+    requestedRespawnAfterWake: false
+  }
+}
+
+export function useWebSessionTabsSync(): void {
+  const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
+  const runtimeSessionMirrorEnvironmentKey = useRuntimeSessionMirrorEnvironmentKey()
+  const activeTarget = useAppStore(
+    useShallow((state): ActiveRuntimeSessionMirrorTarget | null => {
+      const environmentId = getExplicitRuntimeEnvironmentIdForWorktree(
+        state,
+        state.activeWorktreeId
+      )
+      const runtime = environmentId
+        ? state.runtimeStatusByEnvironmentId.get(environmentId)
+        : undefined
+      const environment = state.runtimeEnvironments.find(({ id }) => id === environmentId)
+      return environmentId && runtime?.status && environment
+        ? {
+            environmentId,
+            runtimeId: runtime.status.runtimeId,
+            connectionGeneration: runtime.connectionGeneration ?? 0,
+            pairingRevision: environment.pairingRevision ?? environment.createdAt,
+            supportsAtomicGlobalSubscription:
+              runtime.status.capabilities?.includes(
+                SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY
+              ) === true
+          }
+        : null
+    })
+  )
+  const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
+  const targets = useMemo(
+    () => parseMirrorTargets(runtimeSessionMirrorEnvironmentKey),
+    [runtimeSessionMirrorEnvironmentKey]
+  )
+  const activeContext = useMemo(
+    () => makeActiveContext(activeTarget, activeWorktreeId),
+    [activeTarget, activeWorktreeId]
+  )
+  const activeContextRef = useRef<ActiveSessionTabsContext | null>(activeContext)
+  activeContextRef.current = activeContext
+  const [coverageState, setCoverageState] = useState<CoverageState>({
+    mirrorKey: '',
+    byTarget: new Map()
+  })
+  const updateCoverage = useCallback(
+    (mirrorKey: string, targetKey: string, coverage: GlobalSessionTabsCoverageSignal): void => {
+      setCoverageState((current) => {
+        const byTarget = new Map(current.mirrorKey === mirrorKey ? current.byTarget : [])
+        const previous = byTarget.get(targetKey)
+        const next: GlobalSessionTabsCoverage =
+          coverage.status === 'ready'
+            ? {
+                ...coverage,
+                generation: previous?.status === 'ready' ? previous.generation + 1 : 1
+              }
+            : coverage
+        if (previous?.status === 'unavailable' && next.status === 'unavailable') {
+          return current.mirrorKey === mirrorKey ? current : { mirrorKey, byTarget }
+        }
+        byTarget.set(targetKey, next)
+        return { mirrorKey, byTarget }
+      })
+    },
+    []
+  )
+
+  useEffect(() => {
+    if (!workspaceSessionReady || targets.length === 0) {
+      return
+    }
+    const unsubscribes = targets.flatMap((target) => {
+      if (
+        !shouldSyncAllRuntimeSessionTabs({
+          activeRuntimeEnvironmentId: target.environmentId,
+          workspaceSessionReady
+        })
+      ) {
+        return []
+      }
+      return [
+        startGlobalWebSessionTabsSubscription({
+          environmentId: target.environmentId,
+          targetKey: target.targetKey,
+          expectedRuntimeId: target.runtimeId,
+          expectedEnvironmentPairingRevision: target.pairingRevision,
+          activeContextRef,
+          onCoverage: (coverage) =>
+            updateCoverage(runtimeSessionMirrorEnvironmentKey, target.targetKey, coverage)
+        })
+      ]
+    })
+    return () => {
+      for (const unsubscribe of unsubscribes) {
+        unsubscribe()
+      }
+      for (const target of targets) {
+        clearWebSessionTabsTrackingForEnvironment(target.environmentId)
+        const owner = {
+          environmentId: target.environmentId,
+          pairingRevision: target.pairingRevision
+        }
+        clearWebSessionCloseIntentsForOwner(owner)
+        clearWebSessionFocusIntentsForOwner(owner)
+        clearWebSessionReorderIntentsForOwner(owner)
+      }
+    }
+  }, [runtimeSessionMirrorEnvironmentKey, targets, updateCoverage, workspaceSessionReady])
+
+  const coverage =
+    coverageState.mirrorKey === runtimeSessionMirrorEnvironmentKey && activeContext
+      ? coverageState.byTarget.get(activeContext.targetKey)
+      : undefined
+  const canUseGlobalForActive = activeContext?.supportsAtomicGlobalSubscription === true
+  const readyCoverage = canUseGlobalForActive && coverage?.status === 'ready' ? coverage : undefined
+
+  useActiveWebSessionTabsTransport({
+    context: activeContext,
+    activeContextRef,
+    coverage: readyCoverage,
+    workspaceSessionReady
+  })
+}

--- a/src/renderer/src/runtime/web-session-tabs-active-snapshot.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-active-snapshot.test.ts
@@ -1,0 +1,176 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+
+const mocks = vi.hoisted(() => ({
+  state: {
+    tabsByWorktree: {} as Record<string, { id: string }[]>,
+    ptyIdsByTabId: {} as Record<string, string[]>
+  },
+  acceptReplay: vi.fn(),
+  applySnapshot: vi.fn(() => ({ applied: true })),
+  applySnapshots: vi.fn(() => ({ applied: true })),
+  applyStorePatch: vi.fn((build: (state: unknown) => unknown) => build(mocks.state)),
+  shouldApply: vi.fn(() => true),
+  shouldBootstrap: vi.fn((_args: { requestedInitialTerminal: boolean }) => false),
+  shouldWake: vi.fn(() => false),
+  createTerminal: vi.fn(async () => undefined),
+  beginWake: vi.fn(() => true),
+  endWake: vi.fn(),
+  skipWake: vi.fn(() => false),
+  recover: vi.fn(async (_state: unknown, snapshot: RuntimeMobileSessionTabsResult) => snapshot)
+}))
+
+vi.mock('../store', () => ({
+  useAppStore: { getState: () => mocks.state }
+}))
+vi.mock('./web-session-tabs-sync', () => ({
+  acceptReplayedWebSessionTabsSnapshot: mocks.acceptReplay,
+  applyWebSessionTabsSnapshot: mocks.applySnapshot,
+  applyWebSessionTabsSnapshots: mocks.applySnapshots,
+  applyWebSessionTabsStorePatch: mocks.applyStorePatch,
+  shouldApplyWebSessionTabsSnapshot: mocks.shouldApply,
+  shouldBootstrapInitialWebRuntimeTerminal: mocks.shouldBootstrap,
+  shouldRespawnWebRuntimeTerminalAfterWake: mocks.shouldWake
+}))
+vi.mock('./web-runtime-session', () => ({
+  createWebRuntimeSessionTerminal: mocks.createTerminal
+}))
+vi.mock('./web-runtime-wake-terminal-respawn', () => ({
+  beginWebRuntimeWakeTerminalRespawn: mocks.beginWake,
+  endWebRuntimeWakeTerminalRespawn: mocks.endWake,
+  shouldSkipWebRuntimeWakeTerminalRespawn: mocks.skipWake
+}))
+vi.mock('./web-session-terminal-orphan-recovery', () => ({
+  recoverWebSessionTerminalOrphansBeforeApply: mocks.recover
+}))
+
+import {
+  type ActiveSessionTabsContext,
+  recoverAndApplyWebSessionTabsSnapshots
+} from './web-session-tabs-active-snapshot'
+
+const ENV = 'env-1'
+const WT = 'repo::worktree'
+const TARGET = 'env-1\u0001runtime-1\u00011\u00017'
+
+function snapshot(version = 1): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: WT,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: version,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+}
+
+function context(): ActiveSessionTabsContext {
+  return {
+    targetKey: TARGET,
+    environmentId: ENV,
+    pairingRevision: 7,
+    supportsAtomicGlobalSubscription: true,
+    worktreeId: WT,
+    requestedInitialTerminal: false,
+    requestedRespawnAfterWake: false
+  }
+}
+
+function process(
+  active: { current: ActiveSessionTabsContext | null },
+  options: { acceptCurrent?: boolean; isCurrent?: () => boolean; version?: number } = {}
+): Promise<ActiveSessionTabsContext | null> {
+  return recoverAndApplyWebSessionTabsSnapshots({
+    environmentId: ENV,
+    targetKey: TARGET,
+    snapshots: [{ snapshot: snapshot(options.version), type: 'snapshot' }],
+    replayed: false,
+    acceptCurrent: options.acceptCurrent ?? false,
+    activeContextRef: active,
+    isCurrent: options.isCurrent ?? (() => true)
+  })
+}
+
+describe('active web session snapshot processing', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+    mocks.shouldApply.mockReturnValue(true)
+    mocks.shouldBootstrap.mockReturnValue(false)
+    mocks.shouldWake.mockReturnValue(false)
+    mocks.beginWake.mockReturnValue(true)
+    mocks.recover.mockImplementation(async (_state, value) => value)
+  })
+
+  it('grants exact-current replay after recovery and before freshness', async () => {
+    const active: { current: ActiveSessionTabsContext | null } = { current: context() }
+    await process(active, { acceptCurrent: true })
+
+    expect(mocks.acceptReplay).toHaveBeenCalledWith(ENV, WT)
+    expect(mocks.acceptReplay.mock.invocationCallOrder[0]).toBeLessThan(
+      mocks.shouldApply.mock.invocationCallOrder[0]
+    )
+    expect(mocks.applySnapshot).toHaveBeenCalledTimes(1)
+  })
+
+  it('ignores a recovered result after its active owner becomes stale', async () => {
+    let resolveRecovery: (value: RuntimeMobileSessionTabsResult) => void = () => {}
+    mocks.recover.mockReturnValueOnce(
+      new Promise((resolve) => {
+        resolveRecovery = resolve
+      })
+    )
+    let current = true
+    const active: { current: ActiveSessionTabsContext | null } = { current: context() }
+    const pending = process(active, { acceptCurrent: true, isCurrent: () => current })
+    current = false
+    active.current = null
+    resolveRecovery(snapshot())
+
+    await expect(pending).resolves.toBeNull()
+    expect(mocks.acceptReplay).not.toHaveBeenCalled()
+    expect(mocks.shouldApply).not.toHaveBeenCalled()
+    expect(mocks.createTerminal).not.toHaveBeenCalled()
+  })
+
+  it('shares the wake lock with activation before requesting bootstrap', async () => {
+    const activeContext = context()
+    const active = { current: activeContext }
+    mocks.shouldBootstrap.mockImplementation(
+      ({ requestedInitialTerminal }) => !requestedInitialTerminal
+    )
+    mocks.beginWake.mockReturnValueOnce(false).mockReturnValue(true)
+
+    await process(active)
+    expect(mocks.createTerminal).not.toHaveBeenCalled()
+    expect(activeContext.requestedInitialTerminal).toBe(false)
+
+    await process(active, { version: 2 })
+    await process(active, { version: 3 })
+    expect(mocks.createTerminal).toHaveBeenCalledTimes(1)
+    expect(activeContext.requestedInitialTerminal).toBe(true)
+    expect(mocks.endWake).toHaveBeenCalledTimes(1)
+  })
+
+  it('uses non-selecting terminal recovery for later wake updates', async () => {
+    const active = { current: context() }
+    mocks.shouldWake.mockReturnValue(true)
+
+    await recoverAndApplyWebSessionTabsSnapshots({
+      environmentId: ENV,
+      targetKey: TARGET,
+      snapshots: [{ snapshot: snapshot(), type: 'updated' }],
+      replayed: false,
+      acceptCurrent: false,
+      activeContextRef: active,
+      isCurrent: () => true
+    })
+
+    expect(mocks.createTerminal).toHaveBeenCalledWith({
+      worktreeId: WT,
+      environmentId: ENV,
+      activate: true,
+      selectWorktree: false
+    })
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-active-snapshot.ts
+++ b/src/renderer/src/runtime/web-session-tabs-active-snapshot.ts
@@ -1,0 +1,173 @@
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import { useAppStore } from '../store'
+import {
+  acceptReplayedWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshot,
+  applyWebSessionTabsSnapshots,
+  applyWebSessionTabsStorePatch,
+  shouldApplyWebSessionTabsSnapshot,
+  shouldBootstrapInitialWebRuntimeTerminal,
+  shouldRespawnWebRuntimeTerminalAfterWake
+} from './web-session-tabs-sync'
+import { createWebRuntimeSessionTerminal } from './web-runtime-session'
+import {
+  beginWebRuntimeWakeTerminalRespawn,
+  endWebRuntimeWakeTerminalRespawn,
+  shouldSkipWebRuntimeWakeTerminalRespawn
+} from './web-runtime-wake-terminal-respawn'
+import { recoverWebSessionTerminalOrphansBeforeApply } from './web-session-terminal-orphan-recovery'
+import type { SessionTabsSnapshotEvent } from './web-session-tabs-events'
+
+export type ActiveSessionTabsContext = {
+  targetKey: string
+  environmentId: string
+  pairingRevision: number
+  supportsAtomicGlobalSubscription: boolean
+  worktreeId: string
+  requestedInitialTerminal: boolean
+  requestedRespawnAfterWake: boolean
+}
+
+export type ActiveSessionTabsContextRef = {
+  current: ActiveSessionTabsContext | null
+}
+
+type SnapshotInput = {
+  snapshot: RuntimeMobileSessionTabsResult
+  type: SessionTabsSnapshotEvent['type']
+}
+
+type ProcessSnapshotsArgs = {
+  environmentId: string
+  targetKey: string
+  snapshots: readonly SnapshotInput[]
+  replayed: boolean
+  acceptCurrent: boolean
+  activeContextRef: ActiveSessionTabsContextRef
+  isCurrent: () => boolean
+}
+
+type ActiveLifecycleDecision = {
+  context: ActiveSessionTabsContext
+  bootstrap: boolean
+  wake: boolean
+}
+
+function getActiveLifecycleDecision(
+  context: ActiveSessionTabsContext,
+  event: SessionTabsSnapshotEvent,
+  fresh: boolean
+): ActiveLifecycleDecision {
+  const state = useAppStore.getState()
+  const localWorktreeTabs = state.tabsByWorktree[context.worktreeId] ?? []
+  const localTerminalCount = localWorktreeTabs.length
+  const hasLiveLocalPty = localWorktreeTabs.some(
+    (tab) => (state.ptyIdsByTabId[tab.id] ?? []).length > 0
+  )
+  return {
+    context,
+    bootstrap: shouldBootstrapInitialWebRuntimeTerminal({
+      event,
+      activeWorktreeId: context.worktreeId,
+      requestedInitialTerminal: context.requestedInitialTerminal,
+      snapshotIsFresh: fresh,
+      localTerminalCount
+    }),
+    wake: shouldRespawnWebRuntimeTerminalAfterWake({
+      event,
+      activeWorktreeId: context.worktreeId,
+      requestedRespawnAfterWake: context.requestedRespawnAfterWake,
+      snapshotIsFresh: fresh,
+      localTerminalCount,
+      hasLiveLocalPty,
+      skipWakeRespawn: shouldSkipWebRuntimeWakeTerminalRespawn(context.worktreeId)
+    })
+  }
+}
+
+async function runActiveLifecycle(
+  decision: ActiveLifecycleDecision,
+  activeContextRef: ActiveSessionTabsContextRef
+): Promise<void> {
+  const { context, bootstrap, wake } = decision
+  if (
+    (!bootstrap && !wake) ||
+    activeContextRef.current !== context ||
+    !beginWebRuntimeWakeTerminalRespawn(context.worktreeId)
+  ) {
+    return
+  }
+  if (bootstrap) {
+    context.requestedInitialTerminal = true
+  } else {
+    context.requestedRespawnAfterWake = true
+  }
+  try {
+    await createWebRuntimeSessionTerminal({
+      worktreeId: context.worktreeId,
+      environmentId: context.environmentId,
+      activate: true,
+      ...(wake ? { selectWorktree: false } : {})
+    })
+  } finally {
+    endWebRuntimeWakeTerminalRespawn(context.worktreeId)
+  }
+}
+
+export async function recoverAndApplyWebSessionTabsSnapshots(
+  args: ProcessSnapshotsArgs
+): Promise<ActiveSessionTabsContext | null> {
+  const recovered = await Promise.all(
+    args.snapshots.map(async ({ snapshot, type }) => {
+      const result = await recoverWebSessionTerminalOrphansBeforeApply(
+        useAppStore.getState(),
+        snapshot,
+        args.environmentId
+      )
+      return result ? ({ ...result, type } satisfies SessionTabsSnapshotEvent) : null
+    })
+  )
+  if (!args.isCurrent()) {
+    return null
+  }
+
+  const applicable = recovered.filter((event): event is SessionTabsSnapshotEvent => event !== null)
+  if (args.replayed || args.acceptCurrent) {
+    for (const event of applicable) {
+      acceptReplayedWebSessionTabsSnapshot(args.environmentId, event.worktree)
+    }
+  }
+
+  const freshSnapshots: RuntimeMobileSessionTabsResult[] = []
+  let activeDecision: ActiveLifecycleDecision | null = null
+  let servicedActiveContext: ActiveSessionTabsContext | null = null
+  for (const event of applicable) {
+    const context = args.activeContextRef.current
+    const isActive = context?.targetKey === args.targetKey && context.worktreeId === event.worktree
+    const fresh = shouldApplyWebSessionTabsSnapshot(event, args.environmentId)
+    if (isActive && context) {
+      servicedActiveContext = context
+      activeDecision = getActiveLifecycleDecision(context, event, fresh)
+    }
+    if (fresh) {
+      freshSnapshots.push(event)
+    }
+  }
+  if (freshSnapshots.length === 1) {
+    applyWebSessionTabsStorePatch((state) =>
+      applyWebSessionTabsSnapshot(state, freshSnapshots[0], args.environmentId)
+    )
+  } else if (freshSnapshots.length > 1) {
+    applyWebSessionTabsStorePatch((state) =>
+      applyWebSessionTabsSnapshots(state, freshSnapshots, args.environmentId)
+    )
+  }
+  if (activeDecision && args.isCurrent()) {
+    void runActiveLifecycle(activeDecision, args.activeContextRef).catch((error) => {
+      if (args.isCurrent()) {
+        console.warn('[web-session-tabs-sync] active terminal recovery failed:', error)
+      }
+    })
+  }
+  return servicedActiveContext
+}

--- a/src/renderer/src/runtime/web-session-tabs-events.ts
+++ b/src/renderer/src/runtime/web-session-tabs-events.ts
@@ -1,0 +1,59 @@
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+
+export type SessionTabsSnapshotEvent = RuntimeMobileSessionTabsResult & {
+  type: 'snapshot' | 'updated'
+}
+
+export type SessionTabsStreamEvent =
+  | SessionTabsSnapshotEvent
+  | { type: 'snapshots'; snapshots: RuntimeMobileSessionTabsResult[] }
+  | { type: 'end' }
+
+export type SessionTabsListAllResult = {
+  snapshots: RuntimeMobileSessionTabsResult[]
+}
+
+export type SessionTabsSnapshotsEvent = SessionTabsListAllResult & {
+  type: 'snapshots'
+}
+
+export function isRuntimeSessionTabsSnapshot(
+  value: unknown
+): value is RuntimeMobileSessionTabsResult {
+  if (!value || typeof value !== 'object') {
+    return false
+  }
+  const candidate = value as Partial<RuntimeMobileSessionTabsResult>
+  return (
+    typeof candidate.worktree === 'string' &&
+    typeof candidate.publicationEpoch === 'string' &&
+    typeof candidate.snapshotVersion === 'number' &&
+    Array.isArray(candidate.tabs)
+  )
+}
+
+export function isSessionTabsListAllResult(value: unknown): value is SessionTabsListAllResult {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    Array.isArray((value as { snapshots?: unknown }).snapshots) &&
+    (value as SessionTabsListAllResult).snapshots.every(isRuntimeSessionTabsSnapshot)
+  )
+}
+
+export function isSessionTabsSnapshotsEvent(value: unknown): value is SessionTabsSnapshotsEvent {
+  return (
+    Boolean(value) &&
+    typeof value === 'object' &&
+    (value as { type?: unknown }).type === 'snapshots' &&
+    isSessionTabsListAllResult(value)
+  )
+}
+
+export function isSessionTabsSnapshotEvent(value: unknown): value is SessionTabsSnapshotEvent {
+  return (
+    isRuntimeSessionTabsSnapshot(value) &&
+    ((value as { type?: unknown }).type === 'snapshot' ||
+      (value as { type?: unknown }).type === 'updated')
+  )
+}

--- a/src/renderer/src/runtime/web-session-tabs-global-subscription.test.ts
+++ b/src/renderer/src/runtime/web-session-tabs-global-subscription.test.ts
@@ -1,0 +1,248 @@
+// @vitest-environment happy-dom
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import type { RuntimeMobileSessionTabsResult } from '../../../shared/runtime-types'
+import type { ActiveSessionTabsContext } from './web-session-tabs-active-snapshot'
+import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
+
+const mocks = vi.hoisted(() => ({
+  recover: vi.fn()
+}))
+
+vi.mock('./web-session-tabs-active-snapshot', () => ({
+  recoverAndApplyWebSessionTabsSnapshots: mocks.recover
+}))
+
+import { startGlobalWebSessionTabsSubscription } from './web-session-tabs-global-subscription'
+
+const ENVIRONMENT_ID = 'remote-env'
+const RUNTIME_ID = 'remote-runtime'
+const PAIRING_REVISION = 17
+type SubscribeCallbacks = Parameters<typeof window.api.runtimeEnvironments.subscribe>[1]
+
+function environment(): PublicKnownRuntimeEnvironment {
+  return {
+    id: ENVIRONMENT_ID,
+    name: 'Remote host',
+    createdAt: 1,
+    updatedAt: 1,
+    pairingRevision: PAIRING_REVISION,
+    lastUsedAt: null,
+    runtimeId: RUNTIME_ID,
+    endpoints: [
+      { id: 'endpoint', kind: 'websocket', label: 'WebSocket', endpoint: 'ws://remote.invalid' }
+    ],
+    preferredEndpointId: 'endpoint'
+  }
+}
+
+function response(result: unknown): RuntimeRpcResponse<unknown> {
+  return { id: 'subscribe-all', ok: true, result, _meta: { runtimeId: RUNTIME_ID } }
+}
+
+function snapshot(version: number): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: 'repo::worktree',
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: version,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+}
+
+function deferred<T = null>(): { promise: Promise<T>; resolve: (value: T) => void } {
+  let resolve: (value: T) => void = () => {}
+  const promise = new Promise<T>((done) => {
+    resolve = done
+  })
+  return { promise, resolve }
+}
+
+function activeContext(worktreeId = 'repo::worktree'): ActiveSessionTabsContext {
+  return {
+    targetKey: 'target-1',
+    environmentId: ENVIRONMENT_ID,
+    pairingRevision: PAIRING_REVISION,
+    supportsAtomicGlobalSubscription: true,
+    worktreeId,
+    requestedInitialTerminal: false,
+    requestedRespawnAfterWake: false
+  }
+}
+
+describe('global web session tabs subscription', () => {
+  const unsubscribe = vi.fn()
+  let callbacks: SubscribeCallbacks | undefined
+
+  beforeEach(() => {
+    callbacks = undefined
+    mocks.recover.mockReset()
+    unsubscribe.mockReset()
+    replaceRuntimeEnvironmentRevisions([environment()])
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: {
+        runtimeEnvironments: {
+          call: vi.fn(),
+          subscribe: vi.fn(async (_args, nextCallbacks: SubscribeCallbacks) => {
+            callbacks = nextCallbacks
+            return { unsubscribe, sendBinary: vi.fn() }
+          })
+        }
+      }
+    })
+  })
+
+  afterEach(() => {
+    replaceRuntimeEnvironmentRevisions([])
+  })
+
+  it('does not restore ready coverage after the stream closes during initial recovery', async () => {
+    const recovery = deferred()
+    mocks.recover.mockReturnValue(recovery.promise)
+    const onCoverage = vi.fn()
+    const stop = startGlobalWebSessionTabsSubscription({
+      environmentId: ENVIRONMENT_ID,
+      targetKey: 'target-1',
+      expectedRuntimeId: RUNTIME_ID,
+      expectedEnvironmentPairingRevision: PAIRING_REVISION,
+      activeContextRef: { current: null },
+      onCoverage
+    })
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    await vi.waitFor(() => expect(mocks.recover).toHaveBeenCalledOnce())
+
+    callbacks?.onClose?.()
+    expect(onCoverage).toHaveBeenCalledExactlyOnceWith({ status: 'unavailable' })
+
+    recovery.resolve(null)
+    await recovery.promise
+    await Promise.resolve()
+    expect(onCoverage).toHaveBeenCalledExactlyOnceWith({ status: 'unavailable' })
+    stop()
+  })
+
+  it('publishes ready coverage only for the latest reconnect recovery', async () => {
+    const first = deferred()
+    const second = deferred()
+    mocks.recover.mockReturnValueOnce(first.promise).mockReturnValueOnce(second.promise)
+    const onCoverage = vi.fn()
+    const stop = startGlobalWebSessionTabsSubscription({
+      environmentId: ENVIRONMENT_ID,
+      targetKey: 'target-1',
+      expectedRuntimeId: RUNTIME_ID,
+      expectedEnvironmentPairingRevision: PAIRING_REVISION,
+      activeContextRef: { current: null },
+      onCoverage
+    })
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    callbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    await vi.waitFor(() => expect(mocks.recover).toHaveBeenCalledTimes(2))
+
+    first.resolve(null)
+    await first.promise
+    await Promise.resolve()
+    expect(onCoverage).not.toHaveBeenCalled()
+
+    second.resolve(null)
+    await second.promise
+    await vi.waitFor(() =>
+      expect(onCoverage).toHaveBeenCalledExactlyOnceWith({
+        status: 'ready',
+        servicedActiveContext: null
+      })
+    )
+    stop()
+  })
+
+  it('retains active evidence that recovers before the initial batch', async () => {
+    const initialRecovery = deferred()
+    const context = activeContext()
+    mocks.recover.mockReturnValueOnce(initialRecovery.promise).mockResolvedValueOnce(context)
+    const onCoverage = vi.fn()
+    const stop = startGlobalWebSessionTabsSubscription({
+      environmentId: ENVIRONMENT_ID,
+      targetKey: 'target-1',
+      expectedRuntimeId: RUNTIME_ID,
+      expectedEnvironmentPairingRevision: PAIRING_REVISION,
+      activeContextRef: { current: context },
+      onCoverage
+    })
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    callbacks?.onResponse(response({ ...snapshot(1), type: 'updated' }))
+    await vi.waitFor(() => expect(mocks.recover).toHaveBeenCalledTimes(2))
+    expect(onCoverage).not.toHaveBeenCalled()
+
+    initialRecovery.resolve(null)
+    await initialRecovery.promise
+    await vi.waitFor(() =>
+      expect(onCoverage).toHaveBeenCalledExactlyOnceWith({
+        status: 'ready',
+        servicedActiveContext: context
+      })
+    )
+    stop()
+  })
+
+  it('does not let stale activation recovery replace pending current evidence', async () => {
+    const initialRecovery = deferred()
+    const staleRecovery = deferred<ActiveSessionTabsContext>()
+    const currentRecovery = deferred<ActiveSessionTabsContext>()
+    const staleContext = activeContext('repo::stale')
+    const currentContext = activeContext('repo::current')
+    const activeContextRef: { current: ActiveSessionTabsContext | null } = {
+      current: staleContext
+    }
+    mocks.recover
+      .mockReturnValueOnce(initialRecovery.promise)
+      .mockReturnValueOnce(staleRecovery.promise)
+      .mockReturnValueOnce(currentRecovery.promise)
+    const onCoverage = vi.fn()
+    const stop = startGlobalWebSessionTabsSubscription({
+      environmentId: ENVIRONMENT_ID,
+      targetKey: 'target-1',
+      expectedRuntimeId: RUNTIME_ID,
+      expectedEnvironmentPairingRevision: PAIRING_REVISION,
+      activeContextRef,
+      onCoverage
+    })
+    await vi.waitFor(() => expect(callbacks).toBeDefined())
+
+    callbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    callbacks?.onResponse(
+      response({ ...snapshot(1), worktree: staleContext.worktreeId, type: 'updated' })
+    )
+    activeContextRef.current = currentContext
+    callbacks?.onResponse(
+      response({ ...snapshot(2), worktree: currentContext.worktreeId, type: 'updated' })
+    )
+    await vi.waitFor(() => expect(mocks.recover).toHaveBeenCalledTimes(3))
+
+    currentRecovery.resolve(currentContext)
+    await currentRecovery.promise
+    await Promise.resolve()
+    staleRecovery.resolve(staleContext)
+    await staleRecovery.promise
+    await Promise.resolve()
+    initialRecovery.resolve(null)
+    await initialRecovery.promise
+
+    await vi.waitFor(() =>
+      expect(onCoverage).toHaveBeenCalledExactlyOnceWith({
+        status: 'ready',
+        servicedActiveContext: currentContext
+      })
+    )
+    stop()
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-global-subscription.ts
+++ b/src/renderer/src/runtime/web-session-tabs-global-subscription.ts
@@ -1,0 +1,267 @@
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import { isRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
+import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
+import {
+  isSessionTabsListAllResult,
+  isSessionTabsSnapshotEvent,
+  isSessionTabsSnapshotsEvent
+} from './web-session-tabs-events'
+import {
+  recoverAndApplyWebSessionTabsSnapshots,
+  type ActiveSessionTabsContext,
+  type ActiveSessionTabsContextRef
+} from './web-session-tabs-active-snapshot'
+
+const INITIAL_SNAPSHOT_TIMEOUT_MS = 15_000
+
+export type GlobalSessionTabsCoverage =
+  | {
+      status: 'ready'
+      generation: number
+      servicedActiveContext: ActiveSessionTabsContext | null
+    }
+  | { status: 'unavailable' }
+
+export type GlobalSessionTabsCoverageSignal =
+  | { status: 'ready'; servicedActiveContext: ActiveSessionTabsContext | null }
+  | { status: 'unavailable' }
+
+type StartGlobalSubscriptionArgs = {
+  environmentId: string
+  targetKey: string
+  expectedRuntimeId: string
+  expectedEnvironmentPairingRevision: number
+  activeContextRef: ActiveSessionTabsContextRef
+  onCoverage: (coverage: GlobalSessionTabsCoverageSignal) => void
+}
+
+export function startGlobalWebSessionTabsSubscription(
+  args: StartGlobalSubscriptionArgs
+): () => void {
+  let disposed = false
+  let receivedInitialSnapshots = false
+  let requestedInitialFallback = false
+  let unsubscribe: (() => void) | null = null
+  let coverageRevision = 0
+  let hasReadyCoverage = false
+  let publishedServicedActiveContext: ActiveSessionTabsContext | null = null
+  let pendingServicedActiveContext: ActiveSessionTabsContext | null = null
+  const pairingIsCurrent = (): boolean =>
+    getRuntimeEnvironmentRevision(args.environmentId) === args.expectedEnvironmentPairingRevision
+  const isCurrent = (): boolean => !disposed && pairingIsCurrent()
+  const isRecoveryCurrent = (revision: number): boolean =>
+    isCurrent() && revision === coverageRevision
+  const applySnapshots = (
+    snapshots: Parameters<typeof recoverAndApplyWebSessionTabsSnapshots>[0]['snapshots'],
+    options: { replayed: boolean; acceptCurrent?: boolean; recoveryRevision?: number }
+  ): Promise<ActiveSessionTabsContext | null> => {
+    const recoveryRevision = options.recoveryRevision
+    return recoverAndApplyWebSessionTabsSnapshots({
+      environmentId: args.environmentId,
+      targetKey: args.targetKey,
+      snapshots,
+      replayed: options.replayed,
+      acceptCurrent: options.acceptCurrent ?? false,
+      activeContextRef: args.activeContextRef,
+      isCurrent:
+        recoveryRevision === undefined ? isCurrent : () => isRecoveryCurrent(recoveryRevision)
+    })
+  }
+  const markUnavailable = (): void => {
+    coverageRevision += 1
+    hasReadyCoverage = false
+    publishedServicedActiveContext = null
+    pendingServicedActiveContext = null
+    if (isCurrent()) {
+      args.onCoverage({ status: 'unavailable' })
+    }
+  }
+  const requestInitialSnapshotFallback = (): void => {
+    if (!isCurrent() || receivedInitialSnapshots || requestedInitialFallback) {
+      return
+    }
+    requestedInitialFallback = true
+    clearTimeout(initialSnapshotTimer)
+    void window.api.runtimeEnvironments
+      .call({
+        selector: args.environmentId,
+        method: 'session.tabs.listAll',
+        params: {},
+        timeoutMs: INITIAL_SNAPSHOT_TIMEOUT_MS,
+        expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision
+      })
+      .then((response: RuntimeRpcResponse<unknown>) => {
+        if (!isCurrent()) {
+          return
+        }
+        if (response.ok === false) {
+          console.warn('[web-session-tabs-sync] fallback listAll failed:', response.error.message)
+          return
+        }
+        if (!isSessionTabsListAllResult(response.result)) {
+          console.warn('[web-session-tabs-sync] fallback listAll returned an invalid payload')
+          return
+        }
+        return applySnapshots(
+          response.result.snapshots.map((snapshot) => ({ snapshot, type: 'snapshot' as const })),
+          { replayed: false }
+        )
+      })
+      .catch((error) => {
+        if (isCurrent()) {
+          console.warn(
+            '[web-session-tabs-sync] failed to load fallback session tabs:',
+            error instanceof Error ? error.message : String(error)
+          )
+        }
+      })
+  }
+  const initialSnapshotTimer = setTimeout(() => {
+    markUnavailable()
+    requestInitialSnapshotFallback()
+  }, INITIAL_SNAPSHOT_TIMEOUT_MS)
+
+  void window.api.runtimeEnvironments
+    .subscribe(
+      {
+        selector: args.environmentId,
+        method: 'session.tabs.subscribeAll',
+        params: {},
+        timeoutMs: INITIAL_SNAPSHOT_TIMEOUT_MS,
+        expectedEnvironmentPairingRevision: args.expectedEnvironmentPairingRevision
+      },
+      {
+        onResponse: (response: RuntimeRpcResponse<unknown>) => {
+          if (!isCurrent()) {
+            return
+          }
+          if (response.ok === false) {
+            console.warn(
+              '[web-session-tabs-sync] global subscription failed:',
+              response.error.message
+            )
+            markUnavailable()
+            requestInitialSnapshotFallback()
+            return
+          }
+          if (response._meta.runtimeId !== args.expectedRuntimeId) {
+            markUnavailable()
+            requestInitialSnapshotFallback()
+            return
+          }
+          const replayed = isRuntimeSubscriptionReplayResponse(response)
+          if (isSessionTabsSnapshotsEvent(response.result)) {
+            const recoveryRevision = ++coverageRevision
+            hasReadyCoverage = false
+            publishedServicedActiveContext = null
+            pendingServicedActiveContext = null
+            receivedInitialSnapshots = true
+            clearTimeout(initialSnapshotTimer)
+            void applySnapshots(
+              response.result.snapshots.map((snapshot) => ({
+                snapshot,
+                type: 'snapshot' as const
+              })),
+              { replayed, recoveryRevision }
+            )
+              .then((servicedActiveContext) => {
+                if (isRecoveryCurrent(recoveryRevision)) {
+                  const pendingCurrentContext =
+                    pendingServicedActiveContext === args.activeContextRef.current
+                      ? pendingServicedActiveContext
+                      : null
+                  const effectiveServicedActiveContext =
+                    servicedActiveContext ?? pendingCurrentContext
+                  hasReadyCoverage = true
+                  pendingServicedActiveContext = null
+                  publishedServicedActiveContext = effectiveServicedActiveContext
+                  args.onCoverage({
+                    status: 'ready',
+                    servicedActiveContext: effectiveServicedActiveContext
+                  })
+                }
+              })
+              .catch((error) => {
+                if (isRecoveryCurrent(recoveryRevision)) {
+                  console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
+                  markUnavailable()
+                }
+              })
+            return
+          }
+          if (!isSessionTabsSnapshotEvent(response.result)) {
+            markUnavailable()
+            requestInitialSnapshotFallback()
+            return
+          }
+          if (!receivedInitialSnapshots) {
+            markUnavailable()
+            requestInitialSnapshotFallback()
+          }
+          const recoveryRevision = coverageRevision
+          void applySnapshots([{ snapshot: response.result, type: response.result.type }], {
+            replayed,
+            recoveryRevision
+          })
+            .then((servicedActiveContext) => {
+              if (
+                !isRecoveryCurrent(recoveryRevision) ||
+                !servicedActiveContext ||
+                servicedActiveContext !== args.activeContextRef.current
+              ) {
+                return
+              }
+              if (!hasReadyCoverage) {
+                pendingServicedActiveContext = servicedActiveContext
+                return
+              }
+              if (servicedActiveContext !== publishedServicedActiveContext) {
+                publishedServicedActiveContext = servicedActiveContext
+                args.onCoverage({ status: 'ready', servicedActiveContext })
+              }
+            })
+            .catch((error) => {
+              if (isRecoveryCurrent(recoveryRevision)) {
+                console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
+              }
+            })
+        },
+        onError: (error) => {
+          if (!isCurrent()) {
+            return
+          }
+          console.warn('[web-session-tabs-sync] global subscription error:', error.message)
+          markUnavailable()
+          requestInitialSnapshotFallback()
+        },
+        onClose: () => {
+          markUnavailable()
+          requestInitialSnapshotFallback()
+        }
+      }
+    )
+    .then((handle) => {
+      if (disposed) {
+        handle.unsubscribe()
+      } else {
+        unsubscribe = handle.unsubscribe
+      }
+    })
+    .catch((error) => {
+      if (!disposed) {
+        console.warn(
+          '[web-session-tabs-sync] failed to subscribe globally:',
+          error instanceof Error ? error.message : String(error)
+        )
+        markUnavailable()
+        requestInitialSnapshotFallback()
+      }
+    })
+
+  return () => {
+    disposed = true
+    coverageRevision += 1
+    clearTimeout(initialSnapshotTimer)
+    unsubscribe?.()
+  }
+}

--- a/src/renderer/src/runtime/web-session-tabs-sync-fallback.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-fallback.test.tsx
@@ -1,0 +1,323 @@
+// @vitest-environment happy-dom
+
+import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { getDefaultSettings } from '../../../shared/constants'
+import { SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
+import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
+import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
+import type { RuntimeMobileSessionTabsResult, RuntimeStatus } from '../../../shared/runtime-types'
+import type { Repo, TerminalTab } from '../../../shared/types'
+import { useAppStore } from '../store'
+import { makeWorktree } from '../store/slices/store-test-helpers'
+import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
+import { useWebSessionTabsSync } from './use-web-session-tabs-sync'
+import { resetWebSessionTabsSnapshotFreshnessForTests } from './web-session-tabs-sync'
+
+const ENV = 'remote-env'
+const RUNTIME = 'remote-runtime'
+const REPO = 'remote-repo'
+const WT = `${REPO}::/remote/worktree`
+const REVISION = 17
+const initialState = useAppStore.getInitialState()
+type SubscribeCallbacks = Parameters<typeof window.api.runtimeEnvironments.subscribe>[1]
+
+function snapshot(): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: WT,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: []
+  }
+}
+
+function globalResponse(result: unknown): RuntimeRpcResponse<unknown> {
+  return { id: 'subscribe-all', ok: true, result, _meta: { runtimeId: RUNTIME } }
+}
+
+function seedRemoteWorkspace(): void {
+  const environment: PublicKnownRuntimeEnvironment = {
+    id: ENV,
+    name: 'Remote host',
+    createdAt: 1,
+    updatedAt: 1,
+    pairingRevision: REVISION,
+    lastUsedAt: null,
+    runtimeId: RUNTIME,
+    endpoints: [
+      { id: 'endpoint', kind: 'websocket', label: 'WebSocket', endpoint: 'ws://remote.invalid' }
+    ],
+    preferredEndpointId: 'endpoint'
+  }
+  const repo: Repo = {
+    id: REPO,
+    path: '/remote/repo',
+    displayName: 'Remote repo',
+    badgeColor: '#000',
+    addedAt: 1,
+    connectionId: null,
+    executionHostId: `runtime:${ENV}`
+  }
+  const tab: TerminalTab = {
+    id: 'local-tab',
+    ptyId: 'local-pty',
+    worktreeId: WT,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
+  const status: RuntimeStatus = {
+    runtimeId: RUNTIME,
+    rendererGraphEpoch: 1,
+    graphStatus: 'ready',
+    authoritativeWindowId: null,
+    liveTabCount: 0,
+    liveLeafCount: 0,
+    capabilities: [SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY]
+  }
+  replaceRuntimeEnvironmentRevisions([environment])
+  useAppStore.setState(
+    {
+      ...initialState,
+      settings: { ...getDefaultSettings('/tmp'), activeRuntimeEnvironmentId: ENV },
+      repos: [repo],
+      worktreesByRepo: {
+        [REPO]: [
+          makeWorktree({
+            id: WT,
+            repoId: REPO,
+            path: '/remote/worktree',
+            hostId: `runtime:${ENV}`,
+            runtimeOwnerEnvironmentId: ENV
+          })
+        ]
+      },
+      activeRepoId: REPO,
+      activeWorktreeId: WT,
+      activeWorkspaceExecutionHostId: `runtime:${ENV}`,
+      tabsByWorktree: { [WT]: [tab] },
+      ptyIdsByTabId: { [tab.id]: ['local-pty'] },
+      runtimeEnvironments: [environment],
+      runtimeStatusByEnvironmentId: new Map([
+        [ENV, { status, checkedAt: 1, connectionGeneration: 3 }]
+      ]),
+      workspaceSessionReady: true
+    },
+    true
+  )
+}
+
+function setRuntimeCapabilities(capabilities: RuntimeStatus['capabilities']): void {
+  const current = useAppStore.getState().runtimeStatusByEnvironmentId.get(ENV)
+  if (!current?.status) {
+    throw new Error('Expected seeded remote runtime status')
+  }
+  useAppStore.setState({
+    runtimeStatusByEnvironmentId: new Map([
+      [ENV, { ...current, status: { ...current.status, capabilities } }]
+    ])
+  })
+}
+
+describe('useWebSessionTabsSync global fallback', () => {
+  const runtimeCall = vi.fn()
+  const runtimeSubscribe = vi.fn()
+  const globalUnsubscribe = vi.fn()
+  const activeUnsubscribe = vi.fn()
+  let globalCallbacks: SubscribeCallbacks | undefined
+  let activeCallbacks: SubscribeCallbacks | undefined
+
+  beforeEach(() => {
+    resetWebSessionTabsSnapshotFreshnessForTests()
+    vi.clearAllMocks()
+    globalCallbacks = undefined
+    activeCallbacks = undefined
+    runtimeCall.mockImplementation(async ({ method }: { method: string }) => ({
+      id: method,
+      ok: true,
+      result: method === 'session.tabs.listAll' ? { snapshots: [] } : snapshot()
+    }))
+    runtimeSubscribe.mockImplementation(
+      async (args: { method: string }, callbacks: SubscribeCallbacks) => {
+        if (args.method === 'session.tabs.subscribeAll') {
+          globalCallbacks = callbacks
+        } else {
+          activeCallbacks = callbacks
+        }
+        return {
+          unsubscribe:
+            args.method === 'session.tabs.subscribeAll' ? globalUnsubscribe : activeUnsubscribe,
+          sendBinary: vi.fn()
+        }
+      }
+    )
+    Object.defineProperty(window, 'api', {
+      configurable: true,
+      value: { runtimeEnvironments: { call: runtimeCall, subscribe: runtimeSubscribe } }
+    })
+    seedRemoteWorkspace()
+  })
+
+  afterEach(() => {
+    cleanup()
+    useAppStore.setState(initialState, true)
+    replaceRuntimeEnvironmentRevisions([])
+    resetWebSessionTabsSnapshotFreshnessForTests()
+  })
+
+  it('uses listAll and the scoped stream when subscribeAll cannot start', async () => {
+    let rejectGlobal: (error: Error) => void = () => {}
+    runtimeSubscribe.mockImplementation(async (args: { method: string }) => {
+      if (args.method === 'session.tabs.subscribeAll') {
+        return new Promise<never>((_resolve, reject) => {
+          rejectGlobal = reject
+        })
+      }
+      return { unsubscribe: activeUnsubscribe, sendBinary: vi.fn() }
+    })
+
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await act(async () => rejectGlobal(new Error('unavailable')))
+
+    await waitFor(() =>
+      expect(runtimeSubscribe.mock.calls.map(([args]) => args.method)).toEqual([
+        'session.tabs.subscribeAll',
+        'session.tabs.subscribe'
+      ])
+    )
+    expect(runtimeCall.mock.calls.map(([args]) => args.method)).toContain('session.tabs.listAll')
+    hook.unmount()
+    expect(activeUnsubscribe).toHaveBeenCalledTimes(1)
+  })
+
+  it('once-gates repeated pre-initial failures', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    await act(async () => {
+      globalCallbacks?.onResponse(globalResponse(null))
+      globalCallbacks?.onResponse({
+        id: 'subscribe-all',
+        ok: false,
+        error: { code: 'method_not_found', message: 'missing' }
+      })
+      globalCallbacks?.onError?.({ code: 'transport_closed', message: 'closed' })
+      globalCallbacks?.onClose?.()
+    })
+
+    await waitFor(() =>
+      expect(
+        runtimeSubscribe.mock.calls.filter(([args]) => args.method === 'session.tabs.subscribe')
+      ).toHaveLength(1)
+    )
+    expect(
+      runtimeCall.mock.calls.filter(([args]) => args.method === 'session.tabs.listAll')
+    ).toHaveLength(1)
+    hook.unmount()
+  })
+
+  it('keeps later active wake updates on a protocol-v2 fallback stream', async () => {
+    setRuntimeCapabilities(undefined)
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => {
+      expect(globalCallbacks).toBeDefined()
+      expect(activeCallbacks).toBeDefined()
+    })
+    await act(async () =>
+      globalCallbacks?.onResponse({
+        id: 'subscribe-all',
+        ok: false,
+        error: { code: 'method_not_found', message: 'missing' }
+      })
+    )
+    await waitFor(() => expect(activeCallbacks).toBeDefined())
+    useAppStore.setState({
+      tabsByWorktree: {
+        [WT]: [
+          {
+            id: 'slept-tab',
+            ptyId: null,
+            worktreeId: WT,
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 2
+          }
+        ]
+      },
+      ptyIdsByTabId: {}
+    })
+    await act(async () =>
+      activeCallbacks?.onResponse(
+        globalResponse({ ...snapshot(), snapshotVersion: 2, type: 'updated' })
+      )
+    )
+
+    await waitFor(() =>
+      expect(runtimeCall.mock.calls.map(([args]) => args.method)).toContain(
+        'session.tabs.createTerminal'
+      )
+    )
+    hook.unmount()
+  })
+
+  it('keeps the scoped stream after a pre-atomic v3 global batch', async () => {
+    setRuntimeCapabilities([])
+
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => {
+      expect(globalCallbacks).toBeDefined()
+      expect(activeCallbacks).toBeDefined()
+    })
+    await act(async () =>
+      globalCallbacks?.onResponse(globalResponse({ type: 'snapshots', snapshots: [snapshot()] }))
+    )
+
+    expect(runtimeSubscribe.mock.calls.map(([args]) => args.method)).toEqual([
+      'session.tabs.subscribeAll',
+      'session.tabs.subscribe'
+    ])
+    expect(activeUnsubscribe).not.toHaveBeenCalled()
+    hook.unmount()
+  })
+
+  it('restores scoped updates when a proven global stream closes', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    await act(async () =>
+      globalCallbacks?.onResponse(globalResponse({ type: 'snapshots', snapshots: [snapshot()] }))
+    )
+    await waitFor(() => expect(activeUnsubscribe).toHaveBeenCalledOnce())
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+
+    await act(async () => globalCallbacks?.onClose?.())
+    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(3))
+    expect(runtimeSubscribe.mock.calls[2]?.[0].method).toBe('session.tabs.subscribe')
+    hook.unmount()
+  })
+
+  it('times out to listAll and the scoped stream', async () => {
+    vi.useFakeTimers()
+    try {
+      const hook = renderHook(() => useWebSessionTabsSync())
+      await act(async () => {})
+      expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+
+      await act(async () => vi.advanceTimersByTimeAsync(15_000))
+      expect(runtimeCall.mock.calls.map(([args]) => args.method)).toContain('session.tabs.listAll')
+      expect(runtimeSubscribe.mock.calls.map(([args]) => args.method)).toEqual([
+        'session.tabs.subscribeAll',
+        'session.tabs.subscribe'
+      ])
+      hook.unmount()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+})

--- a/src/renderer/src/runtime/web-session-tabs-sync-subscription.test.tsx
+++ b/src/renderer/src/runtime/web-session-tabs-sync-subscription.test.tsx
@@ -3,22 +3,22 @@
 import { act, cleanup, renderHook, waitFor } from '@testing-library/react'
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { getDefaultSettings } from '../../../shared/constants'
+import { SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY } from '../../../shared/protocol-version'
 import type { PublicKnownRuntimeEnvironment } from '../../../shared/runtime-environments'
 import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
-import type { RuntimeStatus } from '../../../shared/runtime-types'
-import type { Repo } from '../../../shared/types'
+import type { RuntimeMobileSessionTabsResult, RuntimeStatus } from '../../../shared/runtime-types'
+import type { Repo, TerminalTab } from '../../../shared/types'
 import { useAppStore } from '../store'
 import { makeWorktree } from '../store/slices/store-test-helpers'
 import { replaceRuntimeEnvironmentRevisions } from './runtime-environment-revision'
-import {
-  resetWebSessionTabsSnapshotFreshnessForTests,
-  useWebSessionTabsSync
-} from './web-session-tabs-sync'
+import { resetWebSessionTabsSnapshotFreshnessForTests } from './web-session-tabs-sync'
+import { useWebSessionTabsSync } from './use-web-session-tabs-sync'
 
 const ENVIRONMENT_ID = 'remote-env'
 const RUNTIME_ID = 'remote-runtime'
 const REPO_ID = 'remote-repo'
 const WORKTREE_ID = `${REPO_ID}::/remote/worktree`
+const SECOND_WORKTREE_ID = `${REPO_ID}::/remote/second-worktree`
 const PAIRING_REVISION = 17
 const initialState = useAppStore.getInitialState()
 type RuntimeSubscribeCallbacks = Parameters<typeof window.api.runtimeEnvironments.subscribe>[1]
@@ -51,7 +51,8 @@ function runtimeStatus(): RuntimeStatus {
     graphStatus: 'ready',
     authoritativeWindowId: null,
     liveTabCount: 0,
-    liveLeafCount: 0
+    liveLeafCount: 0,
+    capabilities: [SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY]
   }
 }
 
@@ -67,18 +68,43 @@ function repo(): Repo {
   }
 }
 
-function worktree() {
+function worktree(id = WORKTREE_ID) {
   return makeWorktree({
-    id: WORKTREE_ID,
+    id,
     repoId: REPO_ID,
-    path: '/remote/worktree',
+    path: id === WORKTREE_ID ? '/remote/worktree' : '/remote/second-worktree',
     hostId: `runtime:${ENVIRONMENT_ID}`,
     runtimeOwnerEnvironmentId: ENVIRONMENT_ID
   })
 }
 
+function snapshot(
+  overrides: Partial<RuntimeMobileSessionTabsResult> = {}
+): RuntimeMobileSessionTabsResult {
+  return {
+    worktree: WORKTREE_ID,
+    publicationEpoch: 'epoch-1',
+    snapshotVersion: 1,
+    activeGroupId: null,
+    activeTabId: null,
+    activeTabType: null,
+    tabs: [],
+    ...overrides
+  }
+}
+
 function seedRemoteWorkspace(): void {
   const remoteEnvironment = environment()
+  const localTab: TerminalTab = {
+    id: 'local-tab',
+    ptyId: 'local-pty',
+    worktreeId: WORKTREE_ID,
+    title: 'Terminal',
+    customTitle: null,
+    color: null,
+    sortOrder: 0,
+    createdAt: 1
+  }
   replaceRuntimeEnvironmentRevisions([remoteEnvironment])
   useAppStore.setState(
     {
@@ -92,6 +118,8 @@ function seedRemoteWorkspace(): void {
       activeRepoId: REPO_ID,
       activeWorktreeId: WORKTREE_ID,
       activeWorkspaceExecutionHostId: `runtime:${ENVIRONMENT_ID}`,
+      tabsByWorktree: { [WORKTREE_ID]: [localTab] },
+      ptyIdsByTabId: { [localTab.id]: ['local-pty'] },
       runtimeEnvironments: [remoteEnvironment],
       runtimeStatusByEnvironmentId: new Map([
         [
@@ -127,12 +155,21 @@ describe('useWebSessionTabsSync subscription topology', () => {
     runtimeCall.mockReset()
     runtimeSubscribe.mockReset()
     globalCallbacks = undefined
-    runtimeCall.mockResolvedValue({
-      id: 'list-all',
-      ok: true,
-      result: { snapshots: [] },
-      _meta: { runtimeId: RUNTIME_ID }
-    })
+    runtimeCall.mockImplementation(
+      async ({ method, params }: { method: string; params?: { worktree?: string } }) => ({
+        id: method,
+        ok: true,
+        result:
+          method === 'session.tabs.listAll'
+            ? { snapshots: [] }
+            : snapshot({
+                worktree: params?.worktree?.startsWith('id:')
+                  ? params.worktree.slice(3)
+                  : WORKTREE_ID
+              }),
+        _meta: { runtimeId: RUNTIME_ID }
+      })
+    )
     runtimeSubscribe.mockImplementation(
       async (args: { method: string }, callbacks: RuntimeSubscribeCallbacks) => {
         if (args.method === 'session.tabs.subscribeAll') {
@@ -164,110 +201,219 @@ describe('useWebSessionTabsSync subscription topology', () => {
     resetWebSessionTabsSnapshotFreshnessForTests()
   })
 
-  it('hydrates through subscribeAll without an eager listAll request', async () => {
+  it('retires the bootstrap stream when the global batch contains the active worktree', async () => {
     const hook = renderHook(() => useWebSessionTabsSync())
 
     await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
-    expect(runtimeSubscribe.mock.calls.map(([args]) => args)).toEqual(
-      expect.arrayContaining([
-        {
-          selector: ENVIRONMENT_ID,
-          method: 'session.tabs.subscribeAll',
-          params: {},
-          timeoutMs: 15_000,
-          expectedEnvironmentPairingRevision: PAIRING_REVISION
-        },
-        {
-          selector: ENVIRONMENT_ID,
-          method: 'session.tabs.subscribe',
-          params: { worktree: `id:${WORKTREE_ID}` },
-          timeoutMs: 15_000,
-          expectedEnvironmentPairingRevision: PAIRING_REVISION
-        }
-      ])
+    await act(async () => {
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [snapshot()] }))
+    })
+
+    await waitFor(() => expect(activeUnsubscribe).toHaveBeenCalledOnce())
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+    expect(runtimeCall).not.toHaveBeenCalled()
+    hook.unmount()
+  })
+
+  it('uses one scoped list when a valid global batch omits the active worktree', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    await act(async () => {
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    })
+
+    await waitFor(() =>
+      expect(runtimeCall).toHaveBeenCalledWith({
+        selector: ENVIRONMENT_ID,
+        method: 'session.tabs.list',
+        params: { worktree: `id:${WORKTREE_ID}` },
+        timeoutMs: 15_000,
+        expectedEnvironmentPairingRevision: PAIRING_REVISION
+      })
     )
-    expect(runtimeCall).not.toHaveBeenCalled()
-
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+    expect(activeUnsubscribe).toHaveBeenCalledOnce()
+    expect(
+      runtimeCall.mock.calls.filter(([args]) => args.method === 'session.tabs.list')
+    ).toHaveLength(1)
     hook.unmount()
-    expect(globalUnsubscribe).toHaveBeenCalledTimes(1)
-    expect(activeUnsubscribe).toHaveBeenCalledTimes(1)
   })
 
-  it('falls back to one listAll request when subscribeAll cannot start', async () => {
-    let rejectGlobalSubscription: (error: Error) => void = () => {}
-    const globalSubscription = new Promise<never>((_resolve, reject) => {
-      rejectGlobalSubscription = reject
-    })
-    runtimeSubscribe.mockImplementation(async (args: { method: string }) => {
-      if (args.method === 'session.tabs.subscribeAll') {
-        return globalSubscription
-      }
-      return { unsubscribe: activeUnsubscribe, sendBinary: vi.fn() }
-    })
-
+  it('re-lists an omitted active worktree after a global reconnect replay', async () => {
     const hook = renderHook(() => useWebSessionTabsSync())
-
-    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
-    expect(runtimeCall).not.toHaveBeenCalled()
-    rejectGlobalSubscription(new Error('shared-control unavailable'))
-    await waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
-    expect(runtimeCall).toHaveBeenCalledWith({
-      selector: ENVIRONMENT_ID,
-      method: 'session.tabs.listAll',
-      params: {},
-      timeoutMs: 15_000,
-      expectedEnvironmentPairingRevision: PAIRING_REVISION
-    })
-
-    hook.unmount()
-    expect(globalUnsubscribe).not.toHaveBeenCalled()
-    expect(activeUnsubscribe).toHaveBeenCalledTimes(1)
-  })
-
-  it('once-gates fallback across invalid and failed pre-initial stream events', async () => {
-    const hook = renderHook(() => useWebSessionTabsSync())
-
     await waitFor(() => expect(globalCallbacks).toBeDefined())
-    expect(() => globalCallbacks?.onResponse(response(null))).not.toThrow()
-    globalCallbacks?.onResponse({
-      id: 'subscribe-all',
+    await act(async () =>
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    )
+    await waitFor(() =>
+      expect(
+        runtimeCall.mock.calls.filter(([args]) => args.method === 'session.tabs.list')
+      ).toHaveLength(1)
+    )
+
+    await act(async () =>
+      globalCallbacks?.onResponse({
+        ...response({ type: 'snapshots', snapshots: [] }),
+        _replayedAfterReconnect: true
+      } as unknown as RuntimeRpcResponse<unknown>)
+    )
+    await waitFor(() =>
+      expect(
+        runtimeCall.mock.calls.filter(([args]) => args.method === 'session.tabs.list')
+      ).toHaveLength(2)
+    )
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+    hook.unmount()
+  })
+
+  it('routes later global updates through active wake recovery without a scoped stream', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    await act(async () =>
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [snapshot()] }))
+    )
+    useAppStore.setState({
+      tabsByWorktree: {
+        [WORKTREE_ID]: [
+          {
+            id: 'slept-tab',
+            ptyId: null,
+            worktreeId: WORKTREE_ID,
+            title: 'Terminal',
+            customTitle: null,
+            color: null,
+            sortOrder: 0,
+            createdAt: 2
+          }
+        ]
+      },
+      ptyIdsByTabId: {}
+    })
+
+    await act(async () =>
+      globalCallbacks?.onResponse(
+        response({ ...snapshot({ snapshotVersion: 2 }), type: 'updated' })
+      )
+    )
+
+    await waitFor(() =>
+      expect(runtimeCall.mock.calls.map(([args]) => args.method)).toContain(
+        'session.tabs.createTerminal'
+      )
+    )
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
+    expect(activeUnsubscribe).toHaveBeenCalledOnce()
+    hook.unmount()
+  })
+
+  it('retires a list-failure fallback after later global active evidence', async () => {
+    runtimeCall.mockResolvedValueOnce({
+      id: 'session.tabs.list',
       ok: false,
-      error: { code: 'method_not_found', message: 'missing' }
+      error: { code: 'transport_closed', message: 'retry on the live stream' }
     })
-    globalCallbacks?.onError?.({ code: 'transport_closed', message: 'closed' })
-    globalCallbacks?.onClose?.()
-
-    await waitFor(() => expect(runtimeCall).toHaveBeenCalledTimes(1))
-    hook.unmount()
-  })
-
-  it('does not fall back after a valid initial snapshot batch', async () => {
     const hook = renderHook(() => useWebSessionTabsSync())
-
-    await waitFor(() => expect(globalCallbacks).toBeDefined())
-    globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
-    globalCallbacks?.onError?.({ code: 'transport_closed', message: 'closed' })
-    globalCallbacks?.onClose?.()
-
     await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
-    expect(runtimeCall).not.toHaveBeenCalled()
+    await act(async () =>
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [] }))
+    )
+    await waitFor(() =>
+      expect(
+        runtimeSubscribe.mock.calls.filter(([args]) => args.method === 'session.tabs.subscribe')
+      ).toHaveLength(2)
+    )
+
+    await act(async () =>
+      globalCallbacks?.onResponse(
+        response({ ...snapshot({ snapshotVersion: 2 }), type: 'updated' })
+      )
+    )
+    await waitFor(() => expect(activeUnsubscribe).toHaveBeenCalledTimes(2))
+
+    await act(async () =>
+      globalCallbacks?.onResponse(
+        response({ ...snapshot({ snapshotVersion: 3 }), type: 'updated' })
+      )
+    )
+    expect(activeUnsubscribe).toHaveBeenCalledTimes(2)
+    expect(runtimeSubscribe).toHaveBeenCalledTimes(3)
     hook.unmount()
   })
 
-  it('falls back when a started stream never sends its initial batch', async () => {
-    vi.useFakeTimers()
-    try {
-      const hook = renderHook(() => useWebSessionTabsSync())
-      await act(async () => {})
+  it('fails open to scoped coverage when a replay comes from another runtime', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => expect(runtimeSubscribe).toHaveBeenCalledTimes(2))
+    await act(async () =>
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [snapshot()] }))
+    )
+    await waitFor(() => expect(activeUnsubscribe).toHaveBeenCalledOnce())
 
-      expect(runtimeSubscribe).toHaveBeenCalledTimes(2)
-      expect(runtimeCall).not.toHaveBeenCalled()
-      await act(async () => vi.advanceTimersByTimeAsync(15_000))
-      expect(runtimeCall).toHaveBeenCalledTimes(1)
+    await act(async () =>
+      globalCallbacks?.onResponse({
+        ...response({ type: 'snapshots', snapshots: [snapshot({ snapshotVersion: 2 })] }),
+        _meta: { runtimeId: 'restarted-pre-atomic-runtime' },
+        _replayedAfterReconnect: true
+      } as unknown as RuntimeRpcResponse<unknown>)
+    )
 
-      hook.unmount()
-    } finally {
-      vi.useRealTimers()
-    }
+    await waitFor(() =>
+      expect(
+        runtimeSubscribe.mock.calls.filter(([args]) => args.method === 'session.tabs.subscribe')
+      ).toHaveLength(2)
+    )
+    expect(activeUnsubscribe).toHaveBeenCalledOnce()
+    hook.unmount()
+  })
+
+  it('re-lists the same worktree after switching away and back', async () => {
+    const hook = renderHook(() => useWebSessionTabsSync())
+    await waitFor(() => expect(globalCallbacks).toBeDefined())
+    await act(async () =>
+      globalCallbacks?.onResponse(response({ type: 'snapshots', snapshots: [snapshot()] }))
+    )
+
+    await act(async () => {
+      useAppStore.setState((state) => ({
+        worktreesByRepo: { [REPO_ID]: [worktree(), worktree(SECOND_WORKTREE_ID)] },
+        activeWorktreeId: SECOND_WORKTREE_ID,
+        tabsByWorktree: {
+          ...state.tabsByWorktree,
+          [SECOND_WORKTREE_ID]: []
+        }
+      }))
+    })
+    await waitFor(() =>
+      expect(
+        runtimeCall.mock.calls.filter(
+          ([args]) =>
+            args.method === 'session.tabs.list' &&
+            args.params.worktree === `id:${SECOND_WORKTREE_ID}`
+        )
+      ).toHaveLength(1)
+    )
+
+    runtimeCall.mockClear()
+    await act(async () => {
+      useAppStore.setState((state) => ({
+        activeWorktreeId: WORKTREE_ID,
+        tabsByWorktree: { ...state.tabsByWorktree, [WORKTREE_ID]: [] },
+        ptyIdsByTabId: {}
+      }))
+    })
+
+    await waitFor(() =>
+      expect(
+        runtimeCall.mock.calls.filter(
+          ([args]) =>
+            args.method === 'session.tabs.list' && args.params.worktree === `id:${WORKTREE_ID}`
+        )
+      ).toHaveLength(1)
+    )
+    expect(
+      runtimeSubscribe.mock.calls.filter(([args]) => args.method === 'session.tabs.subscribe')
+    ).toHaveLength(1)
+    expect(activeUnsubscribe).toHaveBeenCalledOnce()
+    hook.unmount()
   })
 })

--- a/src/renderer/src/runtime/web-session-tabs-sync.ts
+++ b/src/renderer/src/runtime/web-session-tabs-sync.ts
@@ -1,8 +1,6 @@
 /* eslint-disable max-lines -- web session-tab sync reconciles terminal, unified-tab, group, and PTY maps atomically to avoid split-brain tab state */
-import { useEffect } from 'react'
 import type { AppState } from '../store'
 import { useAppStore } from '../store'
-import type { RuntimeRpcResponse } from '../../../shared/runtime-rpc-envelope'
 import { FLOATING_TERMINAL_WORKTREE_ID } from '../../../shared/constants'
 import {
   AGENT_STATUS_STALE_AFTER_MS,
@@ -34,9 +32,7 @@ import { sanitizeTerminalLayoutPaneTitlesForLabels } from '@/lib/terminal-pane-t
 import { terminalLayoutEqual } from '@/lib/terminal-layout-equality'
 import { normalizeTerminalLayoutPtyOwnership } from '@/components/terminal-pane/terminal-layout-pty-ownership'
 import { isClientAuthoritativeAgentStatusPane } from '@/components/terminal-pane/renderer-owned-agent-status-registry'
-import { getExplicitRuntimeEnvironmentIdForWorktree } from '@/lib/worktree-runtime-owner'
 import {
-  createWebRuntimeSessionTerminal,
   HOST_TERMINAL_SURFACE_SEPARATOR,
   isWebTerminalSurfaceTabId,
   toWebTerminalSurfaceTabId,
@@ -48,33 +44,21 @@ import {
 } from '../../../shared/agent-title-owner'
 import { resolvePaneAgentOwner } from '../../../shared/pane-agent-owner'
 import { resolveTerminalLayoutRoot } from './remote-terminal-layout-resolution'
-import { toRuntimeWorktreeSelector } from './runtime-worktree-selector'
+import { clearWebSessionFocusIntent, peekWebSessionFocusIntent } from './web-session-focus-intent'
 import {
-  clearWebSessionFocusIntent,
-  clearWebSessionFocusIntentsForOwner,
-  peekWebSessionFocusIntent
-} from './web-session-focus-intent'
-import {
-  clearWebSessionCloseIntentsForOwner,
   clearWebSessionCloseIntentsForWorktree,
   isWebSessionCloseIntentPending,
   reconcileWebSessionCloseIntents
 } from './web-session-close-intent'
 import {
-  clearWebSessionReorderIntentsForOwner,
   clearWebSessionReorderIntentsForWorktree,
   resolveWebSessionReorderedOrder
 } from './web-session-reorder-intent'
 import {
-  beginWebRuntimeWakeTerminalRespawn,
   clearAllWebRuntimeWakeTerminalRespawn,
-  clearWebRuntimeWakeTerminalRespawnForWorktree,
-  endWebRuntimeWakeTerminalRespawn,
-  shouldSkipWebRuntimeWakeTerminalRespawn
+  clearWebRuntimeWakeTerminalRespawnForWorktree
 } from './web-runtime-wake-terminal-respawn'
-import { isRuntimeSubscriptionReplayResponse } from '../../../shared/runtime-subscription-replay'
 import { queueAcceptedWebSessionTerminalSnapshot } from './web-session-terminal-handle-events'
-import { recoverWebSessionTerminalOrphansBeforeApply } from './web-session-terminal-orphan-recovery'
 import {
   clearWebAgentSessionHandoff,
   clearWebAgentSessionHandoffsForEnvironment,
@@ -82,25 +66,9 @@ import {
   isWebAgentSessionHandoffPostCreateSnapshotConfirmed,
   resolveWebAgentSessionHandoff
 } from './web-agent-session-handoff'
-import { getRuntimeEnvironmentRevision } from './runtime-environment-revision'
-import { useRuntimeSessionMirrorEnvironmentKey } from './use-runtime-session-mirror-environment-key'
+import type { SessionTabsStreamEvent } from './web-session-tabs-events'
 
 const WEB_SESSION_GROUP_PREFIX = 'web-session-tabs:'
-const WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS = 15_000
-
-type SessionTabsStreamEvent =
-  | (RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' })
-  | { type: 'snapshots'; snapshots: RuntimeMobileSessionTabsResult[] }
-  | { type: 'end' }
-
-type SessionTabsListAllResult = {
-  snapshots: RuntimeMobileSessionTabsResult[]
-}
-
-type SessionTabsSnapshotsEvent = {
-  type: 'snapshots'
-  snapshots: RuntimeMobileSessionTabsResult[]
-}
 
 type SnapshotFreshness = {
   publicationEpoch: string
@@ -170,47 +138,6 @@ export type WebSessionTabsSyncState = Pick<
   | 'sortEpoch'
 > &
   Partial<Pick<AppState, 'automaticAgentResumeClaimsByTabId' | 'pendingStartupByTabId'>>
-
-function isRuntimeSessionTabsSnapshot(value: unknown): value is RuntimeMobileSessionTabsResult {
-  if (!value || typeof value !== 'object') {
-    return false
-  }
-  const candidate = value as Partial<RuntimeMobileSessionTabsResult>
-  return (
-    typeof candidate.worktree === 'string' &&
-    typeof candidate.publicationEpoch === 'string' &&
-    typeof candidate.snapshotVersion === 'number' &&
-    Array.isArray(candidate.tabs)
-  )
-}
-
-function isSessionTabsListAllResult(value: unknown): value is SessionTabsListAllResult {
-  return (
-    Boolean(value) &&
-    typeof value === 'object' &&
-    Array.isArray((value as { snapshots?: unknown }).snapshots) &&
-    (value as SessionTabsListAllResult).snapshots.every(isRuntimeSessionTabsSnapshot)
-  )
-}
-
-function isSessionTabsSnapshotsEvent(value: unknown): value is SessionTabsSnapshotsEvent {
-  return (
-    Boolean(value) &&
-    typeof value === 'object' &&
-    (value as { type?: unknown }).type === 'snapshots' &&
-    isSessionTabsListAllResult(value)
-  )
-}
-
-function isSessionTabsSnapshotEvent(
-  value: unknown
-): value is RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' } {
-  return (
-    isRuntimeSessionTabsSnapshot(value) &&
-    ((value as { type?: unknown }).type === 'snapshot' ||
-      (value as { type?: unknown }).type === 'updated')
-  )
-}
 
 function sessionTabsFreshnessKey(environmentId: string, worktreeId: string): string {
   return `${environmentId}:${worktreeId}`
@@ -2739,438 +2666,4 @@ export function applyWebSessionTabsStorePatch(
   if (mirroredAgentStatusChanged) {
     useAppStore.getState().scheduleAgentStatusFreshness()
   }
-}
-
-function startAllWebSessionTabsSubscription(
-  args: Parameters<typeof window.api.runtimeEnvironments.subscribe>[0],
-  callbacks: Parameters<typeof window.api.runtimeEnvironments.subscribe>[1],
-  onStartError: (error: unknown) => void
-): () => void {
-  let disposed = false
-  let unsubscribe: (() => void) | null = null
-  void window.api.runtimeEnvironments
-    .subscribe(args, callbacks)
-    .then((handle) => {
-      if (disposed) {
-        handle.unsubscribe()
-        return
-      }
-      unsubscribe = handle.unsubscribe
-    })
-    .catch((error) => {
-      if (!disposed) {
-        onStartError(error)
-      }
-    })
-  return () => {
-    disposed = true
-    unsubscribe?.()
-  }
-}
-
-function startWebSessionTabsInitialFallbackTimer(onTimeout: () => void): () => void {
-  const timer = setTimeout(onTimeout, WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS)
-  return () => clearTimeout(timer)
-}
-
-export function useWebSessionTabsSync(): void {
-  const activeWorktreeId = useAppStore((state) => state.activeWorktreeId)
-  const runtimeSessionMirrorEnvironmentKey = useRuntimeSessionMirrorEnvironmentKey()
-  const activeWorktreeRuntimeEnvironmentId = useAppStore((state) =>
-    getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
-  )
-  const activeWorktreeRuntimeId = useAppStore((state) => {
-    const environmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
-    return environmentId
-      ? (state.runtimeStatusByEnvironmentId.get(environmentId)?.status?.runtimeId ?? null)
-      : null
-  })
-  const activeWorktreeRuntimeConnectionGeneration = useAppStore((state) => {
-    const environmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
-    return environmentId
-      ? (state.runtimeStatusByEnvironmentId.get(environmentId)?.connectionGeneration ?? 0)
-      : 0
-  })
-  const activeWorktreeRuntimePairingRevision = useAppStore((state) => {
-    const environmentId = getExplicitRuntimeEnvironmentIdForWorktree(state, state.activeWorktreeId)
-    const environment = state.runtimeEnvironments.find(
-      (candidate) => candidate.id === environmentId
-    )
-    return environment ? (environment.pairingRevision ?? environment.createdAt) : undefined
-  })
-  const workspaceSessionReady = useAppStore((state) => state.workspaceSessionReady)
-
-  useEffect(() => {
-    const environments = runtimeSessionMirrorEnvironmentKey
-      ? runtimeSessionMirrorEnvironmentKey
-          .split('\u0000')
-          .map((entry) => {
-            const [environmentId = '', , , rawRevision = ''] = entry.split('\u0001')
-            return {
-              environmentId,
-              expectedEnvironmentPairingRevision:
-                rawRevision === '' ? undefined : Number(rawRevision)
-            }
-          })
-          .filter(({ environmentId }) => environmentId.trim())
-      : []
-    // Why: mirror all paired runtimes' sessions, not just the selected worktree, so background worktrees don't look asleep (selectedness isn't liveness).
-    // Why: applying the host snapshot before startup hydration writes browser-local session state clobbers it and leaves the sidebar stale.
-    if (!workspaceSessionReady || environments.length === 0) {
-      return
-    }
-
-    let disposed = false
-    const unsubscribes: (() => void)[] = []
-    for (const { environmentId, expectedEnvironmentPairingRevision } of environments) {
-      if (
-        !shouldSyncAllRuntimeSessionTabs({
-          activeRuntimeEnvironmentId: environmentId,
-          workspaceSessionReady
-        })
-      ) {
-        continue
-      }
-      let receivedInitialSnapshots = false
-      let requestedInitialFallback = false
-      let stopInitialFallbackTimer = (): void => {}
-      const pairingIsCurrent = (): boolean =>
-        getRuntimeEnvironmentRevision(environmentId) === expectedEnvironmentPairingRevision
-      const recoverAndApplySnapshots = async (
-        snapshots: RuntimeMobileSessionTabsResult[],
-        replayed: boolean
-      ): Promise<void> => {
-        const recovered = await Promise.all(
-          snapshots.map((snapshot) =>
-            recoverWebSessionTerminalOrphansBeforeApply(
-              useAppStore.getState(),
-              snapshot,
-              environmentId
-            )
-          )
-        )
-        if (disposed || !pairingIsCurrent()) {
-          return
-        }
-        const applicable = recovered.filter(
-          (snapshot): snapshot is RuntimeMobileSessionTabsResult => snapshot !== null
-        )
-        if (replayed) {
-          for (const snapshot of applicable) {
-            acceptReplayedWebSessionTabsSnapshot(environmentId, snapshot.worktree)
-          }
-        }
-        applyWebSessionTabsStorePatch((state) =>
-          applyFreshWebSessionTabsSnapshots(state, applicable, environmentId)
-        )
-      }
-      const requestInitialSnapshotFallback = (): void => {
-        if (
-          disposed ||
-          !pairingIsCurrent() ||
-          receivedInitialSnapshots ||
-          requestedInitialFallback
-        ) {
-          return
-        }
-        requestedInitialFallback = true
-        stopInitialFallbackTimer()
-        void window.api.runtimeEnvironments
-          .call({
-            selector: environmentId,
-            method: 'session.tabs.listAll',
-            params: {},
-            timeoutMs: WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS,
-            expectedEnvironmentPairingRevision
-          })
-          .then((response: RuntimeRpcResponse<unknown>) => {
-            if (disposed || !pairingIsCurrent()) {
-              return
-            }
-            if (response.ok === false) {
-              console.warn(
-                '[web-session-tabs-sync] fallback listAll failed:',
-                response.error.message
-              )
-              return
-            }
-            if (!isSessionTabsListAllResult(response.result)) {
-              console.warn('[web-session-tabs-sync] fallback listAll returned an invalid payload')
-              return
-            }
-            void recoverAndApplySnapshots(response.result.snapshots, false).catch((error) => {
-              if (!disposed) {
-                console.warn('[web-session-tabs-sync] fallback snapshot recovery failed:', error)
-              }
-            })
-          })
-          .catch((error) => {
-            if (!disposed && pairingIsCurrent()) {
-              console.warn(
-                '[web-session-tabs-sync] failed to load fallback session tabs:',
-                error instanceof Error ? error.message : String(error)
-              )
-            }
-          })
-      }
-      stopInitialFallbackTimer = startWebSessionTabsInitialFallbackTimer(
-        requestInitialSnapshotFallback
-      )
-      unsubscribes.push(stopInitialFallbackTimer)
-
-      unsubscribes.push(
-        startAllWebSessionTabsSubscription(
-          {
-            selector: environmentId,
-            method: 'session.tabs.subscribeAll',
-            params: {},
-            timeoutMs: WEB_SESSION_TABS_INITIAL_SNAPSHOT_TIMEOUT_MS,
-            expectedEnvironmentPairingRevision
-          },
-          {
-            onResponse: (response: RuntimeRpcResponse<unknown>) => {
-              if (disposed || !pairingIsCurrent()) {
-                return
-              }
-              if (response.ok === false) {
-                console.warn(
-                  '[web-session-tabs-sync] global subscription failed:',
-                  response.error.message
-                )
-                requestInitialSnapshotFallback()
-                return
-              }
-              const event = response.result
-              const replayed = isRuntimeSubscriptionReplayResponse(response)
-              if (isSessionTabsSnapshotsEvent(event)) {
-                receivedInitialSnapshots = true
-                stopInitialFallbackTimer()
-                void recoverAndApplySnapshots(event.snapshots, replayed).catch((error) => {
-                  if (!disposed) {
-                    console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
-                  }
-                })
-                return
-              }
-              if (!isSessionTabsSnapshotEvent(event)) {
-                requestInitialSnapshotFallback()
-                return
-              }
-              if (!receivedInitialSnapshots) {
-                requestInitialSnapshotFallback()
-              }
-              void recoverWebSessionTerminalOrphansBeforeApply(
-                useAppStore.getState(),
-                event,
-                environmentId
-              )
-                .then((recovered) => {
-                  if (!disposed && recovered) {
-                    if (replayed) {
-                      acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
-                    }
-                    applyWebSessionTabsStorePatch((state) =>
-                      applyFreshWebSessionTabsSnapshot(state, recovered, environmentId)
-                    )
-                  }
-                })
-                .catch((error) => {
-                  if (!disposed) {
-                    console.warn('[web-session-tabs-sync] snapshot recovery failed:', error)
-                  }
-                })
-            },
-            onError: (error) => {
-              if (disposed || !pairingIsCurrent()) {
-                return
-              }
-              console.warn('[web-session-tabs-sync] global subscription error:', error.message)
-              requestInitialSnapshotFallback()
-            },
-            onClose: () => {
-              requestInitialSnapshotFallback()
-            }
-          },
-          (error) => {
-            if (!disposed) {
-              console.warn(
-                '[web-session-tabs-sync] failed to subscribe globally:',
-                error instanceof Error ? error.message : String(error)
-              )
-              requestInitialSnapshotFallback()
-            }
-          }
-        )
-      )
-    }
-
-    return () => {
-      disposed = true
-      for (const unsubscribe of unsubscribes) {
-        unsubscribe()
-      }
-      // Why: environment ids churn as paired runtimes reconnect; don't leak stale tracking for the renderer lifetime.
-      for (const { environmentId, expectedEnvironmentPairingRevision } of environments) {
-        clearWebSessionTabsTrackingForEnvironment(environmentId)
-        const owner = {
-          environmentId,
-          pairingRevision: expectedEnvironmentPairingRevision
-        }
-        clearWebSessionCloseIntentsForOwner(owner)
-        clearWebSessionFocusIntentsForOwner(owner)
-        clearWebSessionReorderIntentsForOwner(owner)
-      }
-    }
-  }, [runtimeSessionMirrorEnvironmentKey, workspaceSessionReady])
-
-  useEffect(() => {
-    const environmentId = activeWorktreeRuntimeEnvironmentId?.trim()
-    const expectedEnvironmentPairingRevision = activeWorktreeRuntimePairingRevision
-    if (
-      !shouldSyncRuntimeSessionTabs({
-        activeWorktreeId,
-        activeWorktreeRuntimeEnvironmentId,
-        workspaceSessionReady
-      }) ||
-      !environmentId ||
-      !activeWorktreeId
-    ) {
-      return
-    }
-
-    // Why: activating a worktree can clear its local mirror after the global stream already recorded this host revision.
-    acceptReplayedWebSessionTabsSnapshot(environmentId, activeWorktreeId)
-    let disposed = false
-    let requestedInitialTerminal = false
-    let requestedRespawnAfterWake = false
-    let unsubscribe: (() => void) | null = null
-    const applyActiveSnapshot = async (
-      event: RuntimeMobileSessionTabsResult & { type: 'snapshot' | 'updated' },
-      response: RuntimeRpcResponse<unknown>
-    ): Promise<void> => {
-      const recovered = await recoverWebSessionTerminalOrphansBeforeApply(
-        useAppStore.getState(),
-        event,
-        environmentId
-      )
-      if (disposed || !recovered) {
-        return
-      }
-      if (isRuntimeSubscriptionReplayResponse(response)) {
-        acceptReplayedWebSessionTabsSnapshot(environmentId, recovered.worktree)
-      }
-      const recoveredEvent: SessionTabsStreamEvent = { ...recovered, type: event.type }
-      const fresh = shouldApplyWebSessionTabsSnapshot(recovered, environmentId)
-      const syncState = useAppStore.getState()
-      const localWorktreeTabs = syncState.tabsByWorktree[activeWorktreeId] ?? []
-      const localTerminalCount = localWorktreeTabs.length
-      const hasLiveLocalPty = localWorktreeTabs.some(
-        (tab) => (syncState.ptyIdsByTabId[tab.id] ?? []).length > 0
-      )
-      const shouldBootstrapInitialTerminal = shouldBootstrapInitialWebRuntimeTerminal({
-        event: recoveredEvent,
-        activeWorktreeId,
-        requestedInitialTerminal,
-        snapshotIsFresh: fresh,
-        localTerminalCount
-      })
-      const shouldRespawnAfterWake = shouldRespawnWebRuntimeTerminalAfterWake({
-        event: recoveredEvent,
-        activeWorktreeId,
-        requestedRespawnAfterWake,
-        snapshotIsFresh: fresh,
-        localTerminalCount,
-        hasLiveLocalPty,
-        skipWakeRespawn: shouldSkipWebRuntimeWakeTerminalRespawn(activeWorktreeId)
-      })
-      if (fresh) {
-        applyWebSessionTabsStorePatch((state) =>
-          applyWebSessionTabsSnapshot(state, recovered, environmentId)
-        )
-      }
-      if (!disposed && shouldBootstrapInitialTerminal) {
-        requestedInitialTerminal = true
-        await createWebRuntimeSessionTerminal({
-          worktreeId: activeWorktreeId,
-          environmentId,
-          activate: true
-        })
-      } else if (
-        !disposed &&
-        shouldRespawnAfterWake &&
-        beginWebRuntimeWakeTerminalRespawn(activeWorktreeId)
-      ) {
-        requestedRespawnAfterWake = true
-        await createWebRuntimeSessionTerminal({
-          worktreeId: activeWorktreeId,
-          environmentId,
-          activate: true,
-          selectWorktree: false
-        }).finally(() => endWebRuntimeWakeTerminalRespawn(activeWorktreeId))
-      }
-    }
-    void window.api.runtimeEnvironments
-      .subscribe(
-        {
-          selector: environmentId,
-          method: 'session.tabs.subscribe',
-          params: { worktree: toRuntimeWorktreeSelector(activeWorktreeId) },
-          timeoutMs: 15_000,
-          expectedEnvironmentPairingRevision
-        },
-        {
-          onResponse: (response: RuntimeRpcResponse<unknown>) => {
-            if (
-              disposed ||
-              getRuntimeEnvironmentRevision(environmentId) !== expectedEnvironmentPairingRevision
-            ) {
-              return
-            }
-            if (response.ok === false) {
-              console.warn('[web-session-tabs-sync] subscription failed:', response.error.message)
-              return
-            }
-            const event = response.result as SessionTabsStreamEvent
-            if (event.type !== 'snapshot' && event.type !== 'updated') {
-              return
-            }
-            void applyActiveSnapshot(event, response).catch((error) => {
-              if (!disposed) {
-                console.warn('[web-session-tabs-sync] active snapshot recovery failed:', error)
-              }
-            })
-          },
-          onError: (error) => {
-            console.warn('[web-session-tabs-sync] subscription error:', error.message)
-          }
-        }
-      )
-      .then((handle) => {
-        if (disposed) {
-          handle.unsubscribe()
-          return
-        }
-        unsubscribe = handle.unsubscribe
-      })
-      .catch((error) => {
-        if (!disposed) {
-          console.warn(
-            '[web-session-tabs-sync] failed to subscribe:',
-            error instanceof Error ? error.message : String(error)
-          )
-        }
-      })
-
-    return () => {
-      disposed = true
-      unsubscribe?.()
-    }
-  }, [
-    activeWorktreeId,
-    activeWorktreeRuntimeEnvironmentId,
-    activeWorktreeRuntimeConnectionGeneration,
-    activeWorktreeRuntimeId,
-    activeWorktreeRuntimePairingRevision,
-    workspaceSessionReady
-  ])
 }

--- a/src/shared/protocol-version.ts
+++ b/src/shared/protocol-version.ts
@@ -73,6 +73,9 @@ export const ACCOUNT_IMPORT_RUNTIME_CAPABILITY = 'accounts.import-host-credentia
 export const TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY =
   'terminal.create-idempotency.v2' as const
 export const SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY = 'session-tabs.close-intent.v1' as const
+// Why: older subscribeAll handlers installed their listener after inventory capture, so clients must retain the scoped stream unless the host promises a gap-free handoff.
+export const SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY =
+  'session-tabs.atomic-subscribe-all.v1' as const
 export const AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY =
   'agent-session.session-boundary.v1' as const
 export { REMOTE_SERVER_UPDATE_CAPABILITY } from './remote-server-update'
@@ -112,6 +115,7 @@ export const RUNTIME_CAPABILITIES = [
   WORKTREE_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   TERMINAL_CREATE_IDEMPOTENCY_RUNTIME_CAPABILITY,
   SESSION_TAB_CLOSE_INTENT_RUNTIME_CAPABILITY,
+  SESSION_TABS_ATOMIC_SUBSCRIBE_ALL_RUNTIME_CAPABILITY,
   AGENT_SESSION_BOUNDARY_RUNTIME_CAPABILITY,
   REMOTE_SERVER_UPDATE_CAPABILITY,
   AGENT_SESSION_HOST_AUTHORITY_RUNTIME_CAPABILITY,


### PR DESCRIPTION
## Summary

- Reuses the atomic all-worktree session-tab stream for active-worktree lifecycle updates after the host proves gap-free coverage.
- Retires the temporary scoped active stream after global proof, while preserving a scoped fallback for old hosts, failures, closes, and runtime restarts.
- Adds runtime-id, pairing-revision, recovery-revision, and exact-activation fences for reconnect and A → B → A races.
- Splits the former monolithic session sync hook into lifecycle, event, global-transport, and active-transport modules.

## ELI5

The renderer was listening to the same remote session news through two radios. Every host update was decoded, projected, reconciled, and sent through orphan recovery twice.

A current host can now say, “my all-worktree radio is gap-free.” Orca briefly keeps both radios during startup, then turns off the active-worktree radio once that proof arrives. If the host is older, restarts as a different runtime, the global radio closes, or recovery fails, Orca keeps or restores the dedicated radio instead of risking missed terminal updates.

## Quantified evidence

For a capability-enabled host in steady state after initial global proof:

| Work per active session-tab publication | Before | After |
| --- | ---: | ---: |
| Logical live streams | 2 | 1 |
| Host client projections | 2 | 1 |
| Renderer orphan-recovery passes | 2 | 1 |
| Parse / IPC / encrypted stream frames | 2 | 1 |

That is a deterministic 50% reduction in each duplicated unit. These are topology counts asserted by tests, not a claimed end-to-end CPU percentage.

Startup intentionally overlaps two streams until proof so a slow host-wide bootstrap cannot stall the active workspace. If the initial batch omits the active worktree, the renderer performs one scoped list. If that list fails, the fallback stream is retired by the next proven global active update.

Protocol-v2 and pre-atomic-v3 hosts retain the existing scoped live stream, so their steady topology stays unchanged.

## Reliability contract

- **Invariant:** `remote-session-tabs.active-live-coverage` — every active worktree retains gap-free live session evidence across mixed versions, reconnect, close, runtime replacement, worktree switching, and empty-worktree bootstrap, while capability-enabled atomic hosts converge to one steady live stream.
- **Failure source:** the v1.4.178 remote-host renderer slowdown and the duplicate active/global session-tab topology.
- **Oracle:** deterministic tests cover capability/no-capability topology, runtime-id mismatch, protocol-v2 fallback, pre-atomic-v3 fallback, close during deferred recovery, overlapping reconnect recovery, list failure followed by global recovery, and A → B → A reactivation.
- **Diagnostics:** existing scoped/global subscription warnings remain intact.
- **Residual:** no end-to-end CPU percentage is claimed; startup overlap is deliberate.

## Compatibility

- Adds only the optional `session-tabs.atomic-subscribe-all.v1` runtime capability; no protocol version or payload shape changes.
- Old clients ignore the capability. New clients fail open to scoped streaming when it is absent or the response runtime identity differs.
- No persisted-state migration or mobile-required field change.
- SSH, relay, folder-workspace, macOS, Linux, and Windows ownership/routing paths are unchanged.

## Validation

- 13 focused session/terminal files: 241 tests passed
- `pnpm run typecheck`
- `pnpm run check:code-quality:changed`
- `pnpm run check:max-lines-ratchet`
- `pnpm run build:electron-vite`
- `git diff --check`
- Two adversarial reviewers: no remaining P0/P1/P2 findings

## Stack

Depends on #13577, which provides the atomic `session.tabs.subscribeAll` inventory boundary.