### PR TITLE
feat(remote): auto-surface CLI-added remote servers in the running IDE

### DIFF
--- a/src/main/index.ts
+++ b/src/main/index.ts
@@ -327,6 +327,8 @@ import { createRuntimeAutomationRunTerminalObserver } from './automations/runtim
 import { AgentAwakeService } from './agent-awake-service'
 import { normalizeComputerAwakeMode } from '../shared/computer-awake-mode'
 import { registerSystemResumeBroadcast } from './system-resume-broadcast'
+import { registerRuntimeEnvironmentStoreWatcher } from './ipc/runtime-environment-store-watcher'
+import { invalidateRuntimeEnvironmentTransport } from './ipc/runtime-environments'
 import { settleTeardownWithinDeadline, settleWithinMs } from './quit-teardown-deadline'
 import { quitTeardownStartGate } from './quit-teardown-start-gate'
 import { beginSshShutdown } from './ipc/ssh-shutdown-drain'
@@ -422,6 +424,7 @@ let agentAwakeService: AgentAwakeService | null = null
 let crashReports: CrashReportStore | null = null
 let unsubscribeAgentAwakeStatusChanges: (() => void) | null = null
 let unsubscribeSystemResumeBroadcast: (() => void) | null = null
+let unsubscribeRuntimeEnvironmentStoreWatcher: (() => void) | null = null
 let watcherShutdownPromise: Promise<void> | null = null
 let watcherShutdownDone = false
 let automations: AutomationService | null = null
@@ -2448,6 +2451,13 @@ void app.whenReady().then(async () => {
     }
   })
   unsubscribeSystemResumeBroadcast = registerSystemResumeBroadcast()
+  // Why: `orca environment add` writes the store from outside the app; without this
+  // the new remote server stays invisible until Settings → Remote Orca Servers.
+  unsubscribeRuntimeEnvironmentStoreWatcher = registerRuntimeEnvironmentStoreWatcher({
+    userDataPath: app.getPath('userData'),
+    getWindows: () => BrowserWindow.getAllWindows(),
+    invalidateTransport: invalidateRuntimeEnvironmentTransport
+  })
   agentAwakeService = new AgentAwakeService()
   agentAwakeService.setMode(
     normalizeComputerAwakeMode(
@@ -3480,6 +3490,8 @@ app.on('will-quit', (e) => {
   }
   unsubscribeSystemResumeBroadcast?.()
   unsubscribeSystemResumeBroadcast = null
+  unsubscribeRuntimeEnvironmentStoreWatcher?.()
+  unsubscribeRuntimeEnvironmentStoreWatcher = null
   // Why: renderer guards can still cancel before this committed phase; `log stream` must survive those vetoes.
   stopTccPromptNotice()
   const updateQuitInProgress = isQuittingForUpdate()

--- a/src/main/ipc/runtime-environment-store-watcher.test.ts
+++ b/src/main/ipc/runtime-environment-store-watcher.test.ts
@@ -1,0 +1,124 @@
+import { mkdtempSync, rmSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import { join } from 'node:path'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { encodePairingOffer } from '../../shared/pairing'
+import {
+  addEnvironmentFromPairingCode,
+  markEnvironmentUsed,
+  removeEnvironment,
+  updateEnvironmentFromPairingCode
+} from '../../shared/runtime-environment-store'
+import {
+  registerRuntimeEnvironmentStoreWatcher,
+  RUNTIME_ENVIRONMENTS_CHANGED_CHANNEL
+} from './runtime-environment-store-watcher'
+
+function pairingCode(endpoint = 'ws://127.0.0.1:6768'): string {
+  return encodePairingOffer({
+    v: 2,
+    endpoint,
+    deviceToken: 'device-token',
+    publicKeyB64: Buffer.from(new Uint8Array(32).fill(1)).toString('base64')
+  })
+}
+
+type Harness = {
+  userDataPath: string
+  send: ReturnType<typeof vi.fn>
+  invalidateTransport: ReturnType<typeof vi.fn>
+  waitForBroadcasts: (count: number) => Promise<void>
+  settle: () => Promise<void>
+}
+
+const cleanups: (() => void)[] = []
+
+function startWatcher(): Harness {
+  const userDataPath = mkdtempSync(join(tmpdir(), 'orca-env-watch-'))
+  const send = vi.fn()
+  const invalidateTransport = vi.fn()
+  const unregister = registerRuntimeEnvironmentStoreWatcher({
+    userDataPath,
+    getWindows: () => [{ isDestroyed: () => false, webContents: { send } }],
+    invalidateTransport,
+    debounceMs: 20
+  })
+  cleanups.push(() => {
+    unregister()
+    rmSync(userDataPath, { recursive: true, force: true })
+  })
+  return {
+    userDataPath,
+    send,
+    invalidateTransport,
+    waitForBroadcasts: (count) =>
+      vi.waitFor(() => {
+        expect(send.mock.calls.length).toBeGreaterThanOrEqual(count)
+      }),
+    // Why: "no broadcast" needs the debounce window plus fs.watch delivery to elapse.
+    settle: () => new Promise((resolve) => setTimeout(resolve, 250))
+  }
+}
+
+afterEach(() => {
+  while (cleanups.length > 0) {
+    cleanups.pop()?.()
+  }
+})
+
+describe('registerRuntimeEnvironmentStoreWatcher', () => {
+  it('broadcasts when an environment is added externally', async () => {
+    const harness = startWatcher()
+    addEnvironmentFromPairingCode(harness.userDataPath, {
+      name: 'sandbox',
+      pairingCode: pairingCode()
+    })
+    await harness.waitForBroadcasts(1)
+    expect(harness.send).toHaveBeenCalledWith(RUNTIME_ENVIRONMENTS_CHANGED_CHANNEL)
+    expect(harness.invalidateTransport).not.toHaveBeenCalled()
+  })
+
+  it('stays silent for lastUsedAt-only rewrites', async () => {
+    const harness = startWatcher()
+    addEnvironmentFromPairingCode(harness.userDataPath, {
+      name: 'sandbox',
+      pairingCode: pairingCode(),
+      now: 100
+    })
+    await harness.waitForBroadcasts(1)
+    harness.send.mockClear()
+    markEnvironmentUsed(harness.userDataPath, 'sandbox', { now: 200_000 })
+    await harness.settle()
+    expect(harness.send).not.toHaveBeenCalled()
+  })
+
+  it('broadcasts and retires the transport when an environment is removed externally', async () => {
+    const harness = startWatcher()
+    const added = addEnvironmentFromPairingCode(harness.userDataPath, {
+      name: 'sandbox',
+      pairingCode: pairingCode()
+    })
+    await harness.waitForBroadcasts(1)
+    harness.send.mockClear()
+    removeEnvironment(harness.userDataPath, added.id)
+    await harness.waitForBroadcasts(1)
+    expect(harness.invalidateTransport).toHaveBeenCalledWith(added.id)
+  })
+
+  it('retires the transport when an environment is re-paired externally', async () => {
+    const harness = startWatcher()
+    const added = addEnvironmentFromPairingCode(harness.userDataPath, {
+      name: 'sandbox',
+      pairingCode: pairingCode(),
+      now: 100
+    })
+    await harness.waitForBroadcasts(1)
+    harness.send.mockClear()
+    updateEnvironmentFromPairingCode(harness.userDataPath, added.id, {
+      pairingCode: pairingCode('ws://127.0.0.1:7777'),
+      now: 5_000
+    })
+    await harness.waitForBroadcasts(1)
+    expect(harness.invalidateTransport).toHaveBeenCalledWith(added.id)
+  })
+})

--- a/src/main/ipc/runtime-environment-store-watcher.ts
+++ b/src/main/ipc/runtime-environment-store-watcher.ts
@@ -1,0 +1,114 @@
+import { watch, type FSWatcher } from 'node:fs'
+import { basename, dirname } from 'node:path'
+import { getEnvironmentStorePath, listEnvironments } from '../../shared/runtime-environment-store'
+
+export const RUNTIME_ENVIRONMENTS_CHANGED_CHANNEL = 'runtimeEnvironments:changed'
+
+type StoreWatcherWindow = {
+  isDestroyed(): boolean
+  webContents: { send(channel: string): void }
+}
+
+type RuntimeEnvironmentStoreWatcherOptions = {
+  userDataPath: string
+  getWindows: () => StoreWatcherWindow[]
+  /** Retires transports for environments that were removed or re-paired outside the app (e.g. `orca environment rm`). */
+  invalidateTransport: (environmentId: string) => void | Promise<void>
+  debounceMs?: number
+}
+
+// Why: lastUsedAt rewrites land at a ≥60s cadence, so a short window only has to
+// coalesce the tmp-write + rename burst of a single store publication.
+const DEFAULT_DEBOUNCE_MS = 200
+
+type StoreFingerprint = Map<string, number>
+
+function readStoreFingerprint(userDataPath: string): StoreFingerprint | null {
+  try {
+    return new Map(
+      listEnvironments(userDataPath).map((environment) => [
+        environment.id,
+        environment.pairingRevision ?? environment.createdAt
+      ])
+    )
+  } catch {
+    // A torn or invalid store file must not broadcast; keep the last-known state.
+    return null
+  }
+}
+
+/**
+ * Watches the saved-environments store for external writers (the `orca` CLI)
+ * and notifies renderers so a newly paired remote server surfaces without a
+ * visit to Settings → Remote Orca Servers.
+ *
+ * Only membership and pairing-revision changes broadcast: markEnvironmentUsed
+ * rewrites the same entries on runtime round-trips and must stay silent.
+ */
+export function registerRuntimeEnvironmentStoreWatcher(
+  options: RuntimeEnvironmentStoreWatcherOptions
+): () => void {
+  const { userDataPath, getWindows, invalidateTransport } = options
+  const debounceMs = options.debounceMs ?? DEFAULT_DEBOUNCE_MS
+  const storePath = getEnvironmentStorePath(userDataPath)
+  const watchedName = basename(storePath)
+  let fingerprint = readStoreFingerprint(userDataPath) ?? new Map<string, number>()
+  let debounceTimer: NodeJS.Timeout | null = null
+  let closed = false
+
+  const handleStoreMaybeChanged = (): void => {
+    debounceTimer = null
+    const next = readStoreFingerprint(userDataPath)
+    if (closed || next === null) {
+      return
+    }
+    const retiredIds = [...fingerprint].filter(([id, revision]) => next.get(id) !== revision)
+    const changed = retiredIds.length > 0 || next.size !== fingerprint.size
+    fingerprint = next
+    if (!changed) {
+      return
+    }
+    // Why: a same-id re-pair or removal outside the app must retire transports that
+    // still authenticate as the old peer — parity with the remove/re-pair IPC handlers.
+    for (const [environmentId] of retiredIds) {
+      // Retirement settles on its own; the broadcast below must not wait on browser-host teardown.
+      void invalidateTransport(environmentId)
+    }
+    for (const window of getWindows()) {
+      if (!window.isDestroyed()) {
+        window.webContents.send(RUNTIME_ENVIRONMENTS_CHANGED_CHANNEL)
+      }
+    }
+  }
+
+  let watcher: FSWatcher
+  try {
+    // Why: the store publishes via tmp-write + rename, so watch the parent
+    // directory — a watch on the file inode detaches after the first update.
+    watcher = watch(dirname(storePath), (_event, changedName) => {
+      if (closed || (changedName !== null && changedName.toString() !== watchedName)) {
+        return
+      }
+      debounceTimer ??= setTimeout(handleStoreMaybeChanged, debounceMs)
+    })
+  } catch (error) {
+    console.warn('[runtime-environments] store watch unavailable:', error)
+    return () => {}
+  }
+  // Why: the watch must not keep the process alive during shutdown.
+  watcher.unref?.()
+  watcher.on('error', (error) => {
+    // Degrade to today's behavior (boot/settings hydration) rather than crash.
+    console.warn('[runtime-environments] store watch failed:', error)
+    watcher.close()
+  })
+
+  return () => {
+    closed = true
+    if (debounceTimer !== null) {
+      clearTimeout(debounceTimer)
+      debounceTimer = null
+    }
+    watcher.close()
+  }
+}

--- a/src/preload/api/runtime-api.ts
+++ b/src/preload/api/runtime-api.ts
@@ -100,6 +100,8 @@ export type RuntimeApi = {
     ) => Promise<BrowserPageCreationPlacement>
     // Why: system resume / browser online advance pending shared-control reconnect timers only.
     retryConnectionsNow?: () => Promise<void>
+    // Fires when the saved-environments store changes on disk (e.g. `orca environment add`).
+    onChanged?: (callback: () => void) => () => void
     call: (args: {
       selector: string
       method: string

--- a/src/preload/index.ts
+++ b/src/preload/index.ts
@@ -4700,6 +4700,11 @@ const api = {
       ipcRenderer.invoke('runtimeEnvironments:prepareBrowserClientHostPlacement', args),
     retryConnectionsNow: (): Promise<void> =>
       ipcRenderer.invoke('runtimeEnvironments:retryConnectionsNow'),
+    onChanged: (callback: () => void): (() => void) => {
+      const listener = (): void => callback()
+      ipcRenderer.on('runtimeEnvironments:changed', listener)
+      return () => ipcRenderer.removeListener('runtimeEnvironments:changed', listener)
+    },
     call: (args: {
       selector: string
       method: string

--- a/src/renderer/src/hooks/ipc-events/runtime-client-ipc-bridge.ts
+++ b/src/renderer/src/hooks/ipc-events/runtime-client-ipc-bridge.ts
@@ -205,5 +205,17 @@ export function registerRuntimeClientIpcBridge(
   unsubs.push(runtimeClientEventsSync.stop)
   unsubs.push(runtimeProjectRefreshScheduler.stop)
 
+  // Why: `orca environment add/rm` rewrites the store outside the app. Re-hydrate so the
+  // server (and, via the store subscription above, its projects) surfaces without a
+  // Settings visit. Optional-chained: minimal window.api assemblies omit it.
+  const onRuntimeEnvironmentsChanged = window.api.runtimeEnvironments?.onChanged
+  if (onRuntimeEnvironmentsChanged) {
+    unsubs.push(
+      onRuntimeEnvironmentsChanged(() => {
+        void useAppStore.getState().hydrateRuntimeEnvironmentStatuses()
+      })
+    )
+  }
+
   return unsubscribeRuntimeEnvironmentStore
 }

--- a/src/renderer/src/hooks/useIpcEvents-lifecycle.test.ts
+++ b/src/renderer/src/hooks/useIpcEvents-lifecycle.test.ts
@@ -28,6 +28,7 @@ const EXPECTED_DIRECT_CALLBACK_METHODS = [
   'runtime.onNativeChatLaunchDraftResolved',
   'runtime.onTerminalDriverChanged',
   'runtime.onTerminalFitOverrideChanged',
+  'runtimeEnvironments.onChanged',
   'settings.onChanged',
   'ssh.onCredentialRequest',
   'ssh.onCredentialResolved',
@@ -102,6 +103,7 @@ const EXPECTED_DIRECT_CALLBACK_METHODS = [
 const EXPECTED_CALLBACK_REGISTRATION_SEQUENCE = [
   'ui.onMobileMarkdownRequest',
   'automations.onChanged',
+  'runtimeEnvironments.onChanged',
   'repos.onChanged',
   'worktrees.onChanged',
   'worktrees.onHeadIdentitiesChanged',


### PR DESCRIPTION
## User-visible change

Running `orca environment add --name <name> --pairing-code <orca://pair?...>` in any terminal now makes the running Orca IDE pick up the new remote server automatically: it appears in the saved-server list, connects, and its remote projects/worktrees surface in the sidebar within a moment — no visit to Settings → Remote Orca Servers required. `orca environment rm` likewise retires the server (and its live transports) from the running app.

There is **no visual change** — no new UI; existing surfaces just populate sooner.

## How

- The CLI writes `orca-environments.json` in the app's userData directory; the running app previously only re-read it at boot or when the settings pane re-listed it.
- New `src/main/ipc/runtime-environment-store-watcher.ts`: watches the store's **parent directory** with `fs.watch` (the store publishes via atomic tmp-write + rename, so a file-inode watch would detach), debounces, and re-reads a fingerprint of `id → pairingRevision ?? createdAt`.
  - Broadcasts `runtimeEnvironments:changed` to all windows only on membership/pairing-revision changes — the ≥60 s `lastUsedAt` rewrites from `markEnvironmentUsed` stay silent.
  - Environments removed or re-paired externally get `invalidateRuntimeEnvironmentTransport(id)`, matching the in-app remove/re-pair IPC handlers.
- Preload exposes `runtimeEnvironments.onChanged` (optional in `api/runtime-api.ts` so partial assemblies stay valid).
- `hooks/ipc-events/runtime-client-ipc-bridge.ts` subscribes and calls the existing `hydrateRuntimeEnvironmentStatuses()`; the existing store subscription then subscribes runtime client events and schedules the project refresh that loads the server's worktrees into the sidebar.

## AI code review summary (Claude)

- **Cross-platform**: `fs.watch` on a local userData directory is supported on macOS/Linux/Windows; paths built with `node:path`; no shell or platform-specific code. Watcher failure degrades to today's behavior (boot/settings hydration) instead of crashing.
- **SSH/remote/local**: no remote wire change — the broadcast is local Electron IPC between same-version main/preload/renderer; no new RPC methods or stream opcodes, so mixed client/server versions are unaffected. SSH-tunnel-dependent environments go through the same store and hydration path. A CLI run *on a remote host* writes that host's store (out of scope by design).
- **Agents/integrations/git providers**: untouched.
- **Performance**: one directory watch; non-matching userData writes cost a basename compare. Broadcast-triggered hydration runs only on real membership/pairing changes, not on `lastUsedAt` persistence.
- **UI quality**: no new UI; existing sidebar/settings surfaces populate through their existing code paths.
- **Security**: the broadcast carries no payload; renderers re-read through existing IPC handlers. No new privileged surface; store file ACL hardening unchanged.

## Tests

`src/main/ipc/runtime-environment-store-watcher.test.ts` (real temp dir, real store writer, real `fs.watch`):
- external add → one broadcast, no transport invalidation
- `markEnvironmentUsed`-only rewrite → silent
- external remove → broadcast + transport invalidated
- external re-pair → broadcast + transport invalidated

`pnpm lint`, `pnpm typecheck`, and `pnpm build` pass. Full `pnpm test`: all failures also reproduce on the parent commit on this machine (host-environment: dash alias behavior, GPU flag detection, git filesystem boundary in /tmp) plus one 30 s timeout flake under full-suite load that passes in isolation — none related to this change.

## Notes

- Platform-specific behavior: none beyond `fs.watch` (used per its documented cross-platform semantics; null-filename events are treated as potential store changes and resolved by the fingerprint compare).
- X (Twitter) handle: @MartinMatus

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

_Rebased onto `main` to resolve conflicts. The preload API types and the IPC-events hook were split into per-domain modules upstream, so the two one-line hooks moved to `src/preload/api/runtime-api.ts` and `src/renderer/src/hooks/ipc-events/runtime-client-ipc-bridge.ts`; the watcher also now `void`s the newly Promise-returning `invalidateRuntimeEnvironmentTransport`, and the new listener is declared in the `useIpcEvents-lifecycle` registration ratchet. No behavior change from the original diff._
