### PR TITLE
perf(orchestration): coalesce drift probes per dispatch tick

### DIFF
--- a/src/main/runtime/orchestration/coordinator-drift-probe-coalescing.test.ts
+++ b/src/main/runtime/orchestration/coordinator-drift-probe-coalescing.test.ts
@@ -73,4 +73,57 @@ describe('Coordinator drift probe coalescing', () => {
 
     await expect(runPromise).resolves.toMatchObject({ status: 'completed' })
   })
+
+  it('reuses capacity after refusing a stale-base task', async () => {
+    db = new OrchestrationDb(':memory:')
+    const sentMessages: { handle: string; text: string }[] = []
+    const probeDriftCalls: string[] = []
+    const runtime: CoordinatorRuntime = {
+      async sendTerminalAgentPrompt(handle, prompt) {
+        sentMessages.push({ handle, text: prompt })
+        return { accepted: true }
+      },
+      async listTerminals() {
+        return {
+          terminals: [{ handle: 'term_a', worktreeId: 'wt1', connected: true, writable: true }]
+        }
+      },
+      async createTerminal() {
+        throw new Error('unexpected terminal create')
+      },
+      async waitForTerminal(handle) {
+        return { handle, condition: 'exit' }
+      },
+      async probeWorktreeDrift(worktreeSelector) {
+        probeDriftCalls.push(worktreeSelector)
+        return {
+          base: 'origin/main',
+          behind: DISPATCH_STALE_THRESHOLD + 1,
+          recentSubjects: ['stale']
+        }
+      }
+    }
+    const refused = db.createTask({ spec: 'requires a current base' })
+    const allowed = db.createTask({ spec: 'can use stale base\nallow-stale-base: true' })
+    const coordinator = new Coordinator(db, runtime, {
+      spec: 'go',
+      coordinatorHandle: 'coord',
+      maxConcurrent: 1,
+      pollIntervalMs: 30,
+      worktree: 'wt1'
+    })
+
+    const runPromise = coordinator.run()
+    await vi.waitFor(() => expect(sentMessages).toHaveLength(1))
+
+    expect(probeDriftCalls).toEqual(['wt1'])
+    expect(db.getTask(refused.id)?.status).toBe('ready')
+    expect(db.getTask(allowed.id)?.status).toBe('dispatched')
+    expect(sentMessages[0]).toMatchObject({ handle: 'term_a' })
+    expect(sentMessages[0].text).toContain('can use stale base')
+    expect(sentMessages[0].text).not.toContain('allow-stale-base: true')
+
+    coordinator.stop()
+    await expect(runPromise).resolves.toMatchObject({ status: 'failed' })
+  })
 })

--- a/src/main/runtime/orchestration/coordinator-drift-probe-coalescing.test.ts
+++ b/src/main/runtime/orchestration/coordinator-drift-probe-coalescing.test.ts
@@ -1,0 +1,76 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { Coordinator, DISPATCH_STALE_THRESHOLD, type CoordinatorRuntime } from './coordinator'
+import { OrchestrationDb } from './db'
+
+describe('Coordinator drift probe coalescing', () => {
+  let db: OrchestrationDb
+
+  afterEach(() => {
+    db?.close()
+  })
+
+  it('shares one drift snapshot across a tick and probes again on the next tick', async () => {
+    db = new OrchestrationDb(':memory:')
+    const sentMessages: { handle: string; text: string }[] = []
+    const probeDriftCalls: string[] = []
+    const terminals = [
+      { handle: 'term_a', worktreeId: 'wt1', connected: true, writable: true },
+      { handle: 'term_b', worktreeId: 'wt1', connected: true, writable: true }
+    ]
+    const runtime: CoordinatorRuntime = {
+      async sendTerminalAgentPrompt(handle, prompt) {
+        sentMessages.push({ handle, text: prompt })
+        return { accepted: true }
+      },
+      async listTerminals() {
+        return { terminals }
+      },
+      async createTerminal() {
+        throw new Error('unexpected terminal create')
+      },
+      async waitForTerminal(handle) {
+        return { handle, condition: 'exit' }
+      },
+      async probeWorktreeDrift(worktreeSelector) {
+        probeDriftCalls.push(worktreeSelector)
+        return probeDriftCalls.length === 1
+          ? {
+              base: 'origin/main',
+              behind: DISPATCH_STALE_THRESHOLD + 1,
+              recentSubjects: ['stale']
+            }
+          : { base: 'origin/main', behind: 0, recentSubjects: [] }
+      }
+    }
+    const first = db.createTask({ spec: 'first task' })
+    const second = db.createTask({ spec: 'second task' })
+    const coordinator = new Coordinator(db, runtime, {
+      spec: 'go',
+      coordinatorHandle: 'coord',
+      pollIntervalMs: 30,
+      worktree: 'wt1'
+    })
+
+    const runPromise = coordinator.run()
+    await vi.waitFor(() => expect(sentMessages).toHaveLength(2))
+
+    expect(probeDriftCalls).toEqual(['wt1', 'wt1'])
+    expect(sentMessages.map((message) => message.handle).sort()).toEqual(['term_a', 'term_b'])
+
+    for (const task of [first, second]) {
+      const dispatch = db.getDispatchContext(task.id)
+      if (!dispatch?.assignee_handle) {
+        throw new Error(`missing dispatch for ${task.id}`)
+      }
+      db.insertMessage({
+        from: dispatch.assignee_handle,
+        to: 'coord',
+        subject: 'Done',
+        type: 'worker_done',
+        payload: JSON.stringify({ taskId: task.id, dispatchId: dispatch.id, outcome: 'succeeded' })
+      })
+    }
+
+    await expect(runPromise).resolves.toMatchObject({ status: 'completed' })
+  })
+})

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -10,6 +10,8 @@ type WorktreeDrift = {
   recentSubjects: string[]
 } | null
 
+type TaskDispatchResult = 'dispatched' | 'stale-base-refused'
+
 export type CoordinatorRuntime = {
   sendTerminalAgentPrompt(handle: string, prompt: string): Promise<unknown>
   listTerminals(
@@ -398,7 +400,11 @@ export class Coordinator {
       slotsAvailable--
 
       try {
-        await this.dispatchTask(task, targetHandle, baseDrift)
+        const result = await this.dispatchTask(task, targetHandle, baseDrift)
+        if (result === 'stale-base-refused') {
+          terminals.unshift(targetHandle)
+          slotsAvailable++
+        }
       } catch (err) {
         this.opts.onLog(`Failed to dispatch task ${task.id}: ${String(err)}`)
       }
@@ -409,7 +415,7 @@ export class Coordinator {
     task: TaskRow,
     targetHandle: string,
     baseDrift: WorktreeDrift
-  ): Promise<void> {
+  ): Promise<TaskDispatchResult> {
     // Why (§3.1): drift check runs before createDispatchContext so a refusal doesn't bump failure_count (carried forward as MAX in db.ts:301-306) and burn the circuit-breaker budget; the task stays `ready` and retries next tick.
     const { allowStale, strippedSpec } = parseAllowStaleBaseFromSpec(task.spec)
 
@@ -425,7 +431,7 @@ export class Coordinator {
           `in the task spec to override. Task remains in 'ready'; coordinator ` +
           `will retry on the next tick.`
       )
-      return
+      return 'stale-base-refused'
     }
 
     const dispatchAuthority = this.runtime.getOrchestrationDispatchAuthority?.(targetHandle)
@@ -482,6 +488,7 @@ export class Coordinator {
 
     this.opts.onLog(`Dispatched task ${task.id} to ${targetHandle}`)
     this.state.phase = 'monitoring'
+    return 'dispatched'
   }
 
   private async getAvailableTerminals(): Promise<string[]> {

--- a/src/main/runtime/orchestration/coordinator.ts
+++ b/src/main/runtime/orchestration/coordinator.ts
@@ -4,6 +4,12 @@ import type { MessageRow, TaskRow, CoordinatorStatus } from './types'
 import { buildDispatchPreamble } from './preamble'
 import { reconcileLifecycleMessage } from './lifecycle-reconciliation'
 
+type WorktreeDrift = {
+  base: string
+  behind: number
+  recentSubjects: string[]
+} | null
+
 export type CoordinatorRuntime = {
   sendTerminalAgentPrompt(handle: string, prompt: string): Promise<unknown>
   listTerminals(
@@ -22,11 +28,7 @@ export type CoordinatorRuntime = {
     options?: { condition?: string; timeoutMs?: number }
   ): Promise<{ handle: string; condition: string }>
   // Why (§3.1): lives on the runtime because it must resolve a worktree, load the repo, and fetch — the coordinator only knows handles + specs.
-  probeWorktreeDrift(worktreeSelector: string): Promise<{
-    base: string
-    behind: number
-    recentSubjects: string[]
-  } | null>
+  probeWorktreeDrift(worktreeSelector: string): Promise<WorktreeDrift>
   // Why: pane-only fallback preserves reservation identity for lightweight runtime fakes.
   getTerminalPaneKey?(handle: string): string | null
   // Why: automatic dispatch persists the same authenticated pane/process tuple as manual dispatch.
@@ -379,6 +381,14 @@ export class Coordinator {
       }
     }
 
+    // Why: every task in one tick dispatches from the same fetched base snapshot.
+    const baseDrift = this.opts.worktree
+      ? await this.runtime.probeWorktreeDrift(this.opts.worktree).catch((err) => {
+          this.opts.onLog(`probeWorktreeDrift failed for ${this.opts.worktree}: ${err}`)
+          return null
+        })
+      : null
+
     for (const task of readyTasks) {
       if (slotsAvailable <= 0 || terminals.length === 0) {
         break
@@ -388,42 +398,34 @@ export class Coordinator {
       slotsAvailable--
 
       try {
-        await this.dispatchTask(task, targetHandle)
+        await this.dispatchTask(task, targetHandle, baseDrift)
       } catch (err) {
         this.opts.onLog(`Failed to dispatch task ${task.id}: ${String(err)}`)
       }
     }
   }
 
-  private async dispatchTask(task: TaskRow, targetHandle: string): Promise<void> {
+  private async dispatchTask(
+    task: TaskRow,
+    targetHandle: string,
+    baseDrift: WorktreeDrift
+  ): Promise<void> {
     // Why (§3.1): drift check runs before createDispatchContext so a refusal doesn't bump failure_count (carried forward as MAX in db.ts:301-306) and burn the circuit-breaker budget; the task stays `ready` and retries next tick.
     const { allowStale, strippedSpec } = parseAllowStaleBaseFromSpec(task.spec)
-    let baseDrift: {
-      base: string
-      behind: number
-      recentSubjects: string[]
-    } | null = null
 
     if (!this.opts.worktree) {
       // Why (§7.4): worktree is optional; with none we can't probe drift, so log that the guard is inert and proceed.
       this.opts.onLog(`stale-base guard inert for ${task.id}: coordinator has no worktree selector`)
-    } else {
-      baseDrift = await this.runtime.probeWorktreeDrift(this.opts.worktree).catch((err) => {
-        this.opts.onLog(`probeWorktreeDrift failed for ${this.opts.worktree}: ${err}`)
-        return null
-      })
-
-      if (baseDrift && baseDrift.behind > DISPATCH_STALE_THRESHOLD && !allowStale) {
-        // Why (§3.1): silent-return, not failDispatch — failing a recoverable stale-base here would burn the circuit-breaker budget.
-        this.opts.onLog(
-          `Skipping dispatch of ${task.id}: worktree is ${baseDrift.behind} commits ` +
-            `behind ${baseDrift.base}. Pull/rebase the worktree, recreate it with ` +
-            `--base-branch ${baseDrift.base}, or include 'allow-stale-base: true' ` +
-            `in the task spec to override. Task remains in 'ready'; coordinator ` +
-            `will retry on the next tick.`
-        )
-        return
-      }
+    } else if (baseDrift && baseDrift.behind > DISPATCH_STALE_THRESHOLD && !allowStale) {
+      // Why (§3.1): silent-return, not failDispatch — failing a recoverable stale-base here would burn the circuit-breaker budget.
+      this.opts.onLog(
+        `Skipping dispatch of ${task.id}: worktree is ${baseDrift.behind} commits ` +
+          `behind ${baseDrift.base}. Pull/rebase the worktree, recreate it with ` +
+          `--base-branch ${baseDrift.base}, or include 'allow-stale-base: true' ` +
+          `in the task spec to override. Task remains in 'ready'; coordinator ` +
+          `will retry on the next tick.`
+      )
+      return
     }
 
     const dispatchAuthority = this.runtime.getOrchestrationDispatchAuthority?.(targetHandle)


### PR DESCRIPTION
## Summary

- resolve worktree drift once for each coordinator dispatch tick
- apply that exact snapshot to every ready task considered in the tick
- probe again on the next tick instead of retaining a cross-cycle cache
- preserve terminal and concurrency capacity when a task refuses a stale base

This is a focused risk-reduction follow-up to #13440.

## Why

The async drift conversion removed Electron main-thread blocking, but the coordinator still called the same probe once per ready task. With the default four dispatch slots, one tick could run four identical `rev-list` probes and four identical `log` probes after one shared fetch. A base update between those calls could also split one dispatch batch across different drift decisions.

The coordinator now takes one cycle-scoped snapshot after terminal availability is known. Every task in that tick gets a consistent stale-base decision, while the next tick performs a fresh probe. A stale-base refusal explicitly restores its unused terminal and concurrency slot so a later task with `allow-stale-base: true` can dispatch in the same tick.

## Reliability contract

- **Invariant:** all tasks considered in one coordinator tick use one fetched-base drift snapshot; later ticks do not reuse it.
- **Capacity invariant:** a task that remains ready after a stale-base refusal does not consume a terminal or concurrency slot.
- **Failure source:** per-task probing multiplied bounded Git subprocesses by ready-task count after #13440.
- **Oracle:** one regression test returns stale drift for the first probe and current drift thereafter, proving both tasks remain blocked in the first tick, both dispatch in the next tick, and exactly two probes occur. A second one-terminal test places a refused task before an override task and proves the override dispatches immediately.
- **Gate:** no registered reliability gate currently owns orchestration stale-base batching; focused deterministic tests cover the lower-layer gap.
- **Provider/platform coverage:** local and WSL probes retain the existing runtime Git routing and 15-second process-tree timeout. SSH worktrees remain explicitly unknown and never reach local Git. No path, shell, wire, persistence, mobile, or Git-provider contract changes.
- **Performance budget:** default four-slot dispatch falls from up to four identical drift/log probes per tick to one. No timer, retry, long-lived cache, listener, or retained map is added.
- **Diagnostics:** the existing probe-failure and per-task stale-skip logs remain; one failed cycle probe now produces one failure log.
- **Residual gap:** separate coordinator instances may still overlap probes. This PR removes deterministic within-coordinator fanout without adding a service-wide cache or stale-result lifetime.

## Testing

- [x] coordinator and real-Git suites: 4 files, 35 tests passed
- [x] `pnpm run typecheck:node`
- [x] `pnpm lint`
- [x] changed-code quality: 0 findings across 2 files
- [x] reliability manifest and max-lines ratchet
- [x] formatting and `git diff --check`
- [x] GitHub CI on updated head: 43 passed, 1 expected e2e skip, 0 failures

## AI Review Report

- Reviewed the scheduling change across native, WSL, SSH, folder-workspace, and git-worktree routing.
- CodeRabbit identified that a stale-base refusal could consume capacity for the tick. Commit `1bb6b4323cf` makes the refusal explicit, restores only that unused capacity, and adds the one-terminal ordering regression test.
- CodeRabbit re-read the fixed head, reports all 5 pre-merge checks passing, and has no unresolved review threads.

## Security Audit

- No new external input, command construction, authentication, authorization, secret handling, RPC, stream, or persistence surface.
- Git execution and timeout behavior are unchanged; this only reduces duplicate calls and carries one in-memory result through a single tick.
- Probe errors retain the fail-open behavior from #13440 and are not cached across ticks.

## Notes

- No visual change.
- No remote wire change. Mixed client/host versions are unaffected.
- SSH worktrees continue to avoid local Git probing; remote-session behavior is unchanged.
