### PR TITLE
[perf-remote] perf(renderer): bound workspace port scan fanout

### DIFF
--- a/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.test.tsx
@@ -14,6 +14,7 @@ import {
   clearRuntimeCompatibilityCache,
   markRuntimeEnvironmentCompatible
 } from '@/runtime/runtime-rpc-client'
+import { WORKSPACE_PORT_SCAN_CONCURRENCY } from '@/lib/workspace-port-scan-batch'
 import { getWorkspacePortsByWorktreeId } from '@/lib/workspace-port-groups'
 import { useAppStore } from '@/store'
 import { WorkspacePortScanner } from './WorkspacePortScanner'
@@ -132,8 +133,9 @@ const compatibleStatus = {
 }
 
 async function flushPromises(): Promise<void> {
-  await Promise.resolve()
-  await Promise.resolve()
+  for (let index = 0; index < 10; index += 1) {
+    await Promise.resolve()
+  }
 }
 
 function seedRemoteWorkspace(environmentId = 'env-1'): void {
@@ -308,6 +310,85 @@ describe('WorkspacePortScanner', () => {
       await flushPromises()
     })
     expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(2)
+  })
+
+  it('bounds all-host scans, refills slots, and pauses queued work while hidden', async () => {
+    const settleScans: ((error?: Error) => void)[] = []
+    let activeScans = 0
+    let peakActiveScans = 0
+    runtimeEnvironmentCall.mockImplementation(({ method }) => {
+      if (method !== 'workspacePorts.scan') {
+        return Promise.resolve({ ok: false, error: { code: 'method_not_found', message: method } })
+      }
+      activeScans += 1
+      peakActiveScans = Math.max(peakActiveScans, activeScans)
+      return new Promise((resolve, reject) => {
+        settleScans.push((error) => {
+          activeScans -= 1
+          if (error) {
+            reject(error)
+            return
+          }
+          resolve({ ok: true, result: emptyScan })
+        })
+      })
+    })
+    for (const environmentId of ['env-2', 'env-3', 'env-4', 'env-5', 'env-6']) {
+      markRuntimeEnvironmentCompatible(environmentId)
+      addRemoteWorkspace(environmentId)
+    }
+
+    await act(async () => {
+      root?.render(<WorkspacePortScanner />)
+      await flushPromises()
+    })
+
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(WORKSPACE_PORT_SCAN_CONCURRENCY)
+    expect(peakActiveScans).toBe(WORKSPACE_PORT_SCAN_CONCURRENCY)
+
+    await act(async () => {
+      settleScans.shift()?.()
+      await flushPromises()
+    })
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(WORKSPACE_PORT_SCAN_CONCURRENCY + 1)
+    expect(peakActiveScans).toBe(WORKSPACE_PORT_SCAN_CONCURRENCY)
+
+    let visibilityState: DocumentVisibilityState = 'visible'
+    const restoreVisibilityState = overrideDocumentVisibilityState(() => visibilityState)
+    try {
+      visibilityState = 'hidden'
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+        settleScans.shift()?.(new Error('temporary hidden failure'))
+        await flushPromises()
+      })
+      expect(activeScans).toBe(WORKSPACE_PORT_SCAN_CONCURRENCY - 1)
+      visibilityState = 'visible'
+      await act(async () => {
+        document.dispatchEvent(new Event('visibilitychange'))
+        await flushPromises()
+      })
+      expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(WORKSPACE_PORT_SCAN_CONCURRENCY + 1)
+    } finally {
+      restoreVisibilityState()
+    }
+
+    await act(async () => {
+      settleScans.splice(0).forEach((settle) => settle())
+      await flushPromises()
+    })
+    expect(activeScans).toBe(2)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(WORKSPACE_PORT_SCAN_CONCURRENCY + 3)
+    expect(peakActiveScans).toBe(WORKSPACE_PORT_SCAN_CONCURRENCY)
+
+    await act(async () => {
+      settleScans.splice(0).forEach((settle) => settle())
+      await flushPromises()
+    })
+    expect(activeScans).toBe(0)
+    expect(runtimeEnvironmentCall).toHaveBeenCalledTimes(WORKSPACE_PORT_SCAN_CONCURRENCY + 3)
+    expect(peakActiveScans).toBe(WORKSPACE_PORT_SCAN_CONCURRENCY)
+    expect(useAppStore.getState().workspacePortScanRefreshing).toBe(false)
   })
 
   it('scans a changed execution host immediately instead of applying the prior throttle', async () => {

--- a/src/renderer/src/components/ports/WorkspacePortScanner.tsx
+++ b/src/renderer/src/components/ports/WorkspacePortScanner.tsx
@@ -5,15 +5,14 @@ import { getActiveRuntimeTarget, type RuntimeClientTarget } from '@/runtime/runt
 import {
   mergeWorkspacePortScans,
   runtimeTargetForExecutionHostId,
-  scanWorkspacePortsForTarget,
   workspacePortScanKeyForTarget
 } from '@/lib/workspace-port-actions'
+import { scanWorkspacePortTargets } from '@/lib/workspace-port-scan-batch'
 import { installWindowVisibilityInterval, isWindowVisible } from '@/lib/window-visibility-interval'
 import {
   reconcileTransientPortScanFailures,
   type PortScanDebounceState
 } from '@/lib/workspace-port-scan-debounce'
-import type { WorkspacePortScanResult } from '../../../../shared/workspace-ports'
 import { buildExecutionHostRegistry } from '../../../../shared/execution-host-registry'
 
 const WORKSPACE_PORT_SCAN_INTERVAL_MS = 30_000
@@ -21,18 +20,10 @@ const WORKSPACE_PORT_ADVERTISED_URL_SETTLE_MS = 1_000
 type WorkspacePortScannerRefreshOptions = {
   force?: boolean
   targets?: readonly RuntimeClientTarget[]
+  waitForInFlight?: boolean
 }
 // Why: keep live ports through one dropped SSH/IPC scan while reachable empty scans clear now.
 const WORKSPACE_PORT_SCAN_FAILURE_THRESHOLD = 2
-
-function makeUnavailableScan(reason: string): WorkspacePortScanResult {
-  return {
-    platform: 'unknown',
-    scannedAt: Date.now(),
-    ports: [],
-    unavailableReason: reason
-  }
-}
 
 export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }): null {
   const settings = useAppStore((s) => s.settings)
@@ -43,8 +34,10 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
   const replaceWorkspacePortScans = useAppStore((s) => s.replaceWorkspacePortScans)
   const setWorkspacePortScanForKey = useAppStore((s) => s.setWorkspacePortScanForKey)
   const setWorkspacePortScanRefreshing = useAppStore((s) => s.setWorkspacePortScanRefreshing)
-  const inFlightRef = useRef<Promise<void> | null>(null)
+  const inFlightRef = useRef<{ generation: number; promise: Promise<void> } | null>(null)
   const generationRef = useRef(0)
+  const admissionGenerationRef = useRef(0)
+  const hiddenInterruptedScanRef = useRef(false)
   const wasEnabledRef = useRef(false)
   const lastRefreshStartedAtByKeyRef = useRef(new Map<string, number>())
   const scanTargetsRef = useRef<RuntimeClientTarget[]>([])
@@ -70,7 +63,7 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
   scanTargetsRef.current = scanTargets
 
   const refresh = useCallback(
-    (options: WorkspacePortScannerRefreshOptions = {}) => {
+    (options: WorkspacePortScannerRefreshOptions = {}): Promise<void> => {
       const allTargets = scanTargetsRef.current
       if (!hasWorktrees || allTargets.length === 0) {
         portScanDebounceRef.current.clear()
@@ -83,8 +76,22 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
       if (requestedTargets.length === 0) {
         return Promise.resolve()
       }
-      if (inFlightRef.current) {
-        return inFlightRef.current
+      const generation = generationRef.current
+      const admissionGeneration = admissionGenerationRef.current
+      const inFlight = inFlightRef.current
+      if (inFlight) {
+        if (inFlight.generation === generation && !options.waitForInFlight) {
+          return inFlight.promise
+        }
+        return inFlight.promise.then(() => {
+          if (
+            generation === generationRef.current &&
+            admissionGeneration === admissionGenerationRef.current
+          ) {
+            return refresh({ ...options, waitForInFlight: false })
+          }
+          return undefined
+        })
       }
       const now = Date.now()
       const targets = options.force
@@ -101,24 +108,21 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
       if (targets.length === 0) {
         return Promise.resolve()
       }
-      for (const target of targets) {
-        lastRefreshStartedAtByKeyRef.current.set(workspacePortScanKeyForTarget(target), now)
-      }
 
-      const generation = generationRef.current
       setWorkspacePortScanRefreshing(true)
-      const promise = Promise.all(
-        targets.map(async (target) => {
-          const key = workspacePortScanKeyForTarget(target)
-          try {
-            const result = await scanWorkspacePortsForTarget(target)
-            return { key, result }
-          } catch (error) {
-            const message = error instanceof Error ? error.message : String(error)
-            return { key, result: makeUnavailableScan(message || 'Workspace port scan failed.') }
+      const promise = scanWorkspacePortTargets({
+        targets,
+        shouldStart: () =>
+          generation === generationRef.current &&
+          admissionGeneration === admissionGenerationRef.current,
+        onStarted: (key) => lastRefreshStartedAtByKeyRef.current.set(key, Date.now()),
+        onFailed: (key) => {
+          if (!isWindowVisible()) {
+            lastRefreshStartedAtByKeyRef.current.delete(key)
           }
-        })
-      )
+        },
+        onSkipped: (key) => lastRefreshStartedAtByKeyRef.current.delete(key)
+      })
         .then((results) => {
           if (generation === generationRef.current) {
             const activeTargetKeys = new Set(
@@ -163,14 +167,14 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
           }
         })
         .finally(() => {
-          if (inFlightRef.current === promise) {
+          if (inFlightRef.current?.promise === promise) {
             inFlightRef.current = null
           }
           if (generation === generationRef.current) {
             setWorkspacePortScanRefreshing(false)
           }
         })
-      inFlightRef.current = promise
+      inFlightRef.current = { generation, promise }
       return promise
     },
     [
@@ -198,6 +202,9 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
     }
     const wasDisabled = !wasEnabledRef.current
     wasEnabledRef.current = true
+    if (wasDisabled) {
+      hiddenInterruptedScanRef.current = false
+    }
     generationRef.current += 1
     const targetKeys = new Set(
       scanTargetsRef.current.map((target) => workspacePortScanKeyForTarget(target))
@@ -244,6 +251,12 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
     const stopVisibleInterval = installWindowVisibilityInterval({
       run: () => void refresh(),
       runOnVisible: () => {
+        if (hiddenInterruptedScanRef.current) {
+          hiddenInterruptedScanRef.current = false
+          shouldRefreshOnlyNewTargets = false
+          void refresh({ waitForInFlight: true })
+          return
+        }
         if (shouldRefreshOnlyNewTargets) {
           shouldRefreshOnlyNewTargets = false
           if (targetsToRefresh.length > 0) {
@@ -255,11 +268,21 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
       },
       intervalMs: WORKSPACE_PORT_SCAN_INTERVAL_MS
     })
+    const supersedeScanWhileHidden = (): void => {
+      const inFlight = inFlightRef.current
+      if (isWindowVisible() || !inFlight) {
+        return
+      }
+      admissionGenerationRef.current += 1
+      hiddenInterruptedScanRef.current = inFlight.generation === generationRef.current
+    }
+    document.addEventListener('visibilitychange', supersedeScanWhileHidden)
 
     return () => {
       generationRef.current += 1
-      inFlightRef.current = null
+      hiddenInterruptedScanRef.current = false
       setWorkspacePortScanRefreshing(false)
+      document.removeEventListener('visibilitychange', supersedeScanWhileHidden)
       stopVisibleInterval()
     }
   }, [
@@ -297,6 +320,7 @@ export function WorkspacePortScanner({ enabled = true }: { enabled?: boolean }):
       const sequence = eventSequence
       clearRetryTimer()
       if (!isWindowVisible()) {
+        lastRefreshStartedAtByKeyRef.current.delete(workspacePortScanKeyForTarget(runtimeTarget))
         return
       }
       void refresh({ force: true, targets: [runtimeTarget] }).finally(() => {

--- a/src/renderer/src/lib/workspace-port-scan-batch.ts
+++ b/src/renderer/src/lib/workspace-port-scan-batch.ts
@@ -1,0 +1,62 @@
+import type { RuntimeClientTarget } from '@/runtime/runtime-rpc-client'
+import {
+  scanWorkspacePortsForTarget,
+  workspacePortScanKeyForTarget
+} from '@/lib/workspace-port-actions'
+import { mapWithConcurrency } from '../../../shared/map-with-concurrency'
+import type { WorkspacePortScanResult } from '../../../shared/workspace-ports'
+
+// Why: per-host RPC queues do not cap aggregate work across remote hosts.
+export const WORKSPACE_PORT_SCAN_CONCURRENCY = 4
+
+export type WorkspacePortScanEntry = {
+  key: string
+  result: WorkspacePortScanResult
+}
+
+type WorkspacePortScanBatchOptions = {
+  targets: readonly RuntimeClientTarget[]
+  shouldStart: () => boolean
+  onStarted: (key: string) => void
+  onFailed: (key: string) => void
+  onSkipped: (key: string) => void
+}
+
+function makeUnavailableScan(reason: string): WorkspacePortScanResult {
+  return {
+    platform: 'unknown',
+    scannedAt: Date.now(),
+    ports: [],
+    unavailableReason: reason
+  }
+}
+
+export async function scanWorkspacePortTargets({
+  targets,
+  shouldStart,
+  onStarted,
+  onFailed,
+  onSkipped
+}: WorkspacePortScanBatchOptions): Promise<WorkspacePortScanEntry[]> {
+  const results = await mapWithConcurrency(
+    targets,
+    WORKSPACE_PORT_SCAN_CONCURRENCY,
+    async (target) => {
+      const key = workspacePortScanKeyForTarget(target)
+      if (!shouldStart()) {
+        onSkipped(key)
+        return null
+      }
+      onStarted(key)
+      try {
+        const result = await scanWorkspacePortsForTarget(target)
+        return { key, result }
+      } catch (error) {
+        onFailed(key)
+        const message = error instanceof Error ? error.message : String(error)
+        return { key, result: makeUnavailableScan(message || 'Workspace port scan failed.') }
+      }
+    }
+  )
+  return results.filter((result): result is WorkspacePortScanEntry => result !== null)
+}


### PR DESCRIPTION
## Summary

Bounds the periodic all-host workspace port scanner so adding remote Orca servers no longer increases simultaneous scan work without limit:

- admits at most four local/runtime scans at once and refills slots as each host completes
- keeps the cap across host-set changes and scanner lifecycle generations instead of overlapping replacement batches
- stamps each host cadence when its scan actually starts, not when it first enters a queue
- stops admitting queued scans when the window is hidden while allowing at most four already-running calls to finish under their existing deadlines
- reuses successful work after a quick hide/show and immediately retries only skipped or hidden-failed targets
- preserves transient-failure debounce, result ordering, new-host refresh, hidden advertised-URL recovery, and stale-generation publication fencing

### ELI5

Before, Orca checked every remote host for open ports at the same time. Ten hosts meant ten simultaneous checkups, and adding more hosts kept adding more work. Now those checkups use four checkout lanes. When Orca is hidden, nobody new joins the line; when it comes back, completed checkups are reused and only unfinished or failed ones retry.

This is structural hardening for the observed many-remote-host slowdown. It is not presented as a confirmed root-cause fix for the v1.4.177 to v1.4.178 regression.

## Screenshots

No visual change.

## Work bounds

| Scenario | Before | After |
| --- | --- | --- |
| One periodic all-host refresh | One simultaneous scan per execution host | At most 4 active scans, with completion-driven refill |
| Host/lifecycle change during a refresh | Replacement batch could overlap the old batch | Replacement waits for admitted calls; stale queued calls never start |
| Window hidden during a refresh | Every already-started host continued | At most 4 admitted calls finish; queued calls stop |
| Quick visibility return | Force-scanned every host again | Reuses successful results; retries skipped and hidden-failed targets |

The four-call limit applies to `WorkspacePortScanner`. It is not an app-global semaphore for unrelated user-triggered port actions, which retain existing per-target in-flight deduplication.

## Testing

- [ ] `pnpm lint` — full repository lint not run; changed-code native/type-aware/React Doctor gates passed with 0 new findings
- [x] `pnpm typecheck`
- [x] `pnpm test` — pinned to `ORCA_CROSS_VERSION_BASELINE_REF=v1.4.177`: 4,595 files / 49,264 tests passed
- [ ] `pnpm build` — full native packaging not run; `pnpm build:electron-vite` passed
- [x] Added or updated high-quality tests that would catch regressions

Additional checks:

- focused `WorkspacePortScanner` suite: 13/13 tests passed
- deterministic six-host test proves peak 4, completion refill, hidden admission stop, successful-result reuse, and retry of one skipped plus one hidden-failed target
- `pnpm check:code-quality:changed`
- `pnpm lint:react-doctor:changed`
- `pnpm check:max-lines-ratchet`
- `git diff --check origin/main...HEAD`

The unpinned full suite first selected an unrelated repository-history tag named `v799`, whose tree predates this repository layout and has no `src/`. Pinning the intended Orca release baseline (`v1.4.177`) made the cross-version suite and the full run pass.

## AI Review Report

Three read-only review passes covered the original fanout evidence, lifecycle/concurrency correctness, and the full readiness checklist. They explicitly checked slow/offline hosts, timeout and failure isolation, host fairness, target additions/removals, disable/unmount, rapid hide/show, stale generations, cadence, advertised-URL recovery, folder workspaces, SSH/runtime routing, mixed versions, and macOS/Linux/Windows compatibility.

The adversarial loop found and drove fixes for:

- a per-refresh cap that could still overlap after a lifecycle change
- stale queued RPCs starting after disable, unmount, or target replacement
- queued scans continuing after the window became hidden
- successful hosts being scanned twice after a quick hide/show
- targets being throttled from queue time rather than actual admission time
- hidden failures waiting for the remaining 30-second cadence instead of retrying on return
- a target/key/enabled change during hide bypassing the replacement effect's force-refresh semantics

Final readiness verdict: no P0, P1, or production P2 findings. One accepted development-only residual is React StrictMode effect replay: a development mount can repeat up to four initial scans after cleanup; production builds do not replay effects.

Cross-platform review found no shortcut, label, path, shell, native module, filesystem, or Electron platform-branch change. SSH and folder-workspace behavior remain on the existing execution-host registry and RPC paths.

## Security Audit

No dependency, command execution, input parser, filesystem path, auth, secret, IPC/RPC method, persistence schema, protocol field, stream opcode, or remote-wire payload changes. The new scheduler only controls when existing validated port-scan calls begin. Errors retain the existing per-target unavailable-result conversion, and one host failure cannot reject the batch.

## Notes

- Mixed client/server versions remain wire-compatible because no exchanged shape or server behavior changes.
- Up to four already-admitted scans can continue after hiding until their existing RPC/worker deadlines; queued scans stop.
- Publication still performs one existing keyed Zustand write per completed host; this PR bounds request fanout rather than changing port-result publication.
- #12611 does not touch this renderer scanner, so this PR should be evaluated as independent hardening rather than a rollback of that change.
