### PR TITLE
perf(relay): skip serialization without recipients

### DIFF
--- a/src/relay/dispatcher-frame-guard-regressions.test.ts
+++ b/src/relay/dispatcher-frame-guard-regressions.test.ts
@@ -44,4 +44,42 @@ describe('RelayDispatcher frame guards', () => {
     expect(internals.enqueueFrame(internals.primaryClient, msg, 'ordinary')).toBe(false)
     expect(spy).not.toHaveBeenCalled()
   })
+
+  it('does not serialize notifications without an active client', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    try {
+      dispatcher.invalidateClient()
+
+      expect(() =>
+        dispatcher.notify('test.event', {
+          data: {
+            toJSON: () => {
+              throw new Error('must not serialize')
+            }
+          }
+        })
+      ).not.toThrow()
+    } finally {
+      dispatcher.dispose()
+    }
+  })
+
+  it('does not serialize pty.data rejected by every active client', () => {
+    const dispatcher = new RelayDispatcher(() => true)
+    const unregister = dispatcher.registerPtyDataPublicationAdmission(() => false)
+    try {
+      expect(() =>
+        dispatcher.notify('pty.data', {
+          data: {
+            toJSON: () => {
+              throw new Error('must not serialize')
+            }
+          }
+        })
+      ).not.toThrow()
+    } finally {
+      unregister()
+      dispatcher.dispose()
+    }
+  })
 })

--- a/src/relay/dispatcher.ts
+++ b/src/relay/dispatcher.ts
@@ -582,9 +582,8 @@ export class RelayDispatcher {
       method,
       ...(params !== undefined ? { params } : {})
     }
-    const frame = this.prepareFrame(msg)
-    const frameBytes = frame.frameBytes
     this.runPublicationTransaction(() => {
+      let frame: PreparedRelayFrame | undefined
       for (const client of this.clients.values()) {
         if (client.closed) {
           continue
@@ -592,6 +591,7 @@ export class RelayDispatcher {
         if (method === 'pty.data' && !this.admitsPtyDataPublication(client.id, params ?? {})) {
           continue
         }
+        frame ??= this.prepareFrame(msg)
         if (method === 'pty.replay') {
           // Why: replay is never re-sent, so it takes the control lane where overflow is fatal — the
           // writer closes the client and reconnect reloads history rather than stranding a short buffer.
@@ -601,7 +601,7 @@ export class RelayDispatcher {
         // Why: closing can never make an oversized frame sendable — the producer regenerates it after
         // reattach and re-kills the link, turning a recoverable drop into an endless reconnect loop.
         if (!this.publishPreparedToClient(client, frame, 'ordinary')) {
-          this.logDroppedProducerNotification(client, method, frameBytes)
+          this.logDroppedProducerNotification(client, method, frame.frameBytes)
         }
       }
     })


### PR DESCRIPTION
## Summary

- prepare a broadcast notification frame only when the first active recipient is eligible
- keep reusing that one prepared frame for every later recipient
- cover both zero active clients and all-clients-vetoed `pty.data`

Follow-up risk reduction for #13516.

## Why

`RelayDispatcher.notify()` serialized and validated every notification before checking client state or PTY publication admission. A notification with no recipient therefore paid the full JSON cost, and a serialization failure or oversized payload could throw even though no bytes could be sent.

This predates #13516: the old `estimateFrameBytes()` path also encoded and validated before entering the client loop. #13516 retained that behavior while replacing the later per-client encodes with one prepared payload. This PR preserves the one-serialization optimization but makes preparation lazy at the first eligible recipient.

## Reliability contract

- **No recipient:** zero JSON serialization and no payload-size failure.
- **One or more recipients:** exactly one payload preparation, reused across the broadcast as in #13516.
- **Admission:** closed clients and vetoed `pty.data` clients remain skipped before publication; admission still runs once per active client in the original order.
- **Wire:** connected-client bytes, sequence/ack headers, queue lanes, capacity accounting, and drop diagnostics are unchanged.
- **Concurrency:** notification publication remains synchronous and inside the existing publication transaction; no cache or retained state is added.
- **Residual risk:** a payload still throws during preparation when at least one eligible recipient exists, preserving the protocol size guard.

## Testing

- [x] before-fix oracle: both new tests fail with `must not serialize`
- [x] focused #13516-related suites: 5 files, 64 tests passed
- [x] complete relay suite: 111 files, 1,289 tests passed
- [x] Docker-backed SSH relay performance/recovery gate: 4/4 passed
- [x] `pnpm run typecheck:node`
- [x] `pnpm lint`
- [x] changed-code quality: 0 findings across 2 files
- [x] formatting and `git diff --check`

## AI Review Report

- Traced client authority/admission, publication transaction, queue capacity, failure, and cleanup paths.
- Kept lazy preparation inside the original client loop to preserve client iteration and admission ordering.
- Checked macOS, Linux, Windows, WSL, SSH, folder-workspace, and git-worktree assumptions; this is platform-neutral relay code with no workspace lookup.
- No unresolved findings from the local review.

## Security Audit

- No new input source, command execution, authentication, authorization, secret handling, persistence, RPC method, or stream opcode.
- Protocol maximum-size validation remains mandatory whenever a recipient is eligible.
- Suppressing serialization only when delivery is impossible prevents irrelevant payload code from running on disconnected/vetoed paths.

## Notes

- No visual change.
- No remote wire change; mixed client/host versions are unaffected.
- The Docker SSH gate covers active delivery, pressure, file/Git churn, and disconnect/reconnect recovery.
