### PR TITLE
fix(editor): refresh WSL files opened from a forward-slash UNC terminal link

### DIFF
--- a/src/renderer/src/components/editor/editor-autosave-wsl-unc-path.test.ts
+++ b/src/renderer/src/components/editor/editor-autosave-wsl-unc-path.test.ts
@@ -1,0 +1,65 @@
+import { describe, expect, it } from 'vitest'
+import { getOpenFilesForExternalFileChange } from './editor-autosave'
+import type { OpenFile } from '@/store/slices/editor'
+
+// Why: a terminal link opens a WSL file through the forward-slash UNC form
+// (`//wsl.localhost/Ubuntu/...`) while the Files sidebar stores the backslash
+// form, so an external-change notification built from the worktree path only
+// matched one of them and the terminal-opened tab never reloaded (#13349).
+function editTab(filePath: string): OpenFile {
+  return {
+    worktreeId: 'wt1',
+    filePath,
+    mode: 'edit'
+  } as unknown as OpenFile
+}
+
+describe('getOpenFilesForExternalFileChange — WSL UNC spellings', () => {
+  const target = {
+    worktreeId: 'wt1',
+    worktreePath: '\\\\wsl.localhost\\Ubuntu\\home\\me\\repo',
+    relativePath: 'media-ui/test.txt'
+  }
+
+  it('matches a tab opened through the forward-slash UNC form', () => {
+    const tab = editTab('//wsl.localhost/Ubuntu/home/me/repo/media-ui/test.txt')
+    expect(getOpenFilesForExternalFileChange([tab], target)).toEqual([tab])
+  })
+
+  it('still matches the backslash form the Files sidebar stores', () => {
+    const tab = editTab('\\\\wsl.localhost\\Ubuntu\\home\\me\\repo\\media-ui\\test.txt')
+    expect(getOpenFilesForExternalFileChange([tab], target)).toEqual([tab])
+  })
+
+  it('matches the legacy \\\\wsl$ alias for the same file', () => {
+    const tab = editTab('//wsl$/Ubuntu/home/me/repo/media-ui/test.txt')
+    expect(getOpenFilesForExternalFileChange([tab], target)).toEqual([tab])
+  })
+
+  it('folds distro case, which the terminal link does not lowercase', () => {
+    const tab = editTab('//wsl.localhost/ubuntu/home/me/repo/media-ui/test.txt')
+    expect(getOpenFilesForExternalFileChange([tab], target)).toEqual([tab])
+  })
+
+  it('does not match a different file in the same worktree', () => {
+    const tab = editTab('//wsl.localhost/Ubuntu/home/me/repo/media-ui/other.txt')
+    expect(getOpenFilesForExternalFileChange([tab], target)).toEqual([])
+  })
+
+  it('does not match the same relative path under a different distro', () => {
+    const tab = editTab('//wsl.localhost/Debian/home/me/repo/media-ui/test.txt')
+    expect(getOpenFilesForExternalFileChange([tab], target)).toEqual([])
+  })
+
+  it('leaves POSIX paths untouched, where backslash is a legal filename char', () => {
+    const posixTarget = {
+      worktreeId: 'wt1',
+      worktreePath: '/home/me/repo',
+      relativePath: 'a/b.txt'
+    }
+    const tab = editTab('/home/me/repo/a/b.txt')
+    expect(getOpenFilesForExternalFileChange([tab], posixTarget)).toEqual([tab])
+    const backslashTab = editTab('/home/me/repo/a\\b.txt')
+    expect(getOpenFilesForExternalFileChange([backslashTab], posixTarget)).toEqual([])
+  })
+})

--- a/src/renderer/src/components/editor/editor-autosave.ts
+++ b/src/renderer/src/components/editor/editor-autosave.ts
@@ -5,6 +5,7 @@ import {
   MAX_EDITOR_AUTO_SAVE_DELAY_MS,
   MIN_EDITOR_AUTO_SAVE_DELAY_MS
 } from '../../../../shared/constants'
+import { normalizeRuntimePathForComparison } from '../../../../shared/cross-platform-path'
 import { clampNumber } from '@/lib/terminal-theme'
 
 export const ORCA_EDITOR_QUIESCE_FILE_SAVES_EVENT = 'orca:editor-quiesce-file-saves'
@@ -121,6 +122,13 @@ export function getOpenFilesForExternalFileChange(
   target: EditorPathMutationTarget
 ): OpenFile[] {
   const absolutePath = joinPath(target.worktreePath, target.relativePath)
+  // Why: the same file reaches `filePath` in two spellings — terminal links open
+  // the forward-slash UNC form (`//wsl.localhost/Distro/...`) while the Files
+  // sidebar stores the backslash form `joinPath` rebuilds here, so raw equality
+  // left the terminal-opened tab out of the reload set forever (#13349).
+  // Normalized once here, not per candidate: the comparison key is deliberately
+  // not idempotent for WSL UNC, so both sides must fold exactly one raw value.
+  const normalizedAbsolutePath = normalizeRuntimePathForComparison(absolutePath)
   const hasRuntimeOwnerFilter = Object.prototype.hasOwnProperty.call(target, 'runtimeEnvironmentId')
   const targetRuntimeOwner = target.runtimeEnvironmentId?.trim() || null
   return openFiles.filter((file) => {
@@ -134,7 +142,11 @@ export function getOpenFilesForExternalFileChange(
       return false
     }
     if (file.mode === 'edit' || file.mode === 'markdown-preview') {
-      return file.filePath === absolutePath
+      // Why: exact match first so the common case never pays for normalization.
+      return (
+        file.filePath === absolutePath ||
+        normalizeRuntimePathForComparison(file.filePath) === normalizedAbsolutePath
+      )
     }
     if (file.mode === 'diff') {
       return (


### PR DESCRIPTION
## Summary

Fixes #13349 — a WSL file opened by clicking a terminal link never refreshed after an external change, while the same file opened from the Files sidebar refreshed correctly.

`getOpenFilesForExternalFileChange` matched open tabs with raw string equality against a path rebuilt by `joinPath(worktreePath, relativePath)`. `joinPath` takes its separator from the base path (`lib/path.ts:77`), so a worktree recorded as `\\wsl.localhost\Ubuntu\…` produces the backslash spelling — which is what the Files sidebar stored, so those tabs matched. Terminal links open the forward-slash form (`mapTerminalFilePath` returns `//wsl.localhost/<distro>/…`), so those tabs never entered the reload set and kept stale contents indefinitely.

Both sides are now folded through `normalizeRuntimePathForComparison`, which already exists for exactly this and additionally collapses the legacy `\\wsl$` alias and distro case (`mapTerminalFilePath` does not lowercase the distro, which was a second way to miss the same file).

Two details worth calling out for review:

- The target is normalized **once outside the filter**, not per candidate. That function is documented as *not* idempotent for WSL UNC paths (`cross-platform-path.ts:77`), so each side must fold exactly one raw value.
- Exact equality is still tried first, so the common non-UNC case pays nothing.

The sibling `diff` branch was already immune — it compares `relativePath`, which carries neither the UNC prefix nor the separator style — and is untouched.

## Screenshots

No visual change.

## Testing

- [x] `pnpm lint`
- [x] `pnpm typecheck`
- [x] `pnpm test`
- [x] `pnpm build`
- [x] Added or updated high-quality tests that would catch regressions, or explained why tests were not needed

New file `editor-autosave-wsl-unc-path.test.ts` (7 cases). I verified the tests fail without the source change: the 3 that exercise the bug (forward-slash form, legacy `\\wsl$` alias, distro case) fail on the unpatched function, and the 4 control cases pass both before and after — so the matcher has not been made over-permissive.

Full-suite comparison against this branch's base (`d9e84d88ef`):

| | test files | tests |
|---|---|---|
| base, no changes | 4 failed / 4564 passed | 10 failed / 49009 passed |
| this branch | 4 failed / 4565 passed | 10 failed / 49016 passed |

Exactly +1 file and +7 tests, all mine and all passing; the same 4 files / 10 tests fail on both. Those pre-existing failures (`src/relay/agent-exec-handler.test.ts` and `terminal-ime-xterm-resumed-preedit-visibility.test.ts` among them) reproduce identically on an unmodified checkout of the base commit — I confirmed the relay pair explicitly by stashing the change and re-running. They are unrelated to this PR.

## AI Review Report

Reviewed with Claude Opus 5. Risks checked and what came of them:

- **Over-matching.** The main risk of loosening an equality is matching the wrong file. Covered by control cases: a different filename in the same worktree, and the same relative path under a *different distro*, both still correctly return no match.
- **Non-idempotent comparison key.** `normalizeRuntimePathForComparison` folds `//wsl.localhost/Ubuntu/A` to `//wsl/ubuntu/A`, which a second pass would lowercase further. The review flagged that normalizing inside the filter, or normalizing an already-normalized value, would be a latent bug; the target is therefore folded once from the raw value and the per-file side folds its own raw value.
- **Comparison key leaking into a real path.** That function is explicitly documented as "comparison key only — never return this as, or splice it into, a real path" (`:16`). The result is used solely in a boolean; `absolutePath` and `file.filePath` are unchanged in every other use.
- **Cross-platform (macOS/Linux/Windows).** This is Windows-shaped behaviour, so POSIX regression was the specific concern. `normalizeRuntimePathForComparison` only folds separators when the path proves Windows drive/UNC semantics — backslash stays a legal POSIX filename character. A control test asserts that on a POSIX worktree `a/b.txt` matches and `a\b.txt` does not. No shortcut, label, or shell behaviour is touched.
- **Performance.** Called per external file change over open tabs. Kept the exact-equality fast path so the normal case is unchanged, and hoisted the target normalization out of the loop.

## Security Audit

Basic audit with the same agent. No new input handling, command execution, auth, secrets, dependency, or IPC surface: the change adds one import of an existing in-repo pure function and one boolean comparison, entirely inside the renderer.

Path handling is the relevant category, and the direction is safe — the normalized value is used **only** to decide whether an already-open tab should reload. It is never passed to `fs`, never used to open, read, or write a file, and never rendered. A hostile path cannot widen access through this comparison; the worst case is an incorrect match, which is bounded by the pre-existing `worktreeId` and runtime-owner filters that run first and are unchanged. No follow-up needed.

## Notes

Windows/WSL only in practice — POSIX and native Windows drive paths already matched exactly and take the fast path.

Two adjacent things I did **not** change, deliberately:

1. `mapTerminalFilePath` (`terminal-file-open-routing.ts:70`) still emits a distro-cased forward-slash path. Normalizing at the comparison site fixes the reported symptom without changing what gets stored in a tab or shown to the user; making the two producers agree on one spelling is a larger change and would want its own PR.
2. The `diff` branch of the same matcher is untouched for the reason given above.

Reported by @aliuq. Diagnosis and fix by me; I do not have a Windows/WSL machine, so the failing and passing behaviour here is established by unit tests against the real helpers rather than by running the app on WSL — a confirmation from the reporter on a real WSL worktree would be worth having before release.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_012ZcrKK54K7sRnSkT6a6Jut
