### PR TITLE
perf(main): abort requests from destroyed renderers

### DIFF
--- a/src/main/ipc/filesystem.test.ts
+++ b/src/main/ipc/filesystem.test.ts
@@ -3120,6 +3120,46 @@ describe('registerFilesystemHandlers', () => {
     })
   })
 
+  it('fs:listFiles aborts an in-flight direct SSH listing when its sender is destroyed', async () => {
+    let capturedSignal: AbortSignal | undefined
+    const listFilesMock = vi.fn(
+      (_rootPath: string, options: { signal?: AbortSignal }) =>
+        new Promise<string[]>((_resolve, reject) => {
+          capturedSignal = options.signal
+          options.signal?.addEventListener('abort', () => reject(new Error('sender destroyed')), {
+            once: true
+          })
+        })
+    )
+    getSshFilesystemProviderMock.mockReturnValue({ listFiles: listFilesMock })
+
+    registerFilesystemHandlers(store as never)
+
+    let destroyed = false
+    const sender = Object.assign(new EventEmitter(), {
+      id: 8,
+      isDestroyed: () => destroyed
+    })
+    const pending = handlers.get('fs:listFiles')!(
+      { sender },
+      {
+        rootPath: '/home/user/repo',
+        connectionId: 'conn-1',
+        requestToken: 'token-destroyed-sender'
+      }
+    ) as Promise<string[]>
+
+    expect(capturedSignal?.aborted).toBe(false)
+    expect(sender.listenerCount('destroyed')).toBe(1)
+
+    destroyed = true
+    sender.emit('destroyed')
+
+    expect(capturedSignal?.aborted).toBe(true)
+    await expect(pending).rejects.toThrow('sender destroyed')
+    expect(sender.listenerCount('destroyed')).toBe(0)
+  })
+
   // Why #7721: without a cancel path, every workspace switch left the previous
   // workspace's full-tree SSH scan running, stacking scans on the relay until
   // interactive fs.readDir/fs.stat starved past their 30s timeout.

--- a/src/main/ipc/sender-scoped-request-cancellation.test.ts
+++ b/src/main/ipc/sender-scoped-request-cancellation.test.ts
@@ -1,0 +1,127 @@
+import { EventEmitter } from 'node:events'
+import type { IpcMainInvokeEvent } from 'electron'
+import { describe, expect, it } from 'vitest'
+import { createSenderScopedRequestCancellations } from './sender-scoped-request-cancellation'
+
+class FakeSender extends EventEmitter {
+  private destroyed: boolean
+
+  constructor(
+    readonly id: number,
+    destroyed = false
+  ) {
+    super()
+    this.destroyed = destroyed
+  }
+
+  isDestroyed(): boolean {
+    return this.destroyed
+  }
+
+  destroy(): void {
+    this.destroyed = true
+    this.emit('destroyed')
+  }
+}
+
+function eventFor(sender: FakeSender): IpcMainInvokeEvent {
+  return { sender } as unknown as IpcMainInvokeEvent
+}
+
+describe('sender-scoped request cancellation', () => {
+  it('aborts every request from a destroyed sender without affecting another sender', () => {
+    const requests = createSenderScopedRequestCancellations()
+    const firstSender = new FakeSender(1)
+    const secondSender = new FakeSender(2)
+    const first = requests.begin(eventFor(firstSender), 'first')
+    const second = requests.begin(eventFor(firstSender), 'second')
+    const other = requests.begin(eventFor(secondSender), 'other')
+
+    firstSender.destroy()
+
+    expect(first?.signal.aborted).toBe(true)
+    expect(second?.signal.aborted).toBe(true)
+    expect(other?.signal.aborted).toBe(false)
+  })
+
+  it('isolates distinct senders that reuse the same numeric id and token', () => {
+    const requests = createSenderScopedRequestCancellations()
+    const firstSender = new FakeSender(1)
+    const secondSender = new FakeSender(1)
+    const firstEvent = eventFor(firstSender)
+    const secondEvent = eventFor(secondSender)
+    const first = requests.begin(firstEvent, 'shared-token')
+    const second = requests.begin(secondEvent, 'shared-token')
+
+    expect(first?.signal.aborted).toBe(false)
+    expect(second?.signal.aborted).toBe(false)
+
+    firstSender.destroy()
+
+    expect(first?.signal.aborted).toBe(true)
+    expect(second?.signal.aborted).toBe(false)
+
+    requests.cancel(secondEvent, 'shared-token')
+    expect(second?.signal.aborted).toBe(true)
+  })
+
+  it('instance-fences finish after the same sender reuses a token', () => {
+    const requests = createSenderScopedRequestCancellations()
+    const event = eventFor(new FakeSender(1))
+    const first = requests.begin(event, 'reused-token')
+    const replacement = requests.begin(event, 'reused-token')
+
+    expect(first?.signal.aborted).toBe(true)
+    expect(replacement?.signal.aborted).toBe(false)
+
+    requests.finish(event, 'reused-token', first)
+    requests.cancel(event, 'reused-token')
+
+    expect(replacement?.signal.aborted).toBe(true)
+  })
+
+  it('registers a replacement before abort cleanup runs synchronously', () => {
+    const requests = createSenderScopedRequestCancellations()
+    const sender = new FakeSender(1)
+    const event = eventFor(sender)
+    const first = requests.begin(event, 'reused-token')
+    first?.signal.addEventListener('abort', () => {
+      requests.finish(event, 'reused-token', first)
+    })
+
+    const replacement = requests.begin(event, 'reused-token')
+    requests.cancel(event, 'reused-token')
+
+    expect(replacement?.signal.aborted).toBe(true)
+    expect(sender.listenerCount('destroyed')).toBe(1)
+
+    requests.finish(event, 'reused-token', replacement)
+    expect(sender.listenerCount('destroyed')).toBe(0)
+  })
+
+  it('removes the destroyed listener after the last request finishes', () => {
+    const requests = createSenderScopedRequestCancellations()
+    const sender = new FakeSender(1)
+    const event = eventFor(sender)
+    const first = requests.begin(event, 'first')
+    const second = requests.begin(event, 'second')
+
+    expect(sender.listenerCount('destroyed')).toBe(1)
+
+    requests.finish(event, 'first', first)
+    expect(sender.listenerCount('destroyed')).toBe(1)
+
+    requests.finish(event, 'second', second)
+    expect(sender.listenerCount('destroyed')).toBe(0)
+  })
+
+  it('immediately aborts a request begun by an already-destroyed sender', () => {
+    const requests = createSenderScopedRequestCancellations()
+    const sender = new FakeSender(1, true)
+
+    const controller = requests.begin(eventFor(sender), 'late-request')
+
+    expect(controller?.signal.aborted).toBe(true)
+    expect(sender.listenerCount('destroyed')).toBe(0)
+  })
+})

--- a/src/main/ipc/sender-scoped-request-cancellation.ts
+++ b/src/main/ipc/sender-scoped-request-cancellation.ts
@@ -16,35 +16,83 @@ export type SenderScopedRequestCancellations = {
 /**
  * Registry for renderer-cancellable IPC requests. Keys are scoped to the
  * issuing webContents so one window's token can never cancel another window's
- * request, and reusing a token aborts the previous request before the new one
- * registers.
+ * request, and reusing a token keeps only the newest request registered.
  */
 export function createSenderScopedRequestCancellations(): SenderScopedRequestCancellations {
-  const controllers = new Map<string, AbortController>()
-  const keyFor = (event: IpcMainInvokeEvent, requestToken: string): string =>
-    `${event.sender.id}\0${requestToken}`
+  type Sender = IpcMainInvokeEvent['sender']
+  type SenderRequests = {
+    controllers: Map<string, AbortController>
+    onDestroyed: () => void
+  }
+
+  const requestsBySender = new WeakMap<Sender, SenderRequests>()
+
+  const releaseSender = (sender: Sender, requests: SenderRequests): void => {
+    if (requestsBySender.get(sender) !== requests) {
+      return
+    }
+    requestsBySender.delete(sender)
+    const senderLifecycle = sender as Partial<Sender>
+    senderLifecycle.removeListener?.('destroyed', requests.onDestroyed)
+  }
+
+  const getOrCreateSenderRequests = (sender: Sender): SenderRequests => {
+    const existing = requestsBySender.get(sender)
+    if (existing) {
+      return existing
+    }
+    const requests: SenderRequests = {
+      controllers: new Map(),
+      onDestroyed: () => {
+        if (requestsBySender.get(sender) !== requests) {
+          return
+        }
+        requestsBySender.delete(sender)
+        const senderLifecycle = sender as Partial<Sender>
+        senderLifecycle.removeListener?.('destroyed', requests.onDestroyed)
+        for (const controller of requests.controllers.values()) {
+          controller.abort()
+        }
+        requests.controllers.clear()
+      }
+    }
+    requestsBySender.set(sender, requests)
+    const senderLifecycle = sender as Partial<Sender>
+    senderLifecycle.once?.('destroyed', requests.onDestroyed)
+    return requests
+  }
+
   return {
     begin: (event, requestToken) => {
       if (!requestToken) {
         return null
       }
-      const key = keyFor(event, requestToken)
-      controllers.get(key)?.abort()
+      const requests = getOrCreateSenderRequests(event.sender)
+      const previous = requests.controllers.get(requestToken)
       const controller = new AbortController()
-      controllers.set(key, controller)
+      requests.controllers.set(requestToken, controller)
+      previous?.abort()
+      // Why: destruction can win before the IPC handler begins on a queued event.
+      const senderLifecycle = event.sender as Partial<Sender>
+      if (senderLifecycle.isDestroyed?.()) {
+        requests.onDestroyed()
+      }
       return controller
     },
     finish: (event, requestToken, controller) => {
       if (!requestToken || !controller) {
         return
       }
-      const key = keyFor(event, requestToken)
-      if (controllers.get(key) === controller) {
-        controllers.delete(key)
+      const requests = requestsBySender.get(event.sender)
+      if (requests?.controllers.get(requestToken) === controller) {
+        requests.controllers.delete(requestToken)
+        if (requests.controllers.size === 0) {
+          releaseSender(event.sender, requests)
+        }
       }
     },
     cancel: (event, requestToken) => {
-      controllers.get(keyFor(event, requestToken))?.abort()
+      requestsBySender.get(event.sender)?.controllers.get(requestToken)?.abort()
     }
   }
 }


### PR DESCRIPTION
## Summary

- Scope cancellable main-process requests to the actual renderer `WebContents`, rather than its reusable numeric ID.
- Abort every owned controller when that renderer is destroyed and remove its lifecycle listener after the final request settles.
- Cover the lifecycle registry plus propagation into an in-flight direct-SSH file listing.

### ELI5

A renderer hands the main process a list of chores. Closing or reloading that renderer used to leave its chores running, including work on a remote host. The main process now keeps a separate chore list for each renderer and cancels the whole list when its owner disappears.

```mermaid
flowchart LR
  A[Renderer A] --> RA[Owned request registry]
  RA --> A1[Request A1]
  RA --> A2[Request A2]
  D[Renderer A destroyed] --> RA
  RA -->|abort| A1
  RA -->|abort| A2
  B[Renderer B] --> B1[Unaffected request]
```

### Improvement proof

- Before: destroying a sender left `N` registered operations active until completion, explicit cancellation, or timeout.
- After: destroying a sender moves its owned operations from `N active -> 0 active`; another sender remains unaffected.
- The lifecycle test exercises `2 -> 0` for the destroyed sender while a second sender stays `1 -> 1`.
- The direct-SSH integration test proves the provider's signal changes from not aborted to aborted and its pending handler rejects.
- After the final request settles, the sender's `destroyed` listener moves from `1 -> 0`.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test` — 4,596 files passed; 49,264 tests passed; 97 skipped
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions
- [x] Affected IPC suites — 411 passed; 1 skipped
- [x] `oxfmt --check` and `git diff --check`

The local full-suite run pinned `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.178` because an unrelated `v799` tag from the configured `noqa` remote otherwise outranks Orca release tags in the cross-version harness. The pinned cross-version suite passed 4/4.

## AI Review Report

Independent review checked sender identity reuse, cross-window isolation, synchronous abort reentrancy, stale completion, already-destroyed senders, multi-token destruction, and final listener cleanup. It found that aborting the prior controller before installing its replacement let a synchronous abort callback remove the registry entry. The replacement is now installed first, with a dedicated regression test; re-review found no remaining P0-P3 issues.

The review also checked macOS, Linux, Windows, SSH, folder-workspace, Electron lifecycle, and mixed-version behavior. This is platform-neutral in-process bookkeeping, introduces no path/shell/shortcut assumptions, and changes no remote wire shape.

## Security Audit

Using sender object identity prevents a recycled numeric `WebContents.id` from crossing ownership boundaries or cancelling another window's request. Instance fencing prevents stale completions from deleting replacement controllers. No command execution, path parsing, auth, secret, dependency, or remote-protocol behavior changes.

## Notes

This registry can only stop downstream work that observes its `AbortSignal`. Direct-SSH file listing does. Known follow-ups remain for the local Quick Open ripgrep path, paired-web file/worktree cancellation, paired-runtime AI Vault signal forwarding, detected-worktree normalization/stat fallbacks, and Git effective-upstream subprobes.
