### PR TITLE
fix(github): stop treating waiting Actions as failures

### DIFF
--- a/src/main/github/mappers.test.ts
+++ b/src/main/github/mappers.test.ts
@@ -1,0 +1,33 @@
+import { describe, expect, it } from 'vitest'
+import {
+  mapCheckConclusion,
+  mapCheckRunRESTConclusion,
+  mapCheckRunRESTStatus,
+  mapCheckStatus
+} from './mappers'
+import { summarizeProviderChecks } from '../../shared/provider-check-summary'
+
+describe('check status mappers', () => {
+  it('keeps waiting/requested check runs non-terminal', () => {
+    expect(mapCheckRunRESTStatus('waiting')).toBe('queued')
+    expect(mapCheckRunRESTStatus('requested')).toBe('queued')
+    expect(mapCheckRunRESTStatus('pending')).toBe('queued')
+    expect(mapCheckRunRESTConclusion('waiting', null)).toBe('pending')
+    expect(mapCheckRunRESTConclusion('requested', null)).toBe('pending')
+  })
+
+  it('maps gh pr checks Waiting/Requested to pending, not failure', () => {
+    expect(mapCheckStatus('WAITING')).toBe('queued')
+    expect(mapCheckStatus('REQUESTED')).toBe('queued')
+    expect(mapCheckConclusion('WAITING')).toBe('pending')
+    expect(mapCheckConclusion('REQUESTED')).toBe('pending')
+    expect(
+      summarizeProviderChecks([
+        { status: mapCheckStatus('WAITING'), conclusion: mapCheckConclusion('WAITING') },
+        { status: mapCheckStatus('REQUESTED'), conclusion: mapCheckConclusion('REQUESTED') }
+      ])
+    ).toMatchObject({ state: 'pending', failed: 0, pending: 2 })
+    expect(mapCheckConclusion('FAILURE')).toBe('failure')
+    expect(mapCheckConclusion('ACTION_REQUIRED')).toBe('action_required')
+  })
+})

--- a/src/main/github/mappers.ts
+++ b/src/main/github/mappers.ts
@@ -8,7 +8,8 @@ import { derivePRCheckStatusFromRollup } from '../../shared/pr-check-status'
 
 export function mapCheckRunRESTStatus(status: string): PRCheckDetail['status'] {
   const s = status?.toLowerCase()
-  if (s === 'queued') {
+  // Waiting/requested/pending are non-terminal manual or environment holds (#13327).
+  if (s === 'queued' || s === 'pending' || s === 'requested' || s === 'waiting') {
     return 'queued'
   }
   if (s === 'in_progress') {
@@ -68,7 +69,7 @@ export function mapCommitStatusRESTConclusion(state: string): PRCheckDetail['con
 
 export function mapCheckStatus(state: string): PRCheckDetail['status'] {
   const s = state?.toUpperCase()
-  if (s === 'PENDING' || s === 'QUEUED') {
+  if (s === 'PENDING' || s === 'QUEUED' || s === 'WAITING' || s === 'REQUESTED') {
     return 'queued'
   }
   if (s === 'IN_PROGRESS') {
@@ -100,7 +101,13 @@ export function mapCheckConclusion(state: string): PRCheckDetail['conclusion'] {
   if (s === 'SKIPPED') {
     return 'skipped'
   }
-  if (s === 'PENDING' || s === 'QUEUED' || s === 'IN_PROGRESS') {
+  if (
+    s === 'PENDING' ||
+    s === 'QUEUED' ||
+    s === 'IN_PROGRESS' ||
+    s === 'WAITING' ||
+    s === 'REQUESTED'
+  ) {
     return 'pending'
   }
   if (s === 'NEUTRAL') {


### PR DESCRIPTION
## ELI5

GitHub Actions that are still waiting or requested now show as pending instead of failed or unresolved.

## What Changed

- Treat REST check-run `waiting`, `requested`, and `pending` statuses as queued/non-terminal.
- Treat `gh pr checks` `WAITING` and `REQUESTED` states as `queued` with a `pending` conclusion.
- Add mapper and real provider-rollup regression coverage proving those states produce `failed: 0` and `pending: 2`.

## Why

Current main does not recognize `WAITING` or `REQUESTED` in the CLI fallback mapper. It therefore produces `status: completed` with `conclusion: null`; the provider rollup classifies that pair as neutral, which surfaces as “Unresolved checks.” Mapping those states to `action_required` is also wrong here because the shared rollup deliberately counts that conclusion in its failure bucket. Pending preserves the non-terminal meaning consistently across the mapper and rollup layers.

## Linked Issue

Fixes #13327

## Visual Proof

N/A — this reuses the existing pending presentation and changes no component layout, styling, or interaction.

## Testing

- [ ] I manually tested these changes locally
- [x] Automated tests added/updated, or explained why not below

Commands run on exact head `f5bf5dfeea5c7b0324eea133d4e965920ddafb73`:

- `pnpm exec vitest run --config config/vitest.config.ts src/main/github/mappers.test.ts src/main/github/client-pr-checks.test.ts src/renderer/src/components/pr-check-counts.test.ts` — 23 passed
- `pnpm run typecheck` — passed
- changed-code quality, type-aware quality, React Doctor, max-lines ratchet, formatting, and `git diff --check` — passed

Focused tests and typecheck are proportionate for a two-file mapper-only change; full Vitest and build are left to approved CI.

Test-change disclosure: the PR-local `mappers.test.ts` assertions were changed from `action_required` to `pending` because the former expectations encoded the defect being corrected. No assertion was deleted or weakened; the test was strengthened with the real provider rollup. The fixed mapper is not mocked.

## AI Disclosure

OpenAI Codex was used for codebase tracing, TDD, and verification.

## Review

Local adversarial review on exact SHA `f5bf5dfeea5c7b0324eea133d4e965920ddafb73`: PASS. `ACTION_REQUIRED` retains its existing mapping; only `WAITING` and `REQUESTED` join the existing pending path.

## AI Review Report

Reviewed mapper inputs, the `getPRChecks` CLI fallback caller, `summarizeProviderChecks`, and `pr-check-counts`. No correctness, cross-provider, or compatibility blocker found.

## Security Audit

No authorization, credential, network-request, command-execution, or persisted-data change.

## Agent skill upstream boundary

- [x] Not applicable; no agent-skill source, tests, fixtures, registry entries, path tables, comments, or documentation are copied or translated.

## Notes

- Cross-platform: pure provider-state mapping; no OS, path, shell, shortcut, or native-module behavior.
- SSH/folder workspaces: the shared GitHub execution path is unchanged.
- Mobile/remote compatibility: no wire or stored-data shape change.
- Performance: constant-size string comparisons only.

## Checklist

- [x] This PR is small and focused
- [x] I explained what changed and why (including ELI5)
- [x] Before/after screenshots or videos attached for UI changes, or `N/A` with reason
- [x] Self-reviewed for correctness, security, and performance
- [x] Cross-platform, SSH/remote, and path/shortcut impact considered (or N/A)
- [x] Focused tests and typecheck pass; remaining full-suite/build coverage is delegated to approved CI

## Author

- GitHub: @bbingz
