### PR TITLE
fix(terminal): preserve Shift+Enter during routing confirmation

### DIFF
--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -15,6 +15,7 @@ describe('createPaneForegroundAgentTracker', () => {
   const publish = vi.fn<(entry: PaneForegroundAgentEntry) => void>()
   const onConfirmedShellForeground = vi.fn<() => void>()
   const onCommandFinishedUnavailable = vi.fn<() => void>()
+  const onVisibleForegroundSettled = vi.fn<(outcome: 'agent' | 'shell' | 'inconclusive') => void>()
   let ptyId: string | null = 'pty-1'
 
   function makeTracker(
@@ -28,7 +29,8 @@ describe('createPaneForegroundAgentTracker', () => {
       publish,
       hasKnownAgentIdentity,
       onConfirmedShellForeground,
-      onCommandFinishedUnavailable
+      onCommandFinishedUnavailable,
+      onVisibleForegroundSettled
     })
   }
 
@@ -44,12 +46,51 @@ describe('createPaneForegroundAgentTracker', () => {
     publish.mockReset()
     onConfirmedShellForeground.mockReset()
     onCommandFinishedUnavailable.mockReset()
+    onVisibleForegroundSettled.mockReset()
     ptyId = 'pty-1'
   })
 
   afterEach(() => {
     vi.clearAllTimers()
     vi.useRealTimers()
+  })
+
+  // Why: callers gate byte authority on "is a read coming?" — onVisiblePtyBound
+  // returning false because a command read already owns the pane must not be
+  // mistaken for "nothing will confirm this pane".
+  it('reports a read in flight when a command-finished read owns the pane', async () => {
+    readForegroundProcess.mockResolvedValue('claude')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+    expect(tracker.hasReadInFlight()).toBe(false)
+
+    expect(tracker.onCommandFinished()).toBe(true)
+    expect(tracker.hasReadInFlight()).toBe(true)
+    // Visibility recovery yields to the higher-authority read...
+    expect(tracker.onVisiblePtyBound(true)).toBe(false)
+    // ...but a confirmation is still coming.
+    expect(tracker.hasReadInFlight()).toBe(true)
+  })
+
+  // Why: this branch publishes nothing, so a visible confirmation it replaced
+  // would otherwise never be settled by anyone.
+  it('settles the visible confirmation when a command-finished read still sees the agent', async () => {
+    readForegroundProcess.mockResolvedValue('claude')
+    const tracker = makeTracker()
+
+    tracker.onCommandStarted()
+    await flushSettleRead(COMMAND_SETTLE_MS)
+    onVisibleForegroundSettled.mockReset()
+
+    // A leaked 133;D cancels the visible read and replaces it with this one.
+    tracker.onVisiblePtyBound(true)
+    tracker.onCommandFinished()
+    readForegroundProcess.mockResolvedValue('git')
+    await flushSettleRead(COMMAND_SETTLE_MS)
+
+    expect(onVisibleForegroundSettled).toHaveBeenCalledWith('inconclusive')
   })
 
   it('reads the foreground once after a command starts and publishes the recognized agent', async () => {

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -55,6 +55,44 @@ describe('createPaneForegroundAgentTracker', () => {
     vi.useRealTimers()
   })
 
+  // Why: detach/remount emits no PTY exit, so the store entry outlives this tracker.
+  // A capability retained pending the disposed read would latch there forever.
+  it('releases a retained capability when disposed mid-read', async () => {
+    readForegroundProcess.mockResolvedValue('pi')
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound(true)
+    tracker.dispose()
+
+    expect(onVisibleForegroundSettled).toHaveBeenCalledWith('inconclusive')
+  })
+
+  it('releases a retained capability when an exit schedules no successor read', async () => {
+    readForegroundProcess.mockResolvedValue('pi')
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound(true)
+    // The pane's pty goes away between the schedule and the next event.
+    ptyId = null
+    expect(tracker.onCommandFinished()).toBe(false)
+
+    expect(onVisibleForegroundSettled).toHaveBeenCalledWith('inconclusive')
+    expect(tracker.hasReadInFlight()).toBe(false)
+  })
+
+  it('does not release when the cancelled read has a successor', async () => {
+    readForegroundProcess.mockResolvedValue('pi')
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound(true)
+    onVisibleForegroundSettled.mockReset()
+    // A trackable pane reschedules, so the successor settles instead.
+    tracker.onCommandStarted()
+
+    expect(onVisibleForegroundSettled).not.toHaveBeenCalled()
+    expect(tracker.hasReadInFlight()).toBe(true)
+  })
+
   // Why: an abandoned read publishes nothing, so a capability retained pending its
   // answer would otherwise be held forever with no read left to release it.
   it('settles the visible confirmation when a pty rebind abandons its read', async () => {

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -80,6 +80,22 @@ describe('createPaneForegroundAgentTracker', () => {
     expect(tracker.hasReadInFlight()).toBe(false)
   })
 
+  it.each([
+    { exit: 'visible bind', run: (t: ReturnType<typeof makeTracker>) => t.onVisiblePtyBound(true) },
+    { exit: 'command start', run: (t: ReturnType<typeof makeTracker>) => t.onCommandStarted() }
+  ])('releases a retained capability when an untrackable $exit ends the read', async ({ run }) => {
+    readForegroundProcess.mockResolvedValue('pi')
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound(true)
+    onVisibleForegroundSettled.mockReset()
+    ptyId = null
+    run(tracker)
+
+    expect(onVisibleForegroundSettled).toHaveBeenCalledWith('inconclusive')
+    expect(tracker.hasReadInFlight()).toBe(false)
+  })
+
   it('does not release when the cancelled read has a successor', async () => {
     readForegroundProcess.mockResolvedValue('pi')
     const tracker = makeTracker()

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.test.ts
@@ -55,6 +55,42 @@ describe('createPaneForegroundAgentTracker', () => {
     vi.useRealTimers()
   })
 
+  // Why: an abandoned read publishes nothing, so a capability retained pending its
+  // answer would otherwise be held forever with no read left to release it.
+  it('settles the visible confirmation when a pty rebind abandons its read', async () => {
+    let resolveRead: (value: string | null) => void = () => {}
+    readForegroundProcess.mockImplementation(
+      () =>
+        new Promise<string | null>((resolve) => {
+          resolveRead = resolve
+        })
+    )
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound(true)
+    await flushSettleRead(VISIBLE_PTY_SETTLE_MS)
+
+    // The pane is rebound to a different PTY while the inspection RPC is in flight.
+    ptyId = 'pty-2'
+    resolveRead('pi')
+    await flushSettleRead(1)
+
+    expect(publish).not.toHaveBeenCalled()
+    expect(onVisibleForegroundSettled).toHaveBeenCalledWith('inconclusive')
+  })
+
+  it('settles the visible confirmation when the pty id is gone before the read runs', async () => {
+    readForegroundProcess.mockResolvedValue('pi')
+    const tracker = makeTracker()
+
+    tracker.onVisiblePtyBound(true)
+    ptyId = null
+    await flushSettleRead(VISIBLE_PTY_SETTLE_MS)
+
+    expect(publish).not.toHaveBeenCalled()
+    expect(onVisibleForegroundSettled).toHaveBeenCalledWith('inconclusive')
+  })
+
   // Why: callers gate byte authority on "is a read coming?" — onVisiblePtyBound
   // returning false because a command read already owns the pane must not be
   // mistaken for "nothing will confirm this pane".

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -99,6 +99,15 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
     }, delayMs)
   }
 
+  // Why: a superseded read has a successor that will settle for it, and a disposed
+  // pane has no one to tell. An untrackable pty id is the last read there will be,
+  // so it must release any capability that was retained pending its answer.
+  const settleAbortedRead = (generation: number): void => {
+    if (!disposed && generation === readGeneration) {
+      deps.onVisibleForegroundSettled?.('inconclusive')
+    }
+  }
+
   async function readForeground(
     generation: number,
     retryIndex: number,
@@ -106,6 +115,7 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
   ): Promise<void> {
     const ptyId = trackablePtyId()
     if (disposed || generation !== readGeneration || !ptyId) {
+      settleAbortedRead(generation)
       return
     }
     let processName: string | null = null
@@ -124,6 +134,7 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
     // Why: a pane key can be rebound while process inspection is pending; the
     // old PTY's identity must never publish into its replacement session.
     if (disposed || generation !== readGeneration || trackablePtyId() !== ptyId) {
+      settleAbortedRead(generation)
       return
     }
     const recognized = recognizeAgentProcess(processName)

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -99,9 +99,17 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
     }, delayMs)
   }
 
-  // Why: a superseded read has a successor that will settle for it, and a disposed
-  // pane has no one to tell. An untrackable pty id is the last read there will be,
-  // so it must release any capability that was retained pending its answer.
+  const hasPendingRead = (): boolean => scheduledReadReason !== null || activeReadReason !== null
+
+  // Why: the store entry outlives this tracker, so any capability a caller retained
+  // pending a read must be released by whichever exit ends that read. A superseded
+  // read is the one exception — its successor settles for it.
+  const releaseRetainedCapability = (hadReadInFlight: boolean): void => {
+    if (hadReadInFlight) {
+      deps.onVisibleForegroundSettled?.('inconclusive')
+    }
+  }
+
   const settleAbortedRead = (generation: number): void => {
     if (!disposed && generation === readGeneration) {
       deps.onVisibleForegroundSettled?.('inconclusive')
@@ -229,7 +237,7 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
     // command read owns the pane, so "it scheduled nothing" must not be read
     // as "nothing will confirm this pane".
     hasReadInFlight(): boolean {
-      return scheduledReadReason !== null || activeReadReason !== null
+      return hasPendingRead()
     },
     onVisiblePtyBound(expectsAgent = false) {
       // Why: command-start and command-finished reads own the exit decision;
@@ -242,8 +250,10 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
       ) {
         return false
       }
+      const hadReadBeforeVisibleBind = hasPendingRead()
       cancelPendingRead()
       if (!trackablePtyId()) {
+        releaseRetainedCapability(hadReadBeforeVisibleBind)
         return false
       }
       if (expectsAgent || deps.hasKnownAgentIdentity?.() === true) {
@@ -255,8 +265,10 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
       return true
     },
     onCommandStarted(expectedAgent = null) {
+      const hadReadBeforeCommandStart = hasPendingRead()
       cancelPendingRead()
       if (!trackablePtyId()) {
+        releaseRetainedCapability(hadReadBeforeCommandStart)
         return
       }
       const alreadyHasKnownIdentity = deps.hasKnownAgentIdentity?.() === true
@@ -283,8 +295,10 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
       // a D that cancels one must re-confirm — never fast-path to shell, which the
       // sampleVisiblePaneForegroundAgent gate would then latch, permanently hiding
       // an idle reattached agent's icon (the "codex reattached at rest" bug).
+      const hadReadBeforeCommandFinish = hasPendingRead()
       cancelPendingRead()
       if (!trackablePtyId()) {
+        releaseRetainedCapability(hadReadBeforeCommandFinish)
         return false
       }
       // Why: trust the 133;D and mark shell without an RPC only when nothing hints
@@ -300,8 +314,10 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
       return true
     },
     dispose() {
+      const hadReadAtDispose = hasPendingRead()
       disposed = true
       cancelPendingRead()
+      releaseRetainedCapability(hadReadAtDispose)
     }
   }
 }

--- a/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
+++ b/src/renderer/src/components/terminal-pane/pane-foreground-agent-tracker.ts
@@ -43,6 +43,8 @@ type PaneForegroundAgentTrackerDeps = {
  * leak their own 133;D onto the main PTY.
  */
 export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTrackerDeps): {
+  /** True while any read is scheduled or running, whatever its authority. */
+  hasReadInFlight: () => boolean
   onVisiblePtyBound: (expectsAgent?: boolean) => boolean
   onCommandStarted: (expectedAgent?: TuiAgent | null) => void
   /** True when pane identity must remain visible until an async shell confirmation. */
@@ -192,6 +194,10 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
         return
       }
       if ((hasForegroundAgentEvidence || hasKnownAgentEvidence) && !isShellProcess(processName)) {
+        // Why: this read may have replaced a cancelled visible-pty confirmation.
+        // It publishes nothing, so without settling here the capability it was
+        // asked to revalidate would be retained with no read left to clear it.
+        deps.onVisibleForegroundSettled?.('inconclusive')
         return
       }
       // Why: the 133;D fired AND the foreground shows no agent — together that is
@@ -208,6 +214,12 @@ export function createPaneForegroundAgentTracker(deps: PaneForegroundAgentTracke
   }
 
   return {
+    // Why: onVisiblePtyBound refuses to schedule while a higher-authority
+    // command read owns the pane, so "it scheduled nothing" must not be read
+    // as "nothing will confirm this pane".
+    hasReadInFlight(): boolean {
+      return scheduledReadReason !== null || activeReadReason !== null
+    },
     onVisiblePtyBound(expectsAgent = false) {
       // Why: command-start and command-finished reads own the exit decision;
       // visibility recovery is lower-authority and must never cancel them.

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-routing.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-routing.test.ts
@@ -471,9 +471,12 @@ describe('connectPanePty', () => {
     expect(mockStoreState.paneForegroundAgentByPaneKey[paneKey]).toEqual({
       agent: 'droid',
       routingRevoked: true,
+      routingConfirmationPending: true,
       shellForeground: false
     })
-    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
+    // The provider read is asynchronous; keep the last known safe capability
+    // so a second Shift+Enter cannot become Pi's submit chord in the gap.
+    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
 
     await vi.advanceTimersByTimeAsync(350 + 1200 + 6000)
 
@@ -522,7 +525,8 @@ describe('connectPanePty', () => {
     foreground = 'cmd.exe'
     sendTerminalInputThroughPane(pane, '\x03')
     await flushAsyncTicks()
-    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('alt-enter')
+    // A provider read is pending; do not turn the next Pi Shift+Enter into submit.
+    expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, paneKey)).toBe('csi-u')
     await vi.advanceTimersByTimeAsync(
       VISIBLE_PTY_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS + SECOND_WRAPPER_RETRY_MS
     )

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
@@ -331,6 +331,47 @@ describe('connectPanePty', () => {
       }
     })
 
+    it('does not confirm foreground routing for a global Windows WSL shell', async () => {
+      vi.useFakeTimers()
+      const restoreUserAgent = temporarilySetNavigatorUserAgent(
+        'Mozilla/5.0 (Windows NT 10.0; Win64; x64)'
+      )
+      const ptyId = 'pty-global-wsl-no-confirm'
+      const tabId = `tab-${ptyId}`
+      mockStoreState.tabsByWorktree = {
+        'wt-1': [{ id: tabId, ptyId }]
+      }
+      mockStoreState.settings = {
+        ...mockStoreState.settings,
+        terminalWindowsShell: 'wsl.exe'
+      }
+
+      try {
+        const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
+          ptyId,
+          tabId
+        })
+        mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+          agent: 'droid',
+          routingTrusted: true,
+          shellForeground: false
+        }
+
+        binding.sampleForegroundAgentOnFocus()
+        await vi.advanceTimersByTimeAsync(10_000)
+
+        expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalledWith(ptyId)
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent: 'droid',
+          routingRevoked: true,
+          shellForeground: false
+        })
+        expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+      } finally {
+        restoreUserAgent()
+      }
+    })
+
     it('keeps trusted Droid routing through a rapid Shift+Enter burst', async () => {
       vi.useFakeTimers()
       const ptyId = 'pty-droid-shift-enter-burst'

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-agent-sampling.test.ts
@@ -320,6 +320,12 @@ describe('connectPanePty', () => {
 
         // Scope to this pane's pty id: a delayed confirm for another test's pane can fire during this advance.
         expect(window.api.pty.confirmForegroundProcess).not.toHaveBeenCalledWith(ptyId)
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent: 'droid',
+          routingRevoked: true,
+          shellForeground: false
+        })
+        expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
       } finally {
         restoreUserAgent()
       }
@@ -359,8 +365,10 @@ describe('connectPanePty', () => {
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'droid',
         routingRevoked: true,
+        routingConfirmationPending: true,
         shellForeground: false
       })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('csi-u')
 
       await vi.advanceTimersByTimeAsync(350)
       await flushAsyncTicks()
@@ -402,9 +410,10 @@ describe('connectPanePty', () => {
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'pi',
         routingRevoked: true,
+        routingConfirmationPending: true,
         shellForeground: false
       })
-      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('csi-u')
 
       await vi.advanceTimersByTimeAsync(
         VISIBLE_PTY_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS + SECOND_WRAPPER_RETRY_MS
@@ -440,12 +449,19 @@ describe('connectPanePty', () => {
       const tabId = `tab-${ptyId}`
       mockStoreState.tabsByWorktree = { 'wt-1': [{ id: tabId, ptyId }] }
 
-      const { cacheKey } = await connectRestoredPaneForForegroundSampling({
+      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
         ptyId,
         tabId,
         launchAgent: 'droid'
       })
       expect(mockStoreState.registerAgentLaunchConfig).not.toHaveBeenCalled()
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'droid',
+        shellForeground: false
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+
+      binding.sampleForegroundAgentOnFocus()
       expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
         agent: 'droid',
         shellForeground: false

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-routing-confirmation.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-routing-confirmation.test.ts
@@ -1,0 +1,308 @@
+import type * as React from 'react'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { makePaneKey } from '../../../../shared/stable-pane-id'
+import type { TuiAgent } from '../../../../shared/tui-agent'
+import { flushAsyncTicks } from './pty-connection-test-async'
+import {
+  VISIBLE_PTY_SETTLE_MS,
+  WRAPPER_RESOLVE_RETRY_MS,
+  SECOND_WRAPPER_RETRY_MS
+} from './pty-connection-test-constants'
+import {
+  LEAF_1,
+  createMockTransport,
+  createPane,
+  createManager,
+  type MockTransport
+} from './pty-connection-test-pane-fixtures'
+import {
+  resolveMockPaneWindowsShiftEnterEncoding,
+  type StoreState
+} from './pty-connection-test-store-state'
+import { buildPaneConnectionDeps } from './pty-connection-test-deps'
+import { createInitialStoreState } from './pty-connection-test-store-fixtures'
+import {
+  installTerminalTestGlobals,
+  restoreTerminalTestGlobals
+} from './pty-connection-test-environment'
+
+const {
+  resetAndRefreshAllTerminalWebglAtlases,
+  scheduleTerminalWebglAtlasRecovery,
+  scheduleRuntimeGraphSync,
+  shouldSeedCacheTimerOnInitialTitle,
+  toastInfo,
+  notifyCodexPaneBoundForStaleSweep
+} = vi.hoisted(() => ({
+  resetAndRefreshAllTerminalWebglAtlases: vi.fn(),
+  scheduleTerminalWebglAtlasRecovery: vi.fn(),
+  scheduleRuntimeGraphSync: vi.fn(),
+  shouldSeedCacheTimerOnInitialTitle: vi.fn(() => false),
+  toastInfo: vi.fn(),
+  notifyCodexPaneBoundForStaleSweep: vi.fn()
+}))
+
+let mockStoreState: StoreState
+let transportFactoryQueue: MockTransport[] = []
+let createdTransportOptions: Record<string, unknown>[] = []
+let storeSubscribers: ((state: StoreState) => void)[] = []
+
+vi.mock('@/runtime/sync-runtime-graph', () => ({
+  scheduleRuntimeGraphSync
+}))
+
+vi.mock('@/lib/pane-manager/pane-manager-registry', async (importOriginal) => ({
+  ...(await importOriginal<Record<string, unknown>>()),
+  resetAndRefreshAllTerminalWebglAtlases
+}))
+
+vi.mock('./terminal-webgl-atlas-recovery', () => ({
+  scheduleTerminalWebglAtlasRecovery
+}))
+
+vi.mock('@/store', () => ({
+  useAppStore: {
+    getState: () => mockStoreState,
+    subscribe: (listener: (state: StoreState) => void) => {
+      storeSubscribers.push(listener)
+      return () => {
+        storeSubscribers = storeSubscribers.filter((candidate) => candidate !== listener)
+      }
+    }
+  }
+}))
+
+vi.mock('@/lib/agent-status', async (importOriginal) => {
+  const { buildAgentStatusModuleMock } = await import('./pty-connection-test-environment')
+  return buildAgentStatusModuleMock(await importOriginal<Record<string, unknown>>())
+})
+
+vi.mock('./cache-timer-seeding', () => ({
+  shouldSeedCacheTimerOnInitialTitle
+}))
+
+vi.mock('sonner', () => ({
+  toast: {
+    info: toastInfo
+  }
+}))
+
+vi.mock('@/lib/codex-stale-pane-sweep', () => ({
+  notifyCodexPaneBoundForStaleSweep
+}))
+
+// Why: the working→idle test invokes the real useNotificationDispatch hook outside React, so useCallback must pass through (safe suite-wide: no test here renders React).
+vi.mock('react', async (importOriginal) => {
+  const actual = await importOriginal<typeof React>()
+  return {
+    ...actual,
+    useCallback: <T extends (...args: unknown[]) => unknown>(fn: T): T => fn
+  }
+})
+
+vi.mock('./pty-transport', () => ({
+  createIpcPtyTransport: vi.fn((options: Record<string, unknown>) => {
+    createdTransportOptions.push(options)
+    const nextTransport = transportFactoryQueue.shift()
+    if (!nextTransport) {
+      throw new Error('No mock transport queued')
+    }
+    return nextTransport
+  })
+}))
+
+vi.mock('./remote-runtime-pty-transport', () => ({
+  createRemoteRuntimePtyTransport: vi.fn(
+    (_environmentId: string, options: Record<string, unknown>) => {
+      createdTransportOptions.push(options)
+      const nextTransport = transportFactoryQueue.shift()
+      if (!nextTransport) {
+        throw new Error('No mock transport queued')
+      }
+      return nextTransport
+    }
+  )
+}))
+
+// Why: stub only getEagerPtyBufferHandle so tests can simulate a live eager buffer (adopt path) without standing up the real IPC dispatcher.
+vi.mock('./pty-dispatcher', async (importOriginal) => {
+  const actual = await importOriginal<Record<string, unknown>>()
+  return {
+    ...actual,
+    getEagerPtyBufferHandle: vi.fn(() => undefined)
+  }
+})
+
+function createDeps(overrides: Record<string, unknown> = {}) {
+  return buildPaneConnectionDeps(() => mockStoreState, overrides)
+}
+
+describe('connectPanePty', () => {
+  beforeEach(() => {
+    vi.resetModules()
+    vi.clearAllMocks()
+    transportFactoryQueue = []
+    createdTransportOptions = []
+    storeSubscribers = []
+    mockStoreState = createInitialStoreState(() => mockStoreState)
+    installTerminalTestGlobals()
+  })
+
+  afterEach(async () => {
+    await restoreTerminalTestGlobals()
+  })
+
+  describe('foreground routing confirmation authority', () => {
+    // Why: bindings share the tab-1/LEAF_1 pane key; give each case its own tabId so no other test's publish pollutes it.
+    async function connectRestoredPaneForForegroundSampling(
+      args: {
+        ptyId?: string
+        tabId?: string
+        isVisibleRef?: { current: boolean }
+        launchConfig?: {
+          agentCommand?: string
+          agentArgs: string
+          agentEnv: Record<string, string>
+        }
+        launchAgent?: TuiAgent
+      } = {}
+    ): Promise<{
+      binding: {
+        noteVisibilityResume: () => void
+        sampleForegroundAgentOnFocus: () => void
+        requestWindowsShiftEnterReconfirmation: () => void
+      }
+      deps: ReturnType<typeof createDeps>
+      transport: MockTransport
+      cacheKey: string
+    }> {
+      const { connectPanePty } = await import('./pty-connection')
+      const ptyId = args.ptyId ?? 'tab-pty'
+      const tabId = args.tabId ?? `tab-${ptyId}`
+      const hasReattachMetadata = args.launchConfig !== undefined || args.launchAgent !== undefined
+      const transport = createMockTransport(hasReattachMetadata ? null : ptyId)
+      let connectedPtyId: string | null = hasReattachMetadata ? null : ptyId
+      transport.getPtyId.mockImplementation(() => connectedPtyId)
+      transport.connect.mockImplementation(async ({ sessionId }: { sessionId?: string }) => {
+        connectedPtyId = sessionId ?? null
+        return sessionId
+          ? {
+              id: sessionId,
+              ...(args.launchConfig ? { launchConfig: args.launchConfig } : {}),
+              ...(args.launchAgent ? { launchAgent: args.launchAgent } : {})
+            }
+          : null
+      })
+      transportFactoryQueue.push(transport)
+      const deps = createDeps({
+        tabId,
+        restoredLeafId: LEAF_1,
+        restoredPtyIdByLeafId: { [LEAF_1]: ptyId },
+        ...(args.isVisibleRef ? { isVisibleRef: args.isVisibleRef } : {})
+      })
+      const binding = connectPanePty(
+        createPane(1) as never,
+        createManager(1) as never,
+        deps as never
+      ) as unknown as {
+        noteVisibilityResume: () => void
+        sampleForegroundAgentOnFocus: () => void
+        requestWindowsShiftEnterReconfirmation: () => void
+      }
+      await vi.advanceTimersByTimeAsync(20)
+      await flushAsyncTicks(20)
+      return { binding, deps, transport, cacheKey: makePaneKey(tabId, LEAF_1) }
+    }
+
+    async function advanceVisibleForegroundRead(): Promise<void> {
+      await vi.advanceTimersByTimeAsync(VISIBLE_PTY_SETTLE_MS)
+      await flushAsyncTicks()
+    }
+
+    it('does not reauthorize explicitly revoked routing before confirmation', async () => {
+      vi.useFakeTimers()
+      const ptyId = 'pty-pi-revoked-focus'
+      const tabId = `tab-${ptyId}`
+      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({ ptyId, tabId })
+      mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+        agent: 'pi',
+        routingRevoked: true,
+        shellForeground: false
+      }
+
+      binding.sampleForegroundAgentOnFocus()
+
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'pi',
+        routingRevoked: true,
+        shellForeground: false
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+    })
+
+    it.each(['null result', 'provider rejection'] as const)(
+      'drops pending routing after an inconclusive %s',
+      async (outcome) => {
+        vi.useFakeTimers()
+        if (outcome === 'provider rejection') {
+          vi.mocked(window.api.pty.confirmForegroundProcess).mockRejectedValue(
+            new Error('inspection unavailable')
+          )
+        } else {
+          vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue(null)
+        }
+        const ptyId = `pty-pi-reconfirm-${outcome.replace(' ', '-')}`
+        const tabId = `tab-${ptyId}`
+        const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
+          ptyId,
+          tabId
+        })
+        mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+          agent: 'pi',
+          routingTrusted: true,
+          shellForeground: false
+        }
+
+        binding.sampleForegroundAgentOnFocus()
+        expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('csi-u')
+
+        await vi.advanceTimersByTimeAsync(
+          VISIBLE_PTY_SETTLE_MS + WRAPPER_RESOLVE_RETRY_MS + SECOND_WRAPPER_RETRY_MS
+        )
+        await flushAsyncTicks()
+
+        expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+          agent: 'pi',
+          routingRevoked: true,
+          shellForeground: false
+        })
+        expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+      }
+    )
+
+    it('replaces pending Pi routing when confirmation finds another agent', async () => {
+      vi.useFakeTimers()
+      vi.mocked(window.api.pty.confirmForegroundProcess).mockResolvedValue('codex')
+      const ptyId = 'pty-pi-reconfirm-codex'
+      const tabId = `tab-${ptyId}`
+      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({ ptyId, tabId })
+      mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+        agent: 'pi',
+        routingTrusted: true,
+        shellForeground: false
+      }
+
+      binding.sampleForegroundAgentOnFocus()
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('csi-u')
+
+      await advanceVisibleForegroundRead()
+
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'codex',
+        routingTrusted: true,
+        shellForeground: false
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+    })
+  })
+})

--- a/src/renderer/src/components/terminal-pane/pty-connection-foreground-routing-confirmation.test.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection-foreground-routing-confirmation.test.ts
@@ -219,6 +219,66 @@ describe('connectPanePty', () => {
       await flushAsyncTicks()
     }
 
+    it('does not retain routing capability when no confirmation read is scheduled', async () => {
+      vi.useFakeTimers()
+      const isVisibleRef = { current: false }
+      const ptyId = 'pty-pi-hidden-no-read'
+      const tabId = `tab-${ptyId}`
+      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({
+        ptyId,
+        tabId,
+        isVisibleRef
+      })
+      mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+        agent: 'pi',
+        routingTrusted: true,
+        shellForeground: false
+      }
+
+      // Hidden pane: sampleVisiblePaneForegroundAgent bails, so nothing would ever
+      // clear a pending flag. It must fail closed to the legacy encoding instead.
+      binding.requestWindowsShiftEnterReconfirmation()
+      await vi.advanceTimersByTimeAsync(350)
+      await flushAsyncTicks()
+
+      expect(mockStoreState.paneForegroundAgentByPaneKey[cacheKey]).toEqual({
+        agent: 'pi',
+        routingRevoked: true,
+        shellForeground: false
+      })
+      expect(resolveMockPaneWindowsShiftEnterEncoding(mockStoreState, cacheKey)).toBe('alt-enter')
+    })
+
+    it('does not let a pending confirmation re-arm itself', async () => {
+      vi.useFakeTimers()
+      // Never resolves: the confirmation stays in flight for the whole test.
+      vi.mocked(window.api.pty.confirmForegroundProcess).mockReturnValue(new Promise(() => {}))
+      const ptyId = 'pty-pi-no-remint'
+      const tabId = `tab-${ptyId}`
+      const { binding, cacheKey } = await connectRestoredPaneForForegroundSampling({ ptyId, tabId })
+      mockStoreState.paneForegroundAgentByPaneKey[cacheKey] = {
+        agent: 'pi',
+        routingTrusted: true,
+        shellForeground: false
+      }
+
+      binding.requestWindowsShiftEnterReconfirmation()
+      await vi.advanceTimersByTimeAsync(350)
+      await flushAsyncTicks()
+      expect(
+        mockStoreState.paneForegroundAgentByPaneKey[cacheKey]?.routingConfirmationPending
+      ).toBe(true)
+      const publishesAfterFirst = mockStoreState.setPaneForegroundAgent.mock.calls.length
+
+      // A pending entry is not trusted evidence: further requests must not republish it.
+      binding.requestWindowsShiftEnterReconfirmation()
+      binding.requestWindowsShiftEnterReconfirmation()
+      await vi.advanceTimersByTimeAsync(1_000)
+      await flushAsyncTicks()
+
+      expect(mockStoreState.setPaneForegroundAgent.mock.calls.length).toBe(publishesAfterFirst)
+    })
+
     it('does not reauthorize explicitly revoked routing before confirmation', async () => {
       vi.useFakeTimers()
       const ptyId = 'pty-pi-revoked-focus'

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2166,6 +2166,18 @@ export function connectPanePty(
     onVisibleForegroundSettled: (outcome) => {
       visibleForegroundSamplePending = false
       visibleForegroundSampleSettled = outcome !== 'inconclusive'
+      if (outcome !== 'inconclusive') {
+        return
+      }
+      const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
+      if (foreground?.routingConfirmationPending !== true) {
+        return
+      }
+      useAppStore.getState().setPaneForegroundAgent(cacheKey, {
+        agent: foreground.agent,
+        routingRevoked: true,
+        shellForeground: foreground.shellForeground
+      })
     }
   })
   // Why: one command-finished policy whether the signal arrives as bytes
@@ -2245,15 +2257,20 @@ export function connectPanePty(
     // to an agent that already exited before confirmation ever ran.
     if (
       !foreground?.agent ||
+      (foreground.routingTrusted !== true && foreground.routingConfirmationPending !== true) ||
       TUI_AGENT_CONFIG[foreground.agent].windowsShiftEnterEncoding !== 'csi-u'
     ) {
       return
     }
-    // Why: cmd.exe and Git Bash have no OSC command boundaries. Keep the icon
-    // as a hint, but revoke bytes until one current provider confirmation lands.
+    // Why: cmd.exe and Git Bash have no OSC command boundaries. Block title
+    // fallback until confirmation, but retain the prior CSI-u capability while
+    // the asynchronous read is pending so an ambiguous gap cannot submit.
+    const ptyId = transport.getPtyId()
+    const canConfirmRouting = ptyId !== null && isForegroundTrackingAllowed(ptyId)
     useAppStore.getState().setPaneForegroundAgent(cacheKey, {
       agent: foreground.agent,
       routingRevoked: true,
+      ...(canConfirmRouting ? { routingConfirmationPending: true } : {}),
       shellForeground: false
     })
     visibleForegroundSamplePending = false

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2258,29 +2258,39 @@ export function connectPanePty(
     // provider read confirms it. Submit/interrupt/title-exit evidence must
     // revoke that launch-only hint too, otherwise Shift+Enter can route bytes
     // to an agent that already exited before confirmation ever ran.
+    // Why: only a live provider read can hand out the retained capability, so a
+    // pending entry must never satisfy this precondition — letting it re-arm
+    // itself would make one old read authorize CSI-u forever on a shell that
+    // emits no OSC boundary to publish over it.
     if (
       !foreground?.agent ||
-      (foreground.routingTrusted !== true && foreground.routingConfirmationPending !== true) ||
+      foreground.routingTrusted !== true ||
       TUI_AGENT_CONFIG[foreground.agent].windowsShiftEnterEncoding !== 'csi-u'
     ) {
       return
     }
-    // Why: cmd.exe and Git Bash have no OSC command boundaries. Block title
-    // fallback until confirmation, but retain the prior CSI-u capability while
-    // the asynchronous read is pending so an ambiguous gap cannot submit.
-    const ptyId = transport.getPtyId()
-    const canConfirmRouting = ptyId !== null && isForegroundTrackingAllowed(ptyId)
-    useAppStore.getState().setPaneForegroundAgent(cacheKey, {
+    const revokedEntry = {
       agent: foreground.agent,
       routingRevoked: true,
-      ...(canConfirmRouting ? { routingConfirmationPending: true } : {}),
       shellForeground: false
-    })
+    }
+    useAppStore.getState().setPaneForegroundAgent(cacheKey, revokedEntry)
     visibleForegroundSamplePending = false
     visibleForegroundSampleSettled = false
     // Why: hook rows can suppress display-only sampling, but cannot restore
     // byte authority after this function explicitly revoked routing trust.
     sampleVisiblePaneForegroundAgent(true)
+    // Why: cmd.exe and Git Bash have no OSC command boundaries. Block title
+    // fallback until confirmation, but retain the prior CSI-u capability while
+    // the asynchronous read is pending so an ambiguous gap cannot submit.
+    // Gated on a read actually being in flight: without one nothing would ever
+    // clear the flag, and the pane would keep the capability indefinitely.
+    if (visibleForegroundSamplePending) {
+      useAppStore.getState().setPaneForegroundAgent(cacheKey, {
+        ...revokedEntry,
+        routingConfirmationPending: true
+      })
+    }
   }
   const commandLifecycle = createTerminalCommandLifecycle({
     onCommandStarted: () => {

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2132,7 +2132,10 @@ export function connectPanePty(
       userAgent: navigator.userAgent,
       connectionId: getConnectionId(deps.worktreeId) ?? null,
       cwd: deps.cwd,
-      shellOverride: tab?.shellOverride,
+      shellOverride: resolveWindowsShellOverride(
+        tab?.shellOverride,
+        state.settings?.terminalWindowsShell
+      ),
       executionHostId: getExecutionHostIdForWorktree(state, deps.worktreeId)
     })
   }

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2254,14 +2254,10 @@ export function connectPanePty(
   }
   requestKnownWindowsShiftEnterReconfirmation = () => {
     const foreground = useAppStore.getState().paneForegroundAgentByPaneKey[cacheKey]
-    // Why: daemon reattach/launch metadata is display-only until a live
-    // provider read confirms it. Submit/interrupt/title-exit evidence must
-    // revoke that launch-only hint too, otherwise Shift+Enter can route bytes
-    // to an agent that already exited before confirmation ever ran.
-    // Why: only a live provider read can hand out the retained capability, so a
-    // pending entry must never satisfy this precondition — letting it re-arm
-    // itself would make one old read authorize CSI-u forever on a shell that
-    // emits no OSC boundary to publish over it.
+    // Why: daemon reattach/launch metadata is display-only until a live provider
+    // read confirms it, so only proven trust may be revoked-and-retained here. A
+    // pending entry must never qualify: re-arming itself would let one old read
+    // authorize CSI-u forever on a shell that emits no OSC boundary to publish over.
     if (
       !foreground?.agent ||
       foreground.routingTrusted !== true ||
@@ -2280,12 +2276,10 @@ export function connectPanePty(
     // Why: hook rows can suppress display-only sampling, but cannot restore
     // byte authority after this function explicitly revoked routing trust.
     sampleVisiblePaneForegroundAgent(true)
-    // Why: cmd.exe and Git Bash have no OSC command boundaries. Block title
-    // fallback until confirmation, but retain the prior CSI-u capability while
-    // the asynchronous read is pending so an ambiguous gap cannot submit.
-    // Gated on a read actually being in flight: without one nothing would ever
-    // clear the flag, and the pane would keep the capability indefinitely.
-    if (visibleForegroundSamplePending || paneForegroundAgentTracker.hasReadInFlight()) {
+    // Why: cmd.exe and Git Bash have no OSC command boundaries, so retain the prior
+    // CSI-u capability across the async read rather than let the gap send Esc+CR.
+    // Only while a read is genuinely in flight — nothing else ever clears the flag.
+    if (paneForegroundAgentTracker.hasReadInFlight()) {
       useAppStore.getState().setPaneForegroundAgent(cacheKey, {
         ...revokedEntry,
         routingConfirmationPending: true

--- a/src/renderer/src/components/terminal-pane/pty-connection.ts
+++ b/src/renderer/src/components/terminal-pane/pty-connection.ts
@@ -2285,7 +2285,7 @@ export function connectPanePty(
     // the asynchronous read is pending so an ambiguous gap cannot submit.
     // Gated on a read actually being in flight: without one nothing would ever
     // clear the flag, and the pane would keep the capability indefinitely.
-    if (visibleForegroundSamplePending) {
+    if (visibleForegroundSamplePending || paneForegroundAgentTracker.hasReadInFlight()) {
       useAppStore.getState().setPaneForegroundAgent(cacheKey, {
         ...revokedEntry,
         routingConfirmationPending: true

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.test.ts
@@ -83,6 +83,19 @@ describe('resolveWindowsShiftEnterEncoding', () => {
     expect(resolveWindowsShiftEnterEncodingForPane(state, 'tab:pane', 'Pi ready')).toBe('alt-enter')
   })
 
+  it('keeps the last CSI-u capability while revocation confirmation is pending', () => {
+    expect(
+      resolveWindowsShiftEnterEncoding({
+        foreground: {
+          agent: 'pi',
+          routingRevoked: true,
+          routingConfirmationPending: true,
+          shellForeground: false
+        }
+      })
+    ).toBe('csi-u')
+  })
+
   it('keeps legacy bytes for plain shell and unsupported-agent titles', () => {
     const state = {
       paneForegroundAgentByPaneKey: {},

--- a/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
+++ b/src/renderer/src/components/terminal-pane/terminal-windows-shift-enter.ts
@@ -23,12 +23,13 @@ export function resolveWindowsShiftEnterEncoding(
   if (signals.foreground?.shellForeground) {
     return 'alt-enter'
   }
-  // Why: an entry marks a newer command/process generation. Until fresh
-  // confirmation trusts it, stale launch ownership must not route input.
-  // Launch metadata is only an expectation used to start confirmation; it is
-  // never byte-routing authority because warm/stale daemon state can outlive
-  // the process that originally launched the agent.
-  const agent = signals.foreground?.routingTrusted === true ? signals.foreground.agent : null
+  // Why: a pending confirmation retains the last allowlisted byte capability;
+  // CSI-u is inert in a shell, while Esc+CR can submit in Pi.
+  const agent =
+    signals.foreground?.routingTrusted === true ||
+    signals.foreground?.routingConfirmationPending === true
+      ? signals.foreground.agent
+      : null
   return agent ? (TUI_AGENT_CONFIG[agent].windowsShiftEnterEncoding ?? 'alt-enter') : 'alt-enter'
 }
 

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -44,6 +44,32 @@ describe('pane foreground agent slice', () => {
     expect(store.getState().paneForegroundAgentByPaneKey).toEqual({})
   })
 
+  // Why: the settle publish drops routingConfirmationPending while every other
+  // compared field stays equal, so the equality short-circuit is the only thing
+  // standing between "confirmation ended" and a pane that keeps CSI-u forever.
+  it('lands the publish that clears a pending confirmation', () => {
+    const store = createTestStore()
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'pi',
+      routingRevoked: true,
+      routingConfirmationPending: true,
+      shellForeground: false
+    })
+
+    // Exactly the entry the inconclusive-settle path republishes.
+    store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
+      agent: 'pi',
+      routingRevoked: true,
+      shellForeground: false
+    })
+
+    expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']).toEqual({
+      agent: 'pi',
+      routingRevoked: true,
+      shellForeground: false
+    })
+  })
+
   it('sweeps only the closed tab prefix, not sibling tabs or prefix-share ids', () => {
     const store = createTestStore()
     store

--- a/src/renderer/src/store/slices/pane-foreground-agent.test.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.test.ts
@@ -31,10 +31,14 @@ describe('pane foreground agent slice', () => {
     store.getState().setPaneForegroundAgent('tab-1:leaf-1', {
       agent: 'aider',
       routingRevoked: true,
+      routingConfirmationPending: true,
       shellForeground: false
     })
     expect(store.getState().paneForegroundAgentByPaneKey).not.toBe(first)
     expect(store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.routingRevoked).toBe(true)
+    expect(
+      store.getState().paneForegroundAgentByPaneKey['tab-1:leaf-1']?.routingConfirmationPending
+    ).toBe(true)
 
     store.getState().clearPaneForegroundAgent('tab-1:leaf-1')
     expect(store.getState().paneForegroundAgentByPaneKey).toEqual({})

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -9,6 +9,8 @@ export type PaneForegroundAgentEntry = {
   routingTrusted?: boolean
   /** True after exit/input evidence revokes routing until provider confirmation. */
   routingRevoked?: boolean
+  /** True while previously trusted routing awaits provider revalidation. */
+  routingConfirmationPending?: boolean
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */
   shellForeground: boolean
@@ -44,6 +46,7 @@ export const createPaneForegroundAgentSlice: StateCreator<
         current.agent === entry.agent &&
         current.routingTrusted === entry.routingTrusted &&
         current.routingRevoked === entry.routingRevoked &&
+        current.routingConfirmationPending === entry.routingConfirmationPending &&
         current.shellForeground === entry.shellForeground
       ) {
         return s

--- a/src/renderer/src/store/slices/pane-foreground-agent.ts
+++ b/src/renderer/src/store/slices/pane-foreground-agent.ts
@@ -9,7 +9,9 @@ export type PaneForegroundAgentEntry = {
   routingTrusted?: boolean
   /** True after exit/input evidence revokes routing until provider confirmation. */
   routingRevoked?: boolean
-  /** True while previously trusted routing awaits provider revalidation. */
+  /** True while previously trusted routing awaits provider revalidation. Retains
+   *  Shift+Enter byte capability only — the Ctrl+Enter resolver deliberately does
+   *  not read it, because its fallback is a plain CR that submits either way. */
   routingConfirmationPending?: boolean
   /** True once the foreground is proven back at the shell (OSC 133;D) —
    *  process-grade launched-agent exit evidence, independent of titles. */


### PR DESCRIPTION
## Summary

While a Windows foreground revalidation is genuinely in flight, keep Shift+Enter on the CSI-u route a provider read already proved, instead of dropping to the Alt+Enter fallback for the length of the gap.

Closes #13597. Follow-up to #12541; addresses the pending-confirmation behaviour after #12618, on the Pi CSI-u routing from #11769.

## The state machine

`requestKnownWindowsShiftEnterReconfirmation` revokes routing and starts an asynchronous provider read. Between those two things the entry was `{agent, routingRevoked: true}`, which resolves to `alt-enter` — so during the gap Shift+Enter sent `ESC CR` rather than the `CSI 13;2u` the pane had been sending a moment earlier.

This adds `routingConfirmationPending`, published **only** while a confirmation read is actually in flight, so the resolver keeps the proven capability for exactly as long as the read that justifies it.

The second commit routes `shellOverride` through `resolveWindowsShellOverride` in `isForegroundTrackingAllowed`, matching the sibling call site. This strictly *narrows*: a user whose global Windows shell is WSL no longer gets native-ConPTY process scans on panes that can never authorize ConPTY bytes.

## Third commit: bounding the capability

Review found the first commit let one old provider read authorize CSI-u indefinitely, in two ways:

1. `routingConfirmationPending` satisfied its own precondition, so a pending entry re-published itself on every reconfirmation request. Only one of the five callers is the Shift+Enter burst timer — the others fire on accepted submit/interrupt bytes, on focus and visibility changes, and on `onAgentExited`, which runs precisely when a shell title proves the agent is gone. On cmd.exe and Git Bash there is no OSC boundary to publish over the entry, so nothing decayed it.
2. The flag was published even when no read was scheduled — hidden pane, a command read already in flight, or a null pty id — while only the read's inconclusive settle clears it.

The fix requires `routingTrusted` to grant the capability and publishes the flag only after sampling reports a read in flight. That also makes the `canConfirmRouting` gate redundant: the tracker already refuses WSL, SSH and remote pty ids.

## Fourth and fifth commits: bounding it correctly

A second review round found the third commit's gate asked the wrong question. `onVisiblePtyBound` deliberately returns `false` while a higher-authority command read owns the pane, and reading that as "no read is coming" dropped CSI-u for the length of that window — reintroducing the very gap this PR exists to close, and regressing against the PR's own earlier behaviour. The tracker now exposes `hasReadInFlight()` so the question asked is "will anything confirm this pane?" rather than "did *I* just schedule something?".

Landing alongside it: the command-finished branch that returns without publishing now settles the visible confirmation it replaced, so the flag cannot outlive the read that justifies it. The two had to land together — fixing either alone widens the other's window.

## Sixth commit: closing the flag's lifetime for good

Two further review rounds found the same root cause twice more: the flag could outlive the read it is tied to. `cancelPendingRead` bumps the read generation before anything can settle, and `dispose()` plus three untrackable early returns schedule no successor to settle for them — while the store entry outlives the tracker, because detach/remount emits no PTY exit. A *visible* remount self-heals, but a hidden pane does not, since the dashboard card resolves the encoding for any pane key regardless of visibility.

Rather than patch a third site, every exit that ends a read without scheduling a successor now releases the capability. A final review enumerated all 22 exits from the tracker and confirmed each one releases the flag — by wholesale `publish` replacement, by settle, or by a successor read — and that the flag is minted in exactly one place, gated on a live read.

## Reproduced on Pi 0.84.2 — the state matters

The symptom only appears while **Pi is working**, which is what #13597 meant by "submit in the affected state". With Pi idle the fallback looks harmless, and an idle-pane test wrongly clears it.

The reason is in Pi's own keymap (`@earendil-works/pi-coding-agent/dist/core/keybindings.js`): `alt+enter` is bound to `app.message.followUp` — *"Queue follow-up message"*, backed by a real `_followUpMessages` queue in `core/agent-session.js`. Idle, there is no turn to follow up, so it degrades to a newline. Busy, it consumes the composer.

Live A/B, same pane, same Pi build, Pi mid-task:

| bytes written to the PTY | result |
|---|---|
| `ESC CR` — what `main` sends during the gap | composer **consumed**; the half-written draft was submitted and the pane title changed to it |
| `CSI 13;2u` — what this PR preserves | **newline**; both lines stayed in the composer, nothing submitted |

So the gap is a real data-loss path: a Shift+Enter landing inside the revalidation window sends your unfinished message to the model. That is the user-visible bug this PR fixes.

## Surface matrix

- **macOS / Linux: no change.** `terminal-shortcut-policy.ts` only consults the Windows encoding behind `isWindowsTerminalHost()`, and the routing side is separately gated on a Windows user agent.
- **WSL / SSH / remote runtime: no change.** The tracker refuses those pty ids, so they stay on revoked-only, exactly as before.
- **Folder workspaces vs git worktrees:** nothing on this path distinguishes them.
- **Paired web / mobile:** `dashboard-card-terminal-input.ts` publishes `windowsShiftEnterEncoding` to remote clients, so the corrected value reaches them too. Wire-safe — existing field, existing value domain, no new opcode — but worth knowing the blast radius includes those surfaces.
- **Other agents:** only `pi`, `prime-agent` and `droid` carry `windowsShiftEnterEncoding: 'csi-u'`; every other agent still resolves to `alt-enter`. The gate is a pure `TUI_AGENT_CONFIG` table lookup, so it is agent-agnostic and `pi`/`droid` exercise the identical branch.

## Known gap, deliberately not fixed here

Ctrl+Enter has the same shape and is **not** covered. `terminal-ctrl-enter.ts` denies authority on `routingRevoked`, and `terminal-shortcut-policy.ts` falls back to plain `\r` — which really does submit. This is pre-existing and unchanged by this PR, but it means the class is only half-addressed, and the two sibling resolvers now read the same entry differently. Fixing it changes Ctrl+Enter byte output for Droid/Grok and deserves its own PR and its own live validation rather than a rider here.

## Testing

- `src/renderer/src/components/terminal-pane` + `store/slices`: **6375 passed, 1 skipped, 0 failed**.
- `pnpm typecheck` clean; oxlint and oxfmt clean on changed files; max-lines ratchet clean.
- Every new test mutation-checked — each fails when its production change is reverted. That includes the slice equality comparison, which is load-bearing: without it the clearing publish is swallowed as a no-op and the pane keeps CSI-u forever, and no `pty-connection` test can catch it because the fixture stubs the store action.

## Takeover notes

Rebased onto current `main` and taken over. `pty-connection.test.ts` no longer exists on `main` (split into per-topic files), so the regressions moved into the topic files that now own them, plus a new `pty-connection-foreground-routing-confirmation.test.ts` to stay under the 800-line cap without a lint suppression. Original authorship preserved on the first two commits.
