### PR TITLE
fix(agent-status): keep a nested child hook's model off the fenced parent row

### DIFF
--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -8162,6 +8162,99 @@ describe('AgentHookServer ingestRemote', () => {
     }
   })
 
+  // Why: `claude` running `codex exec` fires codex hooks on the inherited pane key;
+  // the fenced row must keep the parent's model, not adopt the child's (STA-3754).
+  it('keeps the parent model when a nested hook reports another agent model', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: {
+            state: 'working',
+            prompt: 'parent claude',
+            agentType: 'claude',
+            model: 'claude-fable-5'
+          }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(1_100)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: {
+            state: 'working',
+            prompt: 'nested codex',
+            agentType: 'codex',
+            model: 'gpt-5.6-sol'
+          }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          agentType: 'claude',
+          model: 'claude-fable-5'
+        })
+      ])
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
+  it('drops the nested model when the fenced parent never reported one', () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(1_000)
+    try {
+      const server = new AgentHookServer()
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: { state: 'working', prompt: 'parent claude', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      vi.setSystemTime(1_100)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          hasExplicitPrompt: true,
+          payload: {
+            state: 'working',
+            prompt: 'nested codex',
+            agentType: 'codex',
+            model: 'gpt-5.6-sol'
+          }
+        },
+        'conn-1'
+      )
+
+      const snapshot = server.getStatusSnapshot()[0]
+      expect(snapshot).toMatchObject({ agentType: 'claude' })
+      expect(snapshot?.model).toBeUndefined()
+    } finally {
+      vi.useRealTimers()
+    }
+  })
+
   it('ignores nested remote done while the parent pane agent is still active', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)

--- a/src/main/agent-hooks/server.test.ts
+++ b/src/main/agent-hooks/server.test.ts
@@ -8164,7 +8164,7 @@ describe('AgentHookServer ingestRemote', () => {
 
   // Why: `claude` running `codex exec` fires codex hooks on the inherited pane key;
   // the fenced row must keep the parent's model, not adopt the child's (STA-3754).
-  it('keeps the parent model when a nested hook reports another agent model', () => {
+  it('keeps the parent model through a nested hook and parent completion', () => {
     vi.useFakeTimers()
     vi.setSystemTime(1_000)
     try {
@@ -8205,6 +8205,26 @@ describe('AgentHookServer ingestRemote', () => {
       expect(server.getStatusSnapshot()).toEqual([
         expect.objectContaining({
           paneKey: PANE,
+          agentType: 'claude',
+          model: 'claude-fable-5'
+        })
+      ])
+
+      vi.setSystemTime(1_200)
+      server.ingestRemote(
+        {
+          paneKey: PANE,
+          tabId: 'tab-1',
+          worktreeId: 'wt-1',
+          payload: { state: 'done', prompt: 'parent claude', agentType: 'claude' }
+        },
+        'conn-1'
+      )
+
+      expect(server.getStatusSnapshot()).toEqual([
+        expect.objectContaining({
+          paneKey: PANE,
+          state: 'done',
           agentType: 'claude',
           model: 'claude-fable-5'
         })

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1231,14 +1231,30 @@ export class AgentHookServer {
             ...rootContextPreservingPayload,
             payload: {
               ...rootContextPreservingPayload.payload,
-              agentType: identity.agentType,
-              // Why: a nested child CLI inherits the pane key; its model must not
-              // relabel the fenced parent identity (`claude` running `codex exec`
-              // would otherwise show the codex model on the Claude row for good).
-              ...(identity.inheritedFromActivePane ? { model: previous?.payload.model } : {})
+              agentType: identity.agentType
             }
           }
-    const effectivePayload = attachClaudePermissionToolUseId(previous, identityResolvedPayload)
+    // Why: child hooks can report their own model, while later parent completion hooks may omit it.
+    const modelPreservingPayload = identity.inheritedFromActivePane
+      ? {
+          ...identityResolvedPayload,
+          payload: {
+            ...identityResolvedPayload.payload,
+            model: previous?.payload.model
+          }
+        }
+      : identityResolvedPayload.payload.model === undefined &&
+          previous?.payload.agentType === identity.agentType &&
+          previous.payload.model !== undefined
+        ? {
+            ...identityResolvedPayload,
+            payload: {
+              ...identityResolvedPayload.payload,
+              model: previous.payload.model
+            }
+          }
+        : identityResolvedPayload
+    const effectivePayload = attachClaudePermissionToolUseId(previous, modelPreservingPayload)
     if (previous && shouldKeepClaudePermissionVisible(previous, effectivePayload)) {
       return previous
     }

--- a/src/main/agent-hooks/server.ts
+++ b/src/main/agent-hooks/server.ts
@@ -1231,7 +1231,11 @@ export class AgentHookServer {
             ...rootContextPreservingPayload,
             payload: {
               ...rootContextPreservingPayload.payload,
-              agentType: identity.agentType
+              agentType: identity.agentType,
+              // Why: a nested child CLI inherits the pane key; its model must not
+              // relabel the fenced parent identity (`claude` running `codex exec`
+              // would otherwise show the codex model on the Claude row for good).
+              ...(identity.inheritedFromActivePane ? { model: previous?.payload.model } : {})
             }
           }
     const effectivePayload = attachClaudePermissionToolUseId(previous, identityResolvedPayload)

--- a/src/renderer/src/store/slices/agent-status.test.ts
+++ b/src/renderer/src/store/slices/agent-status.test.ts
@@ -594,6 +594,61 @@ describe('agent status tool + assistant fields', () => {
     expect(store.getState().agentStatusByPaneKey['tab-1:1'].agentType).toBe('codex')
   })
 
+  it('keeps the parent model when a nested hook reports a different model', () => {
+    // Why: `claude` running `codex exec` fires codex hooks on the same pane key;
+    // the fenced row must not relabel the Claude session with the codex model.
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store.getState().setAgentStatus('tab-1:1', {
+      state: 'working',
+      prompt: 'parent claude',
+      agentType: 'claude',
+      model: 'claude-fable-5'
+    })
+    store.getState().setAgentStatus('tab-1:1', {
+      state: 'working',
+      prompt: 'nested codex',
+      agentType: 'codex',
+      model: 'gpt-5.6-sol'
+    })
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    expect(entry.agentType).toBe('claude')
+    expect(entry.model).toBe('claude-fable-5')
+  })
+
+  it('keeps the nested model out of the row after the parent turn completes', () => {
+    vi.useFakeTimers()
+    const store = createTestStore()
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:1',
+        { state: 'working', prompt: 'parent claude', agentType: 'claude', model: 'claude-fable-5' },
+        undefined,
+        { updatedAt: 1_000, stateStartedAt: 1_000 }
+      )
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:1',
+        { state: 'working', prompt: 'nested codex', agentType: 'codex', model: 'gpt-5.6-sol' },
+        undefined,
+        { updatedAt: 1_100, stateStartedAt: 1_100 }
+      )
+    // Parent Stop hook: no model on Claude done events, so a leaked child model would stick.
+    store
+      .getState()
+      .setAgentStatus(
+        'tab-1:1',
+        { state: 'done', prompt: 'parent claude', agentType: 'claude' },
+        undefined,
+        { updatedAt: 1_200, stateStartedAt: 1_200 }
+      )
+    const entry = store.getState().agentStatusByPaneKey['tab-1:1']
+    expect(entry.state).toBe('done')
+    expect(entry.model).toBe('claude-fable-5')
+  })
+
   it('ignores nested done while the parent pane agent is still active', () => {
     vi.useFakeTimers()
     const store = createTestStore()

--- a/src/renderer/src/store/slices/agent-status.ts
+++ b/src/renderer/src/store/slices/agent-status.ts
@@ -1909,9 +1909,12 @@ export const createAgentStatusSlice: StateCreator<AppState, [], [], AgentStatusS
           updatedAt,
           stateStartedAt,
           agentType: identity.agentType,
-          model:
-            payload.model ??
-            (existing?.agentType === identity.agentType ? existing.model : undefined),
+          // Why: a nested child CLI inherits the pane key, and its model would
+          // mislabel the fenced parent identity long after the child exits.
+          model: identity.inheritedFromActivePane
+            ? existing?.model
+            : (payload.model ??
+              (existing?.agentType === identity.agentType ? existing.model : undefined)),
           paneKey,
           terminalHandle: statusTerminalHandle,
           worktreeId:


### PR DESCRIPTION
## Summary

When Claude runs \`codex exec\` (or any agent CLI nests another), the child's hooks fire on the inherited pane key. The identity fence already keeps the parent's \`agentType\`, but the child's **model** rode through the fenced payload and relabeled the parent row — a Claude session showing \`gpt-5.6-sol\` in the sidebar model chip — and it **persisted after the child exited**, because parent Claude Stop events carry no model to overwrite it back.

Fix: fence \`model\` beside \`agentType\` at both merge points —
- \`src/main/agent-hooks/server.ts\`: the authoritative hook merge keeps the previous (parent) model when \`inheritedFromActivePane\` rewrites the agentType.
- \`src/renderer/src/store/slices/agent-status.ts\`: same fence in the slice, which protects paired clients receiving payloads from an older host that lacks the main-side fence (mixed client/host versions are the normal state).

Fixes STA-3754 (parent session identity contaminated by nested delegation). The reported full icon flip is already fenced for hook agents on current main; the model chip was the remaining leak, reproduced live.

## Screenshots

No visual change beyond removing the wrong model label. Live before/after evidence (dev Electron, real Claude session running real \`codex exec\`):
- Before: pane entry \`{agentType: "claude", model: "gpt-5.6-sol"}\` persisting after turn end.
- After (this branch): model never adopts the child's value across the same nested run.

## Testing

- [x] \`pnpm lint\` (oxlint + react-doctor via pre-commit on changed files)
- [x] \`pnpm typecheck\`
- [x] \`pnpm test\` — \`src/main/agent-hooks/server.test.ts\` (270) and \`src/renderer/src/store/slices/agent-status.test.ts\` (52) all pass
- [ ] \`pnpm build\`
- [x] Added regression tests on both sides; all four fail when the fix is reverted (verified via stash)

## AI Review Report

Reviewed by the automation loop that authored it; an independent same-model Codex review round is being dispatched and its outcome will be posted as a PR comment. Risks checked: nested-hook identity fence semantics (working vs done suppression), SSH-relay root-model preservation interplay (\`preservedRootModel\` path is upstream of the fence and unaffected when identity is not inherited), mixed-version wire compatibility (renderer fence retained for old-host payloads), cross-platform: pure TypeScript state logic, no platform-specific behavior, no shortcuts/paths/shell involvement.

## Security Audit

No input handling, command execution, path handling, auth, secrets, dependency, or IPC surface changes; the change narrows which fields of an already-accepted hook payload are merged into displayed state.

## Notes

- The nested child's transient \`prompt\`/\`toolName\` still update the row during the parent's turn (pre-existing, self-healing on the next parent event); scoped out deliberately — only \`model\` persists wrongly.
- Possible follow-up: audit whether a nested child's \`providerSession\` metadata can contaminate the fenced row's resume identity.